### PR TITLE
feat(memory): ship runtime as bundled release asset + bootstrap fetch (ADR 0029)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -154,6 +154,58 @@ jobs:
             git push origin HEAD:main
           fi
 
+      # ADR 0029: the Memory runtime ships as release assets, not committed
+      # build output. esbuild bundles the CLI (all JS deps inlined) into one
+      # platform-independent file; a manifest pins its checksum + the reddb tag
+      # whose per-platform `red` binaries the bootstrap reuses. Assets are
+      # attached at `gh release create` so they exist the moment the Release
+      # publishes.
+      - uses: pnpm/action-setup@v4
+        if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
+        with:
+          node-version: 22
+
+      - name: Build memory runtime bundle + manifest
+        if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
+        working-directory: plugins/memory
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile
+          pnpm bundle
+          node --input-type=module <<'EOF'
+          import { createHash } from 'node:crypto';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+          const sdk = pkg.dependencies['@reddb-io/sdk'];
+          const cli = readFileSync('dist-bundle/memory-cli.mjs');
+          const manifest = {
+            schema: 'red.memory.runtime.v1',
+            version: process.env.NEXT.replace(/^v/, ''),
+            cli: { asset: 'memory-cli.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
+            reddb: {
+              repo: 'reddb-io/reddb',
+              tag: `v${sdk}`,
+              assets: {
+                'linux-x86_64': 'red-linux-x86_64',
+                'linux-aarch64': 'red-linux-aarch64',
+                'linux-armv7': 'red-linux-armv7',
+                'macos-x86_64': 'red-macos-x86_64',
+                'macos-aarch64': 'red-macos-aarch64',
+                'windows-x86_64': 'red-windows-x86_64.exe',
+              },
+            },
+          };
+          writeFileSync('memory-runtime-manifest.json', JSON.stringify(manifest, null, 2));
+          console.log('runtime manifest:', JSON.stringify(manifest));
+          EOF
+
       - name: Tag + GitHub Release
         if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
         env:
@@ -164,13 +216,17 @@ jobs:
           set -euo pipefail
           git tag -a "$NEXT" -m "Release $NEXT"
           git push origin "$NEXT"
+          assets=(
+            plugins/memory/dist-bundle/memory-cli.mjs
+            plugins/memory/memory-runtime-manifest.json
+          )
           if [ -n "$PREVIOUS" ]; then
-            gh release create "$NEXT" \
+            gh release create "$NEXT" "${assets[@]}" \
               --title "$NEXT" \
               --generate-notes \
               --notes-start-tag "$PREVIOUS"
           else
-            gh release create "$NEXT" \
+            gh release create "$NEXT" "${assets[@]}" \
               --title "$NEXT" \
               --generate-notes
           fi

--- a/.red/adr/0029-memory-runtime-ships-as-a-bundled-asset-fetched-by-a-bootstrap.md
+++ b/.red/adr/0029-memory-runtime-ships-as-a-bundled-asset-fetched-by-a-bootstrap.md
@@ -1,0 +1,145 @@
+# Memory runtime ships as an esbuild bundle + `red` binary, fetched post-install by a dependency-free bootstrap
+
+## Context
+
+The Memory plugin's Claude lifecycle hooks (`SessionStart`, `PostToolUse` on
+`Edit|Write`, `Stop`, `PreCompact` — see ADR 0027) invoke
+`node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js hook <event>` with a best-effort
+fallback to `printf "{}"`. `CLAUDE_PLUGIN_ROOT` resolves to the **installed
+plugin cache** (`~/.claude/plugins/cache/red-skills/memory/<ver>/`), which the
+marketplace populates by a plain `git checkout` of the repo at the release SHA.
+Claude Code never runs a build or an install on plugin install or `autoUpdate`.
+
+This breaks the hooks in every installed copy, for three stacked reasons:
+
+1. **No `dist/`.** `plugins/memory/dist/` is gitignored, so no published version
+   carries the compiled JS — the hook hits a missing file and no-ops.
+2. **No JS dependencies.** The CLI is ESM (`"type": "module"`) and unbundled, so
+   even with `dist/` present it imports `@reddb-io/sdk`, `zod`, `gray-matter`,
+   `fast-glob`, and `@modelcontextprotocol/sdk` from `node_modules` (≈137 MB,
+   gitignored, never shipped). Proven empirically: running the full `dist/` with
+   no reachable `node_modules` crashes `ERR_MODULE_NOT_FOUND: zod`, which the
+   hook's `|| printf "{}"` swallows into a silent no-op.
+3. **No engine binary.** Memory connects with a `file://…/graph.rdb` URI, which
+   puts the SDK in **embedded mode**: `connect()` resolves and spawns the native
+   `red` binary (≈25 MB at `@reddb-io/sdk/bin/red`, fetched per-platform by the
+   SDK's `postinstall.js` from GitHub Releases) over stdio JSON-RPC.
+
+The graph (`.red/memory/graph.rdb`, 36 MB) only ever grew via manual
+`/memory:ingest` runs or when the ancient 1.48.1 cache — the only one that
+shipped `node_modules` — was active. The PRD #217 closed loop is
+architecturally complete but operationally dead in installed copies.
+
+Two delivery shapes were considered and rejected (see below): committing
+`dist/` (PR #228) and running a package-manager install into the cache. Neither
+can satisfy requirement 2 portably, and an install cannot be assumed (no
+npm/pnpm on the hook's PATH; `autoUpdate` wipes anything installed into the
+cache dir). A spike confirmed the viable shape:
+
+- `esbuild src/cli.ts --bundle --platform=node --format=esm` produces a single
+  **1.9 MB, platform-independent** `cli.mjs` with all JS dependencies inlined,
+  in ~100 ms.
+- The bundle runs **standalone with no `node_modules`** (help, parsing, all
+  bundled deps resolve internally).
+- An engine-touching command fails at exactly the right boundary —
+  `reddb: binary "red" not found … override: set REDDB_BIN=/path/to/red` — not
+  at module resolution. The SDK's binary lookup order is `REDDB_BIN` env →
+  `<pkg>/bin/red`, so `import.meta.resolve("@reddb-io/sdk")` never fires when
+  `REDDB_BIN` is set. **No source refactor is required.**
+
+## Decision
+
+The Memory runtime is delivered as **two fetched artifacts**, never as committed
+build output and never via an install on the user's machine:
+
+1. **`cli.mjs`** — a single esbuild bundle (all JS deps inlined), produced in
+   `red-release.yml` and uploaded as a **GitHub Release asset**. Platform-
+   independent.
+2. **`red-<platform>-<arch>`** — the native engine binary, published as a
+   per-platform Release asset (or referenced from `reddb-io/reddb` releases).
+
+A **dependency-free `bootstrap.js`** (only `node:` builtins — `fetch`, `node:fs`,
+`node:crypto`) is committed in the plugin and is what the hooks invoke. On each
+hook it ensures the runtime for the plugin's version exists, then delegates:
+
+- Target a **version-keyed cache outside the volatile plugin dir** —
+  `~/.cache/reddb-memory/<version>/{cli.mjs,red}` — so it survives `autoUpdate`
+  and is only re-fetched when the version actually changes.
+- If an artifact is missing or its **checksum** (published in the Release /
+  pinned in the bootstrap) does not match, download it; otherwise skip.
+- Export `REDDB_BIN=~/.cache/reddb-memory/<version>/red` and invoke
+  `node ~/.cache/reddb-memory/<version>/cli.mjs hook <event> …`.
+- On any bootstrap failure (offline, 404, checksum mismatch), **write an
+  actionable line to `~/.cache/reddb-memory/bootstrap.log`** and degrade to the
+  existing no-op. Failure must be diagnosable, never silent.
+
+`red-release.yml` must **upload the assets within the same job, before the
+Release is published**, so a peer's `autoUpdate` can never observe a new plugin
+version whose assets are still in flight.
+
+`plugins/memory/dist/` stays gitignored and uncommitted; the build step is a
+release-time concern only. The runtime that actually executes is always the
+bundle, never `dist/` or `node_modules`.
+
+## Why
+
+- **A bundle is the only portable way to satisfy "no install."** `node` is
+  assumed on the hook PATH; a package manager is not. esbuild inlining removes
+  the entire `node_modules` requirement for the JS half, proven at 1.9 MB.
+- **The `red` binary is irreducibly per-platform**, so it cannot be a single
+  committed artifact and must be fetched — the same mechanism the SDK's
+  postinstall already implements. Folding it into the bootstrap means one
+  fetch step owns both artifacts.
+- **A version-keyed cache outside `${CLAUDE_PLUGIN_ROOT}` is what makes this
+  survive `autoUpdate`.** Anything written into the cache dir is wiped on the
+  next refresh; `~/.cache/reddb-memory/<ver>/` is not, and the version key makes
+  re-download happen exactly once per version bump.
+- **Checksum + a bootstrap log** close the two failure modes that the current
+  design hides: tampered/corrupt payloads, and silent no-ops that look like
+  "memory is working" when it is not.
+
+## Rejected alternatives
+
+- **Commit `dist/` (PR #228).** Necessary-looking but insufficient: it ships the
+  JS files but not the 137 MB of deps they import, so the hooks still crash at
+  `ERR_MODULE_NOT_FOUND`. Superseded by this ADR; PR #228 is closed without
+  merge.
+- **Package-manager install into the cache (`pnpm install --prod`).** Assumes a
+  package manager on PATH, needs network + possible native builds, and lands in
+  the cache dir that `autoUpdate` wipes — so it must re-run every update. The
+  bundle needs none of that for the JS half.
+- **Commit the bundle instead of downloading it.** Viable (it is only 1.9 MB)
+  and gives offline JS, but the hooks all need the `red` binary anyway — which
+  needs network on first run regardless — so committing buys little offline
+  benefit while adding build-artifact churn to git. The `red` fetch path already
+  exists, so the JS bundle rides it.
+- **Node SEA / native single-executable.** Still requires a bundler to produce
+  the JS blob first, the output is a per-platform binary (reintroducing the
+  problem this ADR removes), and it is experimental. Node's native TypeScript
+  support removes only the `tsc` step, not the dependency-inlining need — it is
+  not a bundler.
+- **Rewrite Memory in Rust embedding the `red` crate.** A ~54 k-LOC, 39-subcommand
+  + MCP-server port whose payoff is packaging and in-process embedding, not
+  function. It does not eliminate the per-platform binary fetch (a Rust binary is
+  still per-platform). Out of scope as a fix; revisit only as a separate
+  strategic bet, gated on whether `reddb` exposes a usable library crate.
+
+## Consequences
+
+- The hook command in `hooks/claude.hooks.json` (and the Codex equivalent)
+  changes from `node ${CLAUDE_PLUGIN_ROOT}/dist/cli.js …` to invoking the
+  committed `bootstrap.js`, which resolves/fetches the versioned runtime and
+  delegates.
+- `red-release.yml` gains an esbuild bundle step, asset upload (bundle +
+  per-platform `red`), and published checksums; assets upload before the Release
+  is marked published.
+- First session after an install or version bump pays a one-time download
+  (~1.9 MB bundle + ~25 MB binary); subsequent sessions resolve from
+  `~/.cache/reddb-memory/<ver>/` with no network.
+- Offline first-run degrades to the documented no-op with a `bootstrap.log`
+  entry — strictly better than today's silent failure.
+- `import.meta.resolve("@reddb-io/sdk")` in `vcs-commit.ts` is made dead code in
+  the shipped path (the bootstrap always sets `REDDB_BIN`); no refactor needed,
+  but it may be removed for clarity.
+- This is the operational-delivery half of ADR 0027 / PRD #217: with it, hooks
+  fire the CLI in installed copies for the first time.

--- a/plugins/memory/.gitignore
+++ b/plugins/memory/.gitignore
@@ -2,3 +2,4 @@
 dist/
 node_modules/
 *.tsbuildinfo
+dist-bundle/

--- a/plugins/memory/hooks/claude.hooks.json
+++ b/plugins/memory/hooks/claude.hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'cli=\"${CLAUDE_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook SessionStart --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
+            "command": "sh -c 'bs=\"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook SessionStart --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'cli=\"${CLAUDE_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook PostToolUse --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
+            "command": "sh -c 'bs=\"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook PostToolUse --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'cli=\"${CLAUDE_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook Stop --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
+            "command": "sh -c 'bs=\"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook Stop --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
           }
         ]
       }
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'cli=\"${CLAUDE_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook PreCompact --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
+            "command": "sh -c 'bs=\"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook PreCompact --runner claude || printf \"{}\"; else cat >/dev/null 2>&1 || true; printf \"{}\"; fi'"
           }
         ]
       }

--- a/plugins/memory/hooks/codex.hooks.json
+++ b/plugins/memory/hooks/codex.hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; cli=\"${CODEX_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook SessionStart --runner codex <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; bs=\"${CODEX_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook SessionStart --runner codex <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; cli=\"${CODEX_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook PostToolUse --runner codex <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; bs=\"${CODEX_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook PostToolUse --runner codex <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
           }
         ]
       }
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; cli=\"${CODEX_PLUGIN_ROOT}/dist/cli.js\"; if [ -f \"$cli\" ]; then node \"$cli\" hook Stop --runner codex <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; bs=\"${CODEX_PLUGIN_ROOT}/scripts/bootstrap.mjs\"; if [ -f \"$bs\" ]; then node \"$bs\" hook Stop --runner codex <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
           }
         ]
       }

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.build.json",
+    "bundle": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist-bundle/memory-cli.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "test": "RED_MEMORY_RECALL_P50_TARGET_MS=250 vitest run tests/recall-latency.test.ts && vitest run --exclude tests/recall-latency.test.ts",
     "baseline:competitive": "tsx src/competitive-baseline.ts --json --human",
     "eval:competitive": "tsx src/competitive-baseline.ts --json --human",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "esbuild": "^0.24.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/plugins/memory/pnpm-lock.yaml
+++ b/plugins/memory/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.19
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
       tsx:
         specifier: ^4.19.0
         version: 4.22.3
@@ -45,6 +48,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.24.2':
+    resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
@@ -54,6 +63,12 @@ packages:
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.24.2':
+    resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -69,6 +84,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.24.2':
+    resolution: {integrity: sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.0':
     resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
     engines: {node: '>=18'}
@@ -78,6 +99,12 @@ packages:
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.24.2':
+    resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -93,6 +120,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.24.2':
+    resolution: {integrity: sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
@@ -102,6 +135,12 @@ packages:
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.24.2':
+    resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -117,6 +156,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    resolution: {integrity: sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
@@ -126,6 +171,12 @@ packages:
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.24.2':
+    resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -141,6 +192,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.24.2':
+    resolution: {integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
@@ -150,6 +207,12 @@ packages:
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.24.2':
+    resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -165,6 +228,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.24.2':
+    resolution: {integrity: sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
@@ -174,6 +243,12 @@ packages:
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.24.2':
+    resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -189,6 +264,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.24.2':
+    resolution: {integrity: sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
@@ -198,6 +279,12 @@ packages:
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.24.2':
+    resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -213,6 +300,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.24.2':
+    resolution: {integrity: sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
@@ -222,6 +315,12 @@ packages:
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.24.2':
+    resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -237,11 +336,23 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.24.2':
+    resolution: {integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
@@ -255,11 +366,23 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.24.2':
+    resolution: {integrity: sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.0':
     resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.24.2':
+    resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
@@ -270,6 +393,12 @@ packages:
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.24.2':
+    resolution: {integrity: sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -291,6 +420,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.24.2':
+    resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
     engines: {node: '>=18'}
@@ -300,6 +435,12 @@ packages:
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.24.2':
+    resolution: {integrity: sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -315,6 +456,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.24.2':
+    resolution: {integrity: sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.0':
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
@@ -324,6 +471,12 @@ packages:
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.24.2':
+    resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -672,6 +825,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.24.2:
+    resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.28.0:
@@ -1184,10 +1342,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.24.2':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.24.2':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
@@ -1196,10 +1360,16 @@ snapshots:
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.24.2':
+    optional: true
+
   '@esbuild/android-arm@0.28.0':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.24.2':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
@@ -1208,10 +1378,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.24.2':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.24.2':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
@@ -1220,10 +1396,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.24.2':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.24.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -1232,10 +1414,16 @@ snapshots:
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.24.2':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.24.2':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
@@ -1244,10 +1432,16 @@ snapshots:
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.24.2':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.0':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.24.2':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
@@ -1256,10 +1450,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.24.2':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.24.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -1268,10 +1468,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.24.2':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.0':
     optional: true
 
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.24.2':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
@@ -1280,7 +1486,13 @@ snapshots:
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.24.2':
+    optional: true
+
   '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
@@ -1289,13 +1501,22 @@ snapshots:
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.24.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -1307,10 +1528,16 @@ snapshots:
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.0':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.24.2':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
@@ -1319,10 +1546,16 @@ snapshots:
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.24.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.0':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.24.2':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
@@ -1631,6 +1864,34 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.24.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.24.2
+      '@esbuild/android-arm': 0.24.2
+      '@esbuild/android-arm64': 0.24.2
+      '@esbuild/android-x64': 0.24.2
+      '@esbuild/darwin-arm64': 0.24.2
+      '@esbuild/darwin-x64': 0.24.2
+      '@esbuild/freebsd-arm64': 0.24.2
+      '@esbuild/freebsd-x64': 0.24.2
+      '@esbuild/linux-arm': 0.24.2
+      '@esbuild/linux-arm64': 0.24.2
+      '@esbuild/linux-ia32': 0.24.2
+      '@esbuild/linux-loong64': 0.24.2
+      '@esbuild/linux-mips64el': 0.24.2
+      '@esbuild/linux-ppc64': 0.24.2
+      '@esbuild/linux-riscv64': 0.24.2
+      '@esbuild/linux-s390x': 0.24.2
+      '@esbuild/linux-x64': 0.24.2
+      '@esbuild/netbsd-arm64': 0.24.2
+      '@esbuild/netbsd-x64': 0.24.2
+      '@esbuild/openbsd-arm64': 0.24.2
+      '@esbuild/openbsd-x64': 0.24.2
+      '@esbuild/sunos-x64': 0.24.2
+      '@esbuild/win32-arm64': 0.24.2
+      '@esbuild/win32-ia32': 0.24.2
+      '@esbuild/win32-x64': 0.24.2
 
   esbuild@0.28.0:
     optionalDependencies:

--- a/plugins/memory/scripts/bootstrap.mjs
+++ b/plugins/memory/scripts/bootstrap.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * bootstrap.mjs — dependency-free runtime resolver for the Memory plugin.
+ *
+ * The plugin ships as a marketplace git checkout into the cache; Claude Code /
+ * Codex never run a build or install, so the compiled CLI and its 137 MB of
+ * deps cannot live in the checkout. Instead the release publishes a single
+ * esbuild bundle (`memory-cli.mjs`, all JS deps inlined) plus a runtime
+ * manifest, and the native `red` engine binary is reused from reddb-io/reddb's
+ * own releases. This script — invoked by every lifecycle hook in place of the
+ * old `dist/cli.js` — fetches those artifacts once per plugin version into a
+ * version-keyed cache that survives `autoUpdate`, then delegates the hook call.
+ *
+ * It uses only `node:` builtins because it runs before any dependency exists.
+ * See ADR 0029.
+ *
+ * Contract preserved from the old hook: on any failure it prints `{}` on stdout
+ * (the no-op the hooks expect) and logs an actionable line — never silent.
+ */
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile, chmod, appendFile } from "node:fs/promises";
+import { homedir, platform, arch } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RED_SKILLS_REPO = "reddb-io/red-skills";
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested in tests/bootstrap.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Map node's platform/arch to the reddb release asset key. null = unsupported. */
+export function platformKey(plat = platform(), architecture = arch()) {
+  const os = { linux: "linux", darwin: "macos", win32: "windows" }[plat];
+  const cpu = { x64: "x86_64", arm64: "aarch64", arm: "armv7" }[architecture];
+  if (!os || !cpu) return null;
+  return `${os}-${cpu}`;
+}
+
+export function sha256Hex(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+/** GitHub release asset URL. */
+export function assetUrl(repo, tag, name) {
+  return `https://github.com/${repo}/releases/download/${tag}/${name}`;
+}
+
+/** Parse the first hex token out of a `*.sha256` file body (`<hex>  <name>`). */
+export function parseSha256File(body) {
+  const m = String(body).trim().match(/^[0-9a-f]{64}/i);
+  return m ? m[0].toLowerCase() : null;
+}
+
+// ---------------------------------------------------------------------------
+// IO
+// ---------------------------------------------------------------------------
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function runtimeRoot() {
+  const base =
+    process.env.RED_MEMORY_CACHE_DIR ||
+    process.env.XDG_CACHE_HOME ||
+    join(homedir(), ".cache");
+  return join(base, "reddb-memory");
+}
+
+async function pluginVersion() {
+  const root =
+    process.env.CLAUDE_PLUGIN_ROOT ||
+    process.env.CODEX_PLUGIN_ROOT ||
+    join(HERE, "..");
+  try {
+    const pj = JSON.parse(
+      await readFile(join(root, ".claude-plugin", "plugin.json"), "utf8"),
+    );
+    return pj.version;
+  } catch {
+    return null;
+  }
+}
+
+async function logLine(msg) {
+  try {
+    const line = `[${new Date().toISOString()}] ${msg}\n`;
+    await appendFile(join(runtimeRoot(), "bootstrap.log"), line).catch(
+      () => {},
+    );
+    process.stderr.write(`memory bootstrap: ${msg}\n`);
+  } catch {
+    /* logging must never throw */
+  }
+}
+
+async function fetchBuffer(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) throw new Error(`GET ${url} -> ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+/** Download `url` to `dest` and verify against `expectedSha` (hex) if given. */
+async function ensureFile(url, dest, expectedSha, { mode } = {}) {
+  if (existsSync(dest)) {
+    if (!expectedSha) return;
+    const have = sha256Hex(await readFile(dest));
+    if (have === expectedSha.toLowerCase()) return;
+    await logLine(`checksum drift at ${dest}, refetching`);
+  }
+  const buf = await fetchBuffer(url);
+  if (expectedSha) {
+    const got = sha256Hex(buf);
+    if (got !== expectedSha.toLowerCase()) {
+      throw new Error(`checksum mismatch for ${url}: ${got} != ${expectedSha}`);
+    }
+  }
+  await mkdir(dirname(dest), { recursive: true });
+  await writeFile(dest, buf);
+  if (mode) await chmod(dest, mode);
+}
+
+/**
+ * Ensure {cli.mjs, red} exist for `version` in the version-keyed cache and
+ * return their absolute paths. Throws (caught by main) on any fetch failure.
+ */
+async function ensureRuntime(version) {
+  const dir = join(runtimeRoot(), version);
+  const cliPath = join(dir, "memory-cli.mjs");
+  const redPath = join(dir, process.platform === "win32" ? "red.exe" : "red");
+
+  // 1. manifest — names + checksums for this exact plugin version.
+  const tag = `v${version}`;
+  const manifest = JSON.parse(
+    (
+      await fetchBuffer(
+        assetUrl(RED_SKILLS_REPO, tag, "memory-runtime-manifest.json"),
+      )
+    ).toString("utf8"),
+  );
+
+  // 2. bundled CLI (platform-independent).
+  await ensureFile(
+    assetUrl(RED_SKILLS_REPO, tag, manifest.cli.asset),
+    cliPath,
+    manifest.cli.sha256,
+  );
+
+  // 3. native `red` binary (per-platform), reused from reddb-io/reddb releases.
+  const key = platformKey();
+  const redAsset = key && manifest.reddb?.assets?.[key];
+  if (!redAsset) {
+    throw new Error(`no red binary for platform ${key ?? "unknown"}`);
+  }
+  const redSha = parseSha256File(
+    (
+      await fetchBuffer(
+        assetUrl(manifest.reddb.repo, manifest.reddb.tag, `${redAsset}.sha256`),
+      )
+    ).toString("utf8"),
+  );
+  await ensureFile(
+    assetUrl(manifest.reddb.repo, manifest.reddb.tag, redAsset),
+    redPath,
+    redSha,
+    { mode: 0o755 },
+  );
+
+  return { cliPath, redPath };
+}
+
+function delegate(cliPath, redPath, argv) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cliPath, ...argv], {
+      stdio: "inherit",
+      env: { ...process.env, REDDB_BIN: redPath },
+    });
+    child.on("exit", (code) => resolve(code ?? 0));
+    child.on("error", () => resolve(1));
+  });
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  try {
+    const version = await pluginVersion();
+    if (!version) throw new Error("could not resolve plugin version");
+    const { cliPath, redPath } = await ensureRuntime(version);
+    const code = await delegate(cliPath, redPath, argv);
+    process.exit(code);
+  } catch (err) {
+    // Preserve the hooks' no-op contract; make the failure diagnosable.
+    await logLine(`${err?.message ?? err} (args: ${argv.join(" ")})`);
+    process.stdout.write("{}");
+    process.exit(0);
+  }
+}
+
+// Only run when invoked directly (tests import the pure helpers).
+if (process.argv[1] && process.argv[1].endsWith("bootstrap.mjs")) {
+  main();
+}

--- a/plugins/memory/tests/bootstrap.test.ts
+++ b/plugins/memory/tests/bootstrap.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error — dependency-free .mjs bootstrap ships without type declarations
+import { assetUrl, parseSha256File, platformKey, sha256Hex } from "../scripts/bootstrap.mjs";
+
+describe("bootstrap pure helpers (ADR 0029)", () => {
+  describe("platformKey", () => {
+    it("maps the published reddb release targets", () => {
+      expect(platformKey("linux", "x64")).toBe("linux-x86_64");
+      expect(platformKey("linux", "arm64")).toBe("linux-aarch64");
+      expect(platformKey("linux", "arm")).toBe("linux-armv7");
+      expect(platformKey("darwin", "x64")).toBe("macos-x86_64");
+      expect(platformKey("darwin", "arm64")).toBe("macos-aarch64");
+      expect(platformKey("win32", "x64")).toBe("windows-x86_64");
+    });
+
+    it("returns null for unsupported platform/arch", () => {
+      expect(platformKey("sunos", "x64")).toBeNull();
+      expect(platformKey("linux", "ppc64")).toBeNull();
+    });
+  });
+
+  describe("assetUrl", () => {
+    it("composes the GitHub release download URL", () => {
+      expect(assetUrl("reddb-io/reddb", "v1.7.0", "red-linux-x86_64")).toBe(
+        "https://github.com/reddb-io/reddb/releases/download/v1.7.0/red-linux-x86_64",
+      );
+    });
+  });
+
+  describe("parseSha256File", () => {
+    it("extracts the hex digest from a `<hex>  <name>` line", () => {
+      const hex = "a".repeat(64);
+      expect(parseSha256File(`${hex}  red-linux-x86_64`)).toBe(hex);
+      expect(parseSha256File(`  ${hex}\n`)).toBe(hex);
+    });
+
+    it("lowercases and rejects malformed bodies", () => {
+      expect(parseSha256File("A".repeat(64))).toBe("a".repeat(64));
+      expect(parseSha256File("not a checksum")).toBeNull();
+      expect(parseSha256File("")).toBeNull();
+    });
+  });
+
+  describe("sha256Hex", () => {
+    it("hashes a buffer deterministically", () => {
+      expect(sha256Hex(Buffer.from("reddb"))).toBe(
+        sha256Hex(Buffer.from("reddb")),
+      );
+      expect(sha256Hex(Buffer.from(""))).toBe(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Makes the Memory lifecycle hooks actually run in installed copies. Supersedes #228.

## Why #228 wasn't enough
Committing `dist/` ships the JS but not its 137 MB of deps (`@reddb-io/sdk`, `zod`, `gray-matter`, `fast-glob`, `@mcp/sdk`) — the ESM CLI still crashes `ERR_MODULE_NOT_FOUND`, swallowed by the hook's `|| printf "{}"`. And memory connects `file://…/graph.rdb` → SDK embedded mode → spawns the native `red` binary (~25 MB, per-platform). None of that survives a git-checkout install + `autoUpdate`.

## Approach (ADR 0029)
Deliver the runtime as **fetched artifacts**, never committed build output, never a local install:

- **esbuild bundle**: `src/cli.ts` → one platform-independent `memory-cli.mjs` (~1.9 MB, all JS deps inlined). Published as a release asset + a `memory-runtime-manifest.json` pinning its sha256 and the reddb tag.
- **`red` binary**: reused per-platform from `reddb-io/reddb` releases (the same source the SDK postinstall uses), verified against the published `.sha256`.
- **`scripts/bootstrap.mjs`** (only `node:` builtins): resolves/fetches both into `~/.cache/reddb-memory/<ver>/` (version-keyed, **survives autoUpdate**, re-fetched only on version change), verifies checksums, exports `REDDB_BIN`, delegates the hook. On failure → preserves the no-op contract **and logs to `bootstrap.log`** (no more silent death). `REDDB_BIN` being set means `import.meta.resolve` never fires — no source refactor needed.
- **hooks** (`claude`/`codex`) now invoke the bootstrap instead of `dist/cli.js`.
- **`red-release.yml`** builds the bundle + manifest and attaches them at `gh release create`.

## Validation
- Spike proven locally: bundle runs **standalone with no `node_modules`**; an engine command fails only at `red binary not found` (overridable via `REDDB_BIN`), not at module resolution.
- `pnpm typecheck` ✓, `tests/bootstrap.test.ts` ✓ (6 pure-helper tests), `validate-install-metadata.sh` ✓.
- CI here will exercise the release bundle path.

## Follow-ups (not in this PR)
- MCP server (`mcp-server.ts`) is a separate entry — bundle it too if/when MCP ships enabled.
- First-session-after-update download latency is one-time per version; could be backgrounded.

Closes the operational-delivery half of PRD #217 / ADR 0027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782605102&installation_id=129708444&pr_number=229&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F229&signature=7a7b3dde9a5eb565410a433c28b44bd2f6322180c59fbe1aad6a8be5b9fe1613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->