### PR TITLE
fix(memory): resolveRedBinary honours REDDB_BIN before the SDK package lookup

### DIFF
--- a/.red/adr/0029-memory-runtime-ships-as-a-bundled-asset-fetched-by-a-bootstrap.md
+++ b/.red/adr/0029-memory-runtime-ships-as-a-bundled-asset-fetched-by-a-bootstrap.md
@@ -138,8 +138,12 @@ bundle, never `dist/` or `node_modules`.
   `~/.cache/reddb-memory/<ver>/` with no network.
 - Offline first-run degrades to the documented no-op with a `bootstrap.log`
   entry — strictly better than today's silent failure.
-- `import.meta.resolve("@reddb-io/sdk")` in `vcs-commit.ts` is made dead code in
-  the shipped path (the bootstrap always sets `REDDB_BIN`); no refactor needed,
-  but it may be removed for clarity.
+- `vcs-commit.ts::resolveRedBinary()` **did** require a one-line fix (caught by
+  an end-to-end bootstrap run, not the spike): it fell back to
+  `import.meta.resolve("@reddb-io/sdk")`, which throws in the bundle (no
+  node_modules). It now honours `REDDB_BIN` first — the path the bootstrap sets
+  and the SDK's canonical override (SDK ADR 0006) — so the resolve never fires
+  in the shipped path. Lesson: validate the bundle by actually running a hook
+  end-to-end against the published release, not just `--help`.
 - This is the operational-delivery half of ADR 0027 / PRD #217: with it, hooks
   fire the CLI in installed copies for the first time.

--- a/plugins/memory/src/vcs-commit.ts
+++ b/plugins/memory/src/vcs-commit.ts
@@ -198,6 +198,12 @@ async function redVcsCommit(
 }
 
 function resolveRedBinary(): string {
+  // REDDB_BIN is the canonical override (SDK ADR 0006) and the path the
+  // bundled-runtime bootstrap sets (ADR 0029). Honour it first: in the shipped
+  // bundle there is no node_modules and `import.meta.resolve("@reddb-io/sdk")`
+  // throws, so this must short-circuit before the on-disk package lookups.
+  const override = process.env.REDDB_BIN;
+  if (override && existsSync(override)) return override;
   const bin = process.platform === "win32" ? "red.exe" : "red";
   const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
   const local = join(pluginRoot, "node_modules", "@reddb-io", "sdk", "bin", bin);


### PR DESCRIPTION
Follow-up to #229 / ADR 0029. The v1.127.0 bundle threw `Cannot find package '@reddb-io/sdk'` on the SessionStart path: `resolveRedBinary()` fell back to `import.meta.resolve("@reddb-io/sdk")`, which throws in the bundled runtime (no node_modules). Now honours `REDDB_BIN` first (the path the bootstrap sets; the SDK's canonical override).

**Caught by an end-to-end bootstrap run** against the published v1.127.0 release — the bootstrap downloaded + checksum-verified `memory-cli.mjs` + `red` correctly, but the CLI threw on delegation. With this fix, the same run executes the SessionStart hook fully (spawns `red`, real recall output). Amends ADR 0029's incorrect "no refactor needed" claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782605945&installation_id=129708444&pr_number=230&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F230&signature=28f0cc5a2aab8123aed7fd430818b113aa836a423dfddf53c420c40c262872d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->