### PR TITLE
fix(memory): skills invoke scripts/bootstrap.mjs, not the absent dist/cli.js

### DIFF
--- a/plugins/memory/skills/core/context-status/SKILL.md
+++ b/plugins/memory/skills/core/context-status/SKILL.md
@@ -12,13 +12,13 @@ Read-only healthcheck for the agent context stack. It reports committed context,
 ## 1. Run the status report
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" status context
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" status context
 ```
 
 Use JSON for automation:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" status context --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" status context --json
 ```
 
 ## 2. Interpret the posture

--- a/plugins/memory/skills/core/doctor/SKILL.md
+++ b/plugins/memory/skills/core/doctor/SKILL.md
@@ -24,7 +24,7 @@ initialized or is markdown-only, say so and stop — there is no graph to inspec
 Always list before deleting:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" doctor
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" doctor
 ```
 
 Add `--stale-days N` to change the threshold. This only **lists** — nothing is
@@ -36,7 +36,7 @@ If the user wants the stale nodes gone, re-run with `--prune`. It re-lists the
 candidates and asks for a typed `yes` before deleting:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" doctor --prune
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" doctor --prune
 ```
 
 In a non-interactive shell, `--prune` refuses unless `--yes` is also passed. Pass

--- a/plugins/memory/skills/core/export/SKILL.md
+++ b/plugins/memory/skills/core/export/SKILL.md
@@ -24,7 +24,7 @@ initialized or is markdown-only, say so and stop.
 ## 2. Export
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" export [<out-dir>] [--communities]
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" export [<out-dir>] [--communities]
 ```
 
 `<out-dir>` defaults to `.red/memory/export`. The command prints the three file

--- a/plugins/memory/skills/core/extract/SKILL.md
+++ b/plugins/memory/skills/core/extract/SKILL.md
@@ -26,10 +26,10 @@ Use a transcript/log that contains durable learning: decisions, root causes, got
 
 ```bash
 # From a file
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" extract <transcript-file>
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" extract <transcript-file>
 
 # Or from stdin
-cat <transcript-file> | node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" extract
+cat <transcript-file> | node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" extract
 ```
 
 The command prints how many `INFERRED` facts and edges were written and which provider mode/egress was used.
@@ -39,7 +39,7 @@ The command prints how many `INFERRED` facts and edges were written and which pr
 Run a targeted recall for one or two extracted topics:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" recall "<topic>"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" recall "<topic>"
 ```
 
 Report whether the new facts are discoverable. If extraction produced nothing, say so plainly and do not invent facts.

--- a/plugins/memory/skills/core/improve-skills/SKILL.md
+++ b/plugins/memory/skills/core/improve-skills/SKILL.md
@@ -14,32 +14,32 @@ Generate concrete Skill improvement proposals from Skill telemetry evidence.
 Prefer JSON when another agent or command will inspect the result:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" improve skills --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" improve skills --json
 ```
 
 To write proposal files:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" improve skills --write-proposal --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" improve skills --write-proposal --json
 ```
 
 To list and inspect pending proposal files before applying or archiving:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" improve proposals list --json
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" improve proposals show .red/memory/proposals/<proposal>.md --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" improve proposals list --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" improve proposals show .red/memory/proposals/<proposal>.md --json
 ```
 
 To apply a reviewed proposal that contains a structured patch block:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" improve apply .red/memory/proposals/<proposal>.md --yes --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" improve apply .red/memory/proposals/<proposal>.md --yes --json
 ```
 
 To remove a reviewed proposal from the pending queue without deleting history:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" improve proposals archive .red/memory/proposals/<proposal>.md --reason rejected --yes --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" improve proposals archive .red/memory/proposals/<proposal>.md --reason rejected --yes --json
 ```
 
 The command writes proposals under:

--- a/plugins/memory/skills/core/ingest/SKILL.md
+++ b/plugins/memory/skills/core/ingest/SKILL.md
@@ -33,7 +33,7 @@ tell the user to re-run `memory init --mode graph`.
 ## 2. Ingest
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" ingest <path>
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" ingest <path>
 ```
 
 `<path>` is the directory to walk (defaults to `.`). Add `--max-files N` to cap
@@ -43,9 +43,9 @@ build/coverage output are ignored by default.
 ## 3. Refresh Changed Files
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" refresh <file...> --root .
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" refresh --staged --root .
-git diff --cached --name-only -z | node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" refresh --stdin --root .
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" refresh <file...> --root .
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" refresh --staged --root .
+git diff --cached --name-only -z | node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" refresh --stdin --root .
 ```
 
 Use `refresh` after small edits or from git hooks. It is graph-mode only and

--- a/plugins/memory/skills/core/init/SKILL.md
+++ b/plugins/memory/skills/core/init/SKILL.md
@@ -28,16 +28,14 @@ The `memory` plugin requires the `dev` plugin (it builds on dev's processes —
 
 <what-to-do>
 
-## 1. Build the CLI if needed (first run only)
+## 1. Runtime is fetched automatically (no build step)
 
-The plugin ships **source only** — `dist/` and `node_modules/` are gitignored and
-built on the user's machine. If `${CLAUDE_PLUGIN_ROOT}/dist/cli.js` does not
-exist, build it (needs only node + pnpm, nothing else):
-
-```bash
-pnpm --dir "${CLAUDE_PLUGIN_ROOT}" install
-pnpm --dir "${CLAUDE_PLUGIN_ROOT}" build
-```
+`${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs` ships with the plugin and resolves
+the runtime on first use — it downloads the bundled CLI (`memory-cli.mjs`) plus
+the native `red` engine into `~/.cache/reddb-memory/<version>/` and verifies
+their checksums (ADR 0029). There is nothing to build or `pnpm install`; the
+first command below just pays a one-time download (needs network). Every command
+in these skills runs through the bootstrap, which delegates to the fetched CLI.
 
 ## 2. Run the wizard
 
@@ -46,13 +44,13 @@ Pass the mode the user picked:
 
 ```bash
 # markdown-only — no engine, nothing auto-fires
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" init --mode markdown-only
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" init --mode markdown-only
 
 # graph — typed knowledge graph over a per-project RedDB store
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" init --mode graph
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" init --mode graph
 
 # graph with the four auto-firing hooks on (recall/index/extract/flush)
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" init --mode graph --hooks
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" init --mode graph --hooks
 ```
 
 markdown-only writes `.red/memory/config.json` (all hooks off, MCP off, RedDB

--- a/plugins/memory/skills/core/recall/SKILL.md
+++ b/plugins/memory/skills/core/recall/SKILL.md
@@ -27,7 +27,7 @@ nothing to recall. Suggest `/memory:init`.
 ## 2. Recall
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" recall <query terms>
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" recall <query terms>
 ```
 
 Everything after `recall` is the query. Add `--limit N` to cap results

--- a/plugins/memory/skills/core/skills-status/SKILL.md
+++ b/plugins/memory/skills/core/skills-status/SKILL.md
@@ -12,7 +12,7 @@ Read-only diagnostic for the self-improvement loop. It shows whether Skill telem
 ## 1. Run the diagnostic
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" status skills
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" status skills
 ```
 
 Use `--all` to include bundled plugin/hub skills, and `--json` when another script needs structured output.
@@ -31,7 +31,7 @@ Do not treat non-enabled states as errors; this command is a diagnostic and exit
 - If telemetry is enabled and the user wants maintenance recommendations, run:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" curate skills
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" curate skills
 ```
 
 - If there are archive candidates and the user wants to act, use the `dev` plugin's `/curate` workflow. The Memory plugin's curator is report-only.

--- a/plugins/memory/skills/core/store/SKILL.md
+++ b/plugins/memory/skills/core/store/SKILL.md
@@ -23,7 +23,7 @@ If `.red/memory/config.json` is missing, memory was never initialized — run
 ## 2. Store the fact
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/dist/cli.js" store <the fact text>
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" store <the fact text>
 ```
 
 Pass the fact as the argument (everything after `store` is joined into one


### PR DESCRIPTION
Follow-up to #229 / ADR 0029. The runtime moved off committed `dist/` to a bundle the bootstrap fetches, but the 10 core skills still invoked `${CLAUDE_PLUGIN_ROOT}/dist/cli.js` — which doesn't exist in an installed copy. So `/memory:recall`, `/memory:ingest`, `/memory:doctor`, etc. failed the same way the hooks did (surfaced when `/doctor` was run against the 1.127.1 install).

Points all 10 skills (recall, ingest, store, extract, init, doctor, export, skills-status, context-status, improve-skills) at `scripts/bootstrap.mjs`, which delegates any subcommand. Verified live against the installed 1.127.1 plugin: `bootstrap.mjs doctor` → `healthy — 0 of 1432 stale`; `status context` → score 6/8; `recall` → 10 matches. Also rewrites the `init` skill's obsolete "build the CLI on your machine" section for the fetch-on-first-use model.

Not in this PR: `plugins/memory/README.md` local-dev examples still use `node plugins/memory/dist/cli.js …` — those are contributor/local-build examples (relative repo path, dist exists after `pnpm build`), a different context from the installed plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782608009&installation_id=129708444&pr_number=231&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F231&signature=c2be07f98a19340c2d7b0c2a99d0095b517a5781e2491e45802b948d468f2ab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->