### PR TITLE
#252 cutover: AFK workers move to nested workers/{wid}/{issue}-a{n}/ + worker.pid

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -50,8 +50,16 @@ _Avoid_: branch lock
 The developer's main working clone of the repo, contrasted with an AFK **Worktree**.
 _Avoid_: main repo, root checkout
 
+**Worker**:
+A single AFK orchestrator instance, identified by `w` + 4 characters (e.g. `wZ2R4`). It owns `.red/tmp/workers/{wid}/` and a single `worker.pid` liveness anchor, written once at bootstrap and removed on exit.
+_Avoid_: agent, slot, runner
+
+**Attempt**:
+One numbered AFK execution of an **Issue**, materialised at `.red/tmp/workers/{wid}/{issue}-a{n}/`. The `a{n}` counter is per-**Issue** across all **Workers**, so each retry — even by a different worker — is a fresh attempt directory.
+_Avoid_: iteration, run, retry dir
+
 **Worktree**:
-An isolated `git worktree` created by AFK per issue under `.red/tmp/work-*/`.
+An isolated `git worktree` created by AFK per **Attempt** under `.red/tmp/workers/{wid}/{issue}-a{n}/worktree/`.
 _Avoid_: afk clone, sandbox checkout
 
 **Fleet supervisor**:
@@ -96,6 +104,7 @@ _Avoid_: memory cleaner, silent curator
 - An **Issue** carries one **Triage role** at a time.
 - An **Issue** accumulates **Envelopes**, **Directive blocks**, **Human guidance**, and **Thread discussion**.
 - A **Fleet supervisor** maintains AFK workers; **Auto-monitor loop**, **Task mirror**, **Codex monitor agent**, and `monitor.sh` only observe.
+- A **Worker** owns many **Attempts**; each **Attempt** resolves exactly one **Issue** and holds one **Worktree**. The **Worker**'s `worker.pid` is the single liveness signal consumers read.
 - A **Branch lock** constrains the **Primary checkout**; AFK **Worktrees** remain exempt.
 - A **Pinned branch** constrains AFK base and merge target; it is independent of **Branch lock**.
 - The **Codebase understanding surface** may read Memory graph evidence, but it does not own graph storage or ingest.

--- a/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
+++ b/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
@@ -4,7 +4,7 @@ You are an AFK agent invoked by `/afk`. You are running inside an isolated git w
 
 ## Inputs You Will Receive
 
-- **Handoff file** at `../handoff.md` (relative to the worktree; the file lives in the parent iteration directory `.red/tmp/work-{id}-i{N}/`) — the contract. Read it first.
+- **Handoff file** at `../handoff.md` (relative to the worktree; the file lives in the parent attempt directory `.red/tmp/workers/{id}/{N}-a{n}/`) — the contract. Read it first.
 - **Recent commits** of `main` (last 5).
 - This prompt.
 

--- a/plugins/dev/skills/engineering/afk/SAFETY.md
+++ b/plugins/dev/skills/engineering/afk/SAFETY.md
@@ -5,7 +5,7 @@ Binding for both the orchestrator (the shell loop) and the inner agent (claude/c
 ## Repository Layout Invariants
 
 - The **primary checkout** stays on `main` at all times. Never `git checkout`, `git switch`, or `git branch -m` inside it.
-- All work happens in **worktrees** under `.red/tmp/work-{id}-i{N}/worktree/` (inside the primary checkout but gitignored) on a branch named `afk/{id}/{N}-{slug}`.
+- All work happens in **worktrees** under `.red/tmp/workers/{id}/{N}-a{n}/worktree/` (inside the primary checkout but gitignored) on a branch named `afk/{id}/{N}-{slug}`.
 - The worktree branch is **local-only** until the final push of `main`. The orchestrator pushes `main`, not the worktree branch.
 
 ## Git Operations
@@ -70,7 +70,7 @@ One self-resolve attempt: re-enter the inner agent with the conflict diff in the
 ## Heartbeat and State Files
 
 - The periodic issue-thread heartbeat (`:one:` … `:four:` via `gh issue comment`) was retired in Slice D — there is no sub-shell to track or kill. `heartbeat_pid` in older state files is vestigial and ignored.
-- State file writes are atomic: write to `.red/tmp/work-{id}-i{N}/afk.state.json.tmp`, `mv` over the real path. Never partial writes.
+- State file writes are atomic: write to `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json.tmp`, `mv` over the real path. Never partial writes.
 - The monitor never writes. Only the orchestrator writes state.
 
 ## Signals and Shutdown
@@ -79,7 +79,7 @@ One self-resolve attempt: re-enter the inner agent with the conflict diff in the
 - `SIGTERM`: same as `SIGINT`.
 - Never trap `SIGKILL` — let the OS do its thing.
 
-There is no heartbeat sub-shell to reap on any of these paths since Slice D — the only cleanup work is releasing the in-flight claim and preserving the iteration directory.
+There is no heartbeat sub-shell to reap on any of these paths since Slice D — the only cleanup work is releasing the in-flight claim, preserving the active attempt directory, and removing the per-worker `worker.pid` (and the empty worker dir) on the EXIT trap.
 
 ## What "Blocker" Means
 

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -19,7 +19,7 @@ Drain the agent-ready backlog. Single skill that owns issue selection, worktree 
 - `/afk --request "dont run cargo tests for this issue resolution"` or `/afk -r "..."` — add a special user request block to every inner-agent prompt for this run.
 - `/afk -n 5` — cap at five issues (default: drain until empty).
 - `/afk --once` — single supervised iteration. Same as `scripts/once.sh`. Use for debugging the prompt.
-- `/afk monitor` — readonly status board, aggregates every `.red/tmp/work-*/afk.state.json` so you see all live workers from another terminal. **Also (binding):** mirrors live workers onto the host runner's native task surface — `TaskCreate`/`TaskUpdate` under Claude Code, the sub-agent surface under Codex when present (falls back to the dashboard otherwise). See *Task Mirror* below — this is not optional and you must do it on every tick, even when the user only asked "como estamos?".
+- `/afk monitor` — readonly status board, aggregates every `.red/tmp/workers/*/*/afk.state.json` so you see all live workers from another terminal. **Also (binding):** mirrors live workers onto the host runner's native task surface — `TaskCreate`/`TaskUpdate` under Claude Code, the sub-agent surface under Codex when present (falls back to the dashboard otherwise). See *Task Mirror* below — this is not optional and you must do it on every tick, even when the user only asked "como estamos?".
 - `/afk fleet [N]` — launch the supervisor maintaining `N` concurrent workers (default `2`). See *Fleet Mode* below.
 - `/afk fleet stop` — gracefully shut down a running fleet supervisor and cancel its auto-monitor cron.
 
@@ -33,19 +33,19 @@ Drain the agent-ready backlog. Single skill that owns issue selection, worktree 
 /afk            # terminal C → spawns worker "w9RQP"
 ```
 
-Each invocation generates its own **worker ID** — literal `w` plus 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`, ~1.7M possible IDs) — and uses it as the prefix for every per-run file. The leading `w` makes `work-w*-i*` an unambiguous glob for AFK iteration dirs. The ID is printed on the first line of the run so you can tail or kill it later.
+Each invocation generates its own **worker ID** — literal `w` plus 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`, ~1.7M possible IDs) — and uses it as the prefix for every per-run file. The leading `w` makes the worker directory `.red/tmp/workers/{id}` an unambiguous live-worker anchor. The ID is printed on the first line of the run so you can tail or kill it later.
 
-Per-issue files live under `.red/tmp/work-{id}-i{N}/` in the primary checkout. Everything for one (worker, issue) iteration is in one directory — when the iteration ends successfully the whole directory is removed; when it blocks the whole directory is preserved.
+Per-attempt files live under `.red/tmp/workers/{id}/{N}-a{n}/` in the primary checkout, where `{id}` is the worker ID, `{N}` is the issue number, and `{n}` is the per-issue attempt counter (derived by the attempt-ledger — every retry, even by a different worker, gets a fresh `a{n}` directory). Everything for one (worker, issue, attempt) is in one directory — when the attempt ends successfully the whole directory is removed; when it blocks the whole directory is preserved. The worker also holds a single per-worker liveness anchor at `.red/tmp/workers/{id}/worker.pid` (see the `worker.pid` row below).
 
 | Path | Purpose |
 |---|---|
-| `.red/tmp/work-{id}-i{N}/worktree/` | Git worktree for issue `N`. Lives inside the gitignored `.red/tmp/` so it never pollutes sibling directories. |
-| `.red/tmp/work-{id}-i{N}/afk.pid` | PID of the orchestrator. Used by `/afk monitor` to flag dead workers as `stale` via `kill -0`. Re-written on each iteration. |
-| `.red/tmp/work-{id}-i{N}/afk.log` | Append-only plain log for this iteration (orchestrator output + inner-agent stdout + heartbeat lines). Per-issue scope — each issue gets a fresh log. |
-| `.red/tmp/work-{id}-i{N}/agent.log.jsonl` | Clean **agent lane** (issue #250) — one `type=agent` JSONL record per assistant turn and nothing synthetic, so it is the true liveness signal and reads as a live transcript: `tail -f … \| jq -r .msg`. Single-writer. |
-| `.red/tmp/work-{id}-i{N}/log.jsonl` | The **firehose** (issue #250) — every record of the attempt in the uniform JSONL envelope: agent turns, heartbeat vitals, hook dispatches, runner timings, and errors. Flock-serialised (many concurrent writers). |
-| `.red/tmp/work-{id}-i{N}/afk.state.json` | State snapshot for this iteration. Schema in *State File* below. |
-| `.red/tmp/work-{id}-i{N}/handoff.md` | Handoff file the inner agent reads — `<issue-body>` (issue body verbatim, including the `## Agent brief` markdown section), `<previous-attempts>`, `<human-guidance-thread>` (one `<human-guidance>` per extracted directive), `<thread-discussion>` (advisory comments with no directive marker), `<agent-notes>`. Top-level XML wrappers make body/comments/notes unambiguous. Template in *Handoff File Template* below. |
+| `.red/tmp/workers/{id}/worker.pid` | Per-worker liveness anchor: the orchestrator's PID, written **once at bootstrap** and removed on the worker's EXIT trap (along with rmdir of the empty worker dir). The single liveness anchor for the worker; the fleet supervisor's slot matching keys off it. |
+| `.red/tmp/workers/{id}/{N}-a{n}/worktree/` | Git worktree for issue `N` on attempt `n`. Lives inside the gitignored `.red/tmp/` so it never pollutes sibling directories. |
+| `.red/tmp/workers/{id}/{N}-a{n}/afk.log` | Append-only plain log for this attempt (orchestrator output + inner-agent stdout + heartbeat lines). Per-attempt scope — each attempt gets a fresh log. |
+| `.red/tmp/workers/{id}/{N}-a{n}/agent.log.jsonl` | Clean **agent lane** (issue #250) — one `type=agent` JSONL record per assistant turn and nothing synthetic, so it is the true liveness signal and reads as a live transcript: `tail -f … \| jq -r .msg`. Single-writer. |
+| `.red/tmp/workers/{id}/{N}-a{n}/log.jsonl` | The **firehose** (issue #250) — every record of the attempt in the uniform JSONL envelope: agent turns, heartbeat vitals, hook dispatches, runner timings, and errors. Flock-serialised (many concurrent writers). |
+| `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` | State snapshot for this attempt. Schema in *State File* below. |
+| `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` | Handoff file the inner agent reads — `<issue-body>` (issue body verbatim, including the `## Agent brief` markdown section), `<previous-attempts>`, `<human-guidance-thread>` (one `<human-guidance>` per extracted directive), `<thread-discussion>` (advisory comments with no directive marker), `<agent-notes>`. Top-level XML wrappers make body/comments/notes unambiguous. Template in *Handoff File Template* below. |
 
 Two workers cannot claim the same issue thanks to a local `mkdir` lock at `.red/tmp/claims/{N}/` plus a `gh issue view` pre-check before the edit. The gh edit itself is not atomic (see *Issue Lifecycle* below for the full three-layer scheme). The race surface is the brief window between two separate checkouts on the same host — acceptable for the intended scale.
 
@@ -65,7 +65,7 @@ Run before the first iteration:
 
 1. Ensure `.red/tmp/` exists. Create it.
 2. Ensure `.red/tmp/` is in `.gitignore` of the primary checkout. Append if missing.
-3. **Generate the worker ID.** Literal `w` + 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`). On the astronomically unlikely chance the chosen ID already maps to a live `.red/tmp/work-{id}-*/afk.pid`, regenerate. Print the ID on the first line of the run: `worker: {id}`. All per-iteration paths interpolate `{id}` and the issue number `{N}`.
+3. **Generate the worker ID.** Literal `w` + 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`). On the astronomically unlikely chance the chosen ID already maps to a live worker directory `.red/tmp/workers/{id}` (its `worker.pid` alive), regenerate. Print the ID on the first line of the run: `worker: {id}`. All per-attempt paths interpolate `{id}`, the issue number `{N}`, and the attempt number `{n}`.
 4. Resolve the runner via the detection cascade:
    1. `--runner X` flag (pin) — wins over everything, logged as `detected via --runner pin`.
    2. **Env-var sniff** — `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, or `CLAUDE_CODE_SSE_PORT` → `claude`; `CODEX_HOME`, `CODEX_SANDBOX`, `CODEX_SANDBOX_NETWORK_DISABLED`, or `CODEX_MANAGED_BY_NPM` → `codex`. Logged as `detected via env-var`.
@@ -74,18 +74,19 @@ Run before the first iteration:
    5. **Env fallback** — `${RED_AFK_RUNNER:-claude}`. Logged as `detected via env-fallback`.
    The boot log prints one line per invocation: `runner: <runner> (detected via <method>)`. Load [`runner-claude.md`](runner-claude.md) or [`runner-codex.md`](runner-codex.md) so the spawn command is ready.
 5. Read [`SAFETY.md`](SAFETY.md). It is binding for every shell action the loop takes.
-6. Install signal handlers — SIGINT, SIGTERM, and normal exit all release any in-flight issue claim and preserve the active `work-{id}-i{N}/` directory before terminating.
+6. **Write the per-worker pid file.** Create `.red/tmp/workers/{id}/` and write `worker.pid` (current `$$`) **once** — this is the worker's single liveness anchor for its whole lifetime.
+7. Install signal handlers — SIGINT, SIGTERM, and normal exit all release any in-flight issue claim, preserve the active `workers/{id}/{N}-a{n}/` attempt directory, and on the EXIT trap remove `worker.pid` (and rmdir the empty worker dir) before terminating.
 
-The per-iteration `work-{id}-i{N}/` directory (pid, log, state, handoff, worktree) is created in *Per-Issue Loop* step 1 below, not here — the worker has no files until it claims an issue.
+The per-attempt `workers/{id}/{N}-a{n}/` directory (log, state, handoff, worktree) is created in *Per-Issue Loop* step 1 below, not here — the worker has no attempt files until it claims an issue. Only `worker.pid` exists from bootstrap.
 
 ## Orphan Cleanup (boot-time)
 
-Right after bootstrap and before *Straggler Check*, `/afk` sweeps `.red/tmp/work-*/` for orphaned iteration dirs (orchestrator pid dead). For each:
+Right after bootstrap and before *Straggler Check*, `/afk` runs two passes. First it **drain-wipes** any leftover **legacy flat** `.red/tmp/work-*/` dirs — these are never created under the nested scheme (the drain-first cutover, issue #252), so any survivor is a pre-cutover relic and is removed unconditionally. Then it sweeps the nested attempt dirs `.red/tmp/workers/*/*/` whose parent worker's `worker.pid` is dead, and afterwards removes the dead `worker.pid` files and the now-empty worker dirs. For each orphaned attempt dir:
 
 1. **(Slice D — heartbeat sub-shell retired.)** No zombie reap step is needed; older state files may still carry a `heartbeat_pid` but it's vestigial and ignored.
 2. **Decide fate from issue state.** `gh issue view N --json labels,state`:
    - `state == CLOSED` → `rm -rf`. Work landed; nothing to inspect.
-   - label `ready-for-human` → **split TTL** based on `envelope.posted` in the iteration state file (see *Terminal-Event Envelope* below):
+   - label `ready-for-human` → **split TTL** based on `envelope.posted` in the attempt state file (see *Terminal-Event Envelope* below):
      - `envelope.posted == true` → 1-day TTL. The issue thread already carries the canonical record; the local dir is pure redundancy.
      - `envelope.posted == false` or field missing → 7-day TTL. The envelope POST failed (or this dir predates the envelope writer), so the local notes/log are the only copy.
    - label `running` (orchestrator crashed mid-issue) → restore `ready-for-agent`, post a recovery comment, then `rm -rf`. Leaving the issue eternally `running` is worse than losing the dir.
@@ -197,9 +198,9 @@ Residual gap: two clones of the same repo on the same host (or different hosts) 
 
 For each issue `N`:
 
-1. **Claim.** `gh issue edit N --remove-label ready-for-agent --add-label running`. Then create the iteration directory `.red/tmp/work-{id}-i{N}/` and write `afk.pid` (current `$$`), open `afk.log` (tee target for orchestrator output), and initialise `afk.state.json` per *State File* below. Comment a start line on the issue: ISO timestamp, runner identity, worktree path. If labelling fails because someone else already claimed it, abandon the iteration directory and skip to the next issue.
-2. **Worktree.** Resolve the **pinned branch** (`lib/pin-reader.sh`, ADR 0008): the issue's own `branch:` line, else its parent PRD's, else `main`. Then `git -C primary fetch origin {pinned}` and `git worktree add .red/tmp/work-{id}-i{N}/worktree -b afk/{id}/{N}-{slug} origin/{pinned}` from the primary checkout. The worktree lives inside the gitignored `.red/tmp/` tree so it never appears in `git status` for `main`. Immediately after worktree creation the orchestrator mirrors the new branch on origin (`lib/remote-branch.sh::push_initial` — `git push origin -u HEAD:refs/heads/afk/{id}/{N}-{slug} --force-with-lease`) and installs a per-worktree `post-commit` hook (`install_post_commit_hook`) that fire-and-forgets a `git push origin HEAD --force-with-lease` after every inner-agent commit. Both calls are best-effort: a network/auth failure logs a `warn:` line and the iteration continues — the `afk-attempts/*` failure-push net (see *Terminal-Event Envelope*) still fires on terminal failure. Net effect: `afk/{id}/{N}-{slug}` is a **remote-tracked branch throughout the iteration**, so a SIGKILL anywhere from here on preserves the diff on origin without manual recovery.
-3. **Handoff file.** Materialise the handoff into `.red/tmp/work-{id}-i{N}/handoff.md` using the template below — top-level XML wrappers (`<issue-body>`, `<previous-attempts>`, `<human-guidance-thread>`, `<agent-notes>`) keep the issue body, orchestrator-authored prior attempts, human comments, and the inner-agent scratchpad unambiguous. `<issue-body>` carries the issue body verbatim (including the `## Agent brief` section written by `/triage`). The handoff file lives one level above the worktree so the inner agent reads it via `../handoff.md` from inside the worktree, and so it survives a worktree wipe on retry.
+1. **Claim.** `gh issue edit N --remove-label ready-for-agent --add-label running`. Then resolve the attempt number `{n}` from the attempt-ledger (per-issue across all workers), create the attempt directory `.red/tmp/workers/{id}/{N}-a{n}/`, open `afk.log` (tee target for orchestrator output), and initialise `afk.state.json` per *State File* below. The orchestrator PID is already recorded once in the per-worker `worker.pid` (written at bootstrap) and is also embedded in `afk.state.json`'s `.pid` field — there is no per-attempt pid file. Comment a start line on the issue: ISO timestamp, runner identity, worktree path. If labelling fails because someone else already claimed it, abandon the attempt directory and skip to the next issue.
+2. **Worktree.** Resolve the **pinned branch** (`lib/pin-reader.sh`, ADR 0008): the issue's own `branch:` line, else its parent PRD's, else `main`. Then `git -C primary fetch origin {pinned}` and `git worktree add .red/tmp/workers/{id}/{N}-a{n}/worktree -b afk/{id}/{N}-{slug} origin/{pinned}` from the primary checkout. The worktree lives inside the gitignored `.red/tmp/` tree so it never appears in `git status` for `main`. Immediately after worktree creation the orchestrator mirrors the new branch on origin (`lib/remote-branch.sh::push_initial` — `git push origin -u HEAD:refs/heads/afk/{id}/{N}-{slug} --force-with-lease`) and installs a per-worktree `post-commit` hook (`install_post_commit_hook`) that fire-and-forgets a `git push origin HEAD --force-with-lease` after every inner-agent commit. Both calls are best-effort: a network/auth failure logs a `warn:` line and the iteration continues — the `afk-attempts/*` failure-push net (see *Terminal-Event Envelope*) still fires on terminal failure. Net effect: `afk/{id}/{N}-{slug}` is a **remote-tracked branch throughout the iteration**, so a SIGKILL anywhere from here on preserves the diff on origin without manual recovery.
+3. **Handoff file.** Materialise the handoff into `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` using the template below — top-level XML wrappers (`<issue-body>`, `<previous-attempts>`, `<human-guidance-thread>`, `<agent-notes>`) keep the issue body, orchestrator-authored prior attempts, human comments, and the inner-agent scratchpad unambiguous. `<issue-body>` carries the issue body verbatim (including the `## Agent brief` section written by `/triage`). The handoff file lives one level above the worktree so the inner agent reads it via `../handoff.md` from inside the worktree, and so it survives a worktree wipe on retry.
 4. **Local heartbeat marker.** Write one `[heartbeat] iteration started for #N` line to `afk.log`. Slice D retired the periodic GitHub-comment heartbeat (`:one: :two: :three: :four:`) — local liveness is now signalled by the inner-agent stdout stream tee'd into `afk.log` plus state-file mtime, both of which already exist.
 5. **Inner agent.** Invoke claude/codex per [`runner-*.md`](runner-claude.md) with [`AGENT-PROMPT.md`](AGENT-PROMPT.md) + the handoff file + last 5 commits of `main` + the optional `--request/-r` special user request block. Stream stdout into the loop's header tail. Detect stages by grep on the stream — see *Stage Detection* below.
 6. **Inner result.**
@@ -216,7 +217,7 @@ For each issue `N`:
    - Conflict? Try a one-shot self-resolve (`merge_resolve_conflict`): re-enter the inner agent **in primary** with the conflict diff and `git status` as context, instructing it to fix conflicts and `git commit --no-edit` the merge. Resolved = no unmerged paths and no `MERGE_HEAD` left. On still-conflicting: abort with `git merge --abort`, comment the diff on the issue, re-label `ready-for-human`, move on.
 9. **Push.** `git -C primary push origin {pinned}` over SSH. Rejected? **Roll the merge commit back** to `pre_merge_sha` (`merge_rollback`) so no orphan merge commit lingers on local `{pinned}`, then comment, re-label `ready-for-human`, move on. Do not retry-loop indefinitely.
 10. **Close.** Validation comment on the issue: tests pass/fail, lint, typecheck, build, commits added, files touched. Then `gh issue close N --reason completed`. Remove `running` label. Once the close succeeds, delete the live remote branch with `lib/remote-branch.sh::delete_remote` (`git push origin --delete afk/{id}/{N}-{slug}`) so the remote graveyard stays tidy — the merge commit on `{pinned}` already carries the diff. Best-effort: a failed delete (branch protection, network) logs a `warn:` line and the close still completes; the orphan `afk/*` branch can be cleaned up later.
-11. **Cleanup.** `git worktree remove .red/tmp/work-{id}-i{N}/worktree`, `git branch -D afk/{id}/{N}-{slug}` (the branch is already merged into main), then `rm -rf .red/tmp/work-{id}-i{N}/` so the iteration leaves no trace. The remote `afk/{id}/{N}-{slug}` ref was deleted in step 10 on DONE; failure paths leave the remote ref intact and instead push the canonical `afk-attempts/{id}/{N}-{slug}` ref (see *Terminal-Event Envelope*). On blocker paths the iteration directory is preserved for human inspection.
+11. **Cleanup.** `git worktree remove .red/tmp/workers/{id}/{N}-a{n}/worktree`, `git branch -D afk/{id}/{N}-{slug}` (the branch is already merged into main), then `rm -rf .red/tmp/workers/{id}/{N}-a{n}/` so the attempt leaves no trace. The remote `afk/{id}/{N}-{slug}` ref was deleted in step 10 on DONE; failure paths leave the remote ref intact and instead push the canonical `afk-attempts/{id}/{N}-{slug}` ref (see *Terminal-Event Envelope*). On blocker paths the attempt directory is preserved for human inspection.
 12. **Tick.** Update state file. Recompute ETA from rolling average of last 3 issue durations. Print one summary line: `finished {done}/{total} ({pct}%) — next: #{next}`.
 
 ## Runner Fallback
@@ -399,7 +400,7 @@ Redraw every 3 s on the controlling TTY, top of the scroll buffer. Use `tput sc;
 │ done: 3 / 12 (25%)     blocked: 0          merged: 3      │
 │                                                            │
 │ ▶ #142 wire OAuth callback                                 │
-│   worktree: .red/tmp/work-wZ2R4-i142/worktree               │
+│   worktree: .red/tmp/workers/wZ2R4/142-a1/worktree          │
 │   stage: impl                                              │
 │   last: writing tests for callback handler                 │
 │                                                            │
@@ -411,14 +412,14 @@ If stdout is not a TTY (CI, piped log), skip header rendering and print one JSON
 
 ## State File
 
-Path: `.red/tmp/work-{id}-i{N}/afk.state.json` — one snapshot per (worker, issue) iteration. Schema:
+Path: `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` — one snapshot per (worker, issue, attempt). Schema:
 
 ```json
 {
   "version": 1,
   "worker_id": "wZ2R4",
   "pid": 12340,
-  "log": ".red/tmp/work-wZ2R4-i142/afk.log",
+  "log": ".red/tmp/workers/wZ2R4/142-a1/afk.log",
   "started_at": "2026-05-16T12:00:00-03:00",
   "runner": "codex",
   "filter": { "kind": "prd|issues|all", "value": "42" },
@@ -432,8 +433,8 @@ Path: `.red/tmp/work-{id}-i{N}/afk.state.json` — one snapshot per (worker, iss
     "number": 142,
     "title": "wire OAuth callback",
     "slug": "wire-oauth-callback",
-    "worktree": ".red/tmp/work-wZ2R4-i142/worktree",
-    "handoff": ".red/tmp/work-wZ2R4-i142/handoff.md",
+    "worktree": ".red/tmp/workers/wZ2R4/142-a1/worktree",
+    "handoff": ".red/tmp/workers/wZ2R4/142-a1/handoff.md",
     "started_at": "2026-05-16T12:14:00-03:00",
     "stage": "impl",
     "heartbeat_glyph": null,
@@ -447,7 +448,7 @@ Path: `.red/tmp/work-{id}-i{N}/afk.state.json` — one snapshot per (worker, iss
 }
 ```
 
-Atomic write: write to `afk.state.json.tmp` inside the iteration directory, `mv` over the original. `/afk monitor` and any other reader open it read-only. Between issues the worker has no live state file — monitor renders that as "idle".
+Atomic write: write to `afk.state.json.tmp` inside the attempt directory, `mv` over the original. `/afk monitor` and any other reader open it read-only. Between issues the worker has no live state file — monitor renders that as "idle".
 
 ## Auto-Monitor Loop (Claude Code only — binding)
 
@@ -466,11 +467,11 @@ The monitor invocation handles its own teardown — see *Self-Cancel* under the 
 
 - The invocation is `/afk monitor` (not a worker spawn).
 - The invocation is `/afk --once` (single supervised iteration; user is already watching).
-- `CronCreate` is unavailable (not running under Claude Code — e.g. Codex). Print one line `monitor loop unavailable in this runner; tail .red/tmp/work-*/afk.log manually.` and continue.
+- `CronCreate` is unavailable (not running under Claude Code — e.g. Codex). Print one line `monitor loop unavailable in this runner; tail .red/tmp/workers/*/*/afk.log manually.` and continue.
 
 ## Fleet Mode (runner-portable — binding)
 
-`/dev:afk fleet [N]` and `/dev:afk fleet stop` are user-facing wrappers around [`scripts/supervisor.sh`](scripts/supervisor.sh). They let one terminal command spin up (or shut down) `N` concurrent `afk.sh` workers on the current checkout, with the supervisor handling respawn, the circuit breaker, the **passive stall detector** (samples each slot's per-iteration **agent lane** `agent.log.jsonl` mtime — the clean liveness signal — every `RED_AFK_STALL_POLL_S=30s`; flags any slot alive ≥ `RED_AFK_STALL_THRESHOLD_S=600` whose agent lane has been idle ≥ the same — surfaces as `⏸️ stalled` in `/dev:afk monitor`. It keys off the agent lane, never `afk.log`/`log.jsonl`, because the orchestrator heartbeat writes those every minute and would mask a real stall — the masking that defeated detection in #243), the **hard stall reaper** (a slot silent on the agent lane past `RED_AFK_STALL_KILL_THRESHOLD_S=1800` is only a *candidate*: the irreversible kill is gated behind the reaper-signal predicate [`lib/reaper-signal.sh`], so a worker mid-build/test — an active `vitest`/`tsc`/`cargo`/… descendant under its tree, or non-trivial aggregate cpu — is **busy** and left alone, while a genuinely stuck worker [idle past the threshold, no active descendant, flat cpu] is `kill_tree`d, a `data-attempt-status="no-sentinel"` envelope is posted with the iter-dir `afk.log` tail, the issue label is rotated back to `ready-for-agent`, the worktree + iter dir are removed, and the slot is freed for the next health-check respawn — `RED_AFK_STALL_KILL_THRESHOLD_S` must be strictly greater than `RED_AFK_STALL_THRESHOLD_S`, validated at supervisor boot), and per-slot build isolation (see [`scripts/supervisor.sh`](scripts/supervisor.sh) header for the env contract).
+`/dev:afk fleet [N]` and `/dev:afk fleet stop` are user-facing wrappers around [`scripts/supervisor.sh`](scripts/supervisor.sh). They let one terminal command spin up (or shut down) `N` concurrent `afk.sh` workers on the current checkout, with the supervisor handling respawn, the circuit breaker, the **passive stall detector** (samples each slot's per-attempt **agent lane** `agent.log.jsonl` mtime — the clean liveness signal — every `RED_AFK_STALL_POLL_S=30s`; flags any slot alive ≥ `RED_AFK_STALL_THRESHOLD_S=600` whose agent lane has been idle ≥ the same — surfaces as `⏸️ stalled` in `/dev:afk monitor`. It keys off the agent lane, never `afk.log`/`log.jsonl`, because the orchestrator heartbeat writes those every minute and would mask a real stall — the masking that defeated detection in #243), the **hard stall reaper** (a slot silent on the agent lane past `RED_AFK_STALL_KILL_THRESHOLD_S=1800` is only a *candidate*: the irreversible kill is gated behind the reaper-signal predicate [`lib/reaper-signal.sh`], so a worker mid-build/test — an active `vitest`/`tsc`/`cargo`/… descendant under its tree, or non-trivial aggregate cpu — is **busy** and left alone, while a genuinely stuck worker [idle past the threshold, no active descendant, flat cpu] is `kill_tree`d, a `data-attempt-status="no-sentinel"` envelope is posted with the attempt-dir `afk.log` tail, the issue label is rotated back to `ready-for-agent`, the worktree + attempt dir are removed, and the slot is freed for the next health-check respawn — `RED_AFK_STALL_KILL_THRESHOLD_S` must be strictly greater than `RED_AFK_STALL_THRESHOLD_S`, validated at supervisor boot), and per-slot build isolation (see [`scripts/supervisor.sh`](scripts/supervisor.sh) header for the env contract).
 
 **Worker env passthrough.** Any `RED_AFK_*` variable exported in the operator's shell before `/dev:afk fleet` is auto-forwarded to every worker the supervisor spawns. Use this for worker-side toggles like `RED_AFK_SKIP_PERF=1` or `RED_AFK_SKIP_COMPETITIVE_BASELINE=1` without writing a hook. Internal supervisor knobs (`RED_AFK_TARGET`, `RED_AFK_POLL_S`, `RED_AFK_STALL_*`, `RED_AFK_CIRCUIT_*`, `RED_AFK_RUNNER`, `RED_AFK_REQUEST`, `RED_AFK_PLUGIN_DIR`) and the per-slot `*_BASE` build-isolation vars are excluded — they have dedicated wiring. See `PASSTHROUGH_DENYLIST` in `supervisor.sh` for the canonical list.
 
@@ -540,13 +541,13 @@ Steps, in order:
 
 When the circuit breaker parks a slot (`CIRCUIT_K` fast deaths inside `CIRCUIT_WINDOW_S`) the supervisor — not a human — runs `sweep_parked_slot` to clean up after the burned workers. Three actions, in order, gated on the trip:
 
-1. **Sweep affected iter dirs.** From the slot log (`afk-supervisor-slot-{slot}.log`) the supervisor parses every `[afk] worker: w…` boot stamp emitted while the slot was alive, globs `.red/tmp/work-{wid}-i*/` for each ID, and reads `afk.state.json`'s `.current.number` to identify the affected issues. Each iter dir is `rm -rf`'d after its issue has been processed.
+1. **Sweep affected attempt dirs.** From the slot log (`afk-supervisor-slot-{slot}.log`) the supervisor parses every `[afk] worker: w…` boot stamp emitted while the slot was alive, globs `.red/tmp/workers/{wid}/*/` for each ID, and reads `afk.state.json`'s `.current.number` to identify the affected issues. Each attempt dir is `rm -rf`'d after its issue has been processed.
 2. **Post a discard envelope on each affected issue.** Same `<details data-attempt-status="…">` schema as `build_envelope` in `afk.sh`, with `status="discarded"` and a summary line that names the runner and the trip cause (`runner-broken, slot parked after K fast deaths`). The envelope's `data-section="summary"` block carries the slot index, comma-joined worker IDs, fast-death count, and the supervisor log path. No `notes`, `drop`, or `log` sections — the attempts produced no usable artefacts.
 3. **Restore label state on each affected issue.** Single `gh issue edit` adds `ready-for-agent` and `runner-error`, removes `ready-for-human` and (defensively) `running` — covers both the "issue had already been promoted to `ready-for-human`" path and the "issue was still `running` at the moment of trip" path.
 
 The `runner-error` label is created idempotently by `/setup-red-skills` (see [triage-labels.md](../setup-red-skills/triage-labels.md)). The supervisor still calls `gh label create runner-error` on the fly during a trip so cleanup never fails just because the label is missing.
 
-Idempotency: `SLOT_SWEPT[slot]=1` blocks a second sweep within the same supervisor lifetime. Across restarts a new trip yields fresh worker IDs and fresh iter dirs, so re-tripping never re-touches the previously swept issues. A trip that finds no claimed issues (all workers exited before claiming) parks the slot but posts no envelopes — the iter-dir sweep is a no-op.
+Idempotency: `SLOT_SWEPT[slot]=1` blocks a second sweep within the same supervisor lifetime. Across restarts a new trip yields fresh worker IDs and fresh attempt dirs, so re-tripping never re-touches the previously swept issues. A trip that finds no claimed issues (all workers exited before claiming) parks the slot but posts no envelopes — the attempt-dir sweep is a no-op.
 
 ### Refs
 
@@ -568,8 +569,8 @@ Idempotency: `SLOT_SWEPT[slot]=1` blocks a second sweep within the same supervis
 
 `/afk monitor` is the readonly aggregated view across all live workers. **Implementation is `scripts/monitor.sh` — invoke it directly, do not reinvent the rendering in inline bash.** The script:
 
-1. Globs `.red/tmp/work-*/afk.state.json` and renders one section per active iteration.
-2. Verifies liveness via the sibling `afk.pid` — iterations whose PID is dead are flagged `stale` and not counted as running.
+1. Globs `.red/tmp/workers/*/*/afk.state.json` and renders one section per active attempt.
+2. Verifies liveness via the orchestrator PID recorded in `afk.state.json` (`.pid` field, read through the `state_is_live` helper) — attempts whose PID is dead are flagged `stale`/`gone` and excluded, not counted as running.
 3. Optionally tails the sibling `afk.log` for the most recent line under each worker's header.
 4. Renders the 48h sparkline header (next subsection) on every refresh.
 
@@ -656,7 +657,7 @@ The pure diff logic lives in [`scripts/lib/mirror.sh`](scripts/lib/mirror.sh). A
 
 An empty plan means nothing changed since the last tick — apply no calls. Because the plan is keyed by `worker_id:issue`, an idempotent re-run with no stage advance emits zero descriptors.
 
-**Re-hydration on session reopen.** A native task dies with the Claude Code session; the `nohup` AFK worker does not. When a session opens with workers still running, `TaskList` (step 2) returns no mirror-owned tasks, so the tracked set is **empty** and `mirror_plan` reconciles cold — emitting a `TaskCreate` for every live worker. The status bar recovers the per-worker tasks with no operator action. This is the same path as steady-state, not a new one: only workers whose `afk.pid` is alive re-hydrate (dead workers are untracked-terminal on a cold tick → no ghost task), and the next tick is idempotent because the freshly-created tasks now form the tracked set.
+**Re-hydration on session reopen.** A native task dies with the Claude Code session; the `nohup` AFK worker does not. When a session opens with workers still running, `TaskList` (step 2) returns no mirror-owned tasks, so the tracked set is **empty** and `mirror_plan` reconciles cold — emitting a `TaskCreate` for every live worker. The status bar recovers the per-worker tasks with no operator action. This is the same path as steady-state, not a new one: only workers whose orchestrator PID (the `.pid` field in `afk.state.json`, via `state_is_live`) is alive re-hydrate (dead workers are untracked-terminal on a cold tick → no ghost task), and the next tick is idempotent because the freshly-created tasks now form the tracked set.
 
 When `TaskCreate` / `TaskUpdate` are unavailable because the session is **outside any runner** (a bare terminal), **skip the mirror silently** — there is no native surface to drive, and `monitor.sh` is already the canonical view.
 
@@ -671,7 +672,7 @@ Do **not** invent a cross-runner task abstraction (rejected in ADR 0003) — kee
 
 ## Handoff File Template
 
-`.red/tmp/work-{id}-i{N}/handoff.md`:
+`.red/tmp/workers/{id}/{N}-a{n}/handoff.md`:
 
 Top-level content is XML elements (not markdown headers) so the inner agent
 cannot confuse the issue body with comments, or human direction with

--- a/plugins/dev/skills/engineering/afk/runner-claude.md
+++ b/plugins/dev/skills/engineering/afk/runner-claude.md
@@ -18,7 +18,7 @@ claude \
 `$full_prompt` is built by the orchestrator as:
 
 ```
-Handoff file: <absolute path to .red/tmp/work-{id}-i{N}/handoff.md>
+Handoff file: <absolute path to .red/tmp/workers/{id}/{N}-a{n}/handoff.md>
 
 Recent commits on main:
 <git log -n 5 --format="%H%n%ad%n%B---" --date=short>
@@ -60,7 +60,7 @@ Claude is invoked with the worktree as `cwd`. It has filesystem access only insi
 
 ## Handoff File Contract
 
-Claude reads the handoff file path passed in the prompt at the start of its session. The file lives one level above the worktree, at `.red/tmp/work-{id}-i{N}/handoff.md`, so it survives runner retries.
+Claude reads the handoff file path passed in the prompt at the start of its session. The file lives one level above the worktree, at `.red/tmp/workers/{id}/{N}-a{n}/handoff.md`, so it survives runner retries.
 
 ## Notes On Permissions
 

--- a/plugins/dev/skills/engineering/afk/runner-codex.md
+++ b/plugins/dev/skills/engineering/afk/runner-codex.md
@@ -46,7 +46,7 @@ On any of those, the orchestrator emits `RUNNER_EXHAUSTED`, preserves the worktr
 
 ## Working Directory
 
-`-C $WORKTREE` pins Codex to the worktree. The handoff file lives at `../handoff.md` (one level above the worktree, inside the iteration directory `.red/tmp/work-{id}-i{N}/`).
+`-C $WORKTREE` pins Codex to the worktree. The handoff file lives at `../handoff.md` (one level above the worktree, inside the attempt directory `.red/tmp/workers/{id}/{N}-a{n}/`).
 
 ## Task Mirror Sink
 

--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -272,8 +272,9 @@ emit_history() {
 }
 
 # ---------- orphan iteration cleanup ----------
-# Sweeps $TMP_DIR/work-*/ at boot. An iteration dir is orphaned when its
-# orchestrator pid is dead. For each orphan:
+# Sweeps nested $TMP_DIR/workers/*/*/ attempt dirs at boot (plus a drain-first
+# wipe of any leftover flat work-*/). An attempt dir is orphaned when its parent
+# worker's worker.pid is dead. For each orphan:
 #   - (heartbeat sub-shell retired — Slice D)
 #   - if the issue is closed OR no longer carries ready-for-human → rm -rf
 #   - if the issue is still labelled running (orchestrator crashed mid-issue)
@@ -291,12 +292,31 @@ prune_orphans() {
   local now_s; now_s="$(date +%s)"
 
   shopt -s nullglob
+
+  # Drain-first cutover (#252): old flat-scheme work-* dirs are never created by
+  # this version. Wipe any left over from a pre-cutover run whose orchestrator
+  # is dead, removing their dangling git worktrees first.
   for d in "$TMP_DIR"/work-*/; do
     [[ -d "$d" ]] || continue
-    local pid_file="$d/afk.pid"
+    local op="$d/afk.pid" opid=""
+    [[ -f "$op" ]] && opid="$(cat "$op" 2>/dev/null)"
+    if [[ -z "$opid" ]] || ! kill -0 "$opid" 2>/dev/null; then
+      git -C "$PROJECT_ROOT" worktree remove --force "${d%/}/worktree" 2>/dev/null || true
+      rm -rf "$d"
+      pruned=$((pruned+1))
+    fi
+  done
+  git -C "$PROJECT_ROOT" worktree prune 2>/dev/null || true
+
+  # Orphan attempt dirs under the nested layout: an attempt is orphaned when its
+  # parent worker's worker.pid is dead (PRD #244 #252). Liveness keys off
+  # workers/{wid}/worker.pid, never directory existence.
+  for d in "$TMP_DIR"/workers/*/*/; do
+    [[ -d "$d" ]] || continue
+    local pid_file; pid_file="$(dirname "${d%/}")/worker.pid"
     local state_file="$d/afk.state.json"
 
-    # active worker → skip
+    # parent worker alive → skip (its attempt dirs are in use)
     if [[ -f "$pid_file" ]]; then
       local p; p="$(cat "$pid_file" 2>/dev/null)"
       if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then
@@ -364,6 +384,19 @@ prune_orphans() {
       rm -rf "$d"
       pruned=$((pruned+1))
     fi
+  done
+
+  # Sweep dead per-worker pids and now-empty worker dirs (PRD #244 #252).
+  for pid_file in "$TMP_DIR"/workers/*/worker.pid; do
+    [[ -f "$pid_file" ]] || continue
+    local wp; wp="$(cat "$pid_file" 2>/dev/null)"
+    if [[ -z "$wp" ]] || ! kill -0 "$wp" 2>/dev/null; then
+      rm -f "$pid_file" 2>/dev/null
+    fi
+  done
+  local wdir
+  for wdir in "$TMP_DIR"/workers/*/; do
+    [[ -d "$wdir" ]] && rmdir "$wdir" 2>/dev/null || true
   done
   shopt -u nullglob
 
@@ -522,8 +555,12 @@ iter_close_success() {
 }
 
 iter_close_preserve() {
-  # blocker / interrupt — keep dir for human, only drop the pid so monitor flags as inactive.
-  [[ -n "$ITER_PID_FILE" && -f "$ITER_PID_FILE" ]] && rm -f "$ITER_PID_FILE"
+  # blocker / interrupt — keep the attempt dir for human inspection, but zero the
+  # state file's .pid so monitor / mirror / statusline read it as not-live
+  # (state_is_live → false). Replicates the old per-attempt afk.pid removal.
+  # The per-worker worker.pid is NOT touched — the worker process is still alive
+  # and moves on to the next issue.
+  [[ -n "$STATE_FILE" && -f "$STATE_FILE" ]] && state_write "$STATE_FILE" pid:=0
   ITER_DIR="" STATE_FILE="" ITER_LOG="" ITER_PID_FILE="" AGENT_LANE="" FIREHOSE=""
   claim_lock_release
 }

--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -40,6 +40,12 @@ source "$SCRIPT_DIR/lib/pin-reader.sh"
 source "$SCRIPT_DIR/lib/remote-branch.sh"
 # shellcheck source=./lib/heartbeat.sh
 source "$SCRIPT_DIR/lib/heartbeat.sh"
+# PRD #244 nested layout (#252 cutover): worker-paths owns the
+# workers/{wid}/{issue}-a{n} grammar; attempt-ledger derives the next attempt
+# number from the on-disk attempt tree. attempt-ledger sources worker-paths
+# itself, but we source both explicitly so the order is unambiguous.
+source "$SCRIPT_DIR/lib/worker-paths.sh"
+source "$SCRIPT_DIR/lib/attempt-ledger.sh"
 # shellcheck source=./lib/capabilities.sh
 source "$SCRIPT_DIR/lib/capabilities.sh"
 # shellcheck source=./lib/jsonl-log.sh
@@ -92,21 +98,24 @@ HISTORY_FILE="$STATE_DIR/afk-history.jsonl"
 HISTORY_MAX_LINES=10000
 
 # Worker ID — literal "w" + 4 chars from [A-Z0-9] (e.g. wZ2R4).
-# Regenerated until no live .red/tmp/work-{id}-i*/afk.pid exists.
-# Format is distinct from arbitrary directory globs so `work-w*-i*` reliably
-# matches only AFK iteration dirs, and IDs stand out visually in logs.
+# Regenerated until no `.red/tmp/workers/{id}/` directory already exists, so a
+# fresh worker never collides with a live or retained worker's tree. IDs stand
+# out visually in logs.
 gen_worker_id() {
   local id
   while :; do
     id="w$(LC_ALL=C tr -dc 'A-Z0-9' </dev/urandom | head -c 4)"
-    [[ -z "$(ls -d "$TMP_DIR"/work-"$id"-i* 2>/dev/null)" ]] && { echo "$id"; return; }
+    [[ ! -e "$TMP_DIR/workers/$id" ]] && { echo "$id"; return; }
   done
 }
 WORKER_ID=""        # set in bootstrap
-ITER_DIR=""         # set per-iteration: $TMP_DIR/work-$WORKER_ID-i$N
+WORKER_DIR=""       # set in bootstrap: $TMP_DIR/workers/$WORKER_ID  (groups all attempts)
+WORKER_PID_FILE=""  # set in bootstrap: $WORKER_DIR/worker.pid  (per-worker liveness anchor)
+ITER_DIR=""         # set per-iteration: $TMP_DIR/workers/$WORKER_ID/$N-a$ITER_ATTEMPT
+ITER_ATTEMPT=1      # set per-iteration: attempt-ledger run number for ($WORKER_ID,$N)
 STATE_FILE=""       # set per-iteration: $ITER_DIR/afk.state.json
 ITER_LOG=""         # set per-iteration: $ITER_DIR/afk.log
-ITER_PID_FILE=""    # set per-iteration: $ITER_DIR/afk.pid
+ITER_PID_FILE=""    # vestigial: per-attempt afk.pid no longer written; liveness is WORKER_PID_FILE
 # JSONL lanes added alongside afk.log (issue #250, PRD #244). The clean agent
 # lane carries one type=agent record per assistant turn and nothing synthetic;
 # the firehose carries everything (agent output, heartbeat vitals, hooks,
@@ -236,6 +245,15 @@ bootstrap() {
   grep -qxF '.red/state/' "$gi" 2>/dev/null || { echo '.red/state/' >> "$gi"; log "added .red/state/ to .gitignore"; }
   WORKER_ID="$(gen_worker_id)"
   log "worker: $WORKER_ID"
+  # Per-worker tree + liveness pid (PRD #244 #252). worker.pid is written ONCE
+  # here, before the first claim, and removed on any exit via the EXIT trap —
+  # liveness everywhere keys off `kill -0` on this file, never off directory
+  # existence (retained attempt dirs outlive their worker, ADR 0030).
+  WORKER_DIR="$(worker_paths_worker_dir "$TMP_DIR" "$WORKER_ID")"
+  WORKER_PID_FILE="$(worker_paths_pidfile "$TMP_DIR" "$WORKER_ID")"
+  mkdir -p "$WORKER_DIR"
+  printf '%s' "$$" > "$WORKER_PID_FILE"
+  trap 'rm -f "${WORKER_PID_FILE:-/dev/null}" 2>/dev/null; rmdir "${WORKER_DIR:-/nonexistent}" 2>/dev/null || true' EXIT
 }
 
 # ---------- event log ----------
@@ -450,16 +468,19 @@ AGG_DURATIONS='[]'
 # ---------- per-iteration directory ----------
 iter_open() {
   local n="$1"
-  ITER_DIR="$TMP_DIR/work-${WORKER_ID}-i${n}"
+  # Attempt-first nested layout (PRD #244 #252): the attempt number is one past
+  # the highest already on disk for this (worker, issue), so a retry is its own
+  # {issue}-a{n} dir instead of overwriting. worker-paths owns the path grammar.
+  ITER_ATTEMPT="$(attempt_ledger_next_number "$TMP_DIR" "$WORKER_ID" "$n")"
+  ITER_DIR="$(worker_paths_build "$TMP_DIR" "$WORKER_ID" "$n" "$ITER_ATTEMPT")"
   STATE_FILE="$ITER_DIR/afk.state.json"
   ITER_LOG="$ITER_DIR/afk.log"
-  # JSONL lanes alongside afk.log (issue #250); this slice does not move
-  # directories — it adds the lanes into the current iteration dir.
   AGENT_LANE="$ITER_DIR/agent.log.jsonl"
   FIREHOSE="$ITER_DIR/log.jsonl"
-  ITER_PID_FILE="$ITER_DIR/afk.pid"
+  # No per-attempt afk.pid is written: liveness is the per-worker
+  # WORKER_PID_FILE created at bootstrap. ITER_PID_FILE stays a vestigial empty
+  # global so the existing reset lines remain harmless.
   mkdir -p "$ITER_DIR"
-  printf '%s' "$$" > "$ITER_PID_FILE"
   : >> "$ITER_LOG"
   # Create the clean agent lane empty at t0 so the supervisor's stall detector
   # has a liveness baseline from the very start of the iteration (issue #251).
@@ -2317,7 +2338,7 @@ process_issue() {
 
   iter_open "$n"
   local worktree="$ITER_DIR/worktree"
-  local worktree_rel=".red/tmp/work-${WORKER_ID}-i${n}/worktree"
+  local worktree_rel="${ITER_DIR#"$PROJECT_ROOT"/}/worktree"
 
   # Lifecycle cursor used by run_lifecycle_hook.
   CURRENT_ISSUE="$n"
@@ -2428,7 +2449,7 @@ process_issue() {
     current.title="$title" \
     current.slug="$slug" \
     current.worktree="$worktree_rel" \
-    current.handoff=".red/tmp/work-${WORKER_ID}-i${n}/handoff.md" \
+    current.handoff="${ITER_DIR#"$PROJECT_ROOT"/}/handoff.md" \
     current.started_at="$started_at" \
     current.stage=setup \
     current.heartbeat_glyph:=null \

--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -504,7 +504,10 @@ iter_open() {
   # Attempt-first nested layout (PRD #244 #252): the attempt number is one past
   # the highest already on disk for this (worker, issue), so a retry is its own
   # {issue}-a{n} dir instead of overwriting. worker-paths owns the path grammar.
-  ITER_ATTEMPT="$(attempt_ledger_next_number "$TMP_DIR" "$WORKER_ID" "$n")"
+  # attempt-ledger keys the attempt counter per ISSUE across all workers
+  # (glob workers/*/{issue}-a*), so a retry — even by a different worker — is a
+  # fresh a{n} dir. worker-paths then nests it under THIS worker.
+  ITER_ATTEMPT="$(attempt_ledger_next_number "$TMP_DIR" "$n")"
   ITER_DIR="$(worker_paths_build "$TMP_DIR" "$WORKER_ID" "$n" "$ITER_ATTEMPT")"
   STATE_FILE="$ITER_DIR/afk.state.json"
   ITER_LOG="$ITER_DIR/afk.log"

--- a/plugins/dev/skills/engineering/afk/scripts/lib/mirror.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/mirror.sh
@@ -5,9 +5,10 @@
 # Three layers, two of them pure:
 #
 #   state-reader      mirror_read_workers <project_root>
-#     Globs .red/tmp/work-*/afk.state.json, verifies liveness via the sibling
-#     afk.pid (kill -0), and emits one normalized JSONL record per worker that
-#     currently maps to a task. No harness coupling, never writes state.
+#     Globs .red/tmp/workers/*/*/afk.state.json, verifies liveness via the state
+#     file's .pid (the orchestrator $$; kill -0), and emits one normalized JSONL
+#     record per worker that currently maps to a task. No harness coupling,
+#     never writes state.
 #
 #   mirror-reconciler mirror_reconcile <desired_jsonl> <tracked_jsonl>
 #     Pure diff. Given the desired worker set (from the reader) and the set of
@@ -35,18 +36,20 @@ source "$(dirname "${BASH_SOURCE[0]}")/state.sh"
 # mirror_read_workers <project_root>
 # Emits JSONL, one record per work dir that maps to a live or crashed task.
 # A record is emitted only when the iteration carries a current issue number
-# (an idle worker between issues owns no task). Liveness comes from the sibling
-# afk.pid, not the .pid field, matching monitor.sh and afk.sh prune_orphans.
+# (an idle worker between issues owns no task). Liveness comes from the state
+# file's .pid (the orchestrator $$), matching monitor.sh / statusline.sh via
+# state_is_live. A preserved blocked attempt has its .pid zeroed by
+# iter_close_preserve, so it reads not-live — the same effect the old
+# per-attempt afk.pid removal had under the flat scheme.
 mirror_read_workers() {
   local root="${1:-$(pwd)}"
   local tmp_dir="$root/.red/tmp"
-  local state_file iter_dir pid_file pid live status started
+  local state_file iter_dir live status started
 
   shopt -s nullglob
-  for state_file in "$tmp_dir"/work-*/afk.state.json; do
+  for state_file in "$tmp_dir"/workers/*/*/afk.state.json; do
     [[ -f "$state_file" ]] || continue
     iter_dir="$(dirname "$state_file")"
-    pid_file="$iter_dir/afk.pid"
 
     state_read_into _w "$state_file"
 
@@ -54,10 +57,7 @@ mirror_read_workers() {
     [[ -n "$_w_current_number" && "$_w_current_number" != "null" ]] || continue
 
     live=0
-    if [[ -f "$pid_file" ]]; then
-      pid="$(cat "$pid_file" 2>/dev/null)"
-      [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && live=1
-    fi
+    state_is_live "$state_file" && live=1
 
     if (( live )); then
       status="running"

--- a/plugins/dev/skills/engineering/afk/scripts/lib/state.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/state.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# lib/state.sh — accessor module for .red/tmp/work-*/afk.state.json.
+# lib/state.sh — accessor module for .red/tmp/workers/*/*/afk.state.json.
 #
 # Owns the v1 schema. Callers never write jq filters or touch the state file
 # directly. Adding a new field is a one-line change to _STATE_JQ_FILTER below

--- a/plugins/dev/skills/engineering/afk/scripts/lib/worker-paths.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/worker-paths.sh
@@ -46,6 +46,21 @@
 #   worker_paths_workers_glob <root>
 #     Echo the canonical glob matching all live worker directories:
 #     `<root>/workers/*`. Returns 0 on a non-empty <root>, else non-zero.
+#
+#   worker_paths_worker_dir <root> <worker>
+#     Echo `<root>/workers/<worker>` — the per-worker directory that groups all
+#     of one worker's attempts. Returns 0 on a valid worker, else non-zero.
+#
+#   worker_paths_pidfile <root> <worker>
+#     Echo `<root>/workers/<worker>/worker.pid` — the per-worker pid file the
+#     orchestrator writes once at bootstrap. Liveness is keyed off this file
+#     (`kill -0`), never off directory existence, because retained attempt
+#     directories outlive their worker (PRD #244 split teardown). Returns 0 on a
+#     valid worker, else non-zero.
+#
+#   worker_paths_live_pids_glob <root>
+#     Echo `<root>/workers/*/worker.pid` — the glob consumers walk to find every
+#     worker's pid file for the liveness check. Returns 0 on a non-empty <root>.
 
 # _worker_paths_valid_worker <token>
 # True iff <token> is a single non-empty path segment of [A-Za-z0-9_-].
@@ -111,5 +126,34 @@ worker_paths_workers_glob() {
   [[ -n "$root" ]] || return 1
   root="${root%/}"
   printf '%s/workers/*\n' "$root"
+  return 0
+}
+
+# worker_paths_worker_dir <root> <worker>
+worker_paths_worker_dir() {
+  local root="$1" worker="$2"
+  [[ -n "$root" ]] || return 1
+  _worker_paths_valid_worker "$worker" || return 1
+  root="${root%/}"
+  printf '%s/workers/%s\n' "$root" "$worker"
+  return 0
+}
+
+# worker_paths_pidfile <root> <worker>
+worker_paths_pidfile() {
+  local root="$1" worker="$2"
+  [[ -n "$root" ]] || return 1
+  _worker_paths_valid_worker "$worker" || return 1
+  root="${root%/}"
+  printf '%s/workers/%s/worker.pid\n' "$root" "$worker"
+  return 0
+}
+
+# worker_paths_live_pids_glob <root>
+worker_paths_live_pids_glob() {
+  local root="$1"
+  [[ -n "$root" ]] || return 1
+  root="${root%/}"
+  printf '%s/workers/*/worker.pid\n' "$root"
   return 0
 }

--- a/plugins/dev/skills/engineering/afk/scripts/monitor.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/monitor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# /afk monitor — readonly status board. Globs .red/tmp/work-*/afk.state.json
+# /afk monitor — readonly status board. Globs .red/tmp/workers/*/*/afk.state.json
 # (one file per live iteration) and renders one section per worker.
 #
 # Two modes, auto-selected by stdout type:
@@ -416,9 +416,9 @@ render_full() {
   render_fleet_header
   render_sparkline
   echo
-  local states=( "$TMP_DIR"/work-*/afk.state.json )
+  local states=( "$TMP_DIR"/workers/*/*/afk.state.json )
   if [[ ! -e "${states[0]}" ]]; then
-    echo "no live iterations under $TMP_DIR/work-*/ — /afk not running here?"
+    echo "no live iterations under $TMP_DIR/workers/*/ — /afk not running here?"
   else
     for sf in "${states[@]}"; do render_worker "$sf"; done
   fi
@@ -448,7 +448,7 @@ When you summarise the lines below for the user, follow these rules verbatim. Tr
 EOF
   render_fleet_header
   render_sparkline
-  local states=( "$TMP_DIR"/work-*/afk.state.json )
+  local states=( "$TMP_DIR"/workers/*/*/afk.state.json )
   if [[ ! -e "${states[0]}" ]]; then
     echo "workers: (none — /afk not running here)"
   else

--- a/plugins/dev/skills/engineering/afk/scripts/statusline.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/statusline.sh
@@ -3,7 +3,7 @@
 #
 # Reads the Claude Code statusline JSON payload from stdin (cwd, model,
 # effort, context window) and combines it with live /afk worker state
-# from $cwd/.red/tmp/work-*/.
+# from $cwd/.red/tmp/workers/*/*/.
 #
 # Output example (no truncation, one line):
 #   red-skills · Opus·high · 47k 24% · 🤖4 📋1 🙋11 🚧10 +12 -3 #17
@@ -138,7 +138,7 @@ if [[ -d .red/tmp ]]; then
   total_removed=0
   current_issues=()
 
-  for state in .red/tmp/work-*/afk.state.json; do
+  for state in .red/tmp/workers/*/*/afk.state.json; do
     state_is_live "$state" || continue
     state_read_into st "$state"
 

--- a/plugins/dev/skills/engineering/afk/scripts/supervisor.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/supervisor.sh
@@ -518,16 +518,26 @@ sup_kill_tree() {
 
 # Same matching logic as find_slot_iter_log but returns the iter
 # directory itself. Echoes nothing when the worker is between
-# iterations (no afk.pid match).
+# iterations (no worker.pid match, or no attempt dir yet).
+# Matches the slot's worker pid against the per-worker workers/{wid}/worker.pid
+# (PRD #244 #252), then returns the worker's CURRENT iteration — its newest
+# attempt dir under workers/{wid}/.
 find_slot_iter_dir() {
   local slot="$1"
   local pid="${SLOT_PIDS[$slot]:-}"
-  local pid_file
+  local pid_file wdir d newest
   [[ -n "$pid" ]] || return 0
-  for pid_file in "$TMP_DIR"/work-*/afk.pid; do
+  shopt -s nullglob
+  for pid_file in "$TMP_DIR"/workers/*/worker.pid; do
     [[ -f "$pid_file" ]] || continue
     [[ "$(cat "$pid_file" 2>/dev/null)" == "$pid" ]] || continue
-    printf '%s\n' "$(dirname "$pid_file")"
+    wdir="$(dirname "$pid_file")"
+    newest=""
+    for d in "$wdir"/*/; do
+      [[ -d "$d" ]] || continue
+      if [[ -z "$newest" || "$d" -nt "$newest" ]]; then newest="${d%/}"; fi
+    done
+    [[ -n "$newest" ]] && printf '%s\n' "$newest"
     return 0
   done
 }
@@ -685,13 +695,13 @@ parse_worker_ids_from_log() {
 }
 
 # iter_dir_for_worker <worker_id>
-# Echo every `.red/tmp/work-{wid}-i*/` directory that exists for the
-# given worker ID. Multiple iter dirs per worker are possible when the
-# worker drained several issues before its slot got parked.
+# Echo every `.red/tmp/workers/{wid}/{issue}-a{n}/` attempt directory that
+# exists for the given worker ID. Multiple attempt dirs per worker are possible
+# when the worker drained several issues (or retried) before its slot got parked.
 iter_dirs_for_worker() {
   local wid="$1" d
   shopt -s nullglob
-  for d in "$TMP_DIR"/work-"${wid}"-i*/; do
+  for d in "$TMP_DIR"/workers/"${wid}"/*/; do
     [[ -d "$d" ]] && printf '%s\n' "${d%/}"
   done
   shopt -u nullglob
@@ -922,7 +932,7 @@ reap_stalled_slot() {
 
     local branch="afk/${worker_id}/${issue}-${slug}"
     local remote_name="afk-attempts/${worker_id}/${issue}-${slug}"
-    local worktree_rel=".red/tmp/work-${worker_id}-i${issue}/worktree"
+    local worktree_rel=".red/tmp/${iter_dir#"$TMP_DIR"/}/worktree"
     local repo_dir="$iter_dir/worktree"
     [[ -d "$repo_dir" ]] || repo_dir=""
 

--- a/plugins/dev/skills/engineering/afk/scripts/tests/lifecycle-hooks-executed.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/lifecycle-hooks-executed.test.sh
@@ -254,7 +254,7 @@ FILTER_KIND=""; FILTER_VALUE=""
 AGG_TOTAL=0; AGG_DONE=0; AGG_FAILED=0; AGG_BLOCKED=0
 AGG_COMPLETED="[]"; AGG_QUEUE="[]"; AGG_DURATIONS="[]"
 iter_open 215
-expected_file="$TMP_DIR/work-wTEST-i215/hooks-executed.log"
+expected_file="$ITER_DIR/hooks-executed.log"  # nested workers/wTEST/215-a1 (#252)
 if [[ "$HOOK_EXECUTIONS_FILE" == "$expected_file" ]]; then
   echo "PASS  iter_open: HOOK_EXECUTIONS_FILE set in ITER_DIR"; pass=$((pass+1))
 else

--- a/plugins/dev/skills/engineering/afk/scripts/tests/mirror-codex-sink.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/mirror-codex-sink.test.sh
@@ -52,15 +52,13 @@ trap 'rm -rf "$ROOT"' EXIT
 # Same fixture helper shape as mirror.test.sh: a state file + (optional) live pid.
 mk_worker() {
   local wid="$1" issue="$2" title="$3" stage="$4" pid="$5"
-  local dir="$ROOT/.red/tmp/work-${wid}-i${issue}"
+  # Nested layout (#252): workers/{wid}/{issue}-a1; liveness via state .pid.
+  local dir="$ROOT/.red/tmp/workers/${wid}/${issue}-a1"
   mkdir -p "$dir"
   state_init "$dir/afk.state.json" worker_id="$wid" pid:="${pid/-/0}"
   state_write "$dir/afk.state.json" \
     current.number:="$issue" current.title="$title" \
     current.stage="$stage" current.started_at="2026-05-21T09:00:00-03:00"
-  if [[ "$pid" != "-" ]]; then
-    printf '%s' "$pid" > "$dir/afk.pid"
-  fi
 }
 
 LIVE=$$

--- a/plugins/dev/skills/engineering/afk/scripts/tests/mirror.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/mirror.test.sh
@@ -40,15 +40,14 @@ trap 'rm -rf "$ROOT"' EXIT
 # a live pid file. Usage: mk_worker <wid> <issue> <title> <stage> <pid|->
 mk_worker() {
   local wid="$1" issue="$2" title="$3" stage="$4" pid="$5"
-  local dir="$ROOT/.red/tmp/work-${wid}-i${issue}"
+  # Nested layout (#252): attempt dir is workers/{wid}/{issue}-a1. Liveness is
+  # read from the state file's .pid (state_is_live), so no sibling pid file.
+  local dir="$ROOT/.red/tmp/workers/${wid}/${issue}-a1"
   mkdir -p "$dir"
   state_init "$dir/afk.state.json" worker_id="$wid" pid:="${pid/-/0}"
   state_write "$dir/afk.state.json" \
     current.number:="$issue" current.title="$title" \
     current.stage="$stage" current.started_at="2026-05-21T09:00:00-03:00"
-  if [[ "$pid" != "-" ]]; then
-    printf '%s' "$pid" > "$dir/afk.pid"
-  fi
 }
 
 # A live pid for "running" workers: this test shell is guaranteed alive.
@@ -64,7 +63,7 @@ mk_worker wCCCC 31 "crashed worker"    impl 999999     # pid dead → gone
 mk_worker wDDDD 0  ""                   setup "$LIVE"   # no real issue → omitted
 
 # wDDDD has current.number 0; fix it to be a truly-absent current to test idle
-state_write "$ROOT/.red/tmp/work-wDDDD-i0/afk.state.json" current:=null
+state_write "$ROOT/.red/tmp/workers/wDDDD/0-a1/afk.state.json" current:=null
 
 readers="$(mirror_read_workers "$ROOT" | jq -c '.' | sort)"
 
@@ -84,8 +83,7 @@ d="$(printf '%s\n' "$readers" | jq -c 'select(.worker_id=="wDDDD")')"
 expect_eq "reader: idle worker (current null) omitted" "" "$d"
 
 # Missing / partial state file: a work dir with no state file → no record, no crash.
-mkdir -p "$ROOT/.red/tmp/work-wEEEE-i9"
-printf '%s' "$LIVE" > "$ROOT/.red/tmp/work-wEEEE-i9/afk.pid"
+mkdir -p "$ROOT/.red/tmp/workers/wEEEE/9-a1"
 count2="$(mirror_read_workers "$ROOT" | grep -c .)"
 expect_eq "reader: dir without state file ignored" "3" "$count2"
 
@@ -179,9 +177,9 @@ steady_keys="$(printf '%s\n' "$plan_steady" | jq -r 'select(.key=="wAAAA:22" or 
 expect_eq "plan: unchanged running workers emit no call" "" "$steady_keys"
 
 # Read-only invariant: the reader/plan must never mutate the state files.
-before="$(cat "$ROOT/.red/tmp/work-wAAAA-i22/afk.state.json")"
+before="$(cat "$ROOT/.red/tmp/workers/wAAAA/22-a1/afk.state.json")"
 mirror_plan "$ROOT" "$tracked_all" >/dev/null
-after="$(cat "$ROOT/.red/tmp/work-wAAAA-i22/afk.state.json")"
+after="$(cat "$ROOT/.red/tmp/workers/wAAAA/22-a1/afk.state.json")"
 expect_eq "plan: state file untouched (read-only invariant)" "$before" "$after"
 
 # ----------------------------------------------------------------------

--- a/plugins/dev/skills/engineering/afk/scripts/tests/stall-agent-lane.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/stall-agent-lane.test.sh
@@ -63,12 +63,14 @@ RED_AFK_TARGET=1
 RED_AFK_STALL_THRESHOLD_S=30
 SUPERVISOR_RUNNER="claude"
 
-# stage_fixture <iter_dir> — create a worker iteration dir whose afk.pid is this
-# shell, with afk.log + agent lane + state + handoff, both logs aged 120s.
+# stage_fixture <iter_dir> — create a worker iteration dir (nested #252 layout
+# workers/{wid}/{issue}-a{n}) plus the per-worker workers/{wid}/worker.pid this
+# shell owns, with afk.log + agent lane + state + handoff, both logs aged 120s.
 stage_fixture() {
-  local dir="$1" past; past=$(( $(date +%s) - 120 ))
+  local dir="$1" past wdir; past=$(( $(date +%s) - 120 ))
+  wdir="$(dirname "$dir")"
   mkdir -p "$dir/worktree"
-  echo "$$" > "$dir/afk.pid"
+  echo "$$" > "$wdir/worker.pid"
   cat > "$dir/afk.state.json" <<EOF
 { "worker_id": "wTEST", "started_at": "$(date -Iseconds -d "@$(( $(date +%s) - 200 ))")",
   "current": { "number": 251, "title": "afk reaper agent lane", "slug": "afk-reaper-agent-lane" } }
@@ -98,7 +100,7 @@ reset_slot() {
 # afk.log is fresh (the heartbeat). A fresh worker not yet flagged is staged,
 # poll must flag it from lane silence even though afk.log just moved.
 RED_AFK_STALL_KILL_THRESHOLD_S=600
-ITER_DIR="$TMP_ROOT/.red/tmp/work-wTEST-i251"
+ITER_DIR="$TMP_ROOT/.red/tmp/workers/wTEST/251-a1"
 stage_fixture "$ITER_DIR"
 SLOT_PIDS=("$$")
 SLOT_SPAWN_EPOCH=("$(( $(date +%s) - 200 ))")
@@ -114,7 +116,7 @@ assert_eq "masking fix: flagged from agent-lane silence (afk.log fresh)" "1" "${
 RED_AFK_STALL_KILL_THRESHOLD_S=90
 sup_active_descendant() { echo no; }
 sup_tree_cpu() { echo 0; }
-ITER_DIR="$TMP_ROOT/.red/tmp/work-wTEST-i251"
+ITER_DIR="$TMP_ROOT/.red/tmp/workers/wTEST/251-a1"
 stage_fixture "$ITER_DIR"
 touch "$ITER_DIR/afk.log"   # heartbeat keeps afk.log fresh
 reset_slot "$ITER_DIR"
@@ -131,7 +133,7 @@ if grep -qF 'data-attempt-status="no-sentinel"' "$GH_CALLS"; then ok "reap fires
 RED_AFK_STALL_KILL_THRESHOLD_S=90
 sup_active_descendant() { echo yes; }   # a vitest/build descendant is running
 sup_tree_cpu() { echo 0; }              # even at flat cpu, the descendant protects it
-ITER_DIR="$TMP_ROOT/.red/tmp/work-wTEST-i251"
+ITER_DIR="$TMP_ROOT/.red/tmp/workers/wTEST/251-a1"
 stage_fixture "$ITER_DIR"
 reset_slot "$ITER_DIR"
 : >"$GH_CALLS"; : >"$KILL_CALLS"; : >"$LOG_FILE"
@@ -150,7 +152,7 @@ assert_eq "busy descendant: still flagged stalled" "1" "${SLOT_STALLED[0]}"
 RED_AFK_STALL_KILL_THRESHOLD_S=90
 sup_active_descendant() { echo no; }    # no recognised tool, but...
 sup_tree_cpu() { echo 87.5; }           # ...the worker tree is burning cpu
-ITER_DIR="$TMP_ROOT/.red/tmp/work-wTEST-i251"
+ITER_DIR="$TMP_ROOT/.red/tmp/workers/wTEST/251-a1"
 stage_fixture "$ITER_DIR"
 reset_slot "$ITER_DIR"
 : >"$GH_CALLS"; : >"$KILL_CALLS"

--- a/plugins/dev/skills/engineering/afk/scripts/tests/stall-detector.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/stall-detector.test.sh
@@ -74,9 +74,12 @@ assert_eq "custom threshold 30s → no"  "no"  "$(compute_stalled $((NOW-29))   
 # only reads files.
 RED_AFK_TARGET=1
 RED_AFK_STALL_THRESHOLD_S=30
-ITER_DIR="$TMP_ROOT/.red/tmp/work-wTEST-i1"
+# Nested layout (#252): the attempt dir lives under workers/{wid}/, and the
+# slot pid matches the per-worker workers/{wid}/worker.pid.
+WORKER_DIR="$TMP_ROOT/.red/tmp/workers/wTEST"
+ITER_DIR="$WORKER_DIR/1-a1"
 mkdir -p "$ITER_DIR"
-echo "$$" > "$ITER_DIR/afk.pid"
+echo "$$" > "$WORKER_DIR/worker.pid"
 SLOT_PIDS=("$$")
 
 # Liveness is read from the clean agent lane (agent.log.jsonl), never afk.log

--- a/plugins/dev/skills/engineering/afk/scripts/tests/stall-reaper.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/stall-reaper.test.sh
@@ -110,9 +110,11 @@ SUPERVISOR_RUNNER="claude"
 WID="wTEST"
 ISSUE=190
 SLUG="bug-afk-supervisor-stall"
-ITER_DIR="$TMP_ROOT/.red/tmp/work-${WID}-i${ISSUE}"
+# Nested layout (#252): attempt dir under workers/{wid}/, slot pid lives in the
+# per-worker workers/{wid}/worker.pid that find_slot_iter_dir matches.
+ITER_DIR="$TMP_ROOT/.red/tmp/workers/${WID}/${ISSUE}-a1"
 mkdir -p "$ITER_DIR/worktree"
-echo "$$" > "$ITER_DIR/afk.pid"
+echo "$$" > "$(dirname "$ITER_DIR")/worker.pid"
 cat > "$ITER_DIR/afk.state.json" <<EOF
 {
   "worker_id": "$WID",
@@ -208,9 +210,12 @@ assert_eq "reap: no extra kill calls on second poll" "$PRE_KILL" "$POST_KILL"
 # A reap with no afk.state.json must still kill, free the slot, and
 # remove the iter dir, but post no envelope and rotate no labels.
 WID2="wPREB"
-ITER_DIR2="$TMP_ROOT/.red/tmp/work-${WID2}-i0"
+ITER_DIR2="$TMP_ROOT/.red/tmp/workers/${WID2}/0-a1"
+# First worker fully exited — its EXIT trap would have removed worker.pid and the
+# worker dir; do the same here so only wPREB's worker.pid matches slot pid $$.
+rm -rf "$TMP_ROOT/.red/tmp/workers/${WID}"
 mkdir -p "$ITER_DIR2"
-echo "$$" > "$ITER_DIR2/afk.pid"
+echo "$$" > "$(dirname "$ITER_DIR2")/worker.pid"
 : > "$ITER_DIR2/afk.log"
 : > "$ITER_DIR2/agent.log.jsonl"
 

--- a/plugins/dev/skills/engineering/afk/scripts/tests/statusline.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/statusline.test.sh
@@ -38,7 +38,7 @@ seed_cache() {
 # Build a worker state dir. Args: root, slug, pid, issue, added, removed, blocked.
 make_worker() {
   local root="$1" slug="$2" pid="$3" issue="$4" added="$5" removed="$6" blocked="$7"
-  local dir="$root/.red/tmp/work-$slug"
+  local dir="$root/.red/tmp/workers/$slug/${issue}-a1"
   mkdir -p "$dir"
   jq -n \
     --argjson pid "$pid" \

--- a/plugins/dev/skills/engineering/afk/scripts/tests/trip-sweep.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/trip-sweep.test.sh
@@ -78,26 +78,26 @@ assert_eq "parse: missing log yields nothing" "" "$MISSING_OUT"
 
 # ---------- iter_dirs_for_worker / iter_dir_issue_number ----------
 
-mkdir -p "$TMP_ROOT/.red/tmp/work-wAAAA-i7"
-echo '{"current":{"number":7}}' >"$TMP_ROOT/.red/tmp/work-wAAAA-i7/afk.state.json"
-mkdir -p "$TMP_ROOT/.red/tmp/work-wAAAA-i9"
-echo '{"current":{"number":9}}' >"$TMP_ROOT/.red/tmp/work-wAAAA-i9/afk.state.json"
-mkdir -p "$TMP_ROOT/.red/tmp/work-wBBBB-i7"  # worker died before claim → no state
-mkdir -p "$TMP_ROOT/.red/tmp/work-wXXXX-i1"  # unrelated worker, must be ignored
-echo '{"current":{"number":99}}' >"$TMP_ROOT/.red/tmp/work-wXXXX-i1/afk.state.json"
+mkdir -p "$TMP_ROOT/.red/tmp/workers/wAAAA/7-a1"
+echo '{"current":{"number":7}}' >"$TMP_ROOT/.red/tmp/workers/wAAAA/7-a1/afk.state.json"
+mkdir -p "$TMP_ROOT/.red/tmp/workers/wAAAA/9-a1"
+echo '{"current":{"number":9}}' >"$TMP_ROOT/.red/tmp/workers/wAAAA/9-a1/afk.state.json"
+mkdir -p "$TMP_ROOT/.red/tmp/workers/wBBBB/7-a1"  # worker died before claim → no state
+mkdir -p "$TMP_ROOT/.red/tmp/workers/wXXXX/1-a1"  # unrelated worker, must be ignored
+echo '{"current":{"number":99}}' >"$TMP_ROOT/.red/tmp/workers/wXXXX/1-a1/afk.state.json"
 
 DIRS_A="$(iter_dirs_for_worker "wAAAA" | sort | paste -sd, -)"
 assert_eq "iter_dirs_for_worker: matches both iter dirs" \
-  "$TMP_ROOT/.red/tmp/work-wAAAA-i7,$TMP_ROOT/.red/tmp/work-wAAAA-i9" \
+  "$TMP_ROOT/.red/tmp/workers/wAAAA/7-a1,$TMP_ROOT/.red/tmp/workers/wAAAA/9-a1" \
   "$DIRS_A"
 
 DIRS_C="$(iter_dirs_for_worker "wCCCC")"
 assert_eq "iter_dirs_for_worker: unknown worker yields nothing" "" "$DIRS_C"
 
-ISSUE7="$(iter_dir_issue_number "$TMP_ROOT/.red/tmp/work-wAAAA-i7")"
+ISSUE7="$(iter_dir_issue_number "$TMP_ROOT/.red/tmp/workers/wAAAA/7-a1")"
 assert_eq "iter_dir_issue_number: reads .current.number" "7" "$ISSUE7"
 
-ISSUE_NONE="$(iter_dir_issue_number "$TMP_ROOT/.red/tmp/work-wBBBB-i7")"
+ISSUE_NONE="$(iter_dir_issue_number "$TMP_ROOT/.red/tmp/workers/wBBBB/7-a1")"
 assert_eq "iter_dir_issue_number: no state file → empty" "" "$ISSUE_NONE"
 
 # ---------- build_discard_envelope ----------
@@ -170,11 +170,11 @@ assert_contains "sweep removes ready-for-human" "$EDITS" '--remove-label ready-f
 assert_contains "sweep removes running"        "$EDITS" '--remove-label running'
 
 # Expect: every iter dir for the affected workers removed.
-[ ! -d "$TMP_ROOT/.red/tmp/work-wAAAA-i7" ] && ok "sweep removed work-wAAAA-i7" || bad "sweep left work-wAAAA-i7"
-[ ! -d "$TMP_ROOT/.red/tmp/work-wAAAA-i9" ] && ok "sweep removed work-wAAAA-i9" || bad "sweep left work-wAAAA-i9"
-[ ! -d "$TMP_ROOT/.red/tmp/work-wBBBB-i7" ] && ok "sweep removed work-wBBBB-i7" || bad "sweep left work-wBBBB-i7"
+[ ! -d "$TMP_ROOT/.red/tmp/workers/wAAAA/7-a1" ] && ok "sweep removed workers/wAAAA/7-a1" || bad "sweep left workers/wAAAA/7-a1"
+[ ! -d "$TMP_ROOT/.red/tmp/workers/wAAAA/9-a1" ] && ok "sweep removed workers/wAAAA/9-a1" || bad "sweep left workers/wAAAA/9-a1"
+[ ! -d "$TMP_ROOT/.red/tmp/workers/wBBBB/7-a1" ] && ok "sweep removed workers/wBBBB/7-a1" || bad "sweep left workers/wBBBB/7-a1"
 # Unrelated worker dir must survive.
-[ -d "$TMP_ROOT/.red/tmp/work-wXXXX-i1" ] && ok "sweep preserved unrelated worker dir" || bad "sweep clobbered unrelated worker dir"
+[ -d "$TMP_ROOT/.red/tmp/workers/wXXXX/1-a1" ] && ok "sweep preserved unrelated worker dir" || bad "sweep clobbered unrelated worker dir"
 
 # SLOT_SWEPT guard set.
 assert_eq "sweep sets SLOT_SWEPT=1" "1" "${SLOT_SWEPT[0]}"
@@ -193,7 +193,7 @@ assert_eq "sweep idempotent on re-invocation" "$PRE_CALLS" "$POST_CALLS"
 SLOT_SWEPT=(0)
 SLOT_FAST_DEATHS=("200 210 220 230 240")
 : >"$GH_CALLS"
-mkdir -p "$TMP_ROOT/.red/tmp/work-wDDDD-i1"  # no state file
+mkdir -p "$TMP_ROOT/.red/tmp/workers/wDDDD/1-a1"  # no state file
 cat >"$SWEEP_SLOT_LOG" <<'EOF'
 [afk] worker: wDDDD
 EOF
@@ -204,7 +204,7 @@ ZERO_COMMENTS="$(grep -c 'issue comment' "$GH_CALLS" || true)"
 assert_eq "no-claimed-issues sweep: zero envelopes posted" "0" "$ZERO_COMMENTS"
 ZERO_EDITS="$(grep -c 'issue edit' "$GH_CALLS" || true)"
 assert_eq "no-claimed-issues sweep: zero label edits"      "0" "$ZERO_EDITS"
-[ ! -d "$TMP_ROOT/.red/tmp/work-wDDDD-i1" ] && ok "no-claimed-issues sweep: iter dir removed" || bad "no-claimed-issues sweep: iter dir kept"
+[ ! -d "$TMP_ROOT/.red/tmp/workers/wDDDD/1-a1" ] && ok "no-claimed-issues sweep: iter dir removed" || bad "no-claimed-issues sweep: iter dir kept"
 
 # ---------- no-workers-observed path ----------
 # Brand new slot, slot log never opened (or empty) → sweep is a no-op,

--- a/plugins/dev/skills/engineering/afk/scripts/tests/worker-paths.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/worker-paths.test.sh
@@ -156,6 +156,48 @@ expected_workers="$(printf '%s\n' \
   "$TMPROOT/workers/wCCCC" | sort)"
 expect_eq "workers-glob/expands-to-all-workers" "$expected_workers" "$matched_workers"
 
+# ===========================================================================
+# worker_paths_worker_dir / pidfile / live_pids_glob — literal + rejection
+# ===========================================================================
+expect_eq "worker-dir/literal" \
+  "/tmp/afk/workers/wA1B9" \
+  "$(worker_paths_worker_dir /tmp/afk wA1B9)"
+expect_eq "worker-dir/trailing-slash-normalised" \
+  "/tmp/afk/workers/wA1B9" \
+  "$(worker_paths_worker_dir /tmp/afk/ wA1B9)"
+expect_rc "worker-dir/empty-root rejected"     1 worker_paths_worker_dir "" wA1B9
+expect_rc "worker-dir/worker-with-slash"       1 worker_paths_worker_dir /tmp "w/x"
+
+expect_eq "pidfile/literal" \
+  "/tmp/afk/workers/wA1B9/worker.pid" \
+  "$(worker_paths_pidfile /tmp/afk wA1B9)"
+expect_rc "pidfile/empty-worker rejected"      1 worker_paths_pidfile /tmp ""
+
+expect_eq "live-pids-glob/literal" \
+  "/tmp/afk/workers/*/worker.pid" \
+  "$(worker_paths_live_pids_glob /tmp/afk)"
+expect_rc "live-pids-glob/empty-root rejected" 1 worker_paths_live_pids_glob ""
+
+# round-trip: pidfile sits inside worker_dir, which is the parent of every
+# attempt dir for that worker.
+expect_eq "worker-dir/parents-the-attempt" \
+  "$(worker_paths_worker_dir /tmp/afk wA1B9)/245-a1" \
+  "$(worker_paths_build /tmp/afk wA1B9 245 1)"
+
+# Live-pids glob: expands to exactly the worker.pid files present. Liveness is
+# keyed off the pid file, not directory existence — so a worker dir with no
+# worker.pid (e.g. a retained corpse) is correctly excluded. Drop pids for two
+# of the three fixture workers; the glob must select exactly those two.
+: > "$TMPROOT/workers/wAAAA/worker.pid"
+: > "$TMPROOT/workers/wBBBB/worker.pid"
+pids_glob="$(worker_paths_live_pids_glob "$TMPROOT")"
+# shellcheck disable=SC2086
+matched_pids="$(printf '%s\n' $pids_glob | sort)"
+expected_pids="$(printf '%s\n' \
+  "$TMPROOT/workers/wAAAA/worker.pid" \
+  "$TMPROOT/workers/wBBBB/worker.pid" | sort)"
+expect_eq "live-pids-glob/expands-to-pidfiles-only" "$expected_pids" "$matched_pids"
+
 echo
 echo "summary: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #252 (the HITL drain-first cutover slice of PRD #244).

## What this does
Switches the AFK on-disk scheme from the flat `.red/tmp/work-{id}-i{N}/` (per-iteration `afk.pid`) to the nested `.red/tmp/workers/{wid}/{issue}-a{n}/` attempt tree anchored by a single per-worker `worker.pid`.

This is **drain-first** (no dual-read, Q11c): boot wipes any legacy flat `work-*/` dirs unconditionally, then sweeps the nested tree. See ADR 0030 / 0031 on main.

## Changes
- **afk.sh (producer):** worker.pid written once at bootstrap + removed on EXIT trap; attempt dir built via `worker_paths_build` + `attempt_ledger_next_number` (per-issue-across-workers counter); drain-first `prune_orphans`. Also fixes a real arity bug — `attempt_ledger_next_number` takes `(root, issue)`, not the worker id.
- **6 consumers:** monitor, statusline, mirror, supervisor, state, orphan-cleanup re-globbed to `workers/*/*/`. Liveness now reads the state file's `.pid` (`state_is_live`) for monitor/statusline/mirror; supervisor slot matching keys off `workers/{wid}/worker.pid`.
- **worker-paths.sh:** `worker_paths_worker_dir`, `worker_paths_pidfile`, `worker_paths_live_pids_glob`.
- **Docs + glossary:** SKILL.md / SAFETY.md / AGENT-PROMPT.md / runner-*.md and `contexts/dev/CONTEXT.md` (new **Worker** + **Attempt** terms) describe the nested scheme.
- **Tests:** all fixtures migrated to the nested layout.

## Test status
44/47 green. The 3 reds (`fleet-runner-portability`, `lifecycle-on-session-error`, `statusline` case1) **fail identically on pristine `main`** — pre-existing, unrelated to this cutover.

Branch developed in a worktree; primary checkout stayed on `main` throughout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782676987&installation_id=129708444&pr_number=260&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F260&signature=db846e9c9c2c06eb34e4a630b27ecffa4de3c9cc0632e42eea41cb2435efedd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->