### PR TITLE
chore(upstream): bump pin to e3b90b5 (no cherry-picks)

### DIFF
--- a/.upstream
+++ b/.upstream
@@ -1,2 +1,2 @@
 repo=mattpocock/skills
-sha=0288510dd61ff6ef7c2003834082ab8f2387e80e
+sha=e3b90b5238f38cdea5996e16861dcae28ef52eda

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@ Upstream base: `mattpocock/skills@b8be62ffacb0118fa3eaa29a0923c87c8c11985c` (see
 
 ---
 
+## start (engineering) — upstream CONTEXT-FORMAT.md drift skipped (no cherry-pick)
+
+- **status**: modified
+- **upstream**: `e3b90b5`
+- **why**: Issue #259 — upstream advanced `0288510 → e3b90b5` with a single commit ("Refine rules in CONTEXT-FORMAT.md for clarity and consistency") touching only `grill-with-docs/CONTEXT-FORMAT.md`. That file is our `/start` skill's `CONTEXT-FORMAT.md` (renamed-from `grill-with-docs`), which has intentionally diverged.
+- **what changed**: Reviewed the diff; took nothing. Upstream removed three rules our `/start` flow actively relies on — *Flag conflicts explicitly* (we emit "Flagged ambiguities"), *Show relationships* (cardinality), and *Write an example dialogue* — and reworded *Be opinionated* / loosened *Keep definitions tight* to "one or two sentences" where we already diverged to "One sentence max". Adopting the simplification would regress our grilling session. Same call as the prior drift (#195, bump to `0288510`), which also skipped this file's cosmetic tweaks. Bumped `.upstream` to `e3b90b5`; no skill content changed.
+
+---
+
 ## afk afk-attempts grace-TTL cleanup for completed issues (modified)
 
 - **status**: modified


### PR DESCRIPTION
Resolves #259.

Upstream `mattpocock/skills` advanced `0288510 → e3b90b5` with a single commit refining `grill-with-docs/CONTEXT-FORMAT.md`.

**Decision: no cherry-pick.** That file is our `/start` skill's `CONTEXT-FORMAT.md` (renamed-from `grill-with-docs`), which has intentionally diverged. The upstream change *removes* three rules our grilling flow relies on (Flag conflicts explicitly / Show relationships / Write an example dialogue) and loosens `Keep definitions tight` where we already diverged to "One sentence max". Adopting it would regress `/start`. Same call as the prior drift #195.

- Bumped `.upstream` → `e3b90b5`
- Recorded the skip decision in `CHANGES.md`
- No skill content changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782710054&installation_id=129708444&pr_number=262&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F262&signature=4d5d40e66e6c237dc21412e04ed6cbbec48221bbb70f81d6013b5fd256195806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->