### PR TITLE
feat(afk): statusline reads project root from first arg; 🙋→🆘

### DIFF
--- a/plugins/dev/skills/engineering/afk/scripts/statusline.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/statusline.sh
@@ -3,14 +3,23 @@
 #
 # Reads the Claude Code statusline JSON payload from stdin (cwd, model,
 # effort, context window) and combines it with live /afk worker state
-# from $cwd/.red/tmp/workers/*/*/.
+# from <root>/.red/tmp/workers/*/*/.
+#
+# Root resolution (first match wins):
+#   1. $1 — an explicit project-root directory passed as the first argument.
+#          Wire it in .claude/settings.json as
+#            `bash …/statusline.sh "$CLAUDE_PROJECT_DIR"`
+#          so the statusline always reads the checkout Claude Code was started
+#          in, regardless of where the command itself runs.
+#   2. the stdin payload's .workspace.current_dir / .cwd.
+#   3. $PWD.
 #
 # Output example (no truncation, one line):
-#   red-skills · Opus·high · 47k 24% · 🤖4 📋1 🙋11 🚧10 +12 -3 #17
+#   red-skills · Opus·high · 47k 24% · 🤖4 📋1 🆘11 🚧10 +12 -3 #17
 #
 # Each block is optional and drops out silently when its data is absent
 # (e.g. invoked outside Claude Code → no model/context block;
-#  cwd without `.red/tmp/` → no AFK block).
+#  root without `.red/tmp/` → no AFK block).
 #
 # Stays under 100 ms via a 60 s cache on GitHub-derived counts.
 
@@ -26,9 +35,16 @@ if [[ ! -t 0 ]]; then
   [[ -z "$input" ]] && input='{}'
 fi
 
-# Resolve cwd: prefer payload, fall back to $PWD
-cwd=$(jq -r '.workspace.current_dir // .cwd // empty' <<<"$input" 2>/dev/null)
-[[ -z "$cwd" ]] && cwd="$PWD"
+# Resolve the project root: explicit first arg wins, then the stdin payload,
+# then $PWD. An empty / non-directory first arg falls through to the payload,
+# so `statusline.sh "$CLAUDE_PROJECT_DIR"` stays safe when the var is unset.
+root_arg="${1:-}"
+if [[ -n "$root_arg" && -d "$root_arg" ]]; then
+  cwd="$root_arg"
+else
+  cwd=$(jq -r '.workspace.current_dir // .cwd // empty' <<<"$input" 2>/dev/null)
+  [[ -z "$cwd" ]] && cwd="$PWD"
+fi
 cd "$cwd" 2>/dev/null || true
 
 # ---- Per-project opt-out -------------------------------------------------
@@ -199,7 +215,7 @@ if [[ -d .red/tmp ]]; then
     afk_tokens=()
     (( total_workers > 0 )) && afk_tokens+=("${GREEN}🤖${total_workers}${RESET}")
     (( queue > 0 ))         && afk_tokens+=("📋${queue}")
-    (( human > 0 ))         && afk_tokens+=("${YELLOW}🙋${human}${RESET}")
+    (( human > 0 ))         && afk_tokens+=("${YELLOW}🆘${human}${RESET}")
     (( total_blocked > 0 )) && afk_tokens+=("${RED}🚧${total_blocked}${RESET}")
     (( total_added > 0 ))   && afk_tokens+=("${GREEN}+${total_added}${RESET}")
     (( total_removed > 0 )) && afk_tokens+=("${RED}-${total_removed}${RESET}")

--- a/plugins/dev/skills/engineering/afk/scripts/tests/statusline.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/statusline.test.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # Unit tests for plugins/dev/skills/engineering/afk/scripts/statusline.sh
-# Locks the issue #25 acceptance criteria:
 #
-#   - No live workers (empty .red/tmp) => exit 0, empty stdout.
+# Locks the live render contract:
+#
+#   - No live workers (empty .red/tmp) => the AFK block is absent (no 🤖),
+#     but the project-name block is still emitted.
 #   - One live worker on #17 with +12 -3 from state file => render contains
-#     "🤖 1", "+12 -3", "#17".
-#   - Two live workers => 🤖 2, summed diffstat, both issue numbers.
+#     "🤖1", "+12 -3", "#17", plus the cached counts 📋 / 🆘 / 🚧.
+#   - Two live workers => 🤖2, summed diffstat, both issue numbers, summed 🚧.
 #   - Dead worker (pid not alive) is filtered out via kill -0.
-#   - .red/config.yaml with nested `afk.statusline: false` => exit 0, empty.
+#   - An explicit first-arg root overrides $PWD (the $CLAUDE_PROJECT_DIR wiring).
+#   - .red/config.yaml with `statusline: false` (top-level or nested under
+#     afk:) => exit 0, empty stdout.
 #
 # No GitHub calls: pre-seed the statusline-cache.json so the script never
 # shells out to `gh` during the test.
@@ -26,6 +30,9 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 assert_eq() { assertions=$((assertions+1)); [[ "$1" == "$2" ]] || fail "$3: expected [$2], got [$1]"; }
 assert_contains() { assertions=$((assertions+1)); [[ "$1" == *"$2"* ]] || fail "$3: [$1] does not contain [$2]"; }
 assert_not_contains() { assertions=$((assertions+1)); [[ "$1" != *"$2"* ]] || fail "$3: [$1] should not contain [$2]"; }
+
+# Strip ANSI + OSC 8 hyperlink escapes so assertions match on plain text.
+plain() { sed -E $'s/\e\\[[0-9;]*m//g; s/\e\\]8;;[^\e]*\e\\\\//g'; }
 
 # Pre-seed the cache so the script never calls `gh`.
 seed_cache() {
@@ -50,23 +57,31 @@ make_worker() {
     > "$dir/afk.state.json"
 }
 
+# Run from inside the root (root resolved via $PWD / stdin fallback).
 run_script() {
-  ( cd "$1" && bash "$SCRIPT" )
+  ( cd "$1" && bash "$SCRIPT" ) | plain
+}
+
+# Run from an unrelated cwd, passing the root explicitly as the first arg.
+run_script_arg() {
+  local root="$1"
+  ( cd "$TMP_ROOT" && bash "$SCRIPT" "$root" ) | plain
 }
 
 # ------------------------------------------------------------------
-# Case 1: no .red/tmp => empty stdout, exit 0.
+# Case 1: no .red/tmp => no AFK block (no 🤖), project name still present.
 case1="$TMP_ROOT/c1"
 mkdir -p "$case1"
 out="$(run_script "$case1" || true)"
-assert_eq "$out" "" "case1: empty when .red/tmp missing"
+assert_not_contains "$out" "🤖" "case1: no AFK block when .red/tmp missing"
+assert_contains "$out" "c1" "case1: project-name block still emitted"
 
 # ------------------------------------------------------------------
-# Case 2: .red/tmp exists but no workers => empty stdout.
+# Case 2: .red/tmp exists but no workers => no AFK block.
 case2="$TMP_ROOT/c2"
 mkdir -p "$case2/.red/tmp"
 out="$(run_script "$case2")"
-assert_eq "$out" "" "case2: empty when no worker state files"
+assert_not_contains "$out" "🤖" "case2: no AFK block when no worker state files"
 
 # ------------------------------------------------------------------
 # Case 3: one live worker on #17 with +12 -3 and blocked=2.
@@ -75,12 +90,12 @@ mkdir -p "$case3"
 seed_cache "$case3"
 make_worker "$case3" "alive1" "$$" 17 12 3 2
 out="$(run_script "$case3")"
-assert_contains "$out" "🤖 1" "case3: 🤖 1 worker"
+assert_contains "$out" "🤖1" "case3: 🤖1 worker"
 assert_contains "$out" "+12 -3" "case3: diffstat +12 -3"
 assert_contains "$out" "#17" "case3: issue number"
-assert_contains "$out" "blocked 2" "case3: blocked count"
-assert_contains "$out" "ready 11" "case3: cached ready count"
-assert_contains "$out" "human 3" "case3: cached human count"
+assert_contains "$out" "🚧2" "case3: blocked count"
+assert_contains "$out" "📋11" "case3: cached ready-for-agent count"
+assert_contains "$out" "🆘3" "case3: cached ready-for-human count"
 
 # ------------------------------------------------------------------
 # Case 4: two live workers — diffstats and blocked counts sum, both issue
@@ -91,29 +106,28 @@ seed_cache "$case4"
 make_worker "$case4" "alive1" "$$" 17 12 3 1
 make_worker "$case4" "alive2" "$$" 20 30 7 4
 out="$(run_script "$case4")"
-assert_contains "$out" "🤖 2" "case4: 🤖 2 workers"
+assert_contains "$out" "🤖2" "case4: 🤖2 workers"
 assert_contains "$out" "+42 -10" "case4: summed diffstat"
 assert_contains "$out" "#17" "case4: first issue"
 assert_contains "$out" "#20" "case4: second issue"
-assert_contains "$out" "blocked 5" "case4: summed blocked"
+assert_contains "$out" "🚧5" "case4: summed blocked"
 
 # ------------------------------------------------------------------
 # Case 5: dead worker (pid that no process owns) is excluded.
 case5="$TMP_ROOT/c5"
 mkdir -p "$case5"
 seed_cache "$case5"
-# Pick a pid that is almost certainly not running. 2 is init on some
-# systems and pid 1 is init/systemd. Use a high, unlikely value.
+# Pick a pid that is almost certainly not running.
 dead_pid=99999
 while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid + 1)); done
 make_worker "$case5" "alive1" "$$" 17 5 2 0
 make_worker "$case5" "ghost1" "$dead_pid" 999 100 50 9
 out="$(run_script "$case5")"
-assert_contains "$out" "🤖 1" "case5: 🤖 counts only the live worker"
+assert_contains "$out" "🤖1" "case5: 🤖 counts only the live worker"
 assert_contains "$out" "+5 -2" "case5: diffstat excludes dead worker"
 assert_contains "$out" "#17" "case5: live issue present"
 assert_not_contains "$out" "#999" "case5: dead worker issue absent"
-assert_not_contains "$out" "blocked 9" "case5: dead worker blocked not counted"
+assert_not_contains "$out" "🚧9" "case5: dead worker blocked not counted"
 
 # ------------------------------------------------------------------
 # Case 6: nested afk.statusline: false opt-out.
@@ -139,5 +153,21 @@ statusline: false
 YAML
 out="$(run_script "$case7")"
 assert_eq "$out" "" "case7: opt-out via top-level statusline: false"
+
+# ------------------------------------------------------------------
+# Case 8: explicit first-arg root overrides the cwd. Running from $TMP_ROOT
+# (which has no workers) but passing case8's root must render case8's worker.
+case8="$TMP_ROOT/c8"
+mkdir -p "$case8"
+seed_cache "$case8"
+make_worker "$case8" "alive1" "$$" 42 7 1 0
+out="$(run_script_arg "$case8")"
+assert_contains "$out" "🤖1" "case8: first-arg root is read for workers"
+assert_contains "$out" "#42" "case8: first-arg root's issue number"
+assert_contains "$out" "c8" "case8: project-name block from first-arg root"
+
+# A blank first arg must fall through to the cwd resolution, not break.
+out="$(( cd "$case3" && bash "$SCRIPT" "" ) | plain)"
+assert_contains "$out" "#17" "case8: empty first arg falls back to cwd"
 
 echo "statusline.test.sh: $assertions assertions passed"

--- a/plugins/dev/skills/engineering/statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/statusline/SKILL.md
@@ -33,11 +33,19 @@ numbers. The script is quiet when no AFK worker is active.
 {
   "statusLine": {
     "type": "command",
-    "command": "bash ${CLAUDE_PLUGIN_ROOT}/skills/engineering/afk/scripts/statusline.sh",
+    "command": "bash ${CLAUDE_PLUGIN_ROOT}/skills/engineering/afk/scripts/statusline.sh \"$CLAUDE_PROJECT_DIR\"",
     "refreshInterval": 5
   }
 }
 ```
+
+`${CLAUDE_PLUGIN_ROOT}` is substituted by Claude Code to the installed plugin
+path, so the statusline always runs the newest installed version — never pin a
+`…/cache/<version>/…` path. The trailing `"$CLAUDE_PROJECT_DIR"` is the
+project root Claude Code was started in, passed as the script's first argument
+so it reads that checkout's `.red/tmp/workers/` regardless of where the command
+itself runs; when the variable is unset the script falls back to the stdin
+payload's cwd.
 
 Use `jq` to merge when `.claude/settings.json` already exists. If the file is
 missing, create `.claude/` and write a new settings file. Keep unrelated


### PR DESCRIPTION
## What
- **First-arg root.** `statusline.sh` now takes the project root as `$1` (falling back to the stdin payload / `$PWD`). Wire it as `statusline.sh "$CLAUDE_PROJECT_DIR"` so the statusline always reads the checkout Claude Code was started in, not wherever the command runs. Backward-compatible: a blank/non-dir arg uses the old resolution.
- **Emoji.** ready-for-human `🙋` → `🆘` (clearer 'needs a human').
- **Tests.** `statusline.test.sh` was stale (asserted an old verbose `blocked N / ready N / human N` render and an empty-when-no-workers contract the script dropped once it began always emitting the project-name block). Re-synced to the compact-emoji render and added first-arg + blank-arg coverage. **25 assertions pass.**
- **Docs.** statusline SKILL documents the `"$CLAUDE_PROJECT_DIR"` form and warns against pinning a `cache/<version>` path.

## Why
A user's `.claude/settings.json` had pinned `…/cache/red-skills/dev/1.87.0/…/statusline.sh` (53 versions stale). The documented `${CLAUDE_PLUGIN_ROOT}` form always runs the newest installed version; passing the project root explicitly makes worker discovery robust.

## Validation
`bash …/tests/statusline.test.sh` → 25 assertions passed; `bash -n` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782713865&installation_id=129708444&pr_number=266&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F266&signature=52fc27147d834ffb4a2938095e3fbfb87bce719da747bb138ff65353fb7ba97e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now accepts an explicit directory argument for enhanced working directory resolution, with automatic fallback to default resolution methods.
  * Updated human issue count indicator emoji for improved visual clarity in the statusline display.

* **Documentation**
  * Clarified how the statusline resolves project directories and implements fallback behavior when the primary method is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->