### PR TITLE
merge: #272 AFK reaper: well-formed branch refs + slug guard (kill double-nested names)

### DIFF
--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -38,6 +38,8 @@ source "$SCRIPT_DIR/lib/history.sh"
 source "$SCRIPT_DIR/lib/pin-reader.sh"
 # shellcheck source=./lib/base-resolver.sh
 source "$SCRIPT_DIR/lib/base-resolver.sh"
+# shellcheck source=./lib/branch-ref.sh
+source "$SCRIPT_DIR/lib/branch-ref.sh"
 # Branch-lock value reader (ADR 0031, issue #253). lock-store ships in the
 # sibling branch-lock skill of the same dev plugin, so the relative path is
 # stable. Guard the source — a partial install just behaves as unlocked
@@ -897,9 +899,7 @@ claim_lock_release() {
 
 # ---------- issue selection ----------
 slugify() {
-  echo "$1" | tr '[:upper:]' '[:lower:]' \
-    | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
-    | cut -c1-40
+  afk_ref_slugify "$1"
 }
 
 select_issues() {
@@ -1049,7 +1049,11 @@ branch_diffstat_full() {
 # path now pushes inside envelope_emit_attempt.
 push_attempt_branch() {
   local branch="$1" n="$2" slug="$3"
-  local remote_branch="afk-attempts/${WORKER_ID}/${n}-${slug}"
+  local remote_branch
+  if ! remote_branch="$(afk_ref_build_from_slug afk-attempts "$WORKER_ID" "$n" "$slug")"; then
+    log "warn: refusing malformed attempt branch ref for #${n} (worker=${WORKER_ID}, slug=${slug})"
+    return 1
+  fi
   envelope_push_attempt "$PROJECT_ROOT" "$branch" "$remote_branch" \
     || { log "warn: failed to push attempt branch to origin/${remote_branch}"; return 1; }
 }
@@ -1245,8 +1249,15 @@ emit_envelope() {
   # attempt's handoff can fetch the prior approach and surface why it failed.
   # Written regardless of whether the GitHub envelope post below succeeds — the
   # markers feed the next attempt, not the issue thread.
+  local snapshot_ref=""
   if [[ "$status" != "done" ]]; then
-    record_failure_markers "${ITER_DIR:-}" "afk-attempts/${WORKER_ID}/${n}-${slug}" "$summary"
+    if snapshot_ref="$(afk_ref_build_from_slug afk-attempts "$WORKER_ID" "$n" "$slug")"; then
+      record_failure_markers "${ITER_DIR:-}" "$snapshot_ref" "$summary"
+    else
+      log "warn: refusing malformed snapshot ref for #${n} (worker=${WORKER_ID}, slug=${slug})"
+      record_failure_markers "${ITER_DIR:-}" "" "$summary"
+      snapshot_ref=""
+    fi
   fi
 
   local rc
@@ -1285,7 +1296,7 @@ emit_envelope() {
     envelope_emit_attempt \
       poster=_afk_envelope_poster "status=$status" "issue=$n" "summary=$summary" \
       "repo=$(gh_repo)" "repo_dir=$PROJECT_ROOT" "branch=$branch" \
-      "remote_name=afk-attempts/${WORKER_ID}/${n}-${slug}" \
+      "remote_name=$snapshot_ref" \
       "worktree_rel=$worktree_rel" "diffstat=$full_diffstat" \
       "notes_file=$notes_file" "log_file=$log_file" "hooks_file=$hooks_file"
     rc=$?
@@ -2693,7 +2704,11 @@ _afk_fire_post_attempt() {
 process_issue() {
   local n="$1" title="$2" body="$3"
   local slug; slug="$(slugify "$title")"
-  local branch="afk/${WORKER_ID}/${n}-${slug}"
+  local branch
+  if ! branch="$(afk_ref_build_from_slug afk "$WORKER_ID" "$n" "$slug")"; then
+    log "refusing malformed live branch ref for #${n} (worker=${WORKER_ID}, slug=${slug})"
+    return 0
+  fi
   local started_at; started_at="$(date -Iseconds)"
   local started_epoch; started_epoch="$(date +%s)"
 

--- a/plugins/dev/skills/engineering/afk/scripts/lib/branch-ref.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/branch-ref.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Shared AFK branch-ref construction.
+#
+# Live refs and failed-attempt snapshot refs must keep the same grammar:
+#   afk/{worker}/{issue}-{slug}
+#   afk-attempts/{worker}/{issue}-{slug}
+#
+# The slug is a title slug, not a pre-built branch name. Rejecting slashes in
+# the slug blocks the historic double-nested shape:
+#   afk-attempts/{worker}/{issue}-afk/{worker}/{issue}-{slug}
+
+afk_ref_slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+    | cut -c1-40
+}
+
+afk_ref_validate() {
+  local ref="$1"
+  [[ "$ref" =~ ^afk(-attempts)?/[A-Za-z0-9._-]+/[0-9]+-[a-z0-9-]+$ ]]
+}
+
+afk_ref_build_from_slug() {
+  local namespace="$1" worker_id="$2" issue="$3" slug="$4"
+  case "$namespace" in
+    afk|afk-attempts) ;;
+    *) return 2 ;;
+  esac
+  [[ "$worker_id" =~ ^[A-Za-z0-9._-]+$ ]] || return 2
+  [[ "$issue" =~ ^[0-9]+$ ]] || return 2
+  [[ "$slug" =~ ^[a-z0-9-]+$ ]] || return 2
+
+  local ref="${namespace}/${worker_id}/${issue}-${slug}"
+  afk_ref_validate "$ref" || return 2
+  printf '%s\n' "$ref"
+}
+
+afk_ref_build() {
+  local namespace="$1" worker_id="$2" issue="$3" title="$4"
+  local slug
+  slug="$(afk_ref_slugify "$title")"
+  afk_ref_build_from_slug "$namespace" "$worker_id" "$issue" "$slug"
+}

--- a/plugins/dev/skills/engineering/afk/scripts/supervisor.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/supervisor.sh
@@ -84,6 +84,8 @@ source "$SCRIPT_DIR/config.sh"
 source "$SCRIPT_DIR/hooks.sh"
 # shellcheck source=./lib/envelope.sh
 source "$SCRIPT_DIR/lib/envelope.sh"
+# shellcheck source=./lib/branch-ref.sh
+source "$SCRIPT_DIR/lib/branch-ref.sh"
 # shellcheck source=./lib/reaper-signal.sh
 source "$SCRIPT_DIR/lib/reaper-signal.sh"
 
@@ -876,7 +878,7 @@ reap_stalled_slot() {
   local orch_pid="${SLOT_PIDS[$slot]:-}"
   local iter_dir; iter_dir="$(find_slot_iter_dir "$slot")"
 
-  local issue="" title="" slug="" worker_id="" started_at=""
+  local issue="" title="" slug="" worker_id="" started_at="" branch=""
   if [[ -n "$iter_dir" && -f "$iter_dir/afk.state.json" ]] \
      && command -v jq >/dev/null 2>&1; then
     local sf="$iter_dir/afk.state.json"
@@ -930,8 +932,15 @@ reap_stalled_slot() {
     summary="$(printf 'worker `%s` · status: no-sentinel · duration: %s · diff: stall-reaped · attempt: 1 · reason: stall-reaped' \
       "${worker_id:-unknown}" "$(envelope_fmt_duration "$duration_s")")"
 
-    local branch="afk/${worker_id}/${issue}-${slug}"
-    local remote_name="afk-attempts/${worker_id}/${issue}-${slug}"
+    local remote_name=""
+    if ! branch="$(afk_ref_build_from_slug afk "$worker_id" "$issue" "$slug")"; then
+      log "slot $slot reap: refusing malformed live branch ref (worker=${worker_id:-?}, issue=${issue:-?}, slug=${slug:-?})"
+      branch=""
+    fi
+    if ! remote_name="$(afk_ref_build_from_slug afk-attempts "$worker_id" "$issue" "$slug")"; then
+      log "slot $slot reap: refusing malformed snapshot ref (worker=${worker_id:-?}, issue=${issue:-?}, slug=${slug:-?})"
+      remote_name=""
+    fi
     local worktree_rel=".red/tmp/${iter_dir#"$TMP_DIR"/}/worktree"
     local repo_dir="$iter_dir/worktree"
     [[ -d "$repo_dir" ]] || repo_dir=""
@@ -966,8 +975,8 @@ reap_stalled_slot() {
   if [[ -n "$iter_dir" && -d "$iter_dir/worktree" ]]; then
     git -C "$PROJECT_ROOT" worktree remove --force "$iter_dir/worktree" >/dev/null 2>&1 || true
   fi
-  if [[ -n "$worker_id" && -n "$issue" && -n "$slug" ]]; then
-    git -C "$PROJECT_ROOT" branch -D "afk/${worker_id}/${issue}-${slug}" >/dev/null 2>&1 || true
+  if [[ -n "$branch" ]]; then
+    git -C "$PROJECT_ROOT" branch -D "$branch" >/dev/null 2>&1 || true
   fi
   if [[ -n "$iter_dir" && -d "$iter_dir" ]]; then
     rm -rf "$iter_dir" || true

--- a/plugins/dev/skills/engineering/afk/scripts/tests/branch-ref-guard.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/branch-ref-guard.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Tests for AFK branch-ref construction and malformed nested-ref rejection.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIB="$HERE/../lib/branch-ref.sh"
+
+# shellcheck source=../lib/branch-ref.sh
+source "$LIB"
+
+pass=0
+fail=0
+
+expect_eq() {
+  local label="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "PASS  $label"; pass=$((pass + 1))
+  else
+    printf 'FAIL  %s\n  got:  >>%s<<\n  want: >>%s<<\n' "$label" "$got" "$want"
+    fail=$((fail + 1))
+  fi
+}
+
+expect_ok() {
+  local label="$1"; shift
+  if "$@"; then echo "PASS  $label"; pass=$((pass + 1))
+  else echo "FAIL  $label (command failed: $*)"; fail=$((fail + 1)); fi
+}
+
+expect_not_ok() {
+  local label="$1"; shift
+  if "$@"; then echo "FAIL  $label (unexpectedly succeeded: $*)"; fail=$((fail + 1))
+  else echo "PASS  $label"; pass=$((pass + 1)); fi
+}
+
+expect_matches_ref() {
+  local label="$1" ref="$2" wid="$3" issue="$4"
+  if [[ "$ref" =~ ^afk(-attempts)?/${wid}/${issue}-[a-z0-9-]+$ ]]; then
+    echo "PASS  $label"; pass=$((pass + 1))
+  else
+    echo "FAIL  $label — malformed ref: $ref"; fail=$((fail + 1))
+  fi
+}
+
+expect_slug_has_no_afk_token() {
+  local label="$1" ref="$2"
+  local slug="${ref#*/}"
+  slug="${slug#*/}"
+  slug="${slug#*-}"
+  if [[ "$slug" == *"afk/"* ]]; then
+    echo "FAIL  $label — slug contains embedded afk/ token: $slug"; fail=$((fail + 1))
+  else
+    echo "PASS  $label"; pass=$((pass + 1))
+  fi
+}
+
+# Matrix: namespace x worker x issue x title. Expected slugs preserve the
+# historical slugify contract, including the 40-character byte cut.
+while IFS='|' read -r wid issue title expected_slug; do
+  [[ -n "$wid" ]] || continue
+  for ns in afk afk-attempts; do
+    ref="$(afk_ref_build "$ns" "$wid" "$issue" "$title")"
+    expect_eq "build $ns/$wid/$issue from title" "$ref" "$ns/$wid/$issue-$expected_slug"
+    expect_matches_ref "shape $ns/$wid/$issue" "$ref" "$wid" "$issue"
+    expect_slug_has_no_afk_token "slug has no afk/ token $ns/$wid/$issue" "$ref"
+  done
+done <<'CASES'
+wPMN2|272|AFK reaper: well-formed branch refs + slug guard (kill double-nested names)|afk-reaper-well-formed-branch-refs-slug-
+wAB12|5|Use /afk attempt cleanup!|use-afk-attempt-cleanup
+w9Z0|100|Already good slug|already-good-slug
+CASES
+
+# Known regression: the old bad shape nested the live branch inside the
+# snapshot namespace, e.g. afk-attempts/{wid}/{issue}-afk/{wid}/{issue}-{slug}.
+known_bad="afk-attempts/wPMN2/272-afk/wPMN2/272-afk-reaper-well-formed-branch-refs-slug-"
+expect_not_ok "known double-nested ref is rejected" afk_ref_validate "$known_bad"
+
+bad_slug="afk/wPMN2/272-afk-reaper-well-formed-branch-refs-slug-"
+expect_not_ok "branch-like slug is rejected before construction" \
+  afk_ref_build_from_slug afk-attempts wPMN2 272 "$bad_slug"
+
+legacy_good="$(afk_ref_build_from_slug afk-attempts wPMN2 272 afk-reaper-well-formed-branch-refs-slug-)"
+expect_eq "well-formed slug keeps existing snapshot ref" \
+  "$legacy_good" "afk-attempts/wPMN2/272-afk-reaper-well-formed-branch-refs-slug-"
+
+expect_not_ok "unknown namespace rejected" afk_ref_build nope wPMN2 272 "Some title"
+expect_not_ok "slash in worker rejected" afk_ref_build afk "wPM/N2" 272 "Some title"
+expect_not_ok "non-numeric issue rejected" afk_ref_build afk wPMN2 "272x" "Some title"
+expect_not_ok "empty slug rejected" afk_ref_build_from_slug afk wPMN2 272 ""
+
+echo
+echo "branch-ref-guard: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Automated AFK landing for #272. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782716321&installation_id=129708444&pr_number=276&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F276&signature=1fe6d63afe45a1101d467f3ebdd56e37b6e2302d2e6e9450218b227f7352a88c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized branch and reference naming logic across AFK scripts for consistent handling.
  * Improved validation safeguards for reference names to prevent malformed references.

* **Tests**
  * Added comprehensive test suite for branch reference construction and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->