### PR TITLE
merge: #271 AFK reaper: 404-aware grace cleanup for afk-attempts/* (pure keep/reap decider)

### DIFF
--- a/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
@@ -151,13 +151,166 @@ delete_remote() {
 
 # _attempt_snapshot_grace_s  →  prints the resolved grace window in seconds
 # (default 7 days). A completed issue's snapshot branches survive this long after
-# the issue closed before they are deleted. Defensive: a non-numeric
+# the issue closed; a 404 issue's branch survives this long after the branch's
+# last commit. Defensive: a non-numeric
 # RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S falls back to the default so an operator typo
 # can never silently disable the grace. 0 is honoured (delete immediately on
 # completion) — unlike the count/age caps, a zero grace is a meaningful config.
 _attempt_snapshot_grace_s() {
   local v="${RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S:-$((7 * 86400))}"
   if [[ "$v" =~ ^[0-9]+$ ]]; then echo "$v"; else echo $((7 * 86400)); fi
+}
+
+# _attempt_snapshot_issue_from_branch <branch>
+#
+# Extract the issue number from afk-attempts/{worker}/{N}-slug. Echoes nothing
+# for malformed refs so callers can skip them without treating bad remote data as
+# fatal.
+_attempt_snapshot_issue_from_branch() {
+  local branch="$1" rest issue
+  [[ "$branch" == afk-attempts/*/* ]] || return 0
+  rest="${branch#afk-attempts/*/}"  # {N}-slug
+  issue="${rest%%-*}"               # {N}
+  [[ "$issue" =~ ^[0-9]+$ ]] || return 0
+  printf '%s\n' "$issue"
+}
+
+# attempt_snapshot_cleanup_plan <refs> <classifier-fn> <now-s> <grace-s>
+#
+# Pure keep/reap decider for the `afk-attempts/*` namespace. <refs> is a
+# synthetic ls-remote-shaped list:
+#
+#   <sha><TAB>refs/heads/afk-attempts/{worker}/{issue}-slug[<TAB><commit-s>]
+#
+# The optional third field is the branch's last-commit epoch and is required only
+# for `not-found`, where there is no issue closedAt timestamp to anchor grace.
+# <classifier-fn> is called as `<classifier-fn> <issue>` and must echo one of:
+# open, closed-within-grace, closed-past-grace, not-found, unresolved-transient.
+# The function performs no git/gh/date I/O and emits:
+#
+#   keep|reap<TAB><branch><TAB><issue><TAB><classification>
+attempt_snapshot_cleanup_plan() {
+  local refs="$1" classifier="$2" now_s="$3" grace_s="$4"
+  [[ "$now_s" =~ ^[0-9]+$ ]] || return 0
+  [[ "$grace_s" =~ ^[0-9]+$ ]] || grace_s=$((7 * 86400))
+  declare -F "$classifier" >/dev/null 2>&1 || return 0
+
+  local -A issue_class=()
+  local line sha ref branch commit_s issue class action
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    IFS=$'\t' read -r sha ref commit_s _ <<<"$line"
+    [[ "$ref" == refs/heads/afk-attempts/* ]] || continue
+    branch="${ref#refs/heads/}"
+    issue="$(_attempt_snapshot_issue_from_branch "$branch")"
+    [[ -n "$issue" ]] || continue
+
+    if [[ -n "${issue_class[$issue]+set}" ]]; then
+      class="${issue_class[$issue]}"
+    else
+      class="$("$classifier" "$issue" 2>/dev/null || true)"
+      case "$class" in
+        open|closed-within-grace|closed-past-grace|not-found|unresolved-transient) ;;
+        *) class="unresolved-transient" ;;
+      esac
+      issue_class["$issue"]="$class"
+    fi
+
+    action="keep"
+    case "$class" in
+      closed-past-grace)
+        action="reap"
+        ;;
+      not-found)
+        if [[ "$commit_s" =~ ^[0-9]+$ ]] && (( now_s - commit_s > grace_s )); then
+          action="reap"
+        fi
+        ;;
+      open|closed-within-grace|unresolved-transient)
+        action="keep"
+        ;;
+    esac
+
+    printf '%s\t%s\t%s\t%s\n' "$action" "$branch" "$issue" "$class"
+  done <<<"$refs"
+}
+
+# _attempt_snapshot_branch_commit_s <repo-dir> <sha> <branch>
+#
+# Best-effort branch last-commit epoch for 404 grace decisions. Prefer a local
+# object lookup, then shallow-fetch that one remote branch into a remote-tracking
+# ref. Echoes nothing if the date cannot be proved, which makes not-found refs
+# stay in the keep plan.
+_attempt_snapshot_branch_commit_s() {
+  local repo_dir="$1" sha="$2" branch="$3" remote_ref
+  if [[ -n "$sha" ]] && git -C "$repo_dir" cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    git -C "$repo_dir" show -s --format=%ct "$sha" 2>/dev/null && return 0
+  fi
+  remote_ref="refs/remotes/origin/${branch}"
+  if git -C "$repo_dir" fetch --quiet --depth=1 origin "refs/heads/${branch}:${remote_ref}" >/dev/null 2>&1; then
+    git -C "$repo_dir" show -s --format=%ct "$remote_ref" 2>/dev/null && return 0
+  fi
+  return 0
+}
+
+# _attempt_snapshot_refs_with_commit_dates <repo-dir> <refs>
+#
+# Add a third `<commit-s>` field to ls-remote rows for the pure decider. Tests may
+# pass a synthetic third field already; production rows are augmented
+# best-effort.
+_attempt_snapshot_refs_with_commit_dates() {
+  local repo_dir="$1" refs="$2"
+  local line sha ref commit_s branch
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    IFS=$'\t' read -r sha ref commit_s _ <<<"$line"
+    [[ "$ref" == refs/heads/afk-attempts/* ]] || continue
+    branch="${ref#refs/heads/}"
+    if [[ ! "$commit_s" =~ ^[0-9]+$ ]]; then
+      commit_s="$(_attempt_snapshot_branch_commit_s "$repo_dir" "$sha" "$branch")"
+    fi
+    printf '%s\t%s\t%s\n' "$sha" "$ref" "$commit_s"
+  done <<<"$refs"
+}
+
+# _attempt_snapshot_issue_state_from_gh <repo> <issue> <now-s> <grace-s>
+#
+# Translate the side-effecting GitHub issue lookup into the small state vocabulary
+# consumed by the pure decider. A definitive 404 is `not-found`; every other
+# lookup/parsing problem is `unresolved-transient`, which the planner keeps.
+_attempt_snapshot_issue_state_from_gh() {
+  local repo="$1" issue="$2" now_s="$3" grace_s="$4"
+  local meta state closed_at closed_s lower
+  meta="$(gh -R "$repo" issue view "$issue" --json state,closedAt 2>&1)" || {
+    lower="${meta,,}"
+    if [[ "$lower" == *"404"* || "$lower" == *"not found"* || "$lower" == *"could not resolve"* ]]; then
+      printf 'not-found\n'
+    else
+      printf 'unresolved-transient\n'
+    fi
+    return 0
+  }
+
+  state="$(jq -r '.state // ""' <<<"$meta" 2>/dev/null)"
+  case "$state" in
+    OPEN)
+      printf 'open\n'
+      ;;
+    CLOSED)
+      closed_at="$(jq -r '.closedAt // ""' <<<"$meta" 2>/dev/null)"
+      [[ -n "$closed_at" ]] || { printf 'unresolved-transient\n'; return 0; }
+      closed_s="$(date -d "$closed_at" +%s 2>/dev/null)" || { printf 'unresolved-transient\n'; return 0; }
+      [[ "$closed_s" =~ ^[0-9]+$ ]] || { printf 'unresolved-transient\n'; return 0; }
+      if (( now_s - closed_s > grace_s )); then
+        printf 'closed-past-grace\n'
+      else
+        printf 'closed-within-grace\n'
+      fi
+      ;;
+    *)
+      printf 'unresolved-transient\n'
+      ;;
+  esac
 }
 
 # prune_completed_attempt_branches [root]
@@ -168,7 +321,8 @@ _attempt_snapshot_grace_s() {
 #   - still OPEN                          → never touched (leave every branch).
 #   - CLOSED, closed <= grace ago         → kept (a reopen can still recover it).
 #   - CLOSED, closed >  grace ago         → every snapshot branch deleted.
-#   - unclassifiable (gh error/no close)  → left strictly untouched.
+#   - issue API 404, branch age > grace   → that snapshot branch deleted.
+#   - unclassifiable/transient gh error   → left strictly untouched.
 # The grace window is _attempt_snapshot_grace_s. Best-effort and always rc 0:
 # called at boot, never on the close path, so a slow/failing `gh` or `git` can
 # never block a completion. `gh_repo` is provided by the orchestrator that
@@ -185,43 +339,25 @@ prune_completed_attempt_branches() {
   refs="$(git -C "$repo_dir" ls-remote --heads origin 'refs/heads/afk-attempts/*' 2>/dev/null)" || return 0
   [[ -n "$refs" ]] || return 0
 
-  # Group branch names by the issue number embedded in afk-attempts/{wid}/{N}-slug.
-  local -A issue_branches=()
-  local line ref branch issue rest
-  while IFS= read -r line; do
-    [[ -n "$line" ]] || continue
-    ref="${line#*$'\t'}"          # drop the leading "<sha><TAB>"
-    branch="${ref#refs/heads/}"   # afk-attempts/{wid}/{N}-slug
-    rest="${branch#afk-attempts/*/}"  # {N}-slug
-    issue="${rest%%-*}"               # {N}
-    [[ "$issue" =~ ^[0-9]+$ ]] || continue
-    issue_branches["$issue"]+="${branch}"$'\n'
-  done <<<"$refs"
+  local refs_with_dates plan
+  refs_with_dates="$(_attempt_snapshot_refs_with_commit_dates "$repo_dir" "$refs")"
 
-  local deleted=0 issue
-  for issue in "${!issue_branches[@]}"; do
-    local meta state closed_at closed_s
-    meta="$(gh -R "$repo" issue view "$issue" --json state,closedAt 2>/dev/null)" || continue
-    [[ -n "$meta" ]] || continue
-    state="$(jq -r '.state // ""' <<<"$meta" 2>/dev/null)"
-    # Only a provably-CLOSED issue is eligible; OPEN or unknown → never touched.
-    [[ "$state" == "CLOSED" ]] || continue
-    closed_at="$(jq -r '.closedAt // ""' <<<"$meta" 2>/dev/null)"
-    [[ -n "$closed_at" ]] || continue
-    closed_s="$(date -d "$closed_at" +%s 2>/dev/null)" || continue
-    [[ -n "$closed_s" ]] || continue
-    (( now_s - closed_s > grace )) || continue   # still within grace → keep
+  _attempt_snapshot_prune_classifier() {
+    _attempt_snapshot_issue_state_from_gh "$repo" "$1" "$now_s" "$grace"
+  }
+  plan="$(attempt_snapshot_cleanup_plan "$refs_with_dates" _attempt_snapshot_prune_classifier "$now_s" "$grace")"
+  unset -f _attempt_snapshot_prune_classifier 2>/dev/null || true
 
-    while IFS= read -r branch; do
-      [[ -n "$branch" ]] || continue
-      if git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
-        deleted=$((deleted + 1))
-      else
-        _remote_branch_log "warn: failed to delete remote snapshot ${branch}, survives on origin for cleanup later"
-      fi
-    done <<<"${issue_branches[$issue]}"
-  done
+  local deleted=0 action branch issue class
+  while IFS=$'\t' read -r action branch issue class; do
+    [[ "$action" == "reap" && -n "$branch" ]] || continue
+    if git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
+      deleted=$((deleted + 1))
+    else
+      _remote_branch_log "warn: failed to delete remote snapshot ${branch}, survives on origin for cleanup later"
+    fi
+  done <<<"$plan"
 
-  [[ $deleted -gt 0 ]] && _remote_branch_log "snapshot cleanup: deleted $deleted completed-issue attempt branch(es) past the grace window"
+  [[ $deleted -gt 0 ]] && _remote_branch_log "snapshot cleanup: deleted $deleted attempt snapshot branch(es) past the grace window"
   return 0
 }

--- a/plugins/dev/skills/engineering/afk/scripts/tests/snapshot-grace-cleanup.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/snapshot-grace-cleanup.test.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# Tests for issue #258 (PRD #244): remote-side grace-TTL cleanup of the
-# afk-attempts/{wid}/{n}-{slug} snapshot branches for completed issues.
+# Tests for issue #258 / #271 (PRD #244): remote-side grace-TTL cleanup of the
+# afk-attempts/{wid}/{n}-{slug} snapshot branches for completed or 404 issues.
 #
 #   prune_completed_attempt_branches [root]
 #     Lists the remote afk-attempts/* snapshot branches, groups them by issue,
-#     classifies each issue via `gh issue view`, and deletes the branches of
-#     issues that closed more than RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S seconds ago.
-#     Open issues, within-grace closed issues, and unclassifiable issues are
-#     left strictly untouched. Best-effort, always rc 0, never on the close path.
+#     plans keep/reap decisions through a pure decider, then deletes branches for
+#     issues that closed more than RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S seconds ago
+#     or whose issue 404s and whose branch commit predates the grace window.
+#     Open issues, within-grace branches, and transient API failures are left
+#     strictly untouched. Best-effort, always rc 0, never on the close path.
 #
 # git and gh are mocked via PATH override:
 #   - `git ... ls-remote ...` prints a fixture ref list.
@@ -69,6 +70,9 @@ while (( i <= \$# )); do
 done
 f="$GH_DIR/\$n.json"
 if [[ -n "\$n" && -f "\$f" ]]; then cat "\$f"; exit 0; fi
+if [[ -n "\$n" && -f "$GH_DIR/\$n.404" ]]; then echo "HTTP 404: Not Found" >&2; exit 1; fi
+if [[ -n "\$n" && -f "$GH_DIR/\$n.error" ]]; then cat "$GH_DIR/\$n.error" >&2; exit 1; fi
+echo "HTTP 500: transient failure" >&2
 exit 1
 SHIM
 chmod 0755 "$SHIM_DIR/gh"
@@ -123,12 +127,15 @@ expect_rc0() {
 
 # An ISO-8601 UTC timestamp N seconds in the past (uses the same `date` the lib does).
 iso_ago() { date -u -d "@$(( $(date +%s) - $1 ))" +%Y-%m-%dT%H:%M:%SZ; }
+epoch_ago() { echo "$(( $(date +%s) - $1 ))"; }
 
 # Helper to write a gh fixture for an issue.
 gh_fixture() { # <issue> <state> <closedAt-or-empty>
   local n="$1" state="$2" closed="$3"
   printf '{"state":"%s","closedAt":"%s"}\n' "$state" "$closed" >"$GH_DIR/$n.json"
 }
+gh_404() { rm -f "$GH_DIR/$1.json" "$GH_DIR/$1.error"; : >"$GH_DIR/$1.404"; }
+gh_error() { rm -f "$GH_DIR/$1.json" "$GH_DIR/$1.404"; printf '%s\n' "${2:-rate limit}" >"$GH_DIR/$1.error"; }
 
 DAY=86400
 PROJECT_ROOT="$TMP"   # repo dir for `git -C`; real git verbs are delegated harmlessly
@@ -136,20 +143,58 @@ PROJECT_ROOT="$TMP"   # repo dir for `git -C`; real git verbs are delegated harm
 # shellcheck source=../lib/remote-branch.sh
 source "$LIB"
 
-# Remote ref fixture: three issues, two workers, two snapshots for #300.
+# ---------- pure decider: all classification states ----------
+declare -A DECIDER_CLASS=(
+  [400]=open
+  [401]=closed-within-grace
+  [402]=closed-past-grace
+  [403]=not-found
+  [404]=not-found
+  [405]=unresolved-transient
+)
+decider_classifier() { printf '%s\n' "${DECIDER_CLASS[$1]:-unresolved-transient}"; }
+
+fixed_now=1700000000
+decider_refs="$(cat <<EOF
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk-attempts/wAAA/400-open	$((fixed_now - 30*DAY))
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk-attempts/wAAA/401-fresh-closed	$((fixed_now - 30*DAY))
+cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk-attempts/wAAA/402-old-closed	$((fixed_now - 30*DAY))
+dddddddddddddddddddddddddddddddddddddddd	refs/heads/afk-attempts/wAAA/403-old-missing	$((fixed_now - 30*DAY))
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee	refs/heads/afk-attempts/wAAA/404-fresh-missing	$((fixed_now - 1*DAY))
+ffffffffffffffffffffffffffffffffffffffff	refs/heads/afk-attempts/wAAA/405-rate-limited	$((fixed_now - 30*DAY))
+EOF
+)"
+plan="$(attempt_snapshot_cleanup_plan "$decider_refs" decider_classifier "$fixed_now" "$((7*DAY))")"
+expect_contains "decider: keeps open issue branch" "$plan" $'keep	afk-attempts/wAAA/400-open	400	open'
+expect_contains "decider: keeps closed issue within grace" "$plan" $'keep	afk-attempts/wAAA/401-fresh-closed	401	closed-within-grace'
+expect_contains "decider: reaps closed issue past grace" "$plan" $'reap	afk-attempts/wAAA/402-old-closed	402	closed-past-grace'
+expect_contains "decider: reaps 404 branch past branch-age grace" "$plan" $'reap	afk-attempts/wAAA/403-old-missing	403	not-found'
+expect_contains "decider: keeps 404 branch within branch-age grace" "$plan" $'keep	afk-attempts/wAAA/404-fresh-missing	404	not-found'
+expect_contains "decider: keeps transient issue API failure" "$plan" $'keep	afk-attempts/wAAA/405-rate-limited	405	unresolved-transient'
+
+# Remote ref fixture: six issues, two workers, two snapshots for #300.
 cat >"$LSREMOTE_FILE" <<EOF
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk-attempts/wAAA/300-old-completed
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk-attempts/wBBB/300-old-completed
-cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk-attempts/wAAA/301-fresh-completed
-dddddddddddddddddddddddddddddddddddddddd	refs/heads/afk-attempts/wAAA/302-still-open
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk-attempts/wAAA/300-old-completed	$(epoch_ago $((30*DAY)))
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk-attempts/wBBB/300-old-completed	$(epoch_ago $((30*DAY)))
+cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk-attempts/wAAA/301-fresh-completed	$(epoch_ago $((1*DAY)))
+dddddddddddddddddddddddddddddddddddddddd	refs/heads/afk-attempts/wAAA/302-still-open	$(epoch_ago $((30*DAY)))
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee	refs/heads/afk-attempts/wAAA/303-old-missing	$(epoch_ago $((30*DAY)))
+ffffffffffffffffffffffffffffffffffffffff	refs/heads/afk-attempts/wAAA/304-fresh-missing	$(epoch_ago $((1*DAY)))
+9999999999999999999999999999999999999999	refs/heads/afk-attempts/wAAA/305-rate-limited	$(epoch_ago $((30*DAY)))
 EOF
 
 # #300 closed 30 days ago  → past a 7-day grace → branches deleted (cross-worker)
 # #301 closed 1 day ago    → within a 7-day grace → kept
 # #302 open                → never touched
+# #303 issue 404, commit 30 days ago → past a 7-day grace → branch deleted
+# #304 issue 404, commit 1 day ago   → within a 7-day grace → kept
+# #305 gh transient failure          → never touched
 gh_fixture 300 CLOSED "$(iso_ago $((30*DAY)))"
 gh_fixture 301 CLOSED "$(iso_ago $((1*DAY)))"
 gh_fixture 302 OPEN ""
+gh_404 303
+gh_404 304
+gh_error 305 "rate limit"
 
 # ---------- past-grace completed issue is deleted (cross-worker) ----------
 reset_calls
@@ -165,15 +210,24 @@ expect_not_contains "prune: keeps #301 snapshot (within grace)" "$log_out" "--de
 # ---------- still-open issue is never touched ----------
 expect_not_contains "prune: never deletes open #302 snapshot" "$log_out" "--delete afk-attempts/wAAA/302-still-open"
 
+# ---------- definitive 404s use branch last-commit age for grace ----------
+expect_contains "prune: deletes old 404 #303 snapshot" "$log_out" "push origin --delete afk-attempts/wAAA/303-old-missing"
+expect_not_contains "prune: keeps fresh 404 #304 snapshot" "$log_out" "--delete afk-attempts/wAAA/304-fresh-missing"
+
+# ---------- transient issue API failure is never touched ----------
+expect_not_contains "prune: never deletes transient #305 snapshot" "$log_out" "--delete afk-attempts/wAAA/305-rate-limited"
+
 # ---------- grace is configurable: a huge grace keeps everything ----------
 reset_calls
 RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=$((365*DAY)) prune_completed_attempt_branches
 expect_not_contains "prune: 1y grace keeps #300 too" "$(calls)" "--delete afk-attempts/wAAA/300-old-completed"
+expect_not_contains "prune: 1y grace keeps 404 #303 too" "$(calls)" "--delete afk-attempts/wAAA/303-old-missing"
 
 # ---------- grace of 0 deletes any completed issue immediately ----------
 reset_calls
 RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=0 prune_completed_attempt_branches
 expect_contains "prune: 0 grace deletes #301 (completed)" "$(calls)" "push origin --delete afk-attempts/wAAA/301-fresh-completed"
+expect_contains "prune: 0 grace deletes #304 (404)" "$(calls)" "push origin --delete afk-attempts/wAAA/304-fresh-missing"
 expect_not_contains "prune: 0 grace still spares open #302" "$(calls)" "--delete afk-attempts/wAAA/302-still-open"
 
 # ---------- defensive grace reader: a typo falls back to the default, not disabled ----------
@@ -190,11 +244,11 @@ reset_calls
 RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=$((7*DAY)) \
   expect_rc0 "prune: tolerates a failing git delete" prune_completed_attempt_branches
 
-# ---------- unclassifiable issue (gh error) is left untouched ----------
+# ---------- transient issue (gh error) is left untouched ----------
 reset_calls
 rm -f "$GH_DIR/300.json"   # gh now fails for #300 → cannot classify → skip
 RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=$((7*DAY)) prune_completed_attempt_branches
-expect_not_contains "prune: gh-error issue #300 left untouched" "$(calls)" "--delete afk-attempts/wAAA/300-old-completed"
+expect_not_contains "prune: gh-error issue #300 left untouched as transient" "$(calls)" "--delete afk-attempts/wAAA/300-old-completed"
 gh_fixture 300 CLOSED "$(iso_ago $((30*DAY)))"   # restore for any later use
 
 # ---------- no remote snapshots → rc 0 no-op ----------


### PR DESCRIPTION
Automated AFK landing for #271. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782716334&installation_id=129708444&pr_number=277&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F277&signature=9b627d312276080ca41a4f7df084e0a7fb7053363444cd660eceadc1c438448f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced remote snapshot branch cleanup with improved classification of completed and missing branches, including better handling of retention windows and edge cases.

* **Tests**
  * Expanded test coverage for branch cleanup scenarios, including missing branches, stale snapshots, transient API failures, and various retention configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->