### PR TITLE
merge: #274 AFK reaper: local afk/* branch GC at boot (closed/merged, never checked-out)

### DIFF
--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -3384,6 +3384,10 @@ cap_issue_attempts
 # that closed more than the grace window ago. Within-grace and still-open issues
 # are left in place. Best-effort and never on the close path — runs here at boot.
 prune_completed_attempt_branches
+# Local live-branch cleanup (issue #274, PRD #244): drop stale local afk/*
+# branches for issues that are already closed while explicitly skipping any
+# branch checked out by a registered worktree. Best-effort boot hygiene only.
+prune_completed_local_branches
 sweep_unblocked
 
 # --- straggler check: warn about issues that never made it to ready-for-agent

--- a/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
@@ -28,6 +28,12 @@
 #     0; if delete fails (branch protection, network) the close path still
 #     proceeds.
 #
+#   prune_completed_local_branches [repo-dir]   (issue #274)
+#     The boot-time local reaper for stale `afk/{wid}/{N}-slug` branches. It
+#     reuses the same S1 issue-state classifier as the snapshot reaper, deletes
+#     branches whose issue is CLOSED, keeps OPEN/unclassified branches, and
+#     refuses to touch any branch checked out by a git worktree.
+#
 # The live-push lifecycle above (push_initial / install_post_commit_hook /
 # delete_remote) deliberately touches ONLY the `afk/{wid}/{N}-slug` namespace.
 # The `afk-attempts/{wid}/{N}-slug` failure-push namespace stays the canonical
@@ -146,6 +152,86 @@ delete_remote() {
   if ! git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
     _remote_branch_log "warn: failed to delete remote ${branch} after close, branch survives on origin for cleanup later"
   fi
+  return 0
+}
+
+# _local_afk_issue_from_branch <branch>
+#
+# Extract the issue number from a well-formed local live branch:
+# afk/{worker}/{N}-slug. Echoes nothing for malformed or non-live refs so the
+# cleanup cannot accidentally act on adjacent namespaces such as afk-attempts/*.
+_local_afk_issue_from_branch() {
+  local branch="$1" rest issue
+  [[ "$branch" =~ ^afk/[^/]+/[0-9]+-[a-z0-9-]+$ ]] || return 0
+  rest="${branch#afk/*/}"  # {N}-slug
+  issue="${rest%%-*}"      # {N}
+  [[ "$issue" =~ ^[0-9]+$ ]] || return 0
+  printf '%s\n' "$issue"
+}
+
+# _local_checked_out_branches <repo-dir>
+#
+# Print branch short names currently checked out by any registered worktree.
+# `git branch -d` would reject these too, but this explicit guard is the safety
+# contract for the boot reaper: checked-out branches are skipped before issue
+# classification or deletion.
+_local_checked_out_branches() {
+  local repo_dir="$1" line
+  git -C "$repo_dir" worktree list --porcelain 2>/dev/null | while IFS= read -r line; do
+    [[ "$line" == branch\ refs/heads/* ]] || continue
+    printf '%s\n' "${line#branch refs/heads/}"
+  done
+}
+
+# prune_completed_local_branches [repo-dir]
+#
+# Boot-time cleanup for local `afk/*` live-worker branches left behind after
+# their issue has already closed. Best-effort and always rc 0. Safety rules:
+#   - checked-out branches are skipped without classification.
+#   - OPEN, missing, and transiently unclassifiable issues are kept.
+#   - CLOSED issues are deleted with `git branch -d` only, so an unexpectedly
+#     unmerged branch survives for manual inspection instead of being forced.
+prune_completed_local_branches() {
+  local repo_dir="${1:-${PROJECT_ROOT:-$(pwd)}}"
+  local repo now_s
+  repo="$(gh_repo 2>/dev/null)" || return 0
+  [[ -n "$repo" ]] || return 0
+  now_s="$(date +%s)"
+
+  local branches
+  branches="$(git -C "$repo_dir" for-each-ref --format='%(refname:short)' refs/heads/afk 2>/dev/null)" || return 0
+  [[ -n "$branches" ]] || return 0
+
+  local -A checked=()
+  local b
+  while IFS= read -r b; do
+    [[ -n "$b" ]] && checked["$b"]=1
+  done < <(_local_checked_out_branches "$repo_dir")
+
+  local deleted=0 branch issue class
+  while IFS= read -r branch; do
+    [[ -n "$branch" ]] || continue
+    [[ -z "${checked[$branch]+set}" ]] || continue
+    issue="$(_local_afk_issue_from_branch "$branch")"
+    [[ -n "$issue" ]] || continue
+
+    class="$(_attempt_snapshot_issue_state_from_gh "$repo" "$issue" "$now_s" 0)"
+    case "$class" in
+      closed-within-grace|closed-past-grace)
+        if git -C "$repo_dir" branch -d "$branch" >/dev/null 2>&1; then
+          deleted=$((deleted + 1))
+        else
+          _remote_branch_log "warn: failed to delete local live branch ${branch}, survives for cleanup later"
+        fi
+        ;;
+      open|not-found|unresolved-transient)
+        ;;
+      *)
+        ;;
+    esac
+  done <<<"$branches"
+
+  [[ $deleted -gt 0 ]] && _remote_branch_log "local cleanup: deleted $deleted closed-issue afk branch(es)"
   return 0
 }
 

--- a/plugins/dev/skills/engineering/afk/scripts/tests/local-branch-cleanup.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/local-branch-cleanup.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for issue #274 (PRD #244): boot-time cleanup of stale local afk/*
+# live-worker branches after their issues have closed.
+#
+#   prune_completed_local_branches [repo-dir]
+#     Lists local afk/{wid}/{n}-{slug} branches, classifies each issue through
+#     the same S1 issue-state classifier as the snapshot reaper, deletes CLOSED
+#     issue branches, keeps OPEN/unclassified issue branches, and never deletes
+#     a branch currently checked out by any git worktree.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS="$(dirname "$HERE")"
+LIB="$SCRIPTS/lib/remote-branch.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SHIM_DIR="$TMP/shim"
+GH_DIR="$TMP/gh-meta"
+GIT_LOG="$TMP/git.calls"
+mkdir -p "$SHIM_DIR" "$GH_DIR"
+: >"$GIT_LOG"
+
+cat >"$SHIM_DIR/gh" <<SHIM
+#!/usr/bin/env bash
+printf 'gh %s\n' "\$*" >>"$GIT_LOG"
+n=""; want_view=0; i=1
+while (( i <= \$# )); do
+  a="\${!i}"
+  [[ "\$a" == "view" ]] && want_view=1
+  if [[ "\$want_view" == 1 && "\$a" =~ ^[0-9]+\$ ]]; then n="\$a"; break; fi
+  i=\$((i+1))
+done
+f="$GH_DIR/\$n.json"
+if [[ -n "\$n" && -f "\$f" ]]; then cat "\$f"; exit 0; fi
+echo "HTTP 500: transient failure" >&2
+exit 1
+SHIM
+chmod 0755 "$SHIM_DIR/gh"
+export PATH="$SHIM_DIR:$PATH"
+
+gh_repo() { echo "owner/repo"; }
+
+pass=0
+fail=0
+
+expect_ok() {
+  local label="$1"; shift
+  if "$@"; then echo "PASS  $label"; pass=$((pass + 1))
+  else echo "FAIL  $label (command failed: $*)"; fail=$((fail + 1)); fi
+}
+
+expect_not_ok() {
+  local label="$1"; shift
+  if "$@"; then echo "FAIL  $label (command unexpectedly succeeded: $*)"; fail=$((fail + 1))
+  else echo "PASS  $label"; pass=$((pass + 1)); fi
+}
+
+expect_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then echo "PASS  $label"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n      missing: %q\n      in:       %q\n' "$label" "$needle" "$haystack"; fail=$((fail + 1)); fi
+}
+
+expect_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then echo "PASS  $label"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n      unexpected: %q\n      in:        %q\n' "$label" "$needle" "$haystack"; fail=$((fail + 1)); fi
+}
+
+gh_fixture() {
+  local n="$1" state="$2" closed="$3"
+  printf '{"state":"%s","closedAt":"%s"}\n' "$state" "$closed" >"$GH_DIR/$n.json"
+}
+
+branch_exists() {
+  git -C "$REPO" show-ref --verify --quiet "refs/heads/$1"
+}
+
+checked_out_branch() {
+  git -C "$REPO" worktree list --porcelain | grep -qF "branch refs/heads/$1"
+}
+
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.invalid
+git -C "$REPO" config user.name "Test User"
+printf 'base\n' >"$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -qm base
+git -C "$REPO" branch -M main
+
+git -C "$REPO" branch afk/wAAA/274-closed main
+git -C "$REPO" branch afk/wBBB/275-open main
+git -C "$REPO" branch afk/wCCC/276-checked-out main
+git -C "$REPO" branch afk-attempts/wAAA/274-snapshot main
+
+git -C "$REPO" worktree add -q "$TMP/checked-out" afk/wCCC/276-checked-out
+
+gh_fixture 274 CLOSED "2026-05-01T00:00:00Z"
+gh_fixture 275 OPEN ""
+gh_fixture 276 CLOSED "2026-05-01T00:00:00Z"
+
+# shellcheck source=../lib/remote-branch.sh
+source "$LIB"
+
+PROJECT_ROOT="$REPO" expect_ok "local prune: returns 0" prune_completed_local_branches "$REPO"
+
+expect_not_ok "local prune: deletes closed issue branch" branch_exists "afk/wAAA/274-closed"
+expect_ok     "local prune: keeps open issue branch"     branch_exists "afk/wBBB/275-open"
+expect_ok     "local prune: keeps checked-out branch"    branch_exists "afk/wCCC/276-checked-out"
+expect_ok     "local prune: checked-out branch remains registered" checked_out_branch "afk/wCCC/276-checked-out"
+expect_ok     "local prune: ignores snapshot namespace"  branch_exists "afk-attempts/wAAA/274-snapshot"
+
+calls="$(cat "$GIT_LOG")"
+expect_contains     "local prune: classified closed issue" "$calls" "issue view 274"
+expect_contains     "local prune: classified open issue"   "$calls" "issue view 275"
+expect_not_contains "local prune: skips checked-out issue classification" "$calls" "issue view 276"
+
+expect_ok "guard: afk.sh boot calls prune_completed_local_branches" \
+  grep -q 'prune_completed_local_branches' "$SCRIPTS/afk.sh"
+
+echo
+echo "local-branch-cleanup: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Automated AFK landing for #274. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782716802&installation_id=129708444&pr_number=278&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F278&signature=814c8530359a7e53c78387f65a05bd91ad9875ac2eb0dfbb99408d34ceeae4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic local branch cleanup during startup that removes stale local branches associated with closed issues while preserving branches currently in use by active worktrees.

* **Tests**
  * Added comprehensive test coverage for the new local branch cleanup functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->