### PR TITLE
merge: #273 AFK reaper: completion reaper for the afk/* live-branch namespace

### DIFF
--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -3384,6 +3384,10 @@ cap_issue_attempts
 # that closed more than the grace window ago. Within-grace and still-open issues
 # are left in place. Best-effort and never on the close path — runs here at boot.
 prune_completed_attempt_branches
+# Live-branch completion cleanup (issue #273): delete leftover afk/* refs for
+# CLOSED issues only. OPEN or unresolved issues are left untouched so active
+# workers are never disrupted by a boot sweep.
+prune_completed_live_branches
 sweep_unblocked
 
 # --- straggler check: warn about issues that never made it to ready-for-agent

--- a/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
@@ -43,6 +43,13 @@
 #     still-open issue, they are left strictly in place. Best-effort, boot-time,
 #     never on the close path. Complements the local-disk completion sweep
 #     (completion_sweep_issue, issue #257).
+#
+#   prune_completed_live_branches [root]   (issue #273)
+#     The backstop reaper of the `afk/*` live-iteration namespace. It deletes
+#     live branches for CLOSED issues immediately, keeps OPEN issues strictly in
+#     place, and keeps refs whose issue state cannot be resolved. Best-effort,
+#     boot-time, never on the close path; the per-issue delete_remote fast path
+#     stays responsible for normal DONE cleanup.
 
 # Logger — match the sibling lib/*.sh convention. afk.sh defines `log` as a
 # function; when this lib is sourced into a context that doesn't (e.g. unit
@@ -168,31 +175,54 @@ _attempt_snapshot_grace_s() {
 # fatal.
 _attempt_snapshot_issue_from_branch() {
   local branch="$1" rest issue
-  [[ "$branch" == afk-attempts/*/* ]] || return 0
-  rest="${branch#afk-attempts/*/}"  # {N}-slug
+  _remote_branch_issue_from_branch afk-attempts "$branch"
+}
+
+# _remote_branch_issue_from_branch <namespace> <branch>
+#
+# Extract the issue number from {namespace}/{worker}/{N}-slug. Echoes nothing
+# for malformed refs so callers can skip bad remote data without treating it as
+# fatal.
+_remote_branch_issue_from_branch() {
+  local namespace="$1" branch="$2" rest issue
+  case "$namespace" in
+    afk|afk-attempts) ;;
+    *) return 0 ;;
+  esac
+  [[ "$branch" == "$namespace"/*/* ]] || return 0
+  rest="${branch#"$namespace"/*/}"  # {N}-slug
   issue="${rest%%-*}"               # {N}
   [[ "$issue" =~ ^[0-9]+$ ]] || return 0
   printf '%s\n' "$issue"
 }
 
-# attempt_snapshot_cleanup_plan <refs> <classifier-fn> <now-s> <grace-s>
+# _remote_branch_cleanup_plan <refs> <namespace> <policy> <classifier-fn> <now-s> <grace-s>
 #
-# Pure keep/reap decider for the `afk-attempts/*` namespace. <refs> is a
-# synthetic ls-remote-shaped list:
+# Pure keep/reap decider shared by the `afk-attempts/*` snapshot reaper and the
+# `afk/*` live-branch reaper. <refs> is a synthetic ls-remote-shaped list:
 #
-#   <sha><TAB>refs/heads/afk-attempts/{worker}/{issue}-slug[<TAB><commit-s>]
+#   <sha><TAB>refs/heads/{namespace}/{worker}/{issue}-slug[<TAB><commit-s>]
 #
-# The optional third field is the branch's last-commit epoch and is required only
-# for `not-found`, where there is no issue closedAt timestamp to anchor grace.
+# The optional third field is the branch's last-commit epoch and is used only by
+# the `snapshot` policy for `not-found`, where there is no issue closedAt
+# timestamp to anchor grace.
 # <classifier-fn> is called as `<classifier-fn> <issue>` and must echo one of:
 # open, closed-within-grace, closed-past-grace, not-found, unresolved-transient.
 # The function performs no git/gh/date I/O and emits:
 #
 #   keep|reap<TAB><branch><TAB><issue><TAB><classification>
-attempt_snapshot_cleanup_plan() {
-  local refs="$1" classifier="$2" now_s="$3" grace_s="$4"
+_remote_branch_cleanup_plan() {
+  local refs="$1" namespace="$2" policy="$3" classifier="$4" now_s="$5" grace_s="$6"
   [[ "$now_s" =~ ^[0-9]+$ ]] || return 0
   [[ "$grace_s" =~ ^[0-9]+$ ]] || grace_s=$((7 * 86400))
+  case "$namespace" in
+    afk|afk-attempts) ;;
+    *) return 0 ;;
+  esac
+  case "$policy" in
+    snapshot|live) ;;
+    *) return 0 ;;
+  esac
   declare -F "$classifier" >/dev/null 2>&1 || return 0
 
   local -A issue_class=()
@@ -200,9 +230,9 @@ attempt_snapshot_cleanup_plan() {
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
     IFS=$'\t' read -r sha ref commit_s _ <<<"$line"
-    [[ "$ref" == refs/heads/afk-attempts/* ]] || continue
+    [[ "$ref" == refs/heads/"$namespace"/* ]] || continue
     branch="${ref#refs/heads/}"
-    issue="$(_attempt_snapshot_issue_from_branch "$branch")"
+    issue="$(_remote_branch_issue_from_branch "$namespace" "$branch")"
     [[ -n "$issue" ]] || continue
 
     if [[ -n "${issue_class[$issue]+set}" ]]; then
@@ -217,22 +247,37 @@ attempt_snapshot_cleanup_plan() {
     fi
 
     action="keep"
-    case "$class" in
-      closed-past-grace)
+    case "$policy:$class" in
+      snapshot:closed-past-grace)
         action="reap"
         ;;
-      not-found)
+      snapshot:not-found)
         if [[ "$commit_s" =~ ^[0-9]+$ ]] && (( now_s - commit_s > grace_s )); then
           action="reap"
         fi
         ;;
-      open|closed-within-grace|unresolved-transient)
-        action="keep"
+      live:closed-past-grace|live:closed-within-grace)
+        action="reap"
         ;;
     esac
 
     printf '%s\t%s\t%s\t%s\n' "$action" "$branch" "$issue" "$class"
   done <<<"$refs"
+}
+
+# attempt_snapshot_cleanup_plan <refs> <classifier-fn> <now-s> <grace-s>
+#
+# Back-compatible S1 wrapper for snapshot cleanup.
+attempt_snapshot_cleanup_plan() {
+  _remote_branch_cleanup_plan "$1" afk-attempts snapshot "$2" "$3" "$4"
+}
+
+# live_completion_cleanup_plan <refs> <classifier-fn> <now-s> <grace-s>
+#
+# Live-namespace policy: reap CLOSED issues immediately; keep OPEN, not-found,
+# and unresolved-transient refs. Kept as a wrapper over the same S1 decider.
+live_completion_cleanup_plan() {
+  _remote_branch_cleanup_plan "$1" afk live "$2" "$3" "$4"
 }
 
 # _attempt_snapshot_branch_commit_s <repo-dir> <sha> <branch>
@@ -313,6 +358,32 @@ _attempt_snapshot_issue_state_from_gh() {
   esac
 }
 
+# _live_issue_state_from_gh <repo> <issue>
+#
+# Translate the side-effecting GitHub issue lookup into the shared decider's
+# state vocabulary for live refs. CLOSED maps to the reapable closed-past-grace
+# state because live branches have no post-close grace window.
+_live_issue_state_from_gh() {
+  local repo="$1" issue="$2"
+  local meta state lower
+  meta="$(gh -R "$repo" issue view "$issue" --json state 2>&1)" || {
+    lower="${meta,,}"
+    if [[ "$lower" == *"404"* || "$lower" == *"not found"* || "$lower" == *"could not resolve"* ]]; then
+      printf 'not-found\n'
+    else
+      printf 'unresolved-transient\n'
+    fi
+    return 0
+  }
+
+  state="$(jq -r '.state // ""' <<<"$meta" 2>/dev/null)"
+  case "$state" in
+    OPEN)   printf 'open\n' ;;
+    CLOSED) printf 'closed-past-grace\n' ;;
+    *)      printf 'unresolved-transient\n' ;;
+  esac
+}
+
 # prune_completed_attempt_branches [root]
 #
 # Remote-side completion cleanup (issue #258, PRD #244). Enumerate the
@@ -359,5 +430,43 @@ prune_completed_attempt_branches() {
   done <<<"$plan"
 
   [[ $deleted -gt 0 ]] && _remote_branch_log "snapshot cleanup: deleted $deleted attempt snapshot branch(es) past the grace window"
+  return 0
+}
+
+# prune_completed_live_branches [root]
+#
+# Remote-side cleanup for the `afk/*` live-iteration namespace. Enumerate live
+# branches on origin, group them by issue, and delete only branches whose issue
+# is definitively CLOSED. OPEN issues may still have active workers and
+# unresolved issue/git failures keep the ref untouched.
+prune_completed_live_branches() {
+  local repo_dir="${PROJECT_ROOT:-$(pwd)}"
+  local repo now_s
+  repo="$(gh_repo 2>/dev/null)" || return 0
+  [[ -n "$repo" ]] || return 0
+  now_s="$(date +%s)"
+
+  local refs
+  refs="$(git -C "$repo_dir" ls-remote --heads origin 'refs/heads/afk/*' 2>/dev/null)" || return 0
+  [[ -n "$refs" ]] || return 0
+
+  _live_prune_classifier() {
+    _live_issue_state_from_gh "$repo" "$1"
+  }
+  local plan
+  plan="$(live_completion_cleanup_plan "$refs" _live_prune_classifier "$now_s" 0)"
+  unset -f _live_prune_classifier 2>/dev/null || true
+
+  local deleted=0 action branch issue class
+  while IFS=$'\t' read -r action branch issue class; do
+    [[ "$action" == "reap" && -n "$branch" ]] || continue
+    if git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
+      deleted=$((deleted + 1))
+    else
+      _remote_branch_log "warn: failed to delete remote live branch ${branch}, survives on origin for cleanup later"
+    fi
+  done <<<"$plan"
+
+  [[ $deleted -gt 0 ]] && _remote_branch_log "live cleanup: deleted $deleted closed-issue live branch(es)"
   return 0
 }

--- a/plugins/dev/skills/engineering/afk/scripts/tests/snapshot-grace-cleanup.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/snapshot-grace-cleanup.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Tests for issue #258 / #271 (PRD #244): remote-side grace-TTL cleanup of the
-# afk-attempts/{wid}/{n}-{slug} snapshot branches for completed or 404 issues.
+# Tests for issue #258 / #271 / #273 (PRD #244): remote-side cleanup of AFK
+# branches after issue completion.
 #
 #   prune_completed_attempt_branches [root]
 #     Lists the remote afk-attempts/* snapshot branches, groups them by issue,
@@ -9,6 +9,13 @@
 #     or whose issue 404s and whose branch commit predates the grace window.
 #     Open issues, within-grace branches, and transient API failures are left
 #     strictly untouched. Best-effort, always rc 0, never on the close path.
+#
+#   prune_completed_live_branches [root]
+#     Lists the remote afk/* live-iteration branches, groups them by issue,
+#     plans keep/reap decisions through the same pure decider, then deletes
+#     branches for closed issues immediately. Open issues and transient API
+#     failures are left strictly untouched. Best-effort, always rc 0, never on
+#     the close path.
 #
 # git and gh are mocked via PATH override:
 #   - `git ... ls-remote ...` prints a fixture ref list.
@@ -172,6 +179,24 @@ expect_contains "decider: reaps 404 branch past branch-age grace" "$plan" $'reap
 expect_contains "decider: keeps 404 branch within branch-age grace" "$plan" $'keep	afk-attempts/wAAA/404-fresh-missing	404	not-found'
 expect_contains "decider: keeps transient issue API failure" "$plan" $'keep	afk-attempts/wAAA/405-rate-limited	405	unresolved-transient'
 
+declare -A LIVE_DECIDER_CLASS=(
+  [500]=closed-past-grace
+  [501]=open
+  [502]=unresolved-transient
+)
+live_decider_classifier() { printf '%s\n' "${LIVE_DECIDER_CLASS[$1]:-unresolved-transient}"; }
+
+live_decider_refs="$(cat <<EOF
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk/wAAA/500-done
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk/wAAA/501-open
+cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk/wAAA/502-rate-limited
+EOF
+)"
+live_plan="$(live_completion_cleanup_plan "$live_decider_refs" live_decider_classifier "$fixed_now" "$((7*DAY))")"
+expect_contains "live decider: reaps closed issue branch" "$live_plan" $'reap	afk/wAAA/500-done	500	closed-past-grace'
+expect_contains "live decider: keeps open issue branch" "$live_plan" $'keep	afk/wAAA/501-open	501	open'
+expect_contains "live decider: keeps transient issue API failure" "$live_plan" $'keep	afk/wAAA/502-rate-limited	502	unresolved-transient'
+
 # Remote ref fixture: six issues, two workers, two snapshots for #300.
 cat >"$LSREMOTE_FILE" <<EOF
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk-attempts/wAAA/300-old-completed	$(epoch_ago $((30*DAY)))
@@ -255,12 +280,37 @@ gh_fixture 300 CLOSED "$(iso_ago $((30*DAY)))"   # restore for any later use
 reset_calls
 : >"$LSREMOTE_FILE"
 RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=$((7*DAY)) \
-  expect_rc0 "prune: empty ref list is a rc-0 no-op" prune_completed_attempt_branches
+expect_rc0 "prune: empty ref list is a rc-0 no-op" prune_completed_attempt_branches
 expect_eq "prune: empty ref list issues no delete" "" "$(calls | grep -F -- '--delete' || true)"
+
+# ---------- live afk/* completion cleanup: closed deletes, open/transient survive ----------
+cat >"$LSREMOTE_FILE" <<EOF
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk/wAAA/500-done
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk/wAAA/501-open
+cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk/wAAA/502-rate-limited
+EOF
+gh_fixture 500 CLOSED "$(iso_ago $DAY)"
+gh_fixture 501 OPEN ""
+gh_error 502 "rate limit"
+
+reset_calls
+expect_rc0 "live prune: returns 0" prune_completed_live_branches
+live_out="$(calls)"
+expect_contains "live prune: deletes closed #500 live branch" "$live_out" "push origin --delete afk/wAAA/500-done"
+expect_not_contains "live prune: keeps open #501 live branch" "$live_out" "--delete afk/wAAA/501-open"
+expect_not_contains "live prune: keeps transient #502 live branch" "$live_out" "--delete afk/wAAA/502-rate-limited"
+
+reset_calls
+rm -f "$GH_DIR/500.json"
+gh_error 500 "rate limit"
+expect_rc0 "live prune: transient lookup returns 0" prune_completed_live_branches
+expect_not_contains "live prune: transient closed-unknown #500 left untouched" "$(calls)" "--delete afk/wAAA/500-done"
 
 # ---------- static guard: boot wires the prune after cap_issue_attempts ----------
 expect_rc0 "guard: afk.sh boot calls prune_completed_attempt_branches" \
   grep -q 'prune_completed_attempt_branches' "$SCRIPTS/afk.sh"
+expect_rc0 "guard: afk.sh boot calls prune_completed_live_branches" \
+  grep -q 'prune_completed_live_branches' "$SCRIPTS/afk.sh"
 
 # ---------- summary ----------
 echo


### PR DESCRIPTION
Automated AFK landing for #273. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782716932&installation_id=129708444&pr_number=279&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F279&signature=26424e596cd72839d2134f869855baf0de997012492ad12b1fcdaa10328f5f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of completed work branches on the remote repository for definitively closed issues, while preserving active and open work items.

* **Chores**
  * Refactored internal branch cleanup planning to use generalized logic supporting multiple workflow namespaces with improved policy-driven lifecycle management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->