### PR TITLE
merge: #273 AFK reaper: completion reaper for the afk/* live-branch namespace

### DIFF
--- a/plugins/dev/skills/engineering/afk/scripts/afk.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk.sh
@@ -3384,6 +3384,10 @@ cap_issue_attempts
 # that closed more than the grace window ago. Within-grace and still-open issues
 # are left in place. Best-effort and never on the close path — runs here at boot.
 prune_completed_attempt_branches
+# Remote live-branch cleanup (issue #273, PRD #244): delete origin afk/*
+# branches for issues already closed. This is the boot-time backstop for the
+# DONE path's best-effort delete_remote; open/unclassified issues are kept.
+prune_completed_remote_live_branches
 # Local live-branch cleanup (issue #274, PRD #244): drop stale local afk/*
 # branches for issues that are already closed while explicitly skipping any
 # branch checked out by a registered worktree. Best-effort boot hygiene only.

--- a/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
@@ -34,6 +34,12 @@
 #     branches whose issue is CLOSED, keeps OPEN/unclassified branches, and
 #     refuses to touch any branch checked out by a git worktree.
 #
+#   prune_completed_remote_live_branches [repo-dir]   (issue #273)
+#     The boot-time remote reaper for stale origin `afk/{wid}/{N}-slug` live
+#     branches. It reuses the same S1 issue-state classifier and pure decider as
+#     the snapshot/local reapers with a live policy: CLOSED means delete, OPEN or
+#     unclassified means keep. Best-effort and never on the close path.
+#
 # The live-push lifecycle above (push_initial / install_post_commit_hook /
 # delete_remote) deliberately touches ONLY the `afk/{wid}/{N}-slug` namespace.
 # The `afk-attempts/{wid}/{N}-slug` failure-push namespace stays the canonical
@@ -261,34 +267,36 @@ _attempt_snapshot_issue_from_branch() {
   printf '%s\n' "$issue"
 }
 
-# attempt_snapshot_cleanup_plan <refs> <classifier-fn> <now-s> <grace-s>
+# _branch_cleanup_plan <refs> <ref-prefix> <issue-parser-fn> <classifier-fn> <policy-fn> <now-s> <grace-s>
 #
-# Pure keep/reap decider for the `afk-attempts/*` namespace. <refs> is a
-# synthetic ls-remote-shaped list:
+# Shared pure keep/reap decider for AFK branch namespaces. <refs> is a synthetic
+# ls-remote-shaped list:
 #
-#   <sha><TAB>refs/heads/afk-attempts/{worker}/{issue}-slug[<TAB><commit-s>]
+#   <sha><TAB>refs/heads/{namespace}/{worker}/{issue}-slug[<TAB><commit-s>]
 #
-# The optional third field is the branch's last-commit epoch and is required only
-# for `not-found`, where there is no issue closedAt timestamp to anchor grace.
-# <classifier-fn> is called as `<classifier-fn> <issue>` and must echo one of:
-# open, closed-within-grace, closed-past-grace, not-found, unresolved-transient.
-# The function performs no git/gh/date I/O and emits:
+# <classifier-fn> is called once per issue and must echo one of the S1 issue
+# states: open, closed-within-grace, closed-past-grace, not-found,
+# unresolved-transient. <policy-fn> maps that state plus optional commit/grace
+# context to keep/reap. The function performs no git/gh/date I/O and emits:
 #
 #   keep|reap<TAB><branch><TAB><issue><TAB><classification>
-attempt_snapshot_cleanup_plan() {
-  local refs="$1" classifier="$2" now_s="$3" grace_s="$4"
-  [[ "$now_s" =~ ^[0-9]+$ ]] || return 0
+_branch_cleanup_plan() {
+  local refs="$1" ref_prefix="$2" issue_parser="$3" classifier="$4" policy="$5" now_s="$6" grace_s="$7"
   [[ "$grace_s" =~ ^[0-9]+$ ]] || grace_s=$((7 * 86400))
+  [[ "$now_s" =~ ^[0-9]+$ ]] || now_s=0
+  [[ -n "$ref_prefix" ]] || return 0
+  declare -F "$issue_parser" >/dev/null 2>&1 || return 0
   declare -F "$classifier" >/dev/null 2>&1 || return 0
+  declare -F "$policy" >/dev/null 2>&1 || return 0
 
   local -A issue_class=()
   local line sha ref branch commit_s issue class action
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
     IFS=$'\t' read -r sha ref commit_s _ <<<"$line"
-    [[ "$ref" == refs/heads/afk-attempts/* ]] || continue
+    [[ "$ref" == "$ref_prefix"* ]] || continue
     branch="${ref#refs/heads/}"
-    issue="$(_attempt_snapshot_issue_from_branch "$branch")"
+    issue="$("$issue_parser" "$branch" 2>/dev/null || true)"
     [[ -n "$issue" ]] || continue
 
     if [[ -n "${issue_class[$issue]+set}" ]]; then
@@ -302,23 +310,59 @@ attempt_snapshot_cleanup_plan() {
       issue_class["$issue"]="$class"
     fi
 
-    action="keep"
-    case "$class" in
-      closed-past-grace)
-        action="reap"
-        ;;
-      not-found)
-        if [[ "$commit_s" =~ ^[0-9]+$ ]] && (( now_s - commit_s > grace_s )); then
-          action="reap"
-        fi
-        ;;
-      open|closed-within-grace|unresolved-transient)
-        action="keep"
-        ;;
-    esac
+    action="$("$policy" "$class" "$now_s" "$grace_s" "$commit_s" 2>/dev/null || true)"
+    [[ "$action" == "reap" || "$action" == "keep" ]] || action="keep"
 
     printf '%s\t%s\t%s\t%s\n' "$action" "$branch" "$issue" "$class"
   done <<<"$refs"
+}
+
+_attempt_snapshot_cleanup_policy() {
+  local class="$1" now_s="$2" grace_s="$3" commit_s="$4"
+  case "$class" in
+    closed-past-grace)
+      printf 'reap\n'
+      ;;
+    not-found)
+      if [[ "$commit_s" =~ ^[0-9]+$ && "$now_s" =~ ^[0-9]+$ && "$grace_s" =~ ^[0-9]+$ ]] && (( now_s - commit_s > grace_s )); then
+        printf 'reap\n'
+      else
+        printf 'keep\n'
+      fi
+      ;;
+    *)
+      printf 'keep\n'
+      ;;
+  esac
+}
+
+# attempt_snapshot_cleanup_plan <refs> <classifier-fn> <now-s> <grace-s>
+#
+# Compatibility wrapper for the `afk-attempts/*` snapshot namespace. Snapshot
+# policy keeps open/unresolved/within-grace issues and reaps closed-past-grace
+# issues or old 404s by branch commit age.
+attempt_snapshot_cleanup_plan() {
+  local refs="$1" classifier="$2" now_s="$3" grace_s="$4"
+  [[ "$now_s" =~ ^[0-9]+$ ]] || return 0
+  _branch_cleanup_plan "$refs" "refs/heads/afk-attempts/" _attempt_snapshot_issue_from_branch "$classifier" _attempt_snapshot_cleanup_policy "$now_s" "$grace_s"
+}
+
+_live_branch_cleanup_policy() {
+  local class="$1"
+  case "$class" in
+    closed-within-grace|closed-past-grace) printf 'reap\n' ;;
+    *) printf 'keep\n' ;;
+  esac
+}
+
+# live_branch_cleanup_plan <refs> <classifier-fn>
+#
+# Pure keep/reap decider for the remote `afk/*` live namespace. The live policy
+# has no grace window: once the issue is CLOSED the merge base has the work, so
+# the remote live branch is residue. OPEN/not-found/transient states are kept.
+live_branch_cleanup_plan() {
+  local refs="$1" classifier="$2"
+  _branch_cleanup_plan "$refs" "refs/heads/afk/" _local_afk_issue_from_branch "$classifier" _live_branch_cleanup_policy 0 0
 }
 
 # _attempt_snapshot_branch_commit_s <repo-dir> <sha> <branch>
@@ -445,5 +489,44 @@ prune_completed_attempt_branches() {
   done <<<"$plan"
 
   [[ $deleted -gt 0 ]] && _remote_branch_log "snapshot cleanup: deleted $deleted attempt snapshot branch(es) past the grace window"
+  return 0
+}
+
+# prune_completed_remote_live_branches [root]
+#
+# Remote-side live-branch completion cleanup (issue #273, PRD #244). Enumerate
+# origin `afk/{wid}/{N}-slug` live branches and delete only those whose issue is
+# CLOSED. OPEN, not-found, and transiently unclassifiable issues are left in
+# place so an active or ambiguous worker branch is never destroyed. Best-effort
+# and always rc 0: called at boot as a backstop for close-path delete_remote.
+prune_completed_remote_live_branches() {
+  local repo_dir="${PROJECT_ROOT:-$(pwd)}"
+  local repo now_s
+  repo="$(gh_repo 2>/dev/null)" || return 0
+  [[ -n "$repo" ]] || return 0
+  now_s="$(date +%s)"
+
+  local refs
+  refs="$(git -C "$repo_dir" ls-remote --heads origin 'refs/heads/afk/*' 2>/dev/null)" || return 0
+  [[ -n "$refs" ]] || return 0
+
+  _live_branch_prune_classifier() {
+    _attempt_snapshot_issue_state_from_gh "$repo" "$1" "$now_s" 0
+  }
+  local plan
+  plan="$(live_branch_cleanup_plan "$refs" _live_branch_prune_classifier)"
+  unset -f _live_branch_prune_classifier 2>/dev/null || true
+
+  local deleted=0 action branch issue class
+  while IFS=$'\t' read -r action branch issue class; do
+    [[ "$action" == "reap" && -n "$branch" ]] || continue
+    if git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
+      deleted=$((deleted + 1))
+    else
+      _remote_branch_log "warn: failed to delete remote live branch ${branch}, survives on origin for cleanup later"
+    fi
+  done <<<"$plan"
+
+  [[ $deleted -gt 0 ]] && _remote_branch_log "remote live cleanup: deleted $deleted closed-issue afk branch(es)"
   return 0
 }

--- a/plugins/dev/skills/engineering/afk/scripts/tests/remote-live-branch-cleanup.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/remote-live-branch-cleanup.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Tests for issue #273 (PRD #244): boot-time cleanup of stale remote afk/*
+# live-worker branches after their issues have closed.
+#
+#   prune_completed_remote_live_branches [repo-dir]
+#     Lists remote afk/{wid}/{n}-{slug} live branches, plans keep/reap decisions
+#     through the shared S1 decider, deletes CLOSED issue branches, and keeps
+#     OPEN/unclassified issue branches. Best-effort, always rc 0, boot-time only.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS="$(dirname "$HERE")"
+LIB="$SCRIPTS/lib/remote-branch.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+GIT_LOG="$TMP/git.calls"
+LSREMOTE_FILE="$TMP/ls-remote.out"
+LSREMOTE_FAIL_FILE="$TMP/ls-remote.fail"
+GH_DIR="$TMP/gh-meta"
+SHIM_DIR="$TMP/shim"
+mkdir -p "$SHIM_DIR" "$GH_DIR"
+: >"$GIT_LOG"
+
+REAL_GIT="$(command -v git)"
+
+cat >"$SHIM_DIR/git" <<SHIM
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GIT_LOG"
+verb=""; i=1
+while (( i <= \$# )); do
+  a="\${!i}"
+  if [[ "\$a" == "-C" ]]; then i=\$((i+2)); continue; fi
+  verb="\$a"; break
+done
+case "\$verb" in
+  ls-remote)
+    if [[ -f "$LSREMOTE_FAIL_FILE" ]]; then exit 1; fi
+    cat "$LSREMOTE_FILE" 2>/dev/null
+    exit 0
+    ;;
+  push) exit 0 ;;
+  *) exec "$REAL_GIT" "\$@" ;;
+esac
+SHIM
+chmod 0755 "$SHIM_DIR/git"
+
+cat >"$SHIM_DIR/gh" <<SHIM
+#!/usr/bin/env bash
+printf 'gh %s\n' "\$*" >>"$GIT_LOG"
+n=""; want_view=0; i=1
+while (( i <= \$# )); do
+  a="\${!i}"
+  [[ "\$a" == "view" ]] && want_view=1
+  if [[ "\$want_view" == 1 && "\$a" =~ ^[0-9]+\$ ]]; then n="\$a"; break; fi
+  i=\$((i+1))
+done
+f="$GH_DIR/\$n.json"
+if [[ -n "\$n" && -f "\$f" ]]; then cat "\$f"; exit 0; fi
+if [[ -n "\$n" && -f "$GH_DIR/\$n.error" ]]; then cat "$GH_DIR/\$n.error" >&2; exit 1; fi
+echo "HTTP 500: transient failure" >&2
+exit 1
+SHIM
+chmod 0755 "$SHIM_DIR/gh"
+
+export PATH="$SHIM_DIR:$PATH"
+
+gh_repo() { echo "owner/repo"; }
+
+pass=0
+fail=0
+
+reset_calls() { : >"$GIT_LOG"; rm -f "$LSREMOTE_FAIL_FILE"; }
+calls() { cat "$GIT_LOG"; }
+
+expect_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then echo "PASS  $label"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n      missing: %q\n      in:       %q\n' "$label" "$needle" "$haystack"; fail=$((fail + 1)); fi
+}
+
+expect_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then echo "PASS  $label"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n      unexpected: %q\n      in:        %q\n' "$label" "$needle" "$haystack"; fail=$((fail + 1)); fi
+}
+
+expect_rc0() {
+  local label="$1"; shift
+  if "$@"; then echo "PASS  $label"; pass=$((pass + 1))
+  else echo "FAIL  $label (returned non-zero: $*)"; fail=$((fail + 1)); fi
+}
+
+gh_fixture() {
+  local n="$1" state="$2" closed="$3"
+  printf '{"state":"%s","closedAt":"%s"}\n' "$state" "$closed" >"$GH_DIR/$n.json"
+}
+gh_error() {
+  rm -f "$GH_DIR/$1.json"
+  printf '%s\n' "${2:-rate limit}" >"$GH_DIR/$1.error"
+}
+
+PROJECT_ROOT="$TMP"
+
+# shellcheck source=../lib/remote-branch.sh
+source "$LIB"
+
+# ---------- pure decider: live namespace policy ----------
+declare -A DECIDER_CLASS=(
+  [500]=closed-within-grace
+  [501]=open
+  [502]=unresolved-transient
+  [503]=not-found
+)
+decider_classifier() { printf '%s\n' "${DECIDER_CLASS[$1]:-unresolved-transient}"; }
+
+decider_refs="$(cat <<EOF
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk/wAAA/500-closed
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk/wBBB/501-open
+cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk/wCCC/502-rate-limited
+dddddddddddddddddddddddddddddddddddddddd	refs/heads/afk/wDDD/503-missing
+eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee	refs/heads/afk-attempts/wEEE/500-snapshot
+EOF
+)"
+plan="$(live_branch_cleanup_plan "$decider_refs" decider_classifier)"
+expect_contains "decider: reaps closed live branch" "$plan" $'reap	afk/wAAA/500-closed	500	closed-within-grace'
+expect_contains "decider: keeps open live branch" "$plan" $'keep	afk/wBBB/501-open	501	open'
+expect_contains "decider: keeps transient live branch" "$plan" $'keep	afk/wCCC/502-rate-limited	502	unresolved-transient'
+expect_contains "decider: keeps missing live branch" "$plan" $'keep	afk/wDDD/503-missing	503	not-found'
+expect_not_contains "decider: ignores snapshot namespace" "$plan" "afk-attempts/wEEE/500-snapshot"
+
+cat >"$LSREMOTE_FILE" <<EOF
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/heads/afk/wAAA/500-closed
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/afk/wBBB/501-open
+cccccccccccccccccccccccccccccccccccccccc	refs/heads/afk/wCCC/502-rate-limited
+EOF
+
+gh_fixture 500 CLOSED "2026-05-01T00:00:00Z"
+gh_fixture 501 OPEN ""
+gh_error 502 "rate limit"
+
+# ---------- closed issue live branch is deleted ----------
+reset_calls
+expect_rc0 "remote live prune: returns 0" prune_completed_remote_live_branches
+log_out="$(calls)"
+expect_contains "remote live prune: lists only remote live branches" "$log_out" "ls-remote --heads origin refs/heads/afk/*"
+expect_contains "remote live prune: deletes closed issue branch" "$log_out" "push origin --delete afk/wAAA/500-closed"
+
+# ---------- open and transient issue branches survive ----------
+expect_not_contains "remote live prune: keeps open issue branch" "$log_out" "--delete afk/wBBB/501-open"
+expect_not_contains "remote live prune: keeps transient issue branch" "$log_out" "--delete afk/wCCC/502-rate-limited"
+
+# ---------- transient git listing failure is safe and best-effort ----------
+reset_calls
+: >"$LSREMOTE_FAIL_FILE"
+expect_rc0 "remote live prune: ls-remote failure returns 0" prune_completed_remote_live_branches
+expect_not_contains "remote live prune: ls-remote failure deletes nothing" "$(calls)" "--delete"
+
+# ---------- static guard: boot wires the prune after snapshot cleanup ----------
+expect_rc0 "guard: afk.sh boot calls prune_completed_remote_live_branches" \
+  grep -q 'prune_completed_remote_live_branches' "$SCRIPTS/afk.sh"
+
+echo
+echo "remote-live-branch-cleanup: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Automated AFK landing for #273. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782717357&installation_id=129708444&pr_number=280&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F280&signature=4b74f1dbaec43ffd32015874b96533b7886253075e87977982ac4220be75b851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of remote branches associated with closed GitHub issues during boot.

* **Tests**
  * Added comprehensive test coverage for remote branch cleanup functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->