### PR TITLE
merge: #275 AFK reaper: on-demand invocation + branch-count visibility

### DIFF
--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: afk
 description: Autonomous loop that drains the `ready-for-agent` queue on the issue tracker. Each iteration claims an issue, runs it in an isolated worktree, executes with claude or codex, merges back to main, and closes the issue. Use when the user wants to run AFK execution, drain a PRD, hammer specific issues, or otherwise let agents grind through the backlog.
-argument-hint: "[--prd N | --issues N,N,N] [--runner claude|codex] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] | fleet [N] | fleet stop | monitor"
+argument-hint: "[--prd N | --issues N,N,N] [--runner claude|codex] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] | fleet [N] | fleet stop | monitor | reap"
 ---
 
 # /afk
@@ -22,6 +22,7 @@ Drain the agent-ready backlog. Single skill that owns issue selection, worktree 
 - `/afk monitor` — readonly status board, aggregates every `.red/tmp/workers/*/*/afk.state.json` so you see all live workers from another terminal. **Also (binding):** mirrors live workers onto the host runner's native task surface — `TaskCreate`/`TaskUpdate` under Claude Code, the sub-agent surface under Codex when present (falls back to the dashboard otherwise). See *Task Mirror* below — this is not optional and you must do it on every tick, even when the user only asked "como estamos?".
 - `/afk fleet [N]` — launch the supervisor maintaining `N` concurrent workers (default `2`). See *Fleet Mode* below.
 - `/afk fleet stop` — gracefully shut down a running fleet supervisor and cancel its auto-monitor cron.
+- `/afk reap` — run branch hygiene without starting a worker: one count line for remote `afk/*`, remote `afk-attempts/*`, and local `afk/*`, then the same safe reapers used at boot.
 
 ## Parallelization
 
@@ -113,6 +114,16 @@ The *Completion sweep* and *Attempt Cap* reclaim **local** attempt dirs; the fai
 - **closed longer than the grace window ago** — every snapshot branch for that issue is deleted from origin (cross-worker).
 
 The grace window is `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S` (default 7 days), measured from the issue's GitHub `closedAt`. A non-numeric value falls back to the default so an operator typo can never disable the grace; `0` is honoured as "delete immediately on completion". The pass is best-effort and runs at boot, **never** on the close path — a slow or failing `gh`/`git` can never block a completion, and an issue it cannot classify is left strictly in place.
+
+## On-Demand Branch Reaper (issue #275)
+
+Run `bash plugins/dev/skills/engineering/afk/scripts/afk-reap.sh [project_root]` to perform branch hygiene without starting a worker, claiming an issue, or firing lifecycle hooks. The command first prints one line:
+
+```text
+afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N
+```
+
+It then applies the same three namespace reapers used during `/afk` boot: remote `afk-attempts/*`, remote `afk/*`, and local `afk/*`. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept. Each successful deletion logs the branch, issue number, and classification reason. Re-running is a natural no-op once stale refs are gone. Snapshot grace still comes from `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S`; live `afk/*` cleanup keeps the existing closed-vs-open policy.
 
 ## Unblock Sweep (boot-time)
 

--- a/plugins/dev/skills/engineering/afk/scripts/afk-reap.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/afk-reap.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# On-demand AFK branch reaper (issue #275).
+#
+# Usage:
+#   afk-reap.sh [project_root]
+#
+# Prints one branch-count line, then runs cleanup for:
+#   - origin/afk/*
+#   - origin/afk-attempts/*
+#   - local afk/*
+#
+# It does not claim issues, spawn workers, or run lifecycle hooks.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${1:-$(pwd)}"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
+export PROJECT_ROOT
+
+log() { printf '[afk] %s\n' "$*" >&2; }
+
+gh_repo() {
+  local remote repo
+  remote="$(git -C "$PROJECT_ROOT" remote get-url origin 2>/dev/null || true)"
+  case "$remote" in
+    git@github.com:*.git)
+      repo="${remote#git@github.com:}"
+      printf '%s\n' "${repo%.git}"
+      return 0
+      ;;
+    git@github.com:*)
+      printf '%s\n' "${remote#git@github.com:}"
+      return 0
+      ;;
+    https://github.com/*.git)
+      repo="${remote#https://github.com/}"
+      printf '%s\n' "${repo%.git}"
+      return 0
+      ;;
+    https://github.com/*)
+      printf '%s\n' "${remote#https://github.com/}"
+      return 0
+      ;;
+  esac
+  gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true
+}
+
+command -v git >/dev/null || { log "ERROR: git not installed"; exit 2; }
+command -v gh >/dev/null || { log "ERROR: gh not installed"; exit 2; }
+command -v jq >/dev/null || { log "ERROR: jq not installed"; exit 2; }
+git -C "$PROJECT_ROOT" rev-parse --show-toplevel >/dev/null 2>&1 || {
+  log "ERROR: ${PROJECT_ROOT} is not a git repo"
+  exit 2
+}
+
+# shellcheck source=./lib/remote-branch.sh
+source "$SCRIPT_DIR/lib/remote-branch.sh"
+
+run_afk_branch_reaper "$PROJECT_ROOT"

--- a/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/lib/remote-branch.sh
@@ -34,6 +34,12 @@
 #     branches whose issue is CLOSED, keeps OPEN/unclassified branches, and
 #     refuses to touch any branch checked out by a git worktree.
 #
+#   run_afk_branch_reaper [repo-dir]   (issue #275)
+#     On-demand branch hygiene entry point. Prints one line with current branch
+#     counts for remote afk/*, remote afk-attempts/*, and local afk/*, then runs
+#     the same three namespace reapers that boot uses. It creates no worker and
+#     is safe to repeat.
+#
 #   prune_completed_remote_live_branches [repo-dir]   (issue #273)
 #     The boot-time remote reaper for stale origin `afk/{wid}/{N}-slug` live
 #     branches. It reuses the same S1 issue-state classifier and pure decider as
@@ -65,6 +71,40 @@ _remote_branch_log() {
   else
     printf '[afk] %s\n' "$*" >&2
   fi
+}
+
+_afk_count_lines() {
+  awk 'NF { n++ } END { print n + 0 }'
+}
+
+# afk_branch_count_report [repo-dir]
+#
+# Emit a single human/script-readable count line for branch-sprawl visibility.
+# Remote count failures are reported as 0 because this is best-effort hygiene,
+# matching the reapers' failure policy.
+afk_branch_count_report() {
+  local repo_dir="${1:-${PROJECT_ROOT:-$(pwd)}}"
+  local remote_live remote_snapshots local_live
+  remote_live="$({ git -C "$repo_dir" ls-remote --heads origin 'refs/heads/afk/*' 2>/dev/null || true; } | _afk_count_lines)"
+  remote_snapshots="$({ git -C "$repo_dir" ls-remote --heads origin 'refs/heads/afk-attempts/*' 2>/dev/null || true; } | _afk_count_lines)"
+  local_live="$({ git -C "$repo_dir" for-each-ref --format='%(refname:short)' refs/heads/afk 2>/dev/null || true; } | _afk_count_lines)"
+  printf 'afk branch counts: remote-afk=%s remote-afk-attempts=%s local-afk=%s\n' \
+    "$remote_live" "$remote_snapshots" "$local_live"
+}
+
+# run_afk_branch_reaper [repo-dir]
+#
+# Single on-demand reaper invocation for issue #275. The boot path calls these
+# same reapers separately; this wrapper intentionally only reports counts and
+# delegates, so repeated/concurrent runs inherit the existing open-issue safety
+# and RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S handling.
+run_afk_branch_reaper() {
+  local repo_dir="${1:-${PROJECT_ROOT:-$(pwd)}}"
+  afk_branch_count_report "$repo_dir"
+  prune_completed_attempt_branches "$repo_dir"
+  prune_completed_remote_live_branches "$repo_dir"
+  prune_completed_local_branches "$repo_dir"
+  return 0
 }
 
 # push_initial <worktree> <branch>
@@ -226,6 +266,7 @@ prune_completed_local_branches() {
       closed-within-grace|closed-past-grace)
         if git -C "$repo_dir" branch -d "$branch" >/dev/null 2>&1; then
           deleted=$((deleted + 1))
+          _remote_branch_log "reaper: deleted local live branch ${branch} (issue #${issue}: ${class})"
         else
           _remote_branch_log "warn: failed to delete local live branch ${branch}, survives for cleanup later"
         fi
@@ -458,7 +499,7 @@ _attempt_snapshot_issue_state_from_gh() {
 # never block a completion. `gh_repo` is provided by the orchestrator that
 # sources this lib.
 prune_completed_attempt_branches() {
-  local repo_dir="${PROJECT_ROOT:-$(pwd)}"
+  local repo_dir="${1:-${PROJECT_ROOT:-$(pwd)}}"
   local repo grace now_s
   repo="$(gh_repo 2>/dev/null)" || return 0
   [[ -n "$repo" ]] || return 0
@@ -483,6 +524,7 @@ prune_completed_attempt_branches() {
     [[ "$action" == "reap" && -n "$branch" ]] || continue
     if git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
       deleted=$((deleted + 1))
+      _remote_branch_log "reaper: deleted remote snapshot branch ${branch} (issue #${issue}: ${class})"
     else
       _remote_branch_log "warn: failed to delete remote snapshot ${branch}, survives on origin for cleanup later"
     fi
@@ -500,7 +542,7 @@ prune_completed_attempt_branches() {
 # place so an active or ambiguous worker branch is never destroyed. Best-effort
 # and always rc 0: called at boot as a backstop for close-path delete_remote.
 prune_completed_remote_live_branches() {
-  local repo_dir="${PROJECT_ROOT:-$(pwd)}"
+  local repo_dir="${1:-${PROJECT_ROOT:-$(pwd)}}"
   local repo now_s
   repo="$(gh_repo 2>/dev/null)" || return 0
   [[ -n "$repo" ]] || return 0
@@ -522,6 +564,7 @@ prune_completed_remote_live_branches() {
     [[ "$action" == "reap" && -n "$branch" ]] || continue
     if git -C "$repo_dir" push origin --delete "$branch" >/dev/null 2>&1; then
       deleted=$((deleted + 1))
+      _remote_branch_log "reaper: deleted remote live branch ${branch} (issue #${issue}: ${class})"
     else
       _remote_branch_log "warn: failed to delete remote live branch ${branch}, survives on origin for cleanup later"
     fi

--- a/plugins/dev/skills/engineering/afk/scripts/tests/on-demand-reaper.test.sh
+++ b/plugins/dev/skills/engineering/afk/scripts/tests/on-demand-reaper.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Tests for issue #275: one on-demand command reports AFK branch counts and runs
+# the branch reapers for remote afk/*, remote afk-attempts/*, and local afk/*.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS="$(dirname "$HERE")"
+SCRIPT="$SCRIPTS/afk-reap.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SHIM_DIR="$TMP/shim"
+GH_DIR="$TMP/gh-meta"
+GIT_LOG="$TMP/git.calls"
+ERR_LOG="$TMP/reaper.err"
+OUT_LOG="$TMP/reaper.out"
+mkdir -p "$SHIM_DIR" "$GH_DIR"
+: >"$GIT_LOG"
+
+REAL_GIT="$(command -v git)"
+
+cat >"$SHIM_DIR/gh" <<SHIM
+#!/usr/bin/env bash
+printf 'gh %s\n' "\$*" >>"$GIT_LOG"
+case "\$*" in
+  *"repo view"*) printf '{"nameWithOwner":"owner/repo"}\n'; exit 0 ;;
+esac
+n=""; want_view=0; i=1
+while (( i <= \$# )); do
+  a="\${!i}"
+  [[ "\$a" == "view" ]] && want_view=1
+  if [[ "\$want_view" == 1 && "\$a" =~ ^[0-9]+\$ ]]; then n="\$a"; break; fi
+  i=\$((i+1))
+done
+f="$GH_DIR/\$n.json"
+if [[ -n "\$n" && -f "\$f" ]]; then cat "\$f"; exit 0; fi
+echo "HTTP 500: transient failure" >&2
+exit 1
+SHIM
+chmod 0755 "$SHIM_DIR/gh"
+
+export PATH="$SHIM_DIR:$PATH"
+
+pass=0
+fail=0
+
+expect_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then echo "PASS  $label"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n      missing: %q\n      in:       %q\n' "$label" "$needle" "$haystack"; fail=$((fail + 1)); fi
+}
+
+expect_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then echo "PASS  $label"; pass=$((pass + 1))
+  else printf 'FAIL  %s\n      unexpected: %q\n      in:        %q\n' "$label" "$needle" "$haystack"; fail=$((fail + 1)); fi
+}
+
+expect_rc0() {
+  local label="$1"; shift
+  if "$@"; then echo "PASS  $label"; pass=$((pass + 1))
+  else echo "FAIL  $label (returned non-zero: $*)"; fail=$((fail + 1)); fi
+}
+
+expect_not_ok() {
+  local label="$1"; shift
+  if "$@"; then echo "FAIL  $label (command unexpectedly succeeded: $*)"; fail=$((fail + 1))
+  else echo "PASS  $label"; pass=$((pass + 1)); fi
+}
+
+gh_fixture() {
+  local n="$1" state="$2" closed="$3"
+  printf '{"state":"%s","closedAt":"%s"}\n' "$state" "$closed" >"$GH_DIR/$n.json"
+}
+
+branch_exists() {
+  git -C "$REPO" show-ref --verify --quiet "refs/heads/$1"
+}
+
+worker_tree_exists() {
+  [[ -e "$REPO/.red/tmp/workers" ]]
+}
+
+iso_ago() { date -u -d "@$(( $(date +%s) - $1 ))" +%Y-%m-%dT%H:%M:%SZ; }
+
+REPO="$TMP/repo"
+REMOTE="$TMP/origin.git"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.invalid
+git -C "$REPO" config user.name "Test User"
+printf 'base\n' >"$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -qm base
+git -C "$REPO" branch -M main
+git -C "$REPO" init --bare -q "$REMOTE"
+git -C "$REPO" remote add origin "$REMOTE"
+git -C "$REPO" push -q origin main
+
+git -C "$REPO" branch afk/wLOC/700-closed main
+git -C "$REPO" branch afk/wLOP/701-open main
+git -C "$REPO" push -q origin main:refs/heads/afk/wREM/702-closed
+git -C "$REPO" push -q origin main:refs/heads/afk/wROP/703-open
+git -C "$REPO" push -q origin main:refs/heads/afk-attempts/wATT/704-old
+git -C "$REPO" push -q origin main:refs/heads/afk-attempts/wATP/705-open
+
+DAY=86400
+gh_fixture 700 CLOSED "$(iso_ago $((30*DAY)))"
+gh_fixture 701 OPEN ""
+gh_fixture 702 CLOSED "$(iso_ago $((30*DAY)))"
+gh_fixture 703 OPEN ""
+gh_fixture 704 CLOSED "$(iso_ago $((30*DAY)))"
+gh_fixture 705 OPEN ""
+
+RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=$((7*DAY)) "$SCRIPT" "$REPO" >"$OUT_LOG" 2>"$ERR_LOG"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then echo "PASS  on-demand command exits 0"; pass=$((pass + 1))
+else echo "FAIL  on-demand command exits 0 (rc=$rc)"; fail=$((fail + 1)); fi
+
+out="$(cat "$OUT_LOG")"
+err="$(cat "$ERR_LOG")"
+
+expect_contains "command reports counts in one line" "$out" "afk branch counts: remote-afk=2 remote-afk-attempts=2 local-afk=2"
+expect_not_ok "command does not boot a worker tree" worker_tree_exists
+expect_contains "command logs remote live deletion reason" "$err" "reaper: deleted remote live branch afk/wREM/702-closed (issue #702: closed-within-grace)"
+expect_contains "command logs remote snapshot deletion reason" "$err" "reaper: deleted remote snapshot branch afk-attempts/wATT/704-old (issue #704: closed-past-grace)"
+expect_contains "command logs local deletion reason" "$err" "reaper: deleted local live branch afk/wLOC/700-closed (issue #700: closed-past-grace)"
+
+expect_not_ok "local closed branch deleted" branch_exists "afk/wLOC/700-closed"
+expect_rc0    "local open branch kept" branch_exists "afk/wLOP/701-open"
+
+refs="$(git -C "$REPO" ls-remote --heads origin)"
+expect_not_contains "remote closed live branch deleted" "$refs" "refs/heads/afk/wREM/702-closed"
+expect_contains     "remote open live branch kept"     "$refs" "refs/heads/afk/wROP/703-open"
+expect_not_contains "remote old snapshot deleted"      "$refs" "refs/heads/afk-attempts/wATT/704-old"
+expect_contains     "remote open snapshot kept"        "$refs" "refs/heads/afk-attempts/wATP/705-open"
+
+: >"$ERR_LOG"
+RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S=$((7*DAY)) "$SCRIPT" "$REPO" >/dev/null 2>"$ERR_LOG"
+expect_not_contains "second run is idempotent: no duplicate deletion logs" "$(cat "$ERR_LOG")" "reaper: deleted"
+
+expect_contains "command invoked gh issue classifier" "$(cat "$GIT_LOG")" "issue view 703"
+
+echo
+echo "on-demand-reaper: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
Automated AFK landing for #275. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782718235&installation_id=129708444&pr_number=281&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F281&signature=d47fd66c3f0c93da7ed2085f97f0e3e0bcd1f9a53462afa85fd6dc0fb3502fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/afk reap` subcommand enabling on-demand branch cleanup operations with configurable grace period settings.

* **Documentation**
  * Expanded skill documentation with new command usage, configuration options, and branch cleanup scope details.

* **Tests**
  * Added comprehensive test suite for on-demand branch reaper with deletion verification and idempotency checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->