### PR TITLE
fix(afk): native fleet supervisor — poll cadence + real stall-reaper IO

### DIFF
--- a/packages/afk/src/commands/supervise.ts
+++ b/packages/afk/src/commands/supervise.ts
@@ -15,7 +15,16 @@ import {
   runSupervisor,
   type SupervisorDeps,
 } from "../core/supervisor.js";
-import { afkPaths } from "../runtime/wire.js";
+import { afkPaths, resolveRepoSlug } from "../runtime/wire.js";
+import { inspectProcessTreeNative } from "../runtime/proc-tree.js";
+import {
+  agentLaneMtimeFor,
+  parkedSlotWorkFor,
+  resolveIterDirInfo,
+  teardownIterDirNative,
+} from "../runtime/supervisor-fs.js";
+import * as ghx from "../runtime/gh.js";
+import { removeDir as removeDirNative } from "../runtime/fs.js";
 
 function isAlive(pid: number): boolean {
   try {
@@ -26,14 +35,32 @@ function isAlive(pid: number): boolean {
   }
 }
 
-/** Build SupervisorDeps that spawn `run --once` of this bundle per slot. The
- * stall/teardown/gh surfaces are best-effort no-ops in this cutover — the
- * orchestration + circuit-breaker + respawn loop is the load-bearing part. */
-function buildSupervisorDeps(root: string, logFd: number, runner: string): SupervisorDeps {
+/**
+ * Build SupervisorDeps backed by REAL process / filesystem / gh IO. Every
+ * closure mirrors a supervisor.sh function (see runtime/proc-tree.ts +
+ * runtime/supervisor-fs.ts) and is best-effort: a failed ps / stat / gh degrades
+ * to the SAFE value and never throws out of the closure.
+ *
+ * Slot pids are tracked in a per-slot map keyed by slot index. `spawnSlot`
+ * records the pid; the fs/proc closures resolve the live worker through it
+ * (mirroring SLOT_PIDS[$slot] in bash, which is how find_slot_iter_dir /
+ * agentLaneMtime / inspectTree all reach the running worker tree).
+ */
+function buildSupervisorDeps(
+  root: string,
+  tmpDir: string,
+  logFd: number,
+  runner: string,
+  ghCtx: ghx.GhContext,
+): SupervisorDeps {
   const bundle = process.argv[1];
+  const now = () => Math.floor(Date.now() / 1000);
+  // slot index → live orchestrator pid (SLOT_PIDS parity).
+  const slotPids = new Map<number, number>();
+
   return {
     proc: {
-      spawnSlot: async () => {
+      spawnSlot: async (slot) => {
         const child = spawn(process.execPath, [bundle, "run", "--once", "--runner", runner], {
           cwd: root,
           env: { ...process.env, RED_AFK_RUNNER: runner },
@@ -41,7 +68,9 @@ function buildSupervisorDeps(root: string, logFd: number, runner: string): Super
           stdio: ["ignore", logFd, logFd],
         });
         child.unref();
-        return { pid: child.pid ?? 0, spawnEpoch: Math.floor(Date.now() / 1000) };
+        const pid = child.pid ?? 0;
+        slotPids.set(slot, pid);
+        return { pid, spawnEpoch: now() };
       },
       isAlive,
       killTree: async (pid) => {
@@ -55,21 +84,50 @@ function buildSupervisorDeps(root: string, logFd: number, runner: string): Super
           }
         }
       },
-      inspectTree: () => [],
+      // Real ps-backed tree sample. A ps failure returns a CONSERVATIVE BUSY
+      // snapshot (never []), so a transient ps error can never authorise a reap.
+      inspectTree: (pid) => inspectProcessTreeNative(pid),
+      sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     },
     fs: {
-      agentLaneMtime: () => 0,
-      resolveIterDir: () => null,
-      teardownIterDir: async () => undefined,
-      parkedSlotWork: () => ({ workers: [], fastDeaths: 0, supervisorLogPath: "" }),
-      removeDir: async () => undefined,
+      agentLaneMtime: (slot) => agentLaneMtimeFor(tmpDir, slotPids.get(slot) ?? null),
+      resolveIterDir: (slot) => resolveIterDirInfo(tmpDir, slotPids.get(slot) ?? null, now()),
+      teardownIterDir: async (info) => {
+        await teardownIterDirNative(info, root);
+      },
+      parkedSlotWork: (slot) => parkedSlotWorkFor(tmpDir, root, slot, 0),
+      removeDir: async (path) => {
+        try {
+          await removeDirNative(path);
+        } catch {
+          // best-effort
+        }
+      },
     },
     gh: {
-      comment: async () => undefined,
-      editLabels: async () => undefined,
-      ensureRunnerErrorLabel: async () => undefined,
+      comment: async (issue, body) => {
+        try {
+          await ghx.comment(ghCtx, issue, body);
+        } catch {
+          // best-effort
+        }
+      },
+      editLabels: async (issue, add, remove) => {
+        try {
+          await ghx.editLabels(ghCtx, issue, remove, add);
+        } catch {
+          // best-effort
+        }
+      },
+      ensureRunnerErrorLabel: async () => {
+        try {
+          await ghx.ensureRunnerErrorLabel(ghCtx);
+        } catch {
+          // best-effort
+        }
+      },
     },
-    now: () => Math.floor(Date.now() / 1000),
+    now,
   };
 }
 
@@ -105,7 +163,9 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   const logFd = openSync(logFile, "a");
   const config = resolveSupervisorConfig();
   const state = initSupervisorState(config.target);
-  const deps = buildSupervisorDeps(root, logFd, config.runner);
+  const repo = await resolveRepoSlug(root).catch(() => "");
+  const ghCtx = { cwd: root, repo };
+  const deps = buildSupervisorDeps(root, tmp, logFd, config.runner, ghCtx);
 
   const stopRequested = (): boolean => existsSync(stopFile);
 

--- a/packages/afk/src/core/supervisor.ts
+++ b/packages/afk/src/core/supervisor.ts
@@ -43,6 +43,9 @@ export interface SupervisorConfig {
   /** Runner name carried in the discard / no-sentinel envelopes
    * (RED_AFK_RUNNER, default "claude"). */
   runner: string;
+  /** RED_AFK_POLL_S — seconds the health-check loop sleeps between ticks
+   * (default 15, matching supervisor.sh). Prevents the loop from busy-spinning. */
+  pollIntervalS: number;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -53,6 +56,7 @@ export const SUPERVISOR_DEFAULTS = {
   stallThresholdS: 600,
   stallKillThresholdS: 1800,
   runner: "claude",
+  pollIntervalS: 15,
 } as const satisfies SupervisorConfig;
 
 /**
@@ -80,6 +84,7 @@ export function resolveSupervisorConfig(
       SUPERVISOR_DEFAULTS.stallKillThresholdS,
     ),
     runner: env.RED_AFK_RUNNER && env.RED_AFK_RUNNER.length > 0 ? env.RED_AFK_RUNNER : SUPERVISOR_DEFAULTS.runner,
+    pollIntervalS: num("RED_AFK_POLL_S", SUPERVISOR_DEFAULTS.pollIntervalS),
   };
 }
 
@@ -190,6 +195,10 @@ export interface SupervisorProc {
    * reduction consumes (deriveSnapshot). Mirrors sup_descendant_pids feeding
    * sup_active_descendant + sup_tree_cpu. */
   inspectTree(pid: number): readonly ProcessSnapshotEntry[];
+  /** Sleep for `ms` between health-check ticks — the poll cadence (RED_AFK_POLL_S).
+   * Injected so tests advance the loop without real time. Mirrors the bash
+   * `sleep "$POLL_S"` at the bottom of the supervisor `while :` loop. */
+  sleep(ms: number): Promise<void>;
 }
 
 /** Filesystem side effects. Best-effort, like the bash `|| true` cleanups. */
@@ -621,8 +630,8 @@ export async function terminateAll(state: SupervisorState, deps: SupervisorDeps)
  * The supervisor's startup + health-check loop, composing the steps above. This
  * is the testable shape of supervisor.sh's main body (~1109-1141): validate
  * thresholds, spawn the initial fleet to target, then tick until the stop-file
- * appears. The poll cadence / stagger sleeps are the caller's concern (injected
- * via the tick driver) — this owns only the ordering.
+ * appears. Between ticks it sleeps the poll cadence (config.pollIntervalS, via
+ * the injected deps.proc.sleep) so the loop never busy-spins.
  */
 export async function runSupervisor(
   state: SupervisorState,
@@ -640,9 +649,10 @@ export async function runSupervisor(
     slot.spawnEpoch = spawned.spawnEpoch;
   }
 
-  // Health-check loop until the stop-file.
+  // Health-check loop until the stop-file, sleeping the poll cadence each pass.
   for (;;) {
     const result = await superviseTick(state, deps, config, stopRequested);
     if (result.stopped) return;
+    await deps.proc.sleep(config.pollIntervalS * 1000);
   }
 }

--- a/packages/afk/src/runtime/gh.ts
+++ b/packages/afk/src/runtime/gh.ts
@@ -105,6 +105,25 @@ export async function comment(ctx: GhContext, issue: number, body: string): Prom
   await gh(["issue", "comment", String(issue), ...repoArgs(ctx), "--body", body], opts(ctx));
 }
 
+/** Idempotently create the `runner-error` label (best-effort). Mirrors
+ * supervisor.sh ensure_runner_error_label — a label that already exists exits
+ * non-zero and is swallowed. */
+export async function ensureRunnerErrorLabel(ctx: GhContext): Promise<void> {
+  await gh(
+    [
+      "label",
+      "create",
+      "runner-error",
+      ...repoArgs(ctx),
+      "--color",
+      "B60205",
+      "--description",
+      "AFK supervisor circuit-tripped; runner was misconfigured",
+    ],
+    opts(ctx),
+  );
+}
+
 /** `gh issue close --reason completed`. */
 export async function closeIssue(ctx: GhContext, issue: number): Promise<void> {
   await gh(["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"], opts(ctx));

--- a/packages/afk/src/runtime/proc-tree.ts
+++ b/packages/afk/src/runtime/proc-tree.ts
@@ -1,0 +1,131 @@
+// runtime/proc-tree.ts — the real `ps`-backed worker-tree inspector.
+//
+// Mirrors supervisor.sh's sup_descendant_pids + sup_active_descendant +
+// sup_tree_cpu: collect a worker pid's descendant processes (pid + every
+// transitive child) and project each to a ProcessSnapshotEntry ({command, cpu})
+// the reaper-signal reduction (deriveSnapshot) consumes.
+//
+// This is the load-bearing SAFETY seam for the native fleet's hard-reaper. The
+// reaper only kills a stalled slot when the snapshot shows no active build/test
+// descendant AND flat cpu. An EMPTY snapshot therefore reads as "stuck" and
+// authorises a kill — so a transient `ps` failure must NEVER degrade to []. On
+// any inspection error we return a CONSERVATIVE BUSY snapshot (one synthetic
+// high-cpu entry) so a flaky `ps` can only ever spare a live worker, never reap
+// one.
+
+import { execFileSync } from "node:child_process";
+import type { ProcessSnapshotEntry } from "../core/reaper-signal.js";
+
+/** Synthetic entry returned when process inspection fails. Its cpu sits well
+ * above REAPER_SIGNAL_CPU_BUSY_PCT_DEFAULT (5) so deriveSnapshot →
+ * decideReaperSignal reads the tree as busy and refuses to kill. The command is
+ * deliberately not a recognised build/test tool — the cpu signal alone carries
+ * the conservative "busy" verdict, which is exactly the bash `ps` failure
+ * fallback intent (a failed ps must not authorise a reap). */
+export const CONSERVATIVE_BUSY_SNAPSHOT: readonly ProcessSnapshotEntry[] = [
+  { command: "unknown", cpu: 100 },
+];
+
+/** True when `pid` is a usable, non-foot-gun process id. Mirrors the
+ * sup_descendant_pids / sup_kill_tree guards: empty / non-numeric / <= 1 are
+ * refused. */
+function isInspectablePid(pid: number): boolean {
+  return Number.isInteger(pid) && pid > 1;
+}
+
+/**
+ * Parse the stdout of `ps -o pid=,ppid=,%cpu=,comm= -e` into a child→parent map
+ * plus per-pid {command, cpu}. Each line is whitespace-delimited:
+ *   `<pid> <ppid> <cpu> <comm…>`
+ * comm may contain spaces (rare, but `ps comm=` can emit a path) so everything
+ * past the third field is the command; we take its basename to mirror
+ * `ps -o comm=` semantics the busy regex expects. A malformed line is skipped.
+ */
+export function parsePsTree(stdout: string): {
+  children: Map<number, number[]>;
+  info: Map<number, ProcessSnapshotEntry>;
+} {
+  const children = new Map<number, number[]>();
+  const info = new Map<number, ProcessSnapshotEntry>();
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 4) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    const cpu = Number(parts[2]);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    const commandRaw = parts.slice(3).join(" ");
+    const command = basename(commandRaw);
+    info.set(pid, { command, cpu: Number.isFinite(cpu) ? cpu : 0 });
+    const siblings = children.get(ppid);
+    if (siblings) siblings.push(pid);
+    else children.set(ppid, [pid]);
+  }
+  return { children, info };
+}
+
+/** Basename of a `ps comm` value (strip any directory + trailing args). */
+function basename(comm: string): string {
+  const firstWord = comm.split(/\s+/)[0] ?? comm;
+  const slash = firstWord.lastIndexOf("/");
+  return slash >= 0 ? firstWord.slice(slash + 1) : firstWord;
+}
+
+/**
+ * Walk the parsed tree from `pid` and collect `pid` + every transitive
+ * descendant as ProcessSnapshotEntry[]. Mirrors sup_descendant_pids feeding
+ * sup_active_descendant + sup_tree_cpu. A pid absent from `info` (raced away
+ * between snapshot and walk) contributes nothing.
+ */
+export function collectTree(
+  pid: number,
+  children: Map<number, number[]>,
+  info: Map<number, ProcessSnapshotEntry>,
+): ProcessSnapshotEntry[] {
+  const out: ProcessSnapshotEntry[] = [];
+  const seen = new Set<number>();
+  const stack = [pid];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    const entry = info.get(current);
+    if (entry) out.push(entry);
+    const kids = children.get(current);
+    if (kids) for (const k of kids) stack.push(k);
+  }
+  return out;
+}
+
+/**
+ * Inspect the worker `pid`'s process tree into a ProcessSnapshotEntry[] via a
+ * single `ps` snapshot of all processes. Best-effort and SAFE BY DEFAULT:
+ *   - an un-inspectable pid (<=1, NaN) → [] (no tree, deriveSnapshot is empty;
+ *     a freed/garbage slot pid is genuinely not running anything).
+ *   - a `ps` spawn/parse failure → CONSERVATIVE_BUSY_SNAPSHOT so the reaper
+ *     never kills off the back of a transient inspection error.
+ *   - a successful `ps` that simply does not list the pid (already exited) → []
+ *     — that is a real, observed absence, not an inspection failure.
+ */
+export function inspectProcessTreeNative(pid: number): readonly ProcessSnapshotEntry[] {
+  if (!isInspectablePid(pid)) return [];
+  let stdout: string;
+  try {
+    stdout = execFileSync("ps", ["-e", "-o", "pid=,ppid=,%cpu=,comm="], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+  } catch {
+    // `ps` itself failed (missing binary, EAGAIN, buffer overflow, …). Failing
+    // to [] would read as "stuck" and authorise a kill — refuse: report busy.
+    return CONSERVATIVE_BUSY_SNAPSHOT;
+  }
+  try {
+    const { children, info } = parsePsTree(stdout);
+    return collectTree(pid, children, info);
+  } catch {
+    return CONSERVATIVE_BUSY_SNAPSHOT;
+  }
+}

--- a/packages/afk/src/runtime/supervisor-fs.ts
+++ b/packages/afk/src/runtime/supervisor-fs.ts
@@ -1,0 +1,260 @@
+// runtime/supervisor-fs.ts — real filesystem backing for the native fleet
+// supervisor's SupervisorFs surface.
+//
+// Mirrors the slot→worker→iter-dir resolution chain in supervisor.sh:
+//   parse_worker_ids_from_log  (slot log → worker IDs)
+//   find_slot_iter_dir         (slot pid → worker dir → newest attempt dir)
+//   find_slot_agent_lane       (iter dir → agent.log.jsonl mtime)
+//   iter_dirs_for_worker       (worker dir → every attempt dir)
+//   iter_dir_issue_number      (afk.state.json → .current.number)
+//   reap_stalled_slot reads    (notes, afk.log tail, duration)
+//
+// Every export is BEST-EFFORT: a failed read / stat / glob degrades to the safe
+// value (mtime 0, null iter dir, empty sweep work) and never throws out of a
+// SupervisorFs closure — the bash `|| true` cleanups.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { IterDirInfo, SweepWork, SweepWorker } from "../core/supervisor.js";
+import { workerDir } from "../core/worker-paths.js";
+
+/** Absolute path of a slot's per-worker stdout/stderr log
+ * (`afk-supervisor-slot-{slot}.log`). Mirrors spawn_slot's slot_log. */
+export function slotLogPath(tmpDir: string, slot: number): string {
+  return join(tmpDir, `afk-supervisor-slot-${slot}.log`);
+}
+
+/**
+ * Parse each unique worker ID (`wXXXX`) from a slot log's boot-stamp lines,
+ * first-seen order preserved. Mirrors parse_worker_ids_from_log's awk over
+ * `[afk] worker: wXXXX` lines. A missing / unreadable file → [].
+ */
+export function parseWorkerIdsFromLog(path: string): string[] {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const line of text.split("\n")) {
+    const m = line.match(/^\[afk\] worker: (w[A-Z0-9]+)$/);
+    if (!m) continue;
+    const wid = m[1]!;
+    if (!seen.has(wid)) {
+      seen.add(wid);
+      out.push(wid);
+    }
+  }
+  return out;
+}
+
+/** Every attempt dir (`workers/{wid}/{issue}-a{n}`) for a worker, absolute
+ * paths. Mirrors iter_dirs_for_worker. Missing worker dir → []. */
+export function iterDirsForWorker(root: string, wid: string): string[] {
+  const wdir = workerDir(root, wid);
+  let entries: string[];
+  try {
+    entries = readdirSync(wdir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    const dir = join(wdir, entry);
+    try {
+      if (statSync(dir).isDirectory()) out.push(dir);
+    } catch {
+      // raced away — skip
+    }
+  }
+  return out;
+}
+
+/** `.current.number` from a dir's afk.state.json, or null. Mirrors
+ * iter_dir_issue_number. */
+export function iterDirIssueNumber(dir: string): number | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(dir, "afk.state.json"), "utf8")) as {
+      current?: { number?: unknown };
+    };
+    const n = parsed.current?.number;
+    return typeof n === "number" && Number.isInteger(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the slot's CURRENT iter dir from the slot's live worker pid: find the
+ * `workers/{wid}/worker.pid` whose contents equal `slotPid`, then its newest
+ * attempt dir (by mtime). Mirrors find_slot_iter_dir. Returns null when the
+ * worker is between iterations / no pid match.
+ */
+export function findSlotIterDir(tmpDir: string, slotPid: number | null): string | null {
+  if (slotPid === null || !Number.isInteger(slotPid) || slotPid <= 0) return null;
+  const workersRoot = join(tmpDir, "workers");
+  let workerDirs: string[];
+  try {
+    workerDirs = readdirSync(workersRoot);
+  } catch {
+    return null;
+  }
+  for (const wid of workerDirs) {
+    const wdir = join(workersRoot, wid);
+    let pidText: string;
+    try {
+      pidText = readFileSync(join(wdir, "worker.pid"), "utf8").trim();
+    } catch {
+      continue;
+    }
+    if (Number(pidText) !== slotPid) continue;
+    // newest attempt dir under this worker
+    let entries: string[];
+    try {
+      entries = readdirSync(wdir);
+    } catch {
+      return null;
+    }
+    let newest: string | null = null;
+    let newestMtime = -1;
+    for (const entry of entries) {
+      const dir = join(wdir, entry);
+      try {
+        const st = statSync(dir);
+        if (!st.isDirectory()) continue;
+        const m = st.mtimeMs;
+        if (m > newestMtime) {
+          newestMtime = m;
+          newest = dir;
+        }
+      } catch {
+        // skip
+      }
+    }
+    return newest;
+  }
+  return null;
+}
+
+/**
+ * agentLaneMtime backing: resolve the slot's live worker via the slot log, then
+ * its current attempt's agent.log.jsonl mtime in whole seconds; 0 when absent.
+ * Mirrors find_slot_agent_lane + the `stat -c %Y` read. The slot's live pid is
+ * the bridge from log-parsed worker IDs to the running worker.pid match — but
+ * since the supervisor already holds the slot pid, we resolve the iter dir
+ * directly from it (find_slot_iter_dir), which is exactly what bash does. The
+ * slot-log parse is retained for sweep work; here pid resolution is enough.
+ */
+export function agentLaneMtimeFor(tmpDir: string, slotPid: number | null): number {
+  const dir = findSlotIterDir(tmpDir, slotPid);
+  if (dir === null) return 0;
+  try {
+    return Math.floor(statSync(join(dir, "agent.log.jsonl")).mtimeMs / 1000);
+  } catch {
+    return 0;
+  }
+}
+
+/** Tail of the last `n` lines of a file, or "" when absent. */
+function tailFile(path: string, n: number): string {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+  const lines = text.split("\n");
+  // drop a single trailing empty line from a final newline
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines.slice(-n).join("\n");
+}
+
+/**
+ * resolveIterDir backing: the slot's current iteration + the envelope material
+ * reap_stalled_slot pulls from afk.state.json (issue, worker_id, started_at →
+ * duration), handoff.md (notes), and afk.log (log tail). Returns null when no
+ * iter dir resolves. Best-effort: missing pieces degrade to empty / 0.
+ */
+export function resolveIterDirInfo(
+  tmpDir: string,
+  slotPid: number | null,
+  now: number,
+): IterDirInfo | null {
+  const dir = findSlotIterDir(tmpDir, slotPid);
+  if (dir === null) return null;
+
+  let issue: number | null = null;
+  let workerId = "";
+  let startedAt = "";
+  try {
+    const parsed = JSON.parse(readFileSync(join(dir, "afk.state.json"), "utf8")) as {
+      current?: { number?: unknown };
+      worker_id?: unknown;
+      started_at?: unknown;
+    };
+    const n = parsed.current?.number;
+    if (typeof n === "number" && Number.isInteger(n)) issue = n;
+    if (typeof parsed.worker_id === "string") workerId = parsed.worker_id;
+    if (typeof parsed.started_at === "string") startedAt = parsed.started_at;
+  } catch {
+    // no state → no issue/worker; teardown still proceeds on the dir
+  }
+
+  let durationS = 0;
+  if (startedAt.length > 0) {
+    const startedEpoch = Math.floor(Date.parse(startedAt) / 1000);
+    if (Number.isFinite(startedEpoch) && startedEpoch > 0 && now > startedEpoch) {
+      durationS = now - startedEpoch;
+    }
+  }
+
+  const notes = tailFile(join(dir, "handoff.md"), 200);
+  const logTail = tailFile(join(dir, "afk.log"), 50);
+
+  return { path: dir, issue, workerId, logTail, notes, durationS };
+}
+
+/**
+ * parkedSlotWork backing: every worker ID seen in the slot log → its iter dirs
+ * → each dir's claimed issue. Mirrors the sweep_parked_slot collection. Empty
+ * workers list when the slot log named none (no-op sweep upstream).
+ */
+export function parkedSlotWorkFor(
+  tmpDir: string,
+  root: string,
+  slot: number,
+  fastDeaths: number,
+): SweepWork {
+  const supervisorLogPath = join(tmpDir, "afk-supervisor.log");
+  const wids = parseWorkerIdsFromLog(slotLogPath(tmpDir, slot));
+  const workers: SweepWorker[] = wids.map((wid) => ({
+    workerId: wid,
+    pairs: iterDirsForWorker(root, wid).map((dir) => ({
+      dir,
+      issue: iterDirIssueNumber(dir),
+    })),
+  }));
+  return { workers, fastDeaths, supervisorLogPath };
+}
+
+/** Best-effort worktree teardown + iter-dir removal for a reaped slot. Mirrors
+ * reap_stalled_slot step 4 (git worktree remove + rm -rf). */
+export async function teardownIterDirNative(info: IterDirInfo, root: string): Promise<void> {
+  const fsp = await import("node:fs/promises");
+  const worktree = join(info.path, "worktree");
+  if (existsSync(worktree)) {
+    try {
+      const { git } = await import("./exec.js");
+      await git(["-C", root, "worktree", "remove", "--force", worktree]);
+    } catch {
+      // best-effort
+    }
+  }
+  try {
+    await fsp.rm(info.path, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/afk/tests/proc-tree.test.ts
+++ b/packages/afk/tests/proc-tree.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONSERVATIVE_BUSY_SNAPSHOT,
+  collectTree,
+  inspectProcessTreeNative,
+  parsePsTree,
+} from "../src/runtime/proc-tree.js";
+import { deriveSnapshot } from "../src/core/reaper-signal.js";
+
+// A `ps -e -o pid=,ppid=,%cpu=,comm=` style dump:
+//   1000 is the worker orchestrator; 1001 a pnpm-spawned node; 1002 vitest
+//   under 1001; 2000 is an unrelated process tree the walk must NOT pull in.
+const SAMPLE_PS = [
+  "    1 0 0.0 systemd",
+  " 1000 1 1.2 node",
+  " 1001 1000 3.4 node",
+  " 1002 1001 88.5 vitest",
+  " 2000 1 50.0 firefox",
+].join("\n");
+
+describe("parsePsTree", () => {
+  it("parses pid/ppid/cpu/comm and builds the child map + info", () => {
+    const { children, info } = parsePsTree(SAMPLE_PS);
+    expect(info.get(1000)).toEqual({ command: "node", cpu: 1.2 });
+    expect(info.get(1002)).toEqual({ command: "vitest", cpu: 88.5 });
+    expect(children.get(1000)).toEqual([1001]);
+    expect(children.get(1001)).toEqual([1002]);
+  });
+
+  it("takes the comm basename and skips malformed lines", () => {
+    const { info } = parsePsTree(
+      ["", "  garbage", " 50 1 0.0 /usr/bin/tsc --watch", " x y z foo"].join("\n"),
+    );
+    expect(info.get(50)).toEqual({ command: "tsc", cpu: 0 });
+    expect(info.size).toBe(1);
+  });
+});
+
+describe("collectTree", () => {
+  it("collects the pid + every transitive descendant, not siblings", () => {
+    const { children, info } = parsePsTree(SAMPLE_PS);
+    const tree = collectTree(1000, children, info);
+    const commands = tree.map((e) => e.command).sort();
+    expect(commands).toEqual(["node", "node", "vitest"]);
+    // The unrelated firefox tree is excluded.
+    expect(tree.some((e) => e.command === "firefox")).toBe(false);
+    // The reaper reduction sees the active vitest descendant.
+    const snap = deriveSnapshot(tree);
+    expect(snap.activeDescendant).toBe(true);
+  });
+
+  it("a pid absent from the snapshot yields an empty tree", () => {
+    const { children, info } = parsePsTree(SAMPLE_PS);
+    expect(collectTree(99999, children, info)).toEqual([]);
+  });
+});
+
+describe("inspectProcessTreeNative", () => {
+  it("an un-inspectable pid (<=1) returns [] without running ps", () => {
+    expect(inspectProcessTreeNative(0)).toEqual([]);
+    expect(inspectProcessTreeNative(1)).toEqual([]);
+    expect(inspectProcessTreeNative(Number.NaN)).toEqual([]);
+  });
+
+  it("the conservative busy fallback reads as busy (deriveSnapshot)", () => {
+    // The ps-failure fallback must NOT authorise a reap: its cpu sits above the
+    // busy line so the reaper-signal reduction reports the tree busy.
+    const snap = deriveSnapshot(CONSERVATIVE_BUSY_SNAPSHOT);
+    expect(snap.cpuPct).toBeGreaterThanOrEqual(5);
+  });
+
+  it("a real self-inspection returns this process in its own tree", () => {
+    // process.pid is inspectable; ps should list at least this node process.
+    const tree = inspectProcessTreeNative(process.pid);
+    // Either a real tree (length >= 1) or — on an exotic host where ps failed —
+    // the conservative busy fallback. Both are non-empty and SAFE.
+    expect(tree.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/afk/tests/supervisor.test.ts
+++ b/packages/afk/tests/supervisor.test.ts
@@ -30,6 +30,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     stallThresholdS: 30,
     stallKillThresholdS: 90,
     runner: "claude",
+    pollIntervalS: 15,
     ...over,
   };
 }
@@ -39,6 +40,7 @@ interface FakeIo {
   isAlive: ReturnType<typeof vi.fn>;
   killTree: ReturnType<typeof vi.fn>;
   inspectTree: ReturnType<typeof vi.fn>;
+  sleep: ReturnType<typeof vi.fn>;
   agentLaneMtime: ReturnType<typeof vi.fn>;
   resolveIterDir: ReturnType<typeof vi.fn>;
   teardownIterDir: ReturnType<typeof vi.fn>;
@@ -60,6 +62,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     isAlive: vi.fn(() => true),
     killTree: vi.fn(async () => {}),
     inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
+    sleep: vi.fn(async () => {}),
     agentLaneMtime: vi.fn(() => 0),
     resolveIterDir: vi.fn((): IterDirInfo | null => null),
     teardownIterDir: vi.fn(async () => {}),
@@ -79,6 +82,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       isAlive: io.isAlive,
       killTree: io.killTree,
       inspectTree: io.inspectTree,
+      sleep: io.sleep,
     },
     fs: {
       agentLaneMtime: io.agentLaneMtime,
@@ -417,6 +421,39 @@ describe("runSupervisor", () => {
     expect(io.spawnSlot).toHaveBeenCalledWith(1);
     // Stop-file honoured → workers terminated.
     expect(io.killTree).toHaveBeenCalled();
+    // Stopped on the first tick → no inter-tick sleep happened.
+    expect(io.sleep).not.toHaveBeenCalled();
+  });
+
+  it("sleeps the poll cadence between ticks before stopping on the 2nd", async () => {
+    const { deps, io } = makeDeps({ isAlive: vi.fn(() => true) });
+    const state = initSupervisorState(1);
+
+    // Stop on the SECOND stop-file probe: tick 1 runs (no stop), the loop
+    // sleeps the cadence, tick 2 sees the stop and returns.
+    let probes = 0;
+    const stop = () => {
+      probes += 1;
+      return probes >= 2;
+    };
+
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15 }), stop);
+
+    // Exactly one inter-tick sleep, at the configured cadence (15s → 15000ms).
+    expect(io.sleep).toHaveBeenCalledTimes(1);
+    expect(io.sleep).toHaveBeenCalledWith(15000);
+  });
+
+  it("honours a non-default poll cadence", async () => {
+    const { deps, io } = makeDeps({ isAlive: vi.fn(() => true) });
+    const state = initSupervisorState(1);
+    let probes = 0;
+    const stop = () => (++probes >= 2);
+
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 7 }), stop);
+
+    expect(io.sleep).toHaveBeenCalledTimes(1);
+    expect(io.sleep).toHaveBeenCalledWith(7000);
   });
 });
 

--- a/plugins/dev/skills/engineering/afk/bin/afk.mjs
+++ b/plugins/dev/skills/engineering/afk/bin/afk.mjs
@@ -38720,7 +38720,7 @@ var require_filesystem = __commonJS({
     var LDD_PATH = "/usr/bin/ldd";
     var SELF_PATH = "/proc/self/exe";
     var MAX_LENGTH = 2048;
-    var readFileSync2 = (path2) => {
+    var readFileSync3 = (path2) => {
       const fd = fs.openSync(path2, "r");
       const buffer3 = Buffer.alloc(MAX_LENGTH);
       const bytesRead = fs.readSync(fd, buffer3, 0, MAX_LENGTH, 0);
@@ -38745,7 +38745,7 @@ var require_filesystem = __commonJS({
     module.exports = {
       LDD_PATH,
       SELF_PATH,
-      readFileSync: readFileSync2,
+      readFileSync: readFileSync3,
       readFile: readFile8
     };
   }
@@ -38794,7 +38794,7 @@ var require_detect_libc = __commonJS({
     "use strict";
     var childProcess = __require("child_process");
     var { isLinux, getReport } = require_process();
-    var { LDD_PATH, SELF_PATH, readFile: readFile8, readFileSync: readFileSync2 } = require_filesystem();
+    var { LDD_PATH, SELF_PATH, readFile: readFile8, readFileSync: readFileSync3 } = require_filesystem();
     var { interpreterPath } = require_elf();
     var cachedFamilyInterpreter;
     var cachedFamilyFilesystem;
@@ -38886,7 +38886,7 @@ var require_detect_libc = __commonJS({
       }
       cachedFamilyFilesystem = null;
       try {
-        const lddContent = readFileSync2(LDD_PATH);
+        const lddContent = readFileSync3(LDD_PATH);
         cachedFamilyFilesystem = getFamilyFromLddContent(lddContent);
       } catch (e2) {
       }
@@ -38911,7 +38911,7 @@ var require_detect_libc = __commonJS({
       }
       cachedFamilyInterpreter = null;
       try {
-        const selfContent = readFileSync2(SELF_PATH);
+        const selfContent = readFileSync3(SELF_PATH);
         const path2 = interpreterPath(selfContent);
         cachedFamilyInterpreter = familyFromInterpreterPath(path2);
       } catch (e2) {
@@ -38975,7 +38975,7 @@ var require_detect_libc = __commonJS({
       }
       cachedVersionFilesystem = null;
       try {
-        const lddContent = readFileSync2(LDD_PATH);
+        const lddContent = readFileSync3(LDD_PATH);
         const versionMatch = lddContent.match(RE_GLIBC_VERSION);
         if (versionMatch) {
           cachedVersionFilesystem = versionMatch[1];
@@ -39119,19 +39119,19 @@ var require_node_gyp_build = __commonJS({
       }
       throw new Error(errMessage);
       function resolve6(dir2) {
-        var tuples = readdirSync(path2.join(dir2, "prebuilds")).map(parseTuple);
+        var tuples = readdirSync2(path2.join(dir2, "prebuilds")).map(parseTuple);
         var tuple4 = tuples.filter(matchTuple(platform, arch)).sort(compareTuples)[0];
         if (!tuple4) return;
         return resolveFile(path2.join(dir2, "prebuilds", tuple4.name));
       }
       function resolveFile(prebuilds) {
-        var parsed = readdirSync(prebuilds).map(parseTags);
+        var parsed = readdirSync2(prebuilds).map(parseTags);
         var candidates = parsed.filter(matchTags(runtime5, abi));
         var winner = candidates.sort(compareTags(runtime5))[0];
         if (winner) return path2.join(prebuilds, winner.file);
       }
     };
-    function readdirSync(dir) {
+    function readdirSync2(dir) {
       try {
         return fs.readdirSync(dir);
       } catch (err) {
@@ -39139,7 +39139,7 @@ var require_node_gyp_build = __commonJS({
       }
     }
     function getFirst(dir, filter12) {
-      var files = readdirSync(dir).filter(filter12);
+      var files = readdirSync2(dir).filter(filter12);
       return files[0] && path2.join(dir, files[0]);
     }
     function matchBuild(name) {
@@ -81938,6 +81938,21 @@ async function editLabels(ctx, issue, remove13, add6) {
 async function comment(ctx, issue, body) {
   await gh(["issue", "comment", String(issue), ...repoArgs(ctx), "--body", body], opts(ctx));
 }
+async function ensureRunnerErrorLabel(ctx) {
+  await gh(
+    [
+      "label",
+      "create",
+      "runner-error",
+      ...repoArgs(ctx),
+      "--color",
+      "B60205",
+      "--description",
+      "AFK supervisor circuit-tripped; runner was misconfigured"
+    ],
+    opts(ctx)
+  );
+}
 async function closeIssue(ctx, issue) {
   await gh(["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"], opts(ctx));
 }
@@ -84156,8 +84171,8 @@ async function reapCommand(_args, cwd = process.cwd(), stdout2 = process.stdout)
 
 // src/commands/supervise.ts
 import { spawn as spawn7 } from "node:child_process";
-import { existsSync as existsSync6, openSync, writeFileSync, rmSync } from "node:fs";
-import { join as join23 } from "node:path";
+import { existsSync as existsSync7, openSync, writeFileSync, rmSync } from "node:fs";
+import { join as join24 } from "node:path";
 
 // src/core/reaper-signal.ts
 var REAPER_SIGNAL_CPU_BUSY_PCT_DEFAULT = 5;
@@ -84196,7 +84211,8 @@ var SUPERVISOR_DEFAULTS = {
   circuitWindowS: 90,
   stallThresholdS: 600,
   stallKillThresholdS: 1800,
-  runner: "claude"
+  runner: "claude",
+  pollIntervalS: 15
 };
 function resolveSupervisorConfig(env2 = process.env) {
   const num = (key, fallback) => {
@@ -84214,7 +84230,8 @@ function resolveSupervisorConfig(env2 = process.env) {
       "RED_AFK_STALL_KILL_THRESHOLD_S",
       SUPERVISOR_DEFAULTS.stallKillThresholdS
     ),
-    runner: env2.RED_AFK_RUNNER && env2.RED_AFK_RUNNER.length > 0 ? env2.RED_AFK_RUNNER : SUPERVISOR_DEFAULTS.runner
+    runner: env2.RED_AFK_RUNNER && env2.RED_AFK_RUNNER.length > 0 ? env2.RED_AFK_RUNNER : SUPERVISOR_DEFAULTS.runner,
+    pollIntervalS: num("RED_AFK_POLL_S", SUPERVISOR_DEFAULTS.pollIntervalS)
   };
 }
 function validateStallThresholds(config) {
@@ -84433,10 +84450,249 @@ async function runSupervisor(state, deps, config, stopRequested) {
   for (; ; ) {
     const result = await superviseTick(state, deps, config, stopRequested);
     if (result.stopped) return;
+    await deps.proc.sleep(config.pollIntervalS * 1e3);
+  }
+}
+
+// src/runtime/proc-tree.ts
+import { execFileSync as execFileSync3 } from "node:child_process";
+var CONSERVATIVE_BUSY_SNAPSHOT = [
+  { command: "unknown", cpu: 100 }
+];
+function isInspectablePid(pid) {
+  return Number.isInteger(pid) && pid > 1;
+}
+function parsePsTree(stdout2) {
+  const children2 = /* @__PURE__ */ new Map();
+  const info = /* @__PURE__ */ new Map();
+  for (const rawLine of stdout2.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    const parts2 = line.split(/\s+/);
+    if (parts2.length < 4) continue;
+    const pid = Number(parts2[0]);
+    const ppid = Number(parts2[1]);
+    const cpu = Number(parts2[2]);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    const commandRaw = parts2.slice(3).join(" ");
+    const command = basename2(commandRaw);
+    info.set(pid, { command, cpu: Number.isFinite(cpu) ? cpu : 0 });
+    const siblings = children2.get(ppid);
+    if (siblings) siblings.push(pid);
+    else children2.set(ppid, [pid]);
+  }
+  return { children: children2, info };
+}
+function basename2(comm) {
+  const firstWord = comm.split(/\s+/)[0] ?? comm;
+  const slash = firstWord.lastIndexOf("/");
+  return slash >= 0 ? firstWord.slice(slash + 1) : firstWord;
+}
+function collectTree(pid, children2, info) {
+  const out = [];
+  const seen = /* @__PURE__ */ new Set();
+  const stack = [pid];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (seen.has(current)) continue;
+    seen.add(current);
+    const entry = info.get(current);
+    if (entry) out.push(entry);
+    const kids = children2.get(current);
+    if (kids) for (const k2 of kids) stack.push(k2);
+  }
+  return out;
+}
+function inspectProcessTreeNative(pid) {
+  if (!isInspectablePid(pid)) return [];
+  let stdout2;
+  try {
+    stdout2 = execFileSync3("ps", ["-e", "-o", "pid=,ppid=,%cpu=,comm="], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024
+    });
+  } catch {
+    return CONSERVATIVE_BUSY_SNAPSHOT;
+  }
+  try {
+    const { children: children2, info } = parsePsTree(stdout2);
+    return collectTree(pid, children2, info);
+  } catch {
+    return CONSERVATIVE_BUSY_SNAPSHOT;
+  }
+}
+
+// src/runtime/supervisor-fs.ts
+import { existsSync as existsSync6, readdirSync, readFileSync as readFileSync2, statSync as statSync2 } from "node:fs";
+import { join as join23 } from "node:path";
+function slotLogPath(tmpDir, slot) {
+  return join23(tmpDir, `afk-supervisor-slot-${slot}.log`);
+}
+function parseWorkerIdsFromLog(path2) {
+  let text3;
+  try {
+    text3 = readFileSync2(path2, "utf8");
+  } catch {
+    return [];
+  }
+  const out = [];
+  const seen = /* @__PURE__ */ new Set();
+  for (const line of text3.split("\n")) {
+    const m2 = line.match(/^\[afk\] worker: (w[A-Z0-9]+)$/);
+    if (!m2) continue;
+    const wid = m2[1];
+    if (!seen.has(wid)) {
+      seen.add(wid);
+      out.push(wid);
+    }
+  }
+  return out;
+}
+function iterDirsForWorker(root, wid) {
+  const wdir = workerDir(root, wid);
+  let entries2;
+  try {
+    entries2 = readdirSync(wdir);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const entry of entries2) {
+    const dir = join23(wdir, entry);
+    try {
+      if (statSync2(dir).isDirectory()) out.push(dir);
+    } catch {
+    }
+  }
+  return out;
+}
+function iterDirIssueNumber(dir) {
+  try {
+    const parsed = JSON.parse(readFileSync2(join23(dir, "afk.state.json"), "utf8"));
+    const n = parsed.current?.number;
+    return typeof n === "number" && Number.isInteger(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+function findSlotIterDir(tmpDir, slotPid) {
+  if (slotPid === null || !Number.isInteger(slotPid) || slotPid <= 0) return null;
+  const workersRoot = join23(tmpDir, "workers");
+  let workerDirs;
+  try {
+    workerDirs = readdirSync(workersRoot);
+  } catch {
+    return null;
+  }
+  for (const wid of workerDirs) {
+    const wdir = join23(workersRoot, wid);
+    let pidText;
+    try {
+      pidText = readFileSync2(join23(wdir, "worker.pid"), "utf8").trim();
+    } catch {
+      continue;
+    }
+    if (Number(pidText) !== slotPid) continue;
+    let entries2;
+    try {
+      entries2 = readdirSync(wdir);
+    } catch {
+      return null;
+    }
+    let newest = null;
+    let newestMtime = -1;
+    for (const entry of entries2) {
+      const dir = join23(wdir, entry);
+      try {
+        const st2 = statSync2(dir);
+        if (!st2.isDirectory()) continue;
+        const m2 = st2.mtimeMs;
+        if (m2 > newestMtime) {
+          newestMtime = m2;
+          newest = dir;
+        }
+      } catch {
+      }
+    }
+    return newest;
+  }
+  return null;
+}
+function agentLaneMtimeFor(tmpDir, slotPid) {
+  const dir = findSlotIterDir(tmpDir, slotPid);
+  if (dir === null) return 0;
+  try {
+    return Math.floor(statSync2(join23(dir, "agent.log.jsonl")).mtimeMs / 1e3);
+  } catch {
+    return 0;
+  }
+}
+function tailFile(path2, n) {
+  let text3;
+  try {
+    text3 = readFileSync2(path2, "utf8");
+  } catch {
+    return "";
+  }
+  const lines2 = text3.split("\n");
+  if (lines2.length > 0 && lines2[lines2.length - 1] === "") lines2.pop();
+  return lines2.slice(-n).join("\n");
+}
+function resolveIterDirInfo(tmpDir, slotPid, now) {
+  const dir = findSlotIterDir(tmpDir, slotPid);
+  if (dir === null) return null;
+  let issue = null;
+  let workerId = "";
+  let startedAt = "";
+  try {
+    const parsed = JSON.parse(readFileSync2(join23(dir, "afk.state.json"), "utf8"));
+    const n = parsed.current?.number;
+    if (typeof n === "number" && Number.isInteger(n)) issue = n;
+    if (typeof parsed.worker_id === "string") workerId = parsed.worker_id;
+    if (typeof parsed.started_at === "string") startedAt = parsed.started_at;
+  } catch {
+  }
+  let durationS = 0;
+  if (startedAt.length > 0) {
+    const startedEpoch = Math.floor(Date.parse(startedAt) / 1e3);
+    if (Number.isFinite(startedEpoch) && startedEpoch > 0 && now > startedEpoch) {
+      durationS = now - startedEpoch;
+    }
+  }
+  const notes = tailFile(join23(dir, "handoff.md"), 200);
+  const logTail = tailFile(join23(dir, "afk.log"), 50);
+  return { path: dir, issue, workerId, logTail, notes, durationS };
+}
+function parkedSlotWorkFor(tmpDir, root, slot, fastDeaths) {
+  const supervisorLogPath = join23(tmpDir, "afk-supervisor.log");
+  const wids = parseWorkerIdsFromLog(slotLogPath(tmpDir, slot));
+  const workers = wids.map((wid) => ({
+    workerId: wid,
+    pairs: iterDirsForWorker(root, wid).map((dir) => ({
+      dir,
+      issue: iterDirIssueNumber(dir)
+    }))
+  }));
+  return { workers, fastDeaths, supervisorLogPath };
+}
+async function teardownIterDirNative(info, root) {
+  const fsp = await import("node:fs/promises");
+  const worktree = join23(info.path, "worktree");
+  if (existsSync6(worktree)) {
+    try {
+      const { git: git2 } = await Promise.resolve().then(() => (init_exec(), exec_exports));
+      await git2(["-C", root, "worktree", "remove", "--force", worktree]);
+    } catch {
+    }
+  }
+  try {
+    await fsp.rm(info.path, { recursive: true, force: true });
+  } catch {
   }
 }
 
 // src/commands/supervise.ts
+init_fs();
 function isAlive(pid) {
   try {
     process.kill(pid, 0);
@@ -84445,11 +84701,13 @@ function isAlive(pid) {
     return false;
   }
 }
-function buildSupervisorDeps(root, logFd, runner) {
+function buildSupervisorDeps(root, tmpDir, logFd, runner, ghCtx) {
   const bundle = process.argv[1];
+  const now = () => Math.floor(Date.now() / 1e3);
+  const slotPids = /* @__PURE__ */ new Map();
   return {
     proc: {
-      spawnSlot: async () => {
+      spawnSlot: async (slot) => {
         const child = spawn7(process.execPath, [bundle, "run", "--once", "--runner", runner], {
           cwd: root,
           env: { ...process.env, RED_AFK_RUNNER: runner },
@@ -84457,7 +84715,9 @@ function buildSupervisorDeps(root, logFd, runner) {
           stdio: ["ignore", logFd, logFd]
         });
         child.unref();
-        return { pid: child.pid ?? 0, spawnEpoch: Math.floor(Date.now() / 1e3) };
+        const pid = child.pid ?? 0;
+        slotPids.set(slot, pid);
+        return { pid, spawnEpoch: now() };
       },
       isAlive,
       killTree: async (pid) => {
@@ -84470,32 +84730,57 @@ function buildSupervisorDeps(root, logFd, runner) {
           }
         }
       },
-      inspectTree: () => []
+      // Real ps-backed tree sample. A ps failure returns a CONSERVATIVE BUSY
+      // snapshot (never []), so a transient ps error can never authorise a reap.
+      inspectTree: (pid) => inspectProcessTreeNative(pid),
+      sleep: (ms) => new Promise((resolve6) => setTimeout(resolve6, ms))
     },
     fs: {
-      agentLaneMtime: () => 0,
-      resolveIterDir: () => null,
-      teardownIterDir: async () => void 0,
-      parkedSlotWork: () => ({ workers: [], fastDeaths: 0, supervisorLogPath: "" }),
-      removeDir: async () => void 0
+      agentLaneMtime: (slot) => agentLaneMtimeFor(tmpDir, slotPids.get(slot) ?? null),
+      resolveIterDir: (slot) => resolveIterDirInfo(tmpDir, slotPids.get(slot) ?? null, now()),
+      teardownIterDir: async (info) => {
+        await teardownIterDirNative(info, root);
+      },
+      parkedSlotWork: (slot) => parkedSlotWorkFor(tmpDir, root, slot, 0),
+      removeDir: async (path2) => {
+        try {
+          await removeDir(path2);
+        } catch {
+        }
+      }
     },
     gh: {
-      comment: async () => void 0,
-      editLabels: async () => void 0,
-      ensureRunnerErrorLabel: async () => void 0
+      comment: async (issue, body) => {
+        try {
+          await comment(ghCtx, issue, body);
+        } catch {
+        }
+      },
+      editLabels: async (issue, add6, remove13) => {
+        try {
+          await editLabels(ghCtx, issue, remove13, add6);
+        } catch {
+        }
+      },
+      ensureRunnerErrorLabel: async () => {
+        try {
+          await ensureRunnerErrorLabel(ghCtx);
+        } catch {
+        }
+      }
     },
-    now: () => Math.floor(Date.now() / 1e3)
+    now
   };
 }
 async function superviseCommand(args2, cwd = process.cwd()) {
   const root = cwd;
   const paths = afkPaths(root);
   const tmp = paths.tmpDir;
-  const pidFile = join23(tmp, "afk-supervisor.pid");
-  const stopFile = join23(tmp, "afk-supervisor.stop");
-  const logFile = join23(tmp, "afk-supervisor.log");
+  const pidFile = join24(tmp, "afk-supervisor.pid");
+  const stopFile = join24(tmp, "afk-supervisor.stop");
+  const logFile = join24(tmp, "afk-supervisor.log");
   await Promise.resolve().then(() => (init_fs(), fs_exports)).then((m2) => m2.ensureDir(tmp));
-  if (existsSync6(pidFile)) {
+  if (existsSync7(pidFile)) {
     try {
       const prev = Number(__require("node:fs").readFileSync(pidFile, "utf8").trim());
       if (prev && isAlive(prev)) {
@@ -84507,12 +84792,14 @@ async function superviseCommand(args2, cwd = process.cwd()) {
     }
   }
   writeFileSync(pidFile, String(process.pid), "utf8");
-  if (existsSync6(stopFile)) rmSync(stopFile, { force: true });
+  if (existsSync7(stopFile)) rmSync(stopFile, { force: true });
   const logFd = openSync(logFile, "a");
   const config = resolveSupervisorConfig();
   const state = initSupervisorState(config.target);
-  const deps = buildSupervisorDeps(root, logFd, config.runner);
-  const stopRequested = () => existsSync6(stopFile);
+  const repo = await resolveRepoSlug(root).catch(() => "");
+  const ghCtx = { cwd: root, repo };
+  const deps = buildSupervisorDeps(root, tmp, logFd, config.runner, ghCtx);
+  const stopRequested = () => existsSync7(stopFile);
   try {
     await runSupervisor(state, deps, config, stopRequested);
   } finally {


### PR DESCRIPTION
Resolves the supervisor parts of #284: the native `runSupervisor` busy-spun (no inter-tick sleep) and `buildSupervisorDeps` wired the stall-reaper IO as no-ops (making it reap healthy workers). Adds `RED_AFK_POLL_S` cadence + injected `proc.sleep`, and backs inspectTree (ps, conservative-busy on error), agentLaneMtime, iter-dir resolution, and gh closures with real IO. 543 tests; bundle builds; monitor/reap still native. Only the real-fleet E2E remains in #284.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782746084&installation_id=129708444&pr_number=285&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F285&signature=eff3f3290e859120ceaec4b7196959b9153686b4bb8c8a78e81768179ee8bba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable health-check polling interval to optimize supervisor monitoring performance.
  * Enhanced GitHub integration with automatic runner-error label creation and management.

* **Improvements**
  * Strengthened native process monitoring and supervisor runtime reliability.
  * Improved error handling and best-effort fallbacks for supervisor operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/red-skills/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->