### PR TITLE
feat(afk): req:N dependency labels + event-driven auto-unblock

### DIFF
--- a/.red/agents/triage-labels.md
+++ b/.red/agents/triage-labels.md
@@ -13,6 +13,7 @@ The skills speak in terms of canonical triage roles. Map them here to the actual
 | `ready-for-agent`  | `ready-for-agent`    | `/triage`, `/to-issues`               | `/afk` (when claiming)              |
 | `running`          | `running`            | `/afk` (when claiming an issue)       | `/afk` (on close, blocker, or release) |
 | `ready-for-human`  | `ready-for-human`    | `/triage`, `/afk` (on blocker)        | maintainer                          |
+| `blocked:dependency` | `blocked:dependency` | `/to-issues` (slice with open deps)  | `/afk` auto-unblock when last dep closes |
 | `wontfix`          | `wontfix`            | `/triage` (then close)                | rarely — usually issue closes       |
 
 Edit the right-hand column to match whatever vocabulary you actually use.
@@ -97,6 +98,9 @@ The issue body contains a complete `## Agent brief` section (see `triage/AGENT-B
 ### `ready-for-human`
 The issue requires human implementation. Two sources: `/triage` decides it during evaluation (e.g. architectural call, design review needed), or `/afk` promotes it from `running` after a blocker (inner agent gave up, merge conflict couldn't be auto-resolved, both runners exhausted). When `/afk` promotes, the worktree is **preserved at the moment of blocker** so the human can pick up in place.
 
+### `blocked:dependency`
+The issue is **waiting on one or more other issues to close** — it is healthy, not broken, and **needs no human action**. This is deliberately distinct from `ready-for-human`: a dependency-blocked issue must **never page a human** (nothing for them to do but wait). The specific edges live in `req:N` labels (one per dependency, see below) — the queryable source of truth — mirrored by the human-facing `## Blocked by` task list in the body. When the **last** `req:N` dependency closes, `/afk` auto-promotes the issue to `ready-for-agent` (see *Dependency Edges* below). Applied by `/to-issues` when it publishes a slice whose blockers are still open.
+
 ### `wontfix`
 Will not be actioned. Applied by `/triage`. For bugs, paired with a polite explanation and close. For enhancements, paired with a `.out-of-scope/*.md` entry (see `triage/OUT-OF-SCOPE.md`).
 
@@ -130,6 +134,22 @@ These exist for filtering and don't drive lifecycle transitions:
 | `runner-error` | `/afk` fleet supervisor parked a slot after fast-death streak; affected issues were restored to `ready-for-agent` after the runner was discarded | `/afk` fleet supervisor on circuit trip |
 
 `runner-error` is the only auxiliary label `/afk` may create autonomously: the fleet supervisor calls `gh label create runner-error` when it trips the circuit breaker, so the cleanup never fails just because the label has not been provisioned.
+
+## Dependency Edges (`req:N`) + Auto-Unblock
+
+Dependencies between issues are **first-class queryable edges**, not buried in prose. They mirror the `prd:N` convention.
+
+| Label    | Meaning                                              | Applied by      |
+| -------- | ---------------------------------------------------- | --------------- |
+| `req:{N}` | This issue **requires** #N to close before it can run | `/to-issues` (one per blocker) |
+
+How the edge drives the lifecycle:
+
+- A slice published with open blockers carries **`blocked:dependency`** + one **`req:N`** label per blocker (and the human-facing `## Blocked by` task list in the body). It is **not** `ready-for-human` and never pages.
+- **Event-driven cascade (on close):** when `/afk` closes issue #N, it runs `gh issue list --label req:N --state open`; for every dependent whose **all** `req:*` referenced issues are now closed, it removes `blocked:dependency`, adds `ready-for-agent`, and posts `🤖 /afk unblocked: all dependencies closed (#…)`. The unblock happens **the moment the last dependency closes**, not on the next boot.
+- **Boot sweep (safety net):** at `/afk` boot, the *Unblock Sweep* re-scans `blocked:dependency` issues by their `req:*` labels (preferring labels; falling back to the legacy `## Blocked by` body parse for pre-`req:N` issues) and promotes any whose deps all closed — catching events the cascade missed.
+
+`req:N` labels, like `prd:N`, are created on demand (`gh label create req:<n>` when first applied); `blocked:dependency` is provisioned by `/setup-red-skills`.
 
 ## Naming Convention
 

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -139,18 +139,26 @@ afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N
 
 It then applies the same three namespace reapers used during `/afk` boot: remote `afk-attempts/*`, remote `afk/*`, and local `afk/*`. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept. Each successful deletion logs the branch, issue number, and classification reason. Re-running is a natural no-op once stale refs are gone. Snapshot grace still comes from `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S`; live `afk/*` cleanup keeps the existing closed-vs-open policy.
 
-## Unblock Sweep (boot-time)
+## Dependency Unblock — `req:N` edges, close cascade + boot sweep
 
-After *Orphan Cleanup* and before *Straggler Check*, `/afk` scans every open issue labelled `ready-for-human` and checks whether its declared blockers have all closed. If yes, the issue is auto-promoted back to `ready-for-agent` for this run.
+Dependencies are first-class **`req:N` edge labels** (one per blocker), and a dependency-blocked issue holds the **`blocked:dependency`** state — *not* `ready-for-human` (it is healthy, waiting, and never pages). Two mechanisms promote it to `ready-for-agent`:
 
-How the sweep works:
+**1. Close cascade (event-driven, the fast path).** Immediately after `/afk` closes an issue #N on the DONE path (after the completion sweep), it re-evaluates every dependent of #N:
 
-1. `gh issue list --label ready-for-human --state open --json number,body`.
-2. For each candidate, extract refs (`#N`) under the literal `## Blocked by` heading in the body. Format is the GitHub task list emitted by `/to-issues`: `- [ ] #N` (one per line).
-3. For each ref, `gh issue view <N> --json state`. Auto-promote only when **every** ref resolves to `state == CLOSED`. Checkbox state in the body is human UX — the lookup is the source of truth.
-4. On promotion: `gh issue edit --remove-label ready-for-human --add-label ready-for-agent`, post an audit comment (`🤖 /afk promoted to ready-for-agent: all blockers closed (#X, #Y).`), and log a single orchestrator line `unblocked N issue(s): #A #B`.
+1. `gh issue list --label req:N --state open --json number,labels`.
+2. For each dependent, read its `req:*` labels and resolve each referenced issue's state (the just-closed #N is known closed; others via a cached lookup).
+3. When **every** `req:*` of a dependent is now closed: `gh issue edit --remove-label blocked:dependency --add-label ready-for-agent` + post `🤖 /afk unblocked: all dependencies closed (#…)`.
 
-Trade-off accepted: an issue may have hit `ready-for-human` for a reason unrelated to the listed blockers (test failure, spec ambiguity). Auto-promotion will then bounce it back to `ready-for-human` on the next attempt — cheap, and the fresh BLOCKED Notes the agent writes are more informative than stale ones.
+Best-effort: a `gh` failure here logs a `warn:` and never fails the close — the boot sweep below catches anything the cascade missed.
+
+**2. Unblock Sweep (boot-time, the safety net).** After *Orphan Cleanup* and before *Straggler Check*, `/afk` re-scans dependency-blocked issues by label and promotes any whose deps all closed:
+
+1. `gh issue list` for open `blocked:dependency` (and legacy `ready-for-human`) issues with `number,labels,body`.
+2. Deps come from the `req:*` labels (the source of truth); for pre-`req:N` issues with no such label, fall back to extracting `#N` refs under the literal `## Blocked by` body heading (`- [ ] #N`).
+3. Resolve each dep via `gh issue view <N> --json state`; promote only when **every** dep is `CLOSED`.
+4. On promotion: remove the holding label (`blocked:dependency`, or legacy `ready-for-human`), add `ready-for-agent`, post the audit comment, and log `unblocked N issue(s): #A #B`.
+
+Trade-off accepted: a legacy `ready-for-human` issue may have stopped for a reason unrelated to its listed blockers (test failure, spec ambiguity); auto-promotion bounces it back on the next attempt — cheap. `blocked:dependency` issues never have this ambiguity (the label *means* dependency-wait), which is the whole point of separating it from `ready-for-human`.
 
 ## Straggler Check
 

--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -50,6 +50,7 @@ The five canonical roles:
 - `needs-info` — waiting on reporter
 - `ready-for-agent` — fully specified, AFK-ready (an agent can pick it up with no human context)
 - `ready-for-human` — needs human implementation
+- `blocked:dependency` — waiting on other issues (via `req:N` edges); never pages a human; auto-unblocks when the last dep closes
 - `wontfix` — will not be actioned
 
 Default: each role's string equals its name. Ask the user if they want to override any. If their issue tracker has no existing labels, the defaults are fine.
@@ -72,6 +73,7 @@ Confirm with the user:
 - Install `red-issues-needs-triage.yml` into `.github/workflows/`? Default: yes.
 - Does the `needs-triage` label exist in the issue tracker? If not, create it (`gh label create needs-triage --description "Maintainer needs to evaluate"`).
 - Does the `runner-error` label exist? If not, create it (`gh label create runner-error --color B60205 --description "AFK supervisor circuit-tripped; runner was misconfigured"`). The `/afk` fleet supervisor falls back to creating it on the fly during a circuit trip, but provisioning it here keeps colour/description consistent across repos.
+- Does the `blocked:dependency` label exist? If not, create it (`gh label create blocked:dependency --color D4C5F9 --description "Waiting on other issues (req:N edges); auto-unblocks when the last dependency closes"`). `req:N` edge labels are created on demand by `/to-issues` (`gh label create req:<n>`) like `prd:N`, so they need no upfront provisioning.
 
 Future RedSkills workflows will land in this same step. Filename prefix `red-` is mandatory.
 

--- a/plugins/dev/skills/engineering/to-issues/SKILL.md
+++ b/plugins/dev/skills/engineering/to-issues/SKILL.md
@@ -55,7 +55,7 @@ For each approved slice, publish a new issue. Use the issue template in `<suppor
 
 - Publish in **dependency order** (blockers first) so you can reference real issue identifiers in each "Blocked by" field
 - Tag only currently-unblocked AFK slices with the canonical `ready-for-agent` triage label (mapped string from `/setup-red-skills`).
-- If an AFK slice has open blockers, publish it as `ready-for-human` + `blocked` with the strict `## Blocked by` section; `/afk` will auto-promote it to `ready-for-agent` once every blocker closes.
+- If an AFK slice has open blockers, publish it as `blocked:dependency` + one `req:N` label **per blocker** (NOT `ready-for-human` — a dependency-blocked slice is healthy and must never page a human), keeping the strict `## Blocked by` task list in the body as the human-facing mirror. `req:N` labels are created on demand (`gh label create req:<n>` if missing). `/afk` auto-promotes the issue to `ready-for-agent` the moment its last dependency closes (event-driven close cascade, with the boot sweep as a safety net). See `/setup-red-skills` triage-labels *Dependency Edges*.
 - If a slice is HITL, publish it as `ready-for-human` (and `slice:hitl` when available). Do **not** include a literal `## Blocked by` section unless it should be auto-promoted to AFK after blockers close; use a non-parser heading such as `## Human decision needed` for informational dependencies.
 - If the parent is a PRD (carries `type:prd` + `needs-slicing`), tag every child with `prd:{N}` referencing the parent and, **after** all slices are published, remove `needs-slicing` from the parent PRD. Never remove `type:prd` — it is a permanent type marker. Never apply `ready-for-agent` to the parent PRD itself.
 

--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -214,6 +214,8 @@ function buildProcessDeps(
       editLabels: (issue, remove, add) => ghx.editLabels(ghCtx, issue, remove, add),
       comment: (issue, body) => ghx.comment(ghCtx, issue, body),
       close: (issue) => ghx.closeIssue(ghCtx, issue),
+      listByLabel: (label) => ghx.listByLabel(ghCtx, label),
+      issueClosed: (n) => ghx.issueClosed(ghCtx, n),
     },
     claimLock: {
       acquire: async (issue) => {

--- a/src/domains/dev/src/core/boot-sweep.ts
+++ b/src/domains/dev/src/core/boot-sweep.ts
@@ -70,6 +70,26 @@ export function refToNumber(ref: string): number | null {
   return m ? Number(m[1]) : null;
 }
 
+/** A `req:<N>` dependency label — the queryable edge that mirrors `prd:<N>`. An
+ * issue carrying `req:101` declares it "requires #101 to close before it can be
+ * worked"; multiple `req:*` labels stack (req:101, req:102, …). */
+const REQ_LABEL_RE = /^req:([0-9]+)$/;
+
+/**
+ * Extract the dependency issue numbers from a label set: each `req:<N>` label
+ * contributes `N`. Non-numeric (`req:foo`) and non-`req:` labels are ignored.
+ * The result is sorted-unique ascending NUMERICALLY (so #2 before #10) — these
+ * are real ids, not the lexical `## Blocked by` ref tokens. Pure.
+ */
+export function parseReqLabels(labels: readonly string[]): number[] {
+  const seen = new Set<number>();
+  for (const label of labels) {
+    const m = REQ_LABEL_RE.exec(label.trim());
+    if (m) seen.add(Number(m[1]));
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
 /** The S1 blocker-state vocabulary the promote rule consumes. CLOSED maps to
  * the literal `gh issue view --json state --jq .state` value; everything else
  * (OPEN, a 404, or a transient gh failure) is "not closed". */
@@ -93,10 +113,58 @@ export function auditComment(refs: readonly string[]): string {
   return `🤖 /afk promoted to ready-for-agent: all blockers closed (${refs.join(", ")}).`;
 }
 
-/** A `ready-for-human` candidate the sweep examines: its number and raw body. */
+/** Build the audit comment posted when an issue's `req:*` dependencies all
+ * close. The now-satisfied deps are named as `#N` tokens in ascending order,
+ * e.g. `🤖 /afk unblocked: all dependencies closed (#101, #102).` */
+export function cascadeAuditComment(reqs: readonly number[]): string {
+  return `🤖 /afk unblocked: all dependencies closed (${reqs.map((n) => `#${n}`).join(", ")}).`;
+}
+
+/** A dependent issue (carrying `req:*` labels) re-evaluated by the close
+ * cascade: its number plus each declared dependency's number and closed-state. */
+export interface DependentIssue {
+  number: number;
+  /** One entry per `req:<n>` label, with `n` resolved to its closed-state. */
+  reqs: { n: number; closed: boolean }[];
+}
+
+/**
+ * Plan the event-driven close cascade triggered when `closedIssue` closes. For
+ * each dependent issue carrying `req:closedIssue` (and possibly other `req:*`
+ * deps), promote it to `ready-for-agent` IFF EVERY one of its `req:*` deps is
+ * now CLOSED (and it has ≥1 dep) — the same all-closed semantics as
+ * `shouldPromote`. The audit comment names every now-satisfied dep in ascending
+ * order. `refs` holds the dep ids as `#N` strings for parity with the sweep's
+ * PromotionPlan. Pure — closed-states are resolved by the caller.
+ */
+export function planCloseCascade(
+  closedIssue: number,
+  dependents: readonly DependentIssue[],
+): PromotionPlan[] {
+  const plans: PromotionPlan[] = [];
+  for (const dep of dependents) {
+    const states: BlockerState[] = dep.reqs.map((r) => (r.closed ? "CLOSED" : "open-or-unknown"));
+    if (!shouldPromote(states)) continue;
+    const reqs = dep.reqs.map((r) => r.n).sort((a, b) => a - b);
+    plans.push({
+      number: dep.number,
+      refs: reqs.map((n) => `#${n}`),
+      comment: cascadeAuditComment(reqs),
+    });
+  }
+  return plans;
+}
+
+/** A `ready-for-human` / `blocked:dependency` candidate the boot sweep
+ * examines: its number, raw body, and (preferred) label set. When `labels`
+ * carries `req:*` deps the sweep keys off those; the `## Blocked by` body parse
+ * is the documented fallback for issues that predate the req:N convention. */
 export interface UnblockCandidate {
   number: number;
   body: string;
+  /** Full label set, used to read `req:*` deps. Optional for back-compat with
+   * callers that only know the body (legacy `## Blocked by` parse). */
+  labels?: string[];
 }
 
 /** Issue-state lookup, injected so the sweep stays pure. Given a blocker issue
@@ -116,11 +184,16 @@ export interface PromotionPlan {
 }
 
 /**
- * Plan the Unblock Sweep over `candidates`. For each candidate, parse its
- * `## Blocked by` refs, look up each referenced blocker's state via
- * `fetchBlockerState`, and emit a promotion plan only when every ref is CLOSED
- * (and there is at least one ref). Candidates with no refs are skipped, exactly
- * as the bash `[[ -z "$refs" ]] && continue`.
+ * Plan the Unblock Sweep over `candidates`. For each candidate the sweep PREFERS
+ * the structured `req:*` labels (the queryable dependency edge): when the
+ * candidate carries ≥1 `req:<N>` label, the deps are those N, each looked up via
+ * `fetchBlockerState`, and a promotion is planned only when EVERY one is CLOSED
+ * — the audit comment then uses the `cascadeAuditComment` "all dependencies
+ * closed" wording. When the candidate carries NO `req:*` label, the sweep FALLS
+ * BACK to the legacy `## Blocked by` body parse (documented fallback for issues
+ * that predate the req:N convention), using the original "all blockers closed"
+ * wording. Candidates with neither are skipped (bash `[[ -z "$refs" ]] &&
+ * continue`).
  *
  * Pure modulo the injected lookup: no gh/git/network I/O happens here.
  */
@@ -130,6 +203,26 @@ export async function planUnblockSweep(
 ): Promise<PromotionPlan[]> {
   const plans: PromotionPlan[] = [];
   for (const candidate of candidates) {
+    const reqIds = parseReqLabels(candidate.labels ?? []);
+
+    // Prefer the structured req:* dependency labels when present.
+    if (reqIds.length > 0) {
+      const states: BlockerState[] = [];
+      for (const id of reqIds) {
+        const raw = await fetchBlockerState(id);
+        states.push(raw === "CLOSED" ? "CLOSED" : "open-or-unknown");
+      }
+      if (shouldPromote(states)) {
+        plans.push({
+          number: candidate.number,
+          refs: reqIds.map((n) => `#${n}`),
+          comment: cascadeAuditComment(reqIds),
+        });
+      }
+      continue;
+    }
+
+    // Legacy fallback: the `## Blocked by` body parse.
     const refs = parseBlockedBy(candidate.body);
     if (refs.length === 0) continue;
 

--- a/src/domains/dev/src/core/boot.ts
+++ b/src/domains/dev/src/core/boot.ts
@@ -491,17 +491,25 @@ async function runBranchCleanup(
   return { snapshotReaped, remoteLiveReaped, localLiveReaped };
 }
 
-/** Step 6: planUnblockSweep, then promote each planned issue (remove
- * ready-for-human, add ready-for-agent) and post its audit comment. Mirrors
- * sweep_unblocked. */
+/** Step 6: planUnblockSweep, then promote each planned issue (remove its holding
+ * label — `blocked:dependency` for req:* deps, else `ready-for-human` for the
+ * legacy body-parse path — add ready-for-agent) and post its audit comment.
+ * Mirrors sweep_unblocked. */
 async function runUnblockSweep(
   deps: BootDeps,
   candidates: readonly UnblockCandidate[],
 ): Promise<UnblockSweepResult> {
   const plans = await planUnblockSweep(candidates, deps.lookups.blockerState);
+  // Resolve each promoted issue's holding label from its candidate label set:
+  // a `blocked:dependency` issue sheds that label, a legacy `ready-for-human`
+  // issue sheds `ready-for-human`.
+  const labelsByIssue = new Map<number, string[]>();
+  for (const c of candidates) labelsByIssue.set(c.number, c.labels ?? []);
   const promoted: number[] = [];
   for (const p of plans) {
-    await deps.gh.editLabels(p.number, ["ready-for-human"], ["ready-for-agent"]);
+    const held = labelsByIssue.get(p.number) ?? [];
+    const remove = held.includes("blocked:dependency") ? "blocked:dependency" : "ready-for-human";
+    await deps.gh.editLabels(p.number, [remove], ["ready-for-agent"]);
     await deps.gh.comment(p.number, p.comment);
     promoted.push(p.number);
   }

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -85,6 +85,7 @@ import { emitEnvelope, type EmitEnvelopeDeps, type SectionBodies } from "./envel
 import { dispatchHooks, type HookExec } from "./hook-dispatcher.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
+import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import type { ConfigValues } from "./config.js";
 import type { AttemptStatus } from "./envelope.js";
 import type { Runner } from "../types/runner.js";
@@ -103,6 +104,12 @@ export interface ProcessGh {
   comment(issue: number, body: string): Promise<void>;
   /** gh issue close --reason completed. */
   close(issue: number): Promise<void>;
+  /** List open issues carrying `label` (number + label-name list). Backs the
+   * close cascade's `req:<closedIssue>` dependent lookup. */
+  listByLabel(label: string): Promise<{ number: number; labels: string[] }[]>;
+  /** Resolve whether issue `n` is CLOSED. Resolves the cascade's per-dependency
+   * `req:*` closed-states. A 404 / transient failure resolves to false. */
+  issueClosed(n: number): Promise<boolean>;
 }
 
 /** Claim-lock side effects (the local mkdir lock at .red/tmp/claims/{N}/). */
@@ -631,6 +638,14 @@ export async function processIssue(
   await deps.fs.completionSweep(issue);
   await deps.claimLock.release(issue);
 
+  // ---- 9. close cascade (event-driven auto-unblock) ----
+  // Issue N just closed; re-evaluate every open issue carrying `req:N`. Any
+  // whose `req:*` deps are now ALL closed sheds `blocked:dependency`, gains
+  // `ready-for-agent`, and gets an audit comment. Best-effort: a gh failure logs
+  // a warn and never fails the close — the boot Unblock Sweep catches it next
+  // run.
+  await runCloseCascade(deps, issue);
+
   return {
     outcome: "done",
     issue,
@@ -734,6 +749,59 @@ async function mergeFailed(c: StageCommon, _reason: string, locked = false): Pro
     preserved: true,
     swept: false,
   };
+}
+
+// ---------- close cascade (event-driven auto-unblock) ----------
+
+/**
+ * Re-evaluate the dependents of a just-closed issue and promote any whose
+ * `req:*` dependencies are now ALL closed. Fires only on the DONE close path.
+ *
+ * For each open issue carrying `req:<closedIssue>`, read its `req:*` labels,
+ * resolve each referenced issue's closed-state (the just-closed `closedIssue`
+ * is known-closed without a lookup; the rest are resolved via the injected,
+ * per-cascade-cached `issueClosed` lookup), run `planCloseCascade`, and apply
+ * each promotion: remove `blocked:dependency`, add `ready-for-agent`, post the
+ * audit comment.
+ *
+ * Entirely best-effort: any thrown gh error is swallowed (logged via the
+ * iteration log) so it can never fail the close — the boot Unblock Sweep is the
+ * safety net that re-attempts on the next run.
+ */
+async function runCloseCascade(deps: ProcessIssueDeps, closedIssue: number): Promise<void> {
+  try {
+    const dependentsRaw = await deps.gh.listByLabel(`req:${closedIssue}`);
+    if (dependentsRaw.length === 0) return;
+
+    // Cache closed-state resolutions across the cascade (a dependent set often
+    // shares deps). The just-closed issue is known-closed without a lookup.
+    const closedCache = new Map<number, boolean>([[closedIssue, true]]);
+    const resolveClosed = async (n: number): Promise<boolean> => {
+      const cached = closedCache.get(n);
+      if (cached !== undefined) return cached;
+      const closed = await deps.gh.issueClosed(n);
+      closedCache.set(n, closed);
+      return closed;
+    };
+
+    const dependents: DependentIssue[] = [];
+    for (const dep of dependentsRaw) {
+      const reqIds = parseReqLabels(dep.labels);
+      const reqs: { n: number; closed: boolean }[] = [];
+      for (const n of reqIds) reqs.push({ n, closed: await resolveClosed(n) });
+      dependents.push({ number: dep.number, reqs });
+    }
+
+    const plans = planCloseCascade(closedIssue, dependents);
+    for (const p of plans) {
+      await deps.gh.editLabels(p.number, ["blocked:dependency"], [LABEL_READY]);
+      await deps.gh.comment(p.number, p.comment);
+    }
+  } catch (err) {
+    deps.appendIterLog(
+      `🤖 /afk close-cascade for #${closedIssue} failed (best-effort; boot sweep will retry): ${String(err)}`,
+    );
+  }
 }
 
 // ---------- claim / hook-abort short-circuits ----------

--- a/src/domains/dev/src/runtime/gh.ts
+++ b/src/domains/dev/src/runtime/gh.ts
@@ -267,32 +267,96 @@ export function countNeedsInfo(ctx: GhContext): Promise<number> {
   return countIssues(ctx, ["--label", "needs-info"]);
 }
 
-/** List the `ready-for-human` unblock-sweep candidates (number + body). */
+/** List the unblock-sweep candidates (number + body + labels). The sweep keys
+ * off `blocked:dependency` issues via their `req:*` labels (preferred) and
+ * keeps the legacy `ready-for-human` + `## Blocked by` body parse as fallback,
+ * so both holding states are gathered and de-duplicated by issue number. */
 export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCandidate[]> {
+  const fetch = async (label: string): Promise<UnblockCandidate[]> => {
+    const r = await gh(
+      [
+        "issue",
+        "list",
+        ...repoArgs(ctx),
+        "--label",
+        label,
+        "--state",
+        "open",
+        "--limit",
+        "200",
+        "--json",
+        "number,body,labels",
+      ],
+      opts(ctx),
+    );
+    if (r.code !== 0) return [];
+    try {
+      const rows = JSON.parse(r.stdout) as Array<{
+        number?: number;
+        body?: string;
+        labels?: Array<{ name?: string }>;
+      }>;
+      if (!Array.isArray(rows)) return [];
+      return rows.map((row): UnblockCandidate => ({
+        number: Number(row.number ?? 0),
+        body: String(row.body ?? ""),
+        labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+      }));
+    } catch {
+      return [];
+    }
+  };
+  const [byDependency, byHuman] = await Promise.all([
+    fetch("blocked:dependency"),
+    fetch("ready-for-human"),
+  ]);
+  const merged = new Map<number, UnblockCandidate>();
+  for (const c of [...byDependency, ...byHuman]) {
+    if (!merged.has(c.number)) merged.set(c.number, c);
+  }
+  return [...merged.values()];
+}
+
+/** List open issues carrying `label` (number + label-name list). Backs the
+ * close cascade's `req:<N>` dependent lookup. A failed probe returns []. */
+export async function listByLabel(
+  ctx: GhContext,
+  label: string,
+): Promise<{ number: number; labels: string[] }[]> {
   const r = await gh(
     [
       "issue",
       "list",
       ...repoArgs(ctx),
       "--label",
-      "ready-for-human",
+      label,
       "--state",
       "open",
       "--limit",
       "200",
       "--json",
-      "number,body",
+      "number,labels",
     ],
     opts(ctx),
   );
   if (r.code !== 0) return [];
   try {
-    const rows = JSON.parse(r.stdout) as Array<{ number?: number; body?: string }>;
+    const rows = JSON.parse(r.stdout) as Array<{ number?: number; labels?: Array<{ name?: string }> }>;
     if (!Array.isArray(rows)) return [];
-    return rows.map((row): UnblockCandidate => ({ number: Number(row.number ?? 0), body: String(row.body ?? "") }));
+    return rows.map((row) => ({
+      number: Number(row.number ?? 0),
+      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+    }));
   } catch {
     return [];
   }
+}
+
+/** Resolve whether issue `n` is CLOSED (gh issue view --json state). A 404 /
+ * transient gh failure resolves to false (not-closed), matching the
+ * conservative `blockerState !== "CLOSED"` treatment in the sweep. */
+export async function issueClosed(ctx: GhContext, n: number): Promise<boolean> {
+  return (await blockerState(ctx, n)) === "CLOSED";
 }
 
 /** Branch-cleanup IssueLookup payload: gh issue view --json state,closedAt.

--- a/src/domains/dev/tests/boot-sweep.test.ts
+++ b/src/domains/dev/tests/boot-sweep.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
   auditComment,
+  cascadeAuditComment,
   parseBlockedBy,
+  parseReqLabels,
+  planCloseCascade,
   planUnblockSweep,
   refToNumber,
   shouldPromote,
   shouldWarnStragglers,
   stragglerCounts,
   type BlockerState,
+  type DependentIssue,
   type StragglerCountLookup,
   type UnblockCandidate,
 } from "../src/core/boot-sweep.js";
@@ -70,6 +74,73 @@ describe("refToNumber", () => {
   it("returns null for garbage", () => {
     expect(refToNumber("#")).toBeNull();
     expect(refToNumber("abc")).toBeNull();
+  });
+});
+
+describe("parseReqLabels", () => {
+  it("extracts dependency ids from req:<N> labels, numeric-sorted-unique", () => {
+    expect(parseReqLabels(["req:10", "req:2", "req:10", "blocked:dependency"])).toEqual([2, 10]);
+  });
+
+  it("ignores non-numeric and non-req labels", () => {
+    expect(parseReqLabels(["req:foo", "prd:5", "ready-for-agent", "req:7"])).toEqual([7]);
+  });
+
+  it("returns [] for an empty / req-free label set", () => {
+    expect(parseReqLabels([])).toEqual([]);
+    expect(parseReqLabels(["blocked:dependency", "type:feature"])).toEqual([]);
+  });
+});
+
+describe("cascadeAuditComment", () => {
+  it("names the satisfied deps in #N form, comma-joined", () => {
+    expect(cascadeAuditComment([101, 102])).toBe(
+      "🤖 /afk unblocked: all dependencies closed (#101, #102).",
+    );
+  });
+  it("formats a single dep", () => {
+    expect(cascadeAuditComment([9])).toBe("🤖 /afk unblocked: all dependencies closed (#9).");
+  });
+});
+
+describe("planCloseCascade", () => {
+  it("promotes a dependent whose every req is closed", () => {
+    const deps: DependentIssue[] = [
+      { number: 20, reqs: [{ n: 9, closed: true }] },
+    ];
+    expect(planCloseCascade(9, deps)).toEqual([
+      { number: 20, refs: ["#9"], comment: "🤖 /afk unblocked: all dependencies closed (#9)." },
+    ]);
+  });
+
+  it("does not promote when one req is still open", () => {
+    const deps: DependentIssue[] = [
+      { number: 21, reqs: [{ n: 9, closed: true }, { n: 8, closed: false }] },
+    ];
+    expect(planCloseCascade(9, deps)).toEqual([]);
+  });
+
+  it("does not promote a dependent with no reqs", () => {
+    const deps: DependentIssue[] = [{ number: 22, reqs: [] }];
+    expect(planCloseCascade(9, deps)).toEqual([]);
+  });
+
+  it("names every satisfied dep in ascending order on a multi-req promote", () => {
+    const deps: DependentIssue[] = [
+      { number: 30, reqs: [{ n: 9, closed: true }, { n: 8, closed: true }] },
+    ];
+    expect(planCloseCascade(9, deps)).toEqual([
+      { number: 30, refs: ["#8", "#9"], comment: "🤖 /afk unblocked: all dependencies closed (#8, #9)." },
+    ]);
+  });
+
+  it("plans only the satisfied dependents across a mixed batch", () => {
+    const deps: DependentIssue[] = [
+      { number: 20, reqs: [{ n: 9, closed: true }] }, // promote
+      { number: 21, reqs: [{ n: 9, closed: true }, { n: 8, closed: false }] }, // skip
+      { number: 22, reqs: [] }, // skip
+    ];
+    expect(planCloseCascade(9, deps).map((p) => p.number)).toEqual([20]);
   });
 });
 
@@ -165,6 +236,52 @@ describe("planUnblockSweep", () => {
     const lookup = lookupFor({ 1: "CLOSED", 2: "OPEN" });
     const plans = await planUnblockSweep(candidates, lookup.fetch);
     expect(plans.map((p) => p.number)).toEqual([7]);
+  });
+
+  it("prefers req:* labels over the body parse and uses the dependency wording", async () => {
+    // The candidate carries BOTH a `req:*` label and a `## Blocked by` body.
+    // The structured label wins: deps come from req:*, not the body.
+    const candidates: UnblockCandidate[] = [
+      {
+        number: 7,
+        labels: ["blocked:dependency", "req:101", "req:102"],
+        body: "## Blocked by\n- [ ] #999\n", // ignored when req:* present
+      },
+    ];
+    const lookup = lookupFor({ 101: "CLOSED", 102: "CLOSED", 999: "OPEN" });
+    const plans = await planUnblockSweep(candidates, lookup.fetch);
+    expect(plans).toEqual([
+      {
+        number: 7,
+        refs: ["#101", "#102"],
+        comment: "🤖 /afk unblocked: all dependencies closed (#101, #102).",
+      },
+    ]);
+    // The body ref (#999) was never consulted — only the req:* deps.
+    expect(lookup.calls).toEqual([101, 102]);
+  });
+
+  it("does not promote a req:* candidate while a dep is still open", async () => {
+    const candidates: UnblockCandidate[] = [
+      { number: 7, labels: ["blocked:dependency", "req:101", "req:102"], body: "" },
+    ];
+    const lookup = lookupFor({ 101: "CLOSED", 102: "OPEN" });
+    expect(await planUnblockSweep(candidates, lookup.fetch)).toEqual([]);
+  });
+
+  it("falls back to the body parse when the candidate has no req:* label", async () => {
+    const candidates: UnblockCandidate[] = [
+      { number: 7, labels: ["ready-for-human"], body: "## Blocked by\n- [ ] #1\n" },
+    ];
+    const lookup = lookupFor({ 1: "CLOSED" });
+    const plans = await planUnblockSweep(candidates, lookup.fetch);
+    expect(plans).toEqual([
+      {
+        number: 7,
+        refs: ["#1"],
+        comment: "🤖 /afk promoted to ready-for-agent: all blockers closed (#1).",
+      },
+    ]);
   });
 });
 

--- a/src/domains/dev/tests/boot.test.ts
+++ b/src/domains/dev/tests/boot.test.ts
@@ -440,6 +440,30 @@ describe("runBoot unblock sweep promotes + comments", () => {
     ]);
     expect(r.unblockSweep).toEqual({ promoted: [100] });
   });
+
+  it("promotes a blocked:dependency issue via its req:* labels, shedding blocked:dependency", async () => {
+    const blockerState: BootDeps["lookups"]["blockerState"] = async (issue) =>
+      issue === 10 || issue === 11 ? "CLOSED" : "OPEN";
+    const { deps, ghCalls } = makeDeps({ blockerState });
+    const unblockCandidates: UnblockCandidate[] = [
+      // req:* labels are preferred over the (here, contradictory) body parse.
+      {
+        number: 100,
+        labels: ["blocked:dependency", "req:10", "req:11"],
+        body: "## Blocked by\n\n- [ ] #999\n",
+      },
+      // still-open dep #99 → stays blocked.
+      { number: 200, labels: ["blocked:dependency", "req:10", "req:99"], body: "" },
+    ];
+    const r = await runBoot(deps, options({ unblockCandidates }));
+    expect(ghCalls.editLabels).toEqual([
+      { issue: 100, remove: ["blocked:dependency"], add: ["ready-for-agent"] },
+    ]);
+    expect(ghCalls.comment).toEqual([
+      { issue: 100, body: "🤖 /afk unblocked: all dependencies closed (#10, #11)." },
+    ]);
+    expect(r.unblockSweep).toEqual({ promoted: [100] });
+  });
 });
 
 describe("runBoot straggler check", () => {

--- a/src/domains/dev/tests/process-issue.test.ts
+++ b/src/domains/dev/tests/process-issue.test.ts
@@ -25,6 +25,8 @@ interface Trace {
   postedEnvelopes: Array<{ issue: number; status: string }>;
   released: number[];
   runAgentCalls: RunAgentInput[];
+  /** Labels queried via gh.listByLabel during the close cascade. */
+  listByLabelCalls: string[];
 }
 
 interface HarnessOptions {
@@ -49,6 +51,12 @@ interface HarnessOptions {
   conflictResolve?: "resolve" | "fail";
   /** Records calls into the conflict resolver dispatch. */
   resolverCalls?: string[];
+  /** Close-cascade fixture: open dependents returned by gh.listByLabel(req:N),
+   * keyed by the queried label (e.g. "req:7"). */
+  dependentsByLabel?: Record<string, { number: number; labels: string[] }[]>;
+  /** Close-cascade fixture: issues resolved as CLOSED by gh.issueClosed. The
+   * just-closed issue is treated as closed without consulting this set. */
+  closedIssues?: number[];
 }
 
 function harness(opts: HarnessOptions = {}): {
@@ -66,6 +74,7 @@ function harness(opts: HarnessOptions = {}): {
     postedEnvelopes: [],
     released: [],
     runAgentCalls: [],
+    listByLabelCalls: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -88,6 +97,13 @@ function harness(opts: HarnessOptions = {}): {
       },
       async close(issue) {
         trace.closed.push(issue);
+      },
+      async listByLabel(label) {
+        trace.listByLabelCalls.push(label);
+        return opts.dependentsByLabel?.[label] ?? [];
+      },
+      async issueClosed(n) {
+        return (opts.closedIssues ?? []).includes(n);
       },
     },
     claimLock: {
@@ -582,5 +598,74 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("merge-conflict");
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human"))).toBe(true);
+  });
+});
+
+describe("close cascade (event-driven auto-unblock)", () => {
+  it("promotes a dependent whose req:* deps are all closed, leaves a still-blocked one", async () => {
+    // Issue 9 closes. Two open dependents carry req:9:
+    //   #20 has req:9 only → all closed → promote
+    //   #21 has req:9 + req:8 (8 still open) → stays blocked:dependency
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      dependentsByLabel: {
+        "req:9": [
+          { number: 20, labels: ["blocked:dependency", "req:9"] },
+          { number: 21, labels: ["blocked:dependency", "req:9", "req:8"] },
+        ],
+      },
+      closedIssues: [], // #8 is NOT closed; #9 is known-closed implicitly
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toContain(9);
+    // queried the req:9 dependents exactly once.
+    expect(trace.listByLabelCalls).toEqual(["req:9"]);
+
+    const promote = trace.labelEdits.filter((e) => e.add.includes("ready-for-agent"));
+    expect(promote).toEqual([{ issue: 20, remove: ["blocked:dependency"], add: ["ready-for-agent"] }]);
+    expect(trace.comments).toContainEqual({
+      issue: 20,
+      body: "🤖 /afk unblocked: all dependencies closed (#9).",
+    });
+    // #21 is never promoted nor commented (req:8 still open).
+    expect(trace.labelEdits.some((e) => e.issue === 21)).toBe(false);
+    expect(trace.comments.some((c) => c.issue === 21)).toBe(false);
+  });
+
+  it("names every now-satisfied dep when a multi-req dependent fully unblocks", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      dependentsByLabel: {
+        "req:9": [{ number: 30, labels: ["blocked:dependency", "req:9", "req:8"] }],
+      },
+      closedIssues: [8], // both deps closed (#9 implicit, #8 explicit)
+    });
+    await processIssue(deps, input);
+    expect(trace.comments).toContainEqual({
+      issue: 30,
+      body: "🤖 /afk unblocked: all dependencies closed (#8, #9).",
+    });
+    expect(trace.labelEdits).toContainEqual({
+      issue: 30,
+      remove: ["blocked:dependency"],
+      add: ["ready-for-agent"],
+    });
+  });
+
+  it("does nothing when there are no req:N dependents", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    await processIssue(deps, input);
+    expect(trace.listByLabelCalls).toEqual(["req:9"]);
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-agent"))).toBe(false);
+  });
+
+  it("does not run the cascade on a non-done (blocked) close", async () => {
+    const { deps, input, trace } = harness({ outcome: "blocked" });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("blocked");
+    expect(trace.listByLabelCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
Splits the overloaded `blocked`: dependencies become queryable `req:N` edge labels (like prd:N) + a `blocked:dependency` holding state that never pages, and closing an issue cascades to auto-unblock its dependents the moment their last dep closes. Boot sweep is the safety net. 664 tests. Docs (triage-labels, to-issues, setup-red-skills, AFK SKILL.md) updated. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782775125&installation_id=129708444&pr_number=292&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F292&signature=37883e0ca4378f4444963b549beaf1e41f5480c316becdd282e6f5a3f313d8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->