### PR TITLE
feat(afk): typed blocked:<reason> labels (descriptive, auto-classified)

### DIFF
--- a/.red/agents/triage-labels.md
+++ b/.red/agents/triage-labels.md
@@ -151,6 +151,25 @@ How the edge drives the lifecycle:
 
 `req:N` labels, like `prd:N`, are created on demand (`gh label create req:<n>` when first applied); `blocked:dependency` is provisioned by `/setup-red-skills`.
 
+## Blocked Reasons (`blocked:<reason>`) — typed, auto-classified
+
+`/afk` already computes a precise terminal outcome for every iteration; instead of flattening every failure to one `blocked`, it tags the issue with the matching **`blocked:<reason>`** label so the backlog is filterable by *what kind* of block it is. The reason is derived automatically from the outcome — **no human classification**.
+
+| Outcome (runtime) | Label | Next action |
+| ----------------- | ----- | ----------- |
+| runner quota / both exhausted | `blocked:quota` | transient — retried / runner-swapped |
+| couldn't integrate or land | `blocked:merge-conflict` | base moved; re-attempt after main settles |
+| agent emitted `<promise>BLOCKED</promise>` | `blocked:spec` | a human must **decide / clarify** |
+| feedback gate failed (test/lint/build) | `blocked:validation` | review the diff on the branch |
+| agent exited without a sentinel | `blocked:crashed` | investigate (likely infra/bug) |
+| a user `pre_*` guard hook rejected it | `blocked:policy` | the policy owner looks |
+| stall-reaper killed a hung worker | `blocked:stalled` | task too big / looping |
+| worktree/base/push setup failed | `blocked:infra` | environment, not issue content — ops |
+
+These are **descriptive today**: the typed label is added *alongside* the routing label (e.g. `ready-for-human`, or the restored `ready-for-agent` for quota/policy/stalled), so routing is unchanged — you gain observability (`gh issue list --label blocked:validation`) without any behaviour change. The recoverable reasons (`blocked:quota`, `blocked:merge-conflict`) are the natural candidates for a future **auto-recovery** step (loop back to `ready-for-agent` with bounded backoff instead of paging) — deliberately deferred until opted into. `blocked:dependency` (above) is the only reason already wired to non-paging behaviour.
+
+All `blocked:*` labels are created on the fly when first applied (mirroring `runner-error`) and provisioned by `/setup-red-skills`.
+
 ## Naming Convention
 
 All labels follow one of two shapes:

--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -74,6 +74,7 @@ Confirm with the user:
 - Does the `needs-triage` label exist in the issue tracker? If not, create it (`gh label create needs-triage --description "Maintainer needs to evaluate"`).
 - Does the `runner-error` label exist? If not, create it (`gh label create runner-error --color B60205 --description "AFK supervisor circuit-tripped; runner was misconfigured"`). The `/afk` fleet supervisor falls back to creating it on the fly during a circuit trip, but provisioning it here keeps colour/description consistent across repos.
 - Does the `blocked:dependency` label exist? If not, create it (`gh label create blocked:dependency --color D4C5F9 --description "Waiting on other issues (req:N edges); auto-unblocks when the last dependency closes"`). `req:N` edge labels are created on demand by `/to-issues` (`gh label create req:<n>`) like `prd:N`, so they need no upfront provisioning.
+- Provision the typed **blocked-reason** labels `/afk` applies to describe *why* an iteration stopped (it falls back to creating each on the fly, so this only keeps colour/description consistent): `gh label create blocked:quota`, `blocked:merge-conflict`, `blocked:spec`, `blocked:validation`, `blocked:crashed`, `blocked:policy`, `blocked:stalled`, `blocked:infra` (suggested colour `E99695`, descriptions per the *Blocked Reasons* table in triage-labels). These are descriptive (added alongside the routing label) — see triage-labels.
 
 Future RedSkills workflows will land in this same step. Filename prefix `red-` is mandatory.
 

--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -212,6 +212,13 @@ function buildProcessDeps(
     gh: {
       viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
       editLabels: (issue, remove, add) => ghx.editLabels(ghCtx, issue, remove, add),
+      ensureLabel: async (name) => {
+        try {
+          await ghx.ensureLabel(ghCtx, name);
+        } catch {
+          // best-effort: a missing typed label must never fail the close.
+        }
+      },
       comment: (issue, body) => ghx.comment(ghCtx, issue, body),
       close: (issue) => ghx.closeIssue(ghCtx, issue),
       listByLabel: (label) => ghx.listByLabel(ghCtx, label),

--- a/src/domains/dev/src/commands/supervise.ts
+++ b/src/domains/dev/src/commands/supervise.ts
@@ -247,6 +247,13 @@ function buildSupervisorDeps(
           // best-effort
         }
       },
+      ensureLabel: async (name) => {
+        try {
+          await ghx.ensureLabel(ghCtx, name);
+        } catch {
+          // best-effort
+        }
+      },
     },
     now,
   };

--- a/src/domains/dev/src/core/envelope-emit.ts
+++ b/src/domains/dev/src/core/envelope-emit.ts
@@ -23,6 +23,59 @@ import { buildEnvelope, type AttemptStatus, type EnvelopeSection } from "./envel
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { historyAppend, type HistoryAppendFields, type HistoryClock, type HistoryEvent, type HistoryIO } from "./history.js";
 
+/**
+ * The terminal-failure reasons the AFK runtime distinguishes. A superset of the
+ * `ProcessOutcome` failure values (process-issue.ts) plus two reasons sourced
+ * from outside the per-issue lifecycle:
+ *   - `stalled` — the supervisor stall-reaper hard-killed the slot.
+ *   - `infra`   — worktree/base/push setup failed before the agent ran.
+ *
+ * Successful or abandoned outcomes (`done`, `claim-lost`) are included so the
+ * mapping is total, but they carry no typed label (null).
+ */
+export type BlockedReason =
+  | "exhausted"
+  | "merge-conflict"
+  | "blocked"
+  | "feedback-failed"
+  | "no-sentinel"
+  | "hook-aborted"
+  | "stalled"
+  | "infra"
+  | "done"
+  | "claim-lost";
+
+/**
+ * Pure mapping from a terminal failure reason to its DESCRIPTIVE `blocked:<…>`
+ * observability label, or null when the outcome carries no typed label
+ * (`done` / `claim-lost`). OBSERVABILITY ONLY — this never changes where an
+ * issue routes; the caller adds the returned label ALONGSIDE the existing
+ * routing label (ready-for-human / ready-for-agent).
+ */
+export function blockedReasonLabel(reason: BlockedReason): string | null {
+  switch (reason) {
+    case "exhausted":
+      return "blocked:quota";
+    case "merge-conflict":
+      return "blocked:merge-conflict";
+    case "blocked":
+      return "blocked:spec";
+    case "feedback-failed":
+      return "blocked:validation";
+    case "no-sentinel":
+      return "blocked:crashed";
+    case "hook-aborted":
+      return "blocked:policy";
+    case "stalled":
+      return "blocked:stalled";
+    case "infra":
+      return "blocked:infra";
+    case "done":
+    case "claim-lost":
+      return null;
+  }
+}
+
 /** Render N seconds as `<m>m<s>s`. Mirrors envelope_fmt_duration. */
 export function fmtDuration(seconds: number): string {
   const s = Number.isFinite(seconds) ? Math.trunc(seconds) : 0;

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -81,7 +81,13 @@ import {
   type Exec as MergeExec,
   type ConflictResolver,
 } from "./merge.js";
-import { emitEnvelope, type EmitEnvelopeDeps, type SectionBodies } from "./envelope-emit.js";
+import {
+  blockedReasonLabel,
+  emitEnvelope,
+  type BlockedReason,
+  type EmitEnvelopeDeps,
+  type SectionBodies,
+} from "./envelope-emit.js";
 import { dispatchHooks, type HookExec } from "./hook-dispatcher.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
@@ -100,6 +106,10 @@ export interface ProcessGh {
   viewLabels(issue: number): Promise<string[]>;
   /** gh issue edit --remove-label … --add-label … (returns false on failure). */
   editLabels(issue: number, remove: string[], add: string[]): Promise<boolean>;
+  /** Idempotently create a label on the fly (best-effort) so a missing typed
+   * `blocked:<reason>` label never fails the close. Mirrors the runner-error
+   * label-create pattern. */
+  ensureLabel(name: string): Promise<void>;
   /** gh issue comment --body … */
   comment(issue: number, body: string): Promise<void>;
   /** gh issue close --reason completed. */
@@ -295,6 +305,27 @@ const LABEL_RUNNING = "running";
 const LABEL_HUMAN = "ready-for-human";
 
 /**
+ * ADDITIVE typed-blocked observability tag. Apply the routing label transition
+ * (remove → add) and, ALONGSIDE it in the SAME editLabels call, the DESCRIPTIVE
+ * `blocked:<reason>` label for the terminal failure. The typed label is created
+ * on the fly (best-effort) so a missing label never fails the close — routing is
+ * unchanged: the caller's `add` (e.g. ready-for-human / ready-for-agent) is
+ * preserved exactly, the typed label is merely appended.
+ */
+async function editLabelsTagged(
+  deps: ProcessIssueDeps,
+  issue: number,
+  remove: string[],
+  add: string[],
+  reason: BlockedReason,
+): Promise<boolean> {
+  const typed = blockedReasonLabel(reason);
+  if (typed === null) return deps.gh.editLabels(issue, remove, add);
+  await deps.gh.ensureLabel(typed);
+  return deps.gh.editLabels(issue, remove, [...add, typed]);
+}
+
+/**
  * Run the AFK per-issue lifecycle IN ORDER, composing each pure module and
  * applying its plan through injected IO. The SEQUENCE + the label transitions +
  * the lock-toggled landing are the parity target (process_issue + SKILL.md).
@@ -473,7 +504,7 @@ export async function processIssue(
   // ---- on_attempt_error: the run ended without an AFK sentinel (ADR 0028) ----
   if (run.outcome === "no-sentinel") {
     await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
-    await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_HUMAN]);
+    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], "no-sentinel");
     const posted = await emitFailure(common, "no-sentinel", "no-sentinel", {
       notes: "_(no Notes appended; inner agent exited without a sentinel)_",
       log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
@@ -496,7 +527,7 @@ export async function processIssue(
 
   // ---- BLOCKED ----
   if (run.outcome === "blocked") {
-    await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_HUMAN]);
+    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], "blocked");
     const posted = await emitFailure(common, "blocked", "blocked", {
       notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
     });
@@ -525,7 +556,7 @@ export async function processIssue(
     now: deps.nowEpoch,
   });
   if (!feedback.ok) {
-    await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_HUMAN]);
+    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], "feedback-failed");
     const posted = await emitFailure(common, "blocked", "feedback", {
       notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n"),
@@ -733,7 +764,7 @@ async function emitDone(
  * ready-for-human, preserve the attempt dir. Mirrors the do_merge-false branch. */
 async function mergeFailed(c: StageCommon, _reason: string, locked = false): Promise<ProcessIssueResult> {
   const { deps, input } = c;
-  await deps.gh.editLabels(input.issue, [LABEL_RUNNING], [LABEL_HUMAN]);
+  await editLabelsTagged(deps, input.issue, [LABEL_RUNNING], [LABEL_HUMAN], "merge-conflict");
   const posted = await emitFailure(c, "merge-conflict", "merge-conflict", {
     log: "(no merge log captured)",
   });
@@ -821,7 +852,7 @@ async function abortAfterClaim(
   hooksFired: HookName[],
   _reason: string,
 ): Promise<ProcessIssueResult> {
-  await deps.gh.editLabels(input.issue, [LABEL_RUNNING], [LABEL_READY]);
+  await editLabelsTagged(deps, input.issue, [LABEL_RUNNING], [LABEL_READY], "hook-aborted");
   await deps.gh.comment(
     input.issue,
     `🤖 /afk aborted before runner invocation (${_reason}). Restored \`${LABEL_READY}\`.`,
@@ -855,7 +886,7 @@ async function exhausted(
   runner: Runner,
   both: boolean,
 ): Promise<ProcessIssueResult> {
-  await deps.gh.editLabels(input.issue, [LABEL_RUNNING], [LABEL_READY]);
+  await editLabelsTagged(deps, input.issue, [LABEL_RUNNING], [LABEL_READY], "exhausted");
   await deps.gh.comment(
     input.issue,
     both

--- a/src/domains/dev/src/core/supervisor.ts
+++ b/src/domains/dev/src/core/supervisor.ts
@@ -16,6 +16,7 @@
 
 import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from "./reaper-signal.js";
 import { buildEnvelope } from "./envelope.js";
+import { blockedReasonLabel } from "./envelope-emit.js";
 
 // ---------- tunables ----------
 
@@ -234,6 +235,10 @@ export interface SupervisorGh {
   /** Idempotently ensure the runner-error label exists. Mirrors
    * ensure_runner_error_label. */
   ensureRunnerErrorLabel(): Promise<void>;
+  /** Idempotently create an arbitrary label on the fly (best-effort) so a
+   * missing typed `blocked:<reason>` observability label never fails the reap.
+   * Mirrors the runner-error label-create pattern. */
+  ensureLabel(name: string): Promise<void>;
 }
 
 /** The slot's current iteration, resolved from the filesystem. Mirrors the
@@ -461,10 +466,15 @@ export async function reapStalledSlot(
   state.stalled = false;
   state.stallSinceEpoch = 0;
 
-  // 3. Envelope + label rotation (only with a recovered issue number).
+  // 3. Envelope + label rotation (only with a recovered issue number). ADDITIVE
+  // typed-blocked tag: the routing is unchanged (still rotates back to
+  // ready-for-agent); `blocked:stalled` is appended alongside for observability,
+  // created on the fly so a missing label never fails the reap.
   if (info && info.issue !== null) {
     await deps.gh.comment(info.issue, buildReaperEnvelope(info));
-    await deps.gh.editLabels(info.issue, ["ready-for-agent"], ["running"]);
+    const typed = blockedReasonLabel("stalled");
+    if (typed !== null) await deps.gh.ensureLabel(typed);
+    await deps.gh.editLabels(info.issue, typed !== null ? ["ready-for-agent", typed] : ["ready-for-agent"], ["running"]);
   }
 
   // 4. Teardown.

--- a/src/domains/dev/src/runtime/gh.ts
+++ b/src/domains/dev/src/runtime/gh.ts
@@ -127,6 +127,25 @@ export async function ensureRunnerErrorLabel(ctx: GhContext): Promise<void> {
   );
 }
 
+/** Idempotently create an arbitrary label (best-effort), generalising
+ * ensureRunnerErrorLabel for the typed `blocked:<reason>` observability layer. A
+ * label that already exists exits non-zero and is swallowed by the caller. */
+export async function ensureLabel(ctx: GhContext, name: string): Promise<void> {
+  await gh(
+    [
+      "label",
+      "create",
+      name,
+      ...repoArgs(ctx),
+      "--color",
+      "5319E7",
+      "--description",
+      "AFK terminal-failure reason (observability)",
+    ],
+    opts(ctx),
+  );
+}
+
 /** `gh issue close --reason completed`. */
 export async function closeIssue(ctx: GhContext, issue: number): Promise<void> {
   await gh(["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"], opts(ctx));

--- a/src/domains/dev/tests/envelope-emit.test.ts
+++ b/src/domains/dev/tests/envelope-emit.test.ts
@@ -4,6 +4,7 @@ import {
   buildEnvelopeSummary,
   buildFailureMarkers,
   buildSections,
+  blockedReasonLabel,
   emitEnvelope,
   fmtDuration,
   type EmitEnvelopeDeps,
@@ -396,5 +397,23 @@ describe("emitEnvelope — failure push/markers/posted flow", () => {
     expect(posted.writes).toEqual([false]);
     expect(historyAppend).not.toHaveBeenCalled();
     expect(res.warnings.some((w) => w.includes("failed to post envelope for #11"))).toBe(true);
+  });
+});
+
+describe("blockedReasonLabel — DESCRIPTIVE typed-blocked mapping", () => {
+  it("maps each terminal failure reason to its blocked:<reason> label", () => {
+    expect(blockedReasonLabel("exhausted")).toBe("blocked:quota");
+    expect(blockedReasonLabel("merge-conflict")).toBe("blocked:merge-conflict");
+    expect(blockedReasonLabel("blocked")).toBe("blocked:spec");
+    expect(blockedReasonLabel("feedback-failed")).toBe("blocked:validation");
+    expect(blockedReasonLabel("no-sentinel")).toBe("blocked:crashed");
+    expect(blockedReasonLabel("hook-aborted")).toBe("blocked:policy");
+    expect(blockedReasonLabel("stalled")).toBe("blocked:stalled");
+    expect(blockedReasonLabel("infra")).toBe("blocked:infra");
+  });
+
+  it("returns null for non-blocked outcomes (done / claim-lost)", () => {
+    expect(blockedReasonLabel("done")).toBeNull();
+    expect(blockedReasonLabel("claim-lost")).toBeNull();
   });
 });

--- a/src/domains/dev/tests/process-issue.test.ts
+++ b/src/domains/dev/tests/process-issue.test.ts
@@ -27,6 +27,8 @@ interface Trace {
   runAgentCalls: RunAgentInput[];
   /** Labels queried via gh.listByLabel during the close cascade. */
   listByLabelCalls: string[];
+  /** Typed `blocked:<reason>` labels created on the fly via gh.ensureLabel. */
+  ensuredLabels: string[];
 }
 
 interface HarnessOptions {
@@ -75,6 +77,7 @@ function harness(opts: HarnessOptions = {}): {
     released: [],
     runAgentCalls: [],
     listByLabelCalls: [],
+    ensuredLabels: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -91,6 +94,9 @@ function harness(opts: HarnessOptions = {}): {
       async editLabels(issue, remove, add) {
         trace.labelEdits.push({ issue, remove, add });
         return true;
+      },
+      async ensureLabel(name) {
+        trace.ensuredLabels.push(name);
       },
       async comment(issue, body) {
         trace.comments.push({ issue, body });
@@ -371,8 +377,13 @@ describe("processIssue — BLOCKED", () => {
     expect(result.outcome).toBe("blocked");
     expect(result.preserved).toBe(true);
     expect(result.swept).toBe(false);
-    // claim then ready-for-human; never closed.
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human"]);
+    // claim then ready-for-human + the typed blocked:spec tag; never closed.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:spec"]);
+    // routing unchanged: ready-for-human still applied; typed label added alongside.
+    const blockedEdit = trace.labelEdits.at(-1)!;
+    expect(blockedEdit.add).toContain("ready-for-human");
+    expect(blockedEdit.add).toContain("blocked:spec");
+    expect(trace.ensuredLabels).toContain("blocked:spec");
     expect(trace.closed).toEqual([]);
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
     // no completion sweep, no remote delete, no land-push.
@@ -395,7 +406,11 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
 
     expect(result.outcome).toBe("no-sentinel");
     expect(result.preserved).toBe(true);
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human"]);
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:crashed"]);
+    const nsEdit = trace.labelEdits.at(-1)!;
+    expect(nsEdit.add).toContain("ready-for-human");
+    expect(nsEdit.add).toContain("blocked:crashed");
+    expect(trace.ensuredLabels).toContain("blocked:crashed");
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "no-sentinel" }]);
     // on_attempt_error fires; post_attempt does NOT (ADR 0028).
     expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
@@ -409,7 +424,11 @@ describe("processIssue — feedback fail", () => {
 
     expect(result.outcome).toBe("feedback-failed");
     expect(result.preserved).toBe(true);
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human"]);
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:validation"]);
+    const fbEdit = trace.labelEdits.at(-1)!;
+    expect(fbEdit.add).toContain("ready-for-human");
+    expect(fbEdit.add).toContain("blocked:validation");
+    expect(trace.ensuredLabels).toContain("blocked:validation");
     expect(trace.closed).toEqual([]);
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
     // post_attempt fired (the run authored DONE), pre_merge never reached, and
@@ -446,8 +465,13 @@ describe("processIssue — pre_worktree hook abort", () => {
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("hook-aborted");
     expect(result.preserved).toBe(true);
-    // claim then restore ready-for-agent; sandcastle was never invoked.
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
+    // claim then restore ready-for-agent + the typed blocked:policy tag (routing
+    // unchanged); sandcastle was never invoked.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:policy"]);
+    const haEdit = trace.labelEdits.at(-1)!;
+    expect(haEdit.add).toContain("ready-for-agent");
+    expect(haEdit.add).toContain("blocked:policy");
+    expect(trace.ensuredLabels).toContain("blocked:policy");
     expect(trace.runAgentCalls).toEqual([]);
     expect(result.hooksFired).toEqual(["pre_worktree"]);
   });
@@ -463,8 +487,13 @@ describe("processIssue — runner exhaustion (no --fallback-runner)", () => {
     expect(result.swept).toBe(false);
     // only one run; no swap.
     expect(trace.runAgentCalls.length).toBe(1);
-    // claim → running, then restore ready-for-agent (not ready-for-human).
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
+    // claim → running, then restore ready-for-agent (not ready-for-human) + the
+    // typed blocked:quota tag (routing unchanged).
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:quota"]);
+    const exEdit = trace.labelEdits.at(-1)!;
+    expect(exEdit.add).toContain("ready-for-agent");
+    expect(exEdit.add).toContain("blocked:quota");
+    expect(trace.ensuredLabels).toContain("blocked:quota");
     expect(trace.closed).toEqual([]);
     expect(trace.released).toEqual([9]);
     // no post_attempt fired (exhaustion is terminal before the sentinel branch).
@@ -514,8 +543,10 @@ describe("processIssue — runner exhaustion → fallback swap → retry", () =>
     expect(result.outcome).toBe("exhausted");
     expect(result.preserved).toBe(true);
     expect(trace.runAgentCalls.length).toBe(2);
-    // ready-for-agent restored (both-runners comment posted), claim released.
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
+    // ready-for-agent restored (both-runners comment posted) + the typed
+    // blocked:quota tag (routing unchanged), claim released.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:quota"]);
+    expect(trace.ensuredLabels).toContain("blocked:quota");
     expect(trace.released).toEqual([9]);
     expect(trace.closed).toEqual([]);
     // both attempts closed their post_attempt cycle; no merge ever reached.
@@ -582,8 +613,11 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
     const result = await processIssue(deps, input);
     expect(resolverCalls).toHaveLength(1);
     expect(result.outcome).toBe("merge-conflict");
-    // unresolved → ready-for-human, issue not closed.
+    // unresolved → ready-for-human + the typed blocked:merge-conflict tag
+    // (routing unchanged), issue not closed.
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human"))).toBe(true);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:merge-conflict"))).toBe(true);
+    expect(trace.ensuredLabels).toContain("blocked:merge-conflict");
     expect(trace.closed).not.toContain(9);
   });
 

--- a/src/domains/dev/tests/supervisor.test.ts
+++ b/src/domains/dev/tests/supervisor.test.ts
@@ -49,6 +49,7 @@ interface FakeIo {
   comment: ReturnType<typeof vi.fn>;
   editLabels: ReturnType<typeof vi.fn>;
   ensureRunnerErrorLabel: ReturnType<typeof vi.fn>;
+  ensureLabel: ReturnType<typeof vi.fn>;
   now: ReturnType<typeof vi.fn>;
 }
 
@@ -73,6 +74,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     comment: vi.fn(async () => {}),
     editLabels: vi.fn(async () => {}),
     ensureRunnerErrorLabel: vi.fn(async () => {}),
+    ensureLabel: vi.fn(async () => {}),
     now: vi.fn(() => NOW),
     ...(over as Partial<FakeIo>),
   };
@@ -95,6 +97,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       comment: io.comment,
       editLabels: io.editLabels,
       ensureRunnerErrorLabel: io.ensureRunnerErrorLabel,
+      ensureLabel: io.ensureLabel,
     },
     now: io.now,
   };
@@ -311,7 +314,10 @@ describe("pollStallDetector reaper gating", () => {
     expect(issue).toBe(190);
     expect(body).toContain('data-attempt-status="no-sentinel"');
     expect(body).toContain("stalled tool call");
-    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent"], ["running"]);
+    // ADDITIVE typed-blocked tag: routing unchanged (ready-for-agent restored)
+    // with blocked:stalled appended; the typed label is created on the fly.
+    expect(io.ensureLabel).toHaveBeenCalledWith("blocked:stalled");
+    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent", "blocked:stalled"], ["running"]);
     expect(io.teardownIterDir).toHaveBeenCalledOnce();
     // Slot freed + idempotency guard set.
     const slot = state.slots[0]!;


### PR DESCRIPTION
Stops flattening every failure to one `blocked`: tags the issue with the matching blocked:<reason> derived from the ProcessOutcome the runtime already computes (quota/merge-conflict/spec/validation/crashed/policy/stalled/infra). Additive — routing unchanged; auto-recovery deferred. 666 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782785603&installation_id=129708444&pr_number=293&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F293&signature=93b3fac84939382aa01b04c44200f76cb47450dfd011e758114781f981aba6a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed "blocked reason" labels for categorizing why tasks are blocked or failed (e.g., `blocked:quota`, `blocked:merge-conflict`, `blocked:spec`, `blocked:validation`, `blocked:crashed`, `blocked:policy`, `blocked:stalled`, `blocked:infra`).
  * System now automatically provisions these labels with standardized colors and descriptions.

* **Tests**
  * Added comprehensive test coverage for blocked reason label behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->