### PR TITLE
feat(afk): bounded auto-recovery for recoverable blocks

### DIFF
--- a/.red/agents/triage-labels.md
+++ b/.red/agents/triage-labels.md
@@ -155,18 +155,20 @@ How the edge drives the lifecycle:
 
 `/afk` already computes a precise terminal outcome for every iteration; instead of flattening every failure to one `blocked`, it tags the issue with the matching **`blocked:<reason>`** label so the backlog is filterable by *what kind* of block it is. The reason is derived automatically from the outcome — **no human classification**.
 
-| Outcome (runtime) | Label | Next action |
-| ----------------- | ----- | ----------- |
-| runner quota / both exhausted | `blocked:quota` | transient — retried / runner-swapped |
-| couldn't integrate or land | `blocked:merge-conflict` | base moved; re-attempt after main settles |
-| agent emitted `<promise>BLOCKED</promise>` | `blocked:spec` | a human must **decide / clarify** |
-| feedback gate failed (test/lint/build) | `blocked:validation` | review the diff on the branch |
-| agent exited without a sentinel | `blocked:crashed` | investigate (likely infra/bug) |
-| a user `pre_*` guard hook rejected it | `blocked:policy` | the policy owner looks |
-| stall-reaper killed a hung worker | `blocked:stalled` | task too big / looping |
-| worktree/base/push setup failed | `blocked:infra` | environment, not issue content — ops |
+| Outcome (runtime) | Label | Recovery | Retry cap (env) |
+| ----------------- | ----- | -------- | --------------- |
+| runner quota / both exhausted | `blocked:quota` | **auto-retry** → ready-for-agent | 3 (`RED_AFK_RETRY_QUOTA`) |
+| couldn't integrate or land | `blocked:merge-conflict` | **auto-retry** (base settles) | 3 (`RED_AFK_RETRY_MERGE`) |
+| agent exited without a sentinel | `blocked:crashed` | **auto-retry once** (transient) | 1 (`RED_AFK_RETRY_CRASH`) |
+| a user `pre_*` guard hook rejected it | `blocked:policy` | **auto-retry once** | 1 (`RED_AFK_RETRY_POLICY`) |
+| agent emitted `<promise>BLOCKED</promise>` | `blocked:spec` | **pages** → ready-for-human (decide/clarify) | — (never auto) |
+| feedback gate failed (test/lint/build) | `blocked:validation` | **pages** → ready-for-human (review diff) | — (never auto) |
+| stall-reaper killed a hung worker | `blocked:stalled` | restores ready-for-agent (uncapped — follow-up) | — |
+| worktree/base/push setup failed | `blocked:infra` | pages → ready-for-human (ops) | — |
 
-These are **descriptive today**: the typed label is added *alongside* the routing label (e.g. `ready-for-human`, or the restored `ready-for-agent` for quota/policy/stalled), so routing is unchanged — you gain observability (`gh issue list --label blocked:validation`) without any behaviour change. The recoverable reasons (`blocked:quota`, `blocked:merge-conflict`) are the natural candidates for a future **auto-recovery** step (loop back to `ready-for-agent` with bounded backoff instead of paging) — deliberately deferred until opted into. `blocked:dependency` (above) is the only reason already wired to non-paging behaviour.
+**Bounded auto-recovery (live).** The four recoverable reasons loop back to `ready-for-agent` and are retried, up to their per-reason cap (counting real attempt-ledger attempts); on the cap they **escalate** to `ready-for-human` with a `🤖 /afk escalating … retry budget exhausted (attempt N/cap)` comment. So a transient hiccup self-heals and never pages, but a persistent one still surfaces — bounded, no runaway loop. Caps are env-tunable (non-numeric/0 → default). `spec` and `validation` **always page** (a human must decide / review the diff); `dependency` waits on its `req:N` edges (never pages). The typed `blocked:<reason>` label is added in every case, so the backlog stays filterable by reason regardless of routing.
+
+> Not yet wired: time-based backoff (today the re-queue is immediate; the cap is what prevents runaway) and a cap on the supervisor stall-reaper's `blocked:stalled` restore.
 
 All `blocked:*` labels are created on the fly when first applied (mirroring `runner-error`) and provisioned by `/setup-red-skills`.
 

--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -317,6 +317,8 @@ function buildProcessDeps(
     },
     historyPath: paths.historyPath,
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },
+    // BOUNDED auto-recovery reads its RED_AFK_RETRY_* caps from the process env.
+    recoveryEnv: process.env,
   };
 }
 

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -89,6 +89,7 @@ import {
   type SectionBodies,
 } from "./envelope-emit.js";
 import { dispatchHooks, type HookExec } from "./hook-dispatcher.js";
+import { recoveryCap, recoveryDecision, type RecoveryEnv, type RecoveryReason } from "./recovery.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
@@ -239,6 +240,13 @@ export interface ProcessIssueDeps {
   /** History ledger path + clock for the terminal envelope (optional). */
   historyPath?: string;
   historyClock?: HistoryClock;
+  /**
+   * Env view the BOUNDED auto-recovery policy reads the RED_AFK_RETRY_* caps
+   * from (recovery.ts). Defaults to `process.env` in the CLI; tests inject a
+   * record. Absent → an empty env (every recoverable reason uses its default
+   * cap).
+   */
+  recoveryEnv?: RecoveryEnv;
 }
 
 /** Static per-issue inputs the caller resolves before `processIssue`. */
@@ -323,6 +331,77 @@ async function editLabelsTagged(
   if (typed === null) return deps.gh.editLabels(issue, remove, add);
   await deps.gh.ensureLabel(typed);
   return deps.gh.editLabels(issue, remove, [...add, typed]);
+}
+
+/**
+ * Map an envelope-emit `BlockedReason` to its BOUNDED-recovery policy reason
+ * (recovery.ts). The six terminal failure paths route through `routeRecovery`
+ * using these names; the reasons not listed here never reach the recovery
+ * router (`done` / `claim-lost` carry no typed label; `stalled` / `infra` are
+ * the supervisor / boot paths, out of scope).
+ */
+function recoveryReasonOf(reason: BlockedReason): RecoveryReason | null {
+  switch (reason) {
+    case "merge-conflict":
+      return "merge-conflict";
+    case "no-sentinel":
+      return "crashed";
+    case "exhausted":
+      return "quota";
+    case "hook-aborted":
+      return "policy";
+    case "blocked":
+      return "spec";
+    case "feedback-failed":
+      return "validation";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Apply the BOUNDED auto-recovery routing for a terminal failure. The policy
+ * (recovery.ts) decides retry vs escalate from the reason + the real attempt
+ * number + the env caps:
+ *   - "retry"    → remove [running], add [ready-for-agent, blocked:<reason>]
+ *   - "escalate" → remove [running], add [ready-for-human,  blocked:<reason>]
+ * The typed `blocked:<reason>` label is added in BOTH cases (descriptive). When
+ * we ESCALATE a reason that was recoverable (its retry budget ran out), post a
+ * one-line comment so the human page is self-explanatory. Returns the decision
+ * so the caller can log / shape its terminal result if it cares.
+ */
+async function routeRecovery(
+  deps: ProcessIssueDeps,
+  issue: number,
+  reason: BlockedReason,
+  attemptN: number,
+): Promise<"retry" | "escalate"> {
+  const policyReason = recoveryReasonOf(reason);
+  // A reason with no policy mapping is treated as escalate (page a human),
+  // preserving the pre-recovery default for any unexpected reason.
+  if (policyReason === null) {
+    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], reason);
+    return "escalate";
+  }
+  const env = deps.recoveryEnv ?? {};
+  const decision = recoveryDecision(policyReason, attemptN, env);
+  if (decision === "retry") {
+    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_READY], reason);
+    return "retry";
+  }
+  // escalate
+  await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], reason);
+  const cap = recoveryCap(policyReason, env);
+  if (cap !== null) {
+    // A previously-auto-recoverable reason whose retry budget is exhausted —
+    // announce the page so it is not mistaken for a first-attempt human block.
+    const typed = blockedReasonLabel(reason) ?? `blocked:${policyReason}`;
+    await deps.gh.comment(
+      issue,
+      `🤖 /afk escalating to ready-for-human: ${typed} retry budget exhausted (attempt ${attemptN}/${cap}).`,
+    );
+  }
+  return "escalate";
 }
 
 /**
@@ -504,7 +583,7 @@ export async function processIssue(
   // ---- on_attempt_error: the run ended without an AFK sentinel (ADR 0028) ----
   if (run.outcome === "no-sentinel") {
     await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
-    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], "no-sentinel");
+    await routeRecovery(deps, issue, "no-sentinel", current.attempt);
     const posted = await emitFailure(common, "no-sentinel", "no-sentinel", {
       notes: "_(no Notes appended; inner agent exited without a sentinel)_",
       log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
@@ -527,7 +606,7 @@ export async function processIssue(
 
   // ---- BLOCKED ----
   if (run.outcome === "blocked") {
-    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], "blocked");
+    await routeRecovery(deps, issue, "blocked", current.attempt);
     const posted = await emitFailure(common, "blocked", "blocked", {
       notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
     });
@@ -556,7 +635,7 @@ export async function processIssue(
     now: deps.nowEpoch,
   });
   if (!feedback.ok) {
-    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_HUMAN], "feedback-failed");
+    await routeRecovery(deps, issue, "feedback-failed", current.attempt);
     const posted = await emitFailure(common, "blocked", "feedback", {
       notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n"),
@@ -764,7 +843,7 @@ async function emitDone(
  * ready-for-human, preserve the attempt dir. Mirrors the do_merge-false branch. */
 async function mergeFailed(c: StageCommon, _reason: string, locked = false): Promise<ProcessIssueResult> {
   const { deps, input } = c;
-  await editLabelsTagged(deps, input.issue, [LABEL_RUNNING], [LABEL_HUMAN], "merge-conflict");
+  await routeRecovery(deps, input.issue, "merge-conflict", input.attempt);
   const posted = await emitFailure(c, "merge-conflict", "merge-conflict", {
     log: "(no merge log captured)",
   });
@@ -852,11 +931,16 @@ async function abortAfterClaim(
   hooksFired: HookName[],
   _reason: string,
 ): Promise<ProcessIssueResult> {
-  await editLabelsTagged(deps, input.issue, [LABEL_RUNNING], [LABEL_READY], "hook-aborted");
-  await deps.gh.comment(
-    input.issue,
-    `🤖 /afk aborted before runner invocation (${_reason}). Restored \`${LABEL_READY}\`.`,
-  );
+  // A policy-hook abort is BOUNDED-recoverable (recovery.ts, reason "policy"):
+  // retry under the cap (restore ready-for-agent) else escalate (ready-for-human
+  // + the budget-exhausted comment routeRecovery posts).
+  const decision = await routeRecovery(deps, input.issue, "hook-aborted", input.attempt);
+  if (decision === "retry") {
+    await deps.gh.comment(
+      input.issue,
+      `🤖 /afk aborted before runner invocation (${_reason}). Restored \`${LABEL_READY}\`.`,
+    );
+  }
   await deps.claimLock.release(input.issue);
   return {
     outcome: "hook-aborted",
@@ -886,7 +970,10 @@ async function exhausted(
   runner: Runner,
   both: boolean,
 ): Promise<ProcessIssueResult> {
-  await editLabelsTagged(deps, input.issue, [LABEL_RUNNING], [LABEL_READY], "exhausted");
+  // Quota exhaustion is BOUNDED-recoverable (recovery.ts, reason "quota"):
+  // restore ready-for-agent while under the cap, else escalate to
+  // ready-for-human (routeRecovery posts the budget-exhausted comment).
+  await routeRecovery(deps, input.issue, "exhausted", input.attempt);
   await deps.gh.comment(
     input.issue,
     both

--- a/src/domains/dev/src/core/recovery.ts
+++ b/src/domains/dev/src/core/recovery.ts
@@ -1,0 +1,90 @@
+// recovery — the BOUNDED auto-recovery policy for AFK terminal failures.
+//
+// A terminal failure is either RECOVERABLE (a transient class that often clears
+// on a fresh attempt — a merge conflict, a crash, a quota wall, a policy-hook
+// abort) or NON-RECOVERABLE (a class that needs a human to change something — a
+// spec block, a validation failure). This module is PURE: it maps a failure
+// reason + the current attempt number + the env to a single decision —
+//
+//   "retry"    → re-queue the issue (route back to ready-for-agent)
+//   "escalate" → page a human (route to ready-for-human)
+//
+// Recoverable reasons retry while `attemptN < cap` and escalate once the cap is
+// reached, so a transient failure can self-heal but a STUCK issue can never loop
+// forever. Each recoverable reason has its own cap, defaulted here and overridable
+// via a RED_AFK_RETRY_* env knob (a missing / non-numeric / non-positive value
+// falls back to the default). Non-recoverable reasons always escalate.
+//
+// `attemptN` is the caller's `input.attempt` (1-based, sourced from the
+// attempt-ledger), so the cap counts REAL attempts, not retries-within-an-attempt.
+//
+// NOTE (out of scope): the supervisor stall-reaper (core/supervisor.ts,
+// blocked:stalled) restores ready-for-agent WITHOUT a cap — it lacks the attempt
+// count cheaply. That path is intentionally left uncapped here; capping it is a
+// follow-up. Time-based backoff (vs the immediate re-queue) is also future work —
+// the cap is what prevents the runaway loop today.
+
+/**
+ * The recovery-policy view of a terminal failure reason. These are the *policy*
+ * names (what kind of failure happened), distinct from the routing labels and
+ * from envelope-emit's `BlockedReason`. Recoverable reasons carry a cap;
+ * `spec` / `validation` are terminal-for-a-human.
+ */
+export type RecoveryReason =
+  | "merge-conflict"
+  | "crashed"
+  | "quota"
+  | "policy"
+  | "spec"
+  | "validation";
+
+export type RecoveryDecision = "retry" | "escalate";
+
+interface RecoverableSpec {
+  /** Env knob that overrides the default cap. */
+  knob: string;
+  /** Default cap when the knob is unset / non-numeric / non-positive. */
+  defaultCap: number;
+}
+
+/** The recoverable reasons and their cap configuration. A reason absent from
+ * this table is NON-recoverable (always escalate). */
+const RECOVERABLE: Record<string, RecoverableSpec> = {
+  "merge-conflict": { knob: "RED_AFK_RETRY_MERGE", defaultCap: 3 },
+  crashed: { knob: "RED_AFK_RETRY_CRASH", defaultCap: 1 },
+  quota: { knob: "RED_AFK_RETRY_QUOTA", defaultCap: 3 },
+  policy: { knob: "RED_AFK_RETRY_POLICY", defaultCap: 1 },
+};
+
+/** A loose env view so the policy stays pure and trivially testable. */
+export type RecoveryEnv = Record<string, string | undefined>;
+
+/**
+ * Resolve the effective retry cap for a reason, or `null` when the reason is
+ * non-recoverable. Used both by `recoveryDecision` and by the caller's
+ * escalation comment ("attempt N/cap").
+ */
+export function recoveryCap(reason: RecoveryReason, env: RecoveryEnv): number | null {
+  const spec = RECOVERABLE[reason];
+  if (!spec) return null;
+  const raw = env[spec.knob];
+  if (raw !== undefined) {
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return spec.defaultCap;
+}
+
+/**
+ * The BOUNDED auto-recovery decision. Recoverable reasons retry while
+ * `attemptN < cap`, else escalate; non-recoverable reasons always escalate.
+ */
+export function recoveryDecision(
+  reason: RecoveryReason,
+  attemptN: number,
+  env: RecoveryEnv,
+): RecoveryDecision {
+  const cap = recoveryCap(reason, env);
+  if (cap === null) return "escalate";
+  return attemptN < cap ? "retry" : "escalate";
+}

--- a/src/domains/dev/tests/process-issue.test.ts
+++ b/src/domains/dev/tests/process-issue.test.ts
@@ -59,6 +59,11 @@ interface HarnessOptions {
   /** Close-cascade fixture: issues resolved as CLOSED by gh.issueClosed. The
    * just-closed issue is treated as closed without consulting this set. */
   closedIssues?: number[];
+  /** Attempt number (1-based) the issue runs under — drives the BOUNDED
+   * auto-recovery cap (recovery.ts). Defaults to 1. */
+  attempt?: number;
+  /** Env view the recovery policy reads RED_AFK_RETRY_* caps from. Defaults to {}. */
+  recoveryEnv?: Record<string, string>;
 }
 
 function harness(opts: HarnessOptions = {}): {
@@ -255,6 +260,7 @@ function harness(opts: HarnessOptions = {}): {
     nowEpoch: () => 1000,
     nowIso: () => "2026-05-30T00:00:00Z",
     appendIterLog: () => {},
+    recoveryEnv: opts.recoveryEnv ?? {},
   };
 
   // Wire the hook config + abort marker so dispatchHooks has a command to run.
@@ -269,7 +275,7 @@ function harness(opts: HarnessOptions = {}): {
     runner: "claude",
     workerId: "wAAAA",
     tmpDir: "/tmp/afk",
-    attempt: 1,
+    attempt: opts.attempt ?? 1,
     attemptDir: "/tmp/afk/workers/wAAAA/9-a1",
     repo: "o/r",
     repoDir: "/repo",
@@ -459,14 +465,19 @@ describe("processIssue — claim lost", () => {
   });
 });
 
-describe("processIssue — pre_worktree hook abort", () => {
-  it("restores ready-for-agent and never runs the agent", async () => {
-    const { deps, input, trace } = harness({ abortHook: "pre_worktree" });
+describe("processIssue — pre_worktree hook abort (BOUNDED-recoverable: policy)", () => {
+  it("under the cap → RETRY: restores ready-for-agent and never runs the agent", async () => {
+    // policy cap is 1 by default; raise it so attempt 1 is under-cap and retries.
+    const { deps, input, trace } = harness({
+      abortHook: "pre_worktree",
+      attempt: 1,
+      recoveryEnv: { RED_AFK_RETRY_POLICY: "2" },
+    });
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("hook-aborted");
     expect(result.preserved).toBe(true);
-    // claim then restore ready-for-agent + the typed blocked:policy tag (routing
-    // unchanged); sandcastle was never invoked.
+    // claim then restore ready-for-agent + the typed blocked:policy tag;
+    // sandcastle was never invoked.
     expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:policy"]);
     const haEdit = trace.labelEdits.at(-1)!;
     expect(haEdit.add).toContain("ready-for-agent");
@@ -474,6 +485,29 @@ describe("processIssue — pre_worktree hook abort", () => {
     expect(trace.ensuredLabels).toContain("blocked:policy");
     expect(trace.runAgentCalls).toEqual([]);
     expect(result.hooksFired).toEqual(["pre_worktree"]);
+    // the restore comment is posted on retry; no budget-exhausted page.
+    expect(trace.comments.some((c) => /Restored `ready-for-agent`/.test(c.body))).toBe(true);
+    expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
+  });
+
+  it("at the cap → ESCALATE: routes to ready-for-human + posts the budget-exhausted page", async () => {
+    // default policy cap is 1, so attempt 1 is at-cap → escalate.
+    const { deps, input, trace } = harness({ abortHook: "pre_worktree", attempt: 1 });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("hook-aborted");
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:policy"]);
+    const haEdit = trace.labelEdits.at(-1)!;
+    expect(haEdit.add).toContain("ready-for-human");
+    expect(haEdit.add).toContain("blocked:policy");
+    expect(trace.ensuredLabels).toContain("blocked:policy");
+    expect(trace.runAgentCalls).toEqual([]);
+    // the budget-exhausted page is posted; the restore comment is not.
+    expect(
+      trace.comments.some((c) =>
+        /escalating to ready-for-human: blocked:policy retry budget exhausted \(attempt 1\/1\)/.test(c.body),
+      ),
+    ).toBe(true);
+    expect(trace.comments.some((c) => /Restored `ready-for-agent`/.test(c.body))).toBe(false);
   });
 });
 
@@ -600,7 +634,9 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human"))).toBe(false);
   });
 
-  it("falls back to ready-for-human when the resolver cannot resolve the conflict", async () => {
+  it("falls back to ready-for-human when the resolver cannot resolve the conflict (at the cap)", async () => {
+    // merge-conflict cap is 3; run at attempt 3 (at-cap) so the unresolved
+    // conflict ESCALATES to a human rather than re-queuing.
     const resolverCalls: string[] = [];
     const { deps, input, trace } = harness({
       outcome: "done",
@@ -609,29 +645,140 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
       mergeNoFfCode: 1,
       conflictResolve: "fail",
       resolverCalls,
+      attempt: 3,
     });
     const result = await processIssue(deps, input);
     expect(resolverCalls).toHaveLength(1);
     expect(result.outcome).toBe("merge-conflict");
-    // unresolved → ready-for-human + the typed blocked:merge-conflict tag
-    // (routing unchanged), issue not closed.
+    // unresolved + at-cap → ready-for-human + the typed blocked:merge-conflict tag,
+    // issue not closed.
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human"))).toBe(true);
     expect(trace.labelEdits.some((e) => e.add.includes("blocked:merge-conflict"))).toBe(true);
     expect(trace.ensuredLabels).toContain("blocked:merge-conflict");
     expect(trace.closed).not.toContain(9);
   });
 
-  it("goes straight to ready-for-human when no resolver is registered", async () => {
+  it("escalates to ready-for-human when no resolver is registered (at the cap)", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackOk: true,
       locked: true,
       mergeNoFfCode: 1,
+      attempt: 3, // at the merge-conflict cap → escalate
       // conflictResolve undefined → deps.conflictResolver is undefined
     });
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("merge-conflict");
     expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human"))).toBe(true);
+  });
+});
+
+describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)", () => {
+  it("merge-conflict at attempt 1 (< cap 3) → RETRY: ready-for-agent + blocked:merge-conflict, no page", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: true,
+      mergeNoFfCode: 1, // merge --no-ff conflicts; no resolver registered
+      attempt: 1,
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("merge-conflict");
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-agent");
+    expect(edit.add).toContain("blocked:merge-conflict");
+    expect(edit.add).not.toContain("ready-for-human");
+    expect(trace.ensuredLabels).toContain("blocked:merge-conflict");
+    // a retry never pages; no budget-exhausted comment.
+    expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
+    expect(trace.closed).not.toContain(9);
+  });
+
+  it("merge-conflict at attempt = cap (3) → ESCALATE: ready-for-human + blocked:merge-conflict + budget-exhausted page", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: true,
+      mergeNoFfCode: 1,
+      attempt: 3,
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("merge-conflict");
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-human");
+    expect(edit.add).toContain("blocked:merge-conflict");
+    expect(
+      trace.comments.some((c) =>
+        /escalating to ready-for-human: blocked:merge-conflict retry budget exhausted \(attempt 3\/3\)/.test(c.body),
+      ),
+    ).toBe(true);
+  });
+
+  it("quota (exhausted) at attempt < cap → RETRY: ready-for-agent + blocked:quota", async () => {
+    const { deps, input, trace } = harness({ outcome: "exhausted", fallbackRunner: false, attempt: 2 });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("exhausted");
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-agent");
+    expect(edit.add).toContain("blocked:quota");
+    expect(edit.add).not.toContain("ready-for-human");
+    expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
+  });
+
+  it("quota (exhausted) at attempt = cap (3) → ESCALATE: ready-for-human + blocked:quota + budget-exhausted page", async () => {
+    const { deps, input, trace } = harness({ outcome: "exhausted", fallbackRunner: false, attempt: 3 });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("exhausted");
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-human");
+    expect(edit.add).toContain("blocked:quota");
+    expect(
+      trace.comments.some((c) =>
+        /escalating to ready-for-human: blocked:quota retry budget exhausted \(attempt 3\/3\)/.test(c.body),
+      ),
+    ).toBe(true);
+  });
+
+  it("crashed (no-sentinel) RETRIES once then escalates (cap 1)", async () => {
+    // cap 1: attempt 1 is at-cap → escalate. Raise to 2 to see the single retry.
+    const retry = harness({ outcome: "no-sentinel", attempt: 1, recoveryEnv: { RED_AFK_RETRY_CRASH: "2" } });
+    const r1 = await processIssue(retry.deps, retry.input);
+    expect(r1.outcome).toBe("no-sentinel");
+    expect(retry.trace.labelEdits.at(-1)!.add).toContain("ready-for-agent");
+    expect(retry.trace.labelEdits.at(-1)!.add).toContain("blocked:crashed");
+
+    const escalate = harness({ outcome: "no-sentinel", attempt: 1 }); // default cap 1 → escalate
+    const r2 = await processIssue(escalate.deps, escalate.input);
+    expect(r2.outcome).toBe("no-sentinel");
+    expect(escalate.trace.labelEdits.at(-1)!.add).toContain("ready-for-human");
+    expect(escalate.trace.labelEdits.at(-1)!.add).toContain("blocked:crashed");
+  });
+
+  it("spec (BLOCKED) ALWAYS escalates to ready-for-human, even at attempt 1 and high attempts", async () => {
+    for (const attempt of [1, 5, 99]) {
+      const { deps, input, trace } = harness({ outcome: "blocked", attempt });
+      const result = await processIssue(deps, input);
+      expect(result.outcome).toBe("blocked");
+      const edit = trace.labelEdits.at(-1)!;
+      expect(edit.add).toContain("ready-for-human");
+      expect(edit.add).toContain("blocked:spec");
+      expect(edit.add).not.toContain("ready-for-agent");
+      // non-recoverable → no budget-exhausted page (it was never auto-recovering).
+      expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
+    }
+  });
+
+  it("validation (feedback-failed) ALWAYS escalates to ready-for-human", async () => {
+    for (const attempt of [1, 5, 99]) {
+      const { deps, input, trace } = harness({ outcome: "done", feedbackOk: false, attempt });
+      const result = await processIssue(deps, input);
+      expect(result.outcome).toBe("feedback-failed");
+      const edit = trace.labelEdits.at(-1)!;
+      expect(edit.add).toContain("ready-for-human");
+      expect(edit.add).toContain("blocked:validation");
+      expect(edit.add).not.toContain("ready-for-agent");
+      expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
+    }
   });
 });
 

--- a/src/domains/dev/tests/recovery.test.ts
+++ b/src/domains/dev/tests/recovery.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { recoveryDecision, recoveryCap, type RecoveryReason } from "../src/core/recovery.js";
+
+// recoveryDecision is a PURE policy: (reason, attemptN, env) → retry | escalate.
+// Recoverable reasons retry while attemptN < cap, then escalate. Non-recoverable
+// reasons (spec / validation) always escalate. Caps come from RED_AFK_RETRY_*
+// env knobs; a missing or non-numeric value falls back to the default cap.
+
+describe("recoveryDecision — recoverable reasons honour the cap", () => {
+  const cases: Array<{ reason: RecoveryReason; knob: string; cap: number }> = [
+    { reason: "merge-conflict", knob: "RED_AFK_RETRY_MERGE", cap: 3 },
+    { reason: "crashed", knob: "RED_AFK_RETRY_CRASH", cap: 1 },
+    { reason: "quota", knob: "RED_AFK_RETRY_QUOTA", cap: 3 },
+    { reason: "policy", knob: "RED_AFK_RETRY_POLICY", cap: 1 },
+  ];
+
+  for (const { reason, cap } of cases) {
+    it(`${reason}: retries while attemptN < default cap ${cap}, escalates at/over the cap`, () => {
+      // under the cap → retry
+      expect(recoveryDecision(reason, 1, {})).toBe(cap > 1 ? "retry" : "escalate");
+      for (let n = 1; n < cap; n++) {
+        expect(recoveryDecision(reason, n, {})).toBe("retry");
+      }
+      // at the cap → escalate
+      expect(recoveryDecision(reason, cap, {})).toBe("escalate");
+      // over the cap → escalate
+      expect(recoveryDecision(reason, cap + 5, {})).toBe("escalate");
+    });
+  }
+});
+
+describe("recoveryDecision — non-recoverable reasons always escalate", () => {
+  for (const reason of ["spec", "validation"] as RecoveryReason[]) {
+    it(`${reason} escalates at every attempt`, () => {
+      expect(recoveryDecision(reason, 1, {})).toBe("escalate");
+      expect(recoveryDecision(reason, 99, {})).toBe("escalate");
+    });
+  }
+});
+
+describe("recoveryDecision — env caps override the default", () => {
+  it("a numeric env knob raises the cap (merge-conflict retries to the new cap)", () => {
+    const env = { RED_AFK_RETRY_MERGE: "5" };
+    expect(recoveryDecision("merge-conflict", 4, env)).toBe("retry");
+    expect(recoveryDecision("merge-conflict", 5, env)).toBe("escalate");
+  });
+
+  it("a numeric env knob lowers the cap to 1 (crash-style, escalate at attempt 1)", () => {
+    const env = { RED_AFK_RETRY_QUOTA: "1" };
+    expect(recoveryDecision("quota", 1, env)).toBe("escalate");
+  });
+
+  it("a non-numeric env value falls back to the default cap", () => {
+    expect(recoveryDecision("merge-conflict", 1, { RED_AFK_RETRY_MERGE: "lots" })).toBe("retry");
+    expect(recoveryDecision("merge-conflict", 3, { RED_AFK_RETRY_MERGE: "lots" })).toBe("escalate");
+  });
+
+  it("a missing env value falls back to the default cap", () => {
+    expect(recoveryDecision("crashed", 1, {})).toBe("escalate"); // cap 1
+    expect(recoveryDecision("quota", 2, {})).toBe("retry"); // cap 3
+  });
+
+  it("a zero / negative env value falls back to the default cap", () => {
+    expect(recoveryDecision("quota", 2, { RED_AFK_RETRY_QUOTA: "0" })).toBe("retry");
+    expect(recoveryDecision("quota", 2, { RED_AFK_RETRY_QUOTA: "-4" })).toBe("retry");
+  });
+});
+
+describe("recoveryCap — resolves the effective cap for the escalation comment", () => {
+  it("returns the default cap when the knob is unset", () => {
+    expect(recoveryCap("merge-conflict", {})).toBe(3);
+    expect(recoveryCap("crashed", {})).toBe(1);
+    expect(recoveryCap("quota", {})).toBe(3);
+    expect(recoveryCap("policy", {})).toBe(1);
+  });
+
+  it("returns the env override when numeric", () => {
+    expect(recoveryCap("quota", { RED_AFK_RETRY_QUOTA: "7" })).toBe(7);
+  });
+
+  it("returns null for non-recoverable reasons", () => {
+    expect(recoveryCap("spec", {})).toBeNull();
+    expect(recoveryCap("validation", {})).toBeNull();
+  });
+});


### PR DESCRIPTION
Recoverable failures (quota/merge-conflict/crashed/policy) retry up to a per-reason cap then escalate to ready-for-human; spec/validation always page. Self-heals transient hiccups without paging, bounded against runaway. Caps env-tunable. 688 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782787881&installation_id=129708444&pr_number=294&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F294&signature=2691b85ad46d561479a4dda3d8bd3391966aefa363b76bc3abcbf66d4a2be10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented bounded auto-recovery for terminal failures: certain failure types (merge conflicts, quota issues, policy violations) now auto-retry up to configurable limits before escalating to human review.
  * Recovery caps are now configurable via environment variables.

* **Documentation**
  * Updated triage label documentation with recovery semantics, retry limits, and escalation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->