### PR TITLE
refactor(afk): single-owner Attempt Outcome module

### DIFF
--- a/src/domains/dev/src/core/attempt-outcome.ts
+++ b/src/domains/dev/src/core/attempt-outcome.ts
@@ -1,0 +1,121 @@
+// attempt-outcome — the SINGLE OWNER of the AFK "how an attempt ended, and what
+// it means" vocabulary.
+//
+// Historically this knowledge was smeared across three parallel enums that had
+// to stay in sync by hand — `ProcessOutcome` (process-issue.ts), `BlockedReason`
+// (envelope-emit.ts), and `RecoveryReason` (recovery.ts) — plus a hand-written
+// bridge (`recoveryReasonOf`). Adding one terminal ending touched four files and
+// any drift silently produced a wrong label or a wrong routing decision.
+//
+// This module collapses that into ONE owner:
+//   - `AttemptOutcome`     — every terminal ending an iteration can have.
+//   - `RecoveryReason`     — the recoverable subset's policy keys (recovery.ts
+//                            consumes this; its cap table is keyed on it).
+//   - `blockedLabelFor`    — outcome → DESCRIPTIVE `blocked:<reason>` label.
+//   - `recoveryReasonFor`  — outcome → BOUNDED-recovery policy key (or null).
+//
+// It is PURE (no IO) — decision/mapping only. Execution (editLabels, comment, the
+// cascade gh, routeRecovery) stays at the call sites. The two functions are the
+// canonical source for both the observability label and the recovery routing key,
+// so the 3-enum-desync bug class becomes impossible.
+
+/**
+ * Every terminal ending an AFK iteration can have — the UNION of what
+ * process-issue can return and the two reasons sourced from outside the
+ * per-issue lifecycle:
+ *   - `stalled` — the supervisor stall-reaper hard-killed the slot.
+ *   - `infra`   — worktree/base/push setup failed before the agent ran.
+ *
+ * Successful or abandoned endings (`done`, `claim-lost`) are members so every
+ * mapping is total, but they carry no typed label (null).
+ */
+export type AttemptOutcome =
+  | "done"
+  | "blocked"
+  | "no-sentinel"
+  | "merge-conflict"
+  | "feedback-failed"
+  | "claim-lost"
+  | "hook-aborted"
+  | "exhausted"
+  | "stalled"
+  | "infra";
+
+/**
+ * The recovery-policy view of a terminal failure — the RECOVERABLE subset of the
+ * outcomes, under their policy names (what *kind* of transient failure happened):
+ *   - exhausted     → `quota`
+ *   - no-sentinel   → `crashed`
+ *   - hook-aborted  → `policy`
+ *   - merge-conflict→ `merge-conflict`
+ *
+ * recovery.ts keys its bounded retry-cap table on these. Outcomes outside this
+ * subset are NON-recoverable (always escalate, see `recoveryReasonFor`).
+ */
+export type RecoveryReason = "quota" | "merge-conflict" | "crashed" | "policy";
+
+/**
+ * Pure mapping from a terminal outcome to its DESCRIPTIVE `blocked:<…>`
+ * observability label, or null when the outcome carries no typed label
+ * (`done` / `claim-lost`). The "nice" recovery names live in these strings.
+ *
+ * OBSERVABILITY ONLY — this never changes where an issue routes; the caller adds
+ * the returned label ALONGSIDE the routing label (ready-for-human /
+ * ready-for-agent).
+ */
+export function blockedLabelFor(o: AttemptOutcome): string | null {
+  switch (o) {
+    case "exhausted":
+      return "blocked:quota";
+    case "merge-conflict":
+      return "blocked:merge-conflict";
+    case "blocked":
+      return "blocked:spec";
+    case "feedback-failed":
+      return "blocked:validation";
+    case "no-sentinel":
+      return "blocked:crashed";
+    case "hook-aborted":
+      return "blocked:policy";
+    case "stalled":
+      return "blocked:stalled";
+    case "infra":
+      return "blocked:infra";
+    case "done":
+    case "claim-lost":
+      return null;
+  }
+}
+
+/**
+ * Pure mapping from a terminal outcome to its BOUNDED auto-recovery policy key,
+ * or null when the outcome is NOT auto-recoverable. The recoverable outcomes are
+ * exactly the four transient classes that often clear on a fresh attempt:
+ *   - exhausted     → `quota`
+ *   - no-sentinel   → `crashed`
+ *   - hook-aborted  → `policy`
+ *   - merge-conflict→ `merge-conflict`
+ *
+ * Everything else (`blocked`, `feedback-failed`, `stalled`, `infra`, `done`,
+ * `claim-lost`) returns null — those route straight to a human / carry no
+ * recovery budget, preserving today's behaviour exactly.
+ */
+export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
+  switch (o) {
+    case "exhausted":
+      return "quota";
+    case "no-sentinel":
+      return "crashed";
+    case "hook-aborted":
+      return "policy";
+    case "merge-conflict":
+      return "merge-conflict";
+    case "blocked":
+    case "feedback-failed":
+    case "stalled":
+    case "infra":
+    case "done":
+    case "claim-lost":
+      return null;
+  }
+}

--- a/src/domains/dev/src/core/envelope-emit.ts
+++ b/src/domains/dev/src/core/envelope-emit.ts
@@ -23,59 +23,6 @@ import { buildEnvelope, type AttemptStatus, type EnvelopeSection } from "./envel
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { historyAppend, type HistoryAppendFields, type HistoryClock, type HistoryEvent, type HistoryIO } from "./history.js";
 
-/**
- * The terminal-failure reasons the AFK runtime distinguishes. A superset of the
- * `ProcessOutcome` failure values (process-issue.ts) plus two reasons sourced
- * from outside the per-issue lifecycle:
- *   - `stalled` — the supervisor stall-reaper hard-killed the slot.
- *   - `infra`   — worktree/base/push setup failed before the agent ran.
- *
- * Successful or abandoned outcomes (`done`, `claim-lost`) are included so the
- * mapping is total, but they carry no typed label (null).
- */
-export type BlockedReason =
-  | "exhausted"
-  | "merge-conflict"
-  | "blocked"
-  | "feedback-failed"
-  | "no-sentinel"
-  | "hook-aborted"
-  | "stalled"
-  | "infra"
-  | "done"
-  | "claim-lost";
-
-/**
- * Pure mapping from a terminal failure reason to its DESCRIPTIVE `blocked:<…>`
- * observability label, or null when the outcome carries no typed label
- * (`done` / `claim-lost`). OBSERVABILITY ONLY — this never changes where an
- * issue routes; the caller adds the returned label ALONGSIDE the existing
- * routing label (ready-for-human / ready-for-agent).
- */
-export function blockedReasonLabel(reason: BlockedReason): string | null {
-  switch (reason) {
-    case "exhausted":
-      return "blocked:quota";
-    case "merge-conflict":
-      return "blocked:merge-conflict";
-    case "blocked":
-      return "blocked:spec";
-    case "feedback-failed":
-      return "blocked:validation";
-    case "no-sentinel":
-      return "blocked:crashed";
-    case "hook-aborted":
-      return "blocked:policy";
-    case "stalled":
-      return "blocked:stalled";
-    case "infra":
-      return "blocked:infra";
-    case "done":
-    case "claim-lost":
-      return null;
-  }
-}
-
 /** Render N seconds as `<m>m<s>s`. Mirrors envelope_fmt_duration. */
 export function fmtDuration(seconds: number): string {
   const s = Number.isFinite(seconds) ? Math.trunc(seconds) : 0;

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -82,14 +82,13 @@ import {
   type ConflictResolver,
 } from "./merge.js";
 import {
-  blockedReasonLabel,
   emitEnvelope,
-  type BlockedReason,
   type EmitEnvelopeDeps,
   type SectionBodies,
 } from "./envelope-emit.js";
 import { dispatchHooks, type HookExec } from "./hook-dispatcher.js";
-import { recoveryCap, recoveryDecision, type RecoveryEnv, type RecoveryReason } from "./recovery.js";
+import { recoveryCap, recoveryDecision, type RecoveryEnv } from "./recovery.js";
+import { blockedLabelFor, recoveryReasonFor, type AttemptOutcome } from "./attempt-outcome.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
@@ -275,15 +274,12 @@ export interface ProcessIssueInput {
 
 // ---------- result ----------
 
-export type ProcessOutcome =
-  | "done"
-  | "blocked"
-  | "no-sentinel"
-  | "merge-conflict"
-  | "feedback-failed"
-  | "claim-lost"
-  | "hook-aborted"
-  | "exhausted";
+// The subset of `AttemptOutcome` that the per-issue lifecycle itself can return.
+// `stalled` (supervisor reaper) and `infra` (boot setup) originate outside
+// processIssue, so they are excluded here while the shared owner (attempt-outcome)
+// keeps the full union. Exclude<> ties this to the single owner so the two can
+// never drift.
+export type ProcessOutcome = Exclude<AttemptOutcome, "stalled" | "infra">;
 
 export interface ProcessIssueResult {
   outcome: ProcessOutcome;
@@ -325,38 +321,12 @@ async function editLabelsTagged(
   issue: number,
   remove: string[],
   add: string[],
-  reason: BlockedReason,
+  reason: AttemptOutcome,
 ): Promise<boolean> {
-  const typed = blockedReasonLabel(reason);
+  const typed = blockedLabelFor(reason);
   if (typed === null) return deps.gh.editLabels(issue, remove, add);
   await deps.gh.ensureLabel(typed);
   return deps.gh.editLabels(issue, remove, [...add, typed]);
-}
-
-/**
- * Map an envelope-emit `BlockedReason` to its BOUNDED-recovery policy reason
- * (recovery.ts). The six terminal failure paths route through `routeRecovery`
- * using these names; the reasons not listed here never reach the recovery
- * router (`done` / `claim-lost` carry no typed label; `stalled` / `infra` are
- * the supervisor / boot paths, out of scope).
- */
-function recoveryReasonOf(reason: BlockedReason): RecoveryReason | null {
-  switch (reason) {
-    case "merge-conflict":
-      return "merge-conflict";
-    case "no-sentinel":
-      return "crashed";
-    case "exhausted":
-      return "quota";
-    case "hook-aborted":
-      return "policy";
-    case "blocked":
-      return "spec";
-    case "feedback-failed":
-      return "validation";
-    default:
-      return null;
-  }
 }
 
 /**
@@ -373,10 +343,10 @@ function recoveryReasonOf(reason: BlockedReason): RecoveryReason | null {
 async function routeRecovery(
   deps: ProcessIssueDeps,
   issue: number,
-  reason: BlockedReason,
+  reason: AttemptOutcome,
   attemptN: number,
 ): Promise<"retry" | "escalate"> {
-  const policyReason = recoveryReasonOf(reason);
+  const policyReason = recoveryReasonFor(reason);
   // A reason with no policy mapping is treated as escalate (page a human),
   // preserving the pre-recovery default for any unexpected reason.
   if (policyReason === null) {
@@ -395,7 +365,7 @@ async function routeRecovery(
   if (cap !== null) {
     // A previously-auto-recoverable reason whose retry budget is exhausted —
     // announce the page so it is not mistaken for a first-attempt human block.
-    const typed = blockedReasonLabel(reason) ?? `blocked:${policyReason}`;
+    const typed = blockedLabelFor(reason) ?? `blocked:${policyReason}`;
     await deps.gh.comment(
       issue,
       `🤖 /afk escalating to ready-for-human: ${typed} retry budget exhausted (attempt ${attemptN}/${cap}).`,

--- a/src/domains/dev/src/core/recovery.ts
+++ b/src/domains/dev/src/core/recovery.ts
@@ -24,19 +24,14 @@
 // follow-up. Time-based backoff (vs the immediate re-queue) is also future work —
 // the cap is what prevents the runaway loop today.
 
-/**
- * The recovery-policy view of a terminal failure reason. These are the *policy*
- * names (what kind of failure happened), distinct from the routing labels and
- * from envelope-emit's `BlockedReason`. Recoverable reasons carry a cap;
- * `spec` / `validation` are terminal-for-a-human.
- */
-export type RecoveryReason =
-  | "merge-conflict"
-  | "crashed"
-  | "quota"
-  | "policy"
-  | "spec"
-  | "validation";
+import type { RecoveryReason } from "./attempt-outcome.js";
+
+// `RecoveryReason` (the recoverable policy keys) is now owned by attempt-outcome,
+// the single owner of the outcome vocabulary. recovery.ts CONSUMES it: its cap
+// table is keyed on those policy names. The lookup functions accept any string
+// so a non-recoverable name (absent from RECOVERABLE) resolves to null/escalate
+// exactly as before — this is what keeps the policy "exactly as-is".
+export type { RecoveryReason };
 
 export type RecoveryDecision = "retry" | "escalate";
 
@@ -64,7 +59,7 @@ export type RecoveryEnv = Record<string, string | undefined>;
  * non-recoverable. Used both by `recoveryDecision` and by the caller's
  * escalation comment ("attempt N/cap").
  */
-export function recoveryCap(reason: RecoveryReason, env: RecoveryEnv): number | null {
+export function recoveryCap(reason: RecoveryReason | (string & {}), env: RecoveryEnv): number | null {
   const spec = RECOVERABLE[reason];
   if (!spec) return null;
   const raw = env[spec.knob];
@@ -80,7 +75,7 @@ export function recoveryCap(reason: RecoveryReason, env: RecoveryEnv): number | 
  * `attemptN < cap`, else escalate; non-recoverable reasons always escalate.
  */
 export function recoveryDecision(
-  reason: RecoveryReason,
+  reason: RecoveryReason | (string & {}),
   attemptN: number,
   env: RecoveryEnv,
 ): RecoveryDecision {

--- a/src/domains/dev/src/core/supervisor.ts
+++ b/src/domains/dev/src/core/supervisor.ts
@@ -16,7 +16,7 @@
 
 import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from "./reaper-signal.js";
 import { buildEnvelope } from "./envelope.js";
-import { blockedReasonLabel } from "./envelope-emit.js";
+import { blockedLabelFor } from "./attempt-outcome.js";
 
 // ---------- tunables ----------
 
@@ -472,7 +472,7 @@ export async function reapStalledSlot(
   // created on the fly so a missing label never fails the reap.
   if (info && info.issue !== null) {
     await deps.gh.comment(info.issue, buildReaperEnvelope(info));
-    const typed = blockedReasonLabel("stalled");
+    const typed = blockedLabelFor("stalled");
     if (typed !== null) await deps.gh.ensureLabel(typed);
     await deps.gh.editLabels(info.issue, typed !== null ? ["ready-for-agent", typed] : ["ready-for-agent"], ["running"]);
   }

--- a/src/domains/dev/tests/attempt-outcome.test.ts
+++ b/src/domains/dev/tests/attempt-outcome.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  blockedLabelFor,
+  recoveryReasonFor,
+  type AttemptOutcome,
+  type RecoveryReason,
+} from "../src/core/attempt-outcome.js";
+
+// attempt-outcome is the SINGLE OWNER of the AFK outcome vocabulary. This is an
+// EXHAUSTIVE table: every `AttemptOutcome` value → its expected `blockedLabelFor`
+// label and its expected `recoveryReasonFor` policy key. Pinning the full union
+// here makes the 3-enum-desync bug class impossible — any new outcome or any
+// drifted mapping breaks this table.
+
+interface Row {
+  outcome: AttemptOutcome;
+  label: string | null;
+  recovery: RecoveryReason | null;
+}
+
+// One row PER AttemptOutcome member. If a member is added without a row, the
+// `covers every AttemptOutcome member` assertion below fails.
+const TABLE: Row[] = [
+  // recoverable: carry both a typed label and a recovery policy key
+  { outcome: "exhausted", label: "blocked:quota", recovery: "quota" },
+  { outcome: "no-sentinel", label: "blocked:crashed", recovery: "crashed" },
+  { outcome: "hook-aborted", label: "blocked:policy", recovery: "policy" },
+  { outcome: "merge-conflict", label: "blocked:merge-conflict", recovery: "merge-conflict" },
+  // typed label, but NOT auto-recoverable (route straight to a human)
+  { outcome: "blocked", label: "blocked:spec", recovery: null },
+  { outcome: "feedback-failed", label: "blocked:validation", recovery: null },
+  { outcome: "stalled", label: "blocked:stalled", recovery: null },
+  { outcome: "infra", label: "blocked:infra", recovery: null },
+  // no typed label, no recovery (success / abandoned)
+  { outcome: "done", label: null, recovery: null },
+  { outcome: "claim-lost", label: null, recovery: null },
+];
+
+describe("attempt-outcome — exhaustive outcome → (label, recovery) table", () => {
+  for (const row of TABLE) {
+    it(`${row.outcome} → label ${row.label} · recovery ${row.recovery}`, () => {
+      expect(blockedLabelFor(row.outcome)).toBe(row.label);
+      expect(recoveryReasonFor(row.outcome)).toBe(row.recovery);
+    });
+  }
+
+  it("covers every AttemptOutcome member exactly once", () => {
+    // The full union, spelled out independently of the table so a missing or
+    // duplicated row is caught.
+    const ALL: AttemptOutcome[] = [
+      "done",
+      "blocked",
+      "no-sentinel",
+      "merge-conflict",
+      "feedback-failed",
+      "claim-lost",
+      "hook-aborted",
+      "exhausted",
+      "stalled",
+      "infra",
+    ];
+    const covered = TABLE.map((r) => r.outcome).sort();
+    expect(covered).toEqual([...ALL].sort());
+    expect(TABLE.length).toBe(ALL.length);
+  });
+
+  it("recoveryReasonFor only ever returns the four recoverable policy keys (or null)", () => {
+    const valid = new Set<RecoveryReason>(["quota", "merge-conflict", "crashed", "policy"]);
+    for (const row of TABLE) {
+      const r = recoveryReasonFor(row.outcome);
+      if (r !== null) expect(valid.has(r)).toBe(true);
+    }
+  });
+});

--- a/src/domains/dev/tests/envelope-emit.test.ts
+++ b/src/domains/dev/tests/envelope-emit.test.ts
@@ -4,7 +4,6 @@ import {
   buildEnvelopeSummary,
   buildFailureMarkers,
   buildSections,
-  blockedReasonLabel,
   emitEnvelope,
   fmtDuration,
   type EmitEnvelopeDeps,
@@ -400,20 +399,6 @@ describe("emitEnvelope — failure push/markers/posted flow", () => {
   });
 });
 
-describe("blockedReasonLabel — DESCRIPTIVE typed-blocked mapping", () => {
-  it("maps each terminal failure reason to its blocked:<reason> label", () => {
-    expect(blockedReasonLabel("exhausted")).toBe("blocked:quota");
-    expect(blockedReasonLabel("merge-conflict")).toBe("blocked:merge-conflict");
-    expect(blockedReasonLabel("blocked")).toBe("blocked:spec");
-    expect(blockedReasonLabel("feedback-failed")).toBe("blocked:validation");
-    expect(blockedReasonLabel("no-sentinel")).toBe("blocked:crashed");
-    expect(blockedReasonLabel("hook-aborted")).toBe("blocked:policy");
-    expect(blockedReasonLabel("stalled")).toBe("blocked:stalled");
-    expect(blockedReasonLabel("infra")).toBe("blocked:infra");
-  });
-
-  it("returns null for non-blocked outcomes (done / claim-lost)", () => {
-    expect(blockedReasonLabel("done")).toBeNull();
-    expect(blockedReasonLabel("claim-lost")).toBeNull();
-  });
-});
+// The DESCRIPTIVE typed-blocked mapping moved to attempt-outcome (the single
+// owner of the outcome vocabulary); its exhaustive table lives in
+// tests/attempt-outcome.test.ts.

--- a/src/domains/dev/tests/recovery.test.ts
+++ b/src/domains/dev/tests/recovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { recoveryDecision, recoveryCap, type RecoveryReason } from "../src/core/recovery.js";
+import { recoveryDecision, recoveryCap } from "../src/core/recovery.js";
+import { type RecoveryReason } from "../src/core/attempt-outcome.js";
 
 // recoveryDecision is a PURE policy: (reason, attemptN, env) → retry | escalate.
 // Recoverable reasons retry while attemptN < cap, then escalate. Non-recoverable
@@ -30,7 +31,7 @@ describe("recoveryDecision — recoverable reasons honour the cap", () => {
 });
 
 describe("recoveryDecision — non-recoverable reasons always escalate", () => {
-  for (const reason of ["spec", "validation"] as RecoveryReason[]) {
+  for (const reason of ["spec", "validation"]) {
     it(`${reason} escalates at every attempt`, () => {
       expect(recoveryDecision(reason, 1, {})).toBe("escalate");
       expect(recoveryDecision(reason, 99, {})).toBe("escalate");


### PR DESCRIPTION
Collapses the 3 parallel outcome enums (ProcessOutcome/BlockedReason/RecoveryReason) + the recoveryReasonOf bridge into one owner, core/attempt-outcome.ts. Pure behaviour-preserving refactor — same labels/routing/caps, existing tests pass unchanged; new exhaustive table makes desync impossible. 698 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782789821&installation_id=129708444&pr_number=295&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F295&signature=c2ad09a9c2af427b72f675b94e23a4540a856fe729d57bf42768fc1ec5ce3e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->