### PR TITLE
test(afk): injectable exec seam makes the runtime wiring testable

### DIFF
--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -27,6 +27,7 @@ import * as gitx from "../runtime/git.js";
 import * as fsx from "../runtime/fs.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
+import type { ExecFn } from "../runtime/exec.js";
 import { loadConfig } from "../core/config.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
@@ -187,7 +188,19 @@ async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: numbe
   };
 }
 
-function buildProcessDeps(
+/**
+ * Assemble the per-issue {@link ProcessIssueDeps} — the hand-written binding of
+ * ~21 real gh/git/fs/clock closures the audit flagged as untested. Exported so
+ * the wiring integration test can drive the REAL assembly over a recording exec
+ * fake (see tests/wiring-integration.test.ts).
+ *
+ * `exec` is the sole test-injection point: when supplied it is threaded into the
+ * gh/git Contexts so every gh/git closure assembled here routes through the fake
+ * instead of the OS. PRODUCTION leaves it undefined (see {@link runCommand}),
+ * so the gh/git helpers fall through to the real `execTool` — byte-for-byte the
+ * prior behaviour. Nothing else about the assembly changes.
+ */
+export function buildProcessDeps(
   ctx: RepoContext,
   model: string,
   sandbox: ReturnType<typeof resolveRunSettings>["sandbox"],
@@ -195,9 +208,10 @@ function buildProcessDeps(
   current: CurrentAttempt,
   fallbackRunner: boolean,
   runner: Runner,
+  exec?: ExecFn,
 ): ProcessIssueDeps {
-  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
-  const gitCtx: GitContext = { cwd: ctx.root };
+  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
+  const gitCtx: GitContext = { cwd: ctx.root, exec };
   const paths = afkPaths(ctx.root);
   const lockPath = branchLockPath(ctx.root);
 

--- a/src/domains/dev/src/runtime/exec.ts
+++ b/src/domains/dev/src/runtime/exec.ts
@@ -26,6 +26,15 @@ export interface ExecOptions {
   input?: string;
 }
 
+/**
+ * The injectable exec boundary. `execTool` is the production implementation; the
+ * gh/git Contexts carry an OPTIONAL field of this shape so tests can drive the
+ * REAL gh/git closure assembly over a recording fake instead of the OS. When
+ * unset (production), the gh/git helpers fall through to the real `execTool`, so
+ * behaviour is identical to a static import.
+ */
+export type ExecFn = (cmd: string, args: readonly string[], opts?: ExecOptions) => Promise<ExecOutput>;
+
 const DEFAULT_MAX_BUFFER = 16 * 1024 * 1024;
 
 /**

--- a/src/domains/dev/src/runtime/gh.ts
+++ b/src/domains/dev/src/runtime/gh.ts
@@ -6,7 +6,7 @@
 // call routes through runtime/exec.ts's `gh` helper — the single process seam.
 // Best-effort writes swallow failures (the bash orchestrator's `|| true`).
 
-import { gh, type ExecOptions } from "./exec.js";
+import { execTool, type ExecOptions, type ExecFn, type ExecOutput } from "./exec.js";
 import type { IssueCandidate } from "../core/session.js";
 import type { IssueMeta } from "../core/branch-cleanup.js";
 import type { HandoffComment } from "../core/handoff.js";
@@ -18,10 +18,25 @@ export interface GhContext {
   repo: string;
   /** Working dir gh runs from (the primary checkout). */
   cwd: string;
+  /**
+   * Optional injected exec boundary. Unset in production (the real `execTool`
+   * via the `gh` helper runs). Set in tests to a recording fake so the REAL gh
+   * closure assembly can be driven without touching the OS. See exec.ts::ExecFn.
+   */
+  exec?: ExecFn;
 }
 
 function opts(ctx: GhContext): ExecOptions {
   return { cwd: ctx.cwd };
+}
+
+/**
+ * Dispatch a `gh <args>` invocation through the injected exec when present, else
+ * the real `gh` helper. This is the single seam every gh closure in this module
+ * routes through; the default path is byte-for-byte the prior static `gh` call.
+ */
+function runGh(ctx: GhContext, args: readonly string[]): Promise<ExecOutput> {
+  return (ctx.exec ?? execTool)("gh", args, opts(ctx));
 }
 
 function repoArgs(ctx: GhContext): string[] {
@@ -30,19 +45,19 @@ function repoArgs(ctx: GhContext): string[] {
 
 /** Check `gh` is installed (any exit but 127 = present). */
 export async function ghInstalled(ctx: GhContext): Promise<boolean> {
-  const r = await gh(["--version"], opts(ctx));
+  const r = await runGh(ctx, ["--version"]);
   return r.code !== 127;
 }
 
 /** Check `gh auth status` succeeds. */
 export async function ghAuthenticated(ctx: GhContext): Promise<boolean> {
-  const r = await gh(["auth", "status"], opts(ctx));
+  const r = await runGh(ctx, ["auth", "status"]);
   return r.code === 0;
 }
 
 /** List the ready-for-agent candidate pool projected to IssueCandidate[]. */
 export async function listCandidates(ctx: GhContext): Promise<IssueCandidate[]> {
-  const r = await gh(
+  const r = await runGh(ctx, 
     [
       "issue",
       "list",
@@ -56,7 +71,6 @@ export async function listCandidates(ctx: GhContext): Promise<IssueCandidate[]> 
       "--json",
       "number,title,labels,body",
     ],
-    opts(ctx),
   );
   if (r.code !== 0) return [];
   let raw: unknown;
@@ -79,7 +93,7 @@ export async function listCandidates(ctx: GhContext): Promise<IssueCandidate[]> 
 
 /** `gh issue view --json labels` → flat label-name list. */
 export async function viewLabels(ctx: GhContext, issue: number): Promise<string[]> {
-  const r = await gh(["issue", "view", String(issue), ...repoArgs(ctx), "--json", "labels"], opts(ctx));
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "labels"]);
   if (r.code !== 0) return [];
   try {
     const parsed = JSON.parse(r.stdout) as { labels?: Array<{ name?: string }> };
@@ -99,20 +113,20 @@ export async function editLabels(
   const args = ["issue", "edit", String(issue), ...repoArgs(ctx)];
   for (const label of remove) args.push("--remove-label", label);
   for (const label of add) args.push("--add-label", label);
-  const r = await gh(args, opts(ctx));
+  const r = await runGh(ctx, args);
   return r.code === 0;
 }
 
 /** `gh issue comment --body …` (best-effort). */
 export async function comment(ctx: GhContext, issue: number, body: string): Promise<void> {
-  await gh(["issue", "comment", String(issue), ...repoArgs(ctx), "--body", body], opts(ctx));
+  await runGh(ctx, ["issue", "comment", String(issue), ...repoArgs(ctx), "--body", body]);
 }
 
 /** Idempotently create the `runner-error` label (best-effort). Mirrors
  * supervisor.sh ensure_runner_error_label — a label that already exists exits
  * non-zero and is swallowed. */
 export async function ensureRunnerErrorLabel(ctx: GhContext): Promise<void> {
-  await gh(
+  await runGh(ctx, 
     [
       "label",
       "create",
@@ -123,7 +137,6 @@ export async function ensureRunnerErrorLabel(ctx: GhContext): Promise<void> {
       "--description",
       "AFK supervisor circuit-tripped; runner was misconfigured",
     ],
-    opts(ctx),
   );
 }
 
@@ -131,7 +144,7 @@ export async function ensureRunnerErrorLabel(ctx: GhContext): Promise<void> {
  * ensureRunnerErrorLabel for the typed `blocked:<reason>` observability layer. A
  * label that already exists exits non-zero and is swallowed by the caller. */
 export async function ensureLabel(ctx: GhContext, name: string): Promise<void> {
-  await gh(
+  await runGh(ctx, 
     [
       "label",
       "create",
@@ -142,18 +155,17 @@ export async function ensureLabel(ctx: GhContext, name: string): Promise<void> {
       "--description",
       "AFK terminal-failure reason (observability)",
     ],
-    opts(ctx),
   );
 }
 
 /** `gh issue close --reason completed`. */
 export async function closeIssue(ctx: GhContext, issue: number): Promise<void> {
-  await gh(["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"], opts(ctx));
+  await runGh(ctx, ["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"]);
 }
 
 /** `gh issue view --json body` → raw body, or undefined when absent. */
 export async function issueBody(ctx: GhContext, issue: number): Promise<string | undefined> {
-  const r = await gh(["issue", "view", String(issue), ...repoArgs(ctx), "--json", "body"], opts(ctx));
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "body"]);
   if (r.code !== 0) return undefined;
   try {
     return String((JSON.parse(r.stdout) as { body?: string }).body ?? "");
@@ -164,7 +176,7 @@ export async function issueBody(ctx: GhContext, issue: number): Promise<string |
 
 /** `gh issue view --json url` → the resolved issue url. */
 export async function issueUrl(ctx: GhContext, issue: number): Promise<string> {
-  const r = await gh(["issue", "view", String(issue), ...repoArgs(ctx), "--json", "url"], opts(ctx));
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "url"]);
   if (r.code !== 0) return "";
   try {
     return String((JSON.parse(r.stdout) as { url?: string }).url ?? "");
@@ -176,7 +188,7 @@ export async function issueUrl(ctx: GhContext, issue: number): Promise<string> {
 /** `gh issue view --json comments` → handoff-projected comment list. Each
  * comment carries the author login + body + createdAt the handoff renders. */
 export async function issueComments(ctx: GhContext, issue: number): Promise<HandoffComment[]> {
-  const r = await gh(["issue", "view", String(issue), ...repoArgs(ctx), "--json", "comments"], opts(ctx));
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "comments"]);
   if (r.code !== 0) return [];
   try {
     const parsed = JSON.parse(r.stdout) as {
@@ -202,9 +214,8 @@ export async function orphanState(
   ctx: GhContext,
   issue: number,
 ): Promise<{ ghOk: boolean; state: IssueOpenState; label: string | null; envelopePosted: boolean }> {
-  const r = await gh(
+  const r = await runGh(ctx, 
     ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "state,labels"],
-    opts(ctx),
   );
   if (r.code !== 0) return { ghOk: false, state: "OPEN", label: null, envelopePosted: false };
   try {
@@ -225,7 +236,7 @@ export async function orphanState(
 /** Branch-cleanup/boot blocker-state lookup: gh issue view --json state → the
  * raw state string ("OPEN" | "CLOSED"), or undefined on a 404/transient miss. */
 export async function blockerState(ctx: GhContext, issue: number): Promise<string | undefined> {
-  const r = await gh(["issue", "view", String(issue), ...repoArgs(ctx), "--json", "state"], opts(ctx));
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "state"]);
   if (r.code !== 0) return undefined;
   try {
     return String((JSON.parse(r.stdout) as { state?: string }).state ?? "") || undefined;
@@ -237,9 +248,8 @@ export async function blockerState(ctx: GhContext, issue: number): Promise<strin
 /** Count open issues matching a label expression (`--label`/`--search`). A
  * failed probe returns 0, mirroring the bash `|| echo 0`. */
 async function countIssues(ctx: GhContext, args: string[]): Promise<number> {
-  const r = await gh(
+  const r = await runGh(ctx, 
     ["issue", "list", ...repoArgs(ctx), "--state", "open", "--limit", "500", "--json", "number", ...args],
-    opts(ctx),
   );
   if (r.code !== 0) return 0;
   try {
@@ -252,9 +262,8 @@ async function countIssues(ctx: GhContext, args: string[]): Promise<number> {
 
 /** Count issues that carry NO labels (the unlabeled straggler bucket). */
 export async function countUnlabeled(ctx: GhContext): Promise<number> {
-  const r = await gh(
+  const r = await runGh(ctx, 
     ["issue", "list", ...repoArgs(ctx), "--state", "open", "--limit", "500", "--json", "number,labels"],
-    opts(ctx),
   );
   if (r.code !== 0) return 0;
   try {
@@ -292,7 +301,7 @@ export function countNeedsInfo(ctx: GhContext): Promise<number> {
  * so both holding states are gathered and de-duplicated by issue number. */
 export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCandidate[]> {
   const fetch = async (label: string): Promise<UnblockCandidate[]> => {
-    const r = await gh(
+    const r = await runGh(ctx, 
       [
         "issue",
         "list",
@@ -306,7 +315,6 @@ export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCand
         "--json",
         "number,body,labels",
       ],
-      opts(ctx),
     );
     if (r.code !== 0) return [];
     try {
@@ -342,7 +350,7 @@ export async function listByLabel(
   ctx: GhContext,
   label: string,
 ): Promise<{ number: number; labels: string[] }[]> {
-  const r = await gh(
+  const r = await runGh(ctx, 
     [
       "issue",
       "list",
@@ -356,7 +364,6 @@ export async function listByLabel(
       "--json",
       "number,labels",
     ],
-    opts(ctx),
   );
   if (r.code !== 0) return [];
   try {
@@ -381,9 +388,8 @@ export async function issueClosed(ctx: GhContext, n: number): Promise<boolean> {
 /** Branch-cleanup IssueLookup payload: gh issue view --json state,closedAt.
  * Returns null for a definitive 404, undefined for a transient failure. */
 export async function issueMeta(ctx: GhContext, issue: number): Promise<IssueMeta | null | undefined> {
-  const r = await gh(
+  const r = await runGh(ctx, 
     ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "state,closedAt"],
-    opts(ctx),
   );
   if (r.code !== 0) {
     // gh prints a 404 "Could not resolve" / "not found" on a real miss.

--- a/src/domains/dev/src/runtime/git.ts
+++ b/src/domains/dev/src/runtime/git.ts
@@ -5,7 +5,7 @@
 // merge-Exec executors the orchestrators inject. Every call routes through
 // runtime/exec.ts's `git` helper.
 
-import { git, type ExecOptions } from "./exec.js";
+import { execTool, type ExecOptions, type ExecFn, type ExecOutput } from "./exec.js";
 import type { GitExec, GitExecResult } from "../core/remote-branch.js";
 import type { Exec as MergeExec, ExecResult as MergeExecResult } from "../core/merge.js";
 import type { BranchRef } from "../core/branch-cleanup.js";
@@ -13,20 +13,36 @@ import type { BranchRef } from "../core/branch-cleanup.js";
 export interface GitContext {
   /** The primary checkout dir. */
   cwd: string;
+  /**
+   * Optional injected exec boundary. Unset in production (the real `execTool`
+   * runs). Set in tests to a recording fake so the REAL git closure assembly —
+   * including the gitExec/mergeExec executors merge.ts and remote-branch.ts run
+   * through — can be driven without touching the OS. See exec.ts::ExecFn.
+   */
+  exec?: ExecFn;
 }
 
 function opts(ctx: GitContext): ExecOptions {
   return { cwd: ctx.cwd };
 }
 
+/**
+ * Dispatch a `git <args>` invocation through the injected exec when present, else
+ * the real `execTool`. Single seam every git closure in this module routes
+ * through; the default path is byte-for-byte the prior static `git` helper call.
+ */
+function runGit(ctx: GitContext, args: readonly string[]): Promise<ExecOutput> {
+  return (ctx.exec ?? execTool)("git", args, opts(ctx));
+}
+
 export async function isGitRepo(ctx: GitContext): Promise<boolean> {
-  const r = await git(["rev-parse", "--is-inside-work-tree"], opts(ctx));
+  const r = await runGit(ctx, ["rev-parse", "--is-inside-work-tree"]);
   return r.code === 0 && r.stdout.trim() === "true";
 }
 
 /** Deduped remote URLs from `git remote -v`. */
 export async function remoteUrls(ctx: GitContext): Promise<string[]> {
-  const r = await git(["remote", "-v"], opts(ctx));
+  const r = await runGit(ctx, ["remote", "-v"]);
   if (r.code !== 0) return [];
   const urls = new Set<string>();
   for (const line of r.stdout.split("\n")) {
@@ -37,43 +53,43 @@ export async function remoteUrls(ctx: GitContext): Promise<string[]> {
 }
 
 export async function hasMainBranch(ctx: GitContext): Promise<boolean> {
-  const r = await git(["rev-parse", "--verify", "--quiet", "refs/heads/main"], opts(ctx));
+  const r = await runGit(ctx, ["rev-parse", "--verify", "--quiet", "refs/heads/main"]);
   return r.code === 0;
 }
 
 export async function currentBranch(ctx: GitContext): Promise<string> {
-  const r = await git(["branch", "--show-current"], opts(ctx));
+  const r = await runGit(ctx, ["branch", "--show-current"]);
   return r.code === 0 ? r.stdout.trim() : "";
 }
 
 /** `git -C cwd rev-parse --short HEAD`. */
 export async function headShortSha(ctx: GitContext): Promise<string> {
-  const r = await git(["rev-parse", "--short", "HEAD"], opts(ctx));
+  const r = await runGit(ctx, ["rev-parse", "--short", "HEAD"]);
   return r.code === 0 ? r.stdout.trim() : "";
 }
 
 /** Delete a local branch (git branch -D). Best-effort. */
 export async function deleteLocalBranch(ctx: GitContext, branch: string): Promise<void> {
   if (!branch) return;
-  await git(["branch", "-D", branch], opts(ctx));
+  await runGit(ctx, ["branch", "-D", branch]);
 }
 
 /** Delete an origin branch (git push origin --delete). Best-effort. */
 export async function deleteRemoteBranch(ctx: GitContext, branch: string): Promise<void> {
   if (!branch) return;
-  await git(["push", "origin", "--delete", branch], opts(ctx));
+  await runGit(ctx, ["push", "origin", "--delete", branch]);
 }
 
 /** Changed files of <branch> vs <base> (git diff --name-only base...branch). */
 export async function changedFiles(ctx: GitContext, branch: string, base: string): Promise<string[]> {
-  const r = await git(["diff", "--name-only", `${base}...${branch}`], opts(ctx));
+  const r = await runGit(ctx, ["diff", "--name-only", `${base}...${branch}`]);
   if (r.code !== 0) return [];
   return r.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
 }
 
 /** Diffstat summary line of <branch> vs <base>. */
 export async function diffstat(ctx: GitContext, branch: string, base: string): Promise<string> {
-  const r = await git(["diff", "--shortstat", `${base}...${branch}`], opts(ctx));
+  const r = await runGit(ctx, ["diff", "--shortstat", `${base}...${branch}`]);
   return r.code === 0 ? r.stdout.trim() : "";
 }
 
@@ -84,7 +100,7 @@ export async function diffstat(ctx: GitContext, branch: string, base: string): P
  * on any failure.
  */
 export async function diffstatShortstat(ctx: GitContext, base: string): Promise<{ added: number; removed: number }> {
-  const r = await git(["diff", "--shortstat", base], opts(ctx));
+  const r = await runGit(ctx, ["diff", "--shortstat", base]);
   if (r.code !== 0) return { added: 0, removed: 0 };
   const ins = /(\d+) insertion/.exec(r.stdout);
   const del = /(\d+) deletion/.exec(r.stdout);
@@ -94,7 +110,7 @@ export async function diffstatShortstat(ctx: GitContext, base: string): Promise<
 /** `git log -n <count>` one-line block for a ref (the inner-prompt recent
  * commits block). Best-effort: empty string when the ref/log is unavailable. */
 export async function recentCommits(ctx: GitContext, ref = "main", count = 5): Promise<string> {
-  const r = await git(["log", "-n", String(count), "--oneline", ref], opts(ctx));
+  const r = await runGit(ctx, ["log", "-n", String(count), "--oneline", ref]);
   return r.code === 0 ? r.stdout.trim() : "";
 }
 
@@ -104,24 +120,24 @@ export async function recentCommits(ctx: GitContext, ref = "main", count = 5): P
  * Best-effort cleanup is the caller's via {@link worktreeRemove}.
  */
 export async function worktreeAdd(ctx: GitContext, path: string, branch: string): Promise<boolean> {
-  await git(["fetch", "origin", branch], opts(ctx));
+  await runGit(ctx, ["fetch", "origin", branch]);
   // Prefer the local branch if it exists, else the fetched origin ref.
-  const local = await git(["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], opts(ctx));
+  const local = await runGit(ctx, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]);
   const ref = local.code === 0 ? branch : `origin/${branch}`;
-  const r = await git(["worktree", "add", "--force", "--detach", path, ref], opts(ctx));
+  const r = await runGit(ctx, ["worktree", "add", "--force", "--detach", path, ref]);
   return r.code === 0;
 }
 
 /** Remove a worktree previously added by {@link worktreeAdd} (best-effort). */
 export async function worktreeRemove(ctx: GitContext, path: string): Promise<void> {
   if (!path) return;
-  await git(["worktree", "remove", "--force", path], opts(ctx));
+  await runGit(ctx, ["worktree", "remove", "--force", path]);
 }
 
 /** The GitExec executor for remote-branch.ts (pushAttempt / deleteRemote). */
 export function gitExec(ctx: GitContext): GitExec {
   return async (args: string[]): Promise<GitExecResult> => {
-    const r = await git(args, opts(ctx));
+    const r = await runGit(ctx, args);
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 }
@@ -129,10 +145,12 @@ export function gitExec(ctx: GitContext): GitExec {
 /** The merge.ts Exec executor (integrateOrigin / landMerge / landPr). */
 export function mergeExec(ctx: GitContext): MergeExec {
   return async (args: string[]): Promise<MergeExecResult> => {
-    // merge.ts passes a full argv whose head is "git" or "gh".
+    // merge.ts passes a full argv whose head is "git" or "gh"; route both
+    // through the same injectable seam so the test fake sees the real land
+    // commands (git push / gh pr merge) the close path issues.
     const [head, ...rest] = args;
-    const { execTool } = await import("./exec.js");
-    const r = await execTool(head ?? "git", rest, opts(ctx));
+    const exec = ctx.exec ?? execTool;
+    const r = await exec(head ?? "git", rest, opts(ctx));
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 }
@@ -141,7 +159,7 @@ export function mergeExec(ctx: GitContext): MergeExec {
 
 /** List local branches matching a glob (e.g. "afk/*"), as bare ref names. */
 export async function listLocalBranches(ctx: GitContext, pattern: string): Promise<string[]> {
-  const r = await git(["branch", "--list", pattern, "--format=%(refname:short)"], opts(ctx));
+  const r = await runGit(ctx, ["branch", "--list", pattern, "--format=%(refname:short)"]);
   if (r.code !== 0) return [];
   return r.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
 }
@@ -149,7 +167,7 @@ export async function listLocalBranches(ctx: GitContext, pattern: string): Promi
 /** Local branches currently checked out (to exclude from the local reaper). */
 export async function checkedOutBranches(ctx: GitContext): Promise<Set<string>> {
   const out = new Set<string>();
-  const r = await git(["worktree", "list", "--porcelain"], opts(ctx));
+  const r = await runGit(ctx, ["worktree", "list", "--porcelain"]);
   if (r.code === 0) {
     for (const line of r.stdout.split("\n")) {
       const m = /^branch\s+refs\/heads\/(.+)$/.exec(line.trim());
@@ -167,7 +185,7 @@ export async function checkedOutBranches(ctx: GitContext): Promise<Set<string>> 
  * snapshot 404 grace falls back to "keep" without it).
  */
 export async function listRemoteBranches(ctx: GitContext, namespace: string): Promise<BranchRef[]> {
-  const r = await git(["ls-remote", "--heads", "origin", `refs/heads/${namespace}*`], opts(ctx));
+  const r = await runGit(ctx, ["ls-remote", "--heads", "origin", `refs/heads/${namespace}*`]);
   if (r.code !== 0) return [];
   const refs: BranchRef[] = [];
   for (const line of r.stdout.split("\n")) {

--- a/src/domains/dev/tests/wiring-integration.test.ts
+++ b/src/domains/dev/tests/wiring-integration.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildProcessDeps } from "../src/commands/run.js";
+import { makeFeedbackWorktree } from "../src/runtime/feedback-worktree.js";
+import type { RepoContext } from "../src/runtime/wire.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+/**
+ * Wiring integration test (architecture-review candidate #2 — the "wiring test
+ * gap").
+ *
+ * The pure core (process-issue / merge / remote-branch / gh / git modules) is
+ * already covered by unit tests over fakes. What had ZERO coverage was the
+ * HAND-WRITTEN assembly in commands/run.ts::buildProcessDeps that binds ~21 real
+ * gh/git/fs/clock closures: a closure could be present but bound to the wrong
+ * `cwd`, or silently a no-op, and every existing test would still pass because
+ * they inject their OWN fakes for ProcessIssueDeps rather than exercising the
+ * real binding.
+ *
+ * This test drives the REAL assembly (`buildProcessDeps`, unmodified) over a
+ * recording fake exec injected through the new `exec` seam (exec.ts::ExecFn →
+ * GhContext.exec / GitContext.exec). It then invokes the assembled deps' gh/git
+ * closures in the exact order the DONE close path issues them (process-issue.ts
+ * steps 1 → 9) and asserts the resulting OS-command trace: each entry is the
+ * `{cmd, args, cwd}` the closure actually issued. A wrong-cwd or no-op closure —
+ * the audit bug class — makes this trace wrong.
+ *
+ * We do NOT stub the assembly: `buildProcessDeps` runs for real (it even loads
+ * config + resolves hooks against the tmp repo root), and the closures under
+ * test are the genuine ones it produced. Only `exec` is faked.
+ */
+
+interface TraceEntry {
+  cmd: string;
+  args: string[];
+  cwd: string | undefined;
+}
+
+/** Build a recording fake exec that scripts replies by command shape. */
+function makeFakeExec(repoRoot: string): { exec: ExecFn; trace: TraceEntry[] } {
+  const trace: TraceEntry[] = [];
+  const ok = (stdout = ""): ExecOutput => ({ code: 0, stdout, stderr: "" });
+
+  const exec: ExecFn = (cmd, args, opts) => {
+    const a = [...args];
+    trace.push({ cmd, args: a, cwd: opts?.cwd });
+    const joined = a.join(" ");
+
+    if (cmd === "gh") {
+      // claim pre-check: gh issue view N --json labels
+      if (joined.includes("issue view") && joined.includes("--json labels")) {
+        return Promise.resolve(ok(JSON.stringify({ labels: [{ name: "ready-for-agent" }] })));
+      }
+      // handoff: gh issue view N --json comments
+      if (joined.includes("issue view") && joined.includes("--json comments")) {
+        return Promise.resolve(ok(JSON.stringify({ comments: [] })));
+      }
+      // handoff: gh issue view N --json url
+      if (joined.includes("issue view") && joined.includes("--json url")) {
+        return Promise.resolve(ok(JSON.stringify({ url: `https://github.com/${"acme/widgets"}/issues/42` })));
+      }
+      // close-cascade dependent lookup: gh issue list --label req:42 ...
+      if (joined.includes("issue list") && joined.includes("req:42")) {
+        return Promise.resolve(ok(JSON.stringify([])));
+      }
+      // everything else (edit / comment / close) → ok
+      return Promise.resolve(ok());
+    }
+
+    if (cmd === "git") {
+      if (joined.includes("rev-parse --short HEAD")) return Promise.resolve(ok("abc1234"));
+      return Promise.resolve(ok());
+    }
+
+    return Promise.resolve(ok());
+  };
+
+  // Keep repoRoot referenced for readers of the scripted urls/cwd expectations.
+  void repoRoot;
+  return { exec, trace };
+}
+
+describe("wiring integration — real buildProcessDeps over a fake exec", () => {
+  /**
+   * Build the REAL assembly with the fake exec injected, then drive the gh/git
+   * closures in DONE-close-path order and assert the exact OS-command trace.
+   */
+  it("issues the DONE close-path gh/git commands with the right argv + cwd", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-wiring-"));
+    const ctx: RepoContext = { root, repo: "acme/widgets", remote: "origin" };
+    const { exec, trace } = makeFakeExec(root);
+
+    // A real FeedbackWorktree (its pnpm/layout closures are never invoked here —
+    // we only exercise gh/git). makeRunAgent etc. are likewise assembled but not
+    // run on this path.
+    const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
+    const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "42-a1") };
+
+    // THE REAL ASSEMBLY. exec is the only injected seam; everything else is the
+    // production binding (config loads to defaults from the empty tmp root).
+    const deps = buildProcessDeps(
+      ctx,
+      "claude-opus-4-8",
+      "none",
+      feedback,
+      current,
+      false,
+      "claude",
+      exec,
+    );
+
+    const issue = 42;
+    const base = "main";
+    const branch = "afk/w1/42-fix-thing";
+
+    // ---- replay the DONE close path's gh/git side effects, in order ----
+    // (process-issue.ts: claim → handoff lookups → fetchBase → push →
+    //  integrate/land → close → cleanup → cascade). We invoke the closures the
+    //  real assembly produced; the trace records what each one issued.
+
+    // 1. claim pre-check + label flip (steps 1)
+    const labels = await deps.gh.viewLabels(issue);
+    expect(labels).toEqual(["ready-for-agent"]);
+    const flipped = await deps.gh.editLabels(issue, ["ready-for-agent"], ["running"]);
+    expect(flipped).toBe(true);
+
+    // 2. handoff lookups (step 3)
+    await deps.lookups.comments(issue);
+    await deps.lookups.issueUrl(issue);
+
+    // 3. fetch the resolved base before sandcastle forks (step 4)
+    await deps.git.fetchBase!(base);
+
+    // 4. push the worker branch (step 6) — exact pushAttempt argv shape
+    await deps.remoteGit(["-C", root, "push", "origin", `${branch}:refs/heads/${branch}`]);
+
+    // 5. integrate origin/base (step 6) via mergeExec — fast-forward path argv
+    await deps.mergeExec(["git", "-C", root, "merge", "--ff-only", `origin/${base}`]);
+
+    // 6. read the merge sha (step 7)
+    const sha = await deps.git.headShortSha();
+    expect(sha).toBe("abc1234");
+
+    // 7. close + drop running label (step 7)
+    await deps.gh.close(issue);
+    await deps.gh.editLabels(issue, ["running"], []);
+
+    // 8. delete the remote attempt branch (step 7) — exact deleteRemote argv
+    await deps.remoteGit(["-C", root, "push", "origin", "--delete", branch]);
+
+    // 9. delete the local branch (step 8)
+    await deps.git.deleteLocalBranch(branch);
+
+    // 10. close cascade dependent lookup (step 9)
+    await deps.gh.listByLabel(`req:${issue}`);
+
+    // ---- assert the exact OS-command trace ----
+    // Every closure ran from the primary checkout (ctx.root). A no-op or
+    // wrong-cwd binding would surface here.
+    expect(trace).toEqual([
+      { cmd: "gh", args: ["issue", "view", "42", "--repo", "acme/widgets", "--json", "labels"], cwd: root },
+      {
+        cmd: "gh",
+        args: ["issue", "edit", "42", "--repo", "acme/widgets", "--remove-label", "ready-for-agent", "--add-label", "running"],
+        cwd: root,
+      },
+      { cmd: "gh", args: ["issue", "view", "42", "--repo", "acme/widgets", "--json", "comments"], cwd: root },
+      { cmd: "gh", args: ["issue", "view", "42", "--repo", "acme/widgets", "--json", "url"], cwd: root },
+      { cmd: "git", args: ["fetch", "origin", "main"], cwd: root },
+      { cmd: "git", args: ["-C", root, "push", "origin", `${branch}:refs/heads/${branch}`], cwd: root },
+      { cmd: "git", args: ["-C", root, "merge", "--ff-only", "origin/main"], cwd: root },
+      { cmd: "git", args: ["rev-parse", "--short", "HEAD"], cwd: root },
+      { cmd: "gh", args: ["issue", "close", "42", "--repo", "acme/widgets", "--reason", "completed"], cwd: root },
+      { cmd: "gh", args: ["issue", "edit", "42", "--repo", "acme/widgets", "--remove-label", "running"], cwd: root },
+      { cmd: "git", args: ["-C", root, "push", "origin", "--delete", branch], cwd: root },
+      { cmd: "git", args: ["branch", "-D", branch], cwd: root },
+      {
+        cmd: "gh",
+        args: ["issue", "list", "--repo", "acme/widgets", "--label", "req:42", "--state", "open", "--limit", "200", "--json", "number,labels"],
+        cwd: root,
+      },
+    ]);
+  });
+
+  /**
+   * Guard the production invariant: buildProcessDeps must NOT set exec by
+   * default — the real execTool path stays in force in production. (Static check
+   * that the param is optional and defaults to undefined: the closures below are
+   * assembled, but because we pass no exec, nothing routes through a fake. We
+   * assert by reading the source guarantee — see the grep in the task — and by
+   * exercising the default arity here.)
+   */
+  it("leaves exec undefined by default (production stays on the real execTool)", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-wiring-default-"));
+    const ctx: RepoContext = { root, repo: "acme/widgets", remote: "origin" };
+    const feedback = makeFeedbackWorktree(root, join(root, ".red", "tmp", "feedback"));
+    const current = { attemptDir: join(root, ".red", "tmp", "workers", "w1", "1-a1") };
+    // No exec arg → production binding. Assembling must not throw.
+    const deps = buildProcessDeps(ctx, "claude-opus-4-8", "none", feedback, current, false, "claude");
+    expect(typeof deps.gh.viewLabels).toBe("function");
+    expect(typeof deps.remoteGit).toBe("function");
+    expect(typeof deps.mergeExec).toBe("function");
+  });
+});


### PR DESCRIPTION
Architecture review candidate #2. Adds the optional exec Seam to GhContext/GitContext so the real buildProcessDeps assembly can be driven over a recording fake exec; new integration test asserts the full DONE close-path OS-command trace (argv+cwd) over the real closures. Production untouched (exec unset by default). 700 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782790740&installation_id=129708444&pr_number=296&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F296&signature=008d3bb7d1a85f96b6599a3932d4eed0b144229786243a1e2dad88db3a6486cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal command execution architecture with centralized, injectable routing for `gh` and `git` operations.
  * Exported process dependency builder function for broader extensibility.

* **Tests**
  * Added integration tests to verify command execution patterns and dependency assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->