### PR TITLE
refactor(afk): carve doLanding + terminalFailure from process-issue

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -46,6 +46,10 @@ _Avoid_: pinned branch
 The branch an **Issue** or PRD declares that AFK must base work on and merge back into.
 _Avoid_: branch lock
 
+**Landing**:
+How a completed **Attempt**'s worker branch is integrated into its base, toggled by the **Branch lock** (ADR 0030/0031): a locked branch is merged locally into the locked branch for human promotion (`landMerge`, with a one-shot self-resolve of merge conflicts), an unlocked branch lands via an admin-merged PR carrying the attempt history (`landPr`). Owns the push → integrate → land → post-merge sequence as one operation.
+_Avoid_: merge, merge-back, integrate (these are sub-steps of Landing, not the operation)
+
 **Primary checkout**:
 The developer's main working clone of the repo, contrasted with an AFK **Worktree**.
 _Avoid_: main repo, root checkout

--- a/src/domains/dev/src/core/attempt-outcome.ts
+++ b/src/domains/dev/src/core/attempt-outcome.ts
@@ -13,11 +13,15 @@
 //                            consumes this; its cap table is keyed on it).
 //   - `blockedLabelFor`    — outcome → DESCRIPTIVE `blocked:<reason>` label.
 //   - `recoveryReasonFor`  — outcome → BOUNDED-recovery policy key (or null).
+//   - `envelopeStatusFor`  — outcome → the terminal `data-attempt-status` facet
+//                            of the emitted Envelope (envelope-emit.ts).
 //
 // It is PURE (no IO) — decision/mapping only. Execution (editLabels, comment, the
-// cascade gh, routeRecovery) stays at the call sites. The two functions are the
-// canonical source for both the observability label and the recovery routing key,
-// so the 3-enum-desync bug class becomes impossible.
+// cascade gh, routeRecovery) stays at the call sites. The functions are the
+// canonical source for the observability label, the recovery routing key, and the
+// envelope status, so the multi-enum-desync bug class becomes impossible.
+
+import type { AttemptStatus } from "./envelope.js";
 
 /**
  * Every terminal ending an AFK iteration can have — the UNION of what
@@ -84,6 +88,47 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
     case "done":
     case "claim-lost":
       return null;
+  }
+}
+
+/**
+ * Pure mapping from a terminal outcome to the `data-attempt-status` facet of the
+ * Envelope emitted for it (envelope-emit.ts `AttemptStatus`). This is the THIRD
+ * facet of "what the outcome means", alongside the typed label and the recovery
+ * key, so it belongs with the single owner.
+ *
+ * The mapping mirrors EXACTLY the status passed at each `emitFailure(common,
+ * <status>, …)` call site in process-issue:
+ *   - no-sentinel     → "no-sentinel"
+ *   - blocked         → "blocked"
+ *   - feedback-failed → "blocked"        (a feedback failure emits a `blocked`
+ *                                          envelope, NOT a `feedback-failed` one)
+ *   - merge-conflict  → "merge-conflict"
+ *   - done            → "done"
+ *
+ * The remaining outcomes (`hook-aborted`, `exhausted`, `claim-lost`, `stalled`,
+ * `infra`) emit NO terminal failure envelope from the per-issue lifecycle (they
+ * route via routeRecovery / short-circuit only), so they have no live call site;
+ * they map to the generic `blocked` failure bucket — the same bucket
+ * envelope-emit's `defaultHistoryEvent` folds non-done terminals into — to keep
+ * the mapping total without inventing a new status.
+ */
+export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
+  switch (o) {
+    case "done":
+      return "done";
+    case "no-sentinel":
+      return "no-sentinel";
+    case "merge-conflict":
+      return "merge-conflict";
+    case "blocked":
+    case "feedback-failed":
+    case "hook-aborted":
+    case "exhausted":
+    case "claim-lost":
+    case "stalled":
+    case "infra":
+      return "blocked";
   }
 }
 

--- a/src/domains/dev/src/core/landing.ts
+++ b/src/domains/dev/src/core/landing.ts
@@ -1,0 +1,196 @@
+// landing — the lock-toggled landing of a completed Attempt's worker branch
+// into its base (ADR 0030/0031). Carved out of process-issue so the
+// push → pre_merge → integrate → land → (locked conflict self-resolve) →
+// post_merge sequence lives in ONE place that owns "how lock-toggled landing
+// works", with a direct test surface of its own.
+//
+// PURE SEQUENCING over injected ports — exactly the slice process-issue used to
+// inline. The push, the merge-stage executor, the conflict resolver, the merge
+// hooks, and the headShortSha read are all injected; no real git/gh runs here.
+// The git/gh argv and the step ordering are UNCHANGED from the inline version —
+// this is a behaviour-preserving move.
+//
+// Landing is lock-toggled (ADR 0030):
+//   - LOCKED   → `landMerge` (git merge --no-ff into the locked branch + push),
+//                with a one-shot inner-agent self-resolve of merge conflicts.
+//   - UNLOCKED → `landPr` (admin-merged PR carrying the attempt history).
+//
+// The caller maps a non-ok result to its merge-conflict terminal-failure path.
+// On success the caller reads the FINAL merge sha (post post_merge) and runs the
+// done close — the final sha read stays in the caller to preserve the exact
+// current ordering (it is read AFTER post_merge, identical to before).
+
+import {
+  integrateOrigin,
+  landMerge,
+  landPr,
+  resolveMergeConflict,
+  type ConflictResolver,
+  type Exec as MergeExec,
+} from "./merge.js";
+import { pushAttempt, type GitExec } from "./remote-branch.js";
+
+/** Everything the landing needs, all side effects injected — mirroring how
+ * process-issue called each of these inline. */
+export interface LandingDeps {
+  /** git executor for merge.ts (integrateOrigin / landMerge / landPr / the
+   * locked conflict resolve + abort/reset/push). */
+  mergeExec: MergeExec;
+  /** git executor for remote-branch.ts (pushAttempt). */
+  remoteGit: GitExec;
+  /** git -C primary rev-parse --short HEAD — read once as the captured
+   * pre-merge tip (rollback anchor) before landing. */
+  headShortSha(): Promise<string>;
+  /** Fire a lifecycle hook (pre_merge / post_merge); returns false when the hook
+   * aborted. Wraps process-issue's fireHook so the landing never touches the
+   * dispatcher directly. */
+  fireHook(name: "pre_merge" | "post_merge", context: string): Promise<boolean>;
+  /** One-shot inner-agent merge-conflict resolver (locked path only). Absent →
+   * a locked merge conflict goes straight to the failure path. */
+  conflictResolver?: ConflictResolver;
+}
+
+/** Static per-landing inputs the caller already resolved. */
+export interface LandingInput {
+  /** True when the session is locked — drives the landMerge vs landPr toggle. */
+  locked: boolean;
+  /** `owner/repo` slug for gh (landPr). */
+  repo: string;
+  /** Primary checkout dir for git -C. */
+  repoDir: string;
+  /** Remote name (e.g. `origin`). */
+  remote: string;
+  /** The worker branch sandcastle committed on (push + land source). */
+  branch: string;
+  /** Resolved base branch (lock > pin > main). */
+  base: string;
+  /** Issue number, for the merge/PR message + hook contexts. */
+  issue: number;
+  /** Issue title, for the merge/PR message + hook contexts. */
+  title: string;
+}
+
+/** The pre_merge / post_merge hook context builders the caller owns (so the
+ * exact JSON shape stays defined once, next to the other hook contexts). */
+export interface LandingHookContexts {
+  preMerge(): string;
+  postMerge(): string;
+}
+
+/** Result of a landing. On success the caller reads the final merge sha + runs
+ * the done close; on failure the caller maps `reason` to the merge-conflict
+ * terminal-failure path. `locked` echoes the path taken for the result shape. */
+export type LandingResult =
+  | { ok: true; locked: boolean }
+  | { ok: false; reason: "pre_merge-abort" | "integrate-failed" | "land-failed"; locked: boolean };
+
+/**
+ * Land a completed attempt's worker branch into its base, lock-toggled. Owns the
+ * whole sequence, IDENTICAL in ordering and argv to the previous inline version:
+ *
+ *   1. pushAttempt — make the worker branch's origin state certain so
+ *      landMerge/landPr have a ref to merge.
+ *   2. fireHook("pre_merge") — abort → { ok:false, reason:"pre_merge-abort" }.
+ *   3. integrateOrigin — fail → { ok:false, reason:"integrate-failed" }.
+ *   4. headShortSha — capture the integrated tip as the rollback anchor.
+ *   5. landMerge (locked) | landPr (unlocked).
+ *   6. locked-only one-shot conflict self-resolve (when a resolver is injected):
+ *      on resolve, push the locked branch (reset on push-reject); else
+ *      `git merge --abort`.
+ *   7. land still failed → { ok:false, reason:"land-failed" }.
+ *   8. fireHook("post_merge") → { ok:true }.
+ */
+export async function doLanding(
+  deps: LandingDeps,
+  input: LandingInput,
+  hooks: LandingHookContexts,
+): Promise<LandingResult> {
+  const { locked } = input;
+
+  // 1. push the worker branch so landMerge/landPr have a remote ref.
+  await pushAttempt(deps.remoteGit, input.repoDir, input.branch, input.branch);
+
+  // 2. pre_merge hook.
+  if (!(await deps.fireHook("pre_merge", hooks.preMerge()))) {
+    return { ok: false, reason: "pre_merge-abort", locked };
+  }
+
+  // 3. integrate origin/<base> into local <base>.
+  const integrated = await integrateOrigin(deps.mergeExec, {
+    repo: input.repoDir,
+    remote: input.remote,
+    branch: input.base,
+    stillBehind: true,
+    inSync: false,
+  });
+  if (!integrated.ok) {
+    return { ok: false, reason: "integrate-failed", locked };
+  }
+
+  // 4. capture the integrated tip (rollback anchor for the locked push reject).
+  const preMergeSha = await deps.headShortSha();
+
+  // 5. land per lock state.
+  let landed: boolean;
+  if (locked) {
+    const r = await landMerge(deps.mergeExec, {
+      repo: input.repoDir,
+      remote: input.remote,
+      branch: input.branch,
+      target: input.base,
+      n: input.issue,
+      title: input.title,
+      preMergeSha,
+    });
+    landed = r.ok;
+  } else {
+    const r = await landPr(deps.mergeExec, {
+      repo: input.repo,
+      gitRepo: input.repoDir,
+      remote: input.remote,
+      branch: input.branch,
+      target: input.base,
+      n: input.issue,
+      title: input.title,
+    });
+    landed = r.ok;
+  }
+
+  // 6. One-shot self-resolve (merge_resolve_conflict, SKILL.md step 8): when the
+  // `git merge --no-ff` left conflicts, dispatch the configured runner once to
+  // resolve + commit the merge in the primary checkout. On success the landing
+  // continues to close, otherwise we `git merge --abort` and fall through to the
+  // ready-for-human merge-conflict path. Only attempted on the LOCKED path,
+  // where the merge happens locally — the unlocked PR path never merges in this
+  // checkout (gh admin-merges remotely), so there is nothing to resolve here.
+  if (!landed && locked && deps.conflictResolver) {
+    const resolved = await resolveMergeConflict(deps.mergeExec, deps.conflictResolver, {
+      repo: input.repoDir,
+      branch: input.branch,
+      n: input.issue,
+      title: input.title,
+      target: input.base,
+    });
+    if (resolved.resolved) {
+      const push = await deps.mergeExec(["git", "-C", input.repoDir, "push", input.remote, input.base]);
+      if (push.code === 0) {
+        landed = true;
+      } else {
+        await deps.mergeExec(["git", "-C", input.repoDir, "reset", "--hard", preMergeSha]);
+      }
+    } else {
+      // Still conflicting → abandon the merge so the checkout is clean for the
+      // next iteration, then surface ready-for-human below.
+      await deps.mergeExec(["git", "-C", input.repoDir, "merge", "--abort"]);
+    }
+  }
+  if (!landed) {
+    return { ok: false, reason: "land-failed", locked };
+  }
+
+  // 8. post_merge hook (best-effort; abort here does not unwind the landing,
+  // matching the inline version which never branched on its result).
+  await deps.fireHook("post_merge", hooks.postMerge());
+
+  return { ok: true, locked };
+}

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -1,66 +1,28 @@
 // process-issue — the AFK per-issue lifecycle, ported from afk.sh's
-// process_issue (+ iter_open / iter_close_success / iter_close_preserve /
-// claim_lock_acquire / completion_sweep_issue / the _afk_fire_pre/post_attempt
-// helpers and the do_merge wiring), and the "Per-Issue Loop" / "Issue
-// Lifecycle" sections of SKILL.md.
+// process_issue (+ iter_open / iter_close_* / claim_lock_acquire /
+// completion_sweep_issue / the pre/post_attempt helpers), and the
+// "Per-Issue Loop" / "Issue Lifecycle" sections of SKILL.md.
 //
-// This module is PURE SEQUENCING. It owns only the ORDER of the per-issue
-// lifecycle and the compose-decider-then-apply pattern: every step composes one
-// of the already-ported pure modules (base-resolver / remote-branch / handoff /
-// execution / feedback / merge / envelope-emit / hook-dispatcher / hook-config /
-// heartbeat / state / attempt-ledger) and applies its side effects through
-// injected IO. No real gh, git, spawn, fs, or clock lives here — the composed
-// modules perform no ambient IO, and `processIssue` performs IO only through the
-// injected `deps`.
+// PURE SEQUENCING: it owns only the ORDER of the lifecycle and the
+// compose-decider-then-apply pattern — every step composes an already-ported
+// pure module and applies its side effects through injected IO. No real gh, git,
+// spawn, fs, or clock lives here; `processIssue` performs IO only through `deps`.
 //
-// ---------------------------------------------------------------------------
-// EXECUTION SUBSTRATE DELEGATED TO SANDCASTLE (ADR 0033)
-// ---------------------------------------------------------------------------
-// The "create a worktree + spawn the inner agent + stream/sentinel detect +
-// commit on the worker branch" middle is no longer hand-rolled here. It is a
-// single call to the injected `deps.runAgent` port (a closure over
-// execution.runAgent + defaultSandcastleDeps in the CLI; a fake in tests).
-// sandcastle now OWNS: worktree creation, agent spawn, stream/sentinel
-// detection, and committing on the worker branch via
-// branchStrategy {type:"branch", branch: afk/{id}/{N}-{slug}}.
-//
-// AFK STILL OWNS (unchanged): claim + labels, the attempt dir, handoff
-// materialisation, the feedback gate, the lock-toggled landing, envelope
+// Execution (worktree + agent spawn + sentinel detect + worker-branch commit) is
+// delegated to the injected sandcastle `runAgent` port (ADR 0033). The
+// lock-toggled landing (push → pre_merge → integrate → land → post_merge) is
+// delegated to `doLanding` (landing.ts, ADR 0030/0031). AFK STILL OWNS: claim +
+// labels, the attempt dir, handoff materialisation, the feedback gate, envelope
 // emission, close, completion sweep, and the lifecycle hooks.
 //
-// PRAGMATIC INTEGRATION CHOICES (the seams where AFK's host-side modules meet a
-// sandcastle-owned worktree we never see a path to in-process):
-//   * The handoff is written to the HOST attempt dir (`<attemptDir>/handoff.md`)
-//     and passed to `runAgent` as the sandcastle `promptFile` (handoffPath). The
-//     AGENT-PROMPT contract is unchanged — the DONE/BLOCKED sentinels are the
-//     sandcastle completion signals.
-//   * `runAgent` returns the worker branch + its commits. AFK does NOT create or
-//     push the branch up-front any more (no push_initial / post-commit hook).
-//     After a DONE run, AFK makes the worker branch's origin state certain by
-//     pushing it (remote-branch.pushAttempt to origin/<branch>) BEFORE landing,
-//     so landMerge / landPr (which run from the primary checkout / a host
-//     worktree) have a remote ref to merge.
-//   * Feedback runs against a checkout/worktree of the returned branch through
-//     the injected pnpm/layout execs. We pass `result.branch` as the feedback
-//     `worktree` token; the concrete CLI closure resolves it to a real path
-//     (e.g. a sandcastle worktree handle or a host re-checkout). The unit tests
-//     inject a fake pnpm, so the token is opaque here — this is the one seam that
-//     cannot be fully resolved without a real sandcastle worktree handle.
-//   * `merge-conflict` is no longer a reachable inner-agent outcome (sandcastle
-//     either lands commits or not); the merge stage can still fail to integrate
-//     or land, and that path keeps the `merge-conflict` envelope/outcome.
-// ALL IO stays injected; nothing real is ever spawned from this module.
-//
 // Lifecycle hooks fire (via dispatchHooks over resolveHooks) at pre_worktree,
-// pre_attempt, post_attempt, pre_merge, post_merge, and on_attempt_error — the
-// canonical names; SKILL.md's pre_worker/post_worker/on_worker_error are the
-// deprecated aliases. A terminal envelope is emitted on every exit path.
+// pre_attempt, post_attempt, pre_merge, post_merge, and on_attempt_error. A
+// terminal envelope is emitted on every exit path.
 
 import { resolveBase, type ResolveBaseDeps, type ResolveBaseInput } from "./base-resolver.js";
 import {
   buildRefFromSlug,
   deleteRemote,
-  pushAttempt,
   slugifyRef,
   type GitExec,
 } from "./remote-branch.js";
@@ -74,13 +36,10 @@ import {
   type RunFeedbackResult,
 } from "./feedback.js";
 import {
-  integrateOrigin,
-  landMerge,
-  landPr,
-  resolveMergeConflict,
   type Exec as MergeExec,
   type ConflictResolver,
 } from "./merge.js";
+import { doLanding } from "./landing.js";
 import {
   emitEnvelope,
   type EmitEnvelopeDeps,
@@ -88,7 +47,12 @@ import {
 } from "./envelope-emit.js";
 import { dispatchHooks, type HookExec } from "./hook-dispatcher.js";
 import { recoveryCap, recoveryDecision, type RecoveryEnv } from "./recovery.js";
-import { blockedLabelFor, recoveryReasonFor, type AttemptOutcome } from "./attempt-outcome.js";
+import {
+  blockedLabelFor,
+  envelopeStatusFor,
+  recoveryReasonFor,
+  type AttemptOutcome,
+} from "./attempt-outcome.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
@@ -553,21 +517,10 @@ export async function processIssue(
   // ---- on_attempt_error: the run ended without an AFK sentinel (ADR 0028) ----
   if (run.outcome === "no-sentinel") {
     await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
-    await routeRecovery(deps, issue, "no-sentinel", current.attempt);
-    const posted = await emitFailure(common, "no-sentinel", "no-sentinel", {
+    return await terminalFailure(common, "no-sentinel", "no-sentinel", {
       notes: "_(no Notes appended; inner agent exited without a sentinel)_",
       log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
     });
-    return {
-      outcome: "no-sentinel",
-      issue,
-      branch: workerBranch,
-      base,
-      hooksFired,
-      envelopePosted: posted,
-      preserved: true,
-      swept: false,
-    };
   }
 
   // ---- post_attempt hook (terminal invocation; sentinel-bearing) ----
@@ -576,20 +529,9 @@ export async function processIssue(
 
   // ---- BLOCKED ----
   if (run.outcome === "blocked") {
-    await routeRecovery(deps, issue, "blocked", current.attempt);
-    const posted = await emitFailure(common, "blocked", "blocked", {
+    return await terminalFailure(common, "blocked", "blocked", {
       notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
     });
-    return {
-      outcome: "blocked",
-      issue,
-      branch: workerBranch,
-      base,
-      hooksFired,
-      envelopePosted: posted,
-      preserved: true,
-      swept: false,
-    };
   }
 
   // run.outcome === "done".
@@ -605,105 +547,45 @@ export async function processIssue(
     now: deps.nowEpoch,
   });
   if (!feedback.ok) {
-    await routeRecovery(deps, issue, "feedback-failed", current.attempt);
-    const posted = await emitFailure(common, "blocked", "feedback", {
+    return await terminalFailure(common, "feedback-failed", "feedback", {
       notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n"),
     });
-    return {
-      outcome: "feedback-failed",
-      issue,
-      branch: workerBranch,
-      base,
-      hooksFired,
-      envelopePosted: posted,
-      preserved: true,
-      swept: false,
-    };
   }
 
   // ---- 6. push the worker branch, integrate, then land per lock state ----
-  // sandcastle committed on the worker branch but does not push it; AFK makes
-  // its origin state certain before landing (so landMerge/landPr have a ref).
-  await pushAttempt(deps.remoteGit, input.repoDir, workerBranch, workerBranch);
-
+  // The entire lock-toggled landing (push → pre_merge → integrate → land →
+  // locked conflict self-resolve → post_merge) is owned by doLanding (landing.ts,
+  // ADR 0030/0031). A non-ok result maps to the merge-conflict terminal-failure
+  // path; on success the FINAL merge sha is read below (post post_merge), exactly
+  // as before, to drive the done close.
   const locked = await deps.lookups.isLocked();
-  if (
-    !(await fireHook("pre_merge", hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch })))
-  ) {
-    return await mergeFailed(common, "pre_merge-abort");
-  }
-
-  const integrated = await integrateOrigin(deps.mergeExec, {
-    repo: input.repoDir,
-    remote: input.remote,
-    branch: base,
-    stillBehind: true,
-    inSync: false,
-  });
-  if (!integrated.ok) {
-    return await mergeFailed(common, "integrate-failed");
-  }
-  const preMergeSha = await deps.git.headShortSha();
-
-  let landed: boolean;
-  if (locked) {
-    const r = await landMerge(deps.mergeExec, {
-      repo: input.repoDir,
-      remote: input.remote,
-      branch: workerBranch,
-      target: base,
-      n: issue,
-      title: input.title,
-      preMergeSha,
-    });
-    landed = r.ok;
-  } else {
-    const r = await landPr(deps.mergeExec, {
+  const landing = await doLanding(
+    {
+      mergeExec: deps.mergeExec,
+      remoteGit: deps.remoteGit,
+      headShortSha: () => deps.git.headShortSha(),
+      fireHook,
+      conflictResolver: deps.conflictResolver,
+    },
+    {
+      locked,
       repo: input.repo,
-      gitRepo: input.repoDir,
+      repoDir: input.repoDir,
       remote: input.remote,
       branch: workerBranch,
-      target: base,
-      n: issue,
+      base,
+      issue,
       title: input.title,
-    });
-    landed = r.ok;
+    },
+    {
+      preMerge: () => hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch }),
+      postMerge: () => hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch }),
+    },
+  );
+  if (!landing.ok) {
+    return await mergeFailed(common, landing.reason, landing.locked);
   }
-  // One-shot self-resolve (merge_resolve_conflict, SKILL.md step 8): when the
-  // `git merge --no-ff` left conflicts, dispatch the configured runner once to
-  // resolve + commit the merge in the primary checkout. The resolver verifies
-  // git state (no unmerged paths, MERGE_HEAD cleared); on success the landing
-  // continues to close, otherwise we `git merge --abort` and fall through to the
-  // ready-for-human merge-conflict path. Only attempted on the LOCKED path,
-  // where the merge happens locally — the unlocked PR path never merges in this
-  // checkout (gh admin-merges remotely), so there is nothing to resolve here.
-  if (!landed && locked && deps.conflictResolver) {
-    const resolved = await resolveMergeConflict(deps.mergeExec, deps.conflictResolver, {
-      repo: input.repoDir,
-      branch: workerBranch,
-      n: issue,
-      title: input.title,
-      target: base,
-    });
-    if (resolved.resolved) {
-      const push = await deps.mergeExec(["git", "-C", input.repoDir, "push", input.remote, base]);
-      if (push.code === 0) {
-        landed = true;
-      } else {
-        await deps.mergeExec(["git", "-C", input.repoDir, "reset", "--hard", preMergeSha]);
-      }
-    } else {
-      // Still conflicting → abandon the merge so the checkout is clean for the
-      // next iteration, then surface ready-for-human below.
-      await deps.mergeExec(["git", "-C", input.repoDir, "merge", "--abort"]);
-    }
-  }
-  if (!landed) {
-    return await mergeFailed(common, "land-failed", locked);
-  }
-
-  await fireHook("post_merge", hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch }));
 
   // ---- 7. close: envelope(done) → gh close + remove running → delete remote ----
   const mergeSha = await deps.git.headShortSha();
@@ -784,6 +666,38 @@ async function emitFailure(
   return result.posted;
 }
 
+/**
+ * The uniform terminal-FAILURE tail shared by no-sentinel, blocked, feedback,
+ * and merge-conflict: route the BOUNDED auto-recovery labels (routeRecovery),
+ * emit the failure envelope with the status derived from the outcome
+ * (envelopeStatusFor — the single owner), and build the uniform preserved /
+ * not-swept result. The section BODIES + the `sectionKey` (emitFailure's
+ * diffLabel) stay passed-in per call site; the `outcome`, `preserved:true`,
+ * `swept:false` shape is owned here. Paths whose result shape or side effects
+ * differ (abortAfterClaim, exhausted, mergeFailed's extra claim release) keep
+ * their own tails.
+ */
+async function terminalFailure(
+  c: StageCommon,
+  outcome: ProcessOutcome,
+  sectionKey: string,
+  sections: SectionBodies,
+): Promise<ProcessIssueResult> {
+  const { deps, input } = c;
+  await routeRecovery(deps, input.issue, outcome, input.attempt);
+  const posted = await emitFailure(c, envelopeStatusFor(outcome), sectionKey, sections);
+  return {
+    outcome,
+    issue: input.issue,
+    branch: c.branch,
+    base: c.base,
+    hooksFired: c.hooksFired,
+    envelopePosted: posted,
+    preserved: true,
+    swept: false,
+  };
+}
+
 /** Emit the done envelope with the merge sha + validation report. */
 async function emitDone(
   c: StageCommon,
@@ -814,7 +728,7 @@ async function emitDone(
 async function mergeFailed(c: StageCommon, _reason: string, locked = false): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   await routeRecovery(deps, input.issue, "merge-conflict", input.attempt);
-  const posted = await emitFailure(c, "merge-conflict", "merge-conflict", {
+  const posted = await emitFailure(c, envelopeStatusFor("merge-conflict"), "merge-conflict", {
     log: "(no merge log captured)",
   });
   await deps.claimLock.release(input.issue);

--- a/src/domains/dev/tests/attempt-outcome.test.ts
+++ b/src/domains/dev/tests/attempt-outcome.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   blockedLabelFor,
+  envelopeStatusFor,
   recoveryReasonFor,
   type AttemptOutcome,
   type RecoveryReason,
 } from "../src/core/attempt-outcome.js";
+import type { AttemptStatus } from "../src/core/envelope.js";
 
 // attempt-outcome is the SINGLE OWNER of the AFK outcome vocabulary. This is an
 // EXHAUSTIVE table: every `AttemptOutcome` value → its expected `blockedLabelFor`
@@ -70,5 +72,53 @@ describe("attempt-outcome — exhaustive outcome → (label, recovery) table", (
       const r = recoveryReasonFor(row.outcome);
       if (r !== null) expect(valid.has(r)).toBe(true);
     }
+  });
+});
+
+// envelopeStatusFor is the THIRD facet of the outcome vocabulary: the terminal
+// Envelope `data-attempt-status` emitted for the outcome. This EXHAUSTIVE table
+// pins every member, so a drift away from the real emitFailure(common, <status>)
+// call sites in process-issue breaks here. The only non-identity rows are the
+// ones the lifecycle deliberately re-buckets: feedback-failed emits a `blocked`
+// envelope (not a `feedback-failed` one), and the non-emitting outcomes fold into
+// the generic `blocked` failure bucket.
+describe("attempt-outcome — exhaustive outcome → envelope status table", () => {
+  const STATUS_TABLE: Array<{ outcome: AttemptOutcome; status: AttemptStatus }> = [
+    { outcome: "done", status: "done" },
+    { outcome: "no-sentinel", status: "no-sentinel" },
+    { outcome: "merge-conflict", status: "merge-conflict" },
+    { outcome: "blocked", status: "blocked" },
+    // feedback-failed emits a `blocked` envelope, NOT a `feedback-failed` one.
+    { outcome: "feedback-failed", status: "blocked" },
+    // non-emitting outcomes (no live emitFailure call) fold into `blocked`.
+    { outcome: "hook-aborted", status: "blocked" },
+    { outcome: "exhausted", status: "blocked" },
+    { outcome: "claim-lost", status: "blocked" },
+    { outcome: "stalled", status: "blocked" },
+    { outcome: "infra", status: "blocked" },
+  ];
+
+  for (const row of STATUS_TABLE) {
+    it(`${row.outcome} → envelope status ${row.status}`, () => {
+      expect(envelopeStatusFor(row.outcome)).toBe(row.status);
+    });
+  }
+
+  it("covers every AttemptOutcome member exactly once", () => {
+    const ALL: AttemptOutcome[] = [
+      "done",
+      "blocked",
+      "no-sentinel",
+      "merge-conflict",
+      "feedback-failed",
+      "claim-lost",
+      "hook-aborted",
+      "exhausted",
+      "stalled",
+      "infra",
+    ];
+    const covered = STATUS_TABLE.map((r) => r.outcome).sort();
+    expect(covered).toEqual([...ALL].sort());
+    expect(STATUS_TABLE.length).toBe(ALL.length);
   });
 });

--- a/src/domains/dev/tests/landing.test.ts
+++ b/src/domains/dev/tests/landing.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { doLanding, type LandingDeps, type LandingInput, type LandingHookContexts } from "../src/core/landing.js";
+import type { ExecResult } from "../src/core/merge.js";
+
+// doLanding owns the lock-toggled landing (ADR 0030/0031): push → pre_merge →
+// integrate → land → (locked conflict self-resolve) → post_merge. Before this
+// extraction the sequence was only exercised through process-issue's integration
+// tests; here it has a direct surface. Every git/gh touch is the injected
+// mergeExec / remoteGit fake, and the merge hooks are the injected fireHook.
+
+interface Harness {
+  deps: LandingDeps;
+  input: LandingInput;
+  hooks: LandingHookContexts;
+  mergeCalls: string[][];
+  pushedAttempt: string[][];
+  firedHooks: string[];
+}
+
+interface Opts {
+  locked?: boolean;
+  /** Abort one of the merge hooks. */
+  abortHook?: "pre_merge" | "post_merge";
+  /** rc the integrate fast-forward returns (1 → integrate fails). */
+  integrateCode?: number;
+  /** rc the locked `merge --no-ff` returns (1 → conflict). */
+  mergeNoFfCode?: number;
+  /** "resolve" → resolver clears the conflict; "fail" → leaves it; undefined → no resolver. */
+  conflictResolve?: "resolve" | "fail";
+  /** rc the post-resolve `push <remote> <base>` returns (1 → reject → reset). */
+  resolvePushCode?: number;
+}
+
+function harness(opts: Opts = {}): Harness {
+  const mergeCalls: string[][] = [];
+  const pushedAttempt: string[][] = [];
+  const firedHooks: string[] = [];
+  let mergeResolved = false;
+
+  const deps: LandingDeps = {
+    mergeExec: async (argv): Promise<ExecResult> => {
+      mergeCalls.push(argv);
+      const j = argv.join(" ");
+      if (argv.includes("pr") && argv.includes("list")) {
+        return { code: 0, stdout: "42\n", stderr: "" };
+      }
+      if (opts.integrateCode !== undefined && j.includes("merge --ff-only")) {
+        return { code: opts.integrateCode, stdout: "", stderr: "" };
+      }
+      if (opts.mergeNoFfCode !== undefined && j.includes("merge --no-ff")) {
+        return { code: opts.mergeNoFfCode, stdout: "", stderr: "" };
+      }
+      // The post-resolve push of the locked branch.
+      if (opts.resolvePushCode !== undefined && j === "git -C /repo push origin main") {
+        return { code: opts.resolvePushCode, stdout: "", stderr: "" };
+      }
+      if (j.includes("diff --name-only --diff-filter=U")) {
+        const unresolved = opts.conflictResolve === "fail" || !mergeResolved;
+        return { code: 0, stdout: unresolved ? "src/x.ts\n" : "", stderr: "" };
+      }
+      if (j.includes("rev-parse -q --verify MERGE_HEAD")) {
+        const pending = opts.conflictResolve === "fail" || !mergeResolved;
+        return { code: pending ? 0 : 1, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    remoteGit: async (argv) => {
+      pushedAttempt.push(argv);
+      return { code: 0, stdout: "", stderr: "" };
+    },
+    async headShortSha() {
+      return "abc1234";
+    },
+    async fireHook(name) {
+      firedHooks.push(name);
+      return opts.abortHook !== name;
+    },
+    conflictResolver: opts.conflictResolve
+      ? async () => {
+          if (opts.conflictResolve === "resolve") mergeResolved = true;
+        }
+      : undefined,
+  };
+
+  const input: LandingInput = {
+    locked: opts.locked ?? false,
+    repo: "o/r",
+    repoDir: "/repo",
+    remote: "origin",
+    branch: "afk/wAAAA/9-fix-the-thing",
+    base: "main",
+    issue: 9,
+    title: "Fix the thing",
+  };
+
+  const hooks: LandingHookContexts = {
+    preMerge: () => "pre_merge-ctx",
+    postMerge: () => "post_merge-ctx",
+  };
+
+  return { deps, input, hooks, mergeCalls, pushedAttempt, firedHooks };
+}
+
+const joined = (calls: string[][]): string[] => calls.map((c) => c.join(" "));
+
+describe("doLanding — happy paths", () => {
+  it("unlocked → pushes, fires both hooks, lands via admin PR", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    // worker branch pushed before landing.
+    expect(h.pushedAttempt.length).toBe(1);
+    // both merge hooks fired, in order.
+    expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("pr list"))).toBe(true);
+    expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    // unlocked never merges the attempt branch locally.
+    expect(j.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
+  });
+
+  it("locked → lands via merge --no-ff into the locked branch + push", async () => {
+    const h = harness({ locked: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true });
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("merge --no-ff afk/wAAAA/9-fix-the-thing"))).toBe(true);
+    expect(j.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
+    expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+  });
+});
+
+describe("doLanding — abort / failure short-circuits", () => {
+  it("pre_merge abort → { ok:false, pre_merge-abort } and never integrates/lands", async () => {
+    const h = harness({ locked: false, abortHook: "pre_merge" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "pre_merge-abort", locked: false });
+    // push happened (it precedes pre_merge), but no integrate/land and no post_merge.
+    expect(h.pushedAttempt.length).toBe(1);
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("merge --ff-only"))).toBe(false);
+    expect(j.some((c) => c.includes("pr list"))).toBe(false);
+  });
+
+  it("integrate failure → { ok:false, integrate-failed }, never lands or fires post_merge", async () => {
+    const h = harness({ locked: false, integrateCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "integrate-failed", locked: false });
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("pr list"))).toBe(false);
+  });
+
+  it("land failure (locked, no resolver) → { ok:false, land-failed, locked:true }", async () => {
+    const h = harness({ locked: true, mergeNoFfCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    // post_merge never fires on a failed land.
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+  });
+});
+
+describe("doLanding — locked conflict self-resolve", () => {
+  it("resolver clears the conflict → lands ok, pushes the locked branch", async () => {
+    const h = harness({ locked: true, mergeNoFfCode: 1, conflictResolve: "resolve" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true });
+    const j = joined(h.mergeCalls);
+    // the resolve path pushed the locked base.
+    expect(j).toContain("git -C /repo push origin main");
+    expect(j.some((c) => c.includes("merge --abort"))).toBe(false);
+    expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+  });
+
+  it("resolver fails → aborts the merge, { ok:false, land-failed }", async () => {
+    const h = harness({ locked: true, mergeNoFfCode: 1, conflictResolve: "fail" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    const j = joined(h.mergeCalls);
+    expect(j).toContain("git -C /repo merge --abort");
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+  });
+
+  it("resolved but the locked push is rejected → resets to preMergeSha, land-failed", async () => {
+    const h = harness({ locked: true, mergeNoFfCode: 1, conflictResolve: "resolve", resolvePushCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    const j = joined(h.mergeCalls);
+    expect(j).toContain("git -C /repo reset --hard abc1234");
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+  });
+
+  it("unlocked land failure never attempts the conflict resolver", async () => {
+    // landPr fails when the PR list returns nothing; force that by making pr list empty.
+    const h = harness({ locked: false });
+    h.deps.mergeExec = async (argv) => {
+      const j = argv.join(" ");
+      if (argv.includes("pr") && argv.includes("list")) return { code: 0, stdout: "\n", stderr: "" };
+      if (argv.includes("pr") && argv.includes("create")) return { code: 1, stdout: "", stderr: "" };
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "land-failed", locked: false });
+  });
+});


### PR DESCRIPTION
Architecture review round 2, candidates 1+2. Extracts core/landing.ts (lock-toggled Landing, ADR 0030/0031 — now directly testable) and a terminalFailure() helper from the 1012-LOC process-issue orchestrator; extends attempt-outcome with envelopeStatusFor. Pure behaviour-preserving — all 13 terminal/landing paths identical, oracle tests unchanged. Adds the Landing domain term. 684 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782792307&installation_id=129708444&pr_number=298&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F298&signature=fc39bfc3e3c50ed1b54faee37de64f84e1d0ec5de23a5ddaf5f8bea765da7b19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Landing workflow now executes as a single atomic operation with improved error handling and recovery
  * Enhanced automatic merge conflict resolution for locked branches

* **Documentation**
  * Updated glossary with clarified landing operation behavior and branch lock mechanics

* **Tests**
  * Added comprehensive test coverage for landing workflow and outcome status mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->