### PR TITLE
feat(afk): RED_AFK_SANDBOX env override + fix E2E smoke docker path

### DIFF
--- a/scripts/afk-e2e-smoke.sh
+++ b/scripts/afk-e2e-smoke.sh
@@ -155,7 +155,9 @@ else
     log="$(mktemp -t afk-e2e.XXXXXX.log)"
     echo "  running (live log → $log) ..."
     # Single supervised iteration on exactly this issue, pinned runner + sandbox.
-    if [ "$SANDBOX" != "none" ]; then export AFK_SANDBOX="$SANDBOX"; fi
+    # RED_AFK_SANDBOX overrides afk.sandbox in config (resolveRunSettings), so the
+    # docker/podman path is exercised without touching the target repo's config.
+    if [ "$SANDBOX" != "none" ]; then export RED_AFK_SANDBOX="$SANDBOX"; fi
     node "$BUNDLE" run --issues "$AFK_E2E_ISSUE" --once --runner "$RUNNER" 2>&1 | tee "$log"
     rc=${PIPESTATUS[0]}
     echo "  run exit: $rc"

--- a/src/domains/dev/src/runtime/wire.ts
+++ b/src/domains/dev/src/runtime/wire.ts
@@ -76,10 +76,16 @@ export interface RunSettings {
 
 const SANDBOX_MODES: readonly SandboxMode[] = ["none", "docker", "podman"];
 
-export function resolveRunSettings(root: string): RunSettings {
+export function resolveRunSettings(root: string, env: NodeJS.ProcessEnv = process.env): RunSettings {
   const paths = afkPaths(root);
   const cfg = loadConfig(paths.configPath, { warn: () => undefined });
-  const rawSandbox = getConfig(cfg, "afk.sandbox");
+  // Precedence: RED_AFK_SANDBOX env override > afk.sandbox config > "none".
+  // The env knob lets an E2E/CI run pick the isolation backend without mutating
+  // the target repo's .red/config.yaml, consistent with the other RED_AFK_* knobs.
+  const envSandbox = (env.RED_AFK_SANDBOX ?? "").trim();
+  const rawSandbox = (SANDBOX_MODES as readonly string[]).includes(envSandbox)
+    ? envSandbox
+    : getConfig(cfg, "afk.sandbox");
   const sandbox = (SANDBOX_MODES as readonly string[]).includes(rawSandbox)
     ? (rawSandbox as SandboxMode)
     : "none";

--- a/src/domains/dev/tests/wire.test.ts
+++ b/src/domains/dev/tests/wire.test.ts
@@ -44,12 +44,34 @@ describe("resolveRunSettings", () => {
     }
   });
 
+  it("RED_AFK_SANDBOX env overrides the config sandbox", () => {
+    const root = scratch();
+    try {
+      mkdirSync(join(root, ".red"), { recursive: true });
+      writeFileSync(join(root, ".red", "config.yaml"), "afk:\n  sandbox: none\n");
+      expect(resolveRunSettings(root, { RED_AFK_SANDBOX: "docker" }).sandbox).toBe("docker");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("an invalid RED_AFK_SANDBOX env falls back to the config sandbox", () => {
+    const root = scratch();
+    try {
+      mkdirSync(join(root, ".red"), { recursive: true });
+      writeFileSync(join(root, ".red", "config.yaml"), "afk:\n  sandbox: podman\n");
+      expect(resolveRunSettings(root, { RED_AFK_SANDBOX: "bogus" }).sandbox).toBe("podman");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to none for an unknown sandbox token", () => {
     const root = scratch();
     try {
       mkdirSync(join(root, ".red"), { recursive: true });
       writeFileSync(join(root, ".red", "config.yaml"), "afk:\n  sandbox: bogus\n");
-      expect(resolveRunSettings(root).sandbox).toBe("none");
+      expect(resolveRunSettings(root, {}).sandbox).toBe("none");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
resolveRunSettings only read afk.sandbox from config, so the E2E smoke's docker path was a dead no-op (ran as noSandbox). Adds RED_AFK_SANDBOX env override (env > config > none) so the #284 docker acceptance criterion is actually exercisable; fixes the smoke to export the var the runtime reads. 2 new wire tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782793067&installation_id=129708444&pr_number=310&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F310&signature=718fbdc78e06110d30e0788f1ac5918c1b74e132f5e4fa8a01c38c0030fcff9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `RED_AFK_SANDBOX` environment variable to override sandbox configuration without modifying config files.

* **Tests**
  * Added test coverage for sandbox mode environment variable overrides and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->