### PR TITLE
perf(afk): batch boot issue-state lookups (1 gh list, not N views)

### DIFF
--- a/plugins/dev/skills/engineering/afk/bin/afk.mjs
+++ b/plugins/dev/skills/engineering/afk/bin/afk.mjs
@@ -82150,6 +82150,42 @@ async function listCandidates(ctx) {
     };
   });
 }
+async function listIssueStates(ctx) {
+  const map26 = /* @__PURE__ */ new Map();
+  const r = await runGh(
+    ctx,
+    [
+      "issue",
+      "list",
+      ...repoArgs(ctx),
+      "--state",
+      "all",
+      "--limit",
+      "500",
+      "--json",
+      "number,state,labels,closedAt"
+    ]
+  );
+  if (r.code !== 0) return map26;
+  let raw3;
+  try {
+    raw3 = JSON.parse(r.stdout || "[]");
+  } catch {
+    return map26;
+  }
+  if (!Array.isArray(raw3)) return map26;
+  for (const row of raw3) {
+    const item = row;
+    const n = Number(item.number ?? 0);
+    if (!n) continue;
+    map26.set(n, {
+      state: String(item.state ?? "OPEN"),
+      labels: Array.isArray(item.labels) ? item.labels.map((l) => String(l.name ?? "")) : [],
+      closedAt: item.closedAt ?? null
+    });
+  }
+  return map26;
+}
 async function viewLabels(ctx, issue) {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "labels"]);
   if (r.code !== 0) return [];
@@ -82777,8 +82813,13 @@ async function collectReapInputs(ctx) {
     const n = liveIssueFromBranch2(r.branch);
     if (n !== null) issues.add(n);
   }
+  const states = await listIssueStates(ghCtx);
   const cache = /* @__PURE__ */ new Map();
-  for (const n of issues) cache.set(n, await issueMeta(ghCtx, n));
+  for (const n of issues) {
+    const row = states.get(n);
+    if (row) cache.set(n, { state: row.state, closedAt: row.closedAt });
+    else cache.set(n, await issueMeta(ghCtx, n));
+  }
   return {
     snapshotRefs,
     remoteLiveRefs,
@@ -85353,7 +85394,7 @@ function parseRunFlags(args2) {
     fallbackRunner: values3["fallback-runner"] === true
   };
 }
-async function resolveBranchIssueCache(ghCtx, options2) {
+async function resolveBranchIssueCache(ghCtx, options2, states) {
   const { liveIssueFromBranch: liveIssueFromBranch2, attemptIssueFromBranch: attemptIssueFromBranch2 } = await Promise.resolve().then(() => (init_branch_cleanup(), branch_cleanup_exports));
   const issues = /* @__PURE__ */ new Set();
   for (const r of options2.branches.snapshotRefs) {
@@ -85365,13 +85406,18 @@ async function resolveBranchIssueCache(ghCtx, options2) {
     if (n !== null) issues.add(n);
   }
   const cache = /* @__PURE__ */ new Map();
-  for (const n of issues) cache.set(n, await issueMeta(ghCtx, n));
+  for (const n of issues) {
+    const row = states.get(n);
+    if (row) cache.set(n, { state: row.state, closedAt: row.closedAt });
+    else cache.set(n, await issueMeta(ghCtx, n));
+  }
   return cache;
 }
 async function buildBootDeps(ctx, options2, nowS) {
   const ghCtx = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx = { cwd: ctx.root };
-  const branchCache = await resolveBranchIssueCache(ghCtx, options2);
+  const issueStates = await listIssueStates(ghCtx);
+  const branchCache = await resolveBranchIssueCache(ghCtx, options2, issueStates);
   return {
     fs: {
       ensureDir,
@@ -85391,13 +85437,23 @@ async function buildBootDeps(ctx, options2, nowS) {
     },
     lookups: {
       // Orphan state pairs gh issue state/label with the attempt dir's
-      // envelope.posted flag (read from the state file, not gh).
+      // envelope.posted flag (read from the state file, not gh). Derived from
+      // the batched map, preserving ghx.orphanState's exact label/state →
+      // verdict mapping (ready-for-human > running > null). On a map MISS the
+      // issue isn't in the list window — fall back to the live read so a
+      // truncated/just-created/transient issue still classifies correctly.
       orphanState: async (issue) => {
-        const r = await orphanState(ghCtx, issue);
-        return r;
+        const row = issueStates.get(issue);
+        if (!row) return orphanState(ghCtx, issue);
+        const label = row.labels.includes("ready-for-human") ? "ready-for-human" : row.labels.includes("running") ? "running" : null;
+        return { ghOk: true, state: row.state, label, envelopePosted: false };
       },
       branchIssue: (issue) => branchCache.get(issue),
-      blockerState: (issue) => blockerState(ghCtx, issue),
+      // Blocker state from the batched map: row.state ("OPEN"/"CLOSED") or
+      // undefined on a miss. undefined-on-miss exactly matches the prior
+      // 404→undefined→not-closed semantics — a missing blocker stays
+      // "open-or-unknown" and the dependent issue is NOT promoted.
+      blockerState: async (issue) => issueStates.get(issue)?.state,
       straggler: {
         unlabeled: () => countUnlabeled(ghCtx),
         needsTriage: () => countNeedsTriage(ghCtx),

--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -128,10 +128,15 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
 }
 
 /** Pre-resolve the gh issue-state cache the branch-cleanup reapers + orphan
- * lookup read synchronously. Mirrors collectReapInputs' eager resolution. */
+ * lookup read synchronously. Mirrors collectReapInputs' eager resolution, but
+ * sources every issue's meta from the SINGLE batched `listIssueStates` map
+ * instead of a per-issue `gh issue view` storm. A map miss (issue beyond the
+ * --limit window / just-created / transient list failure) falls back to the
+ * live `ghx.issueMeta` so closedAt-grace classification stays exact. */
 async function resolveBranchIssueCache(
   ghCtx: GhContext,
   options: BootOptions,
+  states: Map<number, import("../runtime/gh.js").IssueStateRow>,
 ): Promise<Map<number, import("../core/branch-cleanup.js").IssueMeta | null | undefined>> {
   const { liveIssueFromBranch, attemptIssueFromBranch } = await import("../core/branch-cleanup.js");
   const issues = new Set<number>();
@@ -144,14 +149,20 @@ async function resolveBranchIssueCache(
     if (n !== null) issues.add(n);
   }
   const cache = new Map<number, import("../core/branch-cleanup.js").IssueMeta | null | undefined>();
-  for (const n of issues) cache.set(n, await ghx.issueMeta(ghCtx, n));
+  for (const n of issues) {
+    const row = states.get(n);
+    if (row) cache.set(n, { state: row.state, closedAt: row.closedAt });
+    else cache.set(n, await ghx.issueMeta(ghCtx, n));
+  }
   return cache;
 }
 
 async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: number): Promise<BootDeps> {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: GitContext = { cwd: ctx.root };
-  const branchCache = await resolveBranchIssueCache(ghCtx, options);
+  // ONE batched issue-state fetch backs every per-issue boot lookup below.
+  const issueStates = await ghx.listIssueStates(ghCtx);
+  const branchCache = await resolveBranchIssueCache(ghCtx, options, issueStates);
   return {
     fs: {
       ensureDir: fsx.ensureDir,
@@ -171,13 +182,27 @@ async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: numbe
     },
     lookups: {
       // Orphan state pairs gh issue state/label with the attempt dir's
-      // envelope.posted flag (read from the state file, not gh).
+      // envelope.posted flag (read from the state file, not gh). Derived from
+      // the batched map, preserving ghx.orphanState's exact label/state →
+      // verdict mapping (ready-for-human > running > null). On a map MISS the
+      // issue isn't in the list window — fall back to the live read so a
+      // truncated/just-created/transient issue still classifies correctly.
       orphanState: async (issue) => {
-        const r = await ghx.orphanState(ghCtx, issue);
-        return r;
+        const row = issueStates.get(issue);
+        if (!row) return ghx.orphanState(ghCtx, issue);
+        const label = row.labels.includes("ready-for-human")
+          ? "ready-for-human"
+          : row.labels.includes("running")
+            ? "running"
+            : null;
+        return { ghOk: true, state: row.state, label, envelopePosted: false };
       },
       branchIssue: (issue) => branchCache.get(issue),
-      blockerState: (issue) => ghx.blockerState(ghCtx, issue),
+      // Blocker state from the batched map: row.state ("OPEN"/"CLOSED") or
+      // undefined on a miss. undefined-on-miss exactly matches the prior
+      // 404→undefined→not-closed semantics — a missing blocker stays
+      // "open-or-unknown" and the dependent issue is NOT promoted.
+      blockerState: async (issue) => issueStates.get(issue)?.state,
       straggler: {
         unlabeled: () => ghx.countUnlabeled(ghCtx),
         needsTriage: () => ghx.countNeedsTriage(ghCtx),

--- a/src/domains/dev/src/runtime/gh.ts
+++ b/src/domains/dev/src/runtime/gh.ts
@@ -91,6 +91,67 @@ export async function listCandidates(ctx: GhContext): Promise<IssueCandidate[]> 
   });
 }
 
+/** A single issue's batched state slice: open/closed state, its label-name
+ * list, and the ISO-8601 closedAt (null/"" when open). Backs every per-issue
+ * boot lookup (orphan state, blocker state, branch issue-meta) from ONE list. */
+export interface IssueStateRow {
+  state: string;
+  labels: string[];
+  closedAt: string | null;
+}
+
+/**
+ * Batched issue-state fetch: ONE `gh issue list --state all --json
+ * number,state,labels,closedAt --limit 500` projected to a `number → row` map.
+ *
+ * This collapses the boot sweeps' per-issue `gh issue view` storms into a
+ * single call. gh's default `--limit` is 30, so we pass an explicit 500 (covers
+ * the repo with margin; an issue beyond 500 simply misses the map and the
+ * caller falls back to a live lookup). Mirrors {@link listCandidates}'s shape
+ * and error handling: a failed probe / unparseable body yields an empty map and
+ * every lookup degrades to its live fallback.
+ */
+export async function listIssueStates(ctx: GhContext): Promise<Map<number, IssueStateRow>> {
+  const map = new Map<number, IssueStateRow>();
+  const r = await runGh(ctx,
+    [
+      "issue",
+      "list",
+      ...repoArgs(ctx),
+      "--state",
+      "all",
+      "--limit",
+      "500",
+      "--json",
+      "number,state,labels,closedAt",
+    ],
+  );
+  if (r.code !== 0) return map;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(r.stdout || "[]");
+  } catch {
+    return map;
+  }
+  if (!Array.isArray(raw)) return map;
+  for (const row of raw) {
+    const item = row as {
+      number?: number;
+      state?: string;
+      labels?: Array<{ name?: string }>;
+      closedAt?: string | null;
+    };
+    const n = Number(item.number ?? 0);
+    if (!n) continue;
+    map.set(n, {
+      state: String(item.state ?? "OPEN"),
+      labels: Array.isArray(item.labels) ? item.labels.map((l) => String(l.name ?? "")) : [],
+      closedAt: item.closedAt ?? null,
+    });
+  }
+  return map;
+}
+
 /** `gh issue view --json labels` → flat label-name list. */
 export async function viewLabels(ctx: GhContext, issue: number): Promise<string[]> {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "labels"]);

--- a/src/domains/dev/src/runtime/wire.ts
+++ b/src/domains/dev/src/runtime/wire.ts
@@ -288,7 +288,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
 
 // ---------- reap inputs ----------
 
-import { issueMeta, type GhContext } from "./gh.js";
+import { issueMeta, listIssueStates, type GhContext } from "./gh.js";
 import type { IssueMeta } from "../core/branch-cleanup.js";
 
 export interface ReapInputs {
@@ -330,8 +330,16 @@ export async function collectReapInputs(ctx: RepoContext): Promise<ReapInputs> {
     const n = liveIssueFromBranch(r.branch);
     if (n !== null) issues.add(n);
   }
+  // ONE batched issue-state fetch replaces the per-issue `gh issue view` storm.
+  // A map miss (issue beyond the --limit window / just-created / transient list
+  // failure) falls back to the live `issueMeta` so closedAt-grace stays exact.
+  const states = await listIssueStates(ghCtx);
   const cache = new Map<number, IssueMeta | null | undefined>();
-  for (const n of issues) cache.set(n, await issueMeta(ghCtx, n));
+  for (const n of issues) {
+    const row = states.get(n);
+    if (row) cache.set(n, { state: row.state, closedAt: row.closedAt });
+    else cache.set(n, await issueMeta(ghCtx, n));
+  }
 
   return {
     snapshotRefs,

--- a/src/domains/dev/tests/gh-batch.test.ts
+++ b/src/domains/dev/tests/gh-batch.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { listIssueStates, type GhContext } from "../src/runtime/gh.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+/**
+ * Boot perf refactor: the three boot sweeps used to issue dozens of SEQUENTIAL
+ * `gh issue view N` calls (one per issue). They now read from a SINGLE batched
+ * `listIssueStates` map. These tests pin (1) the parse from gh's JSON array into
+ * the `number → {state,labels,closedAt}` map, (2) the map-miss contract every
+ * lookup relies on, and (3) the call-count win: ONE `gh issue list`, not N
+ * views, for K issues.
+ */
+
+interface Recorder {
+  exec: ExecFn;
+  calls: { cmd: string; args: string[] }[];
+}
+
+function recording(stdout: string, code = 0): Recorder {
+  const calls: { cmd: string; args: string[] }[] = [];
+  const out: ExecOutput = { code, stdout, stderr: "" };
+  const exec: ExecFn = (cmd, args) => {
+    calls.push({ cmd, args: [...args] });
+    return Promise.resolve(out);
+  };
+  return { exec, calls };
+}
+
+describe("listIssueStates — batched issue-state fetch", () => {
+  it("parses the gh JSON array into a number → {state,labels,closedAt} map", async () => {
+    const rec = recording(
+      JSON.stringify([
+        { number: 1, state: "OPEN", labels: [{ name: "ready-for-agent" }], closedAt: null },
+        { number: 2, state: "CLOSED", labels: [{ name: "running" }, { name: "x" }], closedAt: "2026-05-30T00:00:00Z" },
+        { number: 3, state: "OPEN", labels: [] },
+      ]),
+    );
+    const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec: rec.exec };
+    const map = await listIssueStates(ctx);
+
+    expect(map.size).toBe(3);
+    expect(map.get(1)).toEqual({ state: "OPEN", labels: ["ready-for-agent"], closedAt: null });
+    expect(map.get(2)).toEqual({ state: "CLOSED", labels: ["running", "x"], closedAt: "2026-05-30T00:00:00Z" });
+    expect(map.get(3)).toEqual({ state: "OPEN", labels: [], closedAt: null });
+  });
+
+  it("runs ONE `gh issue list --state all --limit 500` call (not N views)", async () => {
+    // 12 issues in the repo — the old boot path would issue 12 `gh issue view`
+    // calls (orphan + blocker + branch-meta loops). The batch is ONE list.
+    const rows = Array.from({ length: 12 }, (_, i) => ({
+      number: i + 1,
+      state: "OPEN",
+      labels: [],
+      closedAt: null,
+    }));
+    const rec = recording(JSON.stringify(rows));
+    const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec: rec.exec };
+
+    const map = await listIssueStates(ctx);
+
+    expect(map.size).toBe(12);
+    expect(rec.calls).toHaveLength(1);
+    expect(rec.calls[0]).toEqual({
+      cmd: "gh",
+      args: [
+        "issue", "list",
+        "--repo", "acme/widgets",
+        "--state", "all",
+        "--limit", "500",
+        "--json", "number,state,labels,closedAt",
+      ],
+    });
+  });
+
+  it("map-miss → get(n) is undefined (lookups degrade to live fallback / not-closed)", async () => {
+    const rec = recording(JSON.stringify([{ number: 1, state: "OPEN", labels: [], closedAt: null }]));
+    const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec: rec.exec };
+    const map = await listIssueStates(ctx);
+
+    expect(map.has(1)).toBe(true);
+    expect(map.get(999)).toBeUndefined();
+    // The blocker lookup reads `map.get(n)?.state` — undefined on miss keeps the
+    // dependent "open-or-unknown" (NOT promoted), matching the prior 404 path.
+    expect(map.get(999)?.state).toBeUndefined();
+  });
+
+  it("returns an empty map on a failed probe or unparseable body", async () => {
+    const fail: GhContext = { cwd: "/r", repo: "acme/widgets", exec: recording("", 1).exec };
+    expect((await listIssueStates(fail)).size).toBe(0);
+
+    const garbage: GhContext = { cwd: "/r", repo: "acme/widgets", exec: recording("not json").exec };
+    expect((await listIssueStates(garbage)).size).toBe(0);
+  });
+
+  it("omits rows without a usable number", async () => {
+    const rec = recording(JSON.stringify([{ state: "OPEN", labels: [] }, { number: 7, state: "CLOSED", labels: [] }]));
+    const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec: rec.exec };
+    const map = await listIssueStates(ctx);
+    expect([...map.keys()]).toEqual([7]);
+  });
+});


### PR DESCRIPTION
The boot's three sweeps each did a sequential gh issue view per issue (~3K+CxB round-trips, >2min). Replace with one batched gh issue list -> map; all lookups read the map with a live fallback on miss. Pure sweep modules unchanged; behaviour-preserving (oracle tests green). 691 tests. bin/afk.mjs rebuilt. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782823009&installation_id=129708444&pr_number=323&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F323&signature=40f1d4e067a8c62c9a49c92e2aaa8449131eff8031d1185f3445a802401e6bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance & Optimization**
  * Optimized issue state retrieval through batched lookups to reduce individual API calls.
  * Enhanced caching mechanism for issue metadata with improved fallback handling.

* **Tests**
  * Added comprehensive test suite for batched issue state operations, including failure scenarios and miss handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->