### PR TITLE
feat(afk): --boot-only dry-run + parallelize boot reads + fix smoke

### DIFF
--- a/plugins/dev/skills/engineering/afk/bin/afk.mjs
+++ b/plugins/dev/skills/engineering/afk/bin/afk.mjs
@@ -82852,18 +82852,16 @@ async function collectBootOptions(ctx, facts, bootstrap, nowS) {
     list.push({ path: o.path, mtimeS, live });
     byIssue.set(parsed.issue, list);
   }
-  const [snapshotRefs, remoteLiveRefs, localAll, checkedOut] = await Promise.all([
+  const [snapshotRefs, remoteLiveRefs, localAll, checkedOut, unblockCandidates, staleClaimDirs, legacyWorkDirs] = await Promise.all([
     listRemoteBranches(gitCtx, "afk-attempts/"),
     listRemoteBranches(gitCtx, "afk/"),
     listLocalBranches(gitCtx, "afk/*"),
-    checkedOutBranches(gitCtx)
-  ]);
-  const localLiveRefs = localAll.filter((b2) => !checkedOut.has(b2)).map((b2) => ({ branch: b2 }));
-  const unblockCandidates = await listUnblockCandidates(ghCtx);
-  const [staleClaimDirs, legacyWorkDirs] = await Promise.all([
+    checkedOutBranches(gitCtx),
+    listUnblockCandidates(ghCtx),
     listStaleClaimDirs(paths.tmpDir),
     listLegacyWorkDirs(paths.tmpDir)
   ]);
+  const localLiveRefs = localAll.filter((b2) => !checkedOut.has(b2)).map((b2) => ({ branch: b2 }));
   return {
     precheck: facts,
     bootstrap,
@@ -82878,15 +82876,16 @@ async function collectBootOptions(ctx, facts, bootstrap, nowS) {
 async function collectPrecheckFacts(ctx) {
   const gitCtx = { cwd: ctx.root };
   const ghCtx = { cwd: ctx.root, repo: ctx.repo };
-  const [ghInstalled2, ghAuthenticated2, isRepo, remoteUrls2, hasMain, currentBranch2] = await Promise.all([
+  const [ghInstalled2, ghAuthenticated2, isRepo, remoteUrls2, hasMain, currentBranch2, pnpmProbe] = await Promise.all([
     ghInstalled(ghCtx),
     ghAuthenticated(ghCtx),
     isGitRepo(gitCtx),
     remoteUrls(gitCtx),
     hasMainBranch(gitCtx),
-    currentBranch(gitCtx)
+    currentBranch(gitCtx),
+    Promise.resolve().then(() => (init_exec(), exec_exports)).then((m2) => m2.pnpm(["--version"], { cwd: ctx.root }))
   ]);
-  const pnpmInstalled = (await Promise.resolve().then(() => (init_exec(), exec_exports)).then((m2) => m2.pnpm(["--version"], { cwd: ctx.root }))).code !== 127;
+  const pnpmInstalled = pnpmProbe.code !== 127;
   return {
     ghInstalled: ghInstalled2,
     ghAuthenticated: ghAuthenticated2,
@@ -83239,6 +83238,10 @@ async function runSession(deps, ctx) {
   empty43.boot = boot;
   if (!boot.precheck.ok) {
     return empty43;
+  }
+  if (ctx.bootOnly) {
+    deps.emit("boot complete (--boot-only): sweeps ran, no issues processed");
+    return { ...empty43, boot };
   }
   try {
     if (!await fireSessionHook("pre_session", statsContext(0, 0, 0))) {
@@ -85363,7 +85366,8 @@ var RUN_FLAG_SCHEMA = {
   runner: { kind: "value", coerce: (raw3) => raw3 },
   request: { kind: "value", aliases: ["r"], coerce: (raw3) => raw3 },
   alternate: { kind: "boolean" },
-  "fallback-runner": { kind: "boolean" }
+  "fallback-runner": { kind: "boolean" },
+  "boot-only": { kind: "boolean" }
 };
 function parseRunFlags(args2) {
   const { values: values3 } = parseFlags(args2, RUN_FLAG_SCHEMA);
@@ -85391,7 +85395,8 @@ function parseRunFlags(args2) {
     runnerFlag,
     request: values3.request,
     alternate,
-    fallbackRunner: values3["fallback-runner"] === true
+    fallbackRunner: values3["fallback-runner"] === true,
+    bootOnly: values3["boot-only"] === true
   };
 }
 async function resolveBranchIssueCache(ghCtx, options2, states) {
@@ -85617,6 +85622,7 @@ async function runCommand2(options2) {
     once: flags.once,
     filter: flags.filter,
     alternate: flags.alternate,
+    bootOnly: flags.bootOnly,
     issueTemplate: {
       tmpDir: paths.tmpDir,
       repo: ctx.repo,

--- a/scripts/afk-e2e-smoke.sh
+++ b/scripts/afk-e2e-smoke.sh
@@ -106,16 +106,19 @@ fi
 # ===========================================================================
 hdr "Phase 2 — empty-queue drain (boot + select + precheck, no agent)"
 
-# -n 0 caps the drain at zero issues: exercises bootstrap, selection and the
-# precheck without ever spawning an agent. Expect the NO MORE TASKS sentinel
-# (or a clean precheck message such as 'not-on-main' when run off main).
-out="$(node "$BUNDLE" run -n 0 2>&1)"; rc=$?
-if echo "$out" | grep -q 'NO MORE TASKS'; then
-  pass "run -n 0 → NO MORE TASKS (boot+select OK, no agent)"
+# --boot-only is the honest no-agent dry-run: it runs bootstrap + every boot
+# sweep (orphan cleanup, attempt cap, snapshot grace, unblock, straggler) +
+# precheck, then exits BEFORE selecting/claiming/spawning. It never reaches
+# selection, so it does NOT print NO MORE TASKS — a clean exit 0 with no claim
+# is success. (Do NOT use `-n 0` here: in session.ts `-n 0` means unlimited
+# drain — 0/undefined caps to the full queue — so it would spawn agents.)
+out="$(node "$BUNDLE" run --boot-only 2>&1)"; rc=$?
+if [ $rc -eq 0 ]; then
+  pass "run --boot-only → clean exit 0 (boot+sweeps+precheck OK, no agent)"
 elif echo "$out" | grep -qi 'precheck'; then
-  warn "run -n 0 → precheck gate: $(echo "$out" | tail -1) (expected off main / outside a repo)"
+  warn "run --boot-only → precheck gate: $(echo "$out" | tail -1) (expected off main / outside a repo)"
 else
-  fail "run -n 0 unexpected (exit $rc): $(echo "$out" | tail -2)"
+  fail "run --boot-only unexpected (exit $rc): $(echo "$out" | tail -2)"
 fi
 
 # ===========================================================================

--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -55,6 +55,8 @@ interface ParsedRunFlags {
   alternate: boolean;
   /** --fallback-runner: swap runners mid-issue on RUNNER_EXHAUSTED. */
   fallbackRunner: boolean;
+  /** --boot-only: run the boot sweeps then exit without selecting/claiming/processing. */
+  bootOnly: boolean;
 }
 
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
@@ -86,6 +88,7 @@ const RUN_FLAG_SCHEMA = {
   request: { kind: "value", aliases: ["r"], coerce: (raw: string): string => raw },
   alternate: { kind: "boolean" },
   "fallback-runner": { kind: "boolean" },
+  "boot-only": { kind: "boolean" },
 } satisfies FlagSchema;
 
 /** Parse the `run` flags: --prd N / --issues a,b,c / -n N / --once / --request / --runner. */
@@ -124,6 +127,7 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     request: values.request as string | undefined,
     alternate,
     fallbackRunner: values["fallback-runner"] === true,
+    bootOnly: values["boot-only"] === true,
   };
 }
 
@@ -418,6 +422,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
     once: flags.once,
     filter: flags.filter,
     alternate: flags.alternate,
+    bootOnly: flags.bootOnly,
     issueTemplate: {
       tmpDir: paths.tmpDir,
       repo: ctx.repo,

--- a/src/domains/dev/src/core/session.ts
+++ b/src/domains/dev/src/core/session.ts
@@ -200,6 +200,11 @@ export interface SessionContext {
    * issue toggles. Off by default (every issue uses `runner`).
    */
   alternate?: boolean;
+  /**
+   * --boot-only: run the boot sweeps then exit without selecting/claiming/
+   * processing — a dry-run for inspecting the boot, never spawns an agent.
+   */
+  bootOnly?: boolean;
 }
 
 /** Toggle a runner to the other backend (claude↔codex). */
@@ -388,6 +393,13 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
   empty.boot = boot;
   if (!boot.precheck.ok) {
     return empty;
+  }
+
+  // ---- 1a. --boot-only: dry-run. The boot sweeps ran above; return before
+  // any selection/claim/processing so no agent is ever spawned. ----
+  if (ctx.bootOnly) {
+    deps.emit("boot complete (--boot-only): sweeps ran, no issues processed");
+    return { ...empty, boot };
   }
 
   try {

--- a/src/domains/dev/src/runtime/wire.ts
+++ b/src/domains/dev/src/runtime/wire.ts
@@ -400,23 +400,21 @@ export async function collectBootOptions(
     byIssue.set(parsed.issue, list);
   }
 
-  // Branch namespaces for the three reapers.
-  const [snapshotRefs, remoteLiveRefs, localAll, checkedOut] = await Promise.all([
-    gitx.listRemoteBranches(gitCtx, "afk-attempts/"),
-    gitx.listRemoteBranches(gitCtx, "afk/"),
-    gitx.listLocalBranches(gitCtx, "afk/*"),
-    gitx.checkedOutBranches(gitCtx),
-  ]);
+  // Branch namespaces for the three reapers, the unblock-candidate listing, and
+  // the stale claim-lock / pre-cutover work-* sweeps are mutually independent
+  // reads — run them concurrently. (Stale-claim + legacy-work both probe pid
+  // liveness at discovery so boot's orphan step stays a pure removal, #252.)
+  const [snapshotRefs, remoteLiveRefs, localAll, checkedOut, unblockCandidates, staleClaimDirs, legacyWorkDirs] =
+    await Promise.all([
+      gitx.listRemoteBranches(gitCtx, "afk-attempts/"),
+      gitx.listRemoteBranches(gitCtx, "afk/"),
+      gitx.listLocalBranches(gitCtx, "afk/*"),
+      gitx.checkedOutBranches(gitCtx),
+      ghx.listUnblockCandidates(ghCtx),
+      fsx.listStaleClaimDirs(paths.tmpDir),
+      fsx.listLegacyWorkDirs(paths.tmpDir),
+    ]);
   const localLiveRefs = localAll.filter((b) => !checkedOut.has(b)).map((b) => ({ branch: b }));
-
-  const unblockCandidates = await ghx.listUnblockCandidates(ghCtx);
-
-  // Stale claim-lock sweep + pre-cutover work-* drain-wipe (#252). Both probe
-  // pid liveness at discovery so boot's orphan step stays a pure removal.
-  const [staleClaimDirs, legacyWorkDirs] = await Promise.all([
-    fsx.listStaleClaimDirs(paths.tmpDir),
-    fsx.listLegacyWorkDirs(paths.tmpDir),
-  ]);
 
   return {
     precheck: facts,
@@ -433,15 +431,16 @@ export async function collectBootOptions(
 export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFacts> {
   const gitCtx: gitx.GitContext = { cwd: ctx.root };
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
-  const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch] = await Promise.all([
+  const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch, pnpmProbe] = await Promise.all([
     ghx.ghInstalled(ghCtx),
     ghx.ghAuthenticated(ghCtx),
     gitx.isGitRepo(gitCtx),
     gitx.remoteUrls(gitCtx),
     gitx.hasMainBranch(gitCtx),
     gitx.currentBranch(gitCtx),
+    import("./exec.js").then((m) => m.pnpm(["--version"], { cwd: ctx.root })),
   ]);
-  const pnpmInstalled = (await import("./exec.js").then((m) => m.pnpm(["--version"], { cwd: ctx.root }))).code !== 127;
+  const pnpmInstalled = pnpmProbe.code !== 127;
   return {
     ghInstalled,
     ghAuthenticated,

--- a/src/domains/dev/tests/run-flags.test.ts
+++ b/src/domains/dev/tests/run-flags.test.ts
@@ -11,7 +11,13 @@ describe("parseRunFlags", () => {
       request: undefined,
       alternate: false,
       fallbackRunner: false,
+      bootOnly: false,
     });
+  });
+
+  it("parses --boot-only as a boolean, defaulting to false", () => {
+    expect(parseRunFlags(["--boot-only"]).bootOnly).toBe(true);
+    expect(parseRunFlags([]).bootOnly).toBe(false);
   });
 
   it("parses --alternate and --fallback-runner as booleans", () => {

--- a/src/domains/dev/tests/session.test.ts
+++ b/src/domains/dev/tests/session.test.ts
@@ -159,6 +159,10 @@ interface SessionTrace {
   processedRunners: string[];
   /** Session-scoped hook commands the fake exec ran, in order. */
   hookCommands: string[];
+  /** How many times the fake runBoot was invoked. */
+  runBootCalls: number;
+  /** How many times the fake gh.listCandidates was invoked. */
+  listCandidatesCalls: number;
 }
 
 interface RunHarnessOptions {
@@ -176,6 +180,8 @@ interface RunHarnessOptions {
   abortHook?: string;
   /** When true, the fake processIssue throws to exercise on_session_error. */
   throwOnProcess?: boolean;
+  /** --boot-only: run the boot then return before selection/processing. */
+  bootOnly?: boolean;
 }
 
 function makeSession(opts: RunHarnessOptions = {}): {
@@ -189,6 +195,8 @@ function makeSession(opts: RunHarnessOptions = {}): {
     builtInputs: [],
     processedRunners: [],
     hookCommands: [],
+    runBootCalls: 0,
+    listCandidatesCalls: 0,
   };
   const candidates = opts.candidates ?? [cand(1), cand(2), cand(3)];
   const boot: BootResult = opts.bootResult ?? { precheck: { ok: true, warnings: [] } };
@@ -228,10 +236,12 @@ function makeSession(opts: RunHarnessOptions = {}): {
   const deps: SessionDeps = {
     gh: {
       async listCandidates() {
+        trace.listCandidatesCalls += 1;
         return candidates;
       },
     },
     async runBoot() {
+      trace.runBootCalls += 1;
       return boot;
     },
     bootDeps,
@@ -279,6 +289,7 @@ function makeSession(opts: RunHarnessOptions = {}): {
     iterCap: opts.iterCap,
     once: opts.once,
     alternate: opts.alternate,
+    bootOnly: opts.bootOnly,
     filter: opts.filter ?? { kind: "all" },
     issueTemplate: {
       tmpDir: "/tmp/afk",
@@ -369,6 +380,33 @@ describe("runSession", () => {
     expect(summary.total).toBe(0);
     expect(summary.drained).toBe(false);
     expect(summary.boot).toBe(bootResult);
+  });
+});
+
+describe("runSession — --boot-only dry-run", () => {
+  it("runs the boot then returns before selecting/claiming/processing — never spawns an agent", async () => {
+    const bootResult: BootResult = { precheck: { ok: true, warnings: ["a-warning"] } };
+    const { deps, ctx, trace } = makeSession({
+      candidates: [cand(1), cand(2), cand(3)],
+      bootResult,
+      bootOnly: true,
+    });
+    const summary = await runSession(deps, ctx);
+    // The boot sweeps ran exactly once...
+    expect(trace.runBootCalls).toBe(1);
+    // ...but selection and per-issue processing were skipped entirely.
+    expect(trace.listCandidatesCalls).toBe(0);
+    expect(trace.processedOrder).toEqual([]);
+    expect(trace.builtInputs).toEqual([]);
+    // No drain happened: zero counters, not flagged as a drained empty queue.
+    expect(summary.total).toBe(0);
+    expect(summary.done).toBe(0);
+    expect(summary.drained).toBe(false);
+    // The boot result still surfaces on the summary.
+    expect(summary.boot).toBe(bootResult);
+    // A single informational line is emitted, never the NO MORE TASKS sentinel.
+    expect(trace.emitted).not.toContain(NO_MORE_TASKS);
+    expect(trace.emitted).toEqual(["boot complete (--boot-only): sweeps ran, no issues processed"]);
   });
 });
 


### PR DESCRIPTION
Adds an honest --boot-only mode (boot sweeps then exit, no agent — fills the slot -n 0 wrongly occupied since 0=unlimited-drain). Fixes the smoke's false -n 0 assumption. Parallelizes the boot's independent gh/git reads (conservative Promise.all, parity-preserving). 693 tests. bin/afk.mjs rebuilt. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782824376&installation_id=129708444&pr_number=324&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F324&signature=f2688dc066b4ea3bd914bdb0288a0d9d78881516c589b50286e7ff9f93e9d33d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--boot-only` CLI flag to run the bootstrap phase without subsequent issue processing

* **Tests**
  * Added test coverage for the `--boot-only` flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->