### PR TITLE
fix(afk): anchor sandcastle under the attempt dir, not the repo root

### DIFF
--- a/plugins/dev/skills/engineering/afk/bin/afk.mjs
+++ b/plugins/dev/skills/engineering/afk/bin/afk.mjs
@@ -77504,6 +77504,10 @@ function buildRunOptions(deps, input) {
   return {
     agent: deps.agentFor(input.runner, input.model, { effort: input.effort }),
     sandbox: deps.sandboxFor(input.sandboxMode ?? "none"),
+    // Re-anchor sandcastle's `.sandcastle/` dir + git ops at the caller's cwd
+    // (AFK's per-attempt dir under .red/) so nothing is generated at the repo
+    // root. Omitted → sandcastle defaults to process.cwd().
+    ...input.cwd ? { cwd: input.cwd } : {},
     promptFile: input.handoffPath,
     branchStrategy,
     completionSignal: [...COMPLETION_SIGNALS],
@@ -84592,6 +84596,7 @@ async function processIssue(deps, input) {
     handoffPath,
     branch,
     base,
+    cwd: input.attemptDir,
     // Restore the issue #191 continuous-push guarantee: sandcastle pushes the
     // worker branch up-front + after every commit (host worktree hook), so a
     // SIGKILL mid-iteration preserves the diff on origin. Best-effort.
@@ -84618,6 +84623,7 @@ async function processIssue(deps, input) {
       handoffPath,
       branch,
       base,
+      cwd: input.attemptDir,
       remote: input.remote,
       continuousPush: true
     });

--- a/src/domains/dev/src/core/execution.ts
+++ b/src/domains/dev/src/core/execution.ts
@@ -51,6 +51,15 @@ export interface RunAgentInput {
   base?: string;
   /** Isolation: "none" (default, node-only) | "docker" | "podman". */
   sandboxMode?: SandboxMode;
+  /**
+   * Absolute host anchor for sandcastle's `.sandcastle/` dir + git operations.
+   * AFK sets this to the attempt dir so nothing lands at the repo root
+   * (everything under .red/). Defaults to process.cwd() in sandcastle when
+   * omitted. NOTE: sandcastle resolves `promptFile` against process.cwd(), NOT
+   * against `cwd` — so `handoffPath` must stay absolute whenever this is set
+   * (AFK's attempt dir is always absolute, so the handoff path already is).
+   */
+  cwd?: string;
   idleTimeoutSeconds?: number;
   /**
    * The git remote the worker branch is continuously pushed to (issue #191).
@@ -191,6 +200,10 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
   return {
     agent: deps.agentFor(input.runner, input.model, { effort: input.effort }),
     sandbox: deps.sandboxFor(input.sandboxMode ?? "none"),
+    // Re-anchor sandcastle's `.sandcastle/` dir + git ops at the caller's cwd
+    // (AFK's per-attempt dir under .red/) so nothing is generated at the repo
+    // root. Omitted → sandcastle defaults to process.cwd().
+    ...(input.cwd ? { cwd: input.cwd } : {}),
     promptFile: input.handoffPath,
     branchStrategy,
     completionSignal: [...COMPLETION_SIGNALS],

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -442,12 +442,18 @@ export async function processIssue(
   if (deps.git.fetchBase) await deps.git.fetchBase(base);
   let activeRunner: Runner = input.runner === "codex" ? "codex" : "claude";
   let attemptN = input.attempt;
+  // Anchor sandcastle at the per-attempt dir so its `.sandcastle/` (worktrees,
+  // logs, .env, patches) + git ops land under .red/, never at the repo root.
+  // attemptDir is always absolute (built from `${root}/.red/tmp/...`), which is
+  // also why promptFile/handoffPath must stay absolute — sandcastle resolves
+  // promptFile against process.cwd(), not against this cwd.
   let run: RunAgentResult = await deps.runAgent({
     runner: activeRunner,
     model: deps.model,
     handoffPath,
     branch,
     base,
+    cwd: input.attemptDir,
     // Restore the issue #191 continuous-push guarantee: sandcastle pushes the
     // worker branch up-front + after every commit (host worktree hook), so a
     // SIGKILL mid-iteration preserves the diff on origin. Best-effort.
@@ -486,6 +492,7 @@ export async function processIssue(
       handoffPath,
       branch,
       base,
+      cwd: input.attemptDir,
       remote: input.remote,
       continuousPush: true,
     });

--- a/src/domains/dev/tests/execution.test.ts
+++ b/src/domains/dev/tests/execution.test.ts
@@ -128,6 +128,21 @@ describe("buildRunOptions", () => {
     expect(command).toContain(`git push ${DEFAULT_REMOTE} HEAD --force-with-lease`);
   });
 
+  it("re-anchors sandcastle at the caller's cwd (the AFK attempt dir) when supplied", () => {
+    const opts = buildRunOptions(
+      makeDeps(async () => fakeResult()),
+      { ...baseInput, cwd: "/abs/attempt/dir" },
+    );
+    // cwd is forwarded verbatim so sandcastle puts `.sandcastle/` under the
+    // attempt dir (.red/tmp/...), never at the repo root.
+    expect(opts.cwd).toBe("/abs/attempt/dir");
+  });
+
+  it("leaves cwd undefined when omitted (sandcastle's process.cwd() default preserved)", () => {
+    const opts = buildRunOptions(makeDeps(async () => fakeResult()), baseInput);
+    expect(opts.cwd).toBeUndefined();
+  });
+
   it("targets a custom remote when one is supplied", () => {
     const opts = buildRunOptions(
       makeDeps(async () => fakeResult()),

--- a/src/domains/dev/tests/process-issue.test.ts
+++ b/src/domains/dev/tests/process-issue.test.ts
@@ -308,6 +308,9 @@ describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", 
     expect(trace.runAgentCalls[0]?.branch).toBe("afk/wAAAA/9-fix-the-thing");
     expect(trace.runAgentCalls[0]?.handoffPath).toBe("/tmp/afk/workers/wAAAA/9-a1/handoff.md");
     expect(trace.runAgentCalls[0]?.runner).toBe("claude");
+    // cwd is anchored at the attempt dir so sandcastle's `.sandcastle/` lands
+    // under .red/ (the attempt dir), never at the repo root.
+    expect(trace.runAgentCalls[0]?.cwd).toBe("/tmp/afk/workers/wAAAA/9-a1");
 
     // claim: ready-for-agent → running ; close: remove running.
     expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+"]);
@@ -552,6 +555,9 @@ describe("processIssue — runner exhaustion → fallback swap → retry", () =>
     // both runs target the same worker branch + handoff (reused mid-issue).
     expect(trace.runAgentCalls[1]?.branch).toBe(trace.runAgentCalls[0]?.branch);
     expect(trace.runAgentCalls[1]?.handoffPath).toBe(trace.runAgentCalls[0]?.handoffPath);
+    // the fallback run re-anchors at the same attempt dir cwd.
+    expect(trace.runAgentCalls[1]?.cwd).toBe(trace.runAgentCalls[0]?.cwd);
+    expect(trace.runAgentCalls[1]?.cwd).toBe("/tmp/afk/workers/wAAAA/9-a1");
     // per-runner cadence: pre_attempt fires twice, post_attempt twice
     // (exhausted close + terminal success), bracketing pre_merge/post_merge.
     expect(result.hooksFired).toEqual([


### PR DESCRIPTION
sandcastle's .sandcastle/ (worktrees/logs/.env/patches) leaked to the repo root because RunOptions.cwd defaulted to process.cwd(). Set cwd to the per-attempt dir (.red/tmp/workers/.../, absolute, self-cleaning) so everything lands under .red/. Unit-tested wiring; runtime confirmation pending #284. 695 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782834374&installation_id=129708444&pr_number=326&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F326&signature=cfeabb39d7efeb72d39778d83dfc11602d04a5fc5881245db12721d1e1be2e79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom working directory, enabling sandbox artifacts and git operations to be anchored to a specific location instead of the system default.

* **Tests**
  * Added verification tests to ensure custom working directory handling functions correctly across all execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->