### PR TITLE
feat(afk): record reasoning attempts into memory (ADR 0017), CLI-to-CLI direct

### DIFF
--- a/plugins/dev/skills/engineering/afk/bin/afk.mjs
+++ b/plugins/dev/skills/engineering/afk/bin/afk.mjs
@@ -232,6 +232,7 @@ __export(fs_exports, {
   writeEnvelopePosted: () => writeEnvelopePosted,
   writeFailureMarkers: () => writeFailureMarkers,
   writeHandoff: () => writeHandoff,
+  writeValidationSidecar: () => writeValidationSidecar,
   writeWorkerPid: () => writeWorkerPid
 });
 import { constants as constants2 } from "node:fs";
@@ -281,6 +282,11 @@ async function removeDir(path2) {
 async function writeHandoff(path2, content) {
   await mkdir3(dirname2(path2), { recursive: true });
   await writeFile3(path2, content, "utf8");
+}
+async function writeValidationSidecar(path2, lines2) {
+  await mkdir3(dirname2(path2), { recursive: true });
+  await writeFile3(path2, lines2.length > 0 ? `${lines2.join("\n")}
+` : "", "utf8");
 }
 async function readText(path2) {
   try {
@@ -34204,7 +34210,7 @@ var init_Multipart = __esm({
       });
       return loop3;
     });
-    toPersisted = (stream6, writeFile9 = defaultWriteFile) => gen3(function* () {
+    toPersisted = (stream6, writeFile10 = defaultWriteFile) => gen3(function* () {
       const fs = yield* FileSystem;
       const path_ = yield* Path2;
       const dir = yield* fs.makeTempDirectoryScoped();
@@ -34232,7 +34238,7 @@ var init_Multipart = __esm({
         } else {
           persisted[part.key] = [filePart];
         }
-        return writeFile9(path2, file2);
+        return writeFile10(path2, file2);
       });
       return persisted;
     }).pipe(catchTags2({
@@ -39030,7 +39036,7 @@ var require_filesystem = __commonJS({
     var LDD_PATH = "/usr/bin/ldd";
     var SELF_PATH = "/proc/self/exe";
     var MAX_LENGTH = 2048;
-    var readFileSync5 = (path2) => {
+    var readFileSync6 = (path2) => {
       const fd = fs.openSync(path2, "r");
       const buffer3 = Buffer.alloc(MAX_LENGTH);
       const bytesRead = fs.readSync(fd, buffer3, 0, MAX_LENGTH, 0);
@@ -39055,7 +39061,7 @@ var require_filesystem = __commonJS({
     module.exports = {
       LDD_PATH,
       SELF_PATH,
-      readFileSync: readFileSync5,
+      readFileSync: readFileSync6,
       readFile: readFile9
     };
   }
@@ -39104,7 +39110,7 @@ var require_detect_libc = __commonJS({
     "use strict";
     var childProcess = __require("child_process");
     var { isLinux, getReport } = require_process();
-    var { LDD_PATH, SELF_PATH, readFile: readFile9, readFileSync: readFileSync5 } = require_filesystem();
+    var { LDD_PATH, SELF_PATH, readFile: readFile9, readFileSync: readFileSync6 } = require_filesystem();
     var { interpreterPath } = require_elf();
     var cachedFamilyInterpreter;
     var cachedFamilyFilesystem;
@@ -39196,7 +39202,7 @@ var require_detect_libc = __commonJS({
       }
       cachedFamilyFilesystem = null;
       try {
-        const lddContent = readFileSync5(LDD_PATH);
+        const lddContent = readFileSync6(LDD_PATH);
         cachedFamilyFilesystem = getFamilyFromLddContent(lddContent);
       } catch (e2) {
       }
@@ -39221,7 +39227,7 @@ var require_detect_libc = __commonJS({
       }
       cachedFamilyInterpreter = null;
       try {
-        const selfContent = readFileSync5(SELF_PATH);
+        const selfContent = readFileSync6(SELF_PATH);
         const path2 = interpreterPath(selfContent);
         cachedFamilyInterpreter = familyFromInterpreterPath(path2);
       } catch (e2) {
@@ -39285,7 +39291,7 @@ var require_detect_libc = __commonJS({
       }
       cachedVersionFilesystem = null;
       try {
-        const lddContent = readFileSync5(LDD_PATH);
+        const lddContent = readFileSync6(LDD_PATH);
         const versionMatch = lddContent.match(RE_GLIBC_VERSION);
         if (versionMatch) {
           cachedVersionFilesystem = versionMatch[1];
@@ -57674,7 +57680,7 @@ var require_snapshot_utils = __commonJS({
 var require_snapshot_recorder = __commonJS({
   "node_modules/.pnpm/undici@7.26.0/node_modules/undici/lib/mock/snapshot-recorder.js"(exports, module) {
     "use strict";
-    var { writeFile: writeFile9, readFile: readFile9, mkdir: mkdir7 } = __require("node:fs/promises");
+    var { writeFile: writeFile10, readFile: readFile9, mkdir: mkdir7 } = __require("node:fs/promises");
     var { dirname: dirname9, resolve: resolve6 } = __require("node:path");
     var { setTimeout: setTimeout2, clearTimeout: clearTimeout2 } = __require("node:timers");
     var { InvalidArgumentError, UndiciError } = require_errors();
@@ -57911,7 +57917,7 @@ var require_snapshot_recorder = __commonJS({
           hash: hash3,
           snapshot
         }));
-        await writeFile9(resolvedPath, JSON.stringify(data, null, 2), { flush: true });
+        await writeFile10(resolvedPath, JSON.stringify(data, null, 2), { flush: true });
       }
       /**
        * Clears all recorded snapshots
@@ -84561,6 +84567,90 @@ function formatStartedMarker(issue, ts) {
   return `[heartbeat] iteration started for #${issue} at ${ts}`;
 }
 
+// src/core/attempt-record.ts
+var KNOWN_MEMORY_STATUS = /* @__PURE__ */ new Set(["done", "blocked", "no-sentinel", "merge-conflict"]);
+function nonEmpty(s) {
+  if (s === void 0) return void 0;
+  const t = s.trim();
+  return t.length > 0 ? s : void 0;
+}
+function buildAttemptRecordPayload(ctx) {
+  const status2 = KNOWN_MEMORY_STATUS.has(ctx.outcome) ? ctx.outcome : String(ctx.outcome);
+  const payload = {
+    repository: ctx.repo,
+    issueNumber: ctx.issue,
+    attemptNumber: ctx.attempt,
+    status: status2
+  };
+  const title = nonEmpty(ctx.title);
+  if (title !== void 0) payload.issueTitle = title;
+  const url = nonEmpty(ctx.url);
+  if (url !== void 0) payload.issueUrl = url;
+  const body = nonEmpty(ctx.body);
+  if (body !== void 0) payload.issueBody = body;
+  const workerId = nonEmpty(ctx.workerId);
+  if (workerId !== void 0) payload.workerId = workerId;
+  const branch = nonEmpty(ctx.branch);
+  if (branch !== void 0) payload.branch = branch;
+  if (ctx.durationS !== void 0 && Number.isFinite(ctx.durationS) && ctx.durationS >= 0) {
+    payload.durationMs = Math.round(ctx.durationS * 1e3);
+  }
+  const diffstat2 = nonEmpty(ctx.diffstat);
+  if (diffstat2 !== void 0) payload.diffstat = diffstat2;
+  const mergeSha = nonEmpty(ctx.mergeSha);
+  if (mergeSha !== void 0) payload.mergeCommit = mergeSha;
+  const envelopeRef = nonEmpty(ctx.envelopeRef);
+  if (envelopeRef !== void 0) payload.envelopeRef = envelopeRef;
+  const notes = nonEmpty(ctx.notes);
+  if (notes !== void 0) payload.notes = notes;
+  const validationSummary = nonEmpty(ctx.validationSummary);
+  if (validationSummary !== void 0) payload.validationSummary = validationSummary;
+  return payload;
+}
+function toMemoryPayload(payload) {
+  return JSON.stringify(payload);
+}
+function joinPath(...parts2) {
+  return parts2.filter((p2) => p2.length > 0).join("/").replace(/\/+/g, "/");
+}
+function resolveMemoryCli(gitRoot, env2, probes) {
+  if (!probes.exists(joinPath(gitRoot, ".red", "memory", "config.json"))) return void 0;
+  const override = env2.RED_MEMORY_CLI;
+  if (override !== void 0 && override.length > 0) {
+    return probes.exists(override) ? ["node", override] : void 0;
+  }
+  const pathVar = env2.PATH ?? "";
+  for (const dir of pathVar.split(":")) {
+    if (dir.length === 0) continue;
+    if (probes.exists(joinPath(dir, "memory"))) return ["memory"];
+  }
+  const pluginRoot = env2.CLAUDE_PLUGIN_ROOT ?? "";
+  const repoRoot = env2.MEMORY_REPO_ROOT ?? "";
+  const readVersion = probes.readJsonVersion;
+  if (readVersion) {
+    const manifests = [];
+    if (pluginRoot.length > 0)
+      manifests.push(joinPath(pluginRoot, "..", "memory", ".claude-plugin", "plugin.json"));
+    if (repoRoot.length > 0)
+      manifests.push(joinPath(repoRoot, "plugins", "memory", ".claude-plugin", "plugin.json"));
+    const cacheBase = env2.RED_MEMORY_CACHE_DIR ?? env2.XDG_CACHE_HOME ?? joinPath(env2.HOME ?? "", ".cache");
+    for (const manifest of manifests) {
+      if (!probes.exists(manifest)) continue;
+      const version = readVersion(manifest);
+      if (!version) continue;
+      const cacheCli = joinPath(cacheBase, "reddb-memory", version, "memory-cli.mjs");
+      if (probes.exists(cacheCli)) return ["node", cacheCli];
+    }
+  }
+  const distCandidates = [];
+  if (pluginRoot.length > 0) distCandidates.push(joinPath(pluginRoot, "..", "memory", "dist", "cli.js"));
+  if (repoRoot.length > 0) distCandidates.push(joinPath(repoRoot, "plugins", "memory", "dist", "cli.js"));
+  for (const cand of distCandidates) {
+    if (probes.exists(cand)) return ["node", cand];
+  }
+  return void 0;
+}
+
 // src/core/process-issue.ts
 var LABEL_READY = "ready-for-agent";
 var LABEL_RUNNING = "running";
@@ -84753,10 +84843,11 @@ async function processIssue(deps, input) {
     now: deps.nowEpoch
   });
   if (!feedback.ok) {
+    await writeValidationSidecar2(deps, input.attemptDir, feedback.sidecar);
     return await terminalFailure(common, "feedback-failed", "feedback", {
       notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n")
-    });
+    }, { validationSummary: feedback.sidecar.join("\n") });
   }
   const locked = await deps.lookups.isLocked();
   const landing = await doLanding(
@@ -84787,7 +84878,13 @@ async function processIssue(deps, input) {
   }
   const mergeSha = await deps.git.headShortSha();
   const durationS = deps.nowEpoch() - startedEpoch;
+  await writeValidationSidecar2(deps, input.attemptDir, feedback.sidecar);
   const posted = await emitDone(common, mergeSha, durationS, feedback);
+  await recordAttemptBestEffort(common, "done", {
+    durationS,
+    mergeSha,
+    validationSummary: feedback.sidecar.join("\n")
+  });
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
   await deleteRemote(deps.remoteGit, input.repoDir, workerBranch);
@@ -84807,6 +84904,40 @@ async function processIssue(deps, input) {
     preserved: true,
     swept: true
   };
+}
+async function writeValidationSidecar2(deps, attemptDir, lines2) {
+  if (!deps.fs.writeValidationSidecar) return;
+  if (lines2.length === 0) return;
+  try {
+    await deps.fs.writeValidationSidecar(`${attemptDir}/validation.jsonl`, lines2);
+  } catch {
+  }
+}
+async function recordAttemptBestEffort(c, outcome, fields = {}) {
+  const { deps, input } = c;
+  if (!deps.recordAttempt) return;
+  try {
+    const payload = buildAttemptRecordPayload({
+      repo: input.repo,
+      issue: input.issue,
+      attempt: input.attempt,
+      outcome,
+      title: input.title,
+      body: input.body,
+      workerId: input.workerId,
+      branch: c.branch,
+      durationS: fields.durationS,
+      diffstat: void 0,
+      mergeSha: fields.mergeSha,
+      notes: fields.notes,
+      validationSummary: fields.validationSummary
+    });
+    await deps.recordAttempt(payload);
+  } catch (err) {
+    deps.appendIterLog(
+      `\u{1F916} /afk memory attempt-record for #${input.issue} failed (best-effort; ignored): ${String(err)}`
+    );
+  }
 }
 async function emitFailure(c, status2, diffLabel, sections) {
   const { deps, input } = c;
@@ -84832,10 +84963,15 @@ async function emitFailure(c, status2, diffLabel, sections) {
   });
   return result.posted;
 }
-async function terminalFailure(c, outcome, sectionKey, sections) {
+async function terminalFailure(c, outcome, sectionKey, sections, record3 = {}) {
   const { deps, input } = c;
   await routeRecovery(deps, input.issue, outcome, input.attempt);
   const posted = await emitFailure(c, envelopeStatusFor(outcome), sectionKey, sections);
+  await recordAttemptBestEffort(c, outcome, {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: record3.notes,
+    validationSummary: record3.validationSummary
+  });
   return {
     outcome,
     issue: input.issue,
@@ -84870,6 +85006,10 @@ async function mergeFailed(c, _reason, locked = false) {
   await routeRecovery(deps, input.issue, "merge-conflict", input.attempt);
   const posted = await emitFailure(c, envelopeStatusFor("merge-conflict"), "merge-conflict", {
     log: "(no merge log captured)"
+  });
+  await recordAttemptBestEffort(c, "merge-conflict", {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: _reason
   });
   await deps.claimLock.release(input.issue);
   return {
@@ -85317,7 +85457,8 @@ var defaultReader2 = {
 
 // src/commands/run.ts
 init_runner_spawn();
-import { readdirSync } from "node:fs";
+import { readdirSync, existsSync as existsSync8, readFileSync as readFileSync4 } from "node:fs";
+import { writeFile as writeFile9 } from "node:fs/promises";
 
 // src/runtime/lock.ts
 init_fs();
@@ -85615,6 +85756,9 @@ function buildProcessDeps(ctx, model, sandbox3, feedback, current, fallbackRunne
     fs: {
       ensureAttemptDir: (dir) => ensureDir(dir),
       writeHandoff: (path2, content) => writeHandoff(path2, content),
+      // $ITER_DIR/validation.jsonl — the machine-readable feedback sidecar the
+      // Memory bridge consumes (SKILL.md §Validation Sidecar).
+      writeValidationSidecar: (path2, lines2) => writeValidationSidecar(path2, lines2),
       completionSweep: (issue) => completionSweep(paths.workersRoot, issue)
     },
     git: {
@@ -85700,7 +85844,50 @@ function buildProcessDeps(ctx, model, sandbox3, feedback, current, fallbackRunne
     historyPath: paths.historyPath,
     historyClock: { ts: (/* @__PURE__ */ new Date()).toISOString(), epoch: Math.floor(Date.now() / 1e3) },
     // BOUNDED auto-recovery reads its RED_AFK_RETRY_* caps from the process env.
-    recoveryEnv: process.env
+    recoveryEnv: process.env,
+    // ADR 0017: best-effort AFK→Memory "reasoning attempt" recording. Serialise
+    // the payload to a temp JSON file under the attempt dir, then exec the memory
+    // CLI DIRECTLY (`<memoryCli> attempt record --root <root>` with the payload on
+    // stdin). The resolver gates on memory availability (ADR 0009) — a silent
+    // no-op when memory is absent / not opted-in — replacing the old shell-bridge
+    // hop. ALL errors are swallowed (one warn line), so a memory failure can
+    // NEVER fail the close.
+    recordAttempt: makeRecordAttempt(ctx.root, current, exec4)
+  };
+}
+function readManifestVersion(path2) {
+  try {
+    const v2 = JSON.parse(readFileSync4(path2, "utf8")).version;
+    return typeof v2 === "string" && v2.length > 0 ? v2 : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function makeRecordAttempt(gitRoot, current, exec4) {
+  return async (payload) => {
+    try {
+      const env2 = { ...process.env, MEMORY_REPO_ROOT: process.env.MEMORY_REPO_ROOT ?? gitRoot };
+      const memoryCli = resolveMemoryCli(gitRoot, env2, {
+        exists: existsSync8,
+        readJsonVersion: readManifestVersion
+      });
+      if (!memoryCli) return;
+      const dir = current.attemptDir || gitRoot;
+      const payloadFile = join27(dir, `memory-attempt-${payload.issueNumber}-a${payload.attemptNumber}.json`);
+      await ensureDir(dir);
+      const json4 = toMemoryPayload(payload);
+      await writeFile9(payloadFile, json4, "utf8");
+      const run8 = exec4 ?? (await Promise.resolve().then(() => (init_exec(), exec_exports))).execTool;
+      const [cmd, ...head7] = memoryCli;
+      await run8(cmd, [...head7, "attempt", "record", "--root", gitRoot], {
+        cwd: gitRoot,
+        env: env2,
+        input: json4
+      });
+    } catch (err) {
+      process.stderr.write(`[afk] memory attempt-record skipped (best-effort): ${String(err)}
+`);
+    }
   };
 }
 function nextAttemptSync(tmpDir, issue) {
@@ -85862,7 +86049,7 @@ async function reapCommand(_args, cwd = process.cwd(), stdout2 = process.stdout)
 }
 
 // src/commands/statusline.ts
-import { existsSync as existsSync8, statSync as statSync2 } from "node:fs";
+import { existsSync as existsSync9, statSync as statSync2 } from "node:fs";
 import { join as join28, basename as basename2 } from "node:path";
 
 // src/core/statusline.ts
@@ -85965,7 +86152,7 @@ function resolveRoot(rootArg, payload, fallback) {
 }
 function statuslineEnabled(root) {
   const configPath = join28(root, ".red", "config.yaml");
-  if (!existsSync8(configPath)) return true;
+  if (!existsSync9(configPath)) return true;
   const cfg = loadConfig(configPath, { warn: () => void 0 });
   if (getConfig(cfg, "statusline") === "false") return false;
   if (getConfig(cfg, "afk.statusline") === "false") return false;
@@ -86009,7 +86196,7 @@ async function statuslineCommand(args2, cwd = process.cwd(), stdout2 = process.s
 
 // src/commands/supervise.ts
 import { spawn as spawn6 } from "node:child_process";
-import { existsSync as existsSync10, openSync, writeFileSync as writeFileSync2, rmSync } from "node:fs";
+import { existsSync as existsSync11, openSync, writeFileSync as writeFileSync2, rmSync } from "node:fs";
 import { join as join30 } from "node:path";
 
 // src/core/reaper-signal.ts
@@ -86363,7 +86550,7 @@ function inspectProcessTreeNative(pid) {
 }
 
 // src/runtime/supervisor-fs.ts
-import { existsSync as existsSync9, readdirSync as readdirSync2, readFileSync as readFileSync4, statSync as statSync3 } from "node:fs";
+import { existsSync as existsSync10, readdirSync as readdirSync2, readFileSync as readFileSync5, statSync as statSync3 } from "node:fs";
 import { join as join29 } from "node:path";
 function slotLogPath(tmpDir, slot) {
   return join29(tmpDir, `afk-supervisor-slot-${slot}.log`);
@@ -86371,7 +86558,7 @@ function slotLogPath(tmpDir, slot) {
 function parseWorkerIdsFromLog(path2) {
   let text3;
   try {
-    text3 = readFileSync4(path2, "utf8");
+    text3 = readFileSync5(path2, "utf8");
   } catch {
     return [];
   }
@@ -86408,7 +86595,7 @@ function iterDirsForWorker(root, wid) {
 }
 function iterDirIssueNumber(dir) {
   try {
-    const parsed = JSON.parse(readFileSync4(join29(dir, "afk.state.json"), "utf8"));
+    const parsed = JSON.parse(readFileSync5(join29(dir, "afk.state.json"), "utf8"));
     const n = parsed.current?.number;
     return typeof n === "number" && Number.isInteger(n) ? n : null;
   } catch {
@@ -86428,7 +86615,7 @@ function findSlotIterDir(tmpDir, slotPid) {
     const wdir = join29(workersRoot, wid);
     let pidText;
     try {
-      pidText = readFileSync4(join29(wdir, "worker.pid"), "utf8").trim();
+      pidText = readFileSync5(join29(wdir, "worker.pid"), "utf8").trim();
     } catch {
       continue;
     }
@@ -86470,7 +86657,7 @@ function agentLaneMtimeFor(tmpDir, slotPid) {
 function tailFile(path2, n) {
   let text3;
   try {
-    text3 = readFileSync4(path2, "utf8");
+    text3 = readFileSync5(path2, "utf8");
   } catch {
     return "";
   }
@@ -86485,7 +86672,7 @@ function resolveIterDirInfo(tmpDir, slotPid, now) {
   let workerId = "";
   let startedAt = "";
   try {
-    const parsed = JSON.parse(readFileSync4(join29(dir, "afk.state.json"), "utf8"));
+    const parsed = JSON.parse(readFileSync5(join29(dir, "afk.state.json"), "utf8"));
     const n = parsed.current?.number;
     if (typeof n === "number" && Number.isInteger(n)) issue = n;
     if (typeof parsed.worker_id === "string") workerId = parsed.worker_id;
@@ -86518,7 +86705,7 @@ function parkedSlotWorkFor(tmpDir, root, slot, fastDeaths) {
 async function teardownIterDirNative(info, root) {
   const fsp = await import("node:fs/promises");
   const worktree = join29(info.path, "worktree");
-  if (existsSync9(worktree)) {
+  if (existsSync10(worktree)) {
     try {
       const { git: git2 } = await Promise.resolve().then(() => (init_exec(), exec_exports));
       await git2(["-C", root, "worktree", "remove", "--force", worktree]);
@@ -86691,7 +86878,7 @@ async function superviseCommand(args2, cwd = process.cwd()) {
   const stopFile = join30(tmp, "afk-supervisor.stop");
   const logFile = join30(tmp, "afk-supervisor.log");
   await Promise.resolve().then(() => (init_fs(), fs_exports)).then((m2) => m2.ensureDir(tmp));
-  if (existsSync10(pidFile)) {
+  if (existsSync11(pidFile)) {
     try {
       const prev = Number(__require("node:fs").readFileSync(pidFile, "utf8").trim());
       if (prev && isAlive(prev)) {
@@ -86703,7 +86890,7 @@ async function superviseCommand(args2, cwd = process.cwd()) {
     }
   }
   writeFileSync2(pidFile, String(process.pid), "utf8");
-  if (existsSync10(stopFile)) rmSync(stopFile, { force: true });
+  if (existsSync11(stopFile)) rmSync(stopFile, { force: true });
   const logFd = openSync(logFile, "a");
   const config = resolveSupervisorConfig();
   const state = initSupervisorState(config.target);
@@ -86711,7 +86898,7 @@ async function superviseCommand(args2, cwd = process.cwd()) {
   const ghCtx = { cwd: root, repo };
   const slotArgs = slotFilterArgs(args2);
   const deps = buildSupervisorDeps(root, tmp, logFd, config.runner, ghCtx, slotArgs);
-  const stopRequested = () => existsSync10(stopFile);
+  const stopRequested = () => existsSync11(stopFile);
   try {
     await runSupervisor(state, deps, config, stopRequested);
   } finally {

--- a/src/domains/dev/src/commands/run.ts
+++ b/src/domains/dev/src/commands/run.ts
@@ -9,6 +9,11 @@ import {
 import { genWorkerId } from "../core/session.js";
 import { runBoot, type BootDeps, type BootOptions, type BootstrapInput } from "../core/boot.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
+import {
+  toMemoryPayload,
+  resolveMemoryCli,
+  type AttemptRecordPayload,
+} from "../core/attempt-record.js";
 import { isRunner, type Runner } from "../types/runner.js";
 import {
   afkPaths,
@@ -32,7 +37,8 @@ import { loadConfig } from "../core/config.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
 import { isValidWorkerId } from "../core/worker-paths.js";
-import { readdirSync } from "node:fs";
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../core/runner-spawn.js";
 import { buildWorkerAttemptPath } from "../core/worker-paths.js";
 import { branchLockPath, readLockedBranch, isLocked } from "../runtime/lock.js";
@@ -281,6 +287,9 @@ export function buildProcessDeps(
     fs: {
       ensureAttemptDir: (dir) => fsx.ensureDir(dir),
       writeHandoff: (path, content) => fsx.writeHandoff(path, content),
+      // $ITER_DIR/validation.jsonl — the machine-readable feedback sidecar the
+      // Memory bridge consumes (SKILL.md §Validation Sidecar).
+      writeValidationSidecar: (path, lines) => fsx.writeValidationSidecar(path, lines),
       completionSweep: (issue) => fsx.completionSweep(paths.workersRoot, issue),
     },
     git: {
@@ -370,6 +379,72 @@ export function buildProcessDeps(
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },
     // BOUNDED auto-recovery reads its RED_AFK_RETRY_* caps from the process env.
     recoveryEnv: process.env,
+    // ADR 0017: best-effort AFK→Memory "reasoning attempt" recording. Serialise
+    // the payload to a temp JSON file under the attempt dir, then exec the memory
+    // CLI DIRECTLY (`<memoryCli> attempt record --root <root>` with the payload on
+    // stdin). The resolver gates on memory availability (ADR 0009) — a silent
+    // no-op when memory is absent / not opted-in — replacing the old shell-bridge
+    // hop. ALL errors are swallowed (one warn line), so a memory failure can
+    // NEVER fail the close.
+    recordAttempt: makeRecordAttempt(ctx.root, current, exec),
+  };
+}
+
+/** Read the `version` field of a JSON manifest file, or undefined when the file
+ * is missing / unparseable / has no version. The version-keyed cache-bundle
+ * candidate in {@link resolveMemoryCli} uses this to locate the fetched CLI. */
+function readManifestVersion(path: string): string | undefined {
+  try {
+    const v = (JSON.parse(readFileSync(path, "utf8")) as { version?: unknown }).version;
+    return typeof v === "string" && v.length > 0 ? v : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build the best-effort `recordAttempt` port (ADR 0017). On each call it resolves
+ * the memory CLI ({@link resolveMemoryCli}, which gates on the ADR 0009 opt-in
+ * config + the bridge's candidate order), writes the payload to a temp JSON file
+ * under the current attempt dir, and execs the memory CLI DIRECTLY:
+ * `<memoryCli> attempt record --root <gitRoot>` with the payload piped on stdin
+ * — exactly what the bridge's `memory_record_attempt` did, minus the shell hop.
+ * `MEMORY_REPO_ROOT` is set in the child env (as the bridge expected) so an
+ * in-repo memory checkout resolves. When no CLI resolves the call is a silent
+ * no-op (memory not installed). Every error (write failure, non-zero exit, spawn
+ * error) is SWALLOWED — at most one warn line is written.
+ *
+ * `exec` is the test-injection seam (mirrors the rest of buildProcessDeps); in
+ * production it is undefined and the real `execTool` is used.
+ */
+function makeRecordAttempt(
+  gitRoot: string,
+  current: CurrentAttempt,
+  exec?: ExecFn,
+): (payload: AttemptRecordPayload) => Promise<void> {
+  return async (payload: AttemptRecordPayload): Promise<void> => {
+    try {
+      const env = { ...process.env, MEMORY_REPO_ROOT: process.env.MEMORY_REPO_ROOT ?? gitRoot };
+      const memoryCli = resolveMemoryCli(gitRoot, env, {
+        exists: existsSync,
+        readJsonVersion: readManifestVersion,
+      });
+      if (!memoryCli) return; // memory not opted-in / no CLI resolves — silent skip.
+      const dir = current.attemptDir || gitRoot;
+      const payloadFile = join(dir, `memory-attempt-${payload.issueNumber}-a${payload.attemptNumber}.json`);
+      await fsx.ensureDir(dir);
+      const json = toMemoryPayload(payload);
+      await writeFile(payloadFile, json, "utf8");
+      const run = exec ?? (await import("../runtime/exec.js")).execTool;
+      const [cmd, ...head] = memoryCli;
+      await run(cmd, [...head, "attempt", "record", "--root", gitRoot], {
+        cwd: gitRoot,
+        env,
+        input: json,
+      });
+    } catch (err) {
+      process.stderr.write(`[afk] memory attempt-record skipped (best-effort): ${String(err)}\n`);
+    }
   };
 }
 

--- a/src/domains/dev/src/core/attempt-record.ts
+++ b/src/domains/dev/src/core/attempt-record.ts
@@ -1,0 +1,248 @@
+// attempt-record — the AFK→Memory "reasoning attempt" recording seam (ADR 0017).
+//
+// After AFK posts a TERMINAL Envelope it records the attempt into the Memory
+// graph, best-effort, through the existing memory bridge/CLI (ADR 0009). This
+// module owns only the PURE shape + the PURE mapping from the AFK-side attempt
+// context to the bridge payload; the IO (serialise to a temp file + exec the
+// bridge) lives behind the injected `recordAttempt` port wired in run.ts.
+//
+// The dependency is strictly one-directional (ADR 0009): `memory` hard-requires
+// `dev`; `dev` only ever soft-uses `memory`. Recording therefore degrades to a
+// silent no-op — the bridge itself gates on memory availability, and the port's
+// implementation swallows every error so a memory failure can NEVER fail the
+// AFK close.
+
+import type { ProcessOutcome } from "./process-issue.js";
+
+/**
+ * The AFK-side fields needed to build the Memory `ReasoningAttemptPayload`
+ * (src/domains/memory/src/reasoning/attempt-writer.ts). Only the fields AFK
+ * actually knows at a terminal exit are carried; optional ones are omitted when
+ * AFK has no value, so the Memory writer never receives an empty placeholder.
+ *
+ * The JSON the bridge ultimately reads matches the Memory `ReasoningAttemptPayload`
+ * key names exactly (`repository`, `issueNumber`, `attemptNumber`, …) — see
+ * {@link toMemoryPayload}.
+ */
+export interface AttemptRecordPayload {
+  /** Canonical repo identifier, e.g. `reddb-io/red-skills` (gh `owner/repo`). */
+  repository: string;
+  /** GitHub issue number this attempt belonged to. */
+  issueNumber: number;
+  /** Attempt ordinal as recorded by the orchestrator (1-based). */
+  attemptNumber: number;
+  /** Terminal AFK outcome (done / blocked / no-sentinel / merge-conflict / …). */
+  status: ProcessOutcome | string;
+  /** Issue title at the time of recording. */
+  issueTitle?: string;
+  /** Issue URL at the time of recording. */
+  issueUrl?: string;
+  /** Issue body — the Memory writer scans it for an explicit parent-PRD marker. */
+  issueBody?: string;
+  /** AFK worker / runner identifier. */
+  workerId?: string;
+  /** Worker branch the attempt ran on. */
+  branch?: string;
+  /** Wall-clock duration of the attempt, in milliseconds. */
+  durationMs?: number;
+  /** Diffstat summary string from the terminal envelope. */
+  diffstat?: string;
+  /** Merge commit SHA when the attempt landed on the base branch. */
+  mergeCommit?: string;
+  /** Reference to the terminal Envelope comment, when known. */
+  envelopeRef?: string;
+  /** Free-form notes / why summary captured by the orchestrator. */
+  notes?: string;
+  /** Aggregate validation summary (the feedback sidecar, joined). */
+  validationSummary?: string;
+}
+
+/** Terminal AFK outcomes the Memory writer recognises natively. The rest are
+ * forwarded as their string outcome (the Memory side accepts `string`). */
+const KNOWN_MEMORY_STATUS = new Set(["done", "blocked", "no-sentinel", "merge-conflict"]);
+
+/** The AFK-side context one terminal exit carries, from which the payload is
+ * built. Kept separate from {@link AttemptRecordPayload} so the call sites pass
+ * raw lifecycle values and the mapping (duration→ms, status normalisation,
+ * field omission) lives in one pure function. */
+export interface AttemptContext {
+  repo: string;
+  issue: number;
+  attempt: number;
+  outcome: ProcessOutcome | string;
+  title?: string;
+  url?: string;
+  body?: string;
+  workerId?: string;
+  branch?: string;
+  /** Attempt duration in SECONDS (the lifecycle clock unit); mapped to ms. */
+  durationS?: number;
+  diffstat?: string;
+  mergeSha?: string;
+  envelopeRef?: string;
+  notes?: string;
+  validationSummary?: string;
+}
+
+/** Drop empty/undefined string fields so the payload never carries blank values
+ * (the Memory writer treats absent and empty differently for some fields). */
+function nonEmpty(s: string | undefined): string | undefined {
+  if (s === undefined) return undefined;
+  const t = s.trim();
+  return t.length > 0 ? s : undefined;
+}
+
+/**
+ * PURE mapping: AFK terminal context → {@link AttemptRecordPayload}. Maps the
+ * outcome to the Memory status vocabulary (known outcomes pass through verbatim;
+ * any other outcome forwards as its string), converts the lifecycle's SECONDS
+ * duration to milliseconds, and OMITS every optional field AFK has no value for
+ * so the Memory writer receives only real evidence.
+ */
+export function buildAttemptRecordPayload(ctx: AttemptContext): AttemptRecordPayload {
+  const status = KNOWN_MEMORY_STATUS.has(ctx.outcome) ? ctx.outcome : String(ctx.outcome);
+  const payload: AttemptRecordPayload = {
+    repository: ctx.repo,
+    issueNumber: ctx.issue,
+    attemptNumber: ctx.attempt,
+    status,
+  };
+  const title = nonEmpty(ctx.title);
+  if (title !== undefined) payload.issueTitle = title;
+  const url = nonEmpty(ctx.url);
+  if (url !== undefined) payload.issueUrl = url;
+  const body = nonEmpty(ctx.body);
+  if (body !== undefined) payload.issueBody = body;
+  const workerId = nonEmpty(ctx.workerId);
+  if (workerId !== undefined) payload.workerId = workerId;
+  const branch = nonEmpty(ctx.branch);
+  if (branch !== undefined) payload.branch = branch;
+  if (ctx.durationS !== undefined && Number.isFinite(ctx.durationS) && ctx.durationS >= 0) {
+    payload.durationMs = Math.round(ctx.durationS * 1000);
+  }
+  const diffstat = nonEmpty(ctx.diffstat);
+  if (diffstat !== undefined) payload.diffstat = diffstat;
+  const mergeSha = nonEmpty(ctx.mergeSha);
+  if (mergeSha !== undefined) payload.mergeCommit = mergeSha;
+  const envelopeRef = nonEmpty(ctx.envelopeRef);
+  if (envelopeRef !== undefined) payload.envelopeRef = envelopeRef;
+  const notes = nonEmpty(ctx.notes);
+  if (notes !== undefined) payload.notes = notes;
+  const validationSummary = nonEmpty(ctx.validationSummary);
+  if (validationSummary !== undefined) payload.validationSummary = validationSummary;
+  return payload;
+}
+
+/**
+ * Serialise an {@link AttemptRecordPayload} to the exact JSON object the Memory
+ * `attempt` CLI / `ReasoningAttemptPayload` reads. The key names already match
+ * one-to-one, so this is just a stable JSON.stringify — kept as a named function
+ * so the wire format has a single owner and the temp-file write reads clearly.
+ */
+export function toMemoryPayload(payload: AttemptRecordPayload): string {
+  return JSON.stringify(payload);
+}
+
+/**
+ * Injected filesystem/PATH probes so {@link resolveMemoryCli} stays pure and
+ * fully testable. `exists` mirrors `[[ -f path ]]` / a PATH-bin lookup;
+ * `readJsonVersion` mirrors the bridge's `node -e require(manifest).version`
+ * read used by the dynamic-fetch cache candidate (undefined when the manifest is
+ * absent or has no version).
+ */
+export interface MemoryCliProbes {
+  /** True iff a regular file exists at `path` (mirrors bash `[[ -f path ]]`). */
+  exists: (path: string) => boolean;
+  /** The `version` field of the JSON manifest at `path`, or undefined. */
+  readJsonVersion?: (path: string) => string | undefined;
+}
+
+/** POSIX-style path join that does not depend on node:path, so the resolver is
+ * a pure function over its inputs (the only IO is the injected probes). */
+function joinPath(...parts: string[]): string {
+  return parts
+    .filter((p) => p.length > 0)
+    .join("/")
+    .replace(/\/+/g, "/");
+}
+
+/**
+ * Resolve the memory-CLI invocation as a command+args array, replicating the
+ * `plugins/dev/scripts/memory-bridge.sh` gating (`memory_available` →
+ * `memory_record_attempt`) and its `_memory_resolve_cli` candidate ORDER so the
+ * native dev-CLI record-attempt path no longer shells out to the bridge.
+ *
+ * Returns `undefined` (→ silent no-op, memory not installed/opted-in) when:
+ *   - Gate 1: `<gitRoot>/.red/memory/config.json` is absent (ADR 0009 opt-in), or
+ *   - Gate 2: no usable CLI resolves through the candidate chain.
+ *
+ * Candidate order (faithful to `_memory_resolve_cli`):
+ *   1. `RED_MEMORY_CLI` (absolute path to a built cli.js) → `["node", $RED_MEMORY_CLI]`.
+ *      When set but the file is absent, resolution STOPS (undefined) — the host
+ *      pinned an exact binary and a fallback would be wrong (bridge `return 1`).
+ *   2. a `memory` bin on PATH → `["memory"]`.
+ *   3. dynamic-fetch cache bundle: for each memory plugin manifest
+ *      (`${CLAUDE_PLUGIN_ROOT}/../memory/.claude-plugin/plugin.json`,
+ *      `${MEMORY_REPO_ROOT}/plugins/memory/.claude-plugin/plugin.json`), read its
+ *      version and use `<cacheRoot>/<version>/memory-cli.mjs` when present, where
+ *      cacheRoot = `<RED_MEMORY_CACHE_DIR | XDG_CACHE_HOME | $HOME/.cache>/reddb-memory`
+ *      → `["node", <cache-cli>]`.
+ *   4&5. built dist of a sibling/in-repo memory plugin:
+ *      `${CLAUDE_PLUGIN_ROOT}/../memory/dist/cli.js`,
+ *      `${MEMORY_REPO_ROOT}/plugins/memory/dist/cli.js` → `["node", <dist-cli>]`
+ *      (each candidate skipped when its env var is empty, mirroring the bridge's
+ *      guard against a bare `/../memory/dist/cli.js`).
+ */
+export function resolveMemoryCli(
+  gitRoot: string,
+  env: NodeJS.ProcessEnv,
+  probes: MemoryCliProbes,
+): string[] | undefined {
+  // Gate 1 (ADR 0009 opt-in): memory must be configured for this root.
+  if (!probes.exists(joinPath(gitRoot, ".red", "memory", "config.json"))) return undefined;
+
+  // 1. Explicit override.
+  const override = env.RED_MEMORY_CLI;
+  if (override !== undefined && override.length > 0) {
+    return probes.exists(override) ? ["node", override] : undefined;
+  }
+
+  // 2. A `memory` bin on PATH.
+  const pathVar = env.PATH ?? "";
+  for (const dir of pathVar.split(":")) {
+    if (dir.length === 0) continue;
+    if (probes.exists(joinPath(dir, "memory"))) return ["memory"];
+  }
+
+  const pluginRoot = env.CLAUDE_PLUGIN_ROOT ?? "";
+  const repoRoot = env.MEMORY_REPO_ROOT ?? "";
+
+  // 3. Dynamic-fetch cache bundle, version-keyed off the memory plugin manifest.
+  const readVersion = probes.readJsonVersion;
+  if (readVersion) {
+    const manifests: string[] = [];
+    if (pluginRoot.length > 0)
+      manifests.push(joinPath(pluginRoot, "..", "memory", ".claude-plugin", "plugin.json"));
+    if (repoRoot.length > 0)
+      manifests.push(joinPath(repoRoot, "plugins", "memory", ".claude-plugin", "plugin.json"));
+    const cacheBase =
+      env.RED_MEMORY_CACHE_DIR ?? env.XDG_CACHE_HOME ?? joinPath(env.HOME ?? "", ".cache");
+    for (const manifest of manifests) {
+      if (!probes.exists(manifest)) continue;
+      const version = readVersion(manifest);
+      if (!version) continue;
+      const cacheCli = joinPath(cacheBase, "reddb-memory", version, "memory-cli.mjs");
+      if (probes.exists(cacheCli)) return ["node", cacheCli];
+    }
+  }
+
+  // 4 & 5. Built dist of a sibling / in-repo memory plugin.
+  const distCandidates: string[] = [];
+  if (pluginRoot.length > 0) distCandidates.push(joinPath(pluginRoot, "..", "memory", "dist", "cli.js"));
+  if (repoRoot.length > 0) distCandidates.push(joinPath(repoRoot, "plugins", "memory", "dist", "cli.js"));
+  for (const cand of distCandidates) {
+    if (probes.exists(cand)) return ["node", cand];
+  }
+
+  return undefined;
+}

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -56,6 +56,7 @@ import {
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
+import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
 import type { ConfigValues } from "./config.js";
 import type { AttemptStatus } from "./envelope.js";
 import type { Runner } from "../types/runner.js";
@@ -102,6 +103,15 @@ export interface ProcessFs {
   ensureAttemptDir(dir: string): Promise<void>;
   /** Write the handoff.md into the attempt dir (the sandcastle promptFile). */
   writeHandoff(path: string, content: string): Promise<void>;
+  /**
+   * Write the machine-readable validation sidecar (`$ITER_DIR/validation.jsonl`,
+   * SKILL.md §Validation Sidecar) — one `red.afk.validation.v1` JSON record per
+   * line. Consumed by the optional Memory bridge; NOT rendered into the issue
+   * comment. Best-effort: the caller swallows a write failure so it never fails
+   * the close. Optional so older callers/tests that predate the sidecar degrade
+   * to "do not write it".
+   */
+  writeValidationSidecar?(path: string, lines: string[]): Promise<void>;
   /** Remove every attempt dir for a completed issue (completion_sweep_issue). */
   completionSweep(issue: number): Promise<string[]>;
 }
@@ -220,6 +230,17 @@ export interface ProcessIssueDeps {
    * cap).
    */
   recoveryEnv?: RecoveryEnv;
+  /**
+   * AFK→Memory "reasoning attempt" recording (ADR 0017). Called best-effort
+   * AFTER each terminal Envelope is emitted, with the AFK-side attempt context.
+   * The wired implementation (run.ts) serialises the payload to a temp file and
+   * execs the memory CLI DIRECTLY (`attempt record --root <root>` with the
+   * payload on stdin), gating on memory availability (ADR 0009) — a no-op when
+   * memory is absent / not opted-in. The port
+   * SWALLOWS every error so a memory failure can NEVER fail the AFK close.
+   * Optional so tests/older callers omit it entirely (the call is `?.`-guarded).
+   */
+  recordAttempt?(payload: AttemptRecordPayload): Promise<void>;
 }
 
 /** Static per-issue inputs the caller resolves before `processIssue`. */
@@ -598,10 +619,13 @@ export async function processIssue(
     now: deps.nowEpoch,
   });
   if (!feedback.ok) {
+    // The feedback-failed path also has a structured sidecar — persist it for
+    // Memory (best-effort) just like the done path does.
+    await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
     return await terminalFailure(common, "feedback-failed", "feedback", {
       notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n"),
-    });
+    }, { validationSummary: feedback.sidecar.join("\n") });
   }
 
   // ---- 6. push the worker branch, integrate, then land per lock state ----
@@ -641,7 +665,17 @@ export async function processIssue(
   // ---- 7. close: envelope(done) → gh close + remove running → delete remote ----
   const mergeSha = await deps.git.headShortSha();
   const durationS = deps.nowEpoch() - startedEpoch;
+  // Write the machine-readable validation sidecar ($ITER_DIR/validation.jsonl,
+  // SKILL.md) the Memory bridge consumes. Best-effort: never fails the close.
+  await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
   const posted = await emitDone(common, mergeSha, durationS, feedback);
+  // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
+  // (done) envelope. Best-effort, gated, no-op when memory is absent.
+  await recordAttemptBestEffort(common, "done", {
+    durationS,
+    mergeSha,
+    validationSummary: feedback.sidecar.join("\n"),
+  });
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
   await deleteRemote(deps.remoteGit, input.repoDir, workerBranch);
@@ -671,6 +705,71 @@ export async function processIssue(
     preserved: true,
     swept: true,
   };
+}
+
+// ---------- validation sidecar ($ITER_DIR/validation.jsonl) ----------
+
+/**
+ * Write the machine-readable validation sidecar (`$ITER_DIR/validation.jsonl`,
+ * SKILL.md §Validation Sidecar) — one `red.afk.validation.v1` record per line.
+ * The native path BUILDS these records (`feedback.sidecar`) but never wrote them
+ * to disk; this restores that write. ENTIRELY best-effort: the port is optional
+ * (older callers/tests skip it), an empty sidecar writes nothing, and ANY throw
+ * is swallowed so the sidecar write can never fail the close.
+ */
+async function writeValidationSidecar(
+  deps: ProcessIssueDeps,
+  attemptDir: string,
+  lines: string[],
+): Promise<void> {
+  if (!deps.fs.writeValidationSidecar) return;
+  if (lines.length === 0) return;
+  try {
+    await deps.fs.writeValidationSidecar(`${attemptDir}/validation.jsonl`, lines);
+  } catch {
+    // best-effort: the sidecar is an optimisation for Memory; never fail close.
+  }
+}
+
+// ---------- AFK→Memory reasoning-attempt recording (ADR 0017) ----------
+
+/**
+ * Fire the best-effort Memory "reasoning attempt" recording (ADR 0017) AFTER a
+ * terminal envelope was emitted. Builds the payload from the AFK-side context
+ * and hands it to the injected `recordAttempt` port. ENTIRELY best-effort and
+ * defensive: when the port is absent it is a no-op, and ANY throw from the port
+ * is swallowed (logged once to the iteration log) so a memory failure can never
+ * fail the close. ADR 0009: dev only soft-uses memory.
+ */
+async function recordAttemptBestEffort(
+  c: StageCommon,
+  outcome: ProcessOutcome,
+  fields: { durationS?: number; mergeSha?: string; notes?: string; validationSummary?: string } = {},
+): Promise<void> {
+  const { deps, input } = c;
+  if (!deps.recordAttempt) return;
+  try {
+    const payload = buildAttemptRecordPayload({
+      repo: input.repo,
+      issue: input.issue,
+      attempt: input.attempt,
+      outcome,
+      title: input.title,
+      body: input.body,
+      workerId: input.workerId,
+      branch: c.branch,
+      durationS: fields.durationS,
+      diffstat: undefined,
+      mergeSha: fields.mergeSha,
+      notes: fields.notes,
+      validationSummary: fields.validationSummary,
+    });
+    await deps.recordAttempt(payload);
+  } catch (err) {
+    deps.appendIterLog(
+      `🤖 /afk memory attempt-record for #${input.issue} failed (best-effort; ignored): ${String(err)}`,
+    );
+  }
 }
 
 // ---------- shared per-stage context ----------
@@ -733,10 +832,18 @@ async function terminalFailure(
   outcome: ProcessOutcome,
   sectionKey: string,
   sections: SectionBodies,
+  record: { notes?: string; validationSummary?: string } = {},
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   await routeRecovery(deps, input.issue, outcome, input.attempt);
   const posted = await emitFailure(c, envelopeStatusFor(outcome), sectionKey, sections);
+  // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
+  // (failure) envelope. Best-effort, gated, no-op when memory is absent.
+  await recordAttemptBestEffort(c, outcome, {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: record.notes,
+    validationSummary: record.validationSummary,
+  });
   return {
     outcome,
     issue: input.issue,
@@ -781,6 +888,12 @@ async function mergeFailed(c: StageCommon, _reason: string, locked = false): Pro
   await routeRecovery(deps, input.issue, "merge-conflict", input.attempt);
   const posted = await emitFailure(c, envelopeStatusFor("merge-conflict"), "merge-conflict", {
     log: "(no merge log captured)",
+  });
+  // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
+  // (merge-conflict) envelope. Best-effort, gated, no-op when memory is absent.
+  await recordAttemptBestEffort(c, "merge-conflict", {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: _reason,
   });
   await deps.claimLock.release(input.issue);
   return {

--- a/src/domains/dev/src/runtime/fs.ts
+++ b/src/domains/dev/src/runtime/fs.ts
@@ -62,6 +62,17 @@ export async function writeHandoff(path: string, content: string): Promise<void>
   await writeFile(path, content, "utf8");
 }
 
+/**
+ * Write the machine-readable validation sidecar `$ITER_DIR/validation.jsonl`
+ * (SKILL.md §Validation Sidecar) — one `red.afk.validation.v1` JSON record per
+ * line, newline-terminated. Consumed by the optional Memory bridge; not rendered
+ * into the issue comment. Creates the parent dir.
+ */
+export async function writeValidationSidecar(path: string, lines: string[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, lines.length > 0 ? `${lines.join("\n")}\n` : "", "utf8");
+}
+
 export async function readText(path: string): Promise<string | null> {
   try {
     return await readFile(path, "utf8");

--- a/src/domains/dev/tests/attempt-record.test.ts
+++ b/src/domains/dev/tests/attempt-record.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAttemptRecordPayload,
+  toMemoryPayload,
+  resolveMemoryCli,
+  type AttemptContext,
+  type MemoryCliProbes,
+} from "../src/core/attempt-record.js";
+
+const ROOT = "/repo";
+const CONFIG = "/repo/.red/memory/config.json";
+
+/** Build an exists-probe over an explicit allow-set of existing paths. */
+function existsOver(present: Iterable<string>): (p: string) => boolean {
+  const set = new Set(present);
+  return (p) => set.has(p);
+}
+
+/** Probes that say only the opt-in config exists (and optionally more). */
+function probes(present: Iterable<string>, version?: string): MemoryCliProbes {
+  return {
+    exists: existsOver(present),
+    readJsonVersion: version ? () => version : () => undefined,
+  };
+}
+
+const base: AttemptContext = {
+  repo: "reddb-io/red-skills",
+  issue: 42,
+  attempt: 2,
+  outcome: "done",
+};
+
+describe("buildAttemptRecordPayload — identity + status mapping", () => {
+  it("maps the required identity fields verbatim", () => {
+    const p = buildAttemptRecordPayload(base);
+    expect(p.repository).toBe("reddb-io/red-skills");
+    expect(p.issueNumber).toBe(42);
+    expect(p.attemptNumber).toBe(2);
+    expect(p.status).toBe("done");
+  });
+
+  it.each(["done", "blocked", "no-sentinel", "merge-conflict"] as const)(
+    "passes the known terminal status %s through verbatim",
+    (outcome) => {
+      expect(buildAttemptRecordPayload({ ...base, outcome }).status).toBe(outcome);
+    },
+  );
+
+  it("forwards an unknown outcome as its string status", () => {
+    expect(buildAttemptRecordPayload({ ...base, outcome: "exhausted" }).status).toBe("exhausted");
+  });
+});
+
+describe("buildAttemptRecordPayload — optional-field omission", () => {
+  it("omits every optional field AFK has no value for", () => {
+    const p = buildAttemptRecordPayload(base);
+    expect(p).toEqual({
+      repository: "reddb-io/red-skills",
+      issueNumber: 42,
+      attemptNumber: 2,
+      status: "done",
+    });
+    expect("issueTitle" in p).toBe(false);
+    expect("branch" in p).toBe(false);
+    expect("durationMs" in p).toBe(false);
+    expect("mergeCommit" in p).toBe(false);
+    expect("validationSummary" in p).toBe(false);
+  });
+
+  it("drops empty / whitespace-only strings instead of carrying blanks", () => {
+    const p = buildAttemptRecordPayload({
+      ...base,
+      title: "   ",
+      branch: "",
+      notes: "",
+      validationSummary: "  ",
+    });
+    expect("issueTitle" in p).toBe(false);
+    expect("branch" in p).toBe(false);
+    expect("notes" in p).toBe(false);
+    expect("validationSummary" in p).toBe(false);
+  });
+
+  it("carries every field present, mapping seconds → milliseconds", () => {
+    const p = buildAttemptRecordPayload({
+      ...base,
+      title: "Wire the memory bridge",
+      url: "https://github.com/reddb-io/red-skills/issues/42",
+      body: "## brief\nprd: #7",
+      workerId: "wABCD",
+      branch: "afk/wABCD/42-wire-the-memory-bridge",
+      durationS: 12,
+      diffstat: "+10 -2 files=3",
+      mergeSha: "deadbee",
+      envelopeRef: "https://github.com/o/r/issues/42#issuecomment-1",
+      notes: "landed clean",
+      validationSummary: "tests pass",
+    });
+    expect(p.issueTitle).toBe("Wire the memory bridge");
+    expect(p.issueUrl).toBe("https://github.com/reddb-io/red-skills/issues/42");
+    expect(p.issueBody).toContain("prd: #7");
+    expect(p.workerId).toBe("wABCD");
+    expect(p.branch).toBe("afk/wABCD/42-wire-the-memory-bridge");
+    expect(p.durationMs).toBe(12_000);
+    expect(p.diffstat).toBe("+10 -2 files=3");
+    expect(p.mergeCommit).toBe("deadbee");
+    expect(p.envelopeRef).toBe("https://github.com/o/r/issues/42#issuecomment-1");
+    expect(p.notes).toBe("landed clean");
+    expect(p.validationSummary).toBe("tests pass");
+  });
+
+  it("drops a negative / non-finite duration rather than emitting a bad durationMs", () => {
+    expect("durationMs" in buildAttemptRecordPayload({ ...base, durationS: -1 })).toBe(false);
+    expect("durationMs" in buildAttemptRecordPayload({ ...base, durationS: Number.NaN })).toBe(false);
+    expect(buildAttemptRecordPayload({ ...base, durationS: 0 }).durationMs).toBe(0);
+  });
+});
+
+describe("resolveMemoryCli — gating + candidate order (mirrors memory-bridge.sh)", () => {
+  it("Gate 1: returns undefined when the opt-in config.json is absent", () => {
+    // RED_MEMORY_CLI is present + its file exists, but no config → still undefined.
+    const env = { RED_MEMORY_CLI: "/abs/cli.js" } as NodeJS.ProcessEnv;
+    expect(resolveMemoryCli(ROOT, env, probes(["/abs/cli.js"]))).toBeUndefined();
+  });
+
+  it("honours RED_MEMORY_CLI when the config exists and the file exists", () => {
+    const env = { RED_MEMORY_CLI: "/abs/cli.js" } as NodeJS.ProcessEnv;
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG, "/abs/cli.js"]))).toEqual(["node", "/abs/cli.js"]);
+  });
+
+  it("RED_MEMORY_CLI set but missing STOPS resolution (undefined, no fallback)", () => {
+    // A `memory` bin also exists on PATH, but the pinned override wins → undefined.
+    const env = { RED_MEMORY_CLI: "/abs/cli.js", PATH: "/usr/bin" } as NodeJS.ProcessEnv;
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG, "/usr/bin/memory"]))).toBeUndefined();
+  });
+
+  it("falls through to a `memory` bin on PATH when no override is set", () => {
+    const env = { PATH: "/x:/usr/bin:/y" } as NodeJS.ProcessEnv;
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG, "/usr/bin/memory"]))).toEqual(["memory"]);
+  });
+
+  it("falls through to the dynamic-fetch cache bundle (version-keyed)", () => {
+    const env = {
+      CLAUDE_PLUGIN_ROOT: "/plugins/dev",
+      RED_MEMORY_CACHE_DIR: "/cache",
+    } as NodeJS.ProcessEnv;
+    const manifest = "/plugins/dev/../memory/.claude-plugin/plugin.json";
+    const cacheCli = "/cache/reddb-memory/9.9.9/memory-cli.mjs";
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG, manifest, cacheCli], "9.9.9"))).toEqual([
+      "node",
+      cacheCli,
+    ]);
+  });
+
+  it("falls through to the sibling plugin dist (CLAUDE_PLUGIN_ROOT)", () => {
+    const env = { CLAUDE_PLUGIN_ROOT: "/plugins/dev" } as NodeJS.ProcessEnv;
+    const dist = "/plugins/dev/../memory/dist/cli.js";
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG, dist]))).toEqual(["node", dist]);
+  });
+
+  it("falls through to the in-repo plugin dist (MEMORY_REPO_ROOT)", () => {
+    const env = { MEMORY_REPO_ROOT: "/repo" } as NodeJS.ProcessEnv;
+    const dist = "/repo/plugins/memory/dist/cli.js";
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG, dist]))).toEqual(["node", dist]);
+  });
+
+  it("Gate 2: returns undefined when nothing in the candidate chain resolves", () => {
+    const env = {
+      PATH: "/usr/bin",
+      CLAUDE_PLUGIN_ROOT: "/plugins/dev",
+      MEMORY_REPO_ROOT: "/repo",
+    } as NodeJS.ProcessEnv;
+    // Only the config exists; no bin, no cache, no dist → undefined.
+    expect(resolveMemoryCli(ROOT, env, probes([CONFIG]))).toBeUndefined();
+  });
+});
+
+describe("toMemoryPayload — wire format", () => {
+  it("serialises to a JSON object whose keys match ReasoningAttemptPayload", () => {
+    const json = toMemoryPayload(buildAttemptRecordPayload({ ...base, mergeSha: "abc1234" }));
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    expect(parsed.repository).toBe("reddb-io/red-skills");
+    expect(parsed.issueNumber).toBe(42);
+    expect(parsed.attemptNumber).toBe(2);
+    expect(parsed.status).toBe("done");
+    expect(parsed.mergeCommit).toBe("abc1234");
+  });
+});

--- a/src/domains/dev/tests/process-issue.test.ts
+++ b/src/domains/dev/tests/process-issue.test.ts
@@ -7,6 +7,7 @@ import {
 import type { HookName } from "../src/core/hook-config.js";
 import type { ConfigValues } from "../src/core/config.js";
 import type { RunAgentInput, RunAgentResult } from "../src/core/execution.js";
+import type { AttemptRecordPayload } from "../src/core/attempt-record.js";
 
 // Everything injected is a fake — no real gh / git / sandcastle / pnpm / fs ever
 // runs. The harness records the side-effect sequence (label edits, comments,
@@ -29,6 +30,10 @@ interface Trace {
   listByLabelCalls: string[];
   /** Typed `blocked:<reason>` labels created on the fly via gh.ensureLabel. */
   ensuredLabels: string[];
+  /** validation.jsonl writes: (path, lines) per write. */
+  sidecarWrites: Array<{ path: string; lines: string[] }>;
+  /** Memory reasoning-attempt records fired after a terminal envelope. */
+  recordedAttempts: AttemptRecordPayload[];
 }
 
 interface HarnessOptions {
@@ -70,6 +75,13 @@ interface HarnessOptions {
   attempt?: number;
   /** Env view the recovery policy reads RED_AFK_RETRY_* caps from. Defaults to {}. */
   recoveryEnv?: Record<string, string>;
+  /** When set, register the ADR 0017 `recordAttempt` port. "throw" makes it
+   * reject (proving a memory failure never fails the close); "ok" records the
+   * payload; undefined omits the port entirely (older-caller safety). */
+  recordAttempt?: "ok" | "throw";
+  /** When false, omit the optional fs.writeValidationSidecar port (older-caller
+   * safety). Defaults to true (port present + recorded). */
+  withSidecarPort?: boolean;
 }
 
 function harness(opts: HarnessOptions = {}): {
@@ -89,6 +101,8 @@ function harness(opts: HarnessOptions = {}): {
     runAgentCalls: [],
     listByLabelCalls: [],
     ensuredLabels: [],
+    sidecarWrites: [],
+    recordedAttempts: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -134,6 +148,14 @@ function harness(opts: HarnessOptions = {}): {
     fs: {
       async ensureAttemptDir() {},
       async writeHandoff() {},
+      // Optional sidecar port: present unless the test opts it out (older-caller
+      // safety). Records every (path, lines) write for assertion.
+      writeValidationSidecar:
+        opts.withSidecarPort === false
+          ? undefined
+          : async (path, lines) => {
+              trace.sidecarWrites.push({ path, lines });
+            },
       async completionSweep(issue) {
         trace.swept.push(issue);
         return [`/tmp/workers/w/${issue}-a1`];
@@ -275,6 +297,15 @@ function harness(opts: HarnessOptions = {}): {
     nowIso: () => "2026-05-30T00:00:00Z",
     appendIterLog: () => {},
     recoveryEnv: opts.recoveryEnv ?? {},
+    // ADR 0017 recording port: omitted by default (older-caller safety). "ok"
+    // records the payload; "throw" rejects, proving a memory failure never
+    // fails the close.
+    recordAttempt: opts.recordAttempt
+      ? async (payload) => {
+          if (opts.recordAttempt === "throw") throw new Error("memory exploded");
+          trace.recordedAttempts.push(payload);
+        }
+      : undefined,
   };
 
   // Wire the hook config + abort marker so dispatchHooks has a command to run.
@@ -945,5 +976,126 @@ describe("close cascade (event-driven auto-unblock)", () => {
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("blocked");
     expect(trace.listByLabelCalls).toEqual([]);
+  });
+});
+
+// ---------- ADR 0017: validation.jsonl sidecar + AFK→Memory recording ----------
+
+describe("processIssue — validation.jsonl sidecar (SKILL.md §Validation Sidecar)", () => {
+  it("writes the feedback sidecar to <attemptDir>/validation.jsonl on the DONE close", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.sidecarWrites).toHaveLength(1);
+    const write = trace.sidecarWrites[0]!;
+    expect(write.path).toBe(`${input.attemptDir}/validation.jsonl`);
+    expect(write.lines.length).toBeGreaterThan(0);
+    // Each line is a red.afk.validation.v1 JSON record.
+    for (const line of write.lines) {
+      expect(JSON.parse(line).schema).toBe("red.afk.validation.v1");
+    }
+  });
+
+  it("writes the sidecar on the feedback-FAILED close too", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: false });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.sidecarWrites).toHaveLength(1);
+    expect(trace.sidecarWrites[0]!.path).toBe(`${input.attemptDir}/validation.jsonl`);
+    expect(trace.sidecarWrites[0]!.lines.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT write a sidecar on a path with no feedback result (BLOCKED)", async () => {
+    const { deps, input, trace } = harness({ outcome: "blocked" });
+    await processIssue(deps, input);
+    expect(trace.sidecarWrites).toEqual([]);
+  });
+
+  it("is a no-op (and the close still succeeds) when the sidecar port is absent", async () => {
+    const { deps, input } = harness({ outcome: "done", feedbackOk: true, withSidecarPort: false });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(result.envelopePosted).toBe(true);
+  });
+});
+
+describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)", () => {
+  it("records the attempt AFTER the DONE envelope with the mapped payload", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, recordAttempt: "ok" });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.recordedAttempts).toHaveLength(1);
+    const p = trace.recordedAttempts[0]!;
+    expect(p.repository).toBe("o/r");
+    expect(p.issueNumber).toBe(9);
+    expect(p.attemptNumber).toBe(1);
+    expect(p.status).toBe("done");
+    expect(p.issueTitle).toBe("Fix the thing");
+    expect(p.branch).toBe("afk/wAAAA/9-fix-the-thing");
+    expect(p.mergeCommit).toBe("abc1234");
+    expect(p.workerId).toBe("wAAAA");
+    expect(p.validationSummary).toBeTruthy();
+  });
+
+  it("records the attempt on a terminal FAILURE (blocked) with the failure status", async () => {
+    const { deps, input, trace } = harness({ outcome: "blocked", recordAttempt: "ok" });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("blocked");
+    expect(trace.recordedAttempts).toHaveLength(1);
+    expect(trace.recordedAttempts[0]!.status).toBe("blocked");
+  });
+
+  it("records the attempt on the merge-conflict path", async () => {
+    // A locked merge --no-ff conflict with no resolver → merge-conflict terminal.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: true,
+      mergeNoFfCode: 1,
+      recordAttempt: "ok",
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("merge-conflict");
+    expect(trace.recordedAttempts).toHaveLength(1);
+    expect(trace.recordedAttempts[0]!.status).toBe("merge-conflict");
+  });
+
+  // THE key ADR 0017 guarantee: a memory failure never fails the close.
+  it("completes the DONE close normally when recordAttempt is UNDEFINED", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true });
+    // No recordAttempt opt → the port is undefined.
+    expect(deps.recordAttempt).toBeUndefined();
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(result.envelopePosted).toBe(true);
+    expect(result.swept).toBe(true);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.recordedAttempts).toEqual([]);
+  });
+
+  it("completes the DONE close normally when recordAttempt THROWS", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, recordAttempt: "throw" });
+    const result = await processIssue(deps, input);
+
+    // The envelope + close + sweep are unaffected by the memory failure.
+    expect(result.outcome).toBe("done");
+    expect(result.envelopePosted).toBe(true);
+    expect(result.swept).toBe(true);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.postedEnvelopes).toContainEqual({ issue: 9, status: "done" });
+  });
+
+  it("completes a FAILURE close normally when recordAttempt THROWS", async () => {
+    const { deps, input } = harness({ outcome: "blocked", recordAttempt: "throw" });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("blocked");
+    expect(result.envelopePosted).toBe(true);
+    expect(result.preserved).toBe(true);
   });
 });


### PR DESCRIPTION
Restores the AFK→memory reasoning-attempt recording (ADR 0017) dropped in the port. Writes validation.jsonl + records an attempt node after each terminal envelope, best-effort/gated. The dev CLI calls the memory CLI DIRECTLY (no bash→memory-bridge.sh hop) — the two domain CLIs talk CLI-to-CLI; the .sh stays only for the agent-skill recall. 757 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782862385&installation_id=129708444&pr_number=330&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F330&signature=e845b2f764e80ba823cb7de11a4c03f78947476754ec37cc0796cdc42ea3a9ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic recording of reasoning attempts with outcome tracking and duration metrics
  * Introduced validation sidecar support to capture and persist validation results
  * Enhanced failure diagnostics with comprehensive attempt documentation across all terminal states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->