### PR TITLE
fix(afk): restore Task Mirror via monitor --mirror-plan

### DIFF
--- a/plugins/dev/skills/engineering/afk/bin/afk.mjs
+++ b/plugins/dev/skills/engineering/afk/bin/afk.mjs
@@ -82979,8 +82979,151 @@ async function collectPrecheckFacts(ctx) {
   };
 }
 
+// src/core/mirror.ts
+function mirrorKey(worker_id, issue) {
+  return `${worker_id}:${issue}`;
+}
+function mirrorReconcile(desired, tracked) {
+  const trackedMap = /* @__PURE__ */ new Map();
+  for (const t of tracked) trackedMap.set(t.key, t);
+  const desiredKeys = new Set(desired.map((w3) => mirrorKey(w3.worker_id, w3.issue)));
+  const ops = [];
+  for (const w3 of desired) {
+    const key = mirrorKey(w3.worker_id, w3.issue);
+    const cur = trackedMap.get(key);
+    if (w3.status === "running") {
+      if (cur === void 0) {
+        ops.push({
+          op: "create",
+          key,
+          worker_id: w3.worker_id,
+          issue: w3.issue,
+          title: w3.title,
+          stage: w3.stage,
+          status: "running"
+        });
+      } else if (cur.stage !== w3.stage) {
+        ops.push({
+          op: "update",
+          key,
+          worker_id: w3.worker_id,
+          issue: w3.issue,
+          title: w3.title,
+          stage: w3.stage,
+          status: "running"
+        });
+      }
+    } else if (cur !== void 0) {
+      ops.push({
+        op: "complete",
+        key,
+        worker_id: w3.worker_id,
+        issue: w3.issue,
+        result: w3.status === "blocked" ? "failed" : "completed"
+      });
+    }
+  }
+  for (const t of tracked) {
+    if (!desiredKeys.has(t.key)) {
+      ops.push({ op: "complete", key: t.key, result: "completed" });
+    }
+  }
+  return ops;
+}
+function mirrorPlan(desired, tracked) {
+  const calls = [];
+  for (const op of mirrorReconcile(desired, tracked)) {
+    if (op.op === "create") {
+      calls.push({
+        call: "TaskCreate",
+        key: op.key,
+        title: `#${op.issue} ${op.worker_id} \u2014 ${op.title}`,
+        description: `stage: ${op.stage}`,
+        state: "in_progress"
+      });
+    } else if (op.op === "update") {
+      calls.push({
+        call: "TaskUpdate",
+        key: op.key,
+        description: `stage: ${op.stage}`,
+        state: "in_progress"
+      });
+    } else {
+      calls.push({ call: "TaskUpdate", key: op.key, state: op.result });
+    }
+  }
+  return calls;
+}
+var CODEX_NO_NATIVE_NOTICE = "afk: Codex has no native task surface \u2014 mirroring via the monitor.sh dashboard instead.";
+function codexSinkPlan(desired, tracked, options2 = {}) {
+  if (options2.nativeTaskAvailable) {
+    return { plan: mirrorPlan(desired, tracked) };
+  }
+  return { plan: [], notice: CODEX_NO_NATIVE_NOTICE };
+}
+
 // src/commands/monitor.ts
-async function monitorCommand(args2, cwd = process.cwd(), stdout2 = process.stdout) {
+function workersToDesired(workers) {
+  const out = [];
+  for (const w3 of workers) {
+    const number4 = w3.state.current.number;
+    if (number4 === "" || number4 === null || number4 === void 0) continue;
+    const issue = typeof number4 === "number" ? number4 : Number(number4);
+    if (!Number.isFinite(issue)) continue;
+    out.push({
+      worker_id: w3.state.worker_id,
+      issue,
+      title: w3.state.current.title,
+      stage: w3.state.current.stage,
+      started_at: w3.state.current.started_at || w3.state.started_at,
+      status: w3.live ? "running" : "gone"
+    });
+  }
+  return out;
+}
+function parseTrackedJsonl(text3) {
+  const out = [];
+  for (const raw3 of text3.split("\n")) {
+    const line = raw3.trim();
+    if (line === "") continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (parsed === null || typeof parsed !== "object") continue;
+    const rec = parsed;
+    if (typeof rec.key !== "string") continue;
+    out.push({ key: rec.key, stage: typeof rec.stage === "string" ? rec.stage : "" });
+  }
+  return out;
+}
+function runMirrorPlan(workers, trackedJsonl, options2 = {}) {
+  const desired = workersToDesired(workers);
+  const tracked = parseTrackedJsonl(trackedJsonl);
+  const calls = options2.codex ? codexSinkPlan(desired, tracked).plan : mirrorPlan(desired, tracked);
+  if (calls.length === 0) return "";
+  return `${calls.map((c) => JSON.stringify(c)).join("\n")}
+`;
+}
+async function readStdin(stdin3) {
+  const chunks2 = [];
+  for await (const chunk3 of stdin3) {
+    chunks2.push(typeof chunk3 === "string" ? Buffer.from(chunk3) : chunk3);
+  }
+  return Buffer.concat(chunks2).toString("utf8");
+}
+async function monitorCommand(args2, cwd = process.cwd(), stdout2 = process.stdout, stdin3 = process.stdin) {
+  if (args2.includes("--mirror-plan")) {
+    const runnerIdx = args2.indexOf("--runner");
+    const codex2 = args2.includes("--codex") || args2.includes("--runner=codex") || runnerIdx !== -1 && args2[runnerIdx + 1] === "codex";
+    const { workers: workers2 } = await collectMonitorInputs(cwd);
+    const trackedJsonl = await readStdin(stdin3);
+    const out = runMirrorPlan(workers2, trackedJsonl, { codex: codex2 });
+    if (out !== "") stdout2.write(out);
+    return 0;
+  }
   const { workers, events } = await collectMonitorInputs(cwd);
   const now = Math.floor(Date.now() / 1e3);
   const dashboard = renderCompactDashboard(workers, events, now);
@@ -86106,7 +86249,7 @@ function renderStatusline(input) {
 }
 
 // src/commands/statusline.ts
-function readStdin(stdin3) {
+function readStdin2(stdin3) {
   return new Promise((resolve6) => {
     if (stdin3.isTTY) {
       resolve6("");
@@ -86181,7 +86324,7 @@ function resolveClaude(payload) {
 }
 async function statuslineCommand(args2, cwd = process.cwd(), stdout2 = process.stdout, stdin3 = process.stdin) {
   const rootArg = args2[0];
-  const text3 = await readStdin(stdin3);
+  const text3 = await readStdin2(stdin3);
   const payload = parsePayload(text3);
   const root = resolveRoot(rootArg, payload, cwd);
   if (!statuslineEnabled(root)) return 0;

--- a/src/domains/dev/src/commands/monitor.ts
+++ b/src/domains/dev/src/commands/monitor.ts
@@ -1,16 +1,126 @@
-import { renderCompactDashboard } from "../core/monitor.js";
+import { renderCompactDashboard, type CompactWorker } from "../core/monitor.js";
 import { collectMonitorInputs } from "../runtime/wire.js";
+import {
+  mirrorPlan,
+  codexSinkPlan,
+  type MirrorCall,
+  type TrackedTask,
+  type WorkerRecord,
+} from "../core/mirror.js";
+
+/**
+ * Map the dashboard's live worker inputs onto the desired WorkerRecord set the
+ * mirror reconciler consumes. This is the same normalization `readWorkers`
+ * performs, applied to the compact dashboard's CompactWorker shape so the mirror
+ * sees exactly the same live/dead/stage the dashboard renders: a worker between
+ * issues (no current number) owns no task and is omitted; live → running,
+ * not-live → gone (surfaced terminal).
+ */
+export function workersToDesired(workers: readonly CompactWorker[]): WorkerRecord[] {
+  const out: WorkerRecord[] = [];
+  for (const w of workers) {
+    const number = w.state.current.number;
+    if (number === "" || number === null || number === undefined) continue;
+    const issue = typeof number === "number" ? number : Number(number);
+    if (!Number.isFinite(issue)) continue;
+    out.push({
+      worker_id: w.state.worker_id,
+      issue,
+      title: w.state.current.title,
+      stage: w.state.current.stage,
+      started_at: w.state.current.started_at || w.state.started_at,
+      status: w.live ? "running" : "gone",
+    });
+  }
+  return out;
+}
+
+/** Parse the tracked-task JSONL (one TrackedTask per line) read from the agent's
+ * current mirror-owned task list. Blank lines and unparseable lines are skipped;
+ * empty input → empty tracked set (a cold reconcile). */
+export function parseTrackedJsonl(text: string): TrackedTask[] {
+  const out: TrackedTask[] = [];
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (line === "") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (parsed === null || typeof parsed !== "object") continue;
+    const rec = parsed as { key?: unknown; stage?: unknown };
+    if (typeof rec.key !== "string") continue;
+    out.push({ key: rec.key, stage: typeof rec.stage === "string" ? rec.stage : "" });
+  }
+  return out;
+}
+
+export interface MirrorPlanOptions {
+  /** Use the Codex sink (codexSinkPlan) instead of the Claude mirrorPlan. */
+  codex?: boolean;
+}
+
+/**
+ * Pure, testable core of `monitor --mirror-plan`: given the live worker inputs,
+ * the tracked-task JSONL, and the runner, compute the mirror call plan and emit
+ * it as JSONL (one MirrorCall per line, trailing newline). An empty plan yields
+ * the empty string (idempotent: nothing changed → no output).
+ */
+export function runMirrorPlan(
+  workers: readonly CompactWorker[],
+  trackedJsonl: string,
+  options: MirrorPlanOptions = {},
+): string {
+  const desired = workersToDesired(workers);
+  const tracked = parseTrackedJsonl(trackedJsonl);
+  const calls: MirrorCall[] = options.codex
+    ? codexSinkPlan(desired, tracked).plan
+    : mirrorPlan(desired, tracked);
+  if (calls.length === 0) return "";
+  return `${calls.map((c) => JSON.stringify(c)).join("\n")}\n`;
+}
+
+/** Read all of stdin to a string (empty when nothing is piped / TTY). */
+async function readStdin(stdin: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : (chunk as Buffer));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
 
 /**
  * `monitor [--once]` — native compact dashboard. Globs the worker state files
  * and reads the history ledger (no bash), then renders via the pure
  * renderCompactDashboard.
+ *
+ * `monitor --mirror-plan [--runner codex | --codex]` — one-shot Task-mirror
+ * mode: read the agent's tracked mirror tasks as JSONL from stdin, diff against
+ * the live worker state (the same reads the dashboard uses), and emit the mirror
+ * call plan as JSONL to stdout for the agent to apply via TaskCreate/TaskUpdate.
+ * Renders no dashboard; empty plan → no output.
  */
 export async function monitorCommand(
   args: string[],
   cwd = process.cwd(),
   stdout: NodeJS.WritableStream = process.stdout,
+  stdin: NodeJS.ReadableStream = process.stdin,
 ): Promise<number> {
+  if (args.includes("--mirror-plan")) {
+    const runnerIdx = args.indexOf("--runner");
+    const codex =
+      args.includes("--codex") ||
+      args.includes("--runner=codex") ||
+      (runnerIdx !== -1 && args[runnerIdx + 1] === "codex");
+    const { workers } = await collectMonitorInputs(cwd);
+    const trackedJsonl = await readStdin(stdin);
+    const out = runMirrorPlan(workers, trackedJsonl, { codex });
+    if (out !== "") stdout.write(out);
+    return 0;
+  }
+
   const { workers, events } = await collectMonitorInputs(cwd);
   const now = Math.floor(Date.now() / 1000);
   const dashboard = renderCompactDashboard(workers, events, now);

--- a/src/domains/dev/tests/monitor.test.ts
+++ b/src/domains/dev/tests/monitor.test.ts
@@ -4,6 +4,12 @@ import {
   renderWorkerCompactLine,
   type CompactWorker,
 } from "../src/core/monitor.js";
+import {
+  runMirrorPlan,
+  parseTrackedJsonl,
+  workersToDesired,
+} from "../src/commands/monitor.js";
+import type { MirrorCall } from "../src/core/mirror.js";
 
 const baseWorker = (over: Partial<CompactWorker> = {}): CompactWorker => ({
   state: {
@@ -159,5 +165,116 @@ describe("monitor — compact dashboard", () => {
     const lines = out.split("\n");
     expect(lines[0].startsWith("48h:")).toBe(true);
     expect(out).toContain("workers: (none");
+  });
+});
+
+describe("monitor — mirror plan", () => {
+  const liveWorker = (
+    worker_id: string,
+    number: number,
+    title: string,
+    stage: string,
+    live = true,
+  ): CompactWorker =>
+    baseWorker({
+      state: {
+        ...baseWorker().state,
+        worker_id,
+        current: { number, title, stage, started_at: "2026-05-30T11:00:00Z" },
+      },
+      live,
+    });
+
+  const parse = (out: string): MirrorCall[] =>
+    out
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l) as MirrorCall);
+
+  it("cold reconcile: a new live worker emits a TaskCreate", () => {
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "do thing", "impl")], "");
+    const calls = parse(out);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      call: "TaskCreate",
+      key: "wAAAA:42",
+      title: "#42 wAAAA — do thing",
+      description: "stage: impl",
+      state: "in_progress",
+    });
+  });
+
+  it("stage change emits a TaskUpdate carrying the new stage", () => {
+    const tracked = JSON.stringify({ key: "wAAAA:42", stage: "impl" });
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "tests")], tracked);
+    const calls = parse(out);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      call: "TaskUpdate",
+      key: "wAAAA:42",
+      description: "stage: tests",
+      state: "in_progress",
+    });
+  });
+
+  it("terminal (non-live) tracked worker completes", () => {
+    const tracked = JSON.stringify({ key: "wAAAA:42", stage: "impl" });
+    const out = runMirrorPlan(
+      [liveWorker("wAAAA", 42, "t", "impl", false)],
+      tracked,
+    );
+    const calls = parse(out);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      call: "TaskUpdate",
+      key: "wAAAA:42",
+      state: "completed",
+    });
+  });
+
+  it("tracked worker absent from desired completes", () => {
+    const tracked = JSON.stringify({ key: "wAAAA:42", stage: "impl" });
+    const out = runMirrorPlan([], tracked);
+    const calls = parse(out);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ call: "TaskUpdate", key: "wAAAA:42", state: "completed" });
+  });
+
+  it("no change emits no output (idempotent)", () => {
+    const tracked = JSON.stringify({ key: "wAAAA:42", stage: "impl" });
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "impl")], tracked);
+    expect(out).toBe("");
+  });
+
+  it("codex runner falls back to an empty plan (no native surface)", () => {
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "impl")], "", {
+      codex: true,
+    });
+    expect(out).toBe("");
+  });
+
+  it("workersToDesired omits idle workers and maps liveness", () => {
+    const desired = workersToDesired([
+      liveWorker("wAAAA", 42, "t", "impl"),
+      baseWorker({
+        state: {
+          ...baseWorker().state,
+          worker_id: "wIDLE",
+          current: { number: "", title: "", stage: "", started_at: "" },
+        },
+      }),
+      liveWorker("wDEAD", 7, "t", "impl", false),
+    ]);
+    expect(desired.map((d) => d.worker_id)).toEqual(["wAAAA", "wDEAD"]);
+    expect(desired[0]!.status).toBe("running");
+    expect(desired[1]!.status).toBe("gone");
+  });
+
+  it("parseTrackedJsonl skips blank/garbage lines and tolerates missing stage", () => {
+    const text = '\n{"key":"a:1","stage":"impl"}\nnot json\n{"stage":"x"}\n{"key":"b:2"}\n';
+    expect(parseTrackedJsonl(text)).toEqual([
+      { key: "a:1", stage: "impl" },
+      { key: "b:2", stage: "" },
+    ]);
   });
 });


### PR DESCRIPTION
The binding Task Mirror was dead (SKILL.md sourced a deleted mirror.sh). Expose the orphaned core/mirror.ts via a monitor --mirror-plan subcommand and repoint SKILL.md to it. 0 dead refs. 765 tests. [skip release].

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782864874&installation_id=129708444&pr_number=331&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F331&signature=7bc0c336a09b19761e8e81681bd9343d9000060f362ad06cf72aaf4e589402aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--mirror-plan` mode to the monitor command that computes and outputs task operations by reconciling desired worker state against tracked input.
  * Supports both standard and Codex modes with appropriate JSONL-formatted output.

* **Tests**
  * Added comprehensive test coverage for the new mirror plan functionality, including idempotency, completion behavior, and mode-specific handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->