### PR TITLE
fix(afk): salvage a no-sentinel branch that passes feedback instead of abandoning it (#332)

### DIFF
--- a/.red/adr/0037-afk-salvages-no-sentinel-branch-that-passes-feedback.md
+++ b/.red/adr/0037-afk-salvages-no-sentinel-branch-that-passes-feedback.md
@@ -1,0 +1,30 @@
+---
+status: accepted
+---
+
+# AFK salvages a no-sentinel branch that is ahead of base if it passes the feedback gate
+
+When an AFK attempt ends without a `<promise>` sentinel (the ADR 0028 crash
+signal) but its worker branch is **ahead of base** — i.e. a prior attempt
+already committed complete work and the agent crashed before re-emitting the
+sentinel — AFK now SALVAGES the attempt: it runs the feedback gate (typecheck +
+tests) and, if green, LANDS the branch exactly like the DONE path. This is a
+deliberate, feedback-gated deviation from ADR 0028 ("the `<promise>` sentinel is
+the canonical attempt-exit signal"), fixing #332 where a branch carrying valid
+work was abandoned to `blocked:crashed` and the loop never converged.
+
+The sentinel stays canonical for the **no-work** case: a sentinel-less exit on a
+branch that is *not* ahead of base is still terminal `no-sentinel` (a true
+crash, nothing to salvage). The feedback gate is the load-bearing safety — it is
+the only thing that distinguishes "complete prior work" from a half-baked
+crash-edit, so a no-sentinel branch is NEVER landed without passing it. A salvage
+attempt that fails feedback is reported as `feedback-failed`, not merged.
+
+## Consequences
+
+- The agent contract (`AGENT-PROMPT.md`) is the other half of this
+  defense-in-depth: an agent that finds the work already complete MUST still
+  emit `<promise>DONE</promise>` — the runtime salvage is the backstop for when
+  it crashes before doing so.
+- A salvaged-and-landed attempt is reported with `outcome: "done"` (it was
+  merged), keeping the close path and envelope contract coherent.

--- a/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
+++ b/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
@@ -55,6 +55,8 @@ Done = all of:
 
 If a script doesn't exist in `package.json`, skip it silently. Don't invent test runners.
 
+**"Already done" still requires the sentinel.** If you inspect the branch and conclude the issue's work is *already* complete and correct — a prior attempt finished it, or the change was a no-op — you MUST still emit `<promise>DONE</promise>` as your final line. Exiting without a sentinel is read by the orchestrator as a **crash**, not as "nothing to do": a sentinel-less exit on a branch that already carries valid work used to abandon that work entirely. There is no silent "nothing to do" exit — confirm the acceptance criteria hold, then emit `DONE`. If the work is genuinely impossible or contradictory, emit `<promise>BLOCKED</promise>`. One of the two sentinels is always your final line.
+
 ## Task Adherence (binding)
 
 You execute exactly one issue. Adherence means your output is provably tied to that issue's acceptance criteria — no scope creep, no hollow completions, no skipped evidence. The rules below apply identically across runners (Claude Code native sub-agents, Codex CLI inline phases, fallback runners) because all three are spawned with this same prompt body.

--- a/src/domains/dev/src/core/process-issue.ts
+++ b/src/domains/dev/src/core/process-issue.ts
@@ -521,13 +521,31 @@ export async function processIssue(
     startedEpoch,
   } satisfies StageCommon;
 
-  // ---- on_attempt_error: the run ended without an AFK sentinel (ADR 0028) ----
+  // ---- no-sentinel: the run ended without an AFK sentinel (ADR 0028) ----
+  // ADR 0028 keeps `<promise>` canonical: a missing sentinel is a CRASH signal,
+  // not a "nothing to do" signal. But a worker branch can already carry a
+  // COMPLETE commit from a prior attempt (the agent finished the work, then
+  // crashed before re-emitting the sentinel — issue #332). Abandoning such a
+  // branch never converges. So we SALVAGE a no-sentinel attempt IF its branch is
+  // ahead of base — but only THROUGH the feedback gate (typecheck + tests). The
+  // gate is load-bearing: it is the only thing distinguishing "complete prior
+  // work" from a half-baked crash-edit. A branch with no work, or one that fails
+  // feedback, keeps today's terminal behaviour.
   if (run.outcome === "no-sentinel") {
-    await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
-    return await terminalFailure(common, "no-sentinel", "no-sentinel", {
-      notes: "_(no Notes appended; inner agent exited without a sentinel)_",
-      log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
-    });
+    const branchHasWork = (await deps.lookups.changedFiles(workerBranch, base)).length > 0;
+    if (!branchHasWork) {
+      await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
+      return await terminalFailure(common, "no-sentinel", "no-sentinel", {
+        notes: "_(no Notes appended; inner agent exited without a sentinel and the branch carries no work)_",
+        log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
+      });
+    }
+    // Salvage path: the branch is ahead of base. Treat the attempt as a success
+    // for hook purposes (we are about to land it, not error it) and route it
+    // through the SAME feedback+land tail the DONE path uses. on_attempt_error
+    // is NOT fired — a salvaged-and-landed attempt is not an error.
+    await fireHook("post_attempt", postAttemptContext(current, workerBranch, "success", "no-sentinel"));
+    return await landAndClose(common, fireHook, { salvaged: true });
   }
 
   // ---- post_attempt hook (terminal invocation; sentinel-bearing) ----
@@ -542,6 +560,30 @@ export async function processIssue(
   }
 
   // run.outcome === "done".
+  return await landAndClose(common, fireHook, { salvaged: false });
+}
+
+/**
+ * The shared DONE / salvage tail: run the feedback gate, then (if green) push +
+ * integrate + land per lock state, emit the done envelope, close the issue,
+ * clean up, and run the close cascade. Extracted verbatim from the inline DONE
+ * path so the DONE path behaves byte-for-byte as before; the no-sentinel salvage
+ * path (issue #332) reuses it so a branch carrying complete prior work lands
+ * exactly like a DONE attempt would.
+ *
+ * The feedback gate is load-bearing on the salvage path: a feedback failure on a
+ * salvaged attempt is reported as `feedback-failed` (the most accurate reason —
+ * the branch carried work but it did not pass validation), not `no-sentinel`.
+ */
+async function landAndClose(
+  c: StageCommon,
+  fireHook: (name: HookName, context: string) => Promise<boolean>,
+  opts: { salvaged: boolean },
+): Promise<ProcessIssueResult> {
+  const { deps, input } = c;
+  const { issue } = input;
+  const workerBranch = c.branch;
+  const base = c.base;
 
   // ---- 5. feedback loops (the merge gate, ADR 0008) ----
   // Feedback runs against a checkout of the returned worker branch; the injected
@@ -554,8 +596,10 @@ export async function processIssue(
     now: deps.nowEpoch,
   });
   if (!feedback.ok) {
-    return await terminalFailure(common, "feedback-failed", "feedback", {
-      notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
+    return await terminalFailure(c, "feedback-failed", "feedback", {
+      notes: opts.salvaged
+        ? "Feedback validation failed on a salvaged no-sentinel branch. The worker branch was not merged."
+        : "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n"),
     });
   }
@@ -591,13 +635,13 @@ export async function processIssue(
     },
   );
   if (!landing.ok) {
-    return await mergeFailed(common, landing.reason, landing.locked);
+    return await mergeFailed(c, landing.reason, landing.locked);
   }
 
   // ---- 7. close: envelope(done) → gh close + remove running → delete remote ----
   const mergeSha = await deps.git.headShortSha();
-  const durationS = deps.nowEpoch() - startedEpoch;
-  const posted = await emitDone(common, mergeSha, durationS, feedback);
+  const durationS = deps.nowEpoch() - c.startedEpoch;
+  const posted = await emitDone(c, mergeSha, durationS, feedback);
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
   await deleteRemote(deps.remoteGit, input.repoDir, workerBranch);
@@ -622,7 +666,7 @@ export async function processIssue(
     base,
     locked,
     mergeSha,
-    hooksFired,
+    hooksFired: c.hooksFired,
     envelopePosted: posted,
     preserved: true,
     swept: true,

--- a/src/domains/dev/tests/process-issue.test.ts
+++ b/src/domains/dev/tests/process-issue.test.ts
@@ -409,8 +409,11 @@ describe("processIssue — BLOCKED", () => {
 });
 
 describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
-  it("routes through on_attempt_error → ready-for-human, no post_attempt", async () => {
-    const { deps, input, trace } = harness({ outcome: "no-sentinel" });
+  it("with NO work on the branch: routes through on_attempt_error → ready-for-human, no post_attempt", async () => {
+    // Pure crash: the run ended without a sentinel AND the branch is not ahead
+    // of base (nothing committed). There is nothing to salvage, so this keeps
+    // the terminal no-sentinel behaviour (issue #332 salvage does not apply).
+    const { deps, input, trace } = harness({ outcome: "no-sentinel", changedFiles: [] });
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("no-sentinel");
@@ -423,6 +426,72 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "no-sentinel" }]);
     // on_attempt_error fires; post_attempt does NOT (ADR 0028).
     expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
+  });
+});
+
+describe("processIssue — no-sentinel salvage (issue #332)", () => {
+  it("branch ahead of base + feedback green → SALVAGES and lands exactly like DONE", async () => {
+    // The branch carries a complete commit from a prior attempt; the run ended
+    // without a sentinel (crash after the work was done). Because the branch is
+    // ahead of base AND feedback passes, AFK salvages it instead of abandoning.
+    const { deps, input, trace } = harness({
+      outcome: "no-sentinel",
+      changedFiles: ["packages/x/src/a.ts"], // branch is ahead of base
+      feedbackOk: true,
+      locked: false,
+    });
+    const result = await processIssue(deps, input);
+
+    // landed: reported as done (it WAS merged), close path coherent.
+    expect(result.outcome).toBe("done");
+    expect(result.swept).toBe(true);
+    // claim → running, then close → remove running (mirrors the DONE path).
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+"]);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.swept).toEqual([9]);
+    // worker branch pushed for landing; live remote branch deleted on close.
+    expect(trace.pushedAttempt.length).toBe(1);
+    expect(trace.deletedRemote.length).toBe(1);
+    // a done envelope was posted.
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "done" }]);
+    // close cascade ran (done-only).
+    expect(trace.listByLabelCalls).toEqual(["req:9"]);
+    expect(trace.released).toEqual([9]);
+    // post_attempt fires (treated as success); on_attempt_error does NOT fire on
+    // the successful-salvage path.
+    expect(result.hooksFired).toEqual([
+      "pre_worktree",
+      "pre_attempt",
+      "post_attempt",
+      "pre_merge",
+      "post_merge",
+    ]);
+  });
+
+  it("branch ahead of base + feedback red → does NOT land; terminal feedback-failed", async () => {
+    // A no-sentinel branch can carry a half-baked crash-edit. The feedback gate
+    // is the safety: when it fails, the salvage is rejected and routed to a
+    // terminal feedback failure — never merged.
+    const { deps, input, trace } = harness({
+      outcome: "no-sentinel",
+      changedFiles: ["packages/x/src/a.ts"],
+      feedbackOk: false,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(result.preserved).toBe(true);
+    expect(result.swept).toBe(false);
+    // never merged or closed.
+    expect(trace.closed).toEqual([]);
+    expect(trace.pushedAttempt).toEqual([]);
+    expect(trace.deletedRemote).toEqual([]);
+    // routed to ready-for-human with the typed blocked:validation tag.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:validation"]);
+    expect(trace.ensuredLabels).toContain("blocked:validation");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    // post_attempt fired (success, since we attempted salvage); pre_merge never reached.
+    expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "post_attempt"]);
   });
 });
 
@@ -747,13 +816,20 @@ describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)",
 
   it("crashed (no-sentinel) RETRIES once then escalates (cap 1)", async () => {
     // cap 1: attempt 1 is at-cap → escalate. Raise to 2 to see the single retry.
-    const retry = harness({ outcome: "no-sentinel", attempt: 1, recoveryEnv: { RED_AFK_RETRY_CRASH: "2" } });
+    // changedFiles empty so the branch has no work and the no-sentinel salvage
+    // (issue #332) does not apply — this exercises the pure-crash recovery path.
+    const retry = harness({
+      outcome: "no-sentinel",
+      changedFiles: [],
+      attempt: 1,
+      recoveryEnv: { RED_AFK_RETRY_CRASH: "2" },
+    });
     const r1 = await processIssue(retry.deps, retry.input);
     expect(r1.outcome).toBe("no-sentinel");
     expect(retry.trace.labelEdits.at(-1)!.add).toContain("ready-for-agent");
     expect(retry.trace.labelEdits.at(-1)!.add).toContain("blocked:crashed");
 
-    const escalate = harness({ outcome: "no-sentinel", attempt: 1 }); // default cap 1 → escalate
+    const escalate = harness({ outcome: "no-sentinel", changedFiles: [], attempt: 1 }); // default cap 1 → escalate
     const r2 = await processIssue(escalate.deps, escalate.input);
     expect(r2.outcome).toBe("no-sentinel");
     expect(escalate.trace.labelEdits.at(-1)!.add).toContain("ready-for-human");


### PR DESCRIPTION
Closes #332.

## Problem
A worker branch can already carry a complete commit for the issue (prior attempt), and if the current attempt ends WITHOUT the `<promise>DONE</promise>` sentinel, AFK short-circuited to `blocked:crashed` (`terminalFailure`, process-issue.ts) **before** the landing logic — which only ran on the `done` path. The branch with valid work was abandoned and the loop never converged. (Observed live: red-ui#30, branch carried `b67d7d0`, never merged.)

## Fix — defense-in-depth (both halves)
**Runtime salvage (`process-issue.ts`):** in the no-sentinel block, if the worker branch is **ahead of base** (`changedFiles(branch, base)` non-empty), route it through the SAME feedback+land tail the `done` path uses (extracted into a `landAndClose` helper so the done path is byte-for-byte unchanged). Feedback green → land like DONE; feedback red → `feedback-failed`. A branch with **no** work stays terminal `no-sentinel`. **The feedback gate (typecheck + tests) is the load-bearing safety** — it is the only thing distinguishing complete prior work from a half-baked crash-edit, so a no-sentinel branch is NEVER landed without passing it.

**Agent contract (`AGENT-PROMPT.md`):** the inner agent must emit `<promise>DONE</promise>` even when it finds the work already complete — a sentinel-less exit is a crash signal, not "nothing to do". The runtime salvage is the backstop for when it crashes anyway.

**ADR 0037** records this as a deliberate, feedback-gated deviation from ADR 0028 (sentinel-is-canonical), preserved for the no-work case.

## Tests
- Updated the existing no-sentinel test (+ the recovery retry test) to `changedFiles: []` so they still assert the terminal `no-sentinel`/`blocked:crashed` path.
- Added: no-sentinel + branch ahead + feedback green → lands like DONE (pushed, merged, `gh.close`, done envelope, close-cascade); no-sentinel + branch ahead + feedback red → `feedback-failed`, never merged.
- `process-issue.test.ts`: 32 pass / 0 fail. Full dev-domain suite: 701 pass / 0 fail.

## Note
Pre-existing, unrelated: `pnpm typecheck` reports one error in `src/domains/shared/args.ts` (`cli-args-parser` module resolution) present on the base branch — not touched by this PR. Edited files typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782868858&installation_id=129708444&pr_number=335&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F335&signature=920a88568b187ee9f7452cac76bce451123d1d31e3889ac5307ef3ca69cc0ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System now intelligently salvages work attempts missing completion signals if the branch contains actual code changes; automatically validates via feedback checks and merges on success.

* **Documentation**
  * Added architecture decision record and updated agent instructions defining salvage behavior and completion signal requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->