### PR TITLE
feat(improve-codebase-architecture): workflow-aware Explore + adversarial vet; dynamic-workflows ADR

### DIFF
--- a/.claude/workflows/improve-arch-explore.js
+++ b/.claude/workflows/improve-arch-explore.js
@@ -1,0 +1,136 @@
+// DOGFOOD REFERENCE — repo-local, not shipped. Plugins cannot bundle workflows, so this
+// file works only inside the RedSkills repo. It lives in .claude/workflows/ (carved out of
+// the .claude/ gitignore) so it is BOTH committed for contributors AND saved as the
+// /improve-arch-explore command. It is the reference implementation for the OPTIONAL workflow
+// acceleration described in plugins/dev/skills/engineering/improve-codebase-architecture/SKILL.md
+// (step 1). In any other repo the skill authors the equivalent inline; the Agent-tool path is
+// the baseline that works with no workflow support at all.
+export const meta = {
+  name: 'improve-arch-explore',
+  description: 'Fan-out the Explore phase of /improve-codebase-architecture across 4 architecture lenses, then adversarially refute the pooled deepening candidates with the deletion test before returning the vetted list. Minimal profile: 4 explore + 1 consolidated vet agent.',
+  phases: [
+    { title: 'Explore', detail: 'one Explore agent per architecture lens, read-only, top-2 each' },
+    { title: 'Vet', detail: 'single adversarial reviewer over all pooled candidates' },
+  ],
+}
+
+// Target dir comes from args; default to the AFK TS core for the pilot.
+const TARGET = (typeof args === 'string' && args.trim()) ? args.trim() : 'src/domains/dev/src/core'
+
+// Shared vocabulary block — inlined so every agent speaks the same language
+// (mirrors plugins/dev/skills/engineering/improve-codebase-architecture/LANGUAGE.md).
+const GLOSSARY = `
+ARCHITECTURE VOCABULARY — use these terms exactly:
+- Module: anything with an interface and an implementation.
+- Interface: everything a caller must know — types, invariants, error modes, ordering, config. Not just the type signature.
+- Depth: leverage at the interface — a lot of behaviour behind a small interface. Deep = high leverage. Shallow = interface nearly as complex as the implementation.
+- Seam: where an interface lives; a place behaviour can be altered without editing in place. (Use "seam", never "boundary".)
+- Locality: change, bugs, and knowledge concentrated in one place.
+DELETION TEST: imagine deleting the module. If complexity vanishes, it was a pass-through (shallow). If complexity REAPPEARS, concentrated across N callers, it was earning its keep (a real seam worth deepening).
+Before proposing, read .red/CONTEXT.md (domain glossary) and .red/adr/ — use the project's domain nouns, and do NOT re-litigate decisions an ADR already settled.`
+
+const LENSES = [
+  {
+    key: 'shallow-modules',
+    question: 'Where are modules SHALLOW — the interface nearly as complex as the implementation? Pass-throughs, thin wrappers, modules that exist only to forward calls.',
+  },
+  {
+    key: 'concept-scatter',
+    question: 'Where does understanding ONE concept require bouncing between many small modules? Logic that should have locality but is smeared across files.',
+  },
+  {
+    key: 'testability',
+    question: 'Where have pure functions been extracted just for testability, but the real bugs hide in HOW they are called (no locality)? Which parts are untested or hard to test through their current interface?',
+  },
+  {
+    key: 'seam-leakage',
+    question: 'Where do tightly-coupled modules LEAK across their seams — internals exposed, callers depending on implementation details, a seam that is not really a seam?',
+  },
+]
+
+const CANDIDATE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    candidates: {
+      type: 'array',
+      maxItems: 2,
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string', description: 'short name for the deepening opportunity' },
+          files: { type: 'array', items: { type: 'string' }, description: 'files/modules involved' },
+          problem: { type: 'string', description: 'why the current architecture causes friction' },
+          solution: { type: 'string', description: 'plain-English description of what would change' },
+          deletionTest: { type: 'string', description: 'prediction: would deleting this module concentrate complexity (real seam) or just move it (pass-through)?' },
+        },
+        required: ['title', 'files', 'problem', 'solution', 'deletionTest'],
+      },
+    },
+  },
+  required: ['candidates'],
+}
+
+// Polarity is explicit: worthDeepening=true means the REFACTOR holds up — the
+// candidate survived refutation and is worth taking to the human. worthDeepening=false
+// means the adversary refuted it (the module is already a real seam, leave it alone).
+const VET_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdicts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string', description: 'must match the candidate title verbatim' },
+          worthDeepening: { type: 'boolean', description: 'TRUE only if the proposed refactor survives your refutation. FALSE if the module is already a real seam / an ADR settles it / the friction is not real.' },
+          reasoning: { type: 'string', description: 'one paragraph: did deleting the module concentrate complexity (refactor holds) or merely move it (refuted)?' },
+        },
+        required: ['title', 'worthDeepening', 'reasoning'],
+      },
+    },
+  },
+  required: ['verdicts'],
+}
+
+// Phase 1 — barrier: all 4 lenses explore in parallel (top-2 each), then pool.
+const lensResults = await parallel(
+  LENSES.map((lens) => () => agent(
+    `${GLOSSARY}\n\nYou are exploring ONLY the directory \`${TARGET}\` (read-only). LENS: ${lens.question}\n\nWalk the code organically — do not follow rigid heuristics. Apply the deletion test yourself BEFORE surfacing anything, and return ONLY your strongest deepening opportunities that you believe would survive an adversarial deletion-test review (AT MOST 2). Quality over quantity — return fewer, or none, rather than weak candidates. Do NOT propose interfaces or write code.`,
+    { label: `explore:${lens.key}`, phase: 'Explore', agentType: 'Explore', schema: CANDIDATE_SCHEMA },
+  ).then((r) => ({ lens: lens.key, candidates: r?.candidates ?? [] })))
+)
+
+const pooled = lensResults.filter(Boolean).flatMap((r) => r.candidates.map((c) => ({ ...c, lens: r.lens })))
+
+// Phase 2 — a SINGLE adversarial reviewer vets every pooled candidate in one pass.
+let verdicts = []
+if (pooled.length > 0) {
+  const block = pooled.map((c, i) =>
+    `CANDIDATE ${i + 1} [lens: ${c.lens}]\nTitle: ${c.title}\nFiles: ${c.files.join(', ')}\nProblem: ${c.problem}\nProposed solution: ${c.solution}\nTheir deletion-test claim: ${c.deletionTest}`
+  ).join('\n\n')
+  const v = await agent(
+    `${GLOSSARY}\n\nADVERSARIAL REVIEW of ${pooled.length} deepening candidates in \`${TARGET}\`, pooled from four exploration lenses. Read the actual files. For EACH candidate, try to REFUTE it: argue that deleting/merging the modules would merely MOVE complexity rather than concentrate it, or that an ADR already settles it, or that the friction is not real. Several candidates may target the same module from different angles — treat each on its own merits but note overlaps. Set worthDeepening=true ONLY when the refactor genuinely withstands your refutation; default to false when uncertain. Return one verdict per candidate, title matching verbatim.\n\n${block}`,
+    { label: 'vet:pooled', phase: 'Vet', agentType: 'Explore', schema: VET_SCHEMA },
+  )
+  verdicts = v?.verdicts ?? []
+}
+
+const all = pooled.map((c) => {
+  const v = verdicts.find((x) => x.title === c.title)
+  return { ...c, worthDeepening: !!v?.worthDeepening, reasoning: v?.reasoning ?? 'no verdict returned' }
+})
+const survived = all.filter((c) => c.worthDeepening)
+
+log(`Explored ${LENSES.length} lenses over ${TARGET}: ${all.length} candidates, ${survived.length} survived adversarial deletion-test.`)
+
+return {
+  target: TARGET,
+  total: all.length,
+  survived: survived.length,
+  candidates: survived,
+  refuted: all.filter((c) => !c.worthDeepening).map((c) => ({ title: c.title, lens: c.lens, reason: c.reasoning })),
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Claude Code local state
-.claude/
+.claude/*
+# …except shared dogfood workflows (saved as /commands for repo contributors)
+!.claude/workflows/
 
 # Per-repo agent ephemera (never committed)
 .red/tmp/

--- a/.red/adr/0036-workflows-ship-as-skill-behavior-not-bundled-artifacts.md
+++ b/.red/adr/0036-workflows-ship-as-skill-behavior-not-bundled-artifacts.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+---
+
+# Dynamic workflows ship as skill behavior, not as bundled plugin artifacts
+
+Claude Code dynamic workflows (research preview, as of 2026-05-31) **cannot be bundled in a plugin**. The `plugin.json` manifest has no `workflows` key and no `workflows/` component directory — the documented component set is skills, agents, hooks, MCP servers, LSP servers, and monitors, and `claude plugin validate` silently ignores any unrecognized top-level field. Saved workflows are only discovered from `.claude/workflows/` (project) or `~/.claude/workflows/` (personal); the built-in ones (e.g. `/deep-research`) ship inside Claude Code itself. Therefore **no path inside our published plugin delivers a runnable workflow to a consumer repo** — not `plugins/dev/workflows/`, not anywhere.
+
+**Decision.** When a RedSkills skill benefits from a workflow, the durable value ships in the **skill markdown** as the universal baseline (parallel `subagent_type=Explore` fan-out + adversarial verification via the Agent tool), which travels in the plugin and runs in any repo — and on Codex, which has no workflows at all. A workflow is only an **optional accelerator** (parallelism + background) for sessions where the feature is on; a skill must never gate on it. Reference workflow scripts live at `.claude/workflows/*.js` in *this* repo (carved out of the `.claude/` gitignore via `.claude/*` + `!.claude/workflows/`) as committed dogfood + live `/command` for contributors only. The first instance is `improve-codebase-architecture` + `.claude/workflows/improve-arch-explore.js`.
+
+This is the same root cause as the memory plugin's gitignored-`dist/` no-op: an artifact that does not travel with the plugin cannot be relied on at the consumer.
+
+## Considered alternatives
+
+- **Bundle the `.js` under `plugins/dev/workflows/`** — rejected: Claude Code never reads that path, so it would be a dead file masquerading as a shipped component.
+- **Installer copy step (Option B)** — `/setup-red-skills` copies a bundled `.js` resource into the consumer's `.claude/workflows/`. Rejected for now: Claude-only (Codex skip), benefits only the subset of consumers on Claude with workflows enabled (off-by-default on Pro), and adds a silent-vanish-prone copy path to maintain — all while the skill baseline already delivers the behavior to everyone.
+
+## Migration trigger
+
+Revisit if a `workflows` key (or `workflows/` component directory) lands in the `plugin.json` schema. At that point Option B collapses: move the reference script to `plugins/dev/workflows/`, declare it in the manifest, and the workflow ships to consumers as a real bundled component. Verify on a live CLI (`claude plugin validate`) before assuming the key exists.

--- a/plugins/dev/skills/engineering/improve-codebase-architecture/SKILL.md
+++ b/plugins/dev/skills/engineering/improve-codebase-architecture/SKILL.md
@@ -30,23 +30,32 @@ This skill is _informed_ by the project's domain model. The domain language give
 
 ## Process
 
-### 1. Explore
+### 1. Explore (fan out across lenses)
 
 Read the project's domain glossary and any ADRs in the area you're touching first.
 
-Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+Then fan out **one Explore subagent per lens** (Agent tool, `subagent_type=Explore`). Each agent walks the same target tree but hunts for one kind of friction. Don't follow rigid heuristics — explore organically within the lens:
 
-- Where does understanding one concept require bouncing between many small modules?
-- Where are modules **shallow** — interface nearly as complex as the implementation?
-- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
-- Where do tightly-coupled modules leak across their seams?
-- Which parts of the codebase are untested, or hard to test through their current interface?
+- **shallow-modules** — modules where the interface is nearly as complex as the implementation; pass-throughs and thin wrappers.
+- **concept-scatter** — where understanding one concept requires bouncing between many small modules; logic that should have **locality** but is smeared across files.
+- **testability** — pure functions extracted just for testability while the real bugs hide in how they're called; parts untested or hard to test through their current interface.
+- **seam-leakage** — tightly-coupled modules that leak across their seams; callers depending on implementation details.
 
-Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+Tell each agent to apply the **deletion test** itself before surfacing anything, and to return only its strongest candidates (cap ~2 per lens) — fewer, or none, beats weak ones. A "deleting it concentrates complexity" is the signal you want.
 
-### 2. Present candidates
+> **Acceleration (optional).** If dynamic workflows are available in this environment, run steps 1–2 as a workflow instead — fan the lenses out in parallel and run the vet in the background, then read back the vetted list. A reference script lives at `.claude/workflows/improve-arch-explore.js` in the RedSkills repo (saved as the `/improve-arch-explore` command for contributors); in any other repo, author the equivalent inline. **This is only a speed/parallelism win — the result is identical to the Agent-tool path, which is the baseline and must work with no workflow support at all.** Never gate the skill on workflows being on.
 
-Present a numbered list of deepening opportunities. For each candidate:
+### 2. Vet — adversarially refute every candidate (do not skip)
+
+Before showing the user anything, pool the candidates and put each through an **adversarial deletion-test review**: spawn a skeptic (Agent tool, `subagent_type=Explore`) whose job is to **refute** the candidate — argue that deleting/merging the modules would merely *move* complexity rather than concentrate it, that an existing ADR already settles it, or that the friction is not real. The candidate is kept **only if the refactor withstands refutation**; default to dropping it when the skeptic is uncertain.
+
+Keep this cheap: one batched skeptic over the whole pool is enough — you do not need one agent per candidate. This stage is the quality gate; a single-pass exploration without it floods the user with plausible-but-wrong refactors. The AFK core, for instance, refuted most candidates because its "shallow" modules are deliberate seams backed by ADRs.
+
+Discard refuted candidates silently (or mention the count). Only survivors advance.
+
+### 3. Present surviving candidates
+
+Present a numbered list of the deepening opportunities that survived the vet. For each candidate:
 
 - **Files** — which files/modules are involved
 - **Problem** — why the current architecture is causing friction
@@ -59,7 +68,7 @@ Present a numbered list of deepening opportunities. For each candidate:
 
 Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
 
-### 3. Grilling loop
+### 4. Grilling loop
 
 Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
 


### PR DESCRIPTION
Makes `/improve-codebase-architecture` **workflow-aware** and records how dynamic workflows fit the plugin model.

## What changes
- **Phase 1 (Explore) fans out per lens** (shallow-modules / concept-scatter / testability / seam-leakage) + a new **adversarial deletion-test VET stage**: skeptics try to *refute* each deepening candidate before it reaches the user. This is the durable quality win and it runs in **any repo, including Codex**, via the Agent tool — it killed 14/16 (then 5/8) plausible-but-wrong candidates in the pilot.
- **Dynamic workflow = optional accelerator only.** When workflows are available, Phase 1 can run as a background/parallel workflow; otherwise the Agent-tool path is the baseline and the skill **never gates on workflows**.
- **`.claude/workflows/improve-arch-explore.js`** — reference workflow, minimal 5-agent profile (~405k tokens in the pilot vs 1.23M for the first 20-agent cut; also fixes a verdict-polarity bug found in the pilot).
- **`.gitignore`** — carve `.claude/workflows/` out of the `.claude/` ignore so the script is BOTH committed for contributors AND a live `/improve-arch-explore` command (git negation needs `.claude/*`, not `.claude/`).
- **ADR 0036** — plugins cannot bundle workflows (no `workflows` manifest key; verified against current docs), so workflows ship as skill **behavior** (markdown baseline), not bundled artifacts; the `.js` is repo-local dogfood. Migration trigger documented for when a `workflows` key lands.

## Notes
- `improve-codebase-architecture` is original to reddb.io (not upstream-derived), so no `CHANGES.md` entry; already listed in README + plugin.json; `.claude/workflows/` is not a skill, so no manifest edits.
- Validated by the pilot run against the AFK TS core (`src/domains/dev/src/core`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782869630&installation_id=129708444&pr_number=347&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F347&signature=2749a7144ef7738432ce0acb014a6dd37ac501d0d1c4c37735d394ec59cc7ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Architecture exploration now employs a two-phase "Explore then Vet" approach with quality gates, evaluating improvements across multiple architectural lenses and filtering candidates through adversarial review.

* **Documentation**
  * Updated process documentation to reflect the new structured discovery workflow and vetting step.

* **Chores**
  * Updated version control configuration to track workflow files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->