### PR TITLE
#302 Memory extraction: strict-write structural-type gate (provider path)

### DIFF
--- a/src/apps/memory/src/engine.ts
+++ b/src/apps/memory/src/engine.ts
@@ -13,6 +13,7 @@ import type {
   ShortestPathResult,
   StoredNode,
 } from "./graph-store.js";
+import { normalizeEngineeringCode } from "./extraction-schema.js";
 import { tokenize } from "./recall.js";
 import {
   type Confidence,
@@ -81,6 +82,13 @@ export interface RecallOptions {
   depth?: number;
   /** Restrict results to these node types. */
   types?: string[];
+  /**
+   * Restrict results to these engineering codes — the open semantic axis
+   * (ADR 0035). Codes are normalized before comparison, so `root-cause`,
+   * `Root Cause`, and `root_cause` all match. This is the axis being a real
+   * query dimension rather than opaque metadata.
+   */
+  codes?: string[];
   /**
    * Return the full `SUPERSEDED_BY` chain instead of just its head. Default
    * `false`: a superseded node is hidden behind its successor (issue #72 /
@@ -574,10 +582,15 @@ export async function recall(
     k = 8,
     depth = 1,
     types,
+    codes,
     includeSuperseded = false,
     scope = DEFAULT_RECALL_SCOPE,
     now = Date.now(),
   } = opts;
+  // Pre-normalize the engineering-code filter once (ADR 0035): the stored code is
+  // already a normalized slug, so the caller's input is normalized to match.
+  const codeFilter =
+    codes && codes.length > 0 ? new Set(codes.map(normalizeEngineeringCode)) : null;
   const terms = tokenize(query);
   const index = await loadIndex(store, scope);
   if (terms.length === 0) {
@@ -668,6 +681,10 @@ export async function recall(
     const node = index.get(rid);
     if (!node) continue;
     if (types && types.length > 0 && !types.includes(node.node_type)) continue;
+    if (codeFilter) {
+      const code = node.properties.engineering_code;
+      if (!code || !codeFilter.has(normalizeEngineeringCode(code))) continue;
+    }
     // Tier-aware composite score: relevance keeps the strongest text match on
     // top; importance/recency/centrality/tier-weight order comparable nodes.
     const score = rankScore({

--- a/src/apps/memory/src/extract-conversation.ts
+++ b/src/apps/memory/src/extract-conversation.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { EXTRACTION_PROFILES } from "./extraction-schema.js";
+import { EXTRACTION_PROFILES, STRUCTURAL_TYPES } from "./extraction-schema.js";
 import { contentHash } from "./hash.js";
 import type { EdgeLabel, MemoryNode, NodeType } from "./schema.js";
 
@@ -98,7 +98,13 @@ export interface ProviderClient {
 export interface ExtractedFact {
   /** Stable, slug-like graph node label. */
   label: string;
-  node_type: NodeType;
+  /**
+   * The kind the model *proposed* — a free string, not validated against the
+   * structural vocabulary at parse (ADR 0035 strict-write: classification is
+   * never rejected). `factsToGraph` resolves it to a valid structural home and
+   * preserves the proposed kind as an open engineering code.
+   */
+  node_type: string;
   title: string;
   summary?: string;
   tags?: string[];
@@ -256,7 +262,10 @@ const RelationSchema = z.object({
 
 const FactSchema = z.object({
   label: z.string().min(1),
-  node_type: z.enum(NODE_TYPES as [NodeType, ...NodeType[]]),
+  // The proposed kind is a free string. ADR 0035 strict-write: an out-of-vocab
+  // classification is resolved (in `factsToGraph`), never rejected at parse — so
+  // only structural malformation (a missing label/kind/title) drops a fact here.
+  node_type: z.string().min(1),
   title: z.string().min(1),
   summary: z.string().optional(),
   tags: z.array(z.string()).optional(),
@@ -409,6 +418,18 @@ export function extractStructuredTranscript(transcript: string): ExtractedFact[]
   return facts;
 }
 
+/**
+ * Every kind that is a legal {@link NodeType} field value — the runtime
+ * allowlist plus the structural vocabulary (which carries `import`/`transcript`,
+ * absent from {@link NODE_TYPES}). A proposed kind in this set is preserved on
+ * `node_type` as-is; anything else falls back to its structural home so the
+ * `NodeType` field is never an out-of-vocab string (ADR 0035 type-safety).
+ */
+const KNOWN_NODE_TYPES: ReadonlySet<string> = new Set<string>([
+  ...NODE_TYPES,
+  ...STRUCTURAL_TYPES,
+]);
+
 /** A graph fragment ready for the ingest indexer: nodes + label-keyed edges. */
 export interface InferredExtraction {
   nodes: MemoryNode[];
@@ -423,14 +444,20 @@ export interface InferredExtraction {
  */
 export function factsToGraph(facts: ExtractedFact[], source = "conversation"): InferredExtraction {
   const nodes: MemoryNode[] = facts.map((f) => {
-    // Two-axis resolution (ADR 0035): the strict-write profile assigns a valid
-    // structural home and preserves the proposed kind as an open engineering
-    // code. `node_type` is kept for backward compatibility; the two axes are
-    // recorded additively so recall/clustering can use them downstream.
+    // Two-axis resolution (ADR 0035 strict-write). The structural axis is gated:
+    // `structural_type` is always a valid structural home (in-vocab kinds map to
+    // themselves; everything else to the base type), and the proposed kind is
+    // preserved losslessly on the open `engineering_code` axis — never rejected,
+    // never discarded. `node_type` keeps the proposed kind when it is itself a
+    // legal NodeType (backward compat) and only falls back to the structural home
+    // when the kind is out of vocabulary, so the typed field stays valid.
     const resolution = EXTRACTION_PROFILES.strictWrite.resolve(f.node_type);
+    const node_type: NodeType = KNOWN_NODE_TYPES.has(f.node_type)
+      ? (f.node_type as NodeType)
+      : resolution.structuralType;
     return {
       label: f.label,
-      node_type: f.node_type,
+      node_type,
       properties: {
         title: f.title,
         summary: f.summary,

--- a/src/apps/memory/src/schema.ts
+++ b/src/apps/memory/src/schema.ts
@@ -6,6 +6,8 @@
  * the proven shape behind ADR 0007. Keep aligned with PRD #49's data model.
  */
 
+import type { StructuralType } from "./extraction-schema.js";
+
 export const COLLECTIONS = {
   nodes: "memory_nodes",
   edges: "memory_edges",
@@ -159,6 +161,20 @@ export interface MemoryNodeProps {
    */
   expires_at?: number;
   supersedes_rid?: number;
+  /**
+   * Closed structural-type axis (ADR 0035). Set by the strict-write gate on the
+   * provider/`INFERRED` path: the valid structural home a proposed kind resolved
+   * to (in-vocabulary kinds map to themselves; everything else to the base type).
+   * Indexed so recall can filter/rank by it alongside `tier`/`type`.
+   */
+  structural_type?: StructuralType;
+  /**
+   * Open engineering-code axis (ADR 0035): the fine-grained "why"/kind
+   * classification (`decision`, `gotcha`, `root-cause`, …) carried losslessly
+   * even when the proposed kind is out of the structural vocabulary. Indexed —
+   * a real recall filter/rank dimension, not opaque metadata.
+   */
+  engineering_code?: string;
   /** dedupe hash (stable per source+content) */
   hash?: string;
   [extra: string]: unknown;

--- a/src/apps/memory/tests/engine.test.ts
+++ b/src/apps/memory/tests/engine.test.ts
@@ -123,6 +123,61 @@ describe("recall", () => {
   );
 
   test(
+    "codes filter restricts results to an engineering code (ADR 0035 queryable axis)",
+    async () => {
+      const store = await openStore();
+      await seed(store);
+      // Two nodes sharing query terms but different engineering codes: only the
+      // `root-cause`-coded one should survive a code-filtered recall.
+      await store.upsertNode({
+        label: "jwt-expiry-root-cause",
+        node_type: "concept",
+        properties: {
+          title: "jwt expiry root cause",
+          content: "jwt tokens expired early because the clock skew was unbounded",
+          engineering_code: "root-cause",
+        },
+      });
+      await store.upsertNode({
+        label: "jwt-rotation-decision",
+        node_type: "concept",
+        properties: {
+          title: "jwt rotation decision",
+          content: "we decided to rotate jwt signing keys every quarter",
+          engineering_code: "decision",
+        },
+      });
+
+      const { nodes } = await recall(store, "jwt", { codes: ["root-cause"] });
+      expect(nodes.length).toBeGreaterThanOrEqual(1);
+      expect(nodes.every((n) => n.properties.engineering_code === "root-cause")).toBe(true);
+      expect(nodes.some((n) => n.label === "jwt-expiry-root-cause")).toBe(true);
+      expect(nodes.some((n) => n.label === "jwt-rotation-decision")).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "codes filter normalizes the caller's input (Root Cause ≡ root-cause)",
+    async () => {
+      const store = await openStore();
+      await store.upsertNode({
+        label: "jwt-expiry-root-cause",
+        node_type: "concept",
+        properties: {
+          title: "jwt expiry root cause",
+          content: "jwt tokens expired because of clock skew",
+          engineering_code: "root-cause",
+        },
+      });
+
+      const { nodes } = await recall(store, "jwt", { codes: ["Root Cause"] });
+      expect(nodes.some((n) => n.label === "jwt-expiry-root-cause")).toBe(true);
+    },
+    TIMEOUT,
+  );
+
+  test(
     "hides a superseded node behind its successor",
     async () => {
       const store = await openStore();

--- a/src/apps/memory/tests/extract-conversation.test.ts
+++ b/src/apps/memory/tests/extract-conversation.test.ts
@@ -163,16 +163,29 @@ describe("parseExtraction", () => {
     expect(parseExtraction("I could not find anything to extract.")).toEqual([]);
   });
 
-  test("drops individual malformed facts but keeps valid ones", () => {
+  test("keeps an out-of-vocab kind (strict-write resolves, never rejects) but drops structural malformation", () => {
     const raw = JSON.stringify({
       facts: [
         { label: "ok", node_type: "concept", title: "Valid" },
-        { label: "bad-type", node_type: "not-a-type", title: "Invalid type" },
+        { label: "bad-type", node_type: "not-a-type", title: "Out-of-vocab kind" },
         { node_type: "concept", title: "missing label" },
       ],
     });
     const facts = parseExtraction(raw);
-    expect(facts.map((f) => f.label)).toEqual(["ok"]);
+    // ADR 0035: an out-of-vocab classification is admitted at parse (its proposed
+    // kind round-trips on `node_type`); only structural malformation (the missing
+    // label) is dropped.
+    expect(facts.map((f) => f.label)).toEqual(["ok", "bad-type"]);
+    expect(facts.find((f) => f.label === "bad-type")?.node_type).toBe("not-a-type");
+
+    // …and downstream, `factsToGraph` lands it on the base structural type while
+    // preserving the proposed kind as an indexed engineering code — not rejected,
+    // not flattened-with-loss, not a NodeType-violating string on `node_type`.
+    const { nodes } = factsToGraph(facts);
+    const resolved = nodes.find((n) => n.label === "bad-type")!;
+    expect(resolved.node_type).toBe("concept");
+    expect(resolved.properties.structural_type).toBe("concept");
+    expect(resolved.properties.engineering_code).toBe("not-a-type");
   });
 
   test("dedupes facts by label within one response", () => {
@@ -321,5 +334,39 @@ describe("factsToGraph", () => {
   test("source is overridable for the explicit /memory:store path", () => {
     const { nodes } = factsToGraph([GOLDEN[0]], "manual");
     expect(nodes[0].properties.source).toBe("manual");
+  });
+
+  test("an in-vocabulary structural kind maps to itself on both axes", () => {
+    const [node] = factsToGraph([
+      { label: "issue-302", node_type: "issue", title: "Strict-write gate", relations: [] },
+    ]).nodes;
+    expect(node.node_type).toBe("issue");
+    expect(node.properties.structural_type).toBe("issue");
+    // No separate classification for a structural kind: the code mirrors the kind
+    // so the axis is still populated and queryable.
+    expect(node.properties.engineering_code).toBe("issue");
+  });
+
+  test("a valid-but-non-structural kind keeps node_type but lands on the base structural axis", () => {
+    // `decision` is a legal NodeType but a semantic classification, not a
+    // structural type — so it stays on `node_type` (backward compat) while the
+    // structural axis resolves to the base home and the code carries the kind.
+    const [node] = factsToGraph([
+      { label: "deploy-tuesdays", node_type: "decision", title: "Deploy on Tuesdays", relations: [] },
+    ]).nodes;
+    expect(node.node_type).toBe("decision");
+    expect(node.properties.structural_type).toBe("concept");
+    expect(node.properties.engineering_code).toBe("decision");
+  });
+
+  test("an out-of-vocab kind never writes an invalid NodeType, and preserves the classification", () => {
+    const [node] = factsToGraph([
+      { label: "p95-latency", node_type: "Benchmark Result", title: "p95 under load", relations: [] },
+    ]).nodes;
+    // node_type must stay a legal NodeType — falls back to the structural home.
+    expect(node.node_type).toBe("concept");
+    expect(node.properties.structural_type).toBe("concept");
+    // The proposed kind is preserved as a normalized engineering code, not lost.
+    expect(node.properties.engineering_code).toBe("benchmark-result");
   });
 });


### PR DESCRIPTION
Lands the verified work from AFK worker wYQCM for #302. Implementation committed as b4a5310 on the worker branch: strict-write structural-type gate on the provider path, open engineering-code axis (no rejection). Full memory suite 675/675 green, typecheck clean, merge-tree conflict-free against current main. AFK kept re-invoking without emitting the DONE sentinel (the issue's chronic no-sentinel pattern, 30+ attempts), so landing manually via admin-merge. Closes #302.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782937595&installation_id=129708444&pr_number=377&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F377&signature=5e5dae978321ba415e2bb63700328789c211897b1972ae44ffc675d4bdc5490b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added engineering code filtering to refine recall results based on specific classification codes.
  * Introduced new metadata fields for enhanced node categorization: structural type and engineering code.
  * System now supports flexible node type definitions beyond standard categories.

* **Tests**
  * Added comprehensive test coverage for engineering code filtering and metadata field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->