### PR TITLE
fix(statusline): render from cached bundle, not the fetch-launcher (survives plugin updates)

### DIFF
--- a/plugins/dev/skills/engineering/statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/statusline/SKILL.md
@@ -33,7 +33,7 @@ Codex's footer; track AFK under Codex with `/afk monitor` instead.
 {
   "statusLine": {
     "type": "command",
-    "command": "sh -c 'b=$(ls -t \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
+    "command": "sh -c 'b=$(ls -t \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | head -1); [ -z \"$b\" ] && b=$(ls -t \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
     "refreshInterval": 5
   }
 }
@@ -43,10 +43,22 @@ Codex's footer; track AFK under Codex with `/afk monitor` instead.
 `CLAUDE_PLUGIN_ROOT` (nor `CLAUDE_PROJECT_DIR`) to a `statusLine` command — those
 are only set for plugin hooks and MCP/LSP subprocesses. A statusLine that
 references `$CLAUDE_PLUGIN_ROOT` expands it to an empty string and fails with
-`Cannot find module` — the statusline then silently renders blank. The command
-above instead resolves the newest installed AFK bundle straight from the plugin
-cache (`ls -t … | head -1`), so it stays valid across plugin updates without
-pinning a `…/cache/<version>/…` path. The project root is **not** passed as an
+`Cannot find module` — the statusline then silently renders blank.
+
+**Why the cached bundle, not `afk.mjs` directly.** Since ADR 0038, the installed
+`afk.mjs` is a tiny **launcher that fetches** the real runtime bundle from the
+GitHub release on first use (caching it at
+`~/.cache/red-skills/bundles/dev-<version>.bundle.min.mjs`). Pointing the
+statusLine straight at the launcher means **every plugin update** lands a new
+version whose bundle is not cached yet, so the launcher tries a **synchronous
+network download inside the statusline render** — which blows the render's tight
+timeout (blank statusline), or fails outright if that version's release asset is
+not published yet. The command above instead runs the **newest already-fetched
+bundle** (`ls -t …/.cache/red-skills/bundles/dev-*.bundle.min.mjs | head -1`) —
+no network in the hot path, so an update never blanks the line; it keeps showing
+the last good bundle until a normal `afk` run (or a SessionStart pre-fetch)
+caches the new one. It falls back to the launcher only when the cache is empty
+(first-ever install), to bootstrap. The project root is **not** passed as an
 argument: the AFK `statusline` subcommand reads it from `workspace.project_dir`
 in the JSON Claude Code pipes on stdin, which the `sh -c` wrapper forwards
 intact.
@@ -58,7 +70,7 @@ and a fresh file when it is missing. Keep unrelated settings intact.
 
 ```bash
 printf '{"workspace":{"project_dir":"%s"},"model":{"display_name":"Opus"}}' "$PWD" \
-  | sh -c 'b=$(ls -t "$HOME"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n "$b" ] && exec node "$b" statusline'
+  | sh -c 'b=$(ls -t "$HOME"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | head -1); [ -z "$b" ] && b=$(ls -t "$HOME"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n "$b" ] && exec node "$b" statusline'
 ```
 
 It should print a line like `red-skills (main) · Opus`.


### PR DESCRIPTION
## Problem
Every plugin update broke the Claude statusline. Since **ADR 0038**, `bin/afk.mjs` is a ~6 KB launcher that **fetches** the runtime bundle from the GitHub release. The Claude `statusLine` command ran that launcher directly, so each update landed a new version whose bundle wasn't cached — triggering a **synchronous network download inside the statusline render**, which blows the render timeout (blank line) or fails outright if the version's release asset isn't published yet. (Pre-0038, `afk.mjs` was the full committed bundle, so the line rendered instantly.)

## Fix
Point the statusLine at the **newest already-fetched bundle** (`~/.cache/red-skills/bundles/dev-*.bundle.min.mjs`) — no network in the hot path. An update never blanks the line; it keeps rendering the last good bundle until a normal `afk` run re-fetches the new one. Falls back to the launcher only when the cache is empty (first-ever install).

Verified: `… | node ~/.cache/red-skills/bundles/dev-1.148.0.bundle.min.mjs statusline` → `red-skills (main) · Opus`, exit 0, offline.

## Scope
- Updates the `.claude/settings.json` command template, the "why" rationale, and the verify snippet in the statusline `SKILL.md`.
- **Claude only.** The Codex footer is native `tui.status_line` config (no command/bundle), so this doesn't touch it — Codex durability is a separate follow-up (re-assert `[tui].status_line` on session_start via a TOML-safe writer).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782994224&installation_id=129708444&pr_number=379&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F379&signature=759026ef0ee5aaf09a323e659bb1d80d5ac5ed1841bb7b1e7576420382b939ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined statusline skill documentation to implement an intelligent resource resolution strategy. The approach now prioritizes locally cached runtime bundles to prevent blank renders caused by synchronous network fetches. When cached bundles are unavailable, the system automatically falls back to the launcher. Updated corresponding verification commands and explanatory text to reflect this improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->