### PR TITLE
fix(statusline): re-assert Codex tui.status_line on session_start (survives config resets)

### DIFF
--- a/plugins/dev/hooks/codex.hooks.json
+++ b/plugins/dev/hooks/codex.hooks.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; root=\"${CODEX_PLUGIN_ROOT}\"; ver=\"$(node -e \"process.stdout.write(require(process.argv[1]).version)\" \"$root/.codex-plugin/plugin.json\" 2>/dev/null)\"; if [ -n \"$ver\" ]; then for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { node \"$f\" dev \"$ver\" >/dev/null 2>&1 || true; node \"$f\" code-nav \"$ver\" >/dev/null 2>&1 || true; break; }; done; fi; printf \"{}\"'"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; root=\"${CODEX_PLUGIN_ROOT}\"; for f in \"$root/hooks/ensure-codex-statusline.mjs\" \"$root/dist/ensure-codex-statusline.mjs\"; do [ -f \"$f\" ] && { node \"$f\" </dev/null >/dev/null 2>&1 || true; break; }; done; printf \"{}\"'"
           }
         ]
       }

--- a/plugins/dev/hooks/ensure-codex-statusline.mjs
+++ b/plugins/dev/hooks/ensure-codex-statusline.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// RedSkills · Codex statusline ensure (session_start hook)
+//
+// Codex's footer is global config (`~/.codex/config.toml` -> `[tui].status_line`,
+// builtin widgets) with no command hook, so the RedSkills line cannot be injected
+// the way it is on Claude Code. Worse: when Codex re-syncs plugin `[hooks.state]`
+// on update it can rewrite config.toml and drop the `[tui]` section, blanking the
+// footer. This hook re-asserts `status_line` at every session start.
+//
+// Safety contract (do not weaken):
+//   - ADDITIVE ONLY: insert `status_line` solely when it is absent. Never clobber
+//     an existing value — the operator's own choice always wins.
+//   - ATOMIC WRITE: temp file + rename, so a race with Codex's own writer can lose
+//     the update but can never corrupt config.toml.
+//   - BEST EFFORT: any error is swallowed; the hook still emits `{}` so Codex's
+//     session start is never blocked.
+//
+// The default widget set matches the statusline SKILL.md Codex recommendation.
+
+import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_STATUS_LINE =
+  '["project", "git-branch", "model-with-reasoning", "context-remaining", "task-progress"]';
+
+function emitAndExit() {
+  // Codex hook contract: pass the context through unchanged.
+  process.stdout.write("{}");
+  process.exit(0);
+}
+
+// Drain stdin (the piped hook context) so the producer never blocks; ignore it.
+try {
+  readFileSync(0);
+} catch {
+  /* no stdin / closed — fine */
+}
+
+try {
+  const cfgPath = join(homedir(), ".codex", "config.toml");
+  if (!existsSync(cfgPath)) emitAndExit();
+
+  const text = readFileSync(cfgPath, "utf8");
+  const lines = text.split("\n");
+
+  // Locate the [tui] table header.
+  let tuiHeader = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*\[tui\]\s*(#.*)?$/.test(lines[i])) {
+      tuiHeader = i;
+      break;
+    }
+  }
+
+  if (tuiHeader >= 0) {
+    // Scan the [tui] table body (until the next table header or EOF) for an
+    // existing status_line key. If present, respect it and do nothing.
+    for (let i = tuiHeader + 1; i < lines.length; i++) {
+      if (/^\s*\[/.test(lines[i])) break; // next table — key not found
+      if (/^\s*status_line\s*=/.test(lines[i])) emitAndExit(); // already set
+    }
+    lines.splice(tuiHeader + 1, 0, `status_line = ${DEFAULT_STATUS_LINE}`);
+  } else {
+    // No [tui] table at all — append one.
+    if (lines.length && lines[lines.length - 1] !== "") lines.push("");
+    lines.push("[tui]", `status_line = ${DEFAULT_STATUS_LINE}`, "");
+  }
+
+  const tmpPath = `${cfgPath}.redskills.tmp`;
+  writeFileSync(tmpPath, lines.join("\n"));
+  renameSync(tmpPath, cfgPath); // atomic on the same filesystem
+} catch {
+  /* best effort — never block session start */
+}
+
+emitAndExit();

--- a/plugins/dev/skills/engineering/statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/statusline/SKILL.md
@@ -92,6 +92,16 @@ per-repo like the Claude path):
 status_line = ["project", "git-branch", "model-with-reasoning", "context-remaining", "task-progress"]
 ```
 
+**Surviving Codex config resets.** That global `tui.status_line` gets dropped
+whenever Codex rewrites `~/.codex/config.toml` (e.g. re-syncing plugin
+`[hooks.state]` on update), blanking the footer "every update". The dev plugin's
+Codex `SessionStart` hook re-asserts it: `hooks/ensure-codex-statusline.mjs`
+inserts `status_line` **only when absent** (never clobbers an operator's own
+value) via an **atomic** write (temp + rename — a race with Codex's writer can
+lose the update but never corrupt the file). So a reset self-heals on the next
+session start. The hook is additive and idempotent; disable it by removing the
+second `SessionStart` entry in `hooks/codex.hooks.json`.
+
 For live AFK visibility under Codex, point the user at `/afk monitor` (fleet
 spawns a read-only monitor agent; otherwise it falls back to the monitor
 dashboard). When Codex ships a command-backed statusline (openai/codex#17827 /


### PR DESCRIPTION
## Problem
The Codex footer blanks on "every update". Unlike Claude (a command statusLine), Codex's footer is **global builtin config** (`~/.codex/config.toml` → `[tui].status_line`) with **no command hook**. When Codex rewrites `config.toml` (e.g. re-syncing plugin `[hooks.state]` on update) it can drop the `[tui]` section → footer gone.

## Fix
New `plugins/dev/hooks/ensure-codex-statusline.mjs`, wired as a **second Codex `SessionStart` hook**. It re-asserts `status_line`:
- **Additive only** — inserts `status_line` *only when absent*; never clobbers an operator's existing value.
- **Atomic** — temp file + `rename`, so a race with Codex's own writer can lose the update but can **never corrupt** `config.toml`.
- **Idempotent / best-effort** — re-running is a no-op; any error is swallowed and the hook still emits `{}` so session start is never blocked.

A reset self-heals on the next session start (1-session lag).

## Tested
- `[tui]` with `status_line` → no-op (respects existing).
- `[tui]` without `status_line` → inserts, preserves sibling keys.
- no `[tui]` → appends `[tui]` + `status_line`.
- idempotent re-run → exactly one `status_line`.
- live run against the real `~/.codex/config.toml` → no change (already set), exit 0.

Note: Codex's footer can only show **builtin widgets** — the AFK worker block still can't render there (track via `/afk monitor`). This just keeps the chosen widget set from vanishing on update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995089&installation_id=129708444&pr_number=380&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F380&signature=71f06053b54d492eccee50c4af896ef46498a034363bff0fd8f56ff192ec129c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex now automatically initializes status line configuration on session start with safeguards against concurrent write corruption.

* **Documentation**
  * Updated documentation explaining status line configuration management and customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->