### PR TITLE
feat(dev): read-only adoption/process doctor (/dev:doctor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Composable. Boring on purpose where boring is enough. Sharp where it matters.
 | **[zoom-out](./plugins/dev/skills/engineering/zoom-out/SKILL.md)** | Map-first Codebase understanding; graph-aware when Memory Graph mode is ready, read-only when it is not. |
 | **[prototype](./plugins/dev/skills/engineering/prototype/SKILL.md)** | Throwaway prototype — terminal app for state/logic, or UI variations toggleable from one route. |
 | **[setup-red-skills](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md)** | Per-repo config: issue tracker, triage label vocab, domain doc layout, RedSkills workflows, RTK. |
+| **[doctor](./plugins/dev/skills/engineering/doctor/SKILL.md)** | Read-only adoption/process doctor — reports label-vocab conformance, AGENTS≡CLAUDE parity, statusline drift, MCP wiring, and `blocked:*` hygiene, tagging each gap with its fix-home. The recurring counterpart to `/setup-red-skills`. |
 | **[statusline](./plugins/dev/skills/engineering/statusline/SKILL.md)** | Installs or inspects the RedSkills Claude Code statusline, rendering the live AFK block via `node bin/afk.mjs statusline`. |
 
 </details>

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev",
-  "version": "1.148.2",
+  "version": "1.147.6",
   "description": "reddb.io dev plugin — engineering skills for code agents (autonomous /afk loop, triage, tdd, diagnose, graph-aware codebase understanding, wiki, …)",
   "mcpServers": "./.mcp.json",
   "hooks": "./hooks/claude.hooks.json",
@@ -9,6 +9,7 @@
     "./skills/engineering/curate",
     "./skills/engineering/context",
     "./skills/engineering/diagnose",
+    "./skills/engineering/doctor",
     "./skills/engineering/start",
     "./skills/engineering/triage",
     "./skills/engineering/hitl",

--- a/plugins/dev/skills/engineering/README.md
+++ b/plugins/dev/skills/engineering/README.md
@@ -13,6 +13,7 @@ Skills I use daily for code work.
 - **[urgent](./urgent/SKILL.md)** — File a `priority:urgent` issue that bypasses `/triage` and jumps the head of the `/afk` queue, ahead of any `--prd N` / `--issues a,b,c` filter. Use when something is on fire.
 - **[improve-codebase-architecture](./improve-codebase-architecture/SKILL.md)** — Find deepening opportunities in a codebase, informed by the domain language in `.red/CONTEXT.md` and the decisions in `.red/adr/`.
 - **[setup-red-skills](./setup-red-skills/SKILL.md)** — Scaffold the per-repo config (issue tracker, triage label vocabulary, domain doc layout) that the other engineering skills consume.
+- **[doctor](./doctor/SKILL.md)** — Read-only adoption/process doctor. Reports how fully a repo adopted the stack (label vocabulary, AGENTS≡CLAUDE parity, statusline form, MCP wiring, `blocked:*` hygiene) and names each fix's home — never applies it. The recurring counterpart to `/setup-red-skills`.
 - **[statusline](./statusline/SKILL.md)** — Install or inspect the RedSkills Claude Code statusline for the current repo, rendering the live AFK block via `node bin/afk.mjs statusline`.
 - **[tdd](./tdd/SKILL.md)** — Test-driven development with a red-green-refactor loop. Builds features or fixes bugs one vertical slice at a time.
 - **[to-issues](./to-issues/SKILL.md)** — Break any plan, spec, or PRD into independently-grabbable GitHub issues using vertical slices.

--- a/plugins/dev/skills/engineering/doctor/SKILL.md
+++ b/plugins/dev/skills/engineering/doctor/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: doctor
+description: Read-only adoption/process doctor — report how fully a repo has adopted the RedSkills engineering stack (triage label vocabulary, AGENTS≡CLAUDE parity, statusline form, MCP wiring, blocked-label hygiene) and recommend fixes without applying any. The recurring counterpart to the one-time `/setup-red-skills`. Use when asked "is our process round / is this repo set up right", "red doctor", "check adoption", before a large `/afk` drain, or to audit `reddb`/`red-ui`/`red-skills`-style repos against the canonical conventions.
+---
+
+# Doctor (adoption / process)
+
+The read-only, recurring counterpart to the mutating one-time `/setup-red-skills`
+— the same split the `memory` plugin has between `context-status` (read-only) and
+its setup. It reports how fully a repo adopted the RedSkills stack and **names the
+fix-home for each gap**; it never applies a fix.
+
+<what-to-do>
+
+**Run the checks below against the target repo (cwd by default; `--repo <path|owner/name>` for another, or sweep a list). Read only. Then print the scorecard.**
+
+### Hard rules
+
+- ❌ Never mutate: no `gh label create/edit/delete`, no file writes, no `gh issue edit`, no MCP/hook/statusline install. This is a diagnostic.
+- ❌ Never "fix while you're there." Every finding names where the fix lives — you do not perform it.
+- ✅ Compose existing read-only surfaces (`memory context-status`, `/wiki lint`) instead of re-implementing them.
+- ✅ Resolve the canonical vocabulary from the **target repo's** `.red/agents/triage-labels.md` (each repo may map roles to its own strings — respect that mapping, don't impose red-skills' defaults).
+
+### The check loop
+
+1. **Local context stack** — invoke `memory context-status` (or its CLI) and fold its result in. Do not duplicate its checks (CLAUDE/AGENTS, `.red/CONTEXT(-MAP)`, `.red/adr/*`, memory, wiki).
+2. **Label conformance** — `gh label list` vs the canonical families in `triage-labels.md`. Classify every label per the *Label classes* table in `<supporting-info>`. Report `❌ synonym` / `⚠️ legacy` / `⚠️ naming` with the suggested rename; never apply it.
+3. **`blocked:*` hygiene** — list open issues carrying `ready-for-agent` **or** `running` **together with** any `blocked:*` label (stale reason not rotated on re-queue). Count them.
+4. **AGENTS ≡ CLAUDE parity** — both files exist **and** both carry the `## Agent skills` block. Report `C/A` (e.g. `1/0` = block in CLAUDE only).
+5. **Statusline drift** — the installed `.claude/settings.json` `statusLine` command resolves the **cached bundle** (`~/.cache/red-skills/bundles/dev-*.bundle.min.mjs`), not the OLD launcher form (`…/plugins/cache/red-skills/dev/*/…/afk.mjs`) which blanks on every plugin update.
+6. **MCP wiring** — is `code-nav` / `red-memory` wired for this repo's **own** dev (root `.mcp.json` or an agent-doc reference)?
+
+### Output
+
+A scorecard (one row per check: ✅/⚠️/❌ + one-line evidence) + a readiness score (count of green checks, like `context-status`) + a prioritized recommendation list. **Every recommendation carries a fix-home tag** from the *Fix-home* table. End with the single highest-impact next step. Do not offer to perform any of them inside this skill.
+
+</what-to-do>
+
+<supporting-info>
+
+### Label classes (check 2)
+
+| Class | Meaning | Action |
+|---|---|---|
+| ❌ non-canonical synonym | duplicates a canonical role under a different name (`needs-human-decision` ↔ `ready-for-human`) | recommend rename to the canonical role |
+| ⚠️ legacy / superseded | older form replaced by a newer one (bare `blocked` vs typed `blocked:<reason>`) | recommend migrate + retire |
+| ⚠️ naming violation | not kebab-case nor `prefix:value` (uppercase / CamelCase / snake_case / spaces) | recommend normalize |
+| ✅ accepted aux | outside the triage families but legitimate (language labels, repo-custom like `drill`, `release-blocker`) | none |
+| ✅ GitHub default | `bug`, `enhancement`, `documentation`, `duplicate`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix` | none |
+
+Canonical families live in the target repo's `.red/agents/triage-labels.md`: state (`needs-triage`, `needs-info`, `ready-for-agent`, `running`, `ready-for-human`, `wontfix`), dependency (`blocked:dependency`, `req:N`), typed blocked-reasons (`blocked:quota|runner-transient|merge-conflict|spec|validation|crashed|policy|stalled|infra`), type (`type:prd`, `type:bug`, `needs-slicing`), priority (`priority:high|low|urgent`), relationship (`prd:N`), operational (`runner-error`).
+
+### Fix-home (every recommendation must be tagged)
+
+| Fix-home | Findings it owns |
+|---|---|
+| `→ /setup-red-skills` | AGENTS≡CLAUDE parity, statusline drift, MCP wiring, label provisioning. **Note:** `/setup-red-skills` Section F currently still emits the OLD statusline command — flag it as itself drifted until patched. |
+| `→ AFK runtime` | `blocked:*` accumulation (labels must be rotated/cleared on re-queue, plus the re-claim cap) — a bundle change, not a config edit. |
+| `→ manual / maintainer` | label renames (`gh label edit`), retiring legacy labels — the operator decides, the doctor never runs it. |
+
+### Scope & boundaries
+
+- **Single repo** by default; multi-repo sweep is opt-in.
+- **Public-repo safe**: reads only conventions already public in the repo; emits no secrets and proposes no CI/CD standardization (explicitly out of scope — do not recommend forcing `red-`-prefixed workflows on a repo's own CI).
+- Pairs with `/review-adrs` (decision-record coherence) and `memory:doctor` (graph health) — three read-only doctors over different axes; this one owns **process/adoption**.
+
+</supporting-info>


### PR DESCRIPTION
Adds **`/dev:doctor`** — a read-only adoption/process doctor, the recurring counterpart to the one-time `/setup-red-skills` (same split the `memory` plugin has between `context-status` and setup).

Came out of an adoption study across `reddb` / `red-ui` / `red-skills`: the **core process is ~100% adopted** everywhere; the gaps are on the edges and are exactly what a read-only doctor should surface.

## What it checks (read-only — names the fix-home, never applies)
1. Composes `memory:context-status` (local stack: CLAUDE/AGENTS/.red/CONTEXT(-MAP)/adr/memory/wiki).
2. **Label conformance** vs the repo's `.red/agents/triage-labels.md` — flags non-canonical synonyms (`needs-human-decision`→`ready-for-human`), legacy (bare `blocked`), naming violations.
3. **`blocked:*` hygiene** — open issues carrying `ready-for-agent`/`running` + stale `blocked:*` (real: reddb #923-925).
4. **AGENTS≡CLAUDE parity** — both files + both with the `## Agent skills` block.
5. **Statusline drift** — installed command is the cached-bundle form, not the OLD launcher form that blanks on update.
6. **MCP wiring** — `code-nav`/`red-memory` wired for the repo's own dev.

Output: scorecard + readiness score + recommendations, each tagged `→ /setup-red-skills` / `→ AFK runtime` / `→ manual`.

## Notes
- Read-only by design (DON'Ts mirror `context-status`). Public-repo safe; **CI/CD standardization explicitly out of scope**.
- Registered in `plugin.json` + root README + engineering bucket README; Codex picks it up via the `./skills/` wildcard.
- Pairs with the upcoming `/dev:review-adrs` (decision-record coherence) and `memory:doctor` (graph) — three read-only doctors over different axes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782996331&installation_id=129708444&pr_number=381&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F381&signature=be220237cedac82e263fe97c57129260b9b704113f1d964026d08c69f0630aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the "doctor" skill—a read-only diagnostic tool for auditing engineering process adoption with checks for label conformance, issue hygiene, parity verification, and statusline drift detection.

* **Documentation**
  * Added documentation for the new doctor skill and updated plugin references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->