### PR TITLE
feat(dev): review-adrs skill — decision-record doctor (lint + group + propagate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Composable. Boring on purpose where boring is enough. Sharp where it matters.
 | **[prototype](./plugins/dev/skills/engineering/prototype/SKILL.md)** | Throwaway prototype — terminal app for state/logic, or UI variations toggleable from one route. |
 | **[setup-red-skills](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md)** | Per-repo config: issue tracker, triage label vocab, domain doc layout, RedSkills workflows, RTK. |
 | **[doctor](./plugins/dev/skills/engineering/doctor/SKILL.md)** | Read-only adoption/process doctor — reports label-vocab conformance, AGENTS≡CLAUDE parity, statusline drift, MCP wiring, and `blocked:*` hygiene, tagging each gap with its fix-home. The recurring counterpart to `/setup-red-skills`. |
+| **[review-adrs](./plugins/dev/skills/engineering/review-adrs/SKILL.md)** | Decision-record doctor — lints `.red/adr/` for contradictions, missing supersession, stale references, and number collisions; clusters into a thematic index; propagates decision changes into the Wiki + Memory graph (gated). |
 | **[statusline](./plugins/dev/skills/engineering/statusline/SKILL.md)** | Installs or inspects the RedSkills Claude Code statusline, rendering the live AFK block via `node bin/afk.mjs statusline`. |
 
 </details>

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -10,6 +10,7 @@
     "./skills/engineering/context",
     "./skills/engineering/diagnose",
     "./skills/engineering/doctor",
+    "./skills/engineering/review-adrs",
     "./skills/engineering/start",
     "./skills/engineering/triage",
     "./skills/engineering/hitl",

--- a/plugins/dev/skills/engineering/README.md
+++ b/plugins/dev/skills/engineering/README.md
@@ -14,6 +14,7 @@ Skills I use daily for code work.
 - **[improve-codebase-architecture](./improve-codebase-architecture/SKILL.md)** — Find deepening opportunities in a codebase, informed by the domain language in `.red/CONTEXT.md` and the decisions in `.red/adr/`.
 - **[setup-red-skills](./setup-red-skills/SKILL.md)** — Scaffold the per-repo config (issue tracker, triage label vocabulary, domain doc layout) that the other engineering skills consume.
 - **[doctor](./doctor/SKILL.md)** — Read-only adoption/process doctor. Reports how fully a repo adopted the stack (label vocabulary, AGENTS≡CLAUDE parity, statusline form, MCP wiring, `blocked:*` hygiene) and names each fix's home — never applies it. The recurring counterpart to `/setup-red-skills`.
+- **[review-adrs](./review-adrs/SKILL.md)** — Decision-record doctor. Lints `.red/adr/` for contradictions, missing supersession links, stale references, and number collisions; clusters the set into a thematic index; and propagates decision changes into the LLM Wiki and Memory graph (gated). Read-only detect, gated writes.
 - **[statusline](./statusline/SKILL.md)** — Install or inspect the RedSkills Claude Code statusline for the current repo, rendering the live AFK block via `node bin/afk.mjs statusline`.
 - **[tdd](./tdd/SKILL.md)** — Test-driven development with a red-green-refactor loop. Builds features or fixes bugs one vertical slice at a time.
 - **[to-issues](./to-issues/SKILL.md)** — Break any plan, spec, or PRD into independently-grabbable GitHub issues using vertical slices.

--- a/plugins/dev/skills/engineering/review-adrs/SKILL.md
+++ b/plugins/dev/skills/engineering/review-adrs/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: review-adrs
+description: Review the `.red/adr/` set for contradictions, missing supersession links, and staleness (paths/commands that moved), cluster the ADRs into a thematic index, and propagate decision changes into the LLM Wiki and Memory graph. Use when asked to "review the ADRs", "are any ADRs conflicting / out of date / superseded", after adding or reversing an ADR, or to group a large ADR set and keep the wiki/memory claims derived from decisions in sync.
+---
+
+# Review ADRs (decision-record coherence + propagation)
+
+ADRs accumulate (30–40+ per repo) and **derive**: one reverses another, a path it
+cites moves, the wiki and Memory graph hold claims sourced from a decision that
+later changed. This is the "doctor of decisions" — sibling to `/doctor` (adoption)
+and `memory:doctor` (graph). Lint and grouping are read-only/propositional; any
+write (the index, memory supersession, wiki re-ingest) is gated on approval.
+
+<what-to-do>
+
+**Read every `.red/adr/*.md` (and `.red/CONTEXT-MAP.md` / contexts if present). Run the three passes below in order. Detect read-only; only write behind explicit approval.**
+
+### Hard rules
+
+- ❌ Do not edit ADR bodies, rewrite history, or auto-resolve a contradiction. Surface it; the maintainer decides the resolution.
+- ❌ Do not delete or hard-edit Memory nodes — use supersession (hide-not-delete), and only after approval.
+- ✅ Compose existing surfaces: `/wiki lint` for wiki claims, Memory supersession/contradiction reads for graph claims. Do not reimplement them.
+- ✅ Honour ADR conventions in `start/ADR-FORMAT.md` (Status frontmatter, "superseded by ADR-NNNN", Related links).
+
+### Pass 1 — Lint (read-only, detect)
+
+For the ADR set, report:
+
+- **Contradictions** — two ADRs whose decisions oppose on the same topic (e.g. "memory lives in `src/apps`" vs "memory moves to `red-memory`"). Flag pairs that should cross-reference but don't.
+- **Missing supersession** — a later ADR reverses/supersedes an earlier one, but the earlier still reads `Status: accepted` with no "superseded by ADR-NNNN" / Related note.
+- **Stale references** — an ADR cites a path / file / command that no longer exists (grep the body for paths, check existence; e.g. an ADR naming `src/domains/` after the tree became `src/apps/`).
+- **Numbering** — duplicate or gap-colliding ADR numbers (two files claiming the same NNNN, e.g. when parallel branches both grab the next number).
+
+### Pass 2 — Group (the thematic index)
+
+Cluster the ADRs by theme (AFK lifecycle · memory architecture · bundle/fetch · branch-lock · MCP/transport · licensing · repo structure · …). Emit a proposed **`.red/adr/INDEX.md`** — a decision map (the ADR analogue of `CONTEXT-MAP.md`) so a large set is navigable, each entry showing theme, status, and supersession edges. May reuse Memory graph-community clustering when graph mode is available, instead of clustering by hand. *Writing the index is gated on approval.*
+
+### Pass 3 — Propagate to Wiki + Memory (gated)
+
+A changed/superseded ADR leaves derived claims dangling:
+
+- **Wiki** — run `/wiki lint` (contradictions / orphans / stale claims) and find pages whose `REFERENCES` point at the changed ADR → propose a re-ingest of that ADR.
+- **Memory** — ADRs are first-class graph nodes (engineering semantic graph). Find nodes whose provenance cites the changed ADR → propose `memory_supersede` on the obsolete claims (reversible hide-not-delete).
+
+Present Pass-3 actions as an approval list; apply only what the maintainer approves.
+
+### Output
+
+A report: lint findings (contradictions / missing-supersession / stale / numbering) with the ADR pairs, the proposed thematic clustering, and the gated propagation actions for wiki + memory. End with the highest-impact decision to reconcile first.
+
+</what-to-do>
+
+<supporting-info>
+
+### Why each pass exists (worked examples)
+
+- **Contradiction / missing supersession:** ADR 0034 placed memory under `src/apps`; ADR 0039 moves it out to the `red-memory` repo — 0034 should carry a "partially superseded by 0039" note. ADR 0032 → superseded by 0034.
+- **Stale reference:** an ADR whose body says `src/domains/{dev,memory}` after the tree became `src/apps/` is out of date even though the *decision* still stands — flag the prose, not the decision.
+- **Numbering collision:** two PRs each grabbed "next = 0038" (one merged as the afk-bundle-fetch ADR; a second was authored locally and had to renumber to 0039). The lint catches duplicate NNNN before they both land.
+
+### Composition map
+
+| Pass | Reuses |
+|---|---|
+| 1 Lint | filesystem reads + `start/ADR-FORMAT.md` conventions; Memory contradiction reads when graph mode is on |
+| 2 Group | Memory graph communities (optional) for clustering |
+| 3 Propagate | `/wiki lint` + `/wiki ingest`; `memory_supersede` / Memory provenance reads |
+
+### Boundaries
+
+- The skill **proposes** supersession and re-ingest; the maintainer approves. Never silently rewrites a decision, the wiki, or the graph.
+- Pairs with `/doctor` (adoption/process) and `memory:doctor` (graph health) — three read-only-first doctors over different axes; this one owns **the decision record**.
+
+</supporting-info>


### PR DESCRIPTION
Adds **`/dev:review-adrs`** — the "doctor of decisions", sibling to `/dev:doctor` (adoption) and `memory:doctor` (graph).

ADRs accumulate (30–40+/repo) and derive: one reverses another, a cited path moves, and wiki/memory claims sourced from a decision go stale. This skill makes that drift visible and keeps the derived knowledge in sync.

## Three passes
1. **Lint (read-only)** — contradictions, missing "superseded by" links, stale references (paths/commands that moved, e.g. `src/domains` → `src/apps`), and ADR number collisions (the 0038 double-grab this session).
2. **Group** — cluster ADRs by theme into a proposed `.red/adr/INDEX.md` (decision map; the ADR analogue of `CONTEXT-MAP.md`); may reuse Memory graph communities.
3. **Propagate (gated)** — `/wiki lint` + re-ingest for pages referencing a changed ADR; `memory_supersede` for graph nodes whose provenance cites it.

Lint + grouping are read-only/propositional; index/wiki/memory writes are **gated on approval** (never silently rewrites a decision, the wiki, or the graph). Composes existing surfaces (`/wiki lint`, Memory supersession) instead of reimplementing them.

Registered in `plugin.json` + both READMEs; Codex picks it up via the `./skills/` wildcard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782996444&installation_id=129708444&pr_number=382&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F382&signature=4c11f825c64d778a3022aebf13b3dfabbc1fc809832ac445abdd84033bc80564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new skill for reviewing Architecture Decision Records (ADRs) that identifies contradictions, missing supersession, stale references, and numbering collisions.
  * Generates a thematic ADR index and propagates decision changes into the LLM Wiki and Memory graph.

* **Documentation**
  * Added comprehensive skill documentation and registered the new skill in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->