### PR TITLE
docs(adr): 0040 version single-source + version-aware; 0039 two-MCP memory plugin; doctor checks 6/7

### DIFF
--- a/.red/adr/0039-red-skills-consumes-red-memory-and-red-ui-mcps.md
+++ b/.red/adr/0039-red-skills-consumes-red-memory-and-red-ui-mcps.md
@@ -24,7 +24,19 @@ There are two distinct MCPs in play, repeatedly conflated:
    - **`red-ui`** — the visualizer MCP App (was `ui-mcp` / `@reddb-io/ui-mcp`).
    - **`code-nav`** — unchanged; stays built in red-skills under the `dev` plugin. The brand-prefix asymmetry (`code-nav` not `red-code-nav`) is accepted.
 
-3. **red-skills pulls both as bundles from their repos' GitHub releases** (the fetch model of ADR 0029) — one fetch mechanism across the ecosystem, no npm-registry runtime dependency. The memory plugin's `.mcp.json` references `red-memory` (data) and `red-ui` (visualizer); red-skills builds neither.
+3. **red-skills pulls both as bundles from their repos' GitHub releases** (the fetch model of ADR 0029) — one fetch mechanism across the ecosystem, no npm-registry runtime dependency. **Both MCPs live in the memory plugin's `.mcp.json`** — `red-memory` (data) *and* `red-ui` (visualizer) — as consumers; red-skills builds neither. This replaces today's single, standalone-local `memory` server (which runs `scripts/bootstrap.mjs` against the in-repo `src/apps/memory` build). Target shape:
+
+   ```jsonc
+   // plugins/memory/.mcp.json (end state)
+   {
+     "mcpServers": {
+       "red-memory": { /* version-aware launcher: fetch dev-style bundle from the red-memory release */ },
+       "red-ui":     { /* version-aware launcher: fetch @reddb-io/ui-mcp bundle from the red-ui release */ }
+     }
+   }
+   ```
+
+   Both resolve their bundle by **version** (the same version-keyed launcher pattern as `dev`/`code-nav`, ADR 0038), so the fetch coordinates on one version id (see ADR 0040). The `dev` plugin keeps only `code-nav`.
 
 4. **Prerequisites in the owning repos:**
    - `red-memory` receives the migrated implementation and publishes a self-contained bundle as a GitHub release asset.

--- a/.red/adr/0040-version-is-single-source-one-writer-version-aware-clis.md
+++ b/.red/adr/0040-version-is-single-source-one-writer-version-aware-clis.md
@@ -1,0 +1,36 @@
+# Version is a single source, written by one script; CLIs and MCP launchers are version-aware
+
+## Context
+
+The plugin version is duplicated across many files: `plugins/<plugin>/.claude-plugin/plugin.json`, `plugins/<plugin>/.codex-plugin/plugin.json`, the version-keyed bundle assets (`dev-<version>.bundle.min.mjs`, ADR 0038), and their manifests. `red-release` already has a "Sync plugin manifest versions" step that writes the manifests together, and `scripts/validate-install-metadata.sh` is a CI **gate** that rejects a release when a plugin's Claude and Codex manifest versions disagree.
+
+The gate works — but there is **no single committed writer**, so any flow *outside* the release can drift one file. This bit us on 2026-06-02: landing `/dev:doctor` and `/dev:review-adrs` via worktrees copied a stale local `plugins/dev/.claude-plugin/plugin.json` (version `1.147.6`) over `main`'s `1.148.2` while `.codex-plugin` stayed `1.148.2`; `validate-install-metadata.sh` then failed `red-release` on three consecutive pushes, so the skills did not publish until the version was resynced (#384 → v1.149.0). The gate caught it loudly (good) but the drift was avoidable.
+
+Separately, the runtime bundles must be **version-aware**: the ADR 0038 launcher already resolves `dev-<version>.bundle.min.mjs` by the plugin version, and the memory plugin will fetch `red-memory` + `red-ui` by version too (ADR 0039). Version is therefore the coordination key across manifests, bundles, and the fetch — it must come from one place.
+
+## Decision
+
+1. **One source of truth for the version, one writer.** A single committed script (`scripts/set-version.sh <version>`, deriving from the release-computed next version / git tag) is the **only** thing that writes a version. It propagates the value to **every** version-bearing file for a plugin — both `.claude-plugin` and `.codex-plugin` manifests (and any future manifest) — atomically. The `red-release` "sync" step **calls this script** instead of inlining the write; any manual flow uses the same script. Hand-editing a manifest version is disallowed.
+
+2. **`validate-install-metadata.sh` stays the gate.** Belt-and-suspenders: the single writer prevents drift; the validator still fails the release if drift ever appears (the two are independent defenses).
+
+3. **CLIs and MCP launchers are version-aware from that same source.** Each shipped CLI/bundle (`afk`, `code-nav`, the dev runtime, `red-memory`, `red-ui`) derives its version from `build-info` (already embedded at build) and reports it (`--version`). The version-keyed fetch launchers (ADR 0038/0039) resolve their bundle by that same version, so manifests, bundle filenames, and the running CLI all agree on one id.
+
+4. **`/dev:doctor` gains a version-coherence check** (cross-manifest equality per plugin) so the drift class is surfaced read-only, before a release ever fails on it.
+
+## Consequences
+
+- The "edit one manifest, forget the other" footgun is removed; manual landings can no longer desync versions.
+- Manifests, bundle assets, and CLI `--version` all coordinate on one id — the prerequisite for the ADR 0038/0039 version-keyed fetch to be reliable.
+- A small migration: extract the release's inline version write into `scripts/set-version.sh`, repoint `red-release` at it, add `--version` where a CLI lacks it, and wire the doctor check.
+
+## Status
+
+Accepted (direction); implementation pending. The validator gate and the version-keyed launchers already exist; the single-writer script and the `--version`/doctor-check wiring are the new work.
+
+## Related
+
+- ADR 0038 — version-keyed fetch launcher (the runtime's version-awareness).
+- ADR 0039 — memory plugin fetches `red-memory` + `red-ui` by version.
+- ADR 0029 — release-asset bundle fetch.
+- `scripts/validate-install-metadata.sh` — the CI gate this decision keeps.

--- a/plugins/dev/skills/engineering/doctor/SKILL.md
+++ b/plugins/dev/skills/engineering/doctor/SKILL.md
@@ -28,7 +28,8 @@ fix-home for each gap**; it never applies a fix.
 3. **`blocked:*` hygiene** — list open issues carrying `ready-for-agent` **or** `running` **together with** any `blocked:*` label (stale reason not rotated on re-queue). Count them.
 4. **AGENTS ≡ CLAUDE parity** — both files exist **and** both carry the `## Agent skills` block. Report `C/A` (e.g. `1/0` = block in CLAUDE only).
 5. **Statusline drift** — the installed `.claude/settings.json` `statusLine` command resolves the **cached bundle** (`~/.cache/red-skills/bundles/dev-*.bundle.min.mjs`), not the OLD launcher form (`…/plugins/cache/red-skills/dev/*/…/afk.mjs`) which blanks on every plugin update.
-6. **MCP wiring** — is `code-nav` / `red-memory` wired for this repo's **own** dev (root `.mcp.json` or an agent-doc reference)?
+6. **MCP wiring** — does the repo wire the expected MCPs? The `dev` plugin should expose `code-nav`; the `memory` plugin should expose **`red-memory` + `red-ui` as consumers** (fetched from the red-memory / red-ui releases per ADR 0039) — **flag a single standalone-local `memory` server** (running an in-repo `bootstrap.mjs`/build) as the pre-migration state. Also check whether the repo wires `code-nav`/`red-memory` for its **own** dev (root `.mcp.json` or agent-doc reference).
+7. **Version coherence** — every plugin manifest pair is on the same version: for each `plugins/*/`, `.claude-plugin/plugin.json` `version` **==** `.codex-plugin/plugin.json` `version`. A mismatch is what `validate-install-metadata.sh` rejects and what fails `red-release` (e.g. a stale manifest landed manually). Fix-home = `→ release` (the single-writer version script, ADR 0040).
 
 ### Output
 
@@ -57,6 +58,7 @@ Canonical families live in the target repo's `.red/agents/triage-labels.md`: sta
 | `→ /setup-red-skills` | AGENTS≡CLAUDE parity, statusline drift, MCP wiring, label provisioning. **Note:** `/setup-red-skills` Section F currently still emits the OLD statusline command — flag it as itself drifted until patched. |
 | `→ AFK runtime` | `blocked:*` accumulation (labels must be rotated/cleared on re-queue, plus the re-claim cap) — a bundle change, not a config edit. |
 | `→ manual / maintainer` | label renames (`gh label edit`), retiring legacy labels — the operator decides, the doctor never runs it. |
+| `→ release` | cross-manifest version mismatch — owned by the single-writer version script + `validate-install-metadata.sh` gate (ADR 0040); never hand-edit one manifest. |
 
 ### Scope & boundaries
 


### PR DESCRIPTION
Follows up the deploy break (manifest version drift that failed red-release 3×) and the clarification that **both** the memory and red-ui MCPs live inside the memory plugin.

- **ADR 0039** — explicit end-state `plugins/memory/.mcp.json`: `red-memory` (data) **and** `red-ui` (visualizer) as fetched consumers, replacing today's standalone-local `memory` bootstrap server; both version-keyed.
- **ADR 0040 (new)** — version is a single source, written by one script (`scripts/set-version.sh`) that red-release calls; `validate-install-metadata.sh` stays the gate; CLIs/launchers version-aware via `build-info` + `--version`. Removes the 'edit one manifest, forget the other' footgun that broke today's release.
- **/dev:doctor** — check 6 refined (expect red-memory+red-ui consumers; flag standalone-local memory) and **check 7** added (cross-manifest version coherence, `→ release` fix-home) so the doctor would have caught today's drift before release.

Docs + skill only; no manifest/version files touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782998151&installation_id=129708444&pr_number=385&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F385&signature=4fbee15fabb76b6a48ba8983ed33b05f177a42758c85404e11e54af7760677ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision records clarifying component integration patterns and version management approach
* **Chores**
  * Enhanced development environment validation with expanded MCP wiring consistency checks and cross-manifest version verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->