### PR TITLE
feat(config): unify plugin config under .red/config.yaml (plugins.<name>)

### DIFF
--- a/.red/adr/0009-dev-soft-uses-memory-one-directional.md
+++ b/.red/adr/0009-dev-soft-uses-memory-one-directional.md
@@ -1,5 +1,11 @@
 # `dev` soft-uses `memory`, one-directional
 
+> **Status:** accepted; detection-gate mechanism **partially superseded by ADR 0042**.
+> The one-directional soft-use *direction* below still stands. What changed: gate (1)
+> is no longer `.red/memory/config.json` existing — it is a `plugins.memory` block in
+> the unified `.red/config.yaml` (the legacy JSON path is still read as a back-compat
+> fallback). See ADR 0042.
+
 PRD #49 builds the `memory` plugin as a sibling of `dev` under `plugins/`, with
 the product thesis that memory **lives on top of dev and improves its
 processes** — `/afk` recalls prior attempts and known fixes, `/triage` dedupes

--- a/.red/adr/0042-plugin-config-unified-under-red-config-yaml.md
+++ b/.red/adr/0042-plugin-config-unified-under-red-config-yaml.md
@@ -1,0 +1,63 @@
+# Plugin configuration is unified under `.red/config.yaml`, namespaced by `plugins.<name>`
+
+## Context
+
+Each plugin resolved its own configuration, in its own place, in its own format:
+
+- `dev` reads `.red/config.yaml` (YAML) — `afk.*` and `statusline` keys, hand-authored, read-only to the code (`src/apps/dev/src/core/config.ts`).
+- `memory` read **and wrote** `.red/memory/config.json` (JSON) — `mode`, `hooks`, `notesDir`, `storePath`, `provider`, … (`src/apps/memory/src/config.ts`).
+
+There is no shared config-resolution module; the two formats and locations diverged for no principled reason. A maintainer inspecting a repo sees two unrelated config conventions and cannot answer "where do I set plugin X?" from one place.
+
+Two facts make unification cheap and safe:
+
+1. **Memory's config is write-once and choice-or-default.** `writeConfig` is called in exactly two places, both the one-time `memory init` wizard (`initMarkdownOnly`, `initGraph`). Nothing mutates config at runtime — every other site only *reads*. Every persisted field is either a user's wizard answer (`mode`, `hooks` opt-in, `provider`) or a code-resolvable default (`notesDir`, `storePath`, `eventLog.retentionDays`, `l2`); `mcp`/`reddb` are pure functions of `mode`; `version` is a constant. So the "config writer" is just the wizard transcribing answers a human would otherwise type — not a continuous machine-writer fighting a hand-edited file.
+2. **Both sides already have a seam.** Memory's 23 read sites all go through `readConfig`/`configPath` returning a stable `MemoryConfig`; dev's reads all go through `getConfig(cfg, "afk.*")`. The location/format can change behind those seams without touching callers.
+
+## Decision
+
+1. **One config file per repo: `.red/config.yaml`, namespaced by plugin under a `plugins:` key.**
+
+   ```yaml
+   # .red/config.yaml
+   # (global, plugin-agnostic settings live at the top)
+
+   plugins:
+     dev:
+       afk:
+         default_runner: codex
+     memory:
+       mode: graph
+       hooks:
+         sessionStart: true
+   ```
+
+2. **Config is sparse — only non-default choices are written; defaults live in code.** `mode` is the only mandatory `memory` field. Derivable fields are never persisted: `reddb` is derived from `mode` (graph/hybrid → true), `mcp` defaults off, `version` is the `CONFIG_VERSION` constant. `notesDir`/`storePath`/`eventLog`/`l2` are emitted only when they differ from the documented default.
+
+3. **`memory init` emits a sparse `plugins.memory:` block into `.red/config.yaml`** (the agreed write strategy), merging into the existing file and preserving the rest. No new YAML dependency: the same constrained-subset grammar `dev` already parses (2-space-indented nested mappings, scalar leaves) is reused; a small block emitter/merger handles the write. The `MemoryConfig` interface and all `resolve*` helpers are unchanged, so the 23 read sites are untouched.
+
+4. **The memory opt-in gate (ADR 0009) becomes "is there a `plugins.memory` block?"** `dev` soft-detects memory by reading `.red/config.yaml` for a `plugins.memory` block instead of `stat`-ing `.red/memory/config.json`. This partially supersedes ADR 0009's gate mechanism (the *direction* — dev soft-uses memory one-directionally — still stands).
+
+5. **Back-compat, both sides, read-only fallback:**
+   - `dev` reads `plugins.dev.afk.*` first, falling back to a legacy top-level `afk.*` key (older `.red/config.yaml` files keep working).
+   - `memory` reads `plugins.memory` from `.red/config.yaml` first, falling back to a legacy `.red/memory/config.json` (older repos keep working until they re-init).
+   - the gate accepts **either** signal.
+   No automatic migration is forced; a repo upgrades the moment it re-runs `memory init` (or hand-edits the yaml). The legacy fallbacks are a deprecation lane, removable later.
+
+## Consequences
+
+- One place answers "where is plugin X configured?" — `.red/config.yaml`, under `plugins.<name>`. Future plugins (`data`, `ops`) namespace the same way.
+- Memory stops owning a second config format/location; `.red/memory/` keeps only machine-written data (`graph.rdb`, `notes/`), not config. The init wizard writes the same answers, to a different (shared) file.
+- The change is contained at the existing seams + a small, separately-tested `shared-config` module (parse `plugins.memory` / emit sparse block / merge into existing yaml); callers on both sides are untouched.
+- The `dev → memory` detection no longer `stat`s a file; it parses the yaml for the block — a cheap parse with the existing no-dep parser, gated behind the same one-directional soft-use.
+- This decision travels with the memory migration to `red-memory` (ADR 0041): the unified file/namespacing is the contract; each repo keeps its own minimal yaml handling (no cross-repo shared module), which is correct since the apps are splitting.
+
+## Status
+
+Accepted. Implemented behind back-compat fallbacks; the legacy `.red/memory/config.json` and top-level `afk.*` lanes are deprecated and removable in a later cleanup.
+
+## Related
+
+- ADR 0009 — `dev` soft-uses `memory`, one-directional. **Gate mechanism partially superseded by this ADR** (the soft-use direction stands; the probe changes from `stat .red/memory/config.json` to a `plugins.memory` block read).
+- ADR 0026 — AFK lifecycle hooks declared in `.red/config.yaml` under `afk.hooks` (now `plugins.dev.afk.hooks`, with the legacy top-level lane still read).
+- ADR 0041 — red-skills consumes `red-memory`/`red-ui`; this config contract travels with that migration.

--- a/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
+++ b/plugins/dev/skills/engineering/afk/AGENT-PROMPT.md
@@ -128,7 +128,7 @@ Detect and recall in one step from inside the worktree:
 
 ```bash
 # repo root is the worktree you are in
-if [ -f .red/memory/config.json ]; then
+if { [ -f .red/config.yaml ] && grep -qE '^[[:space:]]+memory:' .red/config.yaml; } || [ -f .red/memory/config.json ]; then
   _bridge="${CLAUDE_PLUGIN_ROOT:-}/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] || _bridge="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/dev/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] && source "$_bridge" \

--- a/plugins/dev/skills/engineering/context/SKILL.md
+++ b/plugins/dev/skills/engineering/context/SKILL.md
@@ -26,7 +26,7 @@ Do not ask the user to repeat information that is already present in those files
 
 ### 2. Recall prior memory before re-deriving
 
-If `.red/memory/config.json` exists, run a targeted recall before deep investigation:
+If memory is configured here (a `plugins.memory` block in `.red/config.yaml`, or the legacy `.red/memory/config.json`), run a targeted recall before deep investigation:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/../memory/scripts/bootstrap.mjs" recall "<topic terms>"

--- a/plugins/dev/skills/engineering/diagnose/SKILL.md
+++ b/plugins/dev/skills/engineering/diagnose/SKILL.md
@@ -141,7 +141,7 @@ Do **not** proceed to hypothesise without a loop.
 `memory` is a sibling plugin that, when present, holds root causes from past diagnoses. Recalling at the top of Phase 3 means a recurring or related bug arrives with its previously-found cause already on the table — the single biggest accelerator for "we've seen this before". **Best-effort, never a gate**: if `memory` is not installed, skip it and diagnose exactly as today.
 
 ```bash
-if [ -f .red/memory/config.json ]; then
+if { [ -f .red/config.yaml ] && grep -qE '^[[:space:]]+memory:' .red/config.yaml; } || [ -f .red/memory/config.json ]; then
   _bridge="${CLAUDE_PLUGIN_ROOT:-}/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] || _bridge="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/dev/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] && source "$_bridge" \

--- a/plugins/dev/skills/engineering/triage/SKILL.md
+++ b/plugins/dev/skills/engineering/triage/SKILL.md
@@ -80,7 +80,7 @@ If prior triage notes exist on the issue: read them, check whether the reporter 
 This is **best-effort and never a gate** — if `memory` is not installed, skip it silently; triage proceeds exactly as today (the `.out-of-scope/*.md` scan remains the always-on dedup path).
 
 ```bash
-if [ -f .red/memory/config.json ]; then
+if { [ -f .red/config.yaml ] && grep -qE '^[[:space:]]+memory:' .red/config.yaml; } || [ -f .red/memory/config.json ]; then
   _bridge="${CLAUDE_PLUGIN_ROOT:-}/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] || _bridge="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/dev/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] && source "$_bridge" \

--- a/plugins/dev/skills/engineering/zoom-out/SKILL.md
+++ b/plugins/dev/skills/engineering/zoom-out/SKILL.md
@@ -18,7 +18,7 @@ _zoom_out_path_from="<first explicitly named skill/module/file/concept, or empty
 _zoom_out_path_to="<second explicitly named skill/module/file/concept, or empty>"
 _zoom_out_target_file="<focused file path when the user's request names one, or empty>"
 _zoom_out_target_symbol="<focused symbol name when the user's request names one, or empty>"
-if [ -f .red/memory/config.json ]; then
+if { [ -f .red/config.yaml ] && grep -qE '^[[:space:]]+memory:' .red/config.yaml; } || [ -f .red/memory/config.json ]; then
   _bridge="${CLAUDE_PLUGIN_ROOT:-}/scripts/memory-bridge.sh"
   [ -f "$_bridge" ] || _bridge="$(git rev-parse --show-toplevel 2>/dev/null)/plugins/dev/scripts/memory-bridge.sh"
   if [ -f "$_bridge" ] && source "$_bridge"; then

--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -125,7 +125,7 @@ Graph mode provisions a per-project embedded RedDB file at
 `.red/memory/graph.rdb` through the bundled SDK binary; there is no daemon to
 administer, but the build/install step is required. LLM-backed extraction and
 `memory ask` need a configured provider (`provider` in
-`.red/memory/config.json`, with any referenced API-key env var exported before
+the `plugins.memory` block of `.red/config.yaml`, with any referenced API-key env var exported before
 use). Without a provider key, deterministic store/recall, graph reads, claim
 checks, readiness, exports, and most hooks still run; ASK reports unavailable,
 and `memory extract --local` can still ingest explicit structured transcript
@@ -349,7 +349,7 @@ transcripts.
 
 `memory init` picks one storage mode. Two ship today:
 
-- **markdown-only** — zero engine dependency. Writes `.red/memory/config.json`
+- **markdown-only** — zero engine dependency. Writes the `plugins.memory` block of `.red/config.yaml`
   and `.red/memory/notes/`; `/memory:store` writes a plain markdown note,
   `/memory:recall` full-text-searches the notes.
 - **graph** — governed operational memory over a per-project embedded RedDB store
@@ -408,7 +408,7 @@ sentences. Recall and re-indexing are always zero-token.
 ### Pointing extraction at a local or in-account model
 
 The `INFERRED` extraction path (`memory extract`, the Stop hook) routes through
-whatever you put under `provider` in `.red/memory/config.json`. Export itself
+whatever you put under `provider` in the `plugins.memory` block of `.red/config.yaml`. Export itself
 never needs an LLM — this only governs extraction. For privacy-sensitive
 projects where code must not leave your environment, point `provider` at a
 local or in-account model:
@@ -855,7 +855,7 @@ serving path for status, curation, and recommendations; the event log is the
 raw audit substrate for future readiness and self-improvement views. Raw event
 readers apply a configurable retention horizon: graph init defaults to 30 days,
 and `memory init --mode graph --event-retention-days N` writes a different
-project horizon into `.red/memory/config.json`. The `memory_events` collection
+project horizon into the `plugins.memory` block of `.red/config.yaml`. The `memory_events` collection
 is always non-versioned and skipped by `memory commit`; promoted durable or
 reasoning graph evidence, rollups, and recallable facts survive even when old
 raw operational events age out of event-log reads.
@@ -896,12 +896,12 @@ error with `"no active memory session — call memory_session_start first (or
 rely on the SessionStart hook to mint one)"` so the agent can self-correct
 without a human in the loop.
 
-It resolves its store from the project config (`.red/memory/config.json` in the
+It resolves its store from the project config (the `plugins.memory` block of `.red/config.yaml` in the
 cwd or `$MEMORY_ROOT`, graph mode required), or from an explicit
 `RED_MEMORY_URI`:
 
 ```bash
-memory-mcp          # reads ./.red/memory/config.json
+memory-mcp          # reads ./.red/config.yaml (plugins.memory)
 RED_MEMORY_URI=file:///abs/graph.rdb \
   memory-mcp        # explicit store
 ```

--- a/plugins/memory/skills/core/doctor/SKILL.md
+++ b/plugins/memory/skills/core/doctor/SKILL.md
@@ -16,7 +16,7 @@ fresh; one that nobody reads goes cold and surfaces here.
 
 ## 1. Require graph mode
 
-`doctor` needs `.red/memory/config.json` with `mode: "graph"`. If memory is not
+`doctor` needs a `plugins.memory` block in `.red/config.yaml` with `mode: "graph"`. If memory is not
 initialized or is markdown-only, say so and stop — there is no graph to inspect.
 
 ## 2. Diagnose (read-only first)

--- a/plugins/memory/skills/core/export/SKILL.md
+++ b/plugins/memory/skills/core/export/SKILL.md
@@ -18,7 +18,7 @@ Dumps the whole graph (graph mode only) into a directory as three files:
 
 ## 1. Require graph mode
 
-`export` needs `.red/memory/config.json` with `mode: "graph"`. If memory is not
+`export` needs a `plugins.memory` block in `.red/config.yaml` with `mode: "graph"`. If memory is not
 initialized or is markdown-only, say so and stop.
 
 ## 2. Export

--- a/plugins/memory/skills/core/extract/SKILL.md
+++ b/plugins/memory/skills/core/extract/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: extract
-description: Extract durable facts from a transcript into the Memory graph through the configured AI provider. Use when the user wants to preserve decisions, gotchas, root causes, or reasoning traces from a conversation or log. Graph mode only; requires `provider` in `.red/memory/config.json`.
+description: Extract durable facts from a transcript into the Memory graph through the configured AI provider. Use when the user wants to preserve decisions, gotchas, root causes, or reasoning traces from a conversation or log. Graph mode only; requires `provider` in the `plugins.memory` block of `.red/config.yaml`.
 ---
 
 # memory extract
@@ -11,7 +11,7 @@ Turns a transcript into `INFERRED` memory graph facts. This is the LLM-backed wr
 
 ## 1. Require graph mode and provider
 
-`extract` needs `.red/memory/config.json` with:
+`extract` needs a `plugins.memory` block in `.red/config.yaml` with:
 
 - `mode: "graph"`
 - a configured `provider` block

--- a/plugins/memory/skills/core/health/SKILL.md
+++ b/plugins/memory/skills/core/health/SKILL.md
@@ -28,7 +28,7 @@ Use `--root <dir>` when checking a repository other than the current working dir
 
 Read these JSON fields before deciding the next action:
 
-- `initialized` — whether `.red/memory/config.json` exists.
+- `initialized` — whether memory is configured (a `plugins.memory` block in `.red/config.yaml`, or the legacy `.red/memory/config.json`).
 - `graphMode` — whether graph mode is configured and the graph store exists.
 - `skillTelemetry` — `enabled` or `unavailable`.
 - `graphFreshness` — freshness of the graph store versus project files.

--- a/plugins/memory/skills/core/ingest/SKILL.md
+++ b/plugins/memory/skills/core/ingest/SKILL.md
@@ -26,7 +26,7 @@ This is the `EXTRACTED` (deterministic) ingest path only. Conversation/git
 
 ## 1. Require graph mode
 
-Read `.red/memory/config.json`. If it is missing, memory was never initialized —
+Read the `plugins.memory` block of `.red/config.yaml` (or the legacy `.red/memory/config.json`). If neither is present, memory was never initialized —
 run `/memory:init`. If `mode` is not `graph`, ingest has nothing to write to;
 tell the user to re-run `memory init --mode graph`.
 

--- a/plugins/memory/skills/core/init/SKILL.md
+++ b/plugins/memory/skills/core/init/SKILL.md
@@ -53,7 +53,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" init --mode graph
 node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" init --mode graph --hooks
 ```
 
-markdown-only writes `.red/memory/config.json` (all hooks off, MCP off, RedDB
+markdown-only writes a `plugins.memory` block to `.red/config.yaml` (all hooks off, MCP off, RedDB
 not required) and creates `.red/memory/notes/`. graph writes the same config
 shape with `mode: "graph"`, `reddb: true`, a `storePath`, and provisions the
 RedDB store at `.red/memory/graph.rdb` (graph mode needs step 1's build to have
@@ -83,7 +83,7 @@ context pack when needed.
 - ✅ Ask before passing `--hooks`; the config flag, not the manifest, is what makes a hook active vs dormant.
 - ❌ Don't require, install, or connect to RedDB in markdown-only mode.
 - ❌ Don't commit `.red/memory/graph.rdb*` — the store is per-project local state, like `node_modules/`.
-- ❌ Don't hand-write `.red/memory/config.json` — go through the CLI so the schema stays valid.
+- ❌ Don't hand-write the `plugins.memory` block in `.red/config.yaml` — go through the CLI so the schema stays valid.
 
 </what-to-do>
 

--- a/plugins/memory/skills/core/recall/SKILL.md
+++ b/plugins/memory/skills/core/recall/SKILL.md
@@ -21,7 +21,7 @@ plugin README.
 
 ## 1. Require init
 
-If `.red/memory/config.json` is missing, memory was never initialized — there is
+If memory is not configured (no `plugins.memory` block in `.red/config.yaml`, nor a legacy `.red/memory/config.json`), memory was never initialized — there is
 nothing to recall. Suggest `/memory:init`.
 
 ## 2. Recall

--- a/plugins/memory/skills/core/store/SKILL.md
+++ b/plugins/memory/skills/core/store/SKILL.md
@@ -17,7 +17,7 @@ way the fact is recallable later with `/memory:recall`.
 
 ## 1. Require init
 
-If `.red/memory/config.json` is missing, memory was never initialized — run
+If memory is not configured (no `plugins.memory` block in `.red/config.yaml`, nor a legacy `.red/memory/config.json`), memory was never initialized — run
 `/memory:init` (or tell the user to) before storing.
 
 ## 2. Store the fact

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -488,6 +488,13 @@ function makeRecordAttempt(
       const memoryCli = resolveMemoryCli(gitRoot, env, {
         exists: existsSync,
         readJsonVersion: readManifestVersion,
+        readText: (path) => {
+          try {
+            return readFileSync(path, "utf8");
+          } catch {
+            return undefined;
+          }
+        },
       });
       if (!memoryCli) return; // memory not opted-in / no CLI resolves — silent skip.
       const dir = current.attemptDir || gitRoot;

--- a/src/apps/dev/src/core/attempt-record.ts
+++ b/src/apps/dev/src/core/attempt-record.ts
@@ -155,6 +155,32 @@ export interface MemoryCliProbes {
   exists: (path: string) => boolean;
   /** The `version` field of the JSON manifest at `path`, or undefined. */
   readJsonVersion?: (path: string) => string | undefined;
+  /** Raw text of a file at `path`, or undefined if absent. Used by the ADR 0042
+   * gate to detect a `plugins.memory` block in `.red/config.yaml`. */
+  readText?: (path: string) => string | undefined;
+}
+
+/**
+ * Whether `.red/config.yaml` text declares a `plugins.memory` block — the
+ * ADR 0042 memory opt-in signal that replaces the legacy
+ * `.red/memory/config.json` existence gate. A pure, dependency-free scan over
+ * the same constrained-subset grammar `dev`'s config parser uses: find the
+ * top-level `plugins:` mapping, then a `memory:` child indented exactly two
+ * spaces under it. Comment/blank lines are ignored; a `memory:` key elsewhere
+ * (not nested under `plugins:`) does not count.
+ */
+export function memoryConfiguredInYaml(text: string | undefined): boolean {
+  if (!text) return false;
+  let inPlugins = false;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (line.trim() === "" || line.trim().startsWith("#")) continue;
+    const indent = (line.match(/^ */)?.[0] ?? "").length;
+    const key = line.slice(indent).replace(/:.*$/, "").trim();
+    if (indent === 0) inPlugins = key === "plugins";
+    else if (inPlugins && indent === 2 && key === "memory") return true;
+  }
+  return false;
 }
 
 /** POSIX-style path join that does not depend on node:path, so the resolver is
@@ -173,7 +199,9 @@ function joinPath(...parts: string[]): string {
  * native dev-CLI record-attempt path no longer shells out to the bridge.
  *
  * Returns `undefined` (→ silent no-op, memory not installed/opted-in) when:
- *   - Gate 1: `<gitRoot>/.red/memory/config.json` is absent (ADR 0009 opt-in), or
+ *   - Gate 1: memory is not opted in for this root — neither a `plugins.memory`
+ *     block in `<gitRoot>/.red/config.yaml` (ADR 0042) nor the legacy
+ *     `<gitRoot>/.red/memory/config.json` (ADR 0009 back-compat) is present, or
  *   - Gate 2: no usable CLI resolves through the candidate chain.
  *
  * Candidate order (faithful to `_memory_resolve_cli`):
@@ -198,8 +226,14 @@ export function resolveMemoryCli(
   env: NodeJS.ProcessEnv,
   probes: MemoryCliProbes,
 ): string[] | undefined {
-  // Gate 1 (ADR 0009 opt-in): memory must be configured for this root.
-  if (!probes.exists(joinPath(gitRoot, ".red", "memory", "config.json"))) return undefined;
+  // Gate 1 (opt-in): memory must be configured for this root. Canonical signal
+  // is a `plugins.memory` block in `.red/config.yaml` (ADR 0042); the legacy
+  // `.red/memory/config.json` existence is still honoured (ADR 0009 back-compat).
+  const yamlText = probes.readText?.(joinPath(gitRoot, ".red", "config.yaml"));
+  const optedIn =
+    memoryConfiguredInYaml(yamlText) ||
+    probes.exists(joinPath(gitRoot, ".red", "memory", "config.json"));
+  if (!optedIn) return undefined;
 
   // 1. Explicit override.
   const override = env.RED_MEMORY_CLI;

--- a/src/apps/dev/src/core/config.ts
+++ b/src/apps/dev/src/core/config.ts
@@ -4,8 +4,12 @@ import { z } from "zod";
 /**
  * config.ts — TypeScript port of scripts/config.sh.
  *
- * Loads the `afk.*` block of `.red/config.yaml`. Mirrors the shell loader's
- * semantics exactly:
+ * Loads the dev config from `.red/config.yaml`. Per ADR 0042 the canonical
+ * location is the namespaced `plugins.dev.afk.*` block; the legacy top-level
+ * `afk.*` block is still read as a back-compat fallback. `loadConfig` folds the
+ * namespaced keys down to the bare `afk.*` accessor keys (the namespaced
+ * location wins when both are present), so every `getConfig(cfg, "afk.…")`
+ * caller is unchanged. Mirrors the shell loader's semantics exactly:
  *   - documented v1 defaults seed the map;
  *   - a missing file leaves all defaults;
  *   - malformed YAML emits one warning and falls back to all defaults;
@@ -159,7 +163,14 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
     return configDefaults();
   }
 
+  // Copy raw parsed keys (forward compatibility), then fold the namespaced
+  // `plugins.dev.*` block down to the bare accessor keys so the new location
+  // wins over the legacy top-level one (ADR 0042).
   for (const [key, value] of Object.entries(parsed)) values[key] = value;
+  for (const [key, value] of Object.entries(parsed)) {
+    const m = /^plugins\.dev\.(.+)$/.exec(key);
+    if (m) values[m[1]!] = value;
+  }
   return values;
 }
 

--- a/src/apps/dev/tests/attempt-record.test.ts
+++ b/src/apps/dev/tests/attempt-record.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAttemptRecordPayload,
+  memoryConfiguredInYaml,
   toMemoryPayload,
   resolveMemoryCli,
   type AttemptContext,
@@ -9,6 +10,7 @@ import {
 
 const ROOT = "/repo";
 const CONFIG = "/repo/.red/memory/config.json";
+const YAML = "/repo/.red/config.yaml";
 
 /** Build an exists-probe over an explicit allow-set of existing paths. */
 function existsOver(present: Iterable<string>): (p: string) => boolean {
@@ -185,5 +187,41 @@ describe("toMemoryPayload — wire format", () => {
     expect(parsed.attemptNumber).toBe(2);
     expect(parsed.status).toBe("done");
     expect(parsed.mergeCommit).toBe("abc1234");
+  });
+});
+
+describe("memoryConfiguredInYaml — ADR 0042 opt-in detection", () => {
+  it("detects a plugins.memory block", () => {
+    expect(memoryConfiguredInYaml("plugins:\n  memory:\n    mode: graph\n")).toBe(true);
+    expect(memoryConfiguredInYaml("plugins:\n  dev:\n    afk:\n      x: y\n  memory:\n    mode: graph\n")).toBe(true);
+  });
+  it("ignores a plugins block without memory, and a non-nested memory key", () => {
+    expect(memoryConfiguredInYaml("plugins:\n  dev:\n    afk:\n      x: y\n")).toBe(false);
+    expect(memoryConfiguredInYaml("memory:\n  mode: graph\n")).toBe(false);
+    expect(memoryConfiguredInYaml("")).toBe(false);
+    expect(memoryConfiguredInYaml(undefined)).toBe(false);
+  });
+});
+
+describe("resolveMemoryCli — Gate 1 via .red/config.yaml (ADR 0042)", () => {
+  const env = { PATH: "" } as NodeJS.ProcessEnv;
+
+  it("opts in from a plugins.memory yaml block even when the legacy json is absent", () => {
+    const p: MemoryCliProbes = {
+      exists: existsOver(["/abs/cli.js"]), // note: CONFIG json NOT present
+      readText: (path) => (path === YAML ? "plugins:\n  memory:\n    mode: graph\n" : undefined),
+    };
+    expect(resolveMemoryCli(ROOT, { ...env, RED_MEMORY_CLI: "/abs/cli.js" }, p)).toEqual([
+      "node",
+      "/abs/cli.js",
+    ]);
+  });
+
+  it("stays opted-out when neither the yaml block nor the legacy json is present", () => {
+    const p: MemoryCliProbes = {
+      exists: existsOver(["/abs/cli.js"]),
+      readText: (path) => (path === YAML ? "plugins:\n  dev:\n    afk:\n      x: y\n" : undefined),
+    };
+    expect(resolveMemoryCli(ROOT, { ...env, RED_MEMORY_CLI: "/abs/cli.js" }, p)).toBeUndefined();
   });
 });

--- a/src/apps/dev/tests/config.test.ts
+++ b/src/apps/dev/tests/config.test.ts
@@ -141,3 +141,24 @@ describe("config", () => {
     expect(getConfig(values, "afk.fleet.target")).toBe("9");
   });
 });
+
+describe("config — plugins.dev namespace (ADR 0042)", () => {
+  it("folds plugins.dev.afk.* down to the bare afk.* accessor keys", () => {
+    const text = "plugins:\n  dev:\n    afk:\n      default_runner: codex\n      fleet:\n        target: 4\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "afk.default_runner")).toBe("codex");
+    expect(getConfig(values, "afk.fleet.target")).toBe("4");
+  });
+
+  it("still reads the legacy top-level afk.* block (back-compat)", () => {
+    const text = "afk:\n  default_runner: codex\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "afk.default_runner")).toBe("codex");
+  });
+
+  it("lets the namespaced location win over a legacy top-level key", () => {
+    const text = "afk:\n  default_runner: claude\nplugins:\n  dev:\n    afk:\n      default_runner: codex\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "afk.default_runner")).toBe("codex");
+  });
+});

--- a/src/apps/memory/src/backup.ts
+++ b/src/apps/memory/src/backup.ts
@@ -67,12 +67,22 @@ export async function createMemoryBackup(
   const files = await listMemoryFiles(memoryDir);
   const copied: MemoryBackupFile[] = [];
   for (const file of files) {
+    // The config now lives in `.red/config.yaml` (ADR 0042), not under
+    // `.red/memory`. We synthesize a self-contained `config.json` snapshot
+    // below from the resolved config, so skip any legacy in-tree copy to avoid
+    // a duplicate manifest entry.
+    if (file === "config.json") continue;
     const src = join(memoryDir, file);
     const dest = join(dataDir, file);
     await mkdir(dirname(dest), { recursive: true });
     await copyFile(src, dest);
     copied.push(await fileManifest(dataDir, file));
   }
+
+  // Embed a normalized config snapshot so the backup is self-contained and the
+  // manifest is stable regardless of where the live config is stored.
+  await writeFile(join(dataDir, "config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  copied.push(await fileManifest(dataDir, "config.json"));
 
   const manifest: MemoryBackupManifest = {
     schema_version: "memory.backup.v1",

--- a/src/apps/memory/src/config.ts
+++ b/src/apps/memory/src/config.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { AiProviderConfig } from "./extract-conversation.js";
+import { mergeMemoryBlock, parsePluginsMemory } from "./shared-config.js";
 
 /** Storage backends the `memory init` wizard can configure. */
 export type StorageMode = "markdown-only" | "graph" | "hybrid";
@@ -159,8 +160,19 @@ export const DEFAULT_NOTES_DIR = ".red/memory/notes";
 /** Default location for the per-project RedDB graph store, under `.red/`. */
 export const DEFAULT_STORE_PATH = ".red/memory/graph.rdb";
 
-/** Absolute path to the memory config file for a given repo root. */
+/**
+ * Absolute path to the unified config file for a given repo root (ADR 0042).
+ * Memory config lives under the `plugins.memory` block of this file.
+ */
 export function configPath(rootDir: string): string {
+  return resolve(rootDir, ".red/config.yaml");
+}
+
+/**
+ * Absolute path to the legacy standalone memory config. Read as a back-compat
+ * fallback (ADR 0042); never written. Removable once repos have re-initialized.
+ */
+export function legacyConfigPath(rootDir: string): string {
   return resolve(rootDir, ".red/memory/config.json");
 }
 
@@ -178,21 +190,45 @@ export function resolveStoreUri(rootDir: string, config: MemoryConfig): string {
   return `file://${abs}`;
 }
 
-/** Write the config to `<root>/.red/memory/config.json`, creating parents. */
+/**
+ * Write the memory config into the `plugins.memory` block of
+ * `<root>/.red/config.yaml` (ADR 0042), merging into any existing file and
+ * preserving the rest of it (global keys, a `plugins.dev` sibling, comments).
+ * The block is sparse — only non-default fields are emitted.
+ */
 export async function writeConfig(
   rootDir: string,
   config: MemoryConfig,
 ): Promise<string> {
   const path = configPath(rootDir);
+  let existing = "";
+  try {
+    existing = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await writeFile(path, mergeMemoryBlock(existing, config), "utf8");
   return path;
 }
 
-/** Read the config, or return null if memory was never initialized here. */
+/**
+ * Read the memory config, or return null if memory was never initialized here.
+ * Canonical source is the `plugins.memory` block of `.red/config.yaml`
+ * (ADR 0042); falls back to the legacy standalone `.red/memory/config.json`
+ * so repos that have not re-initialized keep working.
+ */
 export async function readConfig(rootDir: string): Promise<MemoryConfig | null> {
   try {
-    const raw = await readFile(configPath(rootDir), "utf8");
+    const yaml = await readFile(configPath(rootDir), "utf8");
+    const fromYaml = parsePluginsMemory(yaml);
+    if (fromYaml) return fromYaml;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+
+  try {
+    const raw = await readFile(legacyConfigPath(rootDir), "utf8");
     return JSON.parse(raw) as MemoryConfig;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;

--- a/src/apps/memory/src/mcp-server.ts
+++ b/src/apps/memory/src/mcp-server.ts
@@ -9,7 +9,9 @@
  *
  * Store resolution (first match wins):
  *   RED_MEMORY_URI       — explicit RedDB URI (used by tests and advanced setups)
- *   MEMORY_ROOT / cwd    — read `.red/memory/config.json`; requires graph mode
+ *   MEMORY_ROOT / cwd    — read the `plugins.memory` block of `.red/config.yaml`
+ *                          (legacy `.red/memory/config.json` as fallback);
+ *                          requires graph mode
  *
  *   RED_MEMORY_PROJECT   — project tag stamped on stored nodes (defaults to the
  *                          config's project or the root dir name)

--- a/src/apps/memory/src/shared-config.ts
+++ b/src/apps/memory/src/shared-config.ts
@@ -1,0 +1,261 @@
+/**
+ * shared-config.ts — the unified `.red/config.yaml` seam for the memory plugin
+ * (ADR 0042).
+ *
+ * Memory configuration is namespaced under `plugins.memory` in the single
+ * repo-wide `.red/config.yaml`, the same file `dev` reads under `plugins.dev`.
+ * It is written once by the `memory init` wizard and read-only thereafter, so
+ * the block is **sparse**: only `mode` is mandatory; every other field is
+ * emitted only when it differs from the documented default, and derivable
+ * fields (`reddb` from `mode`, `version` constant) are never persisted.
+ *
+ * No YAML dependency: this module parses/emits the same constrained-subset
+ * grammar `dev`'s config parser uses (2-space-indented nested mappings, scalar
+ * leaves). Reads are best-effort (a malformed line is skipped, never thrown);
+ * the wizard owns the only writes.
+ */
+
+import type { AiProviderConfig } from "./extract-conversation.js";
+import {
+  CONFIG_VERSION,
+  DEFAULT_MEMORY_EVENT_RETENTION_DAYS,
+  DEFAULT_L2_BYTE_BUDGET,
+  DEFAULT_L2_TTL_MS,
+  DEFAULT_NOTES_DIR,
+  DEFAULT_STORE_PATH,
+  HOOKS_OFF,
+  type HookConfig,
+  type MemoryConfig,
+  type StorageMode,
+} from "./config.js";
+
+const STORAGE_MODES: readonly StorageMode[] = ["markdown-only", "graph", "hybrid"];
+
+/**
+ * Best-effort parse of the constrained-subset grammar into a `dotted.key ->
+ * value` map. Unlike `dev`'s parser this never throws — a line that violates
+ * the grammar is skipped, so a hand-edited file can never crash a read.
+ */
+export function parseYamlFlat(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const stack: string[] = [];
+  const indents: number[] = [];
+
+  for (const rawLine of text.split("\n")) {
+    let line = rawLine.replace(/\r$/, "");
+
+    // strip inline comments unless the line carries a quoted string
+    if (!/".*"/.test(line) && !/'.*'/.test(line)) {
+      const hash = line.indexOf("#");
+      if (hash >= 0) line = line.slice(0, hash);
+    }
+    if (line.replace(/\s/g, "") === "") continue;
+
+    const indent = (line.match(/^ */)?.[0] ?? "").length;
+    if (indent % 2 !== 0) continue; // skip odd-indent lines rather than throw
+    const rest = line.slice(indent).replace(/\s+$/, "");
+    const colon = rest.indexOf(":");
+    if (colon < 0 || !/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(rest.slice(0, colon))) continue;
+
+    const key = rest.slice(0, colon);
+    let value = rest.slice(colon + 1).replace(/^\s+/, "");
+    if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) value = value.slice(1, -1);
+    else if (value.startsWith("'") && value.endsWith("'") && value.length >= 2) value = value.slice(1, -1);
+
+    while (indents.length > 0 && indents[indents.length - 1]! >= indent) {
+      stack.pop();
+      indents.pop();
+    }
+    const full = stack.length > 0 ? `${stack.join(".")}.${key}` : key;
+    if (value === "") {
+      stack.push(key);
+      indents.push(indent);
+    } else {
+      out[full] = value;
+    }
+  }
+  return out;
+}
+
+function asBool(v: string | undefined): boolean {
+  return v === "true";
+}
+
+/**
+ * Reconstruct a full {@link MemoryConfig} from the `plugins.memory` block of a
+ * `.red/config.yaml`. Returns `null` when there is no such block (no
+ * `plugins.memory.mode`), which is the "memory not configured here" signal.
+ * Defaults are applied and derivable fields reconstructed so the returned
+ * object is indistinguishable from a legacy JSON read.
+ */
+export function parsePluginsMemory(text: string): MemoryConfig | null {
+  const flat = parseYamlFlat(text);
+  const p = "plugins.memory.";
+  const mode = flat[`${p}mode`];
+  if (!mode || !STORAGE_MODES.includes(mode as StorageMode)) return null;
+
+  const hooks: HookConfig = { ...HOOKS_OFF };
+  if (asBool(flat[`${p}hooks.sessionStart`])) hooks.sessionStart = true;
+  if (asBool(flat[`${p}hooks.postToolUse`])) hooks.postToolUse = true;
+  if (asBool(flat[`${p}hooks.stop`])) hooks.stop = true;
+  if (asBool(flat[`${p}hooks.preCompact`])) hooks.preCompact = true;
+
+  const config: MemoryConfig = {
+    version: CONFIG_VERSION,
+    mode: mode as StorageMode,
+    notesDir: flat[`${p}notesDir`] ?? DEFAULT_NOTES_DIR,
+    hooks,
+    mcp: asBool(flat[`${p}mcp`]),
+    reddb: mode !== "markdown-only", // derived, never persisted
+  };
+
+  if (flat[`${p}storePath`] !== undefined) config.storePath = flat[`${p}storePath`];
+  if (asBool(flat[`${p}skillTelemetry`])) config.skillTelemetry = true;
+
+  const retention = Number(flat[`${p}eventLog.retentionDays`]);
+  if (Number.isFinite(retention) && retention > 0) config.eventLog = { retentionDays: retention };
+
+  const ttlMs = Number(flat[`${p}l2.ttlMs`]);
+  const byteBudget = Number(flat[`${p}l2.byteBudget`]);
+  const l2: { ttlMs?: number; byteBudget?: number } = {};
+  if (Number.isFinite(ttlMs) && ttlMs > 0) l2.ttlMs = ttlMs;
+  if (Number.isFinite(byteBudget) && byteBudget > 0) l2.byteBudget = byteBudget;
+  if (l2.ttlMs !== undefined || l2.byteBudget !== undefined) config.l2 = l2;
+
+  const provider: Record<string, string> = {};
+  for (const [k, v] of Object.entries(flat)) {
+    const m = k.startsWith(`${p}provider.`) ? k.slice(`${p}provider.`.length) : undefined;
+    if (m) provider[m] = v;
+  }
+  if (Object.keys(provider).length > 0) config.provider = provider as unknown as AiProviderConfig;
+
+  return config;
+}
+
+function quoteIfNeeded(value: string): string {
+  return /[#:]|^\s|\s$/.test(value) ? `"${value}"` : value;
+}
+
+/**
+ * The sparse `plugins.memory` subtree as indented YAML lines (starting at the
+ * `  memory:` header, indent 2). Only non-default fields are emitted; `reddb`
+ * and `version` are dropped (derived/constant).
+ */
+export function emitMemoryBlockLines(config: MemoryConfig): string[] {
+  const lines: string[] = ["  memory:"];
+  lines.push(`    mode: ${config.mode}`);
+  if (config.notesDir && config.notesDir !== DEFAULT_NOTES_DIR)
+    lines.push(`    notesDir: ${quoteIfNeeded(config.notesDir)}`);
+  if (config.storePath !== undefined && config.storePath !== DEFAULT_STORE_PATH)
+    lines.push(`    storePath: ${quoteIfNeeded(config.storePath)}`);
+  if (config.mcp) lines.push("    mcp: true");
+  if (config.skillTelemetry) lines.push("    skillTelemetry: true");
+
+  const onHooks = (Object.keys(config.hooks) as (keyof HookConfig)[]).filter((h) => config.hooks[h]);
+  if (onHooks.length > 0) {
+    lines.push("    hooks:");
+    for (const h of onHooks) lines.push(`      ${h}: true`);
+  }
+
+  if (config.eventLog && config.eventLog.retentionDays !== DEFAULT_MEMORY_EVENT_RETENTION_DAYS) {
+    lines.push("    eventLog:");
+    lines.push(`      retentionDays: ${config.eventLog.retentionDays}`);
+  }
+
+  if (config.l2) {
+    const sub: string[] = [];
+    if (config.l2.ttlMs !== undefined && config.l2.ttlMs !== DEFAULT_L2_TTL_MS)
+      sub.push(`      ttlMs: ${config.l2.ttlMs}`);
+    if (config.l2.byteBudget !== undefined && config.l2.byteBudget !== DEFAULT_L2_BYTE_BUDGET)
+      sub.push(`      byteBudget: ${config.l2.byteBudget}`);
+    if (sub.length > 0) {
+      lines.push("    l2:");
+      lines.push(...sub);
+    }
+  }
+
+  if (config.provider) {
+    lines.push("    provider:");
+    for (const [k, v] of Object.entries(config.provider as unknown as Record<string, unknown>)) {
+      if (v === undefined || v === null) continue;
+      lines.push(`      ${k}: ${typeof v === "string" ? quoteIfNeeded(v) : String(v)}`);
+    }
+  }
+  return lines;
+}
+
+function lineIndent(line: string): number {
+  return (line.match(/^ */)?.[0] ?? "").length;
+}
+
+function isStructural(line: string): boolean {
+  const t = line.trim();
+  return t !== "" && !t.startsWith("#");
+}
+
+function topKey(line: string): string {
+  return line.replace(/^ */, "").replace(/:.*$/, "").trim();
+}
+
+/**
+ * Merge the sparse `plugins.memory` block into an existing `.red/config.yaml`,
+ * preserving everything else (global keys, a `plugins.dev` sibling, comments).
+ * Replaces an existing `plugins.memory` subtree in place, inserts one under an
+ * existing `plugins:` mapping, or appends a new `plugins:` block. Returns the
+ * new file text with a single trailing newline.
+ */
+export function mergeMemoryBlock(existingText: string, config: MemoryConfig): string {
+  const memoryLines = emitMemoryBlockLines(config);
+  const lines = existingText === "" ? [] : existingText.replace(/\n+$/, "").split("\n");
+
+  // locate a top-level `plugins:` mapping
+  let pluginsIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (isStructural(lines[i]!) && lineIndent(lines[i]!) === 0 && topKey(lines[i]!) === "plugins") {
+      pluginsIdx = i;
+      break;
+    }
+  }
+
+  if (pluginsIdx === -1) {
+    const out = [...lines];
+    if (out.length > 0 && out[out.length - 1]!.trim() !== "") out.push("");
+    out.push("plugins:", ...memoryLines);
+    return `${out.join("\n")}\n`;
+  }
+
+  // within the plugins block, find an existing `memory:` child (indent 2)
+  let memStart = -1;
+  for (let i = pluginsIdx + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!isStructural(line)) continue;
+    const indent = lineIndent(line);
+    if (indent === 0) break; // left the plugins block
+    if (indent === 2 && topKey(line) === "memory") {
+      memStart = i;
+      break;
+    }
+  }
+
+  if (memStart === -1) {
+    // insert the memory block right after the `plugins:` header line
+    const out = [...lines];
+    out.splice(pluginsIdx + 1, 0, ...memoryLines);
+    return `${out.join("\n")}\n`;
+  }
+
+  // replace the existing memory subtree: from memStart up to (exclusive) the
+  // next structural line at indent <= 2, backing up over trailing blanks so a
+  // separator before a sibling is preserved.
+  let memEnd = lines.length;
+  for (let i = memStart + 1; i < lines.length; i++) {
+    if (isStructural(lines[i]!) && lineIndent(lines[i]!) <= 2) {
+      memEnd = i;
+      break;
+    }
+  }
+  while (memEnd - 1 > memStart && lines[memEnd - 1]!.trim() === "") memEnd--;
+
+  const out = [...lines.slice(0, memStart), ...memoryLines, ...lines.slice(memEnd)];
+  return `${out.join("\n")}\n`;
+}

--- a/src/apps/memory/src/vcs-hooks-install.ts
+++ b/src/apps/memory/src/vcs-hooks-install.ts
@@ -47,7 +47,9 @@ export function renderHookScript(event: VcsEvent, bootstrapPath?: string): strin
 # \`memory vcs uninstall-hooks\`. Keeps the memory graph fresh via an incremental
 # re-ingest/export. No-ops silently when memory is not initialized here.
 ${captureArgs}root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-[ -f "$root/.red/memory/config.json" ] || exit 0
+# Opt-in gate: a \`plugins.memory\` block in .red/config.yaml (ADR 0042), or the
+# legacy .red/memory/config.json (back-compat). No-op when neither is present.
+{ [ -f "$root/.red/config.yaml" ] && grep -qE '^[[:space:]]+memory:' "$root/.red/config.yaml"; } || [ -f "$root/.red/memory/config.json" ] || exit 0
 if [ -n "$RED_MEMORY_CLI" ]; then
   # shellcheck disable=SC2086
   set -- $RED_MEMORY_CLI

--- a/src/apps/memory/tests/graph-store.test.ts
+++ b/src/apps/memory/tests/graph-store.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -660,9 +661,12 @@ describe("init graph mode + round-trip", () => {
       });
       expect(config?.mcp).toBe(false);
 
-      // The store file was created under .red/memory/.
-      const raw = await readFile(result.configPath, "utf8");
-      expect(raw).toContain('"storePath"');
+      // Config is the unified yaml (ADR 0042); the default store path is sparse
+      // (omitted) but still resolves, and the store file was provisioned.
+      expect(result.configPath.endsWith("/.red/config.yaml")).toBe(true);
+      const storePath = result.storeUri.replace(/^file:\/\//, "");
+      expect(storePath.endsWith("/.red/memory/graph.rdb")).toBe(true);
+      expect(existsSync(storePath)).toBe(true);
     },
     TIMEOUT,
   );

--- a/src/apps/memory/tests/init-wizard.test.ts
+++ b/src/apps/memory/tests/init-wizard.test.ts
@@ -53,15 +53,19 @@ describe("markdown-only init", () => {
     expect(config.reddb).toBe(false);
   });
 
-  test("writes config to .red/memory/config.json and creates notes dir", async () => {
+  test("writes the plugins.memory block to .red/config.yaml and creates notes dir", async () => {
     const root = await tempRoot();
     const result = await initMarkdownOnly(root);
 
     expect(result.configPath).toBe(configPath(root));
-    const written = JSON.parse(await readFile(result.configPath, "utf8"));
-    expect(written.mode).toBe("markdown-only");
-    expect(written.hooks.sessionStart).toBe(false);
-    expect(written.mcp).toBe(false);
+    expect(result.configPath.endsWith("/.red/config.yaml")).toBe(true);
+    const written = await readFile(result.configPath, "utf8");
+    expect(written).toContain("plugins:");
+    expect(written).toContain("  memory:");
+    expect(written).toContain("    mode: markdown-only");
+    // sparse: derived/default fields are not persisted
+    expect(written).not.toContain("reddb:");
+    expect(written).not.toContain("version:");
 
     const notesStat = await stat(result.notesDir);
     expect(notesStat.isDirectory()).toBe(true);

--- a/src/apps/memory/tests/shared-config.test.ts
+++ b/src/apps/memory/tests/shared-config.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+import { CONFIG_VERSION, DEFAULT_NOTES_DIR } from "../src/config.js";
+import { graphConfig, markdownOnlyConfig } from "../src/init.js";
+import {
+  emitMemoryBlockLines,
+  mergeMemoryBlock,
+  parsePluginsMemory,
+  parseYamlFlat,
+} from "../src/shared-config.js";
+
+describe("parsePluginsMemory", () => {
+  test("reads a markdown-only block, deriving reddb=false and the version constant", () => {
+    const config = parsePluginsMemory("plugins:\n  memory:\n    mode: markdown-only\n");
+    expect(config).not.toBeNull();
+    expect(config?.mode).toBe("markdown-only");
+    expect(config?.reddb).toBe(false);
+    expect(config?.mcp).toBe(false);
+    expect(config?.version).toBe(CONFIG_VERSION);
+    expect(config?.notesDir).toBe(DEFAULT_NOTES_DIR);
+    expect(config?.hooks).toEqual({
+      sessionStart: false,
+      postToolUse: false,
+      stop: false,
+      preCompact: false,
+    });
+  });
+
+  test("reads a graph block with hooks, deriving reddb=true", () => {
+    const text = [
+      "plugins:",
+      "  memory:",
+      "    mode: graph",
+      "    hooks:",
+      "      sessionStart: true",
+      "      stop: true",
+      "    skillTelemetry: true",
+      "",
+    ].join("\n");
+    const config = parsePluginsMemory(text);
+    expect(config?.mode).toBe("graph");
+    expect(config?.reddb).toBe(true);
+    expect(config?.skillTelemetry).toBe(true);
+    expect(config?.hooks).toEqual({
+      sessionStart: true,
+      postToolUse: false,
+      stop: true,
+      preCompact: false,
+    });
+  });
+
+  test("returns null when there is no plugins.memory block", () => {
+    expect(parsePluginsMemory("")).toBeNull();
+    expect(parsePluginsMemory("plugins:\n  dev:\n    afk:\n      default_runner: codex\n")).toBeNull();
+    expect(parsePluginsMemory("# just a comment\nfoo: bar\n")).toBeNull();
+  });
+
+  test("a top-level memory: (not nested under plugins:) does not count", () => {
+    // parseYamlFlat keys it as `memory.mode`, not `plugins.memory.mode`.
+    const flat = parseYamlFlat("memory:\n  mode: graph\n");
+    expect(flat["memory.mode"]).toBe("graph");
+    expect(parsePluginsMemory("memory:\n  mode: graph\n")).toBeNull();
+  });
+});
+
+describe("emitMemoryBlockLines (sparse)", () => {
+  test("markdown-only emits only mode", () => {
+    expect(emitMemoryBlockLines(markdownOnlyConfig())).toEqual(["  memory:", "    mode: markdown-only"]);
+  });
+
+  test("graph drops derived reddb/version and default store/notes", () => {
+    const lines = emitMemoryBlockLines(graphConfig({ hooks: { sessionStart: true } }));
+    expect(lines).toContain("  memory:");
+    expect(lines).toContain("    mode: graph");
+    expect(lines).toContain("    hooks:");
+    expect(lines).toContain("      sessionStart: true");
+    expect(lines.join("\n")).not.toContain("reddb:");
+    expect(lines.join("\n")).not.toContain("version:");
+    expect(lines.join("\n")).not.toContain("storePath:"); // default → omitted
+  });
+});
+
+describe("mergeMemoryBlock", () => {
+  test("creates plugins: from an empty file", () => {
+    const out = mergeMemoryBlock("", markdownOnlyConfig());
+    expect(out).toBe("plugins:\n  memory:\n    mode: markdown-only\n");
+  });
+
+  test("appends a plugins: block after existing global keys", () => {
+    const out = mergeMemoryBlock("# global\nsomeGlobal: 1\n", markdownOnlyConfig());
+    expect(out).toContain("someGlobal: 1");
+    expect(out).toContain("plugins:\n  memory:\n    mode: markdown-only");
+  });
+
+  test("inserts memory under an existing plugins.dev, preserving dev", () => {
+    const existing = "plugins:\n  dev:\n    afk:\n      default_runner: codex\n";
+    const out = mergeMemoryBlock(existing, markdownOnlyConfig());
+    expect(out).toContain("  dev:");
+    expect(out).toContain("default_runner: codex");
+    expect(out).toContain("  memory:");
+    expect(out).toContain("    mode: markdown-only");
+  });
+
+  test("replaces an existing memory block, preserving a dev sibling after it", () => {
+    const existing = [
+      "plugins:",
+      "  memory:",
+      "    mode: markdown-only",
+      "  dev:",
+      "    afk:",
+      "      default_runner: codex",
+      "",
+    ].join("\n");
+    const out = mergeMemoryBlock(existing, graphConfig());
+    expect(out).toContain("    mode: graph");
+    expect(out).not.toContain("    mode: markdown-only");
+    expect(out).toContain("  dev:");
+    expect(out).toContain("default_runner: codex");
+  });
+
+  test("round-trips: merge then parse yields an equivalent config", () => {
+    const merged = mergeMemoryBlock(
+      "plugins:\n  dev:\n    afk:\n      default_runner: codex\n",
+      graphConfig({ hooks: { sessionStart: true, stop: true }, skillTelemetry: true }),
+    );
+    const parsed = parsePluginsMemory(merged);
+    expect(parsed?.mode).toBe("graph");
+    expect(parsed?.reddb).toBe(true);
+    expect(parsed?.skillTelemetry).toBe(true);
+    expect(parsed?.hooks.sessionStart).toBe(true);
+    expect(parsed?.hooks.stop).toBe(true);
+    expect(parsed?.hooks.postToolUse).toBe(false);
+  });
+});

--- a/src/apps/memory/tests/vcs-hooks-install.test.ts
+++ b/src/apps/memory/tests/vcs-hooks-install.test.ts
@@ -27,6 +27,7 @@ describe("renderHookScript", () => {
   test("post-commit script no-ops fast and calls vcs refresh", () => {
     const s = renderHookScript("post-commit");
     expect(s).toContain(HOOK_MARKER);
+    expect(s).toContain('grep -qE \'^[[:space:]]+memory:\' "$root/.red/config.yaml"');
     expect(s).toContain('[ -f "$root/.red/memory/config.json" ] || exit 0');
     expect(s).toContain("vcs refresh --event post-commit");
     // No bootstrap path embedded → no embedded-bootstrap branch.


### PR DESCRIPTION
## What — ADR 0042

One config file per repo: `.red/config.yaml`, namespaced by plugin under `plugins:`. Memory config moves out of the standalone `.red/memory/config.json` (JSON) into a sparse `plugins.memory` block of the same file `dev` reads under `plugins.dev`.

```yaml
plugins:
  dev:
    afk:
      default_runner: codex
  memory:
    mode: graph
    hooks:
      sessionStart: true
```

## Why

Two plugins resolved config in two formats, two locations, for no principled reason. Memory's config is **write-once (the init wizard) and choice-or-default** — never a runtime machine-writer — and both sides already have a read seam, so unification is cheap and safe. (Grilled via `/start`: total unification + wizard emits a sparse block.)

## How (contained at the seams)

- **memory**: new `shared-config.ts` — parse `plugins.memory`, emit a **sparse** block (only non-defaults; `reddb`/`version` derived, never persisted), merge into the yaml preserving the rest. `readConfig`/`writeConfig`/`configPath` retarget the yaml with a **legacy `.red/memory/config.json` read fallback**. `MemoryConfig` interface unchanged → all 23 read sites + the wizard untouched. **No YAML dependency** (same constrained-subset grammar `dev` uses).
- **dev**: `loadConfig` folds `plugins.dev.afk.*` down to the bare `afk.*` accessor keys (namespaced wins; legacy top-level `afk.*` still read) → accessors untouched.
- **gate (ADR 0009)**: `dev` soft-detects memory via a `plugins.memory` block **or** the legacy json. The installed git-hook guard + the triage/zoom-out/diagnose/context/afk skill snippets mirror it.
- **backup** embeds a synthesized `config.json` snapshot → self-contained regardless of where the live config lives.

## Back-compat

Both sides read the legacy location as a fallback (deprecated, removable later). No forced migration — a repo upgrades when it re-runs `memory init`. ADR 0009 annotated (gate mechanism partially superseded). **Bundles unchanged** — release builds from source; the `afk.mjs` launcher (ADR 0038) is untouched.

## Tests

- `dev`: full suite **841 pass**, typecheck clean. New: `plugins.dev` fold + yaml-gate tests.
- `memory`: default gate **689 pass** + impacted integration (init-wizard, backup, graph-store, vcs-hooks-e2e, mcp-server, provenance, extraction-status) pass; typecheck clean. New: `shared-config.test.ts` (parse / sparse emit / merge round-trip).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783002640&installation_id=129708444&pr_number=390&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F390&signature=b719f24c6fcd85e0d10bd1c166d73368da724e583f9b67fb57f1fe9082324b5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Plugin skill documentation updated to reference unified `.red/config.yaml` configuration paths.

* **Refactor**
  * Memory and dev plugin configuration now consolidates under `.red/config.yaml` using `plugins.memory` and `plugins.dev` blocks; legacy standalone config files remain fully supported for backward compatibility.

* **Tests**
  * Added comprehensive test coverage for YAML configuration parsing, merging, and legacy file fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->