### PR TITLE
fix(config): memory built-in handlers use autohooks, not hooks (ADR 0042 refine)

### DIFF
--- a/.red/adr/0042-plugin-config-unified-under-red-config-yaml.md
+++ b/.red/adr/0042-plugin-config-unified-under-red-config-yaml.md
@@ -26,9 +26,12 @@ Two facts make unification cheap and safe:
      dev:
        afk:
          default_runner: codex
+         hooks:                      # user-authored shell hooks (see point 6)
+           pre_session:
+             - ./.red/hooks/boot.sh
      memory:
        mode: graph
-       hooks:
+       autohooks:                    # enable our built-in handlers (see point 6)
          sessionStart: true
    ```
 
@@ -43,6 +46,12 @@ Two facts make unification cheap and safe:
    - `memory` reads `plugins.memory` from `.red/config.yaml` first, falling back to a legacy `.red/memory/config.json` (older repos keep working until they re-init).
    - the gate accepts **either** signal.
    No automatic migration is forced; a repo upgrades the moment it re-runs `memory init` (or hand-edits the yaml). The legacy fallbacks are a deprecation lane, removable later.
+
+6. **`hooks:` is reserved, file-wide, for user-authored shell hooks; built-in plugin hooks are code, exposed at most as an enable toggle.** Two distinct concepts must not share the `hooks:` key:
+   - **User hooks** — shell interceptors the user *writes and controls*, as an ordered list of inline commands or script paths. This is the AFK lifecycle-hook model (ADR 0026), now the meaning of `hooks:` under **any** plugin namespace.
+   - **Built-in hooks** — handlers the plugin *ships and owns* (memory's four auto-firing Claude Code event handlers; AFK's cargo/gradle defaults). These are not user config; where the user may toggle them, the toggle is a plain enable under a **different** key — for memory, `plugins.memory.autohooks.<event>: true` (per-event booleans), never `plugins.memory.hooks`.
+
+   So `autohooks` (enable our handlers) and `hooks` (the user's shell) are deliberately different keys with different value shapes (booleans vs command lists). Memory writes only `autohooks`; it has no user-hook surface today.
 
 ## Consequences
 

--- a/src/apps/memory/src/shared-config.ts
+++ b/src/apps/memory/src/shared-config.ts
@@ -94,11 +94,14 @@ export function parsePluginsMemory(text: string): MemoryConfig | null {
   const mode = flat[`${p}mode`];
   if (!mode || !STORAGE_MODES.includes(mode as StorageMode)) return null;
 
+  // `autohooks` toggles memory's built-in auto-firing handlers (ADR 0042 refine):
+  // they are OURS, not user-authored shell hooks, so they live under `autohooks`,
+  // never under `hooks:` (which the file reserves for user shell interceptors).
   const hooks: HookConfig = { ...HOOKS_OFF };
-  if (asBool(flat[`${p}hooks.sessionStart`])) hooks.sessionStart = true;
-  if (asBool(flat[`${p}hooks.postToolUse`])) hooks.postToolUse = true;
-  if (asBool(flat[`${p}hooks.stop`])) hooks.stop = true;
-  if (asBool(flat[`${p}hooks.preCompact`])) hooks.preCompact = true;
+  if (asBool(flat[`${p}autohooks.sessionStart`])) hooks.sessionStart = true;
+  if (asBool(flat[`${p}autohooks.postToolUse`])) hooks.postToolUse = true;
+  if (asBool(flat[`${p}autohooks.stop`])) hooks.stop = true;
+  if (asBool(flat[`${p}autohooks.preCompact`])) hooks.preCompact = true;
 
   const config: MemoryConfig = {
     version: CONFIG_VERSION,
@@ -153,7 +156,9 @@ export function emitMemoryBlockLines(config: MemoryConfig): string[] {
 
   const onHooks = (Object.keys(config.hooks) as (keyof HookConfig)[]).filter((h) => config.hooks[h]);
   if (onHooks.length > 0) {
-    lines.push("    hooks:");
+    // `autohooks`, not `hooks` — these enable our built-in handlers, not the
+    // user's shell hooks (ADR 0042 refine).
+    lines.push("    autohooks:");
     for (const h of onHooks) lines.push(`      ${h}: true`);
   }
 

--- a/src/apps/memory/tests/shared-config.test.ts
+++ b/src/apps/memory/tests/shared-config.test.ts
@@ -25,12 +25,12 @@ describe("parsePluginsMemory", () => {
     });
   });
 
-  test("reads a graph block with hooks, deriving reddb=true", () => {
+  test("reads a graph block with autohooks, deriving reddb=true", () => {
     const text = [
       "plugins:",
       "  memory:",
       "    mode: graph",
-      "    hooks:",
+      "    autohooks:",
       "      sessionStart: true",
       "      stop: true",
       "    skillTelemetry: true",
@@ -71,8 +71,9 @@ describe("emitMemoryBlockLines (sparse)", () => {
     const lines = emitMemoryBlockLines(graphConfig({ hooks: { sessionStart: true } }));
     expect(lines).toContain("  memory:");
     expect(lines).toContain("    mode: graph");
-    expect(lines).toContain("    hooks:");
+    expect(lines).toContain("    autohooks:");
     expect(lines).toContain("      sessionStart: true");
+    expect(lines.join("\n")).not.toContain("    hooks:"); // never the user-hook key
     expect(lines.join("\n")).not.toContain("reddb:");
     expect(lines.join("\n")).not.toContain("version:");
     expect(lines.join("\n")).not.toContain("storePath:"); // default → omitted


### PR DESCRIPTION
Follow-up to #390 (ADR 0042). Fixes an overload I introduced: `plugins.memory.hooks.sessionStart: true` put **booleans** under `hooks:`, but `.red/config.yaml`'s `hooks:` convention (AFK, ADR 0026) is **user-authored shell** — ordered lists of inline commands or script paths.

## The distinction (ADR 0042 point 6)

- **User hooks** (`hooks:`, any plugin) — shell interceptors the user *writes and controls*. `plugins.dev.afk.hooks.pre_session: [./.red/hooks/boot.sh, …]`.
- **Built-in hooks** — handlers the plugin *ships and owns* (memory's 4 auto-firing Claude Code event handlers; AFK's cargo/gradle defaults). Not user config; where toggleable, the toggle is a plain enable under a **different** key → `plugins.memory.autohooks.<event>: true`.

```yaml
plugins:
  dev:
    afk:
      hooks:                 # user shell
        pre_session: [ ./.red/hooks/boot.sh ]
  memory:
    mode: graph
    autohooks:               # enable OUR handlers
      sessionStart: true
```

## Change

- `shared-config.ts` parse/emit `autohooks` instead of `hooks`. `MemoryConfig` interface unchanged (in-memory `hooks` object stays); only the yaml key changes.
- ADR 0042 example + new decision point 6.

## Tests

memory typecheck clean; `shared-config` 11 pass; init-wizard + backup + graph-store round-trips pass (autohooks flows init→write→read). drift-guard: `Memory-NoIngest` trailer (ADR 0027).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783003615&installation_id=129708444&pr_number=391&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F391&signature=4f6728e3591414487c82ab514bee6c0950527969420da065584b613a56fd15ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Memory plugin configuration now uses `autohooks` for built-in handlers instead of `hooks`.
  * Reserved `hooks:` key for user-authored shell hooks within plugin namespaces.
  * Update existing memory plugin configurations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->