### PR TITLE
fix(afk): monitor diff column counts committed work + relabel issue ratio

### DIFF
--- a/src/apps/dev/src/core/monitor.ts
+++ b/src/apps/dev/src/core/monitor.ts
@@ -59,12 +59,6 @@ export function formatElapsed(seconds: number): string {
   return `${pad(hh)}:${pad(mm)}:${pad(ss)}`;
 }
 
-/** Integer-division percent, matching `done * 100 / total` (0 when total<=0). */
-export function percentDone(done: number, total: number): number {
-  if (total <= 0) return 0;
-  return Math.floor((done * 100) / total);
-}
-
 function isNoIssue(n: number | string): boolean {
   return n === "" || n === "-" || n === "null" || n === 0;
 }
@@ -81,11 +75,17 @@ function elapsedSeconds(state: CompactState, now: number): number {
  * Renders one compact worker line, ANSI-stripped, byte-for-byte matching
  * render_worker_compact's plain text:
  *
- *   w<id> [live|stale] <runner>  <done>/<total> (<pct>%)<flags><cur>
+ *   w<id> [live|stale] <runner>  issues <done>/<total><flags><cur>
  *
- * where <flags> is ` blk:N` / ` fail:N` (each present only when > 0) and <cur>
- * is `  #<n> <title>  stage:<x>  HH:MM:SS<  +A -R>` when an issue is in
- * progress, or `  idle` otherwise. `now` is an epoch in seconds.
+ * The progress counter is labelled `issues <done>/<total>` — issues *closed*
+ * over the queue total, NOT lines changed or a completion percentage. The bare
+ * `<done>/<total> (<pct>%)` form read as "0% done / no code" while a worker had
+ * already committed thousands of lines; lines live in the `+A -R` diff suffix
+ * of <cur>, which is the real "is there work" signal.
+ *
+ * <flags> is ` blk:N` / ` fail:N` (each present only when > 0) and <cur> is
+ * `  #<n> <title>  stage:<x>  HH:MM:SS<  +A -R>` when an issue is in progress,
+ * or `  idle` otherwise. `now` is an epoch in seconds.
  */
 export function renderWorkerCompactLine(worker: CompactWorker, now: number): string {
   const { state } = worker;
@@ -94,7 +94,6 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
   const runner = state.runner || "-";
   const total = state.total;
   const done = state.done;
-  const pct = percentDone(done, total);
 
   let flags = "";
   if (state.blocked > 0) flags += ` blk:${state.blocked}`;
@@ -110,7 +109,7 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
     cur = "  idle";
   }
 
-  return `${workerId} [${tag}] ${runner}  ${done}/${total} (${pct}%)${flags}${cur}`;
+  return `${workerId} [${tag}] ${runner}  issues ${done}/${total}${flags}${cur}`;
 }
 
 /** Stable sort key — the worker-process start, oldest first (the bash glob is

--- a/src/apps/dev/src/runtime/git.ts
+++ b/src/apps/dev/src/runtime/git.ts
@@ -114,13 +114,23 @@ export async function diffstat(ctx: GitContext, branch: string, base: string): P
 }
 
 /**
- * Parsed `git diff --shortstat <base>` from the working tree at `ctx.cwd`.
- * Mirrors statusline.sh's worktree diffstat fallback: extracts the
- * `N insertion` / `N deletion` integers, defaulting each to 0 when absent or
- * on any failure.
+ * Parsed diffstat of the attempt's work at `ctx.cwd` — **committed plus
+ * uncommitted** — measured from where the branch left `<base>`.
+ *
+ * Resolves `merge-base(<base>, HEAD)` and diffs that against the working tree
+ * (`git diff --shortstat <merge-base>`), so the count reflects every commit the
+ * inner agent has made on the branch as well as any uncommitted edits. The
+ * previous `git diff --shortstat <base>` only saw the *uncommitted* worktree, so
+ * it collapsed to 0 the moment the agent committed — the monitor's "live but
+ * empty diff" lie. Falls back to a plain `<base>` diff when no merge-base
+ * resolves (e.g. an unborn branch). Extracts the `N insertion` / `N deletion`
+ * integers, defaulting each to 0 when absent or on any failure.
  */
 export async function diffstatShortstat(ctx: GitContext, base: string): Promise<{ added: number; removed: number }> {
-  const r = await runGit(ctx, ["diff", "--shortstat", base]);
+  let ref = base;
+  const mb = await runGit(ctx, ["merge-base", base, "HEAD"]);
+  if (mb.code === 0 && mb.stdout.trim() !== "") ref = mb.stdout.trim();
+  const r = await runGit(ctx, ["diff", "--shortstat", ref]);
   if (r.code !== 0) return { added: 0, removed: 0 };
   const ins = /(\d+) insertion/.exec(r.stdout);
   const del = /(\d+) deletion/.exec(r.stdout);

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -171,7 +171,8 @@ export interface MonitorInputs {
 }
 
 /** Read every worker state file + the history ledger into the pure renderer's
- * inputs. No process spawn — pure disk reads. */
+ * inputs, plus one `git diff --shortstat` per live worktree for the diff column
+ * (small fleet → a handful of cheap git calls, like the statusline does). */
 export async function collectMonitorInputs(root = process.cwd()): Promise<MonitorInputs> {
   const paths = afkPaths(root);
   const stateFiles = await fsx.globWorkerStates(paths.workersRoot);
@@ -185,6 +186,16 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
     } catch {
       continue;
     }
+    // Diff column: committed + uncommitted work for the attempt, measured from
+    // the branch's merge-base with origin/main (gitx.diffstatShortstat). Without
+    // this the board showed nothing — `diff` was never populated, and even the
+    // statusline's fallback only saw the uncommitted worktree (→ 0 after commit).
+    let diff: string | undefined;
+    if (state.current.worktree) {
+      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, "origin/main");
+      if (stat.added > 0 || stat.removed > 0) diff = `+${stat.added} -${stat.removed}`;
+    }
+
     workers.push({
       state: {
         worker_id: state.worker_id,
@@ -203,6 +214,7 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
         },
       },
       live: isStateLive(state),
+      ...(diff ? { diff } : {}),
     });
   }
 

--- a/src/apps/dev/tests/git-diffstat.test.ts
+++ b/src/apps/dev/tests/git-diffstat.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+import { diffstatShortstat } from "../src/runtime/git.js";
+
+/** A recording exec fake driven by a per-`git <subcommand>` response table. */
+function fakeExec(
+  table: Record<string, ExecOutput>,
+  calls: string[][],
+): ExecFn {
+  return (_cmd, args) => {
+    calls.push([...args]);
+    const key = args[0] ?? "";
+    return Promise.resolve(table[key] ?? { code: 1, stdout: "", stderr: "" });
+  };
+}
+
+const ok = (stdout: string): ExecOutput => ({ code: 0, stdout, stderr: "" });
+
+describe("diffstatShortstat — counts committed + uncommitted from the merge-base", () => {
+  it("diffs against merge-base(base, HEAD), not the bare base, so committed work counts", async () => {
+    const calls: string[][] = [];
+    const exec = fakeExec(
+      {
+        "merge-base": ok("abc1234\n"),
+        diff: ok(" 5 files changed, 1788 insertions(+), 3 deletions(-)\n"),
+      },
+      calls,
+    );
+
+    const stat = await diffstatShortstat({ cwd: "/wt", exec }, "origin/main");
+
+    expect(stat).toEqual({ added: 1788, removed: 3 });
+    // merge-base was resolved first…
+    expect(calls[0]).toEqual(["merge-base", "origin/main", "HEAD"]);
+    // …and the diff used the resolved commit, NOT the bare "origin/main".
+    expect(calls[1]).toEqual(["diff", "--shortstat", "abc1234"]);
+  });
+
+  it("falls back to a plain base diff when no merge-base resolves (unborn branch)", async () => {
+    const calls: string[][] = [];
+    const exec = fakeExec(
+      {
+        "merge-base": { code: 1, stdout: "", stderr: "no merge base" },
+        diff: ok(" 1 file changed, 2 insertions(+)\n"),
+      },
+      calls,
+    );
+
+    const stat = await diffstatShortstat({ cwd: "/wt", exec }, "origin/main");
+
+    expect(stat).toEqual({ added: 2, removed: 0 });
+    expect(calls[1]).toEqual(["diff", "--shortstat", "origin/main"]);
+  });
+
+  it("defaults to 0/0 when the diff itself fails", async () => {
+    const exec = fakeExec({ "merge-base": ok("abc\n") }, []);
+    expect(await diffstatShortstat({ cwd: "/wt", exec }, "origin/main")).toEqual({
+      added: 0,
+      removed: 0,
+    });
+  });
+});

--- a/src/apps/dev/tests/monitor.test.ts
+++ b/src/apps/dev/tests/monitor.test.ts
@@ -38,7 +38,7 @@ describe("monitor — compact line", () => {
     // started 2026-05-30T11:00:00Z = 1780138800; now +1800s (30 min)
     const line = renderWorkerCompactLine(baseWorker(), 1780140600);
     expect(line).toBe(
-      "wAAAA [live] claude  1/4 (25%)  #42 do the thing  stage:impl  00:30:00  +10 -3",
+      "wAAAA [live] claude  issues 1/4  #42 do the thing  stage:impl  00:30:00  +10 -3",
     );
   });
 
@@ -51,12 +51,13 @@ describe("monitor — compact line", () => {
     expect(line).not.toContain("[live]");
   });
 
-  it("rounds percent down via integer division like bash", () => {
+  it("labels the counter as issues closed/total, with no misleading percent", () => {
     const w = baseWorker({
       state: { ...baseWorker().state, total: 3, done: 1 },
     });
     const line = renderWorkerCompactLine(w, 1780140600);
-    expect(line).toContain("1/3 (33%)");
+    expect(line).toContain("issues 1/3");
+    expect(line).not.toContain("%");
   });
 
   it("formats elapsed as zero-padded HH:MM:SS from current.started_at", () => {


### PR DESCRIPTION
## The bug (3rd time it bit a user)

A worker that had **committed +1788 lines** showed in `/afk monitor` as **`live` with an empty diff and `0/0 (0%)`** — reading as "live but zero code". Three independent lies:

1. **Diff range was uncommitted-only.** `diffstatShortstat` ran `git diff --shortstat origin/main` on the worktree → only *uncommitted* changes. The moment the inner agent commits, the worktree is clean → 0.
2. **The board never populated the diff at all.** `collectMonitorInputs` left `CompactWorker.diff` unset, so the column was always empty regardless.
3. **`0/0 (0%)` is issues-closed/total**, trivially misread as lines or completion.

## Fix

- `diffstatShortstat` diffs against `merge-base(origin/main, HEAD)` → **committed + uncommitted** work since the branch point (falls back to the bare base on an unborn branch).
- `collectMonitorInputs` now computes & sets `+N -M` per live worktree using that range → the board shows real work.
- worker line: `<done>/<total> (<pct>%)` → **`issues <done>/<total>`** (issues closed / queue total, explicitly not lines/completion). Dropped the unused `percentDone`.

## Tests

dev suite **844 pass** (+3 new `git-diffstat` tests asserting it resolves merge-base and diffs the resolved commit, with an unborn-branch fallback). typecheck clean. `monitor.test` updated to the `issues N/M` shape.

Ships via release build (no bundle staged). Fixes the recurring "live with empty diff" confusion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007152&installation_id=129708444&pr_number=392&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F392&signature=9a539f7bbba01a5550b253743203e267e5b3b8684c4d3fba0e8c8acd8066bcbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diff column displaying code changes (additions/deletions) for active workers.

* **Updates**
  * Simplified progress display format to show counter-only format (`issues <done>/<total>`) instead of percentages.

* **Tests**
  * Added test suite for diff statistics functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->