### PR TITLE
feat(afk): attempt progress guard — abort a stalled agent, park to ready-for-human (ADR 0044)

### DIFF
--- a/.red/adr/0044-afk-attempt-progress-guard.md
+++ b/.red/adr/0044-afk-attempt-progress-guard.md
@@ -1,0 +1,42 @@
+# AFK attempt progress guard: a commit-anchored wall-clock that parks a stalled agent
+
+## Context
+
+An `/afk` inner-agent iteration could run forever. Observed: a single iteration ran 1h41m — the agent declared its work "complete", then kept re-exploring and re-running tests without ever emitting the `<promise>DONE|BLOCKED</promise>` sentinel, burning cycle (and the cargo guard) indefinitely. The branch had a finished PR; the orchestrator never reached merge because there was no sentinel.
+
+Every existing guard misses this failure, because the agent is **alive and busy**, just not *progressing*:
+
+- **`idleTimeoutSeconds`** (sandcastle, 600s) fails an iteration only on *no output*; a re-exploring agent keeps producing output, so it never fires.
+- **`maxIterations`** (12) caps *re-invocations*; this is a single non-terminating iteration, so it never fires.
+- **The supervisor stall-reaper** keys off the agent lane's mtime (liveness); the lane stays fresh because the agent is genuinely emitting tool calls — so it sees a healthy worker.
+
+Liveness ("is something executing?") is not progress ("is it producing work?"). The missing guard is a wall-clock bound on *progress*.
+
+Sandcastle (`@ai-hero/sandcastle` ≥ 0.6.6) exposes `RunOptions.signal?: AbortSignal`: aborting mid-iteration kills the in-flight agent subprocess and **preserves the worktree on disk**.
+
+## Decision
+
+1. **Add an attempt progress guard.** While the inner agent runs, poll the worker branch's HEAD (`git rev-parse refs/heads/<branch>` — the ref lives in the shared `.git`, so commits made in sandcastle's worktree are visible). If **no new commit lands within the cap**, abort via the sandcastle `AbortSignal`. The deadline **resets on every new commit**, so a steadily-committing agent is never killed — only one that spins without producing work. Commits are the proof of *productive* life; the existing agent lane + `idleTimeoutSeconds` remain the proof of *liveness*.
+
+2. **Cap = `RED_AFK_ATTEMPT_TIMEOUT_S` / `plugins.dev.afk.attempt_timeout`, default 2700s (45min).** Typo-safe parse (non-numeric / zero / negative → default); never silently disabled.
+
+3. **On fire → park, never retry.** The guard surfaces a `timeout` agent-outcome which `processIssue` maps to the existing `stalled` terminal outcome: `recoveryReasonFor("stalled")` is `null` → always escalate → `ready-for-human` + the typed `blocked:stalled` label, a failure envelope, and the attempt dir/branch/PR preserved. No auto-retry — the work is there for a human to review (the maintainer's "review first, don't merge" disposition).
+
+4. **Armed only under no-sandbox isolation.** Under docker/podman the agent commits in an isolated copy not host-visible until final sync, so a commit-anchored probe would false-fire; the guard is skipped there (idle timeout + maxIterations still apply). Default mode is no-sandbox.
+
+## Consequences
+
+- The "productive infinite loop" class is bounded without killing legitimately-long, steadily-committing agents.
+- `ProcessOutcome` widens to include `stalled` (was supervisor-only); `attempt-outcome.ts` already owns the `stalled` → `blocked:stalled` / escalate / `blocked` mappings, so no vocabulary drift.
+- The guard logic (`startAttemptGuard`) is pure over an injected clock / scheduler / headProbe / abort — fully unit-tested with no real timers or git.
+- Liveness signal externalization (a richer heartbeat record + `on_heartbeat` integration hook) is a **follow-up** (PR-B); this ADR is the guard + routing only.
+
+## Status
+
+Accepted; implemented (PR-A). Externalized proof-of-life (heartbeat enrichment + `on_heartbeat` hook) tracked separately.
+
+## Related
+
+- ADR 0026 — AFK lifecycle hooks (the `on_heartbeat` follow-up extends this).
+- ADR 0042 — config under `plugins.dev.afk` (the `attempt_timeout` knob lives here).
+- `attempt-outcome.ts` — the single owner of the outcome vocabulary (`stalled` → `blocked:stalled`).

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -269,6 +269,7 @@ export function buildProcessDeps(
   runner: Runner,
   exec?: ExecFn,
   maxIterations?: number,
+  attemptTimeoutSeconds?: number,
 ): ProcessIssueDeps {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
   const gitCtx: GitContext = { cwd: ctx.root, exec };
@@ -334,7 +335,7 @@ export function buildProcessDeps(
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,
     layout: feedback.layout,
-    runAgent: makeRunAgent(sandbox, process.env, maxIterations),
+    runAgent: makeRunAgent(sandbox, process.env, maxIterations, attemptTimeoutSeconds),
     model,
     fallbackRunner,
     // One-shot merge-conflict resolver (merge_resolve_conflict): re-enter the
@@ -685,7 +686,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }).catch(() => {});
       return result;
     },
-    processDeps: buildProcessDeps(ctx, settings.model, settings.sandbox, feedback, current, flags.fallbackRunner, runner, undefined, settings.maxIterations),
+    processDeps: buildProcessDeps(ctx, settings.model, settings.sandbox, feedback, current, flags.fallbackRunner, runner, undefined, settings.maxIterations, settings.attemptTimeoutSeconds),
     // Session-scoped lifecycle hooks (PRD #207): compose the same config /
     // resolver / exec / env the process deps use, so session + per-issue points
     // share one dispatcher rather than duplicating the wiring.

--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -29,7 +29,12 @@ export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "max";
 // example Codex websocket 502 / thread-start failures). Both ride the same
 // outcome union so process-issue can branch on them without treating the worker
 // as crashed.
-export type AgentOutcome = "done" | "blocked" | "no-sentinel" | "exhausted" | "runner-transient";
+// `timeout` is surfaced when AFK's attempt wall-clock guard aborts a run that is
+// alive but making no progress (no new commit within the cap) — the "productive
+// infinite loop" the idle / max-iteration / stall guards all miss. It maps to the
+// `stalled` terminal outcome downstream (→ blocked:stalled, ready-for-human),
+// preserving the worktree/PR.
+export type AgentOutcome = "done" | "blocked" | "no-sentinel" | "exhausted" | "runner-transient" | "timeout";
 
 /** AFK's canonical sentinels, registered as sandcastle completion signals. */
 export const DONE_SIGNAL = "<promise>DONE</promise>";
@@ -37,6 +42,28 @@ export const BLOCKED_SIGNAL = "<promise>BLOCKED</promise>";
 export const COMPLETION_SIGNALS: readonly string[] = [DONE_SIGNAL, BLOCKED_SIGNAL];
 
 export const DEFAULT_IDLE_TIMEOUT_S = 600;
+
+/**
+ * Attempt wall-clock guard (proof-of-PROGRESS): the inner agent is aborted when
+ * no NEW commit has landed on the worker branch within this many seconds.
+ * `idleTimeoutSeconds` catches *silence* (no output) and `maxIterations` caps
+ * *re-invocations*, but a single iteration that stays busy — re-exploring,
+ * re-running tests — without ever committing or signalling slips past both and
+ * burns cycle indefinitely (the 1h41m #834 hang). The clock resets on every new
+ * commit, so a steadily-committing agent is never killed; only one that spins
+ * without producing work is. Env-tunable via `RED_AFK_ATTEMPT_TIMEOUT_S`.
+ */
+export const DEFAULT_ATTEMPT_TIMEOUT_S = 2700;
+
+/** Parse `RED_AFK_ATTEMPT_TIMEOUT_S` / `afk.attempt_timeout`: a positive integer,
+ * else undefined (caller falls back to {@link DEFAULT_ATTEMPT_TIMEOUT_S}). `0`
+ * is rejected (use a large value to effectively disable; never silently off). */
+export function parseAttemptTimeout(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  return undefined;
+}
 
 /**
  * The re-invocation ceiling handed to sandcastle's Orchestrator (issue #322).
@@ -180,6 +207,21 @@ export interface RunAgentInput {
    * to a live agent. sandcastle swallows any error this callback throws.
    */
   onAgentEvent?: (event: AgentStreamEvent) => void;
+  /**
+   * Attempt wall-clock guard cap in seconds (proof-of-progress). When set,
+   * `runAgent` aborts the sandcastle run if no NEW commit appears on the worker
+   * branch within this window, resetting on each commit. Omitted → no guard
+   * (back-compat for callers/tests that don't opt in). `makeRunAgent` threads
+   * `RED_AFK_ATTEMPT_TIMEOUT_S` / `afk.attempt_timeout` here. See
+   * {@link DEFAULT_ATTEMPT_TIMEOUT_S}.
+   */
+  attemptTimeoutSeconds?: number;
+  /**
+   * Returns the current HEAD sha of the worker branch (the progress signal the
+   * guard watches). Best-effort: resolves `undefined` on any git failure, which
+   * the guard treats as "no progress observed". Required for the guard to arm.
+   */
+  headProbe?: () => Promise<string | undefined>;
 }
 
 /** The git remote the continuous-push hook targets when none is supplied. */
@@ -204,6 +246,17 @@ export interface SandcastleDeps {
    * real wiring; tests inject a recorder. Never throws — these are advisories.
    */
   warn?: (message: string) => void;
+  /** Injectable clock (ms) for the attempt guard. Defaults to `Date.now`. */
+  now?: () => number;
+  /**
+   * Injectable periodic scheduler for the attempt guard — runs `fn` every `ms`
+   * and returns a cancel function. Defaults to a `setInterval` wrapper (with
+   * `unref` so it never keeps the process alive). Tests inject a manual pump.
+   */
+  schedule?: (fn: () => void, ms: number) => () => void;
+  /** Injectable `AbortController` factory for the attempt guard. Defaults to
+   * `() => new AbortController()`. */
+  makeAbortController?: () => AbortController;
 }
 
 /**
@@ -419,6 +472,60 @@ function collectErrorStrings(value: unknown, out: string[], seen: Set<object>, d
   }
 }
 
+/** Default periodic scheduler: a `setInterval` that never keeps the event loop
+ * alive (so a hung guard can't block process exit). */
+function defaultSchedule(fn: () => void, ms: number): () => void {
+  const t = setInterval(fn, ms);
+  (t as { unref?: () => void }).unref?.();
+  return () => clearInterval(t);
+}
+
+/**
+ * Arm the attempt progress guard. Polls `headProbe` every `intervalMs`; the
+ * deadline resets whenever the HEAD sha ADVANCES (a new commit = real progress),
+ * and `abort` fires once `capMs` elapses with no advance. Pure over its injected
+ * clock / scheduler — no real timers, no git — so it is fully unit-testable. The
+ * first observed head anchors the clock (≈ from spawn). A `headProbe` rejection
+ * is treated as "no progress observed" (never resets), so a flaky git read
+ * cannot keep a hung agent alive.
+ */
+export function startAttemptGuard(opts: {
+  capMs: number;
+  intervalMs: number;
+  headProbe: () => Promise<string | undefined>;
+  now: () => number;
+  schedule: (fn: () => void, ms: number) => () => void;
+  abort: () => void;
+}): { stop: () => void; firedTimeout: () => boolean } {
+  let lastProgress = opts.now();
+  let lastHead: string | undefined;
+  let fired = false;
+  const cancel = opts.schedule(() => {
+    void opts
+      .headProbe()
+      .then((head) => {
+        if (fired) return;
+        if (head !== undefined && head !== lastHead) {
+          lastHead = head;
+          lastProgress = opts.now();
+          return;
+        }
+        if (opts.now() - lastProgress >= opts.capMs) {
+          fired = true;
+          opts.abort();
+        }
+      })
+      .catch(() => {
+        // headProbe failure = no progress observed; let the deadline run.
+        if (!fired && opts.now() - lastProgress >= opts.capMs) {
+          fired = true;
+          opts.abort();
+        }
+      });
+  }, opts.intervalMs);
+  return { stop: cancel, firedTimeout: () => fired };
+}
+
 /**
  * Run the inner agent on the issue via sandcastle and normalise the result.
  *
@@ -427,6 +534,11 @@ function collectErrorStrings(value: unknown, out: string[], seen: Set<object>, d
  * raises on a 429 / usage-limit), or by completing with exhaustion text on
  * stdout. Both map to the `exhausted` outcome (no commits, no sentinel). Any
  * other thrown error propagates unchanged.
+ *
+ * When `attemptTimeoutSeconds` + `headProbe` are supplied, an attempt progress
+ * guard runs alongside: if no new commit lands within the cap, the run is
+ * aborted (sandcastle kills the in-flight agent, preserving the worktree) and
+ * the result is the `timeout` outcome.
  */
 export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Promise<RunAgentResult> {
   const warn = deps.warn ?? ((m: string) => console.warn(m));
@@ -449,10 +561,42 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
   // its own process, so this is isolated per-worker. Under docker/podman the env
   // must enter the container instead (sandbox env lane) — out of scope (#284).
   for (const [k, v] of Object.entries(input.env ?? {})) process.env[k] = v;
+
+  // Attempt progress guard (proof-of-progress): abort the run if no new commit
+  // lands within the cap. Armed only when both the cap and a headProbe are
+  // supplied; otherwise behaviour is unchanged.
+  const now = deps.now ?? (() => Date.now());
+  let guard: { stop: () => void; firedTimeout: () => boolean } | undefined;
+  let controller: AbortController | undefined;
+  if (input.attemptTimeoutSeconds && input.attemptTimeoutSeconds > 0 && input.headProbe) {
+    const capMs = input.attemptTimeoutSeconds * 1000;
+    controller = (deps.makeAbortController ?? (() => new AbortController()))();
+    const cap = input.attemptTimeoutSeconds;
+    guard = startAttemptGuard({
+      capMs,
+      intervalMs: Math.min(capMs, 60_000),
+      headProbe: input.headProbe,
+      now,
+      schedule: deps.schedule ?? defaultSchedule,
+      abort: () =>
+        controller?.abort(new Error(`afk: attempt aborted — no new commit within ${cap}s (stalled)`)),
+    });
+  }
+
   let result: RunResult;
   try {
-    result = await deps.run(buildRunOptions(deps, input));
+    const options = buildRunOptions(deps, input);
+    result = await deps.run(controller ? { ...options, signal: controller.signal } : options);
   } catch (error) {
+    // The progress guard aborted: alive but not committing → stalled.
+    if (guard?.firedTimeout()) {
+      return {
+        outcome: "timeout",
+        branch: input.branch,
+        commits: [],
+        stdout: `afk: attempt aborted — no new commit within ${input.attemptTimeoutSeconds}s (stalled)`,
+      };
+    }
     if (isExhaustionError(error)) {
       return { outcome: "exhausted", branch: input.branch, commits: [], stdout: "" };
     }
@@ -465,6 +609,8 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       };
     }
     throw error;
+  } finally {
+    guard?.stop();
   }
   // A run that completed but surfaced exhaustion text on stdout (rather than
   // throwing) is also exhaustion — match the stdout the same way run_inner does.

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -282,11 +282,13 @@ export interface ProcessIssueInput {
 // ---------- result ----------
 
 // The subset of `AttemptOutcome` that the per-issue lifecycle itself can return.
-// `stalled` (supervisor reaper) and `infra` (boot setup) originate outside
-// processIssue, so they are excluded here while the shared owner (attempt-outcome)
-// keeps the full union. Exclude<> ties this to the single owner so the two can
-// never drift.
-export type ProcessOutcome = Exclude<AttemptOutcome, "stalled" | "infra">;
+// `infra` (boot setup) originates outside processIssue, so it is excluded here
+// while the shared owner (attempt-outcome) keeps the full union. `stalled` is
+// now ALSO a processIssue terminal: the attempt progress guard (execution.ts)
+// surfaces a `timeout` agent-outcome which processIssue maps to `stalled` (→
+// blocked:stalled, ready-for-human). Exclude<> ties this to the single owner so
+// the two can never drift.
+export type ProcessOutcome = Exclude<AttemptOutcome, "infra">;
 
 export interface ProcessIssueResult {
   outcome: ProcessOutcome;
@@ -617,6 +619,17 @@ export async function processIssue(
     });
   }
 
+  // ---- attempt progress guard fired: alive but no new commit within the cap.
+  // Park to ready-for-human (blocked:stalled), preserving the pushed branch/PR
+  // — never auto-retry (recoveryReasonFor("stalled") = null → always escalate). ----
+  if (run.outcome === "timeout") {
+    await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "stalled", current.attempt));
+    return await terminalFailure(common, "stalled", "stalled", {
+      notes: "_(no Notes appended; attempt aborted — inner agent made no progress within the wall-clock guard)_",
+      log: run.stdout || "(attempt progress guard fired)",
+    });
+  }
+
   // ---- post_attempt hook (terminal invocation; sentinel-bearing) ----
   const pwStatus = run.outcome === "done" ? "success" : "fail";
   await fireHook("post_attempt", postAttemptContext(current, workerBranch, pwStatus, run.outcome));
@@ -883,6 +896,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         kind: "runner",
         summary: oneLine(sections.log, "Inner agent exited without an AFK completion sentinel."),
         next: "Review the attempt log and decide whether to retry or revise the issue brief.",
+      };
+    case "stalled":
+      return {
+        status: "blocked",
+        kind: "stalled",
+        summary: oneLine(sections.log, "Inner agent made no progress (no new commit) within the attempt wall-clock."),
+        next: "Review the work already pushed (branch/PR) and decide whether to continue, re-scope, or stop.",
       };
     case "merge-conflict":
       return {

--- a/src/apps/dev/src/runtime/git.ts
+++ b/src/apps/dev/src/runtime/git.ts
@@ -93,6 +93,20 @@ export async function branchExists(ctx: GitContext, branch: string): Promise<boo
   return r.code === 0;
 }
 
+/**
+ * The current commit sha of a LOCAL branch ref, or undefined when the branch
+ * has no ref yet / git fails. The attempt progress guard (execution.ts) polls
+ * this: the worker branch's HEAD advances on every inner-agent commit (the ref
+ * lives in the shared `.git`, visible from any cwd in the repo), giving a clean
+ * "is the agent producing work?" signal independent of liveness.
+ */
+export async function branchHead(ctx: GitContext, branch: string): Promise<string | undefined> {
+  if (!branch) return undefined;
+  const r = await runGit(ctx, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]);
+  const sha = r.stdout.trim();
+  return r.code === 0 && sha !== "" ? sha : undefined;
+}
+
 /** Best-effort `git fetch origin <branch>` (FIX E recovery: try once to pull a
  * sandcastle-pushed worker branch onto the host before declaring it absent). */
 export async function fetchBranch(ctx: GitContext, branch: string): Promise<void> {

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -17,7 +17,7 @@ import type { RunAgentInput, RunAgentResult } from "../core/execution.js";
 // Value import (pure, no sandcastle pull — the providers load lazily via
 // defaultSandcastleDeps' dynamic import) so resolveRunSettings can parse the
 // max-iterations knob from env/config without importing the runtime.
-import { parseMaxIterations } from "../core/execution.js";
+import { parseAttemptTimeout, parseMaxIterations } from "../core/execution.js";
 import type { BranchRef } from "../core/branch-cleanup.js";
 import { isRunner, type Runner } from "../types/runner.js";
 import * as ghx from "./gh.js";
@@ -83,6 +83,13 @@ export interface RunSettings {
    * undefined, buildRunOptions applies DEFAULT_MAX_ITERATIONS.
    */
   maxIterations?: number;
+  /**
+   * Attempt progress-guard cap (seconds), resolved with precedence
+   * RED_AFK_ATTEMPT_TIMEOUT_S env > `afk.attempt_timeout` config > undefined
+   * (→ DEFAULT_ATTEMPT_TIMEOUT_S). The guard aborts a run that produces no new
+   * commit within the cap (proof-of-progress) → blocked:stalled / ready-for-human.
+   */
+  attemptTimeoutSeconds?: number;
 }
 
 const SANDBOX_MODES: readonly SandboxMode[] = ["none", "docker", "podman"];
@@ -120,7 +127,13 @@ export function resolveRunSettings(
   // env or the config can never disable the cap or pin the agent to 1 iteration.
   const maxIterations =
     parseMaxIterations(env.RED_AFK_MAX_ITERATIONS) ?? parseMaxIterations(getConfig(cfg, "afk.max_iterations"));
-  return { sandbox, defaultRunner, model, maxIterations };
+  // Precedence mirrors maxIterations: RED_AFK_ATTEMPT_TIMEOUT_S env >
+  // afk.attempt_timeout config > undefined (→ DEFAULT_ATTEMPT_TIMEOUT_S in
+  // makeRunAgent). Typo-safe: a non-numeric / zero / negative value parses to
+  // undefined from either source.
+  const attemptTimeoutSeconds =
+    parseAttemptTimeout(env.RED_AFK_ATTEMPT_TIMEOUT_S) ?? parseAttemptTimeout(getConfig(cfg, "afk.attempt_timeout"));
+  return { sandbox, defaultRunner, model, maxIterations, attemptTimeoutSeconds };
 }
 
 // ---------- lazy sandcastle runAgent binding ----------
@@ -135,10 +148,13 @@ export function makeRunAgent(
   sandbox: SandboxMode,
   env: NodeJS.ProcessEnv = process.env,
   maxIterations?: number,
+  attemptTimeoutSeconds?: number,
 ): (input: RunAgentInput) => Promise<RunAgentResult> {
   let depsPromise: Promise<import("../core/execution.js").SandcastleDeps> | null = null;
   return async (input: RunAgentInput): Promise<RunAgentResult> => {
-    const { runAgent, defaultSandcastleDeps, parseIdleTimeout } = await import("../core/execution.js");
+    const { runAgent, defaultSandcastleDeps, parseIdleTimeout, DEFAULT_ATTEMPT_TIMEOUT_S } = await import(
+      "../core/execution.js"
+    );
     if (!depsPromise) depsPromise = defaultSandcastleDeps();
     const deps = await depsPromise;
     // Sandcastle re-invocation ceiling (issue #322). Precedence: per-call
@@ -150,11 +166,29 @@ export function makeRunAgent(
     // RED_AFK_IDLE_TIMEOUT_S overrides the per-iteration idle watchdog (FIX G),
     // same typo-safe contract.
     const envIdleTimeout = parseIdleTimeout(env.RED_AFK_IDLE_TIMEOUT_S);
+    const effectiveSandbox = input.sandboxMode ?? sandbox;
+    // Attempt progress guard (proof-of-progress). Armed only under no-sandbox
+    // isolation: there the worker branch's commits land in the shared `.git`, so
+    // `branchHead` sees HEAD advance. Under docker/podman the agent commits in an
+    // isolated copy not host-visible until final sync, so a commit-anchored guard
+    // would false-fire — skip it there (idle timeout + maxIterations still apply).
+    const attemptTimeout =
+      input.attemptTimeoutSeconds ??
+      attemptTimeoutSeconds ??
+      parseAttemptTimeout(env.RED_AFK_ATTEMPT_TIMEOUT_S) ??
+      DEFAULT_ATTEMPT_TIMEOUT_S;
+    const guardArmed = effectiveSandbox === "none" && !!input.branch;
     return runAgent(deps, {
       ...input,
-      sandboxMode: input.sandboxMode ?? sandbox,
+      sandboxMode: effectiveSandbox,
       maxIterations: input.maxIterations ?? maxIterations ?? parseMaxIterations(env.RED_AFK_MAX_ITERATIONS),
       idleTimeoutSeconds: input.idleTimeoutSeconds ?? envIdleTimeout,
+      ...(guardArmed
+        ? {
+            attemptTimeoutSeconds: attemptTimeout,
+            headProbe: () => gitx.branchHead({ cwd: input.cwd ?? process.cwd() }, input.branch),
+          }
+        : {}),
     });
   };
 }

--- a/src/apps/dev/tests/execution.test.ts
+++ b/src/apps/dev/tests/execution.test.ts
@@ -18,6 +18,9 @@ import {
   CLAUDE_EFFORTS,
   parseMaxIterations,
   parseIdleTimeout,
+  parseAttemptTimeout,
+  startAttemptGuard,
+  DEFAULT_ATTEMPT_TIMEOUT_S,
   type SandcastleDeps,
   type RunAgentInput,
   type AgentStreamEvent,
@@ -554,5 +557,163 @@ describe("runAgent — runner transient failures", () => {
     expect(r.branch).toBe("afk/wZ2R4/42-fix-oauth");
     expect(r.commits).toEqual([]);
     expect(r.stdout).toContain("failed to connect to websocket");
+  });
+});
+
+// ---- attempt progress guard (proof-of-progress, PR-A) ----
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/** A manual scheduler: captures the periodic fn so the test pumps ticks. */
+function manualScheduler() {
+  const fns: Array<() => void> = [];
+  const schedule = (fn: () => void, _ms: number) => {
+    fns.push(fn);
+    return () => {
+      const i = fns.indexOf(fn);
+      if (i >= 0) fns.splice(i, 1);
+    };
+  };
+  const tick = async () => {
+    for (const fn of [...fns]) fn();
+    await flush();
+  };
+  return { schedule, tick };
+}
+
+describe("parseAttemptTimeout", () => {
+  it("accepts a positive integer, rejects 0 / negative / non-numeric / undefined", () => {
+    expect(parseAttemptTimeout("2700")).toBe(2700);
+    expect(parseAttemptTimeout("0")).toBeUndefined();
+    expect(parseAttemptTimeout("-5")).toBeUndefined();
+    expect(parseAttemptTimeout("abc")).toBeUndefined();
+    expect(parseAttemptTimeout(undefined)).toBeUndefined();
+  });
+  it("documents a sane default", () => {
+    expect(DEFAULT_ATTEMPT_TIMEOUT_S).toBeGreaterThan(0);
+  });
+});
+
+describe("startAttemptGuard — commit-anchored progress watchdog", () => {
+  it("aborts once the cap elapses with no new commit", async () => {
+    let clock = 1000;
+    const sched = manualScheduler();
+    let aborted = false;
+    const g = startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    await sched.tick(); // t=1000 anchor: head observed, deadline = 1000
+    expect(aborted).toBe(false);
+    clock = 1050;
+    await sched.tick(); // 50ms < cap → alive
+    expect(aborted).toBe(false);
+    clock = 1100;
+    await sched.tick(); // 100ms >= cap, head unchanged → abort
+    expect(aborted).toBe(true);
+    expect(g.firedTimeout()).toBe(true);
+    g.stop();
+  });
+
+  it("resets the deadline when HEAD advances (a new commit is real progress)", async () => {
+    let clock = 0;
+    let head = "sha1";
+    const sched = manualScheduler();
+    let aborted = false;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => head,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    clock = 10;
+    await sched.tick(); // anchor at sha1, deadline=10
+    clock = 90;
+    head = "sha2";
+    await sched.tick(); // commit advanced → deadline resets to 90
+    clock = 150;
+    await sched.tick(); // 150-90=60 < cap → alive
+    expect(aborted).toBe(false);
+    clock = 200;
+    await sched.tick(); // 200-90=110 >= cap, no further commit → abort
+    expect(aborted).toBe(true);
+  });
+
+  it("treats an unresolved HEAD (no commit yet) as no progress and still caps", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    let aborted = false;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => undefined,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    clock = 50;
+    await sched.tick();
+    expect(aborted).toBe(false);
+    clock = 100;
+    await sched.tick(); // 100 >= cap from start → abort
+    expect(aborted).toBe(true);
+  });
+});
+
+describe("runAgent — attempt guard wiring", () => {
+  it("returns the 'timeout' outcome when the guard aborts a stalled run", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    const controller = new AbortController();
+    const deps: SandcastleDeps = {
+      ...makeDeps(
+        (o) =>
+          new Promise<RunResult>((_resolve, reject) => {
+            o.signal?.addEventListener("abort", () => reject(o.signal?.reason ?? new Error("aborted")));
+          }),
+      ),
+      now: () => clock,
+      schedule: sched.schedule,
+      makeAbortController: () => controller,
+    };
+    const p = runAgent(deps, { ...baseInput, attemptTimeoutSeconds: 1, headProbe: async () => "static" });
+    await sched.tick(); // anchor (capMs = 1000, deadline = 0)
+    clock = 1000;
+    await sched.tick(); // 1000 >= cap → abort → run rejects
+    const res = await p;
+    expect(res.outcome).toBe("timeout");
+    expect(res.branch).toBe(baseInput.branch);
+    expect(res.commits).toEqual([]);
+  });
+
+  it("does not arm the guard (normal completion) when no timeout/headProbe is supplied", async () => {
+    const deps = makeDeps(async () => fakeResult({ completionSignal: DONE_SIGNAL }));
+    const res = await runAgent(deps, baseInput); // no attemptTimeoutSeconds / headProbe
+    expect(res.outcome).toBe("done");
+  });
+
+  it("passes the abort signal through to sandcastle's run options when armed", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const deps: SandcastleDeps = {
+      ...makeDeps(async (o) => {
+        seenSignal = o.signal;
+        return fakeResult({ completionSignal: DONE_SIGNAL });
+      }),
+      schedule: manualScheduler().schedule,
+    };
+    await runAgent(deps, { ...baseInput, attemptTimeoutSeconds: 60, headProbe: async () => "x" });
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -1184,3 +1184,24 @@ describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)",
     expect(result.preserved).toBe(true);
   });
 });
+
+describe("processIssue — timeout (attempt progress guard fired)", () => {
+  it("routes through on_attempt_error → ready-for-human + blocked:stalled, no post_attempt", async () => {
+    const { deps, input, trace } = harness({ outcome: "timeout" });
+    const result = await processIssue(deps, input);
+
+    // The execution-layer `timeout` maps to the `stalled` terminal outcome.
+    expect(result.outcome).toBe("stalled");
+    expect(result.preserved).toBe(true);
+    // Escalates to a human (non-recoverable) with the typed blocked:stalled tag.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:stalled"]);
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-human");
+    expect(edit.add).toContain("blocked:stalled");
+    expect(trace.ensuredLabels).toContain("blocked:stalled");
+    // The failure envelope rides the generic `blocked` status bucket.
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    // on_attempt_error fires; post_attempt does NOT (same as no-sentinel).
+    expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
+  });
+});


### PR DESCRIPTION
## The bug

An `/afk` iteration can run **forever**. Observed (#834): a single 1h41m iteration where the agent declared its work "complete", then kept re-exploring / re-running tests **without ever committing or emitting the `<promise>` sentinel** — burning cycle, never reaching merge.

Every existing guard misses it because the agent is **alive and busy, just not progressing**:
| Guard | Why it misses |
|---|---|
| `idleTimeoutSeconds` (600s) | wants *silence*; the agent keeps producing output |
| `maxIterations` (12) | counts *re-invocations*; this is one non-terminating iteration |
| stall reaper (agent-lane mtime) | lane is fresh — the agent IS emitting tool calls |

Liveness ≠ progress. The missing guard is a wall-clock bound on **progress**.

## Fix (ADR 0044)

- **Commit-anchored guard** (`startAttemptGuard`): poll the worker branch HEAD; if **no new commit** lands within the cap, abort via sandcastle's `AbortSignal` (kills the in-flight agent, **preserves the worktree/PR**). The deadline **resets on every commit** — a steadily-committing agent is never killed; only one that spins is. Commits = proof of *productive* life.
- **On fire → park, never retry**: new `timeout` outcome maps to the existing `stalled` terminal → **`ready-for-human` + `blocked:stalled`**, PR intact (the "review first, don't merge" disposition). `attempt-outcome.ts` already owns the stalled label/recovery/envelope maps — no vocab drift.
- **Cap**: `RED_AFK_ATTEMPT_TIMEOUT_S` / `plugins.dev.afk.attempt_timeout`, default **2700s (45min)**, typo-safe.
- **Armed only under no-sandbox** (commits aren't host-visible under docker/podman mid-run; idle timeout + maxIterations still apply there).

## Tests

dev suite **853 pass** (+9): guard cap / commit-reset / unborn-branch, `runAgent` timeout wiring + signal pass-through, `parseAttemptTimeout`, and `processIssue` timeout→stalled routing (→ ready-for-human + blocked:stalled, envelope, no post_attempt). typecheck clean. Guard logic is pure over an injected clock/scheduler/headProbe — no real timers.

## Follow-up (PR-B)

Externalize proof-of-life: enrich the firehose heartbeat record with progress/liveness fields + a `state.last_progress_at` + an `on_heartbeat` integration hook (the "externalizar pra quem quiser integrar" piece).

drift-guard: `Memory-NoIngest` trailer (ADR 0027).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783011802&installation_id=129708444&pr_number=400&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F400&signature=730e3bd0fa789bce1cc5d8ffc35e1bafd9f73d273b62e0ae73ca03b579e99e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added progress monitoring that detects stalled operations and escalates them for human review with a `blocked:stalled` label instead of automatic retry.
  * Configurable timeout for detecting operations with no commit progress (default 45 minutes via `RED_AFK_ATTEMPT_TIMEOUT_S`).

* **Documentation**
  * Added architecture decision record documenting the attempt progress guard design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->