### PR TITLE
feat(afk): externalize proof-of-life — heartbeat record, state field, on_heartbeat hook (ADR 0045)

### DIFF
--- a/.red/adr/0045-afk-externalized-proof-of-life.md
+++ b/.red/adr/0045-afk-externalized-proof-of-life.md
@@ -1,0 +1,40 @@
+# AFK externalized proof-of-life: a periodic heartbeat record, state field, and `on_heartbeat` hook
+
+## Context
+
+ADR 0044 added the attempt **progress guard** (abort a stalled-but-busy agent), and noted that externalizing the proof-of-life signal — so an outside system can integrate — was a follow-up. Two facts shaped that follow-up:
+
+- The ported `emitHeartbeatTick` existed but was **never wired** in the native (sandcastle) runtime: no periodic `heartbeat` record was emitted during a run. The only live liveness signal was `recordAgentEvent` (per agent stream event → the agent lane).
+- A periodic `on_heartbeat` **user hook** needs the hook dispatcher (`fireHook`), which lives in `processIssue` — not in `runAgent`/the guard (execution.ts is the sandcastle seam and must stay ignorant of AFK lifecycle hooks).
+
+## Decision
+
+Externalize proof-of-life on the attempt guard's existing **~60s poll cadence** — one signal, three consumer surfaces — without a second loop and without leaking hook knowledge into execution.ts:
+
+1. **The guard exposes an opaque `onTick(info)` callback.** `startAttemptGuard` already polls the worker-branch HEAD; it now invokes an injected `onTick` each poll with `{ head, lastProgressMs, nowMs }`. execution.ts stays ignorant of what the callback does. `runAgent` forwards `RunAgentInput.onHeartbeat` as that `onTick`.
+
+2. **`processIssue` builds the `onHeartbeat` closure** (it owns `fireHook`): each tick it (a) fires the `on_heartbeat` user hook fire-and-forget, and (b) calls a CLI-wired `deps.emitHeartbeat(info)` sink.
+
+3. **Three externalized surfaces:**
+   - **Firehose record** — an enriched `type=heartbeat` line in `log.jsonl` carrying `secs_since_progress`, `last_progress_at`, `head` (integrators *tail* it).
+   - **State field** — `current.last_progress_at` mirrored into `afk.state.json` (integrators/monitors *read* it).
+   - **`on_heartbeat` hook** — a new canonical lifecycle hook (user shell, ADR 0026 model; `continue` exit policy). Unlike the once-per-point lifecycle hooks it fires **periodically** during a run; a user command receives the heartbeat context so an external monitor can be *pushed* to. No built-in default; absent config → no-op.
+
+4. **Armed where the guard is armed** (no-sandbox): the heartbeat rides the guard's tick, so under docker/podman (where the guard is skipped — commits not host-visible mid-run) no periodic heartbeat fires either. Liveness there remains the agent lane + `idleTimeoutSeconds`.
+
+## Consequences
+
+- Proof-of-life is now consumable three ways (tail / read-state / push-hook) without a dedicated loop — the guard's poll is the single cadence.
+- `on_heartbeat` is the first **periodic** entry in `CANONICAL_HOOK_NAMES`; it carries a `continue` exit policy (a failing heartbeat hook never aborts the run).
+- execution.ts stays decoupled from the AFK hook system (the callback is opaque); the hook + IO wiring live in `processIssue` / `run.ts` where they belong.
+- The periodic heartbeat only exists under no-sandbox for now — a documented limit, consistent with the guard.
+
+## Status
+
+Accepted; implemented (PR-B, follow-up to ADR 0044).
+
+## Related
+
+- ADR 0044 — the attempt progress guard (this externalizes its signal).
+- ADR 0026 — AFK lifecycle hooks (the `on_heartbeat` hook extends the model with a periodic point).
+- ADR 0042 — config under `plugins.dev.afk` (where `afk.hooks.on_heartbeat` lives).

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -436,6 +436,28 @@ export function buildProcessDeps(
         }).catch(() => {});
       }
     },
+    // Externalized proof-of-life sink (PR-B): the attempt-guard fires this each
+    // poll (~60s) with the progress signal. Append an enriched `type=heartbeat`
+    // firehose record AND mirror `current.last_progress_at` into the state file,
+    // so external integrators can tail the firehose or read afk.state.json for
+    // the agent's liveness + progress. Best-effort — failures are swallowed.
+    emitHeartbeat: (info) => {
+      const ts = new Date().toISOString();
+      const secs = Math.max(0, Math.floor((info.nowMs - info.lastProgressMs) / 1000));
+      const lastProgressAt = new Date(info.lastProgressMs).toISOString();
+      const head = info.head ?? "";
+      const msg = `progress: ${secs}s since last commit${head ? ` @ ${head.slice(0, 8)}` : ""}`;
+      void appendRecord(join(current.attemptDir, "log.jsonl"), "heartbeat", msg, {
+        ts,
+        fields: {
+          extra: { secs_since_progress: String(secs), last_progress_at: lastProgressAt, head },
+        },
+      }).catch(() => {});
+      void fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${msg}`);
+      void updateState(join(current.attemptDir, "afk.state.json"), {
+        "current.last_progress_at": lastProgressAt,
+      }).catch(() => {});
+    },
     historyPath: paths.historyPath,
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },
     // BOUNDED auto-recovery reads its RED_AFK_RETRY_* caps from the process env.

--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -222,6 +222,13 @@ export interface RunAgentInput {
    * the guard treats as "no progress observed". Required for the guard to arm.
    */
   headProbe?: () => Promise<string | undefined>;
+  /**
+   * Externalized proof-of-life sink (PR-B): invoked once per attempt-guard poll
+   * with the progress signal. Opaque to execution.ts — the caller (processIssue)
+   * uses it to fire the `on_heartbeat` hook + emit the heartbeat record/state.
+   * Only fires when the guard is armed (cap + headProbe present).
+   */
+  onHeartbeat?: (info: AttemptProgressInfo) => void;
 }
 
 /** The git remote the continuous-push hook targets when none is supplied. */
@@ -489,6 +496,15 @@ function defaultSchedule(fn: () => void, ms: number): () => void {
  * is treated as "no progress observed" (never resets), so a flaky git read
  * cannot keep a hung agent alive.
  */
+export interface AttemptProgressInfo {
+  /** The worker branch HEAD observed this tick (undefined when unresolved). */
+  head: string | undefined;
+  /** Epoch ms of the last observed progress (last new commit, or spawn). */
+  lastProgressMs: number;
+  /** The guard's clock (epoch ms) at this tick. */
+  nowMs: number;
+}
+
 export function startAttemptGuard(opts: {
   capMs: number;
   intervalMs: number;
@@ -496,6 +512,10 @@ export function startAttemptGuard(opts: {
   now: () => number;
   schedule: (fn: () => void, ms: number) => () => void;
   abort: () => void;
+  /** Fired once per poll (proof-of-life externalization): the externalized
+   * heartbeat + on_heartbeat hook ride this same cadence (PR-B). Never throws —
+   * the caller wraps its own IO. */
+  onTick?: (info: AttemptProgressInfo) => void;
 }): { stop: () => void; firedTimeout: () => boolean } {
   let lastProgress = opts.now();
   let lastHead: string | undefined;
@@ -506,14 +526,14 @@ export function startAttemptGuard(opts: {
       .then((head) => {
         if (fired) return;
         if (head !== undefined && head !== lastHead) {
+          // A new commit landed — real progress; reset the deadline.
           lastHead = head;
           lastProgress = opts.now();
-          return;
-        }
-        if (opts.now() - lastProgress >= opts.capMs) {
+        } else if (opts.now() - lastProgress >= opts.capMs) {
           fired = true;
           opts.abort();
         }
+        opts.onTick?.({ head: head ?? lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
       })
       .catch(() => {
         // headProbe failure = no progress observed; let the deadline run.
@@ -521,6 +541,7 @@ export function startAttemptGuard(opts: {
           fired = true;
           opts.abort();
         }
+        opts.onTick?.({ head: lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
       });
   }, opts.intervalMs);
   return { stop: cancel, firedTimeout: () => fired };
@@ -580,6 +601,10 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       schedule: deps.schedule ?? defaultSchedule,
       abort: () =>
         controller?.abort(new Error(`afk: attempt aborted — no new commit within ${cap}s (stalled)`)),
+      // Externalized proof-of-life (PR-B): each poll fires the caller's opaque
+      // heartbeat sink (firehose record + state.last_progress_at + on_heartbeat
+      // hook). execution.ts stays ignorant of what it does.
+      ...(input.onHeartbeat ? { onTick: input.onHeartbeat } : {}),
     });
   }
 

--- a/src/apps/dev/src/core/hook-config.ts
+++ b/src/apps/dev/src/core/hook-config.ts
@@ -40,6 +40,11 @@ export const CANONICAL_HOOK_NAMES = [
   "post_merge",
   "on_attempt_error",
   "on_idle",
+  // Periodic proof-of-life (PR-B): fired once per attempt-guard poll (~60s)
+  // during an inner-agent run, NOT a once-per-lifecycle point. A user shell
+  // command here receives the heartbeat context (issue/branch/runner) so an
+  // external monitor can be pinged. No built-in default; absent config → no-op.
+  "on_heartbeat",
   "post_session",
   "on_session_error",
 ] as const;

--- a/src/apps/dev/src/core/hook-dispatcher.ts
+++ b/src/apps/dev/src/core/hook-dispatcher.ts
@@ -53,6 +53,7 @@ export const HOOK_EXIT_POLICY: Record<HookName, HookExitPolicy> = {
   post_merge: "continue",
   on_attempt_error: "continue",
   on_idle: "continue",
+  on_heartbeat: "continue",
   post_session: "continue",
   on_session_error: "continue",
 };

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -27,7 +27,13 @@ import {
   type GitExec,
 } from "./remote-branch.js";
 import { buildHandoff, type HandoffComment } from "./handoff.js";
-import { type AgentOutcome, type AgentStreamEvent, type RunAgentInput, type RunAgentResult } from "./execution.js";
+import {
+  type AgentOutcome,
+  type AgentStreamEvent,
+  type AttemptProgressInfo,
+  type RunAgentInput,
+  type RunAgentResult,
+} from "./execution.js";
 import {
   relevantScopes,
   runFeedback,
@@ -232,6 +238,15 @@ export interface ProcessIssueDeps {
    * absent, runAgent runs without stream forwarding (tests, legacy callers).
    */
   recordAgentEvent?(event: AgentStreamEvent): void;
+  /**
+   * Externalized proof-of-life sink (PR-B): called once per attempt-guard poll
+   * with the progress signal. The CLI (run.ts) wires it to append an enriched
+   * `type=heartbeat` firehose record and update `current.last_progress_at` in
+   * afk.state.json, so external integrators can tail/read the agent's liveness +
+   * progress. The `on_heartbeat` user hook fires alongside it (in processIssue,
+   * which owns the hook dispatcher). Optional → tests/legacy callers omit it.
+   */
+  emitHeartbeat?(info: AttemptProgressInfo): void;
   /** History ledger path + clock for the terminal envelope (optional). */
   historyPath?: string;
   historyClock?: HistoryClock;
@@ -536,6 +551,23 @@ export async function processIssue(
     // so the stall detector / monitor see a live agent instead of a frozen lane.
     logPath: `${input.attemptDir}/sandcastle.log`,
     onAgentEvent: deps.recordAgentEvent,
+    // Externalized proof-of-life (PR-B): the attempt-guard poll fires this each
+    // tick. processIssue owns the hook dispatcher, so it fires the `on_heartbeat`
+    // user hook here (fire-and-forget) AND forwards the progress signal to the
+    // CLI-wired sink (firehose record + state.last_progress_at). Never throws.
+    onHeartbeat: (info) => {
+      void fireHook(
+        "on_heartbeat",
+        hookContext({
+          issue,
+          title: input.title,
+          workspace: branch,
+          runner: input.runner,
+          attempt_n: input.attempt,
+        }),
+      );
+      deps.emitHeartbeat?.(info);
+    },
     // Restore the issue #191 continuous-push guarantee: sandcastle pushes the
     // worker branch up-front + after every commit (host worktree hook), so a
     // SIGKILL mid-iteration preserves the diff on origin. Best-effort.

--- a/src/apps/dev/src/types/state.ts
+++ b/src/apps/dev/src/types/state.ts
@@ -21,6 +21,11 @@ export const AfkCurrentSchema = z.object({
   diff_removed: z.number().default(0),
   last_stream_line: z.string().default(""),
   run_mode: z.string().default(""),
+  /** ISO timestamp of the last observed progress — the last new commit on the
+   * worker branch, or attempt start. Written each attempt-guard poll (PR-B) so an
+   * external monitor reading afk.state.json sees liveness/progress, not just a
+   * stale stream line. Empty until the guard arms (no-sandbox runs). */
+  last_progress_at: z.string().default(""),
 });
 
 export const AfkStateSchema = z.object({

--- a/src/apps/dev/tests/execution.test.ts
+++ b/src/apps/dev/tests/execution.test.ts
@@ -24,6 +24,7 @@ import {
   type SandcastleDeps,
   type RunAgentInput,
   type AgentStreamEvent,
+  type AttemptProgressInfo,
 } from "../src/core/execution.js";
 
 // Sentinel provider objects — the adapter only forwards them to `run`, so a
@@ -715,5 +716,57 @@ describe("runAgent — attempt guard wiring", () => {
     };
     await runAgent(deps, { ...baseInput, attemptTimeoutSeconds: 60, headProbe: async () => "x" });
     expect(seenSignal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+// ---- externalized proof-of-life (PR-B): onTick / onHeartbeat ----
+
+describe("startAttemptGuard — onTick (externalized heartbeat cadence)", () => {
+  it("fires onTick every poll with the progress info, independent of aborting", async () => {
+    let clock = 1000;
+    const sched = manualScheduler();
+    const ticks: AttemptProgressInfo[] = [];
+    startAttemptGuard({
+      capMs: 100_000, // large → never aborts in this test
+      intervalMs: 50,
+      headProbe: async () => "sha1",
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {},
+      onTick: (i) => ticks.push(i),
+    });
+    await sched.tick();
+    clock = 1050;
+    await sched.tick();
+    expect(ticks.length).toBe(2);
+    expect(ticks[0]!.head).toBe("sha1");
+    expect(typeof ticks[0]!.lastProgressMs).toBe("number");
+    expect(typeof ticks[0]!.nowMs).toBe("number");
+  });
+});
+
+describe("runAgent — forwards onHeartbeat to the guard tick", () => {
+  it("invokes onHeartbeat per poll while the run is in flight (armed)", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    const ticks: AttemptProgressInfo[] = [];
+    let resolveRun: ((r: RunResult) => void) | undefined;
+    const deps: SandcastleDeps = {
+      ...makeDeps(() => new Promise<RunResult>((res) => (resolveRun = res))),
+      now: () => clock,
+      schedule: sched.schedule,
+      makeAbortController: () => new AbortController(),
+    };
+    const p = runAgent(deps, {
+      ...baseInput,
+      attemptTimeoutSeconds: 600,
+      headProbe: async () => "static",
+      onHeartbeat: (i) => ticks.push(i),
+    });
+    await sched.tick(); // one poll while the run hangs → onHeartbeat fires
+    expect(ticks.length).toBeGreaterThanOrEqual(1);
+    resolveRun?.(fakeResult({ completionSignal: DONE_SIGNAL }));
+    const res = await p;
+    expect(res.outcome).toBe("done");
   });
 });

--- a/src/apps/dev/tests/hook-dispatcher.test.ts
+++ b/src/apps/dev/tests/hook-dispatcher.test.ts
@@ -66,6 +66,7 @@ describe("hook-dispatcher exit-code policy table", () => {
       post_merge: "continue",
       on_attempt_error: "continue",
       on_idle: "continue",
+      on_heartbeat: "continue",
       post_session: "continue",
       on_session_error: "continue",
     });


### PR DESCRIPTION
Follow-up to #400 (ADR 0044's attempt progress guard). Externalizes the proof-of-life signal **"pra quem quiser integrar"**.

## Two findings that shaped it
- The ported periodic `emitHeartbeatTick` was **never wired** in the native runtime — no periodic heartbeat fired during a run.
- A periodic `on_heartbeat` hook needs `fireHook`, which lives in `processIssue` — **not** in the guard (execution.ts is the sandcastle seam, must stay hook-ignorant).

## Decision (ADR 0045): one signal, three surfaces, on the guard's ~60s poll
- **Guard** exposes an opaque `onTick(info)` callback; `runAgent` forwards `onHeartbeat` as it. execution.ts stays decoupled.
- **`processIssue`** builds the closure (owns `fireHook`): fires `on_heartbeat` (fire-and-forget) + calls `deps.emitHeartbeat`.
- **Surfaces:**
  - **tail** → enriched `type=heartbeat` firehose record (`secs_since_progress`/`last_progress_at`/`head`)
  - **read** → `current.last_progress_at` in `afk.state.json`
  - **push** → `on_heartbeat` user-shell hook (new canonical hook, `continue` policy; the first **periodic** one, ADR 0026 model)

Armed where the guard is armed (no-sandbox); under docker/podman neither fires (commits not host-visible mid-run). No second loop — the guard poll is the single cadence.

## Tests
dev suite **855 pass** (+ `startAttemptGuard` onTick, `runAgent` onHeartbeat forwarding; updated hook-dispatcher policy table). typecheck clean.

drift-guard: `Memory-NoIngest` (ADR 0027).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783013708&installation_id=129708444&pr_number=401&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F401&signature=4b8959c5ac47357845418112b5f4a3115272e4a9fdbf896b2b137ddfbbdba6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `on_heartbeat` lifecycle hook for custom heartbeat event handling
  * Progress tracking now externalized with periodic heartbeat signals logged for external monitoring systems
  * Last progress timestamp persisted for liveness observation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->