### PR TITLE
fix(afk): guard each supervise tick + per-tick heartbeat — unwedgeable fleet supervisor

### DIFF
--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -7,7 +7,7 @@
 // native — no bash anywhere in the loop.
 
 import { spawn } from "node:child_process";
-import { existsSync, openSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, openSync, writeFileSync, writeSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import {
   initSupervisorState,
@@ -256,6 +256,15 @@ function buildSupervisorDeps(
       },
     },
     now,
+    // Per-tick liveness line into afk-supervisor.log (best-effort). Makes a
+    // healthy fleet's heartbeat — and a wedged one's silence — observable.
+    log: (line) => {
+      try {
+        writeSync(logFd, `[${new Date().toISOString()}] ${line}\n`);
+      } catch {
+        // best-effort: a log-write failure must never affect the loop.
+      }
+    },
   };
 }
 

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -47,6 +47,16 @@ export interface SupervisorConfig {
   /** RED_AFK_POLL_S — seconds the health-check loop sleeps between ticks
    * (default 15, matching supervisor.sh). Prevents the loop from busy-spinning. */
   pollIntervalS: number;
+  /**
+   * RED_AFK_TICK_TIMEOUT_S — per-tick wall-clock ceiling (default 120). A single
+   * supervise tick should complete in well under a second; if one exceeds this
+   * (a gh / ps / git call hung with no timeout), the tick is abandoned and the
+   * loop continues to the next pass instead of freezing forever. This is what
+   * keeps the supervisor from going alive-but-quiescent — a live PID that stops
+   * spawning, never recovers, and emits no signal. 0 / non-numeric falls back to
+   * the default so a typo can never disable the guard.
+   */
+  tickTimeoutS: number;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -58,6 +68,7 @@ export const SUPERVISOR_DEFAULTS = {
   stallKillThresholdS: 1800,
   runner: "claude",
   pollIntervalS: 15,
+  tickTimeoutS: 120,
 } as const satisfies SupervisorConfig;
 
 /**
@@ -86,6 +97,10 @@ export function resolveSupervisorConfig(
     ),
     runner: env.RED_AFK_RUNNER && env.RED_AFK_RUNNER.length > 0 ? env.RED_AFK_RUNNER : SUPERVISOR_DEFAULTS.runner,
     pollIntervalS: num("RED_AFK_POLL_S", SUPERVISOR_DEFAULTS.pollIntervalS),
+    // 0 is a valid /^[0-9]+$/ match but would abandon every tick instantly, so
+    // floor it back to the default — the guard can never be silently disabled.
+    tickTimeoutS:
+      num("RED_AFK_TICK_TIMEOUT_S", SUPERVISOR_DEFAULTS.tickTimeoutS) || SUPERVISOR_DEFAULTS.tickTimeoutS,
   };
 }
 
@@ -279,6 +294,13 @@ export interface SupervisorDeps {
   gh: SupervisorGh;
   /** Current epoch seconds (date +%s), injected for determinism. */
   now(): number;
+  /**
+   * Optional liveness sink: one line per supervise tick (the CLI appends it to
+   * afk-supervisor.log). Makes a healthy fleet's heartbeat — and a wedged one's
+   * silence — observable, so an operator never has to guess fleet state from a
+   * stale log. Best-effort; never throws.
+   */
+  log?(line: string): void;
 }
 
 // ---------- per-slot runtime state ----------
@@ -660,9 +682,58 @@ export async function runSupervisor(
   }
 
   // Health-check loop until the stop-file, sleeping the poll cadence each pass.
+  // Every tick is bounded by `guardedTick`: a hung tick (gh/ps/git await with no
+  // timeout) is abandoned after tickTimeoutS and the loop continues — the
+  // supervisor can no longer go alive-but-quiescent. Each pass logs a heartbeat
+  // so the fleet's liveness is observable.
   for (;;) {
-    const result = await superviseTick(state, deps, config, stopRequested);
+    const result = await guardedTick(
+      () => superviseTick(state, deps, config, stopRequested),
+      config.tickTimeoutS * 1000,
+      deps.proc.sleep,
+      deps.log,
+    );
+    deps.log?.(
+      `tick: slots=${state.slots.length} respawned=${result.respawned.length} ` +
+        `deaths=${result.deaths.length} parked=${result.parked.length} reaped=${result.reaped.length}`,
+    );
     if (result.stopped) return;
     await deps.proc.sleep(config.pollIntervalS * 1000);
+  }
+}
+
+/** A non-stop tick result (the abandon/error fallback). */
+function continueResult(): TickResult {
+  return { respawned: [], deaths: [], parked: [], reaped: [], stopped: false };
+}
+
+/**
+ * Run one supervise tick under a wall-clock ceiling. A tick that exceeds
+ * `timeoutMs` (a hung gh/ps/git await) or throws is abandoned — logged, and a
+ * non-stop result returned — so the supervisor loop continues to the next pass
+ * instead of freezing forever on the await. Pure over an injected `sleep`
+ * (the timeout clock) so it is deterministically testable with no real timers.
+ * The abandoned tick promise is left to settle on its own; the loop moves on.
+ */
+export async function guardedTick(
+  tick: () => Promise<TickResult>,
+  timeoutMs: number,
+  sleep: (ms: number) => Promise<void>,
+  log?: (line: string) => void,
+): Promise<TickResult> {
+  const TIMEOUT = Symbol("tick-timeout");
+  try {
+    const raced = await Promise.race<TickResult | typeof TIMEOUT>([
+      tick(),
+      sleep(timeoutMs).then(() => TIMEOUT),
+    ]);
+    if (raced === TIMEOUT) {
+      log?.(`tick exceeded ${Math.round(timeoutMs / 1000)}s — abandoning this pass, loop continues`);
+      return continueResult();
+    }
+    return raced;
+  } catch (err) {
+    log?.(`tick threw: ${err instanceof Error ? err.message : String(err)} — loop continues`);
+    return continueResult();
   }
 }

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -12,6 +12,7 @@ import {
   sweepParkedSlot,
   superviseTick,
   validateStallThresholds,
+  guardedTick,
   type IterDirInfo,
   type SupervisorConfig,
   type SupervisorDeps,
@@ -31,6 +32,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     stallKillThresholdS: 90,
     runner: "claude",
     pollIntervalS: 15,
+    tickTimeoutS: 120,
     ...over,
   };
 }
@@ -492,5 +494,52 @@ describe("envelope builders", () => {
     expect(body).toContain('data-section="notes"');
     expect(body).toContain('data-section="log"');
     expect(body).toContain("stalled tool call");
+  });
+});
+
+describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () => {
+  const never = (): Promise<void> => new Promise<void>(() => {});
+  const immediate = (): Promise<void> => Promise.resolve();
+  const okResult = { respawned: [1], deaths: [], parked: [], reaped: [], stopped: false };
+  const CONTINUE = { respawned: [], deaths: [], parked: [], reaped: [], stopped: false };
+
+  it("returns the tick result when it completes before the ceiling", async () => {
+    const logs: string[] = [];
+    const r = await guardedTick(async () => okResult, 1000, never, (l) => logs.push(l));
+    expect(r).toEqual(okResult);
+    expect(logs).toEqual([]); // no timeout / throw log on the happy path
+  });
+
+  it("abandons a hung tick after the ceiling and continues (non-stop result)", async () => {
+    const logs: string[] = [];
+    const r = await guardedTick(() => new Promise<typeof okResult>(() => {}), 5000, immediate, (l) =>
+      logs.push(l),
+    );
+    expect(r).toEqual(CONTINUE);
+    expect(r.stopped).toBe(false);
+    expect(logs.some((l) => l.includes("exceeded") && l.includes("abandoning"))).toBe(true);
+  });
+
+  it("isolates a throwing tick — logged, loop continues", async () => {
+    const logs: string[] = [];
+    const r = await guardedTick(
+      async () => {
+        throw new Error("gh boom");
+      },
+      1000,
+      never,
+      (l) => logs.push(l),
+    );
+    expect(r).toEqual(CONTINUE);
+    expect(logs.some((l) => l.includes("threw") && l.includes("gh boom"))).toBe(true);
+  });
+});
+
+describe("resolveSupervisorConfig — tick timeout knob", () => {
+  it("defaults tickTimeoutS and floors a 0 back to the default (never silently disabled)", () => {
+    expect(resolveSupervisorConfig({}).tickTimeoutS).toBe(120);
+    expect(resolveSupervisorConfig({ RED_AFK_TICK_TIMEOUT_S: "0" }).tickTimeoutS).toBe(120);
+    expect(resolveSupervisorConfig({ RED_AFK_TICK_TIMEOUT_S: "45" }).tickTimeoutS).toBe(45);
+    expect(resolveSupervisorConfig({ RED_AFK_TICK_TIMEOUT_S: "abc" }).tickTimeoutS).toBe(120);
   });
 });


### PR DESCRIPTION
Root-cause fix for a **live-but-quiescent fleet supervisor** (observed live this session: alive `__supervise` PID for ~6h, stopped spawning, fat `ready-for-agent` queue not draining, no log — had to be killed manually).

## Root cause

`runSupervisor`'s `for(;;)` loop sits on `await superviseTick(...)`, and a tick awaits gh / ps / git calls with **no timeout**. One hung call freezes the loop **forever** — process alive, zero spawn, zero log. Nothing detects or recovers it.

## Fix (the loop-robustness leg of #406/#407)

- **`guardedTick`** races each tick against a wall-clock ceiling (`RED_AFK_TICK_TIMEOUT_S` / `tickTimeoutS`, default **120s**) and isolates throws. A hung/failed tick is **abandoned** and the loop **continues** to the next pass instead of freezing. Pure over an injected `sleep` → fully unit-tested, no real timers.
- **Per-tick heartbeat**: `SupervisorDeps.log?` (wired in `supervise.ts` to append one timestamped line per tick to `afk-supervisor.log`). A healthy fleet's heartbeat **and** a wedged one's silence are now observable — kills the "guess fleet state from a stale log" failure mode that bit us twice.
- `0`/non-numeric `RED_AFK_TICK_TIMEOUT_S` floors to the default (never silently disabled).

## Relation to #406 / #407

- **#406 (detection):** delivers the per-tick liveness log; the richer surfacing (firehose record + fleet state file + monitor "last ticked N ago") remains.
- **#407 (recovery):** delivers the **unwedgeable drain loop** leg; the watchdog/self-heal **architecture decision** remains (HITL).

Supervisor-level analog of the per-worker progress guard (ADR 0044/0045).

## Tests

`guardedTick` (completes-before-ceiling / abandons-hung-tick / isolates-throw) + the tick-timeout knob (default + 0-floors + garbage); typecheck clean. **NOTE:** the full `supervisor.test.ts` OOM'd locally under memory pressure from a concurrent AFK worker hammering the box — the new tests pass in isolation and the existing tests are logically untouched (additive change; the loop change isn't exercised by them).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783025113&installation_id=129708444&pr_number=408&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F408&signature=2197ca24593e5b04868e12020393fc82514a6eb79172249c13332b59045d6a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Supervisor now supports configurable tick timeout protection (default 120 seconds) to prevent indefinite stalls from hung operations.
  * Added heartbeat logging for improved supervisor liveness monitoring and observability.

* **Tests**
  * Expanded test coverage for timeout handling and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->