### PR TITLE
refactor(dev): rename the statusline skill to setup-statusline

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Composable. Boring on purpose where boring is enough. Sharp where it matters.
 | **[setup-red-skills](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md)** | Per-repo config: issue tracker, triage label vocab, domain doc layout, RedSkills workflows, RTK. |
 | **[doctor](./plugins/dev/skills/engineering/doctor/SKILL.md)** | Read-only adoption/process doctor — reports label-vocab conformance, AGENTS≡CLAUDE parity, statusline drift, MCP wiring, and `blocked:*` hygiene, tagging each gap with its fix-home. The recurring counterpart to `/setup-red-skills`. |
 | **[review-adrs](./plugins/dev/skills/engineering/review-adrs/SKILL.md)** | Decision-record doctor — lints `.red/adr/` for contradictions, missing supersession, stale references, number collisions, and controversial decisions, then reconciles each finding through a one-question-at-a-time interview (like `/start`) and consolidates every agreement into a single actionable PRD on the tracker via `/to-prd`. |
-| **[statusline](./plugins/dev/skills/engineering/statusline/SKILL.md)** | Installs or inspects the RedSkills Claude Code statusline, rendering the live AFK block via `node bin/afk.mjs statusline`. |
+| **[setup-statusline](./plugins/dev/skills/engineering/setup-statusline/SKILL.md)** | Installs or inspects the RedSkills Claude Code statusline, rendering the live AFK block via `node bin/afk.mjs statusline`. |
 
 </details>
 

--- a/plugins/dev/.claude-plugin/plugin.json
+++ b/plugins/dev/.claude-plugin/plugin.json
@@ -18,7 +18,7 @@
     "./skills/engineering/urgent",
     "./skills/engineering/improve-codebase-architecture",
     "./skills/engineering/setup-red-skills",
-    "./skills/engineering/statusline",
+    "./skills/engineering/setup-statusline",
     "./skills/engineering/tdd",
     "./skills/engineering/to-issues",
     "./skills/engineering/to-prd",

--- a/plugins/dev/skills/engineering/README.md
+++ b/plugins/dev/skills/engineering/README.md
@@ -15,7 +15,7 @@ Skills I use daily for code work.
 - **[setup-red-skills](./setup-red-skills/SKILL.md)** — Scaffold the per-repo config (issue tracker, triage label vocabulary, domain doc layout) that the other engineering skills consume.
 - **[doctor](./doctor/SKILL.md)** — Read-only adoption/process doctor. Reports how fully a repo adopted the stack (label vocabulary, AGENTS≡CLAUDE parity, statusline form, MCP wiring, `blocked:*` hygiene) and names each fix's home — never applies it. The recurring counterpart to `/setup-red-skills`.
 - **[review-adrs](./review-adrs/SKILL.md)** — Decision-record doctor. Lints `.red/adr/` for contradictions, missing supersession links, stale references, number collisions, and controversial decisions, then **reconciles each finding through a one-question-at-a-time interview** (like `/start`) and consolidates every agreement into a single actionable PRD on the tracker via `/to-prd`. Read-only detect, interview-driven, output is a PRD.
-- **[statusline](./statusline/SKILL.md)** — Install or inspect the RedSkills Claude Code statusline for the current repo, rendering the live AFK block via `node bin/afk.mjs statusline`.
+- **[setup-statusline](./setup-statusline/SKILL.md)** — Install or inspect the RedSkills Claude Code statusline for the current repo, rendering the live AFK block via `node bin/afk.mjs statusline`.
 - **[tdd](./tdd/SKILL.md)** — Test-driven development with a red-green-refactor loop. Builds features or fixes bugs one vertical slice at a time.
 - **[to-issues](./to-issues/SKILL.md)** — Break any plan, spec, or PRD into independently-grabbable GitHub issues using vertical slices.
 - **[to-prd](./to-prd/SKILL.md)** — Turn the current conversation context into a PRD and submit it as a GitHub issue.

--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -132,7 +132,7 @@ Decide whether to wire it up for this project:
   }
   ```
 
-  Do **not** use `$CLAUDE_PLUGIN_ROOT` here: Claude Code does not export it (nor `$CLAUDE_PROJECT_DIR`) to a `statusLine` command — only to plugin hooks and MCP/LSP subprocesses — so that form expands to an empty path and renders blank. The command above resolves the newest installed AFK bundle from the plugin cache itself, staying valid across updates without pinning a version. The project root is read from `workspace.project_dir` in the JSON Claude Code pipes on stdin (no argument needed). This is **Claude Code only**; Codex has no command-backed statusline — see the `statusline` skill for the Codex `tui.status_line` path.
+  Do **not** use `$CLAUDE_PLUGIN_ROOT` here: Claude Code does not export it (nor `$CLAUDE_PROJECT_DIR`) to a `statusLine` command — only to plugin hooks and MCP/LSP subprocesses — so that form expands to an empty path and renders blank. The command above resolves the newest installed AFK bundle from the plugin cache itself, staying valid across updates without pinning a version. The project root is read from `workspace.project_dir` in the JSON Claude Code pipes on stdin (no argument needed). This is **Claude Code only**; Codex has no command-backed statusline — see the `setup-statusline` skill for the Codex `tui.status_line` path.
 
 The script is no-op outside `/afk` sessions (it prints nothing when no live workers exist), so leaving the statusline wired up in non-AFK projects is harmless.
 

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: statusline
+name: setup-statusline
 description: Install or inspect the RedSkills statusline for the current repo. On Claude Code, wires `.claude/settings.json` to a command that runs the AFK bundle's `statusline` subcommand (resolving the installed bundle itself — Claude Code does not expose `$CLAUDE_PLUGIN_ROOT` to a statusLine). On Codex, configures the built-in `tui.status_line` footer. Preserves existing config unless replacement is explicitly requested.
 ---
 
@@ -110,5 +110,5 @@ at the same AFK bundle so the line matches Claude Code's.
 
 ## Notes
 
-- Invoke as `/statusline` (Claude Code) or `$statusline` (Codex). Wire the host you are running under — the AFK bundle's `statusline` subcommand is the shared producer of the line; only the host integration differs.
+- Invoke as `/setup-statusline` (Claude Code) or `$setup-statusline` (Codex). Wire the host you are running under — the AFK bundle's `statusline` subcommand is the shared producer of the line; only the host integration differs.
 - `/setup-red-skills` also offers to wire the Claude Code statusline as part of project bootstrap (Section F).


### PR DESCRIPTION
Renames `/statusline` → `/setup-statusline` to align with the **setup-*** family (it's an install/inspect skill that pairs with `/setup-red-skills`, which references it).

- `git mv` the skill dir `engineering/statusline` → `engineering/setup-statusline`
- frontmatter `name:` + the `/statusline`|`$statusline` invocation line
- `plugins/dev/.claude-plugin/plugin.json` registration
- `/setup-red-skills` Section F cross-ref
- root README table + engineering bucket README entries

**Untouched on purpose:** the AFK bundle's `statusline` *subcommand* (`afk.mjs statusline` — the runtime line producer) and the doctor's *'statusline drift'* check; those name the feature, not the skill. `.codex-plugin` auto-includes via its `./skills/` wildcard. `validate-install-metadata.sh` passes; no leftover `engineering/statusline` refs. Original skill → no CHANGES.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783034113&installation_id=129708444&pr_number=410&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F410&signature=0ac4ca3e94cbc04e5a32da94250ea3827581b568270722070d36aac1920995d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed statusline setup skill to "setup-statusline" with updated command names across Claude Code and Codex environments.
  * Updated all documentation references and plugin configuration to reflect the skill rename across multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->