### PR TITLE
fix(statusline): resolve the AFK bundle by version (sort -V), not mtime

### DIFF
--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -126,13 +126,13 @@ Decide whether to wire it up for this project:
   {
     "statusLine": {
       "type": "command",
-      "command": "sh -c 'b=$(ls -t \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
+      "command": "sh -c 'b=$(ls -1 \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
       "refreshInterval": 5
     }
   }
   ```
 
-  Do **not** use `$CLAUDE_PLUGIN_ROOT` here: Claude Code does not export it (nor `$CLAUDE_PROJECT_DIR`) to a `statusLine` command — only to plugin hooks and MCP/LSP subprocesses — so that form expands to an empty path and renders blank. The command above resolves the newest installed AFK bundle from the plugin cache itself, staying valid across updates without pinning a version. The project root is read from `workspace.project_dir` in the JSON Claude Code pipes on stdin (no argument needed). This is **Claude Code only**; Codex has no command-backed statusline — see the `setup-statusline` skill for the Codex `tui.status_line` path.
+  Do **not** use `$CLAUDE_PLUGIN_ROOT` here: Claude Code does not export it (nor `$CLAUDE_PROJECT_DIR`) to a `statusLine` command — only to plugin hooks and MCP/LSP subprocesses — so that form expands to an empty path and renders blank. The command above resolves the **highest-version** installed AFK bundle from the plugin cache itself (`sort -V | tail -1`, NOT `ls -t | head -1` — version order, not mtime, so a re-touched/re-extracted old dir can't win), staying valid across updates without pinning a version. The project root is read from `workspace.project_dir` in the JSON Claude Code pipes on stdin (no argument needed). This is **Claude Code only**; Codex has no command-backed statusline — see the `setup-statusline` skill for the Codex `tui.status_line` path.
 
 The script is no-op outside `/afk` sessions (it prints nothing when no live workers exist), so leaving the statusline wired up in non-AFK projects is harmless.
 

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -33,7 +33,7 @@ Codex's footer; track AFK under Codex with `/afk monitor` instead.
 {
   "statusLine": {
     "type": "command",
-    "command": "sh -c 'b=$(ls -t \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | head -1); [ -z \"$b\" ] && b=$(ls -t \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
+    "command": "sh -c 'b=$(ls -1 \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z \"$b\" ] && b=$(ls -1 \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
     "refreshInterval": 5
   }
 }
@@ -53,8 +53,10 @@ statusLine straight at the launcher means **every plugin update** lands a new
 version whose bundle is not cached yet, so the launcher tries a **synchronous
 network download inside the statusline render** — which blows the render's tight
 timeout (blank statusline), or fails outright if that version's release asset is
-not published yet. The command above instead runs the **newest already-fetched
-bundle** (`ls -t …/.cache/red-skills/bundles/dev-*.bundle.min.mjs | head -1`) —
+not published yet. The command above instead runs the **highest-version
+already-fetched bundle** (`ls -1 …/.cache/red-skills/bundles/dev-*.bundle.min.mjs | sort -V | tail -1`
+— `sort -V` picks the highest semver, NOT `ls -t` which picks newest-by-mtime and
+can resolve an OLD version when an older dir was touched/re-extracted more recently) —
 no network in the hot path, so an update never blanks the line; it keeps showing
 the last good bundle until a normal `afk` run (or a SessionStart pre-fetch)
 caches the new one. It falls back to the launcher only when the cache is empty
@@ -70,7 +72,7 @@ and a fresh file when it is missing. Keep unrelated settings intact.
 
 ```bash
 printf '{"workspace":{"project_dir":"%s"},"model":{"display_name":"Opus"}}' "$PWD" \
-  | sh -c 'b=$(ls -t "$HOME"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | head -1); [ -z "$b" ] && b=$(ls -t "$HOME"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | head -1); [ -n "$b" ] && exec node "$b" statusline'
+  | sh -c 'b=$(ls -1 "$HOME"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z "$b" ] && b=$(ls -1 "$HOME"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n "$b" ] && exec node "$b" statusline'
 ```
 
 It should print a line like `red-skills (main) · Opus`.


### PR DESCRIPTION
The statusline command resolved the bundle/version with `ls -t … | head -1` — **newest by mtime, not highest version**.

**Demonstrated live** on a real plugin cache:
```
ls -t  .../dev/ | head -1   → 1.153.0   ← OLD version (older dir, newer mtime)
ls -1  .../dev/ | sort -V | tail -1 → 1.154.0   ← correct
```
So the statusline could run an **old bundle** whenever mtime stops tracking version (re-extract / cache repair / restore / rsync). A plain name sort also breaks at `1.9 → 1.10`.

**Fix:** `ls -1 … | sort -V | tail -1` (semver-aware) in the `setup-statusline` command + `setup-red-skills` Section F command (cached-bundle path **and** plugin-cache fallback), rationale prose updated "newest" → "highest-version".

The ADR 0038 launcher (`afk.mjs`) is unaffected — it resolves by reading `plugin.json` version, never mtime.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783039762&installation_id=129708444&pr_number=412&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F412&signature=74458f12b3ec1ed15455a565c18de5cfd20f2b993c8ea4e3d8a0c2ea8ffd69cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup-red-skills and setup-statusline skill documentation to clarify bundle selection behavior
  * Enhanced verification examples to reflect current selection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->