### PR TITLE
feat(afk): raise max iterations to 20 + per-iteration boundary markers

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -48,6 +48,8 @@ import { makeFeedbackWorktree, type FeedbackWorktree } from "../runtime/feedback
 import { join } from "node:path";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
 import { initState, updateState } from "../core/state.js";
+import { formatIterationMarker } from "../core/heartbeat.js";
+import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
 import type { AgentStreamEvent } from "../core/execution.js";
 
 export interface RunOptions {
@@ -275,6 +277,13 @@ export function buildProcessDeps(
   const gitCtx: GitContext = { cwd: ctx.root, exec };
   const paths = afkPaths(ctx.root);
   const lockPath = branchLockPath(ctx.root);
+  // Per-agentic-iteration boundary tracking (observability): when sandcastle's
+  // re-invocation count (event.iteration) ticks, emit "iteration N ended/started"
+  // markers. Reset per attempt — a new attempt's run restarts at iteration 1
+  // (detected by the attempt dir changing or the count going backwards).
+  const iterMax = maxIterations ?? DEFAULT_MAX_ITERATIONS;
+  let lastIter = 0;
+  let lastIterDir = "";
 
   // ---- lifecycle hooks: load config + resolve built-in defaults + real exec ----
   const config = loadConfig(paths.configPath, { warn: () => undefined });
@@ -412,6 +421,28 @@ export function buildProcessDeps(
     // break a run (sandcastle also swallows any throw from this callback).
     recordAgentEvent: (event) => {
       const ts = new Date().toISOString();
+      // Agentic-iteration boundary markers (synthetic — afk.log + firehose, NEVER
+      // the agent lane). Emit "iteration N ended" + "iteration N+1 started" when
+      // sandcastle's re-invocation count advances, so a run burning through
+      // iterations (re-validating instead of emitting DONE) is visible.
+      const dir0 = current.attemptDir;
+      if (dir0 !== lastIterDir) {
+        lastIterDir = dir0;
+        lastIter = 0; // new attempt → fresh iteration count
+      }
+      if (event.iteration !== lastIter) {
+        const emit = (line: string, phase: string, n: number): void => {
+          void fsx.appendLine(join(dir0, "afk.log"), line);
+          void appendRecord(join(dir0, "log.jsonl"), "iteration", line, {
+            ts,
+            fields: { extra: { iteration: String(n), phase } },
+          }).catch(() => {});
+        };
+        if (lastIter > 0) emit(formatIterationMarker(lastIter, "ended", iterMax), "ended", lastIter);
+        lastIter = event.iteration;
+        emit(formatIterationMarker(lastIter, "started", iterMax), "started", lastIter);
+        void updateState(join(dir0, "afk.state.json"), { "current.iteration": String(lastIter) }).catch(() => {});
+      }
       const msg = event.type === "text" ? event.message : `→ ${event.name} ${event.formattedArgs}`;
       void appendAgentRecord(join(current.attemptDir, "agent.log.jsonl"), msg, {
         ts,

--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -73,15 +73,20 @@ export function parseAttemptTimeout(raw: string | undefined): number | undefined
  * exhausts that one iteration's budget BEFORE it can emit `<promise>DONE</promise>`,
  * so AFK sees no completionSignal → no-sentinel → blocked:crashed and never
  * merges. The completionSignal (DONE/BLOCKED) is the REAL terminator; this is
- * only the safety ceiling for "the agent never signals". 12 is generous vs the
+ * only the safety ceiling for "the agent never signals". 20 is generous vs the
  * broken 1 yet bounded vs runaway: each iteration is itself bounded by
  * `idleTimeoutSeconds`, and DONE/BLOCKED stops the loop early, so a normal issue
- * finishes in 1-3 iterations and 12 is purely the cap — enough headroom for a
+ * finishes in 1-3 iterations and 20 is purely the cap — enough headroom for a
  * thorough agent without turning repeated no-sentinel failures into long loops.
- * Env-tunable via RED_AFK_MAX_ITERATIONS (parsed by
- * `parseMaxIterations`).
+ * Raised 12 → 20 because heavy issues (e.g. Rust replication that re-runs the
+ * full `cargo test` suite to re-validate) legitimately spend more agentic turns
+ * and were hitting the cap with a complete, mergeable branch but no sentinel.
+ * The cap is the symptom-bound, not the cure — the real fix is the agent
+ * emitting DONE as soon as the gate is green (AGENT-PROMPT) + a runtime salvage
+ * of a no-sentinel-but-mergeable branch. Env-tunable via RED_AFK_MAX_ITERATIONS
+ * (parsed by `parseMaxIterations`).
  */
-export const DEFAULT_MAX_ITERATIONS = 12;
+export const DEFAULT_MAX_ITERATIONS = 20;
 
 /**
  * Parse a RED_AFK_MAX_ITERATIONS override into a positive integer, or

--- a/src/apps/dev/src/core/heartbeat.ts
+++ b/src/apps/dev/src/core/heartbeat.ts
@@ -94,6 +94,19 @@ export function formatStoppedMarker(ts: string): string {
   return `[heartbeat] iteration stopped at ${ts}`;
 }
 
+/**
+ * Per-agentic-iteration boundary marker — the sandcastle Orchestrator's
+ * re-invocation count (1..maxIterations), NOT the attempt boundary above. Emitted
+ * to afk.log + the firehose when the iteration advances, so a run burning through
+ * iterations (e.g. an agent re-running the full test suite each turn instead of
+ * emitting DONE) is visible. `max` is the resolved ceiling, shown as `N/max` when
+ * known.
+ */
+export function formatIterationMarker(n: number, phase: "started" | "ended", max?: number): string {
+  const of = max !== undefined && max > 0 ? `/${max}` : "";
+  return `[afk] agent iteration ${n}${of} ${phase}`;
+}
+
 export interface FirehoseIdentity {
   worker?: string;
   issue?: number | string;

--- a/src/apps/dev/src/core/jsonl-log.ts
+++ b/src/apps/dev/src/core/jsonl-log.ts
@@ -29,7 +29,7 @@ export const ENVELOPE_FIELD_ORDER = ["ts", "lvl", "worker", "issue", "attempt", 
  * Synthetic record types: orchestrator-authored kinds that must never appear on
  * the agent lane (which carries inner-agent output only).
  */
-export const SYNTHETIC_TYPES = ["boot", "heartbeat", "promotion", "envelope", "audit", "stamp"] as const;
+export const SYNTHETIC_TYPES = ["boot", "heartbeat", "iteration", "promotion", "envelope", "audit", "stamp"] as const;
 
 /** Keys the caller may never set via the `extra` fields map; the module owns them. */
 const RESERVED_KEYS = new Set(["type", "msg", "ts"]);

--- a/src/apps/dev/src/types/state.ts
+++ b/src/apps/dev/src/types/state.ts
@@ -26,6 +26,10 @@ export const AfkCurrentSchema = z.object({
    * external monitor reading afk.state.json sees liveness/progress, not just a
    * stale stream line. Empty until the guard arms (no-sandbox runs). */
   last_progress_at: z.string().default(""),
+  /** Current sandcastle agentic-iteration number (1..maxIterations), advanced
+   * each time the inner agent's re-invocation count ticks. Lets the monitor show
+   * "iter N/max" and surfaces a run burning through iterations re-validating. */
+  iteration: z.union([z.number(), z.string()]).optional().default(""),
 });
 
 export const AfkStateSchema = z.object({

--- a/src/apps/dev/tests/heartbeat.test.ts
+++ b/src/apps/dev/tests/heartbeat.test.ts
@@ -6,6 +6,7 @@ import {
   emitHeartbeatTick,
   escapeStreamLine,
   formatElapsed,
+  formatIterationMarker,
   formatStartedMarker,
   formatStoppedMarker,
   formatVitalsLine,
@@ -171,5 +172,21 @@ describe("heartbeat tick emit", () => {
     expect(isPeriodicEnabled("0")).toBe(false);
     expect(formatStartedMarker(194, TS)).toContain("iteration started");
     expect(formatStoppedMarker(TS)).toContain("iteration stopped");
+  });
+});
+
+describe("formatIterationMarker — per-agentic-iteration boundary", () => {
+  it("renders N/max with the phase when max is known", () => {
+    expect(formatIterationMarker(3, "started", 20)).toBe("[afk] agent iteration 3/20 started");
+    expect(formatIterationMarker(12, "ended", 20)).toBe("[afk] agent iteration 12/20 ended");
+  });
+  it("omits the /max when unknown or non-positive", () => {
+    expect(formatIterationMarker(1, "started")).toBe("[afk] agent iteration 1 started");
+    expect(formatIterationMarker(1, "started", 0)).toBe("[afk] agent iteration 1 started");
+  });
+  it("is distinct from the attempt-level heartbeat marker", () => {
+    // attempt boundary uses [heartbeat] iteration started for #N; this is [afk] agent iteration N
+    expect(formatIterationMarker(1, "started", 20)).not.toContain("[heartbeat]");
+    expect(formatIterationMarker(1, "started", 20).startsWith("[afk] agent iteration")).toBe(true);
   });
 });


### PR DESCRIPTION
For the heavy-issue no-sentinel pattern (#834/#835/#836 — Rust issues that re-run the full `cargo test` suite each turn, exhaust iterations, and hit the cap with a complete-but-unsignaled mergeable branch):

1. **`DEFAULT_MAX_ITERATIONS` 12 → 20** — headroom for legitimately-heavy issues. Symptom-bound, not the cure (the root fixes — agent emits DONE on green + runtime no-sentinel-mergeable salvage — are tracked separately). Still env-tunable via `RED_AFK_MAX_ITERATIONS`.
2. **Per-agentic-iteration boundary markers** — when sandcastle's re-invocation count ticks, emit `[afk] agent iteration N/max ended` + `… N+1 started` to **afk.log + the firehose** (`type=iteration`, a new SYNTHETIC kind — **never** the agent lane), and advance `current.iteration` in `afk.state.json`. So a run burning through iterations is visible at a glance. Reset per attempt. New `formatIterationMarker()`.

Tests: `heartbeat` (formatIterationMarker N/max, no-max, distinct-from-attempt-marker) + execution/jsonl-log/state/wire green; typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783041590&installation_id=129708444&pr_number=413&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F413&signature=bdfd016046b187d1a634001039d2b21950e98be1deeb171da169ed4f4ff0e765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased default maximum agent iterations from 12 to 20, providing more capacity for complex tasks.

* **New Features**
  * Added iteration boundary markers in execution logs to track agent progress across iterations.
  * Enhanced observability with current iteration information in execution state.

* **Tests**
  * Added test coverage for iteration boundary marker generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->