### PR TITLE
feat(afk): always show diff volume in monitor + fleet total

### DIFF
--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -643,14 +643,16 @@ The command has **two modes**, auto-selected by stdout type:
 Compact output shape (≈3 lines total for 2 workers — fits inline without truncation in an agent transcript):
 
 ```
-48h: ···············································█  (4 closed, peak 4/h, all workers)
-wZ2R4 [live] claude  4/5 (80%)  #150 [blog/D] Agent SDK on RedDB  stage:impl  00:23:01  +382 -45
-wK7M2 [stale] codex  0/16 (0%)  #521 Blockchain Collection Kind   stage:impl  02:00:01
+48h: ···············································█  (4 closed, peak 4/h, all workers)   Δ fleet +382 -45
+wZ2R4 [live] claude  issues 4/5  #150 [blog/D] Agent SDK on RedDB  stage:impl  00:23:01  +382 -45
+wK7M2 [live] codex   issues 0/16  idle  +0 -0
 ```
+
+The progress counter is `issues <done>/<total>` — issues *closed* over the queue total, **not** a completion percentage (the old `(80%)` form read as "no work done" while a worker had already committed thousands of lines). The real volume signal is the `+A -R` **diff** (committed + uncommitted, measured from the branch's merge-base with `origin/main`), which is rendered on **every** worker line unconditionally — idle and `+0 -0` included — and **summed across the fleet** into the `Δ fleet +A -R` suffix on the sparkline header, so the total diff volume is always visible at a glance.
 
 When invoking from inside another agent session (Claude Code, Codex), prefer `--once` even if stdin is a pipe — explicit beats inference. Don't use the full TTY mode in agent transcripts; the 3 s refresh loop floods the captured stream and gets truncated to garbage.
 
-Single-worker operation shows one section/line. Multi-worker adds one section/line per live worker, sorted by `started_at`. The sparkline aggregates **all workers** in this checkout's `.red/state/afk-history.jsonl` — not fractured per-worker.
+Single-worker operation shows one section/line. Multi-worker adds one section/line per live worker, sorted by `started_at`. The sparkline aggregates **all workers** in this checkout's `.red/state/afk-history.jsonl` — not fractured per-worker; the `Δ fleet` diff total likewise sums every worker.
 
 The header of every render shows a **48h sparkline** of issues closed, one glyph per hour, scaled to the peak hour:
 

--- a/src/apps/dev/src/core/monitor.ts
+++ b/src/apps/dev/src/core/monitor.ts
@@ -43,8 +43,21 @@ export interface CompactWorker {
   state: CompactState;
   /** Liveness from state_is_live(pid) + freshness, decided by the caller. */
   live: boolean;
-  /** worktree_diff_stats output ("+A -R"); omitted when unavailable. */
-  diff?: string;
+  /** Added lines of the attempt's diff (committed + uncommitted, from the
+   * branch's merge-base with origin/main). Defaults to 0 when unavailable —
+   * the diff volume is rendered unconditionally, so this is never omitted. */
+  diffAdded?: number;
+  /** Removed lines of the attempt's diff. Defaults to 0 — see {@link diffAdded}. */
+  diffRemoved?: number;
+}
+
+/** Formats a diff volume as the `+A -R` suffix the dashboard renders on every
+ * worker line (and aggregates into the header). Always produced, even for a
+ * zero diff (`+0 -0`) — the volume is shown unconditionally. */
+export function formatDiff(added: number, removed: number): string {
+  const a = added > 0 ? added : 0;
+  const r = removed > 0 ? removed : 0;
+  return `+${a} -${r}`;
 }
 
 const TITLE_MAX = 48;
@@ -80,12 +93,13 @@ function elapsedSeconds(state: CompactState, now: number): number {
  * The progress counter is labelled `issues <done>/<total>` — issues *closed*
  * over the queue total, NOT lines changed or a completion percentage. The bare
  * `<done>/<total> (<pct>%)` form read as "0% done / no code" while a worker had
- * already committed thousands of lines; lines live in the `+A -R` diff suffix
- * of <cur>, which is the real "is there work" signal.
+ * already committed thousands of lines; lines live in the `+A -R` diff suffix,
+ * which is the real "is there work" signal.
  *
  * <flags> is ` blk:N` / ` fail:N` (each present only when > 0) and <cur> is
- * `  #<n> <title>  stage:<x>  HH:MM:SS<  +A -R>` when an issue is in progress,
- * or `  idle` otherwise. `now` is an epoch in seconds.
+ * `  #<n> <title>  stage:<x>  HH:MM:SS` when an issue is in progress, or `  idle`
+ * otherwise. The `  +A -R` diff suffix is **always** appended (even idle, even
+ * `+0 -0`) so the diff volume is never hidden. `now` is an epoch in seconds.
  */
 export function renderWorkerCompactLine(worker: CompactWorker, now: number): string {
   const { state } = worker;
@@ -99,14 +113,15 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
   if (state.blocked > 0) flags += ` blk:${state.blocked}`;
   if (state.failed > 0) flags += ` fail:${state.failed}`;
 
+  const diff = `  ${formatDiff(worker.diffAdded ?? 0, worker.diffRemoved ?? 0)}`;
+
   let cur: string;
   if (!isNoIssue(state.current.number)) {
     const title = state.current.title.slice(0, TITLE_MAX);
     const elapsed = formatElapsed(elapsedSeconds(state, now));
-    const diff = worker.diff ? `  ${worker.diff}` : "";
     cur = `  #${state.current.number} ${title}  stage:${state.current.stage}  ${elapsed}${diff}`;
   } else {
-    cur = "  idle";
+    cur = `  idle${diff}`;
   }
 
   return `${workerId} [${tag}] ${runner}  issues ${done}/${total}${flags}${cur}`;
@@ -120,9 +135,11 @@ function startedAtKey(worker: CompactWorker): string {
 
 /**
  * Renders the whole compact one-shot dashboard: the 48h sparkline header line
- * (reused from history.buildSparkline) followed by one line per worker, sorted
- * by started_at. With zero workers it emits the documented "(none …)" line
- * after the header, matching render_compact's
+ * (reused from history.buildSparkline) — suffixed with the fleet-wide diff total
+ * `   Δ fleet +A -R` (summed over every worker, **always** present, even with
+ * zero workers / a zero diff) — followed by one line per worker, sorted by
+ * started_at. With zero workers it emits the documented "(none …)" line after
+ * the header, matching render_compact's
  * `echo "workers: (none — /afk not running here)"`.
  */
 export function renderCompactDashboard(
@@ -130,7 +147,13 @@ export function renderCompactDashboard(
   events: ReadonlyArray<Pick<HistoryRecord, "event" | "epoch">>,
   now: number,
 ): string {
-  const header = buildSparkline(events, now).line;
+  let added = 0;
+  let removed = 0;
+  for (const w of workers) {
+    added += w.diffAdded ?? 0;
+    removed += w.diffRemoved ?? 0;
+  }
+  const header = `${buildSparkline(events, now).line}   Δ fleet ${formatDiff(added, removed)}`;
   if (workers.length === 0) {
     return `${header}\nworkers: (none — /afk not running here)`;
   }

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -220,14 +220,18 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
     } catch {
       continue;
     }
-    // Diff column: committed + uncommitted work for the attempt, measured from
-    // the branch's merge-base with origin/main (gitx.diffstatShortstat). Without
-    // this the board showed nothing — `diff` was never populated, and even the
-    // statusline's fallback only saw the uncommitted worktree (→ 0 after commit).
-    let diff: string | undefined;
-    if (state.current.worktree) {
+    // Diff volume: committed + uncommitted work for the attempt, measured from
+    // the branch's merge-base with origin/main. Prefer the state file's persisted
+    // counts; fall back to a live `git diff --shortstat` of the worktree when both
+    // are 0 (same logic as collectStatuslineAfk). Always populated — the dashboard
+    // renders the +A -R volume unconditionally (idle / zero included) and sums it
+    // into the fleet header, so it is never suppressed.
+    let added = state.current.diff_added;
+    let removed = state.current.diff_removed;
+    if (added === 0 && removed === 0 && state.current.worktree) {
       const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, "origin/main");
-      if (stat.added > 0 || stat.removed > 0) diff = `+${stat.added} -${stat.removed}`;
+      added = stat.added;
+      removed = stat.removed;
     }
 
     workers.push({
@@ -248,7 +252,8 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
         },
       },
       live: isStateLive(state),
-      ...(diff ? { diff } : {}),
+      diffAdded: added,
+      diffRemoved: removed,
     });
   }
 

--- a/src/apps/dev/tests/monitor.test.ts
+++ b/src/apps/dev/tests/monitor.test.ts
@@ -29,7 +29,8 @@ const baseWorker = (over: Partial<CompactWorker> = {}): CompactWorker => ({
     },
   },
   live: true,
-  diff: "+10 -3",
+  diffAdded: 10,
+  diffRemoved: 3,
   ...over,
 });
 
@@ -77,43 +78,44 @@ describe("monitor — compact line", () => {
     expect(line).toContain("01:01:01");
   });
 
-  it("appends the +A -R diff verbatim when provided", () => {
+  it("renders the +A -R diff volume from the numeric fields", () => {
     const line = renderWorkerCompactLine(
-      baseWorker({ diff: "+0 -0" }),
+      baseWorker({ diffAdded: 320, diffRemoved: 47 }),
+      1780140600,
+    );
+    expect(line.endsWith("+320 -47")).toBe(true);
+  });
+
+  it("always renders the diff volume, defaulting to +0 -0 when absent", () => {
+    const line = renderWorkerCompactLine(
+      baseWorker({ diffAdded: undefined, diffRemoved: undefined }),
       1780140600,
     );
     expect(line.endsWith("+0 -0")).toBe(true);
   });
 
-  it("omits the diff suffix when no diff is given", () => {
-    const line = renderWorkerCompactLine(
-      baseWorker({ diff: undefined }),
-      1780140600,
-    );
-    expect(line).not.toContain("+");
-  });
-
   it("appends blk: and fail: flags when present", () => {
     const w = baseWorker({
       state: { ...baseWorker().state, blocked: 2, failed: 1 },
-      diff: undefined,
     });
     const line = renderWorkerCompactLine(w, 1780140600);
     expect(line).toContain("blk:2");
     expect(line).toContain("fail:1");
   });
 
-  it("renders idle when there is no current issue", () => {
+  it("renders idle when there is no current issue, still carrying the diff volume", () => {
     const w = baseWorker({
       state: {
         ...baseWorker().state,
         current: { number: "", title: "", stage: "", started_at: "" },
       },
-      diff: undefined,
+      diffAdded: 18,
+      diffRemoved: 2,
     });
     const line = renderWorkerCompactLine(w, 1780140600);
     expect(line).toContain("idle");
     expect(line).not.toContain("#");
+    expect(line.endsWith("+18 -2")).toBe(true);
   });
 });
 
@@ -130,6 +132,25 @@ describe("monitor — compact dashboard", () => {
     const lines = out.split("\n");
     expect(lines[0].startsWith("48h:")).toBe(true);
     expect(lines[0]).toContain("(2 closed");
+  });
+
+  it("suffixes the header with the fleet-wide diff total, summed over workers", () => {
+    const a = baseWorker({ diffAdded: 320, diffRemoved: 47 });
+    const b = baseWorker({
+      state: { ...baseWorker().state, worker_id: "wBBBB" },
+      diffAdded: 18,
+      diffRemoved: 2,
+    });
+    const out = renderCompactDashboard([a, b], events, 1780140600);
+    const lines = out.split("\n");
+    expect(lines[0]).toContain("Δ fleet +338 -49");
+  });
+
+  it("renders the fleet total as +0 -0 even with zero workers", () => {
+    const out = renderCompactDashboard([], events, 1780140600);
+    const lines = out.split("\n");
+    expect(lines[0]).toContain("Δ fleet +0 -0");
+    expect(out).toContain("workers: (none");
   });
 
   it("renders one line per worker, sorted by started_at", () => {


### PR DESCRIPTION
## What

`/afk monitor` now **always** surfaces the diff volume — how many lines `[+]` added and `[-]` removed:

- **Every worker line** carries the `+A -R` suffix unconditionally — including idle workers and a zero diff (`+0 -0`). Previously the diff only appeared on the in-progress line and was suppressed entirely when `0/0`.
- **Fleet total** in the sparkline header: `   Δ fleet +A -R`, summed over all workers, always present (even with zero workers → `+0 -0`).

## Why

The diff volume is the real "is there work" signal (the `issues N/M` counter is issues *closed*, not lines). Hiding it on idle/zero and having no aggregate meant you couldn't see the overall volume at a glance.

## How

- `core/monitor.ts`: `CompactWorker` carries numeric `diffAdded`/`diffRemoved` (was a pre-formatted optional `diff` string); new `formatDiff()` helper; `renderWorkerCompactLine` appends the volume on both the in-progress and idle branches; `renderCompactDashboard` sums the fleet total into the header.
- `runtime/wire.ts`: prefers the state file's persisted `diff_added`/`diff_removed`, falls back to a live `git diff --shortstat` of the worktree against the `origin/main` merge-base (same logic as the statusline), and always populates the numeric fields.
- `afk/SKILL.md`: refreshed the compact-dashboard sample (also drops the stale `(80%)` percent form the code abandoned).

## Tests

`tests/monitor.test.ts` — 21 pass. New/updated: numeric diff render, always-on `+0 -0` default, idle line carrying the volume, fleet-total header sum, `+0 -0` header with zero workers.

Runtime ships via the release-built bundle (ADR 0038) — not rebuilt here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783046102&installation_id=129708444&pr_number=421&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F421&signature=4f58027ec8a1d7b91335f6b82560e106fea2f11a1a7cb958b29cacea8936c419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compact dashboard now displays per-worker stage and elapsed timer information alongside diff metrics.
  * Fleet-wide aggregated diffs are summed and displayed in the dashboard header.
  * Worker diff format updated from percentages to `+A -R` notation for clearer volume signaling.

* **Documentation**
  * Clarified invocation guidance and sparkline aggregation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->