### PR TITLE
feat(memory): add /memory:view — open the graph in red-ui (ADR 0041)

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Boundaries:
 |---------|------------|
 | `/zoom-out` | Map-first orientation over unfamiliar code; graph-aware when Memory Graph mode is ready. |
 | `/memory:recall` | Search stored Memory notes or graph memory for relevant prior facts. |
+| `/memory:view` | Open the Memory graph visually in red-ui (cluster/query/collections), with a browser Workbench fallback in terminal hosts. |
 | `/wiki query` | Ask over the private `.red/wiki/` knowledge cache and optionally save a synthesis page. |
 | Future Ask surface | Direct question-first answers over project knowledge. This remains out of scope here. |
 

--- a/plugins/memory/.claude-plugin/plugin.json
+++ b/plugins/memory/.claude-plugin/plugin.json
@@ -18,6 +18,7 @@
     "./skills/core/improve-skills",
     "./skills/core/health",
     "./skills/core/doctor",
-    "./skills/core/export"
+    "./skills/core/export",
+    "./skills/core/view"
   ]
 }

--- a/plugins/memory/skills/core/README.md
+++ b/plugins/memory/skills/core/README.md
@@ -25,3 +25,4 @@ Two modes exist:
 | **[context-status](./context-status/SKILL.md)** | Report context stack readiness: agent rules, domain docs, ADRs, Memory mode/graph/freshness/telemetry, Wiki state, score, and recommendations. |
 | **[doctor](./doctor/SKILL.md)** | List stale nodes (long-unaccessed, never recalled) and prune them after confirmation (graph mode). |
 | **[export](./export/SKILL.md)** | Export the graph to a navigable graph.html + graph.json + audit.md (graph mode). |
+| **[view](./view/SKILL.md)** | Open the graph store visually in red-ui (cluster/query/collections) via the red-ui MCP App, with a browser Workbench fallback in terminal hosts (graph mode). |

--- a/plugins/memory/skills/core/view/SKILL.md
+++ b/plugins/memory/skills/core/view/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: view
+description: Open the project Memory graph in red-ui (the visual cluster/query/collections workspace) by pointing the red-ui MCP App at the local RedDB store, falling back to the browser Workbench in terminal hosts. Use when the user wants to SEE the memory graph, clusters, or collections visually rather than recall text.
+---
+
+# memory view
+
+Opens the project's Memory graph store (`.red/memory/graph.rdb`) as a visual workspace. The graph data is served by RedDB; this skill only points a renderer at it — it never mutates the store.
+
+<what-to-do>
+
+**Resolve the store, pick a view, then open it host-aware: the red-ui MCP App in a GUI host, the browser Workbench in a terminal. Read-only — never write to the store, never seed a token in any URL.**
+
+### 1. Resolve the store
+
+- Default store path: `.red/memory/graph.rdb` (repo-relative). If `.red/config.yaml` sets `plugins.memory.storePath`, use that instead. Resolve to an absolute path.
+- If the file does not exist, or Memory is in `markdown-only` mode (no graph): tell the user there is no graph to view, point them at `/memory:init` (graph mode) + `/memory:ingest`, and stop. Do not invent a connection.
+
+### 2. Pick the view
+
+Map the user's intent to red-ui's view enum (default `cluster` — the graph):
+
+- graph / clusters / communities → `cluster`
+- query / search / cypher → `query`
+- collections / tables → `collections`
+- home / overview → `home`
+
+### 3. Open it — host-aware
+
+- **GUI / MCP-Apps host** (Claude Desktop, claude.ai, VS Code, Cursor, …): call the red-ui MCP tool **`open_red_ui`** with `{ "connectionUrl": "<abs path to the .rdb store>", "view": "<view>" }`. red-ui spawns a local single-writer `red server` for the file (read-only if the Memory engine already holds it) and renders the workspace embedded in the chat.
+- **Terminal host** (Claude Code), or red-ui unavailable / the app does not render: MCP Apps need an iframe surface a terminal does not have. Fall back to the **Workbench** — run `memory serve` to expose the store over `http://localhost:<port>` and give the user the URL to open in a browser (or `memory workbench` for the static artifact). State clearly that you used the fallback and why.
+
+### Hard rules
+
+- ❌ Never write to or mutate the store — this is a read-only viewer.
+- ❌ Never put a secret/token in `connectionUrl` or any iframe URL (red-ui seeds only the non-secret endpoint + route; tokens go over the later postMessage channel).
+- ❌ Do not invent a connection — if the store is absent, stop and route to `/memory:init` / `/memory:ingest`.
+- ✅ Default to `cluster` (the graph) when the user just says "show me the memory graph".
+- ✅ Always name which surface opened (embedded MCP App vs browser Workbench fallback).
+
+</what-to-do>
+
+<supporting-info>
+
+### Why host-aware
+
+MCP Apps (SEP-1865) render a server-provided `ui://` HTML resource inside a sandboxed iframe — only GUI hosts have that surface. The red-ui MCP server (wired into this plugin's `.mcp.json` as `red-ui`) advertises `ui://red-ui/app.html`; the graph data itself is read by the red-ui app **directly from RedDB over HTTP**, not through the MCP bridge — the bridge only passes the connection URL and the view. A terminal host (Claude Code) cannot render the iframe, so the Workbench (`memory serve`) is the equivalent surface there.
+
+### connectionUrl forms
+
+- **File path** (e.g. the resolved `.red/memory/graph.rdb`) — red-ui spawns its own `red server` for the file (ADR-0006 single-writer flock; read-only if the Memory engine holds it).
+- **HTTP URL** (e.g. `http://localhost:5055`) — if a `red`/`memory serve` process is already serving the store, pass its URL directly.
+
+### red-ui views
+
+`home · query · collections · cluster · security` — `cluster` is the graph/communities visualization.
+
+</supporting-info>


### PR DESCRIPTION
## What

A new `memory` core skill — **`/memory:view`** — that turns "show me the memory graph" into a concrete action. It resolves the graph store, picks a red-ui view, and opens it **host-aware**:

- **GUI / MCP-Apps host** (Claude Desktop, claude.ai, VS Code, Cursor): calls the `red-ui` MCP tool `open_red_ui` with `connectionUrl` = the store (`.red/memory/graph.rdb`, or `plugins.memory.storePath`) and `view` (default `cluster` = the graph). red-ui spawns a local single-writer `red server` for the file and renders the workspace embedded in chat.
- **Terminal host** (Claude Code): MCP Apps render a `ui://` resource in a sandboxed iframe — a terminal has no iframe surface — so it falls back to the browser **Workbench** (`memory serve`).

## Why

After wiring the `red-ui` MCP into the memory plugin (#423), there was no affordance that actually *opens* the graph — the user had to know to call `open_red_ui` with the right `connectionUrl` by hand. This closes that gap: the data path is RedDB-over-HTTP (the MCP bridge only passes connection + view), and this skill encodes the store resolution + the host-aware open/fallback.

## Notes

- **Read-only**: never mutates the store, never seeds a token in any URL (red-ui seeds only the non-secret endpoint + route; tokens go over the postMessage channel).
- Registered in `plugins/memory/.claude-plugin/plugin.json` (codex uses the `./skills/` wildcard — no edit) + the core bucket README + the root README surfaces table.
- If Memory is `markdown-only` / the store is absent, the skill routes the user to `/memory:init` + `/memory:ingest` instead of inventing a connection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783074287&installation_id=129708444&pr_number=424&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F424&signature=bbd33011c579b1d6b81442535a1d2af7d47d10170c7293f1b4f677dc05e77fbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Memory graph visualization capability with red-ui support for graphical environments and Workbench browser fallback for terminal environments.

* **Documentation**
  * Updated documentation with new Memory view skill specifications, including configuration options and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->