### PR TITLE
feat(bench): memory bench eval spine — single-hop, fixed-pack, exact-match/F1, JSONL (#334)

### DIFF
--- a/src/apps/benchmark-memory/src/cli.ts
+++ b/src/apps/benchmark-memory/src/cli.ts
@@ -27,6 +27,7 @@ import {
   type LiveBaselineRunResult,
 } from "../../memory/src/live-baseline-adapters.js";
 import { formatMarkdownReport, runBenchRecall } from "../../memory/src/bench-recall.js";
+import { formatEvalReport, runBenchEval, toJsonl } from "../../memory/src/bench-eval.js";
 import {
   DEFAULT_WORKLOAD,
   formatLatencyReport,
@@ -42,6 +43,7 @@ const USAGE = `benchmark-memory
 
 Usage:
   benchmark-memory --version [--json]
+  benchmark-memory bench eval        [--corpus <dir>] [--pack N] [--substrate <name>] [--records <file>] [--out <file>] [--report <file>] [--json]
   benchmark-memory bench recall      [--root <dir>] [--corpus <dir>] [--k 1,5,10] [--out <file>] [--report <file>] [--json]
   benchmark-memory bench latency     [--root <dir>] [--workload <dir>] [--iterations N] [--warmup N] [--seed N] [--ops working-get,session-recall,long-term-recall] [--out <file>] [--report <file>] [--json]
   benchmark-memory references eval    [--v2] [--json] [--human] [--out <file>]
@@ -173,9 +175,37 @@ async function runInterop(args: ParsedArgs): Promise<number> {
 
 async function runBench(args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
+  if (sub === "eval") return runBenchEvalCmd(args);
   if (sub === "recall") return runBenchRecallCmd(args);
   if (sub === "latency") return runBenchLatencyCmd(args);
-  throw new Error(`usage: benchmark-memory bench (recall|latency) ...`);
+  throw new Error(`usage: benchmark-memory bench (eval|recall|latency) ...`);
+}
+
+async function runBenchEvalCmd(args: ParsedArgs): Promise<number> {
+  const rootDir = resolve(String(process.cwd()));
+  const corpusDir = stringFlag(args, "corpus") ?? join(rootDir, "src/apps/memory/bench/eval/single-hop");
+  const substrate = stringFlag(args, "substrate") ?? "reddb";
+  const packRaw = stringFlag(args, "pack");
+  let packSize: number | undefined;
+  if (packRaw !== undefined) {
+    const value = Number(packRaw);
+    if (!Number.isFinite(value) || value < 1) {
+      throw new Error("benchmark-memory bench eval: --pack must be a positive integer");
+    }
+    packSize = Math.floor(value);
+  }
+  const report = await runBenchEval({ corpusDir, packSize, substrate });
+  await writeOutputs(args, report, formatEvalReport(report));
+  const recordsPath = stringFlag(args, "records");
+  if (recordsPath) await writeFileEnsured(recordsPath, toJsonl(report.records));
+  if (args.flags.json === true) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(
+      `benchmark-memory bench eval: substrate=${report.substrate} category=${report.category} questions=${report.question_count} exact_match=${report.aggregate.exact_match.toFixed(3)} f1=${report.aggregate.f1.toFixed(3)}\n`,
+    );
+  }
+  return 0;
 }
 
 async function runBenchRecallCmd(args: ParsedArgs): Promise<number> {

--- a/src/apps/memory/bench/eval/single-hop/README.md
+++ b/src/apps/memory/bench/eval/single-hop/README.md
@@ -1,0 +1,34 @@
+# Single-hop eval corpus
+
+`corpus.json` + `questions.json` back `benchmark-memory bench eval` — the
+deterministic eval spine (issue #334, parent PRD #333, ADR 0037).
+
+Each question is **single-hop**: its answer lives in exactly one corpus entry
+(`gold_doc_id`), and `gold_answer` is the **exact gold** — equal to that entry's
+canonical `fact`. The pipeline is:
+
+```
+corpus + question
+  → governed-recall substrate builds a fixed context pack (top-k entries)
+  → the fixed-pack answerer reads the top entry's fact
+  → exact-match / token-F1 scorer scores against gold
+  → raw per-question records → JSONL
+```
+
+Corpus entries carry the two ADR 0035 axes (`structural_type`, the closed axis;
+`engineering_code`, the open one) so the substrate has a typed signal to rank
+on, not just body text — that is the structure plain flat notes lack.
+
+The whole path is a pure function of the checked-in fixtures: same git ref ⇒
+identical scores and identical JSONL bytes. This is the cheap deterministic core
+that gates every memory change in CI (PRD stories 13, 15, 20). The heavier tiers
+— live baselines, an LLM answerer + judge, and the multi-hop / temporal /
+abstention categories — plug into the same `ContextPack` and `QuestionRecord`
+shapes later; this is the spine they hang off.
+
+Run it:
+
+```bash
+benchmark-memory bench eval --json
+benchmark-memory bench eval --records out/single-hop.jsonl --report out/single-hop.md
+```

--- a/src/apps/memory/bench/eval/single-hop/corpus.json
+++ b/src/apps/memory/bench/eval/single-hop/corpus.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "doc-001",
+    "structural_type": "decision",
+    "engineering_code": "decision",
+    "tags": ["package-manager", "tooling"],
+    "text": "Decision: the team standardised on pnpm as the package manager for every workspace in the monorepo. npm and yarn lockfiles are forbidden and must be deleted on sight.",
+    "fact": "pnpm"
+  },
+  {
+    "id": "doc-002",
+    "structural_type": "decision",
+    "engineering_code": "decision",
+    "tags": ["auth", "session", "cookies"],
+    "text": "Decision: session tokens are stored only in HttpOnly, Secure, SameSite=Lax cookies. Storing a session token in localStorage is a security defect and fails review.",
+    "fact": "HttpOnly Secure SameSite=Lax cookies"
+  },
+  {
+    "id": "doc-003",
+    "structural_type": "validation",
+    "engineering_code": "gotcha",
+    "tags": ["pnpm", "hoisting", "dependencies"],
+    "text": "Gotcha: pnpm does not hoist transitive dependencies into the root node_modules by default. Code that imported a package it never declared must add it as a direct dependency.",
+    "fact": "pnpm does not hoist transitive dependencies by default"
+  },
+  {
+    "id": "doc-004",
+    "structural_type": "decision",
+    "engineering_code": "decision",
+    "tags": ["logging", "observability"],
+    "text": "Decision: all backend services log through the shared @tetis-lair/tetis-logger library. It pretty-prints in development and emits structured JSON in production for log aggregation.",
+    "fact": "@tetis-lair/tetis-logger"
+  },
+  {
+    "id": "doc-005",
+    "structural_type": "validation",
+    "engineering_code": "root-cause",
+    "tags": ["ci", "flaky", "timeout"],
+    "text": "Root cause: the nightly CI job flaked because the integration suite bound a fixed port and a leftover process held it. Fix: allocate an ephemeral port per run and wait for readiness before driving the server.",
+    "fact": "a leftover process holding a fixed port"
+  },
+  {
+    "id": "doc-006",
+    "structural_type": "decision",
+    "engineering_code": "decision",
+    "tags": ["database", "migrations"],
+    "text": "Decision: database migrations are forward-only. Rolling back is done by writing a new forward migration, never by editing or reverting an applied one.",
+    "fact": "forward-only"
+  },
+  {
+    "id": "doc-007",
+    "structural_type": "concept",
+    "engineering_code": "constraint",
+    "tags": ["api", "versioning"],
+    "text": "Constraint: the public HTTP API is versioned in the URL path under /v1. Breaking changes require a new version prefix; the old prefix stays live for two release cycles.",
+    "fact": "in the URL path under /v1"
+  },
+  {
+    "id": "doc-008",
+    "structural_type": "validation",
+    "engineering_code": "gotcha",
+    "tags": ["timezone", "dates"],
+    "text": "Gotcha: all timestamps are stored and compared in UTC. A bug where reports were off by a day traced to a server that formatted dates in local time before persisting them.",
+    "fact": "UTC"
+  },
+  {
+    "id": "doc-009",
+    "structural_type": "decision",
+    "engineering_code": "decision",
+    "tags": ["testing", "framework"],
+    "text": "Decision: the repository runs its unit and integration test suite on the vitest test runner. Jest was removed to avoid maintaining two runners and two config dialects.",
+    "fact": "vitest"
+  },
+  {
+    "id": "doc-010",
+    "structural_type": "concept",
+    "engineering_code": "decision",
+    "tags": ["cache", "ttl", "redis"],
+    "text": "Decision: the recall cache uses a 300 second TTL in Redis. The value was chosen to match the prompt-cache window so a warm context survives a typical agent turn.",
+    "fact": "300 seconds"
+  },
+  {
+    "id": "doc-011",
+    "structural_type": "decision",
+    "engineering_code": "decision",
+    "tags": ["language", "repo-policy"],
+    "text": "Decision: all committed repository content is written in English — code comments, docs, and commit messages. Chat with the maintainer may use other languages, the repo may not.",
+    "fact": "English",
+    "decoy_for": "doc-004"
+  },
+  {
+    "id": "doc-012",
+    "structural_type": "concept",
+    "engineering_code": "constraint",
+    "tags": ["secrets", "config"],
+    "text": "Constraint: secrets are injected only through environment variables at deploy time. Committing a secret to the repository, even in a test fixture, is a hard failure of the security gate.",
+    "fact": "environment variables"
+  }
+]

--- a/src/apps/memory/bench/eval/single-hop/questions.json
+++ b/src/apps/memory/bench/eval/single-hop/questions.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "q-001",
+    "category": "single-hop",
+    "question": "Which package manager did the team standardise on for the monorepo?",
+    "gold_doc_id": "doc-001",
+    "gold_answer": "pnpm"
+  },
+  {
+    "id": "q-002",
+    "category": "single-hop",
+    "question": "Where are session tokens stored?",
+    "gold_doc_id": "doc-002",
+    "gold_answer": "HttpOnly Secure SameSite=Lax cookies"
+  },
+  {
+    "id": "q-003",
+    "category": "single-hop",
+    "question": "Does pnpm hoist transitive dependencies into the root node_modules?",
+    "gold_doc_id": "doc-003",
+    "gold_answer": "pnpm does not hoist transitive dependencies by default"
+  },
+  {
+    "id": "q-004",
+    "category": "single-hop",
+    "question": "Which logging library do backend services use?",
+    "gold_doc_id": "doc-004",
+    "gold_answer": "@tetis-lair/tetis-logger"
+  },
+  {
+    "id": "q-005",
+    "category": "single-hop",
+    "question": "What was the root cause of the nightly CI flake?",
+    "gold_doc_id": "doc-005",
+    "gold_answer": "a leftover process holding a fixed port"
+  },
+  {
+    "id": "q-006",
+    "category": "single-hop",
+    "question": "What is the database migration policy?",
+    "gold_doc_id": "doc-006",
+    "gold_answer": "forward-only"
+  },
+  {
+    "id": "q-007",
+    "category": "single-hop",
+    "question": "How is the public HTTP API versioned?",
+    "gold_doc_id": "doc-007",
+    "gold_answer": "in the URL path under /v1"
+  },
+  {
+    "id": "q-008",
+    "category": "single-hop",
+    "question": "In which timezone are timestamps stored and compared?",
+    "gold_doc_id": "doc-008",
+    "gold_answer": "UTC"
+  },
+  {
+    "id": "q-009",
+    "category": "single-hop",
+    "question": "Which test runner does the repository use?",
+    "gold_doc_id": "doc-009",
+    "gold_answer": "vitest"
+  },
+  {
+    "id": "q-010",
+    "category": "single-hop",
+    "question": "What TTL does the recall cache use in Redis?",
+    "gold_doc_id": "doc-010",
+    "gold_answer": "300 seconds"
+  },
+  {
+    "id": "q-011",
+    "category": "single-hop",
+    "question": "What language must all committed repository content be written in?",
+    "gold_doc_id": "doc-011",
+    "gold_answer": "English"
+  },
+  {
+    "id": "q-012",
+    "category": "single-hop",
+    "question": "How are secrets injected into deployed services?",
+    "gold_doc_id": "doc-012",
+    "gold_answer": "environment variables"
+  }
+]

--- a/src/apps/memory/src/bench-eval.ts
+++ b/src/apps/memory/src/bench-eval.ts
@@ -1,0 +1,378 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/* ----------------------------------------------------------------------------
+ * memory bench eval — the deterministic eval spine (#334, parent #333, ADR 0037)
+ *
+ * The minimal end-to-end, deterministic QA path that the substrate benchmark is
+ * built on:
+ *
+ *   corpus + question
+ *     → the governed-recall substrate produces a FIXED context pack per question
+ *     → the same answerer answers from that pack
+ *     → an exact-match / token-F1 scorer scores against exact gold
+ *     → raw per-question records are emitted as JSONL
+ *
+ * This file is one substrate (RedDB governed recall) and one category
+ * (single-hop). It is intentionally pure and dependency-free so the cheap
+ * deterministic core can gate every memory change in CI without a live RedDB
+ * (PRD #333 stories 13, 15, 20). The richer tiers — live baselines, LLM-judge,
+ * multi-hop / temporal / abstention categories — plug into the same shapes
+ * later; this is the spine they hang off.
+ *
+ * Determinism contract: every function here is a pure function of its inputs.
+ * No clocks, no randomness, no I/O beyond reading the checked-in fixtures. Ties
+ * always break on entry id. Same fixture + same git ref ⇒ byte-identical output.
+ * --------------------------------------------------------------------------*/
+
+/** A curated engineering-memory entry. The two axes follow ADR 0035: a closed
+ * `structural_type` and an open `engineering_code`. `fact` is the concise
+ * canonical answer this entry supports — the fixed-pack answerer reads it. */
+export interface CorpusEntry {
+  id: string;
+  structural_type: string;
+  engineering_code: string;
+  tags: string[];
+  text: string;
+  fact: string;
+}
+
+/** A single-hop question with exact gold. `gold_answer` is the authoritative
+ * string the answer is scored against; `gold_doc_id` is the one corpus entry
+ * that supports it (single-hop ⇒ exactly one). */
+export interface Question {
+  id: string;
+  category: string;
+  question: string;
+  gold_doc_id: string;
+  gold_answer: string;
+}
+
+export interface ContextPackEntry {
+  id: string;
+  rank: number;
+  score: number;
+  fact: string;
+  text: string;
+}
+
+/** The fixed context pack a substrate hands to the answerer for one question. */
+export interface ContextPack {
+  question_id: string;
+  substrate: string;
+  entries: ContextPackEntry[];
+}
+
+export const EVAL_SCHEMA_VERSION = "memory.bench.eval.v1" as const;
+
+/** One raw per-question record. Written verbatim as a JSONL line; the schema is
+ * stable and versioned so downstream readers (the RedDB analytics hypertable,
+ * CI regression diffing) can rely on it. */
+export interface QuestionRecord {
+  schema_version: typeof EVAL_SCHEMA_VERSION;
+  substrate: string;
+  category: string;
+  question_id: string;
+  question: string;
+  gold_doc_id: string;
+  gold_answer: string;
+  predicted_answer: string;
+  pack_ids: string[];
+  gold_in_pack: boolean;
+  gold_rank: number | null;
+  exact_match: number;
+  f1: number;
+}
+
+export interface EvalReport {
+  schema_version: typeof EVAL_SCHEMA_VERSION;
+  generated_at: string;
+  substrate: string;
+  category: string;
+  corpus_size: number;
+  question_count: number;
+  pack_size: number;
+  aggregate: {
+    exact_match: number;
+    f1: number;
+    gold_in_pack_rate: number;
+  };
+  records: QuestionRecord[];
+}
+
+/* ----------------------------------------------------------------------------
+ * Corpus + question loaders
+ * --------------------------------------------------------------------------*/
+
+export async function loadCorpus(dir: string): Promise<CorpusEntry[]> {
+  const raw = await readFile(join(dir, "corpus.json"), "utf8");
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("corpus.json must be a JSON array");
+  return parsed.map(asCorpusEntry);
+}
+
+export async function loadQuestions(dir: string): Promise<Question[]> {
+  const raw = await readFile(join(dir, "questions.json"), "utf8");
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("questions.json must be a JSON array");
+  return parsed.map(asQuestion);
+}
+
+function asCorpusEntry(value: unknown): CorpusEntry {
+  if (!value || typeof value !== "object") throw new Error("corpus entry must be an object");
+  const r = value as Record<string, unknown>;
+  const tags = Array.isArray(r.tags) ? r.tags.filter((t): t is string => typeof t === "string") : [];
+  return {
+    id: stringField(r, "id"),
+    structural_type: stringField(r, "structural_type"),
+    engineering_code: stringField(r, "engineering_code"),
+    tags,
+    text: stringField(r, "text"),
+    fact: stringField(r, "fact"),
+  };
+}
+
+function asQuestion(value: unknown): Question {
+  if (!value || typeof value !== "object") throw new Error("question entry must be an object");
+  const r = value as Record<string, unknown>;
+  return {
+    id: stringField(r, "id"),
+    category: stringField(r, "category"),
+    question: stringField(r, "question"),
+    gold_doc_id: stringField(r, "gold_doc_id"),
+    gold_answer: stringField(r, "gold_answer"),
+  };
+}
+
+function stringField(r: Record<string, unknown>, key: string): string {
+  const v = r[key];
+  if (typeof v !== "string") throw new Error(`field "${key}" must be a string`);
+  return v;
+}
+
+/* ----------------------------------------------------------------------------
+ * Governed-recall substrate → fixed context pack
+ *
+ * A deterministic stand-in for RedDB governed recall: it ranks the corpus by a
+ * typed signal (question-token overlap against the entry text, plus a bonus for
+ * tag/engineering-code overlap) and returns the top `packSize` entries as the
+ * fixed pack. The shape mirrors the production recall path; the live RedDB
+ * adapter slots in here later behind the same `ContextPack` contract without
+ * touching the answerer or the scorer.
+ * --------------------------------------------------------------------------*/
+
+const PACK_SIZE_DEFAULT = 5;
+
+export function tokenize(text: string): string[] {
+  return (text.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter((t) => t.length >= 2);
+}
+
+export function scoreEntry(question: Question, entry: CorpusEntry): number {
+  const qTokens = new Set(tokenize(question.question));
+  if (qTokens.size === 0) return 0;
+  let overlap = 0;
+  for (const tok of new Set(tokenize(entry.text))) if (qTokens.has(tok)) overlap += 1;
+  // Typed bonus: the governed substrate also indexes tags + engineering code,
+  // so a question token landing on one of those axes counts for more than a
+  // bare body-text hit. Kept small so body overlap stays the dominant signal.
+  let typed = 0;
+  for (const tag of entry.tags) for (const part of tokenize(tag)) if (qTokens.has(part)) typed += 1;
+  for (const part of tokenize(entry.engineering_code)) if (qTokens.has(part)) typed += 1;
+  return overlap + typed * 0.5;
+}
+
+export function buildContextPack(
+  corpus: CorpusEntry[],
+  question: Question,
+  packSize: number,
+  substrate: string,
+): ContextPack {
+  const scored = corpus
+    .map((entry) => ({ entry, score: scoreEntry(question, entry) }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || a.entry.id.localeCompare(b.entry.id))
+    .slice(0, packSize);
+  const entries: ContextPackEntry[] = scored.map((s, i) => ({
+    id: s.entry.id,
+    rank: i + 1,
+    score: round4(s.score),
+    fact: s.entry.fact,
+    text: s.entry.text,
+  }));
+  return { question_id: question.id, substrate, entries };
+}
+
+/* ----------------------------------------------------------------------------
+ * Answerer (fixed-pack, single-turn, deterministic)
+ *
+ * The fixed-pack answerer reads the top-ranked entry's canonical fact. This
+ * cleanly isolates the substrate's contribution (PRD story 12): a correct
+ * answer means governed recall put the answer-bearing entry on top of the pack;
+ * an empty pack means the substrate surfaced nothing, so the answerer abstains.
+ * The LLM answerer of the heavier tier replaces this one behind the same
+ * (pack) → string signature.
+ * --------------------------------------------------------------------------*/
+
+export function answerFromPack(pack: ContextPack): string {
+  return pack.entries[0]?.fact ?? "";
+}
+
+/* ----------------------------------------------------------------------------
+ * Scorer — pure, unit-tested (PRD story 2; acceptance: pure module)
+ *
+ * SQuAD-style normalisation: lowercase, drop punctuation, drop leading articles,
+ * collapse whitespace. Exact-match is the deterministic primary number; token
+ * F1 gives partial credit so a "right entry, differently phrased" answer is not
+ * scored identically to a wrong one.
+ * --------------------------------------------------------------------------*/
+
+export function normalizeAnswer(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\b(a|an|the)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function exactMatch(predicted: string, gold: string): number {
+  return normalizeAnswer(predicted) === normalizeAnswer(gold) ? 1 : 0;
+}
+
+export function tokenF1(predicted: string, gold: string): number {
+  const predTokens = normalizeAnswer(predicted).split(" ").filter(Boolean);
+  const goldTokens = normalizeAnswer(gold).split(" ").filter(Boolean);
+  if (predTokens.length === 0 && goldTokens.length === 0) return 1;
+  if (predTokens.length === 0 || goldTokens.length === 0) return 0;
+  const goldCounts = new Map<string, number>();
+  for (const t of goldTokens) goldCounts.set(t, (goldCounts.get(t) ?? 0) + 1);
+  let shared = 0;
+  for (const t of predTokens) {
+    const remaining = goldCounts.get(t);
+    if (remaining && remaining > 0) {
+      shared += 1;
+      goldCounts.set(t, remaining - 1);
+    }
+  }
+  if (shared === 0) return 0;
+  const precision = shared / predTokens.length;
+  const recall = shared / goldTokens.length;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+/* ----------------------------------------------------------------------------
+ * Runner — wires substrate → answerer → scorer, emits the report + records
+ * --------------------------------------------------------------------------*/
+
+export interface RunEvalOptions {
+  corpusDir: string;
+  packSize?: number;
+  substrate?: string;
+  now?: () => Date;
+}
+
+export async function runBenchEval(opts: RunEvalOptions): Promise<EvalReport> {
+  const packSize = opts.packSize ?? PACK_SIZE_DEFAULT;
+  const substrate = opts.substrate ?? "reddb";
+  const corpus = await loadCorpus(opts.corpusDir);
+  const questions = await loadQuestions(opts.corpusDir);
+
+  const records: QuestionRecord[] = [];
+  let emSum = 0;
+  let f1Sum = 0;
+  let goldInPackCount = 0;
+
+  for (const q of questions) {
+    const pack = buildContextPack(corpus, q, packSize, substrate);
+    const predicted = answerFromPack(pack);
+    const em = exactMatch(predicted, q.gold_answer);
+    const f1 = tokenF1(predicted, q.gold_answer);
+    const packIds = pack.entries.map((e) => e.id);
+    const goldIdx = packIds.indexOf(q.gold_doc_id);
+    const goldInPack = goldIdx >= 0;
+    emSum += em;
+    f1Sum += f1;
+    if (goldInPack) goldInPackCount += 1;
+    records.push({
+      schema_version: EVAL_SCHEMA_VERSION,
+      substrate,
+      category: q.category,
+      question_id: q.id,
+      question: q.question,
+      gold_doc_id: q.gold_doc_id,
+      gold_answer: q.gold_answer,
+      predicted_answer: predicted,
+      pack_ids: packIds,
+      gold_in_pack: goldInPack,
+      gold_rank: goldInPack ? goldIdx + 1 : null,
+      exact_match: em,
+      f1: round4(f1),
+    });
+  }
+
+  const n = Math.max(questions.length, 1);
+  const category = questions[0]?.category ?? "single-hop";
+  const now = (opts.now ?? (() => new Date()))();
+  return {
+    schema_version: EVAL_SCHEMA_VERSION,
+    generated_at: now.toISOString(),
+    substrate,
+    category,
+    corpus_size: corpus.length,
+    question_count: questions.length,
+    pack_size: packSize,
+    aggregate: {
+      exact_match: round4(emSum / n),
+      f1: round4(f1Sum / n),
+      gold_in_pack_rate: round4(goldInPackCount / n),
+    },
+    records,
+  };
+}
+
+/* ----------------------------------------------------------------------------
+ * JSONL + markdown serialisation
+ * --------------------------------------------------------------------------*/
+
+/** Stable JSONL: one record object per line, trailing newline. Field order is
+ * fixed by `QuestionRecord` construction above, so the bytes are reproducible. */
+export function toJsonl(records: QuestionRecord[]): string {
+  return records.map((r) => JSON.stringify(r)).join("\n") + (records.length > 0 ? "\n" : "");
+}
+
+export function formatEvalReport(report: EvalReport): string {
+  const lines: string[] = [];
+  lines.push(`# memory bench eval — ${report.generated_at.slice(0, 10)}`);
+  lines.push("");
+  lines.push(
+    `Substrate: \`${report.substrate}\` · category: \`${report.category}\` · corpus: ${report.corpus_size} entries · questions: ${report.question_count} · pack size: ${report.pack_size}.`,
+  );
+  lines.push("");
+  lines.push("| metric | score |");
+  lines.push("| --- | --- |");
+  lines.push(`| exact-match | ${report.aggregate.exact_match.toFixed(3)} |`);
+  lines.push(`| token-F1 | ${report.aggregate.f1.toFixed(3)} |`);
+  lines.push(`| gold-in-pack rate | ${report.aggregate.gold_in_pack_rate.toFixed(3)} |`);
+  lines.push("");
+  lines.push("## Per-question");
+  lines.push("");
+  lines.push("| question_id | gold_rank | EM | F1 | predicted |");
+  lines.push("| --- | --- | --- | --- | --- |");
+  for (const r of report.records) {
+    lines.push(
+      `| ${r.question_id} | ${r.gold_rank ?? "—"} | ${r.exact_match} | ${r.f1.toFixed(3)} | ${r.predicted_answer || "(abstain)"} |`,
+    );
+  }
+  lines.push("");
+  lines.push("## Reproducibility");
+  lines.push("");
+  lines.push(
+    "Deterministic by construction: recall, the fixed-pack answerer, and the exact-match/F1 scorer are pure functions of the checked-in corpus and questions. Same git ref ⇒ identical scores and identical JSONL bytes (the test suite asserts byte-equality across runs).",
+  );
+  lines.push("");
+  return lines.join("\n");
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}

--- a/src/apps/memory/tests/bench-eval.test.ts
+++ b/src/apps/memory/tests/bench-eval.test.ts
@@ -1,0 +1,152 @@
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  EVAL_SCHEMA_VERSION,
+  answerFromPack,
+  buildContextPack,
+  exactMatch,
+  formatEvalReport,
+  loadCorpus,
+  loadQuestions,
+  normalizeAnswer,
+  runBenchEval,
+  toJsonl,
+  tokenF1,
+} from "../src/bench-eval.js";
+
+const CORPUS_DIR = join(__dirname, "../bench/eval/single-hop");
+const FIXED_NOW = new Date("2026-06-02T00:00:00.000Z");
+
+describe("memory bench eval — fixture integrity", () => {
+  test("every question's gold_doc_id resolves and its gold_answer matches that entry's fact", async () => {
+    const corpus = await loadCorpus(CORPUS_DIR);
+    const byId = new Map(corpus.map((c) => [c.id, c]));
+    const questions = await loadQuestions(CORPUS_DIR);
+    expect(questions.length).toBeGreaterThanOrEqual(10);
+    for (const q of questions) {
+      expect(q.category).toBe("single-hop");
+      const gold = byId.get(q.gold_doc_id);
+      expect(gold, `gold_doc_id ${q.gold_doc_id} for ${q.id}`).toBeDefined();
+      // Single-hop exact gold: the authoritative answer is the gold entry's fact.
+      expect(exactMatch(q.gold_answer, gold!.fact)).toBe(1);
+    }
+  });
+});
+
+describe("memory bench eval — scorer (pure)", () => {
+  test("normalizeAnswer lowercases, strips punctuation + articles, collapses space", () => {
+    expect(normalizeAnswer("  The   pnpm! ")).toBe("pnpm");
+    expect(normalizeAnswer("HttpOnly, Secure; SameSite=Lax")).toBe("httponly secure samesite lax");
+    expect(normalizeAnswer("a UTC")).toBe("utc");
+  });
+
+  test("exactMatch is 1 only on normalised equality", () => {
+    expect(exactMatch("pnpm", "pnpm")).toBe(1);
+    expect(exactMatch("The pnpm.", "pnpm")).toBe(1);
+    expect(exactMatch("npm", "pnpm")).toBe(0);
+    expect(exactMatch("", "pnpm")).toBe(0);
+  });
+
+  test("tokenF1 gives partial credit and handles edge cases", () => {
+    expect(tokenF1("pnpm", "pnpm")).toBe(1);
+    expect(tokenF1("", "pnpm")).toBe(0);
+    expect(tokenF1("totally wrong", "pnpm")).toBe(0);
+    // 2 shared of 3 predicted, 2 shared of 2 gold → P=2/3, R=1, F1=0.8
+    expect(tokenF1("stored in utc", "in utc")).toBeCloseTo(0.8, 5);
+  });
+
+  test("tokenF1 is symmetric in precision/recall composition", () => {
+    expect(tokenF1("in utc", "stored in utc")).toBeCloseTo(0.8, 5);
+  });
+});
+
+describe("memory bench eval — substrate + answerer", () => {
+  test("the fixed pack is bounded, ranked, and tie-broken by id", async () => {
+    const corpus = await loadCorpus(CORPUS_DIR);
+    const questions = await loadQuestions(CORPUS_DIR);
+    const pack = buildContextPack(corpus, questions[0]!, 5, "reddb");
+    expect(pack.entries.length).toBeLessThanOrEqual(5);
+    expect(pack.entries.map((e) => e.rank)).toEqual(pack.entries.map((_, i) => i + 1));
+    const again = buildContextPack(corpus, questions[0]!, 5, "reddb");
+    expect(pack).toEqual(again);
+  });
+
+  test("governed recall surfaces the gold entry on top for a single-hop question", async () => {
+    const corpus = await loadCorpus(CORPUS_DIR);
+    const questions = await loadQuestions(CORPUS_DIR);
+    const q = questions.find((x) => x.id === "q-001")!;
+    const pack = buildContextPack(corpus, q, 5, "reddb");
+    expect(pack.entries[0]?.id).toBe("doc-001");
+    expect(answerFromPack(pack)).toBe("pnpm");
+  });
+
+  test("answerer abstains (empty string) on an empty pack", () => {
+    expect(answerFromPack({ question_id: "x", substrate: "reddb", entries: [] })).toBe("");
+  });
+});
+
+describe("memory bench eval — runner", () => {
+  test("report shape matches schema v1 and carries an aggregate score", async () => {
+    const report = await runBenchEval({ corpusDir: CORPUS_DIR, now: () => FIXED_NOW });
+    expect(report.schema_version).toBe(EVAL_SCHEMA_VERSION);
+    expect(report.generated_at).toBe(FIXED_NOW.toISOString());
+    expect(report.substrate).toBe("reddb");
+    expect(report.category).toBe("single-hop");
+    expect(report.corpus_size).toBeGreaterThan(0);
+    expect(report.question_count).toBe(report.records.length);
+    expect(report.aggregate.exact_match).toBeGreaterThan(0);
+    expect(report.aggregate.exact_match).toBeLessThanOrEqual(1);
+    expect(report.aggregate.f1).toBeGreaterThanOrEqual(report.aggregate.exact_match);
+  });
+
+  test("each record carries the stable per-question schema", async () => {
+    const report = await runBenchEval({ corpusDir: CORPUS_DIR, now: () => FIXED_NOW });
+    for (const r of report.records) {
+      expect(r.schema_version).toBe(EVAL_SCHEMA_VERSION);
+      expect(typeof r.question_id).toBe("string");
+      expect(typeof r.predicted_answer).toBe("string");
+      expect(Array.isArray(r.pack_ids)).toBe(true);
+      expect([0, 1]).toContain(r.exact_match);
+      expect(r.f1).toBeGreaterThanOrEqual(0);
+      expect(r.f1).toBeLessThanOrEqual(1);
+      if (r.gold_in_pack) expect(r.gold_rank).toBe(r.pack_ids.indexOf(r.gold_doc_id) + 1);
+      else expect(r.gold_rank).toBeNull();
+    }
+  });
+
+  test("run is byte-deterministic across runs (zero tolerance)", async () => {
+    const a = await runBenchEval({ corpusDir: CORPUS_DIR, now: () => FIXED_NOW });
+    const b = await runBenchEval({ corpusDir: CORPUS_DIR, now: () => FIXED_NOW });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    expect(toJsonl(a.records)).toBe(toJsonl(b.records));
+  });
+});
+
+describe("memory bench eval — JSONL emission", () => {
+  test("toJsonl emits one parseable object per line with a trailing newline", async () => {
+    const report = await runBenchEval({ corpusDir: CORPUS_DIR, now: () => FIXED_NOW });
+    const jsonl = toJsonl(report.records);
+    expect(jsonl.endsWith("\n")).toBe(true);
+    const lines = jsonl.trimEnd().split("\n");
+    expect(lines.length).toBe(report.records.length);
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      expect(parsed.schema_version).toBe(EVAL_SCHEMA_VERSION);
+    }
+  });
+
+  test("empty records produce empty JSONL (no stray newline)", () => {
+    expect(toJsonl([])).toBe("");
+  });
+});
+
+describe("memory bench eval — markdown report", () => {
+  test("renders aggregate metrics and a per-question row for every record", async () => {
+    const report = await runBenchEval({ corpusDir: CORPUS_DIR, now: () => FIXED_NOW });
+    const md = formatEvalReport(report);
+    expect(md).toContain("# memory bench eval — 2026-06-02");
+    expect(md).toContain("exact-match");
+    expect(md).toContain("token-F1");
+    for (const r of report.records) expect(md).toContain(r.question_id);
+  });
+});


### PR DESCRIPTION
Lands the completed work from AFK attempt `wCUL2` on #334.

## Context

The AFK agent implemented #334 end-to-end (62m run), committed it, and reported `The branch is ready to merge` — but exited **without emitting the `<promise>` sentinel**, so the runtime classified it `no-sentinel`/`blocked:crashed` and escalated to `ready-for-human`. This is the no-sentinel-on-completion pattern, not a work defect. Resolved via `/dev:hitl` (maintainer decision: merge as-is).

## What's here (780 lines, one commit)

The minimal deterministic eval spine: a hand-authored single-hop engineering question set with exact gold, a fixed context pack per question over the RedDB substrate, an exact-match/F1 scorer, JSONL per-question records, driven by `benchmark-memory bench eval`.

- `src/apps/memory/src/bench-eval.ts` (scorer + runner) + `tests/bench-eval.test.ts`
- `src/apps/memory/bench/eval/single-hop/` — corpus.json, questions.json, README
- `src/apps/benchmark-memory/src/cli.ts` — wires `bench eval` alongside the existing `bench recall`/`bench latency`

## Validation (merged onto current main)

- `tsc --noEmit` clean
- `vitest tests/bench-eval.test.ts` → **14/14 pass**
- Clean merge — none of the 6 files overlap changes main made since the attempt's base.

## Acceptance criteria

- [x] Runs end-to-end + emits a score (`benchmark-memory bench eval`; the bench harness app, consistent with `bench recall`/`bench latency` — the brief's literal `memory bench` is satisfied by the bench app's `bench eval`)
- [x] Exact-match/F1 scorer is a pure, unit-tested module
- [x] Raw per-question records written as JSONL with a stable schema
- [x] Deterministic (same input → same output)

Closes #334.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783074704&installation_id=129708444&pr_number=425&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F425&signature=9c2f84b526ebbce452bb70641e22902c89580786da154520432fa81ad6c8aa3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `bench eval` subcommand for deterministic evaluation of memory retrieval and answering
  * Single-hop evaluation dataset with 12 test questions on repository knowledge
  * Support for JSON, JSONL (detailed records), and markdown output formats

* **Documentation**
  * Added comprehensive guide explaining the evaluation corpus, methodology, and CLI usage

* **Tests**
  * Added test suite validating the evaluation pipeline end-to-end

<!-- end of auto-generated comment: release notes by coderabbit.ai -->