### PR TITLE
fix(afk): salvage a no-sentinel branch that passes feedback (Defeito 2 / issue #332)

### DIFF
--- a/.red/adr/0047-afk-salvages-no-sentinel-branch-that-passes-feedback.md
+++ b/.red/adr/0047-afk-salvages-no-sentinel-branch-that-passes-feedback.md
@@ -1,0 +1,30 @@
+# ADR 0047 — AFK salvages a no-sentinel branch that already passes feedback
+
+## Status
+
+accepted. Complements ADR 0028 (`<promise>` is the canonical attempt-exit). Supersedes the runtime half of the stale PR #335 (`fix/332-afk-salvage-no-sentinel`, ~169 commits behind on the pre-`src/apps` tree); re-implemented here on the current `src/apps/dev/src/core/process-issue.ts`.
+
+## Context
+
+ADR 0028 makes the `<promise>` sentinel the canonical "attempt is over" signal and demotes EOF-without-sentinel to a **crash** detector. That is correct for a true crash, but it has a costly failure mode observed repeatedly (#332, #334, and live on #300):
+
+The inner agent **finishes the work and commits it**, then exits **without** re-emitting `<promise>DONE</promise>` — often because it re-opened a branch a prior iteration already completed and concluded "already done, nothing to do." The runtime read that EOF as a crash, abandoned the (complete, green) branch, and re-invoked the agent. Each re-invocation re-discovered the finished commit and again exited without a sentinel — burning iterations up to `max_iterations` (#300: done at iteration 1, looped to 4/20 over ~50 min, never closed) and finally landing the issue in `ready-for-human` despite the work being mergeable the whole time. This is the dominant cause of AFK appearing "slow" / "adrift."
+
+The preventive half (the agent must emit `DONE` even when work is already complete) shipped in `AGENT-PROMPT.md`. This ADR is the **runtime safety net**.
+
+## Decision
+
+On `run.outcome === "no-sentinel"`, the runtime branches on whether the worker branch carries work:
+
+- **Empty branch** (no diff vs base, or branch absent on host) → unchanged: fire `on_attempt_error`, terminal `no-sentinel` → `ready-for-human`. A genuine crash with nothing to salvage keeps today's behaviour (and its crash-retry budget).
+- **Branch ahead of base AND present** → **salvage**: do NOT fire `on_attempt_error`. Fire `post_attempt` with `success` and route the attempt through the **same feedback gate + landing + close tail the DONE path uses**. The feedback gate (typecheck/tests, ADR 0008) is load-bearing — it is the only thing distinguishing "complete prior work" from a half-baked crash-edit. If feedback fails, the attempt terminates as `feedback-failed` (the accurate reason), never `no-sentinel`.
+
+A salvaged attempt lands, closes, and reports its terminal envelope **exactly like a DONE attempt** — the sentinel was the only thing missing, and the work itself already passed the gate.
+
+## Consequences
+
+- AFK converges on the common "finished-but-forgot-the-sentinel" case instead of looping to `max_iterations` — directly fixes the #300-class slowness.
+- The merge gate is never bypassed: salvage only lands work that passes feedback. No-work / failing-work branches keep the terminal failure path.
+- Pairs with the `AGENT-PROMPT` "already done still requires the sentinel" rule: the prompt is the prevention, this is the cure. Both are needed — a runner that crashes mid-write still hits the empty-branch / failing-feedback path safely.
+
+Memory-NoIngest: ADR + runtime fix; the canonical graph claim for the no-sentinel contract stays with ADR 0028.

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -642,38 +642,63 @@ export async function processIssue(
     startedEpoch,
   } satisfies StageCommon;
 
-  // ---- on_attempt_error: the run ended without an AFK sentinel (ADR 0028) ----
+  // ---- no-sentinel: the run ended without an AFK sentinel (ADR 0028) ----
+  // ADR 0028 keeps `<promise>` canonical: a missing sentinel is a CRASH signal,
+  // not a "nothing to do" signal. But a worker branch can already carry a COMPLETE
+  // commit from a prior iteration — the agent finished the work, then exited
+  // without re-emitting the sentinel (issue #332; the live #300 loop: done at
+  // iteration 1, re-invoked to 4/20, never closed). Abandoning such a branch never
+  // converges. So we SALVAGE a no-sentinel attempt IFF its branch is ahead of base
+  // AND present on the host — but only THROUGH the same feedback gate + landing
+  // tail the DONE path uses. The feedback gate is load-bearing: it is the only
+  // thing that distinguishes "complete prior work" from a half-baked crash-edit.
+  // A branch with no work keeps today's terminal `no-sentinel` behaviour.
+  let salvaged = false;
   if (run.outcome === "no-sentinel") {
-    await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
-    return await terminalFailure(common, "no-sentinel", "no-sentinel", {
-      notes: "_(no Notes appended; inner agent exited without a sentinel)_",
-      log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
-    });
-  }
-
-  // ---- attempt progress guard fired: alive but no new commit within the cap.
-  // Park to ready-for-human (blocked:stalled), preserving the pushed branch/PR
-  // — never auto-retry (recoveryReasonFor("stalled") = null → always escalate). ----
-  if (run.outcome === "timeout") {
+    const branchHasWork =
+      (await deps.lookups.changedFiles(workerBranch, base)).length > 0 &&
+      (!deps.lookups.branchPresent || (await deps.lookups.branchPresent(workerBranch)));
+    if (!branchHasWork) {
+      await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
+      return await terminalFailure(common, "no-sentinel", "no-sentinel", {
+        notes: "_(no Notes appended; inner agent exited without a sentinel and the branch carries no work)_",
+        log: run.stdout ? run.stdout.split("\n").slice(-1)[0] || "(no captured stdout)" : "(no captured stdout)",
+      });
+    }
+    // Salvage path: the branch is ahead of base and present. Treat the attempt as
+    // a success for hook purposes (we are about to LAND it, not error it) and fall
+    // through to the shared feedback + land + close tail. `on_attempt_error` is NOT
+    // fired — a salvaged-and-landed attempt is not an error.
+    salvaged = true;
+    deps.appendIterLog(
+      `🤖 /afk: no-sentinel exit but worker branch \`${workerBranch}\` carries work — salvaging through the feedback gate (issue #332).`,
+    );
+    await fireHook("post_attempt", postAttemptContext(current, workerBranch, "success", "no-sentinel"));
+  } else if (run.outcome === "timeout") {
+    // ---- attempt progress guard fired: alive but no new commit within the cap.
+    // Park to ready-for-human (blocked:stalled), preserving the pushed branch/PR
+    // — never auto-retry (recoveryReasonFor("stalled") = null → always escalate). ----
     await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "stalled", current.attempt));
     return await terminalFailure(common, "stalled", "stalled", {
       notes: "_(no Notes appended; attempt aborted — inner agent made no progress within the wall-clock guard)_",
       log: run.stdout || "(attempt progress guard fired)",
     });
+  } else {
+    // ---- post_attempt hook (terminal invocation; sentinel-bearing) ----
+    const pwStatus = run.outcome === "done" ? "success" : "fail";
+    await fireHook("post_attempt", postAttemptContext(current, workerBranch, pwStatus, run.outcome));
+
+    // ---- BLOCKED ----
+    if (run.outcome === "blocked") {
+      return await terminalFailure(common, "blocked", "blocked", {
+        notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
+      });
+    }
+    // run.outcome === "done" → fall through to the shared land + close tail.
   }
 
-  // ---- post_attempt hook (terminal invocation; sentinel-bearing) ----
-  const pwStatus = run.outcome === "done" ? "success" : "fail";
-  await fireHook("post_attempt", postAttemptContext(current, workerBranch, pwStatus, run.outcome));
-
-  // ---- BLOCKED ----
-  if (run.outcome === "blocked") {
-    return await terminalFailure(common, "blocked", "blocked", {
-      notes: `_(inner agent emitted BLOCKED — see iteration log at \`${input.attemptDir}\`)_`,
-    });
-  }
-
-  // run.outcome === "done".
+  // run.outcome === "done" OR a salvaged no-sentinel branch: shared feedback +
+  // land + close tail (the salvage path lands exactly like a DONE attempt).
 
   // ---- 5a. worker-branch presence gate (FIX E) ----
   // changedFiles() does `git diff base...branch`, which returns [] on a MISSING
@@ -705,7 +730,9 @@ export async function processIssue(
     // Memory (best-effort) just like the done path does.
     await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
     return await terminalFailure(common, "feedback-failed", "feedback", {
-      notes: "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
+      notes: salvaged
+        ? "Salvaged a no-sentinel branch (it carried work), but feedback validation failed — the branch was not merged."
+        : "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.",
       validation: feedback.sidecar.join("\n"),
     }, { validationSummary: feedback.sidecar.join("\n") });
   }

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -479,8 +479,9 @@ describe("processIssue — BLOCKED", () => {
 });
 
 describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
-  it("routes through on_attempt_error → ready-for-human, no post_attempt", async () => {
-    const { deps, input, trace } = harness({ outcome: "no-sentinel" });
+  it("EMPTY branch → on_attempt_error → ready-for-human, no post_attempt", async () => {
+    // No work on the branch: a real crash, kept as today's terminal no-sentinel.
+    const { deps, input, trace } = harness({ outcome: "no-sentinel", changedFiles: [] });
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("no-sentinel");
@@ -493,6 +494,39 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "no-sentinel" }]);
     // on_attempt_error fires; post_attempt does NOT (ADR 0028).
     expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
+  });
+
+  it("branch carries work + passes feedback → SALVAGE: lands like DONE, closes (issue #332)", async () => {
+    // The agent finished + committed but exited without the sentinel (the #300
+    // loop). Branch is ahead of base and green → salvage through the same gate.
+    const { deps, input, trace } = harness({
+      outcome: "no-sentinel",
+      changedFiles: ["packages/x/src/a.ts"],
+      feedbackOk: true,
+      locked: false,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done"); // salvaged → lands exactly like a DONE attempt
+    expect(result.mergeSha).toBe("abc1234");
+    expect(result.swept).toBe(true);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "done" }]);
+    // post_attempt(success) + the full land tail fire; on_attempt_error does NOT.
+    expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "post_attempt", "pre_merge", "post_merge"]);
+  });
+
+  it("branch carries work but FAILS feedback → feedback-failed, never merged, not an error", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "no-sentinel",
+      changedFiles: ["packages/x/src/a.ts"],
+      feedbackOk: false,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.closed).toEqual([]);
+    expect(result.hooksFired).not.toContain("on_attempt_error");
   });
 });
 
@@ -954,13 +988,15 @@ describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)",
 
   it("crashed (no-sentinel) RETRIES once then escalates (cap 1)", async () => {
     // cap 1: attempt 1 is at-cap → escalate. Raise to 2 to see the single retry.
-    const retry = harness({ outcome: "no-sentinel", attempt: 1, recoveryEnv: { RED_AFK_RETRY_CRASH: "2" } });
+    // changedFiles:[] = a real crash (empty branch), so the no-sentinel salvage
+    // (issue #332) does NOT apply and the crash-retry path is exercised.
+    const retry = harness({ outcome: "no-sentinel", attempt: 1, changedFiles: [], recoveryEnv: { RED_AFK_RETRY_CRASH: "2" } });
     const r1 = await processIssue(retry.deps, retry.input);
     expect(r1.outcome).toBe("no-sentinel");
     expect(retry.trace.labelEdits.at(-1)!.add).toContain("ready-for-agent");
     expect(retry.trace.labelEdits.at(-1)!.add).toContain("blocked:crashed");
 
-    const escalate = harness({ outcome: "no-sentinel", attempt: 1 }); // default cap 1 → escalate
+    const escalate = harness({ outcome: "no-sentinel", attempt: 1, changedFiles: [] }); // default cap 1 → escalate
     const r2 = await processIssue(escalate.deps, escalate.input);
     expect(r2.outcome).toBe("no-sentinel");
     expect(escalate.trace.labelEdits.at(-1)!.add).toContain("ready-for-human");


### PR DESCRIPTION
## The runtime cure for the no-sentinel loop

Diagnosed live on **#300**: the inner agent finished + committed at iteration 1, but exited without `<promise>DONE</promise>`; the runtime read EOF as a crash and re-invoked it (iter 1→4/20, ~50 min), never closing — even though the branch was mergeable the whole time. Dominant cause of AFK slowness.

## Fix (`process-issue.ts`)

On `run.outcome === "no-sentinel"`:
- **Empty branch** (no diff vs base, or absent) → unchanged: `on_attempt_error` + terminal `no-sentinel` (keeps the crash-retry budget).
- **Branch ahead of base + present** → **salvage**: skip `on_attempt_error`, fire `post_attempt(success)`, route through the **same feedback gate + landing + close tail the DONE path uses**. Feedback failure → `feedback-failed` (accurate), never `no-sentinel`. A salvaged attempt lands/closes exactly like DONE.

Contained restructure — no big extraction; both DONE and salvaged-no-sentinel enter the shared land tail, timeout/blocked still return early.

## Why it's safe

The feedback gate (typecheck/tests, ADR 0008) is load-bearing — only complete, green work lands. No-work / failing branches keep today's terminal failure path.

## Pairs with

- **#427** (merged) — `AGENT-PROMPT`: "already done still requires the sentinel" (the prevention). This PR is the cure.
- Re-implements the stale **#335** (~169 commits behind, pre-`src/apps`) on the current tree. #335 can be closed in favour of this.

## Tests / record

- `process-issue.test.ts` **52/52** — 3 new salvage cases (empty→terminal, work+green→done, work+fail→feedback-failed) + crash-retry tests pinned to `changedFiles:[]`.
- typecheck clean.
- **ADR 0047** records the decision (avoids the reserved 0043 / planned 0046).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783080898&installation_id=129708444&pr_number=428&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F428&signature=7f929c64c411e0d34f8b65b86498f642ec989885efcd75bb2359c71f235f890c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced handling of incomplete runs: when a branch contains actual work changes, the system now salvages and completes those attempts through standard workflows instead of treating them as terminal failures.

* **Documentation**
  * Added architectural documentation detailing runtime safety improvements for handling incomplete work scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->