### PR TITLE
feat(afk): backpressure gate on the DONE path (#430)

### DIFF
--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -832,12 +832,20 @@ Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside t
 | `afk.models.codex` | — | `gpt-5.5` | Codex model id. |
 | `afk.sandbox` | `RED_AFK_SANDBOX` | `none` | Isolation backend (`none` \| `docker` \| `podman`, ADR 0033). |
 | `afk.max_iterations` | `RED_AFK_MAX_ITERATIONS` | `12` | Sandcastle re-invocation ceiling (issue #322) — the safety cap for "the agent never emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`". The completion sentinel is the real terminator, so a normal issue finishes in 1–3 iterations; this leaves headroom without letting repeated no-sentinel failures run for too long. A non-numeric / zero / negative value in either the env or the config is ignored (falls through to the default) so a typo can never disable the cap or pin the agent to 1. |
+| `afk.backpressure` | — | _(empty)_ | Ordered list of shell commands run as an extra pre-merge gate on the DONE path (issue #430, PRD #429). |
 
 ```yaml
 afk:
   sandbox: none
   max_iterations: 12      # override the default ceiling here
+  backpressure:           # extra pre-merge gate, runs after the feedback gate
+    - npm run test
+    - npm run lint
 ```
+
+### Backpressure gate
+
+`afk.backpressure` is an operator-declared, ordered list of shell commands that **supplements** the auto-derived feedback gate (it does not replace it). On a successful DONE attempt — after the scope-derived `test`/`typecheck`/`lint`/`build` feedback gate passes, before landing — AFK runs each backpressure command in order (`sh -c <command>`) against a checkout of the worker branch. If **any** command exits non-zero the merge is blocked and the issue is parked to `ready-for-human` with `blocked:validation`, exactly like a feedback failure: the failing command and its output tail land in the terminal envelope and in the `red.afk.validation.v1` validation sidecar (records named `backpressure:<command>`). An absent or empty block is a no-op (today's behaviour). The namespaced `plugins.dev.afk.backpressure` location is honoured with the legacy bare `afk.backpressure` fallback (ADR 0042).
 
 ## Lifecycle Hooks
 

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -34,7 +34,7 @@ import * as fsx from "../runtime/fs.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { ExecFn } from "../runtime/exec.js";
-import { loadConfig } from "../core/config.js";
+import { loadConfig, readBackpressure } from "../core/config.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
 import { isValidWorkerId } from "../core/worker-paths.js";
@@ -342,6 +342,10 @@ export function buildProcessDeps(
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,
     layout: feedback.layout,
+    // Backpressure gate (#430, PRD #429): operator-declared `afk.backpressure`
+    // shell commands run against the same worker-branch checkout after feedback.
+    backpressure: feedback.backpressure,
+    backpressureCommands: readBackpressure(config),
     runAgent: makeRunAgent(sandbox, process.env, maxIterations, attemptTimeoutSeconds),
     model,
     fallbackRunner,

--- a/src/apps/dev/src/core/backpressure.ts
+++ b/src/apps/dev/src/core/backpressure.ts
@@ -1,0 +1,100 @@
+// backpressure — the AFK operator-declared pre-merge gate (PRD #429, issue #430).
+//
+// A sibling of feedback.ts. Where feedback derives test/typecheck/lint/build from
+// the touched package scopes, backpressure runs an EXPLICIT, operator-declared,
+// ordered list of shell commands from `.red/config.yaml` (`afk.backpressure`)
+// against the worker-branch worktree. It SUPPLEMENTS the feedback gate — it never
+// replaces it — and runs AFTER feedback passes on the DONE path: any command that
+// exits non-zero blocks the merge and parks the issue to ready-for-human exactly
+// like a feedback failure.
+//
+// Like feedback, IO is fully injected: `exec` runs the real shell command in the
+// worker-branch checkout, and `now` supplies the millisecond clock, so the
+// decision logic and the `red.afk.validation.v1` sidecar record shape are
+// unit-testable against fixed inputs with no real process ever spawned. The
+// record shaping (`buildValidationRecord` / `outputSummary` / `formatValidationLine`)
+// and the `red.afk.validation.v1` schema are reused verbatim from feedback.ts so
+// the two gates emit byte-identical sidecar records.
+
+import {
+  buildValidationRecord,
+  formatValidationLine,
+  outputSummary,
+  type ExecResult,
+  type ValidationRecord,
+  type ValidationStatus,
+} from "./feedback.js";
+
+/**
+ * Injected shell executor for a single backpressure command. Receives the raw
+ * command string (e.g. `npm run test`) and the working directory it runs in
+ * (the worker-branch checkout root); resolves with the captured exit code +
+ * streams. Mirrors the hook executor's `sh -c <command>` contract.
+ */
+export type BackpressureExec = (input: { command: string; cwd: string }) => Promise<ExecResult>;
+
+/** One completed backpressure command, surfaced alongside its sidecar record. */
+export interface BackpressureCheck {
+  /** `backpressure:<cmd>`, e.g. `backpressure:npm run test`. */
+  name: string;
+  /** The exact command string that ran. */
+  command: string;
+  status: ValidationStatus;
+  record: ValidationRecord;
+}
+
+export interface RunBackpressureInput {
+  /** Worker-branch checkout token, passed through as each command's `cwd`. */
+  worktree: string;
+  /** Operator-declared commands (from `afk.backpressure`), run in order. */
+  commands: readonly string[];
+  /** Injected millisecond clock — no `Date.now()` at module scope. */
+  now: () => number;
+}
+
+export interface RunBackpressureResult {
+  /** False when any command exited non-zero — the merge gate (PRD #429). */
+  ok: boolean;
+  /** Every command that ran, in declaration order. */
+  checks: BackpressureCheck[];
+  /** The sidecar lines, one JSONL record per command, in the same order. */
+  sidecar: string[];
+}
+
+/**
+ * Run the operator-declared backpressure commands in order against the
+ * worker-branch worktree. For each command: time it with the injected clock,
+ * run it via the injected exec in the worktree dir, and emit a `passed`/`failed`
+ * `red.afk.validation.v1` record named `backpressure:<cmd>`. Blank/whitespace
+ * entries are skipped (not recorded). Every command runs so the operator sees
+ * the full picture; `ok` is false if ANY command failed, blocking the merge. An
+ * empty command list is a no-op (`ok:true`, no checks, no sidecar) — today's
+ * behaviour. Nothing here touches the filesystem or a real clock.
+ */
+export async function runBackpressure(
+  exec: BackpressureExec,
+  input: RunBackpressureInput,
+): Promise<RunBackpressureResult> {
+  const { worktree, commands, now } = input;
+  const checks: BackpressureCheck[] = [];
+  const sidecar: string[] = [];
+  let failed = false;
+
+  for (const raw of commands) {
+    const command = raw.trim();
+    if (command === "") continue;
+
+    const name = `backpressure:${command}`;
+    const start = now();
+    const result = await exec({ command, cwd: worktree });
+    const durationMs = now() - start;
+    const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
+    if (status === "failed") failed = true;
+    const summary = outputSummary(status, `${result.stdout}${result.stderr}`);
+    const record = buildValidationRecord({ name, status, command, durationMs, summary });
+    checks.push({ name, command, status, record });
+    sidecar.push(formatValidationLine(record));
+  }
+
+  return { ok: !failed, checks, sidecar };
+}

--- a/src/apps/dev/src/core/config.ts
+++ b/src/apps/dev/src/core/config.ts
@@ -60,6 +60,10 @@ export function parseConfigYaml(text: string): ConfigValues {
   const out: ConfigValues = {};
   const stack: string[] = [];
   const indents: number[] = [];
+  // Per-parent running index for block-sequence items (`- value`). A sequence
+  // under the dotted parent path `p` materialises as `p.0`, `p.1`, … so the
+  // flat config map keeps its `dotted.key -> value` shape (see readBackpressure).
+  const seqCounters: Record<string, number> = {};
 
   for (let raw of text.split("\n")) {
     // strip a trailing CR (CRLF tolerance)
@@ -80,6 +84,34 @@ export function parseConfigYaml(text: string): ConfigValues {
     if (indent % 2 !== 0) throw new MalformedConfigError();
 
     let rest = stripped.slice(indent).replace(/\s+$/, "");
+
+    // Block-sequence item: `- value` under the current mapping key. Pop parents
+    // whose indent is >= this line's, exactly like the mapping branch, then
+    // append the scalar at `<parent>.<index>`. A sequence with no enclosing
+    // mapping key (empty stack) or an empty item is malformed.
+    if (/^-(\s|$)/.test(rest)) {
+      while (indents.length > 0 && indents[indents.length - 1]! >= indent) {
+        stack.pop();
+        indents.pop();
+      }
+      if (stack.length === 0) throw new MalformedConfigError();
+
+      let item = rest.slice(1).replace(/^\s+/, "");
+      if (item === "") throw new MalformedConfigError();
+      if (item.startsWith('"')) {
+        if (!item.endsWith('"') || item.length < 2) throw new MalformedConfigError();
+        item = item.slice(1, -1);
+      } else if (item.startsWith("'")) {
+        if (!item.endsWith("'") || item.length < 2) throw new MalformedConfigError();
+        item = item.slice(1, -1);
+      }
+
+      const parent = stack.join(".");
+      const idx = seqCounters[parent] ?? 0;
+      seqCounters[parent] = idx + 1;
+      out[`${parent}.${idx}`] = item;
+      continue;
+    }
 
     if (!/^[a-zA-Z_][a-zA-Z0-9_-]*:/.test(rest)) throw new MalformedConfigError();
 
@@ -177,4 +209,33 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
 /** Read a dotted key. Empty string when unset — same contract as `config_get`. */
 export function getConfig(values: ConfigValues, key: string): string {
   return values[key] ?? "";
+}
+
+/**
+ * Read the operator-declared backpressure command list (`afk.backpressure`),
+ * in declaration order (issue #430). The list form
+ *
+ *   afk:
+ *     backpressure:
+ *       - npm run test
+ *       - npm run lint
+ *
+ * materialises as the indexed keys `afk.backpressure.0`, `afk.backpressure.1`, …
+ * which this reads back in order until the first gap. The namespaced
+ * `plugins.dev.afk.backpressure.*` location already folds down to the bare keys
+ * in {@link loadConfig} (ADR 0042), so both locations are honoured with the
+ * namespaced one winning. A single-line scalar (`afk.backpressure: npm run test`)
+ * is accepted as a one-command list. Absent/empty → `[]` (the gate is a no-op).
+ * Blank entries are dropped.
+ */
+export function readBackpressure(values: ConfigValues): string[] {
+  const indexed: string[] = [];
+  for (let i = 0; ; i++) {
+    const v = values[`afk.backpressure.${i}`];
+    if (v === undefined) break;
+    if (v.trim() !== "") indexed.push(v);
+  }
+  if (indexed.length > 0) return indexed;
+  const scalar = values["afk.backpressure"];
+  return scalar && scalar.trim() !== "" ? [scalar] : [];
 }

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -41,6 +41,7 @@ import {
   type PackageLayout,
   type RunFeedbackResult,
 } from "./feedback.js";
+import { runBackpressure, type BackpressureExec } from "./backpressure.js";
 import {
   type Exec as MergeExec,
   type ConflictResolver,
@@ -196,6 +197,20 @@ export interface ProcessIssueDeps {
   pnpm: PnpmExec;
   /** Package layout probe for feedback scope resolution. */
   layout: PackageLayout;
+  /**
+   * Shell executor for the operator-declared backpressure gate (#430, PRD #429).
+   * Runs each `afk.backpressure` command against the worker-branch checkout.
+   * Optional → when absent (or `backpressureCommands` is empty) the gate is a
+   * no-op (today's behaviour). The CLI binds it to the feedback worktree's
+   * `sh -c` executor rebased onto the materialised worker-branch checkout.
+   */
+  backpressure?: BackpressureExec;
+  /**
+   * Operator-declared backpressure commands (`afk.backpressure`), in order.
+   * Empty/absent → the backpressure gate is skipped. SUPPLEMENTS the
+   * scope-derived feedback gate; it does not replace it.
+   */
+  backpressureCommands?: readonly string[];
   /**
    * The sandcastle execution port (ADR 0033): run the inner agent on a worktree,
    * detect the DONE/BLOCKED sentinel, and commit on the worker branch. The CLI
@@ -737,6 +752,37 @@ export async function processIssue(
     }, { validationSummary: feedback.sidecar.join("\n") });
   }
 
+  // ---- 5c. backpressure gate (the operator-declared merge gate, #430/PRD #429) ----
+  // After the scope-derived feedback gate passes, run the operator's
+  // `afk.backpressure` commands in order against the same worker-branch checkout.
+  // Backpressure SUPPLEMENTS feedback (it never replaces it). Any command exiting
+  // non-zero blocks the merge and parks the issue to ready-for-human EXACTLY like
+  // a feedback failure (same `feedback-failed` outcome → blocked:validation): its
+  // records distinguish it by their `backpressure:<cmd>` names + failing-command
+  // output. An absent executor or an empty command list is a no-op.
+  const backpressureCommands = deps.backpressureCommands ?? [];
+  let backpressureSidecar: string[] = [];
+  if (deps.backpressure && backpressureCommands.length > 0) {
+    const backpressure = await runBackpressure(deps.backpressure, {
+      worktree: workerBranch,
+      commands: backpressureCommands,
+      now: deps.nowEpoch,
+    });
+    backpressureSidecar = backpressure.sidecar;
+    if (!backpressure.ok) {
+      // Persist BOTH gates' records (feedback passed, backpressure failed) for
+      // Memory, but surface only the failing backpressure records in the envelope.
+      await writeValidationSidecar(deps, input.attemptDir, [...feedback.sidecar, ...backpressure.sidecar]);
+      return await terminalFailure(common, "feedback-failed", "feedback", {
+        notes:
+          "Backpressure validation failed after the feedback gate passed. The worker branch was not merged.",
+        validation: backpressure.sidecar.join("\n"),
+      }, { validationSummary: backpressure.sidecar.join("\n") });
+    }
+  }
+  // Both gates passed — the close path's sidecar/envelope carries their union.
+  const validationSidecar = [...feedback.sidecar, ...backpressureSidecar];
+
   // ---- 6. push the worker branch, integrate, then land per lock state ----
   // The entire lock-toggled landing (push → pre_merge → integrate → land →
   // locked conflict self-resolve → post_merge) is owned by doLanding (landing.ts,
@@ -776,14 +822,14 @@ export async function processIssue(
   const durationS = deps.nowEpoch() - startedEpoch;
   // Write the machine-readable validation sidecar ($ITER_DIR/validation.jsonl,
   // SKILL.md) the Memory bridge consumes. Best-effort: never fails the close.
-  await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
-  const posted = await emitDone(common, mergeSha, durationS, feedback);
+  await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
+  const posted = await emitDone(common, mergeSha, durationS, validationSidecar);
   // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
   // (done) envelope. Best-effort, gated, no-op when memory is absent.
   await recordAttemptBestEffort(common, "done", {
     durationS,
     mergeSha,
-    validationSummary: feedback.sidecar.join("\n"),
+    validationSummary: validationSidecar.join("\n"),
   });
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
@@ -1032,12 +1078,14 @@ async function terminalFailure(
   };
 }
 
-/** Emit the done envelope with the merge sha + validation report. */
+/** Emit the done envelope with the merge sha + validation report. The
+ * `validationSidecar` is the union of the feedback gate's records and any
+ * backpressure-gate records (#430). */
 async function emitDone(
   c: StageCommon,
   mergeSha: string,
   durationS: number,
-  feedback: RunFeedbackResult,
+  validationSidecar: string[],
 ): Promise<boolean> {
   const { deps, input } = c;
   const result = await emitEnvelope(deps.envelope, {
@@ -1049,7 +1097,7 @@ async function emitDone(
     attempt: input.attempt,
     mergeSha,
     diff: "merged",
-    sections: { validation: feedback.sidecar.join("\n") },
+    sections: { validation: validationSidecar.join("\n") },
     historyPath: deps.historyPath,
     historyClock: deps.historyClock,
     historyFields: { runner: input.runner, merge_sha: mergeSha },

--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -20,7 +20,8 @@
 import { accessSync, constants, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Exec as PnpmExec, PackageLayout } from "../core/feedback.js";
-import { pnpm as runPnpm } from "./exec.js";
+import type { BackpressureExec } from "../core/backpressure.js";
+import { execTool, pnpm as runPnpm } from "./exec.js";
 import * as gitx from "./git.js";
 
 function slugForBranch(branch: string): string {
@@ -32,6 +33,12 @@ export interface FeedbackWorktree {
   pnpm: PnpmExec;
   /** Package layout probe rebased onto the materialised checkout. */
   layout: PackageLayout;
+  /**
+   * Shell executor for the backpressure gate (#430): runs an operator-declared
+   * command via `sh -c` at the materialised worker-branch checkout root. `cwd`
+   * is the branch token, materialised the same way the pnpm executor does.
+   */
+  backpressure: BackpressureExec;
   /** Remove every worktree this manager created (best-effort). */
   cleanup(): Promise<void>;
 }
@@ -112,9 +119,20 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
     },
   };
 
+  // Backpressure commands are operator-declared shell strings (e.g. `npm run
+  // test`) that run at the worker-branch checkout ROOT. `cwd` is the branch
+  // token; materialise it the same way the pnpm executor does, then run the
+  // command through `sh -c`, mirroring the lifecycle-hook executor.
+  const backpressure: BackpressureExec = async ({ command, cwd }) => {
+    const dir = await pathFor(cwd);
+    const r = await execTool("sh", ["-c", command], { cwd: dir });
+    return { code: r.code, stdout: r.stdout, stderr: r.stderr };
+  };
+
   return {
     pnpm,
     layout,
+    backpressure,
     async cleanup() {
       for (const dest of created) {
         await gitx.worktreeRemove(gitCtx, dest);

--- a/src/apps/dev/tests/backpressure.test.ts
+++ b/src/apps/dev/tests/backpressure.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { runBackpressure, type BackpressureExec } from "../src/core/backpressure.js";
+import { VALIDATION_SCHEMA, type ExecResult, type ValidationRecord } from "../src/core/feedback.js";
+
+/**
+ * Fake backpressure exec recording every (command, cwd) and replying from a
+ * per-call matcher. Default reply is success with empty output, so a test only
+ * overrides the commands whose exit code drives a failure.
+ */
+function fakeExec(
+  rules: Array<{ match: (command: string) => boolean; result: Partial<ExecResult> }> = [],
+): { exec: BackpressureExec; calls: Array<{ command: string; cwd: string }> } {
+  const calls: Array<{ command: string; cwd: string }> = [];
+  const exec: BackpressureExec = async ({ command, cwd }) => {
+    calls.push({ command, cwd });
+    for (const rule of rules) {
+      if (rule.match(command)) return { code: 0, stdout: "", stderr: "", ...rule.result };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  };
+  return { exec, calls };
+}
+
+/** A monotonic injected clock that ticks 5ms per read. */
+function fakeClock(step = 5): () => number {
+  let t = 1000;
+  return () => {
+    const v = t;
+    t += step;
+    return v;
+  };
+}
+
+describe("runBackpressure", () => {
+  it("runs each command in order against the worktree, passing", async () => {
+    const { exec, calls } = fakeExec();
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["npm run test", "npm run lint"],
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(true);
+    // Declaration order, each at the worktree root.
+    expect(calls).toEqual([
+      { command: "npm run test", cwd: "/wt" },
+      { command: "npm run lint", cwd: "/wt" },
+    ]);
+    expect(result.checks.map((c) => c.name)).toEqual([
+      "backpressure:npm run test",
+      "backpressure:npm run lint",
+    ]);
+    expect(result.checks.every((c) => c.status === "passed")).toBe(true);
+  });
+
+  it("blocks the merge (ok:false) when any command fails, recording all", async () => {
+    const { exec } = fakeExec([
+      { match: (c) => c === "npm run lint", result: { code: 1, stdout: "lint broke\nhere\n" } },
+    ]);
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["npm run test", "npm run lint", "npm run build"],
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(false);
+    // Every command still ran (full picture for the operator).
+    expect(result.checks.map((c) => c.name)).toEqual([
+      "backpressure:npm run test",
+      "backpressure:npm run lint",
+      "backpressure:npm run build",
+    ]);
+    const lint = result.checks.find((c) => c.name === "backpressure:npm run lint");
+    expect(lint?.status).toBe("failed");
+    expect(lint?.record.summary).toBe("lint broke here");
+    expect(result.checks.find((c) => c.name === "backpressure:npm run test")?.status).toBe("passed");
+  });
+
+  it("produces the exact red.afk.validation.v1 sidecar record shape", async () => {
+    const { exec } = fakeExec();
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["npm run test"],
+      // start=1000, end=2234 → durationMs 1234.
+      now: (() => {
+        const seq = [1000, 2234];
+        let i = 0;
+        return () => seq[i++] ?? 0;
+      })(),
+    });
+
+    const expected: ValidationRecord = {
+      schema: VALIDATION_SCHEMA,
+      name: "backpressure:npm run test",
+      status: "passed",
+      command: "npm run test",
+      durationMs: 1234,
+      summary: "command exited 0",
+    };
+    expect(result.checks[0]?.record).toEqual(expected);
+    // The sidecar line is the compact JSON of the record, schema-first.
+    expect(result.sidecar).toEqual([JSON.stringify(expected)]);
+  });
+
+  it("is a no-op for an empty command list", async () => {
+    const { exec, calls } = fakeExec();
+    const result = await runBackpressure(exec, { worktree: "/wt", commands: [], now: fakeClock() });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks).toEqual([]);
+    expect(result.sidecar).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  it("skips blank/whitespace entries without recording them", async () => {
+    const { exec, calls } = fakeExec();
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["  ", "npm run test", ""],
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([{ command: "npm run test", cwd: "/wt" }]);
+    expect(result.checks.map((c) => c.name)).toEqual(["backpressure:npm run test"]);
+  });
+
+  it("trims surrounding whitespace from the command before running + naming", async () => {
+    const { exec, calls } = fakeExec();
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["  npm run test  "],
+      now: fakeClock(),
+    });
+
+    expect(calls).toEqual([{ command: "npm run test", cwd: "/wt" }]);
+    expect(result.checks[0]?.name).toBe("backpressure:npm run test");
+    expect(result.checks[0]?.record.command).toBe("npm run test");
+  });
+});

--- a/src/apps/dev/tests/config.test.ts
+++ b/src/apps/dev/tests/config.test.ts
@@ -8,6 +8,7 @@ import {
   loadConfig,
   MalformedConfigError,
   parseConfigYaml,
+  readBackpressure,
 } from "../src/core/config.js";
 
 async function writeConfig(yaml: string): Promise<string> {
@@ -160,5 +161,56 @@ describe("config — plugins.dev namespace (ADR 0042)", () => {
     const text = "afk:\n  default_runner: claude\nplugins:\n  dev:\n    afk:\n      default_runner: codex\n";
     const values = loadConfig("/x/.red/config.yaml", { read: () => text });
     expect(getConfig(values, "afk.default_runner")).toBe("codex");
+  });
+});
+
+describe("config — block sequences (afk.backpressure, #430)", () => {
+  it("parses a `- item` sequence into ordered indexed keys", () => {
+    const text = "afk:\n  backpressure:\n    - npm run test\n    - npm run lint\n";
+    expect(parseConfigYaml(text)).toEqual({
+      "afk.backpressure.0": "npm run test",
+      "afk.backpressure.1": "npm run lint",
+    });
+  });
+
+  it("keeps a sibling scalar key alongside a sequence", () => {
+    const text = "afk:\n  default_runner: codex\n  backpressure:\n    - npm test\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "afk.default_runner")).toBe("codex");
+    expect(readBackpressure(values)).toEqual(["npm test"]);
+  });
+
+  it("strips quotes from sequence items", () => {
+    const text = 'afk:\n  backpressure:\n    - "npm run test -- --reporter=dot"\n';
+    expect(parseConfigYaml(text)).toEqual({
+      "afk.backpressure.0": "npm run test -- --reporter=dot",
+    });
+  });
+
+  it("throws on a top-level sequence with no enclosing mapping", () => {
+    expect(() => parseConfigYaml("- npm test\n")).toThrow(MalformedConfigError);
+  });
+
+  it("readBackpressure reads the list in order", () => {
+    const text = "afk:\n  backpressure:\n    - npm run test\n    - npm run lint\n    - npm run build\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(readBackpressure(values)).toEqual(["npm run test", "npm run lint", "npm run build"]);
+  });
+
+  it("readBackpressure reads the namespaced location (ADR 0042)", () => {
+    const text = "plugins:\n  dev:\n    afk:\n      backpressure:\n        - npm run test\n        - npm run lint\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(readBackpressure(values)).toEqual(["npm run test", "npm run lint"]);
+  });
+
+  it("readBackpressure accepts a single-line scalar as a one-command list", () => {
+    const text = "afk:\n  backpressure: npm run test\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(readBackpressure(values)).toEqual(["npm run test"]);
+  });
+
+  it("readBackpressure returns [] when absent (the gate is a no-op)", () => {
+    const values = loadConfig("/x/.red/config.yaml", { read: () => "afk:\n  default_runner: codex\n" });
+    expect(readBackpressure(values)).toEqual([]);
   });
 });

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -45,6 +45,12 @@ interface HarnessOptions {
   /** Scripted per-call outcomes (overrides `outcome`); one entry per runAgent call. */
   outcomes?: RunAgentResult["outcome"][];
   feedbackOk?: boolean;
+  /** Operator-declared backpressure commands (afk.backpressure, #430). When set,
+   * the backpressure gate runs after feedback against the worker branch. */
+  backpressureCommands?: string[];
+  /** When false, the backpressure exec returns a non-zero code (a failing gate).
+   * Defaults to passing. Only consulted when `backpressureCommands` is set. */
+  backpressureOk?: boolean;
   locked?: boolean;
   config?: ConfigValues;
   abortHook?: HookName;
@@ -213,6 +219,14 @@ function harness(opts: HarnessOptions = {}): {
       hasPackage: (scope) => scope === ".",
       hasScript: () => true,
     },
+    // Backpressure gate (#430): a fake shell exec that fails when opted out. The
+    // failing-command output is captured so the envelope/sidecar carry the tail.
+    backpressure: async ({ command }) => ({
+      code: opts.backpressureOk === false ? 1 : 0,
+      stdout: opts.backpressureOk === false ? `${command} exploded\nstack trace here\n` : "",
+      stderr: "",
+    }),
+    backpressureCommands: opts.backpressureCommands,
     // The sandcastle execution port: a fake returning a scripted outcome on the
     // worker branch sandcastle "committed" to. When `outcomes` is set, each call
     // pops the next scripted outcome (for fallback-swap sequences).
@@ -571,6 +585,56 @@ describe("processIssue — feedback fail", () => {
     // the worker branch was not pushed for landing.
     expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "post_attempt"]);
     expect(trace.pushedAttempt).toEqual([]);
+  });
+});
+
+describe("processIssue — backpressure fail (#430)", () => {
+  it("flips to ready-for-human exactly like a feedback fail when a backpressure command fails", async () => {
+    // Feedback passes; the operator-declared backpressure command fails AFTER it.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: false,
+    });
+    const result = await processIssue(deps, input);
+
+    // Parks exactly like a feedback failure (same outcome + labels + envelope).
+    expect(result.outcome).toBe("feedback-failed");
+    expect(result.preserved).toBe(true);
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:validation"]);
+    expect(trace.ensuredLabels).toContain("blocked:validation");
+    expect(trace.closed).toEqual([]);
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    // The worker branch was NOT pushed for landing (the gate blocked the merge).
+    expect(trace.pushedAttempt).toEqual([]);
+
+    // The validation sidecar carries the failing backpressure command + output
+    // tail, named `backpressure:<cmd>`.
+    const lastSidecar = trace.sidecarWrites.at(-1)!;
+    const records = lastSidecar.lines.map((l) => JSON.parse(l) as { schema: string; name: string; status: string; command?: string; summary?: string });
+    const bp = records.find((r) => r.name === "backpressure:npm run e2e")!;
+    expect(bp.schema).toBe("red.afk.validation.v1");
+    expect(bp.status).toBe("failed");
+    expect(bp.command).toBe("npm run e2e");
+    expect(bp.summary).toBe("npm run e2e exploded stack trace here");
+  });
+
+  it("merges + closes when feedback and backpressure both pass, sidecar carrying both", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: true,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    // The DONE-path sidecar union includes the passed backpressure record.
+    const sidecar = trace.sidecarWrites.at(-1)!;
+    const names = sidecar.lines.map((l) => (JSON.parse(l) as { name: string }).name);
+    expect(names).toContain("backpressure:npm run e2e");
   });
 });
 


### PR DESCRIPTION
Closes #430. PRD #429.

AFK worker wY7AL implemented this (commit d283836); its feedback gate spuriously failed with an infrastructure bug (`ENOENT lstat .../red-skills/wY7AL` — worker-id-in-path), parking it to `blocked:validation` despite the code being correct. **Manually salvaged**: rebased onto current main (clean) and independently verified — typecheck clean, 104 tests green (backpressure 6, config 24, process-issue 54, run-flags+cli-routing 20).

Adds operator-declared `afk.backpressure: [cmd, …]` run after the feedback gate on the DONE (and salvage) path; any non-zero exit blocks the merge and parks to `ready-for-human` exactly like a feedback failure, with the failing command in the envelope + validation sidecar. No-op when unset.

The separate feedback-gate ENOENT bug is tracked for follow-up (it also threatens #431).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783085563&installation_id=129708444&pr_number=436&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F436&signature=464af7b4d6705e201d8320b834cba5dd9c48660739f4ccfef52503cc97240ffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a backpressure validation gate that allows operators to define shell commands executed after feedback validation and before merge. If any command fails, the merge is blocked and the issue transitions to ready-for-human status with the blocked:validation label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->