### PR TITLE
fix(afk): feedback gate resolves multi-slash afk/* branches (#437)

### DIFF
--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -28,6 +28,36 @@ function slugForBranch(branch: string): string {
   return branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "wt";
 }
 
+/**
+ * Split a feedback `-C` token into its worker branch and package scope.
+ *
+ * The feedback gate builds the token via `scopeDir(branch, scope)`: the branch
+ * alone for the root scope, or `branch/<scope>` otherwise. AFK worker branches
+ * are `afk/<id>/<N>-<slug>` — they contain slashes — so splitting at the FIRST
+ * slash mis-parses them (#437: branch became `afk`, scope `<id>/<N>-<slug>`, and
+ * `pnpm -C <root>/<id>/...` ENOENT'd, failing the gate on every afk/* branch).
+ *
+ * Instead peel the scope off the END: the scope is the shortest trailing path
+ * suffix that is an existing package dir (`hasPackage`), and the branch is
+ * everything before it. A token with no package suffix is a pure branch at the
+ * root scope ("."). Package paths are full root-relative paths (e.g.
+ * `src/apps/dev`), so only the genuine suffix matches — a branch slug segment
+ * never collides.
+ */
+export function splitBranchDir(
+  dir: string,
+  hasPackage: (scope: string) => boolean,
+): { branch: string; scope: string } {
+  const parts = dir.split("/");
+  for (let i = 1; i < parts.length; i++) {
+    const scope = parts.slice(parts.length - i).join("/");
+    if (hasPackage(scope)) {
+      return { branch: parts.slice(0, parts.length - i).join("/"), scope };
+    }
+  }
+  return { branch: dir, scope: "." };
+}
+
 export interface FeedbackWorktree {
   /** pnpm executor rebased onto the materialised worker-branch checkout. */
   pnpm: PnpmExec;
@@ -67,35 +97,11 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
     return path;
   }
 
-  // feedback hands pnpm a `-C <token>` arg where <token> is
-  // `<branch>` or `<branch>/<scope>`. Split the leading branch off, materialise
-  // it, and rewrite the dir onto the real checkout path.
-  function splitBranchDir(dir: string): { branch: string; scope: string } {
-    const slash = dir.indexOf("/");
-    if (slash < 0) return { branch: dir, scope: "." };
-    return { branch: dir.slice(0, slash), scope: dir.slice(slash + 1) };
-  }
-
-  const pnpm: PnpmExec = async (args) => {
-    // args === ["pnpm", "-C", dir, script]
-    const cIdx = args.indexOf("-C");
-    if (cIdx >= 0 && args[cIdx + 1] !== undefined) {
-      const { branch, scope } = splitBranchDir(args[cIdx + 1]!);
-      const base = await pathFor(branch);
-      const rewritten = scope === "." ? base : join(base, scope);
-      const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
-      const r = await runPnpm(["-C", rewritten, ...rest], { cwd: root });
-      return { code: r.code, stdout: r.stdout, stderr: r.stderr };
-    }
-    const head = args[0] === "pnpm" ? args.slice(1) : args;
-    const r = await runPnpm(head, { cwd: root });
-    return { code: r.code, stdout: r.stdout, stderr: r.stderr };
-  };
-
   // The layout probe only needs the package topology, which is identical across
   // branches (a worker rarely adds/removes packages); resolving it against the
   // primary checkout keeps `relevantScopes` synchronous as the interface
-  // requires while still reflecting the real monorepo layout.
+  // requires while still reflecting the real monorepo layout. It also drives
+  // `splitBranchDir`'s scope-suffix detection below.
   const layout: PackageLayout = {
     hasPackage: (scope) => {
       const dir = scope === "." ? root : join(root, scope);
@@ -117,6 +123,25 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
         return false;
       }
     },
+  };
+
+  // feedback hands pnpm a `-C <token>` arg where <token> is `<branch>` or
+  // `<branch>/<scope>`. Peel the scope off the end (via the package layout),
+  // materialise the branch, and rewrite the dir onto the real checkout path.
+  const pnpm: PnpmExec = async (args) => {
+    // args === ["pnpm", "-C", dir, script]
+    const cIdx = args.indexOf("-C");
+    if (cIdx >= 0 && args[cIdx + 1] !== undefined) {
+      const { branch, scope } = splitBranchDir(args[cIdx + 1]!, layout.hasPackage);
+      const base = await pathFor(branch);
+      const rewritten = scope === "." ? base : join(base, scope);
+      const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
+      const r = await runPnpm(["-C", rewritten, ...rest], { cwd: root });
+      return { code: r.code, stdout: r.stdout, stderr: r.stderr };
+    }
+    const head = args[0] === "pnpm" ? args.slice(1) : args;
+    const r = await runPnpm(head, { cwd: root });
+    return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 
   // Backpressure commands are operator-declared shell strings (e.g. `npm run

--- a/src/apps/dev/tests/feedback-worktree.test.ts
+++ b/src/apps/dev/tests/feedback-worktree.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { splitBranchDir } from "../src/runtime/feedback-worktree.js";
+
+// A monorepo's package dirs are full root-relative paths. The probe is true for
+// exactly these and nothing else (mirroring the real accessSync layout check).
+const PACKAGES = ["src/apps/dev", "src/apps/memory", "src/packages/shared"];
+const hasPackage = (scope: string): boolean => PACKAGES.includes(scope);
+
+describe("splitBranchDir (#437)", () => {
+  it("keeps a multi-slash afk/* branch intact at the root scope", () => {
+    // The regression: this used to split to { branch: 'afk', scope: 'wY7AL/...' }
+    // and run `pnpm -C <root>/wY7AL/...` → ENOENT.
+    expect(splitBranchDir("afk/wY7AL/430-afk-backpressure-gate", hasPackage)).toEqual({
+      branch: "afk/wY7AL/430-afk-backpressure-gate",
+      scope: ".",
+    });
+  });
+
+  it("peels a nested package scope off a multi-slash afk/* branch", () => {
+    expect(splitBranchDir("afk/wY7AL/430-afk-backpressure-gate/src/apps/dev", hasPackage)).toEqual({
+      branch: "afk/wY7AL/430-afk-backpressure-gate",
+      scope: "src/apps/dev",
+    });
+  });
+
+  it("handles a slash-free branch at the root scope", () => {
+    expect(splitBranchDir("main", hasPackage)).toEqual({ branch: "main", scope: "." });
+  });
+
+  it("peels a package scope off a slash-free branch", () => {
+    expect(splitBranchDir("main/src/packages/shared", hasPackage)).toEqual({
+      branch: "main",
+      scope: "src/packages/shared",
+    });
+  });
+
+  it("treats an unknown trailing path as part of the branch, not a scope", () => {
+    // No suffix is a real package → the whole token is the branch.
+    expect(splitBranchDir("afk/wK7M2/521-add-src-helper", hasPackage)).toEqual({
+      branch: "afk/wK7M2/521-add-src-helper",
+      scope: ".",
+    });
+  });
+
+  it("matches the genuine package suffix, never a shorter coincidental segment", () => {
+    expect(splitBranchDir("afk/wZ9QP/77-x/src/apps/memory", hasPackage)).toEqual({
+      branch: "afk/wZ9QP/77-x",
+      scope: "src/apps/memory",
+    });
+  });
+});


### PR DESCRIPTION
Closes #437.

The feedback worktree seam (`feedback-worktree.ts`) split its `-C <branch>/<scope>` token at the **first** slash, but AFK worker branches are `afk/<id>/<N>-<slug>` (two slashes). So `afk/wY7AL/430-slug` parsed as branch=`afk` → `worktreeAdd` fails → root fallback → `pnpm -C <root>/wY7AL/430-slug` → `ENOENT lstat .../red-skills/wY7AL`. **Every afk/* branch failed the feedback gate**, parking correct work to `blocked:validation` and blocking autonomous merge (observed live on #430/#431).

Fix: `splitBranchDir` now peels the scope as the trailing path suffix that is a real package dir (via the existing `layout` probe), leaving the full branch as the prefix. Promoted to an exported pure fn with a focused unit test. Typecheck clean; feedback-worktree (6) + wiring-integration (2) green.

This is the third AFK-reliability fix this session (sibling of #434 launcher/claim-race and #430 backpressure) and a release-blocker for autonomous merge in the post-reload "definitive AFK."

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783086099&installation_id=129708444&pr_number=438&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F438&signature=89e67150304e8527c7aad0853fca4ac3c46b0718fa1465c3ad7a4e2fd1353de1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch directory parsing to accurately handle paths containing multiple slashes, resolving checkout issues in monorepo environments.

* **Tests**
  * Added test coverage for branch and scope extraction logic, including edge cases with nested packages and complex paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->