### PR TITLE
test(afk): backpressure gate covers the salvaged no-sentinel path (#432)

### DIFF
--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -542,6 +542,52 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(trace.closed).toEqual([]);
     expect(result.hooksFired).not.toContain("on_attempt_error");
   });
+
+  it("salvaged branch passes feedback but FAILS backpressure → parked like a feedback fail, never merged (#432)", async () => {
+    // #432: a no-sentinel attempt salvaged through the gate (branch carries work +
+    // feedback green) is held to the SAME backpressure bar as a DONE attempt — a
+    // failing operator command blocks the merge and parks to ready-for-human, and
+    // it is NOT an error. The gate already lives in the shared DONE/salvage tail
+    // (#430); this locks that coverage in.
+    const { deps, input, trace } = harness({
+      outcome: "no-sentinel",
+      changedFiles: ["packages/x/src/a.ts"],
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: false,
+      locked: false,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.closed).toEqual([]);
+    expect(labelTrace(trace)).toEqual([
+      "-ready-for-agent|+running",
+      "-running|+ready-for-human+blocked:validation",
+    ]);
+    expect(trace.pushedAttempt).toEqual([]);
+    expect(result.hooksFired).not.toContain("on_attempt_error");
+    const lastSidecar = trace.sidecarWrites.at(-1)!;
+    const bp = lastSidecar.lines
+      .map((l) => JSON.parse(l) as { name: string; status: string })
+      .find((r) => r.name === "backpressure:npm run e2e")!;
+    expect(bp.status).toBe("failed");
+  });
+
+  it("salvaged branch merges + closes when feedback AND backpressure both pass (#432)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "no-sentinel",
+      changedFiles: ["packages/x/src/a.ts"],
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: true,
+      locked: false,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done"); // salvaged + both gates green → lands like DONE
+    expect(trace.closed).toEqual([9]);
+  });
 });
 
 describe("processIssue — active Current blocker preflight", () => {


### PR DESCRIPTION
Closes #432. PRD #429.

#430 placed the `afk.backpressure` gate in the **shared DONE/salvage tail** of `process-issue` (after the feedback gate, before landing). So a salvaged no-sentinel attempt already runs operator backpressure **exactly like a DONE attempt**, satisfying ADR 0047's 'salvage is held to the same bar as DONE'. This adds regression tests:

- salvaged + feedback green + backpressure **fails** → `feedback-failed`, parked to `ready-for-human`+`blocked:validation`, never merged, not an `on_attempt_error`; sidecar carries the `backpressure:<cmd>` failure.
- salvaged + both gates green → lands + closes like DONE.

No production change needed. `process-issue.test.ts` 56/56.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783086451&installation_id=129708444&pr_number=439&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F439&signature=585896c0ca92bd0ef11fe1e020ac6c75f5f4dbf2fe69f8b9575f5c4fb574dcf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for issue processing with operator backpressure configuration, validating correct behavior in both failure and success scenarios to ensure reliable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->