### PR TITLE
feat(setup): scaffold afk.backpressure in /setup-red-skills (#433)

### DIFF
--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -140,7 +140,9 @@ The script is no-op outside `/afk` sessions (it prints nothing when no live work
 
 > Explainer: `.red/config.yaml` is the per-project knob file that `/afk` and friends read at runtime. It holds the project's fallback runner, default fleet target, and per-detector opt-outs. The schema is documented by the loader shipped in PRD #16 and is forward-compatible (unknown keys are ignored). A fresh repo should land with a *commented* template of every v1 knob so the user discovers the available settings without reading docs — the file is a no-op until lines are uncommented.
 
-No user decision here — the skill scaffolds the template whenever the file is missing. If `.red/config.yaml` already exists, leave it alone (any prior edits are project state — never clobbered). See step 4 for the write rule.
+No user decision here for the template itself — the skill scaffolds it whenever the file is missing. If `.red/config.yaml` already exists, leave it alone (any prior edits are project state — never clobbered). See step 4 for the write rule.
+
+The template carries a **commented `afk.backpressure`** block (#430 / PRD #429): an ordered list of shell commands (`npm run test`, `npm run lint`, …) AFK runs after the built-in feedback gate on every successful iteration — DONE and salvaged no-sentinel alike — where any non-zero exit blocks the merge and parks the issue to `ready-for-human`. It ships commented (a no-op until uncommented). **One optional offer:** when scaffolding a fresh template into a repo whose root (or a clearly primary package) `package.json` declares `test` and/or `lint` scripts, surface them and ask whether to pre-fill the block with the matching `npm run <script>` (or `pnpm`) lines — uncommented — instead of the commented placeholder. Only pre-fill on explicit confirmation; otherwise leave the block commented. Never touch an existing `.red/config.yaml` (the clobber rule wins over this offer).
 
 ### 3. Confirm and edit
 
@@ -192,8 +194,9 @@ If the user accepted Section D, copy each `workflows/red-*.yml` template from th
 Scaffold `.red/config.yaml` (Section G, no user decision):
 
 1. If `.red/config.yaml` already exists at the repo root, leave it untouched and log a one-line notice (`.red/config.yaml already present — leaving as-is`). Do **not** diff, merge, or overwrite — any existing content is project state.
-2. Otherwise, ensure `.red/` exists and copy [config-template.yaml](./config-template.yaml) verbatim to `.red/config.yaml`. The template is a fully-commented snapshot of every v1 knob the AFK config loader (`src/apps/dev/src/core/config.ts`) reads from `.red/config.yaml`, so the file is a no-op until the user uncomments a line.
-3. Do **not** `git add` or commit the file — the user controls when it lands in git.
+2. Otherwise, ensure `.red/` exists and copy [config-template.yaml](./config-template.yaml) verbatim to `.red/config.yaml`. The template is a fully-commented snapshot of every v1 knob the AFK config loader (`src/apps/dev/src/core/config.ts`) reads from `.red/config.yaml`, so the file is a no-op until the user uncomments a line — including the commented `afk.backpressure` block.
+3. **Backpressure pre-fill offer (only on a fresh scaffold).** Read the repo-root (or primary package) `package.json`; if it declares `test` and/or `lint` scripts, surface them and ask whether to pre-fill `afk.backpressure` with the matching `npm run <script>` (or `pnpm run <script>`) lines, uncommented. On explicit yes, replace the commented `backpressure:` placeholder with the confirmed list; otherwise leave it commented. Skip silently when no such scripts exist. This step never runs when `.red/config.yaml` already existed (step 1 wins).
+4. Do **not** `git add` or commit the file — the user controls when it lands in git.
 
 If the user accepted Section F, wire the statusline:
 

--- a/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
+++ b/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
@@ -5,6 +5,12 @@
 #   default_runner: claude        # fallback runner when no explicit signal
 #   fleet:
 #     target: 2                   # default supervisor worker target
+#   backpressure:                 # extra merge gates run on every successful
+#     - npm run test              # iteration (DONE + salvaged no-sentinel), after
+#     - npm run lint              # the built-in feedback gate. Any non-zero exit
+#                                 # blocks the merge and parks to ready-for-human,
+#                                 # exactly like a feedback failure. Optional;
+#                                 # absent/empty = no-op. (#430 / PRD #429)
 #   hooks:
 #     defaults:
 #       cargo: true               # ship cargo isolation on Rust projects


### PR DESCRIPTION
Closes #433. PRD #429.

Discoverability half of the backpressure feature (#430 is the runtime):

- `config-template.yaml` gains a **commented `afk.backpressure`** block (no-op until uncommented) with the documented shape.
- The setup `SKILL.md` documents the new step: on a **fresh** scaffold, detect `test`/`lint` scripts in the repo's `package.json` and **offer** to pre-fill the block with the matching `npm/pnpm run` lines (operator-confirmed); otherwise leave it commented.
- Existing `.red/config.yaml` is **never clobbered** — the clobber rule wins over the offer.

Template + skill-doc only (setup-red-skills is a prompt-driven skill; no runtime code).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783086632&installation_id=129708444&pr_number=440&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F440&signature=5191642e76480478c5d0e2c1e3e9f298a54140a5f4117635796e5b000751f688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup-red-skills documentation to describe an optional backpressure pre-fill feature during configuration scaffolding.

* **Configuration**
  * Added new optional `backpressure` section to the configuration template, enabling merge-gate commands to run on successful iterations with failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->