### PR TITLE
feat(afk): add afk.merge.wait_for_review knob + document merge-without-advice policy (#431)

### DIFF
--- a/.red/adr/0048-afk-merges-without-advice-backpressure-is-the-guardrail.md
+++ b/.red/adr/0048-afk-merges-without-advice-backpressure-is-the-guardrail.md
@@ -1,0 +1,87 @@
+# ADR 0048 — AFK merges without advice; in-process backpressure is the guardrail
+
+## Status
+
+accepted. Refines ADR 0030 (AFK landing is lock-toggled; the unlocked path
+admin-merges the PR) and ADR 0008 (only mechanism — the feedback gate — can
+refuse a merge). Parent: PRD #429.
+
+## Context
+
+The unlocked AFK landing lands completed work via `gh pr merge --admin --merge`
+(ADR 0030, `landPr`). `--admin` bypasses GitHub's required-review and
+required-status-check rules, so an advisory reviewer such as CodeRabbit has
+**no effect** on whether the merge happens — the merge proceeds the moment the
+PR exists. This was true but implicit, never written down, and occasionally read
+as a bug ("why didn't AFK wait for the review?").
+
+It is not a bug. The worker is autonomous and the queue is the throughput
+constraint (PRD #429 backpressure program). Gating each landing on a
+human-paced or rate-limited external reviewer would stall the loop for minutes
+per issue with no corresponding safety gain — the binding safety gates already
+run **inside** the process, before the merge:
+
+1. **`drift-guard`** — the `pre_merge` hook, a hard gate: a non-zero exit aborts
+   the merge for the issue and routes it to `ready-for-human`.
+2. **In-process feedback/backpressure** — the pre-merge feedback-validation step
+   (typecheck/tests, ADR 0008), the only thing that can refuse a merge.
+
+What was missing was (a) the policy stated explicitly, and (b) an opt-in for
+teams that *do* want the external review to conclude first.
+
+## Decision
+
+1. **Merge-without-advice is the default, and intentional.** With
+   `afk.merge.wait_for_review: false` (the default), the unlocked admin-merge
+   proceeds ignoring advisory review checks. `drift-guard` + in-process
+   backpressure remain the binding gates.
+
+2. **Add an opt-in wait.** `afk.merge.wait_for_review` (bool, default `false`,
+   namespaced `plugins.dev.afk.merge.wait_for_review` with the legacy top-level
+   fallback, ADR 0042). When `true`, the unlocked landing polls
+   `afk.merge.review_check` (default `CodeRabbit`) via `gh pr checks` until the
+   named check reaches a terminal state, **then merges regardless of its
+   verdict**. The review stays advisory — waiting only ensures its comments land
+   before the merge; it never blocks the land. `drift-guard` is a hard gate
+   either way.
+
+3. **The wait is fail-open.** A reviewer that never registers, or never
+   concludes within the poll budget, does not wedge the landing — the wait times
+   out and the merge proceeds. An autonomous loop must never deadlock on an
+   absent external signal.
+
+## Why
+
+- **Throughput.** The dominant AFK cost is PRs left waiting, not merges that
+  shipped without a human glance (see the "merge green PRs same-session" rule).
+  Blocking on an external reviewer trades real throughput for advisory comments
+  that can be read after the fact.
+- **The real guardrail is in-process.** `drift-guard` + feedback validation gate
+  every landing already (ADR 0008). The external reviewer is a second opinion,
+  not the safety boundary — so it should not have merge-veto power by default.
+- **Explicit beats surprising.** Writing the policy down (here + in the AFK
+  `SKILL.md` merge-gate note) turns a recurring "is this a bug?" into a
+  documented decision with a knob.
+
+## Rejected alternatives
+
+- **Wait for review by default.** Stalls the autonomous queue on a human/rate-
+  limited signal with no safety gain over the in-process gates. Rejected as the
+  default; offered as the opt-in.
+- **Gate the merge on the review verdict (block on failure).** Makes an advisory
+  reviewer a hard gate, duplicating `drift-guard`/feedback with a flakier,
+  externally-owned signal. The opt-in waits for *conclusion*, never the verdict.
+- **No knob at all.** Leaves teams that want CodeRabbit's pass before merge with
+  no supported path. The opt-in is cheap and fail-open.
+
+## Consequences
+
+- Default AFK behaviour is unchanged and now documented as intentional.
+- Teams can opt into waiting per repo via `.red/config.yaml` without touching
+  code; the wait is bounded and fail-open.
+- The merge gate's safety contract stays where ADR 0008 put it (in-process
+  feedback), and ADR 0030's admin-merge path is unchanged except for the
+  optional pre-merge poll.
+
+Memory-NoIngest: ADR + config knob; the canonical claim for the admin-merge
+landing stays with ADR 0030 and the merge-refusal contract with ADR 0008.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -34,6 +34,7 @@ stale notes inline.
 - **0030** AFK landing is lock-toggled; the PR carries the history
 - **0031** Branch-lock value drives AFK base/merge; enforcement stays agent-only
 - **0033** AFK agent execution runs on `@ai-hero/sandcastle`
+- **0048** AFK merges without advice; in-process backpressure (`drift-guard` + feedback) is the guardrail — opt into waiting with `afk.merge.wait_for_review` *(refines 0030, 0008)*
 
 ## Branch lock
 - **0006** Branch lock enforces on the agent only, not the human terminal

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -833,6 +833,8 @@ Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside t
 | `afk.sandbox` | `RED_AFK_SANDBOX` | `none` | Isolation backend (`none` \| `docker` \| `podman`, ADR 0033). |
 | `afk.max_iterations` | `RED_AFK_MAX_ITERATIONS` | `12` | Sandcastle re-invocation ceiling (issue #322) — the safety cap for "the agent never emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`". The completion sentinel is the real terminator, so a normal issue finishes in 1–3 iterations; this leaves headroom without letting repeated no-sentinel failures run for too long. A non-numeric / zero / negative value in either the env or the config is ignored (falls through to the default) so a typo can never disable the cap or pin the agent to 1. |
 | `afk.backpressure` | — | _(empty)_ | Ordered list of shell commands run as an extra pre-merge gate on the DONE path (issue #430, PRD #429). |
+| `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding gates are `drift-guard` (the `pre_merge` hook) + in-process backpressure/feedback. When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
+| `afk.merge.review_check` | — | `CodeRabbit` | Name (case-insensitive substring) of the advisory review check `wait_for_review` polls via `gh pr checks`. Only consulted when `afk.merge.wait_for_review` is `true`. |
 
 ```yaml
 afk:
@@ -841,11 +843,23 @@ afk:
   backpressure:           # extra pre-merge gate, runs after the feedback gate
     - npm run test
     - npm run lint
+  merge:
+    wait_for_review: false   # true → hold the unlocked admin-merge until the review check concludes
+    review_check: CodeRabbit
 ```
 
 ### Backpressure gate
 
 `afk.backpressure` is an operator-declared, ordered list of shell commands that **supplements** the auto-derived feedback gate (it does not replace it). On a successful DONE attempt — after the scope-derived `test`/`typecheck`/`lint`/`build` feedback gate passes, before landing — AFK runs each backpressure command in order (`sh -c <command>`) against a checkout of the worker branch. If **any** command exits non-zero the merge is blocked and the issue is parked to `ready-for-human` with `blocked:validation`, exactly like a feedback failure: the failing command and its output tail land in the terminal envelope and in the `red.afk.validation.v1` validation sidecar (records named `backpressure:<command>`). An absent or empty block is a no-op (today's behaviour). The namespaced `plugins.dev.afk.backpressure` location is honoured with the legacy bare `afk.backpressure` fallback (ADR 0042).
+
+### Merge-gate policy
+
+The unlocked admin-merge (`gh pr merge --admin --merge`, ADR 0030) **ignores advisory review checks by default** — this is intentional, not an oversight. The binding gates on a landing are:
+
+1. **`drift-guard`** — the `pre_merge` hook, a hard gate that aborts the merge for this issue (→ `ready-for-human`).
+2. **In-process backpressure / feedback** — the pre-merge feedback-validation step (typecheck/tests, ADR 0008) that only mechanism can refuse a merge on.
+
+External advisory reviewers (CodeRabbit and the like) are **not** binding: the worker is autonomous, and gating an autonomous loop on a human-paced external reviewer would stall the queue (ADR 0048). Opt into waiting with `afk.merge.wait_for_review: true` — the unlocked landing then polls `afk.merge.review_check` until it concludes and merges regardless of the verdict (so its comments are posted before the merge, but the review never blocks the land). The wait is **fail-open**: a reviewer that never registers or never concludes within the poll budget does not wedge the landing.
 
 ## Lifecycle Hooks
 

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -34,7 +34,7 @@ import * as fsx from "../runtime/fs.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { ExecFn } from "../runtime/exec.js";
-import { loadConfig, readBackpressure } from "../core/config.js";
+import { getConfig, loadConfig, readBackpressure } from "../core/config.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
 import { isValidWorkerId } from "../core/worker-paths.js";
@@ -292,6 +292,19 @@ export function buildProcessDeps(
   // process-issue re-resolves per run from the same config + options.
   resolveHooks(config, resolveOptions);
 
+  // Merge-gate policy (ADR 0048). Default off → the unlocked admin-merge ignores
+  // advisory review checks (drift-guard + in-process backpressure stay the
+  // binding gates). When `afk.merge.wait_for_review` is true, the unlocked
+  // landing holds until the configured review check (`afk.merge.review_check`)
+  // concludes, then merges regardless of the verdict.
+  const waitForReview =
+    getConfig(config, "afk.merge.wait_for_review") === "true"
+      ? {
+          check: getConfig(config, "afk.merge.review_check") || "CodeRabbit",
+          sleep: (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+        }
+      : undefined;
+
   return {
     gh: {
       viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
@@ -349,6 +362,7 @@ export function buildProcessDeps(
     runAgent: makeRunAgent(sandbox, process.env, maxIterations, attemptTimeoutSeconds),
     model,
     fallbackRunner,
+    waitForReview,
     // One-shot merge-conflict resolver (merge_resolve_conflict): re-enter the
     // configured runner in the primary checkout with the resolver prompt. The
     // merge primitive verifies git state afterwards, so a non-zero / thrown

--- a/src/apps/dev/src/core/config.ts
+++ b/src/apps/dev/src/core/config.ts
@@ -28,6 +28,13 @@ export const CONFIG_DEFAULTS = {
   "afk.fleet.target": "2",
   "afk.hooks.defaults.cargo": "true",
   "afk.hooks.defaults.gradle": "true",
+  // Merge-gate policy (ADR 0048). The unlocked admin-merge ignores advisory
+  // review checks by default — the binding gates are `drift-guard` (the
+  // pre_merge hook) + in-process backpressure/feedback. Opt into waiting for an
+  // advisory reviewer to conclude (it stays advisory: AFK waits, then merges
+  // regardless of the verdict) with `afk.merge.wait_for_review: true`.
+  "afk.merge.wait_for_review": "false",
+  "afk.merge.review_check": "CodeRabbit",
 } as const;
 
 export type ConfigKey = keyof typeof CONFIG_DEFAULTS;

--- a/src/apps/dev/src/core/landing.ts
+++ b/src/apps/dev/src/core/landing.ts
@@ -27,6 +27,7 @@ import {
   resolveMergeConflict,
   type ConflictResolver,
   type Exec as MergeExec,
+  type WaitForReviewInput,
 } from "./merge.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 
@@ -48,6 +49,14 @@ export interface LandingDeps {
   /** One-shot inner-agent merge-conflict resolver (locked path only). Absent →
    * a locked merge conflict goes straight to the failure path. */
   conflictResolver?: ConflictResolver;
+  /**
+   * Opt-in advisory-review wait for the UNLOCKED admin-PR landing
+   * (`afk.merge.wait_for_review`, ADR 0048). Present → landPr holds until the
+   * named review check concludes before the admin-merge, then merges regardless
+   * of the verdict. Absent (the default) → admin-merge ignores advisory checks.
+   * Ignored on the locked path, which never opens a PR.
+   */
+  waitForReview?: WaitForReviewInput;
 }
 
 /** Static per-landing inputs the caller already resolved. */
@@ -152,6 +161,7 @@ export async function doLanding(
       target: input.base,
       n: input.issue,
       title: input.title,
+      waitForReview: deps.waitForReview,
     });
     landed = r.ok;
   }

--- a/src/apps/dev/src/core/merge.ts
+++ b/src/apps/dev/src/core/merge.ts
@@ -139,6 +139,97 @@ export async function landMerge(exec: Exec, input: LandMergeInput): Promise<Land
   return { ok: true, rolledBack: false };
 }
 
+/** Injected sleep between review-check polls. Tests pass a no-op so the wait
+ * loop runs synchronously with no real timers. */
+export type Sleep = (ms: number) => Promise<void>;
+
+/**
+ * Opt-in wait for an advisory review check to conclude before the admin-merge
+ * (`afk.merge.wait_for_review`, ADR 0048). The review stays ADVISORY: AFK waits
+ * for the named check to reach a terminal state, then merges regardless of its
+ * verdict — `drift-guard` (the pre_merge hook) + in-process backpressure remain
+ * the binding gates. Absent on {@link LandPrInput} → the merge proceeds
+ * immediately (the default; current behaviour, now intentional).
+ */
+export interface WaitForReviewInput {
+  /** Name (or substring, case-insensitive) of the review check to wait on, e.g. `CodeRabbit`. */
+  check: string;
+  /** Injected sleep between polls. */
+  sleep: Sleep;
+  /** Max poll attempts before proceeding fail-open. Default 30. */
+  maxPolls?: number;
+  /** Delay between polls, in ms. Default 10000. */
+  intervalMs?: number;
+}
+
+/** Why {@link waitForReviewCheck} stopped waiting. All three proceed to merge —
+ * the wait never blocks on the verdict (advisory). */
+export type ReviewWaitOutcome = "concluded" | "absent" | "timeout";
+
+interface PrCheck {
+  name: string;
+  state: string;
+}
+
+/** Parse `gh pr checks --json name,state` stdout. Tolerant: any parse failure
+ * (non-JSON, partial output) yields an empty list so the caller polls again. */
+function parsePrChecks(stdout: string): PrCheck[] {
+  const text = stdout.trim();
+  if (text === "") return [];
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.flatMap((entry): PrCheck[] => {
+      if (typeof entry !== "object" || entry === null) return [];
+      const name = (entry as { name?: unknown }).name;
+      const state = (entry as { state?: unknown }).state;
+      if (typeof name !== "string") return [];
+      return [{ name, state: typeof state === "string" ? state : "" }];
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** A gh check `state` is terminal once it leaves the pending family. gh
+ * normalises in-flight runs to `PENDING`; everything else (SUCCESS, FAILURE,
+ * SKIPPED, ERROR, …) has concluded. */
+function isTerminalState(state: string): boolean {
+  const s = state.trim().toUpperCase();
+  return s !== "" && s !== "PENDING";
+}
+
+/**
+ * Poll `gh pr checks <num>` until the configured review check reaches a terminal
+ * state, the budget is exhausted, or the check never registers. Returns the
+ * reason it stopped — but the caller proceeds to merge in every case: this waits
+ * for *conclusion*, never gating on the verdict (the review is advisory, ADR
+ * 0048). Fail-open by design — a missing/never-concluding reviewer must not wedge
+ * the autonomous landing.
+ */
+export async function waitForReviewCheck(
+  exec: Exec,
+  repo: string,
+  prNumber: number,
+  input: WaitForReviewInput,
+): Promise<ReviewWaitOutcome> {
+  const maxPolls = input.maxPolls ?? 30;
+  const intervalMs = input.intervalMs ?? 10_000;
+  const needle = input.check.trim().toLowerCase();
+  let everSeen = false;
+
+  for (let attempt = 0; attempt < maxPolls; attempt++) {
+    const res = await exec(["gh", "-R", repo, "pr", "checks", String(prNumber), "--json", "name,state"]);
+    const match = parsePrChecks(res.stdout).find((c) => c.name.toLowerCase().includes(needle));
+    if (match !== undefined) {
+      everSeen = true;
+      if (isTerminalState(match.state)) return "concluded";
+    }
+    if (attempt + 1 < maxPolls) await input.sleep(intervalMs);
+  }
+  return everSeen ? "timeout" : "absent";
+}
+
 /** Inputs for the UNLOCKED landing path, {@link landPr}. */
 export interface LandPrInput {
   /** `owner/repo` slug passed to `gh -R`. */
@@ -157,6 +248,13 @@ export interface LandPrInput {
   title: string;
   /** Worktree dir to force-push the attempt branch from; skipped when absent. */
   worktree?: string;
+  /**
+   * Opt-in advisory-review wait (`afk.merge.wait_for_review`, ADR 0048). When
+   * present, the PR is held until the named review check concludes before the
+   * admin-merge; the merge then proceeds regardless of the verdict. Absent (the
+   * default) → admin-merge immediately, ignoring advisory checks.
+   */
+  waitForReview?: WaitForReviewInput;
 }
 
 export interface LandPrResult {
@@ -179,7 +277,7 @@ const PR_BODY_PREFIX = "Automated AFK landing for #";
  * Idempotent: a re-attempt reuses the open PR rather than creating a second.
  */
 export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResult> {
-  const { repo, gitRepo, remote, branch, target, n, title, worktree } = input;
+  const { repo, gitRepo, remote, branch, target, n, title, worktree, waitForReview } = input;
 
   // 1. Make the attempt branch's origin state certain before opening the PR.
   if (worktree) {
@@ -217,6 +315,14 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     prNumber = await listOpenPr(exec, repo, branch, target);
   }
   if (prNumber === undefined) return { ok: false };
+
+  // 2b. Opt-in advisory-review wait (afk.merge.wait_for_review, ADR 0048). Hold
+  // until the configured review check concludes, then fall through to merge
+  // regardless of its verdict — the review is advisory; drift-guard (pre_merge)
+  // + in-process backpressure stay the binding gates. Default (absent) → no wait.
+  if (waitForReview) {
+    await waitForReviewCheck(exec, repo, prNumber, waitForReview);
+  }
 
   // 3. Admin-merge: the worker is autonomous, so bypass required-review checks.
   const merge = await exec(["gh", "-R", repo, "pr", "merge", String(prNumber), "--admin", "--merge"]);

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -45,6 +45,7 @@ import { runBackpressure, type BackpressureExec } from "./backpressure.js";
 import {
   type Exec as MergeExec,
   type ConflictResolver,
+  type WaitForReviewInput,
 } from "./merge.js";
 import { doLanding } from "./landing.js";
 import {
@@ -237,6 +238,16 @@ export interface ProcessIssueDeps {
    * conflict goes straight to ready-for-human (the pre-recovery behaviour).
    */
   conflictResolver?: ConflictResolver;
+  /**
+   * Opt-in advisory-review wait for the UNLOCKED admin-PR landing
+   * (`afk.merge.wait_for_review`, ADR 0048). Resolved from config by the CLI:
+   * present → the landing holds until the configured review check concludes
+   * before the admin-merge, then merges regardless of the verdict (the review
+   * stays advisory — drift-guard + in-process backpressure are the binding
+   * gates). Absent (the default) → admin-merge ignores advisory checks. Tests
+   * omit it.
+   */
+  waitForReview?: WaitForReviewInput;
   /** Envelope-emit IO (poster / marker writer / posted writer / git push). */
   envelope: EmitEnvelopeDeps;
   /** Clock: epoch seconds (date +%s) and an ISO timestamp (date -Iseconds). */
@@ -797,6 +808,7 @@ export async function processIssue(
       headShortSha: () => deps.git.headShortSha(),
       fireHook,
       conflictResolver: deps.conflictResolver,
+      waitForReview: deps.waitForReview,
     },
     {
       locked,

--- a/src/apps/dev/tests/config.test.ts
+++ b/src/apps/dev/tests/config.test.ts
@@ -214,3 +214,27 @@ describe("config — block sequences (afk.backpressure, #430)", () => {
     expect(readBackpressure(values)).toEqual([]);
   });
 });
+
+describe("config — afk.merge.wait_for_review (ADR 0048)", () => {
+  it("defaults to false (merge-without-advice) with CodeRabbit as the review check", () => {
+    const values = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });
+    expect(getConfig(values, "afk.merge.wait_for_review")).toBe("false");
+    expect(getConfig(values, "afk.merge.review_check")).toBe("CodeRabbit");
+  });
+
+  it("reads the namespaced plugins.dev.afk.merge.* block", () => {
+    const text =
+      "plugins:\n  dev:\n    afk:\n      merge:\n        wait_for_review: true\n        review_check: my-reviewer\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "afk.merge.wait_for_review")).toBe("true");
+    expect(getConfig(values, "afk.merge.review_check")).toBe("my-reviewer");
+  });
+
+  it("reads the legacy top-level afk.merge.* block (back-compat)", () => {
+    const text = "afk:\n  merge:\n    wait_for_review: true\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "afk.merge.wait_for_review")).toBe("true");
+    // review_check keeps its default when unset.
+    expect(getConfig(values, "afk.merge.review_check")).toBe("CodeRabbit");
+  });
+});

--- a/src/apps/dev/tests/landing.test.ts
+++ b/src/apps/dev/tests/landing.test.ts
@@ -29,6 +29,8 @@ interface Opts {
   conflictResolve?: "resolve" | "fail";
   /** rc the post-resolve `push <remote> <base>` returns (1 → reject → reset). */
   resolvePushCode?: number;
+  /** Enable the opt-in advisory-review wait (afk.merge.wait_for_review). */
+  waitForReview?: boolean;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -62,6 +64,9 @@ function harness(opts: Opts = {}): Harness {
         const pending = opts.conflictResolve === "fail" || !mergeResolved;
         return { code: pending ? 0 : 1, stdout: "", stderr: "" };
       }
+      if (j.includes("pr checks")) {
+        return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
+      }
       return { code: 0, stdout: "", stderr: "" };
     },
     remoteGit: async (argv) => {
@@ -80,6 +85,7 @@ function harness(opts: Opts = {}): Harness {
           if (opts.conflictResolve === "resolve") mergeResolved = true;
         }
       : undefined,
+    waitForReview: opts.waitForReview ? { check: "CodeRabbit", sleep: async () => {} } : undefined,
   };
 
   const input: LandingInput = {
@@ -117,6 +123,24 @@ describe("doLanding — happy paths", () => {
     expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
     // unlocked never merges the attempt branch locally.
     expect(j.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
+  });
+
+  it("unlocked + wait_for_review → polls the review check before the admin-merge", async () => {
+    const h = harness({ locked: false, waitForReview: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    const j = joined(h.mergeCalls);
+    const checksIdx = j.findIndex((c) => c.includes("pr checks"));
+    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --admin --merge"));
+    expect(checksIdx).toBeGreaterThanOrEqual(0);
+    expect(mergeIdx).toBeGreaterThan(checksIdx);
+  });
+
+  it("unlocked, default (no wait_for_review) → never polls review checks", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr checks"))).toBe(false);
   });
 
   it("locked → lands via merge --no-ff into the locked branch + push", async () => {

--- a/src/apps/dev/tests/merge.test.ts
+++ b/src/apps/dev/tests/merge.test.ts
@@ -5,6 +5,7 @@ import {
   landPr,
   resolveMergeConflict,
   buildConflictPrompt,
+  waitForReviewCheck,
   type Exec,
   type ExecResult,
 } from "../src/core/merge.js";
@@ -261,6 +262,127 @@ describe("landPr (unlocked path)", () => {
       title: "t",
     });
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("waitForReviewCheck (afk.merge.wait_for_review)", () => {
+  // gh pr checks --json name,state stdout per attempt, replayed in order.
+  function pollExec(stdouts: string[]): { exec: Exec; calls: string[][] } {
+    const calls: string[][] = [];
+    let i = 0;
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const out = stdouts[Math.min(i, stdouts.length - 1)] ?? "[]";
+      i++;
+      return { code: 0, stdout: out, stderr: "" };
+    };
+    return { exec, calls };
+  }
+  const noSleep = async () => {};
+
+  it("returns once the named check reaches a terminal state, no further polls", async () => {
+    const { exec, calls } = pollExec([
+      JSON.stringify([{ name: "CodeRabbit", state: "PENDING" }]),
+      JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]),
+    ]);
+    const r = await waitForReviewCheck(exec, "o/r", 77, { check: "CodeRabbit", sleep: noSleep });
+    expect(r).toBe("concluded");
+    // two polls: pending then success; no third poll after conclusion.
+    expect(calls.filter((c) => c.join(" ").includes("pr checks 77")).length).toBe(2);
+  });
+
+  it("concludes on a FAILURE state too — the wait never gates on the verdict", async () => {
+    const { exec } = pollExec([JSON.stringify([{ name: "CodeRabbit", state: "FAILURE" }])]);
+    const r = await waitForReviewCheck(exec, "o/r", 77, { check: "coderabbit", sleep: noSleep });
+    expect(r).toBe("concluded");
+  });
+
+  it("matches the check name case-insensitively as a substring", async () => {
+    const { exec } = pollExec([
+      JSON.stringify([{ name: "CodeRabbit / review", state: "SUCCESS" }]),
+    ]);
+    const r = await waitForReviewCheck(exec, "o/r", 1, { check: "coderabbit", sleep: noSleep });
+    expect(r).toBe("concluded");
+  });
+
+  it("times out (fail-open) when the check stays pending past maxPolls", async () => {
+    let sleeps = 0;
+    const { exec, calls } = pollExec([JSON.stringify([{ name: "CodeRabbit", state: "PENDING" }])]);
+    const r = await waitForReviewCheck(exec, "o/r", 9, {
+      check: "CodeRabbit",
+      sleep: async () => { sleeps++; },
+      maxPolls: 3,
+    });
+    expect(r).toBe("timeout");
+    expect(calls.filter((c) => c.join(" ").includes("pr checks")).length).toBe(3);
+    // sleeps between polls only (one fewer than polls).
+    expect(sleeps).toBe(2);
+  });
+
+  it("reports absent when the check never registers", async () => {
+    const { exec } = pollExec([JSON.stringify([{ name: "other-ci", state: "PENDING" }])]);
+    const r = await waitForReviewCheck(exec, "o/r", 9, { check: "CodeRabbit", sleep: noSleep, maxPolls: 2 });
+    expect(r).toBe("absent");
+  });
+
+  it("tolerates non-JSON / empty stdout and keeps polling", async () => {
+    const { exec } = pollExec(["", "not json", JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }])]);
+    const r = await waitForReviewCheck(exec, "o/r", 9, { check: "CodeRabbit", sleep: noSleep });
+    expect(r).toBe("concluded");
+  });
+});
+
+describe("landPr wait_for_review wiring", () => {
+  it("polls the review check before admin-merge when waitForReview is set", async () => {
+    let checksPolled = false;
+    let mergedAfterPoll = false;
+    const calls: string[][] = [];
+    const exec: Exec = async (argv) => {
+      calls.push(argv);
+      const cmd = argv.join(" ");
+      if (cmd.includes("pr list")) return { code: 0, stdout: "77\n", stderr: "" };
+      if (cmd.includes("pr checks")) {
+        checksPolled = true;
+        return { code: 0, stdout: JSON.stringify([{ name: "CodeRabbit", state: "SUCCESS" }]), stderr: "" };
+      }
+      if (cmd.includes("pr merge")) {
+        mergedAfterPoll = checksPolled; // merge must come AFTER the poll
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const result = await landPr(exec, {
+      repo: "o/r",
+      gitRepo: "/repo",
+      remote: "origin",
+      branch: "afk/wX/9-x",
+      target: "main",
+      n: 9,
+      title: "t",
+      waitForReview: { check: "CodeRabbit", sleep: async () => {} },
+    });
+    expect(result.ok).toBe(true);
+    expect(checksPolled).toBe(true);
+    expect(mergedAfterPoll).toBe(true);
+    expect(calls.some((c) => c.join(" ").includes("pr merge 77 --admin --merge"))).toBe(true);
+  });
+
+  it("does NOT poll review checks by default (waitForReview absent)", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.join(" ").includes("pr list"), result: { stdout: "42\n" } },
+    ]);
+    const result = await landPr(exec, {
+      repo: "o/r",
+      gitRepo: "/repo",
+      remote: "origin",
+      branch: "afk/wX/9-x",
+      target: "main",
+      n: 9,
+      title: "t",
+    });
+    expect(result.ok).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pr checks"))).toBe(false);
+    expect(joined(calls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #431.

Makes the AFK **merge-without-advice** policy explicit and adds an opt-in to wait on an advisory reviewer. Today the unlocked admin-merge (`gh pr merge --admin --merge`) already ignores advisory review checks (CodeRabbit et al.) — `drift-guard` (the `pre_merge` hook) + the in-process feedback gate are the binding gates. This slice records that as intentional and adds the knob.

## What changed
- **config** (`config.ts`): `afk.merge.wait_for_review` (bool, default `false`) + `afk.merge.review_check` (default `CodeRabbit`), namespaced under `plugins.dev.afk.merge.*` with the legacy top-level fallback (ADR 0042).
- **merge.ts**: `waitForReviewCheck` polls `gh pr checks` until the named review check concludes; `landPr` calls it before the admin-merge when enabled, then merges regardless of the verdict (advisory). Fail-open — a missing/never-concluding reviewer never wedges the landing.
- **landing.ts / process-issue.ts / run.ts**: thread the opt-in from config to `landPr`; default off preserves current behaviour.
- **SKILL.md**: new "Merge-gate policy" note + the two config knobs.
- **ADR 0048** records merge-without-advice + in-process backpressure as the guardrail (refines ADR 0030/0008).

## Acceptance criteria
- [x] `afk.merge.wait_for_review` parsed (namespaced + legacy fallback), default `false`.
- [x] Default (`false`): unlocked admin-merge proceeds without waiting on advisory review (drift-guard still gates).
- [x] `true`: the unlocked landing waits for the configured review check before merging.
- [x] AFK `SKILL.md` documents the merge-gate policy + the knob.
- [x] An ADR records the merge-without-advice + backpressure-as-guardrail decision.
- [x] Tests cover the knob's effect on the landing decision (injected, no real network).
- [x] Commit carries a `Memory-NoIngest:` trailer (adds an ADR).

## Tests
Full `vitest run` suite green (848 tests). The targeted suites — `merge.test.ts`, `landing.test.ts`, `config.test.ts` (55 tests) — pass: `waitForReviewCheck` poll/terminal/timeout/absent, `landPr` wait-then-merge vs default no-poll, `doLanding` threading, and config parse (default + namespaced + legacy). Typecheck clean.

> Note: `supervisor.test.ts` emits a teardown-time "Worker exited unexpectedly" tinypool flake (it spawns real processes) — pre-existing and unrelated to this change; its 31 tests pass when run alone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783086653&installation_id=129708444&pr_number=441&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F441&signature=5508ae73da775fd0e0bc687bb46619040c56cbc27abd7e16b6ecea658f4a337a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional config to have AFK admin merges wait for a named advisory review check before merging; waiting is opt-in, defaults off, and merges proceed regardless of review verdict (fail-open) with bounded polling.

* **Documentation**
  * Added ADR documenting AFK merge policy and updated config reference with new merge-wait settings and default check name.

* **Tests**
  * Added tests covering default behavior, config precedence, polling outcomes, and landing flow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->