### PR TITLE
docs(adr): 0049 — model-tier routing embedded in the plugin, enforced by the shared trio (per runner)

### DIFF
--- a/.red/adr/0049-model-tier-routing-embedded-in-plugin-enforced-by-shared-trio.md
+++ b/.red/adr/0049-model-tier-routing-embedded-in-plugin-enforced-by-shared-trio.md
@@ -1,0 +1,40 @@
+# Model-tier routing is embedded in the plugin and enforced by the shared skill + hooks + sandcastle trio, per runner
+
+Status: accepted (not yet implemented)
+
+## Context
+
+Running every task on the largest model is slow and expensive. We want work routed to the **cheapest capable** model/effort: structural validation costs no model at all, fuzzy checks go to a small model, simple code to a mid model, complex code and all deep reasoning to the large model. This must hold both in the **interactive session** and in the **autonomous AFK loop**, and across **both runners** (Claude Code and Codex) — not as a soft prose rule a reader might ignore, but embedded in the plugin so every repo that installs it inherits the policy.
+
+## Decision
+
+A single **tier table** — per runner, mapping each tier to `{model, effort}` — lives in the dev plugin's **config defaults** (`config.ts` `CONFIG_DEFAULTS`, e.g. `afk.models.{claude,codex}.{validate,simple,complex,think}`), overridable per-repo via `.red/config.yaml`. It is consumed by the three **host-neutral, shared** surfaces the plugin already ships to both runners:
+
+- **skill** — carries the policy + the classification criterion (the single source of *why/which*, read by both hosts);
+- **hooks** — enforce the routing on subagent dispatch in the **interactive** session, on both hosts;
+- **sandcastle** — enforces the **AFK** side: the inner-agent spawn already takes `--model` and `--effort`, so the per-issue tier resolves straight into those flags.
+
+Tiers (Claude family; Codex maps to its own gpt-5.x family via the per-runner adapter, ADR 0003):
+
+| tier | model | effort | use |
+|---|---|---|---|
+| validate | `claude-haiku-4-5` | low | fuzzy/semantic content checks (structural JSON/YAML/schema validation runs as a **deterministic tool first — zero model tokens**); also the AFK classifier |
+| simple | `claude-sonnet-4-6` | high | simple, well-specified, single-scope code |
+| complex | `claude-opus-4-8` | medium | cross-module / architectural / risk-sensitive code |
+| think | `claude-opus-4-8` | high | design, planning, routing decisions |
+
+Classification is **per-issue** in AFK (a cheap `haiku` classifier reads lightweight metadata before the spawn; under the Codex runner a small gpt model plays the same role) and **inline-opus** in the interactive session (the main loop is already reasoning). Simple-vs-complex uses an explicit criterion **plus escalate-on-failure**: a `simple` attempt that fails the feedback gate is retried on `complex`, so a misclassification costs one cheap miss, not a wedged loop.
+
+## Considered options
+
+- **Policy in `CLAUDE.md` / consumer-repo files** — rejected: soft, not embedded in the plugin, and a plugin cannot auto-inject always-on session context anyway.
+- **A single identical mechanism across both hosts** — infeasible: Codex plugins ship no `agents/` and do not use the Claude model family; the realization must be per-runner (the existing `.claude-plugin`/`.codex-plugin` and `runner-claude.md`/`runner-codex.md` split, ADR 0003).
+- **Per-task routing within one issue** (nested subagent dispatch inside an AFK attempt) — deferred as a stretch goal: it needs nested-spawn capability that is unverified; per-issue tiering at the spawn is what sandcastle enforces natively today.
+
+## Consequences
+
+- One embedded config source, three shared readers (skill/hooks/sandcastle), two runners — no duplicated tier table to desync.
+- The **effort inversion is deliberate**: the cheap model thinks harder (sonnet/high) while the strong model spends less per token on already-designed code (opus/medium), and reasoning itself stays maximal (opus/high).
+- Effort is a **real knob** in the AFK spawn (`--effort`) and Codex reasoning-effort; in the interactive Claude tier-agents it is prompt-convention until/unless agent frontmatter exposes an `effort` field.
+- AFK tiering is **coarse (per-issue)** for now; finer within-issue routing is left open.
+- Codex's interactive per-task subagent-with-model capability is **unverified** — if absent, the Codex interactive session falls back to a single model but still inherits AFK tier-routing.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -35,6 +35,7 @@ stale notes inline.
 - **0031** Branch-lock value drives AFK base/merge; enforcement stays agent-only
 - **0033** AFK agent execution runs on `@ai-hero/sandcastle`
 - **0048** AFK merges without advice; in-process backpressure (`drift-guard` + feedback) is the guardrail — opt into waiting with `afk.merge.wait_for_review` *(refines 0030, 0008)*
+- **0049** Model-tier routing embedded in the plugin (single config source), enforced by the shared skill + hooks + sandcastle trio, per runner *(relates 0003, 0033)*
 
 ## Branch lock
 - **0006** Branch lock enforces on the agent only, not the human terminal


### PR DESCRIPTION
Records the /start decision: route work to the cheapest capable model/effort across the interactive session **and** the AFK loop, **both runners**. Single tier table in the plugin config defaults (per-runner `{model,effort}`), consumed by the three host-neutral shared surfaces — **skill** (policy), **hooks** (interactive enforcement), **sandcastle** (AFK spawn `--model`/`--effort`). Per-runner adapters (ADR 0003); deterministic-first validation; per-issue classification + escalate-on-failure; deliberate effort inversion. Status: accepted (not yet implemented) — `/to-prd` next to slice the build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783093212&installation_id=129708444&pr_number=445&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F445&signature=915df61b4e8edcec909e505a0ae37fade03fa19a6832c6243c14543eabe679f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision record documenting the model-tier routing policy for optimized task allocation across different complexity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->