### PR TITLE
fix(afk): pnpm install the feedback worktree before validating (#458)

### DIFF
--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -21,7 +21,7 @@ import { accessSync, constants, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Exec as PnpmExec, PackageLayout } from "../core/feedback.js";
 import type { BackpressureExec } from "../core/backpressure.js";
-import { execTool, pnpm as runPnpm } from "./exec.js";
+import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
 import * as gitx from "./git.js";
 
 function slugForBranch(branch: string): string {
@@ -58,6 +58,29 @@ export function splitBranchDir(
   return { branch: dir, scope: "." };
 }
 
+/**
+ * Injectable real-process surface for {@link makeFeedbackWorktree}. Production
+ * wiring binds the real git worktree closures + the `pnpm`/`sh` executors from
+ * exec.ts; tests substitute fakes so the whole manager — materialise, install,
+ * script run, backpressure — exercises with zero subprocesses. (Spawning a real
+ * `pnpm` from inside a vitest worker destabilised the tinypool worker pool.)
+ */
+export interface FeedbackWorktreeIO {
+  worktreeAdd(ctx: gitx.GitContext, dest: string, branch: string): Promise<boolean>;
+  worktreeRemove(ctx: gitx.GitContext, dest: string): Promise<void>;
+  /** Run `pnpm <args>` with the given cwd. */
+  pnpm(args: readonly string[], opts: ExecOptions): Promise<ExecOutput>;
+  /** Run an arbitrary tool (used by the backpressure `sh -c` executor). */
+  exec(cmd: string, args: readonly string[], opts: ExecOptions): Promise<ExecOutput>;
+}
+
+const defaultIO: FeedbackWorktreeIO = {
+  worktreeAdd: gitx.worktreeAdd,
+  worktreeRemove: gitx.worktreeRemove,
+  pnpm: runPnpm,
+  exec: execTool,
+};
+
 export interface FeedbackWorktree {
   /** pnpm executor rebased onto the materialised worker-branch checkout. */
   pnpm: PnpmExec;
@@ -79,7 +102,11 @@ export interface FeedbackWorktree {
  * `.red/tmp/feedback`). Worktrees are created on demand keyed by branch and
  * reused; `cleanup()` removes them all.
  */
-export function makeFeedbackWorktree(root: string, feedbackRoot: string): FeedbackWorktree {
+export function makeFeedbackWorktree(
+  root: string,
+  feedbackRoot: string,
+  io: FeedbackWorktreeIO = defaultIO,
+): FeedbackWorktree {
   const gitCtx: gitx.GitContext = { cwd: root };
   // branch -> resolved checkout path (the worktree, or root on fallback).
   const resolved = new Map<string, string>();
@@ -90,9 +117,27 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
     const cached = resolved.get(branch);
     if (cached !== undefined) return cached;
     const dest = join(feedbackRoot, slugForBranch(branch));
-    const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
+    const ok = await io.worktreeAdd(gitCtx, dest, branch);
+    if (ok) {
+      // A freshly added worktree has NO node_modules. Without an install here,
+      // the feedback gate's `pnpm -C <dest> test/build` calls fail with
+      // `tsc/vite/svelte-kit: not found` — a FALSE validation failure that parks
+      // otherwise-green work as blocked:validation (#458). Install before any
+      // check can run.
+      const ins = await io.pnpm(["install", "--frozen-lockfile"], { cwd: dest });
+      if (ins.code !== 0) {
+        // Lockfile drift on the branch, or a transient registry error. Keep the
+        // checkout so validation still reflects the branch's real state instead
+        // of silently validating `main` from the primary checkout — but warn so
+        // the cause is visible in the attempt log.
+        process.stderr.write(
+          `warn: feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
+            `validation may report missing binaries\n${ins.stderr.trim()}\n`,
+        );
+      }
+      created.add(dest);
+    }
     const path = ok ? dest : root;
-    if (ok) created.add(dest);
     resolved.set(branch, path);
     return path;
   }
@@ -136,11 +181,11 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
       const base = await pathFor(branch);
       const rewritten = scope === "." ? base : join(base, scope);
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
-      const r = await runPnpm(["-C", rewritten, ...rest], { cwd: root });
+      const r = await io.pnpm(["-C", rewritten, ...rest], { cwd: root });
       return { code: r.code, stdout: r.stdout, stderr: r.stderr };
     }
     const head = args[0] === "pnpm" ? args.slice(1) : args;
-    const r = await runPnpm(head, { cwd: root });
+    const r = await io.pnpm(head, { cwd: root });
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 
@@ -150,7 +195,7 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
   // command through `sh -c`, mirroring the lifecycle-hook executor.
   const backpressure: BackpressureExec = async ({ command, cwd }) => {
     const dir = await pathFor(cwd);
-    const r = await execTool("sh", ["-c", command], { cwd: dir });
+    const r = await io.exec("sh", ["-c", command], { cwd: dir });
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 
@@ -160,7 +205,7 @@ export function makeFeedbackWorktree(root: string, feedbackRoot: string): Feedba
     backpressure,
     async cleanup() {
       for (const dest of created) {
-        await gitx.worktreeRemove(gitCtx, dest);
+        await io.worktreeRemove(gitCtx, dest);
       }
       created.clear();
       resolved.clear();

--- a/src/apps/dev/tests/feedback-worktree.test.ts
+++ b/src/apps/dev/tests/feedback-worktree.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { splitBranchDir } from "../src/runtime/feedback-worktree.js";
+import {
+  makeFeedbackWorktree,
+  splitBranchDir,
+  type FeedbackWorktreeIO,
+} from "../src/runtime/feedback-worktree.js";
 
 // A monorepo's package dirs are full root-relative paths. The probe is true for
 // exactly these and nothing else (mirroring the real accessSync layout check).
@@ -47,5 +51,77 @@ describe("splitBranchDir (#437)", () => {
       branch: "afk/wZ9QP/77-x",
       scope: "src/apps/memory",
     });
+  });
+});
+
+/**
+ * Recording fake IO: tracks every worktreeAdd/install/script/remove call so a
+ * test can assert the materialise → install ordering and the install `cwd`. Pure
+ * — no real subprocess is ever spawned. `installCode` scripts the `pnpm install`
+ * exit so the install-failure path is exercisable.
+ */
+function fakeIO(installCode = 0): {
+  io: FeedbackWorktreeIO;
+  calls: Array<{ op: "add" | "install" | "script" | "remove"; dest: string }>;
+} {
+  const calls: Array<{ op: "add" | "install" | "script" | "remove"; dest: string }> = [];
+  const io: FeedbackWorktreeIO = {
+    worktreeAdd: async (_ctx, dest) => {
+      calls.push({ op: "add", dest });
+      return true;
+    },
+    pnpm: async (args, opts) => {
+      const isInstall = args[0] === "install";
+      calls.push({ op: isInstall ? "install" : "script", dest: opts.cwd ?? "" });
+      const code = isInstall ? installCode : 0;
+      return { code, stdout: "", stderr: code === 0 ? "" : "boom" };
+    },
+    exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+    worktreeRemove: async (_ctx, dest) => {
+      calls.push({ op: "remove", dest });
+    },
+  };
+  return { io, calls };
+}
+
+describe("makeFeedbackWorktree install (#458)", () => {
+  it("installs in a freshly materialised checkout before any check runs", async () => {
+    const { io, calls } = fakeIO();
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    // Resolve a worker branch by running a pnpm -C token through the executor;
+    // it must materialise + install the checkout, then run the script there.
+    await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+
+    // add → install BEFORE the script runs, the first two keyed to the worktree.
+    expect(calls.map((c) => c.op)).toEqual(["add", "install", "script"]);
+    expect(calls[0]?.dest).toBe("/root/.red/tmp/feedback/afk-w1-42-fix");
+    expect(calls[1]?.dest).toBe("/root/.red/tmp/feedback/afk-w1-42-fix");
+  });
+
+  it("installs the materialised checkout exactly once across reused branches", async () => {
+    const { io, calls } = fakeIO();
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+    await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "build"]);
+
+    // Second resolve hits the cache → no extra add/install for the same branch.
+    expect(calls.filter((c) => c.op === "add")).toHaveLength(1);
+    expect(calls.filter((c) => c.op === "install")).toHaveLength(1);
+  });
+
+  it("keeps the checkout (does not fall back to root) when install fails", async () => {
+    const { io, calls } = fakeIO(1);
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+    await fb.cleanup();
+
+    // A failed install still registers the worktree for cleanup (the checkout is
+    // used, not abandoned to root), so cleanup removes it.
+    expect(calls.filter((c) => c.op === "remove")).toEqual([
+      { op: "remove", dest: "/root/.red/tmp/feedback/afk-w1-42-fix" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #458 — the AFK feedback validation gate was running `pnpm -r test/build` in a freshly `git worktree add`-ed checkout (`.red/tmp/feedback/<slug>`) that had **no `node_modules`**, so every check failed with `tsc/vite/svelte-kit: not found`. That false validation failure parked otherwise-green DONE work as `blocked:validation` (observed on red-ui#73).

## Change

- `makeFeedbackWorktree` now runs `pnpm install --frozen-lockfile` in the materialised checkout **immediately after `worktreeAdd`, before any check runs**.
- On install failure it keeps the checkout (validation reflects the branch's real state rather than silently validating `main`) and logs a `warn:` line.
- The manager's real-process surface is now injectable (`FeedbackWorktreeIO` = `worktreeAdd`/`worktreeRemove`/`pnpm`/`exec`) so the materialise→install ordering is unit-testable with **zero subprocesses**.

## Tests

- 3 new regression tests in `feedback-worktree.test.ts`: `add → install → script` ordering, single-install on branch reuse, and the install-failure-keeps-checkout path.
- `feedback-worktree` / `feedback` / `wiring-integration` suites: **25/25 green**. `tsc --noEmit` clean.

## Note (out of scope)

The full dev suite exits 0 but reports one `tinypool` "Worker exited unexpectedly" unhandled error during **pool teardown** (after the last test). This reproduces identically on clean `main` (`880/911` there vs `883/914` here — the +3 is exactly these new tests) and is **pre-existing and unrelated** to this change. Filed separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783096875&installation_id=129708444&pr_number=459&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F459&signature=e6b88b12a7bab289296c4827f7cf12c0ed58a7fa47ff194dc70b118805fef91f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worktree setup now automatically installs dependencies with `pnpm install --frozen-lockfile` when materializing new checkouts.

* **Bug Fixes**
  * Installation failures now emit warnings and preserve checkout state instead of rolling back completely.

* **Tests**
  * Added test coverage for worktree materialization and dependency installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->