### PR TITLE
fix(afk): carry the line-diff in the heartbeat + persist it for the monitor (#448)

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -48,7 +48,7 @@ import { makeFeedbackWorktree, type FeedbackWorktree } from "../runtime/feedback
 import { join } from "node:path";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
 import { initState, updateState } from "../core/state.js";
-import { formatIterationMarker } from "../core/heartbeat.js";
+import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
 import type { AgentStreamEvent } from "../core/execution.js";
 
@@ -485,25 +485,33 @@ export function buildProcessDeps(
     },
     // Externalized proof-of-life sink (PR-B): the attempt-guard fires this each
     // poll (~60s) with the progress signal. Append an enriched `type=heartbeat`
-    // firehose record AND mirror `current.last_progress_at` into the state file,
-    // so external integrators can tail the firehose or read afk.state.json for
-    // the agent's liveness + progress. Best-effort — failures are swallowed.
+    // firehose record carrying the live LINE-DIFF (+A -R) AND mirror
+    // `current.{last_progress_at,diff_added,diff_removed}` into the state file, so
+    // each tick shows how the attempt is evolving and the monitor's +A -R stays
+    // fresh between its sparse 10-min ticks (#448). Best-effort — swallowed.
     emitHeartbeat: (info) => {
       const ts = new Date().toISOString();
       const secs = Math.max(0, Math.floor((info.nowMs - info.lastProgressMs) / 1000));
       const lastProgressAt = new Date(info.lastProgressMs).toISOString();
       const head = info.head ?? "";
-      const msg = `progress: ${secs}s since last commit${head ? ` @ ${head.slice(0, 8)}` : ""}`;
-      void appendRecord(join(current.attemptDir, "log.jsonl"), "heartbeat", msg, {
-        ts,
-        fields: {
-          extra: { secs_since_progress: String(secs), last_progress_at: lastProgressAt, head },
-        },
-      }).catch(() => {});
-      void fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${msg}`);
-      void updateState(join(current.attemptDir, "afk.state.json"), {
-        "current.last_progress_at": lastProgressAt,
-      }).catch(() => {});
+      void (async () => {
+        const { added, removed } = await gitx
+          .diffstatShortstat({ cwd: join(current.attemptDir, "worktree") }, "origin/main")
+          .catch(() => ({ added: 0, removed: 0 }));
+        const hb = buildProgressHeartbeat({
+          secsSinceProgress: secs,
+          lastProgressAt,
+          head,
+          added,
+          removed,
+        });
+        await appendRecord(join(current.attemptDir, "log.jsonl"), "heartbeat", hb.msg, {
+          ts,
+          fields: { extra: hb.extra },
+        }).catch(() => {});
+        await fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${hb.msg}`);
+        await updateState(join(current.attemptDir, "afk.state.json"), hb.statePatch).catch(() => {});
+      })();
     },
     historyPath: paths.historyPath,
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },

--- a/src/apps/dev/src/core/heartbeat.ts
+++ b/src/apps/dev/src/core/heartbeat.ts
@@ -113,6 +113,67 @@ export interface FirehoseIdentity {
   attempt?: number | string;
 }
 
+/** Format a line-diff volume as `+A -R`, clamping negatives to 0. */
+export function formatDiffVolume(added: number, removed: number): string {
+  const a = added > 0 ? added : 0;
+  const r = removed > 0 ? removed : 0;
+  return `+${a} -${r}`;
+}
+
+export interface ProgressHeartbeatInput {
+  /** Seconds since the last observed commit (or spawn). */
+  secsSinceProgress: number;
+  /** ISO timestamp of the last observed progress. */
+  lastProgressAt: string;
+  /** Worker-branch HEAD this tick ("" when unresolved). */
+  head: string;
+  /** Added lines vs the merge-base with origin/main (committed + uncommitted). */
+  added: number;
+  /** Removed lines vs the same base. */
+  removed: number;
+}
+
+export interface ProgressHeartbeat {
+  /** Human line for both the firehose `msg` and the `[heartbeat] …` afk.log line. */
+  msg: string;
+  /** Firehose record `extra` map (all string-valued, like the bash builder). */
+  extra: Record<string, string>;
+  /** Dotted state-file patch persisting progress + the live diff volume so the
+   * monitor's `+A -R` reflects evolution between its 10-min ticks (#448). */
+  statePatch: Record<string, string | number>;
+}
+
+/**
+ * Build the externalized proof-of-life heartbeat the attempt-progress guard
+ * emits each ~60s poll (ADR 0045). Unlike the bare liveness record it carries
+ * the **line-diff volume** (`+A -R`) so each tick shows how the attempt is
+ * evolving, and persists that volume into `current.diff_{added,removed}` — the
+ * fields the monitor/statusline prefer over a live `git diff` — so the
+ * dashboard's diff stays fresh between its sparse ticks (#448). Pure: the diff
+ * counts and timestamps are computed/read by the caller and passed in.
+ */
+export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressHeartbeat {
+  const diff = formatDiffVolume(input.added, input.removed);
+  const headShort = input.head ? ` @ ${input.head.slice(0, 8)}` : "";
+  const msg = `progress: ${input.secsSinceProgress}s since last commit${headShort} · ${diff}`;
+  return {
+    msg,
+    extra: {
+      secs_since_progress: String(input.secsSinceProgress),
+      last_progress_at: input.lastProgressAt,
+      head: input.head,
+      diff_added: String(input.added > 0 ? input.added : 0),
+      diff_removed: String(input.removed > 0 ? input.removed : 0),
+      diff: diff,
+    },
+    statePatch: {
+      "current.last_progress_at": input.lastProgressAt,
+      "current.diff_added": input.added > 0 ? input.added : 0,
+      "current.diff_removed": input.removed > 0 ? input.removed : 0,
+    },
+  };
+}
+
 /**
  * Build the `type=heartbeat` firehose envelope, composing jsonl-log's
  * {@link buildRecord}. Mirrors the bash `jsonl_log_append_shared` call: the

--- a/src/apps/dev/tests/heartbeat.test.ts
+++ b/src/apps/dev/tests/heartbeat.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { JsonlLogRecord } from "../src/core/jsonl-log.js";
 import {
   buildHeartbeatRecord,
+  buildProgressHeartbeat,
   DEFAULT_HEARTBEAT_S,
   emitHeartbeatTick,
   escapeStreamLine,
+  formatDiffVolume,
   formatElapsed,
   formatIterationMarker,
   formatStartedMarker,
@@ -188,5 +190,51 @@ describe("formatIterationMarker — per-agentic-iteration boundary", () => {
     // attempt boundary uses [heartbeat] iteration started for #N; this is [afk] agent iteration N
     expect(formatIterationMarker(1, "started", 20)).not.toContain("[heartbeat]");
     expect(formatIterationMarker(1, "started", 20).startsWith("[afk] agent iteration")).toBe(true);
+  });
+});
+
+describe("formatDiffVolume", () => {
+  it("renders +A -R and clamps negatives to 0", () => {
+    expect(formatDiffVolume(42, 10)).toBe("+42 -10");
+    expect(formatDiffVolume(0, 0)).toBe("+0 -0");
+    expect(formatDiffVolume(-5, -3)).toBe("+0 -0");
+  });
+});
+
+describe("buildProgressHeartbeat (#448)", () => {
+  it("carries the line-diff in the msg, the firehose extra, and the state patch", () => {
+    const hb = buildProgressHeartbeat({
+      secsSinceProgress: 75,
+      lastProgressAt: "2026-06-03T12:00:00.000Z",
+      head: "40ac9326abcdef",
+      added: 382,
+      removed: 45,
+    });
+    // msg surfaces evolution at a glance: short head + +A -R.
+    expect(hb.msg).toBe("progress: 75s since last commit @ 40ac9326 · +382 -45");
+    // firehose extra carries the diff fields (string-valued like the bash builder).
+    expect(hb.extra.diff).toBe("+382 -45");
+    expect(hb.extra.diff_added).toBe("382");
+    expect(hb.extra.diff_removed).toBe("45");
+    expect(hb.extra.secs_since_progress).toBe("75");
+    // state patch persists the volume the monitor prefers over a live git diff.
+    expect(hb.statePatch).toEqual({
+      "current.last_progress_at": "2026-06-03T12:00:00.000Z",
+      "current.diff_added": 382,
+      "current.diff_removed": 45,
+    });
+  });
+
+  it("omits the head fragment when HEAD is unresolved and clamps the diff", () => {
+    const hb = buildProgressHeartbeat({
+      secsSinceProgress: 0,
+      lastProgressAt: "2026-06-03T12:00:00.000Z",
+      head: "",
+      added: -1,
+      removed: -2,
+    });
+    expect(hb.msg).toBe("progress: 0s since last commit · +0 -0");
+    expect(hb.statePatch["current.diff_added"]).toBe(0);
+    expect(hb.statePatch["current.diff_removed"]).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #448 — the AFK monitor loop runs every ~10min, but the underlying heartbeat carried no line-diff, so between ticks there was no way to see how an attempt was evolving (the frozen-duration symptom in the report). One had to `pstree` the worker to tell "live but quiet" from "stalled".

## Change

The externalized proof-of-life heartbeat (the attempt-progress guard's ~60s poll, ADR 0045) now computes the worktree diff vs the merge-base with `origin/main` and carries the `+A -R` volume in:

- the firehose `type=heartbeat` record (`extra.diff` / `diff_added` / `diff_removed`) and the `[heartbeat] …` `afk.log` line — evolution visible in the log every 60s; **and**
- `current.diff_added` / `current.diff_removed` in `afk.state.json`, which the monitor/statusline **already prefer** over a live `git diff` (`wire.ts`) — so the dashboard's `+A -R` stays fresh between its sparse 10-min ticks for free.

The 60s cadence already satisfies the "more frequent" half (guard interval is `min(capMs, 60_000)`); this PR adds the missing diff half.

## Design

New pure helper `buildProgressHeartbeat` (returns `{msg, extra, statePatch}`) keeps the wiring unit-testable; `run.ts` only adds the async `diffstatShortstat` read (best-effort, swallowed).

## Tests

- 3 new tests in `heartbeat.test.ts` (`formatDiffVolume` + `buildProgressHeartbeat`): diff in msg/extra/state patch, head-omission + negative clamping.
- `heartbeat` + `wiring-integration`: **22/22**. `tsc --noEmit` clean. Full dev suite exits 0 (only the pre-existing #460 tinypool teardown flake remains, unrelated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783098984&installation_id=129708444&pr_number=462&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F462&signature=d782ef07391d1be73b94a3399bd80f0cb98b84c875fd2cf86e48d9bdbe75d930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced progress tracking with detailed heartbeat telemetry capturing elapsed time since last progress event, file change metrics (additions and removals), and persistent state snapshots for improved development activity monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->