### PR TITLE
fix(afk): supervisor.test runSupervisor tests spin → OOM, false-failing every gate (#446)

### DIFF
--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -65,7 +65,14 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     isAlive: vi.fn(() => true),
     killTree: vi.fn(async () => {}),
     inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
-    sleep: vi.fn(async () => {}),
+    // Resolve on a macrotask (not immediately): runSupervisor wraps each tick in
+    // guardedTick, which RACES the tick against `sleep(ceiling)`. An
+    // immediately-resolving sleep makes the ceiling win every race, so the real
+    // `{stopped:true}` is discarded and the `for(;;)` loop spins forever (→ OOM,
+    // #446). A `setTimeout(…, 0)` resolves after the tick's microtasks, so the
+    // tick wins and `stopped` propagates — matching production, where `sleep` is a
+    // real timer that never beats a sub-second tick.
+    sleep: vi.fn((_ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 0))),
     agentLaneMtime: vi.fn(() => 0),
     resolveIterDir: vi.fn((): IterDirInfo | null => null),
     teardownIterDir: vi.fn(async () => {}),
@@ -429,8 +436,10 @@ describe("runSupervisor", () => {
     expect(io.spawnSlot).toHaveBeenCalledWith(1);
     // Stop-file honoured → workers terminated.
     expect(io.killTree).toHaveBeenCalled();
-    // Stopped on the first tick → no inter-tick sleep happened.
-    expect(io.sleep).not.toHaveBeenCalled();
+    // Stopped on the first tick: guardedTick calls sleep(ceiling) once per tick,
+    // but the inter-tick CADENCE sleep is never reached (the loop returns first).
+    expect(io.sleep).toHaveBeenCalledTimes(1);
+    expect(io.sleep).toHaveBeenCalledWith(120000);
   });
 
   it("sleeps the poll cadence between ticks before stopping on the 2nd", async () => {
@@ -447,9 +456,10 @@ describe("runSupervisor", () => {
 
     await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15 }), stop);
 
-    // Exactly one inter-tick sleep, at the configured cadence (15s → 15000ms).
-    expect(io.sleep).toHaveBeenCalledTimes(1);
+    // Exactly one inter-tick CADENCE sleep at 15s (filtering out the per-tick
+    // guardedTick ceiling sleeps, which use config.tickTimeoutS).
     expect(io.sleep).toHaveBeenCalledWith(15000);
+    expect(io.sleep.mock.calls.filter((c) => c[0] === 15000)).toHaveLength(1);
   });
 
   it("honours a non-default poll cadence", async () => {
@@ -460,8 +470,8 @@ describe("runSupervisor", () => {
 
     await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 7 }), stop);
 
-    expect(io.sleep).toHaveBeenCalledTimes(1);
     expect(io.sleep).toHaveBeenCalledWith(7000);
+    expect(io.sleep.mock.calls.filter((c) => c[0] === 7000)).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Closes #446.

## Root cause (the real reason the AFK could not self-merge)
`runSupervisor` wraps each tick in `guardedTick`, which **races the tick against `sleep(ceiling)`**. The `runSupervisor` tests mocked `deps.proc.sleep` as an **immediately-resolving** `vi.fn`, so the ceiling won every race → guardedTick discarded the real `{stopped:true}` → the `for(;;)` loop **spun forever**, ballooning heap to ~2GB and **OOM-crashing the whole `pnpm test` run**. The AFK feedback gate read that crash as a test failure → **false `blocked:validation`** on every `afk/*` attempt touching the dev package.

Production was never affected (real `sleep` is a timer that never beats a sub-second tick); the tests just weren't updated when `guardedTick` landed.

## Fix
- The mocked `sleep` resolves on a **macrotask** (`setTimeout(…, 0)`) so the tick wins the race and `stopped` propagates.
- Updated the three `runSupervisor` assertions for guardedTick's per-tick ceiling sleep (filter the cadence sleeps by arg).

## Validation
- `supervisor.test.ts` alone: **31/31, 171ms** (was hang/OOM).
- Full dev suite: **917/917 in ~77s** (was OOM-crashing at ~64/65 files).

This is *the* unlock for autonomous throughput — the gate stops false-failing, so the AFK can self-merge again. Test-only change; no production code touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783107251&installation_id=129708444&pr_number=464&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F464&signature=277fa330f36f8cea7e0f52ef782fa82c978f58852fdb599ad69c4e5e34eecd79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for timing-sensitive supervisor behavior by fixing mock resolution timing and updating expectations for stop-file handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->