### PR TITLE
fix(afk): orphan sweep skips LIVE sibling workers — no more reaping a running attempt (#444)

### DIFF
--- a/src/apps/dev/src/runtime/fs.ts
+++ b/src/apps/dev/src/runtime/fs.ts
@@ -203,6 +203,13 @@ export async function listOrphanDirs(workersRoot: string, nowS: number): Promise
   }
   for (const worker of workers) {
     const workerPath = join(workersRoot, worker);
+    // #444: only reap attempt dirs whose parent worker is DEAD. A live worker
+    // (its `worker.pid` is alive) owns its attempts; a newly-booted parallel
+    // worker's orphan sweep MUST skip them — otherwise it reaps a live sibling's
+    // running issue (restores it to ready-for-agent + rm -rf's the live worktree).
+    // A missing/blank/dead pid → treated as dead (the conservative orphan path),
+    // matching listStaleClaimDirs / listLegacyWorkDirs.
+    if (pidAlive(await readText(join(workerPath, "worker.pid")))) continue;
     let attempts: string[];
     try {
       attempts = await readdir(workerPath);
@@ -215,6 +222,10 @@ export async function listOrphanDirs(workersRoot: string, nowS: number): Promise
       let ageS = 0;
       try {
         const st = await stat(dir);
+        // Only attempt DIRECTORIES are orphans — skip the per-worker `worker.pid`
+        // file (the liveness anchor) and any stray file, so they are never listed
+        // as orphans (and never `removeDir`'d via the orphan path).
+        if (!st.isDirectory()) continue;
         ageS = Math.max(0, nowS - Math.floor(st.mtimeMs / 1000));
       } catch {
         continue;

--- a/src/apps/dev/tests/fs-sweep.test.ts
+++ b/src/apps/dev/tests/fs-sweep.test.ts
@@ -3,7 +3,12 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
-import { listStaleClaimDirs, listLegacyWorkDirs, tryAcquireClaimDir } from "../src/runtime/fs.js";
+import {
+  listStaleClaimDirs,
+  listLegacyWorkDirs,
+  tryAcquireClaimDir,
+  listOrphanDirs,
+} from "../src/runtime/fs.js";
 
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), "afk-sweep-"));
@@ -153,6 +158,51 @@ describe("listLegacyWorkDirs", () => {
       const orphan = join(root, "work-cccc");
       mkdirSync(orphan, { recursive: true });
       expect(await listLegacyWorkDirs(root)).toEqual([orphan]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("listOrphanDirs (#444 — skip live siblings)", () => {
+  it("returns a dead worker's attempt dir as an orphan", async () => {
+    const root = scratch();
+    try {
+      const att = join(root, "wDEAD", "190-a1");
+      mkdirSync(att, { recursive: true });
+      writeFileSync(join(root, "wDEAD", "worker.pid"), DEAD_PID);
+      const orphans = await listOrphanDirs(root, Math.floor(Date.now() / 1000));
+      expect(orphans.map((o) => o.path)).toEqual([att]);
+      expect(orphans[0]!.issue).toBe(190);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats a worker with no worker.pid as dead (its attempts are orphans)", async () => {
+    const root = scratch();
+    try {
+      const att = join(root, "wNOPID", "7-a1");
+      mkdirSync(att, { recursive: true });
+      const orphans = await listOrphanDirs(root, Math.floor(Date.now() / 1000));
+      expect(orphans.map((o) => o.path)).toEqual([att]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("SKIPS a LIVE worker's attempt dirs — never reaps a live sibling", async () => {
+    const root = scratch();
+    try {
+      const live = join(root, "wLIVE", "363-a1");
+      mkdirSync(live, { recursive: true });
+      writeFileSync(join(root, "wLIVE", "worker.pid"), ALIVE_PID);
+      // a dead sibling alongside the live one is still collected
+      const dead = join(root, "wDEAD", "9-a1");
+      mkdirSync(dead, { recursive: true });
+      writeFileSync(join(root, "wDEAD", "worker.pid"), DEAD_PID);
+      const orphans = await listOrphanDirs(root, Math.floor(Date.now() / 1000));
+      expect(orphans.map((o) => o.path)).toEqual([dead]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #444.

`listOrphanDirs` globbed **every** `.red/tmp/workers/*/*` attempt dir and returned them all — it **never checked the parent `worker.pid` liveness**, unlike its siblings `listStaleClaimDirs`/`listLegacyWorkDirs`. So a newly-booted parallel worker's boot orphan-sweep classified a **live** sibling's running attempt as orphaned → restored its issue to `ready-for-agent` + `rm -rf`'d the live worktree ("orchestrator died mid-issue"). It stayed latent only because normally no sibling is live at boot (observed live when a 2nd worker was spawned alongside a running one).

**Fix:** skip a worker entirely when its `worker.pid` is alive (missing/blank/dead → treated as dead, the conservative orphan path, matching the claim/legacy sweeps). Also skip non-directory entries so the `worker.pid` file is never listed as a bogus orphan.

Tests: dead worker → orphan; no-pid → orphan; **live sibling → skipped** (only the dead sibling collected). Dev suite 920/920.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783107670&installation_id=129708444&pr_number=465&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F465&signature=5210d93f11cadcc1f20a131439705102a48cef41131e36d067ff3944d6edb378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved orphan cleanup logic to prevent accidental removal of attempt directories belonging to active worker processes.
  * Enhanced directory enumeration to only target attempt subdirectories, ignoring non-directory filesystem entries during cleanup operations.

* **Tests**
  * Added test coverage for orphan directory cleanup scenarios, including verification that active workers are properly excluded from cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->