### PR TITLE
fix(afk): slugifyRef trailing dash after slice → sandcastle 'is not a working tree' (#442)

### DIFF
--- a/src/apps/dev/src/core/remote-branch.ts
+++ b/src/apps/dev/src/core/remote-branch.ts
@@ -38,11 +38,19 @@ const REF_RE = /^afk(-attempts)?\/[A-Za-z0-9._-]+\/[0-9]+-[a-z0-9-]+$/;
 /** Lowercase / collapse-to-dash / trim-dashes / cap-40 title slug. Mirrors
  * afk_ref_slugify in lib/branch-ref.sh. */
 export function slugifyRef(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40)
+      // The slice can land mid-word and re-introduce a TRAILING dash after the
+      // earlier trim (e.g. "…hide-a-duplicate-"). That trailing-dash slug feeds
+      // the branch ref and the sandcastle worktree name, which gets normalised
+      // inconsistently downstream → `fatal: … is not a working tree` (#442).
+      // Re-trim trailing dashes after the slice so the slug is always clean.
+      .replace(/-+$/g, "")
+  );
 }
 
 /** True for a well-formed live or attempt ref. Mirrors afk_ref_validate. */

--- a/src/apps/dev/tests/remote-branch.test.ts
+++ b/src/apps/dev/tests/remote-branch.test.ts
@@ -45,6 +45,15 @@ describe("remote-branch ref construction", () => {
     expect(slugifyRef("Fix the Thing!!")).toBe("fix-the-thing");
     expect(buildRef("afk", "wABC", 7, "Fix the Thing!!")).toBe("afk/wABC/7-fix-the-thing");
   });
+
+  it("never ends in a trailing dash even when the 40-char slice lands mid-word (#442)", () => {
+    // This exact title sliced to "…hide-a-duplicate-" → the malformed worktree
+    // name behind `fatal: … is not a working tree`.
+    const slug = slugifyRef("Memory soft-merge edge: hide a duplicate node from recall without deleting it");
+    expect(slug.endsWith("-")).toBe(false);
+    expect(slug).toBe("memory-soft-merge-edge-hide-a-duplicate");
+    expect(slug.length).toBeLessThanOrEqual(40);
+  });
 });
 
 describe("pushInitial (live namespace)", () => {


### PR DESCRIPTION
Closes #442.

`slugifyRef` trimmed leading/trailing dashes and **then** `.slice(0, 40)`, so a slice landing mid-word **re-introduced a trailing dash** — e.g. #301's title `Memory soft-merge edge: hide a duplicate node…` → `memory-soft-merge-edge-hide-a-duplicate-`. That trailing-dash slug fed the branch ref **and** the sandcastle worktree name (`afk-wSG0G-301-…-duplicate-`), which got normalised inconsistently downstream → `fatal: … is not a working tree`, crashing worker wSG0G mid-attempt (observed while babysitting).

**Fix:** re-trim trailing dashes after the slice (one `.replace(/-+$/g, "")`). Regression test uses the exact #301 title. `remote-branch.test.ts` 16/16; typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783108129&installation_id=129708444&pr_number=467&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F467&signature=5bfb51fb73e9f7c85774b82bb71a25dcb518431d066deda25aaeefcb38311610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch reference naming to ensure generated branch identifiers no longer contain trailing dashes, resulting in cleaner and more reliable branch names across the platform.

* **Tests**
  * Added test coverage to verify branch identifiers are properly formatted and never end with unwanted trailing characters, even when names are truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->