### PR TITLE
fix(afk): heartbeat/monitor diff reads the real sandcastle worktree (kills the +0 -0 phantom)

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -500,8 +500,20 @@ export function buildProcessDeps(
       const lastProgressAt = new Date(info.lastProgressMs).toISOString();
       const head = info.head ?? "";
       void (async () => {
+        // sandcastle creates the agent's worktree at
+        // `{attemptDir}/.sandcastle/worktrees/{slug}`, NOT the legacy
+        // `{attemptDir}/worktree` the state seeds — diffing the latter fails
+        // (it never exists) and every tick read a permanent `+0 -0` even with a
+        // dirty worktree, which also starved the attempt-progress guard's
+        // proof-of-life. Resolve the real worktree from `git worktree list`,
+        // and persist it into `current.worktree` so the monitor (which reads
+        // that field for its own diffstat) gets the live path too. Fall back to
+        // the legacy path only when no worktree is registered yet.
+        const worktree =
+          (await gitx.worktreePathUnder(gitCtx, current.attemptDir).catch(() => undefined)) ??
+          join(current.attemptDir, "worktree");
         const { added, removed } = await gitx
-          .diffstatShortstat({ cwd: join(current.attemptDir, "worktree") }, "origin/main")
+          .diffstatShortstat({ cwd: worktree }, "origin/main")
           .catch(() => ({ added: 0, removed: 0 }));
         const hb = buildProgressHeartbeat({
           secsSinceProgress: secs,
@@ -515,7 +527,10 @@ export function buildProcessDeps(
           fields: { extra: hb.extra },
         }).catch(() => {});
         await fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${hb.msg}`);
-        await updateState(join(current.attemptDir, "afk.state.json"), hb.statePatch).catch(() => {});
+        await updateState(join(current.attemptDir, "afk.state.json"), {
+          ...hb.statePatch,
+          "current.worktree": worktree,
+        }).catch(() => {});
       })();
     },
     historyPath: paths.historyPath,

--- a/src/apps/dev/src/runtime/git.ts
+++ b/src/apps/dev/src/runtime/git.ts
@@ -246,6 +246,28 @@ export async function worktreePathForBranch(ctx: GitContext, branch: string): Pr
 }
 
 /**
+ * Resolve the worktree path registered under `dirPrefix` (the attempt dir),
+ * parsed from `git worktree list --porcelain`. sandcastle creates the agent's
+ * worktree at `{attemptDir}/.sandcastle/worktrees/{slug}`, but the state file's
+ * `current.worktree` is seeded to the legacy `{attemptDir}/worktree` path that
+ * never exists — so a `git diff` there fails and the heartbeat / monitor read a
+ * permanent `+0 -0` even with a dirty worktree (the sandcastle-blind hazard). An
+ * attempt has exactly one worktree, so the first match under `dirPrefix` is it.
+ * Returns undefined when none is registered yet (pre-worktree ticks). Routed
+ * through the same `runGit` seam so tests drive it without an OS git.
+ */
+export async function worktreePathUnder(ctx: GitContext, dirPrefix: string): Promise<string | undefined> {
+  const r = await runGit(ctx, ["worktree", "list", "--porcelain"]);
+  if (r.code !== 0) return undefined;
+  const prefix = dirPrefix.replace(/\/+$/, "");
+  for (const line of r.stdout.split("\n")) {
+    const w = /^worktree\s+(.+)$/.exec(line.trim());
+    if (w && w[1] && (w[1] === prefix || w[1].startsWith(`${prefix}/`))) return w[1];
+  }
+  return undefined;
+}
+
+/**
  * Salvage uncommitted work an inner agent left in its worktree without
  * committing. Observed with the codex runner: the agent edits files, passes the
  * gates, and emits `<promise>DONE</promise>`, but never runs `git commit` — so

--- a/src/apps/dev/tests/runtime-git-branch.test.ts
+++ b/src/apps/dev/tests/runtime-git-branch.test.ts
@@ -4,6 +4,7 @@ import {
   fetchBranch,
   changedFiles,
   worktreePathForBranch,
+  worktreePathUnder,
   salvageUncommitted,
 } from "../src/runtime/git.js";
 import type { GitContext } from "../src/runtime/git.js";
@@ -106,6 +107,48 @@ describe("worktreePathForBranch", () => {
     const { exec } = recordingExec(() => ok(porcelain));
     const ctx: GitContext = { cwd: "/repo", exec };
     expect(await worktreePathForBranch(ctx, "afk/w/9-absent")).toBeUndefined();
+  });
+});
+
+describe("worktreePathUnder (sandcastle-blind heartbeat fix)", () => {
+  // sandcastle registers its worktree under the attempt dir; the legacy
+  // `{attemptDir}/worktree` path the state seeds never exists.
+  const porcelain = [
+    "worktree /repo",
+    "HEAD aaaaaaa",
+    "branch refs/heads/main",
+    "",
+    "worktree /repo/.red/tmp/workers/wQDOR/894-a1/.sandcastle/worktrees/afk-wQDOR-894-x",
+    "HEAD bbbbbbb",
+    "branch refs/heads/afk/wQDOR/894-x",
+    "",
+  ].join("\n");
+
+  it("resolves the real sandcastle worktree registered under the attempt dir", async () => {
+    const { exec, calls } = recordingExec(() => ok(porcelain));
+    const ctx: GitContext = { cwd: "/repo", exec };
+    expect(await worktreePathUnder(ctx, "/repo/.red/tmp/workers/wQDOR/894-a1")).toBe(
+      "/repo/.red/tmp/workers/wQDOR/894-a1/.sandcastle/worktrees/afk-wQDOR-894-x",
+    );
+    expect(calls[0]).toEqual(["git", "worktree", "list", "--porcelain"]);
+  });
+
+  it("tolerates a trailing slash on the prefix", async () => {
+    const { exec } = recordingExec(() => ok(porcelain));
+    expect(await worktreePathUnder({ cwd: "/repo", exec }, "/repo/.red/tmp/workers/wQDOR/894-a1/")).toBe(
+      "/repo/.red/tmp/workers/wQDOR/894-a1/.sandcastle/worktrees/afk-wQDOR-894-x",
+    );
+  });
+
+  it("does not match a sibling attempt dir that only shares a prefix string", async () => {
+    // `894-a1` must not match `894-a10` (guards the `startsWith(prefix + '/')` form).
+    const { exec } = recordingExec(() => ok(porcelain));
+    expect(await worktreePathUnder({ cwd: "/repo", exec }, "/repo/.red/tmp/workers/wQDOR/894-a")).toBeUndefined();
+  });
+
+  it("returns undefined when no worktree is registered under the prefix yet", async () => {
+    const { exec } = recordingExec(() => ok("worktree /repo\nbranch refs/heads/main\n"));
+    expect(await worktreePathUnder({ cwd: "/repo", exec }, "/repo/.red/tmp/workers/wQDOR/894-a1")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem (observed live on reddb #894, codex runner)

The attempt heartbeat shows a line-diff (`+A -R`) so you can see progress between commits. But it was stuck at **`+0 -0` for the entire run** even with substantial work in the worktree:

```
heartbeat:      …1140s since last commit @ 7cbb0beb · +0 -0     ← phantom
real worktree:  3 files changed, 228 insertions(+), 29 deletions(-)
```

**Root cause:** `emitHeartbeat` computes the diff with `diffstatShortstat({ cwd: join(attemptDir, "worktree") })`, but sandcastle creates the agent's worktree at `{attemptDir}/.sandcastle/worktrees/{slug}` — the legacy `{attemptDir}/worktree` path **never exists**. `git diff` there fails (`fatal: cannot change to …/worktree`), the error is swallowed → `{added:0, removed:0}` → `+0 -0`.

Impact:
- No real progress precision (the whole point of the diff field).
- Starved the **attempt-progress guard** proof-of-life (it keys off commit-anchored progress; a non-committing runner + a phantom diff = looks stalled).
- Hit the **codex runner** hardest — it doesn't commit mid-run, so there was nothing committed to show either.
- Same blind spot in the **monitor** dashboard, which reads `state.current.worktree` (the same phantom path) for its diff column.

## Fix

- `worktreePathUnder(ctx, dirPrefix)` (runtime/git.ts) — resolve the worktree registered under the attempt dir via `git worktree list --porcelain` (sibling of the salvage's `worktreePathForBranch`, same `runGit` seam → testable).
- `emitHeartbeat` (run.ts) — diff the **real** worktree, and persist it into `current.worktree` so the **monitor gets the live path for free**. Falls back to the legacy path when no worktree is registered yet (pre-worktree ticks).

Now the heartbeat shows `+228 -29` climbing instead of `+0 -0`, and the progress guard sees genuine activity.

## Tests
- 4 new `worktreePathUnder` unit tests (real-path resolution, trailing-slash, **sibling-prefix guard** so `894-a1` ≠ `894-a10`, not-registered-yet).
- Full `src/apps/dev` suite: **938/938**, typecheck clean.

## Lineage
Same sandcastle-blind path hazard as the DONE-without-commit salvage (ADR 0050 / #468) and the monitor note (#392). This closes the heartbeat/monitor half.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783118046&installation_id=129708444&pr_number=469&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F469&signature=f184507c9899cf27d6a3cc782565c0320a3589af0341d9e93cf5f149499c0555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree path detection in the heartbeat monitoring system to more reliably identify and track the correct working directory.

* **Tests**
  * Added comprehensive test coverage for worktree path resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->