### PR TITLE
fix(afk): attempt-progress guard resets on worktree edits, not just commits (ADR 0051)

### DIFF
--- a/.red/adr/0051-afk-attempt-guard-resets-on-worktree-edits-not-just-commits.md
+++ b/.red/adr/0051-afk-attempt-guard-resets-on-worktree-edits-not-just-commits.md
@@ -1,0 +1,38 @@
+# ADR 0051 — AFK attempt-progress guard resets on worktree edits, not just commits
+
+## Status
+
+accepted. Refines ADR 0044 (commit-anchored attempt-progress guard) and ADR 0045 (externalized proof-of-life). Depends on the heartbeat/monitor worktree-path fix (the `worktreePathUnder` / real-worktree diff) so the line-volume signal is real and not a `+0 -0` phantom.
+
+## Context
+
+ADR 0044 armed an attempt-progress guard that aborts an attempt when **no new commit** lands on the worker branch within a wall-clock cap (default 45 min). That was correct for the Claude runner, which commits incrementally as it works.
+
+The **codex runner does not commit mid-run** — it edits the worktree, runs the gates, and commits only at the end (and even then sometimes not at all, see ADR 0050). So for codex, "time since last commit" is not a progress signal: on any issue that takes longer than the cap, the guard aborts a fully-productive agent.
+
+This was observed live on reddb (2026-06-03), twice in one fleet run:
+
+- **#894** (WAL fdatasync): codex produced +228 lines, then the guard aborted it at the 45-min mark for "no commit."
+- **#895** (skip DWB on CoW): codex produced **+497 lines**, passed `cargo check` and `cargo fmt`, and was on the **final** focused test when the guard aborted it at 46m20s. The work was essentially complete.
+
+Both attempts were parked `blocked:stalled` → `ready-for-human`, and because the abort is a `timeout` (not `done`/`no-sentinel`), the ADR 0050 salvage did not run — so 725 lines of green work were stranded in the worktrees. The guard, meant to catch a stuck agent, was instead killing the most productive ones.
+
+## Decision
+
+The guard gains a **second progress signal**: the worker worktree's changed-line **volume** (added + removed vs the merge-base, committed AND uncommitted — the same real-worktree diff the heartbeat now reads). Each poll, the deadline resets when **either**:
+
+- a new commit landed (HEAD changed — the ADR 0044 signal), **or**
+- the line-volume **changed** since the previous poll (the agent edited the worktree).
+
+A change in either direction counts (an edit that nets to fewer lines is still activity). The guard fires only when **neither** a commit nor an edit has happened within the cap — i.e. the agent is genuinely producing nothing, which is the real "stalled" condition.
+
+The edit signal is supplied via an optional `progressProbe`; when absent (or when it rejects), the guard degrades to the pure commit-anchored behaviour of ADR 0044, so no caller regresses and a probe failure can never cause a false *reset*.
+
+## Consequences
+
+- A productive-but-not-committing runner (codex) is no longer falsely stalled. #895 would have reset its deadline on every poll while the +497 lines accrued.
+- The guard still catches a truly stuck agent: a chatty agent producing no code edits, or a hung process, leaves both signals flat and aborts at the cap — the ADR 0044 intent is preserved, just made precise ("no progress" = no commit AND no edit, not merely "no commit").
+- Completes the trio against the codex-doesn't-commit hazard: AGENT-PROMPT step 5 (prevent), ADR 0050 salvage (cure a DONE-without-commit), and this (stop killing the agent before it can finish). It also reduces stranded-work incidents, since fewer attempts reach the un-salvaged `timeout` terminal.
+- Relies on the real-worktree diff (sandcastle worktree, not the `{attemptDir}/worktree` phantom); a regression there would silently drop the edit signal back to commit-anchored, which is safe but reintroduces the false-stall.
+
+Memory-NoIngest: ADR + runtime fix; the canonical guard contract claim stays with ADR 0044.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -37,6 +37,7 @@ stale notes inline.
 - **0048** AFK merges without advice; in-process backpressure (`drift-guard` + feedback) is the guardrail — opt into waiting with `afk.merge.wait_for_review` *(refines 0030, 0008)*
 - **0049** Model-tier routing embedded in the plugin (single config source), enforced by the shared skill + hooks + sandcastle trio, per runner *(relates 0003, 0033)*
 - **0050** AFK salvages an uncommitted worktree when the inner agent emits DONE without committing (codex non-compliance net) *(complements 0047, 0028)*
+- **0051** AFK attempt-progress guard resets on worktree edits, not just commits — stops false-stalling the productive-but-not-committing codex runner *(refines 0044, 0045)*
 
 ## Branch lock
 - **0006** Branch lock enforces on the agent only, not the human terminal

--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -228,6 +228,17 @@ export interface RunAgentInput {
    */
   headProbe?: () => Promise<string | undefined>;
   /**
+   * Returns a monotone-ish "work volume" for the worker's worktree — the total
+   * changed lines (added + removed) vs the merge-base, committed AND uncommitted.
+   * The guard treats a CHANGE in this value between polls as progress and resets
+   * the deadline, so a runner that edits without committing (codex emits DONE
+   * only at the end) is not falsely stalled while it is actively producing code.
+   * Best-effort: resolves `undefined` on any failure (no edit signal → the guard
+   * falls back to the commit-anchored `headProbe` alone — the prior behaviour).
+   * Optional: when absent, the guard is purely commit-anchored (ADR 0044).
+   */
+  progressProbe?: () => Promise<number | undefined>;
+  /**
    * Externalized proof-of-life sink (PR-B): invoked once per attempt-guard poll
    * with the progress signal. Opaque to execution.ts — the caller (processIssue)
    * uses it to fire the `on_heartbeat` hook + emit the heartbeat record/state.
@@ -517,6 +528,10 @@ export function startAttemptGuard(opts: {
   now: () => number;
   schedule: (fn: () => void, ms: number) => () => void;
   abort: () => void;
+  /** Worktree line-volume probe (ADR 0051): a CHANGE between polls counts as
+   * progress and resets the deadline, so an editing-but-not-committing runner
+   * (codex) is not falsely stalled. Optional → guard stays commit-anchored. */
+  progressProbe?: () => Promise<number | undefined>;
   /** Fired once per poll (proof-of-life externalization): the externalized
    * heartbeat + on_heartbeat hook ride this same cadence (PR-B). Never throws —
    * the caller wraps its own IO. */
@@ -524,30 +539,45 @@ export function startAttemptGuard(opts: {
 }): { stop: () => void; firedTimeout: () => boolean } {
   let lastProgress = opts.now();
   let lastHead: string | undefined;
+  let lastVolume: number | undefined;
   let fired = false;
   const cancel = opts.schedule(() => {
-    void opts
-      .headProbe()
-      .then((head) => {
-        if (fired) return;
-        if (head !== undefined && head !== lastHead) {
-          // A new commit landed — real progress; reset the deadline.
-          lastHead = head;
-          lastProgress = opts.now();
-        } else if (opts.now() - lastProgress >= opts.capMs) {
-          fired = true;
-          opts.abort();
+    void (async () => {
+      if (fired) return;
+      // Commit signal (always present). A headProbe rejection = no progress
+      // observed (let the deadline run), matching the prior commit-anchored
+      // behaviour exactly when no progressProbe is supplied.
+      let head: string | undefined;
+      let headOk = true;
+      try {
+        head = await opts.headProbe();
+      } catch {
+        headOk = false;
+      }
+      if (fired) return;
+      // Edit signal (optional). A new commit OR a change in the worktree's
+      // line-volume since the last poll is real progress → reset the deadline.
+      let volume: number | undefined;
+      if (opts.progressProbe) {
+        try {
+          volume = await opts.progressProbe();
+        } catch {
+          volume = undefined;
         }
-        opts.onTick?.({ head: head ?? lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
-      })
-      .catch(() => {
-        // headProbe failure = no progress observed; let the deadline run.
-        if (!fired && opts.now() - lastProgress >= opts.capMs) {
-          fired = true;
-          opts.abort();
-        }
-        opts.onTick?.({ head: lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
-      });
+      }
+      if (fired) return;
+      const committed = headOk && head !== undefined && head !== lastHead;
+      const edited = volume !== undefined && lastVolume !== undefined && volume !== lastVolume;
+      if (committed || edited) {
+        lastProgress = opts.now();
+      } else if (opts.now() - lastProgress >= opts.capMs) {
+        fired = true;
+        opts.abort();
+      }
+      if (headOk && head !== undefined) lastHead = head;
+      if (volume !== undefined) lastVolume = volume;
+      opts.onTick?.({ head: head ?? lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
+    })();
   }, opts.intervalMs);
   return { stop: cancel, firedTimeout: () => fired };
 }
@@ -602,6 +632,7 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       capMs,
       intervalMs: Math.min(capMs, 60_000),
       headProbe: input.headProbe,
+      ...(input.progressProbe ? { progressProbe: input.progressProbe } : {}),
       now,
       schedule: deps.schedule ?? defaultSchedule,
       abort: () =>

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -187,6 +187,18 @@ export function makeRunAgent(
         ? {
             attemptTimeoutSeconds: attemptTimeout,
             headProbe: () => gitx.branchHead({ cwd: input.cwd ?? process.cwd() }, input.branch),
+            // Edit signal (ADR 0051): the changed-line volume of the agent's real
+            // worktree (committed + uncommitted). A change between polls resets
+            // the deadline, so a runner that edits without committing (codex) is
+            // not falsely stalled. Resolve the worktree off the worker branch, and
+            // return undefined on any failure (guard degrades to commit-anchored).
+            progressProbe: async () => {
+              const gitCtx = { cwd: input.cwd ?? process.cwd() };
+              const worktree = await gitx.worktreePathForBranch(gitCtx, input.branch);
+              if (!worktree) return undefined;
+              const { added, removed } = await gitx.diffstatShortstat({ cwd: worktree }, "origin/main");
+              return added + removed;
+            },
           }
         : {}),
     });

--- a/src/apps/dev/tests/execution.test.ts
+++ b/src/apps/dev/tests/execution.test.ts
@@ -719,6 +719,113 @@ describe("runAgent — attempt guard wiring", () => {
   });
 });
 
+describe("startAttemptGuard — diff-anchored progress (ADR 0051, codex false-stall fix)", () => {
+  it("resets the deadline when the worktree diff GROWS even with no new commit (the #895 case)", async () => {
+    // codex edits without committing: head static, but changed-line volume climbs
+    // each poll. The guard must treat that as progress and never false-stall.
+    let clock = 0;
+    let volume = 10;
+    const sched = manualScheduler();
+    let aborted = false;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => volume,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    await sched.tick(); // t=0 anchor (volume=10)
+    for (const [t, v] of [
+      [50, 60],
+      [120, 140],
+      [220, 300],
+      [400, 497],
+    ] as const) {
+      clock = t;
+      volume = v;
+      await sched.tick(); // volume changed since last poll → deadline resets
+      expect(aborted).toBe(false);
+    }
+  });
+
+  it("still aborts when neither a commit NOR an edit lands within the cap (a genuine stall)", async () => {
+    let clock = 1000;
+    const sched = manualScheduler();
+    let aborted = false;
+    const g = startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => 42, // volume frozen → no edit signal
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    await sched.tick(); // anchor
+    clock = 1050;
+    await sched.tick();
+    expect(aborted).toBe(false);
+    clock = 1100;
+    await sched.tick(); // cap elapsed, no commit + frozen volume → abort
+    expect(aborted).toBe(true);
+    expect(g.firedTimeout()).toBe(true);
+  });
+
+  it("treats a volume change in EITHER direction as progress (edits then a partial revert)", async () => {
+    let clock = 0;
+    let volume = 100;
+    const sched = manualScheduler();
+    let aborted = false;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => volume,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    await sched.tick(); // anchor (100)
+    clock = 80;
+    volume = 60; // a revert is still activity
+    await sched.tick();
+    clock = 160;
+    await sched.tick(); // only 80ms since the last change → alive
+    expect(aborted).toBe(false);
+  });
+
+  it("degrades to commit-anchored when progressProbe rejects (never the cause of a false reset)", async () => {
+    let clock = 1000;
+    const sched = manualScheduler();
+    let aborted = false;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => {
+        throw new Error("worktree gone");
+      },
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    await sched.tick();
+    clock = 1100;
+    await sched.tick(); // probe throws → no edit signal → commit-anchored abort
+    expect(aborted).toBe(true);
+  });
+});
+
 // ---- externalized proof-of-life (PR-B): onTick / onHeartbeat ----
 
 describe("startAttemptGuard — onTick (externalized heartbeat cadence)", () => {


### PR DESCRIPTION
## Problem (observed live on reddb, twice in one run)

The attempt-progress guard (ADR 0044) aborts an attempt when **no new commit** lands within the wall-clock cap (~45 min). The **codex runner does not commit mid-run**, so on any issue slower than the cap it false-stalls a fully productive agent:

- **#894** (WAL fdatasync): +228 lines → aborted `blocked:stalled` at 45 min.
- **#895** (skip DWB on CoW): **+497 lines**, `cargo check` + `cargo fmt` green, on the **final** focused test → aborted at 46m20s.

Both were parked `ready-for-human`, and because a `timeout` abort skips the ADR 0050 salvage, ~725 lines of green work were stranded. The guard meant to catch stuck agents was killing the most productive ones.

## Fix

Add an optional `progressProbe` — the worker worktree's changed-line **volume** (added+removed vs merge-base, committed+uncommitted, the same real-worktree diff the heartbeat reads after #469). Each poll, the deadline resets when **either**:
- a new commit landed (HEAD changed — the ADR 0044 signal), **or**
- the line-volume **changed** since the last poll (the agent edited).

The guard fires only when **neither** happened within the cap — the real "stalled" condition. Absent/rejecting `progressProbe` → degrades to the prior commit-anchored behaviour (no regression; a probe failure can never cause a false *reset*).

## Why this is the right cut
- A chatty agent producing no edits, or a hung process, still leaves both signals flat → aborts at the cap. ADR 0044's intent ("catch the stuck agent") is preserved, just made precise: no progress = no commit **and** no edit.
- Completes the trio vs codex-doesn't-commit: AGENT-PROMPT step 5 (prevent) → ADR 0050 salvage (cure DONE-without-commit) → this (stop killing it before it finishes).

## Files
- `execution.ts` — `RunAgentInput.progressProbe` + `startAttemptGuard` edit-signal reset
- `wire.ts` — `makeRunAgent` supplies the worktree line-volume probe (guard-armed only)
- `.red/adr/0051-*` — the decision record

## Tests
- 4 new guard tests: diff-growth resets (the #895 case) / frozen-volume still aborts / change-in-either-direction / probe-reject degrades to commit-anchored.
- Full `src/apps/dev` suite: **942/942**, typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783120591&installation_id=129708444&pr_number=479&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F479&signature=a4aca6a28aa44810ff40b94d7b89d637a6dc5e3ecc2c8acd6c736a73c92161ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system now detects work progress through both code commits and active edits to the worktree, preventing legitimate work from being abandoned when the progress deadline is reached.

* **Documentation**
  * New decision record documents the updated attempt-progress guard detection behavior.

* **Tests**
  * Added comprehensive test coverage for edit-based progress detection, including fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->