### PR TITLE
build(release): one bundle-naming convention, all assets under ./dist/ (ADR 0052)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -257,11 +257,11 @@ jobs:
           RED_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
         run: |
           set -euo pipefail
-          # bundle:legacy keeps emitting dist-bundle/memory-cli.mjs the manifest +
-          # current bootstrap expect (ADR 0029). The new canonical
-          # dist/memory.bundle.min.mjs (ADR 0034) is built by `pnpm bundle`; both
-          # asset models coexist until the dynamic-fetch phase unifies them.
-          pnpm bundle:legacy
+          # ADR 0052: one canonical, minified bundle per entrypoint, all under
+          # ./dist/ (memory.bundle.min.mjs = CLI, memory-mcp.bundle.min.mjs = MCP).
+          # The legacy dist-bundle/*-cli.mjs model was removed; the bootstrap reads
+          # the asset names from this manifest, so the rename follows per-version.
+          pnpm bundle
           node --input-type=module <<'EOF'
           import { createHash } from 'node:crypto';
           import { readFileSync, writeFileSync } from 'node:fs';
@@ -288,16 +288,16 @@ jobs:
             if (!sha256) throw new Error(`invalid sha256 file for ${asset}`);
             redAssets[platform] = { asset, sha256 };
           }
-          const cli = readFileSync('dist-bundle/memory-cli.mjs');
-          const mcp = readFileSync('dist-bundle/memory-mcp.mjs');
+          const cli = readFileSync('../../../dist/memory.bundle.min.mjs');
+          const mcp = readFileSync('../../../dist/memory-mcp.bundle.min.mjs');
           const manifest = {
             schema: 'red.memory.runtime.v1',
             version: process.env.NEXT.replace(/^v/, ''),
-            cli: { asset: 'memory-cli.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
-            mcp: { asset: 'memory-mcp.mjs', sha256: createHash('sha256').update(mcp).digest('hex') },
+            cli: { asset: 'memory.bundle.min.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
+            mcp: { asset: 'memory-mcp.bundle.min.mjs', sha256: createHash('sha256').update(mcp).digest('hex') },
             reddb: { ...reddb, sdk, assets: redAssets },
           };
-          writeFileSync('memory-runtime-manifest.json', JSON.stringify(manifest, null, 2));
+          writeFileSync('../../../dist/memory-runtime-manifest.json', JSON.stringify(manifest, null, 2));
           console.log('runtime manifest:', JSON.stringify(manifest));
           EOF
 
@@ -316,7 +316,9 @@ jobs:
           RED_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
         run: |
           set -euo pipefail
-          pnpm bundle:legacy
+          # ADR 0052: canonical minified bundles under ./dist/ (brain.bundle.min.mjs
+          # = CLI, brain-mcp.bundle.min.mjs = MCP); legacy dist-bundle removed.
+          pnpm bundle
           node --input-type=module <<'EOF'
           import { createHash } from 'node:crypto';
           import { readFileSync, writeFileSync } from 'node:fs';
@@ -343,16 +345,16 @@ jobs:
             if (!sha256) throw new Error(`invalid sha256 file for ${asset}`);
             redAssets[platform] = { asset, sha256 };
           }
-          const cli = readFileSync('dist-bundle/brain-cli.mjs');
-          const mcp = readFileSync('dist-bundle/brain-mcp.mjs');
+          const cli = readFileSync('../../../dist/brain.bundle.min.mjs');
+          const mcp = readFileSync('../../../dist/brain-mcp.bundle.min.mjs');
           const manifest = {
             schema: 'red.brain.runtime.v1',
             version: process.env.NEXT.replace(/^v/, ''),
-            cli: { asset: 'brain-cli.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
-            mcp: { asset: 'brain-mcp.mjs', sha256: createHash('sha256').update(mcp).digest('hex') },
+            cli: { asset: 'brain.bundle.min.mjs', sha256: createHash('sha256').update(cli).digest('hex') },
+            mcp: { asset: 'brain-mcp.bundle.min.mjs', sha256: createHash('sha256').update(mcp).digest('hex') },
             reddb: { ...reddb, sdk, assets: redAssets },
           };
-          writeFileSync('brain-runtime-manifest.json', JSON.stringify(manifest, null, 2));
+          writeFileSync('../../../dist/brain-runtime-manifest.json', JSON.stringify(manifest, null, 2));
           console.log('brain runtime manifest:', JSON.stringify(manifest));
           EOF
 
@@ -457,12 +459,12 @@ jobs:
             dist/benchmark-memory.manifest.json \
             dist/benchmark-code-understanding.bundle.min.mjs \
             dist/benchmark-code-understanding.manifest.json \
-            src/apps/memory/dist-bundle/memory-cli.mjs \
-            src/apps/memory/dist-bundle/memory-mcp.mjs \
-            src/apps/memory/memory-runtime-manifest.json \
-            src/apps/brain/dist-bundle/brain-cli.mjs \
-            src/apps/brain/dist-bundle/brain-mcp.mjs \
-            src/apps/brain/brain-runtime-manifest.json
+            dist/memory.bundle.min.mjs \
+            dist/memory-mcp.bundle.min.mjs \
+            dist/memory-runtime-manifest.json \
+            dist/brain.bundle.min.mjs \
+            dist/brain-mcp.bundle.min.mjs \
+            dist/brain-runtime-manifest.json
 
       - name: Tag + GitHub Release
         if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
@@ -483,12 +485,12 @@ jobs:
             dist/benchmark-memory.manifest.json
             dist/benchmark-code-understanding.bundle.min.mjs
             dist/benchmark-code-understanding.manifest.json
-            src/apps/memory/dist-bundle/memory-cli.mjs
-            src/apps/memory/dist-bundle/memory-mcp.mjs
-            src/apps/memory/memory-runtime-manifest.json
-            src/apps/brain/dist-bundle/brain-cli.mjs
-            src/apps/brain/dist-bundle/brain-mcp.mjs
-            src/apps/brain/brain-runtime-manifest.json
+            dist/memory.bundle.min.mjs
+            dist/memory-mcp.bundle.min.mjs
+            dist/memory-runtime-manifest.json
+            dist/brain.bundle.min.mjs
+            dist/brain-mcp.bundle.min.mjs
+            dist/brain-runtime-manifest.json
             dist/release-manifest.json
           )
           if [ -n "$PREVIOUS" ]; then

--- a/.red/adr/0052-one-bundle-naming-convention-under-dist.md
+++ b/.red/adr/0052-one-bundle-naming-convention-under-dist.md
@@ -1,0 +1,37 @@
+# ADR 0052 — One bundle-naming convention, all release assets under `./dist/`
+
+## Status
+
+accepted. Supersedes the transitional dual-output state described in ADR 0029 (legacy `dist-bundle/*-cli.mjs`) for memory and brain. Aligns memory/brain with the ADR 0034/0038 single-bundle model the dev and code-nav apps already use.
+
+## Context
+
+The release shipped two parallel, inconsistent artifact shapes:
+
+- **dev, code-nav, benchmark-\*** → a single minified bundle in `./dist/`: `<app>.bundle.min.mjs` + `<app>.manifest.json`.
+- **memory, brain** → a non-minified pair under `src/apps/<app>/dist-bundle/`: `<app>-cli.mjs` + `<app>-mcp.mjs`, plus `<app>-runtime-manifest.json` written next to the package.
+
+The memory/brain build *already* produced the clean `dist/<app>.bundle.min.mjs` + `dist/<app>-mcp.bundle.min.mjs` via `pnpm bundle` — but the release ran `pnpm bundle:legacy` and shipped the `dist-bundle/*-cli.mjs` artifacts instead, leaving the clean bundles built and discarded. The result was incoherent: a `dist-bundle/` directory that shouldn't exist, non-minified 1.8 MB CLIs named `*-cli.mjs` (no `.bundle.min`), manifests outside `dist/`, and two naming schemes for the same concept.
+
+This was a half-finished migration (ADR 0029 → 0034): nobody removed the legacy half after adding the canonical one.
+
+## Decision
+
+One convention. Every release asset lives under `./dist/` and follows `<app>[-<role>].bundle.min.mjs`:
+
+- Single-entrypoint apps (dev, code-nav, benchmark-\*): `dist/<app>.bundle.min.mjs`.
+- Multi-entrypoint apps (memory, brain): `dist/<app>.bundle.min.mjs` (the CLI, the primary role) + `dist/<app>-mcp.bundle.min.mjs` (the MCP server).
+- The runtime manifest (which also pins the per-platform native `red` binary) stays a distinct, richer file — `dist/<app>-runtime-manifest.json` — because its schema differs from the single-checksum `<app>.manifest.json`. It now also lives under `./dist/`.
+
+Concretely: drop the `bundle:legacy*` scripts from memory and brain; the release runs `pnpm bundle` and reads/uploads the `dist/` bundles; the runtime manifest's `cli.asset` / `mcp.asset` fields name the `dist/` bundles.
+
+The plugin bootstraps are unaffected at the fetch layer: they read the asset names **from the version-pinned manifest**, so the rename follows automatically and every released version stays internally self-consistent (an old launcher + old tag resolves old names; a new launcher + new tag resolves new names — no cross-version break). Only the dev-checkout *local fallback* path is repointed from `src/apps/<app>/dist-bundle/` to `./dist/`. The version-keyed runtime cache filenames (`<runtimeRoot>/<version>/memory-cli.mjs`) are internal and unchanged, so `memory-bridge.sh` keeps resolving them.
+
+## Consequences
+
+- The `dist-bundle/` directory disappears; one place (`./dist/`), one pattern.
+- No coordinated-release hazard: the manifest is self-describing and version-pinned, so launchers and assets never have to ship in lockstep.
+- **Verification gap:** a wrong asset name or path here is NOT caught by CI — it only surfaces on a real `/plugin` install of memory/brain (the bootstrap fetch). This change MUST be install-smoke-tested before it is relied upon.
+- For **memory** this is interim: ADR 0041 migrates the memory plugin out to `red-memory`, at which point red-skills deletes the memory app entirely. Normalizing now keeps the shipping release coherent until that lands; it does not conflict (red-memory is a separate repo consumed via its own release).
+
+Memory-NoIngest: ADR + build/release plumbing; no canonical domain claim.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -23,6 +23,7 @@ stale notes inline.
 - **0038** Dev runtime ships as a fetched Release asset, not a committed bundle — supersedes 0032's committed-bundle model
 - **0039** Plugin entrypoints share one source, selected by a build role (unifies red-fetch/afk/code-nav/memory launchers)
 - **0040** Version is a single source, written by one script; CLIs & MCP launchers version-aware
+- **0052** One bundle-naming convention — all release assets under `./dist/` as `<app>[-<role>].bundle.min.mjs`; legacy `dist-bundle/*-cli.mjs` removed *(supersedes 0029's dual output for memory/brain)*
 
 ## AFK execution & lifecycle
 - **0003** Native task surface mirrors AFK worker state

--- a/plugins/brain/scripts/bootstrap.mjs
+++ b/plugins/brain/scripts/bootstrap.mjs
@@ -169,13 +169,13 @@ async function ensureRuntime(version) {
   return { cliPath, mcpPath, redPath };
 }
 
-/** Local repo-checkout fallback: built dist-bundle, else run the TS source via
+/** Local repo-checkout fallback: built ./dist bundle, else run the TS source via
  * tsx. Returns a spawn spec; `null` when nothing local is runnable. */
 function localCandidate(kind) {
-  const file = kind === "mcp" ? "brain-mcp.mjs" : "brain-cli.mjs";
+  const file = kind === "mcp" ? "brain-mcp.bundle.min.mjs" : "brain.bundle.min.mjs";
   const source = kind === "mcp" ? "src/mcp-server.ts" : "src/cli.ts";
   const candidates = [
-    { command: process.execPath, args: [join(REPO_ROOT, "src/apps/brain/dist-bundle", file)] },
+    { command: process.execPath, args: [join(REPO_ROOT, "dist", file)] },
     { command: process.execPath, args: ["--import", "tsx", join(REPO_ROOT, "src/apps/brain", source)] },
   ];
   for (const c of candidates) {

--- a/src/apps/brain/package.json
+++ b/src/apps/brain/package.json
@@ -14,13 +14,10 @@
   ],
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "build": "tsc -p tsconfig.build.json && pnpm bundle && pnpm bundle:legacy",
+    "build": "tsc -p tsconfig.build.json && pnpm bundle",
     "bundle": "pnpm bundle:cli && pnpm bundle:mcp",
     "bundle:cli": "node ../../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../../dist/brain.bundle.min.mjs --asset brain.bundle.min.mjs --minify --reddb-from-package",
     "bundle:mcp": "node ../../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile ../../../dist/brain-mcp.bundle.min.mjs --asset brain-mcp.bundle.min.mjs --minify --reddb-from-package",
-    "bundle:legacy": "pnpm bundle:legacy:cli && pnpm bundle:legacy:mcp",
-    "bundle:legacy:cli": "node ../../../scripts/bundle-app.mjs --entry src/cli.ts --outfile dist-bundle/brain-cli.mjs --asset brain-cli.mjs --reddb-from-package",
-    "bundle:legacy:mcp": "node ../../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile dist-bundle/brain-mcp.mjs --asset brain-mcp.mjs --reddb-from-package",
     "test": "vitest run",
     "dev": "node --import tsx src/cli.ts"
   },

--- a/src/apps/memory/package.json
+++ b/src/apps/memory/package.json
@@ -15,13 +15,10 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint:deterministic-extractors": "tsx src/deterministic-extractor-vocabulary-lint.ts",
-    "build": "pnpm lint:deterministic-extractors && tsc -p tsconfig.build.json && pnpm bundle && pnpm bundle:legacy",
+    "build": "pnpm lint:deterministic-extractors && tsc -p tsconfig.build.json && pnpm bundle",
     "bundle": "pnpm bundle:cli && pnpm bundle:mcp",
     "bundle:cli": "node ../../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../../dist/memory.bundle.min.mjs --asset memory.bundle.min.mjs --minify --reddb-from-package",
     "bundle:mcp": "node ../../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile ../../../dist/memory-mcp.bundle.min.mjs --asset memory-mcp.bundle.min.mjs --minify --reddb-from-package",
-    "bundle:legacy": "pnpm bundle:legacy:cli && pnpm bundle:legacy:mcp",
-    "bundle:legacy:cli": "node ../../../scripts/bundle-app.mjs --entry src/cli.ts --outfile dist-bundle/memory-cli.mjs --asset memory-cli.mjs --reddb-from-package",
-    "bundle:legacy:mcp": "node ../../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile dist-bundle/memory-mcp.mjs --asset memory-mcp.mjs --reddb-from-package",
     "test": "vitest run",
     "test:integration": "RED_MEMORY_RECALL_P50_TARGET_MS=250 vitest run --config vitest.integration.config.ts",
     "dev": "node --import tsx src/cli.ts"


### PR DESCRIPTION
## Problem
The release shipped **two inconsistent artifact shapes**:
- dev / code-nav / benchmark-* → `dist/<app>.bundle.min.mjs` (minified, in `dist/`) ✓
- **memory / brain** → `src/apps/<app>/dist-bundle/<app>-cli.mjs` + `<app>-mcp.mjs` (non-minified, wrong dir, no `.bundle.min`), manifest written outside `dist/`.

The clean `dist/<app>.bundle.min.mjs` was **already built by `pnpm bundle`** — but the release ran `pnpm bundle:legacy` and shipped the `dist-bundle/` artifacts instead, discarding the good ones. A half-finished migration (ADR 0029 → 0034) where nobody removed the legacy half.

## Fix (ADR 0052)
One convention: every release asset under `./dist/`, named `<app>[-<role>].bundle.min.mjs`.
- Drop `bundle:legacy*` from memory + brain `package.json`.
- Release runs `pnpm bundle`; the runtime-manifest + upload read `dist/<app>.bundle.min.mjs` (CLI) + `dist/<app>-mcp.bundle.min.mjs` (MCP) + `dist/<app>-runtime-manifest.json`.
- `plugins/brain/scripts/bootstrap.mjs` local dev-checkout fallback repointed `dist-bundle/` → `dist/`.

**Why it's low-coordination-risk:** the bootstraps read asset names **from the version-pinned manifest**, so the rename follows per-version and every released tag is internally self-consistent (no lockstep launcher↔asset release needed). The version-keyed runtime cache filenames (`…/memory-cli.mjs`) are internal and unchanged → `memory-bridge.sh` unaffected.

Bonus: the minified `dist/` bundles are **smaller** than the legacy non-minified ones (memory CLI 955K vs 1.8M).

## Verified
- `pnpm bundle` produces `dist/memory.bundle.min.mjs` + `dist/memory-mcp.bundle.min.mjs` (confirmed locally).
- Repo-wide grep: no remaining `dist-bundle` / `*-cli.mjs` / `bundle:legacy` consumers (except the intentional memory-bridge cache name).
- `red-release.yml` YAML + both `package.json` parse clean.

## ⚠️ Do NOT merge-and-release blindly
A wrong asset name/path here surfaces **only on a real `/plugin` install** of memory/brain (the bootstrap fetch), **not in CI**. Smoke-test the bootstrap fetch against a release built from this branch before relying on it.

## Scope note
For **memory** this is interim — ADR 0041 migrates the memory plugin to `red-memory`, after which red-skills deletes the memory app. Normalizing now keeps the shipping release coherent until then; it does not conflict (separate repo).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783128873&installation_id=129708444&pr_number=480&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F480&signature=79fa00ff9bb2b14c7e6df55c2527048f90c8e660b586407e70c16c472ce52b61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized release artifact naming convention for Memory and Brain runtimes under `./dist/` directory.
  * Simplified build process by removing legacy bundling scripts.
  * Updated GitHub Actions workflow to use canonical minified artifact model for runtime releases.
  * Updated bootstrap fallback logic to reference new artifact locations.

* **Documentation**
  * Added Architecture Decision Record (ADR 0052) documenting unified bundle naming and placement conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->