### PR TITLE
fix(afk): don't read gh rate-limit as an auth failure (Mode B fast-death)

### DIFF
--- a/src/apps/dev/src/runtime/gh.ts
+++ b/src/apps/dev/src/runtime/gh.ts
@@ -50,10 +50,43 @@ export async function ghInstalled(ctx: GhContext): Promise<boolean> {
   return r.code !== 127;
 }
 
-/** Check `gh auth status` succeeds. */
+/**
+ * Definitive "no usable credential" signals in `gh auth status` output: the
+ * token is absent or the host rejected it. ONLY these mean unauthenticated.
+ */
+const ghUnauthenticatedPattern =
+  /not logged in|no GitHub hosts|no accounts? (are )?logged|authentication required|requires authentication|bad credentials|token .*(invalid|expired|revoked)|run.*gh auth login/i;
+
+/**
+ * Transient `gh auth status` failures that DON'T mean unauthenticated: gh
+ * validates the configured token via a live API call, so a rate-limit / network
+ * / 5xx blip makes `gh auth status` exit non-zero while the credential is still
+ * present and valid. Treating these as "unauthenticated" is what bricked the
+ * whole fleet's boot precheck during a GitHub rate-limit burst — every worker
+ * respawn re-ran the precheck and died with a false "gh not authenticated".
+ */
+const ghAuthTransientPattern =
+  /rate limit|api rate limit|abuse detection|secondary rate|timed? ?out|timeout|temporarily unavailable|service unavailable|could not connect|connection (reset|refused)|dial tcp|i\/o timeout|\b5\d\d\b|EOF|TLS handshake/i;
+
+/**
+ * True when `gh` holds a usable credential.
+ *
+ * `gh auth status` exits 0 when the token validates. A non-zero exit is NOT
+ * automatically "unauthenticated": gh exits non-zero both on a real missing /
+ * rejected token AND on a transient failure of the validation API call (rate
+ * limit, network, 5xx) while a valid token is still configured. We discriminate
+ * on the report text (gh writes it to stderr): a definitive unauthenticated
+ * signal → false; a transient blip → true (token present, just couldn't
+ * validate now — boot proceeds and the individual gh calls degrade on their own
+ * `r.code !== 0` guards). An unrecognised non-zero stays conservative → false.
+ */
 export async function ghAuthenticated(ctx: GhContext): Promise<boolean> {
   const r = await runGh(ctx, ["auth", "status"]);
-  return r.code === 0;
+  if (r.code === 0) return true;
+  const report = `${r.stdout}\n${r.stderr}`;
+  if (ghUnauthenticatedPattern.test(report)) return false;
+  if (ghAuthTransientPattern.test(report)) return true;
+  return false;
 }
 
 /** List the ready-for-agent candidate pool projected to IssueCandidate[]. */

--- a/src/apps/dev/tests/gh-auth.test.ts
+++ b/src/apps/dev/tests/gh-auth.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { ghAuthenticated, type GhContext } from "../src/runtime/gh.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+/**
+ * Mode B regression (AFK fast-death taxonomy): `gh auth status` exits non-zero
+ * BOTH on a real missing/rejected token AND on a transient validation failure
+ * (rate-limit / network / 5xx) while a valid token is still configured. The old
+ * `r.code === 0` check collapsed the two — so a GitHub rate-limit burst made the
+ * boot precheck report "gh not authenticated" and brick every worker respawn.
+ * `ghAuthenticated` now discriminates on the report text.
+ */
+
+function execReturning(out: ExecOutput): ExecFn {
+  return () => Promise.resolve(out);
+}
+
+function ctxWith(out: ExecOutput): GhContext {
+  return { cwd: "/r", repo: "acme/widgets", exec: execReturning(out) };
+}
+
+describe("ghAuthenticated — rate-limit vs real auth failure", () => {
+  it("exit 0 → authenticated", async () => {
+    const out: ExecOutput = {
+      code: 0,
+      stdout: "",
+      stderr: "github.com\n  ✓ Logged in to github.com account octocat\n  ✓ Token: gho_****",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(true);
+  });
+
+  it("non-zero with a definitive 'not logged in' → unauthenticated", async () => {
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr: "You are not logged into any GitHub hosts. Run gh auth login to authenticate.",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(false);
+  });
+
+  it("non-zero with 'bad credentials' (rejected token) → unauthenticated", async () => {
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr: "github.com\n  X Failed to log in to github.com using token (GH_TOKEN)\n  error: Bad credentials",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(false);
+  });
+
+  it("non-zero from an API rate-limit burst → still authenticated (token is configured)", async () => {
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr:
+        "github.com\n  X Failed to log in to github.com using token (GH_TOKEN)\n" +
+        "  error validating token: API rate limit already exceeded for user ID 2805436.",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(true);
+  });
+
+  it("non-zero from a transient network/5xx blip → still authenticated", async () => {
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr: "github.com\n  X error connecting to api.github.com\n  503 Service Unavailable",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(true);
+  });
+
+  it("a real rate-limit error must NOT also trip the unauthenticated pattern", async () => {
+    // Guard against the two regexes overlapping: a rate-limit report carries no
+    // 'not logged in' / 'bad credentials' token, so it stays authenticated.
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr: "API rate limit exceeded. try again later",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(true);
+  });
+
+  it("unrecognised non-zero with no auth context → conservative unauthenticated", async () => {
+    const out: ExecOutput = { code: 1, stdout: "", stderr: "some unexpected gh failure" };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of the AFK fast-death investigation. **Mode B**: during a GitHub rate-limit burst, an AFK fleet run logged `ERROR: gh not authenticated — run 'gh auth login'` ×31 and bricked claims/labels fleet-wide — even though `gh` was fully authenticated.

## Root cause
`ghAuthenticated` (`src/apps/dev/src/runtime/gh.ts`) was `gh auth status` → `r.code === 0`. But `gh auth status` validates the configured token via a live API call, so it exits **non-zero on a transient rate-limit / network / 5xx blip while a valid token is still present**. The boot precheck (`boot.ts:85`) then fails with `gh-unauthenticated` and every supervisor respawn re-trips it.

This is structurally identical to the exhaustion-vs-crash collapse on the runner side: a rate-limit signal arriving in a shape the matcher does not recognise.

## Fix
Discriminate on the `gh auth status` report text:
- definitive unauthenticated (not logged in / bad credentials / token invalid/expired/revoked) → `false`
- transient blip (rate limit / abuse / network / 5xx / TLS) → `true` (token is configured; boot proceeds, and each gh call still degrades on its own `r.code !== 0` guard)
- unrecognised non-zero → conservative `false`

## Tests
New `tests/gh-auth.test.ts` (7 cases): exit-0, real not-logged-in, bad-credentials, API rate-limit, network/5xx, rate-limit-must-not-trip-unauth, unrecognised. Full dev suite: **928 passing** (the lone failing suite is `packages/shared/args.test.ts` failing to resolve `cli-args-parser` — an environmental worktree node_modules-symlink gap, verified passing in a normal checkout; unrelated to this change).

## Scope note
Touches AFK runtime source only; the shipped bundle is not rebuilt here (red-release is gated while a fleet runs). Follow-up still open: **Mode A** prevention — a stale-claims boot crash should self-heal or fail as a loud boot-error instead of masquerading as a per-issue no-sentinel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783130681&installation_id=129708444&pr_number=482&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F482&signature=2cf22787cdae986c9581ecbd74346781f5ceec2937ca46a3af490321d7d79d42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub authentication detection to accurately distinguish between credential validity issues and transient failures.

* **Tests**
  * Added comprehensive test coverage for authentication validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->