### PR TITLE
Memory governance reports tidy availability

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -3065,8 +3065,8 @@ async function runServe(args: ParsedArgs): Promise<void> {
   const token = tokenEnv ? process.env[tokenEnv] : undefined;
   if (tokenEnv && !token) throw new Error(`--token-env ${tokenEnv} is not set`);
 
-  const { store } = await openGraphStore(args);
-  const server = createMemoryHttpServer({ rootDir, store, token });
+  const { store, config } = await openGraphStore(args);
+  const server = createMemoryHttpServer({ rootDir, store, token, providerConfig: config.provider });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(port, host, () => {
@@ -4382,10 +4382,11 @@ async function runHealthViewer(args: ParsedArgs): Promise<void> {
 }
 
 async function runGovernance(args: ParsedArgs): Promise<void> {
-  const { store } = await openGraphStore(args);
+  const { store, config } = await openGraphStore(args);
   try {
     const report = await buildMemoryGovernanceReport(store, {
       staleProgressDays: intFlag(args.flags, "stale-progress-days"),
+      providerConfig: config.provider,
     });
     if (args.flags.json === true) {
       console.log(JSON.stringify(report, null, 2));
@@ -4399,10 +4400,11 @@ async function runGovernance(args: ParsedArgs): Promise<void> {
 
 async function runGovernanceViewer(args: ParsedArgs): Promise<void> {
   const rootDir = rootOf(args.flags);
-  const { store } = await openGraphStore(args);
+  const { store, config } = await openGraphStore(args);
   try {
     const report = await buildMemoryGovernanceReport(store, {
       staleProgressDays: intFlag(args.flags, "stale-progress-days"),
+      providerConfig: config.provider,
     });
     const artifact = buildMemoryGovernanceViewerArtifact(report);
     const outPath = resolve(
@@ -4424,6 +4426,10 @@ function printGovernance(report: MemoryGovernanceReport): void {
     `  provenance=${report.summary.nodes_with_provenance}/${report.summary.total_nodes} ` +
       `privacy=${report.summary.privacy_findings} lint=${report.summary.lint_findings} ` +
       `conflicts=${report.summary.unresolved_contradictions} superseded=${report.summary.superseded_nodes}`,
+  );
+  console.log(
+    `  tidy=${report.tidy_availability.status}` +
+      (report.tidy_availability.reason ? ` (${report.tidy_availability.reason})` : ""),
   );
   for (const item of report.provenance.missing.slice(0, 5)) {
     console.log(`  missing provenance: memory_nodes:${item.rid} ${item.title}`);

--- a/src/apps/memory/src/governance-viewer.ts
+++ b/src/apps/memory/src/governance-viewer.ts
@@ -81,7 +81,7 @@ function renderMemoryGovernanceViewer(report: MemoryGovernanceReport): string {
     .bad { color: var(--bad); }
     .metrics {
       display: grid;
-      grid-template-columns: repeat(6, minmax(0, 1fr));
+      grid-template-columns: repeat(7, minmax(0, 1fr));
       gap: 12px;
       margin: 20px 0;
     }
@@ -133,6 +133,7 @@ function renderMemoryGovernanceViewer(report: MemoryGovernanceReport): string {
       ${metric("Lint", report.summary.lint_findings)}
       ${metric("Conflicts", report.summary.unresolved_contradictions)}
       ${metric("Superseded", report.summary.superseded_nodes)}
+      ${metric("Tidy", report.tidy_availability.status)}
     </div>
     <div class="layout">
       <div class="stack">
@@ -143,6 +144,7 @@ function renderMemoryGovernanceViewer(report: MemoryGovernanceReport): string {
             ${signal("Privacy scan", `${report.privacy.findings.length} sensitive-looking finding(s), ${report.privacy.warnings.length} warning(s)`, report.privacy.findings.length > 0 ? "attention" : "ok")}
             ${signal("Memory lint", `${report.lint.findings.length} policy finding(s)`, report.lint.findings.length > 0 ? "attention" : "ok")}
             ${signal("Contradictions", `${report.summary.unresolved_contradictions} unresolved, ${report.summary.resolved_contradictions} resolved`, report.summary.unresolved_contradictions > 0 ? "attention" : "ok")}
+            ${signal("Tidy availability", `${report.tidy_availability.status}${report.tidy_availability.reason ? ` - ${report.tidy_availability.reason}` : ""}`, report.tidy_availability.status === "available" ? "ok" : "attention")}
           </ul>
         </section>
         <section>

--- a/src/apps/memory/src/governance.ts
+++ b/src/apps/memory/src/governance.ts
@@ -15,8 +15,25 @@ import {
   listContradictions,
   type ContradictionSummary,
 } from "./supersession.js";
+import {
+  resolveProvider,
+  type AiProviderConfig,
+  type Egress,
+  type ProviderMode,
+} from "./extract-conversation.js";
 
 export type MemoryGovernanceStatus = "ok" | "attention" | "degraded";
+export type MemoryGovernanceTidyStatus = "available" | "degraded" | "unavailable";
+
+export interface MemoryGovernanceTidyAvailability {
+  status: MemoryGovernanceTidyStatus;
+  configured: boolean;
+  provider_mode: ProviderMode | null;
+  provider_model: string | null;
+  egress: Egress | null;
+  reason: string | null;
+  next_action: string;
+}
 
 export interface MemoryGovernanceReport {
   schema_version: "memory.governance.v1";
@@ -44,6 +61,7 @@ export interface MemoryGovernanceReport {
   lint: LintReport;
   contradictions: ContradictionSummary[];
   supersession: Array<{ rid: number; active_rid: number }>;
+  tidy_availability: MemoryGovernanceTidyAvailability;
   recommended_next_actions: string[];
 }
 
@@ -57,7 +75,7 @@ interface GovernanceEdge {
 
 export async function buildMemoryGovernanceReport(
   store: MemoryStore,
-  opts: { staleProgressDays?: number; now?: number } = {},
+  opts: { staleProgressDays?: number; now?: number; providerConfig?: AiProviderConfig } = {},
 ): Promise<MemoryGovernanceReport> {
   const [nodes, rawEdges] = await Promise.all([store.listNodes(opts.now), store.listEdges()]);
   const edges = rawEdges.map(toGovernanceEdge);
@@ -95,6 +113,7 @@ export async function buildMemoryGovernanceReport(
     superseded_nodes: superseded.size,
     audit_edges: auditEdges,
   };
+  const tidyAvailability = governanceTidyAvailability(opts.providerConfig);
   return {
     schema_version: "memory.governance.v1",
     read_only: true,
@@ -108,7 +127,8 @@ export async function buildMemoryGovernanceReport(
     supersession: [...superseded.entries()]
       .map(([rid, activeRid]) => ({ rid, active_rid: activeRid }))
       .sort((a, b) => a.rid - b.rid),
-    recommended_next_actions: recommendations(summary, privacy, lint),
+    tidy_availability: tidyAvailability,
+    recommended_next_actions: recommendations(summary, privacy, lint, tidyAvailability),
   };
 }
 
@@ -135,6 +155,7 @@ function recommendations(
   summary: MemoryGovernanceReport["summary"],
   privacy: PrivacyReport,
   lint: LintReport,
+  tidyAvailability: MemoryGovernanceTidyAvailability,
 ): string[] {
   const out: string[] = [];
   if (summary.privacy_findings > 0) {
@@ -152,7 +173,50 @@ function recommendations(
   if (privacy.warnings.length > 0 || lint.warnings.length > 0) {
     out.push("investigate governance warnings before treating the report as complete");
   }
+  if (tidyAvailability.status !== "available") {
+    out.push(tidyAvailability.next_action);
+  }
   return [...new Set(out)];
+}
+
+function governanceTidyAvailability(
+  providerConfig: AiProviderConfig | undefined,
+): MemoryGovernanceTidyAvailability {
+  if (!providerConfig) {
+    return {
+      status: "unavailable",
+      configured: false,
+      provider_mode: null,
+      provider_model: null,
+      egress: null,
+      reason: "no AI provider configured for governance tidy",
+      next_action:
+        "configure `provider` to enable provider-backed governance tidy; deterministic governance remains available",
+    };
+  }
+  try {
+    const provider = resolveProvider(providerConfig);
+    return {
+      status: "available",
+      configured: true,
+      provider_mode: provider.mode,
+      provider_model: provider.model,
+      egress: provider.egress,
+      reason: null,
+      next_action:
+        "governance tidy provider is available; run mutating tidy operations only when explicitly requested",
+    };
+  } catch (err) {
+    return {
+      status: "degraded",
+      configured: true,
+      provider_mode: providerConfig.mode,
+      provider_model: providerConfig.model,
+      egress: null,
+      reason: err instanceof Error ? err.message : String(err),
+      next_action: "fix the configured Memory AI provider before running governance tidy",
+    };
+  }
 }
 
 function provenanceCoverage(nodes: StoredNode[]): MemoryGovernanceReport["provenance"] {

--- a/src/apps/memory/src/http-server.ts
+++ b/src/apps/memory/src/http-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { MemoryStore } from "./graph-store.js";
+import type { AiProviderConfig } from "./extract-conversation.js";
 import { recall } from "./engine.js";
 import {
   buildMemoryOperationalDashboard,
@@ -29,6 +30,7 @@ export interface MemoryHttpServerOptions {
   store: MemoryStore;
   token?: string;
   now?: number;
+  providerConfig?: AiProviderConfig;
 }
 
 export interface MemoryHttpHealth {
@@ -248,7 +250,12 @@ async function handleRegistryHttpOperation(
     const body = req.method === "POST" ? await readJsonBody(req) : undefined;
     const output = await executeMemoryOperationFromTransport(
       operation,
-      { store: opts.store, rootDir: opts.rootDir, now: opts.now },
+      {
+        store: opts.store,
+        rootDir: opts.rootDir,
+        now: opts.now,
+        providerConfig: opts.providerConfig,
+      },
       {
         positional: [],
         flags: {},

--- a/src/apps/memory/src/mcp-server.ts
+++ b/src/apps/memory/src/mcp-server.ts
@@ -674,11 +674,15 @@ async function operationStructuredContent(
       };
     case "memory.governance": {
       const summary = isRecord(output.summary) ? output.summary : {};
+      const tidy = isRecord(output.tidy_availability) ? output.tidy_availability : {};
       return {
         operation_id: operationId,
         schema_version: output.schema_version,
         read_only: output.read_only,
         status: output.status,
+        tidy_status: tidy.status ?? null,
+        tidy_reason: tidy.reason ?? null,
+        tidy_next_action: tidy.next_action ?? null,
         total_nodes: summary.total_nodes ?? null,
         missing_provenance: summary.missing_provenance ?? null,
         privacy_findings: summary.privacy_findings ?? null,
@@ -691,11 +695,15 @@ async function operationStructuredContent(
     case "memory.governance-viewer": {
       const report = isRecord(output.report) ? output.report : {};
       const summary = isRecord(report.summary) ? report.summary : {};
+      const tidy = isRecord(report.tidy_availability) ? report.tidy_availability : {};
       return {
         operation_id: operationId,
         contract: isRecord(output.contract) ? output.contract.version : undefined,
         consumes: isRecord(output.contract) ? output.contract.consumes : undefined,
         status: report.status,
+        tidy_status: tidy.status ?? null,
+        tidy_reason: tidy.reason ?? null,
+        tidy_next_action: tidy.next_action ?? null,
         missing_provenance: summary.missing_provenance ?? null,
         privacy_findings: summary.privacy_findings ?? null,
         lint_findings: summary.lint_findings ?? null,

--- a/src/apps/memory/src/operations.ts
+++ b/src/apps/memory/src/operations.ts
@@ -2330,6 +2330,7 @@ const GOVERNANCE_OPERATION: MemoryOperationDefinition<GovernanceInput, MemoryGov
     buildMemoryGovernanceReport(ctx.store, {
       staleProgressDays: input.stale_progress_days,
       now: ctx.now,
+      providerConfig: ctx.providerConfig,
     }),
 };
 
@@ -2358,6 +2359,7 @@ const GOVERNANCE_VIEWER_OPERATION: MemoryOperationDefinition<
       await buildMemoryGovernanceReport(ctx.store, {
         staleProgressDays: input.stale_progress_days,
         now: ctx.now,
+        providerConfig: ctx.providerConfig,
       }),
     ),
 };

--- a/src/apps/memory/src/workbench.ts
+++ b/src/apps/memory/src/workbench.ts
@@ -1,4 +1,5 @@
 import type { MemoryStore } from "./graph-store.js";
+import { readConfig } from "./config.js";
 import {
   buildMemoryAgentIntegrationStatus,
   type MemoryAgentIntegrationStatus,
@@ -124,6 +125,7 @@ export async function buildMemoryWorkbench(
   rootDir: string,
   opts: { staleDays?: number; sessionId?: string; limit?: number; now?: number } = {},
 ): Promise<MemoryWorkbench> {
+  const config = await readConfig(rootDir);
   const [
     dashboard,
     capabilities,
@@ -159,7 +161,7 @@ export async function buildMemoryWorkbench(
       now: opts.now,
     }),
     buildMemoryExtractionStatus(store, rootDir, { now: opts.now }),
-    buildMemoryGovernanceReport(store, { now: opts.now }),
+    buildMemoryGovernanceReport(store, { now: opts.now, providerConfig: config?.provider }),
     buildMemoryHandoff(store, { limit: 12, now: opts.now }),
     buildWorkFrontier(store, { limit: 12, now: opts.now }),
     buildLearningDebtReport(store, {
@@ -775,6 +777,7 @@ function governanceSection(workbench: MemoryWorkbench): string {
       <li><strong>${escapeHtml(governance.status)}</strong><p class="meta">${governance.summary.nodes_with_provenance}/${governance.summary.total_nodes} with provenance, ${governance.summary.missing_provenance} missing</p></li>
       <li><strong>Privacy and lint</strong><p class="meta">${governance.summary.privacy_findings} privacy finding(s), ${governance.summary.lint_findings} lint finding(s)</p></li>
       <li><strong>Contradictions</strong><p class="meta">${governance.summary.unresolved_contradictions} unresolved, ${governance.summary.superseded_nodes} superseded node(s)</p></li>
+      <li><strong>Tidy availability</strong><p class="meta">${escapeHtml(governance.tidy_availability.status)} - ${escapeHtml(governance.tidy_availability.reason ?? governance.tidy_availability.next_action)}</p></li>
     </ul>
     <button id="memory-governance-refresh" type="button">Refresh Governance</button>
     <a class="button-link" href="/governance">Open Governance</a>
@@ -1895,6 +1898,8 @@ function governanceScript(): string {
       addItem(String(report.status || "unknown"), String(summary.nodes_with_provenance ?? 0) + "/" + String(summary.total_nodes ?? 0) + " with provenance, " + String(summary.missing_provenance ?? 0) + " missing");
       addItem("Privacy and lint", String(summary.privacy_findings ?? 0) + " privacy finding(s), " + String(summary.lint_findings ?? 0) + " lint finding(s)");
       addItem("Contradictions", String(summary.unresolved_contradictions ?? 0) + " unresolved, " + String(summary.superseded_nodes ?? 0) + " superseded node(s)");
+      const tidy = report.tidy_availability || {};
+      addItem("Tidy availability", String(tidy.status || "unknown") + " - " + String(tidy.reason || tidy.next_action || "no tidy status reported"));
       const actions = Array.isArray(report.recommended_next_actions) ? report.recommended_next_actions : [];
       status.textContent = actions[0] || "Governance report is clean.";
     } catch (err) {

--- a/src/apps/memory/tests/governance.test.ts
+++ b/src/apps/memory/tests/governance.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import { buildMemoryGovernanceReport } from "../src/governance.js";
 import { buildMemoryGovernanceViewerArtifact } from "../src/governance-viewer.js";
+import { readConfig, writeConfig } from "../src/config.js";
 import { MemoryStore } from "../src/graph-store.js";
 import { initGraph } from "../src/init.js";
 
@@ -91,10 +92,17 @@ describe("Memory governance", () => {
     expect(report.summary.resolved_contradictions).toBe(1);
     expect(report.summary.superseded_nodes).toBe(1);
     expect(report.provenance.by_source_kind).toContainEqual({ source_kind: "manual", count: 1 });
+    expect(report.tidy_availability).toMatchObject({
+      status: "unavailable",
+      configured: false,
+      reason: "no AI provider configured for governance tidy",
+      next_action: expect.stringContaining("deterministic governance remains available"),
+    });
     expect(report.recommended_next_actions).toEqual(
       expect.arrayContaining([
         expect.stringContaining("memory privacy scan"),
         expect.stringContaining("memory lint"),
+        expect.stringContaining("deterministic governance remains available"),
       ]),
     );
 
@@ -107,7 +115,55 @@ describe("Memory governance", () => {
     expect(artifact.html).toContain("Memory Governance");
     expect(artifact.html).toContain('id="memory-governance-data"');
     expect(artifact.html).toContain("Deploys happen on Friday");
+    expect(artifact.html).toContain("Tidy availability");
+    expect(artifact.html).toContain("no AI provider configured for governance tidy");
   });
+
+  test("CLI JSON reports provider-unavailable tidy status without dropping deterministic evidence", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await store.upsertNode({
+      label: "provider-unavailable-governance",
+      node_type: "decision",
+      properties: {
+        title: "Provider unavailable governance",
+        content: "Governance must remain deterministic.",
+        scope: "project",
+        tier: "durable",
+        provenance: { source_kind: "manual", writer: "test", confidence: "EXTRACTED" },
+      },
+    });
+    await store.close();
+    const config = await readConfig(root);
+    if (!config) throw new Error("missing test config");
+    await writeConfig(root, {
+      ...config,
+      provider: {
+        mode: "openai-compat",
+        model: "llama3.1",
+      },
+    });
+
+    const result = runMemory(["governance", "--root", root, "--json"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const report = JSON.parse(result.stdout) as {
+      read_only: boolean;
+      summary: { total_nodes: number; nodes_with_provenance: number };
+      tidy_availability: { status: string; reason: string; next_action: string };
+    };
+    expect(report.read_only).toBe(true);
+    expect(report.summary).toMatchObject({
+      total_nodes: 1,
+      nodes_with_provenance: 1,
+    });
+    expect(report.tidy_availability).toMatchObject({
+      status: "degraded",
+      reason: "openai-compat provider requires a baseUrl",
+      next_action: "fix the configured Memory AI provider before running governance tidy",
+    });
+  }, TIMEOUT);
 
   test("writes a self-contained CLI governance viewer", async () => {
     const root = await tempRoot();
@@ -134,5 +190,6 @@ describe("Memory governance", () => {
     const html = await readFile(out, "utf8");
     expect(html).toContain("Memory Governance");
     expect(html).toContain('id="memory-governance-data"');
+    expect(html).toContain("Tidy availability");
   }, TIMEOUT);
 });

--- a/src/apps/memory/tests/http-server.test.ts
+++ b/src/apps/memory/tests/http-server.test.ts
@@ -327,6 +327,11 @@ describe.skipIf(skipPerf)("Memory local HTTP server", () => {
         schema_version: "memory.governance.v1",
         read_only: true,
         summary: expect.any(Object),
+        tidy_availability: {
+          status: "unavailable",
+          reason: "no AI provider configured for governance tidy",
+          next_action: expect.stringContaining("deterministic governance remains available"),
+        },
       });
 
       const governanceViewer = await fetch(`${base}/governance`);
@@ -335,6 +340,7 @@ describe.skipIf(skipPerf)("Memory local HTTP server", () => {
       const governanceViewerHtml = await governanceViewer.text();
       expect(governanceViewerHtml).toContain("Memory Governance");
       expect(governanceViewerHtml).toContain('id="memory-governance-data"');
+      expect(governanceViewerHtml).toContain("Tidy availability");
 
       const decay = await fetch(`${base}/api/decay`);
       expect(decay.status).toBe(200);

--- a/src/apps/memory/tests/mcp-server.test.ts
+++ b/src/apps/memory/tests/mcp-server.test.ts
@@ -1000,16 +1000,23 @@ describe("MCP server over stdio", () => {
         schema_version: string;
         read_only: boolean;
         summary: { total_nodes: number };
+        tidy_availability: { status: string; reason: string };
       };
       expect(governance).toMatchObject({
         schema_version: "memory.governance.v1",
         read_only: true,
         summary: { total_nodes: 3 },
+        tidy_availability: {
+          status: "unavailable",
+          reason: "no AI provider configured for governance tidy",
+        },
       });
       expect(governanceRes.structuredContent).toMatchObject({
         operation_id: "memory.governance",
         schema_version: "memory.governance.v1",
         read_only: true,
+        tidy_status: "unavailable",
+        tidy_reason: "no AI provider configured for governance tidy",
       });
 
       const decayRes = (await client.callTool({
@@ -1041,9 +1048,12 @@ describe("MCP server over stdio", () => {
       });
       expect(governanceViewer.html).toContain("Memory Governance");
       expect(governanceViewer.html).toContain('id="memory-governance-data"');
+      expect(governanceViewer.html).toContain("Tidy availability");
       expect(governanceViewerRes.structuredContent).toMatchObject({
         operation_id: "memory.governance-viewer",
         consumes: "memory.governance.v1",
+        tidy_status: "unavailable",
+        tidy_reason: "no AI provider configured for governance tidy",
         html_bytes: expect.any(Number),
       });
 

--- a/src/apps/memory/tests/workbench.test.ts
+++ b/src/apps/memory/tests/workbench.test.ts
@@ -92,6 +92,10 @@ describe("Memory workbench", () => {
       governance: {
         schema_version: "memory.governance.v1",
         read_only: true,
+        tidy_availability: {
+          status: "unavailable",
+          reason: "no AI provider configured for governance tidy",
+        },
       },
       memory_decay: {
         schema_version: "memory.decay_plan.v1",
@@ -265,6 +269,8 @@ describe("Memory workbench", () => {
     expect(artifact.html).toContain("Open Extraction Status");
     expect(artifact.html).toContain('fetch("/api/extraction/status"');
     expect(artifact.html).toContain("Governance");
+    expect(artifact.html).toContain("Tidy availability");
+    expect(artifact.html).toContain("no AI provider configured for governance tidy");
     expect(artifact.html).toContain('id="memory-governance-refresh"');
     expect(artifact.html).toContain('href="/governance"');
     expect(artifact.html).toContain("Open Governance");


### PR DESCRIPTION
Closes #485.

## Summary
- add read-only `tidy_availability` to memory governance reports
- expose tidy status/reason/next action through CLI, MCP structured summaries, HTTP JSON, governance viewer, and Workbench governance panel
- cover no-provider and invalid-provider behavior without provider calls

## Validation
- pnpm --dir src/apps/memory typecheck
- pnpm --dir src/apps/memory build
- pnpm exec vitest run --config vitest.integration.config.ts tests/governance.test.ts
- pnpm exec vitest run --config vitest.integration.config.ts tests/http-server.test.ts
- pnpm exec vitest run --config vitest.integration.config.ts tests/mcp-server.test.ts -t "registry-backed readiness and trust tools"
- Workbench smoke: build artifact includes tidy availability

## Known unrelated validation notes
- Full targeted integration batch also exposed existing unrelated failures: `tests/mcp-server.test.ts` hook coverage expected 4 Claude hooks but saw 1, and `tests/workbench.test.ts` expects `memory.references_radar.v1` while implementation returns `memory.reference_radar.v1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783248827&installation_id=129708444&pr_number=492&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F492&signature=9d312c625d1dd70d3dd7a8f59a83d40015eb92f8abe153f96c6d35e633acddc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Tidy availability" governance metric to report AI provider status for system operations, displaying availability state (available/degraded/unavailable) with configuration details and recommended next steps when unavailable.

* **Tests**
  * Extended test coverage for tidy availability status reporting across governance reports, HTTP server, MCP server, and workbench displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->