### PR TITLE
Provider review artifacts persist tidy state outside the graph

### DIFF
--- a/src/apps/memory/src/provider-review-artifacts.ts
+++ b/src/apps/memory/src/provider-review-artifacts.ts
@@ -1,0 +1,327 @@
+import { createHash } from "node:crypto";
+import type { MemoryStore } from "./graph-store.js";
+
+export const PROVIDER_REVIEW_ARTIFACT_STORE_KEY = "provider_review_artifacts.v1";
+export const PROVIDER_REVIEW_FINGERPRINT_ALGORITHM = "sha256:provider-review.v1";
+export const DEFAULT_TIDY_REVIEW_POLICY_VERSION = "memory.governance-tidy.review.v1";
+
+export type ProviderReviewStatus = "open" | "dismissed" | "accepted" | "stale";
+
+export interface ProviderReviewEvidenceSubject {
+  collection?: string;
+  rid?: number;
+  label?: string;
+  node_type?: string;
+  title?: string;
+  hash?: string;
+  content?: string;
+  updated_at?: number;
+  [extra: string]: JsonValue | undefined;
+}
+
+export interface ProviderReviewPairEvidence {
+  pair_id?: string;
+  relation?: string;
+  subjects: ProviderReviewEvidenceSubject[];
+  evidence?: JsonRecord[];
+}
+
+export interface ProviderReviewFingerprintInput {
+  operation: string;
+  policyVersion: string;
+  pairEvidence: ProviderReviewPairEvidence[];
+  evidence?: JsonRecord[];
+}
+
+export interface ProviderReviewFingerprintMetadata {
+  algorithm: typeof PROVIDER_REVIEW_FINGERPRINT_ALGORITHM;
+  fingerprint: string;
+  operation: string;
+  policy_version: string;
+  pair_count: number;
+  evidence_count: number;
+}
+
+export interface ProviderReviewRecommendationInput extends ProviderReviewFingerprintInput {
+  recommendationKey: string;
+  recommendation: {
+    title: string;
+    rationale?: string;
+    suggested_action?: string;
+    provider_output?: JsonRecord;
+  };
+  provider?: {
+    mode?: string;
+    model?: string;
+  };
+}
+
+export interface ProviderReviewArtifact {
+  schema_version: "memory.provider_review_artifact.v1";
+  artifact_id: string;
+  recommendation_id: string;
+  recommendation_key: string;
+  operation: string;
+  status: ProviderReviewStatus;
+  created_at: number;
+  updated_at: number;
+  status_changed_at: number;
+  dismissed_at?: number;
+  accepted_at?: number;
+  stale_at?: number;
+  fingerprint: string;
+  fingerprint_metadata: ProviderReviewFingerprintMetadata;
+  pair_evidence: ProviderReviewPairEvidence[];
+  recommendation: ProviderReviewRecommendationInput["recommendation"];
+  provider?: ProviderReviewRecommendationInput["provider"];
+}
+
+export interface ProviderReviewArtifactState {
+  schema_version: "memory.provider_review_artifacts.v1";
+  artifacts: Record<string, ProviderReviewArtifact>;
+}
+
+export interface PersistProviderReviewArtifactsResult {
+  artifacts: ProviderReviewArtifact[];
+  stale: ProviderReviewArtifact[];
+}
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | JsonRecord;
+type JsonRecord = { [key: string]: JsonValue | undefined };
+
+export function computeProviderReviewFingerprint(
+  input: ProviderReviewFingerprintInput,
+): ProviderReviewFingerprintMetadata {
+  const canonicalPairs = input.pairEvidence.map(canonicalPairEvidence).sort(compareStableJson);
+  const canonicalEvidence = (input.evidence ?? []).map(normalizeJson).sort(compareStableJson);
+  const fingerprint = sha256(
+    stableJson({
+      operation: input.operation,
+      policy_version: input.policyVersion,
+      pair_evidence: canonicalPairs,
+      evidence: canonicalEvidence,
+    }),
+  );
+  return {
+    algorithm: PROVIDER_REVIEW_FINGERPRINT_ALGORITHM,
+    fingerprint,
+    operation: input.operation,
+    policy_version: input.policyVersion,
+    pair_count: canonicalPairs.length,
+    evidence_count:
+      canonicalEvidence.length +
+      input.pairEvidence.reduce((sum, pair) => sum + (pair.evidence?.length ?? 0), 0),
+  };
+}
+
+export function providerReviewRecommendationId(input: ProviderReviewRecommendationInput): string {
+  const subjectIdentities = input.pairEvidence
+    .flatMap((pair) => pair.subjects.map(subjectIdentity))
+    .sort();
+  return `provider-review:${sha256(
+    stableJson({
+      operation: input.operation,
+      recommendation_key: input.recommendationKey,
+      subjects: subjectIdentities,
+    }),
+  ).slice(0, 24)}`;
+}
+
+export function providerReviewArtifactId(input: ProviderReviewRecommendationInput): string {
+  const recommendationId = providerReviewRecommendationId(input);
+  const fingerprint = computeProviderReviewFingerprint(input).fingerprint;
+  return `${recommendationId}:${fingerprint.slice(0, 24)}`;
+}
+
+export async function persistProviderReviewArtifacts(
+  store: Pick<MemoryStore, "kvGet" | "kvPut">,
+  recommendations: ProviderReviewRecommendationInput[],
+  opts: { now?: number; operation?: string } = {},
+): Promise<PersistProviderReviewArtifactsResult> {
+  const now = opts.now ?? Date.now();
+  const state = await readProviderReviewArtifactState(store);
+  const currentArtifactIds = new Set<string>();
+  const operations = new Set(recommendations.map((rec) => rec.operation));
+  if (opts.operation) operations.add(opts.operation);
+
+  const nextArtifacts: ProviderReviewArtifact[] = recommendations.map((rec) => {
+    const fingerprint = computeProviderReviewFingerprint(rec);
+    const recommendationId = providerReviewRecommendationId(rec);
+    const artifactId = `${recommendationId}:${fingerprint.fingerprint.slice(0, 24)}`;
+    currentArtifactIds.add(artifactId);
+    const existing = state.artifacts[artifactId];
+    const status = existing?.status ?? "open";
+    return {
+      schema_version: "memory.provider_review_artifact.v1",
+      artifact_id: artifactId,
+      recommendation_id: recommendationId,
+      recommendation_key: rec.recommendationKey,
+      operation: rec.operation,
+      status,
+      created_at: existing?.created_at ?? now,
+      updated_at: now,
+      status_changed_at: existing?.status_changed_at ?? now,
+      dismissed_at: existing?.dismissed_at,
+      accepted_at: existing?.accepted_at,
+      stale_at: existing?.stale_at,
+      fingerprint: fingerprint.fingerprint,
+      fingerprint_metadata: fingerprint,
+      pair_evidence: cloneJson(rec.pairEvidence) as ProviderReviewPairEvidence[],
+      recommendation: cloneJson(
+        rec.recommendation,
+      ) as ProviderReviewRecommendationInput["recommendation"],
+      provider: rec.provider
+        ? (cloneJson(rec.provider) as ProviderReviewRecommendationInput["provider"])
+        : undefined,
+    };
+  });
+
+  const stale: ProviderReviewArtifact[] = [];
+  for (const [artifactId, artifact] of Object.entries(state.artifacts)) {
+    if (artifact.status !== "open") continue;
+    if (operations.size > 0 && !operations.has(artifact.operation)) continue;
+    if (currentArtifactIds.has(artifactId)) continue;
+    const next = {
+      ...artifact,
+      status: "stale" as const,
+      updated_at: now,
+      status_changed_at: now,
+      stale_at: now,
+    };
+    state.artifacts[artifactId] = next;
+    stale.push(next);
+  }
+
+  for (const artifact of nextArtifacts) {
+    state.artifacts[artifact.artifact_id] = artifact;
+  }
+  await writeProviderReviewArtifactState(store, state);
+  return { artifacts: nextArtifacts, stale };
+}
+
+export async function listProviderReviewArtifacts(
+  store: Pick<MemoryStore, "kvGet">,
+  opts: { operation?: string; status?: ProviderReviewStatus } = {},
+): Promise<ProviderReviewArtifact[]> {
+  const state = await readProviderReviewArtifactState(store);
+  return Object.values(state.artifacts)
+    .filter((artifact) => opts.operation == null || artifact.operation === opts.operation)
+    .filter((artifact) => opts.status == null || artifact.status === opts.status)
+    .sort((a, b) => a.created_at - b.created_at || a.artifact_id.localeCompare(b.artifact_id));
+}
+
+export async function updateProviderReviewArtifactStatus(
+  store: Pick<MemoryStore, "kvGet" | "kvPut">,
+  artifactId: string,
+  status: ProviderReviewStatus,
+  opts: { now?: number } = {},
+): Promise<ProviderReviewArtifact> {
+  const now = opts.now ?? Date.now();
+  const state = await readProviderReviewArtifactState(store);
+  const artifact = state.artifacts[artifactId];
+  if (!artifact) throw new Error(`provider review artifact not found: ${artifactId}`);
+  const next: ProviderReviewArtifact = {
+    ...artifact,
+    status,
+    updated_at: now,
+    status_changed_at: now,
+    dismissed_at: status === "dismissed" ? now : artifact.dismissed_at,
+    accepted_at: status === "accepted" ? now : artifact.accepted_at,
+    stale_at: status === "stale" ? now : artifact.stale_at,
+  };
+  if (status === "open") {
+    delete next.dismissed_at;
+    delete next.accepted_at;
+    delete next.stale_at;
+  }
+  state.artifacts[artifactId] = next;
+  await writeProviderReviewArtifactState(store, state);
+  return next;
+}
+
+export async function readProviderReviewArtifactState(
+  store: Pick<MemoryStore, "kvGet">,
+): Promise<ProviderReviewArtifactState> {
+  const raw = await store.kvGet<ProviderReviewArtifactState | string>(
+    PROVIDER_REVIEW_ARTIFACT_STORE_KEY,
+  );
+  if (raw == null) return emptyState();
+  if (typeof raw === "string") {
+    return normalizeState(JSON.parse(raw) as ProviderReviewArtifactState);
+  }
+  return normalizeState(raw);
+}
+
+async function writeProviderReviewArtifactState(
+  store: Pick<MemoryStore, "kvPut">,
+  state: ProviderReviewArtifactState,
+): Promise<void> {
+  await store.kvPut(PROVIDER_REVIEW_ARTIFACT_STORE_KEY, state);
+}
+
+function emptyState(): ProviderReviewArtifactState {
+  return { schema_version: "memory.provider_review_artifacts.v1", artifacts: {} };
+}
+
+function normalizeState(raw: ProviderReviewArtifactState): ProviderReviewArtifactState {
+  return {
+    schema_version: "memory.provider_review_artifacts.v1",
+    artifacts: raw.artifacts ?? {},
+  };
+}
+
+function canonicalPairEvidence(pair: ProviderReviewPairEvidence): JsonRecord {
+  return {
+    relation: pair.relation ?? null,
+    subjects: pair.subjects.map(canonicalSubject).sort(compareStableJson),
+    evidence: (pair.evidence ?? []).map(normalizeJson).sort(compareStableJson),
+  };
+}
+
+function canonicalSubject(subject: ProviderReviewEvidenceSubject): JsonRecord {
+  return normalizeJson(subject) as JsonRecord;
+}
+
+function subjectIdentity(subject: ProviderReviewEvidenceSubject): string {
+  return stableJson({
+    collection: subject.collection ?? null,
+    rid: subject.rid ?? null,
+    label: subject.label ?? null,
+    node_type: subject.node_type ?? null,
+  });
+}
+
+function normalizeJson(value: unknown): JsonValue {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(normalizeJson);
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const out: JsonRecord = {};
+    for (const key of Object.keys(record).sort()) {
+      const normalized = normalizeJson(record[key]);
+      if (normalized !== undefined) out[key] = normalized;
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(normalizeJson(value));
+}
+
+function compareStableJson(a: unknown, b: unknown): number {
+  return stableJson(a).localeCompare(stableJson(b));
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}

--- a/src/apps/memory/tests/provider-review-artifacts.test.ts
+++ b/src/apps/memory/tests/provider-review-artifacts.test.ts
@@ -1,0 +1,261 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { MemoryStore } from "../src/graph-store.js";
+import {
+  DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+  computeProviderReviewFingerprint,
+  listProviderReviewArtifacts,
+  persistProviderReviewArtifacts,
+  providerReviewRecommendationId,
+  readProviderReviewArtifactState,
+  updateProviderReviewArtifactStatus,
+  type ProviderReviewRecommendationInput,
+} from "../src/provider-review-artifacts.js";
+
+const TIMEOUT = 30_000;
+const roots: string[] = [];
+const stores: MemoryStore[] = [];
+
+async function tempRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "memory-provider-review-"));
+  roots.push(dir);
+  return dir;
+}
+
+async function openStore(root: string): Promise<MemoryStore> {
+  const store = await MemoryStore.open({
+    uri: `file://${join(root, "graph.rdb")}`,
+    project: "test",
+  });
+  stores.push(store);
+  return store;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function tidyRecommendation(content = "Deploys moved to Tuesday."): ProviderReviewRecommendationInput {
+  return {
+    operation: "governance.tidy",
+    policyVersion: DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+    recommendationKey: "resolve-deploy-schedule",
+    pairEvidence: [
+      {
+        pair_id: "deploy-schedule",
+        relation: "contradiction",
+        subjects: [
+          {
+            collection: "memory_nodes",
+            rid: 7,
+            label: "deploys-on-friday",
+            node_type: "decision",
+            title: "Deploys happen on Friday",
+            content: "Deploys happen on Friday.",
+            hash: "friday-hash",
+          },
+          {
+            collection: "memory_nodes",
+            rid: 3,
+            label: "deploys-on-tuesday",
+            node_type: "decision",
+            title: "Deploys happen on Tuesday",
+            content,
+            hash: "tuesday-hash",
+          },
+        ],
+        evidence: [
+          { kind: "edge", label: "CONTRADICTS", from: 3, to: 7, reason: "schedule changed" },
+          { kind: "lint", rule: "conflicting-guidance", severity: "warning" },
+        ],
+      },
+    ],
+    recommendation: {
+      title: "Review conflicting deploy schedule guidance",
+      rationale: "The two Memory facts disagree about deploy day.",
+      suggested_action: "Ask a maintainer which deploy day is current.",
+      provider_output: { confidence: "medium", notes: ["pair needs human review"] },
+    },
+    provider: { mode: "openai-compat", model: "llama3.1" },
+  };
+}
+
+describe("provider review fingerprints", () => {
+  test("are deterministic and order-insensitive for equivalent tidy evidence", () => {
+    const base = tidyRecommendation();
+    const reordered: ProviderReviewRecommendationInput = {
+      ...base,
+      pairEvidence: [
+        {
+          relation: "contradiction",
+          pair_id: "different-noncanonical-id",
+          subjects: [...base.pairEvidence[0].subjects].reverse(),
+          evidence: [
+            { severity: "warning", rule: "conflicting-guidance", kind: "lint" },
+            { to: 7, reason: "schedule changed", from: 3, label: "CONTRADICTS", kind: "edge" },
+          ],
+        },
+      ],
+    };
+
+    const first = computeProviderReviewFingerprint(base);
+    const second = computeProviderReviewFingerprint(reordered);
+
+    expect(first.fingerprint).toBe(second.fingerprint);
+    expect(first).toMatchObject({
+      algorithm: "sha256:provider-review.v1",
+      operation: "governance.tidy",
+      policy_version: DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+      pair_count: 1,
+      evidence_count: 2,
+    });
+  });
+
+  test("change when relevant evidence or review policy version changes", () => {
+    const base = tidyRecommendation();
+    const changedEvidence = tidyRecommendation("Deploys moved to Wednesday.");
+    const changedPolicy = {
+      ...base,
+      policyVersion: "memory.governance-tidy.review.v2",
+    };
+
+    expect(computeProviderReviewFingerprint(base).fingerprint).not.toBe(
+      computeProviderReviewFingerprint(changedEvidence).fingerprint,
+    );
+    expect(computeProviderReviewFingerprint(base).fingerprint).not.toBe(
+      computeProviderReviewFingerprint(changedPolicy).fingerprint,
+    );
+  });
+});
+
+describe("provider review artifact persistence", () => {
+  test(
+    "stores stable recommendation ids, pair evidence, status, timestamps, and fingerprint metadata",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const input = tidyRecommendation();
+
+      const result = await persistProviderReviewArtifacts(store, [input], { now: 1000 });
+      const artifacts = await listProviderReviewArtifacts(store);
+
+      expect(result.stale).toEqual([]);
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0]).toMatchObject({
+        schema_version: "memory.provider_review_artifact.v1",
+        artifact_id: expect.stringContaining(providerReviewRecommendationId(input)),
+        recommendation_id: providerReviewRecommendationId(input),
+        recommendation_key: "resolve-deploy-schedule",
+        operation: "governance.tidy",
+        status: "open",
+        created_at: 1000,
+        updated_at: 1000,
+        status_changed_at: 1000,
+        pair_evidence: input.pairEvidence,
+        recommendation: input.recommendation,
+        provider: input.provider,
+        fingerprint_metadata: {
+          algorithm: "sha256:provider-review.v1",
+          operation: "governance.tidy",
+          policy_version: DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+          pair_count: 1,
+          evidence_count: 2,
+        },
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "marks open recommendations stale when the current fingerprint no longer matches",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const original = tidyRecommendation();
+      const changed = tidyRecommendation("Deploys moved to Wednesday.");
+
+      const first = await persistProviderReviewArtifacts(store, [original], { now: 1000 });
+      const second = await persistProviderReviewArtifacts(store, [changed], { now: 2000 });
+      const artifacts = await listProviderReviewArtifacts(store, { operation: "governance.tidy" });
+
+      expect(providerReviewRecommendationId(changed)).toBe(providerReviewRecommendationId(original));
+      expect(second.stale).toHaveLength(1);
+      expect(second.stale[0]).toMatchObject({
+        artifact_id: first.artifacts[0].artifact_id,
+        status: "stale",
+        stale_at: 2000,
+      });
+      expect(artifacts).toHaveLength(2);
+      expect(artifacts.map((artifact) => artifact.status).sort()).toEqual(["open", "stale"]);
+      expect(artifacts.find((artifact) => artifact.status === "open")?.fingerprint).toBe(
+        second.artifacts[0].fingerprint,
+      );
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "persists dismissed and accepted statuses without graph supersession vocabulary",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const input = tidyRecommendation();
+      const persisted = await persistProviderReviewArtifacts(store, [input], { now: 1000 });
+
+      const dismissed = await updateProviderReviewArtifactStatus(
+        store,
+        persisted.artifacts[0].artifact_id,
+        "dismissed",
+        { now: 1500 },
+      );
+      await persistProviderReviewArtifacts(store, [input], { now: 2000 });
+      const afterRepersist = await listProviderReviewArtifacts(store);
+      const accepted = await updateProviderReviewArtifactStatus(
+        store,
+        persisted.artifacts[0].artifact_id,
+        "accepted",
+        { now: 2500 },
+      );
+
+      expect(dismissed).toMatchObject({
+        status: "dismissed",
+        dismissed_at: 1500,
+      });
+      expect(afterRepersist[0]).toMatchObject({
+        status: "dismissed",
+        dismissed_at: 1500,
+      });
+      expect(accepted).toMatchObject({
+        status: "accepted",
+        accepted_at: 2500,
+      });
+      expect(["open", "dismissed", "accepted", "stale"]).toContain(accepted.status);
+      expect(JSON.stringify(await readProviderReviewArtifactState(store))).not.toMatch(
+        /SUPERSEDED_BY|SAME_AS|MERGED_INTO|DEPRECATED_BY/,
+      );
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "persists artifacts outside the canonical graph and recall evidence",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const beforeStats = await store.stats();
+      const beforeNodes = await store.listNodes();
+      const beforeEdges = await store.listEdges();
+      const beforeDocs = await store.listDocs();
+      const beforeAccess = await store.accessRecords();
+
+      await persistProviderReviewArtifacts(store, [tidyRecommendation()], { now: 1000 });
+
+      expect(await store.stats()).toEqual(beforeStats);
+      expect(await store.listNodes()).toEqual(beforeNodes);
+      expect(await store.listEdges()).toEqual(beforeEdges);
+      expect(await store.listDocs()).toEqual(beforeDocs);
+      expect(await store.accessRecords()).toEqual(beforeAccess);
+      expect(await listProviderReviewArtifacts(store)).toHaveLength(1);
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
Closes #486.

## Summary
- add provider review artifact persistence backed by Memory KV storage outside graph nodes/edges
- add deterministic fingerprints and stable recommendation/artifact ids
- cover stale transitions, status persistence, and graph/recall non-mutation

## Validation
- pnpm exec vitest run tests/provider-review-artifacts.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250022&installation_id=129708444&pr_number=493&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F493&signature=159b36a333cdee8f855185bee9ecb6925fe8b0a734ab79abea8542ec2b996c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced provider review artifact management system with deterministic fingerprinting and persistence capabilities. Supports tracking review statuses (open, dismissed, accepted, stale) and provides querying and status update functionality.

* **Tests**
  * Added comprehensive test suite validating fingerprint determinism, artifact persistence, status transitions, and memory store integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->