### PR TITLE
Context packs render pinned core context

### DIFF
--- a/src/apps/memory/src/context-pack-viewer.ts
+++ b/src/apps/memory/src/context-pack-viewer.ts
@@ -145,7 +145,7 @@ function renderContextPackViewer(pack: ContextPack): string {
     </div>
     <div class="layout">
       <div class="stack">
-        ${pack.entries.length === 0 ? `<section><p class="empty">No active Memory evidence matched this context-pack goal.</p></section>` : groupedEntries(pack.entries)}
+        ${pack.entries.length === 0 ? `<section><p class="empty">No active Memory evidence matched this context-pack goal.</p></section>` : groupedEntries(pack)}
       </div>
       <div class="stack">
         <section>
@@ -168,7 +168,10 @@ function renderContextPackViewer(pack: ContextPack): string {
 </html>`;
 }
 
-function groupedEntries(entries: ContextPackEntry[]): string {
+function groupedEntries(pack: ContextPack): string {
+  const coreContext = pack.coreContext ?? [];
+  const coreRids = new Set(coreContext.map((entry) => entry.citation.rid));
+  const entries = pack.entries.filter((entry) => !coreRids.has(entry.citation.rid));
   const order: ContextPackEntry["section"][] = [
     "hard_constraints",
     "prior_decisions",
@@ -176,7 +179,14 @@ function groupedEntries(entries: ContextPackEntry[]): string {
     "similar_past_work",
     "do_not_do",
   ];
-  return order
+  const coreHtml =
+    coreContext.length === 0
+      ? ""
+      : `<section>
+        <h2>Core Context</h2>
+        <ul>${coreContext.map(entryHtml).join("")}</ul>
+      </section>`;
+  return `${coreHtml}${order
     .map((section) => {
       const sectionEntries = entries.filter((entry) => entry.section === section);
       if (sectionEntries.length === 0) return "";
@@ -185,16 +195,21 @@ function groupedEntries(entries: ContextPackEntry[]): string {
         <ul>${sectionEntries.map(entryHtml).join("")}</ul>
       </section>`;
     })
-    .join("");
+    .join("")}`;
 }
 
 function entryHtml(entry: ContextPackEntry): string {
   const source = entry.citation.source ? ` - ${escapeHtml(entry.citation.source)}` : "";
+  const confidence =
+    entry.confidence_score == null ? "" : ` - confidence ${entry.confidence_score.toFixed(2)}`;
+  const provenance = entry.provenance
+    ? ` - provenance ${escapeHtml(entry.provenance.source_kind)}${entry.provenance.writer ? `/${escapeHtml(entry.provenance.writer)}` : ""}`
+    : "";
   return `<li>
     <div>
-      <h3>${escapeHtml(entry.title)}</h3>
+      <h3>${escapeHtml(entry.citation.marker)} ${escapeHtml(entry.title)}</h3>
       <p>${escapeHtml(entry.excerpt)}</p>
-      <p class="meta"><code>${escapeHtml(entry.citation.urn)}</code>${source} - score ${entry.score.toFixed(4)}</p>
+      <p class="meta"><code>${escapeHtml(entry.citation.urn)}</code>${source} - score ${entry.score.toFixed(4)} - trust ${entry.trust.toFixed(2)} - importance ${entry.importance.toFixed(2)}${confidence}${provenance}</p>
       <p class="meta">${escapeHtml(entry.reason)}</p>
     </div>
     <span class="pill">${escapeHtml(entry.nodeType)}</span>

--- a/src/apps/memory/src/context-pack.ts
+++ b/src/apps/memory/src/context-pack.ts
@@ -1,5 +1,11 @@
-import { recall, type RecallOptions, type RecallStore, type RecalledNode } from "./engine.js";
-import type { Confidence } from "./schema.js";
+import {
+  recall,
+  TRUST_WEIGHT,
+  type RecallOptions,
+  type RecallStore,
+  type RecalledNode,
+} from "./engine.js";
+import type { Confidence, MemoryProvenance } from "./schema.js";
 import {
   buildSkillRecommendationsFromEvidence,
   renderSkillRecommendationsSection,
@@ -29,7 +35,10 @@ export interface ContextPackEntry {
   section: ContextPackSection;
   title: string;
   nodeType: string;
+  importance: number;
   confidence: Confidence;
+  trust: number;
+  provenance: MemoryProvenance | null;
   citation: ContextPackCitation;
   reason: string;
   excerpt: string;
@@ -50,6 +59,9 @@ export interface ContextPack {
   budgetChars: number;
   usedChars: number;
   markdown: string;
+  /** Pinned Memory nodes (`importance >= 0.8`) that passed governed recall and budget. */
+  coreContext: ContextPackEntry[];
+  /** Combined included context in render order. Kept for existing consumers. */
   entries: ContextPackEntry[];
   skillRecommendations: SkillRecommendationReport;
   warnings: ContextPackWarning[];
@@ -65,6 +77,7 @@ export interface ContextPackOptions extends Pick<RecallOptions, "scope" | "now">
 
 const DEFAULT_BUDGET_CHARS = 4_000;
 const DEFAULT_LIMIT = 12;
+const PINNED_IMPORTANCE_THRESHOLD = 0.8;
 const SECTION_ORDER: ContextPackSection[] = [
   "hard_constraints",
   "prior_decisions",
@@ -126,6 +139,7 @@ export async function buildContextPack(
       budgetChars,
       usedChars: markdown.length,
       markdown,
+      coreContext: [],
       entries: [],
       skillRecommendations,
       warnings,
@@ -146,6 +160,7 @@ export async function buildContextPack(
     budgetChars,
     usedChars: rendered.markdown.length,
     markdown: rendered.markdown,
+    coreContext: rendered.coreContext,
     entries: rendered.included,
     skillRecommendations,
     warnings: rendered.warnings,
@@ -194,11 +209,15 @@ function toEntry(node: RecalledNode, marker: number, goal: string): ContextPackE
   const section = classifySection(node);
   const title = node.properties.title ?? node.label;
   const source = typeof node.properties.source === "string" ? node.properties.source : null;
+  const confidence = node.properties.confidence ?? "AMBIGUOUS";
   return {
     section,
     title,
     nodeType: node.node_type,
-    confidence: node.properties.confidence ?? "AMBIGUOUS",
+    importance: node.properties.importance ?? 0.5,
+    confidence,
+    trust: TRUST_WEIGHT[confidence],
+    provenance: node.properties.provenance ?? null,
     citation: {
       marker: `[M${marker}]`,
       urn: `memory_nodes:${node.rid}`,
@@ -251,13 +270,39 @@ function renderPack(
   warnings: ContextPackWarning[],
   budgetChars: number,
   skillRecommendations: SkillRecommendationReport,
-): { markdown: string; included: ContextPackEntry[]; warnings: ContextPackWarning[] } {
+): {
+  markdown: string;
+  coreContext: ContextPackEntry[];
+  included: ContextPackEntry[];
+  warnings: ContextPackWarning[];
+} {
+  const coreCandidates = entries
+    .filter((entry) => entry.importance >= PINNED_IMPORTANCE_THRESHOLD)
+    .sort((a, b) => b.score - a.score || a.citation.rid - b.citation.rid);
+  const ordinaryEntries = entries.filter((entry) => entry.importance < PINNED_IMPORTANCE_THRESHOLD);
+  const coreContext: ContextPackEntry[] = [];
   const included: ContextPackEntry[] = [];
   const renderedWarnings = [...warnings];
   let markdown = header(goal, "ok", renderedWarnings);
 
+  if (coreCandidates.length > 0) {
+    let nextMarkdown = `${markdown}## Core context\n`;
+    const acceptedCore: ContextPackEntry[] = [];
+    for (const entry of coreCandidates) {
+      const candidate = `${nextMarkdown}${renderEntry(entry)}\n`;
+      if (candidate.length > budgetChars) break;
+      nextMarkdown = candidate;
+      acceptedCore.push(entry);
+    }
+    if (acceptedCore.length > 0) {
+      markdown = `${nextMarkdown}\n`;
+      coreContext.push(...acceptedCore);
+      included.push(...acceptedCore);
+    }
+  }
+
   for (const section of SECTION_ORDER) {
-    const sectionEntries = entries
+    const sectionEntries = ordinaryEntries
       .filter((entry) => entry.section === section)
       .sort((a, b) => b.score - a.score || a.citation.rid - b.citation.rid);
     if (sectionEntries.length === 0) continue;
@@ -277,15 +322,16 @@ function renderPack(
   }
 
   if (included.length < entries.length) {
+    const includedRids = new Set(included.map((entry) => entry.citation.rid));
     renderedWarnings.push({
       kind: "budget",
       message: `${entries.length - included.length} recalled item(s) omitted to stay within budget.`,
       rids: entries
-        .filter((entry) => !included.includes(entry))
+        .filter((entry) => !includedRids.has(entry.citation.rid))
         .map((entry) => entry.citation.rid),
     });
     const status = included.length > 0 ? "ok" : "insufficient-context";
-    const rerendered = `${header(goal, status, renderedWarnings)}${renderSections(included)}`;
+    const rerendered = `${header(goal, status, renderedWarnings)}${renderBody(coreContext, included.filter((entry) => entry.importance < PINNED_IMPORTANCE_THRESHOLD))}`;
     if (rerendered.length <= budgetChars) {
       markdown = rerendered;
     } else if (included.length === 0) {
@@ -299,7 +345,7 @@ function renderPack(
     if (candidate.length <= budgetChars) markdown = candidate;
   }
 
-  return { markdown: fitToBudget(markdown, budgetChars), included, warnings: renderedWarnings };
+  return { markdown: fitToBudget(markdown, budgetChars), coreContext, included, warnings: renderedWarnings };
 }
 
 function header(
@@ -313,6 +359,20 @@ function header(
     for (const warning of warnings) lines.push(`- ${warning.kind}: ${warning.message}`);
     lines.push("");
   }
+  return lines.join("\n");
+}
+
+function renderBody(
+  coreContext: ContextPackEntry[],
+  ordinaryEntries: ContextPackEntry[],
+): string {
+  const lines: string[] = [];
+  if (coreContext.length > 0) {
+    lines.push("## Core context");
+    for (const entry of coreContext) lines.push(renderEntry(entry));
+    lines.push("");
+  }
+  lines.push(renderSections(ordinaryEntries));
   return lines.join("\n");
 }
 
@@ -330,8 +390,11 @@ function renderSections(entries: ContextPackEntry[]): string {
 
 function renderEntry(entry: ContextPackEntry): string {
   const source = entry.citation.source ? `; source: ${entry.citation.source}` : "";
+  const provenance = entry.provenance
+    ? `; provenance: ${entry.provenance.source_kind}${entry.provenance.writer ? `/${entry.provenance.writer}` : ""}`
+    : "";
   return [
-    `- ${entry.citation.marker} ${entry.title} (${entry.nodeType}, ${entry.confidence}; urn: ${entry.citation.urn}${source})`,
+    `- ${entry.citation.marker} ${entry.title} (${entry.nodeType}, ${entry.confidence}; trust: ${entry.trust.toFixed(2)}; importance: ${entry.importance.toFixed(2)}; urn: ${entry.citation.urn}${source}${provenance})`,
     `  Reason: ${entry.reason}`,
     `  Evidence: ${entry.excerpt}`,
   ].join("\n");

--- a/src/apps/memory/src/workbench.ts
+++ b/src/apps/memory/src/workbench.ts
@@ -592,6 +592,16 @@ function confidenceBadge(score: number | undefined): string {
   return ` <span class="pill ${cls}" data-confidence="${score.toFixed(3)}" title="Composed confidence (memory.confidence.v1)">conf ${score.toFixed(2)}</span>`;
 }
 
+function contextPackPreviewEntries(pack: ContextPack): Array<{ entry: ContextPack["entries"][number]; core: boolean }> {
+  const coreContext = pack.coreContext ?? [];
+  const coreRids = new Set(coreContext.map((entry) => entry.citation.rid));
+  const ordinary = pack.entries.filter((entry) => !coreRids.has(entry.citation.rid));
+  return [
+    ...coreContext.map((entry) => ({ entry, core: true })),
+    ...ordinary.map((entry) => ({ entry, core: false })),
+  ];
+}
+
 function contextPackSection(workbench: MemoryWorkbench): string {
   const pack = workbench.context_pack;
   return `<section>
@@ -602,8 +612,8 @@ function contextPackSection(workbench: MemoryWorkbench): string {
       <button type="submit">Build Pack</button>
     </form>
     <a id="memory-context-pack-link" class="button-link" href="/context-pack?goal=${encodeURIComponent(pack.goal)}">Open Context Pack</a>
-    <p id="memory-context-pack-status" class="meta">${pack.entries.length} context item(s), status ${escapeHtml(pack.status)}.</p>
-    <ul id="memory-context-pack-results">${pack.entries.slice(0, 4).map((entry) => `<li><strong>${escapeHtml(entry.title)}</strong><p class="meta">${escapeHtml(entry.section)} - <code>${escapeHtml(entry.citation.urn)}</code>${confidenceBadge(entry.confidence_score)}</p></li>`).join("")}</ul>
+    <p id="memory-context-pack-status" class="meta">${pack.entries.length} context item(s), ${pack.coreContext.length} core, status ${escapeHtml(pack.status)}.</p>
+    <ul id="memory-context-pack-results">${contextPackPreviewEntries(pack).slice(0, 4).map(({ entry, core }) => `<li><strong>${escapeHtml(entry.title)}</strong><p class="meta">${core ? "core_context" : escapeHtml(entry.section)} - <code>${escapeHtml(entry.citation.urn)}</code>${confidenceBadge(entry.confidence_score)}</p></li>`).join("")}</ul>
     <pre id="memory-context-pack-markdown" class="doc-body">${escapeHtml(pack.markdown)}</pre>
   </section>`;
 }
@@ -1416,15 +1426,20 @@ function contextPackScript(): string {
       if (!response.ok) throw new Error("HTTP " + response.status);
       const pack = await response.json();
       const entries = Array.isArray(pack.entries) ? pack.entries : [];
-      status.textContent = String(entries.length) + " context item(s), status " + String(pack.status || "unknown") + ".";
-      for (const entry of entries.slice(0, 8)) {
+      const coreContext = Array.isArray(pack.coreContext) ? pack.coreContext : [];
+      const coreRids = new Set(coreContext.map((entry) => entry && entry.citation ? entry.citation.rid : null));
+      const ordinary = entries.filter((entry) => !(entry && entry.citation && coreRids.has(entry.citation.rid)));
+      const previewEntries = coreContext.map((entry) => ({ entry, core: true })).concat(ordinary.map((entry) => ({ entry, core: false })));
+      status.textContent = String(entries.length) + " context item(s), " + String(coreContext.length) + " core, status " + String(pack.status || "unknown") + ".";
+      for (const preview of previewEntries.slice(0, 8)) {
+        const entry = preview.entry || {};
         const item = document.createElement("li");
         const title = document.createElement("h3");
         title.textContent = String(entry.title || "Context entry");
         const meta = document.createElement("p");
         meta.className = "meta";
         const citation = entry.citation || {};
-        meta.textContent = String(entry.section || "evidence") + " - " + String(citation.urn || "");
+        meta.textContent = (preview.core ? "core_context" : String(entry.section || "evidence")) + " - " + String(citation.urn || "");
         item.append(title, meta);
         results.append(item);
       }

--- a/src/apps/memory/tests/context-pack.test.ts
+++ b/src/apps/memory/tests/context-pack.test.ts
@@ -56,7 +56,7 @@ function node(
       content,
       confidence: "EXTRACTED",
       source: "manual",
-      importance: 0.8,
+      importance: 0.5,
       tier: "durable",
       created_at: NOW,
       ...extra,
@@ -80,6 +80,7 @@ describe("context packs", () => {
     });
 
     expect(pack.status).toBe("ok");
+    expect(pack.coreContext).toEqual([]);
     expect(pack.markdown.length).toBeLessThanOrEqual(2_000);
     expect(pack.markdown).toContain("## Hard constraints");
     expect(pack.markdown).toContain("## Prior decisions");
@@ -88,6 +89,8 @@ describe("context packs", () => {
     expect(pack.markdown).toContain("## Do-not-do guidance");
     expect(pack.markdown).toContain("[M1]");
     expect(pack.markdown).toContain("urn: memory_nodes:1");
+    expect(pack.markdown).toContain("trust: 1.00");
+    expect(pack.markdown).toContain("importance: 0.50");
     expect(pack.markdown).toContain("Reason:");
     expect(pack.entries.map((entry) => entry.citation.urn)).toEqual([
       "memory_nodes:1",
@@ -106,6 +109,53 @@ describe("context packs", () => {
     expect(artifact.html).toContain("Memory Context Pack");
     expect(artifact.html).toContain("Auth token constraint");
     expect(artifact.html).toContain('id="memory-context-pack-data"');
+  });
+
+  test("renders pinned eligible nodes as cited core context before ordinary sections", async () => {
+    const store = new MockStore([
+      node(1, "decision", "Pinned JWT invariant", "Decision: JWT token work must update docs/security.md.", {
+        importance: 0.9,
+        confidence: "INFERRED",
+        provenance: {
+          source_kind: "hook",
+          writer: "codex",
+          command: "memory extract",
+          evidence: ["issue #42"],
+        },
+      }),
+      node(2, "problem", "JWT rollout pitfall", "Pitfall: JWT rollout failed when signed fixtures were stale."),
+    ]);
+
+    const pack = await buildContextPack(store, "jwt token work", {
+      budgetChars: 2_000,
+      now: NOW,
+    });
+
+    expect(pack.coreContext.map((entry) => entry.citation.rid)).toEqual([1]);
+    expect(pack.entries.map((entry) => entry.citation.rid)).toEqual([1, 2]);
+    expect(pack.coreContext[0]).toMatchObject({
+      citation: { marker: "[M1]", urn: "memory_nodes:1" },
+      confidence: "INFERRED",
+      confidence_score: expect.any(Number),
+      trust: 0.85,
+      importance: 0.9,
+      provenance: { source_kind: "hook", writer: "codex" },
+    });
+    expect(pack.markdown.indexOf("## Core context")).toBeGreaterThan(-1);
+    expect(pack.markdown.indexOf("## Core context")).toBeLessThan(
+      pack.markdown.indexOf("## Known pitfalls"),
+    );
+    expect(pack.markdown).toContain("[M1] Pinned JWT invariant");
+    expect(pack.markdown).toContain("provenance: hook/codex");
+    expect(pack.markdown).toContain("trust: 0.85");
+    expect(pack.markdown).toContain("[M2] JWT rollout pitfall");
+
+    const artifact = buildContextPackViewerArtifact(pack);
+    expect(artifact.html.indexOf("Core Context")).toBeLessThan(
+      artifact.html.indexOf("Known Pitfalls"),
+    );
+    expect(artifact.html).toContain("[M1] Pinned JWT invariant");
+    expect(artifact.html).toContain("provenance hook/codex");
   });
 
   test("can include shared skill recommendation data", async () => {
@@ -196,6 +246,53 @@ describe("context packs", () => {
     expect(pack.markdown).toContain("contradicts memory_nodes:3");
   });
 
+  test("excludes superseded pinned nodes from core context while warning about them", async () => {
+    const store = new MockStore(
+      [
+        node(1, "decision", "Old pinned JWT decision", "Decision: jwt deploys on Fridays.", {
+          importance: 0.95,
+        }),
+        node(2, "decision", "Current JWT decision", "Decision: jwt deploys on Tuesdays.", {
+          importance: 0.6,
+        }),
+      ],
+      new Map([[1, 2]]),
+    );
+
+    const pack = await buildContextPack(store, "jwt deploy", { budgetChars: 2_000, now: NOW });
+
+    expect(pack.coreContext.map((entry) => entry.citation.rid)).not.toContain(1);
+    expect(pack.entries.map((entry) => entry.citation.rid)).not.toContain(1);
+    expect(pack.warnings).toEqual([
+      expect.objectContaining({ kind: "superseded", rids: [1, 2] }),
+    ]);
+    expect(pack.markdown).toContain("memory_nodes:1 is superseded by memory_nodes:2");
+  });
+
+  test("does not let pinned nodes bypass recall scope eligibility", async () => {
+    const store = new MockStore([
+      node(1, "decision", "Pinned session JWT secret", "Decision: jwt session-only secret.", {
+        importance: 0.95,
+        scope: "session",
+        scope_id: "session-a",
+      }),
+      node(2, "decision", "Project JWT decision", "Decision: jwt project work uses signed fixtures.", {
+        importance: 0.6,
+      }),
+    ]);
+
+    const projectPack = await buildContextPack(store, "jwt", { budgetChars: 2_000, now: NOW });
+    expect(projectPack.entries.map((entry) => entry.citation.rid)).toEqual([2]);
+    expect(projectPack.coreContext).toEqual([]);
+
+    const sessionPack = await buildContextPack(store, "jwt", {
+      budgetChars: 2_000,
+      now: NOW,
+      scope: { level: "session", id: "session-a" },
+    });
+    expect(sessionPack.coreContext.map((entry) => entry.citation.rid)).toEqual([1]);
+  });
+
   test("keeps deterministic ranking order while enforcing the caller budget", async () => {
     const store = new MockStore([
       node(1, "decision", "High rank decision", "Decision: jwt deploy jwt rollout uses canaries."),
@@ -213,6 +310,33 @@ describe("context packs", () => {
       now: NOW,
     });
     expect(budgeted.markdown.length).toBeLessThanOrEqual(360);
+    expect(budgeted.entries.map((entry) => entry.citation.rid)).toEqual([1]);
+    expect(budgeted.omittedEntries).toBe(1);
+    expect(budgeted.warnings).toEqual([
+      expect.objectContaining({ kind: "budget", rids: [2] }),
+    ]);
+  });
+
+  test("accounts for core context before ordinary recalled sections in the budget", async () => {
+    const store = new MockStore([
+      node(1, "decision", "Pinned budget JWT decision", "Decision: jwt budget must preserve core context.", {
+        importance: 0.95,
+      }),
+      node(2, "decision", "Ordinary budget JWT decision", "Decision: jwt budget may omit ordinary context."),
+    ]);
+    const fullPack = await buildContextPack(store, "jwt budget", {
+      budgetChars: 2_000,
+      now: NOW,
+    });
+    const budget = fullPack.markdown.indexOf("[M2]") - 1;
+
+    const budgeted = await buildContextPack(store, "jwt budget", {
+      budgetChars: budget,
+      now: NOW,
+    });
+
+    expect(budgeted.markdown.length).toBeLessThanOrEqual(budget);
+    expect(budgeted.coreContext.map((entry) => entry.citation.rid)).toEqual([1]);
     expect(budgeted.entries.map((entry) => entry.citation.rid)).toEqual([1]);
     expect(budgeted.omittedEntries).toBe(1);
     expect(budgeted.warnings).toEqual([

--- a/src/apps/memory/tests/workbench.test.ts
+++ b/src/apps/memory/tests/workbench.test.ts
@@ -54,6 +54,19 @@ describe("Memory workbench", () => {
   test("builds a unified local UI artifact over dashboard, capabilities, and timeline", async () => {
     const { root, store } = await graphRoot();
     await seedDoc(root, store);
+    await store.upsertNode({
+      label: "pinned-memory-workbench-context",
+      node_type: "decision",
+      properties: {
+        title: "Pinned Memory Workbench context",
+        content: "Decision: memory workbench context packs must show pinned core context first.",
+        confidence: "EXTRACTED",
+        source: "manual",
+        importance: 0.95,
+        tier: "durable",
+        created_at: 1_700_000_000_000,
+      },
+    });
     await appendMemoryEvent(
       store,
       hookLifecycleToMemoryEvent(
@@ -81,7 +94,7 @@ describe("Memory workbench", () => {
       read_only: true,
       dashboard: { schema_version: "memory.operational_dashboard.v1" },
       capabilities: { schema_version: "memory.capability_catalog.v1" },
-      references_radar: { schema_version: "memory.references_radar.v1" },
+      references_radar: { schema_version: "memory.reference_radar.v1" },
       context_pack: {
         goal: "memory",
       },
@@ -139,7 +152,7 @@ describe("Memory workbench", () => {
       consumes: [
         "memory.operational_dashboard.v1",
         "memory.capability_catalog.v1",
-        "memory.references_radar.v1",
+        "memory.reference_radar.v1",
         "memory.context_pack.v1",
         "memory.extraction_status.v1",
         "memory.governance.v1",
@@ -170,8 +183,8 @@ describe("Memory workbench", () => {
     expect(artifact.html).toContain("Open Memory Layers");
     expect(artifact.html).toContain('fetch("/api/layers"');
     expect(artifact.html).toContain("Capabilities");
-    expect(artifact.html).toContain("Competitive Radar");
-    expect(artifact.html).toContain("not a public benchmark claim");
+    expect(artifact.html).toContain("References Radar");
+    expect(artifact.html).toContain("not public benchmark claims");
     expect(artifact.html).toContain("Search Console");
     expect(artifact.html).toContain('action="/api/search"');
     expect(artifact.html).toContain('id="memory-search-form"');
@@ -184,6 +197,14 @@ describe("Memory workbench", () => {
     expect(artifact.html).toContain("asset_hits");
     expect(artifact.html).toContain("vector_hits");
     expect(artifact.html).toContain("Context Pack");
+    expect(workbench.context_pack.coreContext.map((entry) => entry.title)).toContain(
+      "Pinned Memory Workbench context",
+    );
+    expect(artifact.html).toContain("core_context");
+    expect(artifact.html).toContain("Pinned Memory Workbench context");
+    expect(artifact.html.indexOf("core_context")).toBeLessThan(
+      artifact.html.indexOf("memory-context-pack-markdown"),
+    );
     expect(artifact.html).toContain('id="memory-context-pack-form"');
     expect(artifact.html).toContain('href="/context-pack?goal=memory"');
     expect(artifact.html).toContain("Open Context Pack");
@@ -385,7 +406,7 @@ describe("Memory workbench", () => {
       expect(JSON.parse(json.stdout)).toMatchObject({
         schema_version: "memory.workbench.v1",
         dashboard: { schema_version: "memory.operational_dashboard.v1" },
-        references_radar: { schema_version: "memory.references_radar.v1" },
+        references_radar: { schema_version: "memory.reference_radar.v1" },
         context_pack: { goal: "memory" },
         extraction_status: { schema_version: "memory.extraction_status.v1" },
         governance: { schema_version: "memory.governance.v1" },


### PR DESCRIPTION
Closes #487.

## Summary
- add a pinned coreContext projection to Memory context packs
- render core context first in markdown/viewer/Workbench surfaces while suppressing duplicate ordinary previews
- preserve citation, confidence, trust, importance, and warning metadata
- refresh stale Workbench expectations for current reference-radar naming/copy

## Validation
- pnpm --dir src/apps/memory exec vitest run tests/context-pack.test.ts
- pnpm --dir src/apps/memory exec tsc -p tsconfig.json --noEmit
- pnpm --dir src/apps/memory exec vitest run
- pnpm --dir src/apps/memory exec vitest run --config vitest.integration.config.ts tests/context-pack-cli.test.ts tests/workbench.test.ts tests/mcp-server.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250024&installation_id=129708444&pr_number=494&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F494&signature=ca0455c937599e624dae18bb676635badee942b4ebd1ce87862ef1835e17b14b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Core Context" section to prioritize key information in context packs.
  * Enhanced metadata display with trust, importance, and provenance details for each entry.

* **Tests**
  * Added comprehensive test coverage for core context selection and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->