### PR TITLE
Document Brain ownership of personal facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It ships as three plugins:
 |--------|-----|----------------|
 | **`dev`** | Turns plans and GitHub issues into reviewed, tested PRs. | You want `/start`, `/to-prd`, `/to-issues`, `/triage`, `/tdd`, `/diagnose`, `/wiki`, the autonomous `/afk` loop, and the interactive `/ship` finalizer. |
 | **`memory`** | Gives those agents governed operational memory. | You want decisions, gotchas, validations, provenance, claim checks, readiness, context packs, and handoffs to survive `/clear`. |
-| **`brain`** | Gives the workspace a RedDB knowledge repository. | You want to dump notes, ideas, decisions, references, questions, and other knowledge into `.red/brain/*` and connect it later. |
+| **`brain`** | Gives the workspace a RedDB knowledge repository. | You want to dump notes, ideas, Personal facts, decisions, references, questions, and other human-facing knowledge into `.red/brain/*` and connect it later. |
 
 **Install all three in Claude Code:**
 
@@ -45,7 +45,7 @@ It ships as three plugins:
    SessionStart ─▶ .red/brain ─▶ capture ─▶ search ─▶ think
 ```
 
-**The punchline:** `dev` does the work. `memory` keeps the next agent from starting cold. `brain` stores the knowledge the human wants to keep.
+**The punchline:** `dev` does the work. `memory` keeps the next agent from starting cold. `brain` stores the knowledge the human wants to keep. Personal facts belong in Brain, not Memory.
 
 **Highlights**
 
@@ -68,8 +68,8 @@ RedSkills is not a bag of prompts. It is a small operating system for agentic en
 | Layer | Plugin | What it owns | First command |
 |-------|--------|--------------|---------------|
 | Work execution | `dev` | Planning, PRDs, issue slicing, triage, TDD, diagnosis, wiki, codebase orientation, and `/afk` workers. | `/setup-red-skills` |
-| Work memory | `memory` | Durable decisions, gotchas, reasoning traces, validations, provenance, supersession, claim checks, readiness, and handoff context. | `memory init` or `$init` |
-| Knowledge repository | `brain` | Freeform knowledge captures, typed artifacts, graph connections, and human-facing recall under `.red/brain/*`. | `$capture` or `brain capture` |
+| Work memory | `memory` | Durable operational decisions, gotchas, reasoning traces, validations, provenance, supersession, claim checks, readiness, and handoff context. | `memory init` or `$init` |
+| Knowledge repository | `brain` | Freeform knowledge captures, Personal facts, typed artifacts, graph connections, and human-facing recall under `.red/brain/*`. | `$capture` or `brain capture` |
 
 Brain skills: [`capture`](./plugins/brain/skills/core/capture/SKILL.md),
 [`search`](./plugins/brain/skills/core/search/SKILL.md),
@@ -77,7 +77,7 @@ Brain skills: [`capture`](./plugins/brain/skills/core/capture/SKILL.md),
 [`status`](./plugins/brain/skills/core/status/SKILL.md), and
 [`view`](./plugins/brain/skills/core/view/SKILL.md).
 
-Use `dev` when you want an agent to move the repo forward. Add `memory` when you want that movement to compound instead of evaporating after every session. Add `brain` when you want a workspace knowledge repository for arbitrary dumps and later synthesis.
+Use `dev` when you want an agent to move the repo forward. Add `memory` when you want that movement to compound instead of evaporating after every session. Add `brain` when you want a workspace knowledge repository for arbitrary dumps and later synthesis, including Personal facts that provide human-facing context.
 
 The intended loop is simple:
 
@@ -296,6 +296,11 @@ Output: `.red/agents/*.md`, `.red/config.yaml`, an `## Agent skills` block, a `#
 ## Memory — governed operational memory
 
 Agents forget the exact things you need them to remember: why a decision was made, which workaround failed, what the last validation proved, and which warning is stale. The `memory` plugin turns that into a governed local memory surface.
+
+Memory is not the Personal-fact store. Store Odysseus-style biographical facts,
+preferences, identity details, and other human-facing context in Brain via
+`brain capture`; Memory keeps operational evidence that helps agents do repo
+work.
 
 The loop is deliberately boring:
 

--- a/plugins/brain/README.md
+++ b/plugins/brain/README.md
@@ -4,6 +4,10 @@ RedSkills Brain is a project-local knowledge repository. It creates `.red/brain/
 for the workspace, treats RedDB as the source of truth, and stores typed
 artifacts plus graph connections for later search and synthesis.
 
+Brain owns Personal facts: biographical details, identity context, durable human
+preferences, relationship notes, and other human-facing context the user wants
+available later. Capture those as Brain artifacts rather than Memory facts.
+
 Brain root resolution prefers explicit overrides first, then walks up from the
 current directory until it finds a real `.red/brain` directory or a
 `.red/brain.root` marker. If neither exists, it falls back to the nearest
@@ -38,7 +42,8 @@ connection_string: $RED_BRAIN_CONNECTION_STRING
 
 Brain is separate from the Memory plugin. Memory exists to make agents work
 better; Brain exists to hold knowledge the user wants to dump, connect, search,
-and synthesize.
+and synthesize. If the content is about the person or their context rather than
+operational evidence from agent work, route it to Brain.
 
 Core skills: [capture](./skills/core/capture/SKILL.md),
 [search](./skills/core/search/SKILL.md), [think](./skills/core/think/SKILL.md),

--- a/plugins/brain/skills/core/README.md
+++ b/plugins/brain/skills/core/README.md
@@ -1,5 +1,9 @@
 # Brain Core Skills
 
+Brain is the home for Personal facts and other human-facing context: capture
+biographical details, identity context, durable human preferences, relationship
+notes, and similar knowledge here rather than in Memory.
+
 - [capture](./capture/SKILL.md) - Save durable knowledge into the project Brain.
 - [search](./search/SKILL.md) - Search artifacts in the project Brain.
 - [think](./think/SKILL.md) - Synthesize an answer from the project Brain.

--- a/plugins/brain/skills/core/capture/SKILL.md
+++ b/plugins/brain/skills/core/capture/SKILL.md
@@ -9,6 +9,10 @@ Use this when the user asks to save, dump, remember, or capture something in the
 project Brain. Brain stores typed artifacts in the workspace `.red/brain/*`
 RedDB store.
 
+Use Brain, not Memory, for Personal facts: biographical details, identity
+context, durable human preferences, relationship notes, and other human-facing
+context the user wants available later.
+
 Call the `brain_capture` MCP tool when available. Otherwise run:
 
 ```bash

--- a/plugins/dev/skills/engineering/context/SKILL.md
+++ b/plugins/dev/skills/engineering/context/SKILL.md
@@ -78,7 +78,7 @@ After a non-trivial investigation, store one fact per durable lesson:
 node "${CLAUDE_PLUGIN_ROOT}/../memory/scripts/bootstrap.mjs" store "<decision, gotcha, or why-note>"
 ```
 
-Store durable facts, decisions, root causes, and gotchas. Do not store secrets, transient progress, issue numbers, PR numbers, commit SHAs, or "task done" logs that will be stale in a week. If the learning is procedural and reusable, update or create a skill instead of storing it as memory.
+Store durable operational decisions, root causes, and gotchas. Do not store secrets, Personal facts, biographical details, durable human preferences, transient progress, issue numbers, PR numbers, commit SHAs, or "task done" logs that will be stale in a week. Route human-facing context to Brain with `brain capture`. If the learning is procedural and reusable, update or create a skill instead of storing it as memory.
 
 ### 7. Use token-efficient terminal surfaces
 
@@ -145,7 +145,8 @@ Keep this summary concise. The goal is to prove the agent is grounded, not to du
 | Prior decisions/gotchas | `/memory:recall` |
 | Code structure and impact | `/memory:ingest`, graph reads, `/zoom-out` |
 | External docs/research/source synthesis | `/wiki ingest`, `/wiki query` |
-| Durable new fact | `/memory:store` |
+| Durable operational work fact | `/memory:store` |
+| Personal fact or human-facing context | `brain capture` / `/brain:capture` |
 | Reusable procedure | update/create a `SKILL.md` |
 | Skill lifecycle maintenance | `memory status skills`, `memory curate skills`, `/curate` |
 
@@ -154,6 +155,6 @@ Keep this summary concise. The goal is to prove the agent is grounded, not to du
 - **Cold repo:** run `/setup-red-skills`, then `/wiki-init` only if the repo needs a private knowledge base, then `memory init --mode graph` when persistent graph recall is worth the local RedDB store.
 - **Large code change:** recall prior decisions, ingest if graph is stale, zoom out around the target, then drill down.
 - **Repeated agent failures:** recall prior attempts/root causes, inspect Skill telemetry, update the failing skill or file a human-ready curator issue.
-- **Research-heavy project:** ingest sources into the wiki, create synthesis pages, store only stable decisions/gotchas in Memory.
+- **Research-heavy project:** ingest sources into the wiki, create synthesis pages, store only stable operational decisions/gotchas in Memory, and capture Personal facts or human-facing context in Brain.
 
 </supporting-info>

--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -5,6 +5,9 @@ memory: scoped decisions, gotchas, reasoning traces, provenance, supersession,
 and trust checks that survive `/clear` and cross sessions. It is not a generic
 graph clone or a note bucket; the useful unit is agent work evidence that can be
 recalled, verified, aged, superseded, exported, and used by RedSkills workflows.
+It is also not a Personal-fact store: Odysseus-style biographical facts,
+identity details, long-lived human preferences, and other human-facing context
+belong in Brain artifacts under `.red/brain/*`.
 
 It **lives on top of the `dev` plugin** and is meant to improve dev's processes
 (`/afk` recall, `/triage` dedup, `/diagnose` root-cause history, `/zoom-out`
@@ -26,7 +29,7 @@ into governed context. The core path is intentionally small:
 | Step | Command surface | What good output looks like |
 |------|-----------------|-----------------------------|
 | Initialize | `memory init` / `$init` | A project-local `.red/memory` surface with either markdown-only notes or graph-backed governed memory. |
-| Capture | `memory store` / `$store`, hooks, `memory extract` | One scoped decision, gotcha, validation, risk, or root-cause fact with enough provenance to verify later. |
+| Capture | `memory store` / `$store`, hooks, `memory extract` | One scoped operational decision, gotcha, validation, risk, or root-cause fact with enough provenance to verify later. |
 | Recall | `memory recall` / `$recall`, SessionStart hooks | A compact set of relevant claims/evidence, ranked by usefulness and hiding superseded guidance by default. |
 | Verify | `claim-check`, `readiness`, `governance`, `lint`, `decay`, `health` | Stale, contradicted, unsupported, or risky claims are visible before an agent acts on them. |
 | Handoff | `context-pack`, `handoff`, Workbench panels | Cited context that another agent/session can inject without replaying the whole history. |

--- a/plugins/memory/skills/core/extract/SKILL.md
+++ b/plugins/memory/skills/core/extract/SKILL.md
@@ -20,7 +20,7 @@ If either is missing, stop and explain the missing prerequisite. Do not silently
 
 ## 2. Select the transcript deliberately
 
-Use a transcript/log that contains durable learning: decisions, root causes, gotchas, why-notes, failed attempts that explain constraints, or stable preferences. Do not extract secrets, raw credentials, private personal data, issue-only progress, PR numbers, commit SHAs, or stale task-completion logs.
+Use a transcript/log that contains durable operational learning: decisions, root causes, gotchas, why-notes, or failed attempts that explain constraints. Do not extract secrets, raw credentials, private personal data, Odysseus-style Personal facts, biographical details, issue-only progress, PR numbers, commit SHAs, or stale task-completion logs. Long-lived human preferences and identity context belong in Brain, not Memory.
 
 ## 3. Run extraction
 

--- a/plugins/memory/skills/core/store/SKILL.md
+++ b/plugins/memory/skills/core/store/SKILL.md
@@ -5,7 +5,7 @@ description: Save one durable work fact to the project's configured memory surfa
 
 # memory store
 
-Saves one fact to the project's memory and routes to whatever `memory init`
+Saves one operational work fact to the project's memory and routes to whatever `memory init`
 configured. In **markdown-only** mode it writes a markdown note under
 `.red/memory/notes/` — the note **is** the canonical store, human-readable and
 committable. In **graph** mode it writes a deduped operational-memory node to
@@ -39,6 +39,7 @@ Report the note path or graph node id so the user knows what was captured.
 
 - ✅ Store a single, self-contained fact per call (a decision, a gotcha, a why-note).
 - ✅ Capture the *why*, not just the *what*, when the user is explaining a decision.
+- ❌ Don't store Personal facts, biographical details, identity context, or long-lived human preferences in Memory; route them to Brain with `brain capture`.
 - ❌ Don't store secrets — notes are plain text on disk and may be committed.
 - ❌ Don't hand-write files into `notesDir` — go through the CLI so ids and frontmatter stay consistent.
 

--- a/src/apps/dev/tests/memory-brain-boundary-docs.test.ts
+++ b/src/apps/dev/tests/memory-brain-boundary-docs.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..", "..");
+
+async function readRepoFile(path: string): Promise<string> {
+  return readFile(join(ROOT, path), "utf8");
+}
+
+describe("Memory/Brain boundary docs", () => {
+  it("routes Personal facts to Brain and keeps Memory operational", async () => {
+    const readme = await readRepoFile("README.md");
+    const memoryReadme = await readRepoFile("plugins/memory/README.md");
+    const brainReadme = await readRepoFile("plugins/brain/README.md");
+
+    expect(readme).toContain("Personal facts belong in Brain, not Memory.");
+    expect(readme).toContain("Memory is not the Personal-fact store.");
+    expect(memoryReadme).toContain("not a Personal-fact store");
+    expect(memoryReadme).toContain("belong in Brain artifacts under `.red/brain/*`");
+    expect(brainReadme).toContain("Brain owns Personal facts");
+    expect(brainReadme).toContain("human-facing context");
+  });
+
+  it("documents the routing boundary where agents choose a context surface", async () => {
+    const contextSkill = await readRepoFile("plugins/dev/skills/engineering/context/SKILL.md");
+    const memoryStore = await readRepoFile("plugins/memory/skills/core/store/SKILL.md");
+    const memoryExtract = await readRepoFile("plugins/memory/skills/core/extract/SKILL.md");
+    const brainCapture = await readRepoFile("plugins/brain/skills/core/capture/SKILL.md");
+
+    expect(contextSkill).toContain("Route human-facing context to Brain with `brain capture`.");
+    expect(contextSkill).toContain("| Durable operational work fact | `/memory:store` |");
+    expect(contextSkill).toContain("| Personal fact or human-facing context | `brain capture` / `/brain:capture` |");
+    expect(memoryStore).toContain("Don't store Personal facts");
+    expect(memoryStore).toContain("route them to Brain with `brain capture`");
+    expect(memoryExtract).toContain("Do not extract");
+    expect(memoryExtract).toContain("Odysseus-style Personal facts");
+    expect(brainCapture).toContain("Use Brain, not Memory, for Personal facts");
+  });
+});

--- a/src/apps/memory/src/extract-conversation.ts
+++ b/src/apps/memory/src/extract-conversation.ts
@@ -186,6 +186,8 @@ const SYSTEM_PROMPT = [
   `- relation label is one of: ${EDGE_LABELS.join(", ")}.`,
   "- Extract decisions, problems, solutions, fixes, and the concepts/people they",
   "  involve. Skip transient chatter and anything already obvious from the code.",
+  "- Do not extract Odysseus-style Personal facts, biographical details, identity",
+  "  context, or long-lived human preferences; those belong in Brain, not Memory.",
   "- Prefer fewer, higher-signal facts. Return an empty array when nothing is",
   "  worth remembering.",
 ].join("\n");

--- a/src/apps/memory/src/routing-guide.ts
+++ b/src/apps/memory/src/routing-guide.ts
@@ -89,9 +89,9 @@ const RULES: MemoryRoutingRule[] = [
     reason: "Get where-we-left-off context, map-first orientation, and a readiness score with missing-evidence warnings.",
   },
   {
-    when: "When preserving a durable fact, decision, fix, or user preference",
-    call: "memory_store only when the user asked to remember it or the fact is clearly durable",
-    reason: "Keep memory useful without polluting it with transient reasoning.",
+    when: "When preserving a durable operational decision, fix, gotcha, or agent-work preference",
+    call: "memory_store only for operational evidence; route Personal facts and human-facing context to Brain",
+    reason: "Keep Memory useful without turning it into a Personal fact store.",
   },
 ];
 
@@ -134,7 +134,8 @@ export function buildMemoryRoutingGuide(
   const targetFiles = integration.targetFiles;
   const safetyNotes = [
     "Read-only tools are preferred before mutating Memory.",
-    "memory_store is durable; do not store secrets, raw credentials, or transient chain-of-thought.",
+    "memory_store is durable; do not store secrets, raw credentials, Personal facts, human-facing context, or transient chain-of-thought.",
+    "Personal facts, biographical details, identity context, and durable human preferences belong in Brain, not Memory.",
     "memory_supersede and conflict-resolution tools are mutating; use them only with explicit user intent.",
     "Citations such as memory_nodes:<rid> should be kept in summaries when they support an important claim.",
   ];

--- a/src/apps/memory/tests/__snapshots__/viewer-rendering.test.ts.snap
+++ b/src/apps/memory/tests/__snapshots__/viewer-rendering.test.ts.snap
@@ -475,9 +475,9 @@ exports[`Memory viewer rendering > keeps routing guide viewer HTML stable 1`] = 
         <p><code>memory_handoff, then memory_onboarding_map and memory_readiness for the immediate goal</code></p>
         <p class="meta">Get where-we-left-off context, map-first orientation, and a readiness score with missing-evidence warnings.</p>
       </li><li>
-        <strong>When preserving a durable fact, decision, fix, or user preference</strong>
-        <p><code>memory_store only when the user asked to remember it or the fact is clearly durable</code></p>
-        <p class="meta">Keep memory useful without polluting it with transient reasoning.</p>
+        <strong>When preserving a durable operational decision, fix, gotcha, or agent-work preference</strong>
+        <p><code>memory_store only for operational evidence; route Personal facts and human-facing context to Brain</code></p>
+        <p class="meta">Keep Memory useful without turning it into a Personal fact store.</p>
       </li>
     </ul>
   </section>
@@ -535,11 +535,12 @@ Rules:
 - When touching an unfamiliar file or symbol: call \`memory_structural_impact with file/symbol; use memory_path_explain when two labels need a relationship explanation\` - Find graph-backed imports, call/type/schema relationships, and cited paths between concepts.
 - When the user asks about project history, prior discussion, docs, or decisions: call \`memory_recall first; use memory_doc_search and memory_doc_read for ingested document chunks\` - Prefer zero-token retrieval and local source reads before asking an LLM to synthesize.
 - When starting in an unfamiliar repo or after a long gap: call \`memory_handoff, then memory_onboarding_map and memory_readiness for the immediate goal\` - Get where-we-left-off context, map-first orientation, and a readiness score with missing-evidence warnings.
-- When preserving a durable fact, decision, fix, or user preference: call \`memory_store only when the user asked to remember it or the fact is clearly durable\` - Keep memory useful without polluting it with transient reasoning.
+- When preserving a durable operational decision, fix, gotcha, or agent-work preference: call \`memory_store only for operational evidence; route Personal facts and human-facing context to Brain\` - Keep Memory useful without turning it into a Personal fact store.
 
 Safety:
 - Read-only tools are preferred before mutating Memory.
-- memory_store is durable; do not store secrets, raw credentials, or transient chain-of-thought.
+- memory_store is durable; do not store secrets, raw credentials, Personal facts, human-facing context, or transient chain-of-thought.
+- Personal facts, biographical details, identity context, and durable human preferences belong in Brain, not Memory.
 - memory_supersede and conflict-resolution tools are mutating; use them only with explicit user intent.
 - Citations such as memory_nodes:&lt;rid&gt; should be kept in summaries when they support an important claim.
 
@@ -660,18 +661,19 @@ Agent: codex
       "reason": "Get where-we-left-off context, map-first orientation, and a readiness score with missing-evidence warnings."
     },
     {
-      "when": "When preserving a durable fact, decision, fix, or user preference",
-      "call": "memory_store only when the user asked to remember it or the fact is clearly durable",
-      "reason": "Keep memory useful without polluting it with transient reasoning."
+      "when": "When preserving a durable operational decision, fix, gotcha, or agent-work preference",
+      "call": "memory_store only for operational evidence; route Personal facts and human-facing context to Brain",
+      "reason": "Keep Memory useful without turning it into a Personal fact store."
     }
   ],
   "safetyNotes": [
     "Read-only tools are preferred before mutating Memory.",
-    "memory_store is durable; do not store secrets, raw credentials, or transient chain-of-thought.",
+    "memory_store is durable; do not store secrets, raw credentials, Personal facts, human-facing context, or transient chain-of-thought.",
+    "Personal facts, biographical details, identity context, and durable human preferences belong in Brain, not Memory.",
     "memory_supersede and conflict-resolution tools are mutating; use them only with explicit user intent.",
     "Citations such as memory_nodes:\\u003crid> should be kept in summaries when they support an important claim."
   ],
-  "installSnippet": "## Memory Routing\\n\\nUse the Memory MCP tools proactively when prior project knowledge could change the answer.\\n\\nIntegration:\\n- Agent: Codex CLI\\n- Transports: agent-rules, mcp, hooks, http\\n- MCP server command: \`memory-mcp\`\\n- Optional HTTP workbench/API: \`memory serve --host 127.0.0.1 --port 3113\`\\n\\nRules:\\n- Before architecture, migration, or multi-file implementation work: call \`memory_context_pack with the concrete goal\` - Load prior decisions, validations, warnings, and citations before planning.\\n- Before claiming a design or rule is current: call \`memory_claim_check with the exact assertion\` - Check active, superseded, and contradictory evidence instead of trusting memory.\\n- When the task asks what changed, what can break, or what a PR needs: call \`memory_pre_pr_review with explicit changed_files\` - Connect changed files to concepts, decisions, known failures, and validations.\\n- When touching an unfamiliar file or symbol: call \`memory_structural_impact with file/symbol; use memory_path_explain when two labels need a relationship explanation\` - Find graph-backed imports, call/type/schema relationships, and cited paths between concepts.\\n- When the user asks about project history, prior discussion, docs, or decisions: call \`memory_recall first; use memory_doc_search and memory_doc_read for ingested document chunks\` - Prefer zero-token retrieval and local source reads before asking an LLM to synthesize.\\n- When starting in an unfamiliar repo or after a long gap: call \`memory_handoff, then memory_onboarding_map and memory_readiness for the immediate goal\` - Get where-we-left-off context, map-first orientation, and a readiness score with missing-evidence warnings.\\n- When preserving a durable fact, decision, fix, or user preference: call \`memory_store only when the user asked to remember it or the fact is clearly durable\` - Keep memory useful without polluting it with transient reasoning.\\n\\nSafety:\\n- Read-only tools are preferred before mutating Memory.\\n- memory_store is durable; do not store secrets, raw credentials, or transient chain-of-thought.\\n- memory_supersede and conflict-resolution tools are mutating; use them only with explicit user intent.\\n- Citations such as memory_nodes:\\u003crid> should be kept in summaries when they support an important claim.\\n\\nTarget file: AGENTS.md\\nAgent: codex\\n"
+  "installSnippet": "## Memory Routing\\n\\nUse the Memory MCP tools proactively when prior project knowledge could change the answer.\\n\\nIntegration:\\n- Agent: Codex CLI\\n- Transports: agent-rules, mcp, hooks, http\\n- MCP server command: \`memory-mcp\`\\n- Optional HTTP workbench/API: \`memory serve --host 127.0.0.1 --port 3113\`\\n\\nRules:\\n- Before architecture, migration, or multi-file implementation work: call \`memory_context_pack with the concrete goal\` - Load prior decisions, validations, warnings, and citations before planning.\\n- Before claiming a design or rule is current: call \`memory_claim_check with the exact assertion\` - Check active, superseded, and contradictory evidence instead of trusting memory.\\n- When the task asks what changed, what can break, or what a PR needs: call \`memory_pre_pr_review with explicit changed_files\` - Connect changed files to concepts, decisions, known failures, and validations.\\n- When touching an unfamiliar file or symbol: call \`memory_structural_impact with file/symbol; use memory_path_explain when two labels need a relationship explanation\` - Find graph-backed imports, call/type/schema relationships, and cited paths between concepts.\\n- When the user asks about project history, prior discussion, docs, or decisions: call \`memory_recall first; use memory_doc_search and memory_doc_read for ingested document chunks\` - Prefer zero-token retrieval and local source reads before asking an LLM to synthesize.\\n- When starting in an unfamiliar repo or after a long gap: call \`memory_handoff, then memory_onboarding_map and memory_readiness for the immediate goal\` - Get where-we-left-off context, map-first orientation, and a readiness score with missing-evidence warnings.\\n- When preserving a durable operational decision, fix, gotcha, or agent-work preference: call \`memory_store only for operational evidence; route Personal facts and human-facing context to Brain\` - Keep Memory useful without turning it into a Personal fact store.\\n\\nSafety:\\n- Read-only tools are preferred before mutating Memory.\\n- memory_store is durable; do not store secrets, raw credentials, Personal facts, human-facing context, or transient chain-of-thought.\\n- Personal facts, biographical details, identity context, and durable human preferences belong in Brain, not Memory.\\n- memory_supersede and conflict-resolution tools are mutating; use them only with explicit user intent.\\n- Citations such as memory_nodes:\\u003crid> should be kept in summaries when they support an important claim.\\n\\nTarget file: AGENTS.md\\nAgent: codex\\n"
 }</script>
   </main>
 </body>

--- a/src/apps/memory/tests/extract-conversation.test.ts
+++ b/src/apps/memory/tests/extract-conversation.test.ts
@@ -85,6 +85,8 @@ describe("buildExtractionPrompt", () => {
     expect(a.system).toContain("node_type is one of");
     expect(a.system).toContain("problem");
     expect(a.system).toContain("FIXES");
+    expect(a.system).toContain("Do not extract Odysseus-style Personal facts");
+    expect(a.system).toContain("belong in Brain, not Memory");
     expect(a.user).toContain("the deploy kept failing on cold start");
   });
 

--- a/src/apps/memory/tests/routing-guide.test.ts
+++ b/src/apps/memory/tests/routing-guide.test.ts
@@ -41,11 +41,19 @@ describe("Memory routing guide", () => {
       expect.arrayContaining([
         expect.stringContaining("memory_claim_check"),
         expect.stringContaining("memory_structural_impact"),
+        expect.stringContaining("route Personal facts and human-facing context to Brain"),
+      ]),
+    );
+    expect(guide.safetyNotes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Personal facts, human-facing context"),
+        expect.stringContaining("belong in Brain, not Memory"),
       ]),
     );
     expect(guide.installSnippet).toContain("## Memory Routing");
     expect(guide.installSnippet).toContain("MCP server command");
     expect(guide.installSnippet).toContain("Target file: AGENTS.md");
+    expect(guide.installSnippet).toContain("route Personal facts and human-facing context to Brain");
   });
 
   test("builds multi-agent integration metadata for MCP-first agents", () => {


### PR DESCRIPTION
Closes #488.

## Summary
- document that Personal facts belong in Brain, not Memory, across top-level, Brain, Memory, and context routing docs
- tighten Memory store/extract guidance toward operational evidence only
- update Memory runtime routing guide and extraction prompt for Personal fact boundaries
- add doc-contract and routing/extraction tests, plus updated routing viewer snapshot

## Validation
- pnpm --dir src/apps/dev exec vitest run tests/memory-brain-boundary-docs.test.ts
- pnpm --dir src/apps/memory exec vitest run tests/extract-conversation.test.ts tests/viewer-rendering.test.ts
- pnpm --dir src/apps/memory exec vitest run --config vitest.integration.config.ts tests/routing-guide.test.ts
- pnpm --dir src/apps/dev exec tsc -p tsconfig.json --noEmit
- pnpm --dir src/apps/memory exec tsc -p tsconfig.json --noEmit

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250937&installation_id=129708444&pr_number=495&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F495&signature=4255a48f83adf5d344e512896b9b910dfda90023cc53711eba35f17d14576d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between Memory plugin (operational facts) and Brain plugin (personal/biographical details and human-facing context)
  * Updated documentation and skill guides to direct personal facts, identity context, and durable preferences to Brain instead of Memory

* **Tests**
  * Added validation tests to ensure documentation consistency across Memory/Brain boundary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->