### PR TITLE
Provider tidy recommendations appear in read-only governance

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -4431,6 +4431,11 @@ function printGovernance(report: MemoryGovernanceReport): void {
     `  tidy=${report.tidy_availability.status}` +
       (report.tidy_availability.reason ? ` (${report.tidy_availability.reason})` : ""),
   );
+  console.log(
+    `  tidy recommendations=${report.tidy_recommendations.summary.recommended_pairs}/` +
+      `${report.tidy_recommendations.summary.candidate_pairs}` +
+      (report.tidy_recommendations.reason ? ` (${report.tidy_recommendations.reason})` : ""),
+  );
   for (const item of report.provenance.missing.slice(0, 5)) {
     console.log(`  missing provenance: memory_nodes:${item.rid} ${item.title}`);
   }

--- a/src/apps/memory/src/governance-tidy.ts
+++ b/src/apps/memory/src/governance-tidy.ts
@@ -1,0 +1,538 @@
+import type { MemoryStore } from "./graph-store.js";
+import {
+  buildMemoryMergePassReport,
+  type MemoryMergeCandidate,
+} from "./memory-merge-pass.js";
+import {
+  resolveProvider,
+  type AiProviderConfig,
+  type ProviderClient,
+} from "./extract-conversation.js";
+import { redDbProviderClient } from "./provider-client.js";
+import {
+  DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+  listProviderReviewArtifacts,
+  providerReviewArtifactId,
+  providerReviewRecommendationId,
+  type ProviderReviewPairEvidence,
+  type ProviderReviewRecommendationInput,
+  type ProviderReviewStatus,
+} from "./provider-review-artifacts.js";
+
+export const DEFAULT_GOVERNANCE_TIDY_RECOMMENDATION_CAP = 5;
+export const DEFAULT_GOVERNANCE_TIDY_CANDIDATE_LIMIT = 20;
+export const DEFAULT_GOVERNANCE_TIDY_MAX_RECOMMENDATION_RATIO = 0.25;
+export const GOVERNANCE_TIDY_OPERATION = "governance.tidy";
+
+export type MemoryGovernanceTidyRecommendationsStatus =
+  | "available"
+  | "degraded"
+  | "unavailable";
+export type MemoryGovernanceTidyRelation = "duplicate" | "near_duplicate";
+
+export interface MemoryGovernanceTidyRecommendation {
+  id: string;
+  artifact_id: string;
+  recommendation_id: string;
+  recommendation_key: string;
+  operation: typeof GOVERNANCE_TIDY_OPERATION;
+  review_status: ProviderReviewStatus;
+  relation: MemoryGovernanceTidyRelation;
+  confidence: number;
+  rationale: string;
+  proposed_soft_merge: {
+    action: "SOFT_MERGE";
+    edge_label: "SAME_AS";
+    duplicate_rid: number;
+    canonical_rid: number;
+    direction: string;
+  };
+  pair_evidence: ProviderReviewPairEvidence[];
+  provider?: {
+    mode?: string;
+    model?: string;
+  };
+}
+
+export interface MemoryGovernanceTidyRecommendations {
+  schema_version: "memory.governance_tidy_recommendations.v1";
+  read_only: true;
+  source: "provider-review-artifacts";
+  status: MemoryGovernanceTidyRecommendationsStatus;
+  reason: string | null;
+  policy: {
+    operation: typeof GOVERNANCE_TIDY_OPERATION;
+    review_policy_version: typeof DEFAULT_TIDY_REVIEW_POLICY_VERSION;
+    candidate_limit: number;
+    recommendation_cap: number;
+    max_recommendation_ratio: number;
+    allowed_actions: ["SOFT_MERGE"];
+    allowed_relations: ["duplicate", "near_duplicate"];
+  };
+  summary: {
+    candidate_pairs: number;
+    recommended_pairs: number;
+    dropped_recommendations: number;
+  };
+  warnings: string[];
+  recommendations: MemoryGovernanceTidyRecommendation[];
+}
+
+export interface BuildGovernanceTidyRecommendationsOptions {
+  providerConfig?: AiProviderConfig;
+  providerClient?: ProviderClient;
+  now?: number;
+  candidateLimit?: number;
+  recommendationCap?: number;
+  maxRecommendationRatio?: number;
+}
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | JsonRecord;
+type JsonRecord = { [key: string]: JsonValue | undefined };
+
+interface ProviderTidyRecommendationCandidate {
+  candidateId: string;
+  relation: MemoryGovernanceTidyRelation;
+  confidence: number;
+  rationale: string;
+  raw: JsonRecord;
+}
+
+export async function buildMemoryGovernanceTidyRecommendations(
+  store: MemoryStore,
+  opts: BuildGovernanceTidyRecommendationsOptions = {},
+): Promise<MemoryGovernanceTidyRecommendations> {
+  const policy = tidyPolicy(opts);
+  if (!opts.providerConfig) {
+    return emptyTidyRecommendations(policy, "unavailable", "no AI provider configured for governance tidy");
+  }
+
+  let provider: ReturnType<typeof resolveProvider>;
+  try {
+    provider = resolveProvider(opts.providerConfig);
+  } catch (err) {
+    return emptyTidyRecommendations(policy, "degraded", errorMessage(err));
+  }
+
+  const mergePass = await buildMemoryMergePassReport(store, {
+    limit: policy.candidate_limit,
+    now: opts.now,
+  });
+  const candidates = mergePass.candidates;
+  if (candidates.length === 0) {
+    return {
+      ...emptyTidyRecommendations(policy, "available", null),
+      summary: { candidate_pairs: 0, recommended_pairs: 0, dropped_recommendations: 0 },
+    };
+  }
+
+  const warnings: string[] = [];
+  let raw: string;
+  try {
+    const client = opts.providerClient ?? redDbProviderClient(store, opts.providerConfig);
+    raw = await client.complete(buildProviderTidyPrompt(candidates, policy));
+  } catch (err) {
+    return emptyTidyRecommendations(
+      policy,
+      "degraded",
+      `provider tidy failed: ${errorMessage(err)}`,
+      candidates.length,
+    );
+  }
+
+  const parsed = parseProviderTidyResponse(raw, candidates);
+  warnings.push(...parsed.warnings);
+  const allowedByGuard = allowedRecommendationCount(candidates.length, policy);
+  let bounded = parsed.recommendations;
+  if (parsed.recommendations.length > allowedByGuard) {
+    warnings.push(
+      `provider tidy returned ${parsed.recommendations.length} recommendation(s), exceeding guard ${allowedByGuard}; output was bounded`,
+    );
+    bounded = parsed.recommendations.slice(0, allowedByGuard);
+  }
+
+  const statusByArtifact = await providerReviewStatusLookup(store);
+  const recommendations = bounded.map((rec) =>
+    toGovernanceRecommendation(rec, candidates, provider, statusByArtifact),
+  );
+  const dropped = parsed.dropped + Math.max(0, parsed.recommendations.length - bounded.length);
+  return {
+    schema_version: "memory.governance_tidy_recommendations.v1",
+    read_only: true,
+    source: "provider-review-artifacts",
+    status: warnings.length > 0 ? "degraded" : "available",
+    reason: warnings[0] ?? null,
+    policy,
+    summary: {
+      candidate_pairs: candidates.length,
+      recommended_pairs: recommendations.length,
+      dropped_recommendations: dropped,
+    },
+    warnings,
+    recommendations,
+  };
+}
+
+function tidyPolicy(
+  opts: BuildGovernanceTidyRecommendationsOptions,
+): MemoryGovernanceTidyRecommendations["policy"] {
+  return {
+    operation: GOVERNANCE_TIDY_OPERATION,
+    review_policy_version: DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+    candidate_limit: opts.candidateLimit ?? DEFAULT_GOVERNANCE_TIDY_CANDIDATE_LIMIT,
+    recommendation_cap: opts.recommendationCap ?? DEFAULT_GOVERNANCE_TIDY_RECOMMENDATION_CAP,
+    max_recommendation_ratio:
+      opts.maxRecommendationRatio ?? DEFAULT_GOVERNANCE_TIDY_MAX_RECOMMENDATION_RATIO,
+    allowed_actions: ["SOFT_MERGE"],
+    allowed_relations: ["duplicate", "near_duplicate"],
+  };
+}
+
+function emptyTidyRecommendations(
+  policy: MemoryGovernanceTidyRecommendations["policy"],
+  status: MemoryGovernanceTidyRecommendationsStatus,
+  reason: string | null,
+  candidatePairs = 0,
+): MemoryGovernanceTidyRecommendations {
+  return {
+    schema_version: "memory.governance_tidy_recommendations.v1",
+    read_only: true,
+    source: "provider-review-artifacts",
+    status,
+    reason,
+    policy,
+    summary: {
+      candidate_pairs: candidatePairs,
+      recommended_pairs: 0,
+      dropped_recommendations: 0,
+    },
+    warnings: reason ? [reason] : [],
+    recommendations: [],
+  };
+}
+
+function buildProviderTidyPrompt(
+  candidates: MemoryMergeCandidate[],
+  policy: MemoryGovernanceTidyRecommendations["policy"],
+): { system: string; user: string } {
+  return {
+    system: [
+      "You review Memory graph tidy candidates.",
+      "Return ONLY JSON with this shape:",
+      '{"recommendations":[{"candidate_id":string,"relation":"duplicate"|"near_duplicate","confidence":number,"rationale":string,"proposed_action":"SOFT_MERGE"}]}',
+      "Recommend only semantically duplicate or near-duplicate Soft-merge candidates.",
+      "Do not recommend supersession, deprecation, retention, contradiction resolution, deletion, pruning, or content rewrite.",
+    ].join("\n"),
+    user: JSON.stringify({
+      policy,
+      candidates: candidates.map((candidate) => ({
+        candidate_id: candidateId(candidate),
+        rank: candidate.rank,
+        score: candidate.score,
+        proposed_soft_merge: {
+          action: "SOFT_MERGE",
+          edge_label: "SAME_AS",
+          duplicate_rid: candidate.duplicate_rid,
+          canonical_rid: candidate.canonical_rid,
+        },
+        left: candidate.left,
+        right: candidate.right,
+        evidence: candidate.evidence,
+      })),
+    }),
+  };
+}
+
+function parseProviderTidyResponse(
+  raw: string,
+  candidates: MemoryMergeCandidate[],
+): {
+  recommendations: ProviderTidyRecommendationCandidate[];
+  dropped: number;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(unfence(raw));
+  } catch {
+    return {
+      recommendations: [],
+      dropped: 0,
+      warnings: ["provider tidy returned malformed JSON"],
+    };
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.recommendations)) {
+    return {
+      recommendations: [],
+      dropped: 0,
+      warnings: ["provider tidy response missing recommendations[]"],
+    };
+  }
+
+  const knownCandidates = new Map(candidates.map((candidate) => [candidateId(candidate), candidate]));
+  const seen = new Set<string>();
+  const recommendations: ProviderTidyRecommendationCandidate[] = [];
+  let dropped = 0;
+  for (const item of parsed.recommendations) {
+    const rawItem = normalizeJson(item);
+    if (!isRecord(rawItem)) {
+      dropped += 1;
+      warnings.push("provider tidy dropped non-object recommendation");
+      continue;
+    }
+    const candidateIdValue = stringValue(rawItem.candidate_id);
+    const candidate = candidateIdValue ? knownCandidates.get(candidateIdValue) : undefined;
+    if (!candidateIdValue || !candidate) {
+      dropped += 1;
+      warnings.push("provider tidy dropped recommendation for an unknown candidate");
+      continue;
+    }
+    if (seen.has(candidateIdValue)) {
+      dropped += 1;
+      warnings.push("provider tidy dropped duplicate recommendation for the same candidate");
+      continue;
+    }
+    const relation = tidyRelation(rawItem.relation ?? rawItem.kind);
+    if (!relation) {
+      dropped += 1;
+      warnings.push("provider tidy dropped non-duplicate recommendation");
+      continue;
+    }
+    if (!isSoftMergeAction(rawItem.proposed_action ?? rawItem.action)) {
+      dropped += 1;
+      warnings.push("provider tidy dropped non-Soft-merge recommendation");
+      continue;
+    }
+    if (!isSameAsEdge(rawItem.proposed_edge_label ?? rawItem.edge_label)) {
+      dropped += 1;
+      warnings.push("provider tidy dropped non-SAME_AS merge direction");
+      continue;
+    }
+    if (!matchesOptionalRid(rawItem.duplicate_rid, candidate.duplicate_rid)) {
+      dropped += 1;
+      warnings.push("provider tidy dropped recommendation with conflicting duplicate direction");
+      continue;
+    }
+    if (!matchesOptionalRid(rawItem.canonical_rid, candidate.canonical_rid)) {
+      dropped += 1;
+      warnings.push("provider tidy dropped recommendation with conflicting canonical direction");
+      continue;
+    }
+    const confidence = confidenceValue(rawItem.confidence);
+    if (confidence == null) {
+      dropped += 1;
+      warnings.push("provider tidy dropped recommendation without confidence");
+      continue;
+    }
+    const rationale = stringValue(rawItem.rationale);
+    if (!rationale) {
+      dropped += 1;
+      warnings.push("provider tidy dropped recommendation without rationale");
+      continue;
+    }
+    seen.add(candidateIdValue);
+    recommendations.push({
+      candidateId: candidateIdValue,
+      relation,
+      confidence,
+      rationale,
+      raw: rawItem,
+    });
+  }
+  recommendations.sort(
+    (a, b) =>
+      b.confidence - a.confidence ||
+      (knownCandidates.get(a.candidateId)?.rank ?? 0) -
+        (knownCandidates.get(b.candidateId)?.rank ?? 0),
+  );
+  return { recommendations, dropped, warnings: [...new Set(warnings)] };
+}
+
+async function providerReviewStatusLookup(
+  store: Pick<MemoryStore, "kvGet">,
+): Promise<Map<string, ProviderReviewStatus>> {
+  const statuses = new Map<string, ProviderReviewStatus>();
+  for (const artifact of await listProviderReviewArtifacts(store, { operation: GOVERNANCE_TIDY_OPERATION })) {
+    statuses.set(artifact.artifact_id, artifact.status);
+    if (!statuses.has(artifact.recommendation_id)) {
+      statuses.set(artifact.recommendation_id, artifact.status);
+    }
+  }
+  return statuses;
+}
+
+function toGovernanceRecommendation(
+  rec: ProviderTidyRecommendationCandidate,
+  candidates: MemoryMergeCandidate[],
+  provider: ReturnType<typeof resolveProvider>,
+  statusByArtifact: Map<string, ProviderReviewStatus>,
+): MemoryGovernanceTidyRecommendation {
+  const candidate = candidates.find((item) => candidateId(item) === rec.candidateId);
+  if (!candidate) throw new Error(`missing validated governance tidy candidate: ${rec.candidateId}`);
+  const input = providerReviewInput(rec, candidate, provider);
+  const recommendationId = providerReviewRecommendationId(input);
+  const artifactId = providerReviewArtifactId(input);
+  return {
+    id: recommendationId,
+    artifact_id: artifactId,
+    recommendation_id: recommendationId,
+    recommendation_key: input.recommendationKey,
+    operation: GOVERNANCE_TIDY_OPERATION,
+    review_status: statusByArtifact.get(artifactId) ?? statusByArtifact.get(recommendationId) ?? "open",
+    relation: rec.relation,
+    confidence: rec.confidence,
+    rationale: rec.rationale,
+    proposed_soft_merge: {
+      action: "SOFT_MERGE",
+      edge_label: "SAME_AS",
+      duplicate_rid: candidate.duplicate_rid,
+      canonical_rid: candidate.canonical_rid,
+      direction: `SAME_AS memory_nodes:${candidate.duplicate_rid} -> memory_nodes:${candidate.canonical_rid}`,
+    },
+    pair_evidence: input.pairEvidence,
+    provider: input.provider,
+  };
+}
+
+function providerReviewInput(
+  rec: ProviderTidyRecommendationCandidate,
+  candidate: MemoryMergeCandidate,
+  provider: ReturnType<typeof resolveProvider>,
+): ProviderReviewRecommendationInput {
+  return {
+    operation: GOVERNANCE_TIDY_OPERATION,
+    policyVersion: DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+    recommendationKey: `${rec.relation}:${rec.candidateId}`,
+    pairEvidence: [pairEvidence(candidate, rec.relation)],
+    recommendation: {
+      title: `Review ${rec.relation.replace("_", "-")} Memory Soft-merge candidate`,
+      rationale: rec.rationale,
+      suggested_action: `Review and, if approved outside governance, create SAME_AS memory_nodes:${candidate.duplicate_rid} -> memory_nodes:${candidate.canonical_rid}`,
+      provider_output: {
+        candidate_id: rec.candidateId,
+        relation: rec.relation,
+        confidence: rec.confidence,
+      },
+    },
+    provider: { mode: provider.mode, model: provider.model },
+  };
+}
+
+function pairEvidence(
+  candidate: MemoryMergeCandidate,
+  relation: MemoryGovernanceTidyRelation,
+): ProviderReviewPairEvidence {
+  return {
+    pair_id: candidateId(candidate),
+    relation,
+    subjects: [candidate.left, candidate.right].map((node) => ({
+      collection: "memory_nodes",
+      rid: node.rid,
+      label: node.label,
+      node_type: node.node_type,
+      title: node.title,
+      content: node.excerpt,
+    })),
+    evidence: [
+      {
+        kind: "merge-pass-candidate",
+        rank: candidate.rank,
+        score: candidate.score,
+        proposed_edge_label: "SAME_AS",
+        duplicate_rid: candidate.duplicate_rid,
+        canonical_rid: candidate.canonical_rid,
+      },
+      {
+        kind: "similarity",
+        title_similarity: candidate.evidence.title_similarity,
+        content_similarity: candidate.evidence.content_similarity,
+        label_similarity: candidate.evidence.label_similarity,
+        same_node_type: candidate.evidence.same_node_type,
+        shared_terms: candidate.evidence.shared_terms,
+      },
+    ],
+  };
+}
+
+function allowedRecommendationCount(
+  candidateCount: number,
+  policy: MemoryGovernanceTidyRecommendations["policy"],
+): number {
+  if (candidateCount <= 0) return 0;
+  const proportional = Math.max(1, Math.floor(candidateCount * policy.max_recommendation_ratio));
+  return Math.min(policy.recommendation_cap, proportional);
+}
+
+function candidateId(candidate: MemoryMergeCandidate): string {
+  return `merge-pass:${candidate.rank}`;
+}
+
+function tidyRelation(value: unknown): MemoryGovernanceTidyRelation | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase().replace(/[-\s]+/g, "_");
+  return normalized === "duplicate" || normalized === "near_duplicate" ? normalized : null;
+}
+
+function isSoftMergeAction(value: unknown): boolean {
+  if (value == null) return true;
+  return typeof value === "string" && value.trim().toUpperCase().replace(/[-\s]+/g, "_") === "SOFT_MERGE";
+}
+
+function isSameAsEdge(value: unknown): boolean {
+  if (value == null) return true;
+  return typeof value === "string" && value.trim().toUpperCase() === "SAME_AS";
+}
+
+function matchesOptionalRid(value: unknown, expected: number): boolean {
+  if (value == null) return true;
+  return typeof value === "number" && Number.isFinite(value) && value === expected;
+}
+
+function confidenceValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.min(1, value));
+  }
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "high") return 0.9;
+  if (normalized === "medium") return 0.65;
+  if (normalized === "low") return 0.35;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : null;
+}
+
+function unfence(raw: string): string {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  return (fenced ? fenced[1] : raw).trim();
+}
+
+function normalizeJson(value: unknown): JsonValue | undefined {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) return value.map((item) => normalizeJson(item) ?? null);
+  if (typeof value === "object") {
+    const out: JsonRecord = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      const normalized = normalizeJson(child);
+      if (normalized !== undefined) out[key] = normalized;
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/apps/memory/src/governance-viewer.ts
+++ b/src/apps/memory/src/governance-viewer.ts
@@ -152,6 +152,11 @@ function renderMemoryGovernanceViewer(report: MemoryGovernanceReport): string {
           ${report.contradictions.length === 0 ? `<p class="empty">No contradiction edges found.</p>` : `<ul>${report.contradictions.slice(0, 12).map((item) => `<li><div><h3>${escapeHtml(item.from.title)} -> ${escapeHtml(item.to.title)}</h3><p class="meta">${escapeHtml(item.reason ?? "no reason")} - ${item.resolved ? "resolved" : "unresolved"}</p></div><span class="pill ${item.resolved ? "" : "warn"}">${item.resolved ? "resolved" : "open"}</span></li>`).join("")}</ul>`}
         </section>
         <section>
+          <h2>Provider Tidy Recommendations</h2>
+          <p class="meta">Read-only duplicate and near-duplicate Soft-merge inspection output. Governance does not apply these recommendations.</p>
+          ${report.tidy_recommendations.recommendations.length === 0 ? `<p class="empty">${escapeHtml(report.tidy_recommendations.reason ?? "No provider tidy recommendations.")}</p>` : `<ul>${report.tidy_recommendations.recommendations.map((item) => `<li><div><h3>${escapeHtml(item.proposed_soft_merge.direction)}</h3><p class="meta">${escapeHtml(item.relation)} - confidence ${item.confidence.toFixed(2)} - ${escapeHtml(item.rationale)}</p><p class="meta"><code>${escapeHtml(item.id)}</code></p></div><span class="pill">${escapeHtml(item.review_status)}</span></li>`).join("")}</ul>`}
+        </section>
+        <section>
           <h2>Missing Provenance</h2>
           ${report.provenance.missing.length === 0 ? `<p class="empty">All visible nodes have provenance metadata.</p>` : `<ul>${report.provenance.missing.slice(0, 12).map((item) => `<li><div><h3>${escapeHtml(item.title)}</h3><p class="meta"><code>memory_nodes:${item.rid}</code> - ${escapeHtml(item.node_type)} - ${escapeHtml(item.label)}</p></div></li>`).join("")}</ul>`}
         </section>

--- a/src/apps/memory/src/governance.ts
+++ b/src/apps/memory/src/governance.ts
@@ -18,9 +18,14 @@ import {
 import {
   resolveProvider,
   type AiProviderConfig,
+  type ProviderClient,
   type Egress,
   type ProviderMode,
 } from "./extract-conversation.js";
+import {
+  buildMemoryGovernanceTidyRecommendations,
+  type MemoryGovernanceTidyRecommendations,
+} from "./governance-tidy.js";
 
 export type MemoryGovernanceStatus = "ok" | "attention" | "degraded";
 export type MemoryGovernanceTidyStatus = "available" | "degraded" | "unavailable";
@@ -62,6 +67,7 @@ export interface MemoryGovernanceReport {
   contradictions: ContradictionSummary[];
   supersession: Array<{ rid: number; active_rid: number }>;
   tidy_availability: MemoryGovernanceTidyAvailability;
+  tidy_recommendations: MemoryGovernanceTidyRecommendations;
   recommended_next_actions: string[];
 }
 
@@ -75,7 +81,15 @@ interface GovernanceEdge {
 
 export async function buildMemoryGovernanceReport(
   store: MemoryStore,
-  opts: { staleProgressDays?: number; now?: number; providerConfig?: AiProviderConfig } = {},
+  opts: {
+    staleProgressDays?: number;
+    now?: number;
+    providerConfig?: AiProviderConfig;
+    providerClient?: ProviderClient;
+    tidyRecommendationCap?: number;
+    tidyCandidateLimit?: number;
+    tidyMaxRecommendationRatio?: number;
+  } = {},
 ): Promise<MemoryGovernanceReport> {
   const [nodes, rawEdges] = await Promise.all([store.listNodes(opts.now), store.listEdges()]);
   const edges = rawEdges.map(toGovernanceEdge);
@@ -113,7 +127,19 @@ export async function buildMemoryGovernanceReport(
     superseded_nodes: superseded.size,
     audit_edges: auditEdges,
   };
-  const tidyAvailability = governanceTidyAvailability(opts.providerConfig);
+  const baseTidyAvailability = governanceTidyAvailability(opts.providerConfig);
+  const tidyRecommendations = await buildMemoryGovernanceTidyRecommendations(store, {
+    providerConfig: opts.providerConfig,
+    providerClient: opts.providerClient,
+    now: opts.now,
+    recommendationCap: opts.tidyRecommendationCap,
+    candidateLimit: opts.tidyCandidateLimit,
+    maxRecommendationRatio: opts.tidyMaxRecommendationRatio,
+  });
+  const tidyAvailability = tidyAvailabilityWithRecommendationStatus(
+    baseTidyAvailability,
+    tidyRecommendations,
+  );
   return {
     schema_version: "memory.governance.v1",
     read_only: true,
@@ -128,6 +154,7 @@ export async function buildMemoryGovernanceReport(
       .map(([rid, activeRid]) => ({ rid, active_rid: activeRid }))
       .sort((a, b) => a.rid - b.rid),
     tidy_availability: tidyAvailability,
+    tidy_recommendations: tidyRecommendations,
     recommended_next_actions: recommendations(summary, privacy, lint, tidyAvailability),
   };
 }
@@ -217,6 +244,21 @@ function governanceTidyAvailability(
       next_action: "fix the configured Memory AI provider before running governance tidy",
     };
   }
+}
+
+function tidyAvailabilityWithRecommendationStatus(
+  availability: MemoryGovernanceTidyAvailability,
+  tidyRecommendations: MemoryGovernanceTidyRecommendations,
+): MemoryGovernanceTidyAvailability {
+  if (availability.status !== "available" || tidyRecommendations.status !== "degraded") {
+    return availability;
+  }
+  return {
+    ...availability,
+    status: "degraded",
+    reason: tidyRecommendations.reason,
+    next_action: "inspect provider tidy warnings; deterministic governance remains available",
+  };
 }
 
 function provenanceCoverage(nodes: StoredNode[]): MemoryGovernanceReport["provenance"] {

--- a/src/apps/memory/src/mcp-server.ts
+++ b/src/apps/memory/src/mcp-server.ts
@@ -675,6 +675,12 @@ async function operationStructuredContent(
     case "memory.governance": {
       const summary = isRecord(output.summary) ? output.summary : {};
       const tidy = isRecord(output.tidy_availability) ? output.tidy_availability : {};
+      const tidyRecommendations = isRecord(output.tidy_recommendations)
+        ? output.tidy_recommendations
+        : {};
+      const tidyRecommendationsSummary = isRecord(tidyRecommendations.summary)
+        ? tidyRecommendations.summary
+        : {};
       return {
         operation_id: operationId,
         schema_version: output.schema_version,
@@ -683,6 +689,8 @@ async function operationStructuredContent(
         tidy_status: tidy.status ?? null,
         tidy_reason: tidy.reason ?? null,
         tidy_next_action: tidy.next_action ?? null,
+        tidy_recommendations_status: tidyRecommendations.status ?? null,
+        tidy_recommendations: tidyRecommendationsSummary.recommended_pairs ?? null,
         total_nodes: summary.total_nodes ?? null,
         missing_provenance: summary.missing_provenance ?? null,
         privacy_findings: summary.privacy_findings ?? null,
@@ -696,6 +704,12 @@ async function operationStructuredContent(
       const report = isRecord(output.report) ? output.report : {};
       const summary = isRecord(report.summary) ? report.summary : {};
       const tidy = isRecord(report.tidy_availability) ? report.tidy_availability : {};
+      const tidyRecommendations = isRecord(report.tidy_recommendations)
+        ? report.tidy_recommendations
+        : {};
+      const tidyRecommendationsSummary = isRecord(tidyRecommendations.summary)
+        ? tidyRecommendations.summary
+        : {};
       return {
         operation_id: operationId,
         contract: isRecord(output.contract) ? output.contract.version : undefined,
@@ -704,6 +718,8 @@ async function operationStructuredContent(
         tidy_status: tidy.status ?? null,
         tidy_reason: tidy.reason ?? null,
         tidy_next_action: tidy.next_action ?? null,
+        tidy_recommendations_status: tidyRecommendations.status ?? null,
+        tidy_recommendations: tidyRecommendationsSummary.recommended_pairs ?? null,
         missing_provenance: summary.missing_provenance ?? null,
         privacy_findings: summary.privacy_findings ?? null,
         lint_findings: summary.lint_findings ?? null,

--- a/src/apps/memory/src/operations.ts
+++ b/src/apps/memory/src/operations.ts
@@ -2312,7 +2312,7 @@ const GOVERNANCE_OPERATION: MemoryOperationDefinition<GovernanceInput, MemoryGov
   id: "memory.governance",
   title: "Memory governance",
   description:
-    "Read-only governance report over provenance, privacy, lint, contradictions, and supersession.",
+    "Read-only governance report over provenance, privacy, lint, contradictions, supersession, and provider-backed tidy recommendations.",
   inputSchema: GovernanceInputSchema,
   outputSchema: GovernanceOutputSchema,
   safetyClass: "read-only",
@@ -2323,7 +2323,7 @@ const GOVERNANCE_OPERATION: MemoryOperationDefinition<GovernanceInput, MemoryGov
     mcp: {
       toolName: "memory_governance",
       description:
-        "Read-only governance report over local Memory evidence. Returns provenance coverage, privacy findings, lint findings, contradiction/supersession counts, and recommended next actions without mutating Memory.",
+        "Read-only governance report over local Memory evidence. Returns provenance coverage, privacy findings, lint findings, contradiction/supersession counts, provider-backed duplicate or near-duplicate tidy recommendations, and recommended next actions without mutating Memory.",
     },
   },
   execute: (ctx, input) =>
@@ -2340,7 +2340,7 @@ const GOVERNANCE_VIEWER_OPERATION: MemoryOperationDefinition<
 > = {
   id: "memory.governance-viewer",
   title: "Memory governance viewer",
-  description: "Self-contained HTML viewer for Memory governance evidence.",
+  description: "Self-contained HTML viewer for Memory governance evidence and provider tidy recommendations.",
   inputSchema: GovernanceInputSchema,
   outputSchema: GovernanceViewerOutputSchema,
   safetyClass: "read-only",
@@ -2351,7 +2351,7 @@ const GOVERNANCE_VIEWER_OPERATION: MemoryOperationDefinition<
     mcp: {
       toolName: "memory_governance_viewer",
       description:
-        "Read-only self-contained HTML viewer for provenance, privacy, lint, contradictions, supersession, recommended actions, and embedded governance JSON.",
+        "Read-only self-contained HTML viewer for provenance, privacy, lint, contradictions, supersession, provider tidy recommendations, recommended actions, and embedded governance JSON.",
     },
   },
   execute: async (ctx, input) =>

--- a/src/apps/memory/src/workbench.ts
+++ b/src/apps/memory/src/workbench.ts
@@ -788,6 +788,7 @@ function governanceSection(workbench: MemoryWorkbench): string {
       <li><strong>Privacy and lint</strong><p class="meta">${governance.summary.privacy_findings} privacy finding(s), ${governance.summary.lint_findings} lint finding(s)</p></li>
       <li><strong>Contradictions</strong><p class="meta">${governance.summary.unresolved_contradictions} unresolved, ${governance.summary.superseded_nodes} superseded node(s)</p></li>
       <li><strong>Tidy availability</strong><p class="meta">${escapeHtml(governance.tidy_availability.status)} - ${escapeHtml(governance.tidy_availability.reason ?? governance.tidy_availability.next_action)}</p></li>
+      <li><strong>Provider tidy recommendations</strong><p class="meta">${governance.tidy_recommendations.summary.recommended_pairs}/${governance.tidy_recommendations.summary.candidate_pairs} duplicate or near-duplicate Soft-merge recommendation(s)</p></li>
     </ul>
     <button id="memory-governance-refresh" type="button">Refresh Governance</button>
     <a class="button-link" href="/governance">Open Governance</a>
@@ -1915,6 +1916,9 @@ function governanceScript(): string {
       addItem("Contradictions", String(summary.unresolved_contradictions ?? 0) + " unresolved, " + String(summary.superseded_nodes ?? 0) + " superseded node(s)");
       const tidy = report.tidy_availability || {};
       addItem("Tidy availability", String(tidy.status || "unknown") + " - " + String(tidy.reason || tidy.next_action || "no tidy status reported"));
+      const tidyRecommendations = report.tidy_recommendations || {};
+      const tidySummary = tidyRecommendations.summary || {};
+      addItem("Provider tidy recommendations", String(tidySummary.recommended_pairs ?? 0) + "/" + String(tidySummary.candidate_pairs ?? 0) + " duplicate or near-duplicate Soft-merge recommendation(s)");
       const actions = Array.isArray(report.recommended_next_actions) ? report.recommended_next_actions : [];
       status.textContent = actions[0] || "Governance report is clean.";
     } catch (err) {

--- a/src/apps/memory/tests/governance.test.ts
+++ b/src/apps/memory/tests/governance.test.ts
@@ -6,9 +6,11 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import { buildMemoryGovernanceReport } from "../src/governance.js";
 import { buildMemoryGovernanceViewerArtifact } from "../src/governance-viewer.js";
+import type { ProviderClient, ProviderRequest } from "../src/extract-conversation.js";
 import { readConfig, writeConfig } from "../src/config.js";
 import { MemoryStore } from "../src/graph-store.js";
 import { initGraph } from "../src/init.js";
+import { listProviderReviewArtifacts } from "../src/provider-review-artifacts.js";
 
 const TIMEOUT = 30_000;
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -42,6 +44,57 @@ function runMemory(args: string[]) {
     encoding: "utf8",
     timeout: TIMEOUT,
   });
+}
+
+const LOCAL_PROVIDER = {
+  mode: "openai-compat" as const,
+  model: "llama3.1",
+  baseUrl: "http://localhost:11434/v1",
+};
+
+function providerResponse(recommendations: unknown[]): ProviderClient {
+  return {
+    async complete(_req: ProviderRequest): Promise<string> {
+      return JSON.stringify({ recommendations });
+    },
+  };
+}
+
+function failingProvider(message: string): ProviderClient {
+  return {
+    async complete(): Promise<string> {
+      throw new Error(message);
+    },
+  };
+}
+
+async function seedDuplicateNodePair(
+  store: MemoryStore,
+  suffix: string,
+): Promise<{ canonical: number; duplicate: number }> {
+  const canonical = await store.upsertNode({
+    label: `jwt-rotation-${suffix}`,
+    node_type: "decision",
+    properties: {
+      title: `JWT rotation ${suffix}`,
+      content: "JWT rotation must rotate signing keys with a staged overlap window.",
+      scope: "project",
+      tier: "durable",
+      provenance: { source_kind: "manual", writer: "test", confidence: "EXTRACTED" },
+    },
+  });
+  const duplicate = await store.upsertNode({
+    label: `jwt-key-rotation-${suffix}`,
+    node_type: "decision",
+    properties: {
+      title: `JWT rotation ${suffix}`,
+      content: "JWT rotation must rotate signing keys with a staged overlap window.",
+      scope: "project",
+      tier: "durable",
+      provenance: { source_kind: "manual", writer: "test", confidence: "EXTRACTED" },
+    },
+  });
+  return { canonical, duplicate };
 }
 
 describe("Memory governance", () => {
@@ -192,4 +245,233 @@ describe("Memory governance", () => {
     expect(html).toContain('id="memory-governance-data"');
     expect(html).toContain("Tidy availability");
   }, TIMEOUT);
+
+  test("surfaces provider-backed duplicate tidy recommendations as read-only Soft-merge review output", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "provider-success");
+
+    const report = await buildMemoryGovernanceReport(store, {
+      now: Date.UTC(2026, 4, 22),
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([
+        {
+          candidate_id: "merge-pass:1",
+          relation: "near_duplicate",
+          confidence: 0.91,
+          rationale: "Both facts express the same JWT key rotation policy.",
+          proposed_action: "SOFT_MERGE",
+          proposed_edge_label: "SAME_AS",
+        },
+      ]),
+    });
+
+    expect(report.tidy_availability).toMatchObject({
+      status: "available",
+      configured: true,
+      provider_mode: "openai-compat",
+      provider_model: "llama3.1",
+      egress: "local",
+    });
+    expect(report.tidy_recommendations).toMatchObject({
+      schema_version: "memory.governance_tidy_recommendations.v1",
+      read_only: true,
+      source: "provider-review-artifacts",
+      status: "available",
+      summary: {
+        candidate_pairs: 1,
+        recommended_pairs: 1,
+        dropped_recommendations: 0,
+      },
+    });
+    expect(report.tidy_recommendations.recommendations[0]).toMatchObject({
+      id: expect.stringContaining("provider-review:"),
+      artifact_id: expect.stringContaining("provider-review:"),
+      recommendation_id: expect.stringContaining("provider-review:"),
+      operation: "governance.tidy",
+      review_status: "open",
+      relation: "near_duplicate",
+      confidence: 0.91,
+      rationale: "Both facts express the same JWT key rotation policy.",
+      proposed_soft_merge: {
+        action: "SOFT_MERGE",
+        edge_label: "SAME_AS",
+        duplicate_rid: expect.any(Number),
+        canonical_rid: expect.any(Number),
+      },
+      pair_evidence: [
+        expect.objectContaining({
+          relation: "near_duplicate",
+          subjects: expect.arrayContaining([
+            expect.objectContaining({ collection: "memory_nodes", rid: expect.any(Number) }),
+            expect.objectContaining({ collection: "memory_nodes", rid: expect.any(Number) }),
+          ]),
+        }),
+      ],
+      provider: { mode: "openai-compat", model: "llama3.1" },
+    });
+
+    const artifact = buildMemoryGovernanceViewerArtifact(report);
+    expect(artifact.html).toContain("Provider Tidy Recommendations");
+    expect(artifact.html).toContain("SAME_AS memory_nodes");
+  });
+
+  test("bounds provider tidy recommendations by the absolute cap", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "cap-a");
+    await seedDuplicateNodePair(store, "cap-b");
+    await seedDuplicateNodePair(store, "cap-c");
+
+    const report = await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([
+        recFor("merge-pass:1"),
+        recFor("merge-pass:2"),
+        recFor("merge-pass:3"),
+        recFor("merge-pass:4"),
+      ]),
+      tidyRecommendationCap: 2,
+      tidyMaxRecommendationRatio: 1,
+    });
+
+    expect(report.tidy_availability.status).toBe("degraded");
+    expect(report.tidy_recommendations.status).toBe("degraded");
+    expect(report.tidy_recommendations.recommendations).toHaveLength(2);
+    expect(report.tidy_recommendations.summary.dropped_recommendations).toBe(2);
+    expect(report.tidy_recommendations.warnings.join(" ")).toContain("exceeding guard 2");
+  });
+
+  test("uses a proportional guard against recommending too much of the candidate set", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "ratio-a");
+    await seedDuplicateNodePair(store, "ratio-b");
+
+    const report = await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([
+        recFor("merge-pass:1"),
+        recFor("merge-pass:2"),
+        recFor("merge-pass:3"),
+      ]),
+      tidyRecommendationCap: 10,
+      tidyMaxRecommendationRatio: 0.25,
+    });
+
+    expect(report.tidy_recommendations.summary.candidate_pairs).toBeGreaterThanOrEqual(3);
+    expect(report.tidy_recommendations.recommendations).toHaveLength(1);
+    expect(report.tidy_recommendations.status).toBe("degraded");
+    expect(report.tidy_recommendations.warnings.join(" ")).toContain("exceeding guard 1");
+  });
+
+  test("malformed provider tidy output degrades tidy without failing deterministic governance", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "malformed");
+
+    const report = await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: {
+        async complete(): Promise<string> {
+          return "not json";
+        },
+      },
+    });
+
+    expect(report.schema_version).toBe("memory.governance.v1");
+    expect(report.summary.total_nodes).toBe(2);
+    expect(report.tidy_availability.status).toBe("degraded");
+    expect(report.tidy_recommendations).toMatchObject({
+      status: "degraded",
+      reason: "provider tidy returned malformed JSON",
+      recommendations: [],
+    });
+  });
+
+  test("provider tidy failures degrade tidy without failing deterministic governance", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "failure");
+
+    const report = await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: failingProvider("provider unavailable"),
+    });
+
+    expect(report.schema_version).toBe("memory.governance.v1");
+    expect(report.summary.total_nodes).toBe(2);
+    expect(report.tidy_availability).toMatchObject({
+      status: "degraded",
+      reason: "provider tidy failed: provider unavailable",
+    });
+    expect(report.tidy_recommendations.recommendations).toEqual([]);
+  });
+
+  test("provider tidy drops non-duplicate and non-Soft-merge responses", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "unsupported");
+
+    const report = await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([
+        {
+          candidate_id: "merge-pass:1",
+          relation: "supersession",
+          confidence: 0.95,
+          rationale: "Old guidance should be superseded.",
+          proposed_action: "SUPERSEDE",
+        },
+      ]),
+    });
+
+    expect(report.tidy_recommendations.recommendations).toEqual([]);
+    expect(report.tidy_recommendations.status).toBe("degraded");
+    expect(report.tidy_recommendations.summary.dropped_recommendations).toBe(1);
+    expect(report.tidy_recommendations.warnings.join(" ")).toContain(
+      "non-duplicate recommendation",
+    );
+  });
+
+  test("provider tidy recommendations do not mutate graph evidence or review artifacts", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    await seedDuplicateNodePair(store, "nonmutation");
+    const beforeStats = await store.stats();
+    const beforeNodes = await store.listNodes();
+    const beforeEdges = await store.listEdges();
+    const beforeDocs = await store.listDocs();
+    const beforeAccess = await store.accessRecords();
+
+    await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+    });
+
+    expect(await store.stats()).toEqual(beforeStats);
+    expect(await store.listNodes()).toEqual(beforeNodes);
+    expect(await store.listEdges()).toEqual(beforeEdges);
+    expect(await store.listDocs()).toEqual(beforeDocs);
+    expect(await store.accessRecords()).toEqual(beforeAccess);
+    expect(await listProviderReviewArtifacts(store)).toEqual([]);
+  });
 });
+
+function recFor(candidateId: string): Record<string, unknown> {
+  return {
+    candidate_id: candidateId,
+    relation: "duplicate",
+    confidence: 0.9,
+    rationale: `Candidate ${candidateId} is semantically identical.`,
+    proposed_action: "SOFT_MERGE",
+    proposed_edge_label: "SAME_AS",
+  };
+}


### PR DESCRIPTION
Closes #489.

## Summary
- add read-only provider-backed tidy recommendations to memory governance
- limit provider output to bounded duplicate/near-duplicate SOFT_MERGE/SAME_AS recommendations
- expose counts/samples through CLI, MCP summaries, HTTP JSON, Workbench, and governance viewer
- keep provider failure/malformed output degraded without mutating graph/doc/recall data

## Validation
- pnpm -C src/apps/memory typecheck
- pnpm -C src/apps/memory exec vitest run --config vitest.integration.config.ts tests/governance.test.ts
- pnpm -C src/apps/memory exec vitest run --config vitest.integration.config.ts tests/mcp-server.test.ts tests/http-server.test.ts tests/workbench.test.ts
- pnpm -C src/apps/memory exec vitest run tests/operations-registry.test.ts tests/provider-review-artifacts.test.ts
- pnpm -C src/apps/memory exec vitest run --config vitest.integration.config.ts tests/memory-merge-pass.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783252131&installation_id=129708444&pr_number=496&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F496&signature=b9227b23f5cda2ef5ab8dbdde94aded6c1ecfe50594a37e906a41c65e7ea74fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-backed AI recommendations for identifying optimal soft-merge candidate pairs in memory governance. Recommendations include confidence scores and rationales, displayed across CLI, HTML viewer, and workbench with summary statistics on recommended vs. candidate pair counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->