### PR TITLE
Record context-pack and Memory injection observations

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -107,7 +107,11 @@ import { HistoricalMemoryStore } from "./historical-memory-store.js";
 import { createMemoryHttpServer } from "./http-server.js";
 import { ingestGuidance } from "./audit-marker.js";
 import { evaluateDriftGuard } from "./drift-guard.js";
-import { appendMemoryEvent, driftCaughtToMemoryEvent } from "./memory-events.js";
+import {
+  appendContextPackGenerationEvent,
+  appendMemoryEvent,
+  driftCaughtToMemoryEvent,
+} from "./memory-events.js";
 import { collectCandidates, ingestProject, refreshFiles } from "./ingest.js";
 import {
   defaultIgnorePatterns,
@@ -1228,6 +1232,11 @@ async function runContextPack(args: ParsedArgs): Promise<void> {
       scope: scopeFlags(args.flags),
       skillRollups,
     });
+    await appendContextPackGenerationEvent(store, {
+      pack,
+      surface: "cli",
+      metadata: { command: "context-pack", json: args.flags.json === true },
+    });
     if (args.flags.json === true) {
       console.log(JSON.stringify(pack, null, 2));
       return;
@@ -1262,6 +1271,11 @@ async function runContextPackViewer(args: ParsedArgs): Promise<void> {
     );
     await mkdir(dirname(outPath), { recursive: true });
     await writeFile(outPath, artifact.html, "utf8");
+    await appendContextPackGenerationEvent(store, {
+      pack,
+      surface: "cli-viewer",
+      metadata: { command: "context-pack-viewer", out_path: outPath },
+    });
     console.log(`memory: context pack viewer written ${outPath}`);
     console.log(`  status: ${pack.status}`);
     console.log(`  contract: ${artifact.contract.consumes}`);
@@ -2428,7 +2442,12 @@ async function runRegistryCliOperation(
   try {
     const output = await executeMemoryOperationFromTransport(
       operation,
-      { store: graphContext.store, rootDir, providerConfig: graphContext.config?.provider },
+      {
+        store: graphContext.store,
+        rootDir,
+        providerConfig: graphContext.config?.provider,
+        transportSurface: "cli",
+      },
       transportInput,
     );
     if (operation.outputKind.kind === "viewer") {

--- a/src/apps/memory/src/hook-runtime.ts
+++ b/src/apps/memory/src/hook-runtime.ts
@@ -9,7 +9,11 @@ import { recall as engineRecall, type RecallResult } from "./engine.js";
 import { extractStructuredTranscript, factsToGraph } from "./extract-conversation.js";
 import { MemoryStore } from "./graph-store.js";
 import { type IngestReport, reindexFiles } from "./ingest.js";
-import { appendMemoryEvent, hookLifecycleToMemoryEvent } from "./memory-events.js";
+import {
+  appendMemoryEvent,
+  hookLifecycleToMemoryEvent,
+  memoryInjectionToMemoryEvent,
+} from "./memory-events.js";
 import { runPromote } from "./promote.js";
 import type { MemoryNode, NodeType } from "./schema.js";
 import { slugify } from "./store.js";
@@ -62,6 +66,12 @@ export interface HookResult {
   reason?: string;
   /** Context to inject into the model's turn (SessionStart). */
   inject?: string;
+  /** Ids actually delivered through a Memory-controlled hook/transport. */
+  injection?: {
+    goal?: string;
+    deliveredCitationIds: string[];
+    deliveredNodeIds: number[];
+  };
   /** Memories persisted (Stop / PreCompact). */
   stored?: number;
   /** Files re-indexed (PostToolUse). */
@@ -216,6 +226,21 @@ async function recordLifecycle(
     const store = await deps.openStore(resolveStoreUri(rootDir, config));
     try {
       await appendMemoryEvent(store, hookLifecycleToMemoryEvent(input, result));
+      if (result.inject && result.injection) {
+        await appendMemoryEvent(
+          store,
+          memoryInjectionToMemoryEvent({
+            deliverySurface: "hook",
+            deliveredCitationIds: result.injection.deliveredCitationIds,
+            deliveredNodeIds: result.injection.deliveredNodeIds,
+            goal: result.injection.goal,
+            sessionId: input.sessionId,
+            runner: input.runner,
+            hookEvent: input.event,
+            injectedChars: result.inject.length,
+          }),
+        );
+      }
     } finally {
       await store.close();
     }
@@ -239,7 +264,16 @@ async function handleSessionStart(
     if (result.nodes.length === 0) {
       return { noop: true, reason: "no relevant memory" };
     }
-    return { noop: false, inject: result.context_md };
+    const deliveredNodeIds = result.nodes.map((node) => node.rid);
+    return {
+      noop: false,
+      inject: result.context_md,
+      injection: {
+        goal: query,
+        deliveredNodeIds,
+        deliveredCitationIds: deliveredNodeIds.map((rid) => `memory_nodes:${rid}`),
+      },
+    };
   } finally {
     await store.close();
   }

--- a/src/apps/memory/src/http-server.ts
+++ b/src/apps/memory/src/http-server.ts
@@ -255,6 +255,7 @@ async function handleRegistryHttpOperation(
         rootDir: opts.rootDir,
         now: opts.now,
         providerConfig: opts.providerConfig,
+        transportSurface: "http",
       },
       {
         positional: [],

--- a/src/apps/memory/src/mcp-server.ts
+++ b/src/apps/memory/src/mcp-server.ts
@@ -217,7 +217,7 @@ async function main(): Promise<void> {
     if (operation) {
       const output = await executeReadOnlyMemoryOperation(
         operation.id,
-        { store, rootDir: root, providerConfig: config?.provider },
+        { store, rootDir: root, providerConfig: config?.provider, transportSurface: "mcp" },
         args,
       );
       return text(

--- a/src/apps/memory/src/memory-events.ts
+++ b/src/apps/memory/src/memory-events.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import type { QueryParam } from "@reddb-io/sdk";
+import type { ContextPack } from "./context-pack.js";
 import type { MemoryStore } from "./graph-store.js";
 import { COLLECTIONS } from "./schema.js";
 import type { SkillEvent } from "./skill-events.js";
@@ -137,6 +139,60 @@ const driftCaughtPayloadSchema = z
   })
   .strict();
 
+const contextPackGenerationPayloadSchema = z
+  .object({
+    event_type: z.literal("memory.context-pack.generated"),
+    event_id: safeString("payload.event_id", 200),
+    timestamp: z
+      .string()
+      .datetime({ offset: true })
+      .or(z.string().datetime({ offset: false })),
+    goal: safeString("payload.goal", SAFE_TEXT_MAX),
+    pack_id: safeString("payload.pack_id", 240),
+    surface: safeString("payload.surface", 120),
+    status: z.enum(["ok", "insufficient-context"]),
+    citation_ids: z.array(safeString("payload.citation_ids", 240)).max(1_000),
+    node_ids: z.array(z.number().int().positive()).max(1_000),
+    budget_chars: z.number().int().nonnegative().max(10_000_000),
+    used_chars: z.number().int().nonnegative().max(10_000_000),
+    entry_count: z.number().int().nonnegative().max(1_000_000),
+    core_context_count: z.number().int().nonnegative().max(1_000_000),
+    warning_count: z.number().int().nonnegative().max(1_000_000),
+    omitted_entries: z.number().int().nonnegative().max(1_000_000),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+const memoryInjectionPayloadSchema = z
+  .object({
+    event_type: z.literal("memory.injection.delivered"),
+    event_id: safeString("payload.event_id", 200),
+    timestamp: z
+      .string()
+      .datetime({ offset: true })
+      .or(z.string().datetime({ offset: false })),
+    delivery_surface: safeString("payload.delivery_surface", 120),
+    delivered_citation_ids: z.array(safeString("payload.delivered_citation_ids", 240)).max(1_000),
+    delivered_node_ids: z.array(z.number().int().positive()).max(1_000),
+    goal: safeString("payload.goal", SAFE_TEXT_MAX).optional(),
+    pack_id: safeString("payload.pack_id", 240).optional(),
+    session_id: safeString("payload.session_id", 200).optional(),
+    runner: safeString("payload.runner", 80).optional(),
+    hook_event: safeString("payload.hook_event", 120).optional(),
+    injected_chars: z.number().int().nonnegative().max(10_000_000).optional(),
+    metadata: z.record(z.unknown()).optional(),
+  })
+  .strict()
+  .superRefine((payload, ctx) => {
+    if (payload.delivered_citation_ids.length === 0 && payload.delivered_node_ids.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["delivered_citation_ids"],
+        message: "memory injection observations require delivered citation or node ids",
+      });
+    }
+  });
+
 const provenanceSchema = z
   .object({
     source_kind: z.enum(["manual", "hook", "derived", "system"]),
@@ -154,7 +210,14 @@ const memoryEventSchema = z
       .string()
       .datetime({ offset: true })
       .or(z.string().datetime({ offset: false })),
-    kind: z.enum(["skill.telemetry", "hook.lifecycle", "engine.op", "memory.drift.caught"]),
+    kind: z.enum([
+      "skill.telemetry",
+      "hook.lifecycle",
+      "engine.op",
+      "memory.drift.caught",
+      "memory.context-pack.generated",
+      "memory.injection.delivered",
+    ]),
     source: envelopeObject("source"),
     actor: envelopeObject("actor"),
     scope: z
@@ -169,6 +232,8 @@ const memoryEventSchema = z
       hookLifecyclePayloadSchema,
       engineOpPayloadSchema,
       driftCaughtPayloadSchema,
+      contextPackGenerationPayloadSchema,
+      memoryInjectionPayloadSchema,
     ]),
     provenance: provenanceSchema,
   })
@@ -181,6 +246,8 @@ export type EngineOpPayload = z.infer<typeof engineOpPayloadSchema>;
 export type EngineOp = EngineOpPayload["op"];
 export type EngineOpOutcome = EngineOpPayload["outcome"];
 export type DriftCaughtPayload = z.infer<typeof driftCaughtPayloadSchema>;
+export type ContextPackGenerationPayload = z.infer<typeof contextPackGenerationPayloadSchema>;
+export type MemoryInjectionPayload = z.infer<typeof memoryInjectionPayloadSchema>;
 
 export interface DriftCaughtInput {
   /** Watched paths that changed without an audit marker. Must be non-empty. */
@@ -205,6 +272,38 @@ export interface EngineOpInput {
   error?: string;
   timestamp?: string | Date;
   eventId?: string;
+}
+
+export interface ContextPackGenerationInput {
+  pack: ContextPack;
+  surface: string;
+  timestamp?: string | Date;
+  eventId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryInjectionInput {
+  deliveredCitationIds?: readonly string[];
+  deliveredNodeIds?: readonly (string | number)[];
+  deliverySurface: string;
+  goal?: string;
+  packId?: string;
+  sessionId?: string;
+  runner?: string;
+  hookEvent?: string;
+  injectedChars?: number;
+  timestamp?: string | Date;
+  eventId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryInjectionRollup {
+  id: string;
+  delivered_count: number;
+  last_injected_at: string;
+  delivery_surfaces: string[];
+  citation_id?: string;
+  node_id?: number;
 }
 
 export interface MemoryEventReadOptions {
@@ -335,6 +434,115 @@ export function engineOpToMemoryEvent(input: EngineOpInput): MemoryEvent {
   });
 }
 
+export function contextPackIdentity(pack: ContextPack): string {
+  const citationIds = pack.entries.map((entry) => entry.citation.urn).sort();
+  const hash = createHash("sha256")
+    .update(
+      JSON.stringify({
+        goal: pack.goal,
+        status: pack.status,
+        budgetChars: pack.budgetChars,
+        usedChars: pack.usedChars,
+        citationIds,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16);
+  return `context-pack:${hash}`;
+}
+
+export function contextPackGenerationToMemoryEvent(
+  input: ContextPackGenerationInput,
+): MemoryEvent {
+  const timestamp =
+    input.timestamp instanceof Date
+      ? input.timestamp.toISOString()
+      : input.timestamp ?? new Date().toISOString();
+  const packId = contextPackIdentity(input.pack);
+  const eventId =
+    input.eventId ?? `context-pack:${input.surface}:${packId}:${Date.parse(timestamp) || timestamp}`;
+  const citationIds = input.pack.entries.map((entry) => entry.citation.urn);
+  const nodeIds = input.pack.entries.map((entry) => entry.citation.rid);
+  return parseMemoryEvent({
+    id: eventId,
+    occurred_at: timestamp,
+    kind: "memory.context-pack.generated",
+    source: { kind: "memory", name: "memory.context-pack" },
+    actor: { kind: "agent", id: input.surface },
+    scope: { level: "goal", id: input.pack.goal },
+    subject: { kind: "context-pack", id: packId },
+    payload: {
+      event_type: "memory.context-pack.generated",
+      event_id: eventId,
+      timestamp,
+      goal: input.pack.goal,
+      pack_id: packId,
+      surface: input.surface,
+      status: input.pack.status,
+      citation_ids: citationIds,
+      node_ids: nodeIds,
+      budget_chars: input.pack.budgetChars,
+      used_chars: input.pack.usedChars,
+      entry_count: input.pack.entries.length,
+      core_context_count: input.pack.coreContext.length,
+      warning_count: input.pack.warnings.length,
+      omitted_entries: input.pack.omittedEntries,
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    },
+    provenance: {
+      source_kind: "system",
+      writer: "memory",
+      command: "memory context-pack",
+      evidence: [`event_id:${eventId}`, `pack_id:${packId}`],
+    },
+  });
+}
+
+export function memoryInjectionToMemoryEvent(input: MemoryInjectionInput): MemoryEvent {
+  const timestamp =
+    input.timestamp instanceof Date
+      ? input.timestamp.toISOString()
+      : input.timestamp ?? new Date().toISOString();
+  const deliveredCitationIds = [...(input.deliveredCitationIds ?? [])];
+  const deliveredNodeIds = [...(input.deliveredNodeIds ?? [])].map((id) => Number(id));
+  const identity =
+    input.packId ?? deliveredCitationIds[0] ?? deliveredNodeIds[0]?.toString() ?? "unknown";
+  const eventId =
+    input.eventId ??
+    `injection:${input.deliverySurface}:${identity}:${Date.parse(timestamp) || timestamp}`;
+  return parseMemoryEvent({
+    id: eventId,
+    occurred_at: timestamp,
+    kind: "memory.injection.delivered",
+    source: { kind: "memory", name: "memory.injection" },
+    actor: { kind: "agent", id: input.runner ?? input.deliverySurface },
+    scope: { level: input.sessionId ? "session" : "delivery", id: input.sessionId ?? input.deliverySurface },
+    subject: { kind: "memory-injection", id: identity },
+    payload: {
+      event_type: "memory.injection.delivered",
+      event_id: eventId,
+      timestamp,
+      delivery_surface: input.deliverySurface,
+      delivered_citation_ids: deliveredCitationIds,
+      delivered_node_ids: deliveredNodeIds,
+      ...(input.goal ? { goal: input.goal } : {}),
+      ...(input.packId ? { pack_id: input.packId } : {}),
+      ...(input.sessionId ? { session_id: input.sessionId } : {}),
+      ...(input.runner ? { runner: input.runner } : {}),
+      ...(input.hookEvent ? { hook_event: input.hookEvent } : {}),
+      ...(input.injectedChars != null ? { injected_chars: input.injectedChars } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    },
+    provenance: {
+      source_kind: input.deliverySurface === "hook" ? "hook" : "system",
+      writer: "memory",
+      command: "memory injection",
+      ...(input.hookEvent ? { hook: input.hookEvent } : {}),
+      evidence: [`event_id:${eventId}`],
+    },
+  });
+}
+
 /**
  * Build a `memory.drift.caught` event (ADR 0025) for the CI drift guard (#224).
  * The guard emits one of these when it fails a PR so the maintainer can see how
@@ -389,6 +597,51 @@ export async function appendEngineOpEvent(
   } catch {
     // Swallowed by design — see function docs.
   }
+}
+
+export async function appendContextPackGenerationEvent(
+  store: MemoryStore,
+  input: ContextPackGenerationInput,
+): Promise<void> {
+  await appendMemoryEvent(store, contextPackGenerationToMemoryEvent(input));
+}
+
+export async function appendMemoryInjectionEvent(
+  store: MemoryStore,
+  input: MemoryInjectionInput,
+): Promise<void> {
+  await appendMemoryEvent(store, memoryInjectionToMemoryEvent(input));
+}
+
+export function deriveMemoryInjectionRollups(events: readonly MemoryEvent[]): MemoryInjectionRollup[] {
+  const rollups = new Map<string, MemoryInjectionRollup>();
+  for (const event of events) {
+    if (event.kind !== "memory.injection.delivered") continue;
+    const payload = event.payload as MemoryInjectionPayload;
+    const touched = new Map<string, { citation_id?: string; node_id?: number }>();
+    for (const citationId of payload.delivered_citation_ids) {
+      touched.set(`citation:${citationId}`, { citation_id: citationId });
+    }
+    for (const nodeId of payload.delivered_node_ids) {
+      touched.set(`node:${nodeId}`, { node_id: nodeId });
+    }
+    for (const [id, ids] of touched) {
+      const prev = rollups.get(id);
+      const surfaces = new Set(prev?.delivery_surfaces ?? []);
+      surfaces.add(payload.delivery_surface);
+      rollups.set(id, {
+        id,
+        ...ids,
+        delivered_count: (prev?.delivered_count ?? 0) + 1,
+        last_injected_at:
+          !prev || Date.parse(payload.timestamp) >= Date.parse(prev.last_injected_at)
+            ? payload.timestamp
+            : prev.last_injected_at,
+        delivery_surfaces: [...surfaces].sort(),
+      });
+    }
+  }
+  return [...rollups.values()].sort((a, b) => a.id.localeCompare(b.id));
 }
 
 export async function appendMemoryEvent(

--- a/src/apps/memory/src/operations.ts
+++ b/src/apps/memory/src/operations.ts
@@ -51,6 +51,7 @@ import {
   buildContextPackViewerArtifact,
   type ContextPackViewerArtifact,
 } from "./context-pack-viewer.js";
+import { appendContextPackGenerationEvent } from "./memory-events.js";
 import { buildDocBrief, type DocBrief } from "./doc-brief.js";
 import {
   buildDocBriefViewerArtifact,
@@ -380,6 +381,7 @@ export interface MemoryOperationContext {
   rootDir?: string;
   now?: number;
   providerConfig?: AiProviderConfig;
+  transportSurface?: string;
 }
 
 export interface MemoryOperationDefinition<Input, Output> {
@@ -1455,14 +1457,21 @@ const CONTEXT_PACK_OPERATION: MemoryOperationDefinition<ContextPackInput, Contex
         "Read-only agent context pack for a goal. Returns grouped evidence, warnings, citations, markdown, and skill recommendations without writing graph facts.",
     },
   },
-  execute: (ctx, input) =>
-    buildContextPack(ctx.store, input.goal, {
+  execute: async (ctx, input) => {
+    const pack = await buildContextPack(ctx.store, input.goal, {
       budgetChars: input.budget_chars,
       limit: input.limit,
       depth: input.depth,
       now: ctx.now,
       scope: scopeFromInput(input),
-    }),
+    });
+    await appendContextPackGenerationEvent(ctx.store, {
+      pack,
+      surface: ctx.transportSurface ?? "operation",
+      metadata: { operation_id: "memory.context-pack" },
+    });
+    return pack;
+  },
 };
 
 const CONTEXT_PACK_VIEWER_OPERATION: MemoryOperationDefinition<
@@ -1485,16 +1494,21 @@ const CONTEXT_PACK_VIEWER_OPERATION: MemoryOperationDefinition<
         "Read-only self-contained HTML viewer for agent context packs. Returns grouped evidence, warnings, citations, skill recommendations, ready-to-inject markdown, embedded JSON, and HTML.",
     },
   },
-  execute: async (ctx, input) =>
-    buildContextPackViewerArtifact(
-      await buildContextPack(ctx.store, input.goal, {
-        budgetChars: input.budget_chars,
-        limit: input.limit,
-        depth: input.depth,
-        now: ctx.now,
-        scope: scopeFromInput(input),
-      }),
-    ),
+  execute: async (ctx, input) => {
+    const pack = await buildContextPack(ctx.store, input.goal, {
+      budgetChars: input.budget_chars,
+      limit: input.limit,
+      depth: input.depth,
+      now: ctx.now,
+      scope: scopeFromInput(input),
+    });
+    await appendContextPackGenerationEvent(ctx.store, {
+      pack,
+      surface: ctx.transportSurface ?? "operation-viewer",
+      metadata: { operation_id: "memory.context-pack-viewer" },
+    });
+    return buildContextPackViewerArtifact(pack);
+  },
 };
 
 const CLAIM_CHECK_OPERATION: MemoryOperationDefinition<ClaimCheckInput, ClaimCheckResult> = {

--- a/src/apps/memory/src/session-timeline.ts
+++ b/src/apps/memory/src/session-timeline.ts
@@ -125,6 +125,34 @@ function toEntry(event: MemoryEvent): SessionTimelineEntry {
     };
   }
 
+  if (payload.event_type === "memory.context-pack.generated") {
+    return {
+      id: event.id,
+      occurred_at: event.occurred_at,
+      kind: event.kind,
+      session_id: sessionIdOf(event),
+      actor: actorOf(event),
+      title: "context pack generated",
+      detail: `${payload.entry_count} citation(s); ${payload.used_chars} chars; surface:${payload.surface}`,
+      outcome: payload.status === "ok" ? "succeeded" : "noop",
+      source: sourceOf(event),
+    };
+  }
+
+  if (payload.event_type === "memory.injection.delivered") {
+    return {
+      id: event.id,
+      occurred_at: event.occurred_at,
+      kind: event.kind,
+      session_id: sessionIdOf(event),
+      actor: actorOf(event),
+      title: "memory injection delivered",
+      detail: `${payload.delivered_citation_ids.length} citation(s); ${payload.delivered_node_ids.length} node(s); surface:${payload.delivery_surface}`,
+      outcome: "succeeded",
+      source: sourceOf(event),
+    };
+  }
+
   return {
     id: event.id,
     occurred_at: event.occurred_at,

--- a/src/apps/memory/tests/context-pack-cli.test.ts
+++ b/src/apps/memory/tests/context-pack-cli.test.ts
@@ -3,6 +3,9 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import { readConfig, resolveStoreUri } from "../src/config.js";
+import { MemoryStore } from "../src/graph-store.js";
+import { readMemoryEvents } from "../src/memory-events.js";
 
 const TIMEOUT = 40_000;
 const pkgRoot = resolve(__dirname, "..");
@@ -64,6 +67,17 @@ describe("memory context-pack CLI", () => {
       expect(body.markdown).toContain("urn: memory_nodes:");
       expect(body.entries[0].reason).toContain("matched the goal");
       expect(body.entries[0].citation.source).toBe("manual");
+
+      const config = await readConfig(root);
+      if (!config) throw new Error("config missing after init");
+      const store = await MemoryStore.open({ uri: resolveStoreUri(root, config) });
+      try {
+        const events = await readMemoryEvents(store);
+        expect(events.filter((event) => event.kind === "memory.context-pack.generated")).toHaveLength(1);
+        expect(events.filter((event) => event.kind === "memory.injection.delivered")).toHaveLength(0);
+      } finally {
+        await store.close();
+      }
     },
     TIMEOUT,
   );

--- a/src/apps/memory/tests/hook-runtime.test.ts
+++ b/src/apps/memory/tests/hook-runtime.test.ts
@@ -79,6 +79,31 @@ describe("PreCompact flush → SessionStart recall across /clear (AC1, AC2)", ()
       const recall = await dispatch(input("SessionStart", { goal: "zigzag caching" }), root);
       expect(recall.noop).toBe(false);
       expect(recall.inject).toMatch(/zigzag caching/i);
+      expect(recall.injection?.deliveredNodeIds.length).toBeGreaterThan(0);
+
+      const config = await readConfig(root);
+      if (!config) throw new Error("config missing after init");
+      const store = await MemoryStore.open({ uri: resolveStoreUri(root, config) });
+      try {
+        const events = await readMemoryEvents(store);
+        expect(events).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              kind: "memory.injection.delivered",
+              payload: expect.objectContaining({
+                delivery_surface: "hook",
+                hook_event: "SessionStart",
+                delivered_citation_ids: expect.arrayContaining([
+                  expect.stringMatching(/^memory_nodes:/),
+                ]),
+                delivered_node_ids: expect.arrayContaining([expect.any(Number)]),
+              }),
+            }),
+          ]),
+        );
+      } finally {
+        await store.close();
+      }
     },
     TIMEOUT,
   );

--- a/src/apps/memory/tests/memory-events.test.ts
+++ b/src/apps/memory/tests/memory-events.test.ts
@@ -4,12 +4,17 @@ import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { MemoryStore } from "../src/graph-store.js";
 import { initGraph } from "../src/init.js";
+import { buildContextPack, type ContextPack } from "../src/context-pack.js";
 import {
+  appendContextPackGenerationEvent,
   appendEngineOpEvent,
   appendMemoryEvent,
+  contextPackGenerationToMemoryEvent,
+  deriveMemoryInjectionRollups,
   driftCaughtToMemoryEvent,
   engineOpToMemoryEvent,
   hookLifecycleToMemoryEvent,
+  memoryInjectionToMemoryEvent,
   parseMemoryEvent,
   readMemoryEvents,
 } from "../src/memory-events.js";
@@ -236,6 +241,182 @@ describe("Memory event log", () => {
         query: "memory layers",
         hit_count: 3,
       },
+    });
+  });
+
+  test("validates context-pack generation observations with pack identity and citations", () => {
+    const pack: ContextPack = {
+      goal: "jwt rotation",
+      status: "ok",
+      budgetChars: 1200,
+      usedChars: 320,
+      markdown: "# Memory context pack: jwt rotation\n",
+      coreContext: [],
+      entries: [
+        {
+          section: "prior_decisions",
+          title: "JWT rotation",
+          nodeType: "decision",
+          importance: 0.8,
+          confidence: "EXTRACTED",
+          trust: 1,
+          provenance: null,
+          citation: { marker: "[M1]", urn: "memory_nodes:7", rid: 7, source: "manual" },
+          reason: "decision evidence matched the goal",
+          excerpt: "Rotate JWT keys with signed fixtures.",
+          score: 1,
+        },
+      ],
+      skillRecommendations: {
+        task: "jwt rotation",
+        status: "insufficient-evidence",
+        recommendations: [],
+        missingEvidence: [],
+      },
+      warnings: [],
+      omittedEntries: 0,
+    };
+
+    const event = contextPackGenerationToMemoryEvent({
+      pack,
+      surface: "cli",
+      timestamp: "2026-05-22T19:00:00.000Z",
+      eventId: "context-pack:1",
+    });
+
+    expect(event).toMatchObject({
+      id: "context-pack:1",
+      kind: "memory.context-pack.generated",
+      payload: {
+        event_type: "memory.context-pack.generated",
+        goal: "jwt rotation",
+        surface: "cli",
+        citation_ids: ["memory_nodes:7"],
+        node_ids: [7],
+        entry_count: 1,
+      },
+    });
+    expect(event.payload).toHaveProperty("pack_id");
+    expect(() => parseMemoryEvent(event)).not.toThrow();
+  });
+
+  test("validates Memory injection observations and rejects empty deliveries", () => {
+    const event = memoryInjectionToMemoryEvent({
+      deliveredCitationIds: ["memory_nodes:7"],
+      deliveredNodeIds: [7],
+      deliverySurface: "hook",
+      goal: "jwt rotation",
+      sessionId: "session-1",
+      runner: "codex",
+      hookEvent: "SessionStart",
+      injectedChars: 512,
+      timestamp: "2026-05-22T19:10:00.000Z",
+      eventId: "injection:1",
+    });
+
+    expect(event).toMatchObject({
+      id: "injection:1",
+      kind: "memory.injection.delivered",
+      payload: {
+        event_type: "memory.injection.delivered",
+        delivery_surface: "hook",
+        delivered_citation_ids: ["memory_nodes:7"],
+        delivered_node_ids: [7],
+      },
+    });
+    expect(() =>
+      memoryInjectionToMemoryEvent({
+        deliverySurface: "hook",
+        timestamp: "2026-05-22T19:10:00.000Z",
+      }),
+    ).toThrow(/delivered citation or node ids/);
+  });
+
+  test(
+    "context-pack generation records generation without creating injection",
+    async () => {
+      const root = await tempRoot();
+      await initGraph(root);
+      const store = await openStore(root);
+      await store.upsertNode({
+        label: "context-pack-generation",
+        node_type: "decision",
+        properties: {
+          title: "Context pack generation",
+          content: "Decision: context-pack generation cites Memory nodes.",
+          source: "manual",
+        },
+      });
+
+      const pack = await buildContextPack(store, "context-pack generation", { budgetChars: 1200 });
+      await appendContextPackGenerationEvent(store, { pack, surface: "cli" });
+
+      const events = await readMemoryEvents(store);
+      expect(events.filter((event) => event.kind === "memory.context-pack.generated")).toHaveLength(1);
+      expect(events.filter((event) => event.kind === "memory.injection.delivered")).toHaveLength(0);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "manual recall display records recall/access bookkeeping but not injection",
+    async () => {
+      const { graphRecallResult } = await import("../src/graph-recall.js");
+      const root = await tempRoot();
+      await initGraph(root);
+      const store = await openStore(root);
+      const rid = await store.upsertNode({
+        label: "manual-recall-display",
+        node_type: "decision",
+        properties: {
+          title: "Manual recall display",
+          content: "Decision: manual recall display is not Memory injection.",
+          source: "manual",
+        },
+      });
+
+      await graphRecallResult(store, "manual recall display");
+
+      const access = await store.accessRecord(rid);
+      expect(access?.count).toBeGreaterThan(0);
+      const events = await readMemoryEvents(store);
+      expect(events.some((event) => event.kind === "engine.op")).toBe(true);
+      expect(events.filter((event) => event.kind === "memory.injection.delivered")).toHaveLength(0);
+    },
+    TIMEOUT,
+  );
+
+  test("derives injection counters and last timestamps from event-log observations", () => {
+    const first = memoryInjectionToMemoryEvent({
+      deliveredCitationIds: ["memory_nodes:7"],
+      deliveredNodeIds: [7],
+      deliverySurface: "hook",
+      timestamp: "2026-05-22T19:00:00.000Z",
+      eventId: "injection:rollup:1",
+    });
+    const second = memoryInjectionToMemoryEvent({
+      deliveredCitationIds: ["memory_nodes:7"],
+      deliveredNodeIds: [7],
+      deliverySurface: "mcp",
+      timestamp: "2026-05-22T20:00:00.000Z",
+      eventId: "injection:rollup:2",
+    });
+
+    const rollups = deriveMemoryInjectionRollups([first, second]);
+
+    expect(rollups).toContainEqual({
+      id: "citation:memory_nodes:7",
+      citation_id: "memory_nodes:7",
+      delivered_count: 2,
+      last_injected_at: "2026-05-22T20:00:00.000Z",
+      delivery_surfaces: ["hook", "mcp"],
+    });
+    expect(rollups).toContainEqual({
+      id: "node:7",
+      node_id: 7,
+      delivered_count: 2,
+      last_injected_at: "2026-05-22T20:00:00.000Z",
+      delivery_surfaces: ["hook", "mcp"],
     });
   });
 


### PR DESCRIPTION
Closes #491

## Summary
- add validated Memory event-log observations for context-pack generation and Memory injection delivery
- record context-pack generation from CLI/MCP/HTTP surfaces without counting it as injection
- record injection only when SessionStart hook delivery returns Memory context to the runner
- derive injection counters and last-injected timestamps from event-log observations

## Verification
- pnpm -C src/apps/memory exec vitest run tests/memory-events.test.ts tests/hook-runtime.test.ts
- pnpm -C src/apps/memory exec tsc -p tsconfig.json --noEmit
- pnpm -C src/apps/memory exec vitest run --config vitest.integration.config.ts tests/context-pack-cli.test.ts
- pnpm -C src/apps/memory exec vitest run --config vitest.integration.config.ts tests/session-timeline.test.ts tests/session-timeline-viewer.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783253003&installation_id=129708444&pr_number=497&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F497&signature=9e758f7f0665df82b492ff3216818a86ac01ce5b88c81fa37235cf9dc4b562dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Context-pack generation is now tracked across all interfaces (CLI, HTTP, MCP) with metadata about generation surface and status.
  * Memory injection delivery is now recorded with details about delivered citations, nodes, and delivery surface for improved auditing and timeline visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->