### PR TITLE
Add tidy recommendation review workflow

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -213,6 +213,11 @@ import {
   executeMemoryMergeBatch,
   unmergeMemoryMergeBatch,
 } from "./memory-merge-pass.js";
+import {
+  acceptGovernanceTidyRecommendation,
+  dismissGovernanceTidyRecommendation,
+  refreshGovernanceTidyReviewArtifacts,
+} from "./governance-tidy-review.js";
 import { recall } from "./recall.js";
 import { buildFederationReport } from "./federation.js";
 import { runAutoCure } from "./auto-curation.js";
@@ -334,6 +339,9 @@ Usage:
   memory merge-pass                 [--root <dir>] [--min-score N] [--limit N] [--json]
   memory merge-pass execute         --candidate-ranks 1,2 --approver <id> --yes [--root <dir>] [--min-score N] [--limit N] [--batch-id ID] [--json]
   memory merge-pass unmerge         --batch-id ID --yes [--root <dir>] [--json]
+  memory tidy-review refresh        [--root <dir>] [--json]
+  memory tidy-review accept <id>    --approver <id> --yes [--root <dir>] [--reason <text>] [--json]
+  memory tidy-review dismiss <id>   --approver <id> --yes [--root <dir>] [--reason <text>] [--json]
   memory health-viewer              [--root <dir>] [--stale-days N] [--out <file>]
   memory onboarding-map             [--root <dir>] [--stale-days N] [--json]
   memory onboarding-map-viewer      [--root <dir>] [--stale-days N] [--out <file>]
@@ -465,6 +473,7 @@ const LEGACY_CLI_OPERATION_IDS = new Set(["memory.health"]);
 const LEGACY_SUBCOMMANDS_BY_REGISTRY_COMMAND: Readonly<Record<string, readonly string[]>> = {
   "merge-pass": ["execute", "unmerge"],
   "onboarding-map": ["export"],
+  "tidy-review": ["refresh", "accept", "dismiss"],
 };
 const PROOF_REGISTRY_CLI_COMMANDS = new Set(["docs brief", "docs brief-viewer"]);
 const REGISTRY_CLI_OPERATIONS = new Map<string, ReadOnlyMemoryOperation>(
@@ -1727,6 +1736,85 @@ async function runMemoryMergePassUnmerge(args: ParsedArgs): Promise<void> {
         `  ${edge.removed ? "removed" : "missing"} ${edge.label} memory_nodes:${edge.duplicate_rid} -> memory_nodes:${edge.canonical_rid}`,
       );
     }
+  } finally {
+    await store.close();
+  }
+}
+
+async function runTidyReview(args: ParsedArgs): Promise<void> {
+  const action = args.positional[0];
+  if (action === "refresh") return runTidyReviewRefresh(args);
+  if (action === "accept") return runTidyReviewAccept(args);
+  if (action === "dismiss") return runTidyReviewDismiss(args);
+  throw new Error("memory tidy-review action must be one of: refresh, accept, dismiss");
+}
+
+async function runTidyReviewRefresh(args: ParsedArgs): Promise<void> {
+  const { store, config } = await openGraphStore(args);
+  try {
+    const result = await refreshGovernanceTidyReviewArtifacts(store, {
+      providerConfig: config.provider,
+    });
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(
+      `memory tidy-review refresh: ${result.summary.recommendations} open/current recommendation(s), ${result.summary.stale} stale`,
+    );
+    for (const artifact of result.artifacts) {
+      console.log(`  ${artifact.status} ${artifact.artifact_id}`);
+    }
+    for (const artifact of result.stale_artifacts) {
+      console.log(`  stale ${artifact.artifact_id}`);
+    }
+  } finally {
+    await store.close();
+  }
+}
+
+async function runTidyReviewAccept(args: ParsedArgs): Promise<void> {
+  if (args.flags.yes !== true) {
+    throw new Error("memory tidy-review accept requires explicit --yes approval");
+  }
+  const id = args.positional[1] ?? "";
+  const { store } = await openGraphStore(args);
+  try {
+    const result = await acceptGovernanceTidyRecommendation(store, {
+      id,
+      approver: stringFlag(args.flags, "approver") ?? "",
+      reason: stringFlag(args.flags, "reason"),
+    });
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(
+      `memory tidy-review accept: ${result.edge.label} memory_nodes:${result.edge.from_rid} -> memory_nodes:${result.edge.to_rid}`,
+    );
+    console.log(`  artifact: ${result.artifact_id}`);
+  } finally {
+    await store.close();
+  }
+}
+
+async function runTidyReviewDismiss(args: ParsedArgs): Promise<void> {
+  if (args.flags.yes !== true) {
+    throw new Error("memory tidy-review dismiss requires explicit --yes approval");
+  }
+  const id = args.positional[1] ?? "";
+  const { store } = await openGraphStore(args);
+  try {
+    const result = await dismissGovernanceTidyRecommendation(store, {
+      id,
+      approver: stringFlag(args.flags, "approver") ?? "",
+      reason: stringFlag(args.flags, "reason"),
+    });
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(`memory tidy-review dismiss: ${result.artifact_id}`);
   } finally {
     await store.close();
   }
@@ -6741,6 +6829,8 @@ async function main(): Promise<void> {
       return runMemoryDecayViewer(args);
     case "merge-pass":
       return runMemoryMergePass(args);
+    case "tidy-review":
+      return runTidyReview(args);
     case "dashboard":
       return runDashboard(args);
     case "workbench":

--- a/src/apps/memory/src/governance-tidy-review.ts
+++ b/src/apps/memory/src/governance-tidy-review.ts
@@ -1,0 +1,285 @@
+import type { AiProviderConfig, ProviderClient } from "./extract-conversation.js";
+import type { MemoryStore } from "./graph-store.js";
+import {
+  buildMemoryGovernanceTidyRecommendations,
+  GOVERNANCE_TIDY_OPERATION,
+  providerReviewInputFromGovernanceTidyRecommendation,
+  type BuildGovernanceTidyRecommendationsOptions,
+} from "./governance-tidy.js";
+import {
+  listProviderReviewArtifacts,
+  persistProviderReviewArtifacts,
+  updateProviderReviewArtifactStatus,
+  type ProviderReviewArtifact,
+} from "./provider-review-artifacts.js";
+
+export interface GovernanceTidyReviewRefreshResult {
+  schema_version: "memory.governance_tidy_review.v1";
+  action: "refresh";
+  refreshed_at: string;
+  summary: {
+    recommendations: number;
+    stale: number;
+  };
+  artifacts: Array<{
+    artifact_id: string;
+    recommendation_id: string;
+    status: string;
+    fingerprint: string;
+  }>;
+  stale_artifacts: Array<{
+    artifact_id: string;
+    recommendation_id: string;
+    status: "stale";
+    fingerprint: string;
+  }>;
+}
+
+export interface GovernanceTidyReviewAcceptResult {
+  schema_version: "memory.governance_tidy_review.v1";
+  action: "accept";
+  recommendation_id: string;
+  artifact_id: string;
+  accepted_by: string;
+  accepted_at: string;
+  edge: {
+    edge_rid: number;
+    label: "SAME_AS" | "MERGED_INTO";
+    from_rid: number;
+    to_rid: number;
+  };
+  artifact: {
+    status: "accepted";
+    fingerprint: string;
+  };
+}
+
+export interface GovernanceTidyReviewDismissResult {
+  schema_version: "memory.governance_tidy_review.v1";
+  action: "dismiss";
+  recommendation_id: string;
+  artifact_id: string;
+  dismissed_by: string;
+  dismissed_at: string;
+  artifact: {
+    status: "dismissed";
+    fingerprint: string;
+  };
+}
+
+export interface GovernanceTidyReviewDecisionInput {
+  id: string;
+  approver: string;
+  reason?: string;
+  now?: number;
+}
+
+interface RefreshInput extends BuildGovernanceTidyRecommendationsOptions {
+  providerConfig?: AiProviderConfig;
+  providerClient?: ProviderClient;
+}
+
+const SCHEMA_VERSION = "memory.governance_tidy_review.v1";
+const REVIEW_SOURCE = "memory tidy-review";
+
+export async function refreshGovernanceTidyReviewArtifacts(
+  store: MemoryStore,
+  input: RefreshInput = {},
+): Promise<GovernanceTidyReviewRefreshResult> {
+  const now = input.now ?? Date.now();
+  const report = await buildMemoryGovernanceTidyRecommendations(store, input);
+  const providerInputs = report.recommendations.map(
+    providerReviewInputFromGovernanceTidyRecommendation,
+  );
+  const persisted = await persistProviderReviewArtifacts(store, providerInputs, {
+    now,
+    operation: GOVERNANCE_TIDY_OPERATION,
+  });
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    action: "refresh",
+    refreshed_at: new Date(now).toISOString(),
+    summary: {
+      recommendations: persisted.artifacts.length,
+      stale: persisted.stale.length,
+    },
+    artifacts: persisted.artifacts.map((artifact) => ({
+      artifact_id: artifact.artifact_id,
+      recommendation_id: artifact.recommendation_id,
+      status: artifact.status,
+      fingerprint: artifact.fingerprint,
+    })),
+    stale_artifacts: persisted.stale.map((artifact) => ({
+      artifact_id: artifact.artifact_id,
+      recommendation_id: artifact.recommendation_id,
+      status: "stale" as const,
+      fingerprint: artifact.fingerprint,
+    })),
+  };
+}
+
+export async function acceptGovernanceTidyRecommendation(
+  store: MemoryStore,
+  input: GovernanceTidyReviewDecisionInput,
+): Promise<GovernanceTidyReviewAcceptResult> {
+  const approver = requiredApprover(input.approver, "accept");
+  const now = input.now ?? Date.now();
+  const artifact = await resolveOpenTidyArtifact(store, input.id);
+  const proposal = softMergeProposal(artifact);
+
+  const [fromNode, toNode] = await Promise.all([
+    store.getNode(proposal.from_rid),
+    store.getNode(proposal.to_rid),
+  ]);
+  if (!fromNode) throw new Error(`tidy recommendation source node not found: ${proposal.from_rid}`);
+  if (!toNode) throw new Error(`tidy recommendation target node not found: ${proposal.to_rid}`);
+
+  const edgeRid = await store.upsertEdge({
+    label: proposal.label,
+    from_rid: proposal.from_rid,
+    to_rid: proposal.to_rid,
+    properties: {
+      reason: input.reason ?? "accepted provider tidy recommendation",
+      approved_by: approver,
+      approved_at: now,
+      approval_source: `${REVIEW_SOURCE} accept`,
+      provider_review_artifact_id: artifact.artifact_id,
+      provider_review_recommendation_id: artifact.recommendation_id,
+      provider_review_recommendation_key: artifact.recommendation_key,
+      provider_review_fingerprint: artifact.fingerprint,
+      schema_version: SCHEMA_VERSION,
+    },
+  });
+
+  const accepted = await updateProviderReviewArtifactStatus(
+    store,
+    artifact.artifact_id,
+    "accepted",
+    {
+      now,
+      approver,
+      reason: input.reason,
+      source: `${REVIEW_SOURCE} accept`,
+    },
+  );
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    action: "accept",
+    recommendation_id: accepted.recommendation_id,
+    artifact_id: accepted.artifact_id,
+    accepted_by: approver,
+    accepted_at: new Date(now).toISOString(),
+    edge: {
+      edge_rid: edgeRid,
+      label: proposal.label,
+      from_rid: proposal.from_rid,
+      to_rid: proposal.to_rid,
+    },
+    artifact: {
+      status: "accepted",
+      fingerprint: accepted.fingerprint,
+    },
+  };
+}
+
+export async function dismissGovernanceTidyRecommendation(
+  store: MemoryStore,
+  input: GovernanceTidyReviewDecisionInput,
+): Promise<GovernanceTidyReviewDismissResult> {
+  const approver = requiredApprover(input.approver, "dismiss");
+  const now = input.now ?? Date.now();
+  const artifact = await resolveOpenTidyArtifact(store, input.id);
+  const dismissed = await updateProviderReviewArtifactStatus(
+    store,
+    artifact.artifact_id,
+    "dismissed",
+    {
+      now,
+      approver,
+      reason: input.reason,
+      source: `${REVIEW_SOURCE} dismiss`,
+    },
+  );
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    action: "dismiss",
+    recommendation_id: dismissed.recommendation_id,
+    artifact_id: dismissed.artifact_id,
+    dismissed_by: approver,
+    dismissed_at: new Date(now).toISOString(),
+    artifact: {
+      status: "dismissed",
+      fingerprint: dismissed.fingerprint,
+    },
+  };
+}
+
+async function resolveOpenTidyArtifact(
+  store: Pick<MemoryStore, "kvGet">,
+  id: string,
+): Promise<ProviderReviewArtifact> {
+  const normalizedId = id.trim();
+  if (!normalizedId) throw new Error("memory tidy-review requires a recommendation id");
+  const matches = (
+    await listProviderReviewArtifacts(store, { operation: GOVERNANCE_TIDY_OPERATION })
+  ).filter(
+    (artifact) =>
+      artifact.artifact_id === normalizedId || artifact.recommendation_id === normalizedId,
+  );
+  if (matches.length === 0) {
+    throw new Error(`tidy recommendation not found: ${normalizedId}`);
+  }
+
+  const open = matches.filter((artifact) => artifact.status === "open");
+  if (open.length === 1) return open[0]!;
+  if (open.length > 1) {
+    throw new Error(
+      `tidy recommendation id is ambiguous; use an artifact id: ${open
+        .map((artifact) => artifact.artifact_id)
+        .join(", ")}`,
+    );
+  }
+  if (matches.some((artifact) => artifact.status === "stale")) {
+    throw new Error(
+      `tidy recommendation is stale: ${normalizedId}; refresh provider review evidence before accepting or dismissing it`,
+    );
+  }
+  throw new Error(`tidy recommendation is not open: ${normalizedId} (${matches[0]!.status})`);
+}
+
+function softMergeProposal(artifact: ProviderReviewArtifact): {
+  label: "SAME_AS" | "MERGED_INTO";
+  from_rid: number;
+  to_rid: number;
+} {
+  for (const pair of artifact.pair_evidence) {
+    for (const evidence of pair.evidence ?? []) {
+      const label = hiddenSoftMergeLabel(evidence.proposed_edge_label ?? evidence.edge_label);
+      const duplicateRid = numberValue(evidence.duplicate_rid ?? evidence.from_rid ?? evidence.from);
+      const canonicalRid = numberValue(evidence.canonical_rid ?? evidence.to_rid ?? evidence.to);
+      if (label && duplicateRid != null && canonicalRid != null) {
+        return { label, from_rid: duplicateRid, to_rid: canonicalRid };
+      }
+    }
+  }
+  throw new Error(`tidy recommendation has no supported Soft-merge edge: ${artifact.artifact_id}`);
+}
+
+function hiddenSoftMergeLabel(value: unknown): "SAME_AS" | "MERGED_INTO" | null {
+  if (typeof value !== "string") return null;
+  const label = value.trim().toUpperCase();
+  return label === "SAME_AS" || label === "MERGED_INTO" ? label : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function requiredApprover(value: string, action: "accept" | "dismiss"): string {
+  const approver = value.trim();
+  if (!approver) throw new Error(`memory tidy-review ${action} requires --approver`);
+  return approver;
+}

--- a/src/apps/memory/src/governance-tidy.ts
+++ b/src/apps/memory/src/governance-tidy.ts
@@ -14,6 +14,7 @@ import {
   listProviderReviewArtifacts,
   providerReviewArtifactId,
   providerReviewRecommendationId,
+  type ProviderReviewArtifact,
   type ProviderReviewPairEvidence,
   type ProviderReviewRecommendationInput,
   type ProviderReviewStatus,
@@ -121,9 +122,15 @@ export async function buildMemoryGovernanceTidyRecommendations(
   });
   const candidates = mergePass.candidates;
   if (candidates.length === 0) {
+    const reviewed = await reviewedGovernanceRecommendations(store);
     return {
       ...emptyTidyRecommendations(policy, "available", null),
-      summary: { candidate_pairs: 0, recommended_pairs: 0, dropped_recommendations: 0 },
+      summary: {
+        candidate_pairs: 0,
+        recommended_pairs: reviewed.length,
+        dropped_recommendations: 0,
+      },
+      recommendations: reviewed,
     };
   }
 
@@ -156,6 +163,11 @@ export async function buildMemoryGovernanceTidyRecommendations(
   const recommendations = bounded.map((rec) =>
     toGovernanceRecommendation(rec, candidates, provider, statusByArtifact),
   );
+  const reviewed = await reviewedGovernanceRecommendations(
+    store,
+    new Set(recommendations.map((rec) => rec.artifact_id)),
+  );
+  recommendations.push(...reviewed);
   const dropped = parsed.dropped + Math.max(0, parsed.recommendations.length - bounded.length);
   return {
     schema_version: "memory.governance_tidy_recommendations.v1",
@@ -171,6 +183,93 @@ export async function buildMemoryGovernanceTidyRecommendations(
     },
     warnings,
     recommendations,
+  };
+}
+
+async function reviewedGovernanceRecommendations(
+  store: Pick<MemoryStore, "kvGet">,
+  skipArtifactIds: Set<string> = new Set(),
+): Promise<MemoryGovernanceTidyRecommendation[]> {
+  const reviewed: MemoryGovernanceTidyRecommendation[] = [];
+  for (const artifact of await listProviderReviewArtifacts(store, {
+    operation: GOVERNANCE_TIDY_OPERATION,
+  })) {
+    if (skipArtifactIds.has(artifact.artifact_id)) continue;
+    if (artifact.status !== "accepted" && artifact.status !== "dismissed") continue;
+    const recommendation = governanceRecommendationFromArtifact(artifact);
+    if (recommendation) reviewed.push(recommendation);
+  }
+  return reviewed.sort((a, b) => a.artifact_id.localeCompare(b.artifact_id));
+}
+
+function governanceRecommendationFromArtifact(
+  artifact: ProviderReviewArtifact,
+): MemoryGovernanceTidyRecommendation | null {
+  const relation = tidyRelation(artifact.pair_evidence[0]?.relation);
+  const proposal = softMergeProposalFromPairEvidence(artifact.pair_evidence);
+  if (!relation || !proposal) return null;
+  const providerOutput = artifact.recommendation.provider_output;
+  const confidence = isRecord(providerOutput) ? confidenceValue(providerOutput.confidence) : null;
+  return {
+    id: artifact.recommendation_id,
+    artifact_id: artifact.artifact_id,
+    recommendation_id: artifact.recommendation_id,
+    recommendation_key: artifact.recommendation_key,
+    operation: GOVERNANCE_TIDY_OPERATION,
+    review_status: artifact.status,
+    relation,
+    confidence: confidence ?? 0,
+    rationale: artifact.recommendation.rationale ?? "",
+    proposed_soft_merge: {
+      action: "SOFT_MERGE",
+      edge_label: proposal.label,
+      duplicate_rid: proposal.duplicate_rid,
+      canonical_rid: proposal.canonical_rid,
+      direction: `${proposal.label} memory_nodes:${proposal.duplicate_rid} -> memory_nodes:${proposal.canonical_rid}`,
+    },
+    pair_evidence: artifact.pair_evidence,
+    provider: artifact.provider,
+  };
+}
+
+function softMergeProposalFromPairEvidence(
+  pairEvidence: ProviderReviewPairEvidence[],
+): { label: "SAME_AS"; duplicate_rid: number; canonical_rid: number } | null {
+  for (const pair of pairEvidence) {
+    for (const evidence of pair.evidence ?? []) {
+      if (!isSameAsEdge(evidence.proposed_edge_label ?? evidence.edge_label)) continue;
+      const duplicateRid = numberValue(evidence.duplicate_rid);
+      const canonicalRid = numberValue(evidence.canonical_rid);
+      if (duplicateRid != null && canonicalRid != null) {
+        return { label: "SAME_AS", duplicate_rid: duplicateRid, canonical_rid: canonicalRid };
+      }
+    }
+  }
+  return null;
+}
+
+export function providerReviewInputFromGovernanceTidyRecommendation(
+  recommendation: MemoryGovernanceTidyRecommendation,
+): ProviderReviewRecommendationInput {
+  const candidateId =
+    recommendation.pair_evidence[0]?.pair_id ??
+    recommendation.recommendation_key.replace(/^[^:]+:/, "");
+  return {
+    operation: GOVERNANCE_TIDY_OPERATION,
+    policyVersion: DEFAULT_TIDY_REVIEW_POLICY_VERSION,
+    recommendationKey: recommendation.recommendation_key,
+    pairEvidence: recommendation.pair_evidence,
+    recommendation: {
+      title: `Review ${recommendation.relation.replace("_", "-")} Memory Soft-merge candidate`,
+      rationale: recommendation.rationale,
+      suggested_action: `Review and, if approved outside governance, create ${recommendation.proposed_soft_merge.direction}`,
+      provider_output: {
+        candidate_id: candidateId,
+        relation: recommendation.relation,
+        confidence: recommendation.confidence,
+      },
+    },
+    provider: recommendation.provider,
   };
 }
 
@@ -488,6 +587,10 @@ function isSameAsEdge(value: unknown): boolean {
 function matchesOptionalRid(value: unknown, expected: number): boolean {
   if (value == null) return true;
   return typeof value === "number" && Number.isFinite(value) && value === expected;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function confidenceValue(value: unknown): number | null {

--- a/src/apps/memory/src/provider-review-artifacts.ts
+++ b/src/apps/memory/src/provider-review-artifacts.ts
@@ -74,6 +74,15 @@ export interface ProviderReviewArtifact {
   pair_evidence: ProviderReviewPairEvidence[];
   recommendation: ProviderReviewRecommendationInput["recommendation"];
   provider?: ProviderReviewRecommendationInput["provider"];
+  review?: ProviderReviewActionMetadata;
+}
+
+export interface ProviderReviewActionMetadata {
+  action: "accepted" | "dismissed";
+  approver: string;
+  reviewed_at: number;
+  source: string;
+  reason?: string;
 }
 
 export interface ProviderReviewArtifactState {
@@ -174,6 +183,9 @@ export async function persistProviderReviewArtifacts(
       provider: rec.provider
         ? (cloneJson(rec.provider) as ProviderReviewRecommendationInput["provider"])
         : undefined,
+      review: existing?.review
+        ? (cloneJson(existing.review) as ProviderReviewActionMetadata)
+        : undefined,
     };
   });
 
@@ -215,12 +227,13 @@ export async function updateProviderReviewArtifactStatus(
   store: Pick<MemoryStore, "kvGet" | "kvPut">,
   artifactId: string,
   status: ProviderReviewStatus,
-  opts: { now?: number } = {},
+  opts: { now?: number; approver?: string; reason?: string; source?: string } = {},
 ): Promise<ProviderReviewArtifact> {
   const now = opts.now ?? Date.now();
   const state = await readProviderReviewArtifactState(store);
   const artifact = state.artifacts[artifactId];
   if (!artifact) throw new Error(`provider review artifact not found: ${artifactId}`);
+  const action = status === "accepted" || status === "dismissed" ? status : null;
   const next: ProviderReviewArtifact = {
     ...artifact,
     status,
@@ -229,11 +242,25 @@ export async function updateProviderReviewArtifactStatus(
     dismissed_at: status === "dismissed" ? now : artifact.dismissed_at,
     accepted_at: status === "accepted" ? now : artifact.accepted_at,
     stale_at: status === "stale" ? now : artifact.stale_at,
+    review: action
+      ? {
+          action,
+          approver: opts.approver ?? artifact.review?.approver ?? "unknown",
+          reviewed_at: now,
+          source: opts.source ?? artifact.review?.source ?? "provider review artifact status update",
+          ...(opts.reason
+            ? { reason: opts.reason }
+            : artifact.review?.reason
+              ? { reason: artifact.review.reason }
+              : {}),
+        }
+      : artifact.review,
   };
   if (status === "open") {
     delete next.dismissed_at;
     delete next.accepted_at;
     delete next.stale_at;
+    delete next.review;
   }
   state.artifacts[artifactId] = next;
   await writeProviderReviewArtifactState(store, state);

--- a/src/apps/memory/tests/governance-tidy-review.test.ts
+++ b/src/apps/memory/tests/governance-tidy-review.test.ts
@@ -1,0 +1,313 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import type { ProviderClient, ProviderRequest } from "../src/extract-conversation.js";
+import { buildMemoryGovernanceReport } from "../src/governance.js";
+import {
+  acceptGovernanceTidyRecommendation,
+  dismissGovernanceTidyRecommendation,
+  refreshGovernanceTidyReviewArtifacts,
+} from "../src/governance-tidy-review.js";
+import { MemoryStore } from "../src/graph-store.js";
+import { initGraph } from "../src/init.js";
+import {
+  listProviderReviewArtifacts,
+  updateProviderReviewArtifactStatus,
+} from "../src/provider-review-artifacts.js";
+
+const TIMEOUT = 30_000;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, "..");
+const roots: string[] = [];
+const stores: MemoryStore[] = [];
+
+const LOCAL_PROVIDER = {
+  mode: "openai-compat" as const,
+  model: "llama3.1",
+  baseUrl: "http://localhost:11434/v1",
+};
+
+async function tempRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "memory-governance-tidy-review-"));
+  roots.push(dir);
+  return dir;
+}
+
+async function openStore(root: string): Promise<MemoryStore> {
+  const store = await MemoryStore.open({
+    uri: `file://${join(root, ".red/memory/graph.rdb")}`,
+    project: "test",
+  });
+  stores.push(store);
+  return store;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: PLUGIN_ROOT,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+function providerResponse(recommendations: unknown[]): ProviderClient {
+  return {
+    async complete(_req: ProviderRequest): Promise<string> {
+      return JSON.stringify({ recommendations });
+    },
+  };
+}
+
+async function seedDuplicateNodePair(
+  store: MemoryStore,
+  suffix: string,
+): Promise<{ canonical: number; duplicate: number }> {
+  const canonical = await store.upsertNode({
+    label: `jwt-rotation-${suffix}`,
+    node_type: "decision",
+    properties: {
+      title: `JWT rotation ${suffix}`,
+      content: "JWT rotation must rotate signing keys with a staged overlap window.",
+      scope: "project",
+      tier: "durable",
+      importance: 0.9,
+      provenance: {
+        source_kind: "manual",
+        writer: "canonical-writer",
+        evidence: [`transcript:${suffix}:canonical`],
+      },
+    },
+  });
+  const duplicate = await store.upsertNode({
+    label: `jwt-key-rotation-${suffix}`,
+    node_type: "decision",
+    properties: {
+      title: `JWT rotation ${suffix}`,
+      content: "JWT rotation must rotate signing keys with a staged overlap window.",
+      scope: "project",
+      tier: "durable",
+      importance: 0.1,
+      provenance: {
+        source_kind: "manual",
+        writer: "duplicate-writer",
+        evidence: [`transcript:${suffix}:duplicate`],
+      },
+    },
+  });
+  return { canonical, duplicate };
+}
+
+function recFor(candidateId: string): Record<string, unknown> {
+  return {
+    candidate_id: candidateId,
+    relation: "duplicate",
+    confidence: 0.9,
+    rationale: `Candidate ${candidateId} is semantically identical.`,
+    proposed_action: "SOFT_MERGE",
+    proposed_edge_label: "SAME_AS",
+  };
+}
+
+describe("governance tidy review workflow", () => {
+  test("accepts an open recommendation by id through the CLI and preserves both nodes", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    const { canonical, duplicate } = await seedDuplicateNodePair(store, "accept");
+    const refresh = await refreshGovernanceTidyReviewArtifacts(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+      now: 1000,
+    });
+    const artifactId = refresh.artifacts[0]!.artifact_id;
+    const beforeNodes = await store.listNodes();
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const blocked = runMemory([
+      "tidy-review",
+      "accept",
+      artifactId,
+      "--root",
+      root,
+      "--approver",
+      "agent:test",
+      "--json",
+    ]);
+    expect(blocked.status).not.toBe(0);
+    expect(blocked.stderr).toContain("requires explicit --yes approval");
+
+    const accepted = runMemory([
+      "tidy-review",
+      "accept",
+      artifactId,
+      "--root",
+      root,
+      "--approver",
+      "agent:test",
+      "--reason",
+      "reviewed duplicate policy",
+      "--yes",
+      "--json",
+    ]);
+    expect(accepted.status, accepted.stderr).toBe(0);
+    const body = JSON.parse(accepted.stdout) as {
+      action: string;
+      edge: { label: string; from_rid: number; to_rid: number };
+    };
+    expect(body).toMatchObject({
+      action: "accept",
+      edge: {
+        label: "SAME_AS",
+        from_rid: duplicate,
+        to_rid: canonical,
+      },
+    });
+
+    const after = await openStore(root);
+    await expect(after.findEdge(duplicate, canonical, "SAME_AS")).resolves.toBeGreaterThan(0);
+    expect(await after.listNodes()).toHaveLength(beforeNodes.length);
+    await expect(after.getNode(duplicate)).resolves.toMatchObject({
+      properties: {
+        provenance: {
+          writer: "duplicate-writer",
+          evidence: ["transcript:accept:duplicate"],
+        },
+      },
+    });
+    await expect(after.getNode(canonical)).resolves.toMatchObject({
+      properties: {
+        provenance: {
+          writer: "canonical-writer",
+          evidence: ["transcript:accept:canonical"],
+        },
+      },
+    });
+    const artifacts = await listProviderReviewArtifacts(after);
+    expect(artifacts[0]).toMatchObject({
+      status: "accepted",
+      accepted_at: expect.any(Number),
+      review: {
+        action: "accepted",
+        approver: "agent:test",
+        reason: "reviewed duplicate policy",
+        source: "memory tidy-review accept",
+      },
+    });
+
+    const governance = await buildMemoryGovernanceReport(after, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+    });
+    expect(governance.tidy_recommendations.recommendations[0]).toMatchObject({
+      artifact_id: artifactId,
+      review_status: "accepted",
+    });
+  }, TIMEOUT);
+
+  test("dismisses an open recommendation without creating graph evidence", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    const { canonical, duplicate } = await seedDuplicateNodePair(store, "dismiss");
+    const refresh = await refreshGovernanceTidyReviewArtifacts(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+      now: 1000,
+    });
+
+    const dismissed = await dismissGovernanceTidyRecommendation(store, {
+      id: refresh.artifacts[0]!.recommendation_id,
+      approver: "agent:test",
+      reason: "not the same operational policy",
+      now: 2000,
+    });
+
+    expect(dismissed.action).toBe("dismiss");
+    await expect(store.findEdge(duplicate, canonical, "SAME_AS")).resolves.toBeNull();
+    const artifacts = await listProviderReviewArtifacts(store);
+    expect(artifacts[0]).toMatchObject({
+      status: "dismissed",
+      dismissed_at: 2000,
+      review: {
+        action: "dismissed",
+        approver: "agent:test",
+        reason: "not the same operational policy",
+      },
+    });
+
+    const governance = await buildMemoryGovernanceReport(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+    });
+    expect(governance.tidy_recommendations.recommendations[0]).toMatchObject({
+      artifact_id: refresh.artifacts[0]!.artifact_id,
+      review_status: "dismissed",
+    });
+  }, TIMEOUT);
+
+  test("rejects stale recommendations without creating an edge", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    const { canonical, duplicate } = await seedDuplicateNodePair(store, "stale");
+    const refresh = await refreshGovernanceTidyReviewArtifacts(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+      now: 1000,
+    });
+    await updateProviderReviewArtifactStatus(store, refresh.artifacts[0]!.artifact_id, "stale", {
+      now: 2000,
+    });
+
+    await expect(
+      acceptGovernanceTidyRecommendation(store, {
+        id: refresh.artifacts[0]!.artifact_id,
+        approver: "agent:test",
+        now: 3000,
+      }),
+    ).rejects.toThrow(/stale/);
+    await expect(store.findEdge(duplicate, canonical, "SAME_AS")).resolves.toBeNull();
+  }, TIMEOUT);
+
+  test("governance remains read-only even when passed tidy-review-looking arguments", async () => {
+    const root = await tempRoot();
+    await initGraph(root, { hooks: true });
+    const store = await openStore(root);
+    const { canonical, duplicate } = await seedDuplicateNodePair(store, "read-only");
+    const refresh = await refreshGovernanceTidyReviewArtifacts(store, {
+      providerConfig: LOCAL_PROVIDER,
+      providerClient: providerResponse([recFor("merge-pass:1")]),
+      now: 1000,
+    });
+    await store.close();
+    stores.splice(stores.indexOf(store), 1);
+
+    const result = runMemory([
+      "governance",
+      "accept",
+      refresh.artifacts[0]!.artifact_id,
+      "--root",
+      root,
+      "--approver",
+      "agent:test",
+      "--yes",
+      "--json",
+    ]);
+    expect(result.status, result.stderr).toBe(0);
+    const body = JSON.parse(result.stdout) as { read_only: boolean };
+    expect(body.read_only).toBe(true);
+
+    const after = await openStore(root);
+    await expect(after.findEdge(duplicate, canonical, "SAME_AS")).resolves.toBeNull();
+    expect((await listProviderReviewArtifacts(after))[0]).toMatchObject({ status: "open" });
+  }, TIMEOUT);
+});

--- a/src/apps/memory/vitest.suites.ts
+++ b/src/apps/memory/vitest.suites.ts
@@ -48,6 +48,7 @@ export const INTEGRATION_TESTS: readonly string[] = [
   "drift-guard-cli.test.ts",
   "extraction-status.test.ts",
   "governance.test.ts",
+  "governance-tidy-review.test.ts",
   "handoff.test.ts",
   "health.test.ts",
   "hook-coverage.test.ts",


### PR DESCRIPTION
Closes #490.

## Summary
- Add explicit `memory tidy-review refresh|accept|dismiss` commands for provider tidy recommendations.
- Record accept/dismiss review metadata while keeping governance/reporting read-only.
- Validate stale/non-open recommendations and preserve reviewed status in governance output.

## Validation
- `pnpm --dir src/apps/memory typecheck`
- `pnpm --dir src/apps/memory exec vitest run --config vitest.integration.config.ts tests/governance-tidy-review.test.ts`
- `pnpm --dir src/apps/memory exec vitest run tests/suite-split.test.ts`
- Default memory suite: 76 files / 776 tests passed during validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783254232&installation_id=129708444&pr_number=498&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F498&signature=0159b0a787eedb954777341836efcc962ffb29d63b277221ebeaf05c2c409a3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `memory tidy-review` command with `refresh`, `accept`, and `dismiss` subcommands for managing governance recommendations.
  * Enhanced recommendation artifacts to record reviewer actions and approval metadata.

* **Tests**
  * Added integration tests for tidy-review command workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->