### PR TITLE
ship: #499 Brain hybrid search foundation

### DIFF
--- a/plugins/brain/README.md
+++ b/plugins/brain/README.md
@@ -45,6 +45,11 @@ better; Brain exists to hold knowledge the user wants to dump, connect, search,
 and synthesize. If the content is about the person or their context rather than
 operational evidence from agent work, route it to Brain.
 
+Search is deterministic hybrid ranking: lexical title/content matches, tag
+matches, artifact kind matches, and graph connections all contribute to each
+hit's `score_breakdown`. The contract already reserves a `vector` score slot, but
+embeddings are not required for the local Brain MVP.
+
 Core skills: [capture](./skills/core/capture/SKILL.md),
 [search](./skills/core/search/SKILL.md), [think](./skills/core/think/SKILL.md),
 [status](./skills/core/status/SKILL.md), and

--- a/plugins/brain/skills/core/search/SKILL.md
+++ b/plugins/brain/skills/core/search/SKILL.md
@@ -13,3 +13,7 @@ Call `brain_search` when MCP is available. Otherwise run:
 ```bash
 node "${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/bootstrap.mjs" search "<query>"
 ```
+
+Use each hit's `score_breakdown` to explain relevance when needed. The current
+signals are lexical matches, tags, artifact kind, graph connections, and a
+reserved vector slot.

--- a/src/apps/brain/src/store.ts
+++ b/src/apps/brain/src/store.ts
@@ -45,7 +45,17 @@ export interface CaptureInput {
 export interface SearchHit {
   artifact: StoredBrainArtifact;
   score: number;
+  score_breakdown: SearchScoreBreakdown;
   excerpt: string;
+}
+
+export interface SearchScoreBreakdown {
+  lexical: number;
+  tags: number;
+  kind: number;
+  connections: number;
+  vector: number;
+  total: number;
 }
 
 export interface SearchOptions {
@@ -162,17 +172,23 @@ export class BrainStore {
     const terms = tokenize(query);
     const excluded = new Set(options.excludeRids ?? []);
     const artifacts = await this.listArtifacts();
+    const connections = await this.listConnections();
+    const artifactsByRid = new Map(artifacts.map((artifact) => [artifact.rid, artifact]));
     const hits = artifacts
       .filter((artifact) => !excluded.has(artifact.rid))
       .map((artifact) => {
-        const haystack = [
-          artifact.properties.title,
-          artifact.properties.content,
-          artifact.kind,
-          ...(artifact.properties.tags ?? []),
-        ].join(" ").toLowerCase();
-        const score = terms.reduce((sum, term) => sum + occurrences(haystack, term), 0);
-        return { artifact, score, excerpt: excerpt(artifact.properties.content, terms) };
+        const base = scoreArtifact(artifact, terms);
+        const breakdown = withTotal({
+          ...base,
+          connections: scoreConnections(artifact, terms, connections, artifactsByRid),
+          vector: 0,
+        });
+        return {
+          artifact,
+          score: breakdown.total,
+          score_breakdown: breakdown,
+          excerpt: excerpt(artifact.properties.content, terms),
+        };
       })
       .filter((hit) => hit.score > 0)
       .sort((a, b) => b.score - a.score || b.artifact.properties.updated_at - a.artifact.properties.updated_at);
@@ -437,6 +453,93 @@ function occurrences(haystack: string, needle: string): number {
   return count;
 }
 
+function scoreArtifact(
+  artifact: StoredBrainArtifact,
+  terms: string[],
+): Omit<SearchScoreBreakdown, "connections" | "vector" | "total"> {
+  const title = artifact.properties.title.toLowerCase();
+  const content = artifact.properties.content.toLowerCase();
+  const tags = artifact.properties.tags.map((tag) => tag.toLowerCase());
+  const kind = artifact.kind.toLowerCase();
+  return {
+    lexical: terms.reduce(
+      (sum, term) => sum + occurrences(title, term) * 3 + occurrences(content, term),
+      0,
+    ),
+    tags: terms.reduce((sum, term) => {
+      const tagScore = tags.reduce((tagSum, tag) => {
+        if (tag === term) return tagSum + 4;
+        if (tag.includes(term) || term.includes(tag)) return tagSum + 2;
+        return tagSum;
+      }, 0);
+      return sum + tagScore;
+    }, 0),
+    kind: terms.reduce((sum, term) => {
+      if (kind === term) return sum + 3;
+      return kind.includes(term) || term.includes(kind) ? sum + 1 : sum;
+    }, 0),
+  };
+}
+
+function scoreConnections(
+  artifact: StoredBrainArtifact,
+  terms: string[],
+  connections: StoredBrainConnection[],
+  artifactsByRid: Map<number, StoredBrainArtifact>,
+): number {
+  let score = 0;
+  for (const connection of connections) {
+    const otherRid =
+      connection.from_rid === artifact.rid
+        ? connection.to_rid
+        : connection.to_rid === artifact.rid
+          ? connection.from_rid
+          : null;
+    if (otherRid == null) continue;
+    const other = artifactsByRid.get(otherRid);
+    if (!other || isDerivedArtifact(other)) continue;
+    const otherScore = withTotal({ ...scoreArtifact(other, terms), connections: 0, vector: 0 }).total;
+    if (otherScore <= 0) continue;
+    score += Math.min(otherScore, 12) * connectionKindWeight(connection.kind);
+  }
+  return roundScore(score * 0.35);
+}
+
+function connectionKindWeight(kind: ConnectionKind): number {
+  switch (kind) {
+    case "supports":
+    case "contradicts":
+    case "depends_on":
+    case "derived_from":
+    case "part_of":
+      return 1;
+    case "related_to":
+    case "authored":
+      return 0.75;
+    case "preceded_by":
+    case "followed_by":
+      return 0.5;
+    case "tagged":
+      return 0.2;
+  }
+}
+
+function withTotal(parts: Omit<SearchScoreBreakdown, "total">): SearchScoreBreakdown {
+  return {
+    ...parts,
+    lexical: roundScore(parts.lexical),
+    tags: roundScore(parts.tags),
+    kind: roundScore(parts.kind),
+    connections: roundScore(parts.connections),
+    vector: roundScore(parts.vector),
+    total: roundScore(parts.lexical + parts.tags + parts.kind + parts.connections + parts.vector),
+  };
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
 function excerpt(content: string, terms: string[]): string {
   if (content.length <= 220) return content;
   const lower = content.toLowerCase();
@@ -448,7 +551,11 @@ function excerpt(content: string, terms: string[]): string {
 function renderThinkAnswer(query: string, hits: SearchHit[]): string {
   const lines = hits.map((hit, index) => {
     const artifact = hit.artifact;
-    return `[${index + 1}] ${artifact.properties.title} (${artifact.kind}, rid ${artifact.rid}): ${hit.excerpt}`;
+    const signals = Object.entries(hit.score_breakdown)
+      .filter(([key, value]) => key !== "total" && value > 0)
+      .map(([key, value]) => `${key} ${value}`)
+      .join(", ");
+    return `[${index + 1}] ${artifact.properties.title} (${artifact.kind}, rid ${artifact.rid}, score ${hit.score})${signals ? ` [${signals}]` : ""}: ${hit.excerpt}`;
   });
   return lines.length > 0
     ? `Deterministic Brain synthesis for "${query}":\n\n${lines.join("\n")}`

--- a/src/apps/brain/tests/store.test.ts
+++ b/src/apps/brain/tests/store.test.ts
@@ -22,6 +22,95 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
+describe("BrainStore hybrid search", () => {
+  it("returns score breakdowns for lexical, tag, and kind matches", async () => {
+    const root = await tempRoot();
+    const store = await BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+    try {
+      const artifact = await store.capture({
+        title: "OAuth rollout",
+        kind: "decision",
+        tags: ["auth"],
+        content: "Use OAuth for browser sign-in.",
+      });
+
+      const hits = await store.search("auth decision oauth");
+
+      expect(hits[0]).toEqual(expect.objectContaining({
+        artifact: expect.objectContaining({ rid: artifact.rid }),
+        score_breakdown: expect.objectContaining({
+          lexical: expect.any(Number),
+          tags: expect.any(Number),
+          kind: expect.any(Number),
+          connections: 0,
+          vector: 0,
+        }),
+      }));
+      expect(hits[0]?.score_breakdown.lexical).toBeGreaterThan(0);
+      expect(hits[0]?.score_breakdown.tags).toBeGreaterThan(0);
+      expect(hits[0]?.score_breakdown.kind).toBeGreaterThan(0);
+      expect(hits[0]?.score).toBe(hits[0]?.score_breakdown.total);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("boosts artifacts connected to matching artifacts", async () => {
+    const root = await tempRoot();
+    const store = await BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+    try {
+      const decision = await store.capture({
+        title: "Use bearer auth",
+        kind: "decision",
+        content: "Authenticated requests should use bearer tokens.",
+      });
+      const mobileEvidence = await store.capture({
+        title: "Mobile app login",
+        kind: "fact",
+        content: "The mobile app depends on the same authenticated request path.",
+      });
+      await store.link({
+        from: mobileEvidence.rid,
+        to: decision.rid,
+        kind: "supports",
+      });
+
+      const hits = await store.search("mobile", 10);
+      const decisionHit = hits.find((hit) => hit.artifact.rid === decision.rid);
+      const evidenceHit = hits.find((hit) => hit.artifact.rid === mobileEvidence.rid);
+
+      expect(evidenceHit?.score_breakdown.lexical).toBeGreaterThan(0);
+      expect(decisionHit?.score_breakdown.lexical).toBe(0);
+      expect(decisionHit?.score_breakdown.connections).toBeGreaterThan(0);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("renders think answers with evidence scores and ranking signals", async () => {
+    const root = await tempRoot();
+    const store = await BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+    try {
+      await store.capture({
+        title: "Use local Brain",
+        kind: "decision",
+        tags: ["brain"],
+        content: "Keep Brain storage local by default.",
+      });
+
+      const result = await store.think("brain decision");
+
+      expect(result.answer).toContain("score");
+      expect(result.answer).toContain("lexical");
+      expect(result.answer).toContain("tags");
+      expect(result.answer).toContain("kind");
+      expect(result.hits[0]?.score_breakdown.total).toBe(result.hits[0]?.score);
+    } finally {
+      await store.close();
+    }
+  });
+});
+
 describe("BrainStore autolinking", () => {
   it("derives and persists typed edges through an injected provider", async () => {
     const root = await tempRoot();


### PR DESCRIPTION
Interactive /ship landing for #499.

Closes #499

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783274037&installation_id=129708444&pr_number=500&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F500&signature=ea054e797254d3aa2355a7b3f9f4e27b1cbb3f26a1e26173f77e12a669bdeaf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now display detailed ranking information showing which factors contributed to each result's position, including lexical matches, tags, artifact type, and graph connections.

* **Documentation**
  * Updated Brain and search skill documentation to explain the hybrid ranking system and guidance on using score breakdowns to explain result relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->