### PR TITLE
Resolve HITL operational blockers

### DIFF
--- a/.red/adr/0005-memory-three-layer-reddb-architecture.md
+++ b/.red/adr/0005-memory-three-layer-reddb-architecture.md
@@ -88,8 +88,8 @@ existing operational typology (Decision / Problem / Fix / Validation / Gotcha /
 Reasoning), plus `summary` and `preferences` schemas for AMS parity.
 
 LLM and embedding calls go through **RedDB's `red.config.ai.provider`** layer
-(`openai-native`, `anthropic-native`, `openai-compat`). The memory plugin does
-not import LLM SDKs.
+(`openai-native`, `anthropic-native`, `openai-compat`, `bedrock`). The memory
+plugin does not import LLM SDKs.
 
 Rejected: hard-coded AMS strategy enum; LiteLLM dep; bring-your-own-client.
 

--- a/.red/adr/0009-dev-soft-uses-memory-one-directional.md
+++ b/.red/adr/0009-dev-soft-uses-memory-one-directional.md
@@ -1,13 +1,11 @@
 # `dev` soft-uses `memory`, one-directional
 
-## Status
-
-accepted; detection-gate mechanism partially superseded by ADR 0042.
-
-The one-directional soft-use direction below still stands. What changed: gate
-(1) is no longer `.red/memory/config.json` existing; it is a `plugins.memory`
-block in the unified `.red/config.yaml` (the legacy JSON path is still read as a
-back-compat fallback). See ADR 0042.
+> **Status:** accepted; detection-gate mechanism **partially superseded by ADR 0042**.
+> Split: the soft-use *direction* below still stands (`dev` may optionally consume
+> Memory, and Memory still hard-requires `dev`), but the opt-in gate mechanism changed.
+> Gate (1) is no longer `.red/memory/config.json` existing — it is a
+> `plugins.memory` block in the unified `.red/config.yaml` (the legacy JSON path is
+> still read as a back-compat fallback). See ADR 0042.
 
 PRD #49 builds the `memory` plugin as a sibling of `dev` under `plugins/`, with
 the product thesis that memory **lives on top of dev and improves its
@@ -59,3 +57,9 @@ degradation path rather than re-deriving "is memory here?" each.
   (resolution cascade, both gates, graceful degradation, query passthrough).
 - Future `dev` skills that want memory follow the same source-and-gate snippet;
   they must not introduce a hard dependency.
+
+## Related
+
+- ADR 0042 — plugin config is unified under `.red/config.yaml`; this changes
+  the Memory opt-in gate mechanism but not the one-directional soft-use
+  direction.

--- a/.red/adr/0010-llm-extraction-via-reddb-ai-provider.md
+++ b/.red/adr/0010-llm-extraction-via-reddb-ai-provider.md
@@ -16,13 +16,16 @@ nothing through the engine the plugin already embeds (issue #69, slice #69).
 Extraction is done by an **LLM, routed through RedDB's engine-side AI provider
 modes**, selected from user config — not a bundled ML stack.
 
-- **Provider modes.** `MemoryConfig.provider` selects one of `openai-compat`
-  (a local Ollama or any OpenAI-compatible endpoint), `openai-native`, or
-  `anthropic-native`. `resolveProvider` turns that config into a concrete
-  endpoint and classifies egress: an `openai-compat` `baseUrl` on a loopback
-  host is `local` (no external network egress); everything else is `external`.
-  The engine reads the resolved endpoint/model/key from environment
-  (`applyProviderEnv`), the same way it reads the rest of its provider config.
+- **Provider modes.** `MemoryConfig.provider` selects one of four modes:
+  `openai-compat` (a local Ollama or any OpenAI-compatible endpoint),
+  `openai-native`, `anthropic-native`, or `bedrock` (an AWS-account-hosted
+  model, endpoint derived from `region` as `bedrock-runtime.<region>` unless an
+  explicit `baseUrl` is given). `resolveProvider` turns that config into a
+  concrete endpoint and classifies egress: an `openai-compat` `baseUrl` on a
+  loopback host is `local` (no external network egress); everything else,
+  `bedrock` included, is `external`. The engine reads the resolved
+  endpoint/model/key from environment (`applyProviderEnv`), the same way it
+  reads the rest of its provider config.
 
 - **A single mockable seam.** All model access goes through the `ProviderClient`
   interface (`complete(req) → string`). Production wires `redDbProviderClient`
@@ -35,7 +38,10 @@ modes**, selected from user config — not a bundled ML stack.
   `confidence: "INFERRED"`. The deterministic tree-sitter/markdown paths
   (`extractCode`, `extractMarkdown`) are untouched and keep emitting `EXTRACTED`.
   Confidence is the durable signal that separates a parsed fact from an inferred
-  one (ADR 0007's schema).
+  one (ADR 0007's schema). ADR 0035 later extended this INFERRED path:
+  extracted facts now carry a two-axis stamp — a closed structural `node_type`
+  plus an open `engineering_code` — so an out-of-vocabulary inferred type is
+  preserved rather than rejected or flattened.
 
 - **Write-path-only.** Extraction fires only from the Stop hook and explicit
   `/memory:store` (the `memory extract` CLI verb) — never on recall/search. The
@@ -52,7 +58,9 @@ modes**, selected from user config — not a bundled ML stack.
   configured; without one, `ASK` degrades and extraction yields no facts —
   best-effort, exactly like `engine.ask`. It is therefore not unit-tested; the
   deterministic stub behind the same interface is what the suite exercises.
-- `@reddb-io/sdk@1.2.5` exposes only `ASK` as an LLM entrypoint, so the
-  production client folds the system+user turns into one `ASK` prompt. A raw
-  chat-completion entrypoint on the SDK would let the client drop that fold; the
-  `ProviderClient` seam absorbs that change without touching extraction.
+- `@reddb-io/sdk@1.7.0` exposes `ASK` as its single LLM/SQL surface, so the
+  plugin never imports an LLM SDK directly: the production client passes a
+  two-turn (system + user) chat to the `ProviderBridge`, which routes it through
+  `ASK`. A raw chat-completion entrypoint on the SDK would let the bridge drop
+  that routing; the `ProviderClient` seam absorbs that change without touching
+  extraction.

--- a/.red/adr/0013-dev-owns-codebase-understanding-surface.md
+++ b/.red/adr/0013-dev-owns-codebase-understanding-surface.md
@@ -77,3 +77,20 @@ instead of map first.
 - Future work on `ask` should start from the same boundary: `dev` workflow,
   Memory-backed context when available, ordinary code exploration as fallback.
 - Documentation and skill naming should avoid `/understand` for this surface.
+
+## Status
+
+Accepted; post-0041 supersession applies **on migration**. The surviving
+decision is the boundary: `dev` owns the codebase-understanding workflow surface
+and Memory owns the graph/query substrate. What is obsoleted on migration is the
+assumption that `dev` consumes an in-repo Memory CLI or graph-mode verbs by
+shelling through local `memory ...` commands. After ADR 0041 lands, `dev`
+consumes project memory through the `red-memory` MCP exposed by the migrated
+memory plugin; the in-repo implementation and CLI are no longer the contract.
+This record does not rewire the implementation; that migration work is tracked
+separately.
+
+## Related
+
+- ADR 0041 — red-skills consumes the `red-memory` and `red-ui` MCPs instead of
+  building the memory plugin in this repo.

--- a/.red/adr/0014-memory-owns-skill-telemetry-and-report-only-curation.md
+++ b/.red/adr/0014-memory-owns-skill-telemetry-and-report-only-curation.md
@@ -45,3 +45,19 @@ workflow outside the Memory plugin.
 - Background operation has two levels: lightweight checks can follow user-turn
   counts and process only new skill events, while report-only curator reviews
   follow interval/idle gates.
+
+## Status
+
+Accepted; post-0041 supersession applies **on migration**. The surviving
+decision is ownership: Memory owns Skill telemetry persistence, rollups, and
+report-only curation evidence, while mutation remains outside Memory. What is
+obsoleted on migration is the repo-local placement of that runtime inside
+red-skills. Once ADR 0041 lands, the telemetry and report-only curation runtime
+live in `red-memory` and are consumed from red-skills through the `red-memory`
+MCP, not through an in-repo `memory ...` CLI. This record only narrows the
+historical co-location claim; it does not perform the migration.
+
+## Related
+
+- ADR 0041 — red-skills consumes the `red-memory` and `red-ui` MCPs instead of
+  building the memory plugin in this repo.

--- a/.red/adr/0016-dev-owns-the-mutating-skill-curator.md
+++ b/.red/adr/0016-dev-owns-the-mutating-skill-curator.md
@@ -68,3 +68,18 @@ Constraints on the mutation:
 - "A Skill curator does not mutate skills itself" remains true **for the Memory
   plugin**; the mutation now has a named home in `dev` rather than being an
   unowned "separate workflow."
+
+## Status
+
+Accepted; post-0041 supersession applies **on migration**. The surviving
+decision is that the mutating curator remains a `dev` workflow and never reads
+Memory's RedDB/graph internals directly. What is obsoleted on migration is the
+assumption that `/curate` consumes Memory's report-only output through an
+in-repo `memory curate skills --json` CLI. After ADR 0041 lands, `dev` should
+consume that report through the `red-memory` MCP contract. The implementation
+rewiring is intentionally outside this record.
+
+## Related
+
+- ADR 0041 — red-skills consumes the `red-memory` and `red-ui` MCPs instead of
+  building the memory plugin in this repo.

--- a/.red/adr/0026-afk-lifecycle-hooks-as-interceptors.md
+++ b/.red/adr/0026-afk-lifecycle-hooks-as-interceptors.md
@@ -47,6 +47,12 @@ The AFK lifecycle exposes the following hooks, in execution order:
 `docker system prune`) without that cost being paid per-attempt inside
 `post_attempt`.
 
+ADR 0045 extends this model with one **periodic** hook, `on_heartbeat`, fired
+from the attempt guard's cadence while an attempt is still running. It is
+distinct from the once-per-lifecycle-moment interceptors above: it may fire
+many times in one attempt, carries heartbeat/progress context, and has a
+`continue` exit policy so a failing heartbeat hook cannot abort the run.
+
 ### Worker vs attempt vocabulary
 
 The lifecycle uses two distinct terms that earlier drafts conflated:
@@ -336,3 +342,8 @@ reaching under the hood.
   disable defaults, they do not reorder them; promotion of a user
   hook into the defaults bundle is the supported path when ordering
   must change.
+
+## Related
+
+- ADR 0045 — AFK externalized proof-of-life adds the periodic `on_heartbeat`
+  hook.

--- a/.red/adr/0027-memory-plugin-closed-loop-via-hooks-and-ci.md
+++ b/.red/adr/0027-memory-plugin-closed-loop-via-hooks-and-ci.md
@@ -15,8 +15,9 @@ those surfaces is **passive in two directions**:
   `plugins/memory/hooks/{claude,codex}.hooks.json` declare `SessionStart`,
   `PostToolUse` (matcher `Edit|Write` for Claude, `apply_patch` for Codex),
   `Stop`, and `PreCompact` entries that each invoke
-  `dist/cli.js hook <event> --runner <r>` with best-effort failure handling
-  (`|| printf "{}"`). The dispatcher in `plugins/memory/src/hook-runtime.ts`
+  `scripts/bootstrap.mjs hook <event> --runner <r>` with best-effort failure
+  handling (`|| printf "{}"`). The dispatcher in
+  `src/apps/memory/src/hook-runtime.ts`
   routes them to `handleSessionStart` (engine `recall`), `handlePostToolUse`
   (`reindexFiles`), and `handleFlush` (`extractStructuredTranscript` +
   `factsToGraph`, then `PromotionEngine`). `recordLifecycle` writes each
@@ -33,6 +34,21 @@ The result is uneven: ADRs are well-maintained (27 files), the graph holds
 35 MB of older state, the wiki index is 60 bytes, and
 `MEMORY.md` lives outside the repo so it is per-machine rather than
 per-project. The plumbing exists, the loop is open.
+
+## Supersession note — hook entrypoint and source path (2026-06-02)
+
+Two mechanisms cited above were later superseded:
+
+- **Hook entrypoint.** Hooks no longer invoke `dist/cli.js`; **ADR 0029** moved
+  the runtime to a bundled asset fetched by a dependency-free bootstrap, so the
+  `.hooks.json` entries now call `scripts/bootstrap.mjs hook <event> --runner <r>`
+  (resolved under `${CLAUDE_PLUGIN_ROOT}`).
+- **Source location.** **ADR 0034** moved each plugin's implementation out of
+  `plugins/<x>/src/` and under a top-level monorepo `src/`; the hook dispatcher
+  now lives at `src/apps/memory/src/hook-runtime.ts` (`plugins/memory/src/` no
+  longer holds source). The references below have been updated in place to the
+  current paths; ADR 0041 records the pending migration of this code to a
+  separate `red-memory` repo.
 
 ## Amendment — the three real gaps (2026-05-28)
 
@@ -83,7 +99,7 @@ symmetrically catches Codex contributors and the human-only
 ### Already implemented or merged
 
 - SessionStart recall, PostToolUse reindex, Stop / PreCompact flush, and
-  lifecycle logging: shipped in `plugins/memory/src/hook-runtime.ts`
+  lifecycle logging: shipped in `src/apps/memory/src/hook-runtime.ts`
   (issues #221 and #223 closed as already done).
 - PR-merge → wiki extract Action (#219 — merged).
 - Repo-versioned `MEMORY.md` migration (#220 — merged).

--- a/.red/adr/0028-promise-is-the-canonical-attempt-exit-signal.md
+++ b/.red/adr/0028-promise-is-the-canonical-attempt-exit-signal.md
@@ -42,9 +42,24 @@ how the child process winds down.
 
 ## Decision
 
-The `<promise>` sentinel is the **canonical termination signal** for an
-attempt. Pipe EOF and child-process exit become **crash detectors** — fallbacks
-that only matter when the agent failed to author its own exit.
+The `<promise>` sentinel is the **canonical agent-authored termination signal**
+for the happy path of an attempt: `<promise>DONE</promise>` and
+`<promise>BLOCKED</promise>` (plus the outer-loop exhaustion sentinel,
+`<promise>NO MORE TASKS</promise>`). Pipe EOF and child-process exit become
+**crash detectors** — fallbacks that only matter when the agent failed to
+author its own exit.
+
+That canonicality is intentionally scoped to states the agent can author. Some
+terminal paths are initiated by the runtime and emit no promise:
+
+- The ADR 0044 attempt progress guard aborts a stalled attempt on `timeout`;
+  `processIssue` maps that to `blocked:stalled` and parks the issue for human
+  review. A stuck agent cannot reliably emit a `<promise>STALLED</promise>`
+  sentinel, so the runtime must own this path.
+- The no-sentinel-but-mergeable salvage path repairs a completed branch whose
+  work passed feedback even though the agent exited without emitting the
+  sentinel. The absence of a promise is the condition being salvaged, not a new
+  sentinel outcome.
 
 Concretely:
 
@@ -147,3 +162,8 @@ Concretely:
   orchestrator just starts trusting that contract.
 - Codex / Claude parity: both runners emit the same sentinel; both pipes
   behave the same under tear-down. No runner-specific divergence introduced.
+
+## Related
+
+- ADR 0044 — AFK attempt progress guard (`timeout` routes to
+  `blocked:stalled` without requiring an agent-authored sentinel).

--- a/.red/adr/0029-memory-runtime-ships-as-a-bundled-asset-fetched-by-a-bootstrap.md
+++ b/.red/adr/0029-memory-runtime-ships-as-a-bundled-asset-fetched-by-a-bootstrap.md
@@ -151,3 +151,16 @@ bundle, never `dist/` or `node_modules`.
   end-to-end against the published release, not just `--help`.
 - This is the operational-delivery half of ADR 0027 / PRD #217: with it, hooks
   fire the CLI in installed copies for the first time.
+
+## Status
+
+Accepted; post-0041 scope note. The release-asset fetch strategy remains the
+memory-runtime delivery model, but after the ADR 0041 migration the runtime it
+fetches is owned and published by the `red-memory` repo. In red-skills, the
+memory plugin becomes a consumer/launcher for that `red-memory` bundle rather
+than the build source for `plugins/memory/dist/` or an in-repo Memory CLI.
+
+## Related
+
+- ADR 0041 — red-skills consumes the `red-memory` and `red-ui` MCPs instead of
+  building the memory plugin in this repo.

--- a/.red/agents/triage-labels.md
+++ b/.red/agents/triage-labels.md
@@ -160,12 +160,12 @@ How the edge drives the lifecycle:
 | a user `pre_*` guard hook rejected it | `blocked:policy` | **auto-retry once** | 1 (`RED_AFK_RETRY_POLICY`) |
 | agent emitted `<promise>BLOCKED</promise>` | `blocked:spec` | **pages** → ready-for-human (decide/clarify) | — (never auto) |
 | feedback gate failed (test/lint/build) | `blocked:validation` | **pages** → ready-for-human (review diff) | — (never auto) |
-| stall-reaper killed a hung worker | `blocked:stalled` | restores ready-for-agent (uncapped — follow-up) | — |
+| stall-reaper killed a hung worker | `blocked:stalled` | **auto-retry** → ready-for-agent (clean) | 3 (`RED_AFK_RETRY_STALLED`) |
 | worktree/base/push setup failed | `blocked:infra` | pages → ready-for-human (ops) | — |
 
-**Bounded auto-recovery (live).** The five recoverable reasons loop back to `ready-for-agent` and are retried, up to their per-reason cap (counting real attempt-ledger attempts); on the cap they **escalate** to `ready-for-human` with a `🤖 /afk escalating … retry budget exhausted (attempt N/cap)` comment. So a transient hiccup self-heals and never pages, but a persistent one still surfaces — bounded, no runaway loop. Caps are env-tunable (non-numeric/0 → default). `spec` and `validation` **always page** (a human must decide / review the diff); `dependency` waits on its `req:N` edges (never pages). The typed `blocked:<reason>` label is added in every case, so the backlog stays filterable by reason regardless of routing.
+**Bounded auto-recovery (live).** The recoverable reasons loop back to `ready-for-agent` and are retried, up to their per-reason cap (counting real attempt-ledger attempts); on the cap they **escalate** to `ready-for-human` with a `🤖 /afk escalating … retry budget exhausted (attempt N/cap)` comment. So a transient hiccup self-heals and never pages, but a persistent one still surfaces — bounded, no runaway loop. The supervisor stall-reaper's `blocked:stalled` re-queue is bounded by the **same** policy (`RED_AFK_RETRY_STALLED`, default 3), sourcing the real attempt number from the reaped iter-dir path. Caps are env-tunable (non-numeric/0 → default). `spec` and `validation` **always page** (a human must decide / review the diff); `dependency` waits on its `req:N` edges (never pages). **A re-queue is hygienic:** promoting an issue to `ready-for-agent` (auto-retry) or `running` (claim) sheds any `blocked:*` label in the same edit, so no live/queued issue ever carries `ready-for-agent`/`running` together with `blocked:*`. The typed `blocked:<reason>` label rides only the `ready-for-human` escalation, keeping the parked backlog filterable by reason.
 
-> Not yet wired: time-based backoff (today the re-queue is immediate; the cap is what prevents runaway) and a cap on the supervisor stall-reaper's `blocked:stalled` restore.
+> Not yet wired: time-based backoff (today the re-queue is immediate; the cap is what prevents runaway).
 
 All `blocked:*` labels are created on the fly when first applied (mirroring `runner-error`) and provisioned by `/setup-red-skills`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ Upstream base: `mattpocock/skills@b8be62ffacb0118fa3eaa29a0923c87c8c11985c` (see
 
 ---
 
+## afk — SKILL.md execution layer rewritten to match sandcastle reality (#352)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #351 / issue #352. The skill's runtime/invocation prose still described a fictional execution layer — a `claude -p` / `codex exec` session whose stdout was grepped for stages, plus an "attempt-exit reader" teardown pipeline (`RED_AFK_ATTEMPT_GRACE_S`, `RED_AFK_ATTEMPT_KILL_S`, `RED_AFK_WATCHDOG_GRACE_S`, recursive SIGTERM/SIGKILL of `claude|jq|grep|tee`) that does not exist in `src/apps/dev/src/`. Execution actually runs on `@ai-hero/sandcastle` (ADR 0033) as a single `runAgent` call, terminated by the `<promise>` completion signal and bounded by `idleTimeoutSeconds` / `maxIterations` / a commit-anchored attempt guard.
+- **what changed**: re-verified every claim against `src/apps/dev/src/core/execution.ts` and `runtime/wire.ts`:
+  - Added an **Execution Substrate (ADR 0033)** section: sandcastle owns spawn/worktree/sandbox/stream/completion-signal/landing; AFK owns issue policy; the Orchestrator is driven via injected providers (`SandcastleDeps`: `run`, `agentFor`, `sandboxFor`); execution is a single `runAgent` call, not a multi-mode dispatch.
+  - Rewrote Per-Issue Loop step 5 (**Inner agent**) from "invoke claude/codex, grep stdout for stages" to the sandcastle `runAgent` call (handoff `promptFile`, provider/sandbox/branchStrategy, `onAgentStreamEvent`).
+  - Replaced **The attempt-exit reader** section with **Attempt Completion & Termination Bounds**: deleted the non-existent grace/kill/watchdog teardown knobs and recursive-kill pipeline; documented the three real bounds — `idleTimeoutSeconds` (default 600s, `RED_AFK_IDLE_TIMEOUT_S`), `maxIterations` (default 12, `RED_AFK_MAX_ITERATIONS`), and the commit-anchored attempt guard (default 2700s, `RED_AFK_ATTEMPT_TIMEOUT_S`, no-sandbox only) — plus the `exhausted` / `runner-transient` / `no-sentinel` outcome split. Tied the busy-predicate gate (thread discussion / #362–363) to the fleet stall reaper, which is the predicate-gated bound.
+  - Added Configuration rows for `RED_AFK_IDLE_TIMEOUT_S` and `afk.attempt_timeout` / `RED_AFK_ATTEMPT_TIMEOUT_S` with correct defaults and precedence; corrected the Stage Detection + Heartbeat prose from `run_inner` stdout tee to the sandcastle stream capture.
+  - The "Capability Dispatch (#202)" run-mode table was already absent (no `RED_AFK_RUN_MODE` / `claude-native` / `codex-phased` / `hermes-fallback` references remain); confirmed and left removed. `maxIterations` default is **12** in source, not the 25 named in the issue text — documented the source value.
+
+---
+
 ## branch-lock / git-guardrails-claude-code (misc) — primary checkout branch guard (#396)
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -24,7 +24,18 @@ The invoking LLM is responsible for setting `RED_AFK_RUNNER` to its own host run
 
 Commands and their parameters are documented in *When To Use* below — that section is authoritative for the CLI surface. The commands are `run` (the default — a bare token routes here with argv preserved), `monitor`, `dashboard`, `fleet`, `reap`, `statusline` (the Claude Code statusline aggregator; reads the payload on stdin and takes the project root as its one argument), and the hidden `__supervise` (the fleet supervisor entrypoint; never invoked by hand). `run` accepts `--prd`, `--issues`, `--runner`, `--alternate`, `--fallback-runner`, `--request`/`-r`, `-n`, and `--once`; `monitor` accepts `--once`; `dashboard` accepts `--period N|Nd` and `--json`; `fleet` accepts an optional numeric target `N`, the `stop` subcommand, `--request`/`-r`, and `--runner`; `reap` takes no flags; `statusline` takes the project-root path as `$1`.
 
-The bundle is a dependency-free build (one file, no `node_modules`, no install step) and is the public entrypoint. Every command — orchestration, supervisor, statusline, and hooks — executes natively in the bundle; the legacy shell orchestrator under `scripts/` has been removed (ADR 0032, ADR 0034). Treat this `SKILL.md` as the contract: run the bundle, don't read its source.
+The bundle is a single self-contained build (one file, one inlined runtime dependency, no `node_modules`, no install step) and is the public entrypoint. Every command — orchestration, supervisor, statusline, and hooks — executes natively in the bundle; the legacy shell orchestrator under `scripts/` has been removed (ADR 0032, ADR 0034). Treat this `SKILL.md` as the contract: run the bundle, don't read its source.
+
+## Execution Substrate (ADR 0033)
+
+The per-issue **agent run** executes on [`@ai-hero/sandcastle`](https://github.com/mattpocock/sandcastle), not on a hand-rolled `claude -p` / `codex exec` session whose stdout is grepped for stage transitions. The boundary is clean: **sandcastle owns the execution substrate, AFK owns the issue policy**.
+
+- **sandcastle** (one `run()` call per attempt) spawns the inner agent, creates and manages the git worktree, runs the configured sandbox, captures the agent's stream, detects the completion signal, and lands the agent's commits on the worker branch.
+- **AFK** keeps everything around that call: issue selection, the three-layer claim, the handoff file, the package-aware feedback gate, lock-toggled landing (ADR 0030), base resolution (ADR 0031), the terminal-event envelope, close, and the boot/monitor/mirror sweeps.
+
+AFK drives the sandcastle Orchestrator through **injected providers** (`SandcastleDeps`: `run`, `agentFor`, `sandboxFor`) so the single adapter module is the only code coupled to the package. The pure mapping (`buildRunOptions` → `RunOptions`, `interpretOutcome` → outcome) is unit-tested with `run` injected; the real providers are wired lazily once, on the first agent run, so a `monitor` / `reap` / empty-queue path never imports sandcastle. AFK's canonical sentinels `<promise>DONE</promise>` and `<promise>BLOCKED</promise>` are registered as sandcastle `completionSignal`s, so the [`AGENT-PROMPT.md`](AGENT-PROMPT.md) contract is unchanged — the agent still authors its own exit.
+
+`run()` returns `{ branch, commits, completionSignal }`; AFK maps `completionSignal` to an outcome (`done` / `blocked` / `no-sentinel`) and proceeds with its own feedback → landing → envelope → close. Execution is a **single `runAgent` call**, not a multi-mode dispatch over named run-modes.
 
 ## When To Use
 
@@ -285,7 +296,7 @@ For each issue `N`:
 3. **Handoff file.** Materialise the handoff into `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` using the template below — top-level XML wrappers (`<issue-body>`, `<previous-attempts>`, `<prior-attempt-context>`, `<human-guidance-thread>`, `<agent-notes>`) keep the issue body, orchestrator-authored prior attempts, the restart-informed retry block, human comments, and the inner-agent scratchpad unambiguous. `<issue-body>` carries the issue body verbatim (including the `## Agent brief` section written by `/triage`). The handoff file lives one level above the worktree so the inner agent reads it via `../handoff.md` from inside the worktree, and so it survives a worktree wipe on retry.
    - **Restart-informed retries (PRD #244, issue #255).** On a terminal failure the orchestrator writes two marker files into the failing attempt dir: `snapshot-branch.ref` (the `afk-attempts/{id}/{N}-{slug}` ref it pushed to) and `failure.reason` (the envelope summary). On the **next** attempt — the runtime reads those markers *before* the current attempt dir is created, so it sees the prior attempt's state — the handoff builder fetches that snapshot branch into the worktree under the local ref `refs/afk/prior-attempt` and emits a `<prior-attempt-context>` element carrying `prev-snapshot-branch`, the verbatim `prev-failure-reason`, and `prev-fetched-ref`. The retry still branches **fresh off the base** (step 2 is unchanged), so a wrong prior approach never compounds; the fetched ref is read-only history for the inner agent to inspect. First attempts skip all of this and are byte-for-byte unchanged.
 4. **Local heartbeat marker.** Write one `[heartbeat] iteration started for #N` line to `afk.log`. Slice D retired the periodic GitHub-comment heartbeat (`:one: :two: :three: :four:`) — local liveness is now signalled by the inner-agent stdout stream tee'd into `afk.log` plus state-file mtime, both of which already exist.
-5. **Inner agent.** Invoke claude/codex per [`runner-*.md`](runner-claude.md) with [`AGENT-PROMPT.md`](AGENT-PROMPT.md) + the handoff file + last 5 commits of `main` + the optional `--request/-r` special user request block. Stream stdout into the loop's header tail. Detect stages by grep on the stream — see *Stage Detection* below.
+5. **Inner agent.** Drive the inner agent via the single sandcastle `runAgent` call (ADR 0033, *Execution Substrate* above): the handoff file is the `promptFile`, the resolved runner/model selects the provider, the resolved sandbox mode selects the isolation backend, and the worker branch is the `branchStrategy` target forked off the base resolved in step 2. The optional `--request/-r` special user request block is materialised into the handoff. sandcastle captures the agent's stream (surfaced through the `onAgentStreamEvent` callback, which AFK fans out to `agent.log.jsonl` + the firehose) and detects the `<promise>DONE|BLOCKED</promise>` completion signal; AFK reads stages off that stream — see *Stage Detection* below. The call's termination bounds (`idleTimeoutSeconds`, `maxIterations`, and the commit-anchored attempt guard) are documented under *Attempt Completion & Termination Bounds*.
 6. **Inner result.**
    - Inner committed and emits `<promise>DONE</promise>` → continue to feedback loops.
    - Inner emits `<promise>BLOCKED</promise>` plus notes appended to the handoff file → comment the blocker on the issue, re-label `ready-for-human`, drop the worktree, go to next issue.
@@ -316,26 +327,21 @@ Exhaustion detection lives in [`runner-claude.md`](runner-claude.md) and [`runne
 
 When swap happens mid-issue (only with `--fallback-runner`), the same worktree and handoff file are reused; the new runner sees the previous agent's Notes appended.
 
-## The attempt-exit reader (`<promise>` is canonical — ADR 0028)
+## Attempt Completion & Termination Bounds (`<promise>` is canonical — ADR 0028)
 
-The `<promise>…</promise>` sentinel the inner agent emits is the **canonical "attempt is over" signal** — not pipe EOF, not the child process exiting. Pipe EOF and process exit are demoted to **crash detectors**: they only matter when the agent never authored its own exit. This is the architecture fix flagged during the #216 bash-hang diagnosis ("a gente tem que ser mais sensível ao resultado da promise").
+The `<promise>…</promise>` sentinel the inner agent emits is the **canonical "attempt is over" signal**. AFK registers `<promise>DONE</promise>` and `<promise>BLOCKED</promise>` as sandcastle `completionSignal`s, so sandcastle stops re-invoking the agent the moment one is observed (line-anchored, so the agent quoting the sentinel in planning prose does not false-positive). sandcastle owns the stream read and signal detection — there is no hand-rolled foreground pipe reader, no recursive SIGTERM/SIGKILL of a `claude | jq | grep | tee` pipeline, and no `RED_AFK_ATTEMPT_GRACE_S` / `RED_AFK_ATTEMPT_KILL_S` / `RED_AFK_WATCHDOG_GRACE_S` tear-down knobs. This is the architecture fix flagged during the #216 bash-hang diagnosis ("a gente tem que ser mais sensível ao resultado da promise"): the completion signal is the terminator, and the substrate enforces it.
 
-Failure mode it closes: the inner agent emits `<promise>DONE</promise>` (or `BLOCKED`) but then leaves a tool call / background subprocess running — typically `run_in_background` followed by a `bash -c 'until grep "test result" $out; do sleep 5; done'` polling loop without a timeout. The bg task holds the stream-json pipe open, and an orchestrator that waited for EOF would hang for hours.
+`runAgent` maps the returned `completionSignal` to an outcome: `<promise>DONE</promise>` → `done`, `<promise>BLOCKED</promise>` → `blocked`, no signal → `no-sentinel`. The completion signal is the **real** terminator — a normal issue finishes in 1-3 iterations — but three independent bounds cap a run that never signals so a stuck agent cannot burn cycles forever:
 
-The runtime owns the stream-read + sentinel-detection + bounded tear-down, watching the runner's output **in the foreground** instead of waiting on the bare pipe. It tails the runner's stream capture (line-anchored match, so the agent quoting the sentinel in planning prose does not false-positive) and, once it sees `<promise>DONE|BLOCKED|NO MORE TASKS</promise>`:
+- **`idleTimeoutSeconds`** (default **600 s**, env `RED_AFK_IDLE_TIMEOUT_S`) — sandcastle's per-iteration **silence** watchdog: an iteration producing no stream output for this long is aborted. This is the actual termination bound on a quiet hang.
+- **`maxIterations`** (default **12**, env `RED_AFK_MAX_ITERATIONS`) — the sandcastle Orchestrator **re-invocation** ceiling (issue #322). sandcastle's own default is 1, which would cut the agent off after a single agentic invocation before it can emit `DONE`; AFK raises it so the completion signal stays the terminator while bounding repeated no-sentinel failures. A non-numeric / zero / negative value (env or config) is ignored and falls back to the default, so a typo can never disable the cap or pin the agent to 1.
+- **Commit-anchored attempt guard** (default **2700 s**, env `RED_AFK_ATTEMPT_TIMEOUT_S` / `afk.attempt_timeout`, ADR 0044/0045) — proof-of-**progress**: a run that stays *busy* (re-exploring, re-running tests) without landing a **new commit** within the cap is aborted, resetting on every commit. This catches the "productive infinite loop" that `idleTimeoutSeconds` misses because the agent is never silent. It maps to a `timeout` outcome → `blocked:stalled` / `ready-for-human`, preserving the worktree/PR. Armed **only under `none` (no-sandbox) isolation**, where the worker branch's commits land in the shared `.git` so HEAD advance is observable; under docker/podman the commits are not host-visible until final sync, so a commit-anchored guard would false-fire and is skipped (idle timeout + maxIterations still apply). The fleet hard **stall reaper** (see *Fleet Mode*) is separately gated by the active-`vitest`/`tsc`/`cargo`-descendant + flat-cpu predicate, so a worker mid-build/test is never killed for being idle on the agent lane.
 
-1. records the normalized outcome (`done` / `blocked` / `no_more_tasks`) in `ATTEMPT_READER_OUTCOME`;
-2. gives the child `RED_AFK_ATTEMPT_GRACE_S` (default **30**) to exit cleanly;
-3. if still alive, recursively SIGTERM the pipeline pid and every descendant (claude / codex, jq, grep, tee, and any bash child stuck in a polling loop);
-4. waits `RED_AFK_ATTEMPT_KILL_S` (default **10**), then SIGKILL anything still alive.
-
-The orchestrator proceeds with feedback loops / labelling **regardless of how the tear-down resolves** — the agent's commit work, sentinel, and result are all already on disk by the time tear-down fires, and `afk.log` still captures everything the runner printed after the sentinel (the `tee`/fan-out sits upstream of the kill). The legacy `RED_AFK_WATCHDOG_GRACE_S` is still honoured as a back-compat alias for the grace window. Setting the grace below ~5 s risks killing healthy pipelines that just haven't flushed jq's buffer; 30 s is conservative.
-
-**EOF without a sentinel is `on_attempt_error`.** If the pipe closes before any `<promise>` is observed, the agent never declared the attempt over (crash, kill, or a daemon that closed the pipe without speaking): the attempt is recorded as errored (`on_attempt_error` fires, error class `no-sentinel`), the issue lands in `ready-for-human`, and `post_attempt` does **not** fire for that invocation. **Runner exhaustion** (`RUNNER_EXHAUSTED`) stays out of the sentinel channel — it keeps its own branch and the fallback-runner swap.
+**No sentinel is `on_attempt_error`.** When sandcastle's run completes with no completion signal, the agent never declared the attempt over (crash, kill, or a daemon that ended without speaking): the outcome is `no-sentinel`, the issue lands in `ready-for-human`, `on_attempt_error` fires (error class `no-sentinel`), and `post_attempt` does **not** fire for that invocation. **Runner exhaustion** (`RUNNER_EXHAUSTED`, detected by matching the per-runner quota/rate-limit strings against the thrown sandcastle error) stays out of the sentinel channel — it keeps its own `exhausted` outcome and the `--fallback-runner` swap. A **transient runner transport/setup** failure maps to `runner-transient` and is bounded by AFK's retry policy rather than escaping as a crash.
 
 The parsed outcome rides into the `post_attempt` mutable context as `result.outcome` and the `RED_AFK_RESULT_OUTCOME` env var, so hooks (and the Memory `attempt.hooks` record, #216) see the agent-authored exit, not just `success`/`fail`.
 
-Preventive counterpart lives in [`AGENT-PROMPT.md`](AGENT-PROMPT.md) under *Background Tasks and Polling* — inner agents are required to cap every polling loop with a deadline. The bounded tear-down is the safety net; the prompt rule is the design.
+Preventive counterpart lives in [`AGENT-PROMPT.md`](AGENT-PROMPT.md) under *Background Tasks and Polling* — inner agents are required to cap every polling loop with a deadline. The termination bounds are the safety net; the prompt rule is the design.
 
 ## Heartbeat (local-only, post-Slice-D)
 
@@ -343,7 +349,7 @@ The issue-thread heartbeat (`:one:` / `:two:` / `:three:` / `:four:` cycling eve
 
 Local liveness is signalled by:
 
-- **Inner-agent stdout stream**, continuously tee'd into the iteration's `afk.log` by `run_inner` — forensic inspection of a running worker tails this file.
+- **Inner-agent stream**, captured by sandcastle (drained to the attempt dir's `sandcastle.log` via the `logging.path` lane) and surfaced through the `onAgentStreamEvent` callback AFK forwards into `afk.log` + the JSONL lanes — forensic inspection of a running worker tails these files.
 - **Clean agent lane + firehose** (issue #250) — alongside `afk.log`, the runtime fans each assistant turn out to a clean single-writer `agent.log.jsonl` (one `type=agent` record per turn, nothing synthetic — the true liveness signal, readable as a live transcript with `tail -f … | jq -r .msg`) and to a `log.jsonl` firehose that also carries the heartbeat vitals, hook dispatches, runner timings, and errors in the uniform JSONL envelope. The heartbeat writes its vitals to the firehose as a `type=heartbeat` record but never to the agent lane, so the agent lane's silence is real silence (the masking that defeated stall/reaper detection in #243). `afk.log` is unchanged and still carries the tee'd stdout + heartbeat lines below.
 - **State-file mtime**, bumped on every state update. The monitor combines orchestrator pid liveness with state-file freshness to render `🟢 live` vs `🟡 stale`.
 - **Iteration boundary markers** — `heartbeat_start` / `heartbeat_stop` write a single `[heartbeat] iteration started/stopped` line each to `afk.log` so forensic readers can see when an iteration entered and left the inner-agent stage.
@@ -435,7 +441,7 @@ The Slice D heartbeat-glyph cleanup has landed — there is no periodic `:one: :
 
 ## Stage Detection
 
-Inner agent stages, detected from stdout stream of the runner:
+Inner agent stages, derived from the sandcastle agent stream (the `onAgentStreamEvent` callback AFK fans into `agent.log.jsonl` + the firehose), not from a raw runner stdout pipe:
 
 | stage | signal |
 |-------|--------|
@@ -836,6 +842,8 @@ Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside t
 | `afk.models.codex.<tier>.effort` | — | tier-specific | Codex effort for that tier. |
 | `afk.sandbox` | `RED_AFK_SANDBOX` | `none` | Isolation backend (`none` \| `docker` \| `podman`, ADR 0033). |
 | `afk.max_iterations` | `RED_AFK_MAX_ITERATIONS` | `12` | Sandcastle re-invocation ceiling (issue #322) — the safety cap for "the agent never emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`". The completion sentinel is the real terminator, so a normal issue finishes in 1–3 iterations; this leaves headroom without letting repeated no-sentinel failures run for too long. A non-numeric / zero / negative value in either the env or the config is ignored (falls through to the default) so a typo can never disable the cap or pin the agent to 1. |
+| — | `RED_AFK_IDLE_TIMEOUT_S` | `600` | Sandcastle's per-iteration **silence** watchdog (seconds): an iteration that produces no stream output for this long is aborted. The actual termination bound on a quiet hang. Env-only; typo-safe (non-numeric / zero / negative is ignored → default). |
+| `afk.attempt_timeout` | `RED_AFK_ATTEMPT_TIMEOUT_S` | `2700` | Commit-anchored attempt **progress** guard (seconds, ADR 0044/0045): a busy run that lands no new commit within the cap is aborted (`timeout` → `blocked:stalled` / `ready-for-human`, worktree/PR preserved), resetting on every commit. Armed only under `none` isolation. Typo-safe (env > config > default). |
 | `afk.backpressure` | — | _(empty)_ | Ordered list of shell commands run as an extra pre-merge gate on the DONE path (issue #430, PRD #429). |
 | `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding gates are `drift-guard` (the `pre_merge` hook) + in-process backpressure/feedback. When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
 | `afk.merge.review_check` | — | `CodeRabbit` | Name (case-insensitive substring) of the advisory review check `wait_for_review` polls via `gh pr checks`. Only consulted when `afk.merge.wait_for_review` is `true`. |
@@ -852,7 +860,8 @@ afk:
         model: gpt-5.5
         effort: high
   sandbox: none
-  max_iterations: 12      # override the default ceiling here
+  max_iterations: 12      # override the default re-invocation ceiling here
+  attempt_timeout: 2700   # commit-anchored progress guard (seconds)
   backpressure:           # extra pre-merge gate, runs after the feedback gate
     - npm run test
     - npm run lint
@@ -860,6 +869,8 @@ afk:
     wait_for_review: false   # true → hold the unlocked admin-merge until the review check concludes
     review_check: CodeRabbit
 ```
+
+`RED_AFK_IDLE_TIMEOUT_S` is env-only (no `afk.*` config key); `sandbox`, `max_iterations`, and `attempt_timeout` resolve env > config > default. The three runtime bounds — silence (`idleTimeoutSeconds`), re-invocation count (`maxIterations`), and no-commit-progress (attempt guard) — are detailed under *Attempt Completion & Termination Bounds*.
 
 ### Backpressure gate
 

--- a/plugins/dev/skills/engineering/setup-red-skills/triage-labels.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/triage-labels.md
@@ -150,12 +150,12 @@ These exist for filtering and don't drive lifecycle transitions:
 | a user `pre_*` guard hook rejected it | `blocked:policy` | **auto-retry once** | 1 (`RED_AFK_RETRY_POLICY`) |
 | agent emitted `<promise>BLOCKED</promise>` | `blocked:spec` | **pages** → ready-for-human (decide/clarify) | — (never auto) |
 | feedback gate failed (test/lint/build) | `blocked:validation` | **pages** → ready-for-human (review diff) | — (never auto) |
-| stall-reaper killed a hung worker | `blocked:stalled` | restores ready-for-agent (uncapped — follow-up) | — |
+| stall-reaper killed a hung worker | `blocked:stalled` | **auto-retry** → ready-for-agent (clean) | 3 (`RED_AFK_RETRY_STALLED`) |
 | worktree/base/push setup failed | `blocked:infra` | pages → ready-for-human (ops) | — |
 
-**Bounded auto-recovery (live).** The five recoverable reasons loop back to `ready-for-agent` and are retried, up to their per-reason cap (counting real attempt-ledger attempts); on the cap they **escalate** to `ready-for-human` with a `🤖 /afk escalating … retry budget exhausted (attempt N/cap)` comment. So a transient hiccup self-heals and never pages, but a persistent one still surfaces — bounded, no runaway loop. Caps are env-tunable (non-numeric/0 → default). `spec` and `validation` **always page** (a human must decide / review the diff); `dependency` waits on its `req:N` edges (never pages). The typed `blocked:<reason>` label is added in every case, so the backlog stays filterable by reason regardless of routing.
+**Bounded auto-recovery (live).** The recoverable reasons loop back to `ready-for-agent` and are retried, up to their per-reason cap (counting real attempt-ledger attempts); on the cap they **escalate** to `ready-for-human` with a `🤖 /afk escalating … retry budget exhausted (attempt N/cap)` comment. So a transient hiccup self-heals and never pages, but a persistent one still surfaces — bounded, no runaway loop. The supervisor stall-reaper's `blocked:stalled` re-queue is bounded by the **same** policy (`RED_AFK_RETRY_STALLED`, default 3). Caps are env-tunable (non-numeric/0 → default). `spec` and `validation` **always page** (a human must decide / review the diff); `dependency` waits on its `req:N` edges (never pages). **A re-queue is hygienic:** promoting an issue to `ready-for-agent` (auto-retry) or `running` (claim) sheds any `blocked:*` label in the same edit, so no live/queued issue ever carries `ready-for-agent`/`running` together with `blocked:*`. The typed `blocked:<reason>` label rides only the `ready-for-human` escalation.
 
-> Not yet wired: time-based backoff (today the re-queue is immediate; the cap is what prevents runaway) and a cap on the supervisor stall-reaper's `blocked:stalled` restore.
+> Not yet wired: time-based backoff (today the re-queue is immediate; the cap is what prevents runaway).
 
 All `blocked:*` labels are created on the fly when first applied (mirroring `runner-error`) and provisioned by `/setup-red-skills`.
 

--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -296,6 +296,8 @@ function buildSupervisorDeps(
       },
     },
     now,
+    // Env for the bounded stalled re-claim cap (#402): RED_AFK_RETRY_STALLED.
+    recoveryEnv: process.env,
     // Per-tick liveness line into afk-supervisor.log (best-effort). Makes a
     // healthy fleet's heartbeat — and a wedged one's silence — observable.
     log: (line) => {

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -395,6 +395,18 @@ const LABEL_RUNNING = "running";
 const LABEL_HUMAN = "ready-for-human";
 
 /**
+ * The typed `blocked:*` labels present in a label set (#402). Promoting an issue
+ * to `running` (or `ready-for-agent`) must shed any stale `blocked:*` reason in
+ * the SAME edit so no live/queued issue ever carries `running`/`ready-for-agent`
+ * together with `blocked:*` — the exact hygiene gap the adoption doctor flags.
+ * Only labels actually present are returned, so the caller never asks gh to
+ * remove a label the issue does not have.
+ */
+function blockedLabelsIn(labels: string[]): string[] {
+  return labels.filter((l) => l.startsWith("blocked:"));
+}
+
+/**
  * ADDITIVE typed-blocked observability tag. Apply the routing label transition
  * (remove → add) and, ALONGSIDE it in the SAME editLabels call, the DESCRIPTIVE
  * `blocked:<reason>` label for the terminal failure. The typed label is created
@@ -419,10 +431,13 @@ async function editLabelsTagged(
  * Apply the BOUNDED auto-recovery routing for a terminal failure. The policy
  * (recovery.ts) decides retry vs escalate from the reason + the real attempt
  * number + the env caps:
- *   - "retry"    → remove [running], add [ready-for-agent, blocked:<reason>]
- *   - "escalate" → remove [running], add [ready-for-human,  blocked:<reason>]
- * The typed `blocked:<reason>` label is added in BOTH cases (descriptive). When
- * we ESCALATE a reason that was recoverable (its retry budget ran out), post a
+ *   - "retry"    → remove [running], add [ready-for-agent]            (CLEAN)
+ *   - "escalate" → remove [running], add [ready-for-human, blocked:<reason>]
+ * The typed `blocked:<reason>` label rides ONLY the escalation (#402): a re-queued
+ * issue returns to `ready-for-agent` with no `blocked:*` label, so it never trips
+ * the adoption-doctor hygiene check. The failure reason is still recorded by the
+ * attempt envelope + the attempt-ledger; the label is for the parked human lane.
+ * When we ESCALATE a reason that was recoverable (its retry budget ran out), post a
  * one-line comment so the human page is self-explanatory. Returns the decision
  * so the caller can log / shape its terminal result if it cares.
  */
@@ -442,7 +457,10 @@ async function routeRecovery(
   const env = deps.recoveryEnv ?? {};
   const decision = recoveryDecision(policyReason, attemptN, env);
   if (decision === "retry") {
-    await editLabelsTagged(deps, issue, [LABEL_RUNNING], [LABEL_READY], reason);
+    // CLEAN re-queue (#402): promote to ready-for-agent with NO blocked:* tag.
+    // The issue reached here from `running`, which the claim step already stripped
+    // of any blocked:* reason, so the promotion leaves it hygienic.
+    await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_READY]);
     return "retry";
   }
   // escalate
@@ -527,7 +545,10 @@ export async function processIssue(
     };
   }
 
-  if (!(await deps.gh.editLabels(issue, [LABEL_READY], [LABEL_RUNNING]))) {
+  // Promote to running, shedding any stale `blocked:*` reason in the same edit
+  // (#402). `labels` was just fetched above, so we only remove labels the issue
+  // actually carries — a clean promotion the adoption doctor can never flag.
+  if (!(await deps.gh.editLabels(issue, [LABEL_READY, ...blockedLabelsIn(labels)], [LABEL_RUNNING]))) {
     await deps.claimLock.release(issue);
     return claimLost(issue, hooksFired);
   }

--- a/src/apps/dev/src/core/recovery.ts
+++ b/src/apps/dev/src/core/recovery.ts
@@ -19,11 +19,13 @@
 // `attemptN` is the caller's `input.attempt` (1-based, sourced from the
 // attempt-ledger), so the cap counts REAL attempts, not retries-within-an-attempt.
 //
-// NOTE (out of scope): the supervisor stall-reaper (core/supervisor.ts,
-// blocked:stalled) restores ready-for-agent WITHOUT a cap — it lacks the attempt
-// count cheaply. That path is intentionally left uncapped here; capping it is a
-// follow-up. Time-based backoff (vs the immediate re-queue) is also future work —
-// the cap is what prevents the runaway loop today.
+// The supervisor stall-reaper (core/supervisor.ts) is ALSO bounded by this same
+// policy now (#402): it sources the real attempt number from the reaped iter-dir
+// path and asks `recoveryDecision("stalled", …)`, so a worker that keeps stalling
+// can no longer be re-claimed forever — once the `stalled` cap is exhausted it
+// escalates to ready-for-human like every other terminal class. Time-based
+// backoff (vs the immediate re-queue) is still future work — the cap is what
+// prevents the runaway loop today.
 
 import type { RecoveryReason } from "./attempt-outcome.js";
 
@@ -51,6 +53,12 @@ const RECOVERABLE: Record<string, RecoverableSpec> = {
   quota: { knob: "RED_AFK_RETRY_QUOTA", defaultCap: 3 },
   "runner-transient": { knob: "RED_AFK_RETRY_RUNNER_TRANSIENT", defaultCap: 3 },
   policy: { knob: "RED_AFK_RETRY_POLICY", defaultCap: 1 },
+  // The supervisor stall-reaper's bounded re-claim cap (#402). A stall is a
+  // transient class (a wedged worker that usually clears on a fresh attempt), so
+  // it sits with the other transient defaults at 3. It is NOT in the per-issue
+  // `RecoveryReason` subset (recoveryReasonFor never returns "stalled"); only the
+  // reaper asks for it, by the literal string.
+  stalled: { knob: "RED_AFK_RETRY_STALLED", defaultCap: 3 },
 };
 
 /** A loose env view so the policy stays pure and trivially testable. */

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -17,6 +17,7 @@
 import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from "./reaper-signal.js";
 import { buildEnvelope } from "./envelope.js";
 import { blockedLabelFor } from "./attempt-outcome.js";
+import { recoveryCap, recoveryDecision, type RecoveryEnv } from "./recovery.js";
 
 // ---------- tunables ----------
 
@@ -284,6 +285,10 @@ export interface IterDirInfo {
   notes: string;
   /** Worker lifetime in seconds for the envelope duration, or 0 when unknown. */
   durationS: number;
+  /** Real attempt number for this iteration, parsed from the `<issue>-a<N>` iter
+   * dir, or 1 when it cannot be derived. Drives the bounded stalled re-claim cap
+   * (#402) so a worker that keeps stalling escalates instead of looping forever. */
+  attempt: number;
 }
 
 /** One worker's claimed iter dirs for the trip sweep. */
@@ -309,6 +314,12 @@ export interface SupervisorDeps {
   gh: SupervisorGh;
   /** Current epoch seconds (date +%s), injected for determinism. */
   now(): number;
+  /**
+   * Env view for the bounded stalled re-claim cap (#402). Read by the stall-reaper
+   * to resolve `RED_AFK_RETRY_STALLED` via recovery.ts. Defaults to {} (the
+   * built-in cap) when absent, so tests can omit it.
+   */
+  recoveryEnv?: RecoveryEnv;
   /**
    * Optional liveness sink: one line per supervise tick (the CLI appends it to
    * afk-supervisor.log). Makes a healthy fleet's heartbeat — and a wedged one's
@@ -408,7 +419,7 @@ export function buildReaperEnvelope(info: IterDirInfo): string {
     worker: info.workerId.length > 0 ? info.workerId : "unknown",
     duration: `${info.durationS}s · stall-reaped`,
     diff: "stall-reaped",
-    attempt: 1,
+    attempt: info.attempt,
     sections: [
       { name: "notes", body: info.notes.length > 0 ? info.notes : "(no agent notes recorded before stall-reap)" },
       { name: "log", body: info.logTail, fenced: true },
@@ -556,15 +567,36 @@ export async function reapStalledSlot(
   state.stalled = false;
   state.stallSinceEpoch = 0;
 
-  // 3. Envelope + label rotation (only with a recovered issue number). ADDITIVE
-  // typed-blocked tag: the routing is unchanged (still rotates back to
-  // ready-for-agent); `blocked:stalled` is appended alongside for observability,
-  // created on the fly so a missing label never fails the reap.
+  // 3. Envelope + BOUNDED re-claim routing (only with a recovered issue number).
+  // The stall-reaper is now capped (#402): it asks recovery.ts whether this
+  // attempt may retry. While under the `stalled` cap it rotates back to
+  // ready-for-agent CLEAN — no `blocked:*` label rides along, so a re-queued issue
+  // never trips the adoption-doctor's "ready-for-agent + blocked:*" hygiene check.
+  // Once the cap is exhausted it escalates to ready-for-human carrying
+  // `blocked:stalled` (created on the fly) plus a self-explanatory page comment,
+  // exactly like the per-issue routeRecovery escalation.
   if (info && info.issue !== null) {
     await deps.gh.comment(info.issue, buildReaperEnvelope(info));
-    const typed = blockedLabelFor("stalled");
-    if (typed !== null) await deps.gh.ensureLabel(typed);
-    await deps.gh.editLabels(info.issue, typed !== null ? ["ready-for-agent", typed] : ["ready-for-agent"], ["running"]);
+    const env = deps.recoveryEnv ?? {};
+    const decision = recoveryDecision("stalled", info.attempt, env);
+    if (decision === "retry") {
+      await deps.gh.editLabels(info.issue, ["ready-for-agent"], ["running"]);
+    } else {
+      const typed = blockedLabelFor("stalled");
+      if (typed !== null) await deps.gh.ensureLabel(typed);
+      await deps.gh.editLabels(
+        info.issue,
+        typed !== null ? ["ready-for-human", typed] : ["ready-for-human"],
+        ["running", "ready-for-agent"],
+      );
+      const cap = recoveryCap("stalled", env);
+      if (cap !== null) {
+        await deps.gh.comment(
+          info.issue,
+          `🤖 /afk escalating to ready-for-human: blocked:stalled retry budget exhausted (attempt ${info.attempt}/${cap}).`,
+        );
+      }
+    }
   }
 
   // 4. Teardown.

--- a/src/apps/dev/src/runtime/supervisor-fs.ts
+++ b/src/apps/dev/src/runtime/supervisor-fs.ts
@@ -16,7 +16,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { IterDirInfo, SweepWork, SweepWorker } from "../core/supervisor.js";
-import { workerDir } from "../core/worker-paths.js";
+import { parseWorkerAttemptPath, workerDir } from "../core/worker-paths.js";
 
 /** Absolute path of a slot's per-worker stdout/stderr log
  * (`afk-supervisor-slot-{slot}.log`). Mirrors spawn_slot's slot_log. */
@@ -213,7 +213,11 @@ export function resolveIterDirInfo(
   const notes = tailFile(join(dir, "handoff.md"), 200);
   const logTail = tailFile(join(dir, "afk.log"), 50);
 
-  return { path: dir, issue, workerId, logTail, notes, durationS };
+  // Real attempt number from the `<issue>-a<N>` iter dir, for the bounded stalled
+  // re-claim cap (#402). Degrades to attempt 1 when the path is non-canonical.
+  const attempt = parseWorkerAttemptPath(dir)?.attempt ?? 1;
+
+  return { path: dir, issue, workerId, logTail, notes, durationS, attempt };
 }
 
 /**

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -929,12 +929,14 @@ describe("processIssue — worker branch absent (FIX E: merge-gate bypass guard)
     // The issue was NOT closed and NOT merged — the gate held on unvalidated work.
     expect(trace.closed).toEqual([]);
     expect(trace.pushedAttempt).toEqual([]);
-    // Routed through the merge-conflict BOUNDED-recovery reason: the terminal
-    // edit carries the typed blocked:merge-conflict tag (retry-vs-escalate is the
-    // recovery policy's call; what matters here is the gate diverted off merge).
+    // Routed through the merge-conflict BOUNDED-recovery reason. At the default
+    // attempt this is a retry (< cap 3), so #402 routes back to ready-for-agent
+    // CLEAN — no blocked:* tag — while the merge-conflict envelope records the
+    // reason; what matters here is the gate diverted off merge.
     const finalEdit = trace.labelEdits.at(-1)!;
-    expect(finalEdit.add).toContain("blocked:merge-conflict");
-    expect(trace.ensuredLabels).toContain("blocked:merge-conflict");
+    expect(finalEdit.add).toContain("ready-for-agent");
+    expect(finalEdit.add).not.toContain("blocked:merge-conflict");
+    expect(trace.ensuredLabels).not.toContain("blocked:merge-conflict");
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "merge-conflict" }]);
     // The claim was released on this terminal path.
     expect(trace.released).toEqual([9]);
@@ -1006,6 +1008,39 @@ describe("processIssue — claim lost", () => {
   });
 });
 
+describe("processIssue — claim sheds stale blocked:* on promote to running (#402)", () => {
+  it("removes every blocked:* label the issue carried in the SAME claim edit", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      // A ready-for-agent issue that still drags two stale typed blocks.
+      labels: ["ready-for-agent", "blocked:stalled", "blocked:dependency"],
+    });
+    await processIssue(deps, input);
+    // The first edit is the claim: promote to running while removing
+    // ready-for-agent AND both blocked:* reasons — one atomic edit, so no live
+    // issue is ever `running` together with `blocked:*`.
+    const claimEdit = trace.labelEdits[0]!;
+    expect(claimEdit.add).toEqual(["running"]);
+    expect(claimEdit.remove).toContain("ready-for-agent");
+    expect(claimEdit.remove).toContain("blocked:stalled");
+    expect(claimEdit.remove).toContain("blocked:dependency");
+  });
+
+  it("removes only the blocked:* labels actually present (never asks gh to drop absent ones)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent"],
+    });
+    await processIssue(deps, input);
+    const claimEdit = trace.labelEdits[0]!;
+    // No blocked:* present → the claim edit is the plain promotion, unchanged.
+    expect(claimEdit.remove).toEqual(["ready-for-agent"]);
+    expect(claimEdit.add).toEqual(["running"]);
+  });
+});
+
 describe("processIssue — pre_worktree hook abort (BOUNDED-recoverable: policy)", () => {
   it("under the cap → RETRY: restores ready-for-agent and never runs the agent", async () => {
     // policy cap is 1 by default; raise it so attempt 1 is under-cap and retries.
@@ -1017,13 +1052,13 @@ describe("processIssue — pre_worktree hook abort (BOUNDED-recoverable: policy)
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("hook-aborted");
     expect(result.preserved).toBe(true);
-    // claim then restore ready-for-agent + the typed blocked:policy tag;
-    // sandcastle was never invoked.
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:policy"]);
+    // claim then CLEAN restore of ready-for-agent (#402: no blocked:* on a
+    // re-queue); sandcastle was never invoked.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
     const haEdit = trace.labelEdits.at(-1)!;
     expect(haEdit.add).toContain("ready-for-agent");
-    expect(haEdit.add).toContain("blocked:policy");
-    expect(trace.ensuredLabels).toContain("blocked:policy");
+    expect(haEdit.add).not.toContain("blocked:policy");
+    expect(trace.ensuredLabels).not.toContain("blocked:policy");
     expect(trace.runAgentCalls).toEqual([]);
     expect(result.hooksFired).toEqual(["pre_worktree"]);
     // the restore comment is posted on retry; no budget-exhausted page.
@@ -1062,13 +1097,13 @@ describe("processIssue — runner exhaustion (no --fallback-runner)", () => {
     expect(result.swept).toBe(false);
     // only one run; no swap.
     expect(trace.runAgentCalls.length).toBe(1);
-    // claim → running, then restore ready-for-agent (not ready-for-human) + the
-    // typed blocked:quota tag (routing unchanged).
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:quota"]);
+    // claim → running, then CLEAN restore of ready-for-agent (not ready-for-human),
+    // with NO blocked:quota tag riding the re-queue (#402).
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
     const exEdit = trace.labelEdits.at(-1)!;
     expect(exEdit.add).toContain("ready-for-agent");
-    expect(exEdit.add).toContain("blocked:quota");
-    expect(trace.ensuredLabels).toContain("blocked:quota");
+    expect(exEdit.add).not.toContain("blocked:quota");
+    expect(trace.ensuredLabels).not.toContain("blocked:quota");
     expect(trace.closed).toEqual([]);
     expect(trace.released).toEqual([9]);
     // no post_attempt fired (exhaustion is terminal before the sentinel branch).
@@ -1121,10 +1156,10 @@ describe("processIssue — runner exhaustion → fallback swap → retry", () =>
     expect(result.outcome).toBe("exhausted");
     expect(result.preserved).toBe(true);
     expect(trace.runAgentCalls.length).toBe(2);
-    // ready-for-agent restored (both-runners comment posted) + the typed
-    // blocked:quota tag (routing unchanged), claim released.
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:quota"]);
-    expect(trace.ensuredLabels).toContain("blocked:quota");
+    // ready-for-agent restored CLEAN (both-runners comment posted); #402: no
+    // blocked:quota tag rides the re-queue, claim released.
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
+    expect(trace.ensuredLabels).not.toContain("blocked:quota");
     expect(trace.released).toEqual([9]);
     expect(trace.closed).toEqual([]);
     // both attempts closed their post_attempt cycle; no merge ever reached.
@@ -1173,8 +1208,8 @@ describe("processIssue — runner transient transport/setup failure", () => {
     expect(result.outcome).toBe("runner-transient");
     expect(result.preserved).toBe(true);
     expect(trace.runAgentCalls.length).toBe(1);
-    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent+blocked:runner-transient"]);
-    expect(trace.ensuredLabels).toContain("blocked:runner-transient");
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-agent"]);
+    expect(trace.ensuredLabels).not.toContain("blocked:runner-transient");
     expect(trace.released).toEqual([9]);
     expect(trace.closed).toEqual([]);
     expect(trace.comments.some((c) => /transient transport\/setup failure/.test(c.body))).toBe(true);
@@ -1286,7 +1321,7 @@ describe("processIssue — merge-conflict one-shot self-resolve (gap 3)", () => 
 });
 
 describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)", () => {
-  it("merge-conflict at attempt 1 (< cap 3) → RETRY: ready-for-agent + blocked:merge-conflict, no page", async () => {
+  it("merge-conflict at attempt 1 (< cap 3) → RETRY: CLEAN ready-for-agent, no blocked:* tag, no page (#402)", async () => {
     const { deps, input, trace } = harness({
       outcome: "done",
       feedbackOk: true,
@@ -1298,9 +1333,10 @@ describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)",
     expect(result.outcome).toBe("merge-conflict");
     const edit = trace.labelEdits.at(-1)!;
     expect(edit.add).toContain("ready-for-agent");
-    expect(edit.add).toContain("blocked:merge-conflict");
+    // #402: a re-queue routes back CLEAN — no blocked:* rides the promotion.
+    expect(edit.add).not.toContain("blocked:merge-conflict");
     expect(edit.add).not.toContain("ready-for-human");
-    expect(trace.ensuredLabels).toContain("blocked:merge-conflict");
+    expect(trace.ensuredLabels).not.toContain("blocked:merge-conflict");
     // a retry never pages; no budget-exhausted comment.
     expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
     expect(trace.closed).not.toContain(9);
@@ -1326,13 +1362,13 @@ describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)",
     ).toBe(true);
   });
 
-  it("quota (exhausted) at attempt < cap → RETRY: ready-for-agent + blocked:quota", async () => {
+  it("quota (exhausted) at attempt < cap → RETRY: CLEAN ready-for-agent, no blocked:* tag (#402)", async () => {
     const { deps, input, trace } = harness({ outcome: "exhausted", fallbackRunner: false, attempt: 2 });
     const result = await processIssue(deps, input);
     expect(result.outcome).toBe("exhausted");
     const edit = trace.labelEdits.at(-1)!;
     expect(edit.add).toContain("ready-for-agent");
-    expect(edit.add).toContain("blocked:quota");
+    expect(edit.add).not.toContain("blocked:quota");
     expect(edit.add).not.toContain("ready-for-human");
     expect(trace.comments.some((c) => /retry budget exhausted/.test(c.body))).toBe(false);
   });
@@ -1359,7 +1395,8 @@ describe("processIssue — BOUNDED auto-recovery routing (the policy wired in)",
     const r1 = await processIssue(retry.deps, retry.input);
     expect(r1.outcome).toBe("no-sentinel");
     expect(retry.trace.labelEdits.at(-1)!.add).toContain("ready-for-agent");
-    expect(retry.trace.labelEdits.at(-1)!.add).toContain("blocked:crashed");
+    // #402: clean re-queue — the crash reason no longer tags the ready-for-agent promotion.
+    expect(retry.trace.labelEdits.at(-1)!.add).not.toContain("blocked:crashed");
 
     const escalate = harness({ outcome: "no-sentinel", attempt: 1, changedFiles: [] }); // default cap 1 → escalate
     const r2 = await processIssue(escalate.deps, escalate.input);

--- a/src/apps/dev/tests/recovery.test.ts
+++ b/src/apps/dev/tests/recovery.test.ts
@@ -31,6 +31,23 @@ describe("recoveryDecision — recoverable reasons honour the cap", () => {
   }
 });
 
+describe("recoveryDecision — the supervisor stalled re-claim cap (#402)", () => {
+  it("retries under the default cap of 3, escalates at/over it", () => {
+    expect(recoveryDecision("stalled", 1, {})).toBe("retry");
+    expect(recoveryDecision("stalled", 2, {})).toBe("retry");
+    expect(recoveryDecision("stalled", 3, {})).toBe("escalate");
+    expect(recoveryDecision("stalled", 4, {})).toBe("escalate");
+  });
+
+  it("RED_AFK_RETRY_STALLED overrides the cap; garbage falls back to the default", () => {
+    expect(recoveryDecision("stalled", 4, { RED_AFK_RETRY_STALLED: "5" })).toBe("retry");
+    expect(recoveryDecision("stalled", 5, { RED_AFK_RETRY_STALLED: "5" })).toBe("escalate");
+    expect(recoveryDecision("stalled", 3, { RED_AFK_RETRY_STALLED: "nope" })).toBe("escalate");
+    expect(recoveryCap("stalled", {})).toBe(3);
+    expect(recoveryCap("stalled", { RED_AFK_RETRY_STALLED: "8" })).toBe(8);
+  });
+});
+
 describe("recoveryDecision — non-recoverable reasons always escalate", () => {
   for (const reason of ["spec", "validation"]) {
     it(`${reason} escalates at every attempt`, () => {

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -302,7 +302,7 @@ describe("pollStallDetector reaper gating", () => {
     expect(state.slots[0]!.pid).toBe(4242);
   });
 
-  it("DOES reap a genuinely-stalled slot (kill + envelope + label rotate)", async () => {
+  it("retries a genuinely-stalled slot UNDER the cap (kill + envelope + CLEAN re-queue)", async () => {
     const { deps, io } = makeDeps({
       agentLaneMtime: vi.fn(() => NOW - 120),
       // No build/test descendant, flat cpu → genuinely stuck.
@@ -315,6 +315,8 @@ describe("pollStallDetector reaper gating", () => {
           logTail: "[afk] inner: stalled tool call — never returns",
           notes: "mid-iteration progress note",
           durationS: 200,
+          // attempt 1 < cap (3) → retry.
+          attempt: 1,
         }),
       ),
     });
@@ -329,10 +331,11 @@ describe("pollStallDetector reaper gating", () => {
     expect(issue).toBe(190);
     expect(body).toContain('data-attempt-status="no-sentinel"');
     expect(body).toContain("stalled tool call");
-    // ADDITIVE typed-blocked tag: routing unchanged (ready-for-agent restored)
-    // with blocked:stalled appended; the typed label is created on the fly.
-    expect(io.ensureLabel).toHaveBeenCalledWith("blocked:stalled");
-    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent", "blocked:stalled"], ["running"]);
+    // #402: a re-queue UNDER the cap routes back to ready-for-agent CLEAN — no
+    // blocked:stalled rides along, so the adoption-doctor hygiene check stays at
+    // zero offenders. The typed label is NOT created on retry.
+    expect(io.ensureLabel).not.toHaveBeenCalled();
+    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent"], ["running"]);
     expect(io.teardownIterDir).toHaveBeenCalledOnce();
     // Slot freed + idempotency guard set.
     const slot = state.slots[0]!;
@@ -360,6 +363,7 @@ describe("pollStallDetector reaper gating", () => {
           logTail: "",
           notes: "",
           durationS: 0,
+          attempt: 1,
         }),
       ),
     });
@@ -372,6 +376,67 @@ describe("pollStallDetector reaper gating", () => {
     expect(io.comment).not.toHaveBeenCalled();
     expect(io.editLabels).not.toHaveBeenCalled();
     expect(io.teardownIterDir).toHaveBeenCalledOnce();
+  });
+
+  it("escalates to ready-for-human once the stalled re-claim cap is exhausted (#402)", async () => {
+    const { deps, io } = makeDeps({
+      agentLaneMtime: vi.fn(() => NOW - 120),
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
+      resolveIterDir: vi.fn(
+        (): IterDirInfo => ({
+          path: "/w/wTEST/190-a3",
+          issue: 190,
+          workerId: "wTEST",
+          logTail: "[afk] inner: stalled again",
+          notes: "",
+          durationS: 200,
+          // attempt 3 == default cap (3) → escalate, no more retries.
+          attempt: 3,
+        }),
+      ),
+    });
+    const state = stalledState();
+
+    const reaped = await pollStallDetector(state, deps, config());
+
+    expect(reaped).toEqual([0]);
+    expect(io.killTree).toHaveBeenCalledWith(4242);
+    // The reap envelope plus a self-explanatory "budget exhausted" page comment.
+    expect(io.comment).toHaveBeenCalledTimes(2);
+    const pageBody = io.comment.mock.calls[1]![1] as string;
+    expect(pageBody).toContain("ready-for-human");
+    expect(pageBody).toContain("attempt 3/3");
+    // Escalation carries blocked:stalled (allowed alongside ready-for-human) and
+    // removes both running and any ready-for-agent — never re-queued.
+    expect(io.ensureLabel).toHaveBeenCalledWith("blocked:stalled");
+    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-human", "blocked:stalled"], ["running", "ready-for-agent"]);
+    expect(io.teardownIterDir).toHaveBeenCalledOnce();
+  });
+
+  it("honours RED_AFK_RETRY_STALLED to extend the re-claim budget (#402)", async () => {
+    const { deps, io } = makeDeps({
+      agentLaneMtime: vi.fn(() => NOW - 120),
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
+      resolveIterDir: vi.fn(
+        (): IterDirInfo => ({
+          path: "/w/wTEST/190-a3",
+          issue: 190,
+          workerId: "wTEST",
+          logTail: "stall",
+          notes: "",
+          durationS: 200,
+          attempt: 3,
+        }),
+      ),
+    });
+    // Cap raised to 5 → attempt 3 is back under budget → CLEAN re-queue.
+    deps.recoveryEnv = { RED_AFK_RETRY_STALLED: "5" };
+    const state = stalledState();
+
+    await pollStallDetector(state, deps, config());
+
+    expect(io.ensureLabel).not.toHaveBeenCalled();
+    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent"], ["running"]);
   });
 });
 
@@ -531,6 +596,7 @@ describe("envelope builders", () => {
       logTail: "stalled tool call",
       notes: "progress note",
       durationS: 200,
+      attempt: 2,
     });
     expect(body).toContain('data-attempt-status="no-sentinel"');
     expect(body).toContain("worker `wTEST`");


### PR DESCRIPTION
Resolves operational ready-for-human blockers that already had AFK-produced work or stale validation state.\n\nCloses #352\nCloses #355\nCloses #402\nCloses #418\n\nAlso confirms #354 and #403 are already present on main and will be label-cleaned separately.\n\nValidation:\n- git diff --check origin/main..HEAD\n- pnpm -C src/apps/dev test -- process-issue supervisor recovery\n- pnpm -C src/apps/dev typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783288876&installation_id=129708444&pr_number=507&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F507&signature=fd17a3c58287f19d2e62f2deae9a79fd3b453e74640992b655e10bde47761f76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounded auto-recovery for stalled workers with configurable retry caps
  * Support for AWS Bedrock as an LLM provider option

* **Bug Fixes**
  * Improved label hygiene to prevent stale blocked labels from coexisting with active routing labels

* **Documentation**
  * Updated execution model documentation for AFK skill to reflect current runtime behavior and configuration options
  * Expanded ADR documentation on architecture and plugin integration patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->