### PR TITLE
Memory: make recall clock-injected

### DIFF
--- a/src/apps/memory/src/engine.ts
+++ b/src/apps/memory/src/engine.ts
@@ -131,7 +131,7 @@ export interface RecallStore {
     direction?: "outgoing" | "incoming" | "both",
   ): Promise<GraphRow[]>;
   supersededByMany(rids: number[]): Promise<Map<number, number>>;
-  recordAccess?(rids: number[]): Promise<void>;
+  recordAccess?(rids: number[], now?: number): Promise<void>;
   listEdges(): Promise<Record<string, unknown>[]>;
 }
 
@@ -333,9 +333,10 @@ function nodeMatchesScope(node: StoredNode, scope: RecallScope): boolean {
 async function loadIndex(
   store: RecallStore,
   scope: RecallScope = DEFAULT_RECALL_SCOPE,
+  now?: number,
 ): Promise<Map<number, StoredNode>> {
   const index = new Map<number, StoredNode>();
-  for (const node of await store.listNodes()) {
+  for (const node of await store.listNodes(now)) {
     if (nodeMatchesScope(node, scope)) index.set(node.rid, node);
   }
   return index;
@@ -371,7 +372,7 @@ export async function buildConfidenceContext(
   store: RecallStore | MemoryStore,
   now: number = Date.now(),
 ): Promise<ConfidenceContext> {
-  const nodes = await store.listNodes();
+  const nodes = await store.listNodes(now);
   const supersededMap = await store.supersededByMany(nodes.map((n) => n.rid));
   const supersedingSet = new Set<number>();
   for (const successor of supersededMap.values()) supersedingSet.add(successor);
@@ -603,7 +604,7 @@ export async function recall(
   const codeFilter =
     codes && codes.length > 0 ? new Set(codes.map(codeCanonicalize)) : null;
   const terms = tokenize(query);
-  const index = await loadIndex(store, scope);
+  const index = await loadIndex(store, scope, now);
   if (terms.length === 0) {
     const diagnostics = emptyDiagnostics("blank query");
     return { query, nodes: [], context_md: renderContext(query, [], diagnostics), diagnostics };
@@ -718,7 +719,7 @@ export async function recall(
   // (count + last-accessed) so `memory:doctor` can tell what's still earning its
   // keep from what's gone cold. Best-effort — never let it fail a read.
   if (nodes.length > 0 && store.recordAccess) {
-    await store.recordAccess(nodes.map((n) => n.rid)).catch(() => {});
+    await store.recordAccess(nodes.map((n) => n.rid), now).catch(() => {});
   }
 
   return { query, nodes, context_md: renderContext(query, nodes, diagnostics), diagnostics };
@@ -850,7 +851,12 @@ export async function ask(
   question: string,
   opts: { rootDir?: string; now?: number } = {},
 ): Promise<AskResult> {
-  const recalled = await recall(store, question, { includeSuperseded: true, depth: 0, k: 8 });
+  const recalled = await recall(store, question, {
+    includeSuperseded: true,
+    depth: 0,
+    k: 8,
+    now: opts.now,
+  });
   const evidence = await buildAskEvidence(store, recalled.nodes);
   const gapAnalysis = buildAskGapAnalysis(evidence);
   const citations: AskCitation[] = [...evidence.active, ...evidence.superseded].map((item) => ({

--- a/src/apps/memory/src/graph-store.ts
+++ b/src/apps/memory/src/graph-store.ts
@@ -678,9 +678,8 @@ export class MemoryStore {
    * counts are advisory (decay bookkeeping for `doctor`), so the read-modify-
    * write race between concurrent recalls is acceptable.
    */
-  async recordAccess(rids: number[]): Promise<void> {
+  async recordAccess(rids: number[], now: number = Date.now()): Promise<void> {
     if (rids.length === 0) return;
-    const now = Date.now();
     const map = await this.readAccessMap();
     for (const rid of rids) {
       const prev = map[rid];

--- a/src/apps/memory/tests/engine-ranking.test.ts
+++ b/src/apps/memory/tests/engine-ranking.test.ts
@@ -16,14 +16,23 @@ import type { MemoryScope, Tier } from "../src/schema.js";
  * deterministically.
  */
 class MockStore implements RecallStore {
+  readonly listNodeNowValues: Array<number | undefined> = [];
+  readonly recordAccessCalls: Array<{ rids: number[]; now?: number }> = [];
+
   constructor(
     private nodes: StoredNode[],
     private superseded: Map<number, number> = new Map(),
     private edges: Record<string, unknown>[] = [],
     private vectorHits: SearchRow[] = [],
   ) {}
-  async listNodes(): Promise<StoredNode[]> {
-    return this.nodes;
+  async listNodes(now?: number): Promise<StoredNode[]> {
+    this.listNodeNowValues.push(now);
+    const effectiveNow = now ?? Date.now();
+    return this.nodes.filter((n) => {
+      if (n.properties.tier !== "ephemeral") return true;
+      const expiresAt = n.properties.expires_at;
+      return typeof expiresAt !== "number" || effectiveNow < expiresAt;
+    });
   }
   async searchText(): Promise<SearchRow[]> {
     return [];
@@ -42,13 +51,16 @@ class MockStore implements RecallStore {
     }
     return out;
   }
-  async recordAccess(): Promise<void> {}
+  async recordAccess(rids: number[], now?: number): Promise<void> {
+    this.recordAccessCalls.push({ rids, now });
+  }
   async listEdges(): Promise<Record<string, unknown>[]> {
     return this.edges;
   }
 }
 
 const NOW = 1_700_000_000_000;
+const DAY = 86_400_000;
 
 function node(
   rid: number,
@@ -251,6 +263,21 @@ describe("recall ranking with a mock store (#72)", () => {
       candidates: 1,
       contributed: 1,
     });
+  });
+
+  test("uses the injected clock for AS-OF node visibility and access bookkeeping", async () => {
+    const store = new MockStore([
+      node(1, "ephemeral", { content: "alpha as-of visible", expires_at: NOW + DAY }),
+      node(2, "durable", { content: "alpha durable" }),
+    ]);
+
+    const { nodes } = await recall(store, "alpha", { depth: 0, now: NOW });
+
+    expect(nodes.map((n) => n.rid)).toContain(1);
+    expect(store.listNodeNowValues).toEqual([NOW]);
+    expect(store.recordAccessCalls).toEqual([
+      { rids: nodes.map((n) => n.rid), now: NOW },
+    ]);
   });
 
   test("treats doc-grounded vector candidates as governed recall seeds", async () => {


### PR DESCRIPTION
## Summary
- Thread caller-provided `now` through recall node listing, confidence context setup, ASK recall, and access bookkeeping.
- Make `MemoryStore.recordAccess` accept the injected recall timestamp instead of reading `Date.now()` internally.
- Add a ranking regression test that proves AS-OF node visibility and access timestamps use the injected clock.

## Validation
- `pnpm --dir src/apps/memory exec vitest run tests/engine-ranking.test.ts`
- `pnpm --dir src/apps/memory typecheck`
- `pnpm --dir src/apps/memory test`

Refs #312

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783294974&installation_id=129708444&pr_number=509&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F509&signature=fe0306390917171ced26e94fc5a2aeabd79bab3ab4b390284bc0a0c626a730ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced memory recall engine to support deterministic timestamp handling for consistent recency and confidence calculations across memory operations.
  * Updated test coverage to verify time-based memory visibility and access tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->