### PR TITLE
chore: bump mattpocock skills upstream pin

### DIFF
--- a/.upstream
+++ b/.upstream
@@ -1,2 +1,2 @@
 repo=mattpocock/skills
-sha=e3b90b5238f38cdea5996e16861dcae28ef52eda
+sha=aaf2453fbdfe7a15c07f11d861224f34ab4b53cb

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,18 @@
 
 Records every change made to skills inherited from [`mattpocock/skills`](https://github.com/mattpocock/skills), plus new skills created by reddb.io. See the rules in [CLAUDE.md](./CLAUDE.md).
 
-Upstream base: `mattpocock/skills@b8be62ffacb0118fa3eaa29a0923c87c8c11985c` (see `.upstream`).
+Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see `.upstream`).
+
+---
+
+## to-prd (engineering) — upstream testing seam wording (#325)
+
+- **status**: modified
+- **upstream**: `aaf2453`
+- **why**: upstream shifted PRD planning away from extracting deep modules by default and toward agreeing on the highest useful testing seams.
+- **what changed**:
+  - Replaced the deep-module extraction prompt in step 2 with testing-seam planning language while preserving RedSkills' HITL capture and PRD label guardrails.
+  - Updated the PRD testing-decision prompt to allow seams as well as modules.
 
 ---
 

--- a/plugins/dev/skills/engineering/to-prd/SKILL.md
+++ b/plugins/dev/skills/engineering/to-prd/SKILL.md
@@ -11,13 +11,11 @@ The issue tracker and triage label vocabulary should have been provided to you �
 
 1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the PRD, and respect any ADRs in the area you're touching.
 
-2. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+2. Sketch out the testing seams for the feature. Prefer existing, high-level seams over new low-level ones. If new seams are needed, propose them at the highest point that can exercise the behavior.
 
-A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
+Check with the user that these seams match their expectations.
 
-Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
-
-**Capture every HITL call** made during the conversation that led to this PRD — module shape choices, trade-offs the user took a side on, alternatives they rejected, constraints they imposed. These go into the `Human Decisions` section of the template. Do not silently fold them into `Implementation Decisions` — once `/to-issues` slices this PRD and `/afk` picks up the children, the human's calls become indistinguishable from agent inference unless they are flagged here.
+**Capture every HITL call** made during the conversation that led to this PRD — testing seam choices, module shape choices, trade-offs the user took a side on, alternatives they rejected, constraints they imposed. These go into the `Human Decisions` section of the template. Do not silently fold them into `Implementation Decisions` — once `/to-issues` slices this PRD and `/afk` picks up the children, the human's calls become indistinguishable from agent inference unless they are flagged here.
 
 3. Write the PRD using the template below, then publish it to the project issue tracker.
 
@@ -78,7 +76,7 @@ Exception: if a prototype produced a snippet that encodes a decision more precis
 A list of testing decisions that were made. Include:
 
 - A description of what makes a good test (only test external behavior, not implementation details)
-- Which modules will be tested
+- Which seams or modules will be tested
 - Prior art for the tests (i.e. similar types of tests in the codebase)
 
 ## Out of Scope


### PR DESCRIPTION
## Summary\n\n- Bump `.upstream` to `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb`.\n- Cherry-pick the relevant upstream `to-prd` testing-seam wording while preserving RedSkills PRD/HITL rules.\n- Record the upstream drift review in `CHANGES.md`.\n\nThe upstream `in-progress/teach` doc tweak was reviewed but not imported because RedSkills does not carry that draft skill.\n\n## Validation\n\n- `git diff --check origin/main..HEAD`\n\nCloses #325

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783297284&installation_id=129708444&pr_number=511&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F511&signature=0c63b2e6fe32b0f337c19e451434a1000c48319e3c4055b93ab3c6efd9185db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated engineering skill instructions to prioritize testing seams earlier in PRD planning workflows
  * Enhanced guidance for capturing human decisions during seam selection in PRD planning
  * Updated changelog with latest upstream commit information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->