### PR TITLE
docs(adr): refresh ADR index edges

### DIFF
--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -7,6 +7,8 @@ stale notes inline.
 > Resolved numbering collisions: the earlier `0039` consume ADR was renumbered
 > to **0041**, and the superseded single-global `.red/` ADR was renumbered from
 > **0005** to **0046**.
+> **0043** was reserved/pending for PR #393 ("dev loop / ship") while that PR was
+> in flight; do not reclaim the number.
 
 ## Repo structure & contexts
 - **0021** Multi-context plugin glossaries — *accepted*
@@ -15,7 +17,7 @@ stale notes inline.
 - **0046** A single global `.red/` shared by all plugins — *superseded by 0021*
 
 ## Bundle / fetch / release / version
-- **0029** Runtime ships as esbuild bundle + `red` binary, fetched post-install by a bootstrap
+- **0029** Runtime ships as esbuild bundle + `red` binary, fetched post-install by a bootstrap — post-0041, the memory runtime is fetched from the `red-memory` repo rather than built in red-skills
 - **0032** AFK ships as a committed dependency-free bundle — *shipping detail superseded by 0038; location by 0034*
 - **0038** Dev runtime ships as a fetched Release asset, not a committed bundle — supersedes 0032's committed-bundle model
 - **0039** Plugin entrypoints share one source, selected by a build role (unifies red-fetch/afk/code-nav/memory launchers)
@@ -27,11 +29,14 @@ stale notes inline.
 - **0008** `/afk` merges into the pinned branch, not always main
 - **0015** Fleet supervisor is runner-portable; observability degrades per runner
 - **0017** AFK records Reasoning attempts into Memory Graph best-effort
-- **0026** AFK exposes lifecycle hooks as shell interceptors
-- **0028** `<promise>` sentinel is the canonical attempt-exit signal
+- **0026** AFK exposes lifecycle hooks as shell interceptors — extended by **0045** with the periodic `on_heartbeat` hook
+- **0028** `<promise>` sentinel is the canonical agent-authored attempt-exit signal — runtime-initiated exits are mapped by **0044** (`timeout`) and **0047** (no-sentinel salvage)
 - **0030** AFK landing is lock-toggled; the PR carries the history
 - **0031** Branch-lock value drives AFK base/merge; enforcement stays agent-only
 - **0033** AFK agent execution runs on `@ai-hero/sandcastle`
+- **0044** AFK attempt progress guard aborts stalled-but-busy attempts to `blocked:stalled` without requiring a promise sentinel
+- **0045** AFK externalized proof-of-life: heartbeat record, state field, and periodic `on_heartbeat` hook *(extends 0026; follows 0044)*
+- **0047** AFK salvages a no-sentinel branch that already passes feedback *(complements 0028)*
 - **0048** AFK merges without advice; in-process backpressure (`drift-guard` + feedback) is the guardrail — opt into waiting with `afk.merge.wait_for_review` *(refines 0030, 0008)*
 - **0049** Model-tier routing embedded in the plugin (single config source), enforced by the shared skill + hooks + sandcastle trio, per runner *(relates 0003, 0033)*
 - **0050** AFK salvages an uncommitted worktree when the inner agent emits DONE without committing (codex non-compliance net) *(complements 0047, 0028)*
@@ -44,7 +49,7 @@ stale notes inline.
 ## Memory architecture & graph
 - **0005** Memory plugin: three-layer RedDB architecture, local-first per-repo, MCP+CLI
 - **0007** RedDB graph writes go through multi-model DML, not table inserts
-- **0009** `dev` soft-uses `memory`, one-directional
+- **0009** `dev` soft-uses `memory`, one-directional — gate mechanism partially superseded by **0042**; soft-use direction stands
 - **0011** Ephemeral-tier expiry enforced client-side, not engine TTL
 - **0012** Community-coloured graph needs a per-node assignment from the engine
 - **0019** Memory graph is the substrate for codebase mapping
@@ -59,7 +64,7 @@ stale notes inline.
 - **0037** Memory benchmark measures substrate superiority on a curated corpus, not LOCOMO
 
 ## MCP / transport / surfaces
-- **0013** Dev owns the codebase-understanding surface; memory owns the graph
+- **0013** Dev owns the codebase-understanding surface; memory owns the graph — post-0041, `dev` consumes project memory through the `red-memory` MCP rather than an in-repo Memory CLI
 - *(see also 0007, 0036, 0041)*
 
 ## Extraction / provider
@@ -67,8 +72,8 @@ stale notes inline.
 - *(see also 0035)*
 
 ## Skill curation & telemetry
-- **0014** Memory owns skill telemetry and report-only curation
-- **0016** `dev` owns the mutating Skill curator
+- **0014** Memory owns skill telemetry and report-only curation — post-0041 runtime moves to `red-memory`; ownership/report-only boundary stands
+- **0016** `dev` owns the mutating Skill curator — post-0041 it consumes report-only curator output through `red-memory` MCP, not an in-repo `memory` CLI
 
 ## Licensing
 - **0004** Relicense red-skills to Apache-2.0 with a NOTICE for upstream MIT
@@ -77,3 +82,5 @@ stale notes inline.
 - **0001** Explicit `/setup-red-skills` pointer only for hard dependencies
 - **0002** Handoff precedence ladder and two-channel directive protocol
 - **0018** Zoom-out grows impact analysis by composing graph primitives
+- **0042** Plugin configuration is unified under `.red/config.yaml`, namespaced by `plugins.<name>` *(partially supersedes 0009 gate mechanism; carries 0026 hooks and 0041 migration config)*
+- **0043** RedSkills teaches and enforces an interactive development loop — accepted from PR #393's reserved/pending "dev loop / ship" slot *(refines 0006; relates 0030/0031; depends on 0042)*


### PR DESCRIPTION
Closes #419.\n\nRefreshes .red/adr/INDEX.md with the 0046 renumber, 0034 supersession edges, 0043 reserved/pending #393 note, and pass-2 coherence edges from #418.\n\nValidation: git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783299409&installation_id=129708444&pr_number=513&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F513&signature=8f9fd942b965d012d7d3edf1621f86e9d382fde9032be7cb25dea605f57a5616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture and design documentation to reflect current system structure and organizational framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->