### PR TITLE
fix: self-heal stale AFK claim locks

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -686,6 +686,20 @@ interface CurrentAttempt {
 
 const DEFAULT_RUNNER_TRANSIENT_COOLDOWN_S = 300;
 
+async function recordBootError(workerDir: string, type: "boot-error" | "session-error", err: unknown): Promise<void> {
+  const message = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? err.stack : undefined;
+  const payload = {
+    type,
+    at: new Date().toISOString(),
+    message,
+    stack,
+  };
+  await fsx.ensureDir(workerDir);
+  await writeFile(join(workerDir, `${type}.log`), `${JSON.stringify(payload)}\n`, "utf8");
+  process.stderr.write(`[afk] ${type}: ${message}\n`);
+}
+
 function runnerCircuitDir(tmpDir: string): string {
   return join(tmpDir, "runner-circuit");
 }
@@ -814,8 +828,17 @@ export async function runCommand(options: RunOptions): Promise<number> {
     workerPidFile: workerPidFile(paths.tmpDir, workerId),
     workerPid: process.pid,
   };
-  const bootOptions = await collectBootOptions(ctx, facts, bootstrap, nowS);
-  const bootDeps = await buildBootDeps(ctx, bootOptions, nowS);
+  let bootOptions: BootOptions;
+  let bootDeps: BootDeps;
+  try {
+    bootOptions = await collectBootOptions(ctx, facts, bootstrap, nowS);
+    bootDeps = await buildBootDeps(ctx, bootOptions, nowS);
+  } catch (err) {
+    await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
+      process.stderr.write(`[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`);
+    });
+    return 1;
+  }
 
   // Feedback worktree manager — checks out the worker branch for the gate.
   const feedback = makeFeedbackWorktree(ctx.root, join(paths.tmpDir, "feedback"));
@@ -913,6 +936,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   let summary;
   try {
     summary = await runSession(deps, sessionCtx);
+  } catch (err) {
+    await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
+      process.stderr.write(`[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`);
+    });
+    return 1;
   } finally {
     await feedback.cleanup();
   }

--- a/src/apps/dev/src/runtime/fs.ts
+++ b/src/apps/dev/src/runtime/fs.ts
@@ -67,14 +67,33 @@ export async function writeWorkerPid(pidFile: string, pid: number): Promise<void
  */
 export async function tryAcquireClaimDir(dir: string, pid: number): Promise<boolean> {
   await mkdir(dirname(dir), { recursive: true });
-  try {
-    await mkdir(dir); // non-recursive → EEXIST when already held
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") return false;
-    throw err;
+  const claimOnce = async (): Promise<"acquired" | "held"> => {
+    try {
+      await mkdir(dir); // non-recursive → EEXIST when already held
+      return "acquired";
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") return "held";
+      throw err;
+    }
+  };
+
+  if ((await claimOnce()) === "held") {
+    if (await claimPathHeldByLivePid(dir)) return false;
+    await rm(dir, { recursive: true, force: true });
+    if ((await claimOnce()) === "held") return false;
   }
   await writeFile(join(dir, "pid"), String(pid), "utf8");
   return true;
+}
+
+async function claimPathHeldByLivePid(dir: string): Promise<boolean> {
+  try {
+    const st = await stat(dir);
+    if (!st.isDirectory()) return false;
+  } catch {
+    return false;
+  }
+  return pidAlive(await readText(join(dir, "pid")));
 }
 
 export async function removeDir(path: string): Promise<void> {

--- a/src/apps/dev/tests/fs-sweep.test.ts
+++ b/src/apps/dev/tests/fs-sweep.test.ts
@@ -110,9 +110,49 @@ describe("tryAcquireClaimDir (#434 atomic claim)", () => {
     const root = scratch();
     try {
       const dir = join(root, "claims", "430");
-      expect(await tryAcquireClaimDir(dir, 4242)).toBe(true);
+      expect(await tryAcquireClaimDir(dir, process.pid)).toBe(true);
       expect(await tryAcquireClaimDir(dir, 9999)).toBe(false);
-      expect(readFileSync(join(dir, "pid"), "utf8")).toBe("4242");
+      expect(readFileSync(join(dir, "pid"), "utf8")).toBe(String(process.pid));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("self-heals a stale existing claim before acquiring", async () => {
+    const root = scratch();
+    try {
+      const dir = join(root, "claims", "431");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "pid"), DEAD_PID);
+      expect(await tryAcquireClaimDir(dir, process.pid)).toBe(true);
+      expect(readFileSync(join(dir, "pid"), "utf8")).toBe(String(process.pid));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not remove a live existing claim while self-healing", async () => {
+    const root = scratch();
+    try {
+      const dir = join(root, "claims", "432");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "pid"), ALIVE_PID);
+      expect(await tryAcquireClaimDir(dir, 4242)).toBe(false);
+      expect(readFileSync(join(dir, "pid"), "utf8")).toBe(ALIVE_PID);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("quarantines a poisoned non-directory claim path by replacing it", async () => {
+    const root = scratch();
+    try {
+      const claims = join(root, "claims");
+      mkdirSync(claims, { recursive: true });
+      const dir = join(claims, "433");
+      writeFileSync(dir, "not a claim directory");
+      expect(await tryAcquireClaimDir(dir, process.pid)).toBe(true);
+      expect(readFileSync(join(dir, "pid"), "utf8")).toBe(String(process.pid));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #483

## Summary
- self-heal stale or poisoned .red/tmp/claims/<issue> lock paths during claim acquisition
- preserve live claim locks by checking the recorded pid before removing anything
- write explicit boot-error/session-error logs under the worker dir when the session dies before normal issue handling
- cover stale, live, and poisoned claim paths in fs tests

## Verification
- pnpm --filter @reddb-io/dev exec vitest run tests/fs-sweep.test.ts tests/run-flags.test.ts
- pnpm --filter @reddb-io/dev typecheck
- pnpm --filter @reddb-io/dev build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783301184&installation_id=129708444&pr_number=515&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F515&signature=54b4bd6f55e637b2b2d09cd3e6501df1a0c9d074302f0face2be4f3642a4dddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting with improved logging and persistence for boot initialization and session execution failures
  * Strengthened process lock management with automatic detection and self-healing of stale locks to prevent conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->