### PR TITLE
Add Memory map context slices

### DIFF
--- a/.red/contexts/memory/CONTEXT.md
+++ b/.red/contexts/memory/CONTEXT.md
@@ -589,11 +589,11 @@ The semantic and analytic attributes Memory provides as decision inputs for data
 _Avoid_: Memory UI projection, graph layout contract, red-ui implementation detail
 
 **Memory map context slice**:
-A compact, cited answer-shaped subgraph selected from **Memory map** evidence for Claude Code/Codex before broad source-file reading, containing the relevant files, symbols, relations, source locations, connected decisions, validations, risks, and recommended next reads within a token budget.
+A compact, cited subgraph selected from **Memory map** evidence for Claude Code/Codex before broad source-file reading, containing the relevant files, symbols, relations, source locations, connected decisions, validations, risks, and recommended next reads within a token budget.
 _Avoid_: raw graph dump, visual map, generated prose answer
 
 **Memory map edge weight**:
-The topological strength of a Memory map edge, usually the count or aggregate strength of concrete relationships between two vertices or two communities.
+The topological strength of a Memory map edge, usually the count or aggregate strength of concrete relationships between two vertices or two communities, independent of how any UI chooses to draw the edge.
 _Avoid_: confidence score, UI opacity, importance score
 
 **Memory map edge salience**:
@@ -718,6 +718,12 @@ _Avoid_: memory rollback, historical search
 - **Memory ask gap analysis** makes GBrain-style answer gaps explicit while staying grounded in Memory evidence, supersession, contradictions, and confidence.
 - A **Memory backup snapshot** preserves the local RedDB/notes/config persistence surface for restore; graph export remains the read-only inspection bundle.
 - **Memory interop export** emits Graphify/Neo4j-style exchange artifacts while preserving RedDB as the canonical persistence layer.
+- **Memory map** uses RedDB as the canonical destination; Graphify-style HTML/JSON/GraphML outputs are optional interop projections, not Memory's source of truth.
+- **Memory map context slice** is the Graphify-style agent-routing surface: agents query the graph before broad grep or recursive file reads to reduce tokens and sharpen source inspection.
+- **Memory map metadata** may include weight, salience, confidence, provenance, community, source location, and freshness, but graph layout, color palettes, labels, opacity, filtering interactions, and other UI/UX decisions belong to red-ui or another frontend consumer.
+- **Memory map edge weight** and **Memory map edge salience** are separate signals: weight names relationship strength, salience names navigation priority.
+- **Memory map analytic cache** may persist expensive RedDB analytics results such as communities, while cheap metrics may be computed on read.
+- **Memory map boundary** keeps **Brain** totally disconnected from **Memory map**; complementary sources can feed Memory map only when they ground project code, docs, assets, or operational evidence in RedDB.
 - The **Memory local HTTP server** is optional UI/API transport over existing read-only Memory contracts, not the canonical persistence process.
 - The **Memory local HTTP server** exposes docs search/brief/bundle/read/related/coverage/reference-graph and the **Doc brief viewer**, **Doc bundle viewer**, **Doc evidence pack viewer**, **Doc search viewer**, plus **Doc reference graph viewer** from `memory_docs` and graph evidence; it does not read arbitrary filesystem paths.
 - The **Memory multi-agent integration guide** routes multiple coding agents to the same project-local RedDB Memory store through MCP, loopback HTTP, agent rules, and hooks where a runner supports them.

--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -104,6 +104,7 @@ import {
 import { buildMemoryGovernanceViewerArtifact } from "./governance-viewer.js";
 import { MemoryStore, factToNode } from "./graph-store.js";
 import { HistoricalMemoryStore } from "./historical-memory-store.js";
+import { buildMemoryMapContextSlice } from "./map-context.js";
 import { createMemoryHttpServer } from "./http-server.js";
 import { ingestGuidance } from "./audit-marker.js";
 import { evaluateDriftGuard } from "./drift-guard.js";
@@ -278,6 +279,7 @@ const USAGE = `memory — governed operational memory for code agents
 Common workflows:
   remember one fact          memory store "Decision: ..."
   get context before acting  memory recall "topic"
+  map code before reading    memory map-context "who calls token refresh?"
   prepare another agent      memory context-pack "goal"  | memory handoff "focus"
   decide if safe to proceed  memory readiness "goal"     | memory claim-check "assertion"
   search every surface       memory smart-search "query"
@@ -408,6 +410,7 @@ Usage:
 
   Graph-mode read verbs (require \`memory init --mode graph\`):
   memory search <query...>          [--root <dir>] [--limit N]
+  memory map-context <query...>     [--root <dir>] [--depth N] [--mode bfs|dfs] [--context call,import,type,validation,decision,work,reference] [--budget N] [--json]
   memory neighbors <label>          [--root <dir>] [--depth N] [--direction outgoing|incoming|both]
   memory traverse <label>           [--root <dir>] [--depth N] [--strategy bfs|dfs] [--direction ...]
   memory path <from> <to>           [--root <dir>] [--algorithm bfs|dijkstra]
@@ -5496,6 +5499,36 @@ async function runSearch(args: ParsedArgs): Promise<void> {
   }
 }
 
+async function runMapContext(args: ParsedArgs): Promise<void> {
+  const query = args.positional.join(" ").trim();
+  if (!query) throw new Error("nothing to map — pass a query: memory map-context <query>");
+  const { store } = await openGraphStore(args);
+  try {
+    const contextRaw = stringFlag(args.flags, "context");
+    const slice = await buildMemoryMapContextSlice(store, query, {
+      depth: intFlag(args.flags, "depth") ?? 2,
+      mode: mapContextModeFlag(args.flags),
+      tokenBudget: intFlag(args.flags, "budget") ?? 1800,
+      contextFilters: contextRaw
+        ? contextRaw.split(",").map((part) => part.trim()).filter(Boolean)
+        : undefined,
+    });
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(slice, null, 2));
+      return;
+    }
+    console.log(slice.context_md);
+  } finally {
+    await store.close();
+  }
+}
+
+function mapContextModeFlag(flags: Record<string, string | boolean>): "bfs" | "dfs" {
+  const mode = strFlag(flags, "mode", "bfs");
+  if (mode === "bfs" || mode === "dfs") return mode;
+  throw new Error("map-context --mode must be bfs or dfs");
+}
+
 async function runNeighbors(args: ParsedArgs): Promise<void> {
   const label = args.positional[0];
   if (!label) throw new Error("pass a node label: memory neighbors <label>");
@@ -6905,6 +6938,8 @@ async function main(): Promise<void> {
       return runCodeCurate(args);
     case "search":
       return runSearch(args);
+    case "map-context":
+      return runMapContext(args);
     case "neighbors":
       return runNeighbors(args);
     case "traverse":

--- a/src/apps/memory/src/map-context.ts
+++ b/src/apps/memory/src/map-context.ts
@@ -1,0 +1,519 @@
+import type { StoredNode } from "./graph-store.js";
+import type { Confidence, MemoryNodeProps, NodeType } from "./schema.js";
+
+export interface MemoryMapContextStore {
+  listNodes(now?: number): Promise<StoredNode[]>;
+  listEdges(): Promise<Record<string, unknown>[]>;
+  communities?(): Promise<Map<number, string>>;
+  recordAccess?(rids: number[]): Promise<void>;
+}
+
+export interface MemoryMapContextOptions {
+  mode?: "bfs" | "dfs";
+  depth?: number;
+  tokenBudget?: number;
+  seedLimit?: number;
+  contextFilters?: string[];
+  now?: number;
+}
+
+export interface MemoryMapContextNode {
+  rid: number;
+  label: string;
+  node_type: NodeType;
+  source: string | null;
+  source_location: string | null;
+  community: string | null;
+  depth: number;
+  score: number;
+  excerpt: string;
+  confidence: Confidence | null;
+}
+
+export interface MemoryMapContextEdge {
+  source_rid: number;
+  target_rid: number;
+  label: string;
+  context: string;
+  confidence: Confidence | null;
+  weight: number;
+  salience: number;
+}
+
+export interface MemoryMapContextSlice {
+  schema_version: "memory.map_context.v1";
+  query: string;
+  traversal: {
+    mode: "bfs" | "dfs";
+    depth: number;
+    context_filters: string[];
+    context_source: "explicit" | "heuristic" | null;
+    token_budget: number;
+  };
+  seeds: MemoryMapContextNode[];
+  nodes: MemoryMapContextNode[];
+  edges: MemoryMapContextEdge[];
+  context_md: string;
+  diagnostics: {
+    candidates: number;
+    selected_nodes: number;
+    selected_edges: number;
+    truncated: boolean;
+    omitted_nodes: number;
+    hub_threshold: number;
+  };
+}
+
+interface EdgeRecord {
+  source: number;
+  target: number;
+  label: string;
+  context: string;
+  confidence: Confidence | null;
+  weight: number;
+  salience: number;
+}
+
+const CONTEXT_HINTS: Array<[string, string[]]> = [
+  ["call", ["call", "calls", "called", "caller", "callee", "invoke", "invokes", "invoked"]],
+  ["import", ["import", "imports", "imported", "module", "modules", "dependency", "dependencies"]],
+  ["type", ["type", "types", "interface", "interfaces", "generic", "generics"]],
+  ["validation", ["test", "tests", "tested", "validation", "validations", "check", "checks"]],
+  ["decision", ["decision", "decisions", "adr", "adrs", "why", "reason"]],
+  ["work", ["issue", "issues", "prd", "prds", "attempt", "attempts", "task", "tasks"]],
+  ["reference", ["reference", "references", "mention", "mentions", "doc", "docs"]],
+];
+
+const CONTEXT_ALIASES: Record<string, string> = {
+  calls: "call",
+  called: "call",
+  caller: "call",
+  callee: "call",
+  invoke: "call",
+  invocation: "call",
+  imports: "import",
+  imported: "import",
+  dependency: "import",
+  dependencies: "import",
+  uses_type: "type",
+  parameter_type: "type",
+  return_type: "type",
+  generic_arg: "type",
+  tests: "validation",
+  tested: "validation",
+  validates: "validation",
+  adr: "decision",
+  adrs: "decision",
+  decisions: "decision",
+  issues: "work",
+  prd: "work",
+  prds: "work",
+  attempts: "work",
+  refs: "reference",
+  references: "reference",
+  mentions: "reference",
+};
+
+const EDGE_CONTEXT_BY_LABEL: Record<string, string> = {
+  CALLS: "call",
+  IMPORTS: "import",
+  USES_TYPE: "type",
+  IMPLEMENTS: "type",
+  EXTENDS: "type",
+  TESTED_BY: "validation",
+  REVIEWED_BY: "validation",
+  CONFIRMS: "validation",
+  REFERENCES: "reference",
+  MENTIONS: "reference",
+  DESCRIBES: "reference",
+  CONTAINS: "reference",
+  DEFINED_IN: "reference",
+  TOUCHED: "work",
+  BLOCKS: "work",
+  ENABLES: "work",
+  PRECEDES: "work",
+  TRIGGERS: "work",
+  CAUSES: "decision",
+  PREVENTS: "decision",
+  SOLVES: "decision",
+  FIXES: "decision",
+  MITIGATES: "decision",
+};
+
+const TRUST_BY_CONFIDENCE: Record<Confidence, number> = {
+  EXTRACTED: 1,
+  INFERRED: 0.85,
+  AMBIGUOUS: 0.6,
+};
+
+export async function buildMemoryMapContextSlice(
+  store: MemoryMapContextStore,
+  query: string,
+  options: MemoryMapContextOptions = {},
+): Promise<MemoryMapContextSlice> {
+  const trimmed = query.trim();
+  if (!trimmed) throw new Error("memory map-context needs a query");
+
+  const [nodes, rawEdges, communities] = await Promise.all([
+    store.listNodes(options.now),
+    store.listEdges(),
+    store.communities?.().catch(() => new Map<number, string>()) ?? Promise.resolve(new Map<number, string>()),
+  ]);
+  const edges = rawEdges.map(parseEdge).filter((edge): edge is EdgeRecord => edge != null);
+  const degree = degreeMap(nodes, edges);
+  const hubThreshold = hubThresholdFor(degree);
+  const terms = queryTerms(trimmed);
+  const scored = scoreNodes(nodes, terms);
+  const seedRids = pickSeeds(scored, options.seedLimit ?? 3);
+  const { filters, source } = resolveContextFilters(trimmed, options.contextFilters);
+  const traversableEdges = filters.length === 0 ? edges : edges.filter((edge) => filters.includes(edge.context));
+  const traversal = (options.mode ?? "bfs") === "dfs" ? traverseDfs : traverseBfs;
+  const { depths, edgeKeys } = traversal(traversableEdges, seedRids, {
+    depth: Math.max(0, Math.floor(options.depth ?? 2)),
+    degree,
+    hubThreshold,
+  });
+  const nodeByRid = new Map(nodes.map((node) => [node.rid, node]));
+  const selectedRids = [...depths.keys()];
+  const selectedEdges = traversableEdges.filter((edge) => edgeKeys.has(edgeKey(edge)));
+  const scoreByRid = new Map(scored.map((item) => [item.rid, item.score]));
+  const selectedNodes = selectedRids
+    .map((rid) => nodeByRid.get(rid))
+    .filter((node): node is StoredNode => node != null)
+    .map((node) => toContextNode(node, {
+      depth: depths.get(node.rid) ?? 0,
+      score: scoreByRid.get(node.rid) ?? 0,
+      community: communities.get(node.rid) ?? null,
+    }))
+    .sort((a, b) => a.depth - b.depth || b.score - a.score || b.rid - a.rid);
+  const seedNodes = seedRids
+    .map((rid) => selectedNodes.find((node) => node.rid === rid))
+    .filter((node): node is MemoryMapContextNode => node != null);
+  const contextEdges = selectedEdges.map(toContextEdge);
+  const tokenBudget = Math.max(100, Math.floor(options.tokenBudget ?? 1800));
+  const rendered = renderContextMarkdown(trimmed, {
+    mode: options.mode ?? "bfs",
+    depth: Math.max(0, Math.floor(options.depth ?? 2)),
+    filters,
+    source,
+    tokenBudget,
+    seeds: seedNodes,
+    nodes: selectedNodes,
+    edges: contextEdges,
+  });
+  await store.recordAccess?.(selectedNodes.map((node) => node.rid));
+  return {
+    schema_version: "memory.map_context.v1",
+    query: trimmed,
+    traversal: {
+      mode: options.mode ?? "bfs",
+      depth: Math.max(0, Math.floor(options.depth ?? 2)),
+      context_filters: filters,
+      context_source: source,
+      token_budget: tokenBudget,
+    },
+    seeds: seedNodes,
+    nodes: selectedNodes,
+    edges: contextEdges,
+    context_md: rendered.markdown,
+    diagnostics: {
+      candidates: scored.length,
+      selected_nodes: selectedNodes.length,
+      selected_edges: contextEdges.length,
+      truncated: rendered.truncated,
+      omitted_nodes: rendered.omittedNodes,
+      hub_threshold: hubThreshold,
+    },
+  };
+}
+
+export function normalizeContextFilters(filters: string[] | undefined): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of filters ?? []) {
+    const key = CONTEXT_ALIASES[normalizeText(raw)] ?? normalizeText(raw);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(key);
+  }
+  return normalized;
+}
+
+function resolveContextFilters(query: string, explicit: string[] | undefined): {
+  filters: string[];
+  source: "explicit" | "heuristic" | null;
+} {
+  const normalized = normalizeContextFilters(explicit);
+  if (normalized.length > 0) return { filters: normalized, source: "explicit" };
+  const terms = new Set(queryTerms(query));
+  const inferred: string[] = [];
+  for (const [context, hints] of CONTEXT_HINTS) {
+    if (hints.some((hint) => terms.has(hint))) inferred.push(context);
+  }
+  return inferred.length > 0
+    ? { filters: inferred, source: "heuristic" }
+    : { filters: [], source: null };
+}
+
+function queryTerms(query: string): string[] {
+  return normalizeText(query)
+    .split(/[^a-z0-9_/-]+/i)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 2);
+}
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .normalize("NFKD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+function scoreNodes(nodes: StoredNode[], terms: string[]): Array<{ rid: number; score: number }> {
+  if (terms.length === 0) return [];
+  const idf = computeIdf(nodes, terms);
+  const scored: Array<{ rid: number; score: number }> = [];
+  for (const node of nodes) {
+    const label = normalizeText(node.label);
+    const bareLabel = label.replace(/^.*[#:/]/, "").replace(/\(\)$/, "");
+    const source = normalizeText(node.properties.source ?? "");
+    const title = normalizeText(node.properties.title ?? "");
+    const summary = normalizeText(node.properties.summary ?? "");
+    const content = normalizeText(node.properties.content ?? "");
+    let score = 0;
+    for (const term of terms) {
+      const weight = idf.get(term) ?? 1;
+      if (term === label || term === bareLabel || term === title) {
+        score += 1000 * weight;
+      } else if (label.startsWith(term) || bareLabel.startsWith(term) || title.startsWith(term)) {
+        score += 100 * weight;
+      } else if (label.includes(term) || title.includes(term)) {
+        score += 5 * weight;
+      } else if (summary.includes(term)) {
+        score += 2 * weight;
+      } else if (content.includes(term)) {
+        score += 1 * weight;
+      }
+      if (source.includes(term)) score += 0.5 * weight;
+    }
+    if (score > 0) scored.push({ rid: node.rid, score });
+  }
+  return scored.sort((a, b) => b.score - a.score || b.rid - a.rid);
+}
+
+function computeIdf(nodes: StoredNode[], terms: string[]): Map<string, number> {
+  const out = new Map<string, number>();
+  const nodeTexts = nodes.map((node) => normalizeText(`${node.label} ${node.properties.title ?? ""}`));
+  for (const term of terms) {
+    const df = nodeTexts.filter((text) => text.includes(term)).length;
+    out.set(term, Math.log(1 + nodes.length / (1 + df)));
+  }
+  return out;
+}
+
+function pickSeeds(scored: Array<{ rid: number; score: number }>, limit: number): number[] {
+  const first = scored[0];
+  if (!first) return [];
+  const seeds: number[] = [];
+  for (const item of scored.slice(0, Math.max(1, limit))) {
+    if (seeds.length > 0 && item.score < first.score * 0.2) break;
+    seeds.push(item.rid);
+  }
+  return seeds;
+}
+
+function parseEdge(edge: Record<string, unknown>): EdgeRecord | null {
+  const source = numberFrom(edge.from_rid, edge.from, edge.FROM, edge.source, edge.source_id);
+  const target = numberFrom(edge.to_rid, edge.to, edge.TO, edge.target, edge.target_id);
+  if (!Number.isFinite(source) || !Number.isFinite(target)) return null;
+  const label = String(edge.label ?? edge.edge_label ?? edge.LABEL ?? "REFERENCES");
+  const properties = (edge.properties ?? edge.PROPERTIES ?? {}) as Record<string, unknown>;
+  const confidence = parseConfidence(properties.confidence ?? edge.confidence ?? edge.CONFIDENCE);
+  const weight = numberFrom(edge.weight, edge.WEIGHT, properties.weight) || 1;
+  const context = normalizeContextFilters([
+    String(properties.context ?? edge.context ?? EDGE_CONTEXT_BY_LABEL[label] ?? "reference"),
+  ])[0] ?? "reference";
+  const salience = weight * (confidence ? TRUST_BY_CONFIDENCE[confidence] : 0.8);
+  return { source, target, label, context, confidence, weight, salience };
+}
+
+function numberFrom(...values: unknown[]): number {
+  for (const value of values) {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return Number.NaN;
+}
+
+function parseConfidence(value: unknown): Confidence | null {
+  return value === "EXTRACTED" || value === "INFERRED" || value === "AMBIGUOUS"
+    ? value
+    : null;
+}
+
+function degreeMap(nodes: StoredNode[], edges: EdgeRecord[]): Map<number, number> {
+  const degree = new Map(nodes.map((node) => [node.rid, 0]));
+  for (const edge of edges) {
+    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1);
+    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1);
+  }
+  return degree;
+}
+
+function hubThresholdFor(degree: Map<number, number>): number {
+  const values = [...degree.values()].sort((a, b) => a - b);
+  if (values.length === 0) return 50;
+  const index = Math.min(values.length - 1, Math.floor(values.length * 0.99));
+  return Math.max(50, values[index] ?? 50);
+}
+
+function traverseBfs(
+  edges: EdgeRecord[],
+  seeds: number[],
+  opts: { depth: number; degree: Map<number, number>; hubThreshold: number },
+): { depths: Map<number, number>; edgeKeys: Set<string> } {
+  const adjacency = adjacencyMap(edges);
+  const depths = new Map(seeds.map((seed) => [seed, 0]));
+  const edgeKeys = new Set<string>();
+  let frontier = new Set(seeds);
+  const seedSet = new Set(seeds);
+  for (let depth = 0; depth < opts.depth; depth++) {
+    const next = new Set<number>();
+    for (const rid of frontier) {
+      if (!seedSet.has(rid) && (opts.degree.get(rid) ?? 0) >= opts.hubThreshold) continue;
+      for (const item of adjacency.get(rid) ?? []) {
+        edgeKeys.add(edgeKey(item.edge));
+        if (!depths.has(item.neighbor)) {
+          depths.set(item.neighbor, depth + 1);
+          next.add(item.neighbor);
+        }
+      }
+    }
+    frontier = next;
+  }
+  return { depths, edgeKeys };
+}
+
+function traverseDfs(
+  edges: EdgeRecord[],
+  seeds: number[],
+  opts: { depth: number; degree: Map<number, number>; hubThreshold: number },
+): { depths: Map<number, number>; edgeKeys: Set<string> } {
+  const adjacency = adjacencyMap(edges);
+  const depths = new Map<number, number>();
+  const edgeKeys = new Set<string>();
+  const seedSet = new Set(seeds);
+  const stack = seeds.map((rid) => ({ rid, depth: 0 })).reverse();
+  while (stack.length > 0) {
+    const item = stack.pop()!;
+    const previous = depths.get(item.rid);
+    if (previous != null && previous <= item.depth) continue;
+    if (item.depth > opts.depth) continue;
+    depths.set(item.rid, item.depth);
+    if (!seedSet.has(item.rid) && (opts.degree.get(item.rid) ?? 0) >= opts.hubThreshold) continue;
+    if (item.depth >= opts.depth) continue;
+    for (const next of adjacency.get(item.rid) ?? []) {
+      edgeKeys.add(edgeKey(next.edge));
+      stack.push({ rid: next.neighbor, depth: item.depth + 1 });
+    }
+  }
+  return { depths, edgeKeys };
+}
+
+function adjacencyMap(edges: EdgeRecord[]): Map<number, Array<{ neighbor: number; edge: EdgeRecord }>> {
+  const adjacency = new Map<number, Array<{ neighbor: number; edge: EdgeRecord }>>();
+  for (const edge of edges) {
+    const from = adjacency.get(edge.source) ?? [];
+    from.push({ neighbor: edge.target, edge });
+    adjacency.set(edge.source, from);
+    const to = adjacency.get(edge.target) ?? [];
+    to.push({ neighbor: edge.source, edge });
+    adjacency.set(edge.target, to);
+  }
+  return adjacency;
+}
+
+function edgeKey(edge: EdgeRecord): string {
+  return `${edge.source}->${edge.target}:${edge.label}`;
+}
+
+function toContextNode(
+  node: StoredNode,
+  opts: { depth: number; score: number; community: string | null },
+): MemoryMapContextNode {
+  return {
+    rid: node.rid,
+    label: node.label,
+    node_type: node.node_type,
+    source: stringOrNull(node.properties.source),
+    source_location: stringOrNull(node.properties.source_location ?? node.properties.location),
+    community: opts.community,
+    depth: opts.depth,
+    score: Number(opts.score.toFixed(3)),
+    excerpt: excerpt(node.properties),
+    confidence: parseConfidence(node.properties.confidence),
+  };
+}
+
+function toContextEdge(edge: EdgeRecord): MemoryMapContextEdge {
+  return {
+    source_rid: edge.source,
+    target_rid: edge.target,
+    label: edge.label,
+    context: edge.context,
+    confidence: edge.confidence,
+    weight: edge.weight,
+    salience: Number(edge.salience.toFixed(3)),
+  };
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function excerpt(props: MemoryNodeProps): string {
+  const text = String(props.summary ?? props.content ?? props.title ?? "").replace(/\s+/g, " ").trim();
+  return text.length > 180 ? `${text.slice(0, 177)}...` : text;
+}
+
+function renderContextMarkdown(
+  query: string,
+  input: {
+    mode: "bfs" | "dfs";
+    depth: number;
+    filters: string[];
+    source: "explicit" | "heuristic" | null;
+    tokenBudget: number;
+    seeds: MemoryMapContextNode[];
+    nodes: MemoryMapContextNode[];
+    edges: MemoryMapContextEdge[];
+  },
+): { markdown: string; truncated: boolean; omittedNodes: number } {
+  const lines = [
+    `Memory map context: ${query}`,
+    `Traversal: ${input.mode.toUpperCase()} depth=${input.depth} | Start: ${input.seeds.map((s) => s.label).join(", ") || "none"}${input.filters.length ? ` | Context: ${input.filters.join(", ")} (${input.source})` : ""} | ${input.nodes.length} node(s)`,
+    "",
+  ];
+  for (const node of input.nodes) {
+    lines.push(
+      `NODE ${node.rid} ${node.label} [type=${node.node_type} src=${node.source ?? "-"} loc=${node.source_location ?? "-"} community=${node.community ?? "-"} depth=${node.depth}]`,
+    );
+    if (node.excerpt) lines.push(`  ${node.excerpt}`);
+  }
+  for (const edge of input.edges) {
+    lines.push(
+      `EDGE ${edge.source_rid} --${edge.label} [${edge.confidence ?? "UNKNOWN"} context=${edge.context} weight=${edge.weight} salience=${edge.salience}]--> ${edge.target_rid}`,
+    );
+  }
+  const charBudget = input.tokenBudget * 3;
+  const output = lines.join("\n");
+  if (output.length <= charBudget) return { markdown: output, truncated: false, omittedNodes: 0 };
+  const cut = Math.max(0, output.slice(0, charBudget).lastIndexOf("\n"));
+  const shown = output.slice(0, cut).split("\n").filter((line) => line.startsWith("NODE ")).length;
+  const omitted = Math.max(0, input.nodes.length - shown);
+  return {
+    markdown: `${output.slice(0, cut)}\n... (truncated: ${omitted} node(s) omitted by ~${input.tokenBudget}-token budget; narrow with --context or --depth)`,
+    truncated: true,
+    omittedNodes: omitted,
+  };
+}

--- a/src/apps/memory/src/mcp-server.ts
+++ b/src/apps/memory/src/mcp-server.ts
@@ -1500,6 +1500,23 @@ async function operationStructuredContent(
         html_bytes: typeof output.html === "string" ? Buffer.byteLength(output.html, "utf8") : 0,
       };
     }
+    case "memory.map-context": {
+      const diagnostics = isRecord(output.diagnostics) ? output.diagnostics : {};
+      const traversal = isRecord(output.traversal) ? output.traversal : {};
+      return {
+        operation_id: operationId,
+        schema_version: output.schema_version,
+        query: output.query,
+        mode: traversal.mode,
+        depth: traversal.depth,
+        context_filters: arrayLength(traversal.context_filters),
+        seeds: arrayLength(output.seeds),
+        nodes: arrayLength(output.nodes),
+        edges: arrayLength(output.edges),
+        truncated: diagnostics.truncated,
+        omitted_nodes: diagnostics.omitted_nodes,
+      };
+    }
     case "memory.routing-guide":
       return {
         operation_id: operationId,

--- a/src/apps/memory/src/operations.ts
+++ b/src/apps/memory/src/operations.ts
@@ -228,6 +228,10 @@ import {
   type MemoryRoutingGuide,
 } from "./routing-guide.js";
 import {
+  buildMemoryMapContextSlice,
+  type MemoryMapContextSlice,
+} from "./map-context.js";
+import {
   buildMemoryRoutingGuideViewerArtifact,
   type MemoryRoutingGuideViewerArtifact,
 } from "./routing-guide-viewer.js";
@@ -450,6 +454,15 @@ const ContextPackInputSchema = ScopeInputSchema.extend({
   depth: z.number().int().min(0).max(5).optional(),
 });
 type ContextPackInput = z.infer<typeof ContextPackInputSchema>;
+
+const MapContextInputSchema = z.object({
+  query: z.string().min(1),
+  depth: z.number().int().min(0).max(5).optional(),
+  mode: z.enum(["bfs", "dfs"]).optional(),
+  budget: z.number().int().min(100).max(20_000).optional(),
+  context: z.union([z.string(), z.array(z.string())]).optional(),
+});
+type MapContextInput = z.infer<typeof MapContextInputSchema>;
 
 const ClaimCheckInputSchema = z.object({ assertion: z.string().min(1) });
 type ClaimCheckInput = z.infer<typeof ClaimCheckInputSchema>;
@@ -812,6 +825,7 @@ const GlobalSearchOutputSchema = z.object({
 const AskOutputSchema = objectOutputSchema<AskResult>();
 const ReadinessOutputSchema = objectOutputSchema<MemoryReadinessEnvelope>();
 const ContextPackOutputSchema = objectOutputSchema<ContextPack>();
+const MapContextOutputSchema = objectOutputSchema<MemoryMapContextSlice>();
 const ContextPackViewerOutputSchema = objectOutputSchema<ContextPackViewerArtifact>();
 const ClaimCheckOutputSchema = objectOutputSchema<ClaimCheckResult>();
 const DocBriefOutputSchema = objectOutputSchema<DocBrief>();
@@ -1023,6 +1037,16 @@ const MEMORY_OPERATION_FACETS: Record<string, MemoryOperationFacets> = {
       "memory.context-pack": JSON_REPORT_OUTPUT,
       "memory.context-pack-viewer": VIEWER_OUTPUT,
     },
+  ),
+  ...operationFacets(
+    ["memory.map-context"],
+    joinedPositionalInput("query", [
+      flagField("depth", "number"),
+      flagField("mode", "string"),
+      flagField("context", "string"),
+      flagField("budget", "number"),
+    ]),
+    JSON_REPORT_OUTPUT,
   ),
   ...operationFacets(
     ["memory.doc-search", "memory.doc-search-viewer"],
@@ -1509,6 +1533,40 @@ const CONTEXT_PACK_VIEWER_OPERATION: MemoryOperationDefinition<
     });
     return buildContextPackViewerArtifact(pack);
   },
+};
+
+const MAP_CONTEXT_OPERATION: MemoryOperationDefinition<
+  MapContextInput,
+  MemoryMapContextSlice
+> = {
+  id: "memory.map-context",
+  title: "Memory map context",
+  description:
+    "Graphify-style compact graph slice for orienting code agents before broad source reads.",
+  inputSchema: MapContextInputSchema,
+  outputSchema: MapContextOutputSchema,
+  safetyClass: "read-only",
+  sideEffectClass: "none",
+  capabilities: ["graph-store"],
+  renderer: {
+    cli: { command: "map-context", supportsJson: true },
+    mcp: {
+      toolName: "memory_map_context",
+      description:
+        "Read-only RedDB graph context slice for code agents. Scores node seeds from a query, traverses typed edges, returns compact NODE/EDGE markdown plus JSON metadata with edge weight, salience, confidence, and diagnostics.",
+    },
+  },
+  execute: (ctx, input) =>
+    buildMemoryMapContextSlice(ctx.store, input.query, {
+      depth: input.depth,
+      mode: input.mode,
+      tokenBudget: input.budget,
+      contextFilters:
+        typeof input.context === "string"
+          ? input.context.split(",").map((part) => part.trim()).filter(Boolean)
+          : input.context,
+      now: ctx.now,
+    }),
 };
 
 const CLAIM_CHECK_OPERATION: MemoryOperationDefinition<ClaimCheckInput, ClaimCheckResult> = {
@@ -3364,6 +3422,7 @@ const READ_ONLY_OPERATIONS = createReadOnlyMemoryOperationRegistry([
   REFERENCE_RADAR_OPERATION,
   CONTEXT_PACK_OPERATION,
   CONTEXT_PACK_VIEWER_OPERATION,
+  MAP_CONTEXT_OPERATION,
   DASHBOARD_OPERATION,
   DOC_COVERAGE_OPERATION,
   DOC_COVERAGE_VIEWER_OPERATION,

--- a/src/apps/memory/src/routing-guide.ts
+++ b/src/apps/memory/src/routing-guide.ts
@@ -59,6 +59,11 @@ export const SUPPORTED_ROUTING_AGENTS: MemoryRoutingAgent[] = [
 
 const RULES: MemoryRoutingRule[] = [
   {
+    when: "Before broad grep, recursive file reads, or opening many source files to understand code structure",
+    call: "memory_map_context with the concrete code question; use context filters such as call, import, type, validation, decision, work, or reference when known",
+    reason: "Route through the RedDB graph first so the agent gets a compact cited NODE/EDGE slice with weights, salience, confidence, and sources before spending tokens on raw code.",
+  },
+  {
     when: "Before architecture, migration, or multi-file implementation work",
     call: "memory_context_pack with the concrete goal",
     reason: "Load prior decisions, validations, warnings, and citations before planning.",
@@ -96,6 +101,7 @@ const RULES: MemoryRoutingRule[] = [
 ];
 
 const MCP_TOOLS = [
+  "memory_map_context",
   "memory_recall",
   "memory_context_pack",
   "memory_handoff",
@@ -111,6 +117,7 @@ const MCP_TOOLS = [
 ];
 
 const CLI_FALLBACKS = [
+  "memory map-context <query> --json",
   "memory recall <query>",
   "memory context-pack <goal> --json",
   "memory handoff [focus] --json",

--- a/src/apps/memory/tests/map-context.test.ts
+++ b/src/apps/memory/tests/map-context.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildMemoryMapContextSlice,
+  normalizeContextFilters,
+  type MemoryMapContextStore,
+} from "../src/map-context.js";
+import type { StoredNode } from "../src/graph-store.js";
+
+function node(rid: number, label: string, content: string, source = `src/${label}.ts`): StoredNode {
+  return {
+    rid,
+    label,
+    node_type: label.startsWith("sym:") ? "symbol" : "concept",
+    properties: {
+      title: label,
+      content,
+      source,
+      confidence: "EXTRACTED",
+    },
+  };
+}
+
+function store(): MemoryMapContextStore & { accessed: number[] } {
+  const accessed: number[] = [];
+  return {
+    accessed,
+    async listNodes() {
+      return [
+        node(1, "sym:src/auth.ts#issueToken", "issues signed jwt tokens for users"),
+        node(2, "sym:src/auth.ts#verifyToken", "verifies signed jwt tokens"),
+        node(3, "sym:src/cache.ts#cacheTtl", "redis cache ttl is 300 seconds"),
+        node(4, "jwt-rotation-decision", "decision: rotate jwt signing keys quarterly", "docs/adr.md"),
+        node(5, "generic-error-handler", "error error error handler"),
+      ];
+    },
+    async listEdges() {
+      return [
+        {
+          from_rid: 1,
+          to_rid: 2,
+          label: "CALLS",
+          weight: 2,
+          properties: { confidence: "EXTRACTED" },
+        },
+        {
+          from_rid: 2,
+          to_rid: 3,
+          label: "IMPORTS",
+          properties: { confidence: "EXTRACTED" },
+        },
+        {
+          from_rid: 4,
+          to_rid: 1,
+          label: "REFERENCES",
+          properties: { confidence: "INFERRED" },
+        },
+      ];
+    },
+    async communities() {
+      return new Map([
+        [1, "auth"],
+        [2, "auth"],
+        [3, "cache"],
+        [4, "docs"],
+      ]);
+    },
+    async recordAccess(rids: number[]) {
+      accessed.push(...rids);
+    },
+  };
+}
+
+describe("memory map context slice", () => {
+  test("selects a rare symbol seed and emits compact NODE/EDGE context", async () => {
+    const s = store();
+    const slice = await buildMemoryMapContextSlice(s, "issueToken jwt", { depth: 1 });
+
+    expect(slice.schema_version).toBe("memory.map_context.v1");
+    expect(slice.seeds[0]?.label).toBe("sym:src/auth.ts#issueToken");
+    expect(slice.context_md).toContain("NODE 1 sym:src/auth.ts#issueToken");
+    expect(slice.context_md).toContain("EDGE 1 --CALLS");
+    expect(slice.context_md).toContain("community=auth");
+    expect(s.accessed).toContain(1);
+  });
+
+  test("infers call context from the question and avoids import/reference traversal", async () => {
+    const slice = await buildMemoryMapContextSlice(store(), "who calls issueToken", { depth: 2 });
+
+    expect(slice.traversal.context_filters).toEqual(["call"]);
+    expect(slice.traversal.context_source).toBe("heuristic");
+    expect(slice.nodes.map((n) => n.rid).sort()).toEqual([1, 2]);
+    expect(slice.nodes.some((n) => n.rid === 3)).toBe(false);
+    expect(slice.nodes.some((n) => n.rid === 4)).toBe(false);
+  });
+
+  test("explicit context aliases normalize before traversal", async () => {
+    expect(normalizeContextFilters(["calls", "refs", "parameter_type"])).toEqual([
+      "call",
+      "reference",
+      "type",
+    ]);
+
+    const slice = await buildMemoryMapContextSlice(store(), "jwt rotation", {
+      depth: 1,
+      contextFilters: ["refs"],
+    });
+    expect(slice.traversal.context_source).toBe("explicit");
+    expect(slice.edges.every((edge) => edge.context === "reference")).toBe(true);
+  });
+
+  test("keeps edge weight topological and derives salience separately", async () => {
+    const slice = await buildMemoryMapContextSlice(store(), "issueToken", { depth: 1 });
+    const call = slice.edges.find((edge) => edge.label === "CALLS");
+
+    expect(call?.weight).toBe(2);
+    expect(call?.salience).toBe(2);
+  });
+
+  test("dfs does not include edges beyond the selected depth", async () => {
+    const slice = await buildMemoryMapContextSlice(store(), "issueToken", {
+      depth: 1,
+      mode: "dfs",
+    });
+    const selected = new Set(slice.nodes.map((node) => node.rid));
+
+    expect(slice.edges.length).toBeGreaterThan(0);
+    expect(
+      slice.edges.every(
+        (edge) => selected.has(edge.source_rid) && selected.has(edge.target_rid),
+      ),
+    ).toBe(true);
+  });
+
+  test("truncates markdown by token budget without dropping JSON result details", async () => {
+    const slice = await buildMemoryMapContextSlice(store(), "jwt", {
+      depth: 2,
+      tokenBudget: 100,
+    });
+
+    expect(slice.diagnostics.truncated).toBe(true);
+    expect(slice.context_md).toContain("truncated");
+    expect(slice.nodes.length).toBeGreaterThan(1);
+  });
+});

--- a/src/apps/memory/tests/mcp-server.test.ts
+++ b/src/apps/memory/tests/mcp-server.test.ts
@@ -59,8 +59,19 @@ async function seedStore(): Promise<string> {
       hash: "jwt-doc",
       updated_at: 123,
     });
-    await store.upsertEdge({ label: "REFERENCES", from_rid: auth, to_rid: jwt });
-    await store.upsertEdge({ label: "REFERENCES", from_rid: jwt, to_rid: cache });
+    await store.upsertEdge({
+      label: "REFERENCES",
+      from_rid: auth,
+      to_rid: jwt,
+      weight: 2,
+      properties: { confidence: "EXTRACTED" },
+    });
+    await store.upsertEdge({
+      label: "REFERENCES",
+      from_rid: jwt,
+      to_rid: cache,
+      properties: { confidence: "INFERRED" },
+    });
   } finally {
     await store.close();
   }
@@ -219,6 +230,7 @@ describe("MCP server over stdio", () => {
           "memory_layers",
           "memory_layers_viewer",
           "memory_lint",
+          "memory_map_context",
           "memory_merge_pass",
           "memory_neighbors",
           "memory_onboarding_map",
@@ -1705,6 +1717,40 @@ describe("MCP server over stdio", () => {
       expect(nodes.some((n) => n.label === "auth-service")).toBe(true);
       expect(result.structuredContent?.diagnostics).toMatchObject({
         vector: { status: "unavailable" },
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "memory_map_context returns a compact graph slice for code-agent routing",
+    async () => {
+      const client = await connect(await seedStore());
+      const result = (await client.callTool({
+        name: "memory_map_context",
+        arguments: { query: "jwt rotation references", depth: 1, context: "reference" },
+      })) as ToolResult;
+
+      const slice = JSON.parse(result.content[0]?.text ?? "{}") as {
+        schema_version: string;
+        context_md: string;
+        nodes: Array<{ label: string; source: string | null }>;
+        edges: Array<{ label: string; weight: number; salience: number }>;
+        diagnostics: { selected_nodes: number; selected_edges: number };
+      };
+      expect(slice.schema_version).toBe("memory.map_context.v1");
+      expect(slice.context_md).toContain("NODE");
+      expect(slice.context_md).toContain("EDGE");
+      expect(slice.nodes.some((node) => node.label === "jwt-rotation")).toBe(true);
+      expect(slice.edges.some((edge) => edge.weight === 2 && edge.salience === 2)).toBe(true);
+      expect(result.structuredContent).toMatchObject({
+        operation_id: "memory.map-context",
+        schema_version: "memory.map_context.v1",
+        query: "jwt rotation references",
+        mode: "bfs",
+        depth: 1,
+        nodes: slice.diagnostics.selected_nodes,
+        edges: slice.diagnostics.selected_edges,
       });
     },
     TIMEOUT,

--- a/src/apps/memory/tests/operations-registry.test.ts
+++ b/src/apps/memory/tests/operations-registry.test.ts
@@ -99,6 +99,7 @@ describe("read-only Memory operations registry", () => {
         "memory.layers",
         "memory.layers-viewer",
         "memory.lint",
+        "memory.map-context",
         "memory.merge-pass",
         "memory.onboarding-map",
         "memory.onboarding-map-viewer",
@@ -182,6 +183,7 @@ describe("read-only Memory operations registry", () => {
         "memory_layers",
         "memory_layers_viewer",
         "memory_lint",
+        "memory_map_context",
         "memory_merge_pass",
         "memory_onboarding_map",
         "memory_onboarding_map_viewer",
@@ -247,6 +249,19 @@ describe("read-only Memory operations registry", () => {
       kind: "viewer",
       artifact: "self-contained-html",
       fileSink: { field: "out", sources: ["flag", "query"], type: "path" },
+    });
+    expect(getReadOnlyMemoryOperation("memory.map-context")).toMatchObject({
+      renderer: {
+        cli: { command: "map-context", supportsJson: true },
+        mcp: { toolName: "memory_map_context" },
+      },
+      inputBinding: {
+        fields: expect.arrayContaining([
+          expect.objectContaining({ field: "query", variadic: true }),
+          expect.objectContaining({ field: "context", sources: ["flag", "query"] }),
+        ]),
+      },
+      outputKind: { kind: "report", format: "json" },
     });
     expect(
       getReadOnlyMemoryOperation("memory.smart-search-viewer").outputKind,

--- a/src/apps/memory/tests/routing-guide.test.ts
+++ b/src/apps/memory/tests/routing-guide.test.ts
@@ -111,12 +111,14 @@ describe("Memory routing guide", () => {
     expect(body.supportedAgents).toContain("cursor");
     expect(body.integration.transports).toContain("mcp");
     expect(body.integration.configSnippets[0]?.body).toContain("memory-mcp");
+    expect(body.installSnippet).toContain("memory_map_context");
     expect(body.installSnippet).toContain("memory_pre_pr_review");
 
     const text = runMemory(["routing-guide", "--agent", "codex"]);
     expect(text.status, text.stderr).toBe(0);
     expect(text.stdout).toContain("memory: routing guide");
     expect(text.stdout).toContain("Target file: AGENTS.md");
+    expect(text.stdout).toContain("memory_map_context");
 
     const root = await mkdtemp(join(tmpdir(), "memory-routing-guide-"));
     roots.push(root);


### PR DESCRIPTION
## Summary
- add `memory map-context` to build Graphify-style compact RedDB graph slices for code-agent routing
- expose `memory_map_context` through the read-only operation registry and MCP structured content
- update routing guidance and Memory glossary to keep UI decisions in red-ui and Brain disconnected from Memory map

## Validation
- `pnpm --dir src/apps/memory typecheck`
- `pnpm --dir src/apps/memory exec vitest run tests/map-context.test.ts tests/operations-registry.test.ts`
- `pnpm --dir src/apps/memory exec vitest run --config vitest.integration.config.ts tests/routing-guide.test.ts`
- `pnpm --dir src/apps/memory exec vitest run --config vitest.integration.config.ts tests/mcp-server.test.ts`
- CLI smoke: `memory init/store/map-context --json` against a temp graph store

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783363903&installation_id=129708444&pr_number=519&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F519&signature=ef99e3896781215ac67af8ed3b0d88869b18160da313e875e5cb6312f1b06fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New memory map context query: graph traversal with depth, BFS/DFS modes, context filters, hub throttling, token‑budgeted markdown output and optional JSON; accessible via CLI and as a discoverable read-only operation (MCP).

* **Documentation**
  * Expanded glossary and clarified Memory map concepts, relationships, weight vs salience, analytic caching, and separation from Brain.

* **Tests**
  * Added tests for traversal, filter normalization, scoring, truncation behavior, CLI/MCP integration, and registry visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->