### PR TITLE
fix: record provider tidy governance

### DIFF
--- a/.red/CONTEXT-MAP.md
+++ b/.red/CONTEXT-MAP.md
@@ -25,9 +25,10 @@ domain language or writing ADRs.
   issue workflow vocabulary, and operator-facing workflows that consume memory
   evidence.
 - **Brain -> Memory**: `brain` is a separate plugin and separate directory
-  surface. It may optionally reuse Memory capabilities, but its mission is
-  human-facing knowledge capture and connection rather than agent-performance
-  memory.
+  surface. Its mission is human-facing knowledge capture and connection rather
+  than agent-performance memory, but Memory recall/context-pack may rank cited
+  Brain hits in the same result and trust model without sharing a canonical
+  store.
 - **Brain -> Dev**: `brain` follows the same marketplace and repo setup
   conventions as other RedSkills plugins, but owns its `.red/brain/*` knowledge
   repository semantics.

--- a/.red/adr/0053-provider-tidy-is-report-only-governance.md
+++ b/.red/adr/0053-provider-tidy-is-report-only-governance.md
@@ -1,0 +1,5 @@
+# Provider tidy is report-only governance until an explicit soft-merge approval
+
+Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts keyed by a fingerprint over the relevant nodes/edges plus operation and review-policy version; `memory governance` reports those recommendations read-only and degrades to deterministic output when provider tidy is unavailable. A recommendation affects governed recall only after an explicit mutating workflow accepts it and creates an approval-gated `SAME_AS`/`MERGED_INTO` Soft-merge edge.
+
+This keeps Odysseus-style conservative tidy useful without letting provider output silently collapse the RedDB Memory graph, bypass provenance, or turn governance into a mutating surface.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -62,6 +62,7 @@ stale notes inline.
 - **0035** Extraction schema splits closed structural type from open engineering code
 - **0036** Memory transports are adapters over the operation registry
 - **0037** Memory benchmark measures substrate superiority on a curated corpus, not LOCOMO
+- **0053** Provider tidy is report-only governance until explicit soft-merge approval
 
 ## MCP / transport / surfaces
 - **0013** Dev owns the codebase-understanding surface; memory owns the graph — post-0041, `dev` consumes project memory through the `red-memory` MCP rather than an in-repo Memory CLI

--- a/.red/contexts/brain/CONTEXT.md
+++ b/.red/contexts/brain/CONTEXT.md
@@ -23,6 +23,10 @@ from conversation residue, notes, documents, decisions, questions, plans,
 references, or any other durable knowledge dump.
 _Avoid_: memory note, page
 
+**Personal fact**:
+A durable fact about a person, preference, contact, relationship, identity, habit, goal, or other human-facing context; it belongs in Brain as a Brain artifact, not in the Memory plugin's operational evidence graph.
+_Avoid_: Memory node, Reasoning memory, agent-performance evidence
+
 **Brain artifact kind**:
 The required type of a Brain artifact. MVP kinds are rigid so the Brain can
 route, search, and connect knowledge predictably from the start.
@@ -33,27 +37,85 @@ The MVP set of Brain artifact kinds and connection kinds, based on a
 GBrain-style knowledge graph rather than a flat note store. Artifact kinds start
 from pillar, decision, concept, question, playbook, task, event, pattern,
 hypothesis, fact, source, bookmark, note, reference, custom, project, idea,
-meeting, claim, organization, and person. `contact` is an ingestion alias that
-must resolve to `person` or `organization` before persistence. Connection kinds
-start from supports, contradicts, depends_on, derived_from, related_to, part_of,
+meeting, claim, organization, person, agent, workflow, rule, tool, output,
+workspace, and department. `contact` is an ingestion alias that must resolve to
+`person` or `organization` before persistence. Connection kinds start from
+supports, contradicts, depends_on, derived_from, related_to, part_of,
 preceded_by, followed_by, authored, and tagged. `tagged` is derived from
 artifact tag metadata and may be rebuilt.
 _Avoid_: untyped graph, tag-only graph
 
+**AI OS artifact**:
+A Brain artifact that represents an executable or reusable operating-system component such as an agent, workflow, rule, tool, output, workspace, or department.
+_Avoid_: tag-only component, freeform operating-system note
+
+**Brain workflow**:
+A Brain artifact that describes a reusable sequence of work or decision steps inside the Brain's own vocabulary.
+_Avoid_: n8n workflow, external automation target, runtime-specific flow
+
+**Brain storm**:
+A Brain-owned interview workflow that absorbs tacit human knowledge through
+one-question-at-a-time grilling, checkpoints the evolving discovery record into
+the Project brain, and later offers explicit promotion into Brain artifacts,
+Memory operational evidence, or Dev documentation. Its initial persistence model
+is hybrid: each checkpoint updates one structured session artifact, and granular
+Brain artifacts are created only by an explicit promotion step.
+_Avoid_: Dev start replacement, raw transcript dump, automatic Memory extraction
+
+**Brain index**:
+A curated Brain artifact that orients agents across a topic, workspace, project, or entity by summarizing relevant artifacts and pointing to where deeper context lives.
+_Avoid_: automatic cache, search result, folder listing
+
+**Generated Brain index**:
+A derived view or cache that summarizes a slice of the Brain until a human or agent curates it into a **Brain index**.
+_Avoid_: canonical artifact, promoted knowledge, durable decision
+
 **Brain capture**:
 The ingestion act that creates or updates a Brain artifact.
 _Avoid_: memory store, transcript logging
+
+**Brain automatic ingestion**:
+An opt-in Brain capture path where brain-scoped connectors turn external events or context into Brain artifacts.
+_Avoid_: capturing everything an agent sees, transcript scraping, Memory hook ingestion
+
+**Brain connector boundary**:
+The rule that external connector tools stay behind the Brain runtime and the agent sees only Brain-scoped operations.
+_Avoid_: raw connector MCPs, generic messaging tools, tool-surface sprawl
+
+**Brain graph explorer**:
+The red-ui view over the Brain store used for early visual exploration and debugging of artifacts and connections.
+_Avoid_: daily dashboard, curated operating surface
+
+**Brain daily dashboard**:
+A future curated Brain interface for recurring decisions, KPIs, and recent knowledge, considered only after graph exploration and event semantics are useful.
+_Avoid_: red-ui replacement, first visualization surface, Memory Workbench
+
+**Brain KPI**:
+A Brain read over artifacts and connections that summarizes a decision-relevant count, trend, or status even before automatic event ingestion exists.
+_Avoid_: decorative metric, separate analytics subsystem, dashboard-only number
+
+**Brain structural KPI**:
+An initial Brain KPI about the Brain itself, such as artifact counts by kind, connection counts, orphan artifacts, recent activity, and missing indexes.
+_Avoid_: business KPI, manually reported metric, external analytics
 
 **Brain store**:
 The RedDB database owned by a Project brain and treated as the canonical source
 of truth for captured knowledge and derived connections.
 _Avoid_: markdown source of truth, export folder
 
+**Brain markdown interop**:
+A derived import/export surface that makes Brain artifacts readable in markdown-oriented tools while keeping the Brain store canonical.
+_Avoid_: markdown source of truth, dual-write vault, Obsidian database
+
 **Brain database boundary**:
 The Brain store is separate from the Memory database. Brain and Memory may share
 deployment patterns and integration points, but they must not share a canonical
 database.
 _Avoid_: shared memory database, memory namespace
+
+**Brain-to-Memory federation**:
+The read path where Memory recall or context-pack may rank cited Brain artifacts in the same result and trust model as Memory evidence, without moving Brain artifacts into the Memory store.
+_Avoid_: shared canonical store, uncited Brain context, separate supplemental-only recall
 
 **Brain deployment target**:
 The configured location of a Brain store. The default target is offline-first
@@ -84,7 +146,7 @@ _Avoid_: git-root-only brain, process cwd drift
 A file associated with a Brain artifact, such as a document, transcript, image,
 audio file, or exported markdown. Attachments may live under `.red/brain/*`, but
 they are not the canonical source of truth.
-_Avoid_: page, memory asset
+_Avoid_: page, memory asset, standalone artifact, OCR source
 
 **Brain operation contract**:
 The initial GBrain-like operation set exposed by the Brain plugin: `init`,
@@ -108,13 +170,19 @@ A derived relationship between Brain captures, such as shared entities, topics,
 references, decisions, contradictions, follow-ups, or provenance.
 _Avoid_: memory edge, code reference
 
+**Brain promotion**:
+The act of copying a Brain artifact into a higher-level Brain, such as department or company, while preserving provenance back to the source artifact.
+_Avoid_: moving the original, cross-brain live reference, shared mutable artifact
+
 **Brain mission**:
 Human-facing knowledge repository behavior: accept arbitrary dumps, preserve
 them, and make connections across them for later recall and synthesis.
 _Avoid_: agent performance memory, token optimization layer
 
+**Brain operating model**:
+Agents operate the Brain on behalf of the user, while humans inspect and correct Brain artifacts through readable views and explicit operations.
+_Avoid_: markdown-first editing, human-only note system, fully automatic black box
+
 **Memory mission**:
-Agent-performance memory behavior: make agents work better through governed
-operational evidence, recall, context packs, telemetry, and token-efficient
-workflow support.
+Agent-performance memory behavior in a separate Memory store: make agents work better through governed operational evidence, recall, context packs, telemetry, and token-efficient workflow support.
 _Avoid_: personal knowledge repository

--- a/.red/contexts/memory/CONTEXT.md
+++ b/.red/contexts/memory/CONTEXT.md
@@ -8,7 +8,39 @@ workflows.
 
 **Memory plugin**:
 The RedSkills plugin that gives agents persistent, queryable per-project memory.
-_Avoid_: memory skill, harness memory
+_Avoid_: memory skill, harness memory, personal fact store, Brain interface
+
+**Operational evidence**:
+A durable fact about agent work, validation, decisions, risks, attempts, or codebase reasoning that can improve future agent execution.
+_Avoid_: personal knowledge, freeform dump, second brain note
+
+**Evidence card**:
+A YAML review unit distilled from one or more raw signals, carrying source, cited evidence, proposed lesson, confidence, privacy posture, routing target, and blast radius before any durable Memory or Skill proposal is written.
+_Avoid_: raw transcript, proposal file, JSON inbox item, unstructured inbox note
+
+**Hermes-like refinement loop**:
+A governed Memory workflow inspired by Hermes-style self-improvement, where captured signals become routed evidence and approval-gated proposals rather than automatic Skill creation or silent instruction rewrites.
+_Avoid_: Hermes runner, automatic skill factory, self-rewriting agent
+
+**Internal refinement signal**:
+A Memory-visible agent signal, such as Skill telemetry, hook observations, reasoning attempts, validations, or explicit user rejection feedback, that can seed an **Evidence card** without external-system integration.
+_Avoid_: third-party webhook, raw SaaS transcript, arbitrary import
+
+**User rejection signal**:
+An internal refinement signal where the user rejects, corrects, or constrains agent behavior; command/button feedback is high-confidence, while natural-language rejection is captured as lower-confidence evidence that cannot autopromote.
+_Avoid_: casual preference, inferred mood, silent edit
+
+**Evidence route**:
+The destination verdict on an **Evidence card**: durable Memory fact, Skill improvement proposal, Red context update, issue/PRD candidate, or discard.
+_Avoid_: automatic write target, ADR decision, unreviewed patch
+
+**Low-risk autopromotion**:
+Automatic promotion of high-confidence, internal, low-blast-radius evidence such as validation outcomes or telemetry rollups into governed Memory, excluding Skill behavior changes and Red context updates.
+_Avoid_: autorefine, silent patch, automatic context rewrite
+
+**Refinement blast-radius gate**:
+The review gate that blocks autopromotion when an evidence route could affect an external audience, customer/commercial/security outcomes, or shared workflow/context semantics.
+_Avoid_: gut-check, trust score, generic risk
 
 **Markdown-only mode**:
 The lightest Memory storage mode: plain markdown facts, no RedDB, hooks, or MCP server.
@@ -37,6 +69,10 @@ _Avoid_: memory record, entry
 **Memory node**:
 The graph-mode unit for a stored fact, work item, attempt, file, symbol, validation, or other typed entity.
 _Avoid_: note, row
+
+**Pinned Memory node**:
+A **Memory node** whose `importance >= 0.8`; it is protected from stale-node pruning and treated as core context by context-pack policy when it is applicable to the current goal, not globally injected into every prompt. Recall ranking may learn from the same signal later, but context-pack is the first validation surface.
+_Avoid_: pinned field, separate always-include flag
 
 **Memory tier**:
 The retention class on a **Memory node**: `ephemeral`, `durable`, or `reasoning`.
@@ -69,6 +105,18 @@ _Avoid_: envelope hook dump, hook log
 **Memory event log**:
 The RedDB-backed operational telemetry stream for Memory-visible agent events, including skill events, attempt validations, hook events, and derived lifecycle observations.
 _Avoid_: separate telemetry tables, raw logs
+
+**Memory injection observation**:
+A Memory event-log observation that a recalled **Memory node** or **Memory context pack** citation was actually placed into agent context by a Memory-controlled hook or transport; event-log records are the source of truth, while node-level injection counters or timestamps are derived rollups for cheap doctor/decay queries. Manual recall display does not create an injection observation. Distinct from recall access bookkeeping such as `access_count`.
+_Avoid_: recall hit, access count, prompt transcript, rollup source of truth
+
+**Memory context pack generation observation**:
+A Memory event-log observation that a **Memory context pack** was produced for a goal; distinct from a **Memory injection observation**, because generating ready-to-inject Markdown does not prove that an integration or hook delivered it to an agent.
+_Avoid_: injection observation, recall access, prompt delivery
+
+**Brain federated context**:
+Cited Brain hits that Memory recall or context-pack may rank in the same result and trust model as Memory evidence, while preserving Brain as the canonical source for those artifacts rather than treating Brain as a Memory store.
+_Avoid_: shared store, uncited Brain injection, separate supplemental section
 
 **Memory readiness envelope**:
 The shared JSON contract consumed by future UI and competitive evaluation, combining task readiness, trust evidence, operational telemetry, VCS/time-travel status, and graph-community signals for a requested goal.
@@ -354,6 +402,12 @@ _Avoid_: HTTP server health endpoint, mutating repair wizard
 The read-only trust report over graph provenance coverage, privacy scan findings, lint findings, contradiction state, supersession state, and recommended next actions.
 _Avoid_: compliance certification, auto-fix workflow
 
+**Memory tidy recommendation**:
+A read-only duplicate or near-duplicate recommendation to merge Memory evidence through an approval-gated **Soft-merge edge**; the first provider-backed tidy scope does not decide supersession, deprecation, or contradiction resolution. Memory does not apply tidy recommendations automatically. Each provider tidy run is bounded by an absolute recommendation cap and a proportional guard against collapsing too much of the candidate set.
+The first product surface for provider-backed tidy recommendations is **Memory governance**. When no provider is configured or provider tidy is unavailable, Memory governance remains deterministic and reports tidy as unavailable with the reason and next action.
+A tidy recommendation's review status is `open`, `accepted`, `dismissed`, or `stale`; `accepted` means a human approved it through an explicit mutating workflow and Memory created the corresponding **Soft-merge edge**, while `stale` means the recommendation's **Provider review fingerprint** no longer matches current evidence or policy. `memory governance` only reports recommendations and never applies them. Graph supersession vocabulary is not used for provider review artifacts.
+_Avoid_: automatic tidy, auto-merge, destructive cleanup, supersession decision, contradiction resolution, retention recommendation
+
 **Memory lint rule suggestion**:
 The read-only recommendation emitted by Memory lint when hygiene findings imply a reusable agent rule or Red context update, including target files, evidence IDs, rationale, and ready-to-paste markdown.
 _Avoid_: automatic rule writer, Memory mutation
@@ -373,6 +427,10 @@ _Avoid_: mutating governance dashboard, public benchmark claim
 **Memory context pack viewer**:
 The self-contained HTML artifact that renders **Memory context pack** evidence for local agent-context inspection, including embedded JSON, grouped citations, warnings, skill recommendations, and ready-to-inject Markdown.
 _Avoid_: model-generated summary, separate prompt artifact store
+
+**Memory context pack core context**:
+The cited, provenance-preserving section of a **Memory context pack** for applicable **Pinned Memory nodes**; pinned nodes must still pass the same governed eligibility filters as ordinary context, then appear before ordinary recalled context without removing citations or trust metadata.
+_Avoid_: uncited always-include preface, ranking-only boost, governance bypass
 
 **Path explanation viewer**:
 The self-contained HTML artifact that renders a **Memory path explanation** for local inspection.
@@ -405,6 +463,14 @@ _Avoid_: CI runner, container build parser
 **Memory extraction status**:
 The read-only operator report that shows deterministic extractor coverage, local structured-transcript fallback readiness, inferred provider mode/model/egress, Stop hook readiness, and stored `INFERRED` fact count.
 _Avoid_: provider installer, extraction quality benchmark
+
+**Provider review fingerprint**:
+A stable hash over the relevant Memory nodes/edges plus the Memory operation id and provider-review policy/prompt version; used to skip repeated provider-backed review work only when both evidence and review policy are unchanged. Deterministic readers still recompute their reports rather than trusting the fingerprint.
+_Avoid_: report cache, governance cache, deterministic skip
+
+**Provider review artifact**:
+A persisted, non-canonical review result keyed by **Provider review fingerprint**, such as stable **Memory tidy recommendation** ids and pair-level evidence for reviewers. It lives in Memory persistence outside the canonical graph, such as RedDB KV or a side collection. It is not a **Memory node** or edge and does not change governed recall until an approved action creates canonical graph evidence.
+_Avoid_: Memory node, Soft-merge edge, recall evidence, markdown review file
 
 **Extraction status viewer**:
 The self-contained HTML artifact that renders **Memory extraction status** for local inspection, including deterministic extractor coverage, inferred provider readiness, Stop hook readiness, inferred fact counts, recommendations, and embedded JSON.
@@ -502,6 +568,42 @@ _Avoid_: demo project, synthetic showcase
 The goal of covering practical repository-understanding capabilities: ingestion, graph construction, impact queries, context maps, and exportable artifacts.
 _Avoid_: Understand clone, Graphify clone
 
+**Memory map**:
+A RedDB-backed, rebuildable projection of codebase-map evidence used by Memory to sharpen agent context between Claude Code/Codex and the repository while reducing unnecessary token use. It is derived from canonical Memory graph evidence and complementary ingest sources without becoming a second source of truth. It includes structural codebase entities plus operational evidence such as ADRs, decisions, validations, issues, PRDs, and attempts only when they are explicitly connected to files, symbols, docs, or assets. red-ui can inspect the same data as a database visualization client, but the primary product loop is agent context selection.
+_Avoid_: graphify-out clone, static map artifact, separate map database
+
+**Memory map versioning**:
+The rule that **Memory map** does not maintain its own snapshot/versioning system; it is recomputed from the queried RedDB graph state and relies on RedDB VCS/time-travel for historical reads.
+_Avoid_: map snapshot store, parallel graph history, committed map version
+
+**Memory map analytic cache**:
+The rebuildable RedDB-backed cache for expensive **Memory map metadata** such as community assignments and cohesion, computed through RedDB analytics capabilities for database visualization clients. Cheap metrics such as edge weight or salience may be computed on read unless materialization is proven necessary.
+_Avoid_: map snapshot, canonical evidence, UI cache
+
+**Memory map boundary**:
+The rule that **Memory map** and Brain remain disconnected surfaces. Brain artifacts do not participate as Memory map vertices, edges, citations, or federated context.
+_Avoid_: Brain-enriched map, federated Brain map context, shared project graph
+
+**Memory map metadata**:
+The semantic and analytic attributes Memory provides as decision inputs for database graph visualization, such as entity type, relation kind, edge weight, edge salience, confidence, provenance, community assignment, cohesion, and source freshness. It does not encode UI/UX decisions such as color palettes, layout, label visibility, opacity, interaction behavior, or visual hierarchy; those belong to red-ui or another frontend consumer.
+_Avoid_: Memory UI projection, graph layout contract, red-ui implementation detail
+
+**Memory map context slice**:
+A compact, cited answer-shaped subgraph selected from **Memory map** evidence for Claude Code/Codex before broad source-file reading, containing the relevant files, symbols, relations, source locations, connected decisions, validations, risks, and recommended next reads within a token budget.
+_Avoid_: raw graph dump, visual map, generated prose answer
+
+**Memory map edge weight**:
+The topological strength of a Memory map edge, usually the count or aggregate strength of concrete relationships between two vertices or two communities.
+_Avoid_: confidence score, UI opacity, importance score
+
+**Memory map edge salience**:
+A navigation-oriented ranking score derived from **Memory map edge weight** plus evidence quality, relation kind, recency, and centrality signals.
+_Avoid_: raw edge weight, visual style, confidence field
+
+**TypeScript map source**:
+The first complementary source for **Memory map** structural code evidence, using TypeScript compiler API or `tsserver` data to derive symbols, imports, exports, and call/type relationships before writing them into RedDB-backed map evidence.
+_Avoid_: Graphify dependency, separate TypeScript index, tsserver as source of truth
+
 **Onboarding map viewer**:
 The self-contained HTML artifact that renders **Memory onboarding map** evidence for local inspection, including concepts, workflows, decisions, risks, validations, suggested skills, warnings, markdown, and embedded JSON.
 _Avoid_: documentation generator, replacement README
@@ -542,6 +644,13 @@ _Avoid_: memory rollback, historical search
 - A **Validation sidecar** feeds **Validation nodes** and `TESTED_BY` edges; `validation_summary` remains a quick aggregate property.
 - **Reasoning attempt hooks** live as a property on the **Reasoning attempt** node; absent when the project declared no user hooks, never represented as an edge or separate node.
 - The **Memory event log** is the shared telemetry substrate for skill, attempt, and hook observations before specialized rollups are produced.
+- A **Hermes-like refinement loop** distills raw signals into **Evidence cards**, routes them into **Operational evidence** or proposal artifacts, and keeps mutation behind proposal review gates.
+- An **Evidence card** can cite **Memory event log** records, hook observations, rejection notes, validation nodes, or external-system summaries without making the raw source itself the durable Memory fact.
+- The first **Hermes-like refinement loop** is seeded by **Internal refinement signals**; external customer, SaaS, or webhook sources are later inputs that must pass the same evidence and privacy gates.
+- A **User rejection signal** can seed an **Evidence card**, but only explicit command or UI feedback should be treated as high-confidence rejection evidence.
+- An **Evidence route** determines what review artifact is proposed from an **Evidence card**; ADR candidates are outside the first routing set and remain governed by architecture-decision criteria.
+- **Low-risk autopromotion** may store internal operational evidence, but **Skill improvement proposal** and Red context updates remain approval-gated.
+- The **Refinement blast-radius gate** decides whether an **Evidence route** is eligible for **Low-risk autopromotion** or must become a human-reviewed proposal.
 - The **Memory readiness envelope** is the contract shared by UI and `eval:competitive:v2`, so product views and benchmarks are backed by the same evidence.
 - A **Memory handoff report** composes live graph evidence for cross-agent continuation; it does not read or expose raw transcripts.
 - The **Handoff viewer** consumes a **Memory handoff report** instead of recomputing cross-agent continuation evidence.


### PR DESCRIPTION
Records provider tidy governance as report-only until explicit soft-merge approval.\n\nCloses #520

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783377505&installation_id=129708444&pr_number=521&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F521&signature=6e8a1a91fbfdc8902ecb42368ddc7a539f379e4e168cbda313efeb4e8f2cebd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Brain as a human-facing knowledge capture and Memory as agent-focused evidence/recall.
  * Added ADR declaring provider tidy as report-only until explicit soft-merge approval.
  * Introduced glossary entries for Brain workflows, artifacts, promotion model, and federation behavior.
  * Expanded Memory contracts for governance, evidence routing, context-pack composition, and provider-review artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->