### PR TITLE
Add compiler-backed TypeScript memory extraction

### DIFF
--- a/src/apps/memory/src/extract-code.ts
+++ b/src/apps/memory/src/extract-code.ts
@@ -1,14 +1,28 @@
 import { readFile } from "node:fs/promises";
-import { extname } from "node:path";
+import { dirname, extname, resolve } from "node:path";
 import { contentHash } from "./hash.js";
 import { extractImportsForFile } from "./import-extractors.js";
-import type { EdgeLabel, MemoryNode } from "./schema.js";
+import type { Confidence, EdgeLabel, MemoryEdgeProps, MemoryNode } from "./schema.js";
+import type * as TypeScript from "typescript";
 
 /** A code file's extracted graph fragment: nodes plus label-keyed edges. */
 export interface CodeExtraction {
   nodes: MemoryNode[];
-  /** Edges declared by label — the indexer resolves labels to rids after upsert. */
-  edges: Array<{ fromLabel: string; toLabel: string; label: EdgeLabel }>;
+  /** Edges declared by label - the indexer resolves labels to rids after upsert. */
+  edges: CodeEdgeExtraction[];
+}
+
+export interface CodeEdgeExtraction {
+  fromLabel: string;
+  toLabel: string;
+  label: EdgeLabel;
+  weight?: number;
+  properties?: MemoryEdgeProps;
+}
+
+export interface ExtractCodeOptions {
+  /** Test seam for exercising compiler-unavailable degradation. */
+  loadTypeScript?: () => Promise<typeof TypeScript | null>;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -23,27 +37,180 @@ const LANG_BY_EXT: Record<string, string> = {
   ".rs": "rust",
 };
 
+const TS_LANGS = new Set(["typescript", "tsx"]);
+const TS_JS_LANGS = new Set(["typescript", "tsx", "javascript"]);
+
+const EDGE_WEIGHTS: Partial<Record<EdgeLabel, number>> = {
+  DEFINED_IN: 1.2,
+  IMPORTS: 0.9,
+  CALLS: 1.1,
+  USES_TYPE: 1.0,
+};
+
 /**
  * Symbol-level code extraction (the deterministic `EXTRACTED` path).
  *
- * Ported from red-memory `packages/extractor/src/code.ts`. This slice ships the
- * regex symbol scanner — a fully deterministic parse that needs no native
- * toolchain. It also extracts conservative intra-file TS/JS call and type-use
- * edges between symbols. tree-sitter grammars (richer call/type graphs) are the planned
- * upgrade and slot in behind this same `CodeExtraction` shape; until then the
- * regex path is the tested surface, per issue #53 ("deterministic paths only").
+ * TypeScript/TSX files prefer the TypeScript compiler API so Memory gets AST
+ * source locations and checker-backed call/type-use edges. If the compiler is
+ * unavailable or cannot parse the file, extraction falls back to the historical
+ * deterministic regex scanner and marks the file node as degraded. Other
+ * languages keep the regex import/symbol scanner.
  *
  * Produces one `file` node plus one `symbol` node per top-level declaration,
  * with a `DEFINED_IN` edge from each symbol to its file. Unsupported extensions
  * yield an empty extraction.
  */
-export async function extractCode(path: string): Promise<CodeExtraction> {
+export async function extractCode(
+  path: string,
+  options: ExtractCodeOptions = {},
+): Promise<CodeExtraction> {
   const ext = extname(path).toLowerCase();
   const lang = LANG_BY_EXT[ext];
   if (!lang) return { nodes: [], edges: [] };
 
   const source = await readFile(path, "utf8");
-  const exports = exportedNames(source, lang);
+  if (TS_LANGS.has(lang)) {
+    const tsResult = await extractTypeScriptMap(path, source, lang, options);
+    if ("extraction" in tsResult) return tsResult.extraction;
+    return regexExtraction(path, source, lang, tsResult.fallbackReason);
+  }
+
+  return regexExtraction(path, source, lang);
+}
+
+type TypeScriptMapResult =
+  | { extraction: CodeExtraction }
+  | { fallbackReason: string };
+
+async function extractTypeScriptMap(
+  path: string,
+  source: string,
+  lang: string,
+  options: ExtractCodeOptions,
+): Promise<TypeScriptMapResult> {
+  const ts = await (options.loadTypeScript ?? loadTypeScript)();
+  if (ts == null) return { fallbackReason: "typescript compiler unavailable" };
+
+  try {
+    const program = createTypeScriptProgram(ts, path);
+    const sourceFile = program.getSourceFile(path) ?? sourceFileByPath(ts, program, path);
+    if (sourceFile == null) return { fallbackReason: "typescript source file unavailable" };
+
+    const syntacticErrors = program
+      .getSyntacticDiagnostics(sourceFile)
+      .filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error);
+    if (syntacticErrors.length > 0) {
+      const first = syntacticErrors[0];
+      return {
+        fallbackReason: `typescript syntax diagnostic ${first?.code ?? "unknown"}`,
+      };
+    }
+
+    const checker = program.getTypeChecker();
+    const symbols = compilerSymbols(ts, checker, sourceFile);
+    const exports = compilerExportedNames(ts, checker, sourceFile, source);
+    const imports = importLineMap(ts, sourceFile);
+    const extraction = buildExtraction({
+      path,
+      source,
+      lang,
+      symbols,
+      exports,
+      backend: "typescript-compiler",
+      importLines: imports,
+      extraEdges: [
+        ...compilerCallEdges(ts, checker, sourceFile, path, symbols),
+        ...compilerTypeEdges(ts, checker, sourceFile, path, symbols),
+      ],
+    });
+    return { extraction };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { fallbackReason: `typescript compiler extraction failed: ${message}` };
+  }
+}
+
+async function loadTypeScript(): Promise<typeof TypeScript | null> {
+  try {
+    return await import("typescript");
+  } catch {
+    return null;
+  }
+}
+
+function createTypeScriptProgram(ts: typeof TypeScript, path: string): TypeScript.Program {
+  const configPath = ts.findConfigFile(dirname(path), ts.sys.fileExists, "tsconfig.json");
+  if (configPath) {
+    const config = ts.readConfigFile(configPath, ts.sys.readFile);
+    const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, dirname(configPath));
+    return ts.createProgram([path], {
+      ...parsed.options,
+      noEmit: true,
+      skipLibCheck: true,
+    });
+  }
+
+  return ts.createProgram([path], {
+    allowJs: true,
+    esModuleInterop: true,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: false,
+    target: ts.ScriptTarget.ES2022,
+  });
+}
+
+function sourceFileByPath(
+  ts: typeof TypeScript,
+  program: TypeScript.Program,
+  path: string,
+): TypeScript.SourceFile | undefined {
+  const wanted = normalizePath(ts, path);
+  return program.getSourceFiles().find((sourceFile) => normalizePath(ts, sourceFile.fileName) === wanted);
+}
+
+function normalizePath(ts: typeof TypeScript, path: string): string {
+  return ts.sys.useCaseSensitiveFileNames ? resolve(path) : resolve(path).toLowerCase();
+}
+
+function regexExtraction(
+  path: string,
+  source: string,
+  lang: string,
+  fallbackReason?: string,
+): CodeExtraction {
+  const symbolHits = regexSymbols(source, lang);
+  return buildExtraction({
+    path,
+    source,
+    lang,
+    symbols: symbolHits,
+    exports: exportedNames(source, lang),
+    backend: fallbackReason ? "regex-fallback" : "regex",
+    fallbackReason,
+    extraEdges: [
+      ...extractCallEdges(path, source, lang, symbolHits, fallbackReason ? "regex-fallback" : "regex"),
+      ...extractTypeEdges(path, source, lang, symbolHits, fallbackReason ? "regex-fallback" : "regex"),
+    ],
+  });
+}
+
+interface BuildExtractionInput {
+  path: string;
+  source: string;
+  lang: string;
+  symbols: SymbolHit[];
+  exports: string[];
+  backend: string;
+  fallbackReason?: string;
+  importLines?: Map<string, number>;
+  extraEdges?: CodeEdgeExtraction[];
+}
+
+function buildExtraction(input: BuildExtractionInput): CodeExtraction {
+  const { path, source, lang, symbols: symbolHits, exports, backend, fallbackReason } = input;
   const fileNode: MemoryNode = {
     label: `file:${path}`,
     node_type: "file",
@@ -51,6 +218,7 @@ export async function extractCode(path: string): Promise<CodeExtraction> {
       title: path,
       language: lang,
       source: path,
+      source_location: sourceLocation(path, 1),
       confidence: "EXTRACTED",
       provenance: {
         source_kind: "derived",
@@ -59,76 +227,150 @@ export async function extractCode(path: string): Promise<CodeExtraction> {
         evidence: [path],
       },
       hash: contentHash(path, source),
-      // Exported symbol names, surfaced so the graph contract (#234) can
-      // round-trip a file's public surface to consumers.
+      extraction_backend: backend,
+      ...(fallbackReason
+        ? { extraction_degraded: true, extraction_degradation_reason: fallbackReason }
+        : {}),
       ...(exports.length > 0 ? { exports } : {}),
     },
   };
 
-  const symbolHits = regexSymbols(source, lang);
   const symbols = symbolHits.map<MemoryNode>((sym) => ({
     label: `sym:${path}#${sym.name}`,
     node_type: "symbol",
     properties: {
       title: sym.name,
       summary: sym.kind,
-      source: `${path}:${sym.line}`,
+      source: sourceLocation(path, sym.line),
+      source_location: sourceLocation(path, sym.line, sym.column),
+      ...(sym.endLine
+        ? {
+            source_span: {
+              path,
+              start_line: sym.line,
+              start_column: sym.column,
+              end_line: sym.endLine,
+              end_column: sym.endColumn,
+            },
+          }
+        : {}),
       language: lang,
       confidence: "EXTRACTED",
       provenance: {
         source_kind: "derived",
         writer: "extract-code",
         confidence: "EXTRACTED",
-        evidence: [`${path}:${sym.line}`],
+        evidence: [sourceLocation(path, sym.line)],
       },
       hash: contentHash(path, sym.name, sym.kind),
+      extraction_backend: backend,
     },
   }));
 
-  const imports = extractImportsForFile(path, null, source).map<MemoryNode>((imp) => ({
-    label: `import:${path}#${imp.specifier}`,
-    node_type: "import",
-    properties: {
-      title: imp.specifier,
-      summary: imp.kind === "relative" ? imp.resolvedPath : undefined,
-      source: path,
-      language: lang,
-      confidence: "EXTRACTED",
-      provenance: {
-        source_kind: "derived",
-        writer: "extract-code",
+  const imports = extractImportsForFile(path, null, source).map<MemoryNode>((imp) => {
+    const line = input.importLines?.get(imp.specifier);
+    const location = line ? sourceLocation(path, line) : path;
+    return {
+      label: `import:${path}#${imp.specifier}`,
+      node_type: "import",
+      properties: {
+        title: imp.specifier,
+        summary: imp.kind === "relative" ? imp.resolvedPath : undefined,
+        source: location,
+        source_location: location,
+        language: lang,
         confidence: "EXTRACTED",
-        evidence: [path],
+        provenance: {
+          source_kind: "derived",
+          writer: "extract-code",
+          confidence: "EXTRACTED",
+          evidence: [location],
+        },
+        hash: contentHash(path, "import", imp.specifier),
+        import_kind: imp.kind,
+        extraction_backend: backend,
+        ...(imp.resolvedPath ? { resolved_path: imp.resolvedPath } : {}),
       },
-      hash: contentHash(path, "import", imp.specifier),
-      import_kind: imp.kind,
-      ...(imp.resolvedPath ? { resolved_path: imp.resolvedPath } : {}),
-    },
-  }));
+    };
+  });
 
-  const edges: CodeExtraction["edges"] = symbols.map((s) => ({
-    fromLabel: s.label,
-    toLabel: fileNode.label,
-    label: "DEFINED_IN",
-  }));
+  const edges: CodeExtraction["edges"] = symbols.map((s) =>
+    codeEdge({
+      path,
+      fromLabel: s.label,
+      toLabel: fileNode.label,
+      label: "DEFINED_IN",
+      backend,
+      source: stringValue(s.properties.source) ?? path,
+      reason: "symbol is declared in file",
+    }),
+  );
   edges.push(
-    ...imports.map((imp) => ({
-      fromLabel: fileNode.label,
-      toLabel: imp.label,
-      label: "IMPORTS" as const,
-    })),
-    ...extractCallEdges(path, source, lang, symbolHits),
-    ...extractTypeEdges(path, source, lang, symbolHits),
+    ...imports.map((imp) =>
+      codeEdge({
+        path,
+        fromLabel: fileNode.label,
+        toLabel: imp.label,
+        label: "IMPORTS",
+        backend,
+        source: stringValue(imp.properties.source) ?? path,
+        reason: "file imports module specifier",
+      }),
+    ),
+    ...(input.extraEdges ?? []),
   );
 
   return { nodes: [fileNode, ...symbols, ...imports], edges };
 }
 
+interface CodeEdgeInput {
+  path: string;
+  fromLabel: string;
+  toLabel: string;
+  label: EdgeLabel;
+  backend: string;
+  source?: string;
+  reason?: string;
+  confidence?: Confidence;
+}
+
+function codeEdge(input: CodeEdgeInput): CodeEdgeExtraction {
+  const confidence = input.confidence ?? "EXTRACTED";
+  const weight = EDGE_WEIGHTS[input.label] ?? 1.0;
+  const evidence = input.source ?? input.path;
+  return {
+    fromLabel: input.fromLabel,
+    toLabel: input.toLabel,
+    label: input.label,
+    weight,
+    properties: {
+      confidence,
+      source: evidence,
+      source_location: evidence,
+      weight,
+      topological_weight: weight,
+      reason: input.reason,
+      extraction_backend: input.backend,
+      provenance: {
+        source_kind: "derived",
+        writer: "extract-code",
+        confidence,
+        evidence: [evidence],
+      },
+    },
+  };
+}
+
 interface SymbolHit {
   name: string;
-  kind: "function" | "class" | "interface" | "type" | "const" | "struct";
+  kind: "function" | "class" | "interface" | "type" | "const" | "struct" | "enum";
   line: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
   index: number;
+  tsSymbol?: TypeScript.Symbol;
+  node?: TypeScript.Node;
 }
 
 const PATTERNS: Record<string, Array<{ kind: SymbolHit["kind"]; re: RegExp }>> = {
@@ -170,7 +412,273 @@ function regexSymbols(source: string, lang: string): SymbolHit[] {
       hits.push({ name, kind, line, index: m.index ?? 0 });
     }
   }
+  return sortSymbols(hits);
+}
+
+function compilerSymbols(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  sourceFile: TypeScript.SourceFile,
+): SymbolHit[] {
+  const hits: SymbolHit[] = [];
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name) {
+      hits.push(symbolHitForNode(ts, checker, sourceFile, statement.name, statement, "function"));
+      continue;
+    }
+    if (ts.isClassDeclaration(statement) && statement.name) {
+      hits.push(symbolHitForNode(ts, checker, sourceFile, statement.name, statement, "class"));
+      continue;
+    }
+    if (ts.isInterfaceDeclaration(statement)) {
+      hits.push(symbolHitForNode(ts, checker, sourceFile, statement.name, statement, "interface"));
+      continue;
+    }
+    if (ts.isTypeAliasDeclaration(statement)) {
+      hits.push(symbolHitForNode(ts, checker, sourceFile, statement.name, statement, "type"));
+      continue;
+    }
+    if (ts.isEnumDeclaration(statement)) {
+      hits.push(symbolHitForNode(ts, checker, sourceFile, statement.name, statement, "enum"));
+      continue;
+    }
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) continue;
+        hits.push(symbolHitForNode(ts, checker, sourceFile, declaration.name, declaration, "const"));
+      }
+    }
+  }
+
+  return sortSymbols(hits);
+}
+
+function symbolHitForNode(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  sourceFile: TypeScript.SourceFile,
+  nameNode: TypeScript.Identifier,
+  node: TypeScript.Node,
+  kind: SymbolHit["kind"],
+): SymbolHit {
+  const start = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile));
+  const end = ts.getLineAndCharacterOfPosition(sourceFile, node.getEnd());
+  return {
+    name: nameNode.text,
+    kind,
+    line: start.line + 1,
+    column: start.character + 1,
+    endLine: end.line + 1,
+    endColumn: end.character + 1,
+    index: node.getStart(sourceFile),
+    tsSymbol: checker.getSymbolAtLocation(nameNode),
+    node,
+  };
+}
+
+function sortSymbols(hits: SymbolHit[]): SymbolHit[] {
   return hits.sort((a, b) => a.index - b.index || a.name.localeCompare(b.name));
+}
+
+function compilerExportedNames(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  sourceFile: TypeScript.SourceFile,
+  source: string,
+): string[] {
+  const names = new Set(exportedNames(source, "typescript"));
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (moduleSymbol) {
+    for (const exported of checker.getExportsOfModule(moduleSymbol)) {
+      if (exported.name !== "default") names.add(exported.name);
+    }
+  }
+  sourceFile.forEachChild((node) => {
+    if (
+      (ts.isFunctionDeclaration(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isInterfaceDeclaration(node) ||
+        ts.isTypeAliasDeclaration(node) ||
+        ts.isEnumDeclaration(node)) &&
+      node.name &&
+      hasExportModifier(ts, node)
+    ) {
+      names.add(node.name.text);
+    }
+  });
+  return [...names].sort();
+}
+
+function hasExportModifier(ts: typeof TypeScript, node: TypeScript.Node): boolean {
+  return Boolean(
+    ts.canHaveModifiers(node) &&
+      ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword),
+  );
+}
+
+function importLineMap(
+  ts: typeof TypeScript,
+  sourceFile: TypeScript.SourceFile,
+): Map<string, number> {
+  const lines = new Map<string, number>();
+  const remember = (literal: TypeScript.StringLiteralLike): void => {
+    const line = ts.getLineAndCharacterOfPosition(sourceFile, literal.getStart(sourceFile)).line + 1;
+    if (!lines.has(literal.text)) lines.set(literal.text, line);
+  };
+  for (const statement of sourceFile.statements) {
+    if (
+      (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)) &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteralLike(statement.moduleSpecifier)
+    ) {
+      remember(statement.moduleSpecifier);
+    }
+  }
+  return lines;
+}
+
+function compilerCallEdges(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  sourceFile: TypeScript.SourceFile,
+  path: string,
+  symbols: SymbolHit[],
+): CodeExtraction["edges"] {
+  const bySymbol = localSymbolMap(checker, symbols);
+  const byName = new Map(symbols.map((symbol) => [symbol.name, symbol]));
+  const callable = new Set(
+    symbols
+      .filter((symbol) => symbol.kind === "function" || symbol.kind === "const" || symbol.kind === "class")
+      .map((symbol) => symbol.name),
+  );
+  const edges: CodeExtraction["edges"] = [];
+
+  for (const from of symbols) {
+    if (!from.node || !callable.has(from.name)) continue;
+    const called = new Map<string, number>();
+    visit(from.node, (node) => {
+      if (!ts.isCallExpression(node) && !ts.isNewExpression(node)) return;
+      const expression = node.expression;
+      const symbol = checker.getSymbolAtLocation(
+        ts.isPropertyAccessExpression(expression) ? expression.name : expression,
+      );
+      const resolved = resolveAlias(checker, symbol);
+      const to = (resolved ? bySymbol.get(resolved) : undefined) ?? byName.get(symbol?.name ?? "");
+      if (!to || to.name === from.name || !callable.has(to.name)) return;
+      const line = ts.getLineAndCharacterOfPosition(sourceFile, expression.getStart(sourceFile)).line + 1;
+      called.set(to.name, line);
+    });
+    for (const [name, line] of called) {
+      edges.push(
+        codeEdge({
+          path,
+          fromLabel: `sym:${path}#${from.name}`,
+          toLabel: `sym:${path}#${name}`,
+          label: "CALLS",
+          backend: "typescript-compiler",
+          source: sourceLocation(path, line),
+          reason: "checker resolved call expression to local symbol",
+        }),
+      );
+    }
+  }
+  return edges;
+}
+
+function compilerTypeEdges(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  sourceFile: TypeScript.SourceFile,
+  path: string,
+  symbols: SymbolHit[],
+): CodeExtraction["edges"] {
+  const bySymbol = localSymbolMap(checker, symbols);
+  const byName = new Map(symbols.map((symbol) => [symbol.name, symbol]));
+  const typeNames = new Set(
+    symbols
+      .filter((symbol) => symbol.kind === "type" || symbol.kind === "interface" || symbol.kind === "class" || symbol.kind === "enum")
+      .map((symbol) => symbol.name),
+  );
+  const edges: CodeExtraction["edges"] = [];
+
+  for (const from of symbols) {
+    if (!from.node) continue;
+    const used = new Map<string, number>();
+    visit(from.node, (node) => {
+      const targetNode = typeReferenceNameNode(ts, node);
+      if (!targetNode) return;
+      const symbol = checker.getSymbolAtLocation(targetNode);
+      const resolved = resolveAlias(checker, symbol);
+      const to = (resolved ? bySymbol.get(resolved) : undefined) ?? byName.get(targetNode.getText(sourceFile));
+      if (!to || to.name === from.name || !typeNames.has(to.name)) return;
+      const line = ts.getLineAndCharacterOfPosition(sourceFile, targetNode.getStart(sourceFile)).line + 1;
+      used.set(to.name, line);
+    });
+    for (const [name, line] of used) {
+      edges.push(
+        codeEdge({
+          path,
+          fromLabel: `sym:${path}#${from.name}`,
+          toLabel: `sym:${path}#${name}`,
+          label: "USES_TYPE",
+          backend: "typescript-compiler",
+          source: sourceLocation(path, line),
+          reason: "checker resolved type reference to local symbol",
+        }),
+      );
+    }
+  }
+
+  return edges;
+}
+
+function localSymbolMap(
+  checker: TypeScript.TypeChecker,
+  symbols: SymbolHit[],
+): Map<TypeScript.Symbol, SymbolHit> {
+  const bySymbol = new Map<TypeScript.Symbol, SymbolHit>();
+  for (const symbol of symbols) {
+    if (!symbol.tsSymbol) continue;
+    bySymbol.set(symbol.tsSymbol, symbol);
+    const resolved = resolveAlias(checker, symbol.tsSymbol);
+    if (resolved) bySymbol.set(resolved, symbol);
+  }
+  return bySymbol;
+}
+
+function resolveAlias(
+  checker: TypeScript.TypeChecker,
+  symbol: TypeScript.Symbol | undefined,
+): TypeScript.Symbol | undefined {
+  if (!symbol) return undefined;
+  try {
+    return checker.getAliasedSymbol(symbol);
+  } catch {
+    return symbol;
+  }
+}
+
+function typeReferenceNameNode(
+  ts: typeof TypeScript,
+  node: TypeScript.Node,
+): TypeScript.Node | null {
+  if (ts.isTypeReferenceNode(node)) {
+    return rightmostEntityName(ts, node.typeName);
+  }
+  if (ts.isExpressionWithTypeArguments(node)) {
+    return ts.isPropertyAccessExpression(node.expression) ? node.expression.name : node.expression;
+  }
+  return null;
+}
+
+function rightmostEntityName(ts: typeof TypeScript, name: TypeScript.EntityName): TypeScript.Node {
+  return ts.isQualifiedName(name) ? name.right : name;
+}
+
+function visit(node: TypeScript.Node, each: (node: TypeScript.Node) => void): void {
+  each(node);
+  node.forEachChild((child) => visit(child, each));
 }
 
 function extractCallEdges(
@@ -178,8 +686,9 @@ function extractCallEdges(
   source: string,
   lang: string,
   symbols: SymbolHit[],
+  backend: string,
 ): CodeExtraction["edges"] {
-  if (!["typescript", "tsx", "javascript"].includes(lang) || symbols.length === 0) {
+  if (!TS_JS_LANGS.has(lang) || symbols.length === 0) {
     return [];
   }
   const callableNames = new Set(
@@ -200,11 +709,17 @@ function extractCallEdges(
       called.add(name);
     }
     for (const name of called) {
-      edges.push({
-        fromLabel: `sym:${path}#${from.name}`,
-        toLabel: `sym:${path}#${name}`,
-        label: "CALLS",
-      });
+      edges.push(
+        codeEdge({
+          path,
+          fromLabel: `sym:${path}#${from.name}`,
+          toLabel: `sym:${path}#${name}`,
+          label: "CALLS",
+          backend,
+          source: sourceLocation(path, from.line),
+          reason: "regex scanner found local call expression",
+        }),
+      );
     }
   }
   return edges;
@@ -215,13 +730,14 @@ function extractTypeEdges(
   source: string,
   lang: string,
   symbols: SymbolHit[],
+  backend: string,
 ): CodeExtraction["edges"] {
-  if (!["typescript", "tsx", "javascript"].includes(lang) || symbols.length === 0) {
+  if (!TS_JS_LANGS.has(lang) || symbols.length === 0) {
     return [];
   }
   const typeNames = new Set(
     symbols
-      .filter((symbol) => symbol.kind === "type" || symbol.kind === "interface" || symbol.kind === "class")
+      .filter((symbol) => symbol.kind === "type" || symbol.kind === "interface" || symbol.kind === "class" || symbol.kind === "enum")
       .map((symbol) => symbol.name),
   );
   const edges: CodeExtraction["edges"] = [];
@@ -235,11 +751,17 @@ function extractTypeEdges(
       if (new RegExp(`\\b${escapeRegExp(name)}\\b`).test(body)) used.add(name);
     }
     for (const name of used) {
-      edges.push({
-        fromLabel: `sym:${path}#${from.name}`,
-        toLabel: `sym:${path}#${name}`,
-        label: "USES_TYPE",
-      });
+      edges.push(
+        codeEdge({
+          path,
+          fromLabel: `sym:${path}#${from.name}`,
+          toLabel: `sym:${path}#${name}`,
+          label: "USES_TYPE",
+          backend,
+          source: sourceLocation(path, from.line),
+          reason: "regex scanner found local type reference",
+        }),
+      );
     }
   }
   return edges;
@@ -249,6 +771,14 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function sourceLocation(path: string, line: number, column?: number): string {
+  return column == null ? `${path}:${line}` : `${path}:${line}:${column}`;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 /**
  * Conservative, deterministic list of a file's exported names. Covers the
  * common declaration and re-export forms across the supported languages:
@@ -256,11 +786,11 @@ function escapeRegExp(value: string): string {
  *  - `export { a, b as c }` named clauses (TS/JS)
  *  - `pub fn/struct/trait/enum <name>` (Rust)
  * Python and Go have no keyword-level export marker (Go uses capitalization),
- * so they contribute nothing here — `exports` stays empty rather than guessing.
+ * so they contribute nothing here - `exports` stays empty rather than guessing.
  */
 function exportedNames(source: string, lang: string): string[] {
   const names = new Set<string>();
-  if (["typescript", "tsx", "javascript"].includes(lang)) {
+  if (TS_JS_LANGS.has(lang)) {
     const decl =
       /^\s*export\s+(?:default\s+)?(?:async\s+)?(?:abstract\s+)?(?:function|class|interface|type|const|let|var)\s+([A-Za-z_]\w*)/gm;
     for (const m of source.matchAll(decl)) if (m[1]) names.add(m[1]);
@@ -275,5 +805,5 @@ function exportedNames(source: string, lang: string): string[] {
     const decl = /^\s*pub\s+(?:async\s+)?(?:fn|struct|trait|enum|type|const|static)\s+([A-Za-z_]\w*)/gm;
     for (const m of source.matchAll(decl)) if (m[1]) names.add(m[1]);
   }
-  return [...names];
+  return [...names].sort();
 }

--- a/src/apps/memory/src/ingest.ts
+++ b/src/apps/memory/src/ingest.ts
@@ -9,7 +9,7 @@ import { extractSql } from "./extract-sql.js";
 import { contentHash } from "./hash.js";
 import { readMemoryIgnore } from "./scope.js";
 import type { MemoryStore } from "./graph-store.js";
-import type { EdgeLabel, MemoryDoc, MemoryNode } from "./schema.js";
+import type { EdgeLabel, MemoryDoc, MemoryEdgeProps, MemoryNode } from "./schema.js";
 
 export interface IngestOptions {
   /** Root directory to walk. */
@@ -125,7 +125,13 @@ interface FileExtraction {
   doc?: MemoryDoc;
   nodes: MemoryNode[];
   edges: Array<
-    | { fromLabel: string; toLabel: string; label: EdgeLabel }
+    | {
+        fromLabel: string;
+        toLabel: string;
+        label: EdgeLabel;
+        weight?: number;
+        properties?: MemoryEdgeProps;
+      }
     | { fromHash: string; toLabel: string; label: EdgeLabel }
   >;
   elements: string[];
@@ -223,7 +229,13 @@ async function writeExtraction(
       if (!("toLabel" in e)) continue;
       const toRid = await store.findNodeByLabel(e.toLabel);
       if (rootRid != null && toRid != null) {
-        await store.upsertEdge({ from_rid: rootRid, to_rid: toRid, label: e.label });
+        await store.upsertEdge({
+          from_rid: rootRid,
+          to_rid: toRid,
+          label: e.label,
+          ...("weight" in e && e.weight != null ? { weight: e.weight } : {}),
+          ...("properties" in e && e.properties ? { properties: e.properties } : {}),
+        });
         report.edges += 1;
       }
     }
@@ -239,7 +251,13 @@ async function writeExtraction(
       const fromRid = labelToRid.get(e.fromLabel);
       const toRid = labelToRid.get(e.toLabel);
       if (fromRid != null && toRid != null) {
-        await store.upsertEdge({ from_rid: fromRid, to_rid: toRid, label: e.label });
+        await store.upsertEdge({
+          from_rid: fromRid,
+          to_rid: toRid,
+          label: e.label,
+          weight: e.weight,
+          properties: e.properties,
+        });
         report.edges += 1;
       }
     }

--- a/src/apps/memory/src/schema.ts
+++ b/src/apps/memory/src/schema.ts
@@ -216,7 +216,11 @@ export interface MemoryEdgeProps {
   confidence?: Confidence;
   source?: string;
   weight?: number;
+  topological_weight?: number;
   reason?: string;
+  provenance?: MemoryProvenance;
+  extraction_backend?: string;
+  source_location?: string;
   created_at?: number;
   [extra: string]: unknown;
 }

--- a/src/apps/memory/tests/extract-code.test.ts
+++ b/src/apps/memory/tests/extract-code.test.ts
@@ -53,21 +53,67 @@ describe("extractCode", () => {
   test("emits conservative intra-file CALLS edges for TS/JS symbols", async () => {
     const { edges } = await extractCode(TS_FIXTURE);
 
-    expect(edges).toContainEqual({
-      fromLabel: `sym:${TS_FIXTURE}#issueToken`,
-      toLabel: `sym:${TS_FIXTURE}#verifyToken`,
-      label: "CALLS",
-    });
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        fromLabel: `sym:${TS_FIXTURE}#issueToken`,
+        toLabel: `sym:${TS_FIXTURE}#verifyToken`,
+        label: "CALLS",
+      }),
+    );
   });
 
   test("emits conservative intra-file USES_TYPE edges for TS/JS symbols", async () => {
     const { edges } = await extractCode(TS_FIXTURE);
 
-    expect(edges).toContainEqual({
-      fromLabel: `sym:${TS_FIXTURE}#issueToken`,
-      toLabel: `sym:${TS_FIXTURE}#UserId`,
-      label: "USES_TYPE",
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        fromLabel: `sym:${TS_FIXTURE}#issueToken`,
+        toLabel: `sym:${TS_FIXTURE}#UserId`,
+        label: "USES_TYPE",
+      }),
+    );
+  });
+
+  test("uses compiler-backed TypeScript extraction with locations and edge metadata", async () => {
+    const { nodes, edges } = await extractCode(TS_FIXTURE);
+
+    const file = nodes.find((n) => n.node_type === "file");
+    const issueToken = nodes.find((n) => n.label === `sym:${TS_FIXTURE}#issueToken`);
+    const call = edges.find((e) => e.label === "CALLS");
+
+    expect(file?.properties.extraction_backend).toBe("typescript-compiler");
+    expect(issueToken?.properties.source_location).toMatch(/auth\.ts:\d+:\d+$/);
+    expect(call).toEqual(
+      expect.objectContaining({
+        weight: expect.any(Number),
+        properties: expect.objectContaining({
+          confidence: "EXTRACTED",
+          extraction_backend: "typescript-compiler",
+          topological_weight: expect.any(Number),
+          provenance: expect.objectContaining({
+            source_kind: "derived",
+            writer: "extract-code",
+            confidence: "EXTRACTED",
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("marks TypeScript extraction as degraded when compiler extraction is unavailable", async () => {
+    const { nodes, edges } = await extractCode(TS_FIXTURE, {
+      loadTypeScript: async () => null,
     });
+
+    const file = nodes.find((n) => n.node_type === "file");
+    const call = edges.find((e) => e.label === "CALLS");
+
+    expect(file?.properties.extraction_backend).toBe("regex-fallback");
+    expect(file?.properties.extraction_degraded).toBe(true);
+    expect(file?.properties.extraction_degradation_reason).toBe(
+      "typescript compiler unavailable",
+    );
+    expect(call?.properties?.extraction_backend).toBe("regex-fallback");
   });
 
   test("emits IMPORTS edges from the file node to import specifier nodes", async () => {

--- a/src/apps/memory/tests/ingest.test.ts
+++ b/src/apps/memory/tests/ingest.test.ts
@@ -86,11 +86,23 @@ describe("ingestProject over a TS+MD fixture repo", () => {
       expect(issueToken).toBeDefined();
       expect(verifyToken).toBeDefined();
       expect(userId).toBeDefined();
-      expect(edges).toContainEqual(
+      const callEdge = edges.find(
+        (edge) =>
+          edge.from_rid === issueToken?.rid &&
+          edge.to_rid === verifyToken?.rid &&
+          edge.label === "CALLS",
+      );
+      expect(callEdge).toBeDefined();
+      expect(Number(callEdge?.weight ?? callEdge?.WEIGHT)).toBeGreaterThan(0);
+      expect(callEdge?.properties ?? callEdge?.PROPERTIES).toEqual(
         expect.objectContaining({
-          from_rid: issueToken?.rid,
-          to_rid: verifyToken?.rid,
-          label: "CALLS",
+          confidence: "EXTRACTED",
+          extraction_backend: "typescript-compiler",
+          topological_weight: expect.any(Number),
+          provenance: expect.objectContaining({
+            source_kind: "derived",
+            writer: "extract-code",
+          }),
         }),
       );
       expect(edges).toContainEqual(


### PR DESCRIPTION
Closes #522.\n\n## Summary\n- Add compiler-backed TypeScript/TSX extraction for Memory code maps with stable file/symbol/import nodes and source locations.\n- Persist IMPORTS/CALLS/USES_TYPE/DEFINED_IN edge metadata with confidence, provenance, and initial topological weights.\n- Keep a marked regex fallback when TypeScript compiler extraction is unavailable.\n\n## Validation\n- pnpm --dir src/apps/memory typecheck\n- pnpm --dir src/apps/memory exec vitest run tests/extract-code.test.ts tests/ingest.test.ts\n- pnpm --dir src/apps/memory lint:deterministic-extractors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783381578&installation_id=129708444&pr_number=529&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F529&signature=f0040ecf6847daca899e75d8a46628df2d2d401f4480bfe7d8f55e3a4be241f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TypeScript compiler-based code extraction for improved accuracy in identifying symbols and code relationships.

* **Refactor**
  * Enhanced code relationship metadata with extraction source tracking, confidence scoring, and improved provenance information.
  * Updated extraction API to support configurable backends with automatic fallback to regex-based extraction for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->