### PR TITLE
Extract cross-file TypeScript map edges

### DIFF
--- a/src/apps/memory/src/extract-code.ts
+++ b/src/apps/memory/src/extract-code.ts
@@ -110,18 +110,17 @@ async function extractTypeScriptMap(
     const symbols = compilerSymbols(ts, checker, sourceFile);
     const exports = compilerExportedNames(ts, checker, sourceFile, source);
     const imports = importLineMap(ts, sourceFile);
+    const compilerRelations = compilerRelationEdges(ts, checker, sourceFile, path, symbols);
     const extraction = buildExtraction({
       path,
       source,
       lang,
       symbols,
+      externalSymbols: compilerRelations.externalSymbols,
       exports,
       backend: "typescript-compiler",
       importLines: imports,
-      extraEdges: [
-        ...compilerCallEdges(ts, checker, sourceFile, path, symbols),
-        ...compilerTypeEdges(ts, checker, sourceFile, path, symbols),
-      ],
+      extraEdges: compilerRelations.edges,
     });
     return { extraction };
   } catch (error) {
@@ -202,6 +201,7 @@ interface BuildExtractionInput {
   source: string;
   lang: string;
   symbols: SymbolHit[];
+  externalSymbols?: SymbolHit[];
   exports: string[];
   backend: string;
   fallbackReason?: string;
@@ -235,18 +235,19 @@ function buildExtraction(input: BuildExtractionInput): CodeExtraction {
     },
   };
 
-  const symbols = symbolHits.map<MemoryNode>((sym) => ({
-    label: `sym:${path}#${sym.name}`,
+  const allSymbols = dedupeSymbols([...symbolHits, ...(input.externalSymbols ?? [])], path);
+  const symbolNodes = allSymbols.map<MemoryNode>((sym) => ({
+    label: symbolLabel(sym, path),
     node_type: "symbol",
     properties: {
       title: sym.name,
       summary: sym.kind,
-      source: sourceLocation(path, sym.line),
-      source_location: sourceLocation(path, sym.line, sym.column),
+      source: sourceLocation(symbolPath(sym, path), sym.line),
+      source_location: sourceLocation(symbolPath(sym, path), sym.line, sym.column),
       ...(sym.endLine
         ? {
             source_span: {
-              path,
+              path: symbolPath(sym, path),
               start_line: sym.line,
               start_column: sym.column,
               end_line: sym.endLine,
@@ -260,12 +261,13 @@ function buildExtraction(input: BuildExtractionInput): CodeExtraction {
         source_kind: "derived",
         writer: "extract-code",
         confidence: "EXTRACTED",
-        evidence: [sourceLocation(path, sym.line)],
+        evidence: [sourceLocation(symbolPath(sym, path), sym.line)],
       },
-      hash: contentHash(path, sym.name, sym.kind),
+      hash: contentHash(symbolPath(sym, path), sym.name, sym.kind),
       extraction_backend: backend,
     },
   }));
+  const localSymbolLabels = new Set(symbolHits.map((sym) => symbolLabel(sym, path)));
 
   const imports = extractImportsForFile(path, null, source).map<MemoryNode>((imp) => {
     const line = input.importLines?.get(imp.specifier);
@@ -294,17 +296,19 @@ function buildExtraction(input: BuildExtractionInput): CodeExtraction {
     };
   });
 
-  const edges: CodeExtraction["edges"] = symbols.map((s) =>
-    codeEdge({
-      path,
-      fromLabel: s.label,
-      toLabel: fileNode.label,
-      label: "DEFINED_IN",
-      backend,
-      source: stringValue(s.properties.source) ?? path,
-      reason: "symbol is declared in file",
-    }),
-  );
+  const edges: CodeExtraction["edges"] = symbolNodes
+    .filter((s) => localSymbolLabels.has(s.label))
+    .map((s) =>
+      codeEdge({
+        path,
+        fromLabel: s.label,
+        toLabel: fileNode.label,
+        label: "DEFINED_IN",
+        backend,
+        source: stringValue(s.properties.source) ?? path,
+        reason: "symbol is declared in file",
+      }),
+    );
   edges.push(
     ...imports.map((imp) =>
       codeEdge({
@@ -320,7 +324,7 @@ function buildExtraction(input: BuildExtractionInput): CodeExtraction {
     ...(input.extraEdges ?? []),
   );
 
-  return { nodes: [fileNode, ...symbols, ...imports], edges };
+  return { nodes: [fileNode, ...symbolNodes, ...imports], edges };
 }
 
 interface CodeEdgeInput {
@@ -369,6 +373,7 @@ interface SymbolHit {
   endLine?: number;
   endColumn?: number;
   index: number;
+  sourcePath?: string;
   tsSymbol?: TypeScript.Symbol;
   node?: TypeScript.Node;
 }
@@ -477,6 +482,23 @@ function symbolHitForNode(
   };
 }
 
+function symbolPath(sym: SymbolHit, fallbackPath: string): string {
+  return sym.sourcePath ?? fallbackPath;
+}
+
+function symbolLabel(sym: SymbolHit, fallbackPath: string): string {
+  return `sym:${symbolPath(sym, fallbackPath)}#${sym.name}`;
+}
+
+function dedupeSymbols(symbols: SymbolHit[], fallbackPath: string): SymbolHit[] {
+  const byLabel = new Map<string, SymbolHit>();
+  for (const symbol of symbols) {
+    const label = symbolLabel(symbol, fallbackPath);
+    if (!byLabel.has(label)) byLabel.set(label, symbol);
+  }
+  return [...byLabel.values()];
+}
+
 function sortSymbols(hits: SymbolHit[]): SymbolHit[] {
   return hits.sort((a, b) => a.index - b.index || a.name.localeCompare(b.name));
 }
@@ -538,25 +560,120 @@ function importLineMap(
   return lines;
 }
 
+interface CompilerRelationExtraction {
+  edges: CodeExtraction["edges"];
+  externalSymbols: SymbolHit[];
+}
+
+function compilerRelationEdges(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  sourceFile: TypeScript.SourceFile,
+  path: string,
+  symbols: SymbolHit[],
+): CompilerRelationExtraction {
+  const externals = new Map<string, SymbolHit>();
+  const externalSymbol = (symbol: TypeScript.Symbol | undefined): SymbolHit | undefined => {
+    const hit = compilerExternalSymbol(ts, checker, sourceFile, symbol);
+    if (!hit) return undefined;
+    const label = symbolLabel(hit, path);
+    const existing = externals.get(label);
+    if (existing) return existing;
+    externals.set(label, hit);
+    return hit;
+  };
+  return {
+    edges: [
+      ...compilerCallEdges(ts, checker, sourceFile, path, symbols, externalSymbol),
+      ...compilerTypeEdges(ts, checker, sourceFile, path, symbols, externalSymbol),
+    ],
+    externalSymbols: [...externals.values()],
+  };
+}
+
+function compilerExternalSymbol(
+  ts: typeof TypeScript,
+  checker: TypeScript.TypeChecker,
+  currentSourceFile: TypeScript.SourceFile,
+  symbol: TypeScript.Symbol | undefined,
+): SymbolHit | undefined {
+  const resolved = resolveAlias(checker, symbol);
+  const declaration = resolved?.declarations?.find((candidate) => {
+    const declarationSource = candidate.getSourceFile();
+    return (
+      declarationSource.fileName !== currentSourceFile.fileName &&
+      !declarationSource.isDeclarationFile &&
+      declarationKind(ts, candidate) != null
+    );
+  });
+  if (!declaration) return undefined;
+
+  const sourceFile = declaration.getSourceFile();
+  const nameNode = declarationNameNode(ts, declaration);
+  const kind = declarationKind(ts, declaration);
+  if (!nameNode || !kind) return undefined;
+
+  return {
+    ...symbolHitForNode(ts, checker, sourceFile, nameNode, declaration, kind),
+    sourcePath: sourceFile.fileName,
+  };
+}
+
+function declarationNameNode(
+  ts: typeof TypeScript,
+  node: TypeScript.Declaration,
+): TypeScript.Identifier | undefined {
+  if (
+    (ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isEnumDeclaration(node) ||
+      ts.isVariableDeclaration(node)) &&
+    node.name &&
+    ts.isIdentifier(node.name)
+  ) {
+    return node.name;
+  }
+  return undefined;
+}
+
+function declarationKind(
+  ts: typeof TypeScript,
+  node: TypeScript.Declaration,
+): SymbolHit["kind"] | undefined {
+  if (ts.isFunctionDeclaration(node)) return "function";
+  if (ts.isClassDeclaration(node)) return "class";
+  if (ts.isInterfaceDeclaration(node)) return "interface";
+  if (ts.isTypeAliasDeclaration(node)) return "type";
+  if (ts.isEnumDeclaration(node)) return "enum";
+  if (ts.isVariableDeclaration(node)) return "const";
+  return undefined;
+}
+
+function isCallableKind(kind: SymbolHit["kind"]): boolean {
+  return kind === "function" || kind === "const" || kind === "class";
+}
+
+function isTypeKind(kind: SymbolHit["kind"]): boolean {
+  return kind === "type" || kind === "interface" || kind === "class" || kind === "enum";
+}
+
 function compilerCallEdges(
   ts: typeof TypeScript,
   checker: TypeScript.TypeChecker,
   sourceFile: TypeScript.SourceFile,
   path: string,
   symbols: SymbolHit[],
+  externalSymbol?: (symbol: TypeScript.Symbol | undefined) => SymbolHit | undefined,
 ): CodeExtraction["edges"] {
   const bySymbol = localSymbolMap(checker, symbols);
   const byName = new Map(symbols.map((symbol) => [symbol.name, symbol]));
-  const callable = new Set(
-    symbols
-      .filter((symbol) => symbol.kind === "function" || symbol.kind === "const" || symbol.kind === "class")
-      .map((symbol) => symbol.name),
-  );
   const edges: CodeExtraction["edges"] = [];
 
   for (const from of symbols) {
-    if (!from.node || !callable.has(from.name)) continue;
-    const called = new Map<string, number>();
+    if (!from.node || !isCallableKind(from.kind)) continue;
+    const called = new Map<string, { symbol: SymbolHit; line: number }>();
     visit(from.node, (node) => {
       if (!ts.isCallExpression(node) && !ts.isNewExpression(node)) return;
       const expression = node.expression;
@@ -564,21 +681,31 @@ function compilerCallEdges(
         ts.isPropertyAccessExpression(expression) ? expression.name : expression,
       );
       const resolved = resolveAlias(checker, symbol);
-      const to = (resolved ? bySymbol.get(resolved) : undefined) ?? byName.get(symbol?.name ?? "");
-      if (!to || to.name === from.name || !callable.has(to.name)) return;
-      const line = ts.getLineAndCharacterOfPosition(sourceFile, expression.getStart(sourceFile)).line + 1;
-      called.set(to.name, line);
+      const to =
+        (resolved ? bySymbol.get(resolved) : undefined) ??
+        byName.get(symbol?.name ?? "") ??
+        externalSymbol?.(resolved ?? symbol);
+      if (
+        !to ||
+        symbolLabel(to, path) === symbolLabel(from, path) ||
+        !isCallableKind(to.kind)
+      ) {
+        return;
+      }
+      const line =
+        ts.getLineAndCharacterOfPosition(sourceFile, expression.getStart(sourceFile)).line + 1;
+      called.set(symbolLabel(to, path), { symbol: to, line });
     });
-    for (const [name, line] of called) {
+    for (const { symbol, line } of called.values()) {
       edges.push(
         codeEdge({
           path,
-          fromLabel: `sym:${path}#${from.name}`,
-          toLabel: `sym:${path}#${name}`,
+          fromLabel: symbolLabel(from, path),
+          toLabel: symbolLabel(symbol, path),
           label: "CALLS",
           backend: "typescript-compiler",
           source: sourceLocation(path, line),
-          reason: "checker resolved call expression to local symbol",
+          reason: "checker resolved call expression to symbol",
         }),
       );
     }
@@ -592,39 +719,41 @@ function compilerTypeEdges(
   sourceFile: TypeScript.SourceFile,
   path: string,
   symbols: SymbolHit[],
+  externalSymbol?: (symbol: TypeScript.Symbol | undefined) => SymbolHit | undefined,
 ): CodeExtraction["edges"] {
   const bySymbol = localSymbolMap(checker, symbols);
   const byName = new Map(symbols.map((symbol) => [symbol.name, symbol]));
-  const typeNames = new Set(
-    symbols
-      .filter((symbol) => symbol.kind === "type" || symbol.kind === "interface" || symbol.kind === "class" || symbol.kind === "enum")
-      .map((symbol) => symbol.name),
-  );
   const edges: CodeExtraction["edges"] = [];
 
   for (const from of symbols) {
     if (!from.node) continue;
-    const used = new Map<string, number>();
+    const used = new Map<string, { symbol: SymbolHit; line: number }>();
     visit(from.node, (node) => {
       const targetNode = typeReferenceNameNode(ts, node);
       if (!targetNode) return;
       const symbol = checker.getSymbolAtLocation(targetNode);
       const resolved = resolveAlias(checker, symbol);
-      const to = (resolved ? bySymbol.get(resolved) : undefined) ?? byName.get(targetNode.getText(sourceFile));
-      if (!to || to.name === from.name || !typeNames.has(to.name)) return;
-      const line = ts.getLineAndCharacterOfPosition(sourceFile, targetNode.getStart(sourceFile)).line + 1;
-      used.set(to.name, line);
+      const to =
+        (resolved ? bySymbol.get(resolved) : undefined) ??
+        byName.get(targetNode.getText(sourceFile)) ??
+        externalSymbol?.(resolved ?? symbol);
+      if (!to || symbolLabel(to, path) === symbolLabel(from, path) || !isTypeKind(to.kind)) {
+        return;
+      }
+      const line =
+        ts.getLineAndCharacterOfPosition(sourceFile, targetNode.getStart(sourceFile)).line + 1;
+      used.set(symbolLabel(to, path), { symbol: to, line });
     });
-    for (const [name, line] of used) {
+    for (const { symbol, line } of used.values()) {
       edges.push(
         codeEdge({
           path,
-          fromLabel: `sym:${path}#${from.name}`,
-          toLabel: `sym:${path}#${name}`,
+          fromLabel: symbolLabel(from, path),
+          toLabel: symbolLabel(symbol, path),
           label: "USES_TYPE",
           backend: "typescript-compiler",
           source: sourceLocation(path, line),
-          reason: "checker resolved type reference to local symbol",
+          reason: "checker resolved type reference to symbol",
         }),
       );
     }

--- a/src/apps/memory/src/extract-code.ts
+++ b/src/apps/memory/src/extract-code.ts
@@ -822,7 +822,7 @@ function extractCallEdges(
   }
   const callableNames = new Set(
     symbols
-      .filter((symbol) => symbol.kind === "function" || symbol.kind === "const" || symbol.kind === "class")
+      .filter((symbol) => isCallableKind(symbol.kind))
       .map((symbol) => symbol.name),
   );
   const edges: CodeExtraction["edges"] = [];
@@ -866,7 +866,7 @@ function extractTypeEdges(
   }
   const typeNames = new Set(
     symbols
-      .filter((symbol) => symbol.kind === "type" || symbol.kind === "interface" || symbol.kind === "class" || symbol.kind === "enum")
+      .filter((symbol) => isTypeKind(symbol.kind))
       .map((symbol) => symbol.name),
   );
   const edges: CodeExtraction["edges"] = [];

--- a/src/apps/memory/tests/extract-code.test.ts
+++ b/src/apps/memory/tests/extract-code.test.ts
@@ -6,6 +6,7 @@ import { extractCode } from "../src/extract-code.js";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const TS_FIXTURE = join(HERE, "fixtures/repo/src/auth.ts");
 const IMPORT_FIXTURE = join(HERE, "fixtures/imports/src/app.ts");
+const IMPORT_LOCAL_FIXTURE = join(HERE, "fixtures/imports/src/local.ts");
 
 describe("extractCode", () => {
   test("extracts a file node plus one symbol per top-level declaration", async () => {
@@ -137,6 +138,47 @@ describe("extractCode", () => {
       expect(edge.fromLabel).toBe(fileNode?.label);
       expect(imports.some((n) => n.label === edge.toLabel)).toBe(true);
     }
+  });
+
+  test("emits compiler-resolved cross-file CALLS and USES_TYPE edges", async () => {
+    const { nodes, edges } = await extractCode(IMPORT_FIXTURE);
+
+    expect(nodes).toContainEqual(
+      expect.objectContaining({
+        label: `sym:${IMPORT_LOCAL_FIXTURE}#localValue`,
+        node_type: "symbol",
+        properties: expect.objectContaining({
+          title: "localValue",
+          source_location: expect.stringContaining(`${IMPORT_LOCAL_FIXTURE}:`),
+          extraction_backend: "typescript-compiler",
+        }),
+      }),
+    );
+    expect(nodes).toContainEqual(
+      expect.objectContaining({
+        label: `sym:${IMPORT_LOCAL_FIXTURE}#LocalOptions`,
+        node_type: "symbol",
+      }),
+    );
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        fromLabel: `sym:${IMPORT_FIXTURE}#render`,
+        toLabel: `sym:${IMPORT_LOCAL_FIXTURE}#localValue`,
+        label: "CALLS",
+        properties: expect.objectContaining({
+          confidence: "EXTRACTED",
+          extraction_backend: "typescript-compiler",
+          topological_weight: expect.any(Number),
+        }),
+      }),
+    );
+    expect(edges).toContainEqual(
+      expect.objectContaining({
+        fromLabel: `sym:${IMPORT_FIXTURE}#render`,
+        toLabel: `sym:${IMPORT_LOCAL_FIXTURE}#LocalOptions`,
+        label: "USES_TYPE",
+      }),
+    );
   });
 
   test("ignores unsupported file extensions", async () => {

--- a/src/apps/memory/tests/extract-code.test.ts
+++ b/src/apps/memory/tests/extract-code.test.ts
@@ -158,6 +158,11 @@ describe("extractCode", () => {
       expect.objectContaining({
         label: `sym:${IMPORT_LOCAL_FIXTURE}#LocalOptions`,
         node_type: "symbol",
+        properties: expect.objectContaining({
+          title: "LocalOptions",
+          source_location: expect.stringContaining(`${IMPORT_LOCAL_FIXTURE}:`),
+          extraction_backend: "typescript-compiler",
+        }),
       }),
     );
     expect(edges).toContainEqual(
@@ -177,6 +182,11 @@ describe("extractCode", () => {
         fromLabel: `sym:${IMPORT_FIXTURE}#render`,
         toLabel: `sym:${IMPORT_LOCAL_FIXTURE}#LocalOptions`,
         label: "USES_TYPE",
+        properties: expect.objectContaining({
+          confidence: "EXTRACTED",
+          extraction_backend: "typescript-compiler",
+          topological_weight: expect.any(Number),
+        }),
       }),
     );
   });

--- a/src/apps/memory/tests/fixtures/imports/src/app.ts
+++ b/src/apps/memory/tests/fixtures/imports/src/app.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
-import { localValue } from "./local.js";
+import { localValue, type LocalOptions } from "./local.js";
 
-export function render(): string {
-  return join("fixture", localValue);
+export function render(options: LocalOptions): string {
+  return join("fixture", localValue(options));
 }

--- a/src/apps/memory/tests/fixtures/imports/src/local.ts
+++ b/src/apps/memory/tests/fixtures/imports/src/local.ts
@@ -1,1 +1,7 @@
-export const localValue = "fixture";
+export type LocalOptions = {
+  value: string;
+};
+
+export function localValue(options: LocalOptions): string {
+  return options.value;
+}

--- a/src/apps/memory/tests/ingest.test.ts
+++ b/src/apps/memory/tests/ingest.test.ts
@@ -247,6 +247,19 @@ describe("ingestProject over a TS+MD fixture repo", () => {
       const after = await store.stats();
       expect(after.edges).toBe(before.edges);
       expect(after.nodes).toBe(before.nodes);
+
+      const render = nodes.find((n) => n.label.endsWith("/src/app.ts#render"));
+      const localValue = nodes.find((n) => n.label.endsWith("/src/local.ts#localValue"));
+      const localOptions = nodes.find((n) => n.label.endsWith("/src/local.ts#LocalOptions"));
+      expect(render).toBeDefined();
+      expect(localValue).toBeDefined();
+      expect(localOptions).toBeDefined();
+      await expect(store.findEdge(render!.rid, localValue!.rid, "CALLS")).resolves.toBeTypeOf(
+        "number",
+      );
+      await expect(store.findEdge(render!.rid, localOptions!.rid, "USES_TYPE")).resolves.toBeTypeOf(
+        "number",
+      );
     },
     TIMEOUT,
   );

--- a/src/apps/memory/tests/ingest.test.ts
+++ b/src/apps/memory/tests/ingest.test.ts
@@ -218,7 +218,7 @@ describe("ingestProject over a TS+MD fixture repo", () => {
   );
 
   test(
-    "ingests IMPORTS edges and does not duplicate them on re-ingest",
+    "ingests IMPORTS plus compiler-resolved cross-file edges without duplicating on re-ingest",
     async () => {
       const store = await openStore();
       await ingestProject(store, { cwd: IMPORT_FIXTURE_REPO });


### PR DESCRIPTION
Follow-up to #522 / #529.\n\nAdds compiler-resolved cross-file TypeScript symbol targets so imported function calls and imported type references can be written as Memory map edges without graph UI/layout metadata.\n\nValidation:\n- pnpm --dir src/apps/memory exec vitest run tests/extract-code.test.ts\n- pnpm --dir src/apps/memory exec vitest run tests/ingest.test.ts\n- pnpm --dir src/apps/memory run typecheck\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783383335&installation_id=129708444&pr_number=534&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F534&signature=0b8043c44e4729a899601dd2cf8a279d2333e297b0d5e029787e40a91990f639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved code analysis: richer, cross-file symbol graph that records calls and type-usage relationships and standardizes symbol labeling, including handling of externally declared symbols.

* **Tests**
  * Added and updated tests to validate compiler-resolved cross-file symbol relationships and adjusted fixtures to exercise the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->