### PR TITLE
Add Memory community navigation analytics

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -5583,10 +5583,15 @@ async function runCommunities(args: ParsedArgs): Promise<void> {
     console.log(
       `memory: ${report.communities.length} community(ies), ${report.assignments.length} assigned node(s)`,
     );
+    console.log(
+      `  navigation: ${report.node_analytics.length} ranked node(s), ${report.inter_community_edges.length} inter-community edge(s)`,
+    );
     console.log(`  graph hash: ${report.graph_hash}`);
     console.log(`  cache: ${report.cached ? "hit" : "miss"}`);
     for (const community of report.communities) {
-      console.log(`  ${community.id}: ${community.count} node(s)`);
+      console.log(
+        `  ${community.id}: ${community.count} node(s), degree ${community.total_degree}, centrality ${community.avg_centrality}`,
+      );
       if (community.titles.length > 0) {
         console.log(`        top titles: ${community.titles.join(", ")}`);
       }

--- a/src/apps/memory/src/communities-viewer.ts
+++ b/src/apps/memory/src/communities-viewer.ts
@@ -3,6 +3,7 @@ import type {
   CommunityAnalyticsReport,
   CommunityAssignment,
   CommunitySummary,
+  InterCommunityEdge,
 } from "./communities.js";
 
 export interface CommunitiesViewerArtifact {
@@ -136,14 +137,18 @@ function renderCommunitiesViewer(report: CommunityAnalyticsReport): string {
     <div class="metrics">
       ${metric("Communities", report.communities.length)}
       ${metric("Assigned Nodes", report.assignments.length)}
+      ${metric("Inter-community Edges", report.inter_community_edges.length)}
       ${metric("Largest", report.communities[0]?.count ?? 0)}
-      ${metric("Generated", report.generated_at)}
     </div>
     <div class="layout">
       <div class="stack">
         <section>
           <h2>Communities</h2>
           ${report.communities.length === 0 ? `<p class="empty">No community assignments available.</p>` : `<ul>${report.communities.map((community) => communityItem(community, assignmentsByCommunity.get(community.id) ?? [])).join("")}</ul>`}
+        </section>
+        <section>
+          <h2>Community Links</h2>
+          ${report.inter_community_edges.length === 0 ? `<p class="empty">No inter-community relationships.</p>` : `<ul>${report.inter_community_edges.slice(0, 40).map(interCommunityEdgeItem).join("")}</ul>`}
         </section>
       </div>
       <div class="stack">
@@ -174,6 +179,7 @@ function communityItem(
       <h3>${escapeHtml(community.id)}</h3>
       <p class="meta">${escapeHtml(community.titles.join(", ") || "No titles")}</p>
       <p class="meta">${escapeHtml(nodeTypes.join(", ") || "unknown node types")}</p>
+      <p class="meta">degree ${community.total_degree} - centrality ${community.avg_centrality} - external weight ${community.external_edge_weight}</p>
     </div>
     <span class="pill">${community.count} node(s)</span>
   </li>`;
@@ -186,5 +192,15 @@ function assignmentItem(assignment: CommunityAssignment): string {
       <p class="meta"><code>memory_nodes:${assignment.rid}</code> - ${escapeHtml(assignment.label)} - ${escapeHtml(assignment.node_type)}</p>
     </div>
     <span class="pill">${escapeHtml(assignment.community_id)}</span>
+  </li>`;
+}
+
+function interCommunityEdgeItem(edge: InterCommunityEdge): string {
+  return `<li>
+    <div>
+      <h3>${escapeHtml(edge.from_community_id)} -> ${escapeHtml(edge.to_community_id)}</h3>
+      <p class="meta">${edge.edge_count} edge(s), weight ${edge.weight}</p>
+    </div>
+    <span class="pill">${edge.weight}</span>
   </li>`;
 }

--- a/src/apps/memory/src/communities.ts
+++ b/src/apps/memory/src/communities.ts
@@ -14,8 +14,28 @@ export interface CommunityAssignment {
 export interface CommunitySummary {
   id: string;
   count: number;
+  total_degree: number;
+  avg_centrality: number;
+  external_edge_weight: number;
   labels: string[];
   titles: string[];
+}
+
+export interface CommunityNodeAnalytics {
+  rid: number;
+  community_id: string;
+  degree: number;
+  in_degree: number;
+  out_degree: number;
+  weighted_degree: number;
+  centrality: number;
+}
+
+export interface InterCommunityEdge {
+  from_community_id: string;
+  to_community_id: string;
+  weight: number;
+  edge_count: number;
 }
 
 export interface CommunityAnalyticsReport {
@@ -27,11 +47,16 @@ export interface CommunityAnalyticsReport {
   generated_at: string;
   communities: CommunitySummary[];
   assignments: CommunityAssignment[];
+  node_analytics: CommunityNodeAnalytics[];
+  inter_community_edges: InterCommunityEdge[];
 }
 
-interface CachedAssignments {
+interface CachedCommunityAnalytics {
+  schema_version: "memory.communities.cache.v2";
   graph_hash: string;
   assignments: Array<{ rid: number; community_id: string }>;
+  node_analytics: CommunityNodeAnalytics[];
+  inter_community_edges: InterCommunityEdge[];
   generated_at: string;
 }
 
@@ -47,20 +72,29 @@ export async function buildCommunityAnalytics(
   const cacheMode = opts.cache ?? "read-write";
   const [nodes, edges] = await Promise.all([store.listNodes(), store.listEdges()]);
   const graphHash = graphStateHash(nodes, edges);
-  const cacheKey = `cache:communities:${graphHash}`;
+  const cacheKey = `cache:communities:v2:${graphHash}`;
   const cached =
-    cacheMode === "off" ? null : parseCached(await store.kvGet<CachedAssignments | string>(cacheKey));
-  const communityPairs =
-    cached?.graph_hash === graphHash
-      ? cached.assignments
-      : mapToPairs(await store.communities());
+    cacheMode === "off"
+      ? null
+      : parseCached(await store.kvGet<CachedCommunityAnalytics | string>(cacheKey));
+  const generatedAt = (opts.now ?? new Date()).toISOString();
+  const cacheHit = cached?.graph_hash === graphHash;
+  const communityPairs = cacheHit ? cached.assignments : mapToPairs(await store.communities());
+  const analytics = cacheHit
+    ? {
+        node_analytics: cached.node_analytics,
+        inter_community_edges: cached.inter_community_edges,
+      }
+    : buildNavigationAnalytics(communityPairs, edges);
 
-  if (cacheMode === "read-write" && cached?.graph_hash !== graphHash) {
+  if (cacheMode === "read-write" && !cacheHit) {
     await store.kvPut(cacheKey, {
+      schema_version: "memory.communities.cache.v2",
       graph_hash: graphHash,
       assignments: communityPairs,
-      generated_at: (opts.now ?? new Date()).toISOString(),
-    } satisfies CachedAssignments);
+      ...analytics,
+      generated_at: generatedAt,
+    } satisfies CachedCommunityAnalytics);
   }
 
   const assignments = decorateAssignments(nodes, communityPairs);
@@ -69,21 +103,37 @@ export async function buildCommunityAnalytics(
     read_only: true,
     graph_hash: graphHash,
     cache_key: cacheKey,
-    cached: cached?.graph_hash === graphHash,
-    generated_at: (opts.now ?? new Date()).toISOString(),
-    communities: summarizeCommunities(assignments),
+    cached: cacheHit,
+    generated_at: cacheHit ? cached.generated_at : generatedAt,
+    communities: summarizeCommunities(assignments, analytics.node_analytics, analytics.inter_community_edges),
     assignments,
+    node_analytics: analytics.node_analytics,
+    inter_community_edges: analytics.inter_community_edges,
   };
 }
 
-function parseCached(raw: CachedAssignments | string | null): CachedAssignments | null {
+function parseCached(raw: CachedCommunityAnalytics | string | null): CachedCommunityAnalytics | null {
   if (raw == null) return null;
-  if (typeof raw !== "string") return raw;
+  if (typeof raw !== "string") return isCachedCommunityAnalytics(raw) ? raw : null;
   try {
-    return JSON.parse(raw) as CachedAssignments;
+    const parsed = JSON.parse(raw) as unknown;
+    return isCachedCommunityAnalytics(parsed) ? parsed : null;
   } catch {
     return null;
   }
+}
+
+function isCachedCommunityAnalytics(value: unknown): value is CachedCommunityAnalytics {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<CachedCommunityAnalytics>;
+  return (
+    item.schema_version === "memory.communities.cache.v2" &&
+    typeof item.graph_hash === "string" &&
+    Array.isArray(item.assignments) &&
+    Array.isArray(item.node_analytics) &&
+    Array.isArray(item.inter_community_edges) &&
+    typeof item.generated_at === "string"
+  );
 }
 
 function mapToPairs(map: Map<number, string>): Array<{ rid: number; community_id: string }> {
@@ -113,24 +163,141 @@ function decorateAssignments(
     .sort((a, b) => a.community_id.localeCompare(b.community_id) || a.label.localeCompare(b.label));
 }
 
-function summarizeCommunities(assignments: CommunityAssignment[]): CommunitySummary[] {
+function summarizeCommunities(
+  assignments: CommunityAssignment[],
+  nodeAnalytics: CommunityNodeAnalytics[],
+  interCommunityEdges: InterCommunityEdge[],
+): CommunitySummary[] {
   const groups = new Map<string, CommunityAssignment[]>();
   for (const assignment of assignments) {
     const group = groups.get(assignment.community_id) ?? [];
     group.push(assignment);
     groups.set(assignment.community_id, group);
   }
+  const analyticsByCommunity = new Map<string, CommunityNodeAnalytics[]>();
+  for (const item of nodeAnalytics) {
+    const group = analyticsByCommunity.get(item.community_id) ?? [];
+    group.push(item);
+    analyticsByCommunity.set(item.community_id, group);
+  }
+  const externalWeight = new Map<string, number>();
+  for (const edge of interCommunityEdges) {
+    externalWeight.set(
+      edge.from_community_id,
+      (externalWeight.get(edge.from_community_id) ?? 0) + edge.weight,
+    );
+    externalWeight.set(
+      edge.to_community_id,
+      (externalWeight.get(edge.to_community_id) ?? 0) + edge.weight,
+    );
+  }
   return [...groups.entries()]
     .map(([id, group]) => {
       const sorted = [...group].sort((a, b) => a.title.localeCompare(b.title));
+      const analytics = analyticsByCommunity.get(id) ?? [];
+      const totalDegree = analytics.reduce((sum, item) => sum + item.degree, 0);
+      const avgCentrality =
+        analytics.length === 0
+          ? 0
+          : round6(analytics.reduce((sum, item) => sum + item.centrality, 0) / analytics.length);
       return {
         id,
         count: group.length,
+        total_degree: totalDegree,
+        avg_centrality: avgCentrality,
+        external_edge_weight: round6(externalWeight.get(id) ?? 0),
         labels: sorted.slice(0, 5).map((item) => item.label),
         titles: sorted.slice(0, 5).map((item) => item.title),
       };
     })
     .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id));
+}
+
+function buildNavigationAnalytics(
+  assignments: Array<{ rid: number; community_id: string }>,
+  edges: Record<string, unknown>[],
+): {
+  node_analytics: CommunityNodeAnalytics[];
+  inter_community_edges: InterCommunityEdge[];
+} {
+  const communityByRid = new Map(assignments.map((assignment) => [assignment.rid, assignment.community_id]));
+  const degree = new Map<number, number>();
+  const inDegree = new Map<number, number>();
+  const outDegree = new Map<number, number>();
+  const weightedDegree = new Map<number, number>();
+  for (const rid of communityByRid.keys()) {
+    degree.set(rid, 0);
+    inDegree.set(rid, 0);
+    outDegree.set(rid, 0);
+    weightedDegree.set(rid, 0);
+  }
+
+  const interCommunity = new Map<string, InterCommunityEdge>();
+  for (const edge of edges) {
+    const from = edgeEndpoint(edge, "from");
+    const to = edgeEndpoint(edge, "to");
+    if (!communityByRid.has(from) || !communityByRid.has(to)) continue;
+    const weight = edgeWeight(edge);
+    outDegree.set(from, (outDegree.get(from) ?? 0) + 1);
+    inDegree.set(to, (inDegree.get(to) ?? 0) + 1);
+    degree.set(from, (degree.get(from) ?? 0) + 1);
+    degree.set(to, (degree.get(to) ?? 0) + 1);
+    weightedDegree.set(from, (weightedDegree.get(from) ?? 0) + weight);
+    weightedDegree.set(to, (weightedDegree.get(to) ?? 0) + weight);
+
+    const fromCommunity = communityByRid.get(from);
+    const toCommunity = communityByRid.get(to);
+    if (!fromCommunity || !toCommunity || fromCommunity === toCommunity) continue;
+    const key = `${fromCommunity}\u0000${toCommunity}`;
+    const current = interCommunity.get(key) ?? {
+      from_community_id: fromCommunity,
+      to_community_id: toCommunity,
+      weight: 0,
+      edge_count: 0,
+    };
+    current.weight = round6(current.weight + weight);
+    current.edge_count += 1;
+    interCommunity.set(key, current);
+  }
+
+  const maxDegree = Math.max(1, ...degree.values());
+  return {
+    node_analytics: [...communityByRid.entries()]
+      .map(([rid, community_id]) => ({
+        rid,
+        community_id,
+        degree: degree.get(rid) ?? 0,
+        in_degree: inDegree.get(rid) ?? 0,
+        out_degree: outDegree.get(rid) ?? 0,
+        weighted_degree: round6(weightedDegree.get(rid) ?? 0),
+        centrality: round6((degree.get(rid) ?? 0) / maxDegree),
+      }))
+      .sort((a, b) => b.centrality - a.centrality || b.degree - a.degree || a.rid - b.rid),
+    inter_community_edges: [...interCommunity.values()].sort(
+      (a, b) =>
+        b.weight - a.weight ||
+        b.edge_count - a.edge_count ||
+        a.from_community_id.localeCompare(b.from_community_id) ||
+        a.to_community_id.localeCompare(b.to_community_id),
+    ),
+  };
+}
+
+function edgeEndpoint(edge: Record<string, unknown>, side: "from" | "to"): number {
+  const value =
+    side === "from"
+      ? edge.from ?? edge.from_id ?? edge.from_rid ?? edge.source ?? edge.FROM
+      : edge.to ?? edge.to_id ?? edge.to_rid ?? edge.target ?? edge.TO;
+  return Number(value ?? 0);
+}
+
+function edgeWeight(edge: Record<string, unknown>): number {
+  const weight = Number(edge.weight ?? edge.WEIGHT ?? 1);
+  return Number.isFinite(weight) && weight > 0 ? weight : 1;
+}
+
+function round6(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
 }
 
 export function graphStateHash(nodes: StoredNode[], edges: Record<string, unknown>[]): string {

--- a/src/apps/memory/src/mcp-server.ts
+++ b/src/apps/memory/src/mcp-server.ts
@@ -930,6 +930,8 @@ async function operationStructuredContent(
         read_only: output.read_only,
         communities: arrayLength(output.communities),
         assignments: arrayLength(output.assignments),
+        node_analytics: arrayLength(output.node_analytics),
+        inter_community_edges: arrayLength(output.inter_community_edges),
         graph_hash: output.graph_hash,
         cached: output.cached,
         nodes: stats.nodes,
@@ -983,6 +985,8 @@ async function operationStructuredContent(
         consumes: isRecord(output.contract) ? output.contract.consumes : undefined,
         communities: arrayLength(report.communities),
         assignments: arrayLength(report.assignments),
+        node_analytics: arrayLength(report.node_analytics),
+        inter_community_edges: arrayLength(report.inter_community_edges),
         graph_hash: report.graph_hash,
         cached: report.cached,
         html_bytes:

--- a/src/apps/memory/src/operations.ts
+++ b/src/apps/memory/src/operations.ts
@@ -712,6 +712,9 @@ type FederationInput = z.infer<typeof FederationInputSchema>;
 const CommunitySummarySchema = z.object({
   id: z.string(),
   count: z.number(),
+  total_degree: z.number(),
+  avg_centrality: z.number(),
+  external_edge_weight: z.number(),
   labels: z.array(z.string()),
   titles: z.array(z.string()),
 });
@@ -724,6 +727,23 @@ const CommunityAssignmentSchema = z.object({
   title: z.string(),
 });
 
+const CommunityNodeAnalyticsSchema = z.object({
+  rid: z.number(),
+  community_id: z.string(),
+  degree: z.number(),
+  in_degree: z.number(),
+  out_degree: z.number(),
+  weighted_degree: z.number(),
+  centrality: z.number(),
+});
+
+const InterCommunityEdgeSchema = z.object({
+  from_community_id: z.string(),
+  to_community_id: z.string(),
+  weight: z.number(),
+  edge_count: z.number(),
+});
+
 const CommunitiesOutputSchema = z.object({
   schema_version: z.literal("memory.communities.v1"),
   read_only: z.literal(true),
@@ -733,6 +753,8 @@ const CommunitiesOutputSchema = z.object({
   generated_at: z.string(),
   communities: z.array(CommunitySummarySchema),
   assignments: z.array(CommunityAssignmentSchema),
+  node_analytics: z.array(CommunityNodeAnalyticsSchema),
+  inter_community_edges: z.array(InterCommunityEdgeSchema),
 }) satisfies z.ZodType<CommunityAnalyticsReport>;
 const CommunitiesViewerOutputSchema = objectOutputSchema<CommunitiesViewerArtifact>();
 
@@ -2704,7 +2726,7 @@ const COMMUNITIES_OPERATION: MemoryOperationDefinition<CommunitiesInput, Communi
     mcp: {
       toolName: "memory_communities",
       description:
-        "Read-only Memory graph community analytics: native Louvain assignments, community counts, top labels/titles, and graph-hash cache metadata. Does not write derived clusters into Memory graph evidence.",
+        "Read-only Memory graph community analytics: native Louvain assignments, node degree/centrality ranking metadata, weighted inter-community edges, community counts, top labels/titles, and graph-hash cache metadata. Does not write derived clusters into Memory graph evidence.",
     },
   },
   execute: (ctx, input) => buildCommunityAnalytics(ctx.store, { cache: input.cache }),
@@ -2727,7 +2749,7 @@ const COMMUNITIES_VIEWER_OPERATION: MemoryOperationDefinition<
     mcp: {
       toolName: "memory_communities_viewer",
       description:
-        "Read-only self-contained HTML viewer for RedDB graph community analytics. Returns native Louvain community summaries, assignments, cache metadata, embedded JSON, and HTML without writing derived clusters into Memory evidence.",
+        "Read-only self-contained HTML viewer for RedDB graph community analytics. Returns native Louvain community summaries, assignments, degree/centrality ranking metadata, weighted inter-community edges, cache metadata, embedded JSON, and HTML without writing derived clusters into Memory evidence.",
     },
   },
   execute: async (ctx, input) =>

--- a/src/apps/memory/src/readiness.ts
+++ b/src/apps/memory/src/readiness.ts
@@ -342,6 +342,8 @@ async function communitySummary(
       generated_at: now.toISOString(),
       communities: [],
       assignments: [],
+      node_analytics: [],
+      inter_community_edges: [],
       error: err instanceof Error ? err.message : String(err),
     };
   }

--- a/src/apps/memory/tests/communities-cli.test.ts
+++ b/src/apps/memory/tests/communities-cli.test.ts
@@ -95,17 +95,50 @@ describe("memory communities CLI", () => {
         read_only: boolean;
         cached: boolean;
         graph_hash: string;
-        communities: Array<{ id: string; count: number; labels: string[]; titles: string[] }>;
+        cache_key: string;
+        communities: Array<{
+          id: string;
+          count: number;
+          total_degree: number;
+          avg_centrality: number;
+          external_edge_weight: number;
+          labels: string[];
+          titles: string[];
+        }>;
         assignments: Array<{ rid: number; community_id: string; label: string; title: string }>;
+        node_analytics: Array<{
+          rid: number;
+          community_id: string;
+          degree: number;
+          in_degree: number;
+          out_degree: number;
+          weighted_degree: number;
+          centrality: number;
+        }>;
+        inter_community_edges: Array<{
+          from_community_id: string;
+          to_community_id: string;
+          weight: number;
+          edge_count: number;
+        }>;
       };
 
       expect(firstBody.schema_version).toBe("memory.communities.v1");
       expect(firstBody.read_only).toBe(true);
       expect(firstBody.cached).toBe(false);
       expect(firstBody.graph_hash).toMatch(/^[a-f0-9]{64}$/);
+      expect(firstBody.cache_key).toContain("cache:communities:v2:");
       expect(firstBody.communities).toHaveLength(2);
       expect(firstBody.assignments).toHaveLength(6);
+      expect(firstBody.node_analytics).toHaveLength(6);
+      expect(firstBody.inter_community_edges).toHaveLength(1);
+      expect(firstBody.inter_community_edges[0]).toMatchObject({ weight: 1, edge_count: 1 });
+      expect(firstBody.node_analytics[0].centrality).toBeGreaterThan(0);
+      expect(firstBody.node_analytics[0].degree).toBeGreaterThan(0);
       expect(firstBody.communities.map((c) => c.count).sort()).toEqual([3, 3]);
+      expect(firstBody.communities.every((c) => c.total_degree > 0)).toBe(true);
+      expect(firstBody.communities.every((c) => c.avg_centrality > 0)).toBe(true);
+      expect(firstBody.communities.every((c) => c.external_edge_weight === 1)).toBe(true);
       expect(firstBody.communities.some((c) => c.labels.includes("auth-login"))).toBe(true);
       expect(firstBody.communities.some((c) => c.titles.includes("cache ttl"))).toBe(true);
 
@@ -115,6 +148,8 @@ describe("memory communities CLI", () => {
       expect(secondBody.cached).toBe(true);
       expect(secondBody.graph_hash).toBe(firstBody.graph_hash);
       expect(secondBody.assignments).toEqual(firstBody.assignments);
+      expect(secondBody.node_analytics).toEqual(firstBody.node_analytics);
+      expect(secondBody.inter_community_edges).toEqual(firstBody.inter_community_edges);
 
       const out = join(root, "communities.html");
       const viewer = runMemory(["communities-viewer", "--root", root, "--out", out]);
@@ -127,10 +162,40 @@ describe("memory communities CLI", () => {
       expect(html).toContain('id="communities-data"');
       expect(html).not.toContain("<script src=");
 
+      const afterAnalytics = await openStore(root);
+      const afterAnalyticsStats = await afterAnalytics.stats();
+      await afterAnalytics.close();
+      expect(afterAnalyticsStats).toEqual(beforeStats);
+
+      const changed = await openStore(root);
+      const newRid = await changed.upsertNode({
+        label: "auth-metrics",
+        node_type: "concept",
+        properties: { title: "auth metrics", content: "auth metrics" },
+      });
+      const authLogin = firstBody.assignments.find((assignment) => assignment.label === "auth-login");
+      expect(authLogin).toBeDefined();
+      await changed.upsertEdge({ label: "REFERENCES", from_rid: newRid, to_rid: authLogin!.rid });
+      await changed.close();
+
+      const regenerated = runMemory(["communities", "--root", root, "--json"]);
+      expect(regenerated.status).toBe(0);
+      const regeneratedBody = JSON.parse(regenerated.stdout) as typeof firstBody;
+      expect(regeneratedBody.cached).toBe(false);
+      expect(regeneratedBody.graph_hash).not.toBe(firstBody.graph_hash);
+      expect(regeneratedBody.assignments).toHaveLength(7);
+      expect(regeneratedBody.node_analytics).toHaveLength(7);
+
+      const regeneratedSecond = runMemory(["communities", "--root", root, "--json"]);
+      expect(regeneratedSecond.status).toBe(0);
+      const regeneratedSecondBody = JSON.parse(regeneratedSecond.stdout) as typeof firstBody;
+      expect(regeneratedSecondBody.cached).toBe(true);
+      expect(regeneratedSecondBody.graph_hash).toBe(regeneratedBody.graph_hash);
+
       const after = await openStore(root);
       const afterStats = await after.stats();
       await after.close();
-      expect(afterStats).toEqual(beforeStats);
+      expect(afterStats).toEqual({ nodes: beforeStats.nodes + 1, edges: beforeStats.edges + 1 });
     },
     TIMEOUT,
   );


### PR DESCRIPTION
Closes #524

## Summary
- extend memory.communities.v1 with node degree/centrality navigation metadata
- add weighted inter-community edge summaries cached under a graph-hash analytic cache key
- surface the metadata through CLI, MCP summaries, readiness fallback, and the communities viewer

## Tests
- pnpm --dir src/apps/memory typecheck
- pnpm --dir src/apps/memory exec vitest run --config vitest.integration.config.ts tests/communities-cli.test.ts
- pnpm --dir src/apps/memory test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783384302&installation_id=129708444&pr_number=536&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F536&signature=1746770557440acfa8d936ef138b11dc74b2ff9772c59689f1e6030c937abb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced community analytics with additional per-community metrics (total degree, average centrality, external edge weight)
  * Added inter-community relationship data showing weighted edges and connections between communities
  * Improved navigation analytics with per-node community details

* **Tests**
  * Expanded test coverage for analytics output, caching behavior, and cache invalidation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->