### PR TITLE
Import complementary map sources into Memory

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -83,6 +83,10 @@ import { dispatch, type HookEvent, type Runner } from "./hook-runtime.js";
 import { refreshFromGit, type VcsEvent } from "./vcs-refresh.js";
 import { installGitHooks, uninstallGitHooks } from "./vcs-hooks-install.js";
 import { importAmsDump } from "./import-ams.js";
+import {
+  importComplementaryMapFile,
+  type ComplementaryMapSourceKind,
+} from "./import-complementary-map.js";
 import { runPromote } from "./promote.js";
 import { runAfkLifecycle } from "./afk-lifecycle.js";
 import {
@@ -446,6 +450,7 @@ Usage:
   AMS migration (PRD #174, issue #184) — one-shot offline importer for Redis
   agent-memory-server JSON dumps. See \`docs/migrating-from-ams.md\`.
   memory import ams <dump.json>     [--root <dir>] [--json]
+  memory import map <artifact.json> [--kind graphify|scip|lsp|static-analysis] [--root <dir>] [--json]
 
   Benchmarks and reference eval live in the embedded app \`benchmark-memory\`.
 
@@ -518,6 +523,7 @@ const SOURCE_KINDS: readonly MemoryProvenance["source_kind"][] = [
   "hook",
   "derived",
   "system",
+  "external-map",
 ];
 
 function parseSourceKind(
@@ -6547,15 +6553,34 @@ async function runAttemptLearnApply(args: ParsedArgs): Promise<void> {
 async function runImport(args: ParsedArgs): Promise<void> {
   const source = args.positional[0];
   const file = args.positional[1];
-  if (source !== "ams") {
-    throw new Error(`usage: memory import ams <dump.json> [--root <dir>] [--json]`);
-  }
   if (!file) {
-    throw new Error("memory import ams: missing <dump.json> path");
+    throw new Error("usage: memory import ams <dump.json> | memory import map <artifact.json>");
   }
   const rootDir = rootOf(args.flags);
   const { store } = await openGraphStore(args);
   try {
+    if (source === "map") {
+      const report = await importComplementaryMapFile(store, file, {
+        rootDir,
+        sourceKind: parseComplementaryMapKind(stringFlag(args.flags, "kind")),
+        command: "memory import map",
+      });
+      if (args.flags.json === true) {
+        console.log(JSON.stringify(report, null, 2));
+        return;
+      }
+      console.log(
+        `memory import map: ${report.source_kind} nodes=${report.nodes.imported} imported/${report.nodes.overlapped} overlapped edges=${report.edges.imported} imported/${report.edges.overlapped} overlapped`,
+      );
+      console.log(`  destination: ${report.destination}`);
+      for (const warning of report.warnings.slice(0, 5)) console.log(`  warning: ${warning}`);
+      return;
+    }
+    if (source !== "ams") {
+      throw new Error(
+        `usage: memory import ams <dump.json> | memory import map <artifact.json> [--kind graphify|scip|lsp|static-analysis]`,
+      );
+    }
     const report = await importAmsDump(store, rootDir, file);
     if (args.flags.json === true) {
       console.log(JSON.stringify(report, null, 2));
@@ -6570,6 +6595,22 @@ async function runImport(args: ParsedArgs): Promise<void> {
   } finally {
     await store.close();
   }
+}
+
+function parseComplementaryMapKind(
+  value: string | undefined,
+): ComplementaryMapSourceKind | undefined {
+  if (value == null) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "graphify" ||
+    normalized === "scip" ||
+    normalized === "lsp" ||
+    normalized === "static-analysis"
+  ) {
+    return normalized;
+  }
+  throw new Error(`invalid complementary map kind "${value}"`);
 }
 
 async function runPromoteCmd(args: ParsedArgs): Promise<void> {

--- a/src/apps/memory/src/import-complementary-map.ts
+++ b/src/apps/memory/src/import-complementary-map.ts
@@ -1,0 +1,483 @@
+import { readFile, stat } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { contentHash } from "./hash.js";
+import type { MemoryStore } from "./graph-store.js";
+import type { Confidence, EdgeLabel, MemoryEdge, MemoryNode, NodeType } from "./schema.js";
+
+export type ComplementaryMapSourceKind = "graphify" | "scip" | "lsp" | "static-analysis";
+
+export interface ComplementaryMapImportOptions {
+  rootDir: string;
+  sourceKind?: ComplementaryMapSourceKind;
+  command?: string;
+  now?: number;
+}
+
+export interface ComplementaryMapImportReport {
+  schema_version: "memory.complementary_map_import.v1";
+  destination: "RedDB";
+  source_kind: ComplementaryMapSourceKind;
+  artifact_path: string;
+  nodes: {
+    input: number;
+    imported: number;
+    overlapped: number;
+    skipped: number;
+  };
+  edges: {
+    input: number;
+    imported: number;
+    overlapped: number;
+    skipped: number;
+  };
+  warnings: string[];
+}
+
+interface RawComplementaryMap {
+  source_kind?: unknown;
+  kind?: unknown;
+  tool?: unknown;
+  generated_at?: unknown;
+  nodes?: unknown;
+  edges?: unknown;
+}
+
+interface RawMapNode {
+  id?: unknown;
+  kind?: unknown;
+  type?: unknown;
+  label?: unknown;
+  name?: unknown;
+  path?: unknown;
+  confidence?: unknown;
+  freshness?: unknown;
+  generated_at?: unknown;
+  updated_at?: unknown;
+  properties?: unknown;
+}
+
+interface RawMapEdge {
+  from?: unknown;
+  source?: unknown;
+  to?: unknown;
+  target?: unknown;
+  kind?: unknown;
+  type?: unknown;
+  label?: unknown;
+  weight?: unknown;
+  salience?: unknown;
+  confidence?: unknown;
+  freshness?: unknown;
+  generated_at?: unknown;
+  updated_at?: unknown;
+  properties?: unknown;
+}
+
+interface NormalizedNode {
+  sourceId: string;
+  node: MemoryNode;
+}
+
+interface NormalizedEdge {
+  fromSourceId: string;
+  toSourceId: string;
+  edge: Omit<MemoryEdge, "from_rid" | "to_rid">;
+}
+
+const NODE_KIND_MAP: Record<string, NodeType> = {
+  file: "file",
+  module: "file",
+  symbol: "symbol",
+  function: "symbol",
+  method: "symbol",
+  class: "symbol",
+  interface: "symbol",
+  type: "symbol",
+  struct: "symbol",
+  import: "import",
+  dependency: "import",
+  community: "concept",
+  concept: "concept",
+};
+
+const SYMBOL_KINDS = new Set(["symbol", "function", "method", "class", "interface", "type", "struct"]);
+
+const EDGE_KIND_MAP: Record<string, { label: EdgeLabel; reverse?: boolean; baseWeight: number }> = {
+  CALLS: { label: "CALLS", baseWeight: 0.85 },
+  CALL: { label: "CALLS", baseWeight: 0.85 },
+  USES_TYPE: { label: "USES_TYPE", baseWeight: 0.8 },
+  USES: { label: "USES_TYPE", baseWeight: 0.65 },
+  IMPORTS: { label: "IMPORTS", baseWeight: 0.8 },
+  IMPORT: { label: "IMPORTS", baseWeight: 0.8 },
+  DEFINES: { label: "DEFINED_IN", reverse: true, baseWeight: 0.9 },
+  DEFINED_IN: { label: "DEFINED_IN", baseWeight: 0.9 },
+  IMPLEMENTS: { label: "IMPLEMENTS", baseWeight: 0.75 },
+  EXTENDS: { label: "EXTENDS", baseWeight: 0.75 },
+  REFERENCES: { label: "REFERENCES", baseWeight: 0.6 },
+  REFERENCE: { label: "REFERENCES", baseWeight: 0.6 },
+  MENTIONS: { label: "MENTIONS", baseWeight: 0.5 },
+  GROUPS: { label: "CONTAINS", baseWeight: 0.55 },
+  CONTAINS: { label: "CONTAINS", baseWeight: 0.7 },
+  DEPENDS_ON: { label: "REFERENCES", baseWeight: 0.6 },
+};
+
+export async function importComplementaryMapFile(
+  store: MemoryStore,
+  artifactPath: string,
+  opts: ComplementaryMapImportOptions,
+): Promise<ComplementaryMapImportReport> {
+  const resolved = isAbsolute(artifactPath) ? artifactPath : resolve(opts.rootDir, artifactPath);
+  const raw = parseComplementaryMap(await readFile(resolved, "utf8"));
+  const sourceKind = normalizeSourceKind(opts.sourceKind ?? stringValue(raw.source_kind) ?? stringValue(raw.kind) ?? stringValue(raw.tool));
+  return importComplementaryMap(store, raw, resolved, {
+    ...opts,
+    sourceKind,
+  });
+}
+
+export async function importComplementaryMap(
+  store: MemoryStore,
+  raw: RawComplementaryMap,
+  artifactPath: string,
+  opts: ComplementaryMapImportOptions,
+): Promise<ComplementaryMapImportReport> {
+  const now = opts.now ?? Date.now();
+  const sourceKind = normalizeSourceKind(opts.sourceKind ?? stringValue(raw.source_kind));
+  const artifactFreshness = await artifactFreshnessMs(artifactPath, raw.generated_at);
+  const rawNodes = arrayOfRecords(raw.nodes);
+  const rawEdges = arrayOfRecords(raw.edges);
+  const warnings: string[] = [];
+  const sourceIdToRid = new Map<string, number>();
+  const nodeReport = { input: rawNodes.length, imported: 0, overlapped: 0, skipped: 0 };
+  const edgeReport = { input: rawEdges.length, imported: 0, overlapped: 0, skipped: 0 };
+
+  for (const rawNode of rawNodes) {
+    const normalized = normalizeNode(rawNode, {
+      artifactPath,
+      rootDir: opts.rootDir,
+      sourceKind,
+      now,
+      artifactFreshness,
+      command: opts.command,
+    });
+    if (!normalized) {
+      nodeReport.skipped += 1;
+      continue;
+    }
+    const existing = await store.findNodeByLabel(normalized.node.label, normalized.node.node_type);
+    const before = await store.findNodeByHash(String(normalized.node.properties.hash ?? ""));
+    const rid = existing ?? (await store.upsertNode(normalized.node));
+    sourceIdToRid.set(normalized.sourceId, rid);
+    if (existing != null || before != null) nodeReport.overlapped += 1;
+    else nodeReport.imported += 1;
+  }
+
+  for (const rawEdge of rawEdges) {
+    const normalized = normalizeEdge(rawEdge, {
+      artifactPath,
+      sourceKind,
+      now,
+      artifactFreshness,
+      command: opts.command,
+    });
+    if (!normalized) {
+      edgeReport.skipped += 1;
+      continue;
+    }
+    const fromRid = sourceIdToRid.get(normalized.fromSourceId);
+    const toRid = sourceIdToRid.get(normalized.toSourceId);
+    if (fromRid == null || toRid == null) {
+      edgeReport.skipped += 1;
+      warnings.push(
+        `skipped edge ${normalized.fromSourceId} -> ${normalized.toSourceId}: endpoint missing`,
+      );
+      continue;
+    }
+    const existing = await store.findEdge(fromRid, toRid, normalized.edge.label);
+    await store.upsertEdge({
+      ...normalized.edge,
+      from_rid: fromRid,
+      to_rid: toRid,
+    });
+    if (existing != null) edgeReport.overlapped += 1;
+    else edgeReport.imported += 1;
+  }
+
+  return {
+    schema_version: "memory.complementary_map_import.v1",
+    destination: "RedDB",
+    source_kind: sourceKind,
+    artifact_path: artifactPath,
+    nodes: nodeReport,
+    edges: edgeReport,
+    warnings,
+  };
+}
+
+function parseComplementaryMap(raw: string): RawComplementaryMap {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isRecord(parsed)) throw new Error("complementary map import expects a JSON object");
+  if (!Array.isArray(parsed.nodes)) throw new Error("complementary map import expects nodes[]");
+  if (!Array.isArray(parsed.edges)) throw new Error("complementary map import expects edges[]");
+  return parsed as RawComplementaryMap;
+}
+
+function normalizeNode(
+  raw: Record<string, unknown>,
+  context: {
+    artifactPath: string;
+    rootDir: string;
+    sourceKind: ComplementaryMapSourceKind;
+    now: number;
+    artifactFreshness: number | undefined;
+    command: string | undefined;
+  },
+): NormalizedNode | null {
+  const sourceId = stringValue(raw.id);
+  if (!sourceId) return null;
+  const kind = lowerKind(raw.kind ?? raw.type);
+  const nodeType = NODE_KIND_MAP[kind] ?? "concept";
+  const title = stringValue(raw.name) ?? stringValue(raw.label) ?? sourceId;
+  const rawPath = stringValue(raw.path) ?? pathFromSourceId(sourceId);
+  const path = rawPath && !isAbsolute(rawPath) ? resolve(context.rootDir, rawPath) : rawPath;
+  const label = canonicalNodeLabel({ sourceId, kind, nodeType, title, path });
+  const sourceConfidence = normalizeConfidenceScore(raw.confidence);
+  const freshness = normalizeFreshness(raw.freshness ?? raw.updated_at ?? raw.generated_at, context.artifactFreshness);
+  const rawProps = isRecord(raw.properties) ? raw.properties : {};
+  const confidence: Confidence = "EXTRACTED";
+  const symbolKind = SYMBOL_KINDS.has(kind) ? symbolKindForHash(kind) : undefined;
+  return {
+    sourceId,
+    node: {
+      label,
+      node_type: nodeType,
+      properties: {
+        ...rawProps,
+        title,
+        summary: kind || undefined,
+        source: context.artifactPath,
+        confidence,
+        provenance: {
+          source_kind: "external-map",
+          writer: "import-complementary-map",
+          command: context.command,
+          confidence,
+          evidence: [`${context.artifactPath}#node:${sourceId}`],
+          created_at: context.now,
+          updated_at: context.now,
+          map_source_kind: context.sourceKind,
+          freshness,
+        },
+        map_source_kind: context.sourceKind,
+        map_source_id: sourceId,
+        map_node_kind: kind || undefined,
+        map_confidence: sourceConfidence,
+        map_freshness: freshness,
+        path,
+        hash: canonicalNodeHash({
+          label,
+          nodeType,
+          title,
+          path,
+          sourceId,
+          sourceKind: context.sourceKind,
+          symbolKind,
+        }),
+      },
+    },
+  };
+}
+
+function normalizeEdge(
+  raw: Record<string, unknown>,
+  context: {
+    artifactPath: string;
+    sourceKind: ComplementaryMapSourceKind;
+    now: number;
+    artifactFreshness: number | undefined;
+    command: string | undefined;
+  },
+): NormalizedEdge | null {
+  const sourceFrom = stringValue(raw.from) ?? stringValue(raw.source);
+  const sourceTo = stringValue(raw.to) ?? stringValue(raw.target);
+  if (!sourceFrom || !sourceTo) return null;
+  const originalKind = upperKind(raw.kind ?? raw.type ?? raw.label);
+  const mapped = EDGE_KIND_MAP[originalKind] ?? { label: "REFERENCES" as const, baseWeight: 0.45 };
+  const sourceConfidence = normalizeConfidenceScore(raw.confidence);
+  const sourceSalience = normalizeConfidenceScore(raw.salience);
+  const weight = normalizeWeight(raw.weight, sourceSalience, sourceConfidence, mapped.baseWeight);
+  const freshness = normalizeFreshness(raw.freshness ?? raw.updated_at ?? raw.generated_at, context.artifactFreshness);
+  const rawProps = isRecord(raw.properties) ? raw.properties : {};
+  return {
+    fromSourceId: mapped.reverse ? sourceTo : sourceFrom,
+    toSourceId: mapped.reverse ? sourceFrom : sourceTo,
+    edge: {
+      label: mapped.label,
+      weight,
+      properties: {
+        ...rawProps,
+        confidence: "EXTRACTED",
+        source: context.artifactPath,
+        weight,
+        original_edge_kind: originalKind || undefined,
+        map_source_kind: context.sourceKind,
+        map_confidence: sourceConfidence,
+        map_salience: sourceSalience,
+        map_weight_normalized: weight,
+        map_freshness: freshness,
+        provenance: {
+          source_kind: "external-map",
+          writer: "import-complementary-map",
+          command: context.command,
+          confidence: "EXTRACTED",
+          evidence: [`${context.artifactPath}#edge:${sourceFrom}->${sourceTo}:${originalKind}`],
+          created_at: context.now,
+          updated_at: context.now,
+          map_source_kind: context.sourceKind,
+          freshness,
+        },
+      },
+    },
+  };
+}
+
+function canonicalNodeLabel(input: {
+  sourceId: string;
+  kind: string;
+  nodeType: NodeType;
+  title: string;
+  path?: string;
+}): string {
+  if (input.nodeType === "file") {
+    return `file:${input.path ?? input.title}`;
+  }
+  if (input.nodeType === "symbol") {
+    if (input.path) return `sym:${input.path}#${input.title}`;
+    if (input.sourceId.startsWith("sym:")) return input.sourceId;
+    return `sym:${input.title}`;
+  }
+  if (input.nodeType === "import") {
+    if (input.path) return `import:${input.path}#${input.title}`;
+    return input.sourceId.startsWith("import:") ? input.sourceId : `import:${input.title}`;
+  }
+  if (input.sourceId.startsWith("concept:")) return input.sourceId;
+  return input.kind === "community" ? `concept:${input.title}` : `map:${input.sourceId}`;
+}
+
+function canonicalNodeHash(input: {
+  label: string;
+  nodeType: NodeType;
+  title: string;
+  path?: string;
+  sourceId: string;
+  sourceKind: ComplementaryMapSourceKind;
+  symbolKind?: string;
+}): string {
+  if (input.nodeType === "symbol" && input.path && input.symbolKind) {
+    return contentHash(input.path, input.title, input.symbolKind);
+  }
+  return contentHash("complementary-map", input.sourceKind, input.nodeType, input.label, input.sourceId);
+}
+
+function symbolKindForHash(kind: string): string {
+  if (kind === "method") return "function";
+  return kind === "symbol" ? "function" : kind;
+}
+
+function normalizeWeight(
+  rawWeight: unknown,
+  salience: number | undefined,
+  confidence: number | undefined,
+  baseWeight: number,
+): number {
+  const explicit = normalizeConfidenceScore(rawWeight);
+  const weighted =
+    explicit ??
+    (salience != null && confidence != null
+      ? salience * 0.6 + confidence * 0.4
+      : salience ?? confidence ?? baseWeight);
+  return round3(Math.min(1, Math.max(0.1, weighted)));
+}
+
+function normalizeConfidenceScore(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 1 ? round3(Math.min(1, value / 100)) : round3(Math.max(0, Math.min(1, value)));
+  }
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "") return undefined;
+  if (trimmed === "high") return 0.85;
+  if (trimmed === "medium") return 0.6;
+  if (trimmed === "low") return 0.35;
+  const parsed = Number(trimmed.replace(/%$/, ""));
+  if (!Number.isFinite(parsed)) return undefined;
+  return parsed > 1 ? round3(Math.min(1, parsed / 100)) : round3(Math.max(0, Math.min(1, parsed)));
+}
+
+function normalizeFreshness(raw: unknown, artifactFreshness: number | undefined): Record<string, unknown> {
+  const sourceUpdatedAt = millisValue(raw) ?? artifactFreshness;
+  return {
+    ...(sourceUpdatedAt != null ? { source_updated_at: sourceUpdatedAt } : {}),
+  };
+}
+
+async function artifactFreshnessMs(path: string, generatedAt: unknown): Promise<number | undefined> {
+  const generated = millisValue(generatedAt);
+  if (generated != null) return generated;
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+function pathFromSourceId(id: string): string | undefined {
+  if (id.startsWith("file:")) return id.slice("file:".length);
+  const match = /^symbol:([^#]+)#(.+)$/.exec(id) ?? /^sym:([^#]+)#(.+)$/.exec(id);
+  return match?.[1];
+}
+
+function normalizeSourceKind(value: string | undefined): ComplementaryMapSourceKind {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "graphify") return "graphify";
+  if (normalized === "scip") return "scip";
+  if (normalized === "lsp") return "lsp";
+  return "static-analysis";
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function lowerKind(value: unknown): string {
+  return stringValue(value)?.toLowerCase().replace(/[\s-]+/g, "_") ?? "";
+}
+
+function upperKind(value: unknown): string {
+  return stringValue(value)?.toUpperCase().replace(/[\s-]+/g, "_") ?? "";
+}
+
+function arrayOfRecords(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecord);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function millisValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  if (isRecord(value)) {
+    return millisValue(value.updated_at ?? value.generated_at ?? value.source_updated_at);
+  }
+  return undefined;
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/src/apps/memory/src/schema.ts
+++ b/src/apps/memory/src/schema.ts
@@ -197,7 +197,7 @@ export interface MemoryNodeProps {
 }
 
 export interface MemoryProvenance {
-  source_kind: "manual" | "hook" | "derived" | "system";
+  source_kind: "manual" | "hook" | "derived" | "system" | "external-map";
   writer?: string;
   command?: string;
   hook?: string;

--- a/src/apps/memory/tests/fixtures/complementary-map/graphify-map.json
+++ b/src/apps/memory/tests/fixtures/complementary-map/graphify-map.json
@@ -1,0 +1,45 @@
+{
+  "source_kind": "graphify",
+  "generated_at": "2026-06-01T00:00:00.000Z",
+  "nodes": [
+    {
+      "id": "file:src/auth.ts",
+      "kind": "file",
+      "label": "src/auth.ts",
+      "path": "src/auth.ts",
+      "confidence": 0.95
+    },
+    {
+      "id": "symbol:src/auth.ts#authenticateUser",
+      "kind": "function",
+      "label": "authenticateUser",
+      "name": "authenticateUser",
+      "path": "src/auth.ts",
+      "confidence": 0.88
+    },
+    {
+      "id": "symbol:src/auth.ts#SessionStore",
+      "kind": "class",
+      "label": "SessionStore",
+      "name": "SessionStore",
+      "path": "src/auth.ts",
+      "confidence": "high"
+    }
+  ],
+  "edges": [
+    {
+      "from": "file:src/auth.ts",
+      "to": "symbol:src/auth.ts#authenticateUser",
+      "kind": "DEFINES",
+      "confidence": 0.9,
+      "salience": 0.8
+    },
+    {
+      "from": "symbol:src/auth.ts#authenticateUser",
+      "to": "symbol:src/auth.ts#SessionStore",
+      "kind": "CALLS",
+      "confidence": 0.8,
+      "salience": 0.9
+    }
+  ]
+}

--- a/src/apps/memory/tests/import-complementary-map.test.ts
+++ b/src/apps/memory/tests/import-complementary-map.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import { MemoryStore } from "../src/graph-store.js";
+import { importComplementaryMapFile } from "../src/import-complementary-map.js";
+
+const TIMEOUT = 30_000;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GRAPHIFY_FIXTURE = resolve(HERE, "fixtures/complementary-map/graphify-map.json");
+
+const roots: string[] = [];
+const stores: MemoryStore[] = [];
+
+async function openStore(): Promise<MemoryStore> {
+  const dir = await mkdtemp(join(tmpdir(), "memory-map-import-"));
+  roots.push(dir);
+  const store = await MemoryStore.open({
+    uri: `file://${join(dir, "graph.rdb")}`,
+    project: "test",
+  });
+  stores.push(store);
+  return store;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+describe("complementary map import", () => {
+  test(
+    "imports a Graphify-like map into RedDB with provenance, confidence, freshness, and normalized edges",
+    async () => {
+      const store = await openStore();
+
+      const report = await importComplementaryMapFile(store, GRAPHIFY_FIXTURE, {
+        rootDir: HERE,
+        sourceKind: "graphify",
+        now: Date.parse("2026-06-07T00:00:00.000Z"),
+      });
+
+      expect(report).toMatchObject({
+        destination: "RedDB",
+        source_kind: "graphify",
+        nodes: { input: 3, imported: 3, overlapped: 0, skipped: 0 },
+        edges: { input: 2, imported: 2, overlapped: 0, skipped: 0 },
+      });
+
+      const nodes = await store.listNodes();
+      const edges = await store.listEdges();
+      expect(nodes).toHaveLength(3);
+      expect(edges).toHaveLength(2);
+
+      const authPath = resolve(HERE, "src/auth.ts");
+      const authFile = nodes.find((node) => node.label === `file:${authPath}`);
+      const authenticateUser = nodes.find(
+        (node) => node.label === `sym:${authPath}#authenticateUser`,
+      );
+      const sessionStore = nodes.find((node) => node.label === `sym:${authPath}#SessionStore`);
+      expect(authFile?.properties.provenance).toMatchObject({
+        source_kind: "external-map",
+        writer: "import-complementary-map",
+        confidence: "EXTRACTED",
+        map_source_kind: "graphify",
+        freshness: { source_updated_at: Date.parse("2026-06-01T00:00:00.000Z") },
+      });
+      expect(authenticateUser?.properties).toMatchObject({
+        map_source_kind: "graphify",
+        map_source_id: "symbol:src/auth.ts#authenticateUser",
+        map_node_kind: "function",
+        map_confidence: 0.88,
+        map_freshness: { source_updated_at: Date.parse("2026-06-01T00:00:00.000Z") },
+      });
+
+      expect(edges).toContainEqual(
+        expect.objectContaining({
+          from_rid: authenticateUser?.rid,
+          to_rid: authFile?.rid,
+          label: "DEFINED_IN",
+        }),
+      );
+      const calls = edges.find(
+        (edge) =>
+          edge.from_rid === authenticateUser?.rid &&
+          edge.to_rid === sessionStore?.rid &&
+          edge.label === "CALLS",
+      );
+      const callProps = edgeProperties(calls);
+      expect(Number(calls?.weight)).toBeCloseTo(0.86);
+      expect(callProps).toEqual(
+        expect.objectContaining({
+          original_edge_kind: "CALLS",
+          map_source_kind: "graphify",
+          map_confidence: 0.8,
+          map_salience: 0.9,
+          map_weight_normalized: 0.86,
+          provenance: expect.objectContaining({
+            source_kind: "external-map",
+            map_source_kind: "graphify",
+          }),
+        }),
+      );
+      expect(callProps.color).toBeUndefined();
+
+      const statsAfterFirstImport = await store.stats();
+      const second = await importComplementaryMapFile(store, GRAPHIFY_FIXTURE, {
+        rootDir: HERE,
+        sourceKind: "graphify",
+        now: Date.parse("2026-06-07T00:00:00.000Z"),
+      });
+      expect(second.nodes).toMatchObject({ input: 3, imported: 0, overlapped: 3, skipped: 0 });
+      expect(second.edges).toMatchObject({ input: 2, imported: 0, overlapped: 2, skipped: 0 });
+      await expect(store.stats()).resolves.toEqual(statsAfterFirstImport);
+    },
+    TIMEOUT,
+  );
+});
+
+function edgeProperties(edge: Record<string, unknown> | undefined): Record<string, unknown> {
+  const properties = edge?.properties ?? edge?.PROPERTIES;
+  return typeof properties === "object" && properties !== null && !Array.isArray(properties)
+    ? (properties as Record<string, unknown>)
+    : {};
+}


### PR DESCRIPTION
Closes #528\n\n## Summary\n- add a RedDB-backed complementary map importer exposed as `memory import map`\n- support Graphify-like node/edge JSON with external-map provenance, confidence, freshness, and normalized edge weights\n- test imported metadata, deterministic overlap handling, and RedDB as the destination\n\n## Validation\n- `pnpm --dir src/apps/memory run typecheck`\n- `pnpm --dir src/apps/memory test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783388511&installation_id=129708444&pr_number=539&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F539&signature=f90753b07584e3eba9180cdbee5305cb10d814520da591e543f67ccbc27f9b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI subcommand for importing complementary maps into graph storage with automatic validation.
  * System now tracks imported maps as external data sources and returns detailed reports including node/edge counts, warnings, and deduplication metrics.
  * Imports are idempotent—re-running the same import does not create duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->