### PR TITLE
Add Evidence card fingerprint refresh rules

### DIFF
--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -892,7 +892,7 @@ hooks on.
 `hooks coverage-viewer` writes the same report as embedded JSON plus HTML for
 local inspection and MCP/HTTP handoff.
 
-Proposals live under `.red/memory/proposals/`. Each proposal has a deterministic fingerprint, and repeated generation refreshes the matching pending proposal instead of creating duplicate files. Draft structured patches prefer semantic section anchors derived from the dominant failure stage/class before falling back to a safe tail anchor. Archiving moves reviewed files to
+Proposals live under `.red/memory/proposals/`. Each Evidence card has a deterministic fingerprint from telemetry source, refinement route, dominant error pattern, and telemetry window. Repeated generation refreshes matching unresolved cards in `captured`, `routed`, or `proposed` status instead of creating duplicate files; reviewed or terminal cards are preserved and the next run creates a new card. Draft structured patches prefer semantic section anchors derived from the dominant failure stage/class before falling back to a safe tail anchor. Archiving moves reviewed files to
 `.red/memory/proposals/archive/<applied|rejected|stale>/`, so `memory health`
 counts only actionable pending proposals while retaining audit history.
 

--- a/plugins/memory/skills/core/improve-skills/SKILL.md
+++ b/plugins/memory/skills/core/improve-skills/SKILL.md
@@ -115,7 +115,7 @@ Patch block format:
 
 <supporting-info>
 
-`memory improve skills` currently proposes fixes for curatable skills flagged as `frequently-failing` by partitioned Skill telemetry rollups. Each proposal gets a deterministic fingerprint from skill name, category, target path, dominant error stage, and dominant error class; pending proposals with the same fingerprint are refreshed in place. Draft patch blocks choose a semantic section anchor from the dominant failure stage/class before falling back to a tail anchor. It is deliberately proposal-gated: the Memory plugin may write `.red/memory/proposals/*.md`, but applying a patch remains an explicit review step handled outside this command.
+`memory improve skills` currently proposes fixes for curatable skills flagged as `frequently-failing` by partitioned Skill telemetry rollups. Each Evidence card gets a deterministic fingerprint from its telemetry source, refinement route, dominant error pattern, and telemetry window; unresolved cards in `captured`, `routed`, or `proposed` status with the same fingerprint are refreshed in place, while reviewed or terminal cards (`approved`, `rejected`, `promoted`, `archived`) are preserved and a later run creates a new card. Draft patch blocks choose a semantic section anchor from the dominant failure stage/class before falling back to a tail anchor. It is deliberately proposal-gated: the Memory plugin may write `.red/memory/proposals/*.md`, but applying a patch remains an explicit review step handled outside this command.
 
 This is the first mutating stage in the self-improvement loop. Proposal generation mutates only `.red/memory/proposals/`; proposal application can patch a target skill only when a reviewed structured block plus `--yes` are both present.
 

--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -4241,6 +4241,11 @@ interface SkillImprovementProposalSummary {
   priority: "high" | "medium" | "low";
   scoreReasons: string[];
   fingerprint: string;
+  evidenceSource: string;
+  evidenceRoute: string;
+  dominantErrorPattern: string;
+  telemetryWindow: string;
+  cardStatus: SkillTelemetryEvidenceCardStatus;
   reusedExisting: boolean;
   path: string | null;
   written: boolean;
@@ -4252,6 +4257,8 @@ interface SkillTelemetryEvidenceCardArtifact {
   kind: "skill_telemetry";
   skill: string;
   skillPath: string;
+  status: SkillTelemetryEvidenceCardStatus;
+  signalFingerprint: string;
   fingerprint: string;
   path: string;
   proposalPath: string;
@@ -4294,7 +4301,22 @@ async function buildSkillImprovementProposals(
     const evidence = recentFailureEvidence(rec.name, recentEvents);
     const dominantErrorStage = topValues(evidence.map((event) => event.error_stage))[0] ?? null;
     const dominantErrorClass = topValues(evidence.map((event) => event.error_class))[0] ?? null;
+    const dominantErrorCode = topValues(evidence.map((event) => event.error_code))[0] ?? null;
     const relSkillPath = isAbsolute(rec.path) ? toPosix(relative(rootDir, rec.path)) : rec.path;
+    const evidenceSource = skillTelemetryEvidenceSource(rec.name, evidence);
+    const evidenceRoute = skillTelemetryEvidenceRoute(rec.category, relSkillPath);
+    const dominantErrorPattern = skillTelemetryDominantErrorPattern({
+      dominantErrorStage,
+      dominantErrorClass,
+      dominantErrorCode,
+    });
+    const telemetryWindow = skillTelemetryWindow(evidence);
+    const signalFingerprint = skillTelemetrySignalFingerprint({
+      evidenceSource,
+      evidenceRoute,
+      dominantErrorPattern,
+      telemetryWindow,
+    });
     const fingerprint = proposalFingerprint({
       skill: rec.name,
       category: rec.category,
@@ -4315,6 +4337,10 @@ async function buildSkillImprovementProposals(
       }
     }
 
+    const reusableCard =
+      writeProposal && proposalPath
+        ? await findReusableSkillTelemetryEvidenceCard(rootDir, evidenceCardDir, signalFingerprint)
+        : null;
     const cardlessBody = await renderSkillImprovementProposal(rootDir, rec, evidence, fingerprint, null);
     const patchDrafted = cardlessBody.includes("```json memory-skill-patch");
     const priority = computeProposalPriority({
@@ -4325,9 +4351,9 @@ async function buildSkillImprovementProposals(
       patchDrafted,
     });
     const existingCardCount = writeProposal
-      ? await countSkillTelemetryEvidenceCardsForProposalFingerprint(evidenceCardDir, fingerprint)
+      ? await countSkillTelemetryEvidenceCardsForSignal(evidenceCardDir, signalFingerprint)
       : 0;
-    const cardRevision = reusedExisting ? Math.max(0, existingCardCount - 1) : existingCardCount;
+    const cardRevision = reusableCard ? reusableCard.revision : existingCardCount;
     const card = buildSkillTelemetryEvidenceCard({
       rootDir,
       rec,
@@ -4336,7 +4362,13 @@ async function buildSkillImprovementProposals(
       dominantErrorStage,
       dominantErrorClass,
       proposalFingerprint: fingerprint,
+      signalFingerprint,
+      evidenceSource,
+      evidenceRoute,
+      dominantErrorPattern,
+      telemetryWindow,
       cardRevision,
+      reusableCard,
       priority,
     });
     if (writeProposal && proposalPath) {
@@ -4357,6 +4389,8 @@ async function buildSkillImprovementProposals(
         kind: "skill_telemetry",
         skill: rec.name,
         skillPath: rec.path,
+        status: card.status,
+        signalFingerprint: card.signal_fingerprint,
         fingerprint: card.fingerprint,
         path: cardPath,
         proposalPath,
@@ -4377,6 +4411,11 @@ async function buildSkillImprovementProposals(
       priority: priority.priority,
       scoreReasons: priority.reasons,
       fingerprint,
+      evidenceSource,
+      evidenceRoute,
+      dominantErrorPattern,
+      telemetryWindow,
+      cardStatus: card.status,
       reusedExisting,
       path: proposalPath,
       written: writeProposal,
@@ -4388,26 +4427,133 @@ async function buildSkillImprovementProposals(
   };
 }
 
-async function countSkillTelemetryEvidenceCardsForProposalFingerprint(
+type SkillTelemetryEvidenceCardStatus =
+  | "captured"
+  | "routed"
+  | "proposed"
+  | "approved"
+  | "rejected"
+  | "promoted"
+  | "archived";
+
+interface ExistingSkillTelemetryEvidenceCardRef {
+  file: string;
+  id: string;
+  fingerprint: string;
+  status: SkillTelemetryEvidenceCardStatus;
+  createdAt: string | null;
+  proposalPath: string | null;
+  revision: number;
+  review: SkillTelemetryEvidenceCard["review"];
+}
+
+async function countSkillTelemetryEvidenceCardsForSignal(
   evidenceCardDir: string,
-  proposalFingerprint: string,
+  signalFingerprint: string,
 ): Promise<number> {
+  return (await listSkillTelemetryEvidenceCardsForSignal(evidenceCardDir, signalFingerprint)).length;
+}
+
+async function findReusableSkillTelemetryEvidenceCard(
+  rootDir: string,
+  evidenceCardDir: string,
+  signalFingerprint: string,
+): Promise<ExistingSkillTelemetryEvidenceCardRef | null> {
+  const cards = await listSkillTelemetryEvidenceCardsForSignal(evidenceCardDir, signalFingerprint);
+  for (const card of cards) {
+    if (!isUnresolvedSkillTelemetryEvidenceCardStatus(card.status)) continue;
+    if (skillTelemetryReviewHasHumanDecision(card.review)) continue;
+    if (card.proposalPath && !existsSync(resolve(rootDir, card.proposalPath))) continue;
+    return card;
+  }
+  return null;
+}
+
+async function listSkillTelemetryEvidenceCardsForSignal(
+  evidenceCardDir: string,
+  signalFingerprint: string,
+): Promise<ExistingSkillTelemetryEvidenceCardRef[]> {
   let entries;
   try {
     entries = await readdir(evidenceCardDir, { withFileTypes: true });
   } catch {
-    return 0;
+    return [];
   }
-  const fingerprintLine = `fingerprint: ${yamlScalar(proposalFingerprint)}`;
-  let count = 0;
+  const signalLine = `signal_fingerprint: ${yamlScalar(signalFingerprint)}`;
+  const cards: ExistingSkillTelemetryEvidenceCardRef[] = [];
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".yaml")) continue;
     const body = await readFile(join(evidenceCardDir, entry.name), "utf8");
-    if (body.includes('kind: "skill_telemetry"') && body.includes(fingerprintLine)) count += 1;
+    if (!body.includes('kind: "skill_telemetry"') || !body.includes(signalLine)) continue;
+    const status = parseSkillTelemetryEvidenceCardStatus(firstTopLevelYamlScalarField(body, "status"));
+    cards.push({
+      file: entry.name,
+      id: firstTopLevelYamlScalarField(body, "id") ?? "",
+      fingerprint: firstTopLevelYamlScalarField(body, "fingerprint") ?? "",
+      status,
+      createdAt: firstTopLevelYamlScalarField(body, "created_at"),
+      proposalPath: lastYamlScalarField(body, "path"),
+      revision: Number(lastYamlScalarField(body, "revision") ?? "0") || 0,
+      review: {
+        reviewer: lastYamlScalarField(body, "reviewer"),
+        reviewed_at: lastYamlScalarField(body, "reviewed_at"),
+        decision: lastYamlScalarField(body, "decision"),
+        notes: lastYamlScalarField(body, "notes"),
+      },
+    });
   }
-  return count;
+  return cards.sort((a, b) => b.revision - a.revision || a.file.localeCompare(b.file));
 }
 
+function firstTopLevelYamlScalarField(body: string, key: string): string | null {
+  const match = body.match(new RegExp(`^${escapeRegExp(key)}:\\s*([^\\n]*)$`, "m"));
+  if (!match) return null;
+  return parseYamlScalar(match[1]);
+}
+
+function lastYamlScalarField(body: string, key: string): string | null {
+  const matches = [...body.matchAll(new RegExp(`^\\s*${escapeRegExp(key)}:\\s*([^\\n]*)$`, "gm"))];
+  const match = matches.at(-1);
+  if (!match) return null;
+  return parseYamlScalar(match[1]);
+}
+
+function parseYamlScalar(value: string): string | null {
+  const raw = value.trim();
+  if (raw === "" || raw === "null") return null;
+  try {
+    return String(JSON.parse(raw));
+  } catch {
+    return raw;
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseSkillTelemetryEvidenceCardStatus(value: string | null): SkillTelemetryEvidenceCardStatus {
+  if (
+    value === "captured" ||
+    value === "routed" ||
+    value === "proposed" ||
+    value === "approved" ||
+    value === "rejected" ||
+    value === "promoted" ||
+    value === "archived"
+  ) {
+    return value;
+  }
+  return "proposed";
+}
+
+function isUnresolvedSkillTelemetryEvidenceCardStatus(status: SkillTelemetryEvidenceCardStatus): boolean {
+  return status === "captured" || status === "routed" || status === "proposed";
+}
+
+function skillTelemetryReviewHasHumanDecision(review: SkillTelemetryEvidenceCard["review"]): boolean {
+  return Boolean(review.reviewed_at || review.decision);
+}
 
 function proposalFingerprint(input: {
   skill: string;
@@ -4426,15 +4572,68 @@ function proposalFingerprint(input: {
   return `sha256:${createHash("sha256").update(payload).digest("hex")}`;
 }
 
+function skillTelemetryEvidenceSource(skillName: string, evidence: readonly SkillEventSummary[]): string {
+  const sourceKinds = topValues(evidence.map((event) => event.source_kind));
+  return `skill-telemetry:${skillName}:${sourceKinds.length > 0 ? sourceKinds.join("+") : "unknown-source"}`;
+}
+
+function skillTelemetryEvidenceRoute(category: string, skillPath: string): string {
+  return `skill-improvement:${category}:${skillPath}`;
+}
+
+function skillTelemetryDominantErrorPattern(input: {
+  dominantErrorStage: string | null;
+  dominantErrorClass: string | null;
+  dominantErrorCode: string | null;
+}): string {
+  return [
+    `stage=${input.dominantErrorStage ?? ""}`,
+    `class=${input.dominantErrorClass ?? ""}`,
+    `code=${input.dominantErrorCode ?? ""}`,
+  ].join("|");
+}
+
+function skillTelemetryWindow(evidence: readonly SkillEventSummary[]): string {
+  const timestamps = evidence.map((event) => event.timestamp).filter(Boolean).sort();
+  if (timestamps.length === 0) return "none";
+  return `${timestamps[0]}..${timestamps[timestamps.length - 1]} count=${timestamps.length}`;
+}
+
+function skillTelemetrySignalFingerprint(input: {
+  evidenceSource: string;
+  evidenceRoute: string;
+  dominantErrorPattern: string;
+  telemetryWindow: string;
+}): string {
+  return `sha256:${createHash("sha256")
+    .update(
+      JSON.stringify({
+        evidenceSource: input.evidenceSource,
+        evidenceRoute: input.evidenceRoute,
+        dominantErrorPattern: input.dominantErrorPattern,
+        telemetryWindow: input.telemetryWindow,
+      }),
+    )
+    .digest("hex")}`;
+}
+
 interface SkillTelemetryEvidenceCard {
   contract: "memory.evidence-card.experimental.v1";
   id: string;
   kind: "skill_telemetry";
-  status: "proposed";
+  status: SkillTelemetryEvidenceCardStatus;
   created_at: string;
   updated_at: string;
+  signal_fingerprint: string;
   fingerprint: string;
   file: string;
+  refresh: {
+    evidence_source: string;
+    evidence_route: string;
+    dominant_error_pattern: string;
+    telemetry_window: string;
+    revision: number;
+  };
   source: {
     kind: "skill_telemetry";
     source_kind: string;
@@ -4486,6 +4685,12 @@ interface SkillTelemetryEvidenceCard {
     redaction: "not_required";
     findings: string[];
   };
+  review: {
+    reviewer: string | null;
+    reviewed_at: string | null;
+    decision: string | null;
+    notes: string | null;
+  };
   proposal: {
     path: string;
     fingerprint: string;
@@ -4500,7 +4705,13 @@ function buildSkillTelemetryEvidenceCard(input: {
   dominantErrorStage: string | null;
   dominantErrorClass: string | null;
   proposalFingerprint: string;
+  signalFingerprint: string;
+  evidenceSource: string;
+  evidenceRoute: string;
+  dominantErrorPattern: string;
+  telemetryWindow: string;
   cardRevision: number;
+  reusableCard: ExistingSkillTelemetryEvidenceCardRef | null;
   priority: { score: number; priority: "high" | "medium" | "low"; reasons: string[] };
 }): SkillTelemetryEvidenceCard {
   const relSkillPath = isAbsolute(input.rec.path)
@@ -4508,19 +4719,19 @@ function buildSkillTelemetryEvidenceCard(input: {
     : input.rec.path;
   const runner = topValues(input.evidence.map((event) => event.runner))[0] ?? "unknown";
   const recentEventRefs = input.evidence.map((event) => `skill-event:${event.event_id}`);
-  const fingerprint = `sha256:${createHash("sha256")
+  const fingerprint =
+    input.reusableCard?.fingerprint ||
+    `sha256:${createHash("sha256")
     .update(
       JSON.stringify({
         contract: "memory.evidence-card.experimental.v1",
-        source: "skill.telemetry",
-        route: "skill_proposal",
-        proposalFingerprint: input.proposalFingerprint,
+        signalFingerprint: input.signalFingerprint,
         cardRevision: input.cardRevision,
       }),
     )
     .digest("hex")}`;
   const short = fingerprint.slice("sha256:".length, "sha256:".length + 12);
-  const id = `skill-telemetry:${slugify(input.rec.name)}:${short}`;
+  const id = input.reusableCard?.id || `skill-telemetry:${slugify(input.rec.name)}:${short}`;
   const now = new Date().toISOString();
   const rollupRef =
     input.rollup != null
@@ -4532,10 +4743,18 @@ function buildSkillTelemetryEvidenceCard(input: {
     id,
     kind: "skill_telemetry",
     status: "proposed",
-    created_at: now,
+    created_at: input.reusableCard?.createdAt || now,
     updated_at: now,
+    signal_fingerprint: input.signalFingerprint,
     fingerprint,
-    file: `skill-telemetry-${slugify(input.rec.name)}-${short}.yaml`,
+    file: input.reusableCard?.file || `skill-telemetry-${slugify(input.rec.name)}-${short}.yaml`,
+    refresh: {
+      evidence_source: input.evidenceSource,
+      evidence_route: input.evidenceRoute,
+      dominant_error_pattern: input.dominantErrorPattern,
+      telemetry_window: input.telemetryWindow,
+      revision: input.cardRevision,
+    },
     source: {
       kind: "skill_telemetry",
       source_kind: input.rec.source_kind,
@@ -4587,6 +4806,12 @@ function buildSkillTelemetryEvidenceCard(input: {
     privacy: {
       redaction: "not_required",
       findings: [],
+    },
+    review: input.reusableCard?.review || {
+      reviewer: null,
+      reviewed_at: null,
+      decision: null,
+      notes: null,
     },
     proposal: {
       path: "",

--- a/src/apps/memory/tests/improve-skills.test.ts
+++ b/src/apps/memory/tests/improve-skills.test.ts
@@ -341,12 +341,6 @@ describe("memory improve skills CLI", () => {
       const firstPath = firstBody.proposals[0].path;
       const firstCard = firstBody.evidenceCards[0];
 
-      const newFailure = runMemory(
-        ["event", "skill", "--root", root],
-        JSON.stringify(skillResultEvent(6, skillFile, "failed")),
-      );
-      expect(newFailure.status).toBe(0);
-
       const second = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
       expect(second.status).toBe(0);
       const secondBody = JSON.parse(second.stdout);
@@ -402,6 +396,111 @@ describe("memory improve skills CLI", () => {
       expect(listed.status).toBe(0);
       const listedBody = JSON.parse(listed.stdout);
       expect(listedBody.proposals[0].fingerprint).toBe(firstBody.proposals[0].fingerprint);
+      expect(firstBody.proposals[0].cardStatus).toBe("proposed");
+      expect(firstBody.proposals[0].evidenceSource).toBe("skill-telemetry:flaky-skill:project");
+      expect(firstBody.proposals[0].evidenceRoute).toBe("skill-improvement:frequently-failing:skills/flaky-skill/SKILL.md");
+      expect(firstBody.proposals[0].dominantErrorPattern).toBe("stage=verify|class=ValidationError|code=");
+      expect(firstBody.proposals[0].telemetryWindow).toBe(
+        "2026-05-22T16:01:00.000Z..2026-05-22T16:04:00.000Z count=4",
+      );
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "refreshes unresolved evidence cards by fingerprint without dropping review metadata",
+    async () => {
+      const root = await tempRoot();
+      await initGraph(root, { skillTelemetry: true });
+      const skillFile = join(root, "skills", "flaky-skill", "SKILL.md");
+      await mkdir(dirname(skillFile), { recursive: true });
+      await writeFile(skillFile, "---\nname: flaky-skill\ndescription: fixture\n---\n\n# flaky-skill\n\nOriginal content.\n", "utf8");
+      const events = [
+        skillResultEvent(1, skillFile, "failed"),
+        skillResultEvent(2, skillFile, "failed"),
+        skillResultEvent(3, skillFile, "failed"),
+        skillResultEvent(4, skillFile, "failed"),
+        skillResultEvent(5, skillFile, "succeeded"),
+      ];
+      const ingest = runMemory(["event", "skill", "--root", root], events.map((event) => JSON.stringify(event)).join("\n"));
+      expect(ingest.status).toBe(0);
+
+      const first = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(first.status).toBe(0);
+      const firstBody = JSON.parse(first.stdout);
+      const firstCard = firstBody.evidenceCards[0];
+      const original = await readFile(firstCard.path, "utf8");
+      const routed = original
+        .replace(/^status: "proposed"$/m, 'status: "routed"')
+        .replace(/^  reviewer: null$/m, '  reviewer: "triager"')
+        .replace(/^  notes: null$/m, '  notes: "keep active-review context"');
+      await writeFile(firstCard.path, routed, "utf8");
+
+      const second = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(second.status).toBe(0);
+      const secondBody = JSON.parse(second.stdout);
+      expect(secondBody.proposals[0].fingerprint).toBe(firstBody.proposals[0].fingerprint);
+      expect(secondBody.proposals[0].reusedExisting).toBe(true);
+      expect(secondBody.evidenceCards[0].id).toBe(firstCard.id);
+      expect(secondBody.evidenceCards[0].path).toBe(firstCard.path);
+      expect(secondBody.evidenceCards[0].reusedExisting).toBe(true);
+
+      const evidenceFiles = await readdir(join(root, ".red", "memory", "inbox", "evidence"));
+      expect(evidenceFiles.filter((file) => file.endsWith(".yaml"))).toHaveLength(1);
+      const refreshed = await readFile(firstCard.path, "utf8");
+      expect(refreshed).toContain('status: "proposed"');
+      expect(refreshed).toContain('reviewer: "triager"');
+      expect(refreshed).toContain('notes: "keep active-review context"');
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "preserves reviewed evidence cards and creates a new card for the same signal",
+    async () => {
+      const root = await tempRoot();
+      await initGraph(root, { skillTelemetry: true });
+      const skillFile = join(root, "skills", "flaky-skill", "SKILL.md");
+      await mkdir(dirname(skillFile), { recursive: true });
+      await writeFile(skillFile, "---\nname: flaky-skill\ndescription: fixture\n---\n\n# flaky-skill\n\nOriginal content.\n", "utf8");
+      const events = [
+        skillResultEvent(1, skillFile, "failed"),
+        skillResultEvent(2, skillFile, "failed"),
+        skillResultEvent(3, skillFile, "failed"),
+        skillResultEvent(4, skillFile, "failed"),
+        skillResultEvent(5, skillFile, "succeeded"),
+      ];
+      const ingest = runMemory(["event", "skill", "--root", root], events.map((event) => JSON.stringify(event)).join("\n"));
+      expect(ingest.status).toBe(0);
+
+      const first = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(first.status).toBe(0);
+      const firstBody = JSON.parse(first.stdout);
+      const firstCard = firstBody.evidenceCards[0];
+      const approved = (await readFile(firstCard.path, "utf8"))
+        .replace(/^status: "proposed"$/m, 'status: "approved"')
+        .replace(/^  reviewer: null$/m, '  reviewer: "alice"')
+        .replace(/^  reviewed_at: null$/m, '  reviewed_at: "2026-05-22T17:00:00.000Z"')
+        .replace(/^  decision: null$/m, '  decision: "approved"')
+        .replace(/^  notes: null$/m, '  notes: "keep this reviewed decision"');
+      await writeFile(firstCard.path, approved, "utf8");
+
+      const second = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(second.status).toBe(0);
+      const secondBody = JSON.parse(second.stdout);
+      expect(secondBody.proposals[0].fingerprint).toBe(firstBody.proposals[0].fingerprint);
+      expect(secondBody.proposals[0].path).toBe(firstBody.proposals[0].path);
+      expect(secondBody.proposals[0].reusedExisting).toBe(true);
+      expect(secondBody.evidenceCards[0].id).not.toBe(firstCard.id);
+      expect(secondBody.evidenceCards[0].path).not.toBe(firstCard.path);
+      expect(secondBody.evidenceCards[0].reusedExisting).toBe(false);
+
+      expect(await readFile(firstCard.path, "utf8")).toBe(approved);
+      const evidenceFiles = await readdir(join(root, ".red", "memory", "inbox", "evidence"));
+      expect(evidenceFiles.filter((file) => file.endsWith(".yaml"))).toHaveLength(2);
+      const nextCard = await readFile(secondBody.evidenceCards[0].path, "utf8");
+      expect(nextCard).toContain('status: "proposed"');
+      expect(nextCard).not.toContain("keep this reviewed decision");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
Closes #548

## Summary
- Adds deterministic Evidence card fingerprints from telemetry source, refinement route, dominant error pattern, and telemetry window.
- Refreshes unresolved cards while preserving review metadata and avoids reusing cards with terminal/reviewed status or human decision metadata.
- Adds regression coverage for unresolved refresh and reviewed-card preservation.

## Validation
- pnpm --filter @reddb-io/memory exec vitest run --config vitest.integration.config.ts tests/improve-skills.test.ts
- pnpm --filter @reddb-io/memory typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783486752&installation_id=129708444&pr_number=554&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F554&signature=d06751dd4a523aaa17c1a95b2d15f8d2e74e8f33add1f0175a2c36a92a98e4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Memory plugin and skill improvement documentation to reflect enhanced proposal lifecycle and evidence card fingerprinting mechanisms.

* **Improvements**
  * Enhanced evidence card deduplication and refresh logic to prevent duplicates while preserving reviewed proposals.
  * Extended proposal metadata tracking with telemetry source, refinement route, error patterns, and windows.
  * Improved proposal archiving with explicit status organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->