### PR TITLE
Handle linked proposal evidence card review

### DIFF
--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -938,6 +938,7 @@ async function rejectLinkedEvidenceCard(
   const rawStatus = firstYamlScalar(found.body, "status");
   const proposalPath = firstNestedYamlScalar(found.body, "proposal", "path");
   if (rawStatus === "rejected") {
+    if (proposalPath) await markProposalEvidenceRejected(rootDir, proposalPath, id, reason);
     return { id, status: "rejected", path: found.path, ...(proposalPath ? { proposalPath } : {}) };
   }
   if (rawStatus !== "proposed") {
@@ -981,10 +982,10 @@ function withLinkedEvidenceReview(
   next = next.replace(/\nreview:\n(?:  .+\n)*/m, "\n");
   const review = [
     "review:",
-    `  state: ${yamlScalar(status)}`,
+    `  decision: ${yamlScalar(status)}`,
     ...(reviewer ? [`  reviewer: ${yamlScalar(reviewer)}`] : []),
     `  reviewed_at: ${yamlScalar(now)}`,
-    ...(reason ? [`  reason: ${yamlScalar(reason)}`] : []),
+    ...(reason ? [`  notes: ${yamlScalar(status === "rejected" ? (redactSensitiveValue(reason) as string) : reason)}`] : []),
   ].join("\n");
   return next.replace(/\nproposal:\n/, `\n${review}\nproposal:\n`);
 }

--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -938,7 +938,8 @@ async function rejectLinkedEvidenceCard(
   const rawStatus = firstYamlScalar(found.body, "status");
   const proposalPath = firstNestedYamlScalar(found.body, "proposal", "path");
   if (rawStatus === "rejected") {
-    if (proposalPath) await markProposalEvidenceRejected(rootDir, proposalPath, id, reason);
+    const reviewNotes = firstNestedYamlScalar(found.body, "review", "notes");
+    if (proposalPath) await markProposalEvidenceRejected(rootDir, proposalPath, id, reviewNotes ?? reason);
     return { id, status: "rejected", path: found.path, ...(proposalPath ? { proposalPath } : {}) };
   }
   if (rawStatus !== "proposed") {

--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -866,7 +866,10 @@ async function runEvidence(args: ParsedArgs): Promise<void> {
       if (args.flags.yes !== true) {
         throw new Error("memory evidence approve requires explicit --yes approval");
       }
-      const card = await approveEvidenceCard(rootDir, id, stringFlag(args.flags, "reviewer"));
+      const reviewer = stringFlag(args.flags, "reviewer");
+      const linked = await approveLinkedEvidenceCard(rootDir, id, reviewer);
+      if (linked) return printLinkedEvidenceResult("approved", linked, args.flags.json === true);
+      const card = await approveEvidenceCard(rootDir, id, reviewer);
       return printEvidenceResult("approved", card, args.flags.json === true);
     }
     case "reject": {
@@ -877,17 +880,160 @@ async function runEvidence(args: ParsedArgs): Promise<void> {
       }
       const reason = stringFlag(args.flags, "reason")?.trim();
       if (!reason) throw new Error("memory evidence reject requires a non-empty --reason");
+      const reviewer = stringFlag(args.flags, "reviewer");
+      const linked = await rejectLinkedEvidenceCard(rootDir, id, reason, reviewer);
+      if (linked) return printLinkedEvidenceResult("rejected", linked, args.flags.json === true);
       const card = await rejectEvidenceCard(
         rootDir,
         id,
         reason,
-        stringFlag(args.flags, "reviewer"),
+        reviewer,
       );
+      if (card.proposal_link.path) {
+        await markProposalEvidenceRejected(rootDir, card.proposal_link.path, card.id, reason);
+      }
       return printEvidenceResult("rejected", card, args.flags.json === true);
     }
     default:
       throw new Error("usage: memory evidence create|list|show|approve|reject [args]");
   }
+}
+
+interface LinkedEvidenceReviewResult {
+  id: string;
+  status: "approved" | "rejected";
+  path: string;
+  proposalPath?: string;
+}
+
+async function approveLinkedEvidenceCard(
+  rootDir: string,
+  id: string,
+  reviewer: string | undefined,
+): Promise<LinkedEvidenceReviewResult | null> {
+  const found = await findLinkedEvidenceCard(rootDir, id);
+  if (!found) return null;
+  const rawStatus = firstYamlScalar(found.body, "status");
+  if (rawStatus === "approved") {
+    const proposalPath = firstNestedYamlScalar(found.body, "proposal", "path");
+    return { id, status: "approved", path: found.path, ...(proposalPath ? { proposalPath } : {}) };
+  }
+  if (rawStatus !== "proposed") {
+    throw new Error(`memory evidence card ${id} cannot be approved from status ${rawStatus ?? "unknown"}`);
+  }
+  const updated = withLinkedEvidenceReview(found.body, "approved", reviewer);
+  await writeFile(found.path, updated, "utf8");
+  const proposalPath = firstNestedYamlScalar(updated, "proposal", "path");
+  return { id, status: "approved", path: found.path, ...(proposalPath ? { proposalPath } : {}) };
+}
+
+async function rejectLinkedEvidenceCard(
+  rootDir: string,
+  id: string,
+  reason: string,
+  reviewer: string | undefined,
+): Promise<LinkedEvidenceReviewResult | null> {
+  const found = await findLinkedEvidenceCard(rootDir, id);
+  if (!found) return null;
+  const rawStatus = firstYamlScalar(found.body, "status");
+  const proposalPath = firstNestedYamlScalar(found.body, "proposal", "path");
+  if (rawStatus === "rejected") {
+    return { id, status: "rejected", path: found.path, ...(proposalPath ? { proposalPath } : {}) };
+  }
+  if (rawStatus !== "proposed") {
+    throw new Error(`memory evidence card ${id} cannot be rejected from status ${rawStatus ?? "unknown"}`);
+  }
+  const updated = withLinkedEvidenceReview(found.body, "rejected", reviewer, reason);
+  await writeFile(found.path, updated, "utf8");
+  if (proposalPath) await markProposalEvidenceRejected(rootDir, proposalPath, id, reason);
+  return { id, status: "rejected", path: found.path, ...(proposalPath ? { proposalPath } : {}) };
+}
+
+async function findLinkedEvidenceCard(rootDir: string, id: string): Promise<{ path: string; body: string } | null> {
+  const dir = join(rootDir, ".red", "memory", "inbox", "evidence");
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const idLine = `id: ${yamlScalar(id)}`;
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".yaml")) continue;
+    const path = join(dir, entry.name);
+    const body = await readFile(path, "utf8");
+    if (body.includes('contract: "memory.evidence-card.experimental.v1"') && body.includes(idLine)) {
+      return { path, body };
+    }
+  }
+  return null;
+}
+
+function withLinkedEvidenceReview(
+  body: string,
+  status: "approved" | "rejected",
+  reviewer: string | undefined,
+  reason?: string,
+): string {
+  const now = new Date().toISOString();
+  let next = body.replace(/^status: .+$/m, `status: ${yamlScalar(status)}`);
+  next = next.replace(/^updated_at: .+$/m, `updated_at: ${yamlScalar(now)}`);
+  next = next.replace(/\nreview:\n(?:  .+\n)*/m, "\n");
+  const review = [
+    "review:",
+    `  state: ${yamlScalar(status)}`,
+    ...(reviewer ? [`  reviewer: ${yamlScalar(reviewer)}`] : []),
+    `  reviewed_at: ${yamlScalar(now)}`,
+    ...(reason ? [`  reason: ${yamlScalar(reason)}`] : []),
+  ].join("\n");
+  return next.replace(/\nproposal:\n/, `\n${review}\nproposal:\n`);
+}
+
+async function markProposalEvidenceRejected(
+  rootDir: string,
+  proposalPathValue: string,
+  evidenceCardId: string,
+  reason: string,
+): Promise<void> {
+  const proposalPath = resolve(rootDir, proposalPathValue);
+  assertInsideRoot(rootDir, proposalPath, "proposal file");
+  assertInsideProposalTree(rootDir, proposalPath);
+  const body = await readFile(proposalPath, "utf8");
+  const marker = `Evidence card id: ${evidenceCardId}`;
+  if (body.includes(marker) && body.includes("Evidence Card Review Warning")) return;
+  const redactedReason = redactSensitiveValue(reason) as string;
+  const warning = [
+    "",
+    "## Evidence Card Review Warning",
+    "",
+    `- Evidence card id: ${evidenceCardId}`,
+    "- Status: rejected",
+    `- Reason: ${redactedReason}`,
+    "",
+    "The evidence interpretation for the linked card was rejected. This warning does not archive, move, delete, apply, or otherwise approve this proposal.",
+    "",
+  ].join("\n");
+  await writeFile(proposalPath, `${body.trimEnd()}\n${warning}`, "utf8");
+}
+
+function firstYamlScalar(body: string, key: string): string | null {
+  const match = body.match(new RegExp(`^${escapeRegExp(key)}: (.+)$`, "m"));
+  return match ? unquoteYamlScalar(match[1]) : null;
+}
+
+function firstNestedYamlScalar(body: string, parent: string, key: string): string | null {
+  const match = body.match(new RegExp(`^${escapeRegExp(parent)}:\\n(?:  .+\\n)*?  ${escapeRegExp(key)}: (.+)$`, "m"));
+  return match ? unquoteYamlScalar(match[1]) : null;
+}
+
+function unquoteYamlScalar(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"')) return JSON.parse(trimmed) as string;
+  return trimmed;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function evidenceCardInputFromFlags(args: ParsedArgs): CreateEvidenceCardInput {
@@ -982,6 +1128,17 @@ function printEvidenceResult(action: string, card: EvidenceCard, json: boolean):
   }
   console.log(`memory evidence: ${action} ${card.id}`);
   console.log(`  status: ${card.status}`);
+}
+
+function printLinkedEvidenceResult(action: string, card: LinkedEvidenceReviewResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify({ state: action, card }, null, 2));
+    return;
+  }
+  console.log(`memory evidence: ${action} ${card.id}`);
+  console.log(`  status: ${card.status}`);
+  console.log(`  card: ${card.path}`);
+  if (card.proposalPath) console.log(`  proposal: ${card.proposalPath}`);
 }
 
 function printEvidenceList(cards: EvidenceCard[]): void {
@@ -4526,10 +4683,6 @@ function parseYamlScalar(value: string): string | null {
   } catch {
     return raw;
   }
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function parseSkillTelemetryEvidenceCardStatus(value: string | null): SkillTelemetryEvidenceCardStatus {

--- a/src/apps/memory/tests/evidence-card.test.ts
+++ b/src/apps/memory/tests/evidence-card.test.ts
@@ -286,6 +286,9 @@ describe("memory evidence CLI", () => {
     const approve = runMemory(["evidence", "approve", approvedId, "--root", root, "--reviewer", "maintainer", "--yes", "--json"]);
     expect(approve.status, approve.stderr).toBe(0);
     expect(await readFile(approvedProposal, "utf8")).toBe(beforeApprove);
+    const approvedCardBody = await readFile(join(evidenceInboxRoot(root), `${approvedId}.yaml`), "utf8");
+    expect(approvedCardBody).toContain("status: approved");
+    expect(approvedCardBody).toContain("state: approved");
 
     const createRejected = runMemory([
       "evidence",
@@ -317,18 +320,78 @@ describe("memory evidence CLI", () => {
       "--root",
       root,
       "--reason",
-      "evidence interpretation was wrong",
+      "evidence interpretation was wrong for token sk-test_1234567890abcdefghijklmnopqrstuv",
       "--reviewer",
       "maintainer",
       "--yes",
       "--json",
     ]);
     expect(reject.status, reject.stderr).toBe(0);
+    const rejectedCardBody = await readFile(join(evidenceInboxRoot(root), `${rejectedId}.yaml`), "utf8");
+    expect(rejectedCardBody).toContain("status: rejected");
+    expect(rejectedCardBody).toContain("state: rejected");
     const rejectedProposalBody = await readFile(rejectedProposal, "utf8");
     expect(rejectedProposalBody).toContain("## Evidence Card Review Warning");
     expect(rejectedProposalBody).toContain(`Evidence card id: ${rejectedId}`);
-    expect(rejectedProposalBody).toContain("evidence interpretation was wrong");
+    expect(rejectedProposalBody).toContain("evidence interpretation was wrong for token [REDACTED:openai-token]");
     expect((await readdir(proposalDir)).sort()).toEqual(["approve-linked.md", "reject-linked.md"].sort());
+
+    const v1RejectedId = "skill-card-549-rejected";
+    const v1RejectedCard = join(evidenceInboxRoot(root), `${v1RejectedId}.yaml`);
+    await writeFile(
+      v1RejectedCard,
+      [
+        'contract: "memory.evidence-card.experimental.v1"',
+        `id: "${v1RejectedId}"`,
+        'status: "proposed"',
+        'updated_at: "2026-01-01T00:00:00.000Z"',
+        "review:",
+        "  decision: null",
+        "proposal:",
+        '  path: ".red/memory/proposals/reject-linked.md"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(rejectedProposal, "# Skill Improvement Proposal: reject\n\nPatch later.\n", "utf8");
+    const rejectV1 = runMemory([
+      "evidence",
+      "reject",
+      v1RejectedId,
+      "--root",
+      root,
+      "--reason",
+      "evidence interpretation was wrong for token sk-test_1234567890abcdefghijklmnopqrstuv",
+      "--reviewer",
+      "maintainer",
+      "--yes",
+      "--json",
+    ]);
+    expect(rejectV1.status, rejectV1.stderr).toBe(0);
+    const rejectedV1CardBody = await readFile(v1RejectedCard, "utf8");
+    expect(rejectedV1CardBody).toContain('status: "rejected"');
+    expect(rejectedV1CardBody).toContain('decision: "rejected"');
+    expect(rejectedV1CardBody).toContain('notes: "evidence interpretation was wrong for token [REDACTED:openai-token]"');
+
+    await writeFile(rejectedProposal, "# Skill Improvement Proposal: reject\n\nPatch later.\n", "utf8");
+    const rejectAgain = runMemory([
+      "evidence",
+      "reject",
+      v1RejectedId,
+      "--root",
+      root,
+      "--reason",
+      "evidence interpretation was still wrong",
+      "--reviewer",
+      "maintainer",
+      "--yes",
+      "--json",
+    ]);
+    expect(rejectAgain.status, rejectAgain.stderr).toBe(0);
+    const retriedProposalBody = await readFile(rejectedProposal, "utf8");
+    expect(retriedProposalBody).toContain("## Evidence Card Review Warning");
+    expect(retriedProposalBody).toContain(`Evidence card id: ${v1RejectedId}`);
+    expect(retriedProposalBody).toContain("evidence interpretation was still wrong");
 
     const applyWithoutApproval = runMemory(["improve", "apply", rejectedProposal, "--root", root, "--json"]);
     expect(applyWithoutApproval.status).not.toBe(0);

--- a/src/apps/memory/tests/evidence-card.test.ts
+++ b/src/apps/memory/tests/evidence-card.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
@@ -247,5 +247,94 @@ describe("memory evidence CLI", () => {
 
     const files = await readdir(evidenceInboxRoot(root));
     expect(files.sort()).toEqual([`${approvedId}.yaml`, `${rejectedId}.yaml`].sort());
+  }, TIMEOUT);
+
+  test("reviews linked proposal cards without applying or archiving proposals", async () => {
+    const root = await tempRoot();
+    expect(runMemory(["init", "--mode", "graph", "--root", root, "--yes"]).status).toBe(0);
+    const proposalDir = join(root, ".red", "memory", "proposals");
+    await mkdir(proposalDir, { recursive: true });
+    const approvedProposal = join(proposalDir, "approve-linked.md");
+    const rejectedProposal = join(proposalDir, "reject-linked.md");
+    await writeFile(approvedProposal, "# Skill Improvement Proposal: approve\n\nPatch later.\n", "utf8");
+    await writeFile(rejectedProposal, "# Skill Improvement Proposal: reject\n\nPatch later.\n", "utf8");
+
+    const createApproved = runMemory([
+      "evidence",
+      "create",
+      "--root",
+      root,
+      "--summary",
+      "Approving a linked Evidence card validates only the evidence interpretation.",
+      "--source-ref",
+      "issue 549",
+      "--citation",
+      "issue 549||approve linked card",
+      "--lesson",
+      "Keep linked proposal application separate from card approval.",
+      "--proposal-kind",
+      "skill-improvement",
+      "--proposal-path",
+      ".red/memory/proposals/approve-linked.md",
+      "--proposal-apply-state",
+      "pending",
+      "--json",
+    ]);
+    expect(createApproved.status, createApproved.stderr).toBe(0);
+    const approvedId = (JSON.parse(createApproved.stdout) as { card: { id: string } }).card.id;
+    const beforeApprove = await readFile(approvedProposal, "utf8");
+    const approve = runMemory(["evidence", "approve", approvedId, "--root", root, "--reviewer", "maintainer", "--yes", "--json"]);
+    expect(approve.status, approve.stderr).toBe(0);
+    expect(await readFile(approvedProposal, "utf8")).toBe(beforeApprove);
+
+    const createRejected = runMemory([
+      "evidence",
+      "create",
+      "--root",
+      root,
+      "--summary",
+      "Rejecting a linked Evidence card warns the linked proposal only.",
+      "--source-ref",
+      "issue 549",
+      "--citation",
+      "issue 549||reject linked card",
+      "--lesson",
+      "Warn when evidence interpretation is rejected.",
+      "--proposal-kind",
+      "skill-improvement",
+      "--proposal-path",
+      ".red/memory/proposals/reject-linked.md",
+      "--proposal-apply-state",
+      "pending",
+      "--json",
+    ]);
+    expect(createRejected.status, createRejected.stderr).toBe(0);
+    const rejectedId = (JSON.parse(createRejected.stdout) as { card: { id: string } }).card.id;
+    const reject = runMemory([
+      "evidence",
+      "reject",
+      rejectedId,
+      "--root",
+      root,
+      "--reason",
+      "evidence interpretation was wrong",
+      "--reviewer",
+      "maintainer",
+      "--yes",
+      "--json",
+    ]);
+    expect(reject.status, reject.stderr).toBe(0);
+    const rejectedProposalBody = await readFile(rejectedProposal, "utf8");
+    expect(rejectedProposalBody).toContain("## Evidence Card Review Warning");
+    expect(rejectedProposalBody).toContain(`Evidence card id: ${rejectedId}`);
+    expect(rejectedProposalBody).toContain("evidence interpretation was wrong");
+    expect((await readdir(proposalDir)).sort()).toEqual(["approve-linked.md", "reject-linked.md"].sort());
+
+    const applyWithoutApproval = runMemory(["improve", "apply", rejectedProposal, "--root", root, "--json"]);
+    expect(applyWithoutApproval.status).not.toBe(0);
+    expect(applyWithoutApproval.stderr).toContain("requires explicit --yes approval");
+    const applyWithoutStructuredBlock = runMemory(["improve", "apply", rejectedProposal, "--root", root, "--yes", "--json"]);
+    expect(applyWithoutStructuredBlock.status).not.toBe(0);
+    expect(applyWithoutStructuredBlock.stderr).toContain("structured memory-skill-patch block");
   }, TIMEOUT);
 });

--- a/src/apps/memory/tests/evidence-card.test.ts
+++ b/src/apps/memory/tests/evidence-card.test.ts
@@ -391,7 +391,8 @@ describe("memory evidence CLI", () => {
     const retriedProposalBody = await readFile(rejectedProposal, "utf8");
     expect(retriedProposalBody).toContain("## Evidence Card Review Warning");
     expect(retriedProposalBody).toContain(`Evidence card id: ${v1RejectedId}`);
-    expect(retriedProposalBody).toContain("evidence interpretation was still wrong");
+    expect(retriedProposalBody).toContain("evidence interpretation was wrong for token [REDACTED:openai-token]");
+    expect(retriedProposalBody).not.toContain("evidence interpretation was still wrong");
 
     const applyWithoutApproval = runMemory(["improve", "apply", rejectedProposal, "--root", root, "--json"]);
     expect(applyWithoutApproval.status).not.toBe(0);


### PR DESCRIPTION
Closes #549.

## Summary
- keep linked Evidence card approval scoped to card review metadata
- append an Evidence Card Review Warning to linked proposals on card rejection
- preserve proposal apply/archive/delete behavior behind explicit proposal gates

## Validation
- `pnpm --dir src/apps/memory typecheck`
- `pnpm --dir src/apps/memory test:integration evidence-card.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783489613&installation_id=129708444&pr_number=555&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F555&signature=466844e51c636187a7f68bfdf0215a46ca0f2a0dc0c62b8d20a5765f71129796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands for approving/rejecting evidence now support linked evidence cards, report linked card and proposal paths, accept an optional reviewer, and print linked-result summaries
  * Reject now accepts a reason, applies sensitive-redaction to notes, is idempotent for already-approved/rejected cards, and appends a review warning to linked proposals

* **Tests**
  * Tests updated to cover linked proposal workflows, approval no-ops, rejection warning injection, and related apply/check behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->