### PR TITLE
ship: #550 Tracer-bullet regression coverage for governed self-improvement

### DIFF
--- a/.github/actions/install-red-binary/action.yml
+++ b/.github/actions/install-red-binary/action.yml
@@ -1,0 +1,93 @@
+name: Install red binary
+description: Download and verify the red binary used by @reddb-io/sdk in CI.
+
+inputs:
+  version:
+    description: red release tag to install.
+    required: false
+    default: v1.7.0
+  asset:
+    description: red release asset name to install.
+    required: false
+    default: red-linux-x86_64
+  github-token:
+    description: Optional GitHub token used for Releases API requests.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Download and verify red
+      shell: bash
+      env:
+        RED_VERSION: ${{ inputs.version }}
+        RED_ASSET: ${{ inputs.asset }}
+        RED_GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        curl_auth=()
+        if [ -n "${RED_GITHUB_TOKEN:-}" ]; then
+          curl_auth=(-H "Authorization: Bearer ${RED_GITHUB_TOKEN}")
+        fi
+
+        curl_json() {
+          curl -fsSL \
+            --retry 3 \
+            --retry-connrefused \
+            --retry-delay 2 \
+            --max-time 60 \
+            "${curl_auth[@]}" \
+            -H "Accept: application/vnd.github+json" \
+            "$@"
+        }
+
+        curl_asset() {
+          curl -fsSL \
+            --retry 3 \
+            --retry-connrefused \
+            --retry-delay 2 \
+            --max-time 120 \
+            "${curl_auth[@]}" \
+            -H "Accept: application/octet-stream" \
+            "$@"
+        }
+
+        release_json="$RUNNER_TEMP/red-release.json"
+        curl_json "https://api.github.com/repos/reddb-io/reddb/releases/tags/${RED_VERSION}" \
+          -o "$release_json"
+
+        asset_id="$(
+          node -e 'const fs = require("node:fs"); const name = process.argv[1]; const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === name); if (!asset) throw new Error(`${name} release asset not found`); console.log(asset.id);' \
+            "$RED_ASSET" < "$release_json"
+        )"
+        checksum_asset_id="$(
+          node -e 'const fs = require("node:fs"); const name = `${process.argv[1]}.sha256`; const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === name); if (!asset) throw new Error(`${name} release asset not found`); console.log(asset.id);' \
+            "$RED_ASSET" < "$release_json"
+        )"
+
+        if [ -z "$asset_id" ] || [ -z "$checksum_asset_id" ]; then
+          echo "red asset lookup returned an empty id" >&2
+          exit 1
+        fi
+
+        red_bin="$RUNNER_TEMP/red"
+        checksum_file="$RUNNER_TEMP/red.sha256"
+        curl_asset "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
+          -o "$red_bin"
+        curl_asset "https://api.github.com/repos/reddb-io/reddb/releases/assets/${checksum_asset_id}" \
+          -o "$checksum_file"
+
+        expected="$(awk '{print $1}' "$checksum_file")"
+        actual="$(sha256sum "$red_bin" | awk '{print $1}')"
+        if [ -z "$expected" ] || [ "$actual" != "$expected" ]; then
+          echo "red binary checksum mismatch" >&2
+          echo "expected: $expected" >&2
+          echo "actual:   $actual" >&2
+          exit 1
+        fi
+
+        chmod +x "$red_bin"
+        echo "REDDB_BIN=$red_bin" >> "$GITHUB_ENV"
+        echo "REDDB_SKIP_POSTINSTALL=1" >> "$GITHUB_ENV"

--- a/.github/workflows/red-memory-bench.yml
+++ b/.github/workflows/red-memory-bench.yml
@@ -21,6 +21,23 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install red binary for SDK
+        run: |
+          set -euo pipefail
+          asset_id="$(
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/reddb-io/reddb/releases/tags/v1.7.0 |
+            node -e 'const fs = require("node:fs"); const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === "red-linux-x86_64"); if (!asset) throw new Error("red-linux-x86_64 release asset not found"); console.log(asset.id);'
+          )"
+          curl -fsSL \
+            -H "Accept: application/octet-stream" \
+            "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
+            -o "$RUNNER_TEMP/red"
+          chmod +x "$RUNNER_TEMP/red"
+          echo "REDDB_BIN=$RUNNER_TEMP/red" >> "$GITHUB_ENV"
+          echo "REDDB_SKIP_POSTINSTALL=1" >> "$GITHUB_ENV"
+
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/red-memory-bench.yml
+++ b/.github/workflows/red-memory-bench.yml
@@ -22,21 +22,9 @@ jobs:
           node-version: 22
 
       - name: Install red binary for SDK
-        run: |
-          set -euo pipefail
-          asset_id="$(
-            curl -fsSL \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/reddb-io/reddb/releases/tags/v1.7.0 |
-            node -e 'const fs = require("node:fs"); const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === "red-linux-x86_64"); if (!asset) throw new Error("red-linux-x86_64 release asset not found"); console.log(asset.id);'
-          )"
-          curl -fsSL \
-            -H "Accept: application/octet-stream" \
-            "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
-            -o "$RUNNER_TEMP/red"
-          chmod +x "$RUNNER_TEMP/red"
-          echo "REDDB_BIN=$RUNNER_TEMP/red" >> "$GITHUB_ENV"
-          echo "REDDB_SKIP_POSTINSTALL=1" >> "$GITHUB_ENV"
+        uses: ./.github/actions/install-red-binary
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/red-memory-drift-guard.yml
+++ b/.github/workflows/red-memory-drift-guard.yml
@@ -49,21 +49,9 @@ jobs:
           node-version: 22
 
       - name: Install red binary for SDK
-        run: |
-          set -euo pipefail
-          asset_id="$(
-            curl -fsSL \
-              -H "Accept: application/vnd.github+json" \
-              https://api.github.com/repos/reddb-io/reddb/releases/tags/v1.7.0 |
-            node -e 'const fs = require("node:fs"); const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === "red-linux-x86_64"); if (!asset) throw new Error("red-linux-x86_64 release asset not found"); console.log(asset.id);'
-          )"
-          curl -fsSL \
-            -H "Accept: application/octet-stream" \
-            "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
-            -o "$RUNNER_TEMP/red"
-          chmod +x "$RUNNER_TEMP/red"
-          echo "REDDB_BIN=$RUNNER_TEMP/red" >> "$GITHUB_ENV"
-          echo "REDDB_SKIP_POSTINSTALL=1" >> "$GITHUB_ENV"
+        uses: ./.github/actions/install-red-binary
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/red-memory-drift-guard.yml
+++ b/.github/workflows/red-memory-drift-guard.yml
@@ -48,6 +48,23 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install red binary for SDK
+        run: |
+          set -euo pipefail
+          asset_id="$(
+            curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/reddb-io/reddb/releases/tags/v1.7.0 |
+            node -e 'const fs = require("node:fs"); const release = JSON.parse(fs.readFileSync(0, "utf8")); const asset = release.assets.find((entry) => entry.name === "red-linux-x86_64"); if (!asset) throw new Error("red-linux-x86_64 release asset not found"); console.log(asset.id);'
+          )"
+          curl -fsSL \
+            -H "Accept: application/octet-stream" \
+            "https://api.github.com/repos/reddb-io/reddb/releases/assets/${asset_id}" \
+            -o "$RUNNER_TEMP/red"
+          chmod +x "$RUNNER_TEMP/red"
+          echo "REDDB_BIN=$RUNNER_TEMP/red" >> "$GITHUB_ENV"
+          echo "REDDB_SKIP_POSTINSTALL=1" >> "$GITHUB_ENV"
+
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 

--- a/src/apps/memory/src/cli.ts
+++ b/src/apps/memory/src/cli.ts
@@ -4893,7 +4893,7 @@ function buildSkillTelemetryEvidenceCard(input: {
       ? `skill-rollup:${contentHash(input.rollup.source_kind, input.rollup.name, input.rollup.path)}`
       : `skill-rollup:${contentHash(input.rec.source_kind, input.rec.name, input.rec.path)}`;
 
-  return {
+  const card: SkillTelemetryEvidenceCard = {
     contract: "memory.evidence-card.experimental.v1",
     id,
     kind: "skill_telemetry",
@@ -4973,6 +4973,7 @@ function buildSkillTelemetryEvidenceCard(input: {
       fingerprint: input.proposalFingerprint,
     },
   };
+  return redactSensitiveValue(card) as SkillTelemetryEvidenceCard;
 }
 
 function suggestedSectionOrAnchor(

--- a/src/apps/memory/tests/improve-skills.test.ts
+++ b/src/apps/memory/tests/improve-skills.test.ts
@@ -6,11 +6,15 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import { initGraph } from "../src/init.js";
 
-const TIMEOUT = 30_000;
+const TIMEOUT = 90_000;
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = join(HERE, "..");
 
 const roots: string[] = [];
+
+function stableProposalText(markdown: string): string {
+  return markdown.replace(/^Generated: .+$/m, "Generated: <stable>");
+}
 
 async function tempRoot(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "memory-improve-skills-"));
@@ -201,6 +205,129 @@ describe("memory improve skills CLI", () => {
 
       await expect(readdir(join(root, ".red", "memory", "proposals"))).rejects.toThrow();
       await expect(readdir(join(root, ".red", "memory", "inbox", "evidence"))).rejects.toThrow();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "runs the governed self-improvement tracer bullet from telemetry through card review",
+    async () => {
+      const root = await tempRoot();
+      await initGraph(root, { skillTelemetry: true });
+      const skillFile = join(root, "skills", "flaky-skill", "SKILL.md");
+      await mkdir(dirname(skillFile), { recursive: true });
+      await writeFile(skillFile, "---\nname: flaky-skill\ndescription: fixture\n---\n\n# flaky-skill\n\nOriginal content.\n", "utf8");
+      const token = "sk-test_1234567890abcdefghijklmnopqrstuv";
+      const events = [
+        skillResultEvent(1, skillFile, "failed"),
+        skillResultEvent(2, skillFile, "failed"),
+        skillResultEvent(3, skillFile, "failed"),
+        skillResultEvent(4, skillFile, "failed"),
+        skillResultEvent(5, skillFile, "succeeded"),
+      ].map((event) =>
+        event.result.status === "failed"
+          ? { ...event, event_id: `${event.event_id}-${token}` }
+          : event,
+      );
+      const ingest = runMemory(["event", "skill", "--root", root], events.map((event) => JSON.stringify(event)).join("\n"));
+      expect(ingest.status).toBe(0);
+
+      const first = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(first.status, first.stderr).toBe(0);
+      const firstBody = JSON.parse(first.stdout);
+      expect(firstBody.state).toBe("proposal-written");
+      expect(firstBody.proposals).toHaveLength(1);
+      expect(firstBody.proposals[0]).toMatchObject({
+        skill: "flaky-skill",
+        written: true,
+        reusedExisting: false,
+        cardStatus: "proposed",
+        evidenceSource: "skill-telemetry:flaky-skill:project",
+        evidenceRoute: "skill-improvement:frequently-failing:skills/flaky-skill/SKILL.md",
+        dominantErrorPattern: "stage=verify|class=ValidationError|code=",
+      });
+      expect(firstBody.proposals[0].fingerprint).toMatch(/^sha256:/);
+      expect(firstBody.proposals[0].path).toContain(".red/memory/proposals/");
+      expect(firstBody.evidenceCards).toHaveLength(1);
+      expect(firstBody.evidenceCards[0]).toMatchObject({
+        contract: "memory.evidence-card.experimental.v1",
+        skill: "flaky-skill",
+        status: "proposed",
+        proposalPath: firstBody.proposals[0].path,
+        reusedExisting: false,
+        written: true,
+      });
+
+      const proposalBeforeReview = await readFile(firstBody.proposals[0].path, "utf8");
+      expect(proposalBeforeReview).toContain("## Evidence Card");
+      expect(proposalBeforeReview).toContain(firstBody.evidenceCards[0].id);
+      expect(proposalBeforeReview).toContain(firstBody.evidenceCards[0].path.replace(`${root}/`, ""));
+      expect(proposalBeforeReview).toContain("```json memory-skill-patch");
+      expect(proposalBeforeReview).not.toContain(token);
+
+      const cardBeforeReview = await readFile(firstBody.evidenceCards[0].path, "utf8");
+      expect(cardBeforeReview).toContain('contract: "memory.evidence-card.experimental.v1"');
+      expect(cardBeforeReview).toContain(`path: "${firstBody.proposals[0].path.replace(`${root}/`, "")}"`);
+      expect(cardBeforeReview).toContain("[REDACTED:openai-token]");
+      expect(cardBeforeReview).not.toContain(token);
+
+      const second = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(second.status, second.stderr).toBe(0);
+      const secondBody = JSON.parse(second.stdout);
+      expect(secondBody.proposals[0].fingerprint).toBe(firstBody.proposals[0].fingerprint);
+      expect(secondBody.proposals[0].reusedExisting).toBe(true);
+      expect(secondBody.evidenceCards[0].id).toBe(firstBody.evidenceCards[0].id);
+      expect(secondBody.evidenceCards[0].path).toBe(firstBody.evidenceCards[0].path);
+      expect(secondBody.evidenceCards[0].reusedExisting).toBe(true);
+
+      const approve = runMemory([
+        "evidence",
+        "approve",
+        firstBody.evidenceCards[0].id,
+        "--root",
+        root,
+        "--reviewer",
+        "maintainer",
+        "--yes",
+        "--json",
+      ]);
+      expect(approve.status, approve.stderr).toBe(0);
+      const approvedCard = await readFile(firstBody.evidenceCards[0].path, "utf8");
+      expect(approvedCard).toContain('status: "approved"');
+      expect(approvedCard).toContain('decision: "approved"');
+      expect(stableProposalText(await readFile(firstBody.proposals[0].path, "utf8"))).toBe(
+        stableProposalText(proposalBeforeReview),
+      );
+
+      const third = runMemory(["improve", "skills", "--root", root, "--write-proposal", "--json"]);
+      expect(third.status, third.stderr).toBe(0);
+      const thirdBody = JSON.parse(third.stdout);
+      expect(thirdBody.proposals[0].fingerprint).toBe(firstBody.proposals[0].fingerprint);
+      expect(thirdBody.proposals[0].reusedExisting).toBe(true);
+      expect(thirdBody.evidenceCards[0].id).not.toBe(firstBody.evidenceCards[0].id);
+      expect(await readFile(firstBody.evidenceCards[0].path, "utf8")).toBe(approvedCard);
+
+      const reject = runMemory([
+        "evidence",
+        "reject",
+        thirdBody.evidenceCards[0].id,
+        "--root",
+        root,
+        "--reason",
+        "tracer bullet rejected this evidence interpretation",
+        "--reviewer",
+        "maintainer",
+        "--yes",
+        "--json",
+      ]);
+      expect(reject.status, reject.stderr).toBe(0);
+      const proposalAfterReject = await readFile(firstBody.proposals[0].path, "utf8");
+      expect(proposalAfterReject).toContain("## Evidence Card Review Warning");
+      expect(proposalAfterReject).toContain(`Evidence card id: ${thirdBody.evidenceCards[0].id}`);
+
+      const applyWithoutApproval = runMemory(["improve", "apply", firstBody.proposals[0].path, "--root", root, "--json"]);
+      expect(applyWithoutApproval.status).not.toBe(0);
+      expect(applyWithoutApproval.stderr).toContain("requires explicit --yes approval");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
Interactive /ship landing for #550.

Closes #550

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783492143&installation_id=129708444&pr_number=556&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F556&signature=a9e3efff90e73dfa04330e4e3a0f316dc9d0af62bf3f586a19731430c1e25a8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive values (e.g., tokens) are now redacted in evidence cards to protect secrets.
  * Applying a proposal without explicit approval now fails as expected.

* **New Features**
  * Evidence card approval and rejection workflows available for skill-improvement flows.
  * Evidence cards are reused reliably across repeated skill-improvement runs.
  * Rejected evidence cards show a review-warning section. 

* **Chores**
  * CI workflows updated to install a runtime tool used in memory regression and drift checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->