### PR TITLE
merge: #407 (salvage — gate green, reconcile/ADR-0055)

### DIFF
--- a/src/apps/dev/src/commands/fleet.ts
+++ b/src/apps/dev/src/commands/fleet.ts
@@ -1,9 +1,12 @@
-import { spawn } from "node:child_process";
 import { constants } from "node:fs";
-import { access, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
+import { classifySupervisor, resolveSupervisorConfig } from "../core/supervisor.js";
+import { teardownWedgedSupervisor } from "../core/watchdog.js";
+import { buildWatchdogIO } from "../runtime/watchdog-io.js";
+import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
 
 export interface FleetLaunchResult {
   status: "launched";
@@ -45,16 +48,6 @@ async function fileExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-async function waitForPidFile(pidFile: string, deadlineMs: number): Promise<number | null> {
-  const deadline = Date.now() + deadlineMs;
-  while (Date.now() < deadline) {
-    const pid = await readPid(pidFile);
-    if (pid && isLivePid(pid)) return pid;
-    await sleep(100);
-  }
-  return null;
 }
 
 function parseFleetArgs(args: readonly string[]): { stop: boolean; target: number; request?: string; runnerFlag?: string; passthrough: string[] } {
@@ -133,7 +126,25 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   const logFile = join(tmp, "afk-supervisor.log");
   const existing = await readPid(pidFile);
   if (existing && isLivePid(existing)) {
-    throw new Error(`fleet already running (supervisor pid=${existing}, log .red/tmp/afk-supervisor.log).\n  to stop it: /dev:afk fleet stop`);
+    // A live PID is not necessarily a healthy fleet (#407): a supervisor whose
+    // #406 heartbeat has gone stale past RED_AFK_SUPERVISOR_STALE_S is hard-hung
+    // (drain loop wedged) and cannot re-arm itself. This launch is an
+    // already-alive surface, so it doubles as the recovery watchdog — tear the
+    // wedged supervisor down and fall through to a clean relaunch. A FRESH
+    // heartbeat still refuses the launch, exactly as before.
+    const staleS = resolveSupervisorConfig().supervisorStaleS;
+    const io = buildWatchdogIO(root, stdout);
+    const liveness = await io.liveness();
+    const health = classifySupervisor(liveness, io.now(), staleS);
+    if (health !== "quiescent") {
+      throw new Error(`fleet already running (supervisor pid=${existing}, log .red/tmp/afk-supervisor.log).\n  to stop it: /dev:afk fleet stop`);
+    }
+    const staleForS = liveness.lastHeartbeatEpoch !== null ? io.now() - liveness.lastHeartbeatEpoch : null;
+    io.log(
+      `⚠️  fleet pre-check: supervisor pid=${existing} is QUIESCENT — heartbeat stale ` +
+        `${staleForS ?? "?"}s ≥ ${staleS}s; recovering before relaunch.`,
+    );
+    await teardownWedgedSupervisor(io, liveness.pid);
   }
 
   const detection = detectRunner({
@@ -141,26 +152,14 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     processTree: callerProcessTreeNative(),
     scriptPath: process.argv[1],
   });
-  const childArgs = [...parsed.passthrough];
-  if (parsed.request) childArgs.unshift("--request", parsed.request);
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    RED_AFK_TARGET: String(parsed.target),
-    RED_AFK_RUNNER: detection.runner,
-  };
-  if (parsed.request) env.RED_AFK_REQUEST = parsed.request;
 
-  const out = await import("node:fs").then((fs) => fs.openSync(logFile, "a"));
-  // Spawn the native supervisor: `node <this-bundle> __supervise`.
-  const child = spawn(process.execPath, [process.argv[1]!, "__supervise", ...childArgs], {
-    cwd: root,
-    env,
-    detached: true,
-    stdio: ["ignore", out, out],
+  const supervisorPid = await spawnSupervisor({
+    root,
+    target: parsed.target,
+    runner: detection.runner,
+    passthrough: parsed.passthrough,
+    request: parsed.request,
   });
-  child.unref();
-
-  const supervisorPid = await waitForPidFile(pidFile, 3_000);
   if (!supervisorPid) {
     let tail = "";
     try {

--- a/src/apps/dev/src/commands/monitor.ts
+++ b/src/apps/dev/src/commands/monitor.ts
@@ -1,5 +1,8 @@
 import { renderCompactDashboard, type CompactWorker } from "../core/monitor.js";
 import { collectMonitorInputs } from "../runtime/wire.js";
+import { resolveSupervisorConfig } from "../core/supervisor.js";
+import { runWatchdog } from "../core/watchdog.js";
+import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import {
   mirrorPlan,
   codexSinkPlan,
@@ -119,6 +122,21 @@ export async function monitorCommand(
     const out = runMirrorPlan(workers, trackedJsonl, { codex });
     if (out !== "") stdout.write(out);
     return 0;
+  }
+
+  // Auto-monitor watchdog tick (#407): this render is an already-alive surface,
+  // so it doubles as the external recovery watchdog. A supervisor whose #406
+  // heartbeat is stale past RED_AFK_SUPERVISOR_STALE_S is hard-hung (live PID,
+  // drain loop wedged) — surface it loudly above the dashboard AND restart it.
+  // Idempotent: the relaunch stamps a fresh heartbeat, so a subsequent tick sees
+  // a healthy fleet and does not double-fire. Best-effort — a watchdog failure
+  // never blocks the dashboard render. Opt out with RED_AFK_WATCHDOG=0.
+  if (process.env.RED_AFK_WATCHDOG !== "0") {
+    try {
+      await runWatchdog(buildWatchdogIO(cwd, stdout), resolveSupervisorConfig().supervisorStaleS);
+    } catch {
+      // best-effort: recovery must never break monitoring.
+    }
   }
 
   const { workers, events, fleet } = await collectMonitorInputs(cwd);

--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -46,6 +46,7 @@ function fleetHeartbeatState(hb: FleetHeartbeat): string {
     {
       ts: hb.ts,
       epoch: hb.epoch,
+      runner: hb.runner,
       ready_for_agent: hb.readyForAgent,
       slots: {
         busy: hb.slotsBusy,
@@ -320,6 +321,7 @@ function buildSupervisorDeps(
             worker: "fleet",
             extra: {
               scope: "fleet",
+              runner: hb.runner,
               ready_for_agent: String(hb.readyForAgent),
               slots_busy: String(hb.slotsBusy),
               slots_free: String(hb.slotsFree),

--- a/src/apps/dev/src/core/monitor.ts
+++ b/src/apps/dev/src/core/monitor.ts
@@ -54,6 +54,8 @@ export interface CompactWorker {
 export interface FleetState {
   ts: string;
   epoch: number;
+  /** Runner the fleet was launched with (default "" for pre-#407 state files). */
+  runner: string;
   readyForAgent: number;
   slotsBusy: number;
   slotsFree: number;

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -58,6 +58,20 @@ export interface SupervisorConfig {
    * the default so a typo can never disable the guard.
    */
   tickTimeoutS: number;
+  /**
+   * RED_AFK_SUPERVISOR_STALE_S — the EXTERNAL watchdog's quiescence threshold
+   * (default 300). A supervisor whose #406 heartbeat has not advanced within this
+   * many seconds is treated as hard-hung (alive PID, drain loop wedged) and
+   * recovered by an already-alive surface (fleet pre-check / monitor tick) — see
+   * watchdog.ts + classifySupervisor. This is the recovery half of the
+   * unwedgeable-loop work: tickTimeoutS keeps a SINGLE tick from freezing the
+   * loop; this knob catches the case where the whole process is hung below the
+   * tick boundary (e.g. an un-timed gh call inside the heartbeat emit). Must be
+   * strictly greater than tickTimeoutS — validateSupervisorStaleThreshold enforces
+   * it at boot so a slow-but-live tick is never misread as quiescent. 0 /
+   * non-numeric falls back to the default so a typo can never disable recovery.
+   */
+  supervisorStaleS: number;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -70,6 +84,7 @@ export const SUPERVISOR_DEFAULTS = {
   runner: "claude",
   pollIntervalS: 15,
   tickTimeoutS: 120,
+  supervisorStaleS: 300,
 } as const satisfies SupervisorConfig;
 
 /**
@@ -102,6 +117,11 @@ export function resolveSupervisorConfig(
     // floor it back to the default — the guard can never be silently disabled.
     tickTimeoutS:
       num("RED_AFK_TICK_TIMEOUT_S", SUPERVISOR_DEFAULTS.tickTimeoutS) || SUPERVISOR_DEFAULTS.tickTimeoutS,
+    // 0 would make every live supervisor look quiescent — floor it back to the
+    // default so the watchdog can never be silently disabled by a typo.
+    supervisorStaleS:
+      num("RED_AFK_SUPERVISOR_STALE_S", SUPERVISOR_DEFAULTS.supervisorStaleS) ||
+      SUPERVISOR_DEFAULTS.supervisorStaleS,
   };
 }
 
@@ -118,6 +138,69 @@ export function validateStallThresholds(config: Pick<SupervisorConfig, "stallThr
       `RED_AFK_STALL_KILL_THRESHOLD_S (${config.stallKillThresholdS}) must be > RED_AFK_STALL_THRESHOLD_S (${config.stallThresholdS})`,
     );
   }
+}
+
+/**
+ * validateSupervisorStaleThreshold — boot-time invariant for the external
+ * watchdog (#407). The quiescence threshold must be strictly greater than the
+ * per-tick wall-clock ceiling; otherwise a tick that legitimately runs up to
+ * `tickTimeoutS` (a slow-but-live gh/ps/git call) followed by the next poll
+ * could be misread as a hung loop and a healthy supervisor needlessly killed.
+ * Throws (the supervisor `exit $?`s on a bad config) when violated.
+ */
+export function validateSupervisorStaleThreshold(
+  config: Pick<SupervisorConfig, "supervisorStaleS" | "tickTimeoutS">,
+): void {
+  if (config.supervisorStaleS <= config.tickTimeoutS) {
+    throw new Error(
+      `RED_AFK_SUPERVISOR_STALE_S (${config.supervisorStaleS}) must be > RED_AFK_TICK_TIMEOUT_S (${config.tickTimeoutS})`,
+    );
+  }
+}
+
+// ---------- quiescence detection (pure) ----------
+
+/**
+ * A point-in-time read of the fleet supervisor's liveness, gathered by an
+ * already-alive surface (fleet pre-check / monitor tick) from the pid file + the
+ * #406 heartbeat state file. Pure input to {@link classifySupervisor}.
+ */
+export interface SupervisorLiveness {
+  /** The supervisor pid from afk-supervisor.pid, or null when no pid file. */
+  pid: number | null;
+  /** Whether that pid is alive (kill -0). Meaningless when pid is null. */
+  pidAlive: boolean;
+  /** Epoch seconds of the last #406 heartbeat, or null when none was observed. */
+  lastHeartbeatEpoch: number | null;
+}
+
+/**
+ * The watchdog's verdict on a supervisor:
+ *   - "absent"    — no live supervisor (no pid / dead pid): nothing to recover;
+ *                   a launch may proceed, a monitor tick stays quiet.
+ *   - "healthy"   — a live PID whose heartbeat is fresh (or not yet observed, so
+ *                   it cannot be PROVEN wedged): leave it alone.
+ *   - "quiescent" — a live PID whose heartbeat is stale past the threshold: the
+ *                   drain loop is hard-hung and must be recovered.
+ */
+export type SupervisorHealth = "absent" | "healthy" | "quiescent";
+
+/**
+ * classifySupervisor — the pure quiescence detector (#407). A live PID is
+ * "quiescent" only when its last heartbeat is at least `staleS` seconds old; a
+ * missing heartbeat (a freshly-launched supervisor that has not ticked yet) is
+ * never enough to prove a wedge, so it stays "healthy" — the watchdog must never
+ * kill a supervisor that simply has not emitted its first heartbeat. Clock skew
+ * (a heartbeat stamped in the future) yields a negative age < staleS → healthy.
+ */
+export function classifySupervisor(
+  liveness: SupervisorLiveness,
+  now: number,
+  staleS: number,
+): SupervisorHealth {
+  if (liveness.pid === null || !liveness.pidAlive) return "absent";
+  if (liveness.lastHeartbeatEpoch === null) return "healthy";
+  return now - liveness.lastHeartbeatEpoch >= staleS ? "quiescent" : "healthy";
 }
 
 // ---------- circuit breaker (pure) ----------
@@ -264,6 +347,9 @@ export interface FleetHeartbeat {
   ts: string;
   /** Epoch seconds for cheap age calculations in monitor/statusline. */
   epoch: number;
+  /** Runner this fleet was launched with — lets the watchdog relaunch a recovered
+   * supervisor with the same runner instead of re-detecting from its own tree. */
+  runner: string;
   readyForAgent: number;
   slotsBusy: number;
   slotsFree: number;
@@ -464,6 +550,7 @@ async function emitFleetHeartbeat(
   state: SupervisorState,
   deps: SupervisorDeps,
   result: TickResult,
+  runner: string,
 ): Promise<FleetHeartbeat> {
   let readyForAgent = 0;
   try {
@@ -475,6 +562,7 @@ async function emitFleetHeartbeat(
   const heartbeat: FleetHeartbeat = {
     ts: isoFromEpoch(epoch),
     epoch,
+    runner,
     readyForAgent,
     ...fleetSlotCounts(state),
     spawnsThisTick: result.respawned.length,
@@ -772,6 +860,10 @@ export async function runSupervisor(
   stopRequested: () => boolean,
 ): Promise<void> {
   validateStallThresholds(config);
+  // The external watchdog (#407) reads this heartbeat to recover a hard-hung
+  // loop; refuse to boot with a threshold that could misread a slow-but-live
+  // tick as quiescent.
+  validateSupervisorStaleThreshold(config);
 
   // Spawn the initial fleet to target.
   for (let i = 0; i < state.slots.length; i += 1) {
@@ -793,7 +885,7 @@ export async function runSupervisor(
       deps.proc.sleep,
       deps.log,
     );
-    const heartbeat = await emitFleetHeartbeat(state, deps, result);
+    const heartbeat = await emitFleetHeartbeat(state, deps, result, config.runner);
     deps.log?.(
       `tick: slots=${state.slots.length} respawned=${result.respawned.length} ` +
         `deaths=${result.deaths.length} parked=${result.parked.length} reaped=${result.reaped.length} ` +

--- a/src/apps/dev/src/core/watchdog.ts
+++ b/src/apps/dev/src/core/watchdog.ts
@@ -1,0 +1,113 @@
+// watchdog — the EXTERNAL recovery layer for a hard-hung fleet supervisor
+// (#407). The HITL decision (2026-06-08) was: a live-but-quiescent supervisor
+// (alive PID, drain loop wedged, #406 heartbeat gone stale) cannot re-arm
+// itself, so recovery is driven by an ALREADY-ALIVE surface — the fleet-launch
+// pre-check (fleet.ts) and the auto-monitor tick (monitor.ts) — never a new
+// standalone daemon.
+//
+// This module is PURE SEQUENCING over injected IO, mirroring supervisor.ts:
+// every side effect (reading the pid/heartbeat, killing a tree, clearing the
+// control files, reconciling stranded claims, relaunching `__supervise`) is
+// injected through `WatchdogIO`. The decision itself — quiescent vs healthy vs
+// absent — is `classifySupervisor` in supervisor.ts and is never re-implemented
+// here. No real process / fs / gh call lives in this file.
+
+import { classifySupervisor, type SupervisorHealth, type SupervisorLiveness } from "./supervisor.js";
+
+/**
+ * Injected IO for one watchdog pass. Each closure is best-effort — the same
+ * `|| true` discipline the supervisor's gh/fs closures already follow — so a
+ * failed kill / reconcile never throws out of the recovery sequence and the
+ * relaunch still fires.
+ */
+export interface WatchdogIO {
+  /** Current epoch seconds (date +%s), injected for determinism. */
+  now(): number;
+  /** Read the supervisor's pid + liveness + last #406 heartbeat epoch. */
+  liveness(): Promise<SupervisorLiveness>;
+  /** kill_tree the wedged supervisor pid + its descendants. */
+  killTree(pid: number): Promise<void>;
+  /** Remove the supervisor pid + stop control files so a relaunch is unblocked. */
+  clearControlFiles(): Promise<void>;
+  /** Reconcile claims/labels the wedged supervisor left so no issue is stranded
+   * in `running` across the restart (reuse the trip-sweep / reap cleanup). */
+  reconcile(): Promise<void>;
+  /** Spawn a fresh `__supervise` and stamp a fresh heartbeat so the next tick is
+   * not itself misread as quiescent during the boot window. */
+  relaunch(): Promise<void>;
+  /** Loud, structured progress line (best-effort). */
+  log(line: string): void;
+}
+
+export interface WatchdogResult {
+  health: SupervisorHealth;
+  /** True only when this pass tore down + relaunched a quiescent supervisor. */
+  recovered: boolean;
+  /** The wedged supervisor pid that was recovered, when recovered. */
+  pid: number | null;
+  /** Heartbeat age in seconds at detection, when a heartbeat was observed. */
+  staleForS: number | null;
+}
+
+/**
+ * Tear down a supervisor proven quiescent: kill its tree, clear the control
+ * files, then reconcile any claims/labels it stranded. Order matters — the
+ * pid/stop files are cleared BEFORE the relaunch so the fresh supervisor's
+ * single-supervisor lock is not tripped by the wedged process's leftover pid
+ * file, and reconcile runs after the kill so a still-live worker the wedged
+ * supervisor spawned is judged dead-or-alive against reality, not a phantom.
+ * Best-effort throughout: every step is wrapped so one failure never aborts the
+ * rest of the recovery.
+ */
+export async function teardownWedgedSupervisor(io: WatchdogIO, pid: number | null): Promise<void> {
+  if (pid !== null) {
+    try {
+      await io.killTree(pid);
+    } catch {
+      // best-effort: the pid may already be gone.
+    }
+  }
+  try {
+    await io.clearControlFiles();
+  } catch {
+    // best-effort
+  }
+  try {
+    await io.reconcile();
+  } catch {
+    // best-effort: reconcile is also finished by the relaunched workers' boot.
+  }
+}
+
+/**
+ * Run one watchdog pass: classify the supervisor, and if quiescent, tear it down
+ * and relaunch. Idempotent across repeated invocations of an already-alive
+ * surface (a monitor cron tick firing every poll): the relaunch stamps a fresh
+ * heartbeat, so the very next pass sees "healthy" and does not double-fire while
+ * the new supervisor boots. A supervisor that is absent or healthy is left
+ * untouched — the launch pre-check handles the "refuse to stack on a healthy
+ * fleet" case itself by inspecting the returned `health`.
+ */
+export async function runWatchdog(io: WatchdogIO, staleS: number): Promise<WatchdogResult> {
+  const now = io.now();
+  const liveness = await io.liveness();
+  const health = classifySupervisor(liveness, now, staleS);
+  const staleForS = liveness.lastHeartbeatEpoch !== null ? now - liveness.lastHeartbeatEpoch : null;
+
+  if (health !== "quiescent") {
+    return { health, recovered: false, pid: liveness.pid, staleForS };
+  }
+
+  io.log(
+    `⚠️  watchdog: supervisor pid=${liveness.pid ?? "?"} is QUIESCENT — heartbeat stale ` +
+      `${staleForS ?? "?"}s ≥ ${staleS}s threshold; the drain loop is wedged. Recovering.`,
+  );
+  await teardownWedgedSupervisor(io, liveness.pid);
+  try {
+    await io.relaunch();
+  } catch (err) {
+    io.log(`watchdog: relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  io.log(`watchdog: wedged supervisor recovered — fresh fleet relaunched.`);
+  return { health, recovered: true, pid: liveness.pid, staleForS };
+}

--- a/src/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/src/apps/dev/src/runtime/supervisor-spawn.ts
@@ -1,0 +1,115 @@
+// supervisor-spawn — the single place that spawns the native `__supervise`
+// process. Shared by the fleet-launch command (fleet.ts) and the external
+// watchdog's relaunch (watchdog-io.ts) so both speak the same pid/stop-file
+// protocol and forward the same filter/policy args. No decision logic lives
+// here — callers resolve target/runner/passthrough and inject them.
+
+import { spawn } from "node:child_process";
+import { openSync, renameSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isLivePid(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPid(path: string): Promise<number | null> {
+  try {
+    const raw = (await readFile(path, "utf8")).trim();
+    if (!/^\d+$/.test(raw)) return null;
+    return Number(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function waitForPidFile(pidFile: string, deadlineMs: number): Promise<number | null> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    const pid = await readPid(pidFile);
+    if (pid && isLivePid(pid)) return pid;
+    await sleep(100);
+  }
+  return null;
+}
+
+export interface SpawnSupervisorOptions {
+  root: string;
+  target: number;
+  runner: string;
+  /** Filter/policy argv (--prd/--issues/--alternate/--fallback-runner) threaded
+   * into each slot's `run --once`. */
+  passthrough?: readonly string[];
+  /** Optional fleet request, forwarded as RED_AFK_REQUEST + `--request`. */
+  request?: string;
+}
+
+/**
+ * Spawn a detached `__supervise` process for `root`, waiting up to 3s for it to
+ * write its pid file. Returns the supervisor pid, or null when the pid file
+ * never appeared (the caller surfaces the log tail). Mirrors fleet.ts's original
+ * inline spawn so launch + watchdog-relaunch stay byte-identical.
+ */
+export async function spawnSupervisor(opts: SpawnSupervisorOptions): Promise<number | null> {
+  const tmp = join(opts.root, ".red", "tmp");
+  const pidFile = join(tmp, "afk-supervisor.pid");
+  const logFile = join(tmp, "afk-supervisor.log");
+
+  const childArgs = [...(opts.passthrough ?? [])];
+  if (opts.request) childArgs.unshift("--request", opts.request);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    RED_AFK_TARGET: String(opts.target),
+    RED_AFK_RUNNER: opts.runner,
+  };
+  if (opts.request) env.RED_AFK_REQUEST = opts.request;
+
+  const out = openSync(logFile, "a");
+  const child = spawn(process.execPath, [process.argv[1]!, "__supervise", ...childArgs], {
+    cwd: opts.root,
+    env,
+    detached: true,
+    stdio: ["ignore", out, out],
+  });
+  child.unref();
+
+  return waitForPidFile(pidFile, 3_000);
+}
+
+/**
+ * Stamp a placeholder #406 fleet-heartbeat state file with `epoch` so a freshly
+ * relaunched supervisor is not itself read as quiescent during its boot window
+ * (the watchdog's idempotency guard). The new supervisor overwrites this on its
+ * first real tick. Atomic write (tmp + rename), best-effort — a failure to stamp
+ * only narrows the double-fire guard, it never blocks the relaunch.
+ */
+export function stampFreshFleetHeartbeat(
+  statePath: string,
+  epoch: number,
+  runner: string,
+  target: number,
+): void {
+  const body = JSON.stringify(
+    {
+      ts: new Date(epoch * 1000).toISOString(),
+      epoch,
+      runner,
+      ready_for_agent: 0,
+      slots: { busy: 0, free: target, total: target, parked: 0 },
+      spawns_this_tick: 0,
+    },
+    null,
+    2,
+  );
+  const tmp = `${statePath}.tmp`;
+  writeFileSync(tmp, body, "utf8");
+  renameSync(tmp, statePath);
+}

--- a/src/apps/dev/src/runtime/watchdog-io.ts
+++ b/src/apps/dev/src/runtime/watchdog-io.ts
@@ -1,0 +1,177 @@
+// watchdog-io — REAL process / fs IO backing the external supervisor watchdog
+// (core/watchdog.ts). Built once per surface (fleet pre-check / monitor tick),
+// bound to a repo root. Every closure is best-effort, mirroring the supervisor's
+// own injected IO: a failed kill / stat / spawn degrades to the safe value and
+// never throws out of the closure.
+
+import { constants } from "node:fs";
+import { access, readFile, rm } from "node:fs/promises";
+import { closeSync, openSync, writeSync } from "node:fs";
+import { join } from "node:path";
+import type { SupervisorLiveness } from "../core/supervisor.js";
+import type { WatchdogIO } from "../core/watchdog.js";
+import { afkPaths, readFleetState } from "./wire.js";
+import { listStaleClaimDirs, removeDir } from "./fs.js";
+import { detectRunner } from "../core/runner-detection.js";
+import { callerProcessTreeNative } from "./caller-process.js";
+import { spawnSupervisor, stampFreshFleetHeartbeat } from "./supervisor-spawn.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isLivePid(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function signalTree(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/**
+ * SIGTERM the wedged supervisor's tree, then WAIT for it to actually exit
+ * (polling up to ~2s, escalating to SIGKILL) before returning. This matters for
+ * recovery correctness: the supervisor's own `finally` removes the pid/stop
+ * files on exit, so the relaunch must not write a fresh pid file until the dying
+ * process has finished cleaning up — otherwise it would clobber the new one.
+ */
+async function killTreeAndWait(pid: number): Promise<void> {
+  signalTree(pid, "SIGTERM");
+  for (let i = 0; i < 20; i += 1) {
+    if (!isLivePid(pid)) return;
+    await sleep(100);
+  }
+  signalTree(pid, "SIGKILL");
+  for (let i = 0; i < 10; i += 1) {
+    if (!isLivePid(pid)) return;
+    await sleep(100);
+  }
+}
+
+async function readPid(path: string): Promise<number | null> {
+  try {
+    const raw = (await readFile(path, "utf8")).trim();
+    if (!/^\d+$/.test(raw)) return null;
+    return Number(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build a WatchdogIO bound to `root`. `log` lines are written to `stdout` (so a
+ * monitor tick / launch surfaces the recovery loudly) AND appended to
+ * afk-supervisor.log so the recovery is durable in the same place the fleet's
+ * own heartbeat lives. The last fleet-state read by `liveness()` is cached so a
+ * relaunch restores the prior target/runner instead of guessing.
+ */
+export function buildWatchdogIO(
+  root: string,
+  stdout: NodeJS.WritableStream = process.stdout,
+): WatchdogIO {
+  const paths = afkPaths(root);
+  const pidFile = join(paths.tmpDir, "afk-supervisor.pid");
+  const stopFile = join(paths.tmpDir, "afk-supervisor.stop");
+  const logFile = join(paths.tmpDir, "afk-supervisor.log");
+
+  // Carried from liveness() → relaunch() so a recovered fleet keeps its target
+  // and runner. Falls back to a 2-slot, freshly-detected-runner fleet when the
+  // wedged supervisor left no usable heartbeat.
+  let lastTarget = 2;
+  let lastRunner = "";
+
+  return {
+    now: () => Math.floor(Date.now() / 1000),
+
+    liveness: async (): Promise<SupervisorLiveness> => {
+      const pid = await readPid(pidFile);
+      const fleet = await readFleetState(paths.fleetStatePath);
+      if (fleet) {
+        if (fleet.slotsTotal > 0) lastTarget = fleet.slotsTotal;
+        if (fleet.runner) lastRunner = fleet.runner;
+      }
+      return {
+        pid,
+        pidAlive: pid !== null && isLivePid(pid),
+        lastHeartbeatEpoch: fleet ? fleet.epoch : null,
+      };
+    },
+
+    killTree: async (pid) => {
+      await killTreeAndWait(pid);
+    },
+
+    clearControlFiles: async () => {
+      await rm(pidFile, { force: true });
+      await rm(stopFile, { force: true });
+    },
+
+    // Reconcile stranded claims: drop every claim-lock dir whose owning worker
+    // pid is dead, so no issue stays claimed (and unre-grabbable) across the
+    // restart. listStaleClaimDirs already gates on liveness, so a claim a still-
+    // live orphaned worker holds is left untouched. The relaunched fleet's
+    // worker boot finishes the gh label rotation (the trip-sweep / orphan path).
+    reconcile: async () => {
+      const stale = await listStaleClaimDirs(paths.tmpDir).catch(() => []);
+      for (const dir of stale) {
+        await removeDir(dir.path).catch(() => {});
+      }
+    },
+
+    relaunch: async () => {
+      const runner =
+        lastRunner ||
+        detectRunner({
+          processTree: callerProcessTreeNative(),
+          scriptPath: process.argv[1],
+        }).runner;
+      await spawnSupervisor({ root, target: lastTarget, runner });
+      // Stamp a fresh heartbeat so the very next watchdog pass (a monitor cron
+      // tick firing every poll) sees the new supervisor as healthy and does not
+      // double-fire while it boots.
+      try {
+        stampFreshFleetHeartbeat(paths.fleetStatePath, Math.floor(Date.now() / 1000), runner, lastTarget);
+      } catch {
+        // best-effort
+      }
+    },
+
+    log: (line) => {
+      try {
+        stdout.write(`${line}\n`);
+      } catch {
+        // best-effort
+      }
+      try {
+        const fd = openSync(logFile, "a");
+        try {
+          writeSync(fd, `[${new Date().toISOString()}] ${line}\n`);
+        } finally {
+          closeSync(fd);
+        }
+      } catch {
+        // best-effort: a log-write failure must never affect recovery.
+      }
+    },
+  };
+}

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -327,6 +327,7 @@ function parseFleetState(raw: unknown): FleetState | null {
   const rec = raw as {
     ts?: unknown;
     epoch?: unknown;
+    runner?: unknown;
     ready_for_agent?: unknown;
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
     spawns_this_tick?: unknown;
@@ -336,6 +337,7 @@ function parseFleetState(raw: unknown): FleetState | null {
   return {
     ts: typeof rec.ts === "string" ? rec.ts : "",
     epoch,
+    runner: typeof rec.runner === "string" ? rec.runner : "",
     readyForAgent: Number(rec.ready_for_agent ?? 0) || 0,
     slotsBusy: Number(rec.slots?.busy ?? 0) || 0,
     slotsFree: Number(rec.slots?.free ?? 0) || 0,

--- a/src/apps/dev/tests/monitor.test.ts
+++ b/src/apps/dev/tests/monitor.test.ts
@@ -39,6 +39,7 @@ const baseWorker = (over: Partial<CompactWorker> = {}): CompactWorker => ({
 const baseFleet = (over: Partial<FleetState> = {}): FleetState => ({
   ts: "2026-05-30T11:00:00Z",
   epoch: 1780138800,
+  runner: "claude",
   readyForAgent: 0,
   slotsBusy: 0,
   slotsFree: 2,

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -12,6 +12,8 @@ import {
   sweepParkedSlot,
   superviseTick,
   validateStallThresholds,
+  validateSupervisorStaleThreshold,
+  classifySupervisor,
   guardedTick,
   type IterDirInfo,
   type SupervisorConfig,
@@ -33,6 +35,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     runner: "claude",
     pollIntervalS: 15,
     tickTimeoutS: 120,
+    supervisorStaleS: 300,
     ...over,
   };
 }
@@ -140,6 +143,73 @@ describe("validateStallThresholds", () => {
     await expect(
       runSupervisor(state, deps, config({ stallThresholdS: 600, stallKillThresholdS: 600 }), () => true),
     ).rejects.toThrow();
+  });
+});
+
+// ---------- validateSupervisorStaleThreshold (#407) ----------
+
+describe("validateSupervisorStaleThreshold", () => {
+  it("passes when STALE > TICK_TIMEOUT", () => {
+    expect(() => validateSupervisorStaleThreshold({ supervisorStaleS: 300, tickTimeoutS: 120 })).not.toThrow();
+  });
+
+  it("throws when STALE == TICK_TIMEOUT", () => {
+    expect(() => validateSupervisorStaleThreshold({ supervisorStaleS: 120, tickTimeoutS: 120 })).toThrow();
+  });
+
+  it("throws when STALE < TICK_TIMEOUT", () => {
+    expect(() => validateSupervisorStaleThreshold({ supervisorStaleS: 60, tickTimeoutS: 120 })).toThrow();
+  });
+
+  it("runSupervisor refuses to boot with STALE <= TICK_TIMEOUT", async () => {
+    const { deps } = makeDeps();
+    const state = initSupervisorState(1);
+    await expect(
+      runSupervisor(state, deps, config({ supervisorStaleS: 120, tickTimeoutS: 120 }), () => true),
+    ).rejects.toThrow(/RED_AFK_SUPERVISOR_STALE_S/);
+  });
+});
+
+// ---------- classifySupervisor (#407 quiescence detector, pure) ----------
+
+describe("classifySupervisor", () => {
+  const STALE = 300;
+
+  it("is absent when there is no pid", () => {
+    expect(classifySupervisor({ pid: null, pidAlive: false, lastHeartbeatEpoch: NOW }, NOW, STALE)).toBe("absent");
+  });
+
+  it("is absent when the pid is dead", () => {
+    expect(classifySupervisor({ pid: 42, pidAlive: false, lastHeartbeatEpoch: NOW - 9999 }, NOW, STALE)).toBe(
+      "absent",
+    );
+  });
+
+  it("is healthy when a live pid has a fresh heartbeat", () => {
+    expect(classifySupervisor({ pid: 42, pidAlive: true, lastHeartbeatEpoch: NOW - 10 }, NOW, STALE)).toBe("healthy");
+  });
+
+  it("is healthy at exactly one second under the threshold", () => {
+    expect(classifySupervisor({ pid: 42, pidAlive: true, lastHeartbeatEpoch: NOW - (STALE - 1) }, NOW, STALE)).toBe(
+      "healthy",
+    );
+  });
+
+  it("is quiescent at exactly the threshold and beyond", () => {
+    expect(classifySupervisor({ pid: 42, pidAlive: true, lastHeartbeatEpoch: NOW - STALE }, NOW, STALE)).toBe(
+      "quiescent",
+    );
+    expect(classifySupervisor({ pid: 42, pidAlive: true, lastHeartbeatEpoch: NOW - 999999 }, NOW, STALE)).toBe(
+      "quiescent",
+    );
+  });
+
+  it("never proves a wedge on a live pid that has no heartbeat yet (just booted)", () => {
+    expect(classifySupervisor({ pid: 42, pidAlive: true, lastHeartbeatEpoch: null }, NOW, STALE)).toBe("healthy");
+  });
+
+  it("treats a future-stamped heartbeat (clock skew) as healthy", () => {
+    expect(classifySupervisor({ pid: 42, pidAlive: true, lastHeartbeatEpoch: NOW + 50 }, NOW, STALE)).toBe("healthy");
   });
 });
 
@@ -650,5 +720,14 @@ describe("resolveSupervisorConfig — tick timeout knob", () => {
     expect(resolveSupervisorConfig({ RED_AFK_TICK_TIMEOUT_S: "0" }).tickTimeoutS).toBe(120);
     expect(resolveSupervisorConfig({ RED_AFK_TICK_TIMEOUT_S: "45" }).tickTimeoutS).toBe(45);
     expect(resolveSupervisorConfig({ RED_AFK_TICK_TIMEOUT_S: "abc" }).tickTimeoutS).toBe(120);
+  });
+});
+
+describe("resolveSupervisorConfig — supervisor stale knob (#407)", () => {
+  it("defaults supervisorStaleS and floors a 0/garbage back to the default", () => {
+    expect(resolveSupervisorConfig({}).supervisorStaleS).toBe(300);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "0" }).supervisorStaleS).toBe(300);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "900" }).supervisorStaleS).toBe(900);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "abc" }).supervisorStaleS).toBe(300);
   });
 });

--- a/src/apps/dev/tests/watchdog.test.ts
+++ b/src/apps/dev/tests/watchdog.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { runWatchdog, teardownWedgedSupervisor, type WatchdogIO } from "../src/core/watchdog.js";
+import type { SupervisorLiveness } from "../src/core/supervisor.js";
+
+const NOW = 1700000000;
+const STALE = 300;
+
+interface FakeIo {
+  now: ReturnType<typeof vi.fn>;
+  liveness: ReturnType<typeof vi.fn>;
+  killTree: ReturnType<typeof vi.fn>;
+  clearControlFiles: ReturnType<typeof vi.fn>;
+  reconcile: ReturnType<typeof vi.fn>;
+  relaunch: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.fn>;
+}
+
+function makeIo(liveness: SupervisorLiveness): { io: WatchdogIO; fake: FakeIo } {
+  const fake: FakeIo = {
+    now: vi.fn(() => NOW),
+    liveness: vi.fn(async () => liveness),
+    killTree: vi.fn(async () => {}),
+    clearControlFiles: vi.fn(async () => {}),
+    reconcile: vi.fn(async () => {}),
+    relaunch: vi.fn(async () => {}),
+    log: vi.fn(),
+  };
+  return { io: fake as unknown as WatchdogIO, fake };
+}
+
+describe("runWatchdog — quiescent supervisor recovery (#407)", () => {
+  it("recovers a wedged supervisor: kill → clear → reconcile → relaunch, exactly once", async () => {
+    const { io, fake } = makeIo({ pid: 4242, pidAlive: true, lastHeartbeatEpoch: NOW - 9999 });
+
+    const result = await runWatchdog(io, STALE);
+
+    expect(result.recovered).toBe(true);
+    expect(result.health).toBe("quiescent");
+    expect(result.pid).toBe(4242);
+    expect(result.staleForS).toBe(9999);
+
+    // The full recovery sequence fired exactly once.
+    expect(fake.killTree).toHaveBeenCalledTimes(1);
+    expect(fake.killTree).toHaveBeenCalledWith(4242);
+    expect(fake.clearControlFiles).toHaveBeenCalledTimes(1);
+    expect(fake.reconcile).toHaveBeenCalledTimes(1);
+    expect(fake.relaunch).toHaveBeenCalledTimes(1);
+
+    // Ordering: kill before clear before reconcile before relaunch.
+    const order = [
+      fake.killTree.mock.invocationCallOrder[0]!,
+      fake.clearControlFiles.mock.invocationCallOrder[0]!,
+      fake.reconcile.mock.invocationCallOrder[0]!,
+      fake.relaunch.mock.invocationCallOrder[0]!,
+    ];
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it("leaves a healthy supervisor untouched (no kill, no relaunch)", async () => {
+    const { io, fake } = makeIo({ pid: 4242, pidAlive: true, lastHeartbeatEpoch: NOW - 10 });
+
+    const result = await runWatchdog(io, STALE);
+
+    expect(result.health).toBe("healthy");
+    expect(result.recovered).toBe(false);
+    expect(fake.killTree).not.toHaveBeenCalled();
+    expect(fake.clearControlFiles).not.toHaveBeenCalled();
+    expect(fake.reconcile).not.toHaveBeenCalled();
+    expect(fake.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no supervisor is alive (absent)", async () => {
+    const { io, fake } = makeIo({ pid: null, pidAlive: false, lastHeartbeatEpoch: null });
+
+    const result = await runWatchdog(io, STALE);
+
+    expect(result.health).toBe("absent");
+    expect(result.recovered).toBe(false);
+    expect(fake.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("does not double-fire once the relaunched fleet reports a fresh heartbeat", async () => {
+    // First pass: wedged. Second pass: the relaunch stamped a fresh heartbeat,
+    // so classify sees healthy and recovery does NOT fire again.
+    const wedged: SupervisorLiveness = { pid: 4242, pidAlive: true, lastHeartbeatEpoch: NOW - 9999 };
+    const fresh: SupervisorLiveness = { pid: 5555, pidAlive: true, lastHeartbeatEpoch: NOW - 1 };
+    const { io, fake } = makeIo(wedged);
+    fake.liveness.mockResolvedValueOnce(wedged).mockResolvedValueOnce(fresh);
+
+    const first = await runWatchdog(io, STALE);
+    const second = await runWatchdog(io, STALE);
+
+    expect(first.recovered).toBe(true);
+    expect(second.recovered).toBe(false);
+    expect(fake.relaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers even if relaunch throws (logged, never rejects)", async () => {
+    const { io, fake } = makeIo({ pid: 4242, pidAlive: true, lastHeartbeatEpoch: NOW - 9999 });
+    fake.relaunch.mockRejectedValueOnce(new Error("spawn failed"));
+
+    const result = await runWatchdog(io, STALE);
+
+    expect(result.recovered).toBe(true);
+    expect(fake.killTree).toHaveBeenCalledTimes(1);
+    expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("relaunch failed"));
+  });
+});
+
+describe("teardownWedgedSupervisor", () => {
+  it("kills, clears, and reconciles best-effort even when a step throws", async () => {
+    const { io, fake } = makeIo({ pid: 7, pidAlive: true, lastHeartbeatEpoch: NOW - 9999 });
+    fake.killTree.mockRejectedValueOnce(new Error("already gone"));
+
+    await expect(teardownWedgedSupervisor(io, 7)).resolves.toBeUndefined();
+    expect(fake.clearControlFiles).toHaveBeenCalledTimes(1);
+    expect(fake.reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips killTree when there is no pid", async () => {
+    const { io, fake } = makeIo({ pid: null, pidAlive: false, lastHeartbeatEpoch: null });
+    await teardownWedgedSupervisor(io, null);
+    expect(fake.killTree).not.toHaveBeenCalled();
+    expect(fake.clearControlFiles).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Salvage-land of a parked-but-green AFK branch (ADR 0055 reconcile, done manually). Gate verified locally: typecheck ✓, vitest ✓ (src/apps/dev). Closes #407.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783537942&installation_id=129708444&pr_number=559&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F559&signature=adf8bd7a1495daecf3b209e804fc096c6658edca574797bcf75ac163a2324b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and recovery of stalled supervisors via watchdog mechanism
  * Configurable supervisor staleness threshold (default 300 seconds) to identify unresponsive supervisors
  * Enhanced monitoring with pre-flight health checks

* **Improvements**
  * Centralized supervisor spawning for more reliable launches
  * Improved fleet state tracking with runner identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->