### PR TITLE
merge: #456 (salvage — gate green, reconcile/ADR-0055)

### DIFF
--- a/plugins/dev/hooks/claude.hooks.json
+++ b/plugins/dev/hooks/claude.hooks.json
@@ -19,6 +19,15 @@
             "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; hook=\"${CLAUDE_PLUGIN_ROOT}/skills/misc/branch-lock/scripts/branch-lock-hook.sh\"; if [ -f \"$hook\" ]; then bash \"$hook\" <\"$tmp\"; else printf \"{}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat >\"$tmp\" 2>/dev/null || true; root=\"${CLAUDE_PLUGIN_ROOT}\"; out=\"\"; for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { out=\"$(node \"$f\" run dev route-model-tier --host claude <\"$tmp\" 2>/dev/null)\"; break; }; done; if [ -n \"$out\" ]; then printf \"%s\" \"$out\"; else printf \"{}\"; fi'"
+          }
+        ]
       }
     ]
   }

--- a/plugins/dev/skills/engineering/model-tier-policy/SKILL.md
+++ b/plugins/dev/skills/engineering/model-tier-policy/SKILL.md
@@ -55,3 +55,13 @@ Start with the cheapest capable tier, but escalate immediately when evidence sho
 - Codex receives this same skill through `plugins/dev/.codex-plugin/plugin.json` (`"skills": "./skills/"`). Codex does not ship the Claude `agents/` wrappers.
 - AFK sandcastle execution lives in `plugins/dev/skills/engineering/afk/SKILL.md`, with host adapters in `runner-claude.md` and `runner-codex.md`. Runtime tier resolution flows through `resolveTier` in `src/apps/dev/src/core/process-issue.ts` and the config resolver in `src/apps/dev/src/core/config.ts`.
 - Host hooks live in `plugins/dev/hooks/claude.hooks.json` and `plugins/dev/hooks/codex.hooks.json`; they are host-specific enforcement surfaces, not places to duplicate the policy.
+
+## Interactive enforcement (issue #456, ADR 0049)
+
+The interactive session's tier is enforced — not merely suggested — by a PreToolUse hook on the subagent-dispatch tool (`Task`/`Agent`). On Claude Code, `plugins/dev/hooks/claude.hooks.json` routes the dispatch payload through the dev bundle's `route-model-tier` command (`src/apps/dev/src/commands/route-model-tier.ts`, pure decision in `core/model-tier-route.ts`). The command:
+
+- maps a dispatch to a tier-agent (`validate` → `validate`, `simple-code` → `simple`, `complex-code` → `complex`) and asks `resolveTier` for the policy model from the **single config source** (`plugins.dev.afk.models.claude.<tier>.model`); it hardcodes no model id;
+- when the dispatched model's family disagrees with the tier (or is unset), corrects it via the enforcement contract decided at HITL on 2026-06-08: **(a) rewrite** the dispatch model in place using Claude's `hookSpecificOutput.updatedInput` → **(b) fallback block-and-retry** (`permissionDecision: "deny"`) → **(c) degrade to audit** (`additionalContext`). Claude supports rewrite, so it always takes path (a);
+- leaves dispatches to any non-tier subagent untouched (the hook enforces a declared tier, it does not semantically classify arbitrary tasks).
+
+Codex safe-degrades to a no-op until the per-task subagent-with-model capability lands (#457): the `route-model-tier --host codex` path emits no change, and `codex.hooks.json` does not wire an enforcing hook yet. When #457 resolves Codex's dispatch tool shape, wire it the same way — the command already accepts `--host codex` and the contract is shared, so there is still exactly one tier table.

--- a/src/apps/dev/src/cli.ts
+++ b/src/apps/dev/src/cli.ts
@@ -7,6 +7,7 @@ import { monitorCommand } from "./commands/monitor.js";
 import { runCommand } from "./commands/run.js";
 import { reapCommand } from "./commands/reap.js";
 import { retakeCommand } from "./commands/retake.js";
+import { routeModelTierCommand } from "./commands/route-model-tier.js";
 import { shipCommand } from "./commands/ship.js";
 import { statuslineCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
@@ -23,6 +24,7 @@ export type CliCommand =
   | "reap"
   | "retake"
   | "ship"
+  | "route-model-tier"
   | "statusline"
   | "inject-development-workflow"
   | "version"
@@ -50,6 +52,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     reap: {},
     retake: {},
     ship: {},
+    "route-model-tier": {},
     statusline: {},
     "inject-development-workflow": {},
     version: {},
@@ -79,6 +82,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "reap") return reapCommand(parsed.args);
   if (parsed.command === "retake") return retakeCommand(parsed.args);
   if (parsed.command === "ship") return shipCommand(parsed.args);
+  if (parsed.command === "route-model-tier") return routeModelTierCommand(parsed.args);
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);
   if (parsed.command === "inject-development-workflow") return injectDevelopmentWorkflowCommand(parsed.args);
   if (parsed.command === "__supervise") return superviseCommand(parsed.args);

--- a/src/apps/dev/src/commands/route-model-tier.ts
+++ b/src/apps/dev/src/commands/route-model-tier.ts
@@ -1,0 +1,163 @@
+// commands/route-model-tier.ts — the IO half of the interactive model-tier
+// routing hook (issue #456, ADR 0049).
+//
+// Wired as a Claude Code PreToolUse hook on the subagent-dispatch tool
+// (`Task`/`Agent`) via plugins/dev/hooks/claude.hooks.json. The hook pipes the
+// PreToolUse payload to this command on stdin; the command resolves the project
+// `.red/config.yaml`, asks the PURE decision in core/model-tier-route.ts how to
+// route the dispatch, and prints the host's PreToolUse response on stdout.
+//
+// It is best-effort and never wedges a dispatch: any error (no stdin, malformed
+// payload, no config) prints `{}` (no change) and exits 0.
+//
+// Invocation: `node bin/afk.mjs route-model-tier [--host claude|codex]` with the
+// PreToolUse JSON on stdin.
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { loadConfig } from "../core/config.js";
+import {
+  routeModelTier,
+  type EnforcementCapability,
+  type PreToolUseInput,
+  type RouteAction,
+} from "../core/model-tier-route.js";
+
+function readStdin(stdin: NodeJS.ReadableStream & { isTTY?: boolean }): Promise<string> {
+  return new Promise((resolve) => {
+    if (stdin.isTTY) {
+      resolve("");
+      return;
+    }
+    let data = "";
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve(data);
+    };
+    stdin.setEncoding("utf8");
+    stdin.on("data", (chunk: string) => {
+      data += chunk;
+    });
+    stdin.on("end", done);
+    stdin.on("error", done);
+    stdin.on("close", done);
+  });
+}
+
+function parsePayload(text: string): PreToolUseInput {
+  if (!text.trim()) return {};
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return typeof parsed === "object" && parsed !== null ? (parsed as PreToolUseInput) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** The cwd a PreToolUse payload carries, if any (Claude sends `cwd`). */
+interface PayloadDirs {
+  cwd?: unknown;
+  workspace?: { current_dir?: unknown };
+}
+
+function payloadCwd(payload: PreToolUseInput): string | undefined {
+  const p = payload as PayloadDirs;
+  const dir = p.workspace?.current_dir ?? p.cwd;
+  return typeof dir === "string" && dir.length > 0 ? dir : undefined;
+}
+
+/**
+ * Find the project `.red/config.yaml` by walking up from `start`. Returns the
+ * first existing config path, or the `start/.red/config.yaml` candidate (which
+ * `loadConfig` resolves to all-defaults when absent — the correct degrade).
+ */
+export function resolveConfigPath(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 64; i++) {
+    const candidate = join(dir, ".red", "config.yaml");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return join(start, ".red", "config.yaml");
+}
+
+/**
+ * Serialize a `RouteAction` into a Claude Code PreToolUse response.
+ *
+ *  - `noop`    → `{}` (no change; normal permission flow).
+ *  - `rewrite` → `hookSpecificOutput.updatedInput` applies the corrected model;
+ *                a `systemMessage` surfaces the routing to the operator.
+ *  - `block`   → `permissionDecision: "deny"` so the orchestrator retries.
+ *  - `audit`   → `permissionDecision: "allow"` + the reason as a nudge.
+ */
+export function renderClaudeDecision(action: RouteAction): Record<string, unknown> {
+  if (action.kind === "noop") return {};
+  if (action.kind === "rewrite") {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: action.updatedInput,
+      },
+      systemMessage: `[model-tier] routed to ${action.tier} (${action.model}). ${action.reason}`,
+    };
+  }
+  if (action.kind === "block") {
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: action.reason,
+      },
+    };
+  }
+  // audit
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: action.reason,
+    },
+  };
+}
+
+function parseHost(args: string[]): "claude" | "codex" {
+  const i = args.indexOf("--host");
+  if (i >= 0 && args[i + 1] === "codex") return "codex";
+  return "claude";
+}
+
+/**
+ * `route-model-tier [--host claude|codex]` — read a PreToolUse payload on
+ * stdin, decide the routing against `.red/config.yaml`, and print the host
+ * response. Claude enforces via rewrite (path a). Codex degrades to a safe
+ * no-op audit until its per-task subagent-with-model capability lands (#457).
+ */
+export async function routeModelTierCommand(
+  args: string[],
+  cwd = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+  stdin: NodeJS.ReadableStream & { isTTY?: boolean } = process.stdin,
+): Promise<number> {
+  const host = parseHost(args);
+  const text = await readStdin(stdin);
+  const payload = parsePayload(text);
+
+  // Codex cannot yet rewrite a per-task subagent model (#457). Until it can,
+  // never enforce on Codex: emit no change. The Claude path rewrites in place.
+  if (host === "codex") {
+    stdout.write("{}\n");
+    return 0;
+  }
+
+  const root = payloadCwd(payload) ?? cwd;
+  const configPath = resolveConfigPath(root);
+  const config = loadConfig(configPath, { warn: () => undefined });
+
+  const capability: EnforcementCapability = "rewrite";
+  const action = routeModelTier(payload, config, capability);
+  stdout.write(`${JSON.stringify(renderClaudeDecision(action))}\n`);
+  return 0;
+}

--- a/src/apps/dev/src/core/model-tier-route.ts
+++ b/src/apps/dev/src/core/model-tier-route.ts
@@ -1,0 +1,170 @@
+// core/model-tier-route.ts — the pure decision half of the interactive
+// model-tier routing hook (issue #456, ADR 0049).
+//
+// A Claude Code / Codex PreToolUse hook fires on every subagent dispatch (the
+// `Task` / `Agent` tool). This module decides, deterministically, whether the
+// dispatch is mis-tiered and how to correct it — it never reads stdin, the
+// filesystem, or the host; the IO half lives in commands/route-model-tier.ts.
+//
+// Enforcement contract (HITL 2026-06-08): (a) REWRITE the dispatch model where
+// the host supports it → (b) fallback BLOCK-and-retry → (c) degrade to AUDIT.
+// Claude Code PreToolUse hooks can rewrite a dispatch via
+// `hookSpecificOutput.updatedInput`, so the Claude surface always takes path
+// (a). The block/audit ladder is encoded here as `RouteAction` variants so a
+// capability-limited host (Codex, pending #457) can degrade safely without a
+// second copy of this logic.
+//
+// Single source of truth: the tier→model mapping is read from the same
+// `.red/config.yaml` (`plugins.dev.afk.models.claude.<tier>.model`, ADR 0042)
+// that sandcastle (`resolveTier`) and the model-tier-policy skill use. This
+// module hardcodes NO model ids — it only maps a tier-agent's `subagent_type`
+// to its config tier and asks `resolveTier` for the model.
+
+import { resolveTier, type AfkModelTier, type ConfigValues } from "./config.js";
+import type { AgentEffort } from "./execution.js";
+
+/**
+ * The three Claude tier-agents (#453) and the config tier each one pins.
+ * A dispatch to one of these subagent types is the enforcement surface: its
+ * model must match the tier the agent represents. Dispatches to any other
+ * subagent type (general-purpose, Explore, Plan, …) are left untouched — the
+ * hook cannot semantically classify an arbitrary task, only enforce the tier a
+ * tier-agent already declares.
+ */
+export const TIER_AGENT_TIERS: Readonly<Record<string, AfkModelTier>> = {
+  validate: "validate",
+  "simple-code": "simple",
+  "complex-code": "complex",
+};
+
+/** The model families the Claude tier table spans. The "tier" the savings lever
+ * cares about is the model class, so routing compares families, not exact ids:
+ * a `simple-code` dispatch already on a sonnet alias is correctly tiered. */
+export type ModelFamily = "haiku" | "sonnet" | "opus";
+
+/** Extract the Claude model family from a model id or alias, or `undefined`
+ * when the string names no known family (e.g. a Codex `gpt-*` id). */
+export function modelFamily(model: string | undefined): ModelFamily | undefined {
+  if (!model) return undefined;
+  const m = model.toLowerCase();
+  if (m.includes("haiku")) return "haiku";
+  if (m.includes("sonnet")) return "sonnet";
+  if (m.includes("opus")) return "opus";
+  return undefined;
+}
+
+/** The PreToolUse payload slice this module reads. Tolerant of extra fields. */
+export interface PreToolUseInput {
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+}
+
+/**
+ * The host-agnostic routing decision. `commands/route-model-tier.ts` serializes
+ * it into the host's PreToolUse response shape.
+ *
+ *  - `noop`    — the dispatch is not a tier-agent, or is already correctly
+ *                tiered: emit no change.
+ *  - `rewrite` — path (a): correct the dispatch model in place via the host's
+ *                input-rewrite capability (`updatedInput` on Claude).
+ *  - `block`   — path (b): the host can decide but not rewrite; deny so the
+ *                orchestrator retries on the right tier-agent.
+ *  - `audit`   — path (c): the host can neither rewrite nor block; surface a
+ *                nudge and allow.
+ */
+export type RouteAction =
+  | { kind: "noop" }
+  | {
+      kind: "rewrite";
+      tier: AfkModelTier;
+      model: string;
+      effort: AgentEffort;
+      updatedInput: Record<string, unknown>;
+      reason: string;
+    }
+  | { kind: "block"; tier: AfkModelTier; model: string; reason: string }
+  | { kind: "audit"; tier: AfkModelTier; model: string; reason: string };
+
+/** Which leg of the enforcement ladder the host can honour. */
+export type EnforcementCapability = "rewrite" | "block" | "audit";
+
+const SUBAGENT_TOOLS = new Set(["Task", "Agent"]);
+
+function readSubagentType(input: PreToolUseInput): string | undefined {
+  const v = input.tool_input?.["subagent_type"];
+  return typeof v === "string" ? v : undefined;
+}
+
+function readModel(input: PreToolUseInput): string | undefined {
+  const v = input.tool_input?.["model"];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Decide how to route a subagent dispatch against the config tier table.
+ *
+ * Returns `noop` unless the dispatch targets a tier-agent whose model family
+ * disagrees with the family its config tier resolves to. When it disagrees,
+ * the action follows the host's `capability`:
+ *   - `rewrite` → carries the full `updatedInput` with `model` corrected to the
+ *     config-resolved id (the rest of the original input preserved verbatim);
+ *   - `block`   → deny-and-retry, leaving the model uncorrected;
+ *   - `audit`   → allow with a nudge.
+ *
+ * The comparison is family-based: a dispatch already on the right model class
+ * (even via a bare alias like `opus`) is a `noop`, so the hook never churns a
+ * correctly-tiered call. An absent model on a tier-agent is treated as needing
+ * correction — the config tier is authoritative over the agent frontmatter
+ * default, so the resolved id is injected.
+ */
+export function routeModelTier(
+  input: PreToolUseInput,
+  config: ConfigValues,
+  capability: EnforcementCapability = "rewrite",
+): RouteAction {
+  if (!input.tool_name || !SUBAGENT_TOOLS.has(input.tool_name)) return { kind: "noop" };
+
+  const subagentType = readSubagentType(input);
+  if (!subagentType) return { kind: "noop" };
+
+  const tier = TIER_AGENT_TIERS[subagentType];
+  if (!tier) return { kind: "noop" };
+
+  const resolved = resolveTier(config, "claude", tier);
+  const expectedFamily = modelFamily(resolved.model);
+  const dispatched = readModel(input);
+  const dispatchedFamily = modelFamily(dispatched);
+
+  // Already correctly tiered: a model on the expected family. Nothing to do.
+  if (dispatchedFamily !== undefined && dispatchedFamily === expectedFamily) {
+    return { kind: "noop" };
+  }
+
+  const reason =
+    `model-tier-policy: ${subagentType} resolves to the '${tier}' tier ` +
+    `(${resolved.model}, effort ${resolved.effort}) per .red/config.yaml ` +
+    `plugins.dev.afk.models.claude.${tier} (ADR 0049); ` +
+    (dispatched
+      ? `dispatch requested '${dispatched}'`
+      : `dispatch left the model unset`) +
+    `.`;
+
+  if (capability === "block") {
+    return { kind: "block", tier, model: resolved.model, reason };
+  }
+  if (capability === "audit") {
+    return { kind: "audit", tier, model: resolved.model, reason };
+  }
+
+  // path (a): rewrite. Preserve the full original input, override only model.
+  const original = input.tool_input ?? {};
+  const updatedInput: Record<string, unknown> = { ...original, model: resolved.model };
+  return {
+    kind: "rewrite",
+    tier,
+    model: resolved.model,
+    effort: resolved.effort,
+    updatedInput,
+    reason,
+  };
+}

--- a/src/apps/dev/tests/cli-routing.test.ts
+++ b/src/apps/dev/tests/cli-routing.test.ts
@@ -15,6 +15,13 @@ describe("cli routing — native commands", () => {
     expect(parseCli(["retake", "#395", "--json"])).toEqual({ command: "retake", args: ["#395", "--json"] });
   });
 
+  it("routes route-model-tier with its host flag preserved", () => {
+    expect(parseCli(["route-model-tier", "--host", "claude"])).toEqual({
+      command: "route-model-tier",
+      args: ["--host", "claude"],
+    });
+  });
+
   it("routes statusline with the project-root arg preserved", () => {
     expect(parseCli(["statusline", "/repo"])).toEqual({ command: "statusline", args: ["/repo"] });
   });

--- a/src/apps/dev/tests/model-tier-route.test.ts
+++ b/src/apps/dev/tests/model-tier-route.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig, type ConfigValues } from "../src/core/config.js";
+import {
+  modelFamily,
+  routeModelTier,
+  TIER_AGENT_TIERS,
+  type PreToolUseInput,
+} from "../src/core/model-tier-route.js";
+import { Readable } from "node:stream";
+import { renderClaudeDecision, routeModelTierCommand } from "../src/commands/route-model-tier.js";
+
+/** Run the command with a JSON payload on a fake stdin, capturing stdout. */
+async function runCommand(args: string[], payload: unknown): Promise<string> {
+  const stdin = Readable.from([JSON.stringify(payload)]) as NodeJS.ReadableStream & { isTTY?: boolean };
+  stdin.isTTY = false;
+  let out = "";
+  const stdout = { write: (s: string) => ((out += s), true) } as NodeJS.WritableStream;
+  await routeModelTierCommand(args, "/tmp", stdout, stdin);
+  return out.trim();
+}
+
+/** Config with all defaults (no `.red/config.yaml` present). */
+const defaults = (): ConfigValues => loadConfig("/nope", { read: () => undefined, warn: () => {} });
+
+/** Config overriding the simple tier's Claude model (single-source check). */
+const withSimpleOverride = (model: string): ConfigValues =>
+  loadConfig("/cfg", {
+    read: () => `plugins:\n  dev:\n    afk:\n      models:\n        claude:\n          simple:\n            model: ${model}\n`,
+    warn: () => {},
+  });
+
+const task = (tool_input: Record<string, unknown>): PreToolUseInput => ({
+  tool_name: "Task",
+  tool_input,
+});
+
+describe("modelFamily", () => {
+  it("extracts the family from full ids and aliases", () => {
+    expect(modelFamily("claude-haiku-4-5")).toBe("haiku");
+    expect(modelFamily("claude-sonnet-4-6")).toBe("sonnet");
+    expect(modelFamily("claude-opus-4-8")).toBe("opus");
+    expect(modelFamily("opus")).toBe("opus");
+  });
+  it("returns undefined for unknown / absent models", () => {
+    expect(modelFamily("gpt-5.5")).toBeUndefined();
+    expect(modelFamily(undefined)).toBeUndefined();
+    expect(modelFamily("")).toBeUndefined();
+  });
+});
+
+describe("routeModelTier — scope", () => {
+  it("no-ops on non-subagent tools", () => {
+    expect(routeModelTier({ tool_name: "Bash", tool_input: { command: "ls" } }, defaults())).toEqual({
+      kind: "noop",
+    });
+  });
+  it("no-ops on dispatches to non-tier subagents", () => {
+    expect(routeModelTier(task({ subagent_type: "general-purpose", model: "haiku" }), defaults())).toEqual(
+      { kind: "noop" },
+    );
+  });
+  it("no-ops when the dispatch is already on the correct family (alias)", () => {
+    // complex-code → complex tier → opus; a bare `opus` alias is already correct.
+    expect(routeModelTier(task({ subagent_type: "complex-code", model: "opus" }), defaults())).toEqual({
+      kind: "noop",
+    });
+  });
+  it("maps every tier-agent to its tier", () => {
+    expect(TIER_AGENT_TIERS).toEqual({
+      validate: "validate",
+      "simple-code": "simple",
+      "complex-code": "complex",
+    });
+  });
+});
+
+describe("routeModelTier — rewrite (path a)", () => {
+  it("clamps a mis-tiered validate dispatch (opus) back to the haiku tier", () => {
+    const action = routeModelTier(task({ subagent_type: "validate", model: "opus", prompt: "p" }), defaults());
+    expect(action.kind).toBe("rewrite");
+    if (action.kind !== "rewrite") return;
+    expect(action.tier).toBe("validate");
+    expect(action.model).toBe("claude-haiku-4-5");
+    expect(action.effort).toBe("low");
+    // full input preserved, only model overridden
+    expect(action.updatedInput).toEqual({ subagent_type: "validate", model: "claude-haiku-4-5", prompt: "p" });
+  });
+
+  it("injects the config model when a tier-agent dispatch leaves model unset", () => {
+    const action = routeModelTier(task({ subagent_type: "simple-code", prompt: "p" }), defaults());
+    expect(action.kind).toBe("rewrite");
+    if (action.kind !== "rewrite") return;
+    expect(action.model).toBe("claude-sonnet-4-6");
+    expect(action.updatedInput.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("clamps simple-code dispatched on opus down to the simple tier (savings enforced)", () => {
+    const action = routeModelTier(task({ subagent_type: "simple-code", model: "claude-opus-4-8" }), defaults());
+    expect(action.kind === "rewrite" && action.model).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("routeModelTier — single config source", () => {
+  it("routes to the config-overridden model, never a hardcoded id", () => {
+    const action = routeModelTier(
+      task({ subagent_type: "simple-code", model: "opus" }),
+      withSimpleOverride("claude-haiku-4-5"),
+    );
+    // override moves the simple tier to a haiku-family model; opus now mismatches.
+    expect(action.kind).toBe("rewrite");
+    if (action.kind !== "rewrite") return;
+    expect(action.model).toBe("claude-haiku-4-5");
+  });
+});
+
+describe("routeModelTier — capability degrade ladder", () => {
+  it("blocks (deny-and-retry) when the host can only decide", () => {
+    const action = routeModelTier(task({ subagent_type: "validate", model: "opus" }), defaults(), "block");
+    expect(action.kind).toBe("block");
+    if (action.kind !== "block") return;
+    expect(action.model).toBe("claude-haiku-4-5");
+  });
+  it("audits (allow + nudge) when the host can neither rewrite nor block", () => {
+    const action = routeModelTier(task({ subagent_type: "validate", model: "opus" }), defaults(), "audit");
+    expect(action.kind).toBe("audit");
+  });
+});
+
+describe("renderClaudeDecision", () => {
+  it("renders noop as an empty object", () => {
+    expect(renderClaudeDecision({ kind: "noop" })).toEqual({});
+  });
+  it("renders rewrite as hookSpecificOutput.updatedInput", () => {
+    const out = renderClaudeDecision({
+      kind: "rewrite",
+      tier: "validate",
+      model: "claude-haiku-4-5",
+      effort: "low",
+      updatedInput: { subagent_type: "validate", model: "claude-haiku-4-5" },
+      reason: "r",
+    });
+    const hso = (out as { hookSpecificOutput?: Record<string, unknown> }).hookSpecificOutput;
+    expect(hso?.hookEventName).toBe("PreToolUse");
+    expect(hso?.updatedInput).toEqual({ subagent_type: "validate", model: "claude-haiku-4-5" });
+  });
+  it("renders block as a deny permission decision", () => {
+    const out = renderClaudeDecision({ kind: "block", tier: "validate", model: "claude-haiku-4-5", reason: "r" });
+    const hso = (out as { hookSpecificOutput?: Record<string, unknown> }).hookSpecificOutput;
+    expect(hso?.permissionDecision).toBe("deny");
+  });
+});
+
+describe("routeModelTierCommand — IO", () => {
+  it("emits updatedInput for a mis-tiered Claude dispatch", async () => {
+    const out = await runCommand([], {
+      tool_name: "Task",
+      tool_input: { subagent_type: "validate", model: "opus", prompt: "p" },
+    });
+    const decision = JSON.parse(out) as { hookSpecificOutput?: { updatedInput?: { model?: string } } };
+    expect(decision.hookSpecificOutput?.updatedInput?.model).toBe("claude-haiku-4-5");
+  });
+
+  it("emits an empty object for a correctly-tiered dispatch", async () => {
+    const out = await runCommand([], {
+      tool_name: "Task",
+      tool_input: { subagent_type: "validate", model: "haiku" },
+    });
+    expect(JSON.parse(out)).toEqual({});
+  });
+
+  it("safe-degrades to no-op on Codex regardless of payload (#457)", async () => {
+    const out = await runCommand(["--host", "codex"], {
+      tool_name: "Task",
+      tool_input: { subagent_type: "validate", model: "opus" },
+    });
+    expect(JSON.parse(out)).toEqual({});
+  });
+
+  it("emits an empty object on a malformed payload (never wedges a dispatch)", async () => {
+    const stdin = Readable.from(["not json"]) as NodeJS.ReadableStream & { isTTY?: boolean };
+    stdin.isTTY = false;
+    let out = "";
+    const stdout = { write: (s: string) => ((out += s), true) } as NodeJS.WritableStream;
+    await routeModelTierCommand([], "/tmp", stdout, stdin);
+    expect(JSON.parse(out.trim())).toEqual({});
+  });
+});


### PR DESCRIPTION
Salvage-land of a parked-but-green AFK branch (ADR 0055 reconcile, done manually). Gate verified locally: typecheck ✓, vitest ✓ (src/apps/dev). Closes #456.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783537955&installation_id=129708444&pr_number=560&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F560&signature=c6e4822a9647791a64a09121c42d3eecaf919db1d2cd71504a6f0b53bfc35e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added model tier routing command that automatically assigns the correct model variant during interactive task dispatch and agent operations.

* **Documentation**
  * Added documentation describing model tier enforcement during interactive dispatch, including routing mechanisms and enforcement decisions.

* **Tests**
  * Added tests for model tier routing functionality and CLI command argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->