### PR TITLE
feat(afk): supervisor tick dispatches reconcile workers for parked-mechanical issues

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -10,7 +10,7 @@ import {
 import { genWorkerId } from "../core/session.js";
 import { runBoot, type BootDeps, type BootOptions, type BootstrapInput, type ReconcileBootRunner } from "../core/boot.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
-import type { ReconcileSweepPlan } from "../core/boot-sweep.js";
+import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
 import {
   toMemoryPayload,
@@ -77,6 +77,12 @@ interface ParsedRunFlags {
   fallbackRunner: boolean;
   /** --boot-only: run the boot sweeps then exit without selecting/claiming/processing. */
   bootOnly: boolean;
+  /**
+   * --reconcile-issue <n>: supervisor-dispatched reconcile worker mode (ADR 0055,
+   * #562). Bypass the normal boot+session; validate-and-land the parked branch for
+   * issue `n` without re-running the agent.
+   */
+  reconcileIssue?: number;
 }
 
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
@@ -109,6 +115,7 @@ const RUN_FLAG_SCHEMA = {
   alternate: { kind: "boolean" },
   "fallback-runner": { kind: "boolean" },
   "boot-only": { kind: "boolean" },
+  "reconcile-issue": { kind: "value", coerce: (raw: string): number => Number(raw) },
 } satisfies FlagSchema;
 
 /** Parse the `run` flags: --prd N / --issues a,b,c / -n N / --once / --request / --runner. */
@@ -139,6 +146,12 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     throw new RunFlagError("--alternate is mutually exclusive with --runner");
   }
 
+  const rawReconcileIssue = values["reconcile-issue"];
+  const reconcileIssue =
+    typeof rawReconcileIssue === "number" && Number.isFinite(rawReconcileIssue) && rawReconcileIssue > 0
+      ? rawReconcileIssue
+      : undefined;
+
   return {
     filter,
     iterCap: values.n as number | undefined,
@@ -148,6 +161,7 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     alternate,
     fallbackRunner: values["fallback-runner"] === true,
     bootOnly: values["boot-only"] === true,
+    reconcileIssue,
   };
 }
 
@@ -265,6 +279,54 @@ function makeBootReconcileRunner(
       : "skipped" as const;
     return { outcome };
   };
+}
+
+/**
+ * Supervisor-dispatched reconcile worker (ADR 0055, #562): validate-and-land the
+ * parked branch for `issue` without re-running the agent. Fetches the issue
+ * metadata + its `afk/…` branch, then delegates to `makeBootReconcileRunner`.
+ * Best-effort: a missing branch or failed fetch exits 0 (nothing to reconcile).
+ */
+async function runReconcileWorker(
+  issue: number,
+  runner: Runner,
+  ctx: RepoContext,
+  paths: AfkPaths,
+  workerId: string,
+): Promise<number> {
+  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  const gitCtx: GitContext = { cwd: ctx.root };
+
+  const issueData = await ghx.viewIssueFull(ghCtx, issue);
+  if (!issueData) {
+    process.stderr.write(`[afk reconcile-worker] #${issue} not found or fetch failed — nothing to reconcile\n`);
+    return 0;
+  }
+
+  const remoteBranches = await gitx.listRemoteBranches(gitCtx, "afk/");
+  const branch = findOwnedBranch(remoteBranches.map((r) => r.branch), issue);
+  if (!branch) {
+    process.stderr.write(`[afk reconcile-worker] no afk branch for #${issue} — nothing to reconcile\n`);
+    return 0;
+  }
+
+  const plan: ReconcileSweepPlan = {
+    number: issueData.number,
+    title: issueData.title,
+    body: issueData.body,
+    labels: issueData.labels,
+    branch,
+  };
+
+  const feedback = makeFeedbackWorktree(ctx.root, join(paths.tmpDir, "feedback"));
+  try {
+    const reconcileRunner = makeBootReconcileRunner(ctx, paths, workerId, runner, feedback);
+    await reconcileRunner(plan);
+  } finally {
+    await feedback.cleanup();
+  }
+
+  return 0;
 }
 
 async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: number): Promise<BootDeps> {
@@ -883,6 +945,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Worker id — probe the workers root for collisions.
   const existing = new Set((await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id));
   const workerId = genWorkerId(Math.random, (id) => existing.has(id));
+
+  // Supervisor-dispatched reconcile worker: bypass the normal boot+session and
+  // validate-and-land the specific parked branch for `--reconcile-issue <n>`.
+  if (flags.reconcileIssue !== undefined) {
+    return runReconcileWorker(flags.reconcileIssue, runner, ctx, paths, workerId);
+  }
 
   const facts = await collectPrecheckFacts(ctx);
   const nowS = Math.floor(Date.now() / 1000);

--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -26,6 +26,8 @@ import {
   teardownIterDirNative,
 } from "../runtime/supervisor-fs.js";
 import * as ghx from "../runtime/gh.js";
+import * as gitx from "../runtime/git.js";
+import { planReconcileSweep } from "../core/boot-sweep.js";
 import { removeDir as removeDirNative } from "../runtime/fs.js";
 
 function isAlive(pid: number): boolean {
@@ -227,6 +229,23 @@ function buildSupervisorDeps(
         slotPids.set(slot, pid);
         return { pid, spawnEpoch: now() };
       },
+      spawnReconcileWorker: async (slot, candidate) => {
+        const runArgs = [
+          "run", "--once", "--runner", runner,
+          "--reconcile-issue", String(candidate.issue),
+          ...slotArgs,
+        ];
+        const child = spawn(process.execPath, [bundle, ...runArgs], {
+          cwd: root,
+          env: workerEnv,
+          detached: true,
+          stdio: ["ignore", logFd, logFd],
+        });
+        child.unref();
+        const pid = child.pid ?? 0;
+        slotPids.set(slot, pid);
+        return { pid, spawnEpoch: now() };
+      },
       isAlive,
       killTree: async (pid) => {
         try {
@@ -293,6 +312,21 @@ function buildSupervisorDeps(
           return await ghx.countReadyForAgent(ghCtx);
         } catch {
           return 0;
+        }
+      },
+      findReconcileCandidate: async () => {
+        try {
+          const [candidates, remoteBranches] = await Promise.all([
+            ghx.listParkedMechanicalCandidates(ghCtx),
+            gitx.listRemoteBranches({ cwd: root }, "afk/"),
+          ]);
+          const branchNames = remoteBranches.map((r) => r.branch);
+          const plans = planReconcileSweep(candidates, branchNames);
+          if (plans.length === 0) return null;
+          const first = plans[0]!;
+          return { issue: first.number, branch: first.branch };
+        } catch {
+          return null;
         }
       },
     },

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -279,6 +279,13 @@ export function computeStalled(
 
 // ---------- injected IO ----------
 
+/** A parked-mechanical issue with a landable branch, detected cheaply by the
+ * supervisor tick for reconcile dispatch (ADR 0055, #562). */
+export interface ReconcileCandidate {
+  issue: number;
+  branch: string;
+}
+
 /** Process side effects the supervisor drives. All real spawn/kill/inspect IO
  * is injected so tests run with no real processes (parity with the bash
  * sup_kill_tree / sup_active_descendant / sup_tree_cpu stubs in the tests). */
@@ -299,6 +306,12 @@ export interface SupervisorProc {
    * Injected so tests advance the loop without real time. Mirrors the bash
    * `sleep "$POLL_S"` at the bottom of the supervisor `while :` loop. */
   sleep(ms: number): Promise<void>;
+  /**
+   * Spawn a reconcile worker for `candidate` into `slot` (ADR 0055, #562). The
+   * worker validates-and-lands `candidate.branch` without re-running the agent.
+   * Returns its pid and spawn epoch. Absent when reconcile dispatch is not wired.
+   */
+  spawnReconcileWorker?(slot: number, candidate: ReconcileCandidate): Promise<{ pid: number; spawnEpoch: number }>;
 }
 
 /** Filesystem side effects. Best-effort, like the bash `|| true` cleanups. */
@@ -340,6 +353,14 @@ export interface SupervisorGh {
   ensureLabel(name: string): Promise<void>;
   /** Current open `ready-for-agent` queue depth for the fleet heartbeat. */
   readyQueueDepth?(): Promise<number>;
+  /**
+   * Cheaply detect the first parked-mechanical issue with an `afk/…` live
+   * branch (blocked:stalled | blocked:crashed label + remote branch list). Runs
+   * inside the supervisor tick — must complete well under `RED_AFK_TICK_TIMEOUT_S`.
+   * Returns null when no candidate is found or on any gh/git failure (best-effort).
+   * Absent when reconcile dispatch is not wired.
+   */
+  findReconcileCandidate?(): Promise<ReconcileCandidate | null>;
 }
 
 export interface FleetHeartbeat {
@@ -522,6 +543,8 @@ export interface TickResult {
   deaths: number[];
   parked: number[];
   reaped: number[];
+  /** Slots into which a reconcile worker was dispatched this tick. */
+  reconciledSlots: number[];
   /** True when the stop-file was honoured and all workers terminated. */
   stopped: boolean;
 }
@@ -784,11 +807,57 @@ export async function handleDeadSlot(
 }
 
 /**
+ * dispatchReconcileIfPossible — attempt to dispatch ONE reconcile worker into
+ * the first free slot (ADR 0055, #562). Called at the end of every superviseTick,
+ * after normal lifecycle handling (respawn / stall / reap). Returns the slot
+ * index of the dispatched worker, or null when no dispatch occurred.
+ *
+ * A "free slot" is one that is not parked and has no live pid — typically freed
+ * by the stall-reaper within the same tick. The heavy validate+land runs in the
+ * worker process (its own timeout), off the tick's critical path.
+ *
+ * Both `deps.proc.spawnReconcileWorker` and `deps.gh.findReconcileCandidate` are
+ * optional — when either is absent this is a no-op, preserving backward
+ * compatibility with existing SupervisorDeps implementations (tests, boot-only).
+ */
+export async function dispatchReconcileIfPossible(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+): Promise<number | null> {
+  if (!deps.proc.spawnReconcileWorker || !deps.gh.findReconcileCandidate) return null;
+
+  // Find the first free slot: not parked and no live pid.
+  const freeIdx = state.slots.findIndex((s) => !s.parked && s.pid === null);
+  if (freeIdx < 0) return null;
+
+  // Cheap detection: one gh label query + remote branch list via the injected closure.
+  let candidate: ReconcileCandidate | null = null;
+  try {
+    candidate = await deps.gh.findReconcileCandidate();
+  } catch {
+    return null;
+  }
+  if (candidate === null) return null;
+
+  // Dispatch the reconcile worker into the free slot.
+  const spawned = await deps.proc.spawnReconcileWorker(freeIdx, candidate);
+  const slot = state.slots[freeIdx]!;
+  slot.pid = spawned.pid;
+  slot.spawnEpoch = spawned.spawnEpoch;
+  // Clear stale stall/reap flags — this is a fresh worker start.
+  slot.stalled = false;
+  slot.stallSinceEpoch = 0;
+  slot.reaped = false;
+  return freeIdx;
+}
+
+/**
  * superviseTick — advance the health-check loop one cycle (the body of
  * supervisor.sh's `while :` at ~1122-1141). In order:
  *   1. honour the stop-file: terminate every worker and return early.
  *   2. respawn / park dead non-parked slots (handleDeadSlot).
  *   3. poll the passive stall detector + gated hard reaper (pollStallDetector).
+ *   4. reconcile dispatch: fill a free slot with a reconcile worker if eligible.
  *
  * `stopRequested` is the injected stop-file probe (the bash `[[ -f $STOP_FILE ]]`
  * check). The real loop is `while (!await superviseTick(...).stopped)`.
@@ -804,6 +873,7 @@ export async function superviseTick(
     deaths: [],
     parked: [],
     reaped: [],
+    reconciledSlots: [],
     stopped: false,
   };
 
@@ -829,6 +899,11 @@ export async function superviseTick(
   // Passive stall detector + gated hard reaper.
   const reaped = await pollStallDetector(state, deps, config);
   result.reaped = reaped;
+
+  // Reconcile dispatch: use any free slot (e.g. just stall-reaped) for a parked
+  // candidate. Best-effort; a failure or absent candidate is silently skipped.
+  const reconciledSlot = await dispatchReconcileIfPossible(state, deps);
+  if (reconciledSlot !== null) result.reconciledSlots.push(reconciledSlot);
 
   return result;
 }
@@ -898,7 +973,7 @@ export async function runSupervisor(
 
 /** A non-stop tick result (the abandon/error fallback). */
 function continueResult(): TickResult {
-  return { respawned: [], deaths: [], parked: [], reaped: [], stopped: false };
+  return { respawned: [], deaths: [], parked: [], reaped: [], reconciledSlots: [], stopped: false };
 }
 
 /**

--- a/src/apps/dev/src/runtime/gh.ts
+++ b/src/apps/dev/src/runtime/gh.ts
@@ -307,6 +307,39 @@ export async function closeIssue(ctx: GhContext, issue: number): Promise<void> {
   await runGh(ctx, ["issue", "close", String(issue), ...repoArgs(ctx), "--reason", "completed"]);
 }
 
+/** Full metadata for a single issue (`gh issue view --json number,title,body,labels`).
+ * Returns null on a 404 or transient gh failure. */
+export async function viewIssueFull(
+  ctx: GhContext,
+  issue: number,
+): Promise<{ number: number; title: string; body: string; labels: string[] } | null> {
+  const r = await runGh(ctx, [
+    "issue",
+    "view",
+    String(issue),
+    ...repoArgs(ctx),
+    "--json",
+    "number,title,body,labels",
+  ]);
+  if (r.code !== 0) return null;
+  try {
+    const parsed = JSON.parse(r.stdout) as {
+      number?: number;
+      title?: string;
+      body?: string;
+      labels?: Array<{ name?: string }>;
+    };
+    return {
+      number: Number(parsed.number ?? issue),
+      title: String(parsed.title ?? ""),
+      body: String(parsed.body ?? ""),
+      labels: Array.isArray(parsed.labels) ? parsed.labels.map((l) => String(l.name ?? "")) : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
 /** `gh issue view --json body` → raw body, or undefined when absent. */
 export async function issueBody(ctx: GhContext, issue: number): Promise<string | undefined> {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "body"]);

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -3,6 +3,8 @@ import {
   buildDiscardEnvelope,
   buildReaperEnvelope,
   computeStalled,
+  dispatchReconcileIfPossible,
+  freshSlot,
   handleDeadSlot,
   initSupervisorState,
   pollStallDetector,
@@ -16,8 +18,10 @@ import {
   classifySupervisor,
   guardedTick,
   type IterDirInfo,
+  type ReconcileCandidate,
   type SupervisorConfig,
   type SupervisorDeps,
+  type SupervisorState,
   type SweepWork,
 } from "../src/core/supervisor.js";
 import type { ProcessSnapshotEntry } from "../src/core/reaper-signal.js";
@@ -42,6 +46,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
 
 interface FakeIo {
   spawnSlot: ReturnType<typeof vi.fn>;
+  spawnReconcileWorker: ReturnType<typeof vi.fn>;
   isAlive: ReturnType<typeof vi.fn>;
   killTree: ReturnType<typeof vi.fn>;
   inspectTree: ReturnType<typeof vi.fn>;
@@ -56,6 +61,7 @@ interface FakeIo {
   ensureRunnerErrorLabel: ReturnType<typeof vi.fn>;
   ensureLabel: ReturnType<typeof vi.fn>;
   readyQueueDepth: ReturnType<typeof vi.fn>;
+  findReconcileCandidate: ReturnType<typeof vi.fn>;
   emitFleetHeartbeat: ReturnType<typeof vi.fn>;
   now: ReturnType<typeof vi.fn>;
 }
@@ -67,6 +73,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
   let nextPid = 1000;
   const io: FakeIo = {
     spawnSlot: vi.fn(async () => ({ pid: ++nextPid, spawnEpoch: NOW })),
+    spawnReconcileWorker: vi.fn(async () => ({ pid: ++nextPid, spawnEpoch: NOW })),
     isAlive: vi.fn(() => true),
     killTree: vi.fn(async () => {}),
     inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
@@ -90,6 +97,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     ensureRunnerErrorLabel: vi.fn(async () => {}),
     ensureLabel: vi.fn(async () => {}),
     readyQueueDepth: vi.fn(async () => 0),
+    findReconcileCandidate: vi.fn(async (): Promise<ReconcileCandidate | null> => null),
     emitFleetHeartbeat: vi.fn(async () => {}),
     now: vi.fn(() => NOW),
     ...(over as Partial<FakeIo>),
@@ -97,6 +105,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
   const deps: SupervisorDeps = {
     proc: {
       spawnSlot: io.spawnSlot,
+      spawnReconcileWorker: io.spawnReconcileWorker,
       isAlive: io.isAlive,
       killTree: io.killTree,
       inspectTree: io.inspectTree,
@@ -115,6 +124,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       ensureRunnerErrorLabel: io.ensureRunnerErrorLabel,
       ensureLabel: io.ensureLabel,
       readyQueueDepth: io.readyQueueDepth,
+      findReconcileCandidate: io.findReconcileCandidate,
     },
     now: io.now,
     emitFleetHeartbeat: io.emitFleetHeartbeat,
@@ -679,8 +689,8 @@ describe("envelope builders", () => {
 describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () => {
   const never = (): Promise<void> => new Promise<void>(() => {});
   const immediate = (): Promise<void> => Promise.resolve();
-  const okResult = { respawned: [1], deaths: [], parked: [], reaped: [], stopped: false };
-  const CONTINUE = { respawned: [], deaths: [], parked: [], reaped: [], stopped: false };
+  const okResult = { respawned: [1], deaths: [], parked: [], reaped: [], reconciledSlots: [], stopped: false };
+  const CONTINUE = { respawned: [], deaths: [], parked: [], reaped: [], reconciledSlots: [], stopped: false };
 
   it("returns the tick result when it completes before the ceiling", async () => {
     const logs: string[] = [];
@@ -729,5 +739,207 @@ describe("resolveSupervisorConfig — supervisor stale knob (#407)", () => {
     expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "0" }).supervisorStaleS).toBe(300);
     expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "900" }).supervisorStaleS).toBe(900);
     expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "abc" }).supervisorStaleS).toBe(300);
+  });
+});
+
+// ---------- dispatchReconcileIfPossible (#562) ----------
+
+/** Build a SupervisorState with slot 0 free (pid null, not parked). */
+function freeSlotState(): SupervisorState {
+  const state = initSupervisorState(1);
+  state.slots[0] = freshSlot(); // pid: null, parked: false
+  return state;
+}
+
+describe("dispatchReconcileIfPossible — dispatch decision and slot accounting", () => {
+  const CANDIDATE: ReconcileCandidate = { issue: 42, branch: "afk/wAAAA/42-some-fix" };
+
+  it("is a no-op when spawnReconcileWorker is absent", async () => {
+    const { deps, io } = makeDeps();
+    // Remove the optional method.
+    delete (deps.proc as Partial<typeof deps.proc>).spawnReconcileWorker;
+    io.findReconcileCandidate.mockResolvedValueOnce(CANDIDATE);
+
+    const state = freeSlotState();
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBeNull();
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when findReconcileCandidate is absent", async () => {
+    const { deps, io } = makeDeps();
+    delete (deps.gh as Partial<typeof deps.gh>).findReconcileCandidate;
+
+    const state = freeSlotState();
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBeNull();
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no free slot exists (all slots have a live pid)", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockResolvedValueOnce(CANDIDATE);
+
+    const state = initSupervisorState(2);
+    // Both slots occupied.
+    state.slots[0]!.pid = 1001;
+    state.slots[1]!.pid = 1002;
+
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBeNull();
+    expect(io.findReconcileCandidate).not.toHaveBeenCalled(); // slot check first
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
+  });
+
+  it("returns null when findReconcileCandidate returns null (no eligible candidate)", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockResolvedValueOnce(null);
+
+    const state = freeSlotState();
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBeNull();
+    expect(io.findReconcileCandidate).toHaveBeenCalledOnce();
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
+  });
+
+  it("returns null when findReconcileCandidate throws (best-effort: swallowed)", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockRejectedValueOnce(new Error("gh timeout"));
+
+    const state = freeSlotState();
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBeNull();
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a reconcile worker into the free slot when a candidate is found", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockResolvedValueOnce(CANDIDATE);
+    io.spawnReconcileWorker.mockResolvedValueOnce({ pid: 9999, spawnEpoch: NOW });
+
+    const state = freeSlotState();
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBe(0); // slot 0 received the worker
+    expect(io.findReconcileCandidate).toHaveBeenCalledOnce();
+    expect(io.spawnReconcileWorker).toHaveBeenCalledOnce();
+    expect(io.spawnReconcileWorker).toHaveBeenCalledWith(0, CANDIDATE);
+  });
+
+  it("updates the slot state after dispatch: pid set, stale flags cleared", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockResolvedValueOnce(CANDIDATE);
+    io.spawnReconcileWorker.mockResolvedValueOnce({ pid: 9999, spawnEpoch: NOW + 5 });
+
+    const state = freeSlotState();
+    // Pre-set stale stall flags to verify they are cleared.
+    state.slots[0]!.stalled = true;
+    state.slots[0]!.stallSinceEpoch = NOW - 100;
+    state.slots[0]!.reaped = true;
+
+    await dispatchReconcileIfPossible(state, deps);
+
+    const slot = state.slots[0]!;
+    expect(slot.pid).toBe(9999);
+    expect(slot.spawnEpoch).toBe(NOW + 5);
+    expect(slot.stalled).toBe(false);
+    expect(slot.stallSinceEpoch).toBe(0);
+    expect(slot.reaped).toBe(false);
+  });
+
+  it("picks the first free slot when multiple slots exist", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockResolvedValueOnce(CANDIDATE);
+    io.spawnReconcileWorker.mockResolvedValueOnce({ pid: 7777, spawnEpoch: NOW });
+
+    const state = initSupervisorState(3);
+    // Slots 0 and 2 are busy; slot 1 is free.
+    state.slots[0]!.pid = 1001;
+    state.slots[1]!.pid = null; // free
+    state.slots[2]!.pid = 1003;
+
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    expect(result).toBe(1);
+    expect(io.spawnReconcileWorker).toHaveBeenCalledWith(1, CANDIDATE);
+    expect(state.slots[1]!.pid).toBe(7777);
+  });
+
+  it("skips parked slots when looking for a free slot", async () => {
+    const { deps, io } = makeDeps();
+    io.findReconcileCandidate.mockResolvedValueOnce(CANDIDATE);
+
+    const state = initSupervisorState(2);
+    // Slot 0 is parked (circuit-tripped); slot 1 has a live worker.
+    state.slots[0]!.parked = true;
+    state.slots[0]!.pid = null;
+    state.slots[1]!.pid = 1002;
+
+    const result = await dispatchReconcileIfPossible(state, deps);
+
+    // No free non-parked slot → no dispatch.
+    expect(result).toBeNull();
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
+  });
+});
+
+describe("superviseTick — reconciledSlots accounting (#562)", () => {
+  // Stall-reap setup: slot has a live pid, stalled past the kill threshold, and
+  // an empty inspectTree so decideReaperSignal returns "kill". After the stall-
+  // reaper fires (step 3 of superviseTick), the slot's pid is null → free for
+  // dispatchReconcileIfPossible (step 4) to fill with a reconcile worker.
+  function stalledSlotDeps(candidate: ReconcileCandidate | null) {
+    return makeDeps({
+      isAlive: vi.fn(() => true), // pid alive so step 2 never respawns
+      agentLaneMtime: vi.fn(() => NOW - 1000), // agent lane silent for 1000s
+      now: vi.fn(() => NOW),
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []), // no active → "kill"
+      resolveIterDir: vi.fn(() => null),
+      findReconcileCandidate: vi.fn(async (): Promise<ReconcileCandidate | null> => candidate),
+    });
+  }
+
+  it("dispatches into a stall-reaped slot when a candidate is found", async () => {
+    const CANDIDATE: ReconcileCandidate = { issue: 77, branch: "afk/wBBBB/77-fix" };
+    const { deps, io } = stalledSlotDeps(CANDIDATE);
+    io.spawnReconcileWorker.mockResolvedValueOnce({ pid: 8888, spawnEpoch: NOW });
+
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 9001;
+    state.slots[0]!.spawnEpoch = NOW - 3600;
+    state.slots[0]!.stalled = true;
+    state.slots[0]!.stallSinceEpoch = NOW - 1000; // 1000s > stallKillThresholdS(90)
+
+    const result = await superviseTick(
+      state, deps, config({ target: 1, stallThresholdS: 30, stallKillThresholdS: 90 }), () => false,
+    );
+
+    expect(result.reaped).toEqual([0]);
+    expect(result.reconciledSlots).toEqual([0]);
+    expect(io.spawnReconcileWorker).toHaveBeenCalledOnce();
+    expect(io.spawnReconcileWorker).toHaveBeenCalledWith(0, CANDIDATE);
+  });
+
+  it("reconciledSlots is empty when no candidate is found after a stall-reap", async () => {
+    const { deps, io } = stalledSlotDeps(null);
+
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 9001;
+    state.slots[0]!.spawnEpoch = NOW - 3600;
+    state.slots[0]!.stalled = true;
+    state.slots[0]!.stallSinceEpoch = NOW - 1000;
+
+    const result = await superviseTick(
+      state, deps, config({ target: 1, stallThresholdS: 30, stallKillThresholdS: 90 }), () => false,
+    );
+
+    expect(result.reaped).toEqual([0]);
+    expect(result.reconciledSlots).toEqual([]);
+    expect(io.spawnReconcileWorker).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `dispatchReconcileIfPossible` to `supervisor.ts`: at the end of every `superviseTick`, after normal lifecycle handling, the supervisor cheaply detects one parked-mechanical issue (via `deps.gh.findReconcileCandidate`) and dispatches a reconcile worker into the first free slot.
- Wires `spawnReconcileWorker` and `findReconcileCandidate` into `buildSupervisorDeps` in `supervise.ts`: the worker spawns `run --once --reconcile-issue <N>` and the candidate probe uses `listParkedMechanicalCandidates` + `planReconcileSweep`.
- The heavy validate+land runs in the worker process (its own timeout), keeping the tick well under `RED_AFK_TICK_TIMEOUT_S`.
- Both `spawnReconcileWorker` and `findReconcileCandidate` are optional on `SupervisorDeps` — existing tests and boot-only paths are unaffected (backward compat).
- 11 new tests in `supervisor.test.ts` cover all dispatch decisions (eligible/ineligible, no-op cases, slot accounting, parked slot skip, stall-reap + reconcile in the same tick).

Closes #562. Depends on #558.

## Test plan

- [ ] `pnpm --filter dev test` passes (1148 tests)
- [ ] `dispatchReconcileIfPossible` no-op cases: absent `spawnReconcileWorker`, absent `findReconcileCandidate`, no free slot, null candidate, throwing candidate
- [ ] Dispatch: correct slot chosen, pid set, stale flags cleared
- [ ] Multi-slot: picks first free, skips parked
- [ ] `superviseTick` integration: stall-reap frees a slot → reconcile dispatch fills it; no candidate → `reconciledSlots` empty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783547388&installation_id=129708444&pr_number=565&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F565&signature=65170b1efb7b9618ef6e3fc1d05984de3fabe11146f476fc29b7617602ca5e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new command-line option to streamline branch reconciliation independent of standard bootstrap processes
  * Supervisor now intelligently discovers and automatically dispatches reconciliation workflows to available worker slots with best-effort resource cleanup
  * Enhanced issue information retrieval provides complete metadata including titles, descriptions, and labels for comprehensive branch validation
  * Improved error handling with diagnostic feedback when reconciliation attempts fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->