### PR TITLE
fix(afk): boot-reconcile base resolution + claim-race recovery safety (#568)

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -10,6 +10,7 @@ import {
 import { genWorkerId } from "../core/session.js";
 import { runBoot, type BootDeps, type BootOptions, type BootstrapInput, type ReconcileBootRunner } from "../core/boot.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
+import { resolveBase } from "../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
 import {
@@ -210,6 +211,14 @@ function makeBootReconcileRunner(
   const lockPath = branchLockPath(ctx.root);
 
   return async (plan: ReconcileSweepPlan) => {
+    // Acquire the per-issue claim before validating/landing so a concurrent live
+    // worker or a second concurrent boot cannot double-land the same parked
+    // branch (#568). Uses the same claims/{N} dir as the per-issue path, so the
+    // two are mutually exclusive; skip when another live pid already holds it.
+    const claimDir = `${paths.tmpDir}/claims/${plan.number}`;
+    if (!(await fsx.tryAcquireClaimDir(claimDir, process.pid))) {
+      return { outcome: "skipped" as const };
+    }
     const reconcileDeps: ReconcileDeps = {
       gh: {
         editLabels: async (issue, remove, add) => {
@@ -257,27 +266,40 @@ function makeBootReconcileRunner(
       appendIterLog: () => {},
     };
 
-    const reconcileInput: ReconcileInput = {
-      issue: plan.number,
-      title: plan.title,
-      body: plan.body,
-      labels: plan.labels,
-      branch: plan.branch,
-      base: "main",
-      repo: ctx.repo,
-      repoDir: ctx.root,
-      remote: ctx.remote,
-      workerId,
-      attempt: 0,
-      attemptDir: join(paths.tmpDir, "boot-reconcile", String(plan.number)),
-      runner,
-    };
+    try {
+      // Resolve the effective base (lock > pin > main, ADR 0031) instead of a
+      // literal "main": a parked issue pinned to a non-main branch — or a
+      // branch-locked session — must reconcile and land against that branch,
+      // never the trunk (#568, trunk safety). Mirrors the per-issue base lookup.
+      const base = await resolveBase(
+        { issueBody: plan.body },
+        { readLockedBranch: () => readLockedBranch(lockPath), fetchIssueBody: (n) => ghx.issueBody(ghCtx, n) },
+      );
 
-    const result = await reconcile(reconcileDeps, reconcileInput);
-    const outcome = result.outcome === "landed" ? "landed" as const
-      : result.outcome === "parked" ? "parked" as const
-      : "skipped" as const;
-    return { outcome };
+      const reconcileInput: ReconcileInput = {
+        issue: plan.number,
+        title: plan.title,
+        body: plan.body,
+        labels: plan.labels,
+        branch: plan.branch,
+        base,
+        repo: ctx.repo,
+        repoDir: ctx.root,
+        remote: ctx.remote,
+        workerId,
+        attempt: 0,
+        attemptDir: join(paths.tmpDir, "boot-reconcile", String(plan.number)),
+        runner,
+      };
+
+      const result = await reconcile(reconcileDeps, reconcileInput);
+      const outcome = result.outcome === "landed" ? "landed" as const
+        : result.outcome === "parked" ? "parked" as const
+        : "skipped" as const;
+      return { outcome };
+    } finally {
+      await fsx.removeDir(claimDir);
+    }
   };
 }
 

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -1257,6 +1257,12 @@ async function terminalFailure(
     notes: record.notes,
     validationSummary: record.validationSummary,
   });
+  // Release the per-issue claim before returning. Every other terminal path
+  // (mergeFailed/exhausted/abortAfterClaim/runnerRecoverable) releases; this
+  // shared tail (no-sentinel / blocked / feedback-failed / stalled) did not, so
+  // a retry-routed or human-requeued issue stayed un-claimable until the live
+  // worker process exited and boot's stale-claim sweep reclaimed the dir (#568).
+  await deps.claimLock.release(input.issue);
   return {
     outcome,
     issue: input.issue,

--- a/src/apps/dev/src/core/reconcile.ts
+++ b/src/apps/dev/src/core/reconcile.ts
@@ -176,7 +176,7 @@ export interface ReconcileInput {
 
 // ---------- result ----------
 
-export type ReconcileSkipReason = "not-mechanical" | "active-blocker" | "no-commits" | "branch-absent";
+export type ReconcileSkipReason = "not-mechanical" | "active-blocker" | "no-commits" | "branch-absent" | "already-closed";
 
 export type ReconcileResult =
   | { outcome: "landed"; mergeSha: string; locked: boolean; posted: boolean }
@@ -237,6 +237,18 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   // ---- 3b. RED → ready-for-human with the real failing checks ----
   if (!feedback.ok) {
     return await park(deps, input, feedback, startedEpoch);
+  }
+
+  // ---- 3a-pre. re-verify the issue is still open immediately before landing ----
+  // The candidate list and the claim window can go stale between selection and
+  // here: a concurrent worker or a human may have closed the issue. Landing +
+  // closing an already-closed issue churns labels on a closed thread (#568), so
+  // bail before doLanding when it is no longer open.
+  if (await deps.gh.issueClosed(issue)) {
+    deps.appendIterLog(
+      `🤖 /afk reconcile #${issue}: skipped (already-closed) — issue closed since selection; not landing.`,
+    );
+    return { outcome: "skipped", reason: "already-closed" };
   }
 
   // ---- 3a. GREEN → land via the existing landing path, then close ----

--- a/src/apps/dev/src/runtime/fs.ts
+++ b/src/apps/dev/src/runtime/fs.ts
@@ -12,6 +12,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  rename,
   rm,
   stat,
   writeFile,
@@ -53,6 +54,12 @@ export async function writeWorkerPid(pidFile: string, pid: number): Promise<void
   await writeFile(pidFile, String(pid), "utf8");
 }
 
+/** Monotonic per-process counter so concurrent stale-claim reclaims (even from
+ * the same pid) each rename to a UNIQUE temp dir — the atomic rename of the
+ * shared claim dir is what serialises the winners, so the temp targets must not
+ * collide. */
+let claimReclaimSeq = 0;
+
 /**
  * Atomically claim `dir` as a fresh lock directory. A plain `mkdir` (NOT
  * recursive) is the POSIX-atomic primitive: it fails with `EEXIST` when another
@@ -79,8 +86,23 @@ export async function tryAcquireClaimDir(dir: string, pid: number): Promise<bool
 
   if ((await claimOnce()) === "held") {
     if (await claimPathHeldByLivePid(dir)) return false;
-    await rm(dir, { recursive: true, force: true });
-    if ((await claimOnce()) === "held") return false;
+    // Dead holder → reclaim ATOMICALLY. The prior `rm` + re-`mkdir` was a TOCTOU:
+    // two boots that both observed the dead pid would both rm the dir and both
+    // mkdir it, each believing it held the lock — the #434 duplicate-claim race
+    // reappeared on the recovery path that fires after any worker crash (#568).
+    // rename(2) is atomic, so of N racing reclaimers exactly one rename of the
+    // SAME stale dir succeeds; the losers get ENOENT and bail. Only the winner
+    // deletes it and re-claims through the exclusive mkdir, which still
+    // serialises against any fresh claimer that slipped in after the rename.
+    const stealing = `${dir}.stale-${pid}-${claimReclaimSeq++}`;
+    await rm(stealing, { recursive: true, force: true }).catch(() => {});
+    try {
+      await rename(dir, stealing);
+    } catch {
+      return false; // lost the steal race — another reclaimer already moved it
+    }
+    await rm(stealing, { recursive: true, force: true });
+    if ((await claimOnce()) !== "acquired") return false; // a fresh claimer won the re-mkdir
   }
   await writeFile(join(dir, "pid"), String(pid), "utf8");
   return true;

--- a/src/apps/dev/tests/fs-sweep.test.ts
+++ b/src/apps/dev/tests/fs-sweep.test.ts
@@ -131,6 +131,27 @@ describe("tryAcquireClaimDir (#434 atomic claim)", () => {
     }
   });
 
+  it("lets exactly ONE of N concurrent claimers win when RECLAIMING a stale dir (#568 recovery race)", async () => {
+    const root = scratch();
+    try {
+      const dir = join(root, "claims", "568");
+      // A crashed worker left a stale claim (dead pid). Several workers boot at
+      // once and all observe the dead holder. The prior rm-then-mkdir reclaim was
+      // a TOCTOU that let two of them both reclaim it (the #434 dup-PR race,
+      // reopened on the recovery path); the atomic-rename reclaim lets exactly one
+      // win even when every racer sees the same dead holder.
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "pid"), DEAD_PID);
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () => tryAcquireClaimDir(dir, process.pid)),
+      );
+      expect(results.filter((won) => won)).toHaveLength(1);
+      expect(readFileSync(join(dir, "pid"), "utf8")).toBe(String(process.pid));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not remove a live existing claim while self-healing", async () => {
     const root = scratch();
     try {

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -558,6 +558,10 @@ describe("processIssue — BLOCKED", () => {
     expect(trace.swept).toEqual([]);
     expect(trace.deletedRemote).toEqual([]);
     expect(trace.pushedAttempt).toEqual([]);
+    // #568: the shared terminalFailure tail must release the per-issue claim so a
+    // retry-routed / re-queued issue is immediately re-claimable — it previously
+    // leaked the lock until the worker process died and boot reclaimed the dir.
+    expect(trace.released).toEqual([9]);
   });
 
   it("writes Current blocker state when a terminal blocker pages a human", async () => {
@@ -595,6 +599,8 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "no-sentinel" }]);
     // on_attempt_error fires; post_attempt does NOT (ADR 0028).
     expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
+    // #568: the no-sentinel terminal also releases the per-issue claim.
+    expect(trace.released).toEqual([9]);
   });
 
   it("branch carries work + passes feedback → SALVAGE: lands like DONE, closes (issue #332)", async () => {

--- a/src/apps/dev/tests/reconcile.test.ts
+++ b/src/apps/dev/tests/reconcile.test.ts
@@ -347,6 +347,18 @@ describe("reconcile — guards (mechanical class only)", () => {
     expect(result).toEqual({ outcome: "skipped", reason: "branch-absent" });
     expect(trace.pnpmCalls).toBe(0);
   });
+
+  it("skips when the issue was closed since selection — does not land or close (#568)", async () => {
+    const { deps, input, trace } = harness({ feedbackOk: true, closedIssues: [9] });
+    const result = await reconcile(deps, input);
+
+    expect(result).toEqual({ outcome: "skipped", reason: "already-closed" });
+    // The re-check fires AFTER the green feedback gate but BEFORE landing, so the
+    // already-closed thread is never landed, closed, or relabelled.
+    expect(trace.closed).toEqual([]);
+    expect(trace.deletedRemote).toEqual([]);
+    expect(trace.labelEdits).toEqual([]);
+  });
 });
 
 describe("mechanicalDisqualifier", () => {


### PR DESCRIPTION
Closes #568 (the urgent trunk-safety / claim-race cluster extracted from PRD #567). Implemented directly (worktree→PR) because the autonomous fleet on the buggy 1.180.0 bundle lost two attempts here (orchestrator died mid-commit).

## The four fixes
1. **CRITICAL — wrong-base merge onto the trunk** (`commands/run.ts`): the boot reconcile sweep hardcoded `base: "main"`, so a parked issue pinned to a non-main branch — or a branch-locked session — was validated and **merged onto `main`**, bypassing the human's pin/lock. Now resolves the effective base via `resolveBase` (lock > pin > main, ADR 0031), mirroring the per-issue path.
2. **Boot reconcile sweep took no claim lock** (`commands/run.ts`): two concurrent boots could both validate-and-land the same parked branch. The runner now acquires the per-issue `claims/{N}` lock before validate/land (released in `finally`), mutually exclusive with the live per-issue path; skips when another live pid holds it.
3. **Stale-claim reclaim TOCTOU** (`runtime/fs.ts`): the `rm`-then-`mkdir` reclaim let two workers that both saw a dead holder both reclaim it — the #434 duplicate-claim race, reopened on the post-crash recovery path. Reclaim is now **atomic**: rename the dead dir to a unique temp (rename(2) is atomic → exactly one winner; losers get ENOENT and bail), only the winner deletes + re-claims.
4. **terminalFailure leaked the claim** (`core/process-issue.ts`): the shared no-sentinel / blocked / feedback-failed / stalled tail never released the per-issue claim, so a retry-routed / re-queued issue stayed un-claimable until the worker died. Now releases, matching every other terminal path.

Plus a belt-and-suspenders re-check in `core/reconcile.ts`: re-verify the issue is still open immediately before landing (`already-closed` skip).

## Tests
- `fs-sweep`: N concurrent reclaimers on a stale dir → **exactly one** wins.
- `process-issue`: `trace.released` now asserted on the **BLOCKED** and **no-sentinel** terminals (the test gap the audit flagged).
- `reconcile`: `already-closed` skip does not land/close/relabel.

Gate green in the worktree: **typecheck + 1150 tests + build**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783609428&installation_id=129708444&pr_number=601&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F601&signature=8cfdda8678af505d6b2c10509019cd9bc6ef54b9bf3fa396941a876d8493d1d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Base branch selection now respects branch locks and pinned branches for improved accuracy
  * Atomic stale-lock recovery prevents race conditions during concurrent operations
  * Added per-issue claim logic to prevent duplicate reconciliation attempts
  * Reconciliation now skips already-closed issues to avoid unnecessary updates
  * Fixed claim lock cleanup on terminal failure paths to prevent leaks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->