### PR TITLE
fix(ff): translate to English + add --dispatch flag; default is reframe-only (#590)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see
 
 ---
 
+## ff (productivity) — translate to English + `--dispatch` flag; default is reframe-only (no auto-execute)
+
+- **status**: modified
+- **upstream**: —
+- **why**: Two issues. (1) `/ff` shipped a Portuguese body (recommendation template, the seven option labels, trigger phrases), violating the repo English-only rule and emitting Portuguese to every consumer (subsumes #590). (2) The old contract auto-continued the underlying task once the user picked a framing, so `/ff` "went executing all at once" instead of just handing the rewritten prompt back.
+- **what changed**: Translated the entire skill to English (recommendation line `I think you want (x), because …`, the seven option labels, and the trigger phrases `use a` / `mix a with d` / `go with that one`). Split behavior into two modes: **default** `/ff <text>` reframes, lets the user pick, then outputs the finalized rewrite and **stops** (hands it back — never executes); new **`--dispatch`/`-d`** flag (`/ff --dispatch <text>`) reframes, lets the user pick the format, and then **runs** the underlying task with that framing. Updated the frontmatter `description` and `argument-hint` accordingly.
+
 ## afk (engineering) — AGENT-PROMPT foreground-execution rule + drop stale pre-sandcastle machinery
 
 - **status**: modified

--- a/plugins/dev/skills/productivity/ff/SKILL.md
+++ b/plugins/dev/skills/productivity/ff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ff
-description: Reframes the user's latest message into several useful versions with short previews and one explicit recommendation. Use when the user invokes `/ff`, says fast-forward, asks to rewrite their own message, or wants to clarify intent without continuing the underlying task yet.
-argument-hint: "[optional text to reframe]"
+description: Reframes the user's latest message into several useful versions with short previews and one explicit recommendation, then hands the chosen rewrite back to the user — it does NOT execute the underlying task unless invoked with `--dispatch`/`-d`. Use when the user invokes `/ff`, says fast-forward, asks to rewrite their own message, or wants to clarify intent before acting.
+argument-hint: "[--dispatch|-d] [text to reframe]"
 ---
 
 # /ff
@@ -9,53 +9,77 @@ argument-hint: "[optional text to reframe]"
 Fast-forward clarity. Reframe the user's latest message, or the text passed after
 `/ff`, into multiple preview versions so the user can pick the framing they want.
 
-## Contract
+By default `/ff` **ends by handing the chosen rewrite back to the user** — it does
+not start executing the underlying task. Pass `--dispatch` (or `-d`) to have `/ff`
+reframe, let the user pick a format, and **then run** the task with that framing.
 
-- Do not solve the underlying task.
-- Do not edit files or run commands.
-- Do not continue a paused `/start`, `/diagnose`, `/afk`, or implementation task.
-- Return previews for every option below, then stop.
-- Start with one recommendation in this exact spirit: `Acho que você quer (x), porque ...`
-- Keep each preview short by default: 3-8 lines, or a compact summary when the source text is long.
+## Modes
+
+- **`/ff <text>`** (default — reframe only): present the previews, and once the
+  user picks a framing, output the finalized rewrite and **stop**. That rewritten
+  prompt is the deliverable; the user takes it and decides what to do next. Never
+  continue a paused workflow or execute the underlying task.
+- **`/ff --dispatch <text>`** / **`/ff -d <text>`** (reframe then run): present the
+  previews exactly the same way; once the user picks a framing, adopt that rewrite
+  as the active message and **immediately carry out the underlying task**.
+
+`--dispatch`/`-d` may appear anywhere in the arguments; strip it before reframing
+the remaining text.
+
+## Contract (both modes)
+
+- While presenting previews, reframe only: do not solve the underlying task, do
+  not edit files or run commands, and do not continue a paused `/start`,
+  `/diagnose`, `/afk`, or implementation task.
+- Return previews for every option below, then stop and wait for the user's pick.
+- Start with one recommendation in this exact spirit: `I think you want (x), because ...`
+- Keep each preview short by default: 3-8 lines, or a compact summary when the
+  source text is long.
 
 ## Output
 
 Use this shape:
 
 ```md
-Acho que você quer (a), porque ...
+I think you want (a), because ...
 
-(a) Para dev junior
+(a) For a junior dev
 ...
 
-(b) Para criança de 10 anos
+(b) For a 10-year-old
 ...
 
-(c) Para dev senior
+(c) For a senior dev
 ...
 
-(d) Como prompt melhorado
+(d) As an improved prompt
 ...
 
-(e) Como issue implementável
+(e) As an implementable issue
 ...
 
-(f) Como pedido de decisão
+(f) As a decision request
 ...
 
-(g) Versão curta e direta
+(g) Short and direct
 ...
 ```
 
 ## Option Semantics
 
-- **(a) Para dev junior**: precise but simple technical language, minimal jargon, practical examples.
-- **(b) Para criança de 10 anos**: plain language, one analogy if useful, no patronizing tone.
-- **(c) Para dev senior**: dense technical vocabulary, explicit assumptions, constraints, edge cases, and tradeoffs.
-- **(d) Como prompt melhorado**: prompt-engineered request with role/context, objective, constraints, desired output, and success criteria.
-- **(e) Como issue implementável**: title, context, scope, acceptance criteria, and validation.
-- **(f) Como pedido de decisão**: decision needed, options, tradeoffs, recommendation, and what answer unblocks.
-- **(g) Versão curta e direta**: the shortest clear version.
+- **(a) For a junior dev**: precise but simple technical language, minimal jargon, practical examples.
+- **(b) For a 10-year-old**: plain language, one analogy if useful, no patronizing tone.
+- **(c) For a senior dev**: dense technical vocabulary, explicit assumptions, constraints, edge cases, and tradeoffs.
+- **(d) As an improved prompt**: prompt-engineered request with role/context, objective, constraints, desired output, and success criteria.
+- **(e) As an implementable issue**: title, context, scope, acceptance criteria, and validation.
+- **(f) As a decision request**: decision needed, options, tradeoffs, recommendation, and what answer unblocks.
+- **(g) Short and direct**: the shortest clear version.
 
-If the user later says `usa a`, `mistura a com d`, or `continua com essa versão`,
-use that chosen rewrite as the active message and continue the original workflow.
+## When the user picks a framing
+
+The user picks with phrases like `use a`, `mix a with d`, or `go with that one`.
+
+- **Default mode** (no `--dispatch`): produce the finalized rewrite from the chosen
+  option(s) and **stop**. Hand that rewritten prompt back — do not start executing it.
+- **`--dispatch` mode**: produce the finalized rewrite from the chosen option(s),
+  adopt it as the active message, and **proceed to carry out the underlying task**.


### PR DESCRIPTION
Two fixes to the `/ff` skill.

**1. English-only (subsumes #590).** `/ff` shipped a Portuguese body — the recommendation template (`Acho que você quer …`), the seven option labels, and the trigger phrases — emitting Portuguese to every consumer and violating the repo English-only rule. Translated the whole skill to English.

**2. Default is reframe-only; `--dispatch` runs.** The old contract auto-continued the underlying task once the user picked a framing, so `/ff` 'went executing all at once' instead of handing the rewrite back. Now:
- **`/ff <text>`** (default): reframe → user picks → output the finalized rewrite and **stop**. Hands the prompt back; never executes.
- **`/ff --dispatch <text>`** / **`/ff -d <text>`** (new): reframe → user picks the format → **then run** the underlying task with that framing.

Frontmatter `description` + `argument-hint` updated. Doc-only (no runtime code). Recorded in `CHANGES.md`.

Closes #590.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783612613&installation_id=129708444&pr_number=602&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F602&signature=bf25e3c13e37907cb5a33ab6dae3ee67cfa1757804856332edcf3c30cbf8e4bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `/ff` (fast-forward) skill: default mode now reframes text only, with new `--dispatch` flag to enable task execution after selecting a reframing option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->