### PR TITLE
fix(afk): killed/timed-out exec is a failure + bounded backpressure timeout (#574)

### DIFF
--- a/src/apps/dev/src/core/backpressure.ts
+++ b/src/apps/dev/src/core/backpressure.ts
@@ -16,6 +16,7 @@
 // and the `red.afk.validation.v1` schema are reused verbatim from feedback.ts so
 // the two gates emit byte-identical sidecar records.
 
+import { KILLED_EXIT_CODE } from "../runtime/exec.js";
 import {
   buildValidationRecord,
   formatValidationLine,
@@ -26,12 +27,28 @@ import {
 } from "./feedback.js";
 
 /**
- * Injected shell executor for a single backpressure command. Receives the raw
- * command string (e.g. `npm run test`) and the working directory it runs in
- * (the worker-branch checkout root); resolves with the captured exit code +
- * streams. Mirrors the hook executor's `sh -c <command>` contract.
+ * Default per-command kill deadline for the backpressure gate (10 minutes).
+ * The gate runs arbitrary operator `sh -c` commands AFTER the inner agent has
+ * emitted DONE — outside the reach of the attempt-progress guard and the fleet
+ * reaper — so without a bound a hung command deadlocks the worker forever
+ * (PRD #567). Bounding it makes a hung command resolve as a non-zero failure
+ * (via {@link KILLED_EXIT_CODE}) that surfaces as a validation block instead.
  */
-export type BackpressureExec = (input: { command: string; cwd: string }) => Promise<ExecResult>;
+export const DEFAULT_BACKPRESSURE_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Injected shell executor for a single backpressure command. Receives the raw
+ * command string (e.g. `npm run test`), the working directory it runs in (the
+ * worker-branch checkout root), and the per-command kill deadline; resolves with
+ * the captured exit code + streams. Mirrors the hook executor's
+ * `sh -c <command>` contract. A command killed by `timeoutMs` resolves
+ * non-zero (the exec edge reports {@link KILLED_EXIT_CODE}), never code 0.
+ */
+export type BackpressureExec = (input: {
+  command: string;
+  cwd: string;
+  timeoutMs: number;
+}) => Promise<ExecResult>;
 
 /** One completed backpressure command, surfaced alongside its sidecar record. */
 export interface BackpressureCheck {
@@ -50,6 +67,12 @@ export interface RunBackpressureInput {
   commands: readonly string[];
   /** Injected millisecond clock — no `Date.now()` at module scope. */
   now: () => number;
+  /**
+   * Per-command kill deadline. Defaults to
+   * {@link DEFAULT_BACKPRESSURE_TIMEOUT_MS}; a command that overruns it is
+   * killed and recorded as a `failed` (timed-out) validation block.
+   */
+  timeoutMs?: number;
 }
 
 export interface RunBackpressureResult {
@@ -64,18 +87,24 @@ export interface RunBackpressureResult {
 /**
  * Run the operator-declared backpressure commands in order against the
  * worker-branch worktree. For each command: time it with the injected clock,
- * run it via the injected exec in the worktree dir, and emit a `passed`/`failed`
- * `red.afk.validation.v1` record named `backpressure:<cmd>`. Blank/whitespace
- * entries are skipped (not recorded). Every command runs so the operator sees
- * the full picture; `ok` is false if ANY command failed, blocking the merge. An
- * empty command list is a no-op (`ok:true`, no checks, no sidecar) — today's
- * behaviour. Nothing here touches the filesystem or a real clock.
+ * run it via the injected exec in the worktree dir under a bounded kill
+ * deadline (`timeoutMs`, default {@link DEFAULT_BACKPRESSURE_TIMEOUT_MS}), and
+ * emit a `passed`/`failed` `red.afk.validation.v1` record named
+ * `backpressure:<cmd>`. A command killed by the deadline resolves non-zero (the
+ * exec edge reports {@link KILLED_EXIT_CODE}) and is recorded as a `failed`
+ * (timed-out) block, never silently passing — so a hung command surfaces as a
+ * validation block instead of deadlocking the worker. Blank/whitespace entries
+ * are skipped (not recorded). Every command runs so the operator sees the full
+ * picture; `ok` is false if ANY command failed, blocking the merge. An empty
+ * command list is a no-op (`ok:true`, no checks, no sidecar). Nothing here
+ * touches the filesystem or a real clock.
  */
 export async function runBackpressure(
   exec: BackpressureExec,
   input: RunBackpressureInput,
 ): Promise<RunBackpressureResult> {
   const { worktree, commands, now } = input;
+  const timeoutMs = input.timeoutMs ?? DEFAULT_BACKPRESSURE_TIMEOUT_MS;
   const checks: BackpressureCheck[] = [];
   const sidecar: string[] = [];
   let failed = false;
@@ -86,11 +115,17 @@ export async function runBackpressure(
 
     const name = `backpressure:${command}`;
     const start = now();
-    const result = await exec({ command, cwd: worktree });
+    const result = await exec({ command, cwd: worktree, timeoutMs });
     const durationMs = now() - start;
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
-    const summary = outputSummary(status, `${result.stdout}${result.stderr}`);
+    // A timed-out command (killed at the deadline) reports KILLED_EXIT_CODE with
+    // no useful captured output — give the operator an explicit timed-out
+    // summary instead of the generic `command exited non-zero`.
+    const summary =
+      result.code === KILLED_EXIT_CODE
+        ? `command timed out after ${timeoutMs}ms`
+        : outputSummary(status, `${result.stdout}${result.stderr}`);
     const record = buildValidationRecord({ name, status, command, durationMs, summary });
     checks.push({ name, command, status, record });
     sidecar.push(formatValidationLine(record));

--- a/src/apps/dev/src/runtime/exec.ts
+++ b/src/apps/dev/src/runtime/exec.ts
@@ -38,10 +38,24 @@ export type ExecFn = (cmd: string, args: readonly string[], opts?: ExecOptions) 
 const DEFAULT_MAX_BUFFER = 16 * 1024 * 1024;
 
 /**
+ * Exit code reported for a command killed by the exec timeout or an external
+ * signal. Node's execFile leaves `error.code` null in that case (the numeric
+ * exit slot is empty when the child died from a signal), so without this the
+ * old `typeof code === "number" ? code : 0` fallthrough read a killed/timed-out
+ * command as success — a slow model classification, or a future timed-out land,
+ * silently passing (PRD #567). 124 mirrors GNU `timeout(1)`'s killed-process
+ * code so any caller branching on `code !== 0` reads the kill as a failure.
+ */
+export const KILLED_EXIT_CODE = 124;
+
+/**
  * Run `cmd args…` and resolve with the captured exit code + streams. A spawn
  * error (ENOENT for a missing binary, etc.) resolves with code 127 and the
  * error message on stderr rather than rejecting, so a missing `gh` reads as a
- * clean precondition signal upstream instead of an unhandled rejection.
+ * clean precondition signal upstream instead of an unhandled rejection. A
+ * command killed by the `timeoutMs` deadline or an external signal resolves with
+ * {@link KILLED_EXIT_CODE} — never code 0 — so callers branching on a non-zero
+ * code read the kill as a failure.
  */
 export function execTool(cmd: string, args: readonly string[], opts: ExecOptions = {}): Promise<ExecOutput> {
   return new Promise((resolve) => {
@@ -59,6 +73,17 @@ export function execTool(cmd: string, args: readonly string[], opts: ExecOptions
         if (error && typeof (error as NodeJS.ErrnoException).code === "string") {
           // Spawn failure (ENOENT etc.) — surface as 127 like a shell would.
           resolve({ code: 127, stdout: String(stdout ?? ""), stderr: String((error as Error).message) });
+          return;
+        }
+        if (error && (error.killed || error.signal != null)) {
+          // Timed out (timeoutMs deadline) or killed by an external signal. The
+          // numeric exit code is null here, so report a non-zero failure instead
+          // of letting the kill read as success.
+          resolve({
+            code: KILLED_EXIT_CODE,
+            stdout: String(stdout ?? ""),
+            stderr: String(stderr ?? "") || String((error as Error).message),
+          });
           return;
         }
         const code = error && typeof error.code === "number" ? error.code : 0;

--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -192,10 +192,14 @@ export function makeFeedbackWorktree(
   // Backpressure commands are operator-declared shell strings (e.g. `npm run
   // test`) that run at the worker-branch checkout ROOT. `cwd` is the branch
   // token; materialise it the same way the pnpm executor does, then run the
-  // command through `sh -c`, mirroring the lifecycle-hook executor.
-  const backpressure: BackpressureExec = async ({ command, cwd }) => {
+  // command through `sh -c`, mirroring the lifecycle-hook executor. The gate
+  // runs post-DONE, outside the progress guard and reaper, so it carries its own
+  // bounded `timeoutMs` kill deadline: a hung command is killed and reads as a
+  // non-zero failure (the exec edge reports KILLED_EXIT_CODE) instead of
+  // deadlocking the worker (PRD #567).
+  const backpressure: BackpressureExec = async ({ command, cwd, timeoutMs }) => {
     const dir = await pathFor(cwd);
-    const r = await io.exec("sh", ["-c", command], { cwd: dir });
+    const r = await io.exec("sh", ["-c", command], { cwd: dir, timeoutMs });
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 

--- a/src/apps/dev/tests/backpressure.test.ts
+++ b/src/apps/dev/tests/backpressure.test.ts
@@ -1,18 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { runBackpressure, type BackpressureExec } from "../src/core/backpressure.js";
+import {
+  DEFAULT_BACKPRESSURE_TIMEOUT_MS,
+  runBackpressure,
+  type BackpressureExec,
+} from "../src/core/backpressure.js";
+import { KILLED_EXIT_CODE } from "../src/runtime/exec.js";
 import { VALIDATION_SCHEMA, type ExecResult, type ValidationRecord } from "../src/core/feedback.js";
 
 /**
- * Fake backpressure exec recording every (command, cwd) and replying from a
- * per-call matcher. Default reply is success with empty output, so a test only
- * overrides the commands whose exit code drives a failure.
+ * Fake backpressure exec recording every (command, cwd, timeoutMs) and replying
+ * from a per-call matcher. Default reply is success with empty output, so a test
+ * only overrides the commands whose exit code drives a failure.
  */
 function fakeExec(
   rules: Array<{ match: (command: string) => boolean; result: Partial<ExecResult> }> = [],
-): { exec: BackpressureExec; calls: Array<{ command: string; cwd: string }> } {
-  const calls: Array<{ command: string; cwd: string }> = [];
-  const exec: BackpressureExec = async ({ command, cwd }) => {
-    calls.push({ command, cwd });
+): { exec: BackpressureExec; calls: Array<{ command: string; cwd: string; timeoutMs: number }> } {
+  const calls: Array<{ command: string; cwd: string; timeoutMs: number }> = [];
+  const exec: BackpressureExec = async ({ command, cwd, timeoutMs }) => {
+    calls.push({ command, cwd, timeoutMs });
     for (const rule of rules) {
       if (rule.match(command)) return { code: 0, stdout: "", stderr: "", ...rule.result };
     }
@@ -41,10 +46,10 @@ describe("runBackpressure", () => {
     });
 
     expect(result.ok).toBe(true);
-    // Declaration order, each at the worktree root.
+    // Declaration order, each at the worktree root, under the default bound.
     expect(calls).toEqual([
-      { command: "npm run test", cwd: "/wt" },
-      { command: "npm run lint", cwd: "/wt" },
+      { command: "npm run test", cwd: "/wt", timeoutMs: DEFAULT_BACKPRESSURE_TIMEOUT_MS },
+      { command: "npm run lint", cwd: "/wt", timeoutMs: DEFAULT_BACKPRESSURE_TIMEOUT_MS },
     ]);
     expect(result.checks.map((c) => c.name)).toEqual([
       "backpressure:npm run test",
@@ -121,7 +126,9 @@ describe("runBackpressure", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(calls).toEqual([{ command: "npm run test", cwd: "/wt" }]);
+    expect(calls).toEqual([
+      { command: "npm run test", cwd: "/wt", timeoutMs: DEFAULT_BACKPRESSURE_TIMEOUT_MS },
+    ]);
     expect(result.checks.map((c) => c.name)).toEqual(["backpressure:npm run test"]);
   });
 
@@ -133,8 +140,47 @@ describe("runBackpressure", () => {
       now: fakeClock(),
     });
 
-    expect(calls).toEqual([{ command: "npm run test", cwd: "/wt" }]);
+    expect(calls).toEqual([
+      { command: "npm run test", cwd: "/wt", timeoutMs: DEFAULT_BACKPRESSURE_TIMEOUT_MS },
+    ]);
     expect(result.checks[0]?.name).toBe("backpressure:npm run test");
     expect(result.checks[0]?.record.command).toBe("npm run test");
+  });
+
+  it("runs each command under the caller's bounded timeout when supplied (PRD #567)", async () => {
+    const { exec, calls } = fakeExec();
+    await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["sleep 999"],
+      now: fakeClock(),
+      timeoutMs: 250,
+    });
+
+    // The explicit bound is threaded to the exec edge so the `sh -c` child is
+    // killed at the deadline instead of hanging the worker.
+    expect(calls).toEqual([{ command: "sleep 999", cwd: "/wt", timeoutMs: 250 }]);
+  });
+
+  it("blocks the merge as a timed-out validation failure when a command is killed (PRD #567)", async () => {
+    // The exec edge reports KILLED_EXIT_CODE for a command killed at the bound;
+    // backpressure must read that as a FAILED block, never silently pass.
+    const { exec } = fakeExec([
+      { match: (c) => c === "sleep 999", result: { code: KILLED_EXIT_CODE, stdout: "", stderr: "" } },
+    ]);
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["npm run test", "sleep 999"],
+      now: fakeClock(),
+      timeoutMs: 250,
+    });
+
+    // A hung post-DONE command surfaces as a validation block, not a hang.
+    expect(result.ok).toBe(false);
+    const hung = result.checks.find((c) => c.name === "backpressure:sleep 999");
+    expect(hung?.status).toBe("failed");
+    // Explicit timed-out summary (not the generic `command exited non-zero`).
+    expect(hung?.record.summary).toBe("command timed out after 250ms");
+    // The earlier command still passed — only the hung one blocks.
+    expect(result.checks.find((c) => c.name === "backpressure:npm run test")?.status).toBe("passed");
   });
 });

--- a/src/apps/dev/tests/exec.test.ts
+++ b/src/apps/dev/tests/exec.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { KILLED_EXIT_CODE, execTool } from "../src/runtime/exec.js";
+
+describe("execTool", () => {
+  it("captures the real exit code + streams of a finished command", async () => {
+    const r = await execTool("sh", ["-c", "printf out; printf err 1>&2; exit 3"]);
+    expect(r.code).toBe(3);
+    expect(r.stdout).toBe("out");
+    expect(r.stderr).toBe("err");
+  });
+
+  it("resolves a missing binary as 127 instead of rejecting", async () => {
+    const r = await execTool("definitely-no-such-binary-xyz", []);
+    expect(r.code).toBe(127);
+    // The spawn error message is surfaced on stderr (ENOENT etc.).
+    expect(r.stderr.length).toBeGreaterThan(0);
+  });
+
+  it("reports a command killed by the timeout as a non-zero failure, never code 0 (PRD #567)", async () => {
+    // The classic bug: Node leaves error.code === null for a timeout-killed
+    // child, so the old `typeof code === 'number' ? code : 0` fallthrough read
+    // the kill as success (code 0). It must read as a failure instead.
+    const r = await execTool("sh", ["-c", "sleep 5"], { timeoutMs: 150 });
+    expect(r.code).not.toBe(0);
+    expect(r.code).toBe(KILLED_EXIT_CODE);
+  });
+
+  it("reports a signal-killed command as a non-zero failure (PRD #567)", async () => {
+    // A process that kills itself with a signal also leaves error.code null with
+    // a non-null error.signal — likewise a failure, not success.
+    const r = await execTool("sh", ["-c", "kill -TERM $$"]);
+    expect(r.code).not.toBe(0);
+    expect(r.code).toBe(KILLED_EXIT_CODE);
+  });
+});


### PR DESCRIPTION
Closes #574. Landed via the PRD #567 parallel-landing workflow — a worktree-isolated agent implemented + tested the slice and ran the dev gate green (typecheck + the dev vitest suite) before pushing. Part of PRD #567.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783624406&installation_id=129708444&pr_number=606&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F606&signature=888f13127fa11457d3b011202cd42db5b97d553f40f6e3c548769552f4fe4064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command execution now enforces timeout deadlines, preventing indefinite hangs
  * Improved error detection for processes terminated by timeout or signal, ensuring they are properly reported as failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->