### PR TITLE
fix(afk): HITL extractor ignores its own prior resolution + sheds stale blocked labels (#586)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see
 
 ---
 
+## hitl (engineering) — ignore the loop's own prior resolution directive + shed stale blocked:* labels (#586)
+
+- **status**: modified
+- **upstream**: —
+- **why**: On a HITL re-loop, the pending-decision extractor re-read the loop's own prior `<details data-kind="directive"><summary>HITL resolution</summary>` comment and surfaced the literal placeholder label `Pending decision:` instead of the real `## Current blocker` next-field. Separately, a delegable resolution moved the issue back to `ready-for-agent` while still wearing the stale `blocked:*` reason that parked it.
+- **what changed**: Documented in Step 3 that extraction must ignore self-authored HITL-resolution directives (summary `HITL resolution`, or a first useful line that is a bare field label like `Pending decision:`), and in the delegable mutation step that every stale `blocked:*` label is shed alongside `ready-for-human`. Mirrors the runtime fix in `src/apps/dev/src/core/hitl-decision-extraction.ts` and `hitl-resolution-plan.ts`.
+
 ## afk (engineering) — inner agent must not create PRs / wait on CI; commit + DONE only
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/hitl/SKILL.md
+++ b/plugins/dev/skills/engineering/hitl/SKILL.md
@@ -65,6 +65,8 @@ Try to identify a single pending decision from:
 - latest AFK Envelope with status `blocked`, `no-sentinel`, or `merge-conflict`;
 - advisory thread discussion only when it contains one clear question or decision point.
 
+Ignore this loop's own prior HITL-resolution directives when extracting: skip any `<details data-kind="directive">` block whose `<summary>` is `HITL resolution`, or whose first useful line is a bare field label such as `Pending decision:`, `Human answer:`, `Disposition:`, or `Next pending decision:`. Those echo the placeholder header rather than a real decision, so re-reading them on a re-loop would surface the literal string `Pending decision:` instead of the real `## Current blocker` next-field.
+
 If exactly one pending decision is clear, present it:
 
 ```text
@@ -124,7 +126,7 @@ If delegable:
 
 1. Clear the issue-body `## Current blocker` section to `None` and add a checked entry under `## Resolved blockers`.
 2. Update or create the issue-body `## Agent brief` section.
-3. Remove `ready-for-human`.
+3. Remove `ready-for-human` and every stale `blocked:*` label — the blocker is resolved, so the reason that parked the issue must not survive into `ready-for-agent`.
 4. Add `ready-for-agent`.
 
 If non-delegable:

--- a/src/apps/dev/src/core/hitl-decision-extraction.ts
+++ b/src/apps/dev/src/core/hitl-decision-extraction.ts
@@ -141,11 +141,28 @@ function agentBriefSignal(issue: HitlDecisionIssue): DecisionSignal | null {
   };
 }
 
+/** Bare placeholder labels the loop's own HITL-resolution directive starts with.
+ * They are field headers, not decisions, so a directive whose first useful line
+ * is one of these is the loop re-reading its own prior resolution. */
+const SELF_RESOLUTION_LABELS = ["pending decision:", "human answer:", "disposition:", "next pending decision:"];
+
+/** True when a directive body is one of the loop's own `<summary>HITL resolution</summary>`
+ * blocks (or otherwise opens with a bare resolution field label). Such directives
+ * echo the literal "Pending decision:" header instead of a real decision and must
+ * not be re-extracted on a HITL re-loop. */
+function isSelfHitlResolution(directive: string): boolean {
+  const summary = /<summary>\s*(.*?)\s*<\/summary>/i.exec(directive);
+  if (summary && summary[1]!.replace(/\s+/g, " ").trim().toLowerCase() === "hitl resolution") return true;
+  const first = firstUsefulLine(directive).toLowerCase();
+  return SELF_RESOLUTION_LABELS.includes(first);
+}
+
 function directiveSignals(comments: readonly HandoffComment[]): DecisionSignal[] {
   const out: DecisionSignal[] = [];
   for (const comment of comments) {
     if (classifyComment({ body: comment.body }) !== "directive") continue;
     for (const directive of extractDirectives(comment.body)) {
+      if (isSelfHitlResolution(directive)) continue;
       const line = firstUsefulLine(directive);
       if (!line) continue;
       out.push({

--- a/src/apps/dev/src/core/hitl-resolution-plan.ts
+++ b/src/apps/dev/src/core/hitl-resolution-plan.ts
@@ -5,6 +5,9 @@ export interface HitlResolutionIssue {
   number: number;
   title: string;
   body: string;
+  /** The issue's current labels, used to shed stale `blocked:*` reasons when the
+   * issue becomes delegable. Optional; when absent no blocker labels are shed. */
+  labels?: string[];
 }
 
 export type HitlResolutionDisposition =
@@ -33,6 +36,14 @@ export interface HitlResolutionPlan {
 
 function trimBlock(value: string): string {
   return value.trim().replace(/\n{3,}/g, "\n\n");
+}
+
+/** The stale `blocked:*` reason labels carried by the issue. When it becomes
+ * delegable the blocker is resolved, so these must be shed alongside
+ * `ready-for-human` — otherwise the issue returns to `ready-for-agent` still
+ * wearing the reason that parked it. */
+function staleBlockerLabels(labels: readonly string[] | undefined): string[] {
+  return (labels ?? []).filter((label) => label.startsWith("blocked:"));
 }
 
 function directiveComment(input: HitlResolutionInput): string {
@@ -94,7 +105,7 @@ export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPl
       commentBody: directiveComment(input),
       bodyUpdate: upsertMarkdownSection(cleared, "Agent brief", input.disposition.agentBrief),
       addLabels: ["ready-for-agent"],
-      removeLabels: ["ready-for-human"],
+      removeLabels: ["ready-for-human", ...staleBlockerLabels(input.issue.labels)],
     };
   }
 

--- a/src/apps/dev/tests/hitl-decision-extraction.test.ts
+++ b/src/apps/dev/tests/hitl-decision-extraction.test.ts
@@ -70,6 +70,83 @@ describe("extractPendingHitlDecision", () => {
     });
   });
 
+  it("ignores the loop's own prior HITL-resolution directive on a re-loop and surfaces the real Current blocker", () => {
+    // The loop's previous resolution comment, exactly as planHitlResolution emits it:
+    // a directive whose summary is "HITL resolution" and whose first useful line is
+    // the bare "Pending decision:" label. Re-reading it would surface that placeholder.
+    const priorResolution = `<details data-kind="directive">
+<summary>HITL resolution</summary>
+
+Pending decision:
+Decide the API shape.
+
+Human answer:
+Use RPC for now.
+
+Disposition:
+non-delegable
+
+Next pending decision:
+Decide whether retries should be capped.
+</details>`;
+    const body = upsertCurrentBlocker("## Summary\nBuild the thing.", {
+      status: "blocked",
+      kind: "decision",
+      summary: "Retry policy is undecided.",
+      next: "Decide whether retries should be capped.",
+    });
+
+    const result = extractPendingHitlDecision(issue({ body, comments: [{ author: "afk", body: priorResolution }] }));
+
+    expect(result).toMatchObject({
+      kind: "pending-decision",
+      source: "current-blocker",
+      prompt: "Decide whether retries should be capped.",
+    });
+    expect(result.prompt).not.toBe("Pending decision:");
+  });
+
+  it("ignores a self-resolution directive that opens with a bare field label even without the HITL summary", () => {
+    const priorResolution = directive("Pending decision:\nDecide the API shape.\n\nHuman answer:\nUse RPC.");
+    const body = upsertCurrentBlocker("## Summary\nBuild the thing.", {
+      status: "blocked",
+      kind: "decision",
+      summary: "Retry policy is undecided.",
+      next: "Decide whether retries should be capped.",
+    });
+
+    const result = extractPendingHitlDecision(issue({ body, comments: [{ author: "afk", body: priorResolution }] }));
+
+    expect(result).toMatchObject({
+      kind: "pending-decision",
+      source: "current-blocker",
+      prompt: "Decide whether retries should be capped.",
+    });
+  });
+
+  it("still extracts a genuine human directive that is not a HITL resolution", () => {
+    const priorResolution = `<details data-kind="directive">
+<summary>HITL resolution</summary>
+
+Pending decision:
+Old question.
+</details>`;
+    const result = extractPendingHitlDecision(
+      issue({
+        comments: [
+          { author: "afk", body: priorResolution },
+          { author: "alice", body: directive("Remove the legacy label; do not preserve compatibility.") },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "pending-decision",
+      source: "human-guidance",
+      prompt: "Remove the legacy label; do not preserve compatibility.",
+    });
+  });
+
   it("uses the latest blocked envelope when there is no authoritative decision section", () => {
     const envelope = buildEnvelope({
       status: "blocked",

--- a/src/apps/dev/tests/hitl-resolution-plan.test.ts
+++ b/src/apps/dev/tests/hitl-resolution-plan.test.ts
@@ -39,6 +39,38 @@ describe("planHitlResolution", () => {
     expect(plan.removeLabels).toEqual(["ready-for-human"]);
   });
 
+  it("sheds stale blocked:* labels when a delegable resolution moves the issue back to ready-for-agent", () => {
+    const plan = planHitlResolution(
+      base({
+        issue: {
+          number: 42,
+          title: "Resolve HITL blocker",
+          body: "## Summary\nExisting summary.\n",
+          labels: ["ready-for-human", "blocked:spec", "blocked:validation", "priority:high"],
+        },
+      }),
+    );
+
+    expect(plan.addLabels).toEqual(["ready-for-agent"]);
+    expect(plan.removeLabels).toEqual(["ready-for-human", "blocked:spec", "blocked:validation"]);
+    expect(plan.removeLabels).not.toContain("priority:high");
+  });
+
+  it("does not invent blocked:* removals when the issue carries none", () => {
+    const plan = planHitlResolution(
+      base({
+        issue: {
+          number: 42,
+          title: "Resolve HITL blocker",
+          body: "## Summary\nExisting summary.\n",
+          labels: ["ready-for-human"],
+        },
+      }),
+    );
+
+    expect(plan.removeLabels).toEqual(["ready-for-human"]);
+  });
+
   it("clears Current blocker and records it when the answer makes the issue delegable", () => {
     const body = upsertCurrentBlocker("## Summary\nExisting summary.\n", {
       status: "blocked",


### PR DESCRIPTION
Closes #586. Landed via the PRD #567 parallel-landing workflow — a worktree-isolated agent implemented + tested the slice and ran the dev gate green (typecheck + the dev vitest suite) before pushing. Part of PRD #567.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783624432&installation_id=129708444&pr_number=607&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F607&signature=aeda4dffaa59db71de2299bbae0a073dbc808927fb1af90de3bac90789aeaa6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HITL re-loops incorrectly re-processing previous HITL-resolution directives as new human guidance.
  * Improved cleanup of stale blocker labels when issues transition from blocked to ready-for-agent state.

* **Documentation**
  * Updated HITL workflow documentation to clarify handling of prior resolution directives and label cleanup behavior.

* **Tests**
  * Added test coverage for HITL decision extraction with prior resolution directives.
  * Added test coverage for blocker label removal during delegable resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->