### PR TITLE
fix(afk): runtime IO — salvage un-escapes porcelain paths + gh-auth transient ordering (#588)

### DIFF
--- a/src/apps/dev/src/runtime/gh.ts
+++ b/src/apps/dev/src/runtime/gh.ts
@@ -75,17 +75,24 @@ const ghAuthTransientPattern =
  * automatically "unauthenticated": gh exits non-zero both on a real missing /
  * rejected token AND on a transient failure of the validation API call (rate
  * limit, network, 5xx) while a valid token is still configured. We discriminate
- * on the report text (gh writes it to stderr): a definitive unauthenticated
- * signal → false; a transient blip → true (token present, just couldn't
- * validate now — boot proceeds and the individual gh calls degrade on their own
- * `r.code !== 0` guards). An unrecognised non-zero stays conservative → false.
+ * on the report text (gh writes it to stderr): a transient blip → true (token
+ * present, just couldn't validate now — boot proceeds and the individual gh
+ * calls degrade on their own `r.code !== 0` guards); a definitive
+ * unauthenticated signal → false. An unrecognised non-zero stays conservative →
+ * false.
+ *
+ * The transient pattern is tested BEFORE the unauthenticated one: a transient
+ * report may itself carry an auth hint ("…try again later; run `gh auth login`
+ * if this persists"), and a rate-limit / 5xx blip with a valid token configured
+ * must NOT be misread as unauthenticated just because the hint matched. The
+ * live-API failure is the stronger signal that the credential is present.
  */
 export async function ghAuthenticated(ctx: GhContext): Promise<boolean> {
   const r = await runGh(ctx, ["auth", "status"]);
   if (r.code === 0) return true;
   const report = `${r.stdout}\n${r.stderr}`;
-  if (ghUnauthenticatedPattern.test(report)) return false;
   if (ghAuthTransientPattern.test(report)) return true;
+  if (ghUnauthenticatedPattern.test(report)) return false;
   return false;
 }
 

--- a/src/apps/dev/src/runtime/git.ts
+++ b/src/apps/dev/src/runtime/git.ts
@@ -268,6 +268,64 @@ export async function worktreePathUnder(ctx: GitContext, dirPrefix: string): Pro
 }
 
 /**
+ * Decode a single `git status --porcelain` path. When git deems a path "safe"
+ * (only printable ASCII, no quote/control bytes) it emits it verbatim — returned
+ * unchanged. Otherwise git wraps it in double quotes and C-style escapes the
+ * payload (`core.quotePath` default): `\\`, `\"`, the named escapes
+ * `\a \b \f \n \r \t \v`, and three-digit OCTAL escapes (`\303\251`) for each
+ * raw byte of a non-ASCII / control character. We reverse that exactly: octal
+ * runs are collected as bytes and UTF-8 decoded so a unicode filename round-trips
+ * to the literal path `git add --` accepts. A path that isn't quote-wrapped is
+ * passed through untouched.
+ */
+export function unquotePorcelainPath(raw: string): string {
+  if (!(raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"'))) return raw;
+  const body = raw.slice(1, -1);
+  const bytes: number[] = [];
+  const named: Record<string, number> = {
+    a: 0x07,
+    b: 0x08,
+    f: 0x0c,
+    n: 0x0a,
+    r: 0x0d,
+    t: 0x09,
+    v: 0x0b,
+    '"': 0x22,
+    "\\": 0x5c,
+  };
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (ch !== "\\") {
+      // A non-escaped character — emit its UTF-8 bytes.
+      for (const b of Buffer.from(ch, "utf8")) bytes.push(b);
+      continue;
+    }
+    const next = body[i + 1] ?? "";
+    if (next >= "0" && next <= "7") {
+      // Octal escape: exactly up to three octal digits → one raw byte.
+      let j = i + 1;
+      let oct = "";
+      while (j < body.length && oct.length < 3 && body[j] >= "0" && body[j] <= "7") {
+        oct += body[j];
+        j += 1;
+      }
+      bytes.push(parseInt(oct, 8) & 0xff);
+      i = j - 1;
+      continue;
+    }
+    if (next in named) {
+      bytes.push(named[next]);
+      i += 1;
+      continue;
+    }
+    // Unknown escape — keep the backslash literally (defensive; git won't emit
+    // this) and let the following char be processed normally.
+    bytes.push(0x5c);
+  }
+  return Buffer.from(bytes).toString("utf8");
+}
+
+/**
  * Salvage uncommitted work an inner agent left in its worktree without
  * committing. Observed with the codex runner: the agent edits files, passes the
  * gates, and emits `<promise>DONE</promise>`, but never runs `git commit` — so
@@ -293,12 +351,15 @@ export async function salvageUncommitted(ctx: GitContext, branch: string, remote
     const t = line.replace(/\s+$/, "");
     if (!t) continue;
     // porcelain v1: "XY path" — the path begins at column 3. A rename is
-    // "old -> new"; take the destination. Quoted paths (spaces/unicode) are
-    // unwrapped to the literal path `git add --` accepts.
+    // "old -> new"; take the destination. Paths with special/non-ASCII bytes
+    // are C-quoted by git (core.quotePath default), so they are unwrapped AND
+    // un-escaped to the literal path `git add --` accepts — stripping the quotes
+    // alone leaves backslash escapes that don't name the file, silently dropping
+    // it from the salvage.
     let p = t.slice(3);
     const arrow = p.indexOf(" -> ");
     if (arrow !== -1) p = p.slice(arrow + 4);
-    p = p.replace(/^"(.*)"$/, "$1");
+    p = unquotePorcelainPath(p);
     if (p) paths.push(p);
   }
   let committed = 0;

--- a/src/apps/dev/tests/gh-auth.test.ts
+++ b/src/apps/dev/tests/gh-auth.test.ts
@@ -82,4 +82,27 @@ describe("ghAuthenticated — rate-limit vs real auth failure", () => {
     const out: ExecOutput = { code: 1, stdout: "", stderr: "some unexpected gh failure" };
     expect(await ghAuthenticated(ctxWith(out))).toBe(false);
   });
+
+  it("transient error carrying an auth hint → transient wins (still authenticated)", async () => {
+    // A rate-limit / 5xx blip whose retry advice mentions `gh auth login` would
+    // ALSO match the unauthenticated pattern. The transient classifier must be
+    // tested FIRST so the still-configured token is not misread as missing.
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr:
+        "github.com\n  X error validating token: API rate limit exceeded for user ID 42.\n" +
+        "  try again later; run `gh auth login` if this persists.",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(true);
+  });
+
+  it("5xx blip whose body also names bad credentials → transient still wins", async () => {
+    const out: ExecOutput = {
+      code: 1,
+      stdout: "",
+      stderr: "503 Service Unavailable while checking token — would otherwise read: Bad credentials",
+    };
+    expect(await ghAuthenticated(ctxWith(out))).toBe(true);
+  });
 });

--- a/src/apps/dev/tests/runtime-git-branch.test.ts
+++ b/src/apps/dev/tests/runtime-git-branch.test.ts
@@ -6,6 +6,7 @@ import {
   worktreePathForBranch,
   worktreePathUnder,
   salvageUncommitted,
+  unquotePorcelainPath,
 } from "../src/runtime/git.js";
 import type { GitContext } from "../src/runtime/git.js";
 import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
@@ -152,6 +153,32 @@ describe("worktreePathUnder (sandcastle-blind heartbeat fix)", () => {
   });
 });
 
+describe("unquotePorcelainPath", () => {
+  it("passes a plain (unquoted) ASCII path through unchanged", () => {
+    expect(unquotePorcelainPath("src/a.ts")).toBe("src/a.ts");
+  });
+
+  it("decodes octal-escaped UTF-8 bytes back to the unicode literal", () => {
+    expect(unquotePorcelainPath('"caf\\303\\251.txt"')).toBe("café.txt");
+  });
+
+  it("decodes a multi-codepoint unicode name (emoji)", () => {
+    // 🚀 is U+1F680 → UTF-8 F0 9F 9A 80 → octal \360\237\232\200.
+    expect(unquotePorcelainPath('"\\360\\237\\232\\200.md"')).toBe("🚀.md");
+  });
+
+  it("unwraps a quoted path with a space and no escapes", () => {
+    expect(unquotePorcelainPath('"na me.txt"')).toBe("na me.txt");
+  });
+
+  it("decodes named C escapes (tab, newline, escaped quote, backslash)", () => {
+    expect(unquotePorcelainPath('"a\\tb.txt"')).toBe("a\tb.txt");
+    expect(unquotePorcelainPath('"a\\nb.txt"')).toBe("a\nb.txt");
+    expect(unquotePorcelainPath('"a\\"b.txt"')).toBe('a"b.txt');
+    expect(unquotePorcelainPath('"a\\\\b.txt"')).toBe("a\\b.txt");
+  });
+});
+
 describe("salvageUncommitted (codex DONE-without-commit)", () => {
   const porcelain = "worktree /repo/.red/tmp/wt\nHEAD bbb\nbranch refs/heads/afk/w/1-x\n";
 
@@ -180,6 +207,45 @@ describe("salvageUncommitted (codex DONE-without-commit)", () => {
       "origin",
       "HEAD:refs/heads/afk/w/1-x",
     ]);
+  });
+
+  it("un-escapes a C-quoted unicode porcelain path before staging", async () => {
+    // git core.quotePath wraps non-ASCII paths in quotes AND octal-escapes each
+    // raw UTF-8 byte: café.txt → "caf\303\251.txt". Stripping the quotes alone
+    // leaves the backslash escapes, naming a file that doesn't exist → the work
+    // is silently dropped. The literal path must reach `git add --`.
+    const { exec, calls } = recordingExec((_c, args) => {
+      if (args.includes("list")) return ok(porcelain);
+      if (args.includes("status")) return ok('?? "caf\\303\\251.txt"\n');
+      return ok();
+    });
+    expect(await salvageUncommitted({ cwd: "/repo", exec }, "afk/w/1-x")).toBe(1);
+    const add = calls.find((c) => c[1] === "add")!;
+    expect(add[add.length - 1]).toBe("café.txt");
+    const commit = calls.find((c) => c[1] === "commit")!;
+    expect(commit[commit.length - 1]).toBe("café.txt");
+  });
+
+  it("un-escapes a quoted path with a space and stages the literal name", async () => {
+    const { exec, calls } = recordingExec((_c, args) => {
+      if (args.includes("list")) return ok(porcelain);
+      if (args.includes("status")) return ok('?? "na me.txt"\n');
+      return ok();
+    });
+    expect(await salvageUncommitted({ cwd: "/repo", exec }, "afk/w/1-x")).toBe(1);
+    const add = calls.find((c) => c[1] === "add")!;
+    expect(add[add.length - 1]).toBe("na me.txt");
+  });
+
+  it("un-escapes the quoted destination path of a rename", async () => {
+    const { exec, calls } = recordingExec((_c, args) => {
+      if (args.includes("list")) return ok(porcelain);
+      if (args.includes("status")) return ok('R  old.ts -> "caf\\303\\251.ts"\n');
+      return ok();
+    });
+    expect(await salvageUncommitted({ cwd: "/repo", exec }, "afk/w/1-x")).toBe(1);
+    const add = calls.find((c) => c[1] === "add")!;
+    expect(add[add.length - 1]).toBe("café.ts");
   });
 
   it("commits the destination path of a rename", async () => {


### PR DESCRIPTION
Closes #588. Landed via the PRD #567 parallel-landing workflow — a worktree-isolated agent implemented + tested the slice and ran the dev gate green (typecheck + the dev vitest suite) before pushing. Part of PRD #567.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783624411&installation_id=129708444&pr_number=608&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F608&signature=eb07fa5bfe5a14c876924b81e5d9add3618e49246c0b09850471a2dcb96c421e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed GitHub authentication detection to correctly distinguish temporary network/rate-limit errors from permanent credential issues, reducing false "not authenticated" errors.
  * Improved handling of special characters, unicode, and spaces in Git filenames when staging uncommitted changes.

* **Tests**
  * Added test coverage for authentication status edge cases.
  * Enhanced Git path handling tests with unicode, emoji, and quoted filename scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->