### PR TITLE
fix(afk): reconcile salvage fetches origin-only branch before the commits gate

### DIFF
--- a/src/apps/dev/src/core/reconcile.ts
+++ b/src/apps/dev/src/core/reconcile.ts
@@ -12,11 +12,13 @@
 // The flow mirrors the DONE path's tail, composing the SAME building blocks — no
 // new merge code:
 //   1. guard      — mechanical class only (never blocked:spec / a non-mechanical
-//                    active `## Current blocker`); the branch must carry work.
-//   2. runFeedback — the scoped gate is the verdict, the SAME authority the DONE
+//                    active `## Current blocker`).
+//   2. fetch gate — branchPresent() fetches origin-only branches before the diff.
+//   3. commits gate — the branch must carry work (changedFiles vs base).
+//   4. runFeedback — the scoped gate is the verdict, the SAME authority the DONE
 //                    path trusts.
-//   3a. green     → doLanding (landing.ts) + close + drop blocked:*/ready-for-human.
-//   3b. red       → ready-for-human with the REAL failing checks (blocked:validation).
+//   4a. green     → doLanding (landing.ts) + close + drop blocked:*/ready-for-human.
+//   4b. red       → ready-for-human with the REAL failing checks (blocked:validation).
 //
 // PURE SEQUENCING over injected IO: every git/gh/pnpm/fs touch is a port, so the
 // whole decision tree is unit-testable with zero subprocesses. `ReconcileDeps`
@@ -206,17 +208,11 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     return { outcome: "skipped", reason: disqualifier };
   }
 
-  // ---- 2. commits gate: the branch must carry work AND be present on the host ----
-  // changedFiles() is a three-dot diff that returns [] for an EMPTY or MISSING
-  // branch, so an empty set means "nothing to land" — exactly the no-work case
-  // that should fall through to the caller's escalation untouched.
-  const changedFiles = await deps.lookups.changedFiles(branch, base);
-  if (changedFiles.length === 0) {
-    deps.appendIterLog(
-      `🤖 /afk reconcile #${issue}: skipped (no-commits) — \`${branch}\` carries no work vs \`${base}\`.`,
-    );
-    return { outcome: "skipped", reason: "no-commits" };
-  }
+  // ---- 2. fetch gate: materialize origin-only branches before the commits diff ----
+  // branchPresent() fetches from origin on a local miss, so a branch force-pushed
+  // by a now-dead worker (present on origin, absent locally) is available for the
+  // three-dot diff below. Without this fetch, changedFiles() would silently return
+  // [] for the missing ref, triggering a false skipped:no-commits.
   if (deps.lookups.branchPresent && !(await deps.lookups.branchPresent(branch))) {
     deps.appendIterLog(
       `🤖 /afk reconcile #${issue}: skipped (branch-absent) — \`${branch}\` is not present on the host; cannot validate.`,
@@ -224,7 +220,19 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     return { outcome: "skipped", reason: "branch-absent" };
   }
 
-  // ---- 3. feedback gate (the verdict — SAME authority as the DONE path) ----
+  // ---- 3. commits gate: the branch must carry work ----
+  // changedFiles() is a three-dot diff that returns [] for an EMPTY branch.
+  // The fetch gate above guarantees the branch is local, so [] here means
+  // genuinely no commits — not a missing ref.
+  const changedFiles = await deps.lookups.changedFiles(branch, base);
+  if (changedFiles.length === 0) {
+    deps.appendIterLog(
+      `🤖 /afk reconcile #${issue}: skipped (no-commits) — \`${branch}\` carries no work vs \`${base}\`.`,
+    );
+    return { outcome: "skipped", reason: "no-commits" };
+  }
+
+  // ---- 4. feedback gate (the verdict — SAME authority as the DONE path) ----
   const startedEpoch = deps.nowEpoch();
   const feedback: RunFeedbackResult = await runFeedback(deps.pnpm, {
     worktree: branch,
@@ -234,12 +242,12 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   });
   await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
 
-  // ---- 3b. RED → ready-for-human with the real failing checks ----
+  // ---- 4b. RED → ready-for-human with the real failing checks ----
   if (!feedback.ok) {
     return await park(deps, input, feedback, startedEpoch);
   }
 
-  // ---- 3a-pre. re-verify the issue is still open immediately before landing ----
+  // ---- 4a-pre. re-verify the issue is still open immediately before landing ----
   // The candidate list and the claim window can go stale between selection and
   // here: a concurrent worker or a human may have closed the issue. Landing +
   // closing an already-closed issue churns labels on a closed thread (#568), so
@@ -251,7 +259,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     return { outcome: "skipped", reason: "already-closed" };
   }
 
-  // ---- 3a. GREEN → land via the existing landing path, then close ----
+  // ---- 4a. GREEN → land via the existing landing path, then close ----
   const locked = await deps.lookups.isLocked();
   const landing = await doLanding(
     {

--- a/src/apps/dev/tests/reconcile.test.ts
+++ b/src/apps/dev/tests/reconcile.test.ts
@@ -359,6 +359,24 @@ describe("reconcile — guards (mechanical class only)", () => {
     expect(trace.deletedRemote).toEqual([]);
     expect(trace.labelEdits).toEqual([]);
   });
+
+  it("fetches an origin-only branch before the commits gate so it is not skipped as no-commits", async () => {
+    // Simulate: branch exists on origin but not yet locally. Before branchPresent
+    // (which fetches), changedFiles would return []. After the fetch it returns work.
+    let fetched = false;
+    const { deps, input } = harness({ feedbackOk: true });
+    deps.lookups.changedFiles = async () => (fetched ? ["packages/x/src/a.ts"] : []);
+    deps.lookups.branchPresent = async () => {
+      fetched = true;
+      return true;
+    };
+
+    const result = await reconcile(deps, input);
+
+    // branchPresent ran first (fetching the branch), so changedFiles found work
+    // and the issue was salvaged rather than skipped as no-commits.
+    expect(result.outcome).toBe("landed");
+  });
 });
 
 describe("mechanicalDisqualifier", () => {


### PR DESCRIPTION
## Summary

- Moves the `branchPresent()` fetch gate before `changedFiles()` in `reconcile.ts` so a branch that exists only on origin (force-pushed by a now-dead worker) is materialized locally before the three-dot diff
- Previously, `changedFiles()` silently returned `[]` for the missing local ref, causing reconcile to return `skipped:no-commits` and no-op on the most common salvage case
- Adds a test covering the origin-only-branch path at the reconcile seam

Closes #571. Parent: #567.

## Test plan

- [ ] New test: `fetches an origin-only branch before the commits gate so it is not skipped as no-commits` — verifies `branchPresent` is called before `changedFiles`, simulating origin-only fetch behavior
- [ ] All 1138 tests pass (`pnpm test --run`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783635959&installation_id=129708444&pr_number=611&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F611&signature=1cb09ec61e949865eb311ba779e35a1748bd5122c4581ef9720c385c0f97ba44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect status classification where branches present on the host but missing locally could be misreported as "skipped: no-commits"; such cases are now detected earlier and reported as "skipped: branch-absent" so valid changes are not ignored.

* **Tests**
  * Added a test that verifies branch-presence is checked before commit checks to prevent false skips and ensure correct landing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->