### PR TITLE
fix(afk): bound synchronous ps and cold-cache gh calls to prevent event-loop stalls

### DIFF
--- a/src/apps/dev/src/runtime/caller-process.ts
+++ b/src/apps/dev/src/runtime/caller-process.ts
@@ -39,7 +39,15 @@ export function callerProcessTree(
   for (let depth = 0; depth < maxDepth; depth += 1) {
     if (!Number.isInteger(pid) || pid <= 1 || seen.has(pid)) break;
     seen.add(pid);
-    const parsed = parsePsAncestorLine(inspect(pid));
+    let raw: string;
+    try {
+      raw = inspect(pid);
+    } catch {
+      // Transient ps failure (ETIMEDOUT, EAGAIN, vanished ancestor) — stop
+      // the walk rather than propagating; runner detection gets a partial tree.
+      break;
+    }
+    const parsed = parsePsAncestorLine(raw);
     if (!parsed) break;
     if (parsed.command) commands.push(parsed.command);
     pid = parsed.ppid;
@@ -53,6 +61,7 @@ export function callerProcessTreeNative(startPid = process.ppid): string {
     execFileSync("ps", ["-o", "pid=,ppid=,comm=", "-p", String(pid)], {
       encoding: "utf8",
       maxBuffer: 64 * 1024,
+      timeout: 3000,
     }),
   );
 }

--- a/src/apps/dev/src/runtime/proc-tree.ts
+++ b/src/apps/dev/src/runtime/proc-tree.ts
@@ -116,6 +116,7 @@ export function inspectProcessTreeNative(pid: number): readonly ProcessSnapshotE
     stdout = execFileSync("ps", ["-e", "-o", "pid=,ppid=,%cpu=,comm="], {
       encoding: "utf8",
       maxBuffer: 16 * 1024 * 1024,
+      timeout: 5000,
     });
   } catch {
     // `ps` itself failed (missing binary, EAGAIN, buffer overflow, …). Failing

--- a/src/apps/dev/src/runtime/proc-tree.ts
+++ b/src/apps/dev/src/runtime/proc-tree.ts
@@ -99,28 +99,33 @@ export function collectTree(
   return out;
 }
 
+/** A synchronous runner that executes `ps -e -o pid=,ppid=,%cpu=,comm=` and
+ * returns its stdout. Injectable for testing. */
+export type PsTreeRunner = () => string;
+
 /**
- * Inspect the worker `pid`'s process tree into a ProcessSnapshotEntry[] via a
- * single `ps` snapshot of all processes. Best-effort and SAFE BY DEFAULT:
+ * Inspect the worker `pid`'s process tree into a ProcessSnapshotEntry[] using
+ * the provided `run` function to obtain the full-process-list stdout. Best-
+ * effort and SAFE BY DEFAULT:
  *   - an un-inspectable pid (<=1, NaN) → [] (no tree, deriveSnapshot is empty;
  *     a freed/garbage slot pid is genuinely not running anything).
- *   - a `ps` spawn/parse failure → CONSERVATIVE_BUSY_SNAPSHOT so the reaper
- *     never kills off the back of a transient inspection error.
- *   - a successful `ps` that simply does not list the pid (already exited) → []
+ *   - a runner throw (timeout, EAGAIN, missing binary) →
+ *     CONSERVATIVE_BUSY_SNAPSHOT so the reaper never kills off the back of a
+ *     transient inspection error.
+ *   - a successful run that simply does not list the pid (already exited) → []
  *     — that is a real, observed absence, not an inspection failure.
  */
-export function inspectProcessTreeNative(pid: number): readonly ProcessSnapshotEntry[] {
+export function inspectProcessTree(
+  pid: number,
+  run: PsTreeRunner,
+): readonly ProcessSnapshotEntry[] {
   if (!isInspectablePid(pid)) return [];
   let stdout: string;
   try {
-    stdout = execFileSync("ps", ["-e", "-o", "pid=,ppid=,%cpu=,comm="], {
-      encoding: "utf8",
-      maxBuffer: 16 * 1024 * 1024,
-      timeout: 5000,
-    });
+    stdout = run();
   } catch {
-    // `ps` itself failed (missing binary, EAGAIN, buffer overflow, …). Failing
-    // to [] would read as "stuck" and authorise a kill — refuse: report busy.
+    // runner failed (timeout, missing binary, EAGAIN, …). Falling to [] would
+    // read as "stuck" and authorise a kill — refuse: report busy.
     return CONSERVATIVE_BUSY_SNAPSHOT;
   }
   try {
@@ -129,4 +134,14 @@ export function inspectProcessTreeNative(pid: number): readonly ProcessSnapshotE
   } catch {
     return CONSERVATIVE_BUSY_SNAPSHOT;
   }
+}
+
+export function inspectProcessTreeNative(pid: number): readonly ProcessSnapshotEntry[] {
+  return inspectProcessTree(pid, () =>
+    execFileSync("ps", ["-e", "-o", "pid=,ppid=,%cpu=,comm="], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: 5000,
+    }),
+  );
 }

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -552,8 +552,9 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
 
   if (!cached) {
     // Cold cache: refresh with a bounded deadline so a hanging gh CLI cannot
-    // block the statusline render indefinitely. queue/human stay 0/0 on timeout.
-    await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined);
+    // block the statusline render indefinitely. queue/human stay 0/0 on timeout
+    // or on any gh/auth/network error.
+    await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
   } else if (nowS - cached.ts >= STATUSLINE_CACHE_TTL_S) {
     // Stale: use the cached numbers now, refresh in the background.
     void refresh().catch(() => undefined);

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -424,6 +424,29 @@ import type { AfkInput } from "../core/statusline.js";
  * statusline.sh's 60 s window. */
 export const STATUSLINE_CACHE_TTL_S = 60;
 
+/** Maximum milliseconds to wait for a cold-cache gh count refresh. If the gh
+ * CLI hangs (network stall, rate-limit backoff) the statusline falls back to
+ * 0/0 rather than blocking the render indefinitely. */
+export const STATUSLINE_GH_COLD_TIMEOUT_MS = 5000;
+
+/**
+ * Race `promise` against a deadline. If the deadline fires first, resolves
+ * with `fallback` immediately; the original promise is left to settle on its
+ * own (no cancel). If the promise settles first, clears the timer and resolves
+ * with its value.
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), ms);
+  });
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 interface StatuslineCache {
   queue: number;
   human: number;
@@ -528,8 +551,9 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   };
 
   if (!cached) {
-    // Cold cache: refresh synchronously so the first render is correct.
-    await refresh();
+    // Cold cache: refresh with a bounded deadline so a hanging gh CLI cannot
+    // block the statusline render indefinitely. queue/human stay 0/0 on timeout.
+    await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined);
   } else if (nowS - cached.ts >= STATUSLINE_CACHE_TTL_S) {
     // Stale: use the cached numbers now, refresh in the background.
     void refresh().catch(() => undefined);

--- a/src/apps/dev/tests/caller-process.test.ts
+++ b/src/apps/dev/tests/caller-process.test.ts
@@ -30,4 +30,33 @@ describe("caller-process", () => {
     const tree = callerProcessTree(30, () => "30 30 codex\n", 8);
     expect(tree).toBe("codex");
   });
+
+  it("degrades to a partial tree when the inspector throws (transient ps failure)", () => {
+    // First call succeeds, second throws — the walk stops at depth 1 and
+    // returns what it already collected rather than propagating the error.
+    const table = new Map<number, string>([
+      [30, "30 20 node\n"],
+    ]);
+    const tree = callerProcessTree(
+      30,
+      (pid) => {
+        const row = table.get(pid);
+        if (row) return row;
+        throw Object.assign(new Error("spawnSync ps ETIMEDOUT"), { code: "ETIMEDOUT" });
+      },
+      8,
+    );
+    expect(tree).toContain("node");
+    // Walk stopped — deeper ancestors not included, but no throw.
+    expect(tree).not.toContain("openai-codex");
+  });
+
+  it("returns empty string when the very first inspector call throws", () => {
+    const tree = callerProcessTree(
+      30,
+      () => { throw Object.assign(new Error("spawnSync ps ETIMEDOUT"), { code: "ETIMEDOUT" }); },
+      8,
+    );
+    expect(tree).toBe("");
+  });
 });

--- a/src/apps/dev/tests/proc-tree.test.ts
+++ b/src/apps/dev/tests/proc-tree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CONSERVATIVE_BUSY_SNAPSHOT,
   collectTree,
+  inspectProcessTree,
   inspectProcessTreeNative,
   parsePsTree,
 } from "../src/runtime/proc-tree.js";
@@ -55,18 +56,48 @@ describe("collectTree", () => {
   });
 });
 
+describe("inspectProcessTree — degrade / timeout paths", () => {
+  it("an un-inspectable pid (<=1) returns [] without calling the runner", () => {
+    const neverCalled = (): string => { throw new Error("must not be called"); };
+    expect(inspectProcessTree(0, neverCalled)).toEqual([]);
+    expect(inspectProcessTree(1, neverCalled)).toEqual([]);
+    expect(inspectProcessTree(Number.NaN, neverCalled)).toEqual([]);
+  });
+
+  it("returns CONSERVATIVE_BUSY_SNAPSHOT when the runner throws (simulated ETIMEDOUT)", () => {
+    const timeout = (): string => {
+      throw Object.assign(new Error("spawnSync ps ETIMEDOUT"), { code: "ETIMEDOUT" });
+    };
+    expect(inspectProcessTree(process.pid, timeout)).toBe(CONSERVATIVE_BUSY_SNAPSHOT);
+  });
+
+  it("a runner timeout reads as busy — reaper must not kill (deriveSnapshot)", () => {
+    const timeout = (): string => {
+      throw Object.assign(new Error("spawnSync ps ETIMEDOUT"), { code: "ETIMEDOUT" });
+    };
+    const snap = deriveSnapshot(inspectProcessTree(process.pid, timeout));
+    expect(snap.cpuPct).toBeGreaterThanOrEqual(5);
+  });
+
+  it("returns CONSERVATIVE_BUSY_SNAPSHOT when the runner throws (ENOENT — ps missing)", () => {
+    const noent = (): string => {
+      throw Object.assign(new Error("spawnSync ps ENOENT"), { code: "ENOENT" });
+    };
+    expect(inspectProcessTree(process.pid, noent)).toBe(CONSERVATIVE_BUSY_SNAPSHOT);
+  });
+
+  it("the conservative busy snapshot constant reads as busy (deriveSnapshot)", () => {
+    // Guards the constant value independent of any code path.
+    const snap = deriveSnapshot(CONSERVATIVE_BUSY_SNAPSHOT);
+    expect(snap.cpuPct).toBeGreaterThanOrEqual(5);
+  });
+});
+
 describe("inspectProcessTreeNative", () => {
   it("an un-inspectable pid (<=1) returns [] without running ps", () => {
     expect(inspectProcessTreeNative(0)).toEqual([]);
     expect(inspectProcessTreeNative(1)).toEqual([]);
     expect(inspectProcessTreeNative(Number.NaN)).toEqual([]);
-  });
-
-  it("the conservative busy fallback reads as busy (deriveSnapshot)", () => {
-    // The ps-failure fallback must NOT authorise a reap: its cpu sits above the
-    // busy line so the reaper-signal reduction reports the tree busy.
-    const snap = deriveSnapshot(CONSERVATIVE_BUSY_SNAPSHOT);
-    expect(snap.cpuPct).toBeGreaterThanOrEqual(5);
   });
 
   it("a real self-inspection returns this process in its own tree", () => {

--- a/src/apps/dev/tests/wire.test.ts
+++ b/src/apps/dev/tests/wire.test.ts
@@ -294,4 +294,19 @@ describe("withTimeout — bounded cold-cache refresh", () => {
     const result = await withTimeout(lateResolve, 20, -1);
     expect(result).toBe(-1);
   });
+
+  it("propagates rejection when the promise rejects before the deadline", async () => {
+    const failing = Promise.reject(new Error("gh auth failed"));
+    await expect(withTimeout(failing, 500, -1)).rejects.toThrow("gh auth failed");
+  });
+
+  it("returns fallback and avoids unhandled rejection when promise rejects after deadline", async () => {
+    let lateReject!: (err: Error) => void;
+    const lateRejecting = new Promise<number>((_, reject) => {
+      lateReject = reject;
+    });
+    const result = await withTimeout(lateRejecting.catch(() => -1), 20, -1);
+    lateReject(new Error("network gone"));
+    expect(result).toBe(-1);
+  });
 });

--- a/src/apps/dev/tests/wire.test.ts
+++ b/src/apps/dev/tests/wire.test.ts
@@ -8,6 +8,7 @@ import {
   collectMonitorInputs,
   readFleetState,
   resolveAttemptGuardArming,
+  withTimeout,
 } from "../src/runtime/wire.js";
 
 function scratch(): string {
@@ -271,5 +272,26 @@ describe("collectMonitorInputs", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("withTimeout — bounded cold-cache refresh", () => {
+  it("resolves with the promise value when it settles before the deadline", async () => {
+    const result = await withTimeout(Promise.resolve(42), 500, -1);
+    expect(result).toBe(42);
+  });
+
+  it("resolves with the fallback when the promise does not settle within the deadline", async () => {
+    const never = new Promise<number>(() => { /* intentionally never resolves */ });
+    const result = await withTimeout(never, 20, -1);
+    expect(result).toBe(-1);
+  });
+
+  it("resolves with fallback when promise settles after the deadline (no unhandled rejection)", async () => {
+    const lateResolve = new Promise<number>((resolve) => {
+      setTimeout(() => resolve(99), 200);
+    });
+    const result = await withTimeout(lateResolve, 20, -1);
+    expect(result).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary
- `proc-tree`: adds `timeout:5000` to `execFileSync` so a hung `ps` falls through to the existing `catch → CONSERVATIVE_BUSY_SNAPSHOT` rather than blocking the supervisor tick
- `caller-process`: catches inspector throws inside `callerProcessTree` so a transient ETIMEDOUT or vanished-ancestor degrades to a partial/empty tree; adds `timeout:3000` to the native `execFileSync` call
- `wire`: exports `withTimeout<T>` helper and `STATUSLINE_GH_COLD_TIMEOUT_MS`; cold-cache `gh` refresh now races against a 5 s deadline so a stalled `gh` CLI cannot hang the statusline render (queue/human fall back to 0/0)

## Test plan
- [ ] `pnpm -C src/apps/dev test --run` passes (1142 tests, 79 test files)
- [ ] New `withTimeout` cases in `wire.test.ts` cover timeout + happy-path
- [ ] New throwing-inspector degrade cases in `caller-process.test.ts` cover partial tree and empty tree on error

Closes #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783639264&installation_id=129708444&pr_number=612&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F612&signature=bf71dcaa6a9b7981eb84d2d2a78601393259df6141d9ef7f239643c5cc5d19d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Statusline and background refreshes no longer hang: GitHub-derived counts use a bounded cold-cache timeout so UI stays responsive.
  * Process inspection failures degrade safely: transient errors or timeouts return partial or conservative fallback snapshots instead of crashing.

* **Tests**
  * New and expanded tests cover timeout, degradation, and partial-result behaviors for process inspection and bounded refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->