### PR TITLE
fix(afk): circuit-tripped parked slot restores claimed issue via boot-stamp sweep (#577)

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -883,6 +883,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Worker id — probe the workers root for collisions.
   const existing = new Set((await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id));
   const workerId = genWorkerId(Math.random, (id) => existing.has(id));
+  // Emit the per-slot boot-stamp immediately so the supervisor's slot log
+  // captures this worker's ID before any failure. The circuit-trip sweep
+  // (sweepParkedSlot) parses `[afk] worker: wXXXX` lines from the slot log
+  // to resolve all workers that ran in a parked slot — this stamp must appear
+  // even when the worker fast-dies before writing worker.pid.
+  process.stdout.write(`[afk] worker: ${workerId}\n`);
 
   const facts = await collectPrecheckFacts(ctx);
   const nowS = Math.floor(Date.now() / 1000);

--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -7,7 +7,7 @@
 // native — no bash anywhere in the loop.
 
 import { spawn } from "node:child_process";
-import { existsSync, openSync, writeFileSync, writeSync, rmSync, renameSync } from "node:fs";
+import { existsSync, openSync, closeSync, writeFileSync, writeSync, rmSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import {
   type FleetHeartbeat,
@@ -216,12 +216,19 @@ function buildSupervisorDeps(
         // Forward the PRD/issue filter + runner-swap policy so a supervised
         // fleet honours the same filter a single `/afk run` would (gap 5).
         const runArgs = ["run", "--once", "--runner", runner, ...slotArgs];
+        // Each slot gets its own log file so the circuit-trip sweep can
+        // resolve which worker IDs ran in the slot via parseWorkerIdsFromLog
+        // (mirrors spawn_slot's per-slot slot_log in supervisor.sh).
+        const slotLogFile = join(tmpDir, `afk-supervisor-slot-${slot}.log`);
+        const slotFd = openSync(slotLogFile, "a");
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
           env: workerEnv,
           detached: true,
-          stdio: ["ignore", logFd, logFd],
+          stdio: ["ignore", slotFd, slotFd],
         });
+        // Close the parent's copy — the child inherits it and keeps it open.
+        closeSync(slotFd);
         child.unref();
         const pid = child.pid ?? 0;
         slotPids.set(slot, pid);
@@ -250,7 +257,7 @@ function buildSupervisorDeps(
       teardownIterDir: async (info) => {
         await teardownIterDirNative(info, root);
       },
-      parkedSlotWork: (slot) => parkedSlotWorkFor(tmpDir, root, slot, 0),
+      parkedSlotWork: (slot) => parkedSlotWorkFor(tmpDir, root, slot),
       removeDir: async (path) => {
         try {
           await removeDirNative(path);

--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -257,7 +257,7 @@ function buildSupervisorDeps(
       teardownIterDir: async (info) => {
         await teardownIterDirNative(info, root);
       },
-      parkedSlotWork: (slot) => parkedSlotWorkFor(tmpDir, root, slot),
+      parkedSlotWork: (slot, lastPid) => parkedSlotWorkFor(tmpDir, slot, lastPid),
       removeDir: async (path) => {
         try {
           await removeDirNative(path);

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -387,8 +387,6 @@ export interface SweepWorker {
 /** The worker IDs + claimed work that occupied a parked slot. */
 export interface SweepWork {
   workers: SweepWorker[];
-  /** Fast-death count for the discard envelope summary. */
-  fastDeaths: number;
   /** Supervisor log path quoted in the discard envelope body. */
   supervisorLogPath: string;
 }
@@ -597,6 +595,9 @@ export async function sweepParkedSlot(
   if (work.workers.length === 0) return;
 
   const workerIdsCsv = work.workers.map((w) => w.workerId).join(",");
+  // Real fast-death count lives in the circuit ring at the time of the trip,
+  // not in the FS layer (which has no visibility into the breaker state).
+  const fastDeaths = state.deaths.length;
   const hasAnyClaim = work.workers.some((w) => w.pairs.some((p) => p.issue !== null));
   if (hasAnyClaim) await deps.gh.ensureRunnerErrorLabel();
 
@@ -607,7 +608,7 @@ export async function sweepParkedSlot(
           config.runner,
           slot,
           workerIdsCsv,
-          work.fastDeaths,
+          fastDeaths,
           work.supervisorLogPath,
         );
         await deps.gh.comment(pair.issue, body);

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -315,10 +315,11 @@ export interface SupervisorFs {
    * Mirrors reap_stalled_slot step 4. */
   teardownIterDir(info: IterDirInfo): Promise<void>;
   /** Worker IDs + their claimed (iterDir, issue) pairs that occupied a parked
-   * slot. Resolved first from the per-slot boot-stamp log; falls back to the
-   * slot's last known PID (worker.pid match) when the log yields no workers
-   * (the native supervisor never writes the boot-stamp). Mirrors
-   * parse_worker_ids_from_log + iter_dirs_for_worker + iter_dir_issue_number. */
+   * slot. Resolved first from the per-slot slot-log boot-stamp (`[afk] worker:
+   * wXXXX` lines the worker emits immediately on startup); falls back to the
+   * slot's last known PID (worker.pid match) when the log yields no workers.
+   * Mirrors parse_worker_ids_from_log + iter_dirs_for_worker +
+   * iter_dir_issue_number. */
   parkedSlotWork(slot: number, lastPid: number | null): SweepWork;
   /** Remove a swept iter dir (rm -rf). Mirrors the per-pair `rm -rf "$dir"`. */
   removeDir(path: string): Promise<void>;

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -315,9 +315,11 @@ export interface SupervisorFs {
    * Mirrors reap_stalled_slot step 4. */
   teardownIterDir(info: IterDirInfo): Promise<void>;
   /** Worker IDs + their claimed (iterDir, issue) pairs that occupied a parked
-   * slot, parsed from the slot log + per-worker state. Mirrors
+   * slot. Resolved first from the per-slot boot-stamp log; falls back to the
+   * slot's last known PID (worker.pid match) when the log yields no workers
+   * (the native supervisor never writes the boot-stamp). Mirrors
    * parse_worker_ids_from_log + iter_dirs_for_worker + iter_dir_issue_number. */
-  parkedSlotWork(slot: number): SweepWork;
+  parkedSlotWork(slot: number, lastPid: number | null): SweepWork;
   /** Remove a swept iter dir (rm -rf). Mirrors the per-pair `rm -rf "$dir"`. */
   removeDir(path: string): Promise<void>;
 }
@@ -591,7 +593,9 @@ export async function sweepParkedSlot(
   if (state.swept) return;
   state.swept = true;
 
-  const work = deps.fs.parkedSlotWork(slot);
+  // state.pid is the last dead worker's PID — the fs layer uses it as a
+  // fallback when the slot log has no boot-stamp (native fleet path).
+  const work = deps.fs.parkedSlotWork(slot, state.pid);
   if (work.workers.length === 0) return;
 
   const workerIdsCsv = work.workers.map((w) => w.workerId).join(",");

--- a/src/apps/dev/src/runtime/supervisor-fs.ts
+++ b/src/apps/dev/src/runtime/supervisor-fs.ts
@@ -226,12 +226,14 @@ export function resolveIterDirInfo(
  *
  * Two resolution paths, tried in order:
  *   1. Slot log: parse `[afk] worker: wXXXX` boot-stamp lines from the
- *      per-slot log file.  Works when the worker emits the stamp before dying.
- *   2. PID fallback (lastPid): when the log yields no workers, resolve the
- *      slot's last worker via its `worker.pid` file (findSlotIterDir).  This
- *      is the primary live path for the native fleet supervisor, which routes
- *      the child's stdout/stderr to the slot log file but never writes the
- *      boot-stamp itself, so the log parse always returns [].
+ *      per-slot log file.  Each worker emits this stamp to stdout immediately
+ *      after generating its worker ID (before any I/O that could fail); the
+ *      supervisor routes the child's stdout/stderr to the slot log so the stamp
+ *      is captured even when the worker fast-dies before writing worker.pid.
+ *      This is the primary path for the native fleet.
+ *   2. PID fallback (lastPid): when the log yields no workers (e.g. a slot log
+ *      that predates the stamp or was rotated), resolve the slot's last worker
+ *      via its `worker.pid` file (findSlotIterDir).
  *
  * Empty workers list when neither path finds a worker → no-op sweep upstream.
  */

--- a/src/apps/dev/src/runtime/supervisor-fs.ts
+++ b/src/apps/dev/src/runtime/supervisor-fs.ts
@@ -221,25 +221,55 @@ export function resolveIterDirInfo(
 }
 
 /**
- * parkedSlotWork backing: every worker ID seen in the slot log → its iter dirs
- * → each dir's claimed issue. Mirrors the sweep_parked_slot collection. Empty
- * workers list when the slot log named none (no-op sweep upstream).
+ * parkedSlotWork backing: resolve every worker that occupied a parked slot and
+ * the claimed issues they held. Mirrors the sweep_parked_slot collection.
+ *
+ * Two resolution paths, tried in order:
+ *   1. Slot log: parse `[afk] worker: wXXXX` boot-stamp lines from the
+ *      per-slot log file.  Works when the worker emits the stamp before dying.
+ *   2. PID fallback (lastPid): when the log yields no workers, resolve the
+ *      slot's last worker via its `worker.pid` file (findSlotIterDir).  This
+ *      is the primary live path for the native fleet supervisor, which routes
+ *      the child's stdout/stderr to the slot log file but never writes the
+ *      boot-stamp itself, so the log parse always returns [].
+ *
+ * Empty workers list when neither path finds a worker → no-op sweep upstream.
  */
 export function parkedSlotWorkFor(
   tmpDir: string,
-  root: string,
   slot: number,
+  lastPid: number | null = null,
 ): SweepWork {
   const supervisorLogPath = join(tmpDir, "afk-supervisor.log");
+
+  // Path 1: slot log boot-stamp parse.
   const wids = parseWorkerIdsFromLog(slotLogPath(tmpDir, slot));
-  const workers: SweepWorker[] = wids.map((wid) => ({
-    workerId: wid,
-    pairs: iterDirsForWorker(root, wid).map((dir) => ({
-      dir,
-      issue: iterDirIssueNumber(dir),
-    })),
+  if (wids.length > 0) {
+    const workers: SweepWorker[] = wids.map((wid) => ({
+      workerId: wid,
+      pairs: iterDirsForWorker(tmpDir, wid).map((dir) => ({
+        dir,
+        issue: iterDirIssueNumber(dir),
+      })),
+    }));
+    return { workers, supervisorLogPath };
+  }
+
+  // Path 2: PID-based fallback — resolve the last worker via worker.pid match.
+  const iterDir = findSlotIterDir(tmpDir, lastPid);
+  if (iterDir === null) return { workers: [], supervisorLogPath };
+
+  const parsed = parseWorkerAttemptPath(iterDir);
+  if (parsed === null) return { workers: [], supervisorLogPath };
+
+  const pairs = iterDirsForWorker(tmpDir, parsed.worker).map((dir) => ({
+    dir,
+    issue: iterDirIssueNumber(dir),
   }));
-  return { workers, supervisorLogPath };
+  return {
+    workers: [{ workerId: parsed.worker, pairs }],
+    supervisorLogPath,
+  };
 }
 
 /** Best-effort worktree teardown + iter-dir removal for a reaped slot. Mirrors

--- a/src/apps/dev/src/runtime/supervisor-fs.ts
+++ b/src/apps/dev/src/runtime/supervisor-fs.ts
@@ -229,7 +229,6 @@ export function parkedSlotWorkFor(
   tmpDir: string,
   root: string,
   slot: number,
-  fastDeaths: number,
 ): SweepWork {
   const supervisorLogPath = join(tmpDir, "afk-supervisor.log");
   const wids = parseWorkerIdsFromLog(slotLogPath(tmpDir, slot));
@@ -240,7 +239,7 @@ export function parkedSlotWorkFor(
       issue: iterDirIssueNumber(dir),
     })),
   }));
-  return { workers, fastDeaths, supervisorLogPath };
+  return { workers, supervisorLogPath };
 }
 
 /** Best-effort worktree teardown + iter-dir removal for a reaped slot. Mirrors

--- a/src/apps/dev/tests/supervisor-fs.test.ts
+++ b/src/apps/dev/tests/supervisor-fs.test.ts
@@ -71,10 +71,12 @@ describe("parseWorkerIdsFromLog", () => {
 // ---------- parkedSlotWorkFor — the REAL path exercised end-to-end ----------
 
 describe("parkedSlotWorkFor (real fs — not a fake)", () => {
-  it("returns empty workers when no slot log exists", () => {
+  // --- slot-log path ---
+
+  it("returns empty workers when no slot log and no lastPid", () => {
     const tmp = scratch();
     try {
-      const work = parkedSlotWorkFor(tmp, tmp, 0);
+      const work = parkedSlotWorkFor(tmp, 0);
       expect(work.workers).toEqual([]);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
@@ -84,11 +86,8 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
   it("resolves worker ID + claimed issue from slot log + afk.state.json", () => {
     const tmp = scratch();
     try {
-      // Write the per-slot log with a worker boot-stamp (the native supervisor
-      // now writes this via spawnSlot's per-slot logFd).
       writeFileSync(slotLogPath(tmp, 0), "[afk] worker: wAAAA\n", "utf8");
 
-      // Worker dir + iter dir + state file (as a live worker would leave them).
       const iterDir = join(tmp, "workers", "wAAAA", "42-a1");
       mkdirSync(iterDir, { recursive: true });
       writeFileSync(
@@ -97,7 +96,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
         "utf8",
       );
 
-      const work = parkedSlotWorkFor(tmp, tmp, 0);
+      const work = parkedSlotWorkFor(tmp, 0);
       expect(work.workers).toHaveLength(1);
       expect(work.workers[0]!.workerId).toBe("wAAAA");
       expect(work.workers[0]!.pairs).toHaveLength(1);
@@ -117,7 +116,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       mkdirSync(iterDir, { recursive: true });
       // No afk.state.json — worker died before claiming.
 
-      const work = parkedSlotWorkFor(tmp, tmp, 1);
+      const work = parkedSlotWorkFor(tmp, 1);
       expect(work.workers).toHaveLength(1);
       expect(work.workers[0]!.pairs[0]!.issue).toBeNull();
     } finally {
@@ -151,7 +150,7 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
         "utf8",
       );
 
-      const work = parkedSlotWorkFor(tmp, tmp, 0);
+      const work = parkedSlotWorkFor(tmp, 0);
       expect(work.workers).toHaveLength(2);
       const wids = work.workers.map((w) => w.workerId);
       expect(wids).toContain("wCCCC");
@@ -167,10 +166,135 @@ describe("parkedSlotWorkFor (real fs — not a fake)", () => {
       writeFileSync(slotLogPath(tmp, 0), "[afk] worker: wEEEE\n", "utf8");
       writeFileSync(slotLogPath(tmp, 1), "[afk] worker: wFFFF\n", "utf8");
 
-      const work0 = parkedSlotWorkFor(tmp, tmp, 0);
-      const work1 = parkedSlotWorkFor(tmp, tmp, 1);
+      const work0 = parkedSlotWorkFor(tmp, 0);
+      const work1 = parkedSlotWorkFor(tmp, 1);
       expect(work0.workers.map((w) => w.workerId)).toEqual(["wEEEE"]);
       expect(work1.workers.map((w) => w.workerId)).toEqual(["wFFFF"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // --- PID-based fallback path (native fleet: no boot-stamp in slot log) ---
+
+  it("resolves worker + claimed issue from lastPid when no slot log exists", () => {
+    // This is the REAL native-fleet path: the supervisor never writes the
+    // [afk] worker: boot-stamp to the slot log, so the log parse returns [].
+    // parkedSlotWorkFor falls back to findSlotIterDir(tmpDir, lastPid) to
+    // locate the last worker via its worker.pid file.
+    const tmp = scratch();
+    try {
+      const wid = "wPPPP";
+      const pid = 99999;
+
+      // Worker dir with worker.pid matching the slot's last known PID.
+      const workerPath = join(tmp, "workers", wid);
+      mkdirSync(workerPath, { recursive: true });
+      writeFileSync(join(workerPath, "worker.pid"), String(pid), "utf8");
+
+      // Iter dir with a claimed issue (as a live worker leaves it).
+      const iterDir = join(workerPath, "55-a1");
+      mkdirSync(iterDir, { recursive: true });
+      writeFileSync(
+        join(iterDir, "afk.state.json"),
+        JSON.stringify({ current: { number: 55 } }),
+        "utf8",
+      );
+
+      const work = parkedSlotWorkFor(tmp, 0, pid);
+      expect(work.workers).toHaveLength(1);
+      expect(work.workers[0]!.workerId).toBe(wid);
+      expect(work.workers[0]!.pairs).toHaveLength(1);
+      expect(work.workers[0]!.pairs[0]!.issue).toBe(55);
+      expect(work.workers[0]!.pairs[0]!.dir).toBe(iterDir);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("PID fallback returns pre-claim worker (no afk.state.json) with issue null", () => {
+    const tmp = scratch();
+    try {
+      const wid = "wQQQQ";
+      const pid = 11111;
+
+      const workerPath = join(tmp, "workers", wid);
+      mkdirSync(workerPath, { recursive: true });
+      writeFileSync(join(workerPath, "worker.pid"), String(pid), "utf8");
+
+      // Iter dir created but worker died before writing afk.state.json.
+      const iterDir = join(workerPath, "7-a1");
+      mkdirSync(iterDir, { recursive: true });
+
+      const work = parkedSlotWorkFor(tmp, 0, pid);
+      expect(work.workers).toHaveLength(1);
+      expect(work.workers[0]!.workerId).toBe(wid);
+      expect(work.workers[0]!.pairs[0]!.issue).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("PID fallback returns empty workers when no worker.pid matches the given pid", () => {
+    const tmp = scratch();
+    try {
+      // A worker dir exists but its worker.pid does not match the lastPid.
+      const workerPath = join(tmp, "workers", "wRRRR");
+      mkdirSync(workerPath, { recursive: true });
+      writeFileSync(join(workerPath, "worker.pid"), "22222", "utf8");
+
+      const work = parkedSlotWorkFor(tmp, 0, 99999);
+      expect(work.workers).toEqual([]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("PID fallback returns empty workers when lastPid is null", () => {
+    const tmp = scratch();
+    try {
+      const work = parkedSlotWorkFor(tmp, 0, null);
+      expect(work.workers).toEqual([]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("slot-log path takes precedence over PID fallback when log has workers", () => {
+    // When the slot log has boot-stamps, use those rather than the PID path.
+    const tmp = scratch();
+    try {
+      const logWid = "wLOGG";
+      const pidWid = "wPIDD";
+      const pid = 33333;
+
+      // Slot log lists logWid.
+      writeFileSync(slotLogPath(tmp, 0), `[afk] worker: ${logWid}\n`, "utf8");
+      const logIterDir = join(tmp, "workers", logWid, "20-a1");
+      mkdirSync(logIterDir, { recursive: true });
+      writeFileSync(
+        join(logIterDir, "afk.state.json"),
+        JSON.stringify({ current: { number: 20 } }),
+        "utf8",
+      );
+
+      // PID-matched worker also exists (should be ignored).
+      const pidWorkerPath = join(tmp, "workers", pidWid);
+      mkdirSync(pidWorkerPath, { recursive: true });
+      writeFileSync(join(pidWorkerPath, "worker.pid"), String(pid), "utf8");
+      const pidIterDir = join(pidWorkerPath, "21-a1");
+      mkdirSync(pidIterDir, { recursive: true });
+      writeFileSync(
+        join(pidIterDir, "afk.state.json"),
+        JSON.stringify({ current: { number: 21 } }),
+        "utf8",
+      );
+
+      const work = parkedSlotWorkFor(tmp, 0, pid);
+      // Only the log-path worker is returned.
+      expect(work.workers).toHaveLength(1);
+      expect(work.workers[0]!.workerId).toBe(logWid);
+      expect(work.workers[0]!.pairs[0]!.issue).toBe(20);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/src/apps/dev/tests/supervisor-fs.test.ts
+++ b/src/apps/dev/tests/supervisor-fs.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseWorkerIdsFromLog,
+  parkedSlotWorkFor,
+  slotLogPath,
+} from "../src/runtime/supervisor-fs.js";
+
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), "afk-sup-fs-"));
+}
+
+// ---------- parseWorkerIdsFromLog ----------
+
+describe("parseWorkerIdsFromLog", () => {
+  it("returns [] for a missing file", () => {
+    expect(parseWorkerIdsFromLog("/no/such/file.log")).toEqual([]);
+  });
+
+  it("extracts a single worker ID from a boot-stamp line", () => {
+    const tmp = scratch();
+    try {
+      const p = join(tmp, "slot-0.log");
+      writeFileSync(p, "[afk] worker: wAAAA\n", "utf8");
+      expect(parseWorkerIdsFromLog(p)).toEqual(["wAAAA"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates IDs appearing on multiple lines (same worker respawned in slot)", () => {
+    const tmp = scratch();
+    try {
+      const p = join(tmp, "slot-0.log");
+      writeFileSync(p, "[afk] worker: wAAAA\nsome other output\n[afk] worker: wAAAA\n", "utf8");
+      expect(parseWorkerIdsFromLog(p)).toEqual(["wAAAA"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves first-seen order for multiple distinct workers", () => {
+    const tmp = scratch();
+    try {
+      const p = join(tmp, "slot-0.log");
+      writeFileSync(p, "[afk] worker: wAAAA\n[afk] worker: wBBBB\n", "utf8");
+      expect(parseWorkerIdsFromLog(p)).toEqual(["wAAAA", "wBBBB"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores lines that do not match the exact boot-stamp format", () => {
+    const tmp = scratch();
+    try {
+      const p = join(tmp, "slot-0.log");
+      writeFileSync(
+        p,
+        "starting worker wXXXX\n[afk] worker:wYYYY\n[afk] worker: wZZZZ extra\n[afk] worker: wAAAA\n",
+        "utf8",
+      );
+      expect(parseWorkerIdsFromLog(p)).toEqual(["wAAAA"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------- parkedSlotWorkFor — the REAL path exercised end-to-end ----------
+
+describe("parkedSlotWorkFor (real fs — not a fake)", () => {
+  it("returns empty workers when no slot log exists", () => {
+    const tmp = scratch();
+    try {
+      const work = parkedSlotWorkFor(tmp, tmp, 0);
+      expect(work.workers).toEqual([]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves worker ID + claimed issue from slot log + afk.state.json", () => {
+    const tmp = scratch();
+    try {
+      // Write the per-slot log with a worker boot-stamp (the native supervisor
+      // now writes this via spawnSlot's per-slot logFd).
+      writeFileSync(slotLogPath(tmp, 0), "[afk] worker: wAAAA\n", "utf8");
+
+      // Worker dir + iter dir + state file (as a live worker would leave them).
+      const iterDir = join(tmp, "workers", "wAAAA", "42-a1");
+      mkdirSync(iterDir, { recursive: true });
+      writeFileSync(
+        join(iterDir, "afk.state.json"),
+        JSON.stringify({ current: { number: 42 } }),
+        "utf8",
+      );
+
+      const work = parkedSlotWorkFor(tmp, tmp, 0);
+      expect(work.workers).toHaveLength(1);
+      expect(work.workers[0]!.workerId).toBe("wAAAA");
+      expect(work.workers[0]!.pairs).toHaveLength(1);
+      expect(work.workers[0]!.pairs[0]!.issue).toBe(42);
+      expect(work.workers[0]!.pairs[0]!.dir).toBe(iterDir);
+      expect(work.supervisorLogPath).toContain("afk-supervisor.log");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("handles a pre-claim worker (no afk.state.json → issue null)", () => {
+    const tmp = scratch();
+    try {
+      writeFileSync(slotLogPath(tmp, 1), "[afk] worker: wBBBB\n", "utf8");
+      const iterDir = join(tmp, "workers", "wBBBB", "7-a1");
+      mkdirSync(iterDir, { recursive: true });
+      // No afk.state.json — worker died before claiming.
+
+      const work = parkedSlotWorkFor(tmp, tmp, 1);
+      expect(work.workers).toHaveLength(1);
+      expect(work.workers[0]!.pairs[0]!.issue).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("collects multiple workers that ran in the same slot over successive fast deaths", () => {
+    const tmp = scratch();
+    try {
+      // Two distinct workers ran in slot 0 (K fast deaths → K workers logged).
+      writeFileSync(
+        slotLogPath(tmp, 0),
+        "[afk] worker: wCCCC\n[afk] worker: wDDDD\n",
+        "utf8",
+      );
+
+      const ccDir = join(tmp, "workers", "wCCCC", "10-a1");
+      mkdirSync(ccDir, { recursive: true });
+      writeFileSync(
+        join(ccDir, "afk.state.json"),
+        JSON.stringify({ current: { number: 10 } }),
+        "utf8",
+      );
+
+      const ddDir = join(tmp, "workers", "wDDDD", "11-a1");
+      mkdirSync(ddDir, { recursive: true });
+      writeFileSync(
+        join(ddDir, "afk.state.json"),
+        JSON.stringify({ current: { number: 11 } }),
+        "utf8",
+      );
+
+      const work = parkedSlotWorkFor(tmp, tmp, 0);
+      expect(work.workers).toHaveLength(2);
+      const wids = work.workers.map((w) => w.workerId);
+      expect(wids).toContain("wCCCC");
+      expect(wids).toContain("wDDDD");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("slot index is independent — slot 0 and slot 1 read from separate log files", () => {
+    const tmp = scratch();
+    try {
+      writeFileSync(slotLogPath(tmp, 0), "[afk] worker: wEEEE\n", "utf8");
+      writeFileSync(slotLogPath(tmp, 1), "[afk] worker: wFFFF\n", "utf8");
+
+      const work0 = parkedSlotWorkFor(tmp, tmp, 0);
+      const work1 = parkedSlotWorkFor(tmp, tmp, 1);
+      expect(work0.workers.map((w) => w.workerId)).toEqual(["wEEEE"]);
+      expect(work1.workers.map((w) => w.workerId)).toEqual(["wFFFF"]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -315,6 +315,26 @@ describe("circuit trip and sweep", () => {
     expect(io.removeDir).toHaveBeenCalledWith("/w/wAAAA/7-a1");
   });
 
+  it("passes the slot's last pid to parkedSlotWork so the fs layer can use PID-based resolution", async () => {
+    // The fs layer falls back to findSlotIterDir(tmpDir, lastPid) when the slot
+    // log has no boot-stamp (the native fleet path). sweepParkedSlot must thread
+    // state.pid through so the fallback has the dead worker's PID.
+    const { deps, io } = makeDeps({
+      parkedSlotWork: vi.fn(
+        (): SweepWork => ({ workers: [], supervisorLogPath: "" }),
+      ),
+    });
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.pid = 4242; // last dead worker's PID
+    slot.deaths = [NOW - 40, NOW - 30, NOW - 20, NOW - 10];
+    slot.spawnEpoch = NOW - 5;
+
+    await handleDeadSlot(0, slot, deps, config());
+
+    expect(io.parkedSlotWork).toHaveBeenCalledWith(0, 4242);
+  });
+
   it("sweep is idempotent and cleans dirs with no claimed issue without posting", async () => {
     const { deps, io } = makeDeps({
       parkedSlotWork: vi.fn(

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildDiscardEnvelope,
   buildReaperEnvelope,
@@ -20,6 +23,7 @@ import {
   type SupervisorDeps,
   type SweepWork,
 } from "../src/core/supervisor.js";
+import { parkedSlotWorkFor, slotLogPath } from "../src/runtime/supervisor-fs.js";
 import type { ProcessSnapshotEntry } from "../src/core/reaper-signal.js";
 
 const NOW = 1700000000;
@@ -357,6 +361,116 @@ describe("circuit trip and sweep", () => {
     io.removeDir.mockClear();
     await sweepParkedSlot(0, slot, deps, config());
     expect(io.removeDir).not.toHaveBeenCalled();
+  });
+});
+
+// ---------- circuit trip integration (real FS, native fleet path) ----------
+
+/**
+ * Integration test: the full path from circuit trip → sweepParkedSlot →
+ * parkedSlotWorkFor (real filesystem) → label restore. Uses no fake for
+ * parkedSlotWork so it exercises the actual slot-log boot-stamp resolution
+ * that the native fleet depends on.
+ *
+ * Covers acceptance criterion: "The parked-slot work resolution is exercised
+ * by an integration test over the REAL path (current coverage injects a fake
+ * and never runs it)."
+ */
+describe("circuit trip — real FS integration (slot-log boot-stamp path)", () => {
+  it("restores the claimed issue and posts a discard envelope with the correct fast-death count", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "afk-sup-int-"));
+    try {
+      // Two workers ran in slot 0 across successive fast deaths; both emit the
+      // boot-stamp so the slot log records them. Only the second claimed an issue.
+      writeFileSync(slotLogPath(tmp, 0), "[afk] worker: wAAA1\n[afk] worker: wBBB2\n", "utf8");
+
+      // wAAA1 — died before claiming (no afk.state.json → issue null).
+      const dir1 = join(tmp, "workers", "wAAA1", "9-a1");
+      mkdirSync(dir1, { recursive: true });
+
+      // wBBB2 — claimed issue #99 before fast-dying.
+      const dir2 = join(tmp, "workers", "wBBB2", "99-a1");
+      mkdirSync(dir2, { recursive: true });
+      writeFileSync(
+        join(dir2, "afk.state.json"),
+        JSON.stringify({ current: { number: 99 } }),
+        "utf8",
+      );
+
+      // Build deps with real parkedSlotWorkFor (not mocked) and mocked gh.
+      const { deps, io } = makeDeps({
+        parkedSlotWork: (slot: number, lastPid: number | null) =>
+          parkedSlotWorkFor(tmp, slot, lastPid),
+      });
+
+      // Slot state at trip: 5 fast deaths (circuitK=5), last pid irrelevant
+      // for the slot-log path but still threaded through for Path 2 fallback.
+      const state = initSupervisorState(1);
+      const slot = state.slots[0]!;
+      slot.pid = 7777;
+      slot.deaths = [NOW - 40, NOW - 30, NOW - 20, NOW - 10];
+      slot.spawnEpoch = NOW - 5; // lifetime 5s < fastDeathThresholdS(30)
+
+      const { parked } = await handleDeadSlot(0, slot, deps, config());
+
+      expect(parked).toBe(true);
+      expect(slot.parked).toBe(true);
+
+      // Discard envelope posted only for the worker that held a claim (#99).
+      expect(io.comment).toHaveBeenCalledOnce();
+      const [issue, body] = io.comment.mock.calls[0]!;
+      expect(issue).toBe(99);
+      expect(body).toContain('data-attempt-status="discarded"');
+      // Fast-death count must reflect the circuit ring (5 deaths), not 0.
+      expect(body).toContain("fast deaths: 5");
+      expect(body).toContain("slot parked after 5 fast deaths");
+
+      // Labels restored for the claimed issue.
+      expect(io.editLabels).toHaveBeenCalledWith(
+        99,
+        ["ready-for-agent", "runner-error"],
+        ["ready-for-human", "running"],
+      );
+      expect(io.ensureRunnerErrorLabel).toHaveBeenCalledOnce();
+
+      // The pre-claim worker dir is also cleaned up (issue null → no envelope,
+      // no label edit, but removeDir still fires for the iter dir).
+      const removedDirs = io.removeDir.mock.calls.map((c: unknown[]) => c[0]);
+      expect(removedDirs).toContain(dir1);
+      expect(removedDirs).toContain(dir2);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("no-ops cleanly when the slot log is empty (no stamp yet) and lastPid yields nothing", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "afk-sup-int-"));
+    try {
+      // Slot log exists but has no boot-stamp lines (pre-fix scenario or very
+      // early crash before the stamp was emitted). No worker.pid file either.
+      writeFileSync(slotLogPath(tmp, 0), "some unrelated output\n", "utf8");
+
+      const { deps, io } = makeDeps({
+        parkedSlotWork: (slot: number, lastPid: number | null) =>
+          parkedSlotWorkFor(tmp, slot, lastPid),
+      });
+
+      const state = initSupervisorState(1);
+      const slot = state.slots[0]!;
+      slot.pid = null; // no last PID → Path 2 also yields nothing
+      slot.deaths = [NOW - 40, NOW - 30, NOW - 20, NOW - 10];
+      slot.spawnEpoch = NOW - 5;
+
+      const { parked } = await handleDeadSlot(0, slot, deps, config());
+
+      expect(parked).toBe(true);
+      // No workers resolved → sweep no-ops: no envelope, no label edits.
+      expect(io.comment).not.toHaveBeenCalled();
+      expect(io.editLabels).not.toHaveBeenCalled();
+      expect(io.removeDir).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -82,7 +82,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     resolveIterDir: vi.fn((): IterDirInfo | null => null),
     teardownIterDir: vi.fn(async () => {}),
     parkedSlotWork: vi.fn(
-      (): SweepWork => ({ workers: [], fastDeaths: 0, supervisorLogPath: ".red/tmp/afk-supervisor.log" }),
+      (): SweepWork => ({ workers: [], supervisorLogPath: ".red/tmp/afk-supervisor.log" }),
     ),
     removeDir: vi.fn(async () => {}),
     comment: vi.fn(async () => {}),
@@ -285,7 +285,6 @@ describe("circuit trip and sweep", () => {
       parkedSlotWork: vi.fn(
         (): SweepWork => ({
           workers: [{ workerId: "wAAAA", pairs: [{ dir: "/w/wAAAA/7-a1", issue: 7 }] }],
-          fastDeaths: 5,
           supervisorLogPath: ".red/tmp/afk-supervisor.log",
         }),
       ),
@@ -321,7 +320,6 @@ describe("circuit trip and sweep", () => {
       parkedSlotWork: vi.fn(
         (): SweepWork => ({
           workers: [{ workerId: "wDDDD", pairs: [{ dir: "/w/wDDDD/1-a1", issue: null }] }],
-          fastDeaths: 5,
           supervisorLogPath: ".red/tmp/afk-supervisor.log",
         }),
       ),


### PR DESCRIPTION
## Summary

Fixes the circuit-trip sweep dead code path that stranded claimed issues in `running` forever when a slot's circuit breaker tripped.

- **Root cause**: `parkedSlotWorkFor` resolved workers from a per-slot log file (`afk-supervisor-slot-{N}.log`) that the native supervisor never wrote, so it always returned `[]` — causing `sweepParkedSlot` to early-return without restoring labels or posting discard envelopes.
- **Fix 1** (`supervisor-fs.ts`): Two-path resolution — primary path parses `[afk] worker: wXXXX` boot-stamp lines from the slot log; PID-based fallback for pre-stamp or rotated logs. Also fixed `iterDirsForWorker` to use `tmpDir` (not git root) and threaded `state.pid` for the Path 2 fallback.
- **Fix 2** (`run.ts`): Emit the boot-stamp immediately after generating the worker ID (before any I/O that could fail), so fast-dying workers appear in the slot log even if they crash before writing `worker.pid`.
- **Fix 3** (`supervisor.ts`): Fast-death count in the discard envelope now reads from `state.deaths.length` (the circuit ring at trip time), not a hardcoded 0.

## Acceptance criteria

- [x] When a slot's circuit breaker trips, the claimed issue is restored to `ready-for-agent` (labels: `+ready-for-agent +runner-error -ready-for-human -running`), never stranded in `running`
- [x] The parked-slot work resolution is exercised by an integration test over the REAL path — `supervisor.test.ts` "circuit trip — real FS integration (slot-log boot-stamp path)" uses `parkedSlotWorkFor` directly (no fake)
- [x] The trip-sweep discard envelope reports the true fast-death count (`state.deaths.length`, not 0)

## Test plan

- `pnpm vitest run tests/supervisor.test.ts tests/supervisor-fs.test.ts` — 64 tests, all pass
- `pnpm vitest run` — full suite 1134 tests, all pass

Closes #577

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783646192&installation_id=129708444&pr_number=616&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F616&signature=9da267009acb0d27e84a7a3007016bc220a7fc64a337f97d0626705b8a05c1e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved worker tracking by logging worker IDs immediately upon creation
  * Enhanced per-slot log file management for better worker process isolation and failure recovery
  * Refined supervisor slot-sweep logic for improved stalled worker recovery and failure handling

* **Tests**
  * Added comprehensive integration test coverage for supervisor slot management and worker ID resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->