### PR TITLE
fix(afk): circuit-tripped slot restores claimed issue + boot-stamp makes sweep reliable (#577)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see
 
 ---
 
+## afk (engineering) — circuit-tripped slot restores claimed issue; boot-stamp makes sweep reliable (#577)
+
+- **status**: modified
+- **upstream**: —
+- **why**: Three related bugs in the circuit-trip sweep (`sweepParkedSlot`). (1) The sweep resolved parked-slot workers from a per-slot log file (`afk-supervisor-slot-N.log`) that the native supervisor routed child stdout to but the worker never wrote a `[afk] worker: wXXXX` boot-stamp line into — so `parseWorkerIdsFromLog` always returned `[]` and the sweep always early-returned, stranding the claimed issue in `running` forever with no label restore and no discard envelope. (2) The PID-based fallback path (`findSlotIterDir`) was never reached in practice because the log-parse short-circuit fired first. (3) The discard envelope's fast-death count was always correct in the model (`state.deaths.length`) but was never verified to reach the envelope in an end-to-end test — a pure-fake test exercised it, but no test drove the real `parkedSlotWorkFor` filesystem path.
+- **what changed**:
+  - `src/apps/dev/src/commands/run.ts`: emit `[afk] worker: ${workerId}` to stdout immediately after generating the worker ID, before any I/O that could fail. The supervisor routes the child's stdout/stderr to the per-slot log, so the stamp is captured even when the worker fast-dies before writing `worker.pid`. This makes Path 1 (slot-log boot-stamp parse) the primary sweep-resolution path for the native fleet.
+  - `src/apps/dev/src/runtime/supervisor-fs.ts`: updated doc comments to reflect Path 1 as primary (native fleet) and Path 2 as fallback (rotated / pre-stamp logs).
+  - `src/apps/dev/src/core/supervisor.ts`: updated `SupervisorFs.parkedSlotWork` doc comment to match.
+  - `src/apps/dev/tests/supervisor.test.ts`: added a real-FS integration describe block (`circuit trip — real FS integration (slot-log boot-stamp path)`) that drives the full path `handleDeadSlot → sweepParkedSlot → parkedSlotWorkFor` against a real temp directory with boot-stamp log + worker iter dirs, verifying (a) the claimed issue is restored with `ready-for-agent`/`runner-error` labels, (b) the discard envelope carries `fast deaths: 5` (not 0), and (c) pre-claim iter dirs are also cleaned up.
+  - `src/apps/dev/tests/supervisor-fs.test.ts`: separate test suite for `parkedSlotWorkFor` real-FS paths (slot-log parse, PID fallback, empty log, missing file, multi-slot isolation).
+
+---
+
 ## model-tier-policy / branch-lock + Codex dev manifest (engineering, misc) — frontmatter + manifest hygiene (#593)
 
 - **status**: modified


### PR DESCRIPTION
## Summary

- **Root cause**: The circuit-trip sweep (`sweepParkedSlot`) resolved parked-slot workers from `parseWorkerIdsFromLog`, but the native fleet worker never emitted the `[afk] worker: wXXXX` boot-stamp to stdout — so the log parse always returned `[]` and the sweep always early-returned, stranding any claimed issue in `running` forever with no label restore and no discard envelope.
- **Fix**: Emit `[afk] worker: ${workerId}` to stdout immediately after generating the worker ID in `run.ts` (before any I/O that could fail). The supervisor routes the child's stdout/stderr to the per-slot log, so the stamp is captured even when the worker fast-dies before writing `worker.pid`.
- **Integration test**: Added a real-FS integration describe block that drives the full path `handleDeadSlot → sweepParkedSlot → parkedSlotWorkFor` against a real temp directory, verifying the claimed issue is restored with correct labels AND the discard envelope carries the true fast-death count (5, not 0).

## Acceptance criteria

- [x] When a slot's circuit breaker trips, the claimed issue is restored to the queue, never left stranded in `running`
- [x] The parked-slot work resolution is exercised by an integration test over the REAL path (current coverage injected a fake and never ran it)
- [x] The trip-sweep discard envelope reports the true fast-death count

## Test plan

- [x] `pnpm test` in `src/apps/dev` — 1207/1207 pass
- [x] New integration tests in `supervisor.test.ts` exercise the real `parkedSlotWorkFor` FS path end-to-end
- [x] New unit tests in `supervisor-fs.test.ts` cover slot-log parse, PID fallback, empty log, and multi-slot isolation

Closes #577

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783650820&installation_id=129708444&pr_number=618&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F618&signature=e75f06ea29b230dae0efccfae7da4e9a6b2e6dbb48536bf18a7a2431d7b91e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sweep reliability for AFK worker management through enhanced worker identification and logging mechanisms

* **Tests**
  * Added comprehensive integration test coverage validating worker state management, identification, and behavioral scenarios
  * Expanded test coverage for label restoration and worker lifecycle handling

* **Documentation**
  * Updated CHANGES.md with detailed documentation of engineering improvements and reliability enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->