### PR TITLE
feat(afk): exempt idle drain from fast-death ring, idle-park fleet on empty queue

### DIFF
--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -204,6 +204,8 @@ function buildSupervisorDeps(
   const now = () => Math.floor(Date.now() / 1000);
   // slot index → live orchestrator pid (SLOT_PIDS parity).
   const slotPids = new Map<number, number>();
+  // slot index → exit code of the most recent worker for that slot.
+  const slotExitCodes = new Map<number, number>();
   // Worker env (build_passthrough_env parity): start from the supervisor's full
   // env, then STRIP every internal supervisor knob in PASSTHROUGH_DENYLIST plus
   // every per-slot `_BASE` build-isolation var, so they never leak to the worker
@@ -248,11 +250,16 @@ function buildSupervisorDeps(
           detached: true,
           stdio: ["ignore", logFd, logFd],
         });
+        child.on("exit", (code) => {
+          // null means the process was killed by a signal; treat as non-clean (1).
+          slotExitCodes.set(slot, code ?? 1);
+        });
         child.unref();
         const pid = child.pid ?? 0;
         slotPids.set(slot, pid);
         return { pid, spawnEpoch: now() };
       },
+      lastExitCode: (slot) => slotExitCodes.get(slot) ?? null,
       isAlive,
       killTree: async (pid) => {
         try {

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -312,6 +312,12 @@ export interface SupervisorProc {
    * Returns its pid and spawn epoch. Absent when reconcile dispatch is not wired.
    */
   spawnReconcileWorker?(slot: number, candidate: ReconcileCandidate): Promise<{ pid: number; spawnEpoch: number }>;
+  /** Exit code of the last worker that ran in this slot, or null when unknown
+   * (killed externally, never spawned, or the impl does not track codes). A
+   * clean drain returns 0; null is treated conservatively as non-clean so it
+   * still feeds the circuit breaker. Optional so test harnesses that do not
+   * track exit codes compile without change. */
+  lastExitCode?(slot: number): number | null;
 }
 
 /** Filesystem side effects. Best-effort, like the bash `|| true` cleanups. */
@@ -462,6 +468,14 @@ export interface SlotState {
   stallSinceEpoch: number;
   /** SLOT_REAPED — the hard reap fired once. */
   reaped: boolean;
+  /** True while a spawnSlot call is in-flight for this slot. Prevents a
+   * duplicate spawn on the same slot if an enclosing tick is abandoned by
+   * the guardedTick ceiling before the spawn resolves. */
+  spawning: boolean;
+  /** True when the slot idle-parked after a clean drain (exit 0) with an
+   * empty ready queue. Distinct from a breaker-trip park: no sweep is run
+   * and the slot un-parks automatically when the queue refills. */
+  idleParked: boolean;
 }
 
 export function freshSlot(): SlotState {
@@ -475,6 +489,8 @@ export function freshSlot(): SlotState {
     stalled: false,
     stallSinceEpoch: 0,
     reaped: false,
+    spawning: false,
+    idleParked: false,
   };
 }
 
@@ -542,12 +558,19 @@ export interface TickResult {
   respawned: number[];
   /** Slots whose worker died and were handled (respawn or park). */
   deaths: number[];
+  /** Slots parked by a circuit-breaker trip this tick. */
   parked: number[];
+  /** Slots that entered idle-park this tick (clean drain, empty queue). */
+  idleParked: number[];
   reaped: number[];
   /** Slots into which a reconcile worker was dispatched this tick. */
   reconciledSlots: number[];
   /** True when the stop-file was honoured and all workers terminated. */
   stopped: boolean;
+  /** Ready-queue depth sampled at the start of this tick (0 on an abandoned
+   * tick or when readyQueueDepth is unavailable). Used by emitFleetHeartbeat
+   * so the queue is fetched exactly once per tick. */
+  queueDepth: number;
 }
 
 function fleetSlotCounts(state: SupervisorState): Pick<FleetHeartbeat, "slotsBusy" | "slotsFree" | "slotsTotal" | "slotsParked"> {
@@ -555,7 +578,7 @@ function fleetSlotCounts(state: SupervisorState): Pick<FleetHeartbeat, "slotsBus
   let slotsFree = 0;
   let slotsParked = 0;
   for (const slot of state.slots) {
-    if (slot.parked) {
+    if (slot.parked || slot.idleParked) {
       slotsParked += 1;
     } else if (slot.pid === null) {
       slotsFree += 1;
@@ -576,12 +599,10 @@ async function emitFleetHeartbeat(
   result: TickResult,
   runner: string,
 ): Promise<FleetHeartbeat> {
-  let readyForAgent = 0;
-  try {
-    readyForAgent = (await deps.gh.readyQueueDepth?.()) ?? 0;
-  } catch {
-    readyForAgent = 0;
-  }
+  // Queue depth was fetched once by superviseTick at the start of this tick
+  // and stored in result.queueDepth — reuse it here so there is exactly one
+  // readyQueueDepth call per tick (0 on a stop tick or abandoned tick).
+  const readyForAgent = result.queueDepth;
   const epoch = deps.now();
   const heartbeat: FleetHeartbeat = {
     ts: isoFromEpoch(epoch),
@@ -739,7 +760,7 @@ export async function pollStallDetector(
 
   for (let i = 0; i < state.slots.length; i += 1) {
     const slot = state.slots[i]!;
-    if (slot.parked) continue;
+    if (slot.parked || slot.idleParked) continue;
 
     const laneMtime = deps.fs.agentLaneMtime(i);
     const flagged = computeStalled(slot.spawnEpoch, laneMtime, now, config.stallThresholdS);
@@ -784,13 +805,49 @@ export async function pollStallDetector(
  * death against the circuit breaker; on a trip park the slot and run the trip
  * sweep, otherwise respawn. Returns whether the slot parked. Compose recordDeath
  * (pure) then apply the spawn / sweep side effects.
+ *
+ * A clean exit (exit code 0, i.e. NO_MORE_TASKS / empty queue drain) is exempt
+ * from the circuit breaker: it is never a fast-death, so K consecutive drains
+ * can never trip the breaker. When the queue is empty the slot idle-parks
+ * (no sweep, no discard envelope); when the queue has work it respawns
+ * immediately. Non-zero / unknown exit codes follow the original breaker logic.
+ *
+ * The spawning flag is set around the spawnSlot await so that a tick abandoned
+ * by the guardedTick ceiling (hung gh/ps call elsewhere in the tick) does not
+ * double-spawn the slot on the next pass.
  */
 export async function handleDeadSlot(
   slot: number,
   state: SlotState,
   deps: SupervisorDeps,
   config: SupervisorConfig,
+  queueDepth = 0,
 ): Promise<{ parked: boolean }> {
+  const exitCode = deps.proc.lastExitCode?.(slot) ?? null;
+  const cleanExit = exitCode === 0;
+
+  if (cleanExit) {
+    if (queueDepth === 0) {
+      // Clean drain with empty queue → idle-park (no sweep, no discard envelope).
+      state.idleParked = true;
+      return { parked: true };
+    }
+    // Clean drain but queue has work → respawn immediately without feeding the breaker.
+    state.spawning = true;
+    try {
+      const spawned = await deps.proc.spawnSlot(slot);
+      state.pid = spawned.pid;
+      state.spawnEpoch = spawned.spawnEpoch;
+    } finally {
+      state.spawning = false;
+    }
+    state.stalled = false;
+    state.stallSinceEpoch = 0;
+    state.reaped = false;
+    return { parked: false };
+  }
+
+  // Non-clean exit: record against the circuit breaker.
   const now = deps.now();
   const decision = recordDeath(state.deaths, state.spawnEpoch, now, config);
   state.deaths = decision.deaths;
@@ -802,9 +859,14 @@ export async function handleDeadSlot(
     return { parked: true };
   }
 
-  const spawned = await deps.proc.spawnSlot(slot);
-  state.pid = spawned.pid;
-  state.spawnEpoch = spawned.spawnEpoch;
+  state.spawning = true;
+  try {
+    const spawned = await deps.proc.spawnSlot(slot);
+    state.pid = spawned.pid;
+    state.spawnEpoch = spawned.spawnEpoch;
+  } finally {
+    state.spawning = false;
+  }
   // A respawn opens a fresh worker lifetime; clear any stale stall flags.
   state.stalled = false;
   state.stallSinceEpoch = 0;
@@ -861,9 +923,11 @@ export async function dispatchReconcileIfPossible(
  * superviseTick — advance the health-check loop one cycle (the body of
  * supervisor.sh's `while :` at ~1122-1141). In order:
  *   1. honour the stop-file: terminate every worker and return early.
- *   2. respawn / park dead non-parked slots (handleDeadSlot).
- *   3. poll the passive stall detector + gated hard reaper (pollStallDetector).
- *   4. reconcile dispatch: fill a free slot with a reconcile worker if eligible.
+ *   2. sample ready-queue depth (single fetch per tick, shared with heartbeat).
+ *   3. un-park idle-parked slots when the queue has work.
+ *   4. respawn / park dead non-parked, non-idle-parked, non-spawning slots.
+ *   5. poll the passive stall detector + gated hard reaper (pollStallDetector).
+ *   6. reconcile dispatch: fill a free slot with a reconcile worker if eligible.
  *
  * `stopRequested` is the injected stop-file probe (the bash `[[ -f $STOP_FILE ]]`
  * check). The real loop is `while (!await superviseTick(...).stopped)`.
@@ -878,9 +942,11 @@ export async function superviseTick(
     respawned: [],
     deaths: [],
     parked: [],
+    idleParked: [],
     reaped: [],
     reconciledSlots: [],
     stopped: false,
+    queueDepth: 0,
   };
 
   if (stopRequested()) {
@@ -889,16 +955,51 @@ export async function superviseTick(
     return result;
   }
 
-  // Respawn / park dead slots.
+  // Sample queue depth once per tick for idle-park / un-park decisions and the
+  // fleet heartbeat. Best-effort: 0 on any failure or missing implementation.
+  let queueDepth = 0;
+  try {
+    queueDepth = (await deps.gh.readyQueueDepth?.()) ?? 0;
+  } catch {
+    queueDepth = 0;
+  }
+  result.queueDepth = queueDepth;
+
+  // Un-park idle-parked slots when the queue has work to do.
   for (let i = 0; i < state.slots.length; i += 1) {
     const slot = state.slots[i]!;
-    if (slot.parked) continue;
+    if (!slot.idleParked || queueDepth === 0) continue;
+    slot.idleParked = false;
+    slot.spawning = true;
+    try {
+      const spawned = await deps.proc.spawnSlot(i);
+      slot.pid = spawned.pid;
+      slot.spawnEpoch = spawned.spawnEpoch;
+      slot.stalled = false;
+      slot.stallSinceEpoch = 0;
+      slot.reaped = false;
+    } finally {
+      slot.spawning = false;
+    }
+    result.respawned.push(i);
+  }
+
+  // Respawn / park dead non-parked, non-idle-parked, non-spawning slots.
+  // `slot.spawning` guards against a duplicate spawn when the enclosing tick
+  // was abandoned mid-spawnSlot by the guardedTick ceiling.
+  for (let i = 0; i < state.slots.length; i += 1) {
+    const slot = state.slots[i]!;
+    if (slot.parked || slot.idleParked || slot.spawning) continue;
     const pid = slot.pid;
     if (pid === null || !deps.proc.isAlive(pid)) {
       result.deaths.push(i);
-      const { parked } = await handleDeadSlot(i, slot, deps, config);
-      if (parked) result.parked.push(i);
-      else result.respawned.push(i);
+      const { parked } = await handleDeadSlot(i, slot, deps, config, queueDepth);
+      if (parked) {
+        if (slot.idleParked) result.idleParked.push(i);
+        else result.parked.push(i);
+      } else {
+        result.respawned.push(i);
+      }
     }
   }
 
@@ -969,8 +1070,8 @@ export async function runSupervisor(
     const heartbeat = await emitFleetHeartbeat(state, deps, result, config.runner);
     deps.log?.(
       `tick: slots=${state.slots.length} respawned=${result.respawned.length} ` +
-        `deaths=${result.deaths.length} parked=${result.parked.length} reaped=${result.reaped.length} ` +
-        `ready=${heartbeat.readyForAgent} busy=${heartbeat.slotsBusy} free=${heartbeat.slotsFree}`,
+        `deaths=${result.deaths.length} parked=${result.parked.length} idle-parked=${result.idleParked.length} ` +
+        `reaped=${result.reaped.length} ready=${heartbeat.readyForAgent} busy=${heartbeat.slotsBusy} free=${heartbeat.slotsFree}`,
     );
     if (result.stopped) return;
     await deps.proc.sleep(config.pollIntervalS * 1000);
@@ -979,7 +1080,7 @@ export async function runSupervisor(
 
 /** A non-stop tick result (the abandon/error fallback). */
 function continueResult(): TickResult {
-  return { respawned: [], deaths: [], parked: [], reaped: [], reconciledSlots: [], stopped: false };
+  return { respawned: [], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0 };
 }
 
 /**

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -55,6 +55,7 @@ interface FakeIo {
   killTree: ReturnType<typeof vi.fn>;
   inspectTree: ReturnType<typeof vi.fn>;
   sleep: ReturnType<typeof vi.fn>;
+  lastExitCode: ReturnType<typeof vi.fn>;
   agentLaneMtime: ReturnType<typeof vi.fn>;
   resolveIterDir: ReturnType<typeof vi.fn>;
   teardownIterDir: ReturnType<typeof vi.fn>;
@@ -89,6 +90,8 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     // tick wins and `stopped` propagates — matching production, where `sleep` is a
     // real timer that never beats a sub-second tick.
     sleep: vi.fn((_ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 0))),
+    // Default: exit code unknown (null) → treated as non-clean → circuit-breaker path.
+    lastExitCode: vi.fn((_slot: number) => null as number | null),
     agentLaneMtime: vi.fn(() => 0),
     resolveIterDir: vi.fn((): IterDirInfo | null => null),
     teardownIterDir: vi.fn(async () => {}),
@@ -111,6 +114,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       spawnSlot: io.spawnSlot,
       spawnReconcileWorker: io.spawnReconcileWorker,
       isAlive: io.isAlive,
+      lastExitCode: io.lastExitCode,
       killTree: io.killTree,
       inspectTree: io.inspectTree,
       sleep: io.sleep,
@@ -758,9 +762,13 @@ describe("runSupervisor", () => {
   });
 
   it("emits one structured fleet heartbeat per supervise tick with queue and slot counts", async () => {
+    // readyQueueDepth is now called once per tick (in superviseTick, not in
+    // emitFleetHeartbeat). The stop tick returns early and skips the fetch, so
+    // only one call happens (tick 1). The second heartbeat uses queueDepth: 0
+    // (the default for a stop tick).
     const { deps, io } = makeDeps({
       isAlive: vi.fn((pid: number) => pid !== 1001),
-      readyQueueDepth: vi.fn().mockResolvedValueOnce(5).mockResolvedValueOnce(4),
+      readyQueueDepth: vi.fn().mockResolvedValueOnce(5),
       now: vi.fn().mockReturnValueOnce(NOW).mockReturnValueOnce(NOW).mockReturnValueOnce(NOW).mockReturnValueOnce(NOW + 15),
     });
     const state = initSupervisorState(1);
@@ -779,7 +787,8 @@ describe("runSupervisor", () => {
     });
     expect(io.emitFleetHeartbeat.mock.calls[1]![0]).toMatchObject({
       ts: new Date((NOW + 15) * 1000).toISOString(),
-      readyForAgent: 4,
+      // Stop tick returns early before the queue-depth fetch; readyForAgent: 0.
+      readyForAgent: 0,
       spawnsThisTick: 0,
     });
   });
@@ -821,8 +830,8 @@ describe("envelope builders", () => {
 describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () => {
   const never = (): Promise<void> => new Promise<void>(() => {});
   const immediate = (): Promise<void> => Promise.resolve();
-  const okResult = { respawned: [1], deaths: [], parked: [], reaped: [], reconciledSlots: [], stopped: false };
-  const CONTINUE = { respawned: [], deaths: [], parked: [], reaped: [], reconciledSlots: [], stopped: false };
+  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0 };
+  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0 };
 
   it("returns the tick result when it completes before the ceiling", async () => {
     const logs: string[] = [];
@@ -853,6 +862,175 @@ describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () =>
     );
     expect(r).toEqual(CONTINUE);
     expect(logs.some((l) => l.includes("threw") && l.includes("gh boom"))).toBe(true);
+  });
+});
+
+// ---------- idle-drain: exit 0 idle-parks and un-parks on queue refill (#578) ----------
+
+describe("idle-drain: exit 0 idle-parks without tripping the circuit breaker", () => {
+  it("exit 0 with empty queue idle-parks the slot — no fast-death, no sweep, no spawn", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => false),
+      readyQueueDepth: vi.fn(async () => 0),
+    });
+    io.lastExitCode.mockImplementation((slot: number) => (slot === 0 ? 0 : null));
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.pid = 5000;
+    slot.spawnEpoch = NOW - 5; // would be a fast-death lifetime if counted
+
+    const result = await superviseTick(state, deps, config(), () => false);
+
+    expect(result.deaths).toEqual([0]);
+    expect(result.idleParked).toEqual([0]);
+    expect(result.parked).toEqual([]);
+    expect(result.respawned).toEqual([]);
+    expect(slot.idleParked).toBe(true);
+    expect(slot.parked).toBe(false);
+    // Death ring untouched — a clean exit is never a fast-death.
+    expect(slot.deaths).toEqual([]);
+    // No spawn, no discard envelope, no label edits.
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(io.comment).not.toHaveBeenCalled();
+    expect(io.editLabels).not.toHaveBeenCalled();
+  });
+
+  it("five consecutive exit-0 drains do NOT trip the circuit breaker", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => false),
+      readyQueueDepth: vi.fn(async () => 0),
+    });
+    io.lastExitCode.mockReturnValue(0);
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+
+    for (let i = 0; i < 5; i++) {
+      slot.idleParked = false;
+      slot.pid = 1000 + i;
+      slot.spawnEpoch = NOW - 5;
+      await superviseTick(state, deps, config(), () => false);
+    }
+
+    expect(slot.parked).toBe(false);
+    expect(slot.idleParked).toBe(true);
+    expect(slot.deaths).toEqual([]);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+  });
+
+  it("exit 0 with non-empty queue respawns immediately without counting as fast-death", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => false),
+      readyQueueDepth: vi.fn(async () => 2),
+      spawnSlot: vi.fn(async () => ({ pid: 8888, spawnEpoch: NOW })),
+    });
+    io.lastExitCode.mockReturnValue(0);
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.pid = 5000;
+    slot.spawnEpoch = NOW - 5;
+
+    const result = await superviseTick(state, deps, config(), () => false);
+
+    expect(result.respawned).toEqual([0]);
+    expect(result.idleParked).toEqual([]);
+    expect(result.parked).toEqual([]);
+    expect(slot.idleParked).toBe(false);
+    expect(slot.parked).toBe(false);
+    expect(slot.deaths).toEqual([]);
+    expect(slot.pid).toBe(8888);
+    expect(io.spawnSlot).toHaveBeenCalledWith(0);
+  });
+
+  it("idle-parked slot respawns when queue refills", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      readyQueueDepth: vi.fn(async () => 3),
+      spawnSlot: vi.fn(async () => ({ pid: 7777, spawnEpoch: NOW })),
+    });
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.idleParked = true;
+    slot.pid = null;
+
+    const result = await superviseTick(state, deps, config(), () => false);
+
+    expect(slot.idleParked).toBe(false);
+    expect(slot.pid).toBe(7777);
+    expect(result.respawned).toEqual([0]);
+    expect(result.idleParked).toEqual([]);
+    expect(io.spawnSlot).toHaveBeenCalledWith(0);
+  });
+
+  it("idle-parked slot stays parked when queue is empty", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      readyQueueDepth: vi.fn(async () => 0),
+    });
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.idleParked = true;
+    slot.pid = null;
+
+    const result = await superviseTick(state, deps, config(), () => false);
+
+    expect(slot.idleParked).toBe(true);
+    expect(result.respawned).toEqual([]);
+    expect(result.idleParked).toEqual([]);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+  });
+
+  it("idle-parked slot is skipped by the stall detector", async () => {
+    // A slot that idle-parked has no live process; the stall detector must not
+    // try to inspect or reap it (it has no pid and no lane to measure).
+    const { deps, io } = makeDeps({
+      agentLaneMtime: vi.fn(() => NOW - 9999),
+      readyQueueDepth: vi.fn(async () => 0),
+    });
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.idleParked = true;
+    slot.pid = null;
+    slot.spawnEpoch = NOW - 9999;
+
+    await pollStallDetector(state, deps, config({ stallThresholdS: 30, stallKillThresholdS: 90 }));
+
+    expect(io.killTree).not.toHaveBeenCalled();
+    expect(io.comment).not.toHaveBeenCalled();
+    expect(slot.reaped).toBe(false);
+  });
+});
+
+// ---------- spawning guard: prevents duplicate spawn on abandoned tick (#578) ----------
+
+describe("spawning guard: prevents duplicate spawn when tick is abandoned mid-spawn", () => {
+  it("skips a slot with spawning=true to prevent double-spawn", async () => {
+    const { deps, io } = makeDeps({ isAlive: vi.fn(() => false) });
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.pid = null;
+    slot.spawning = true; // in-flight spawn from an abandoned tick
+
+    const result = await superviseTick(state, deps, config(), () => false);
+
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(result.deaths).toEqual([]);
+    expect(result.respawned).toEqual([]);
+  });
+
+  it("spawning flag is cleared after a successful spawn inside handleDeadSlot", async () => {
+    const { deps } = makeDeps({
+      isAlive: vi.fn(() => false),
+      readyQueueDepth: vi.fn(async () => 0),
+    });
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.pid = 5000;
+    slot.spawnEpoch = NOW - 1000; // slow death → respawn
+
+    await handleDeadSlot(0, slot, deps, config());
+
+    expect(slot.spawning).toBe(false);
+    expect(slot.pid).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #578 (parent: #567).

- A clean drain (exit 0 / NO_MORE_TASKS) is now exempt from the fast-death ring: K consecutive drains can never trip the circuit breaker
- An empty queue causes idle-park (`slot.idleParked = true`) with no sweep, no discard envelope, and no breaker recording
- When the queue refills, `superviseTick` un-parks idle-parked slots and spawns a new worker immediately
- The `spawning` flag set around every `spawnSlot` await prevents a double-spawn when an enclosing tick is abandoned by the `guardedTick` ceiling before the spawn resolves

## Acceptance criteria

- [x] A clean drain (exit 0 / NO_MORE_TASKS) is not counted as a fast-death
- [x] An idle fleet does not park its slots; a refilled queue is picked up
- [x] Respawn is gated on ready-queue depth and a parked slot can un-park
- [x] An abandoned (timed-out) tick does not double-spawn a slot
- [x] Tests cover idle-drain-does-not-trip and exit-0-not-fast-death

## Test plan

- `tests/supervisor.test.ts` — 54 tests (all passing), including new describe blocks:
  - `idle-drain: exit 0 idle-parks without tripping the circuit breaker` (6 tests)
  - `spawning guard: prevents duplicate spawn when tick is abandoned mid-spawn` (2 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783654419&installation_id=129708444&pr_number=620&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F620&signature=3608f0003533d043ec2ed27efbfdaeb485f29f28518290e2ad605a9721638aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-worker exit-code tracking and an “idle‑parked” state to keep cleanly idle workers paused.
  * Queue depth sampled once per supervisor tick, used for heartbeats and spawn decisions.

* **Bug Fixes**
  * Prevented duplicate worker spawns during interrupted/respawn flows.
  * Stall detector skips parked/idle slots to avoid false alerts.

* **Tests**
  * Expanded coverage for idle‑drain, spawn‑guard, and tick/heartbeat behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->