### PR TITLE
feat(afk): OpenCode as the third runner, addressing OpenRouter (ADR 0059)

### DIFF
--- a/.red/adr/0059-opencode-is-the-third-afk-runner-over-openrouter.md
+++ b/.red/adr/0059-opencode-is-the-third-afk-runner-over-openrouter.md
@@ -1,0 +1,89 @@
+# OpenCode is the third AFK runner, addressing OpenRouter through its own model slug
+
+## Status
+
+accepted.
+
+## Context
+
+AFK ships two inner-agent runners — Claude Code and Codex — each integrated the
+same per-runner way: a `runner-<name>.md` contract (spawn shape, stdout parsing,
+exhaustion strings, model-tier table) plus a sandcastle agent provider injected
+through the `agentFor` seam (ADR 0003 per-runner adapters, ADR 0033 sandcastle
+execution substrate, ADR 0049 model-tier routing). Both are **session-auth**: the
+runner authenticates through an interactive host session (a logged-in Claude Code
+or Codex), and the detection cascade can therefore sniff "which host am I running
+under" from ambient env / process tree / script path.
+
+We want a third runner that runs where there is **no host session** — most
+concretely the CI Actions lane — and that reaches a broad set of models through a
+single API key. OpenCode over OpenRouter fits: OpenCode is a coding agent that
+addresses any OpenRouter model through its own `openrouter/<vendor>/<model>` slug
+and an `OPENROUTER_API_KEY`. sandcastle 0.6.6 already ships `opencode(model,
+options)` as a first-class agent, where `OpenCodeOptions.env` carries the API key
+and `OpenCodeOptions.variant` is OpenCode's reasoning knob — so no upstream
+sandcastle work is needed, only AFK-side wiring.
+
+The novelty versus the existing two runners is that OpenCode has no caller
+identity: **no host session is ever OpenCode**. Auto-sniffing it would be
+incorrect by construction.
+
+## Decision
+
+Integrate OpenCode as the third runner following the established per-runner
+pattern, with one deliberate divergence in the detection cascade:
+
+- **Contract.** `plugins/dev/skills/engineering/afk/runner-opencode.md` documents
+  the provider wiring, the OpenRouter slug + env seam, the per-tier model table,
+  and the exhaustion strings.
+- **Provider.** `execution.ts` adds `opencode` to `AgentRunner` and a pure,
+  unit-tested `buildAgent` seam that maps a runner+model+effort to a sandcastle
+  provider. For opencode it forwards the `openrouter/<vendor>/<model>` slug
+  unchanged, maps AFK's per-tier `effort` to OpenCode's `variant` (no gating —
+  variant is a free-form string), and delivers `OPENROUTER_API_KEY` through
+  `OpenCodeOptions.env`. `defaultSandcastleDeps` binds the real
+  `core.{claudeCode,codex,opencode}` factories and `process.env`.
+- **Detection — explicit pin only.** `opencode` joins the runner vocabulary so
+  `--runner opencode` and `RED_AFK_RUNNER=opencode` validate, but is added to
+  **none** of the ambient-detection surfaces (env keys, process-tree regex, script
+  path). The cascade can never resolve to opencode from caller identity; only an
+  explicit pin or an operator-configured `afk.default_runner: opencode` selects it.
+- **Model tiers.** `config.ts` `CONFIG_DEFAULTS` gains `afk.models.opencode.<tier>.
+  {model,effort}` rows (validate/simple/complex/think), and `resolveTier` reads the
+  opencode table for an opencode runner. Defaults mirror the Claude tier
+  capabilities over OpenRouter; operators override per repo under
+  `plugins.dev.afk.models.opencode.*` (ADR 0042 unified config).
+
+## Considered options
+
+- **Auto-sniff opencode like claude/codex** — rejected: there is no OpenCode host
+  session to detect, so any sniff would be a false positive. Pin-only is the
+  correct model for an API-auth runner.
+- **A generic OpenRouter runner decoupled from OpenCode** — rejected: it would
+  duplicate the agent/spawn machinery sandcastle's `opencode` provider already
+  owns, and OpenRouter is reachable purely through OpenCode's own slug, so the
+  thin path is to ride the existing provider.
+- **Thread the API key through a new `agentFor` parameter** — rejected as
+  unnecessary surface: the key lives in the worker environment, and `buildAgent`
+  reads it from the injected `env`, keeping the `agentFor` signature unchanged and
+  the env passthrough unit-testable with a fake env.
+
+## Consequences
+
+- AFK gains an API-auth lane that runs without a host session — the substrate the
+  CI Actions lane needs. The CI E2E that exercises that lane end-to-end is a
+  separate slice; this decision covers the runner integration and local invocation
+  given an `OPENROUTER_API_KEY`.
+- `effort` is overloaded across runners: a numeric knob for Claude/Codex (gated per
+  provider, FIX D) and a free-form `variant` string for OpenCode. `buildAgent`
+  centralises both so the divergence is in one tested place.
+- Auxiliary host-CLI spawns that predate this work — the per-issue classifier, the
+  merge conflict resolver, the validation sidecar — still branch only on
+  `codex` vs `claude` and fall to the `claude` branch under an opencode pin. They
+  degrade safely (the host spawn returns non-zero rather than throwing, so the
+  classifier falls back to its deterministic result), but routing them through
+  OpenCode is deferred to the Actions-lane slice.
+- `--fallback-runner` swaps to a session-auth runner on exhaustion; in an
+  OpenRouter-only lane with no host session, opencode should run without it so an
+  exhaustion is terminal-through-recovery rather than a swap to an unavailable
+  runner.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -42,6 +42,7 @@ stale notes inline.
 - **0050** AFK salvages an uncommitted worktree when the inner agent emits DONE without committing (codex non-compliance net) *(complements 0047, 0028)*
 - **0051** AFK attempt-progress guard resets on worktree edits, not just commits — stops false-stalling the productive-but-not-committing codex runner *(refines 0044, 0045)*
 - **0054** AFK arms the attempt guard + heartbeat under docker/podman isolation via an attempt-dir bind mount; lane-idle reaper stays host-only *(supersedes 0044 §4 / 0045 §4; relies on 0033; absorbs #284 docker E2E)*
+- **0059** OpenCode is the third AFK runner, addressing OpenRouter through its own `openrouter/<vendor>/<model>` slug + the `OpenCodeOptions.env` auth seam; accepted only as an explicit pin, never auto-sniffed *(follows 0003, 0033, 0049)*
 
 ## Branch lock
 - **0006** Branch lock enforces on the agent only, not the human terminal

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: afk
 description: Autonomous loop that drains the `ready-for-agent` queue on the issue tracker. Each iteration claims an issue, runs it in an isolated worktree, executes with claude or codex, merges back to main, and closes the issue. Use when the user wants to run AFK execution, drain a PRD, hammer specific issues, or otherwise let agents grind through the backlog.
-argument-hint: "[--prd N | --issues N,N,N] [--runner claude|codex] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] [--boot-only] | fleet [N] | fleet stop | monitor | dashboard | daily-review | weekly-review | retake N | reap"
+argument-hint: "[--prd N | --issues N,N,N] [--runner claude|codex|opencode] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] [--boot-only] | fleet [N] | fleet stop | monitor | dashboard | daily-review | weekly-review | retake N | reap"
 ---
 
 # /afk
@@ -102,13 +102,13 @@ Run before the first iteration:
 2. Ensure `.red/tmp/` is in `.gitignore` of the primary checkout. Append if missing.
 3. **Generate the worker ID.** Literal `w` + 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`). On the astronomically unlikely chance the chosen ID already maps to a live worker directory `.red/tmp/workers/{id}` (its `worker.pid` alive), regenerate. Print the ID on the first line of the run: `worker: {id}`. All per-attempt paths interpolate `{id}`, the issue number `{N}`, and the attempt number `{n}`.
 4. Resolve the runner via the detection cascade:
-   1. `--runner X` flag (pin) — wins over everything, logged as `detected via --runner pin`.
-   2. **Caller runner env** — `RED_AFK_RUNNER=claude|codex|hermes` is the host-session identity and wins over ambient env/process/path sniffing. Under Codex, invoke the bundle as `RED_AFK_RUNNER=codex ...`; under Claude Code, invoke it as `RED_AFK_RUNNER=claude ...`. Logged as `detected via env-var`.
+   1. `--runner X` flag (pin) — wins over everything, logged as `detected via --runner pin`. `opencode` (ADR 0059) is valid **only here or via `RED_AFK_RUNNER`** — it is never auto-sniffed below, since no host session is OpenCode.
+   2. **Caller runner env** — `RED_AFK_RUNNER=claude|codex|hermes|opencode` is the host-session identity (or, for `opencode`, an explicit API-auth pin) and wins over ambient env/process/path sniffing. Under Codex, invoke the bundle as `RED_AFK_RUNNER=codex ...`; under Claude Code, invoke it as `RED_AFK_RUNNER=claude ...`. Logged as `detected via env-var`.
    3. **Env-var sniff** — `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, or `CLAUDE_CODE_SSE_PORT` → `claude`; `CODEX_HOME`, `CODEX_SANDBOX`, `CODEX_SANDBOX_NETWORK_DISABLED`, or `CODEX_MANAGED_BY_NPM` → `codex`. Logged as `detected via env-var`.
    4. **Process-tree sniff** — if the invoking process tree contains Claude Code, use `claude`; if it contains Codex, use `codex`. Logged as `detected via process`. This is the normal path for repo-local skill copies whose filesystem path is neutral.
    5. **`$BASH_SOURCE` path sniff** — script lives under `~/.claude/...` → `claude`; under `~/.codex/...` → `codex`. Logged as `detected via path`.
    6. **Default fallback** — `claude`. Logged as `detected via env-fallback`.
-   The boot log prints one line per invocation: `runner: <runner> (detected via <method>)`. Load [`runner-claude.md`](runner-claude.md) or [`runner-codex.md`](runner-codex.md) so the spawn command is ready.
+   The boot log prints one line per invocation: `runner: <runner> (detected via <method>)`. Load [`runner-claude.md`](runner-claude.md), [`runner-codex.md`](runner-codex.md), or [`runner-opencode.md`](runner-opencode.md) so the spawn command is ready.
    Do not probe `command -v claude` / `command -v codex` to choose a different runner after a transport failure. Installed binaries are capabilities, not caller identity. A runner swap is allowed only when the user explicitly passes `--fallback-runner`.
 5. Read [`SAFETY.md`](SAFETY.md). It is binding for every shell action the loop takes.
 6. **Write the per-worker pid file.** Create `.red/tmp/workers/{id}/` and write `worker.pid` (current `$$`) **once** — this is the worker's single liveness anchor for its whole lifetime.
@@ -356,7 +356,7 @@ Default behaviour is **no rotation and no fallback** — the runner resolved by 
 - `--alternate` re-enables round-robin rotation between consecutive issues (claude → codex → claude → …). Mutually exclusive with `--runner`.
 - `--fallback-runner` re-enables mid-issue swap when the active runner returns `RUNNER_EXHAUSTED`. Without it, exhaustion is terminal for the current runner invocation and routes through bounded recovery as `blocked:quota`.
 
-Exhaustion detection lives in [`runner-claude.md`](runner-claude.md) and [`runner-codex.md`](runner-codex.md) — they own the per-runner error strings. The orchestrator only sees `RUNNER_EXHAUSTED` as a structured signal.
+Exhaustion detection lives in [`runner-claude.md`](runner-claude.md), [`runner-codex.md`](runner-codex.md), and [`runner-opencode.md`](runner-opencode.md) — they own the per-runner error strings. The orchestrator only sees `RUNNER_EXHAUSTED` as a structured signal. Note `opencode` is an API-auth runner (OpenRouter); in an OpenRouter-only lane with no host session, run it without `--fallback-runner` so exhaustion is terminal-through-recovery rather than a swap to a session-auth runner that is not present.
 
 When swap happens mid-issue (only with `--fallback-runner`), the same worktree and handoff file are reused; the new runner sees the previous agent's Notes appended.
 

--- a/plugins/dev/skills/engineering/afk/runner-opencode.md
+++ b/plugins/dev/skills/engineering/afk/runner-opencode.md
@@ -1,0 +1,97 @@
+# Runner: OpenCode
+
+How `/afk` invokes OpenCode as the inner agent for one issue (ADR 0059). OpenCode
+is the **API-auth** runner: it addresses OpenRouter through OpenCode's own model
+slug and an API key, with no host session of its own. The other two runners
+(Claude Code, Codex) authenticate through an interactive host session; OpenCode
+is the lane that runs where there is no such session — notably the CI Actions lane.
+
+## Selection — explicit pin only
+
+OpenCode is accepted **only as an explicit pin**:
+
+- `--runner opencode`, or
+- `RED_AFK_RUNNER=opencode`.
+
+It is **never auto-sniffed** from caller identity (ambient env, process tree, or
+script path) — no host session is OpenCode, so there is nothing to sniff. The
+detection cascade (`runner-detection.ts`) lists opencode in the runner vocabulary
+so the flag / env pin validates, but adds opencode to none of the ambient-detection
+surfaces. An operator-configured `afk.default_runner: opencode` is honoured (that
+is configuration, not a sniff).
+
+## Spawn
+
+OpenCode is a first-class sandcastle agent (`@ai-hero/sandcastle` ≥ 0.6.6 ships
+`opencode(model, options)`), so AFK does **not** assemble a CLI invocation itself —
+it injects the provider through the `agentFor` seam (ADR 0033) and sandcastle owns
+the spawn, the worktree, the sandbox, and completion-signal detection. The wiring
+lives in `execution.ts` (`buildAgent`):
+
+- **model** — OpenCode's own `openrouter/<vendor>/<model>` slug, taken verbatim
+  from the resolved `afk.models.opencode.<tier>.model` entry and forwarded
+  unchanged. OpenRouter is addressed purely through this slug; there is no
+  separate provider config.
+- **variant** — AFK's per-tier `effort` maps to `OpenCodeOptions.variant` (OpenCode's
+  own reasoning knob, a free-form string such as `low`/`medium`/`high`). Unlike
+  Claude/Codex, which take a numeric `effort`, OpenCode's variant is not gated —
+  the configured effort passes straight through.
+- **env** — the OpenRouter API key is delivered through `OpenCodeOptions.env` as
+  `OPENROUTER_API_KEY`, read from the worker process environment. This is the auth
+  seam: under a container sandbox (which does not inherit `process.env`) the
+  explicit `env` option is what carries the key into the agent.
+
+The handoff/prompt, branch strategy, sentinels, and continuous-push behaviour are
+identical to the other runners — they are owned by the shared execution layer, not
+the runner.
+
+## Model tier table (ADR 0049)
+
+Defaults under `afk.models.opencode.<tier>.{model,effort}` mirror the Claude tier
+**capabilities** (cheap → strong) over OpenRouter. Operators override per repo via
+`plugins.dev.afk.models.opencode.*` in `.red/config.yaml` — point the tiers at any
+OpenRouter vendor/model (e.g. `openrouter/openai/...`, `openrouter/google/...`).
+
+| tier | default model | variant (effort) | use |
+|---|---|---|---|
+| validate | `openrouter/anthropic/claude-3.5-haiku` | low | fuzzy/semantic checks; the AFK per-issue classifier |
+| simple | `openrouter/anthropic/claude-sonnet-4` | high | simple, well-specified, single-scope code |
+| complex | `openrouter/anthropic/claude-opus-4` | medium | cross-module / architectural / risk-sensitive code |
+| think | `openrouter/anthropic/claude-opus-4` | high | design, planning, routing (the default class) |
+
+## Exhaustion Detection
+
+OpenCode rides OpenRouter, so quota / rate-limit exhaustion surfaces as OpenRouter
+errors. The orchestrator's exhaustion matcher (`isRunnerExhausted`, `runner-spawn.ts`)
+keys off these strings in the agent output / error chain:
+
+- `usage limit`, `weekly cap`, `session exhausted`, `try again later`,
+- `quota`, `rate_limit` / `rate_limit_error`,
+- OpenRouter HTTP `402` (insufficient credits) / `429` (rate limited) responses,
+  which carry one of the substrings above.
+
+On any of those the orchestrator emits the internal `RUNNER_EXHAUSTED` signal,
+preserves the worktree, and (only under `--fallback-runner`) swaps to the
+alternate runner. Note that the alternate is a session-auth runner (claude/codex);
+in an OpenRouter-only lane with no host session, run OpenCode **without**
+`--fallback-runner` so an exhaustion is terminal-through-recovery rather than a
+swap to an unavailable runner.
+
+## Working Directory
+
+OpenCode runs with the sandcastle-created worktree as its working directory and
+has filesystem access only inside it, exactly like the other runners. The handoff
+file lives one level above the worktree, at
+`.red/tmp/workers/{id}/{N}-a{n}/handoff.md`, so it survives runner retries.
+
+## Known limitations (this slice)
+
+- The per-issue **classifier** and the merge **conflict resolver** / **validation
+  sidecar** spawn a host CLI directly (`codex` or, by default, `claude`) rather
+  than OpenCode. Under an opencode pin they fall to the `claude` branch; if no
+  Claude session is present the classifier degrades cleanly to its deterministic
+  result (the host spawn returns non-zero, never throws), so the attempt is not
+  wedged. Routing these auxiliary spawns through OpenCode is left to the CI
+  Actions-lane slice.
+- The CI E2E that exercises the Actions lane end-to-end is a separate slice; this
+  contract covers local invocation given an `OPENROUTER_API_KEY`.

--- a/src/apps/dev/src/core/config.ts
+++ b/src/apps/dev/src/core/config.ts
@@ -46,6 +46,20 @@ export const CONFIG_DEFAULTS = {
   "afk.models.codex.complex.effort": "medium",
   "afk.models.codex.think.model": "gpt-5.5",
   "afk.models.codex.think.effort": "high",
+  // OpenCode tiers (ADR 0059). The model is OpenCode's own
+  // `openrouter/<vendor>/<model>` slug — OpenRouter is addressed purely through
+  // that slug, no provider config beyond OPENROUTER_API_KEY. The effort maps to
+  // OpenCode's `variant`. Defaults mirror the Claude tier capabilities (cheap →
+  // strong) via OpenRouter; operators override per repo under
+  // `plugins.dev.afk.models.opencode.<tier>.*`.
+  "afk.models.opencode.validate.model": "openrouter/anthropic/claude-3.5-haiku",
+  "afk.models.opencode.validate.effort": "low",
+  "afk.models.opencode.simple.model": "openrouter/anthropic/claude-sonnet-4",
+  "afk.models.opencode.simple.effort": "high",
+  "afk.models.opencode.complex.model": "openrouter/anthropic/claude-opus-4",
+  "afk.models.opencode.complex.effort": "medium",
+  "afk.models.opencode.think.model": "openrouter/anthropic/claude-opus-4",
+  "afk.models.opencode.think.effort": "high",
   "afk.hooks.defaults.cargo": "true",
   "afk.hooks.defaults.gradle": "true",
   // Merge-gate policy (ADR 0048). The unlocked admin-merge ignores advisory
@@ -275,14 +289,17 @@ export function resolveTier(
   runner: string,
   taskClass: AfkModelTier = "think",
 ): ResolvedTier {
-  const fallbackRunner = runner === "codex" ? "codex" : "claude";
+  // The runner whose tier table to read. claude/codex/opencode each ship a full
+  // table (CONFIG_DEFAULTS); any other runner (e.g. the runner-neutral hermes)
+  // falls back to the claude table.
+  const tierRunner = runner === "codex" || runner === "opencode" ? runner : "claude";
   const tier = (AFK_MODEL_TIERS as readonly string[]).includes(taskClass) ? taskClass : "think";
-  const modelKey = defaultTierKey(fallbackRunner, tier, "model")!;
-  const effortKey = defaultTierKey(fallbackRunner, tier, "effort")!;
+  const modelKey = defaultTierKey(tierRunner, tier, "model")!;
+  const effortKey = defaultTierKey(tierRunner, tier, "effort")!;
   const defaultModel = CONFIG_DEFAULTS[modelKey];
   const defaultEffort = CONFIG_DEFAULTS[effortKey] as AgentEffort;
   const tierModel = getConfig(values, modelKey);
-  const scalarRunnerModel = getConfig(values, `afk.models.${fallbackRunner}`);
+  const scalarRunnerModel = getConfig(values, `afk.models.${tierRunner}`);
   const scalarGlobalModel = getConfig(values, "afk.model");
 
   return {

--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -21,7 +21,14 @@ import { startLaneIdleReaper, DEFAULT_STALL_POLL_S } from "./lane-idle-reaper.js
 // coupled to sandcastle, ADR 0033).
 export type { AgentStreamEvent } from "@ai-hero/sandcastle";
 
-export type AgentRunner = "claude" | "codex";
+// The runners with a first-class sandcastle agent provider. `opencode` (ADR
+// 0059) addresses OpenRouter through OpenCode's own `openrouter/<vendor>/<model>`
+// slug + the `OpenCodeOptions.env` auth seam; it is accepted only as an explicit
+// pin (`--runner opencode` / `RED_AFK_RUNNER=opencode`), never auto-sniffed
+// (runner-detection.ts), since no host session is OpenCode. `hermes` is a
+// runner-neutral fallback contract with NO sandcastle provider, so it is not in
+// this union — process-issue coerces it onto a backed runner before spawning.
+export type AgentRunner = "claude" | "codex" | "opencode";
 export type SandboxMode = "none" | "docker" | "podman";
 export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "max";
 // `exhausted` is surfaced when sandcastle's run() signals quota / rate-limit
@@ -350,6 +357,68 @@ export function effortForProvider(
   if (effort === undefined) return undefined;
   const accepted = runner === "codex" ? CODEX_EFFORTS : CLAUDE_EFFORTS;
   return accepted.includes(effort) ? effort : undefined;
+}
+
+/** The env var carrying the OpenRouter API key into the OpenCode agent (ADR 0059). */
+export const OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY";
+
+/**
+ * The subset of the sandcastle package surface `buildAgent` needs — the three
+ * provider factories AFK can drive. Injected so the runner→provider mapping
+ * (model slug, effort/variant gating, OpenRouter env passthrough) is unit-testable
+ * with fakes, without importing the package (which pulls real provider deps).
+ * `defaultSandcastleDeps` supplies the real `core.{claudeCode,codex,opencode}`.
+ */
+export interface AgentFactories {
+  claudeCode: (model: string, options?: { effort?: AgentEffort }) => RunOptions["agent"];
+  codex: (model: string, options?: { effort?: AgentEffort }) => RunOptions["agent"];
+  opencode: (model: string, options?: { variant?: string; env?: Record<string, string> }) => RunOptions["agent"];
+}
+
+/**
+ * Map a runner+model+effort to a sandcastle agent provider, reading any provider
+ * env passthrough from `env`. Pure: the package factories and the environment are
+ * injected.
+ *
+ * - **claude / codex**: the requested effort is gated per provider (FIX D, see
+ *   {@link effortForProvider}); an out-of-range value is DROPPED to the provider
+ *   default with a warn rather than cast through to a runtime rejection. It is
+ *   passed as the provider's numeric `effort` option.
+ * - **opencode** (ADR 0059): the model is OpenCode's own `openrouter/<vendor>/<model>`
+ *   slug, forwarded unchanged. AFK's effort maps to OpenCode's `variant` (its own
+ *   reasoning knob — a free-form string, distinct from the numeric effort the
+ *   other two take), so no gating applies. The OpenRouter API key is delivered
+ *   through `OpenCodeOptions.env` — the auth seam — when present in `env`.
+ */
+export function buildAgent(
+  factories: AgentFactories,
+  runner: AgentRunner,
+  model: string,
+  opts: { effort?: AgentEffort } | undefined,
+  env: NodeJS.ProcessEnv,
+  warn?: (message: string) => void,
+): RunOptions["agent"] {
+  const requested = opts?.effort;
+
+  if (runner === "opencode") {
+    const options: { variant?: string; env?: Record<string, string> } = {};
+    if (requested !== undefined) options.variant = requested;
+    const key = env[OPENROUTER_API_KEY_ENV];
+    if (key) options.env = { [OPENROUTER_API_KEY_ENV]: key };
+    return factories.opencode(model, Object.keys(options).length > 0 ? options : undefined);
+  }
+
+  const effort = effortForProvider(runner, requested);
+  if (requested !== undefined && effort === undefined) {
+    warn?.(
+      `[afk] warn: effort '${requested}' is not accepted by runner '${runner}' ` +
+        `(accepted: ${(runner === "codex" ? CODEX_EFFORTS : CLAUDE_EFFORTS).join(", ")}); ` +
+        "falling back to the provider default.",
+    );
+  }
+  return runner === "codex"
+    ? factories.codex(model, effort ? { effort } : undefined)
+    : factories.claudeCode(model, effort ? { effort } : undefined);
 }
 
 /** Map an AFK completion signal back to an iteration outcome. */
@@ -802,28 +871,20 @@ export async function defaultSandcastleDeps(): Promise<SandcastleDeps> {
     import("@ai-hero/sandcastle/sandboxes/docker"),
     import("@ai-hero/sandcastle/sandboxes/podman"),
   ]);
-  // FIX D: the effort unions differ per provider (codex tops out at "xhigh", no
-  // "max"). Gate the requested effort against the provider's accepted set BEFORE
-  // building the agent: an out-of-range value (e.g. codex + "max") is DROPPED
-  // (provider default) with a warn rather than cast through to a runtime provider
-  // rejection / infra crash. Degrade safely — never throw on a misconfig.
+  // FIX D / ADR 0059: the per-provider mapping (effort gating for claude/codex,
+  // effort→`variant` + OPENROUTER_API_KEY passthrough for opencode) lives in the
+  // pure `buildAgent`, unit-tested with fake factories. Here we just bind the real
+  // `core.*` factories and `process.env`. The casts narrow the shared option shape
+  // to each provider's option literal — `buildAgent` only ever passes options the
+  // factory accepts.
   const warn = (m: string) => console.warn(m);
-  const agentFor: SandcastleDeps["agentFor"] = (runner, model, opts) => {
-    const requested = opts?.effort;
-    const effort = effortForProvider(runner, requested);
-    if (requested !== undefined && effort === undefined) {
-      warn(
-        `[afk] warn: effort '${requested}' is not accepted by runner '${runner}' ` +
-          `(accepted: ${(runner === "codex" ? CODEX_EFFORTS : CLAUDE_EFFORTS).join(", ")}); ` +
-          "falling back to the provider default.",
-      );
-    }
-    // `effort` is now guaranteed to be in the provider's accepted union; the cast
-    // narrows the shared AgentEffort union to each provider's option literal.
-    return runner === "codex"
-      ? core.codex(model, effort ? ({ effort } as Parameters<typeof core.codex>[1]) : undefined)
-      : core.claudeCode(model, effort ? ({ effort } as Parameters<typeof core.claudeCode>[1]) : undefined);
+  const factories: AgentFactories = {
+    claudeCode: (model, options) => core.claudeCode(model, options as Parameters<typeof core.claudeCode>[1]),
+    codex: (model, options) => core.codex(model, options as Parameters<typeof core.codex>[1]),
+    opencode: (model, options) => core.opencode(model, options as Parameters<typeof core.opencode>[1]),
   };
+  const agentFor: SandcastleDeps["agentFor"] = (runner, model, opts) =>
+    buildAgent(factories, runner, model, opts, process.env, warn);
   const sandboxFor: SandcastleDeps["sandboxFor"] = (mode, opts) => {
     // Issue #405: bind-mount the host attempt dir at the identical path so the
     // worktree sandcastle creates under it + the proof-of-life lane files are

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -628,7 +628,12 @@ export async function processIssue(
   // Make the resolved base ref current so sandcastle forks the worker branch off
   // it (ADR 0031): the pinned/locked base becomes the branch's parent, not HEAD.
   if (deps.git.fetchBase) await deps.git.fetchBase(base);
-  let activeRunner: Runner = input.runner === "codex" ? "codex" : "claude";
+  // Pin to a sandcastle-backed runner. claude/codex/opencode (ADR 0059) each have
+  // a first-class provider and pass through; any other value (e.g. the
+  // runner-neutral hermes, which has no provider) coerces to claude so the spawn
+  // always has a real agent.
+  let activeRunner: Runner =
+    input.runner === "codex" || input.runner === "opencode" ? input.runner : "claude";
   let attemptN = input.attempt;
   // Anchor sandcastle at the per-attempt dir so its `.sandcastle/` (worktrees,
   // logs, .env, patches) + git ops land under .red/, never at the repo root.

--- a/src/apps/dev/src/types/runner.ts
+++ b/src/apps/dev/src/types/runner.ts
@@ -1,4 +1,4 @@
-export const runners = ["claude", "codex", "hermes"] as const;
+export const runners = ["claude", "codex", "hermes", "opencode"] as const;
 export type Runner = (typeof runners)[number];
 
 export type RunnerDetectionMethod =

--- a/src/apps/dev/tests/config.test.ts
+++ b/src/apps/dev/tests/config.test.ts
@@ -274,6 +274,36 @@ describe("config — AFK model tier table (ADR 0049)", () => {
     expect(resolveTier(values, "codex", "think")).toEqual({ model: "gpt-5.5", effort: "high" });
   });
 
+  it("resolves every OpenCode tier from the default openrouter table (ADR 0059)", () => {
+    const values = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });
+    expect(resolveTier(values, "opencode", "validate")).toEqual({
+      model: "openrouter/anthropic/claude-3.5-haiku",
+      effort: "low",
+    });
+    expect(resolveTier(values, "opencode", "simple")).toEqual({
+      model: "openrouter/anthropic/claude-sonnet-4",
+      effort: "high",
+    });
+    expect(resolveTier(values, "opencode", "complex")).toEqual({
+      model: "openrouter/anthropic/claude-opus-4",
+      effort: "medium",
+    });
+    expect(resolveTier(values, "opencode", "think")).toEqual({
+      model: "openrouter/anthropic/claude-opus-4",
+      effort: "high",
+    });
+  });
+
+  it("honours an overridden opencode tier under plugins.dev.afk.models.opencode.*", () => {
+    const text =
+      "plugins:\n  dev:\n    afk:\n      models:\n        opencode:\n          simple:\n            model: openrouter/openai/gpt-4o-mini\n            effort: medium\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(resolveTier(values, "opencode", "simple")).toEqual({
+      model: "openrouter/openai/gpt-4o-mini",
+      effort: "medium",
+    });
+  });
+
   it("lets explicit tier entries override legacy scalar model keys", () => {
     const text =
       "afk:\n  model: shared-model\n  models:\n    claude:\n      think:\n        model: claude-tier-model\n        effort: max\n";

--- a/src/apps/dev/tests/execution.test.ts
+++ b/src/apps/dev/tests/execution.test.ts
@@ -8,6 +8,9 @@ import {
   isTransientRunnerError,
   runAgent,
   effortForProvider,
+  buildAgent,
+  OPENROUTER_API_KEY_ENV,
+  type AgentFactories,
   DONE_SIGNAL,
   BLOCKED_SIGNAL,
   COMPLETION_SIGNALS,
@@ -97,6 +100,12 @@ describe("buildRunOptions", () => {
       { ...baseInput, runner: "codex", model: "gpt-5.4", effort: "high" },
     );
     expect(codexOpts.agent).toEqual({ __agent: "codex:gpt-5.4:high" });
+    // ADR 0059: opencode forwards its `openrouter/<vendor>/<model>` slug unchanged.
+    const opencodeOpts = buildRunOptions(
+      makeDeps(async () => fakeResult()),
+      { ...baseInput, runner: "opencode", model: "openrouter/anthropic/claude-sonnet-4", effort: "high" },
+    );
+    expect(opencodeOpts.agent).toEqual({ __agent: "opencode:openrouter/anthropic/claude-sonnet-4:high" });
   });
 
   it("defaults the sandbox to none and the idle timeout to 600s", () => {
@@ -413,6 +422,72 @@ describe("effortForProvider (FIX D — per-provider effort gating)", () => {
   it("passes undefined through unchanged (no effort requested)", () => {
     expect(effortForProvider("codex", undefined)).toBeUndefined();
     expect(effortForProvider("claude", undefined)).toBeUndefined();
+  });
+});
+
+describe("buildAgent — provider mapping (ADR 0059 opencode wiring)", () => {
+  // Recording fakes: each factory captures the (model, options) it was handed so
+  // the pure runner→provider mapping is asserted without the real sandcastle deps.
+  type Call = { model: string; options: unknown };
+  function recorder() {
+    const calls: Record<"claudeCode" | "codex" | "opencode", Call[]> = {
+      claudeCode: [],
+      codex: [],
+      opencode: [],
+    };
+    const factories: AgentFactories = {
+      claudeCode: (model, options) => (calls.claudeCode.push({ model, options }), fakeAgent("claude")),
+      codex: (model, options) => (calls.codex.push({ model, options }), fakeAgent("codex")),
+      opencode: (model, options) => (calls.opencode.push({ model, options }), fakeAgent("opencode")),
+    };
+    return { calls, factories };
+  }
+
+  it("routes claude/codex with gated effort as the numeric `effort` option", () => {
+    const { calls, factories } = recorder();
+    buildAgent(factories, "claude", "claude-opus-4-8", { effort: "max" }, {});
+    expect(calls.claudeCode).toEqual([{ model: "claude-opus-4-8", options: { effort: "max" } }]);
+    // codex tops out at xhigh → "max" is dropped to the provider default (no options).
+    const warned: string[] = [];
+    buildAgent(factories, "codex", "gpt-5.5", { effort: "max" }, {}, (m) => warned.push(m));
+    expect(calls.codex).toEqual([{ model: "gpt-5.5", options: undefined }]);
+    expect(warned.some((l) => l.includes("not accepted by runner 'codex'"))).toBe(true);
+  });
+
+  it("maps opencode effort to `variant` and forwards the openrouter model slug unchanged", () => {
+    const { calls, factories } = recorder();
+    buildAgent(factories, "opencode", "openrouter/anthropic/claude-sonnet-4", { effort: "high" }, {});
+    expect(calls.opencode).toEqual([
+      { model: "openrouter/anthropic/claude-sonnet-4", options: { variant: "high" } },
+    ]);
+    // opencode never touches the claude/codex factories.
+    expect(calls.claudeCode).toEqual([]);
+    expect(calls.codex).toEqual([]);
+  });
+
+  it("delivers OPENROUTER_API_KEY through OpenCodeOptions.env (the auth seam)", () => {
+    const { calls, factories } = recorder();
+    buildAgent(factories, "opencode", "openrouter/x/y", { effort: "low" }, { [OPENROUTER_API_KEY_ENV]: "sk-or-123" });
+    expect(calls.opencode[0]!.options).toEqual({
+      variant: "low",
+      env: { OPENROUTER_API_KEY: "sk-or-123" },
+    });
+  });
+
+  it("omits env when no key is present and omits variant when no effort is requested", () => {
+    const { calls, factories } = recorder();
+    buildAgent(factories, "opencode", "openrouter/x/y", undefined, {});
+    // No effort and no key → no options object at all (provider defaults apply).
+    expect(calls.opencode).toEqual([{ model: "openrouter/x/y", options: undefined }]);
+  });
+
+  it("does not gate opencode effort — any AgentEffort maps straight to variant", () => {
+    const { calls, factories } = recorder();
+    const warned: string[] = [];
+    // "max" is rejected by codex but is a legal opencode variant; no warn fires.
+    buildAgent(factories, "opencode", "openrouter/x/y", { effort: "max" }, {}, (m) => warned.push(m));
+    expect(calls.opencode[0]!.options).toEqual({ variant: "max" });
+    expect(warned).toEqual([]);
   });
 });
 

--- a/src/apps/dev/tests/runner-detection.test.ts
+++ b/src/apps/dev/tests/runner-detection.test.ts
@@ -32,4 +32,41 @@ describe("runner detection", () => {
     expect(parseRunnerFlag(["--runner=codex"])).toBe("codex");
     expect(parseRunnerFlag(["--once"])).toBeUndefined();
   });
+
+  // ADR 0059: opencode is a valid pin via --runner / RED_AFK_RUNNER, but is NEVER
+  // auto-sniffed from caller identity — no host session is OpenCode.
+  it("accepts opencode only as an explicit pin (flag or RED_AFK_RUNNER)", () => {
+    expect(detectRunner({ flag: "opencode" })).toMatchObject({ runner: "opencode", method: "flag" });
+    expect(detectRunner({ env: { RED_AFK_RUNNER: "opencode" } })).toMatchObject({
+      runner: "opencode",
+      method: "env-var",
+      detail: "RED_AFK_RUNNER",
+    });
+  });
+
+  it("never auto-sniffs opencode from ambient env / process tree / path", () => {
+    // No ambient surface maps to opencode, so an opencode-ish process tree or
+    // script path must NOT promote it — the cascade falls through to claude.
+    expect(detectRunner({ env: {}, processTree: "node /opt/opencode/bin/opencode" })).toMatchObject({
+      runner: "claude",
+      method: "env-fallback",
+    });
+    expect(detectRunner({ env: { OPENCODE_HOME: "/x", OPENROUTER_API_KEY: "sk-x" } })).toMatchObject({
+      runner: "claude",
+      method: "env-fallback",
+    });
+    expect(detectRunner({ env: {}, scriptPath: "/home/me/.opencode/run.sh" })).toMatchObject({
+      runner: "claude",
+      method: "env-fallback",
+    });
+  });
+
+  it("honours an operator-configured opencode default (afk.default_runner), not a sniff", () => {
+    // The injected fallback IS the operator's explicit `afk.default_runner` choice,
+    // so opencode there is honoured — that is configuration, not caller-identity sniffing.
+    expect(detectRunner({ env: {}, fallback: "opencode" })).toMatchObject({
+      runner: "opencode",
+      method: "env-fallback",
+    });
+  });
 });


### PR DESCRIPTION
Resolves #626

## What

Adds OpenCode as the third AFK runner (ADR 0059, parent PRD #614):

- `runner-opencode.md` contract with exhaustion strings + tier table
- sandcastle provider through the existing `agentFor` seam; pure `buildAgent` is unit-testable
- Cascade accepts `opencode` only as an explicit pin (never auto-sniffed)
- Model tier config under `afk.models.opencode.*`

## Verification

- 1147/1147 tests pass
- typecheck clean
- E2E with real `OPENROUTER_API_KEY` deferred to CI Actions-lane slice (per acceptance)

Refs #626

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783661284&installation_id=129708444&pr_number=635&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F635&signature=3bfa7eadbeceac3660bdc4974a9400024e6e5868944c356a0849ced6c2c9e04d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCode as a third AFK runner option, selectable via `--runner opencode` or `RED_AFK_RUNNER` environment variable. Integrates with OpenRouter for model access and requires explicit selection (no auto-detection).

* **Documentation**
  * Added comprehensive documentation for OpenCode runner integration, including configuration, tier mappings, and usage guidelines.

* **Tests**
  * Added test coverage for OpenCode runner configuration, execution, and detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->