### PR TITLE
fix(afk): commit-anchored hard cap bounds the edit-signal guard extension

### DIFF
--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -74,6 +74,29 @@ export function parseAttemptTimeout(raw: string | undefined): number | undefined
 }
 
 /**
+ * Commit-anchored HARD cap on the attempt guard (issue #637): the edit-signal
+ * (ADR 0051) may extend the soft deadline only this many seconds past the last
+ * commit (or spawn). A busy-but-unproductive agent that re-validates in a loop
+ * while occasionally touching a file resets the soft deadline forever — the
+ * observed #579 worker burned 5h+ that way. Past the hard cap with no NEW
+ * commit, the guard aborts regardless of worktree edits, which routes the
+ * attempt to the `timeout` terminal where the ADR 0055 reconcile can land an
+ * already-committed green branch without re-running the agent. Env-tunable via
+ * `RED_AFK_ATTEMPT_HARD_CAP_S`.
+ */
+export const DEFAULT_ATTEMPT_HARD_CAP_S = 5400;
+
+/** Parse `RED_AFK_ATTEMPT_HARD_CAP_S`: a positive integer, else undefined
+ * (caller falls back to {@link DEFAULT_ATTEMPT_HARD_CAP_S}). Same typo-safe
+ * contract as {@link parseAttemptTimeout} — `0` cannot disable the cap. */
+export function parseAttemptHardCap(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  return undefined;
+}
+
+/**
  * The re-invocation ceiling handed to sandcastle's Orchestrator (issue #322).
  *
  * sandcastle's own DEFAULT_MAX_ITERATIONS is 1 (run.js), which cuts the inner
@@ -229,6 +252,14 @@ export interface RunAgentInput {
    * {@link DEFAULT_ATTEMPT_TIMEOUT_S}.
    */
   attemptTimeoutSeconds?: number;
+  /**
+   * Commit-anchored HARD cap in seconds (issue #637): bounds how long the
+   * edit-signal (`progressProbe`) may keep extending the soft deadline past the
+   * last commit. Only meaningful when the guard is armed. Omitted → soft cap
+   * only (back-compat). `makeRunAgent` threads `RED_AFK_ATTEMPT_HARD_CAP_S`
+   * here. See {@link DEFAULT_ATTEMPT_HARD_CAP_S}.
+   */
+  attemptHardCapSeconds?: number;
   /**
    * Returns the current HEAD sha of the worker branch (the progress signal the
    * guard watches). Best-effort: resolves `undefined` on any git failure, which
@@ -645,17 +676,27 @@ export function startAttemptGuard(opts: {
   headProbe: () => Promise<string | undefined>;
   now: () => number;
   schedule: (fn: () => void, ms: number) => () => void;
-  abort: () => void;
+  /** `reason` distinguishes the soft commit/edit deadline ("stalled") from the
+   * commit-anchored hard cap ("hard-cap", issue #637). Callbacks that ignore
+   * the argument keep the prior behaviour. */
+  abort: (reason: "stalled" | "hard-cap") => void;
   /** Worktree line-volume probe (ADR 0051): a CHANGE between polls counts as
    * progress and resets the deadline, so an editing-but-not-committing runner
    * (codex) is not falsely stalled. Optional → guard stays commit-anchored. */
   progressProbe?: () => Promise<number | undefined>;
+  /** Commit-anchored hard cap (issue #637): when set, edit-signal resets may
+   * extend the deadline only this long past the last commit (or spawn) — once
+   * `hardCapMs` elapses with no NEW commit, abort fires regardless of worktree
+   * edits. Without it a busy-but-unproductive agent that touches a file every
+   * <capMs resets the soft deadline forever. Optional → soft cap only. */
+  hardCapMs?: number;
   /** Fired once per poll (proof-of-life externalization): the externalized
    * heartbeat + on_heartbeat hook ride this same cadence (PR-B). Never throws —
    * the caller wraps its own IO. */
   onTick?: (info: AttemptProgressInfo) => void;
 }): { stop: () => void; firedTimeout: () => boolean } {
   let lastProgress = opts.now();
+  let lastCommit = opts.now();
   let lastHead: string | undefined;
   let lastVolume: number | undefined;
   let fired = false;
@@ -686,11 +727,20 @@ export function startAttemptGuard(opts: {
       if (fired) return;
       const committed = headOk && head !== undefined && head !== lastHead;
       const edited = volume !== undefined && lastVolume !== undefined && volume !== lastVolume;
-      if (committed || edited) {
+      if (committed) {
         lastProgress = opts.now();
-      } else if (opts.now() - lastProgress >= opts.capMs) {
+        lastCommit = opts.now();
+      } else if (edited) {
+        lastProgress = opts.now();
+      }
+      // The soft deadline resets on commit OR edit; the hard cap resets on
+      // commit ONLY, so periodic edits cannot keep an uncommitting agent alive
+      // past it (issue #637 — the 5h+ re-validation loop).
+      const softExpired = !committed && !edited && opts.now() - lastProgress >= opts.capMs;
+      const hardExpired = !committed && opts.hardCapMs !== undefined && opts.now() - lastCommit >= opts.hardCapMs;
+      if (softExpired || hardExpired) {
         fired = true;
-        opts.abort();
+        opts.abort(hardExpired && !softExpired ? "hard-cap" : "stalled");
       }
       if (headOk && head !== undefined) lastHead = head;
       if (volume !== undefined) lastVolume = volume;
@@ -749,15 +799,23 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
     const capMs = input.attemptTimeoutSeconds * 1000;
     controller = makeController();
     const cap = input.attemptTimeoutSeconds;
+    const hardCap = input.attemptHardCapSeconds;
     guard = startAttemptGuard({
       capMs,
       intervalMs: Math.min(capMs, 60_000),
       headProbe: input.headProbe,
       ...(input.progressProbe ? { progressProbe: input.progressProbe } : {}),
+      ...(hardCap && hardCap > 0 ? { hardCapMs: hardCap * 1000 } : {}),
       now,
       schedule,
-      abort: () =>
-        controller?.abort(new Error(`afk: attempt aborted — no new commit within ${cap}s (stalled)`)),
+      abort: (reason) =>
+        controller?.abort(
+          new Error(
+            reason === "hard-cap"
+              ? `afk: attempt aborted — no new commit within ${hardCap}s despite worktree edits (hard cap, stalled)`
+              : `afk: attempt aborted — no new commit within ${cap}s (stalled)`,
+          ),
+        ),
       // Externalized proof-of-life (PR-B): each poll fires the caller's opaque
       // heartbeat sink (firehose record + state.last_progress_at + on_heartbeat
       // hook). execution.ts stays ignorant of what it does.

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -231,9 +231,14 @@ export function makeRunAgent(
 ): (input: RunAgentInput) => Promise<RunAgentResult> {
   let depsPromise: Promise<import("../core/execution.js").SandcastleDeps> | null = null;
   return async (input: RunAgentInput): Promise<RunAgentResult> => {
-    const { runAgent, defaultSandcastleDeps, parseIdleTimeout, DEFAULT_ATTEMPT_TIMEOUT_S } = await import(
-      "../core/execution.js"
-    );
+    const {
+      runAgent,
+      defaultSandcastleDeps,
+      parseIdleTimeout,
+      DEFAULT_ATTEMPT_TIMEOUT_S,
+      DEFAULT_ATTEMPT_HARD_CAP_S,
+      parseAttemptHardCap,
+    } = await import("../core/execution.js");
     if (!depsPromise) depsPromise = defaultSandcastleDeps();
     const deps = await depsPromise;
     // Sandcastle re-invocation ceiling (issue #322). Precedence: per-call
@@ -260,6 +265,13 @@ export function makeRunAgent(
       attemptTimeoutSeconds ??
       parseAttemptTimeout(env.RED_AFK_ATTEMPT_TIMEOUT_S) ??
       DEFAULT_ATTEMPT_TIMEOUT_S;
+    // Commit-anchored hard cap (issue #637): bounds how long the edit-signal
+    // below may keep extending the soft deadline. Never below the soft cap, so
+    // a low override cannot make the hard cap fire before plain ADR 0044 would.
+    const attemptHardCap = Math.max(
+      input.attemptHardCapSeconds ?? parseAttemptHardCap(env.RED_AFK_ATTEMPT_HARD_CAP_S) ?? DEFAULT_ATTEMPT_HARD_CAP_S,
+      attemptTimeout,
+    );
     // Resolved lane-idle config is threaded from resolveRunSettings (validated at
     // boot); a caller that constructed makeRunAgent without one falls back to the
     // env-resolved config.
@@ -278,6 +290,7 @@ export function makeRunAgent(
       ...(guardArmed
         ? {
             attemptTimeoutSeconds: attemptTimeout,
+            attemptHardCapSeconds: attemptHardCap,
             headProbe: () => gitx.branchHead({ cwd: input.cwd ?? process.cwd() }, input.branch),
             // Edit signal (ADR 0051): the changed-line volume of the agent's real
             // worktree (committed + uncommitted). A change between polls resets

--- a/src/apps/dev/tests/execution.test.ts
+++ b/src/apps/dev/tests/execution.test.ts
@@ -969,6 +969,165 @@ describe("startAttemptGuard — diff-anchored progress (ADR 0051, codex false-st
   });
 });
 
+describe("startAttemptGuard — commit-anchored hard cap (issue #637, busy-but-unproductive loop)", () => {
+  it("aborts at the hard cap when periodic edits keep resetting the soft deadline but no commit lands", async () => {
+    // The #579 worker: code committed, then an open-ended re-validation loop
+    // that occasionally touches a test file. Every edit resets the soft
+    // deadline, so without the hard cap the guard never fires.
+    let clock = 0;
+    let volume = 10;
+    const sched = manualScheduler();
+    let reason: string | undefined;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      hardCapMs: 200,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => volume,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: (r) => {
+        reason = r;
+      },
+    });
+    await sched.tick(); // t=0 anchor (first head = spawn commit anchor)
+    for (const [t, v] of [
+      [50, 60],
+      [100, 140],
+      [150, 300],
+    ] as const) {
+      clock = t;
+      volume = v;
+      await sched.tick(); // edit each poll → soft deadline resets, still under the hard cap
+      expect(reason).toBeUndefined();
+    }
+    clock = 200;
+    volume = 999;
+    await sched.tick(); // edits continue, but 200ms since last commit >= hardCapMs → abort
+    expect(reason).toBe("hard-cap");
+  });
+
+  it("a new commit re-anchors the hard cap", async () => {
+    let clock = 0;
+    let head = "sha1";
+    let volume = 10;
+    const sched = manualScheduler();
+    let reason: string | undefined;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      hardCapMs: 200,
+      headProbe: async () => head,
+      progressProbe: async () => volume,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: (r) => {
+        reason = r;
+      },
+    });
+    await sched.tick(); // t=0 anchor at sha1
+    clock = 150;
+    head = "sha2";
+    await sched.tick(); // commit → hard cap re-anchors to 150
+    clock = 300;
+    volume = 20;
+    await sched.tick(); // 300-150=150 < 200 → alive (edits within the re-anchored cap)
+    expect(reason).toBeUndefined();
+    clock = 350;
+    volume = 30;
+    await sched.tick(); // 350-150=200 >= hardCapMs, no further commit → abort
+    expect(reason).toBe("hard-cap");
+  });
+
+  it("reports 'stalled' (not 'hard-cap') when the plain soft deadline expires first", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    let reason: string | undefined;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      hardCapMs: 200,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => 42, // frozen volume → no edit signal
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: (r) => {
+        reason = r;
+      },
+    });
+    await sched.tick(); // anchor
+    clock = 100;
+    await sched.tick(); // soft cap expires with no commit and no edit
+    expect(reason).toBe("stalled");
+  });
+
+  it("without hardCapMs, continuous edits extend indefinitely (ADR 0051 behaviour unchanged)", async () => {
+    let clock = 0;
+    let volume = 10;
+    const sched = manualScheduler();
+    let aborted = false;
+    startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => volume,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: () => {
+        aborted = true;
+      },
+    });
+    await sched.tick();
+    for (const [t, v] of [
+      [90, 20],
+      [180, 30],
+      [600, 40],
+      [1200, 50],
+    ] as const) {
+      clock = t;
+      volume = v;
+      await sched.tick();
+      expect(aborted).toBe(false);
+    }
+  });
+});
+
+describe("runAgent — hard cap wiring (issue #637)", () => {
+  it("returns the 'timeout' outcome when the hard cap aborts an editing-but-never-committing run", async () => {
+    let clock = 0;
+    let volume = 0;
+    const sched = manualScheduler();
+    const controller = new AbortController();
+    const deps: SandcastleDeps = {
+      ...makeDeps(
+        (o) =>
+          new Promise<RunResult>((_resolve, reject) => {
+            o.signal?.addEventListener("abort", () => reject(o.signal?.reason ?? new Error("aborted")));
+          }),
+      ),
+      now: () => clock,
+      schedule: sched.schedule,
+      makeAbortController: () => controller,
+    };
+    const p = runAgent(deps, {
+      ...baseInput,
+      attemptTimeoutSeconds: 1,
+      attemptHardCapSeconds: 2,
+      headProbe: async () => "static",
+      progressProbe: async () => ++volume, // an edit every poll → soft deadline never expires
+    });
+    await sched.tick(); // anchor
+    clock = 1000;
+    await sched.tick(); // soft cap held open by the edit signal → alive
+    clock = 2000;
+    await sched.tick(); // hard cap (2s) since anchor with no commit → abort
+    const res = await p;
+    expect(res.outcome).toBe("timeout");
+    expect(controller.signal.reason).toBeInstanceOf(Error);
+    expect(String((controller.signal.reason as Error).message)).toContain("hard cap");
+  });
+});
+
 // ---- lane-idle stall reaper wiring (issue #363) ----
 
 describe("runAgent — lane-idle reaper wiring", () => {


### PR DESCRIPTION
Closes #637.

## Problem

The ADR 0051 edit-signal (`progressProbe`) resets the attempt guard deadline on ANY worktree line-volume change. A busy-but-unproductive agent that re-validates in a loop while occasionally touching a file therefore never accumulates 45min of "no progress" — the observed #579 worker burned 5h+ this way, and the ADR 0055 reconcile backstop on the `timeout` terminal (which would have landed its already-committed green branch) was never reached.

## Fix

- `startAttemptGuard` takes an optional `hardCapMs`: edit-signal resets extend the soft deadline only up to the hard cap since the last **commit** (or spawn); past it the guard aborts regardless of edits.
- Abort reason is now `"stalled" | "hard-cap"`, surfaced in the abort error message for operator forensics.
- Default 90min (`DEFAULT_ATTEMPT_HARD_CAP_S = 5400`), env-tunable via `RED_AFK_ATTEMPT_HARD_CAP_S` (typo-safe; `0` cannot disable it). Clamped in `wire.ts` to never fire before the plain soft cap.
- Codex non-regression: editing-without-committing within the hard cap still counts as progress (ADR 0051 behaviour unchanged when `hardCapMs` is absent — pinned by test).

## Known gap (documented, out of scope)

Per-iteration post-commit DONE enforcement ("committed but no DONE after K iterations → stop and reconcile") is not implementable from AFK today: sandcastle 0.6.x exposes `maxIterations`/`completionSignal` but no per-iteration hook. The hard cap bounds the same failure at the whole-run level (guard spans iterations), so the practical stall ceiling drops from unbounded to ~90min, after which reconcile lands the branch.

## Tests

5 new tests: hard cap fires despite periodic edits; commit re-anchors the cap; soft expiry still reports `stalled`; no-hardCap behaviour unchanged (ADR 0051 pin); `runAgent` wiring returns `timeout` with a "hard cap" abort message. `tests/execution.test.ts` 83/83, `tests/wire.test.ts` 26/26, tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783681196&installation_id=129708444&pr_number=639&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F639&signature=c67f5ef4f53e9480d6d8d4e27000c847bac4f5cedb0bc8868576abe0aafdc6d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a hard cap timeout for agent execution that cannot be extended by edits, providing an absolute deadline alongside the existing soft timeout.
  * Enhanced error messaging to distinguish between soft timeout failures and hard cap timeout failures.

* **Tests**
  * Added comprehensive test coverage for hard cap timeout behavior across various execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->