### PR TITLE
fix(afk): inject RED_AFK_SLOT per fleet slot so cargo/gradle build isolation works

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -439,6 +439,12 @@ export function deriveStage(event: AgentStreamEvent): string | undefined {
   return undefined;
 }
 
+function parseSlot(val: string | undefined): number | undefined {
+  if (val === undefined) return undefined;
+  const n = parseInt(val, 10);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
 export function buildProcessDeps(
   ctx: RepoContext,
   model: string,
@@ -572,7 +578,7 @@ export function buildProcessDeps(
       config,
       resolveOptions,
       exec: makeHookExec(ctx.root),
-      env: hookEnv(ctx.repo, ctx.root),
+      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT)),
     },
     lookups: {
       base: {
@@ -1066,7 +1072,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       config: loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined }),
       resolveOptions: makeHookResolveOptions(ctx.root),
       exec: makeHookExec(ctx.root),
-      env: hookEnv(ctx.repo, ctx.root),
+      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT)),
     },
     runnerCircuit: {
       isOpen: (r) => runnerCircuitOpen(paths.tmpDir, r, Math.floor(Date.now() / 1000)),

--- a/src/apps/dev/src/commands/supervise.ts
+++ b/src/apps/dev/src/commands/supervise.ts
@@ -133,6 +133,19 @@ export function buildWorkerEnv(
 }
 
 /**
+ * Pin RED_AFK_SLOT on a worker env for a specific fleet slot. The base env
+ * was stripped of RED_AFK_SLOT by buildWorkerEnv (it is in PASSTHROUGH_DENYLIST
+ * so it cannot leak from one slot to another); this re-adds it per-slot so the
+ * cargo/gradle pre_worktree defaults can resolve the correct per-slot build dir.
+ */
+export function buildSlotEnv(
+  workerEnv: Record<string, string>,
+  slot: number,
+): Record<string, string> {
+  return { ...workerEnv, RED_AFK_SLOT: String(slot) };
+}
+
+/**
  * Parse the supervisor's own argv (forwarded by fleet.ts) into the filter /
  * runner-swap policy flags each slot's `run --once` must carry, so a supervised
  * fleet honours the same PRD/issue filter + alternate/fallback policy a single
@@ -227,7 +240,7 @@ function buildSupervisorDeps(
         const slotFd = openSync(slotLogFile, "a");
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
-          env: workerEnv,
+          env: buildSlotEnv(workerEnv, slot),
           detached: true,
           stdio: ["ignore", slotFd, slotFd],
         });
@@ -250,7 +263,7 @@ function buildSupervisorDeps(
         ];
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
-          env: workerEnv,
+          env: buildSlotEnv(workerEnv, slot),
           detached: true,
           stdio: ["ignore", logFd, logFd],
         });

--- a/src/apps/dev/src/runtime/hooks.ts
+++ b/src/apps/dev/src/runtime/hooks.ts
@@ -56,9 +56,13 @@ export function makeHookResolveOptions(root: string): ResolveHooksOptions {
 }
 
 /** The RED_AFK_* env handed to every hook command. */
-export function hookEnv(repo: string, root: string): Record<string, string> {
-  return {
+export function hookEnv(repo: string, root: string, slot?: number): Record<string, string> {
+  const env: Record<string, string> = {
     RED_AFK_REPO: repo,
     RED_AFK_ROOT: root,
   };
+  if (slot !== undefined) {
+    env.RED_AFK_SLOT = String(slot);
+  }
+  return env;
 }

--- a/src/apps/dev/tests/runtime-hooks.test.ts
+++ b/src/apps/dev/tests/runtime-hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { makeHookResolveOptions } from "../src/runtime/hooks.js";
+import { hookEnv, makeHookResolveOptions } from "../src/runtime/hooks.js";
 import { skillDirFromModule } from "../src/platform/skill-paths.js";
 import { resolveHooks } from "../src/core/hook-config.js";
 
@@ -71,5 +71,28 @@ describe("makeHookResolveOptions (gap 6: built-in defaults anchor on the plugin)
     // path or undefined, never a crash.
     const cargo = opts.defaultCommand("cargo");
     expect(cargo === undefined || typeof cargo === "string").toBe(true);
+  });
+});
+
+describe("hookEnv (per-slot RED_AFK_SLOT in hook environment)", () => {
+  it("includes RED_AFK_REPO and RED_AFK_ROOT always", () => {
+    const env = hookEnv("owner/repo", "/repo");
+    expect(env.RED_AFK_REPO).toBe("owner/repo");
+    expect(env.RED_AFK_ROOT).toBe("/repo");
+  });
+
+  it("omits RED_AFK_SLOT when no slot is given", () => {
+    const env = hookEnv("owner/repo", "/repo");
+    expect(env.RED_AFK_SLOT).toBeUndefined();
+  });
+
+  it("includes RED_AFK_SLOT when a slot is given", () => {
+    expect(hookEnv("owner/repo", "/repo", 0).RED_AFK_SLOT).toBe("0");
+    expect(hookEnv("owner/repo", "/repo", 3).RED_AFK_SLOT).toBe("3");
+  });
+
+  it("each slot gets a distinct RED_AFK_SLOT value", () => {
+    const slots = [0, 1, 2].map((s) => hookEnv("owner/repo", "/repo", s).RED_AFK_SLOT);
+    expect(slots).toEqual(["0", "1", "2"]);
   });
 });

--- a/src/apps/dev/tests/supervise-passthrough.test.ts
+++ b/src/apps/dev/tests/supervise-passthrough.test.ts
@@ -3,6 +3,7 @@ import {
   PASSTHROUGH_DENYLIST,
   passthroughKeys,
   buildWorkerEnv,
+  buildSlotEnv,
   slotFilterArgs,
 } from "../src/commands/supervise.js";
 
@@ -56,6 +57,35 @@ describe("buildWorkerEnv / passthroughKeys (gap 4: passthrough denylist)", () =>
   it("re-pins the runner even when RED_AFK_RUNNER was set in the source", () => {
     const env = buildWorkerEnv({ RED_AFK_RUNNER: "claude" }, "codex");
     expect(env.RED_AFK_RUNNER).toBe("codex");
+  });
+});
+
+describe("buildSlotEnv (per-slot RED_AFK_SLOT injection)", () => {
+  it("pins RED_AFK_SLOT to the given slot index", () => {
+    const base = buildWorkerEnv({ PATH: "/usr/bin" }, "claude");
+    expect(buildSlotEnv(base, 0).RED_AFK_SLOT).toBe("0");
+    expect(buildSlotEnv(base, 3).RED_AFK_SLOT).toBe("3");
+  });
+
+  it("each slot gets a distinct RED_AFK_SLOT (no shared slot-0 default)", () => {
+    const base = buildWorkerEnv({}, "claude");
+    const envs = [0, 1, 2].map((s) => buildSlotEnv(base, s));
+    expect(envs[0]!.RED_AFK_SLOT).toBe("0");
+    expect(envs[1]!.RED_AFK_SLOT).toBe("1");
+    expect(envs[2]!.RED_AFK_SLOT).toBe("2");
+  });
+
+  it("overrides any pre-existing RED_AFK_SLOT value", () => {
+    const env = buildSlotEnv({ RED_AFK_SLOT: "0", PATH: "/x" }, 5);
+    expect(env.RED_AFK_SLOT).toBe("5");
+  });
+
+  it("preserves all other keys from the base worker env", () => {
+    const base = buildWorkerEnv({ PATH: "/usr/bin", RED_AFK_SKIP_PERF: "1" }, "codex");
+    const slotted = buildSlotEnv(base, 2);
+    expect(slotted.PATH).toBe("/usr/bin");
+    expect(slotted.RED_AFK_SKIP_PERF).toBe("1");
+    expect(slotted.RED_AFK_RUNNER).toBe("codex");
   });
 });
 


### PR DESCRIPTION
## Summary

- Export `buildSlotEnv()` in `supervise.ts`; use it in both `spawnSlot` and `spawnReconcileWorker` so each child process gets `RED_AFK_SLOT=<slot>`
- Extend `hookEnv()` in `hooks.ts` to accept an optional slot and include `RED_AFK_SLOT` when set
- Parse `process.env.RED_AFK_SLOT` in `run.ts` and pass it to both `hookEnv` call sites (`buildProcessDeps` + session hooks)
- Add 8 new tests covering `buildSlotEnv` (4) and `hookEnv` slot param (4)

Each fleet worker was receiving no `RED_AFK_SLOT`, causing every slot's `cargo-pre-worktree.sh` and `gradle-pre-worktree.sh` defaults to fall back to the `slot-0` path and serialize on the same build lock.

Closes #581

## Test plan

- [x] All 1233 tests pass (`pnpm test`)
- [x] `buildSlotEnv` unit tests: each slot gets its own `RED_AFK_SLOT` value, pre-existing value is overridden
- [x] `hookEnv` unit tests: `RED_AFK_SLOT` included when slot provided, omitted when not

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783686733&installation_id=129708444&pr_number=645&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F645&signature=edf38957af2f058239ebc9373e474a8b8f0bdf73043fdff03cbfbfcd83389805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced worker process environment setup to properly track and assign fleet slots
  * Worker processes now receive correct slot-specific configuration during initialization and reconciliation

* **Tests**
  * Added test coverage verifying slot assignment propagation and environment variable injection across worker processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->