### PR TITLE
fix(afk): claim-race loser skips instead of dying, and never clobbers the winner's claim

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -375,6 +375,11 @@ async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: numbe
       deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
     },
     lookups: {
+      // Live-claim ownership for the orphan sweep (#644): a dead attempt dir
+      // naming an issue whose claims/{N}/pid is a LIVE process is claim-race
+      // debris, not a mid-issue crash — the sweep removes it without touching
+      // the winner's `running` label.
+      claimHolderAlive: (issue) => fsx.claimPathHeldByLivePid(join(afkPaths(ctx.root).tmpDir, "claims", String(issue))),
       // Orphan state pairs gh issue state/label with the attempt dir's
       // envelope.posted flag (read from the state file, not gh). Derived from
       // the batched map, preserving ghx.orphanState's exact label/state →
@@ -1053,6 +1058,15 @@ export async function runCommand(options: RunOptions): Promise<number> {
       const result = await processIssue(pd, pi);
       if (result.outcome === "runner-transient") {
         await openRunnerCircuit(paths.tmpDir, pi.runner, Math.floor(Date.now() / 1000), process.env).catch(() => {});
+      }
+      // Abandon means DELETE (#644): buildProcessInput pre-creates the attempt
+      // dir + state (current.number, live pid) BEFORE the claim, so a lost race
+      // leaves them naming an issue this worker never owned. The next boot's
+      // orphan sweep would misread that as a mid-issue crash and restore
+      // ready-for-agent over the live winner's `running` label.
+      if (result.outcome === "claim-lost") {
+        await fsx.removeDir(pi.attemptDir).catch(() => {});
+        return result;
       }
       const sp = join(pi.attemptDir, "afk.state.json");
       if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }).catch(() => {});

--- a/src/apps/dev/src/core/boot.ts
+++ b/src/apps/dev/src/core/boot.ts
@@ -161,6 +161,12 @@ export interface BootLookups {
   blockerState: BlockerStateLookup;
   /** Straggler per-bucket count lookups (boot-sweep.ts StragglerCountLookup). */
   straggler: StragglerCountLookup;
+  /** True when the issue's local claim lock (`.red/tmp/claims/{N}/pid`) names a
+   * LIVE process (#644). Optional: absent → false (restore behaviour
+   * unchanged). The orphan sweep consults this before a restore-and-remove so
+   * a claim-race loser's debris dir can never clobber the live winner's
+   * `running` label back to ready-for-agent. */
+  claimHolderAlive?: (issue: number) => Promise<boolean>;
 }
 
 /** Outcome of one boot reconcile run — a coarser view of `ReconcileResult`
@@ -439,14 +445,25 @@ async function runOrphanCleanup(
       await deps.fs.removeDir(dir.path);
       removed.push(dir.path);
     } else if (fate.kind === "restore-and-remove") {
-      await deps.gh.editLabels(dir.issue!, ["running"], ["ready-for-agent"]);
-      await deps.gh.comment(
-        dir.issue!,
-        "🤖 /afk orchestrator died mid-issue; restoring ready-for-agent.",
-      );
-      restored.push(dir.issue!);
-      await deps.fs.removeDir(dir.path);
-      removed.push(dir.path);
+      // A dead attempt dir naming issue N does not prove the ISSUE is orphaned
+      // (#644): a claim-race loser leaves one behind while the winner is alive
+      // and working. Restore only when no live worker holds the claim lock;
+      // otherwise the dir is debris of a lost race → plain remove, no label
+      // edit, no recovery comment.
+      const ownedByLiveWorker = (await deps.lookups.claimHolderAlive?.(dir.issue!).catch(() => false)) ?? false;
+      if (ownedByLiveWorker) {
+        await deps.fs.removeDir(dir.path);
+        removed.push(dir.path);
+      } else {
+        await deps.gh.editLabels(dir.issue!, ["running"], ["ready-for-agent"]);
+        await deps.gh.comment(
+          dir.issue!,
+          "🤖 /afk orchestrator died mid-issue; restoring ready-for-agent.",
+        );
+        restored.push(dir.issue!);
+        await deps.fs.removeDir(dir.path);
+        removed.push(dir.path);
+      }
     } else {
       // keep-until(ttlS): remove only once the dir has aged past the TTL.
       if (dir.ageS > fate.ttlS) {

--- a/src/apps/dev/src/core/session.ts
+++ b/src/apps/dev/src/core/session.ts
@@ -488,7 +488,13 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
         break;
       }
 
-      if (ctx.once) break;
+      // --once consumes the single supervised iteration only when an attempt
+      // actually ran. A lost claim race (another worker owns the issue) must
+      // skip to the next candidate (SKILL §Per-Issue Loop step 1), not burn the
+      // iteration: under the fleet supervisor every worker IS --once, so
+      // exiting here respawns a fresh worker that re-races the same head issue
+      // forever — the #644 churn that starved 2 of 3 slots.
+      if (ctx.once && result.outcome !== "claim-lost") break;
       if (ctx.alternate) activeRunner = otherRunner(activeRunner);
     }
 

--- a/src/apps/dev/src/runtime/fs.ts
+++ b/src/apps/dev/src/runtime/fs.ts
@@ -108,7 +108,11 @@ export async function tryAcquireClaimDir(dir: string, pid: number): Promise<bool
   return true;
 }
 
-async function claimPathHeldByLivePid(dir: string): Promise<boolean> {
+/** True when `dir` is a claim-lock dir whose recorded `pid` file names a live
+ * process — the issue is actively owned by a running worker. Exported for the
+ * boot orphan sweep (#644): a dead attempt dir naming issue N does not prove
+ * the ISSUE is orphaned when another live worker holds its claim. */
+export async function claimPathHeldByLivePid(dir: string): Promise<boolean> {
   try {
     const st = await stat(dir);
     if (!st.isDirectory()) return false;

--- a/src/apps/dev/tests/boot.test.ts
+++ b/src/apps/dev/tests/boot.test.ts
@@ -120,6 +120,7 @@ function makeDeps(over: Partial<{
   branchIssue: BootDeps["lookups"]["branchIssue"];
   blockerState: BootDeps["lookups"]["blockerState"];
   straggler: BootDeps["lookups"]["straggler"];
+  claimHolderAlive: BootDeps["lookups"]["claimHolderAlive"];
   env: Record<string, string | undefined>;
   reconcileRunner: ReconcileBootRunner;
 }> = {}) {
@@ -190,6 +191,7 @@ function makeDeps(over: Partial<{
           needsTriage: async () => 0,
           needsInfo: async () => 0,
         },
+      ...(over.claimHolderAlive ? { claimHolderAlive: over.claimHolderAlive } : {}),
     },
     nowS: NOW,
     env: over.env ?? {},
@@ -288,6 +290,57 @@ describe("runBoot orphan cleanup applies each fate", () => {
       "gh.comment:7",
       "fs.removeDir:/d/running",
     ]);
+  });
+
+  it("downgrades restore-and-remove to plain remove when a live worker holds the claim (#644)", async () => {
+    // A claim-race loser's debris dir names an issue the WINNER is actively
+    // working: restoring ready-for-agent here would clobber the live worker's
+    // `running` label and put the issue back at the head of every queue.
+    const orphanState: BootDeps["lookups"]["orphanState"] = async () => ({
+      ghOk: true,
+      state: "OPEN",
+      label: "running",
+      envelopePosted: false,
+    });
+    const { deps, ghCalls, fsCalls } = makeDeps({ orphanState, claimHolderAlive: async () => true });
+    const orphans: OrphanDir[] = [{ path: "/d/debris", issue: 9, ageS: 0 }];
+    const r = await runBoot(deps, options({ orphans }));
+    expect(ghCalls.editLabels).toEqual([]); // no label restore
+    expect(ghCalls.comment).toEqual([]); // no recovery comment
+    expect(fsCalls.removeDir).toEqual(["/d/debris"]);
+    expect(r.orphanCleanup).toEqual({ removed: ["/d/debris"], restored: [], kept: [], legacyWiped: [], claimsReleased: [] });
+  });
+
+  it("still restores when the claim lookup reports no live holder (#644)", async () => {
+    const orphanState: BootDeps["lookups"]["orphanState"] = async () => ({
+      ghOk: true,
+      state: "OPEN",
+      label: "running",
+      envelopePosted: false,
+    });
+    const { deps, ghCalls } = makeDeps({ orphanState, claimHolderAlive: async () => false });
+    const orphans: OrphanDir[] = [{ path: "/d/crashed", issue: 11, ageS: 0 }];
+    const r = await runBoot(deps, options({ orphans }));
+    expect(ghCalls.editLabels).toEqual([{ issue: 11, remove: ["running"], add: ["ready-for-agent"] }]);
+    expect(r.orphanCleanup?.restored).toEqual([11]);
+  });
+
+  it("treats a throwing claim lookup as no-live-holder and restores (#644 fail-open)", async () => {
+    const orphanState: BootDeps["lookups"]["orphanState"] = async () => ({
+      ghOk: true,
+      state: "OPEN",
+      label: "running",
+      envelopePosted: false,
+    });
+    const { deps, ghCalls } = makeDeps({
+      orphanState,
+      claimHolderAlive: async () => {
+        throw new Error("fs unavailable");
+      },
+    });
+    const orphans: OrphanDir[] = [{ path: "/d/crashed2", issue: 13, ageS: 0 }];
+    await runBoot(deps, options({ orphans }));
+    expect(ghCalls.editLabels).toEqual([{ issue: 13, remove: ["running"], add: ["ready-for-agent"] }]);
   });
 
   it("keep-until removes only once the dir has aged past the TTL", async () => {

--- a/src/apps/dev/tests/session.test.ts
+++ b/src/apps/dev/tests/session.test.ts
@@ -379,6 +379,33 @@ describe("runSession", () => {
     expect(trace.processedOrder).toEqual([1]);
   });
 
+  it("--once skips past a lost claim race to the next candidate (#644 churn)", async () => {
+    // Under the fleet supervisor every worker is --once. A claim-lost on the
+    // head issue must not consume the single iteration — exiting here respawns
+    // a fresh worker that re-races the same head issue forever.
+    const { deps, ctx, trace } = makeSession({
+      candidates: [cand(1), cand(2), cand(3)],
+      once: true,
+      outcomeFor: (issue) => (issue === 1 ? "claim-lost" : "done"),
+    });
+    const summary = await runSession(deps, ctx);
+    expect(trace.processedOrder).toEqual([1, 2]); // lost #1 → moved on, ran #2, then stopped
+    expect(summary.done).toBe(1);
+    expect(summary.failed).toBe(1);
+  });
+
+  it("--once with every claim lost drains the whole queue without an attempt", async () => {
+    const { deps, ctx, trace } = makeSession({
+      candidates: [cand(1), cand(2)],
+      once: true,
+      outcomeFor: () => "claim-lost",
+    });
+    const summary = await runSession(deps, ctx);
+    expect(trace.processedOrder).toEqual([1, 2]);
+    expect(summary.done).toBe(0);
+    expect(summary.failed).toBe(2);
+  });
+
   it("aborts the drain on a precheck failure — no listing, no NO MORE TASKS", async () => {
     const bootResult: BootResult = { precheck: { ok: false, failed: "gh-missing" } };
     const { deps, ctx, trace } = makeSession({ candidates: [cand(1)], bootResult });

--- a/src/apps/dev/tests/supervisor.test.ts
+++ b/src/apps/dev/tests/supervisor.test.ts
@@ -442,8 +442,11 @@ describe("guardedTick — abandoned flag", () => {
       respawned: [],
       deaths: [],
       parked: [],
+      idleParked: [],
       reaped: [],
+      reconciledSlots: [],
       stopped: false,
+      queueDepth: 0,
       abandoned: false,
     }));
     const sleep = vi.fn((_ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 0)));
@@ -1097,8 +1100,8 @@ describe("envelope builders", () => {
 describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () => {
   const never = (): Promise<void> => new Promise<void>(() => {});
   const immediate = (): Promise<void> => Promise.resolve();
-  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0 };
-  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0 };
+  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0, abandoned: false };
+  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], reaped: [], reconciledSlots: [], stopped: false, queueDepth: 0, abandoned: true };
 
   it("returns the tick result when it completes before the ceiling", async () => {
     const logs: string[] = [];


### PR DESCRIPTION
Closes #644.

## The live failure

With a fleet of `--once` workers, every claim-race loser on the head-of-queue issue exited instead of moving on (the `--once` break fired on a `claim-lost` outcome), and the attempt dir + state that `buildProcessInput` pre-creates BEFORE the claim survived as debris naming an issue the loser never owned. The next boot's orphan sweep read that debris as a mid-issue crash and restored `ready-for-agent` over the live winner's `running` label — putting the issue back at the head of every respawned worker's queue. Net: deaths+respawns every 16s tick for ~25 min, 2 of 3 slots starved, breaker never tripped (claim-lost exits are clean — exempt by design, which this PR documents rather than changes).

## Fixes

1. **session.ts** — `--once` consumes the single supervised iteration only when an attempt actually ran; `claim-lost` continues to the next candidate (SKILL §Per-Issue Loop step 1: "abandon the attempt directory and skip to the next issue").
2. **run.ts** — abandon means **delete**: on `claim-lost` the pre-claim attempt dir/state are removed, so no debris dir can impersonate a crash.
3. **boot.ts** — the orphan sweep's `restore-and-remove` consults the issue's local claim lock first (new optional `BootLookups.claimHolderAlive`, wired to `claims/{N}/pid` liveness via the newly-exported `fs.claimPathHeldByLivePid`); a live holder downgrades to plain remove. Fail-open: a throwing lookup restores as before.

Drive-by: three `tests/supervisor.test.ts` mocks updated to the current `TickResult` shape — the #579 merge left main's typecheck broken (`abandoned`/`idleParked`/`reconciledSlots`/`queueDepth` missing).

## Tests

- session: `--once` + claim-lost skips to next candidate; all-lost drains the queue without burning the iteration.
- boot: live claim holder → no restore/no comment, dir removed; no live holder → restores as before; throwing lookup → fail-open restore.
- `tsc` clean (was broken on main); session+boot 71/71; supervisor `guardedTick` describes 6/6 (full suite validated by CI — local host is saturated by the running fleet).

## Breaker note (#644 item 4)

The circuit breaker exempts clean exits by design (a NO-MORE-TASKS drain must never trip it). The churn was only possible because claim-lost produced clean instant exits — fix 1 removes that source, so the exemption stays as-is.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783688282&installation_id=129708444&pr_number=646&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F646&signature=3b9bbd230511d4d4c7c656a2a766c03a117c62f294ba80e9e1e76a68430bbd71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live process detection for claim locks to better handle claim race scenarios.

* **Bug Fixes**
  * Fixed orphan directory cleanup to skip unnecessary restoration steps when processes are still active.
  * Corrected session behavior to properly continue processing when claim races occur with the `--once` flag.
  * Improved attempt directory handling to prevent orphaned state files from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->