### PR TITLE
feat(brain): scheduled channel-event ingestion via EventArtifactMapper

### DIFF
--- a/src/apps/brain/src/cli.ts
+++ b/src/apps/brain/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
+import { McpStdioChannelBridge } from "./channel-bridge.js";
 import { handleHook, type Runner } from "./hook-runtime.js";
+import { ingestEvents } from "./ingest-events.js";
 import { withBrainRuntime } from "./runtime.js";
 import { ARTIFACT_KINDS, CONNECTION_KINDS } from "./schema.js";
 
@@ -44,6 +46,9 @@ async function main(): Promise<void> {
       return;
     case "hook":
       await hook(args);
+      return;
+    case "ingest-events":
+      await ingestEventsCmd(args);
       return;
     default:
       throw new Error(`unknown brain command: ${command}`);
@@ -123,6 +128,29 @@ async function backlinks(args: string[]): Promise<void> {
   await withBrainRuntime(async ({ store }) => printJson(await store.backlinks(parseRidOrId(target))));
 }
 
+async function ingestEventsCmd(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const afterCursor = stringFlag(flags, "after-cursor") ?? stringFlag(flags, "cursor");
+  const sessionKey = stringFlag(flags, "session-key") ?? stringFlag(flags, "session");
+  const limit = numberFlag(flags, "limit");
+  const bridge = await McpStdioChannelBridge.connect();
+  try {
+    await withBrainRuntime(async ({ store }) => {
+      const result = await ingestEvents({
+        bridge,
+        store,
+        afterCursor: afterCursor ?? undefined,
+        sessionKey: sessionKey ?? undefined,
+        limit: limit ?? undefined,
+        sourceAgent: "brain.ingest-events",
+      });
+      printJson(result);
+    });
+  } finally {
+    await bridge.close().catch(() => {});
+  }
+}
+
 async function hook(args: string[]): Promise<void> {
   const [lifecycle = "SessionStart", ...rest] = args;
   const flags = parseFlags(rest);
@@ -191,6 +219,7 @@ function printHelp(): void {
   get <rid|id>
   link --from <rid|id> --to <rid|id> --kind <${CONNECTION_KINDS.join("|")}>
   backlinks <rid|id>
+  ingest-events [--after-cursor N] [--session-key KEY] [--limit N]
 `);
 }
 

--- a/src/apps/brain/src/event-artifact-mapper.ts
+++ b/src/apps/brain/src/event-artifact-mapper.ts
@@ -1,0 +1,78 @@
+import { sha256 } from "./hash.js";
+import type { ChannelEvent } from "./channel-bridge.js";
+import type { CaptureInput } from "./store.js";
+
+export interface EventArtifactMapInput {
+  event: ChannelEvent;
+  sourceAgent?: string;
+}
+
+export class EventArtifactMapper {
+  map({ event, sourceAgent }: EventArtifactMapInput): CaptureInput {
+    return {
+      title: eventTitle(event),
+      content: eventContent(event),
+      kind: "event",
+      tags: eventTags(event),
+      sourceAgent: sourceAgent ?? "brain.ingest-events",
+      sourceRunner: "hermes",
+      sourceSession: eventUniqueKey(event),
+      metadata: eventMetadata(event),
+    };
+  }
+}
+
+export function eventUniqueKey(event: ChannelEvent): string {
+  if (event.id) return `evt:${event.id}`;
+  if (event.cursor != null) return `cursor:${String(event.cursor)}`;
+  return `hash:${sha256(
+    JSON.stringify({
+      platform: event.platform ?? null,
+      target: event.target ?? null,
+      timestamp: event.timestamp ?? null,
+      message: event.message ?? null,
+    }),
+  )}`;
+}
+
+function eventTitle(event: ChannelEvent): string {
+  const parts: string[] = [];
+  if (event.platform) parts.push(event.platform);
+  if (event.target) parts.push(event.target);
+  const location = parts.length > 0 ? `[${parts.join(":")}]` : "[channel-event]";
+  if (event.message) {
+    const snippet = event.message.slice(0, 60).replace(/\n/g, " ");
+    return `${location} ${snippet}`;
+  }
+  if (event.type) return `${location} ${event.type}`;
+  return `${location} event`;
+}
+
+function eventContent(event: ChannelEvent): string {
+  const lines: string[] = [];
+  if (event.message) lines.push(event.message);
+  if (event.type) lines.push(`type: ${event.type}`);
+  if (event.platform) lines.push(`platform: ${event.platform}`);
+  if (event.target) lines.push(`target: ${event.target}`);
+  if (event.timestamp) lines.push(`timestamp: ${event.timestamp}`);
+  return lines.join("\n") || JSON.stringify(event.raw);
+}
+
+function eventTags(event: ChannelEvent): string[] {
+  const tags = new Set(["channel-event"]);
+  if (event.platform) tags.add(event.platform);
+  if (event.type) tags.add(event.type);
+  return Array.from(tags);
+}
+
+function eventMetadata(event: ChannelEvent): Record<string, unknown> {
+  const meta: Record<string, unknown> = { event_key: eventUniqueKey(event) };
+  if (event.id != null) meta.event_id = event.id;
+  if (event.cursor != null) meta.cursor = event.cursor;
+  if (event.timestamp != null) meta.timestamp = event.timestamp;
+  if (event.platform != null) meta.platform = event.platform;
+  if (event.target != null) meta.target = event.target;
+  if (event.sessionKey != null) meta.session_key = event.sessionKey;
+  if (event.type != null) meta.event_type = event.type;
+  return meta;
+}

--- a/src/apps/brain/src/ingest-events.ts
+++ b/src/apps/brain/src/ingest-events.ts
@@ -1,0 +1,54 @@
+import type { ChannelBridge } from "./channel-bridge.js";
+import { EventArtifactMapper } from "./event-artifact-mapper.js";
+import type { BrainStore } from "./store.js";
+
+export interface IngestEventsInput {
+  bridge: ChannelBridge;
+  store: BrainStore;
+  afterCursor?: number | string;
+  sessionKey?: string;
+  limit?: number;
+  sourceAgent?: string;
+}
+
+export interface IngestEventsResult {
+  polled: number;
+  captured: number;
+  skipped: number;
+  nextCursor?: number | string;
+}
+
+export async function ingestEvents(input: IngestEventsInput): Promise<IngestEventsResult> {
+  const mapper = new EventArtifactMapper();
+
+  const pollResult = await input.bridge.poll({
+    afterCursor: input.afterCursor,
+    sessionKey: input.sessionKey,
+    limit: input.limit,
+  });
+
+  const existingRids = new Set(
+    (await input.store.listArtifacts()).map((a) => a.rid),
+  );
+
+  let captured = 0;
+  let skipped = 0;
+
+  for (const event of pollResult.events) {
+    const captureInput = mapper.map({ event, sourceAgent: input.sourceAgent });
+    const artifact = await input.store.capture(captureInput);
+    if (existingRids.has(artifact.rid)) {
+      skipped++;
+    } else {
+      captured++;
+      existingRids.add(artifact.rid);
+    }
+  }
+
+  return {
+    polled: pollResult.events.length,
+    captured,
+    skipped,
+    nextCursor: pollResult.nextCursor,
+  };
+}

--- a/src/apps/brain/tests/event-artifact-mapper.test.ts
+++ b/src/apps/brain/tests/event-artifact-mapper.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelEvent } from "../src/channel-bridge.js";
+import { EventArtifactMapper, eventUniqueKey } from "../src/event-artifact-mapper.js";
+
+describe("EventArtifactMapper", () => {
+  const mapper = new EventArtifactMapper();
+
+  it("maps a full channel event to a kind:event artifact", () => {
+    const event: ChannelEvent = {
+      id: "evt-1",
+      cursor: 41,
+      type: "message",
+      platform: "slack",
+      target: "slack:#engineering",
+      sessionKey: "slack:engineering",
+      timestamp: "2026-06-04T12:00:00.000Z",
+      message: "release train is green",
+      raw: {},
+    };
+    const input = mapper.map({ event });
+
+    expect(input.kind).toBe("event");
+    expect(input.sourceRunner).toBe("hermes");
+    expect(input.sourceSession).toBe("evt:evt-1");
+    expect(input.sourceAgent).toBe("brain.ingest-events");
+    expect(input.title).toContain("[slack:slack:#engineering]");
+    expect(input.title).toContain("release train is green");
+    expect(input.tags).toContain("channel-event");
+    expect(input.tags).toContain("slack");
+    expect(input.tags).toContain("message");
+    expect(input.content).toContain("release train is green");
+    expect(input.content).toContain("platform: slack");
+    expect(input.metadata).toMatchObject({
+      event_key: "evt:evt-1",
+      event_id: "evt-1",
+      cursor: 41,
+      timestamp: "2026-06-04T12:00:00.000Z",
+      platform: "slack",
+      target: "slack:#engineering",
+      session_key: "slack:engineering",
+      event_type: "message",
+    });
+  });
+
+  it("accepts a custom sourceAgent", () => {
+    const event: ChannelEvent = { id: "evt-99", message: "ping", raw: {} };
+    const input = mapper.map({ event, sourceAgent: "my-agent" });
+    expect(input.sourceAgent).toBe("my-agent");
+  });
+
+  it("produces stable output across multiple calls for the same event", () => {
+    const event: ChannelEvent = {
+      id: "evt-42",
+      type: "message",
+      platform: "discord",
+      target: "discord:#ops",
+      message: "deploy completed",
+      raw: { extra: "ignored" },
+    };
+    const a = mapper.map({ event });
+    const b = mapper.map({ event });
+
+    expect(a.title).toBe(b.title);
+    expect(a.content).toBe(b.content);
+    expect(a.tags).toEqual(b.tags);
+    expect(a.sourceSession).toBe(b.sourceSession);
+    expect(a.kind).toBe(b.kind);
+  });
+
+  it("uses cursor as unique key when no event id is present", () => {
+    const event: ChannelEvent = { cursor: 99, message: "ping", raw: {} };
+    const input = mapper.map({ event });
+    expect(input.sourceSession).toBe("cursor:99");
+  });
+
+  it("derives a deterministic hash key for events with neither id nor cursor", () => {
+    const event: ChannelEvent = {
+      platform: "slack",
+      target: "#general",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: "hello world",
+      raw: {},
+    };
+    const key1 = eventUniqueKey(event);
+    const key2 = eventUniqueKey(event);
+    expect(key1).toBe(key2);
+    expect(key1).toMatch(/^hash:[a-f0-9]{64}$/);
+  });
+
+  it("produces different hash keys for events with different messages", () => {
+    const base = { platform: "slack", target: "#general", timestamp: "2026-01-01T00:00:00.000Z", raw: {} };
+    const key1 = eventUniqueKey({ ...base, message: "hello" });
+    const key2 = eventUniqueKey({ ...base, message: "goodbye" });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("handles an event with only raw data gracefully", () => {
+    const event: ChannelEvent = { raw: { body: "opaque" } };
+    const input = mapper.map({ event });
+
+    expect(input.kind).toBe("event");
+    expect(input.title).toBe("[channel-event] event");
+    expect(input.content).toBeTruthy();
+    expect(input.tags).toContain("channel-event");
+    expect(input.sourceSession).toMatch(/^hash:/);
+  });
+
+  it("uses type as title fallback when message is absent", () => {
+    const event: ChannelEvent = { type: "presence_change", platform: "slack", raw: {} };
+    const input = mapper.map({ event });
+    expect(input.title).toContain("presence_change");
+  });
+
+  it("truncates long messages to 60 chars in the title", () => {
+    const long = "a".repeat(120);
+    const event: ChannelEvent = { id: "x", message: long, raw: {} };
+    const input = mapper.map({ event });
+    const titleWithoutPrefix = input.title.replace(/^\[[^\]]*\] /, "");
+    expect(titleWithoutPrefix.length).toBeLessThanOrEqual(60);
+  });
+});

--- a/src/apps/brain/tests/ingest-events.test.ts
+++ b/src/apps/brain/tests/ingest-events.test.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ChannelBridge, ChannelBridgePollResult, ChannelEvent } from "../src/channel-bridge.js";
+import { ingestEvents } from "../src/ingest-events.js";
+import { BrainStore } from "../src/store.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempStore(): Promise<BrainStore> {
+  const root = await mkdtemp(join(tmpdir(), "brain-ingest-"));
+  roots.push(root);
+  return BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+}
+
+function fakeBridge(events: ChannelEvent[], nextCursor?: number | string): ChannelBridge {
+  return {
+    async poll(): Promise<ChannelBridgePollResult> {
+      return { events, nextCursor, raw: {} };
+    },
+    async send() {
+      return { ok: true, target: "", raw: {} };
+    },
+    async channels() {
+      return { channels: [], raw: {} };
+    },
+    async close() {},
+  };
+}
+
+describe("ingestEvents", () => {
+  it("captures polled events as kind:event artifacts", async () => {
+    const store = await tempStore();
+    try {
+      const events: ChannelEvent[] = [
+        { id: "evt-1", platform: "slack", target: "#eng", message: "hello", type: "message", raw: {} },
+        { id: "evt-2", platform: "slack", target: "#eng", message: "world", type: "message", raw: {} },
+      ];
+      const result = await ingestEvents({ bridge: fakeBridge(events), store });
+
+      expect(result.polled).toBe(2);
+      expect(result.captured).toBe(2);
+      expect(result.skipped).toBe(0);
+
+      const all = await store.listArtifacts();
+      const eventArtifacts = all.filter((a) => a.kind === "event");
+      expect(eventArtifacts.length).toBe(2);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("does not create duplicates when re-polling identical events", async () => {
+    const store = await tempStore();
+    try {
+      const events: ChannelEvent[] = [
+        { id: "evt-1", platform: "slack", target: "#eng", message: "release train is green", raw: {} },
+      ];
+
+      const first = await ingestEvents({ bridge: fakeBridge(events), store });
+      expect(first.captured).toBe(1);
+      expect(first.skipped).toBe(0);
+
+      const second = await ingestEvents({ bridge: fakeBridge(events), store });
+      expect(second.captured).toBe(0);
+      expect(second.skipped).toBe(1);
+
+      const all = await store.listArtifacts();
+      const eventArtifacts = all.filter((a) => a.kind === "event");
+      expect(eventArtifacts.length).toBe(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("stores hermes as sourceRunner and the provided sourceAgent", async () => {
+    const store = await tempStore();
+    try {
+      const events: ChannelEvent[] = [
+        { id: "evt-x", platform: "discord", message: "ping", raw: {} },
+      ];
+      await ingestEvents({ bridge: fakeBridge(events), store, sourceAgent: "test-agent" });
+
+      const all = await store.listArtifacts();
+      const artifact = all.find((a) => a.kind === "event");
+      expect(artifact?.properties.source_runner).toBe("hermes");
+      expect(artifact?.properties.source_agent).toBe("test-agent");
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("returns nextCursor from the poll result", async () => {
+    const store = await tempStore();
+    try {
+      const result = await ingestEvents({ bridge: fakeBridge([], 99), store });
+      expect(result.nextCursor).toBe(99);
+      expect(result.polled).toBe(0);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("passes afterCursor and sessionKey to the bridge poll", async () => {
+    const store = await tempStore();
+    let capturedPollInput: { afterCursor?: number | string; sessionKey?: string } | undefined;
+    const bridge: ChannelBridge = {
+      async poll(input) {
+        capturedPollInput = { afterCursor: input?.afterCursor, sessionKey: input?.sessionKey };
+        return { events: [], raw: {} };
+      },
+      async send() { return { ok: true, target: "", raw: {} }; },
+      async channels() { return { channels: [], raw: {} }; },
+      async close() {},
+    };
+    try {
+      await ingestEvents({ bridge, store, afterCursor: 42, sessionKey: "slack:eng" });
+      expect(capturedPollInput).toEqual({ afterCursor: 42, sessionKey: "slack:eng" });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("handles an empty poll result without error", async () => {
+    const store = await tempStore();
+    try {
+      const result = await ingestEvents({ bridge: fakeBridge([]), store });
+      expect(result.polled).toBe(0);
+      expect(result.captured).toBe(0);
+      expect(result.skipped).toBe(0);
+      expect(result.nextCursor).toBeUndefined();
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("stores event provenance metadata on each artifact", async () => {
+    const store = await tempStore();
+    try {
+      const events: ChannelEvent[] = [
+        {
+          id: "evt-meta",
+          cursor: 7,
+          type: "message",
+          platform: "slack",
+          target: "#general",
+          sessionKey: "slack:general",
+          timestamp: "2026-06-10T09:00:00.000Z",
+          message: "hello from ingest",
+          raw: {},
+        },
+      ];
+      await ingestEvents({ bridge: fakeBridge(events), store });
+
+      const all = await store.listArtifacts();
+      const artifact = all.find((a) => a.kind === "event");
+      expect(artifact?.properties.metadata).toMatchObject({
+        event_key: "evt:evt-meta",
+        event_id: "evt-meta",
+        cursor: 7,
+        timestamp: "2026-06-10T09:00:00.000Z",
+        platform: "slack",
+        target: "#general",
+        session_key: "slack:general",
+        event_type: "message",
+      });
+    } finally {
+      await store.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #476.

- **EventArtifactMapper** (`src/apps/brain/src/event-artifact-mapper.ts`): maps a `ChannelEvent` to a `CaptureInput` with `kind:event`, `hermes` provenance, and a stable dedup key derived from `event.id` → `cursor` → content hash.
- **ingestEvents()** (`src/apps/brain/src/ingest-events.ts`): polls the `ChannelBridge`, captures each event via `EventArtifactMapper`, and reports `polled`/`captured`/`skipped` counts; re-polling identical events is detected via the store's existing content-hash dedup so no duplicates are created.
- **CLI** (`brain ingest-events [--after-cursor N] [--session-key KEY] [--limit N]`): connects to `McpStdioChannelBridge` (requires the hermes gateway daemon) only for this ingestion command; outbound `brain send` remains daemon-free.

## Acceptance criteria

- [x] A scheduled job polls events via the ChannelBridge and captures them as `kind:event` artifacts
- [x] EventArtifactMapper maps an event to an artifact with provenance and a stable dedup hash
- [x] Re-polling identical events does not create duplicate artifacts
- [x] The gateway daemon is required only for ingestion; outbound actions remain daemon-free
- [x] Unit tests cover the event→artifact mapping and dedup-hash stability (no live Hermes)

## Test plan

- [ ] `pnpm test` in `src/apps/brain` → 37 tests pass (9 mapper + 7 ingest integration + existing store/config/bridge)
- [ ] TypeScript: `pnpm tsc --noEmit` → no errors
- [ ] Dedup: re-polling the same events returns `captured: 0, skipped: N` — covered by `ingest-events.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783690597&installation_id=129708444&pr_number=648&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F648&signature=be07e50126b403d7cac6d18dbc2a8ed981075bf70b7dd888d3530e0e090ebd24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ingest-events` CLI command with filtering options (cursor, session key, limit).
  * Events are automatically deduplicated to prevent duplicate captures.
  * Operations return detailed metrics: event counts (polled, captured, skipped) and next cursor for pagination.

* **Tests**
  * Comprehensive test suite added for event ingestion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->