### PR TITLE
feat(brain): add scheduled ingestion with cursor-state persistence (#476)

### DIFF
--- a/src/apps/brain/src/cli.ts
+++ b/src/apps/brain/src/cli.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { McpStdioChannelBridge } from "./channel-bridge.js";
 import { handleHook, type Runner } from "./hook-runtime.js";
 import { ingestEvents } from "./ingest-events.js";
 import { withBrainRuntime } from "./runtime.js";
 import { ARTIFACT_KINDS, CONNECTION_KINDS } from "./schema.js";
+import { loadIngestionState, saveIngestionState, scheduledIngest } from "./scheduled-ingestion.js";
 
 async function main(): Promise<void> {
   const [command = "help", ...args] = process.argv.slice(2);
@@ -49,6 +51,9 @@ async function main(): Promise<void> {
       return;
     case "ingest-events":
       await ingestEventsCmd(args);
+      return;
+    case "schedule-ingest":
+      await scheduleIngestCmd(args);
       return;
     default:
       throw new Error(`unknown brain command: ${command}`);
@@ -126,6 +131,31 @@ async function backlinks(args: string[]): Promise<void> {
   const target = args[0];
   if (!target) throw new Error("brain backlinks requires a rid or artifact id");
   await withBrainRuntime(async ({ store }) => printJson(await store.backlinks(parseRidOrId(target))));
+}
+
+async function scheduleIngestCmd(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const sessionKey = stringFlag(flags, "session-key") ?? stringFlag(flags, "session");
+  const limit = numberFlag(flags, "limit");
+  const bridge = await McpStdioChannelBridge.connect();
+  try {
+    await withBrainRuntime(async ({ config, store }) => {
+      const statePath = stringFlag(flags, "state") ?? join(config.rootDir, ".red", "brain", "ingestion-state.json");
+      const state = await loadIngestionState(statePath);
+      const result = await scheduledIngest({
+        bridge,
+        store,
+        state,
+        sessionKey: sessionKey ?? undefined,
+        limit: limit ?? undefined,
+        sourceAgent: "brain.schedule-ingest",
+      });
+      await saveIngestionState(statePath, result.state);
+      printJson(result);
+    });
+  } finally {
+    await bridge.close().catch(() => {});
+  }
 }
 
 async function ingestEventsCmd(args: string[]): Promise<void> {
@@ -220,6 +250,7 @@ function printHelp(): void {
   link --from <rid|id> --to <rid|id> --kind <${CONNECTION_KINDS.join("|")}>
   backlinks <rid|id>
   ingest-events [--after-cursor N] [--session-key KEY] [--limit N]
+  schedule-ingest [--session-key KEY] [--limit N] [--state PATH]
 `);
 }
 

--- a/src/apps/brain/src/scheduled-ingestion.ts
+++ b/src/apps/brain/src/scheduled-ingestion.ts
@@ -1,0 +1,64 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ChannelBridge } from "./channel-bridge.js";
+import { ingestEvents } from "./ingest-events.js";
+import type { BrainStore } from "./store.js";
+
+export interface IngestionState {
+  cursor?: number | string;
+  lastRunAt?: string;
+}
+
+export interface ScheduledIngestInput {
+  bridge: ChannelBridge;
+  store: BrainStore;
+  state: IngestionState;
+  sessionKey?: string;
+  limit?: number;
+  sourceAgent?: string;
+}
+
+export interface ScheduledIngestResult {
+  polled: number;
+  captured: number;
+  skipped: number;
+  state: IngestionState;
+}
+
+export async function scheduledIngest(input: ScheduledIngestInput): Promise<ScheduledIngestResult> {
+  const result = await ingestEvents({
+    bridge: input.bridge,
+    store: input.store,
+    afterCursor: input.state.cursor,
+    sessionKey: input.sessionKey,
+    limit: input.limit,
+    sourceAgent: input.sourceAgent,
+  });
+
+  const nextState: IngestionState = {
+    cursor: result.nextCursor ?? input.state.cursor,
+    lastRunAt: new Date().toISOString(),
+  };
+
+  return {
+    polled: result.polled,
+    captured: result.captured,
+    skipped: result.skipped,
+    state: nextState,
+  };
+}
+
+export async function loadIngestionState(path: string): Promise<IngestionState> {
+  try {
+    const text = await readFile(path, "utf8");
+    return JSON.parse(text) as IngestionState;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+export async function saveIngestionState(path: string, state: IngestionState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+}

--- a/src/apps/brain/tests/scheduled-ingestion.test.ts
+++ b/src/apps/brain/tests/scheduled-ingestion.test.ts
@@ -1,0 +1,166 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ChannelBridge, ChannelBridgePollResult, ChannelEvent } from "../src/channel-bridge.js";
+import {
+  loadIngestionState,
+  saveIngestionState,
+  scheduledIngest,
+  type IngestionState,
+} from "../src/scheduled-ingestion.js";
+import { BrainStore } from "../src/store.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "brain-sched-"));
+  roots.push(root);
+  return root;
+}
+
+async function tempStore(root: string): Promise<BrainStore> {
+  return BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+}
+
+function fakeBridge(events: ChannelEvent[], nextCursor?: number | string): ChannelBridge {
+  return {
+    async poll(): Promise<ChannelBridgePollResult> {
+      return { events, nextCursor, raw: {} };
+    },
+    async send() {
+      return { ok: true, target: "", raw: {} };
+    },
+    async channels() {
+      return { channels: [], raw: {} };
+    },
+    async close() {},
+  };
+}
+
+describe("scheduledIngest", () => {
+  it("advances cursor to nextCursor from the bridge poll", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const result = await scheduledIngest({
+        bridge: fakeBridge([], 42),
+        store,
+        state: {},
+      });
+      expect(result.state.cursor).toBe(42);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("passes saved cursor as afterCursor on successive runs", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    const capturedCursors: Array<number | string | undefined> = [];
+    const bridge: ChannelBridge = {
+      async poll(input) {
+        capturedCursors.push(input?.afterCursor);
+        return { events: [], nextCursor: (input?.afterCursor ?? 0) as number + 10, raw: {} };
+      },
+      async send() { return { ok: true, target: "", raw: {} }; },
+      async channels() { return { channels: [], raw: {} }; },
+      async close() {},
+    };
+    try {
+      const first = await scheduledIngest({ bridge, store, state: {} });
+      expect(capturedCursors[0]).toBeUndefined();
+      expect(first.state.cursor).toBe(10);
+
+      const second = await scheduledIngest({ bridge, store, state: first.state });
+      expect(capturedCursors[1]).toBe(10);
+      expect(second.state.cursor).toBe(20);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("retains cursor when nextCursor is absent from the bridge", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const first = await scheduledIngest({ bridge: fakeBridge([], 77), store, state: {} });
+      expect(first.state.cursor).toBe(77);
+
+      const second = await scheduledIngest({ bridge: fakeBridge([]), store, state: first.state });
+      expect(second.state.cursor).toBe(77);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("captures events and deduplicates across runs", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const events: ChannelEvent[] = [
+        { id: "evt-1", platform: "slack", target: "#eng", message: "hello", raw: {} },
+      ];
+
+      const first = await scheduledIngest({ bridge: fakeBridge(events), store, state: {} });
+      expect(first.captured).toBe(1);
+      expect(first.skipped).toBe(0);
+
+      const second = await scheduledIngest({ bridge: fakeBridge(events), store, state: first.state });
+      expect(second.captured).toBe(0);
+      expect(second.skipped).toBe(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("records lastRunAt on each run", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const result = await scheduledIngest({ bridge: fakeBridge([]), store, state: {} });
+      expect(result.state.lastRunAt).toBeDefined();
+      expect(typeof result.state.lastRunAt).toBe("string");
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("loadIngestionState / saveIngestionState", () => {
+  it("returns empty state when file does not exist", async () => {
+    const root = await tempDir();
+    const state = await loadIngestionState(join(root, "missing.json"));
+    expect(state).toEqual({});
+  });
+
+  it("round-trips a state through save and load", async () => {
+    const root = await tempDir();
+    const path = join(root, "state.json");
+    const saved: IngestionState = { cursor: 123, lastRunAt: "2026-06-10T00:00:00.000Z" };
+    await saveIngestionState(path, saved);
+    const loaded = await loadIngestionState(path);
+    expect(loaded).toEqual(saved);
+  });
+
+  it("creates missing parent directories on save", async () => {
+    const root = await tempDir();
+    const path = join(root, "deep", "nested", "state.json");
+    await saveIngestionState(path, { cursor: 1 });
+    const loaded = await loadIngestionState(path);
+    expect(loaded.cursor).toBe(1);
+  });
+
+  it("overwrites existing state on successive saves", async () => {
+    const root = await tempDir();
+    const path = join(root, "state.json");
+    await saveIngestionState(path, { cursor: 10 });
+    await saveIngestionState(path, { cursor: 20 });
+    const loaded = await loadIngestionState(path);
+    expect(loaded.cursor).toBe(20);
+  });
+});


### PR DESCRIPTION
Closes #476

## Summary

- Add `scheduledIngest()`: wraps `ingestEvents` with `IngestionState` tracking so successive cron/scheduled runs automatically advance the poll cursor without caller having to supply `--after-cursor` manually
- Add `loadIngestionState()` / `saveIngestionState()` to persist `cursor + lastRunAt` in a JSON state file between invocations (defaults to `.red/brain/ingestion-state.json`)
- Wire `brain schedule-ingest [--session-key KEY] [--limit N] [--state PATH]` CLI command as the entry point for cron-driven scheduled ingestion

## Test plan

- [ ] All 46 brain tests pass (`pnpm test` in `src/apps/brain`)
- [ ] 9 new `scheduled-ingestion.test.ts` tests cover: cursor advancement, successive-run cursor forwarding, cursor retention when `nextCursor` is absent, cross-run dedup, `lastRunAt` recording, and state-file round-trip / directory-creation / overwrite
- [ ] `brain schedule-ingest` requires hermes gateway only for ingestion; outbound `brain` commands remain daemon-free

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783692385&installation_id=129708444&pr_number=649&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F649&signature=b56047d01d319d4e5d541f6421183be957e3105f487e93cf28c96bdd0702db99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `schedule-ingest` CLI command to enable scheduled event ingestion with configurable session keys, limits, and state tracking.
  * Ingestion state is automatically persisted between runs, allowing cursor continuity and deduplication across successive executions.

* **Tests**
  * Added comprehensive test suite for scheduled ingestion functionality, including cursor behavior, event deduplication, and state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->