### PR TITLE
feat(brain): scheduled channel-event ingestion with cursor-state persistence (#476)

### DIFF
--- a/src/apps/brain/src/cli.ts
+++ b/src/apps/brain/src/cli.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { McpStdioChannelBridge } from "./channel-bridge.js";
 import { handleHook, type Runner } from "./hook-runtime.js";
 import { ingestEvents } from "./ingest-events.js";
 import { withBrainRuntime } from "./runtime.js";
 import { brainAct } from "./brain-act.js";
 import { ARTIFACT_KINDS, CONNECTION_KINDS } from "./schema.js";
+import { loadIngestionState, saveIngestionState, scheduledIngest } from "./scheduled-ingestion.js";
 
 async function main(): Promise<void> {
   const [command = "help", ...args] = process.argv.slice(2);
@@ -53,6 +55,9 @@ async function main(): Promise<void> {
       return;
     case "ingest-events":
       await ingestEventsCmd(args);
+      return;
+    case "schedule-ingest":
+      await scheduleIngestCmd(args);
       return;
     default:
       throw new Error(`unknown brain command: ${command}`);
@@ -130,6 +135,31 @@ async function backlinks(args: string[]): Promise<void> {
   const target = args[0];
   if (!target) throw new Error("brain backlinks requires a rid or artifact id");
   await withBrainRuntime(async ({ store }) => printJson(await store.backlinks(parseRidOrId(target))));
+}
+
+async function scheduleIngestCmd(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const sessionKey = stringFlag(flags, "session-key") ?? stringFlag(flags, "session");
+  const limit = numberFlag(flags, "limit");
+  const bridge = await McpStdioChannelBridge.connect();
+  try {
+    await withBrainRuntime(async ({ config, store }) => {
+      const statePath = stringFlag(flags, "state") ?? join(config.rootDir, ".red", "brain", "ingestion-state.json");
+      const state = await loadIngestionState(statePath);
+      const result = await scheduledIngest({
+        bridge,
+        store,
+        state,
+        sessionKey: sessionKey ?? undefined,
+        limit: limit ?? undefined,
+        sourceAgent: "brain.schedule-ingest",
+      });
+      await saveIngestionState(statePath, result.state);
+      printJson(result);
+    });
+  } finally {
+    await bridge.close().catch(() => {});
+  }
 }
 
 async function ingestEventsCmd(args: string[]): Promise<void> {
@@ -234,6 +264,7 @@ function printHelp(): void {
   backlinks <rid|id>
   act --target <channel> --message <text>
   ingest-events [--after-cursor N] [--session-key KEY] [--limit N]
+  schedule-ingest [--session-key KEY] [--limit N] [--state PATH]
 `);
 }
 

--- a/src/apps/brain/src/scheduled-ingestion.ts
+++ b/src/apps/brain/src/scheduled-ingestion.ts
@@ -1,0 +1,64 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ChannelBridge } from "./channel-bridge.js";
+import { ingestEvents } from "./ingest-events.js";
+import type { BrainStore } from "./store.js";
+
+export interface IngestionState {
+  cursor?: number | string;
+  lastRunAt?: string;
+}
+
+export interface ScheduledIngestInput {
+  bridge: ChannelBridge;
+  store: BrainStore;
+  state: IngestionState;
+  sessionKey?: string;
+  limit?: number;
+  sourceAgent?: string;
+}
+
+export interface ScheduledIngestResult {
+  polled: number;
+  captured: number;
+  skipped: number;
+  state: IngestionState;
+}
+
+export async function scheduledIngest(input: ScheduledIngestInput): Promise<ScheduledIngestResult> {
+  const result = await ingestEvents({
+    bridge: input.bridge,
+    store: input.store,
+    afterCursor: input.state.cursor,
+    sessionKey: input.sessionKey,
+    limit: input.limit,
+    sourceAgent: input.sourceAgent,
+  });
+
+  const nextState: IngestionState = {
+    cursor: result.nextCursor ?? input.state.cursor,
+    lastRunAt: new Date().toISOString(),
+  };
+
+  return {
+    polled: result.polled,
+    captured: result.captured,
+    skipped: result.skipped,
+    state: nextState,
+  };
+}
+
+export async function loadIngestionState(path: string): Promise<IngestionState> {
+  try {
+    const text = await readFile(path, "utf8");
+    return JSON.parse(text) as IngestionState;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+export async function saveIngestionState(path: string, state: IngestionState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + "\n", "utf8");
+}

--- a/src/apps/brain/tests/scheduled-ingestion.test.ts
+++ b/src/apps/brain/tests/scheduled-ingestion.test.ts
@@ -1,0 +1,166 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ChannelBridge, ChannelBridgePollResult, ChannelEvent } from "../src/channel-bridge.js";
+import {
+  loadIngestionState,
+  saveIngestionState,
+  scheduledIngest,
+  type IngestionState,
+} from "../src/scheduled-ingestion.js";
+import { BrainStore } from "../src/store.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function tempDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "brain-sched-"));
+  roots.push(root);
+  return root;
+}
+
+async function tempStore(root: string): Promise<BrainStore> {
+  return BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+}
+
+function fakeBridge(events: ChannelEvent[], nextCursor?: number | string): ChannelBridge {
+  return {
+    async poll(): Promise<ChannelBridgePollResult> {
+      return { events, nextCursor, raw: {} };
+    },
+    async send() {
+      return { ok: true, target: "", raw: {} };
+    },
+    async channels() {
+      return { channels: [], raw: {} };
+    },
+    async close() {},
+  };
+}
+
+describe("scheduledIngest", () => {
+  it("advances cursor to nextCursor from the bridge poll", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const result = await scheduledIngest({
+        bridge: fakeBridge([], 42),
+        store,
+        state: {},
+      });
+      expect(result.state.cursor).toBe(42);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("passes saved cursor as afterCursor on successive runs", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    const capturedCursors: Array<number | string | undefined> = [];
+    const bridge: ChannelBridge = {
+      async poll(input) {
+        capturedCursors.push(input?.afterCursor);
+        return { events: [], nextCursor: (input?.afterCursor ?? 0) as number + 10, raw: {} };
+      },
+      async send() { return { ok: true, target: "", raw: {} }; },
+      async channels() { return { channels: [], raw: {} }; },
+      async close() {},
+    };
+    try {
+      const first = await scheduledIngest({ bridge, store, state: {} });
+      expect(capturedCursors[0]).toBeUndefined();
+      expect(first.state.cursor).toBe(10);
+
+      const second = await scheduledIngest({ bridge, store, state: first.state });
+      expect(capturedCursors[1]).toBe(10);
+      expect(second.state.cursor).toBe(20);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("retains cursor when nextCursor is absent from the bridge", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const first = await scheduledIngest({ bridge: fakeBridge([], 77), store, state: {} });
+      expect(first.state.cursor).toBe(77);
+
+      const second = await scheduledIngest({ bridge: fakeBridge([]), store, state: first.state });
+      expect(second.state.cursor).toBe(77);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("captures events and deduplicates across runs", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const events: ChannelEvent[] = [
+        { id: "evt-1", platform: "slack", target: "#eng", message: "hello", raw: {} },
+      ];
+
+      const first = await scheduledIngest({ bridge: fakeBridge(events), store, state: {} });
+      expect(first.captured).toBe(1);
+      expect(first.skipped).toBe(0);
+
+      const second = await scheduledIngest({ bridge: fakeBridge(events), store, state: first.state });
+      expect(second.captured).toBe(0);
+      expect(second.skipped).toBe(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("records lastRunAt on each run", async () => {
+    const root = await tempDir();
+    const store = await tempStore(root);
+    try {
+      const result = await scheduledIngest({ bridge: fakeBridge([]), store, state: {} });
+      expect(result.state.lastRunAt).toBeDefined();
+      expect(typeof result.state.lastRunAt).toBe("string");
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("loadIngestionState / saveIngestionState", () => {
+  it("returns empty state when file does not exist", async () => {
+    const root = await tempDir();
+    const state = await loadIngestionState(join(root, "missing.json"));
+    expect(state).toEqual({});
+  });
+
+  it("round-trips a state through save and load", async () => {
+    const root = await tempDir();
+    const path = join(root, "state.json");
+    const saved: IngestionState = { cursor: 123, lastRunAt: "2026-06-10T00:00:00.000Z" };
+    await saveIngestionState(path, saved);
+    const loaded = await loadIngestionState(path);
+    expect(loaded).toEqual(saved);
+  });
+
+  it("creates missing parent directories on save", async () => {
+    const root = await tempDir();
+    const path = join(root, "deep", "nested", "state.json");
+    await saveIngestionState(path, { cursor: 1 });
+    const loaded = await loadIngestionState(path);
+    expect(loaded.cursor).toBe(1);
+  });
+
+  it("overwrites existing state on successive saves", async () => {
+    const root = await tempDir();
+    const path = join(root, "state.json");
+    await saveIngestionState(path, { cursor: 10 });
+    await saveIngestionState(path, { cursor: 20 });
+    const loaded = await loadIngestionState(path);
+    expect(loaded.cursor).toBe(20);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scheduledIngest` function that wraps `ingestEvents` with cursor-state persistence, allowing repeated polls to pick up only new events
- Adds `loadIngestionState`/`saveIngestionState` helpers for reading/writing a JSON cursor file (creates parent dirs, tolerates missing file)
- Wires up a `schedule-ingest` CLI command in `brain` that loads state, runs a poll, and saves the updated cursor + timestamp

## Acceptance criteria coverage

- Scheduled job polls events via ChannelBridge and captures them as `kind:event` artifacts ✅
- EventArtifactMapper maps events with provenance and stable dedup hash ✅ (landed in prior commit on main)
- Re-polling identical events does not create duplicate artifacts ✅ (store-level hash dedup + ingestEvents skip counter)
- Gateway daemon required only for ingestion; outbound `brain act` remains daemon-free ✅
- Unit tests cover event→artifact mapping and dedup-hash stability with no live Hermes ✅ (9 new tests, 58 total pass)

## Test plan

- [ ] `pnpm test --run` in `src/apps/brain` → all 58 tests pass
- [ ] `pnpm exec tsc --noEmit` → no type errors
- [ ] `brain schedule-ingest` CLI command listed in `brain help`

Closes #476

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783695412&installation_id=129708444&pr_number=654&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F654&signature=eb7c89f48a79672c9820397044f465bc650d80d29a373bc42c56ae895ac6180b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `schedule-ingest` CLI command for managing data ingestion operations with configurable session keys and limit options
  * Ingestion state is now automatically persisted, enabling resumable operations with progress tracking

* **Tests**
  * Added comprehensive test coverage for scheduled ingestion workflows and state persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->