### PR TITLE
fix(afk): progress probe and heartbeat diffstat compute against resolved base

### DIFF
--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -711,8 +711,9 @@ export function buildProcessDeps(
         const worktree =
           (await gitx.worktreePathUnder(gitCtx, current.attemptDir).catch(() => undefined)) ??
           join(current.attemptDir, "worktree");
+        const baseRef = info.base ? `origin/${info.base}` : "origin/main";
         const { added, removed } = await gitx
-          .diffstatShortstat({ cwd: worktree }, "origin/main")
+          .diffstatShortstat({ cwd: worktree }, baseRef)
           .catch(() => ({ added: 0, removed: 0 }));
         const hb = buildProgressHeartbeat({
           secsSinceProgress: secs,
@@ -729,6 +730,7 @@ export function buildProcessDeps(
         await updateState(join(current.attemptDir, "afk.state.json"), {
           ...hb.statePatch,
           "current.worktree": worktree,
+          ...(info.base ? { "current.base": info.base } : {}),
         }).catch(() => {});
       })();
     },

--- a/src/apps/dev/src/core/execution.ts
+++ b/src/apps/dev/src/core/execution.ts
@@ -682,6 +682,9 @@ export interface AttemptProgressInfo {
   lastProgressMs: number;
   /** The guard's clock (epoch ms) at this tick. */
   nowMs: number;
+  /** Resolved base branch (lock > pin > main) for this attempt — populated by
+   * processIssue so the emitHeartbeat sink can diff against the correct ref. */
+  base?: string;
 }
 
 export function startAttemptGuard(opts: {

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -685,7 +685,7 @@ export async function processIssue(
             attempt_n: attemptN,
           }),
         );
-        deps.emitHeartbeat?.(info);
+        deps.emitHeartbeat?.({ ...info, base });
       },
       // Restore the issue #191 continuous-push guarantee: sandcastle pushes the
       // worker branch up-front + after every commit (host worktree hook), so a

--- a/src/apps/dev/src/runtime/wire.ts
+++ b/src/apps/dev/src/runtime/wire.ts
@@ -301,7 +301,8 @@ export function makeRunAgent(
               const gitCtx = { cwd: input.cwd ?? process.cwd() };
               const worktree = await gitx.worktreePathForBranch(gitCtx, input.branch);
               if (!worktree) return undefined;
-              const { added, removed } = await gitx.diffstatShortstat({ cwd: worktree }, "origin/main");
+              const baseRef = input.base ? `origin/${input.base}` : "origin/main";
+              const { added, removed } = await gitx.diffstatShortstat({ cwd: worktree }, baseRef);
               return added + removed;
             },
           }
@@ -398,7 +399,8 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
     let added = state.current.diff_added;
     let removed = state.current.diff_removed;
     if (added === 0 && removed === 0 && state.current.worktree) {
-      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, "origin/main");
+      const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
+      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
       added = stat.added;
       removed = stat.removed;
     }
@@ -535,7 +537,8 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     let r = state.current.diff_removed;
     if (a === 0 && r === 0 && state.current.worktree) {
       // Fallback: compute the diffstat from the worktree like statusline.sh.
-      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, "origin/main");
+      const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
+      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
       a = stat.added;
       r = stat.removed;
     }

--- a/src/apps/dev/src/types/state.ts
+++ b/src/apps/dev/src/types/state.ts
@@ -30,6 +30,10 @@ export const AfkCurrentSchema = z.object({
    * each time the inner agent's re-invocation count ticks. Lets the monitor show
    * "iter N/max" and surfaces a run burning through iterations re-validating. */
   iteration: z.union([z.number(), z.string()]).optional().default(""),
+  /** Resolved base branch (lock > pin > main) for this attempt. Persisted on
+   * first heartbeat so the monitor/statusline fallback diffstat uses the correct
+   * ref instead of hardcoding origin/main. */
+  base: z.string().default(""),
 });
 
 export const AfkStateSchema = z.object({

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -10,6 +10,7 @@ import type { AgentEffort, RunAgentInput, RunAgentResult } from "../src/core/exe
 import type { AttemptRecordPayload } from "../src/core/attempt-record.js";
 import type { IssueClassificationMetadata } from "../src/core/issue-classifier.js";
 import { parseCurrentBlocker, upsertCurrentBlocker } from "../src/core/blocker-state.js";
+import type { AttemptProgressInfo } from "../src/core/execution.js";
 
 // Everything injected is a fake — no real gh / git / sandcastle / pnpm / fs ever
 // runs. The harness records the side-effect sequence (label edits, comments,
@@ -1684,5 +1685,52 @@ describe("processIssue — timeout (attempt progress guard fired)", () => {
     expect(edit.add).toContain("blocked:validation");
     // The park envelope rides the generic `blocked` status bucket.
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+  });
+});
+
+describe("processIssue — emitHeartbeat receives resolved base (issue #570)", () => {
+  it("passes the resolved non-main base to emitHeartbeat when the issue body pins a branch", async () => {
+    const heartbeatInfos: AttemptProgressInfo[] = [];
+    const pinBody = "branch: release/v2\n## Agent brief\nDo it.";
+    const { deps, input } = harness({ outcome: "done", feedbackOk: true, body: pinBody });
+    const customDeps: ProcessIssueDeps = {
+      ...deps,
+      emitHeartbeat: (info) => heartbeatInfos.push(info),
+      runAgent: async (ri) => {
+        ri.onHeartbeat?.({ head: "abc123", lastProgressMs: 0, nowMs: 0 });
+        return {
+          outcome: "done",
+          branch: ri.branch,
+          commits: [{ sha: "deadbee" }],
+          completionSignal: "<promise>DONE</promise>",
+          stdout: "",
+        };
+      },
+    };
+    await processIssue(customDeps, input);
+    expect(heartbeatInfos).toHaveLength(1);
+    expect(heartbeatInfos[0]?.base).toBe("release/v2");
+  });
+
+  it("passes main as base when no pin and no lock", async () => {
+    const heartbeatInfos: AttemptProgressInfo[] = [];
+    const { deps, input } = harness({ outcome: "done", feedbackOk: true });
+    const customDeps: ProcessIssueDeps = {
+      ...deps,
+      emitHeartbeat: (info) => heartbeatInfos.push(info),
+      runAgent: async (ri) => {
+        ri.onHeartbeat?.({ head: "abc123", lastProgressMs: 0, nowMs: 0 });
+        return {
+          outcome: "done",
+          branch: ri.branch,
+          commits: [{ sha: "deadbee" }],
+          completionSignal: "<promise>DONE</promise>",
+          stdout: "",
+        };
+      },
+    };
+    await processIssue(customDeps, input);
+    expect(heartbeatInfos).toHaveLength(1);
+    expect(heartbeatInfos[0]?.base).toBe("main");
   });
 });


### PR DESCRIPTION
Closes #570

## Summary

Both the attempt-progress probe (edit-signal gate) and the heartbeat `+A/-R` diffstat hardcoded `origin/main` as the comparison ref. On a locked/pinned non-main branch the displayed line-diff and the edit-progress signal were wrong.

**Fix:** derive the comparison ref from the attempt's resolved base (`lock > pin > main`) across all five paths that compute it.

| Path | File | Change |
|------|------|--------|
| Attempt progress probe | `wire.ts` | `input.base → origin/<base>` |
| Heartbeat live diffstat | `run.ts` | `info.base → origin/<base>` |
| processIssue spreads base | `process-issue.ts` | `{ ...info, base }` into emitHeartbeat |
| Monitor fallback diffstat | `wire.ts` | `state.current.base → origin/<base>` |
| Statusline fallback diffstat | `wire.ts` | `state.current.base → origin/<base>` |

Supporting: `AttemptProgressInfo.base?` (`execution.ts`) + `AfkCurrentSchema.base` default `""` (`state.ts`).

## Tests

New describe block `processIssue — emitHeartbeat receives resolved base` (2 cases):
- Pinned `release/v2` body → heartbeat receives `base: "release/v2"`
- No pin/lock → heartbeat receives `base: "main"`

`process-issue.test.ts`: 72 pass / 0 fail. `tsc --noEmit`: no errors in changed files.

## Note

This is a clean cherry-pick of `2dbab1aa` from `afk/wBZWE/570-fix-afk-attempt-progress-guard-and-heart` — the original branch had AFK salvage commits that added local machine symlinks for `node_modules`, which caused `blocked:validation`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783695734&installation_id=129708444&pr_number=655&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F655&signature=17261dcf9fd528f5dc127bd78fdf8402fcc1a9a099216b77c1f369410432a041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->