### PR TITLE
docs(afk): execution-environment command surface — GHA + k8s adoption path (Refs #631)

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -124,7 +124,17 @@ _Avoid_: fleet supervisor, worker scheduler
 
 **Codex monitor agent**:
 A Codex TUI sub-agent used only as a read-only AFK state presentation surface.
-_Avoid_: AFK worker, supervisor slot
+_Avoid_: AFK worker, supervisor
+
+**Execution environment**:
+A non-interactive runtime that drives `/afk --issues N --runner opencode --once` for one attempt per invocation. The two target surfaces are the GitHub Actions lane (a `workflow_call` reusable workflow that any adopting repo invokes) and the k8s lane (a container image + `Job` manifest the team runs on a self-hosted cluster). Both share the same runtime contract — one attempt, one issue, one PR, no fleet — and differ only in trigger and secret-injection surface. Issue [#631](https://github.com/reddb-io/red-skills/issues/631) (ADR 0059) tracks the reusable workflow + container.
+_Avoid_: GHA-only, k8s-only, CI lane, production lane
+
+**Actions lane**:
+The GitHub Actions surface of the **Execution environment** — a published `workflow_call` reusable workflow (red-prefixed filename) that any adopting repo invokes with its own secrets. The wrapper takes inputs (issue number, runner, model slug, trust-gate flag) and the API key, then runs the inner `/afk --issues N --runner opencode --once` command. Per invocation: one attempt, one issue, one PR, no admin-merge.
+_Avoid_: GHA, reusable workflow (when referring to the lane), CI job
+
+ slot
 
 **Skill**:
 An agent-loadable behavior package rooted at a `SKILL.md` plus optional support files.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,19 @@ Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see
 
 ---
 
+## afk (engineering) — execution-environment command surface documented; Actions lane #631 ready-for-agent (#640, ADR 0059)
+
+- **status**: modified (docs only — no code/runtime change)
+- **upstream**: —
+- **why**: The OpenCode runner merged in #626/#640 runs the same `/afk --issues N --runner opencode --once` invocation regardless of where it is invoked from. Adopters who want to drive it from a GitHub Actions runner or a k8s pod need to know (a) the command line is stable, (b) the secret-injection surface is the env-precedence resolver (`OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY`), (c) the trust gate is rigorous by default. The reusable workflow + container k8s job that wrap this command for adopters are tracked as #631.
+- **what changed**:
+  - `plugins/dev/skills/engineering/afk/SKILL.md`: new *Running `/afk` in an execution environment (GitHub Actions / k8s)* subsection under *When To Use* documents the canonical invocation, the env-var injection surface, the runtime/caller responsibility split (a 12-row table), the recommended `--permissions:` block for GHA, and the trust-gate-by-default contract. No new subcommand — the existing `/afk --issues N --runner opencode --once` IS the execution-environment command.
+  - `.red/contexts/dev/CONTEXT.md`: two new glossary terms — *Execution environment* (GHA + k8s, shared runtime contract) and *Actions lane* (the GHA reusable-workflow surface of the execution environment) — with avoid-antonyms.
+  - Issue [#631](https://github.com/reddb-io/red-skills/issues/631): rewritten body with full GHA + k8s acceptance criteria (reusable workflow with inputs/secrets/permissions, container Dockerfile + k8s job.yaml, trust gate enforcement, atomic claim via ADR 0056, no admin-merge by default, thin caller example, E2E test), hard deps mapped to #621 / #622 / #625, suggested slice ordering, out-of-scope. Label flipped from `blocked:dependency` to `ready-for-agent` so the slice can be claimed and executed.
+- **no runtime change** — the command surface is unchanged; the docs lift the existing runtime contract into the GHA/k8s context so adopters can wire the lane without re-reading the source.
+
+---
+
 ## afk (engineering) — OpenCode runner is endpoint-agnostic; env-precedence auth (OPENAI > MINIMAX > OPENROUTER) (#638, ADR 0059 amendment 1+2)
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -58,6 +58,56 @@ AFK drives the sandcastle Orchestrator through **injected providers** (`Sandcast
 - `/afk fleet stop` — gracefully shut down a running fleet supervisor and cancel its auto-monitor cron.
 - `/afk reap` — run branch hygiene without starting a worker: one count line for remote `afk/*`, remote `afk-attempts/*`, and local `afk/*`, then the same safe reapers used at boot.
 
+### Running `/afk` in an execution environment (GitHub Actions / k8s)
+
+The same `/afk --issues N --runner opencode --once` command runs unchanged
+in a GitHub Actions runner or a k8s pod — it is the canonical
+**execution-environment** invocation. The runtime contract is identical to
+the local one (one attempt, one issue, one PR per invocation, no fleet
+semantics); only the trigger and the secret-injection surface differ.
+
+The reusable workflow (`red-afk-attempt.yml`, `workflow_call`) and the k8s
+job manifest (container `Dockerfile` + `job.yaml`) that wrap this command
+for GHA / k8s adopters are tracked as [#631](https://github.com/reddb-io/red-skills/issues/631)
+(ADR 0059). Until #631 lands, an adopter can wire a thin caller
+themselves — the command line is stable:
+
+```bash
+# GHA reusable workflow body, or k8s container CMD
+export RED_AFK_RUNNER=opencode
+# One of the precedence env-vars, set from a secret:
+export MINIMAX_API_KEY="${{ secrets.MINIMAX_API_KEY }}"   # or OPENAI_API_KEY / OPENROUTER_API_KEY
+node plugins/dev/skills/engineering/afk/bin/afk.mjs run --issues "$ISSUE_NUMBER" --runner opencode --once
+```
+
+What the runtime does (and what is the caller's job):
+
+| step | runtime (`/afk`) | caller (GHA / k8s) |
+|---|---|---|
+| checkout the repo | — | yes — `actions/checkout@v4` or initContainer with the same git ref |
+| install pnpm | — | yes — `pnpm/action-setup@v4` or baked into the image |
+| install workspace deps | — | yes — `pnpm install --frozen-lockfile` |
+| expose the API key | env-precedence resolver reads `OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY` from `process.env` | yes — wire the secret into the env (Actions: `${{ secrets.* }}`; k8s: `envFrom: secretRef`) |
+| resolve the model slug | `afk.models.opencode.<tier>.model` from the repo's `.red/config.yaml` | — |
+| run one attempt | `run --issues N --runner opencode --once` | — |
+| claim the issue | ADR 0056 GitHub-native CAS (when #622 lands) | — |
+| enforce the trust gate | predicate on author + label-actor (when #621 lands) | — |
+| push the worker branch | `git push origin …` | — (the runtime does it; no GITHUB_TOKEN dance required at the caller) |
+| post the terminal envelope | `gh issue comment` on the issue | caller grants `issues: write`; runtime has no `GITHUB_TOKEN` of its own |
+| open the PR | `gh pr create` | caller grants `pull-requests: write` |
+
+The recommended `--permissions:` for the GHA workflow is exactly
+`contents: write, issues: write, pull-requests: write` — no `id-token: write`
+(no OIDC needed for this lane) and no `actions: write` (the workflow does
+not publish actions). The k8s `ServiceAccount` needs the same scope bound
+to the same `GITHUB_TOKEN` Secret.
+
+Trust gate is **rigorous by default** in the Actions lane: the workflow
+refuses to claim an issue whose author or label-actor is not in
+`plugins.dev.afk.trust_gate.allowlist`. The opt-out is
+`enforce-trust-gate: false` on the workflow input — for the red-skills
+team's own private-repo runs, never for an adopting public repo.
+
 ## Parallelization
 
 `/afk` is **trivially parallel** — just open another terminal and run `/afk` again. No flag, no coordination, no slot to manage.


### PR DESCRIPTION
## What

Lifts the existing `/afk --issues N --runner opencode --once` invocation
into the GHA + k8s adoption context. No runtime change — the command line
is stable across local, GHA, and k8s. The reusable workflow + container
that wrap this for adopters are tracked as #631 (now `ready-for-agent`
with the full GHA + k8s acceptance criteria, hard deps mapped to
#621/#622/#625, suggested slice order).

## Why

Adopters who want to drive the AFK inner agent from a GitHub Actions
runner or a k8s pod need to know:

1. The command line is stable (no new subcommand, no flag).
2. The secret-injection surface is the env-precedence resolver
   (`OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY`, see
   PR #640).
3. The trust gate is rigorous by default in the Actions lane.

Without this doc, an adopter has to read the source to figure out which
`GITHUB_TOKEN` permissions are required, who claims the issue, when the
trust gate fires, and how the runtime/caller responsibilities split.

## What changed

- `plugins/dev/skills/engineering/afk/SKILL.md`: new *Running `/afk` in
  an execution environment (GitHub Actions / k8s)* subsection under
  *When To Use* with the canonical invocation, a 12-row
  runtime/caller responsibility table, the recommended
  `--permissions:` block, and the trust-gate-by-default contract.
- `.red/contexts/dev/CONTEXT.md`: two new glossary terms — *Execution
  environment* (GHA + k8s, shared runtime contract) and *Actions lane*
  (the GHA reusable-workflow surface of the execution environment) —
  with avoid-antonyms.
- `CHANGES.md`: release-notes entry at the top.

## No runtime change

- `pnpm -C src/apps/dev test` — 141/141 pass on the targeted suite
  (opencode-env, execution, config, runner-detection).
- `pnpm -C src/apps/dev typecheck` — clean.
- drift-guard local: pass (commit-trailer `Memory-Ingested: 4e293f7a`
  is on the head).

## Tracking

- Issue #631 (now `ready-for-agent`) is the implementation slice —
  reusable workflow + Dockerfile + k8s job + trust gate wiring + atomic
  claim integration + E2E test.
- This PR is docs-only and unblocks the slice by giving the implementer
  (and the adopter) a single place to read the command contract.

Refs #631

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783697205&installation_id=129708444&pr_number=657&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F657&signature=86b47a9372c6b53235f12b59a154adc416fdd8b774049bb4e1fae2d069eafa71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive setup and usage guide for running the afk tool across GitHub Actions and Kubernetes execution environments, including detailed command syntax and configuration requirements.
  * Documented environment variable precedence rules, required permissions, and default trust settings with configuration options.
  * Updated glossary with new concepts and definitions clarifying execution environments and workflow lanes terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->