### PR TITLE
fix(afk): inline comment after quoted scalar/sequence no longer disarms config guards

### DIFF
--- a/src/apps/dev/src/core/config.ts
+++ b/src/apps/dev/src/core/config.ts
@@ -155,6 +155,15 @@ export function parseConfigYaml(text: string): ConfigValues {
 
       let item = rest.slice(1).replace(/^\s+/, "");
       if (item === "") throw new MalformedConfigError();
+      // Strip an inline comment that follows the closing quote (e.g. `- "cmd" # note`).
+      if (item[0] === '"' || item[0] === "'") {
+        const q = item[0];
+        const close = item.indexOf(q, 1);
+        if (close > 0) {
+          const tail = item.slice(close + 1).trimStart();
+          if (tail === "" || tail.startsWith("#")) item = item.slice(0, close + 1);
+        }
+      }
       if (item.startsWith('"')) {
         if (!item.endsWith('"') || item.length < 2) throw new MalformedConfigError();
         item = item.slice(1, -1);
@@ -176,6 +185,15 @@ export function parseConfigYaml(text: string): ConfigValues {
     const key = rest.slice(0, colon);
     let value = rest.slice(colon + 1).replace(/^\s+/, "");
 
+    // Strip an inline comment that follows the closing quote (e.g. `key: "v" # note`).
+    if (value[0] === '"' || value[0] === "'") {
+      const q = value[0];
+      const close = value.indexOf(q, 1);
+      if (close > 0) {
+        const tail = value.slice(close + 1).trimStart();
+        if (tail === "" || tail.startsWith("#")) value = value.slice(0, close + 1);
+      }
+    }
     // unclosed-quote detection / strip matching quotes
     if (value.startsWith('"')) {
       if (!value.endsWith('"') || value.length < 2) throw new MalformedConfigError();

--- a/src/apps/dev/tests/config.test.ts
+++ b/src/apps/dev/tests/config.test.ts
@@ -147,6 +147,24 @@ describe("config", () => {
     expect(() => parseConfigYaml("- not a mapping\n")).toThrow(MalformedConfigError);
   });
 
+  it("inline comment after double-quoted scalar parses without throwing", () => {
+    const text = 'afk:\n  default_runner: "codex" # preferred runner\n';
+    expect(parseConfigYaml(text)).toEqual({ "afk.default_runner": "codex" });
+  });
+
+  it("inline comment after single-quoted scalar parses without throwing", () => {
+    const text = "afk:\n  default_runner: 'codex' # preferred runner\n";
+    expect(parseConfigYaml(text)).toEqual({ "afk.default_runner": "codex" });
+  });
+
+  it("block-sequence config does not disable the primary-branch guard", () => {
+    const text =
+      'dev:\n  lock-primary-branch: true\nafk:\n  backpressure:\n    - "npm run test" # full suite\n    - npm run lint\n';
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "dev.lock-primary-branch")).toBe("true");
+    expect(readBackpressure(values)).toEqual(["npm run test", "npm run lint"]);
+  });
+
   it("injectable reader bypasses the filesystem", () => {
     const values = loadConfig("virtual.yaml", {
       read: () => "afk:\n  fleet:\n    target: 9\n",
@@ -197,6 +215,11 @@ describe("config — block sequences (afk.backpressure, #430)", () => {
     expect(parseConfigYaml(text)).toEqual({
       "afk.backpressure.0": "npm run test -- --reporter=dot",
     });
+  });
+
+  it("strips inline comment after closing quote on a sequence item", () => {
+    const text = 'afk:\n  backpressure:\n    - "npm run test" # full suite\n';
+    expect(parseConfigYaml(text)).toEqual({ "afk.backpressure.0": "npm run test" });
   });
 
   it("throws on a top-level sequence with no enclosing mapping", () => {


### PR DESCRIPTION
## Summary

- Quoted scalar with trailing inline comment (`key: "value" # note`) now parses correctly instead of throwing `MalformedConfigError`
- Quoted block-sequence item with trailing inline comment (`- "cmd" # note`) also handled the same way
- Both cases previously caused `loadConfig` to revert ALL config to defaults, silently resetting `dev.lock-primary-branch` to `"false"` and disarming the primary-branch guard

## Root cause

`parseConfigYaml` skips comment stripping when it detects a quoted string on the line (to avoid misinterpreting a `#` inside a quoted value). But the quote-validation step that follows then sees the leftover comment text after the closing quote and throws `MalformedConfigError`.

## Fix

After extracting the raw scalar value or block-sequence item, detect the pattern `<closing-quote> <optional-whitespace> # <comment>` and trim the comment before the quote validation runs. Unclosed quotes still throw as before.

## Test plan

- [x] `parseConfigYaml` with `key: "v" # comment` → `{key: "v"}`, no throw
- [x] `parseConfigYaml` with `key: 'v' # comment` → `{key: "v"}`, no throw
- [x] `parseConfigYaml` with `- "cmd" # comment` → `{parent.0: "cmd"}`, no throw
- [x] `loadConfig` with block-sequence + `dev.lock-primary-branch: true` → guard reads as `"true"`
- [x] Full test suite: 1231 tests pass

Closes #582
Parent: #567

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698156&installation_id=129708444&pr_number=659&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F659&signature=c698d4b2fedbb9f3f44138bfb9070ad3717cc38eea5a8466e202965958a0ad40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration parser now correctly handles and processes inline comments appearing after quoted scalar values in YAML configuration files, supporting both single and double-quoted strings across configuration contexts.

* **Tests**
  * Added comprehensive test coverage for inline comment handling in YAML configuration parsing, including validation across various entry types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->