### PR TITLE
fix(afk): feedback gate fails closed on worktree-add/install failure and validates origin tip

### DIFF
--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -108,38 +108,44 @@ export function makeFeedbackWorktree(
   io: FeedbackWorktreeIO = defaultIO,
 ): FeedbackWorktree {
   const gitCtx: gitx.GitContext = { cwd: root };
-  // branch -> resolved checkout path (the worktree, or root on fallback).
-  const resolved = new Map<string, string>();
+  // branch -> resolved checkout path, or null when setup failed (block all runs).
+  const resolved = new Map<string, string | null>();
   const created = new Set<string>();
 
-  async function pathFor(branch: string): Promise<string> {
+  async function pathFor(branch: string): Promise<string | null> {
     if (!branch) return root;
     const cached = resolved.get(branch);
     if (cached !== undefined) return cached;
     const dest = join(feedbackRoot, slugForBranch(branch));
     const ok = await io.worktreeAdd(gitCtx, dest, branch);
-    if (ok) {
-      // A freshly added worktree has NO node_modules. Without an install here,
-      // the feedback gate's `pnpm -C <dest> test/build` calls fail with
-      // `tsc/vite/svelte-kit: not found` — a FALSE validation failure that parks
-      // otherwise-green work as blocked:validation (#458). Install before any
-      // check can run.
-      const ins = await io.pnpm(["install", "--frozen-lockfile"], { cwd: dest });
-      if (ins.code !== 0) {
-        // Lockfile drift on the branch, or a transient registry error. Keep the
-        // checkout so validation still reflects the branch's real state instead
-        // of silently validating `main` from the primary checkout — but warn so
-        // the cause is visible in the attempt log.
-        process.stderr.write(
-          `warn: feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
-            `validation may report missing binaries\n${ins.stderr.trim()}\n`,
-        );
-      }
-      created.add(dest);
+    if (!ok) {
+      process.stderr.write(
+        `error: feedback worktree add failed for ${branch}; blocking validation\n`,
+      );
+      resolved.set(branch, null);
+      return null;
     }
-    const path = ok ? dest : root;
-    resolved.set(branch, path);
-    return path;
+    // A freshly added worktree has NO node_modules. Without an install here,
+    // the feedback gate's `pnpm -C <dest> test/build` calls fail with
+    // `tsc/vite/svelte-kit: not found` — a FALSE validation failure that parks
+    // otherwise-green work as blocked:validation (#458). Install before any
+    // check can run.
+    const ins = await io.pnpm(["install", "--frozen-lockfile"], { cwd: dest });
+    if (ins.code !== 0) {
+      // Lockfile drift on the branch, or a transient registry error. Remove the
+      // partial checkout eagerly and block — continuing would silently validate
+      // the wrong environment (binaries absent, wrong lockfile).
+      await io.worktreeRemove(gitCtx, dest);
+      process.stderr.write(
+        `error: feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
+          `blocking validation\n${ins.stderr.trim()}\n`,
+      );
+      resolved.set(branch, null);
+      return null;
+    }
+    created.add(dest);
+    resolved.set(branch, dest);
+    return dest;
   }
 
   // The layout probe only needs the package topology, which is identical across
@@ -179,6 +185,9 @@ export function makeFeedbackWorktree(
     if (cIdx >= 0 && args[cIdx + 1] !== undefined) {
       const { branch, scope } = splitBranchDir(args[cIdx + 1]!, layout.hasPackage);
       const base = await pathFor(branch);
+      if (base === null) {
+        return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${branch}; validation blocked` };
+      }
       const rewritten = scope === "." ? base : join(base, scope);
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
       const r = await io.pnpm(["-C", rewritten, ...rest], { cwd: root });
@@ -199,6 +208,9 @@ export function makeFeedbackWorktree(
   // deadlocking the worker (PRD #567).
   const backpressure: BackpressureExec = async ({ command, cwd, timeoutMs }) => {
     const dir = await pathFor(cwd);
+    if (dir === null) {
+      return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${cwd}; validation blocked` };
+    }
     const r = await io.exec("sh", ["-c", command], { cwd: dir, timeoutMs });
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };

--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -13,9 +13,9 @@
 // feedback gate consumes, both rebased onto the materialised checkout. Every
 // worktree it created is torn down by `cleanup()` after the session.
 //
-// When the worktree cannot be materialised (e.g. tests, or an origin ref that
-// never got pushed) it degrades to the primary checkout so feedback still runs
-// the package topology rather than silently passing.
+// When the worktree cannot be materialised (worktreeAdd failure) or the
+// install fails, the gate fails closed: all validation calls return code 1.
+// A failed setup never silently validates the primary checkout.
 
 import { accessSync, constants, readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/src/apps/dev/src/runtime/git.ts
+++ b/src/apps/dev/src/runtime/git.ts
@@ -165,10 +165,9 @@ export async function recentCommits(ctx: GitContext, ref = "main", count = 5): P
  */
 export async function worktreeAdd(ctx: GitContext, path: string, branch: string): Promise<boolean> {
   await runGit(ctx, ["fetch", "origin", branch]);
-  // Prefer the local branch if it exists, else the fetched origin ref.
-  const local = await runGit(ctx, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]);
-  const ref = local.code === 0 ? branch : `origin/${branch}`;
-  const r = await runGit(ctx, ["worktree", "add", "--force", "--detach", path, ref]);
+  // Always use the freshly-fetched origin tip so validation never runs against
+  // a stale local ref that diverges from what was pushed.
+  const r = await runGit(ctx, ["worktree", "add", "--force", "--detach", path, `origin/${branch}`]);
   return r.code === 0;
 }
 

--- a/src/apps/dev/tests/feedback-worktree.test.ts
+++ b/src/apps/dev/tests/feedback-worktree.test.ts
@@ -58,9 +58,10 @@ describe("splitBranchDir (#437)", () => {
  * Recording fake IO: tracks every worktreeAdd/install/script/remove call so a
  * test can assert the materialise → install ordering and the install `cwd`. Pure
  * — no real subprocess is ever spawned. `installCode` scripts the `pnpm install`
- * exit so the install-failure path is exercisable.
+ * exit so the install-failure path is exercisable. `addOk` controls whether
+ * `worktreeAdd` succeeds so the worktree-add-failure path is exercisable.
  */
-function fakeIO(installCode = 0): {
+function fakeIO(installCode = 0, addOk = true): {
   io: FeedbackWorktreeIO;
   calls: Array<{ op: "add" | "install" | "script" | "remove"; dest: string }>;
 } {
@@ -68,7 +69,7 @@ function fakeIO(installCode = 0): {
   const io: FeedbackWorktreeIO = {
     worktreeAdd: async (_ctx, dest) => {
       calls.push({ op: "add", dest });
-      return true;
+      return addOk;
     },
     pnpm: async (args, opts) => {
       const isInstall = args[0] === "install";
@@ -111,17 +112,33 @@ describe("makeFeedbackWorktree install (#458)", () => {
     expect(calls.filter((c) => c.op === "install")).toHaveLength(1);
   });
 
-  it("keeps the checkout (does not fall back to root) when install fails", async () => {
+  it("blocks validation (returns exit code 1) when install fails", async () => {
     const { io, calls } = fakeIO(1);
     const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
 
-    await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+    const result = await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
     await fb.cleanup();
 
-    // A failed install still registers the worktree for cleanup (the checkout is
-    // used, not abandoned to root), so cleanup removes it.
+    // A failed install must block: the pnpm executor returns code 1.
+    expect(result.code).toBe(1);
+    // The partially-created worktree is torn down immediately (not deferred to cleanup).
     expect(calls.filter((c) => c.op === "remove")).toEqual([
       { op: "remove", dest: "/root/.red/tmp/feedback/afk-w1-42-fix" },
     ]);
+    // The script was never run.
+    expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
+  });
+
+  it("blocks validation (returns exit code 1) when worktree-add fails", async () => {
+    const { io, calls } = fakeIO(0, false);
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const result = await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+
+    // A failed worktree-add must block: the pnpm executor returns code 1.
+    expect(result.code).toBe(1);
+    // No install or script should run after a failed worktree add.
+    expect(calls.filter((c) => c.op === "install")).toHaveLength(0);
+    expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #576.

The feedback gate had three silent-pass bugs that could cause the gate to validate the wrong code or skip validation:

- **Worktree-add failure → fallback to primary checkout**: when `git worktree add` failed, the path resolver returned `root` (main) and validated that instead of the branch. Fixed: failures now return `null`, which propagates code 1 through all validation calls.
- **Failed frozen-lockfile install → warn-and-continue**: a non-zero `pnpm install --frozen-lockfile` only warned; the gate continued without binaries (tsc/vite/etc.) causing false validation results. Fixed: install failure removes the partial checkout and blocks.
- **Stale local ref**: validation could run against a local branch ref that diverged from what was pushed. Fixed: `worktreeAdd` always fetches origin first and checks out `origin/<branch>`.

## Acceptance criteria

- [x] A `git worktree add` failure blocks the attempt — never falls back to validating the primary checkout (`feedback-worktree.ts:121–127`)
- [x] A failed frozen-lockfile install blocks rather than warning-and-continuing (`feedback-worktree.ts:133–145`)
- [x] The gate validates the freshly-pushed origin tip, not a stale local ref (`git.ts:167–170`)
- [x] Tests cover worktree-add-fails → block at the feedback-worktree seam (`feedback-worktree.test.ts:132–143`)

## Test plan

- `pnpm test` in `src/apps/dev` — all 10 `feedback-worktree.test.ts` tests pass; 1197 total tests pass
- `pnpm tsc --noEmit` — no type errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698230&installation_id=129708444&pr_number=660&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F660&signature=8723e4d567db8ad5b05c0ca328dbc8fae81f6fd6c6e19df940845449d4019cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling for git worktree initialization failures—validation now fails cleanly instead of falling back to a secondary checkout path.

* **Tests**
  * Enhanced test coverage to verify proper blocking behavior when worktree setup or dependency installation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->