### PR TITLE
fix(afk): guard locked landing against zero-commit branch

### DIFF
--- a/src/apps/dev/src/core/landing.ts
+++ b/src/apps/dev/src/core/landing.ts
@@ -202,6 +202,20 @@ async function landLockedInWorktree(deps: LandingDeps, input: LandingInput): Pro
     });
     if (!integrated.ok) return { ok: false, reason: "integrate-failed", locked: true };
 
+    // Zero-commit guard: `git merge --no-ff` succeeds on a branch with no new
+    // commits (it creates a no-op merge commit), which would incorrectly close
+    // the issue as done without delivering any work. The unlocked path rejects
+    // this naturally — `gh pr create` fails on an empty branch — so mirror that
+    // guard here: route a zero-commit locked landing to land-failed.
+    const countRes = await deps.mergeExec([
+      "git", "-C", landDir,
+      "rev-list", "--count", `origin/${input.base}..origin/${input.branch}`,
+    ]);
+    const commitCount = parseInt(countRes.stdout.trim(), 10);
+    if (countRes.code !== 0 || !Number.isInteger(commitCount) || commitCount === 0) {
+      return { ok: false, reason: "land-failed", locked: true };
+    }
+
     // Capture the integrated tip from the worktree as the rollback anchor.
     const preMergeSha = (await deps.mergeExec(["git", "-C", landDir, "rev-parse", "--short", "HEAD"])).stdout.trim();
 

--- a/src/apps/dev/tests/landing.test.ts
+++ b/src/apps/dev/tests/landing.test.ts
@@ -41,6 +41,8 @@ interface Opts {
   waitForReview?: boolean;
   /** Make the landing-worktree provisioner fail (returns null). */
   noWorktree?: boolean;
+  /** Commits ahead of base returned by `git rev-list --count`. Default 3. */
+  commitCount?: number;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -61,6 +63,9 @@ function harness(opts: Opts = {}): Harness {
       // The rollback anchor + landed sha the locked worktree path reads.
       if (j.includes("rev-parse --short HEAD")) {
         return { code: 0, stdout: "abc1234\n", stderr: "" };
+      }
+      if (j.includes("rev-list") && j.includes("--count")) {
+        return { code: 0, stdout: `${opts.commitCount ?? 3}\n`, stderr: "" };
       }
       if (opts.integrateCode !== undefined && j.includes("merge --ff-only")) {
         return { code: opts.integrateCode, stdout: "", stderr: "" };
@@ -239,6 +244,18 @@ describe("doLanding — abort / failure short-circuits", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
     // post_merge never fires on a failed land.
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+  });
+
+  it("locked zero-commit branch → land-failed without merging (mirrors unlocked empty-branch)", async () => {
+    // A branch with no commits relative to base would produce an empty no-op merge
+    // on the locked path, wrongly closing the issue as done. Guard must catch this.
+    const h = harness({ locked: true, commitCount: 0 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "land-failed", locked: true });
+    // No merge --no-ff must have been attempted.
+    expect(joined(h.mergeCalls).some((c) => c.includes("merge --no-ff"))).toBe(false);
+    // post_merge must not fire.
     expect(h.firedHooks).toEqual(["pre_merge"]);
   });
 });

--- a/src/apps/dev/tests/process-issue.test.ts
+++ b/src/apps/dev/tests/process-issue.test.ts
@@ -231,6 +231,10 @@ function harness(opts: HarnessOptions = {}): {
         const pending = opts.conflictResolve === "fail" || !mergeResolved;
         return { code: pending ? 0 : 1, stdout: "", stderr: "" };
       }
+      // Zero-commit guard: report 3 commits ahead so normal locked landings proceed.
+      if (j.includes("rev-list") && j.includes("--count")) {
+        return { code: 0, stdout: "3\n", stderr: "" };
+      }
       return { code: 0, stdout: "", stderr: "" };
     },
     remoteGit: async (argv) => {


### PR DESCRIPTION
Closes #573

On the locked landing path, `git merge --no-ff` succeeds silently on a branch with no commits relative to the base (it creates a no-op merge commit), causing the issue to be incorrectly marked done. The unlocked path rejects this naturally (`gh pr create` fails on an empty branch). This ports that guard into `landLockedInWorktree`: count commits via `git rev-list --count origin/<base>..origin/<branch>` before calling `landMerge`; return `land-failed` if the count is zero.

Ported from `afk/w9HNK/573-fix-afk-a-zero-commit-branch-never-lands` onto current main (which had `landLockedInWorktree` restructured by #572). The original worker branch has a merge conflict with #572; this is a clean forward-port.

Validation: tsc clean, all 17 landing tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783699190&installation_id=129708444&pr_number=662&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F662&signature=9373918897dff90aa27613e844e520807f43490720c3d799da1215a5a638fb82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->