### PR TITLE
fix(afk): malformed or block-sequence config silently disarms guards

### DIFF
--- a/plugins/dev/skills/misc/branch-lock/scripts/lib/dev-config.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/lib/dev-config.sh
@@ -15,6 +15,7 @@ dev_config_lock_primary_branch_enabled() {
   local -a _stack=()
   local -a _indents=()
   local _raw _line _indent_str _indent _rest _key _value _full _i
+  local _inner _before_close _close_len _tail
 
   while IFS= read -r _raw || [[ -n "$_raw" ]]; do
     _raw="${_raw%$'\r'}"
@@ -30,6 +31,13 @@ dev_config_lock_primary_branch_enabled() {
     _indent=${#_indent_str}
     (( _indent % 2 == 0 )) || return 1
     _rest="${_line:$_indent}"
+
+    # Skip block-sequence items (`- value`) — they never contain dev flags.
+    # A top-level sequence (empty stack) mirrors the TS parser: malformed → bail.
+    if [[ "$_rest" =~ ^-([[:space:]]|$) ]]; then
+      (( ${#_stack[@]} == 0 )) && return 1
+      continue
+    fi
 
     [[ "$_rest" =~ ^[A-Za-z_][A-Za-z0-9_-]*: ]] || return 1
     _key="${_rest%%:*}"
@@ -55,6 +63,29 @@ dev_config_lock_primary_branch_enabled() {
       _stack+=("$_key")
       _indents+=("$_indent")
       continue
+    fi
+
+    # Strip an inline comment that follows a closing quote (e.g. `key: "v" # note`).
+    if [[ "${_value:0:1}" == '"' ]]; then
+      _inner="${_value:1}"
+      _before_close="${_inner%%\"*}"
+      if [[ "$_inner" == *'"'* ]]; then
+        _close_len=$(( 1 + ${#_before_close} + 1 ))
+        _tail="${_value:$_close_len}"
+        if [[ "$_tail" =~ ^[[:space:]]*(#.*)?$ ]]; then
+          _value="${_value:0:$_close_len}"
+        fi
+      fi
+    elif [[ "${_value:0:1}" == "'" ]]; then
+      _inner="${_value:1}"
+      _before_close="${_inner%%\'*}"
+      if [[ "$_inner" == *"'"* ]]; then
+        _close_len=$(( 1 + ${#_before_close} + 1 ))
+        _tail="${_value:$_close_len}"
+        if [[ "$_tail" =~ ^[[:space:]]*(#.*)?$ ]]; then
+          _value="${_value:0:$_close_len}"
+        fi
+      fi
     fi
 
     if [[ "$_value" == \"*\" && "$_value" == *\" ]]; then

--- a/plugins/dev/skills/misc/branch-lock/scripts/tests/dev-config.test.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/tests/dev-config.test.sh
@@ -62,6 +62,31 @@ dev:
 EOF
 expect_rc "malformed indentation: disabled" 1 "$cfg"
 
+cat > "$cfg" <<'EOF'
+dev:
+  lock-primary-branch: "true" # branch protection on
+EOF
+expect_rc "inline comment after quoted true: enabled" 0 "$cfg"
+
+cat > "$cfg" <<'EOF'
+dev:
+  lock-primary-branch: true
+afk:
+  backpressure:
+    - npm run test
+    - npm run lint
+EOF
+expect_rc "block-sequence sibling does not disable guard: enabled" 0 "$cfg"
+
+cat > "$cfg" <<'EOF'
+afk:
+  backpressure:
+    - npm run test
+dev:
+  lock-primary-branch: true
+EOF
+expect_rc "block-sequence before dev key: enabled" 0 "$cfg"
+
 echo
 echo "summary: $pass passed, $fail failed"
 [[ "$fail" -eq 0 ]]

--- a/src/apps/dev/src/core/config.ts
+++ b/src/apps/dev/src/core/config.ts
@@ -155,6 +155,15 @@ export function parseConfigYaml(text: string): ConfigValues {
 
       let item = rest.slice(1).replace(/^\s+/, "");
       if (item === "") throw new MalformedConfigError();
+      // Strip an inline comment that follows the closing quote (e.g. `- "cmd" # note`).
+      if (item[0] === '"' || item[0] === "'") {
+        const q = item[0];
+        const close = item.indexOf(q, 1);
+        if (close > 0) {
+          const tail = item.slice(close + 1).trimStart();
+          if (tail === "" || tail.startsWith("#")) item = item.slice(0, close + 1);
+        }
+      }
       if (item.startsWith('"')) {
         if (!item.endsWith('"') || item.length < 2) throw new MalformedConfigError();
         item = item.slice(1, -1);
@@ -176,6 +185,15 @@ export function parseConfigYaml(text: string): ConfigValues {
     const key = rest.slice(0, colon);
     let value = rest.slice(colon + 1).replace(/^\s+/, "");
 
+    // Strip an inline comment that follows the closing quote (e.g. `key: "v" # note`).
+    if (value[0] === '"' || value[0] === "'") {
+      const q = value[0];
+      const close = value.indexOf(q, 1);
+      if (close > 0) {
+        const tail = value.slice(close + 1).trimStart();
+        if (tail === "" || tail.startsWith("#")) value = value.slice(0, close + 1);
+      }
+    }
     // unclosed-quote detection / strip matching quotes
     if (value.startsWith('"')) {
       if (!value.endsWith('"') || value.length < 2) throw new MalformedConfigError();

--- a/src/apps/dev/tests/config.test.ts
+++ b/src/apps/dev/tests/config.test.ts
@@ -147,6 +147,24 @@ describe("config", () => {
     expect(() => parseConfigYaml("- not a mapping\n")).toThrow(MalformedConfigError);
   });
 
+  it("inline comment after double-quoted scalar parses without throwing", () => {
+    const text = 'afk:\n  default_runner: "codex" # preferred runner\n';
+    expect(parseConfigYaml(text)).toEqual({ "afk.default_runner": "codex" });
+  });
+
+  it("inline comment after single-quoted scalar parses without throwing", () => {
+    const text = "afk:\n  default_runner: 'codex' # preferred runner\n";
+    expect(parseConfigYaml(text)).toEqual({ "afk.default_runner": "codex" });
+  });
+
+  it("block-sequence config does not disable the primary-branch guard", () => {
+    const text =
+      'dev:\n  lock-primary-branch: true\nafk:\n  backpressure:\n    - "npm run test" # full suite\n    - npm run lint\n';
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "dev.lock-primary-branch")).toBe("true");
+    expect(readBackpressure(values)).toEqual(["npm run test", "npm run lint"]);
+  });
+
   it("injectable reader bypasses the filesystem", () => {
     const values = loadConfig("virtual.yaml", {
       read: () => "afk:\n  fleet:\n    target: 9\n",
@@ -197,6 +215,11 @@ describe("config — block sequences (afk.backpressure, #430)", () => {
     expect(parseConfigYaml(text)).toEqual({
       "afk.backpressure.0": "npm run test -- --reporter=dot",
     });
+  });
+
+  it("strips inline comment after closing quote on a sequence item", () => {
+    const text = 'afk:\n  backpressure:\n    - "npm run test" # full suite\n';
+    expect(parseConfigYaml(text)).toEqual({ "afk.backpressure.0": "npm run test" });
   });
 
   it("throws on a top-level sequence with no enclosing mapping", () => {


### PR DESCRIPTION
## Summary

- **TS config parser** (`config.ts`): strip inline comments that follow a closing quote on a mapping scalar or block-sequence item (e.g. `key: "value" # note`, `- "cmd" # note`) before the quote-validation check, so they no longer throw `MalformedConfigError` and silently revert all config to defaults
- **Shell config reader** (`dev-config.sh`): skip nested block-sequence items (`- value`) instead of returning 1 on them, and strip post-quote inline comments before the `== "true"` check for `dev.lock-primary-branch`

Both bugs could disarm the primary-branch guard: the TS bug by triggering `MalformedConfigError` on a stray comment, and the shell bug by bailing early on an `afk.backpressure` list in the config file.

Closes #582

## Test plan

- [x] `pnpm -C src/apps/dev test tests/config.test.ts` — 40 tests pass, 0 fail (covers inline-comment scalar and block-sequence guard cases)
- [x] `bash plugins/dev/skills/misc/branch-lock/scripts/tests/dev-config.test.sh` — 9 tests pass, 0 fail (covers inline-comment-after-quoted-true and block-sequence-sibling/block-sequence-before-dev-key)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783699795&installation_id=129708444&pr_number=664&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F664&signature=d2b919ed9cb475a1e06ebe351e169cf2c3f0db4200c1739e44e3c6232e18e9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced YAML configuration parsing to correctly handle inline comments following quoted values, preventing parsing errors
  * Improved robustness when processing malformed or non-standard YAML structures
  * Strengthened validation for block-sequence items to ensure reliable configuration loading

<!-- end of auto-generated comment: release notes by coderabbit.ai -->