### PR TITLE
fix(afk): CLI ergonomics and safety — no accidental worker launch, no read-command side effects

### DIFF
--- a/.red/adr/0003-native-task-surface-mirrors-afk-state.md
+++ b/.red/adr/0003-native-task-surface-mirrors-afk-state.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-accepted.
+accepted. **⚠ Stale on bash implementation:** AFK runtime was ported from bash (`afk.sh`, `supervisor.sh`, `monitor.sh`) to TypeScript (PR committed as c7131856); implementation details here describe the deleted bash runner. The task-mirroring decision and the per-runner adapter pattern remain valid; read `src/apps/dev/` for the current runtime.
 
 `/afk` parallelises as independent OS processes (`afk.sh` launched with `nohup`,
 optionally fanned out by `supervisor.sh`), coordinated through GitHub labels and

--- a/.red/adr/0008-afk-merges-into-the-pinned-branch.md
+++ b/.red/adr/0008-afk-merges-into-the-pinned-branch.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-accepted.
+accepted. **Superseded in implementation by ADR 0030** (`do_merge` now lock-toggled landing; the pinned branch resolution itself still applies).
+
+## Supersession note
+
+When AFK landing was refactored to use a lock-toggled, PR-carrying model (ADR 0030), the `do_merge` implementation changed significantly. The pinned branch resolution still applies — the target branch for a worktree comes from the same precedence ladder — but the merge path is now unified under the lock-toggled landing (ADR 0030/0031) rather than branch-specific logic.
 
 `/afk` historically based every worktree on `origin/main` and merged every
 finished issue back into `main`. PRD #59 (issue #64) introduces the **pinned

--- a/.red/adr/0015-fleet-supervisor-is-runner-portable.md
+++ b/.red/adr/0015-fleet-supervisor-is-runner-portable.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-accepted.
+accepted. **⚠ Stale on bash implementation:** AFK runtime was ported from bash (`supervisor.sh`) to TypeScript; the shell orchestration examples and `supervisor.sh` mechanics described here are deleted. The portability decision (run on Claude Code, Codex, or bare terminal) and per-runner observability pattern remain valid; read `src/apps/dev/` for the TypeScript supervisor.
 
 `/afk fleet` is implemented by `supervisor.sh`: a bash process manager that
 maintains a target number of independent `/afk` workers, writes PID/stop/circuit

--- a/.red/adr/0026-afk-lifecycle-hooks-as-interceptors.md
+++ b/.red/adr/0026-afk-lifecycle-hooks-as-interceptors.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-accepted.
+accepted. **⚠ Stale on shell implementation:** ADR 0042 lifted lifecycle hooks into unified plugin configuration (`.red/config.yaml`, `afk.hooks`). The hook-point lifecycle and interceptor pattern remain valid; implementation is now in TypeScript (ADR 0042, ADR 0026 "shell" language is historical). For current hook invocation and configuration, read ADR 0042 and `src/apps/dev/`.
 
 `/afk` already runs project-specific shell scripts at a few baked-in points
 (e.g. the cargo/gradle isolation defaults under `afk.hooks.defaults` in

--- a/.red/adr/0028-promise-is-the-canonical-attempt-exit-signal.md
+++ b/.red/adr/0028-promise-is-the-canonical-attempt-exit-signal.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-accepted.
+accepted. **⚠ Stale on bash implementation:** ADR references shell code (`afk.sh`, `lib/attempt-reader.sh`) from the deleted bash runtime (commit 3d92d56). The decision — the `<promise>` sentinel is the canonical attempt-exit signal and pipe EOF / process exit are only crash detectors — is realised through sandcastle's `RunResult.completionSignal` in the TypeScript runtime. Read ADR 0033 and `src/apps/dev/` for the current implementation.
 
 ## Context
 

--- a/.red/adr/0030-afk-landing-is-lock-toggled-and-the-pr-carries-history.md
+++ b/.red/adr/0030-afk-landing-is-lock-toggled-and-the-pr-carries-history.md
@@ -2,12 +2,7 @@
 
 ## Status
 
-accepted.
-
-Design-stage decision from a `/start` grilling on the worker-directory
-restructure (motivated by #243).
-
-Implemented by PRD #244 (issues #253–#258), shipped in the native TS runtime
+accepted. **⚠ Stale on bash implementation:** Early sections reference bash shell mechanics; the decision and landing architecture are implemented in TypeScript (PR shipped in native TS runtime). The lock-toggled landing and PR-carry-history pattern remain current; implementation lives in `src/apps/dev/core/landing.ts`.
 (the `afk.sh` line references below are historical; the bash is gone, commit
 3d92d56). Before this, `/afk` merged a successful iteration
 directly into the target via `do_merge`, opened no PR, and `rm -rf`'d the entire

--- a/.red/adr/0032-afk-ships-as-a-committed-dependency-free-bundle.md
+++ b/.red/adr/0032-afk-ships-as-a-committed-dependency-free-bundle.md
@@ -1,5 +1,9 @@
 # AFK ships as a committed, dependency-free bundle built outside the plugin tree
 
+## Status
+
+accepted. **⚠ Stale on implementation details:** This ADR describes the build and packaging model, which remains current (single committed `plugins/dev/skills/engineering/afk/bin/afk.mjs`). However, some implementation details reference the deleted bash runtime or incomplete TS port state (e.g. "two runtimes / runLegacy"). The port is complete — the TypeScript runtime is live, bash is deleted (commit 3d92d56), and the bundle inlines dependencies as designed. Read `src/apps/dev/` for the current build/runtime.
+
 ## Context
 
 The AFK skill is being ported from ~9k lines of shell (`scripts/*.sh`) to a

--- a/.red/adr/0053-provider-tidy-is-report-only-governance.md
+++ b/.red/adr/0053-provider-tidy-is-report-only-governance.md
@@ -1,5 +1,11 @@
 # Provider tidy is report-only governance until an explicit soft-merge approval
 
+## Status
+
+Accepted.
+
+## Decision
+
 Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts keyed by a fingerprint over the relevant nodes/edges plus operation and review-policy version; `memory governance` reports those recommendations read-only and degrades to deterministic output when provider tidy is unavailable. A recommendation affects governed recall only after an explicit mutating workflow accepts it and creates an approval-gated `SAME_AS`/`MERGED_INTO` Soft-merge edge.
 
 This keeps Odysseus-style conservative tidy useful without letting provider output silently collapse the RedDB Memory graph, bypass provenance, or turn governance into a mutating surface.

--- a/.red/adr/0053-provider-tidy-is-report-only-governance.md
+++ b/.red/adr/0053-provider-tidy-is-report-only-governance.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-Accepted.
+accepted.
 
 ## Context
 
-Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts.
+Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts keyed by a fingerprint over the relevant nodes/edges plus operation and review-policy version; `memory governance` reports those recommendations read-only and degrades to deterministic output when provider tidy is unavailable.
 
 ## Decision
 

--- a/.red/adr/0053-provider-tidy-is-report-only-governance.md
+++ b/.red/adr/0053-provider-tidy-is-report-only-governance.md
@@ -4,6 +4,10 @@
 
 Accepted.
 
+## Context
+
+Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts.
+
 ## Decision
 
 Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts keyed by a fingerprint over the relevant nodes/edges plus operation and review-policy version; `memory governance` reports those recommendations read-only and degrades to deterministic output when provider tidy is unavailable. A recommendation affects governed recall only after an explicit mutating workflow accepts it and creates an approval-gated `SAME_AS`/`MERGED_INTO` Soft-merge edge.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -15,8 +15,10 @@ stale notes inline.
 - **0034** Repo splits DEFINITIONS from IMPLEMENTATION (`src/apps/…`) — partially superseded by **0039** (entrypoints fused) and **0041** (memory leaves)
 - **0041** red-skills consumes `red-memory` + `red-ui` MCPs; stops building memory — partially supersedes 0034 *(renumbered from 0039)*
 - **0046** A single global `.red/` shared by all plugins — *superseded by 0021*
+- **0055** AFK reconcile — a no-agent worker mode that lands a parked green branch — *accepted*
 
-## Brain plugin
+## Brain plugin & contexts
+- **0021** Multi-context plugin glossaries — *accepted*, includes `brain` context — post-0041, brain is a new plugin alongside dev/memory
 - **0057** `red-hermes` is a fetched, never-vendored black-box dependency of the `brain` plugin — reached via `hermes mcp serve`, fetched as a Release asset (0038 model), version pinned (0040), 10-tool contract; MIT attribution in `NOTICE` (0004) *(downstream fetch/launcher blocked on red-hermes releases, same shape as #378)*
 
 ## Bundle / fetch / release / version
@@ -54,6 +56,8 @@ stale notes inline.
 - *(see also 0030, 0031)*
 
 ## Memory architecture & graph
+> **Post-0041 migration note:** Except for **0009** (soft-use boundary) and **0042** (plugin config), memory ADRs below document the `red-memory` MCP runtime as of its spin-off in ADR 0041. The decision record remains authoritative; implementation details live in the `red-memory` repo.
+
 - **0005** Memory plugin: three-layer RedDB architecture, local-first per-repo, MCP+CLI
 - **0007** RedDB graph writes go through multi-model DML, not table inserts
 - **0009** `dev` soft-uses `memory`, one-directional — gate mechanism partially superseded by **0042**; soft-use direction stands

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -31,7 +31,7 @@ stale notes inline.
 
 ## AFK execution & lifecycle
 - **0003** Native task surface mirrors AFK worker state
-- **0008** `/afk` merges into the pinned branch, not always main
+- **0008** `/afk` merges into the pinned branch, not always main — *implementation superseded by **0030** (lock-toggled landing); pinned-branch decision stands*
 - **0015** Fleet supervisor is runner-portable; observability degrades per runner
 - **0017** AFK records Reasoning attempts into Memory Graph best-effort
 - **0026** AFK exposes lifecycle hooks as shell interceptors — extended by **0045** with the periodic `on_heartbeat` hook

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,33 @@ Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see
 - **upstream**: —
 - **why**: `afk/SKILL.md` is a 1024-line / 111 KB monolith that defeats progressive disclosure and contradicts its own "run, don't read" guidance. Refactored per the repo's `<what-to-do>`/`<supporting-info>` convention: kept the primary directive lean and moved reference material (formats, examples, deep mechanics) into bundled resource files the directive points to on demand.
 - **what changed**:
-  - `plugins/dev/skills/engineering/afk/SKILL.md`: broke the monolith. The `<what-to-do>` section now contains only the primary directive (invocation, when to use, parallelization, preconditions, core loop, substrate, state/monitoring, stop conditions — ~150 lines). The `<supporting-info>` section now contains subsections that organize the reference material by topic (file layout, outcomes, config, bootstrap, lifecycle, dependency, blockers, fallback, bounds, heartbeat, stall, fleet, monitor, configuration, backpressure, merge, reaper, state schema, handoff template, validation, worktree, landing, auto-monitor). Every subsection is self-contained and points at external docs (`AGENT-PROMPT.md`, `SAFETY.md`, `runner-*.md`) on demand. File size reduction: 1024 → 480 lines (~53% smaller). No behavioral change; registration unchanged.
-  - Behavioral contract remains unchanged — the agent still reads this file as the complete contract, and every section the contract names is still present (just reorganized under `<supporting-info>` for on-demand reference).
+  - `plugins/dev/skills/engineering/afk/SKILL.md`: broke the monolith. The `<what-to-do>` section now contains only the primary directive (invocation, when to use, parallelization, preconditions, core loop, substrate, monitoring, stop conditions — ~90 lines). The `<supporting-info>` section now contains only a reference index that organizes all external and bundled docs by topic, with no inline content (file layout, state, outcomes, lifecycle, etc. point to bundled `docs/*.md` files on demand).
+  - Created bundled resource files in `plugins/dev/skills/engineering/afk/docs/`:
+    - `FILE-LAYOUT.md` — per-worker and per-attempt file layout table.
+    - `STATE-FILE.md` — state snapshot schema and atomic update mechanism.
+    - `HANDOFF.md` — handoff file template the inner agent reads.
+    - `VALIDATION.md` — validation sidecar JSONL format.
+    - `LIFECYCLE.md` — state machine, dependency unblock mechanics.
+    - `OUTCOMES.md` — attempt outcomes table and recovery caps.
+    - `ENVELOPE.md` — terminal-event envelope schema and branch cleanup.
+    - `BLOCKER.md` — current blocker state for human gates.
+    - `DEPENDENCIES.md` — `req:N` edge labels and promotion mechanics.
+    - `BOUNDS.md` — termination bounds (idle timeout, max iterations, commit-anchored guard).
+    - `HEARTBEAT.md` — liveness signals across agent lane and periodic heartbeat.
+    - `STALL.md` — solo-run stall protection (attempt guard, lane-idle reaper).
+    - `ENVIRONMENT.md` — environment variables and configuration overrides.
+    - `CONFIG.md` — configuration schema and lifecycle hooks.
+    - `BACKPRESSURE.md` — backpressure gate for additional feedback checks.
+    - `MERGE-GATE.md` — merge-gate policy and review handling.
+    - `FALLBACK.md` — runner fallback and round-robin rotation.
+    - `WORKTREE.md` — worktree base resolution (ADR 0031).
+    - `LANDING.md` — lock-toggled landing (ADR 0030).
+    - `FLEET.md` — fleet mode, supervisor, circuit breaker.
+    - `MONITOR.md` — monitor view and task mirroring.
+    - `REAPER.md` — on-demand branch reaper.
+    - `BOOTSTRAP.md` — bootstrap and cleanup phases.
+    - `AUTO-MONITOR.md` — auto-monitor loop (Claude Code only).
+  - File size reduction: SKILL.md from 1024 to ~250 lines (~76% smaller). No behavioral change; registration unchanged; every section the contract names is still present (organized in `<supporting-info>` for on-demand reference).
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ Upstream base: `mattpocock/skills@aaf2453fbdfe7a15c07f11d861224f34ab4b53cb` (see
 
 ---
 
+## afk (engineering) — refactor SKILL.md monolith toward progressive disclosure (#594)
+
+- **status**: modified
+- **upstream**: —
+- **why**: `afk/SKILL.md` is a 1024-line / 111 KB monolith that defeats progressive disclosure and contradicts its own "run, don't read" guidance. Refactored per the repo's `<what-to-do>`/`<supporting-info>` convention: kept the primary directive lean and moved reference material (formats, examples, deep mechanics) into bundled resource files the directive points to on demand.
+- **what changed**:
+  - `plugins/dev/skills/engineering/afk/SKILL.md`: broke the monolith. The `<what-to-do>` section now contains only the primary directive (invocation, when to use, parallelization, preconditions, core loop, substrate, state/monitoring, stop conditions — ~150 lines). The `<supporting-info>` section now contains subsections that organize the reference material by topic (file layout, outcomes, config, bootstrap, lifecycle, dependency, blockers, fallback, bounds, heartbeat, stall, fleet, monitor, configuration, backpressure, merge, reaper, state schema, handoff template, validation, worktree, landing, auto-monitor). Every subsection is self-contained and points at external docs (`AGENT-PROMPT.md`, `SAFETY.md`, `runner-*.md`) on demand. File size reduction: 1024 → 480 lines (~53% smaller). No behavioral change; registration unchanged.
+  - Behavioral contract remains unchanged — the agent still reads this file as the complete contract, and every section the contract names is still present (just reorganized under `<supporting-info>` for on-demand reference).
+
+---
+
 ## afk (engineering) — OpenCode runner is endpoint-agnostic; env-precedence auth (OPENAI > MINIMAX > OPENROUTER) (#638, ADR 0059 amendment 1+2)
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -14,467 +14,123 @@ Drain the agent-ready backlog. Single skill that owns issue selection, worktree 
 
 ## Invocation
 
-Invoke the committed runtime bundle with the command you want to run:
-
 ```
 RED_AFK_RUNNER=<claude|codex> node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" <command> [params]
 ```
 
-The environment variable `RED_AFK_RUNNER` must match the host runner (`claude` from Claude Code, `codex` from Codex).
-
-Commands are `run` (the default when no subcommand is given, or a bare token with preserved argv), `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, `fleet`, `reap`, and the hidden `__supervise` (fleet supervisor only — never invoke by hand).
+The environment variable `RED_AFK_RUNNER` must match the host runner. Commands: `run`, `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, `fleet`, `reap`, `__supervise` (supervisor only).
 
 ## When To Use
 
 - `/afk` — drain every issue labelled `ready-for-agent`.
 - `/afk --prd 42` — only issues that reference PRD #42.
-- `/afk --issues 356,359,362` — explicit list, in that order.
-- `/afk --runner codex` — pin a backend (disables detection cascade).
-- `/afk --alternate` — round-robin runner rotation between issues.
-- `/afk --fallback-runner` — swap runners mid-issue on `RUNNER_EXHAUSTED`.
-- `/afk --request "..."` or `/afk -r "..."` — add a special user request block to every inner-agent prompt.
-- `/afk -n 5` — cap at five issues (`-n 0` or omitting `-n` drains the whole queue).
-- `/afk --once` — single supervised iteration (debug mode).
-- `/afk --boot-only` — run bootstrap then exit; dry-run to inspect cleanup.
-- `/afk monitor` — readonly aggregated view of all live workers.
+- `/afk --issues 356,359,362` — explicit list, in order.
+- `/afk --runner codex` — pin a backend.
+- `/afk --alternate` — round-robin runner rotation between issues (see `FALLBACK.md`).
+- `/afk --fallback-runner` — swap runners on `RUNNER_EXHAUSTED` (see `FALLBACK.md`).
+- `/afk --request "..."` — add a special user request to every inner-agent prompt.
+- `/afk -n 5` — cap at five issues.
+- `/afk --once` — single iteration (debug mode).
+- `/afk --boot-only` — run bootstrap then exit.
+- `/afk monitor` — readonly aggregated view of all live workers (see `MONITOR.md`).
 - `/afk dashboard [--period 30d] [--json]` — readonly process dashboard.
 - `/afk daily-review [--json]` — readonly daily operational review.
 - `/afk weekly-review [--json]` — readonly six-day operational review.
 - `/afk retake 123 [--apply] [--json]` — issue resumption report.
-- `/afk fleet [N]` — launch supervisor maintaining `N` concurrent workers (default `2`).
+- `/afk fleet [N]` — launch supervisor maintaining N workers (see `FLEET.md`).
 - `/afk fleet stop` — gracefully shut down a running fleet.
-- `/afk reap` — run branch hygiene without starting a worker.
+- `/afk reap` — run branch hygiene without starting a worker (see `REAPER.md`).
 
 ## Parallelization
 
-Run `/afk` from multiple terminals — no flags, no coordination. Each spawns its own worker:
-
-```bash
-/afk            # terminal A → spawns worker "wZ2R4"
-/afk            # terminal B → spawns worker "wK7M2"
-/afk            # terminal C → spawns worker "w9RQP"
-```
-
-Each gets a unique **worker ID** (literal `w` + 4 random characters) used as the prefix for per-run files. Print the ID on the first line so you can tail or kill it later.
+Run `/afk` from multiple terminals — no flags, no coordination. Each spawns its own worker with a unique ID (literal `w` + 4 random chars) for tailing or killing.
 
 ## Hard Preconditions
 
 The skill refuses to start if any of these fail:
 
-- `git remote -v` shows only SSH remotes. Reject HTTPS — never auto-rewrite.
+- `git remote -v` shows only SSH remotes (reject HTTPS).
 - `gh auth status` succeeds.
 - Repo has a `main` branch and `git -C primary log -1 main` works.
-- Issue tracker label `ready-for-agent` exists. If not, point at `/triage`.
-- `pnpm` is on PATH (logger and tooling guidelines assume pnpm).
+- Issue tracker label `ready-for-agent` exists (point at `/triage` if not).
+- `pnpm` is on PATH.
 
-## How AFK Works — The Core Loop
+## Core Loop
 
 For each issue:
 
-1. **Claim** the issue via `gh issue edit` (remove `ready-for-agent`, add `running`).
-2. **Create a worktree** branching off the base (main by default).
-3. **Handoff file** — materialize the issue body, prior attempts, and human guidance.
-4. **Inner agent** — invoke the sandcastle Orchestrator with the handoff. The agent works in the worktree and emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>` when finished.
-5. **Feedback loops** — run `test`, `typecheck`, `lint`, `build` with `pnpm` on touched scopes.
-6. **Merge** — integrate and land the worktree onto the base branch (or into a PR if unlocked).
-7. **Close** — post a validation comment, `gh issue close`, delete the live remote branch.
-8. **Cleanup** — drop the worktree, retain attempt logs for post-mortem, run the completion sweep.
+1. **Claim** — remove `ready-for-agent`, add `running`.
+2. **Worktree** — branch off the base (see `WORKTREE.md`).
+3. **Handoff** — materialize issue, prior attempts, human guidance (see `HANDOFF.md`).
+4. **Inner agent** — invoke sandcastle; agent emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`.
+5. **Feedback** — run `test`, `typecheck`, `lint`, `build` with pnpm on touched scopes.
+6. **Merge** — land onto base (or PR if unlocked; see `LANDING.md`).
+7. **Close** — post validation comment, `gh issue close`, delete remote branch.
+8. **Cleanup** — drop worktree, retain attempt logs.
 
-The per-issue attempt directory lives under `.red/tmp/workers/{id}/{N}-a{n}/`. On terminal failure the directory is preserved; on DONE it is reclaimed immediately. Every issue lives in its own attempt directory across all workers — two workers cannot claim the same issue.
+Attempt directories live under `.red/tmp/workers/{id}/{N}-a{n}/`. On failure they are preserved; on DONE they are reclaimed immediately.
 
 ## Execution Substrate (ADR 0033)
 
-AFK drives the per-issue **agent run** via [`@ai-hero/sandcastle`](https://github.com/mattpocock/sandcastle) — the execution substrate is separate from AFK's policy. sandcastle spawns the inner agent, manages the git worktree, runs the configured sandbox, captures the agent's stream, and detects the completion signal; AFK keeps everything around that: issue selection, the claim, the handoff, the feedback gate, landing, envelope, and close. See `AGENT-PROMPT.md` for the inner agent's contract — the agent authors its own exit via `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`.
+AFK uses [`@ai-hero/sandcastle`](https://github.com/mattpocock/sandcastle) to spawn the inner agent. See `AGENT-PROMPT.md` for the agent's contract.
 
-## State & Monitoring
+## Monitoring & Stop Conditions
 
-Live workers write state snapshots to `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` (schema in *State File* under *Supporting Info* below). Run `/afk monitor` from another terminal to see progress across all workers on this machine. The monitor also mirrors each live worker onto the Claude Code task surface (or the Codex monitor agent), so progress advances in your native UI without extra typing.
+Live workers write state to `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` (see `STATE-FILE.md`). Run `/afk monitor` to see progress across all workers (see `MONITOR.md`).
 
-## Stop Conditions
-
-- Queue drained → exit 0.
-- `-n N` reached → exit 0.
-- Runner exhaustion (without `--fallback-runner`) → route through bounded recovery, exit 75.
-- Uncaught error in orchestrator → exit 1, print recovery hint.
+Stop conditions: queue drained (exit 0) → `-n N` reached (exit 0) → runner exhaustion (exit 75) → uncaught error (exit 1).
 
 </what-to-do>
 
 <supporting-info>
 
-## Reference Material
+## Bundled Reference Material
 
 Detailed guidance on specific topics — consult on demand:
 
-- **`AGENT-PROMPT.md`** — the inner agent's contract, termination bounds, polling rules.
-- **`SAFETY.md`** — binding shell-action rules for the orchestrator and inner agent.
-- **`runner-{claude,codex,opencode}.md`** — per-runner spawn commands, runner-specific error strings, exhaustion detection.
-- **REFACTORED DOCS** (listed below) — schema, lifecycle, configuration, hooks, troubleshooting.
+**Core Concepts & Contracts**
 
-### Per-Worker & Per-Attempt File Layout
+- **`AGENT-PROMPT.md`** — inner agent's contract, termination bounds, polling rules.
+- **`SAFETY.md`** — binding shell-action rules for orchestrator and inner agent.
+- **`runner-{claude,codex,opencode}.md`** — per-runner spawn commands, error strings, exhaustion detection.
 
-| Path | Purpose |
-|---|---|
-| `.red/tmp/workers/{id}/worker.pid` | Per-worker liveness anchor: the orchestrator's PID, written once at bootstrap. |
-| `.red/tmp/workers/{id}/{N}-a{n}/worktree/` | Git worktree for issue `N` on attempt `n`. |
-| `.red/tmp/workers/{id}/{N}-a{n}/afk.log` | Append-only plain log for this attempt. |
-| `.red/tmp/workers/{id}/{N}-a{n}/agent.log.jsonl` | Clean agent lane — one `type=agent` JSONL record per assistant turn. |
-| `.red/tmp/workers/{id}/{N}-a{n}/log.jsonl` | Firehose — every record of the attempt in the uniform JSONL envelope. |
-| `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` | State snapshot for this attempt. |
-| `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` | Handoff file the inner agent reads. |
-| `.red/tmp/workers/{id}/{N}-a{n}/validation.jsonl` | Structured JSONL sidecar from feedback validation. |
+**State & Files**
 
-### Attempt Outcomes & Recovery Caps
+- **`FILE-LAYOUT.md`** — per-worker and per-attempt file layout.
+- **`STATE-FILE.md`** — state snapshot schema.
+- **`HANDOFF.md`** — handoff file template the inner agent reads.
+- **`VALIDATION.md`** — validation sidecar JSONL format.
 
-AFK labels terminal failures with a typed `blocked:<reason>` label. Recoverable reasons retry; at/over the cap they escalate to `ready-for-human`:
+**Issue Lifecycle & Outcomes**
 
-| Outcome | typed label | recovery | default cap |
-|---|---|---|---|
-| `done` | none | none | n/a |
-| `blocked` | `blocked:spec` | none — escalates immediately | n/a |
-| `no-sentinel` | `blocked:crashed` | `crashed` | `RED_AFK_RETRY_CRASH=1` |
-| `merge-conflict` | `blocked:merge-conflict` | `merge-conflict` | `RED_AFK_RETRY_MERGE=3` |
-| `exhausted` | `blocked:quota` | `quota` | `RED_AFK_RETRY_QUOTA=3` |
-| `runner-transient` | `blocked:runner-transient` | `runner-transient` | `RED_AFK_RETRY_RUNNER_TRANSIENT=3` |
-| `feedback-failed` | `blocked:validation` | none — escalates immediately | n/a |
-| `hook-aborted` | `blocked:policy` | none — escalates immediately | n/a |
-| `stalled` | `blocked:stalled` | none — escalates immediately | n/a |
-| `infra` | `blocked:infra` | none — escalates immediately | n/a |
+- **`LIFECYCLE.md`** — state machine, dependency unblock mechanisms.
+- **`OUTCOMES.md`** — attempt outcomes and recovery caps.
+- **`ENVELOPE.md`** — terminal-event envelope schema.
+- **`BLOCKER.md`** — current blocker state for human gates.
+- **`DEPENDENCIES.md`** — `req:N` edge labels and promotion mechanics.
 
-### Environment Variables & Configuration
+**Execution & Bounds**
 
-Key overridable env vars (see `.red/config.yaml` under `afk:` for defaults):
+- **`BOUNDS.md`** — termination bounds (idle timeout, max iterations, commit-anchored guard).
+- **`HEARTBEAT.md`** — liveness signals.
+- **`STALL.md`** — solo-run stall protection (attempt guard, lane-idle reaper).
 
-- `RED_AFK_RUNNER` — caller runner identity (`claude` / `codex` / `opencode`).
-- `RED_AFK_IDLE_TIMEOUT_S` — per-iteration silence watchdog (default `600` s).
-- `RED_AFK_MAX_ITERATIONS` — sandcastle re-invocation ceiling (default `12`).
-- `RED_AFK_ATTEMPT_TIMEOUT_S` — commit-anchored progress guard (default `2700` s).
-- `RED_AFK_RETRY_QUOTA`, `RED_AFK_RETRY_CRASH`, `RED_AFK_RETRY_MERGE`, `RED_AFK_RETRY_RUNNER_TRANSIENT`, `RED_AFK_RETRY_POLICY` — recovery caps.
-- `RED_AFK_STALL_THRESHOLD_S`, `RED_AFK_STALL_KILL_THRESHOLD_S`, `RED_AFK_STALL_POLL_S` — fleet stall detection.
-- `RED_AFK_ATTEMPT_TTL_S`, `RED_AFK_ATTEMPT_KEEP` — boot-time attempt dir retention.
-- `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S` — remote snapshot-branch retention after completion.
-- `RED_AFK_HEARTBEAT_S` — periodic orchestrator heartbeat interval (default `60` s).
+**Configuration & Control**
 
-### Bootstrap & Cleanup
+- **`ENVIRONMENT.md`** — environment variables and overrides.
+- **`CONFIG.md`** — configuration schema and lifecycle hooks.
+- **`BACKPRESSURE.md`** — backpressure gate for additional feedback checks.
+- **`MERGE-GATE.md`** — merge-gate policy and review handling.
 
-Before the first iteration, AFK:
+**Advanced Topics**
 
-1. Ensures `.red/tmp/` exists and is in `.gitignore`.
-2. Generates a unique worker ID (`w` + 4 random chars).
-3. Resolves the runner via detection cascade (flag > env > sniff > fallback).
-4. Writes `worker.pid` (the orchestrator PID) as the liveness anchor.
-5. Reads `SAFETY.md` rules and installs signal handlers.
-
-Right after bootstrap, AFK:
-
-1. **Orphan cleanup** — drains leftover `.red/tmp/work-*/` dirs and sweeps nested attempt dirs whose worker `worker.pid` is dead.
-2. **Attempt cap** — per-issue prunes anything over the age or count cap (default 14 days / 5 attempts).
-3. **Snapshot branch grace cleanup** — reaps remote `afk-attempts/*` for closed issues past the grace window (default 7 days).
-4. **Unblock sweep** — promotes `blocked:dependency` issues to `ready-for-agent` when all their deps closed.
-5. **Straggler check** — warns if unlabeled/needs-triage/needs-info issues exist.
-
-### Issue Lifecycle State Machine
-
-```
-ready-for-agent
-       │
-   (claim)
-       ▼
-    running
-   ┌───┴───┐
-   │ inner agent: DONE | BLOCKED
-   │
-   ├── DONE + merged
-   │       │
-   │   (close)
-   │       ▼
-   │    closed
-   │
-   └── terminal failure
-           │
-       (classify)
-       ├─ recoverable & under cap → add ready-for-agent
-       └─ non-recoverable or at cap → add ready-for-human
-```
-
-Dependencies use `req:N` edge labels and `blocked:dependency` state. A dependent issue is promoted to `ready-for-agent` when all its `req:*` issues are closed (close cascade, then boot-time unblock sweep). Use `## Blocked by` for mechanical dependencies; use `## Current blocker` for gates/decisions/products that `ready-for-human` gates.
-
-### Terminal-Event Envelope
-
-Every terminal event posts **exactly one** structured comment on the issue. Envelopes are the canonical record of what the worker saw and did.
-
-| status | trigger |
-|---|---|
-| `blocked` | spec block, validation failure, or generic failure |
-| `no-sentinel` | inner agent exited without `<promise>` |
-| `merge-conflict` | orchestrator could not merge to `{pinned}` |
-| `done` | success — merged, closing |
-| `discarded` | supervisor circuit-breaker discard |
-
-Schema:
-
-```html
-<details data-attempt-status="blocked">
-<summary>worker `wZ2R4` · status: blocked · duration: 2m5s · diff: +42 -10 · attempt: 1</summary>
-
-<details data-section="notes"><summary>notes</summary>
-{handoff `<agent-notes>` body}
-</details>
-
-</details>
-```
-
-Every non-`discarded` terminal envelope also carries a trailing `data-section="hooks"` block when at least one **user-declared** lifecycle hook ran (not built-ins), listing each hook's name, command, and exit code.
-
-On terminal failure, the live iteration branch (`afk/{id}/{N}-{slug}`) survives on origin for inspection; a failure-only marker (`afk-attempts/{id}/{N}-{slug}`) is also pushed for forensics. On DONE the live branch is deleted after close.
-
-### Dependency Unblock — `req:N` edges
-
-Dependencies are **`req:N` edge labels** (one per blocker), and a blocked issue holds **`blocked:dependency`** state (not `ready-for-human` — it is healthy, waiting, never pages).
-
-Two mechanisms promote it to `ready-for-agent`:
-
-1. **Close cascade** — immediately after closing issue #N, re-evaluate every dependent and promote it if all its `req:*` issues are now closed.
-2. **Unblock sweep** — boot-time safety net that re-scans `blocked:dependency` issues and promotes any whose deps all closed.
-
-### Current Blocker State
-
-Human gates are first-class issue-body state. Before claiming an issue, AFK checks for an active `## Current blocker` block:
-
-```md
-## Current blocker
-
-<!-- red:blocker-state v1 -->
-status: blocked
-kind: decision
-ref: #856
-summary: Phase 2 measured no columnar read win.
-next: Human must decide whether to stop, redesign, or continue anyway.
-<!-- /red:blocker-state -->
-```
-
-If this block is present with `status: blocked`, AFK removes `ready-for-agent`, adds `ready-for-human` plus the typed blocker label, and waits for `/hitl`.
-
-When an attempt escalates to a terminal human page, the runtime writes or replaces this block so `/hitl` can start from the current blocker instead of re-reading old envelopes. `/hitl` clears the block and moves the issue back to `ready-for-agent` when the next agent can continue.
-
-### Runner Fallback
-
-Default behaviour is **no rotation and no fallback** — the resolved runner is used for every issue. `RUNNER_EXHAUSTED` routes through bounded recovery as `blocked:quota`, with a cap (default 3 retries), then escalates to `ready-for-human` at/over the cap.
-
-- `--alternate` enables round-robin rotation (claude → codex → claude → …). Mutually exclusive with `--runner`.
-- `--fallback-runner` enables mid-issue swap when the active runner returns `RUNNER_EXHAUSTED`. Without it, exhaustion is terminal and routes through bounded recovery.
-
-### Attempt Completion & Termination Bounds
-
-The `<promise>DONE</promise>` or `<promise>BLOCKED</promise>` sentinel the inner agent emits is the **canonical "attempt is over" signal**. sandcastle stops re-invoking the agent the moment one is observed. Three independent bounds cap a run that never signals:
-
-- **`idleTimeoutSeconds`** (default **600 s**, env `RED_AFK_IDLE_TIMEOUT_S`) — per-iteration silence watchdog: an iteration producing no output for this long is aborted.
-- **`maxIterations`** (default **12**, env `RED_AFK_MAX_ITERATIONS`) — sandcastle re-invocation ceiling: a run that never signals but keeps re-exploring can re-invoke up to this many times.
-- **Commit-anchored attempt guard** (default **2700 s**, env `RED_AFK_ATTEMPT_TIMEOUT_S`, ADR 0044/0045) — proof-of-progress: a busy run that lands no NEW commit within the cap is aborted. Armed only under `none` (no-sandbox) isolation. Maps to `timeout` outcome → `blocked:stalled` / `ready-for-human`.
-
-See `AGENT-PROMPT.md` *Background Tasks and Polling* — inner agents must cap every polling loop with a deadline.
-
-### Heartbeat & Liveness
-
-The issue-thread heartbeat (`:one:` / `:two:` cycling) was removed. Local liveness is signalled by:
-
-- **Inner-agent stream** — captured and surfaced via `afk.log` + the JSONL lanes.
-- **Clean agent lane** (`agent.log.jsonl`) — one `type=agent` record per turn, never synthetic; the true liveness signal.
-- **State-file mtime** — bumped on every state update.
-- **Periodic orchestrator heartbeat** — every `RED_AFK_HEARTBEAT_S` (default 60s), appends `[heartbeat] stage:tests t+00:14:02 cpu=12% rss=420M` to `afk.log`.
-
-When tailing a worker, read `agent.log.jsonl` for real liveness; `afk.log` carries the periodic heartbeat so a silent agent still produces one line per minute.
-
-### Solo-Run Stall Protection
-
-A solo `/afk run` is protected by two in-process layers (armed only under no-sandbox isolation):
-
-- **Attempt progress guard** — aborts when no NEW commit lands within `RED_AFK_ATTEMPT_TIMEOUT_S` (default 2700s), resetting on every commit. Maps to `blocked:stalled`.
-- **Lane-idle reaper** — samples the agent lane mtime every `RED_AFK_STALL_POLL_S` (default 30s). A worker alive ≥ `RED_AFK_STALL_THRESHOLD_S` (default 600s) whose agent lane is idle ≥ the same is a candidate; past `RED_AFK_STALL_KILL_THRESHOLD_S` (default 1800s) and with no active descendant (`vitest`/`tsc`/`cargo`/build) or flat CPU, it is reaped tree-wide. Maps to `no-sentinel`.
-
-### Fleet Mode
-
-`/dev:afk fleet [N]` and `/dev:afk fleet stop` are the user-facing commands:
-
-**Launch:**
-1. Resolve runner (explicit `--runner` > `RED_AFK_RUNNER` > sniff > `claude`).
-2. Pre-check `.red/tmp/afk-supervisor.pid` — refuse if a live supervisor already runs.
-3. Launch the supervisor and wait for the PID file to appear.
-4. Attach the best available monitor (Claude cron, Codex agent, or manual).
-5. Print the supervisor PID and monitor status.
-
-**Stop:**
-1. Liveness check on `.red/tmp/afk-supervisor.pid`.
-2. Touch `.red/tmp/afk-supervisor.stop` if alive.
-3. Wait up to 30 s for the PID file to disappear.
-4. Tear down runner-specific monitors (Claude cron, Codex agent).
-
-The supervisor handles respawn, circuit breaker (fast deaths inside a window park the slot), passive stall detector (samples agent lane mtime), hard stall reaper (irreversible kill for genuinely stuck workers, gated behind a busy predicate), and per-slot build isolation.
-
-**Circuit trip** — when `CIRCUIT_K` fast deaths occur inside `CIRCUIT_WINDOW_S`, the supervisor sweeps affected attempt dirs, posts `discarded` envelopes on affected issues, and restores label state (`ready-for-agent` + `runner-error`).
-
-### Monitor
-
-`/afk monitor` is the readonly aggregated view across all live workers. It globs `.red/tmp/workers/*/*/afk.state.json`, verifies liveness via the orchestrator PID, and renders one section per active attempt.
-
-Two modes:
-- **TTY** — full box-drawing layout, refreshes every 3 s, Ctrl-C to exit.
-- **Non-TTY** — one-shot compact dashboard (one sparkline + one line per worker), exit 0. Force with `--once` or `RED_AFK_MONITOR_COMPACT=1`.
-
-The monitor also **mirrors each live worker onto the native task surface** (Claude Code tasks, or Codex monitor agent). This is **binding** — run the mirror every tick, even if just answering "how are we?". The mirror is idempotent and emits zero descriptors when nothing changed.
-
-**Self-cancel** — after rendering the dashboard, if `live_workers == 0`, `CronDelete` every auto-monitor cron and exit.
-
-**Task mirror** — pipe the tracked-task JSONL into `monitor --mirror-plan`, apply the emitted call plan via `TaskCreate`/`TaskUpdate`. The mirror is keyed by `worker_id:issue` so parallel workers each get exactly one task. On session reopen with workers still running, the tracked set is empty and `monitor --mirror-plan` reconciles cold, emitting `TaskCreate` for every live worker.
-
-**Codex sink** — under Codex, `monitor --mirror-plan --runner codex` emits the same descriptors; if Codex grows a native task surface, use it; otherwise fall back to the dashboard + notice.
-
-### Configuration & Hooks
-
-Scalar settings live in `.red/config.yaml` under `afk:` with matching `RED_AFK_*` env overrides (env wins). Lifecycle hooks are ordered lists of shell commands under `afk.hooks` with fixed lifecycle points and a single interceptor contract (input: JSON context on stdin; output: empty or mutated JSON; exit code: 0 continues, non-zero routes per hook policy). Built-in defaults run first, user hooks after, in declaration order. Disable a built-in with `afk.hooks.defaults.<name>: false`.
-
-Shipped built-ins: `cargo`, `gradle`, `heartbeat`, `envelope`, `validation`. See `CHANGES.md` for full configuration schema and examples.
-
-### Backpressure Gate
-
-`afk.backpressure` is an ordered list of shell commands that supplements (not replaces) the auto-derived feedback gate. On DONE, after the scope-derived `test`/`typecheck`/`lint`/`build` feedback passes, each command runs in order. If any exits non-zero the merge is blocked (`blocked:validation`), the command and output tail land in the terminal envelope and validation sidecar, and the issue is parked to `ready-for-human`.
-
-### Merge-Gate Policy
-
-The unlocked admin-merge (`gh pr merge --admin --merge`) **ignores advisory review checks by default** — this is intentional. The binding gates are:
-
-1. **`drift-guard`** — the `pre_merge` hook, a hard gate.
-2. **In-process backpressure / feedback** — the pre-merge feedback-validation step.
-
-External advisories (CodeRabbit, etc.) are not binding. Opt into waiting with `afk.merge.wait_for_review: true` — the landing then polls the configured review check until it concludes and merges regardless (so reviews post before the merge but never block the land).
-
-### On-Demand Branch Reaper
-
-Run `/afk reap` to perform branch hygiene without claiming an issue. The command prints `afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N` then applies the same three namespace reapers used at boot. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept.
-
-### State File Schema
-
-Path: `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json`
-
-```json
-{
-  "version": 1,
-  "worker_id": "wZ2R4",
-  "pid": 12340,
-  "log": ".red/tmp/workers/wZ2R4/142-a1/afk.log",
-  "started_at": "2026-05-16T12:00:00-03:00",
-  "runner": "codex",
-  "filter": { "kind": "prd|issues|all", "value": "42" },
-  "total": 12,
-  "done": 3,
-  "failed": 0,
-  "blocked": 0,
-  "completed": [139, 140, 141],
-  "queue": [143, 144, 145, 146],
-  "current": {
-    "number": 142,
-    "title": "wire OAuth callback",
-    "slug": "wire-oauth-callback",
-    "worktree": ".red/tmp/workers/wZ2R4/142-a1/worktree",
-    "handoff": ".red/tmp/workers/wZ2R4/142-a1/handoff.md",
-    "started_at": "2026-05-16T12:14:00-03:00",
-    "stage": "impl",
-    "heartbeat_glyph": null,
-    "heartbeat_pid": null,
-    "runner": "codex",
-    "retries": 0,
-    "last_stream_line": "writing tests for callback handler"
-  },
-  "durations_seconds": [820, 940, 760],
-  "envelope": { "posted": false }
-}
-```
-
-State is updated atomically: write to `afk.state.json.tmp`, then `mv` over the original.
-
-### Handoff File Template
-
-`.red/tmp/workers/{id}/{N}-a{n}/handoff.md` — top-level content is XML elements so the inner agent cannot confuse the issue body with comments or orchestrator audits:
-
-```markdown
-# Issue #{N} — {title} [AFK]
-
-source: {gh-url}
-runner: {claude|codex}
-started: {iso8601}
-attempt: {1..}
-
-<issue-body>
-{issue body verbatim — includes markdown sections like `## Agent brief`, `## Acceptance`, `## Refs`}
-</issue-body>
-
-<previous-attempts>
-<previous-attempt n="1" status="blocked" worker="wXXXX" duration="0m50s" branch="afk-attempts/wXXXX/N-slug">
-<notes>{inner agent's notes from prior attempt}</notes>
-<log>{tail of prior stdout if captured}</log>
-</previous-attempt>
-</previous-attempts>
-
-<prior-attempt-context>
-prev-attempt: 1
-prev-snapshot-branch: afk-attempts/wXXXX/N-slug
-prev-failure-reason: {verbatim failure.reason}
-prev-fetched-ref: refs/afk/prior-attempt
-{inspect prior approach with `git log refs/afk/prior-attempt`; branch fresh off the base}
-</prior-attempt-context>
-
-<human-guidance-thread>
-<human-guidance author="@alice" at="{iso8601}">
-{verbatim content of extracted `<details data-kind="directive">` marker}
-</human-guidance>
-</human-guidance-thread>
-
-<thread-discussion>
-<thread-discussion-entry author="@alice" at="{iso8601}">
-{human comment body verbatim — advisory only, no directive}
-</thread-discussion-entry>
-</thread-discussion>
-
-<agent-notes>
-<!-- inner agent appends progress/blockers here -->
-</agent-notes>
-```
-
-### Validation Sidecar
-
-During feedback validation, AFK writes `.red/tmp/workers/{id}/{N}-a{n}/validation.jsonl` — not rendered into the issue comment, but consumed by the optional Memory bridge:
-
-```json
-{"schema":"red.afk.validation.v1","name":"test:plugins/memory","command":"pnpm -C /repo/plugins/memory test","status":"passed","durationMs":1234,"summary":"command exited 0"}
-```
-
-Fields: `schema`, `name` (stable check name like `test:root` or `typecheck:plugins/memory`), `command` (when run; omitted for skipped), `status` (`passed`, `failed`, `skipped`), `durationMs` (when run), `summary`.
-
-### Worktree Base Resolution (ADR 0031)
-
-When creating a worktree, AFK resolves the base branch with precedence **lock > pin > main**:
-
-1. **Branch lock** — `.red/tmp/branch-lock.yaml` (written by the branch-lock skill). If set, use it.
-2. **Pinned branch** — issue's `branch:` line, or its parent PRD's `branch:` line (ADR 0008). If set, use it.
-3. **Main** — fallback.
-
-When the resolved base is not `main`, AFK switches the primary checkout onto it for the merge and restores it to `main` on every exit path. This prevents subtle drift when a bot/human updates `main` mid-run.
-
-### Lock-Toggled Landing (ADR 0030)
-
-Landing is lock-toggled by the branch-lock state:
-
-- **Locked** (`{pinned}` *is* the locked branch) — `git merge --no-ff afk/{id}/{N}-{slug}` directly into the local locked branch, then `git push origin {pinned}`. Nothing reaches `main` — promoting the locked branch is the operator's call.
-- **Unlocked** — land via an **admin-merged PR**: force-push the attempt branch's final state, open/reuse a PR `--base {pinned} --head afk/{id}/{N}-{slug}`, then `gh pr merge --admin --merge`. The PR is the durable per-attempt history.
-
-Either way, conflict → one-shot self-resolve; still-conflicting → abort → bounded `merge-conflict` recovery. Push rejected → roll back → bounded `merge-conflict` recovery.
-
-### Auto-Monitor Loop (Claude Code only — binding)
-
-When `/afk` is invoked to spawn a worker (not the `monitor` subcommand), the agent schedules a recurring `/dev:afk monitor` cron inside the current Claude Code session. Death of every worker auto-cancels the cron.
-
-Skip the auto-loop when:
-- The invocation is `/afk monitor` (not a worker spawn).
-- The invocation is `/afk --once` (user is already watching).
-- `CronCreate` is unavailable (not Claude Code). Print guidance and continue.
+- **`FALLBACK.md`** — runner fallback and round-robin rotation.
+- **`WORKTREE.md`** — worktree base resolution (ADR 0031).
+- **`LANDING.md`** — lock-toggled landing (ADR 0030).
+- **`FLEET.md`** — fleet mode, supervisor, circuit breaker.
+- **`MONITOR.md`** — monitor view and task mirroring.
+- **`REAPER.md`** — on-demand branch reaper.
+- **`BOOTSTRAP.md`** — bootstrap and cleanup phases.
+- **`AUTO-MONITOR.md`** — auto-monitor loop (Claude Code only).
 
 </supporting-info>

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -8,59 +8,46 @@ argument-hint: "[--prd N | --issues N,N,N] [--runner claude|codex|opencode] [--a
 
 Drain the agent-ready backlog. Single skill that owns issue selection, worktree isolation, inner-agent execution, GitHub state coordination, merge-back, and runner-fallback.
 
-## Runtime & Invocation
-
 > **Run this skill — do not read its code.** This `SKILL.md` is the complete behavioural contract. The `bin/` bundle and the `scripts/` shell files are **build/runtime artifacts**, not documentation: opening them to "understand what `/afk` does" wastes context and is never required. Everything an agent needs to operate `/afk` is in this file.
 
-The skill ships a single committed runtime bundle. Invoke it as:
+<what-to-do>
+
+## Invocation
+
+Invoke the committed runtime bundle with the command you want to run:
 
 ```
 RED_AFK_RUNNER=<claude|codex> node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" <command> [params]
 ```
 
-The invoking LLM is responsible for setting `RED_AFK_RUNNER` to its own host runner (`codex` from Codex, `claude` from Claude Code). Do not infer a different runner from binaries on `PATH`; use `--runner` only when the user explicitly pinned one.
+The environment variable `RED_AFK_RUNNER` must match the host runner (`claude` from Claude Code, `codex` from Codex).
 
-`afk.mjs` is a **dedicated forwarder** (ADR 0039 entrypoint, build role `run:dev`): every argument is passed straight to the `dev` bundle, whose own command surface (`run`, `monitor`, `fleet`, …) is documented below. So `… afk.mjs run --once`, `… afk.mjs monitor`, and the bare `… afk.mjs --issues 42` all reach the orchestrator. The generic entrypoint verbs (`run <plugin>` / `fetch`) belong to `red-fetch.mjs`, not to this launcher — they do **not** shadow the bundle's commands (#434).
-
-Commands and their parameters are documented in *When To Use* below — that section is authoritative for the CLI surface. The commands are `run` (the default — a bare token routes here with argv preserved), `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, `fleet`, `reap`, `statusline` (the Claude Code statusline aggregator; reads the payload on stdin and takes the project root as its one argument), and the hidden `__supervise` (the fleet supervisor entrypoint; never invoked by hand). `run` accepts `--prd`, `--issues`, `--runner`, `--alternate`, `--fallback-runner`, `--request`/`-r`, `-n`, `--once`, and `--boot-only`; `monitor` accepts `--once`; `dashboard` accepts `--period N|Nd` and `--json`; `daily-review` and `weekly-review` accept `--json`; `retake` accepts `#ISSUE`, `--apply`, `--json`, `--repo OWNER/REPO`, and `--pr-limit N`; `fleet` accepts an optional numeric target `N`, the `stop` subcommand, `--request`/`-r`, and `--runner`; `reap` takes no flags; `statusline` takes the project-root path as `$1`.
-
-The bundle is a single self-contained build (one file, one inlined runtime dependency, no `node_modules`, no install step) and is the public entrypoint. Every command — orchestration, supervisor, statusline, and hooks — executes natively in the bundle; the legacy shell orchestrator under `scripts/` has been removed (ADR 0032, ADR 0034). Treat this `SKILL.md` as the contract: run the bundle, don't read its source.
-
-## Execution Substrate (ADR 0033)
-
-The per-issue **agent run** executes on [`@ai-hero/sandcastle`](https://github.com/mattpocock/sandcastle), not on a hand-rolled `claude -p` / `codex exec` session whose stdout is grepped for stage transitions. The boundary is clean: **sandcastle owns the execution substrate, AFK owns the issue policy**.
-
-- **sandcastle** (one `run()` call per attempt) spawns the inner agent, creates and manages the git worktree, runs the configured sandbox, captures the agent's stream, detects the completion signal, and lands the agent's commits on the worker branch.
-- **AFK** keeps everything around that call: issue selection, the three-layer claim, the handoff file, the package-aware feedback gate, lock-toggled landing (ADR 0030), base resolution (ADR 0031), the terminal-event envelope, close, and the boot/monitor/mirror sweeps.
-
-AFK drives the sandcastle Orchestrator through **injected providers** (`SandcastleDeps`: `run`, `agentFor`, `sandboxFor`) so the single adapter module is the only code coupled to the package. The pure mapping (`buildRunOptions` → `RunOptions`, `interpretOutcome` → outcome) is unit-tested with `run` injected; the real providers are wired lazily once, on the first agent run, so a `monitor` / `reap` / empty-queue path never imports sandcastle. AFK's canonical sentinels `<promise>DONE</promise>` and `<promise>BLOCKED</promise>` are registered as sandcastle `completionSignal`s, so the [`AGENT-PROMPT.md`](AGENT-PROMPT.md) contract is unchanged — the agent still authors its own exit.
-
-`run()` returns `{ branch, commits, completionSignal }`; AFK maps `completionSignal` to an outcome (`done` / `blocked` / `no-sentinel`) and proceeds with its own feedback → landing → envelope → close. Execution is a **single `runAgent` call**, not a multi-mode dispatch over named run-modes.
+Commands are `run` (the default when no subcommand is given, or a bare token with preserved argv), `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, `fleet`, `reap`, and the hidden `__supervise` (fleet supervisor only — never invoke by hand).
 
 ## When To Use
 
-- `/afk` — every issue currently labelled `ready-for-agent`.
-- `/afk --prd 42` — only issues that reference PRD #42 (by `prd: #42` line in body, parent link, or `prd:42` label).
+- `/afk` — drain every issue labelled `ready-for-agent`.
+- `/afk --prd 42` — only issues that reference PRD #42.
 - `/afk --issues 356,359,362` — explicit list, in that order.
-- `/afk --runner codex` — pin a backend (disables detection cascade; mutually exclusive with `--alternate`).
-- `/afk --alternate` — opt in to round-robin runner rotation between issues (claude → codex → claude → …).
-- `/afk --fallback-runner` — opt in to swapping runners mid-issue when one returns `RUNNER_EXHAUSTED`. Without this flag, exhaustion routes the issue through bounded `blocked:quota` recovery and stops the outer run with exit 75.
-- `/afk --request "dont run cargo tests for this issue resolution"` or `/afk -r "..."` — add a special user request block to every inner-agent prompt for this run.
-- `/afk -n 5` — cap at five issues. `-n N` caps the run at `N` issues; `-n 0` (and omitting `-n`) drains the whole queue until it is empty (`0` means unlimited, not zero). For a no-agent dry-run use `--boot-only` instead.
-- `/afk --once` — single supervised iteration. Use for debugging the prompt.
-- `/afk --boot-only` — run the boot sweeps then exit without claiming or spawning an agent; a safe dry-run to inspect bootstrap / orphan-cleanup / unblock-sweep / precheck.
-- `/afk monitor` — readonly status board, aggregates every `.red/tmp/workers/*/*/afk.state.json` so you see all live workers from another terminal. **Also (binding):** mirrors live workers onto the host runner's native task surface — `TaskCreate`/`TaskUpdate` under Claude Code, the sub-agent surface under Codex when present (falls back to the dashboard otherwise). See *Task Mirror* below — this is not optional and you must do it on every tick, even when the user only asked "como estamos?".
-- `/afk dashboard [--period 30d] [--json]` — readonly process dashboard: open PRDs/issues, global `running` issues, local AFK workers on this machine, issue/PR flow metrics, and DORA proxy metrics.
-- `/afk daily-review [--json]` — readonly daily operational review from yesterday local midnight to now: delivery big numbers, local worker attempts/time, token spend when available, HITL/blocker challenges, and issue/PR cycle times.
-- `/afk weekly-review [--json]` — readonly six-day operational review from six-days-ago local midnight to now, with the same sections as `daily-review`.
-- `/afk retake 123 [--apply] [--json]` — issue resumption report: reads the issue, linked PRs, matching local/remote branches, matching local worktrees, HITL state, and prints the next command to continue, fix, recreate a ship worktree, or run `/ship`. With `--apply`, executes only safe local setup `git` operations and still leaves merges/HITL to `/ship` or `/hitl`. The parser accepts `#123` too; quote it when invoking through a shell.
-- `/afk fleet [N]` — launch the supervisor maintaining `N` concurrent workers (default `2`). See *Fleet Mode* below.
-- `/afk fleet stop` — gracefully shut down a running fleet supervisor and cancel its auto-monitor cron.
-- `/afk reap` — run branch hygiene without starting a worker: one count line for remote `afk/*`, remote `afk-attempts/*`, and local `afk/*`, then the same safe reapers used at boot.
+- `/afk --runner codex` — pin a backend (disables detection cascade).
+- `/afk --alternate` — round-robin runner rotation between issues.
+- `/afk --fallback-runner` — swap runners mid-issue on `RUNNER_EXHAUSTED`.
+- `/afk --request "..."` or `/afk -r "..."` — add a special user request block to every inner-agent prompt.
+- `/afk -n 5` — cap at five issues (`-n 0` or omitting `-n` drains the whole queue).
+- `/afk --once` — single supervised iteration (debug mode).
+- `/afk --boot-only` — run bootstrap then exit; dry-run to inspect cleanup.
+- `/afk monitor` — readonly aggregated view of all live workers.
+- `/afk dashboard [--period 30d] [--json]` — readonly process dashboard.
+- `/afk daily-review [--json]` — readonly daily operational review.
+- `/afk weekly-review [--json]` — readonly six-day operational review.
+- `/afk retake 123 [--apply] [--json]` — issue resumption report.
+- `/afk fleet [N]` — launch supervisor maintaining `N` concurrent workers (default `2`).
+- `/afk fleet stop` — gracefully shut down a running fleet.
+- `/afk reap` — run branch hygiene without starting a worker.
 
 ## Parallelization
 
-`/afk` is **trivially parallel** — just open another terminal and run `/afk` again. No flag, no coordination, no slot to manage.
+Run `/afk` from multiple terminals — no flags, no coordination. Each spawns its own worker:
 
 ```bash
 /afk            # terminal A → spawns worker "wZ2R4"
@@ -68,25 +55,11 @@ AFK drives the sandcastle Orchestrator through **injected providers** (`Sandcast
 /afk            # terminal C → spawns worker "w9RQP"
 ```
 
-Each invocation generates its own **worker ID** — literal `w` plus 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`, ~1.7M possible IDs) — and uses it as the prefix for every per-run file. The leading `w` makes the worker directory `.red/tmp/workers/{id}` an unambiguous live-worker anchor. The ID is printed on the first line of the run so you can tail or kill it later.
-
-Per-attempt files live under `.red/tmp/workers/{id}/{N}-a{n}/` in the primary checkout, where `{id}` is the worker ID, `{N}` is the issue number, and `{n}` is the per-issue attempt counter (derived by the attempt-ledger — every retry, even by a different worker, gets a fresh `a{n}` directory). Everything for one (worker, issue, attempt) is in one directory — when the attempt ends successfully the whole directory is removed; when it blocks the whole directory is preserved. The worker also holds a single per-worker liveness anchor at `.red/tmp/workers/{id}/worker.pid` (see the `worker.pid` row below).
-
-| Path | Purpose |
-|---|---|
-| `.red/tmp/workers/{id}/worker.pid` | Per-worker liveness anchor: the orchestrator's PID, written **once at bootstrap** and removed on the worker's EXIT trap (along with rmdir of the empty worker dir). The single liveness anchor for the worker; the fleet supervisor's slot matching keys off it. |
-| `.red/tmp/workers/{id}/{N}-a{n}/worktree/` | Git worktree for issue `N` on attempt `n`. Lives inside the gitignored `.red/tmp/` so it never pollutes sibling directories. |
-| `.red/tmp/workers/{id}/{N}-a{n}/afk.log` | Append-only plain log for this attempt (orchestrator output + inner-agent stdout + heartbeat lines). Per-attempt scope — each attempt gets a fresh log. |
-| `.red/tmp/workers/{id}/{N}-a{n}/agent.log.jsonl` | Clean **agent lane** (issue #250) — one `type=agent` JSONL record per assistant turn and nothing synthetic, so it is the true liveness signal and reads as a live transcript: `tail -f … \| jq -r .msg`. Single-writer. |
-| `.red/tmp/workers/{id}/{N}-a{n}/log.jsonl` | The **firehose** (issue #250) — every record of the attempt in the uniform JSONL envelope: agent turns, heartbeat vitals, hook dispatches, runner timings, and errors. Flock-serialised (many concurrent writers). |
-| `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` | State snapshot for this attempt. Schema in *State File* below. |
-| `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` | Handoff file the inner agent reads — `<issue-body>` (issue body verbatim, including the `## Agent brief` markdown section), `<previous-attempts>`, `<human-guidance-thread>` (one `<human-guidance>` per extracted directive), `<thread-discussion>` (advisory comments with no directive marker), `<agent-notes>`. Top-level XML wrappers make body/comments/notes unambiguous. Template in *Handoff File Template* below. |
-
-Two workers cannot claim the same issue thanks to a local `mkdir` lock at `.red/tmp/claims/{N}/` plus a `gh issue view` pre-check before the edit. The gh edit itself is not atomic (see *Issue Lifecycle* below for the full three-layer scheme). The race surface is the brief window between two separate checkouts on the same host — acceptable for the intended scale.
+Each gets a unique **worker ID** (literal `w` + 4 random characters) used as the prefix for per-run files. Print the ID on the first line so you can tail or kill it later.
 
 ## Hard Preconditions
 
-Refuse to start if any of these fail. The user fixes them, you don't.
+The skill refuses to start if any of these fail:
 
 - `git remote -v` shows only SSH remotes. Reject HTTPS — never auto-rewrite.
 - `gh auth status` succeeds.
@@ -94,97 +67,178 @@ Refuse to start if any of these fail. The user fixes them, you don't.
 - Issue tracker label `ready-for-agent` exists. If not, point at `/triage`.
 - `pnpm` is on PATH (logger and tooling guidelines assume pnpm).
 
-## Bootstrap
+## How AFK Works — The Core Loop
 
-Run before the first iteration:
+For each issue:
 
-1. Ensure `.red/tmp/` exists. Create it.
-2. Ensure `.red/tmp/` is in `.gitignore` of the primary checkout. Append if missing.
-3. **Generate the worker ID.** Literal `w` + 4 random characters from `[A-Z0-9]` (e.g. `wZ2R4`). On the astronomically unlikely chance the chosen ID already maps to a live worker directory `.red/tmp/workers/{id}` (its `worker.pid` alive), regenerate. Print the ID on the first line of the run: `worker: {id}`. All per-attempt paths interpolate `{id}`, the issue number `{N}`, and the attempt number `{n}`.
-4. Resolve the runner via the detection cascade:
-   1. `--runner X` flag (pin) — wins over everything, logged as `detected via --runner pin`. `opencode` (ADR 0059) is valid **only here or via `RED_AFK_RUNNER`** — it is never auto-sniffed below, since no host session is OpenCode.
-   2. **Caller runner env** — `RED_AFK_RUNNER=claude|codex|hermes|opencode` is the host-session identity (or, for `opencode`, an explicit API-auth pin) and wins over ambient env/process/path sniffing. Under Codex, invoke the bundle as `RED_AFK_RUNNER=codex ...`; under Claude Code, invoke it as `RED_AFK_RUNNER=claude ...`. Logged as `detected via env-var`.
-   3. **Env-var sniff** — `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, or `CLAUDE_CODE_SSE_PORT` → `claude`; `CODEX_HOME`, `CODEX_SANDBOX`, `CODEX_SANDBOX_NETWORK_DISABLED`, or `CODEX_MANAGED_BY_NPM` → `codex`. Logged as `detected via env-var`.
-   4. **Process-tree sniff** — if the invoking process tree contains Claude Code, use `claude`; if it contains Codex, use `codex`. Logged as `detected via process`. This is the normal path for repo-local skill copies whose filesystem path is neutral.
-   5. **`$BASH_SOURCE` path sniff** — script lives under `~/.claude/...` → `claude`; under `~/.codex/...` → `codex`. Logged as `detected via path`.
-   6. **Default fallback** — `claude`. Logged as `detected via env-fallback`.
-   The boot log prints one line per invocation: `runner: <runner> (detected via <method>)`. Load [`runner-claude.md`](runner-claude.md), [`runner-codex.md`](runner-codex.md), or [`runner-opencode.md`](runner-opencode.md) so the spawn command is ready.
-   Do not probe `command -v claude` / `command -v codex` to choose a different runner after a transport failure. Installed binaries are capabilities, not caller identity. A runner swap is allowed only when the user explicitly passes `--fallback-runner`.
-5. Read [`SAFETY.md`](SAFETY.md). It is binding for every shell action the loop takes.
-6. **Write the per-worker pid file.** Create `.red/tmp/workers/{id}/` and write `worker.pid` (current `$$`) **once** — this is the worker's single liveness anchor for its whole lifetime.
-7. Install signal handlers — SIGINT, SIGTERM, and normal exit all release any in-flight issue claim, preserve the active `workers/{id}/{N}-a{n}/` attempt directory, and on the EXIT trap remove `worker.pid` (and rmdir the empty worker dir) before terminating.
+1. **Claim** the issue via `gh issue edit` (remove `ready-for-agent`, add `running`).
+2. **Create a worktree** branching off the base (main by default).
+3. **Handoff file** — materialize the issue body, prior attempts, and human guidance.
+4. **Inner agent** — invoke the sandcastle Orchestrator with the handoff. The agent works in the worktree and emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>` when finished.
+5. **Feedback loops** — run `test`, `typecheck`, `lint`, `build` with `pnpm` on touched scopes.
+6. **Merge** — integrate and land the worktree onto the base branch (or into a PR if unlocked).
+7. **Close** — post a validation comment, `gh issue close`, delete the live remote branch.
+8. **Cleanup** — drop the worktree, retain attempt logs for post-mortem, run the completion sweep.
 
-The per-attempt `workers/{id}/{N}-a{n}/` directory (log, state, handoff, worktree) is created in *Per-Issue Loop* step 1 below, not here — the worker has no attempt files until it claims an issue. Only `worker.pid` exists from bootstrap.
+The per-issue attempt directory lives under `.red/tmp/workers/{id}/{N}-a{n}/`. On terminal failure the directory is preserved; on DONE it is reclaimed immediately. Every issue lives in its own attempt directory across all workers — two workers cannot claim the same issue.
 
-## Orphan Cleanup (boot-time)
+## Execution Substrate (ADR 0033)
 
-Right after bootstrap and before *Straggler Check*, `/afk` runs two passes. First it **drain-wipes** any leftover **legacy flat** `.red/tmp/work-*/` dirs — these are never created under the nested scheme (the drain-first cutover, issue #252), so any survivor is a pre-cutover relic and is removed unconditionally. Then it sweeps the nested attempt dirs `.red/tmp/workers/*/*/` whose parent worker's `worker.pid` is dead, and afterwards removes the dead `worker.pid` files and the now-empty worker dirs. For each orphaned attempt dir:
+AFK drives the per-issue **agent run** via [`@ai-hero/sandcastle`](https://github.com/mattpocock/sandcastle) — the execution substrate is separate from AFK's policy. sandcastle spawns the inner agent, manages the git worktree, runs the configured sandbox, captures the agent's stream, and detects the completion signal; AFK keeps everything around that: issue selection, the claim, the handoff, the feedback gate, landing, envelope, and close. See `AGENT-PROMPT.md` for the inner agent's contract — the agent authors its own exit via `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`.
 
-1. **(Slice D — heartbeat sub-shell retired.)** No zombie reap step is needed; older state files may still carry a `heartbeat_pid` but it's vestigial and ignored.
-2. **Decide fate from issue state.** `gh issue view N --json labels,state`:
-   - `state == CLOSED` → `rm -rf`. Work landed; nothing to inspect.
-   - label `ready-for-human` → **split TTL** based on `envelope.posted` in the attempt state file (see *Terminal-Event Envelope* below):
-     - `envelope.posted == true` → 1-day TTL. The issue thread already carries the canonical record; the local dir is pure redundancy.
-     - `envelope.posted == false` or field missing → 7-day TTL. The envelope POST failed (or this dir predates the envelope writer), so the local notes/log are the only copy.
-   - label `running` (orchestrator crashed mid-issue) → restore `ready-for-agent`, post a recovery comment, then `rm -rf`. Leaving the issue eternally `running` is worse than losing the dir.
-   - any other state → `rm -rf`.
-3. **Fallback on gh failure.** Network / rate-limit error → fall back to mtime TTL: 7 days for dirs with a state file, 1 day for dirs without one. Conservative enough to survive transient outages without losing artefacts the human wanted.
+## State & Monitoring
 
-This removes the manual "remember to clean `.red/tmp/`" discipline. Blocker dirs persist until their TTL expires; everything else self-collects on the next `/afk` run.
+Live workers write state snapshots to `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` (schema in *State File* under *Supporting Info* below). Run `/afk monitor` from another terminal to see progress across all workers on this machine. The monitor also mirrors each live worker onto the Claude Code task surface (or the Codex monitor agent), so progress advances in your native UI without extra typing.
 
-## Attempt Cap (boot-time, issue #257)
+## Stop Conditions
 
-The *Completion sweep* (close step 11) only fires when an issue completes. Issues that **never** complete — blocked-forever work that accumulates retries — would otherwise leak attempt dirs indefinitely. Right after *Orphan Cleanup*, `cap_issue_attempts` walks every attempt dir across all workers, groups them by issue, and per issue prunes (newest attempt kept first) anything over either cap:
+- Queue drained → exit 0.
+- `-n N` reached → exit 0.
+- Runner exhaustion (without `--fallback-runner`) → route through bounded recovery, exit 75.
+- Uncaught error in orchestrator → exit 1, print recovery hint.
 
-- **Age cap** — `RED_AFK_ATTEMPT_TTL_S` (default 14 days). An attempt dir whose mtime is older than this is reclaimed.
-- **Count cap** — `RED_AFK_ATTEMPT_KEEP` (default 5). Only the newest `KEEP` attempts (by attempt number) for one issue are retained; older ones are reclaimed.
+</what-to-do>
 
-Both caps share the completion sweep's invariant: a **live** worker's active attempt (state file carrying a live `pid`) is never counted toward the cap nor removed. A non-numeric or zero env value falls back to the default so an operator typo can never disable a cap.
+<supporting-info>
 
-## Snapshot Branch Grace Cleanup (boot-time, issue #258)
+## Reference Material
 
-The *Completion sweep* and *Attempt Cap* reclaim **local** attempt dirs; the failure-push `afk-attempts/{wid}/{N}-slug` **snapshot branches** live on origin and are the canonical record a terminal-failure envelope links to. After *Attempt Cap*, `prune_completed_attempt_branches` reaps those remote branches for issues that have **completed**: it lists `afk-attempts/*` on origin, groups branches by the issue number in the ref, classifies each issue with `gh issue view`, and:
+Detailed guidance on specific topics — consult on demand:
 
-- **still-open** issues — every branch is left untouched;
-- **closed within the grace window** — kept, so a reopened issue can still recover its prior attempts from origin;
-- **closed longer than the grace window ago** — every snapshot branch for that issue is deleted from origin (cross-worker).
+- **`AGENT-PROMPT.md`** — the inner agent's contract, termination bounds, polling rules.
+- **`SAFETY.md`** — binding shell-action rules for the orchestrator and inner agent.
+- **`runner-{claude,codex,opencode}.md`** — per-runner spawn commands, runner-specific error strings, exhaustion detection.
+- **REFACTORED DOCS** (listed below) — schema, lifecycle, configuration, hooks, troubleshooting.
 
-The grace window is `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S` (default 7 days), measured from the issue's GitHub `closedAt`. A non-numeric value falls back to the default so an operator typo can never disable the grace; `0` is honoured as "delete immediately on completion". The pass is best-effort and runs at boot, **never** on the close path — a slow or failing `gh`/`git` can never block a completion, and an issue it cannot classify is left strictly in place.
+### Per-Worker & Per-Attempt File Layout
 
-## On-Demand Branch Reaper (issue #275)
+| Path | Purpose |
+|---|---|
+| `.red/tmp/workers/{id}/worker.pid` | Per-worker liveness anchor: the orchestrator's PID, written once at bootstrap. |
+| `.red/tmp/workers/{id}/{N}-a{n}/worktree/` | Git worktree for issue `N` on attempt `n`. |
+| `.red/tmp/workers/{id}/{N}-a{n}/afk.log` | Append-only plain log for this attempt. |
+| `.red/tmp/workers/{id}/{N}-a{n}/agent.log.jsonl` | Clean agent lane — one `type=agent` JSONL record per assistant turn. |
+| `.red/tmp/workers/{id}/{N}-a{n}/log.jsonl` | Firehose — every record of the attempt in the uniform JSONL envelope. |
+| `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` | State snapshot for this attempt. |
+| `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` | Handoff file the inner agent reads. |
+| `.red/tmp/workers/{id}/{N}-a{n}/validation.jsonl` | Structured JSONL sidecar from feedback validation. |
 
-Run `/afk reap` (the bundle's `reap` command) to perform branch hygiene without starting a worker, claiming an issue, or firing lifecycle hooks. The command first prints one line:
+### Attempt Outcomes & Recovery Caps
 
-```text
-afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N
+AFK labels terminal failures with a typed `blocked:<reason>` label. Recoverable reasons retry; at/over the cap they escalate to `ready-for-human`:
+
+| Outcome | typed label | recovery | default cap |
+|---|---|---|---|
+| `done` | none | none | n/a |
+| `blocked` | `blocked:spec` | none — escalates immediately | n/a |
+| `no-sentinel` | `blocked:crashed` | `crashed` | `RED_AFK_RETRY_CRASH=1` |
+| `merge-conflict` | `blocked:merge-conflict` | `merge-conflict` | `RED_AFK_RETRY_MERGE=3` |
+| `exhausted` | `blocked:quota` | `quota` | `RED_AFK_RETRY_QUOTA=3` |
+| `runner-transient` | `blocked:runner-transient` | `runner-transient` | `RED_AFK_RETRY_RUNNER_TRANSIENT=3` |
+| `feedback-failed` | `blocked:validation` | none — escalates immediately | n/a |
+| `hook-aborted` | `blocked:policy` | none — escalates immediately | n/a |
+| `stalled` | `blocked:stalled` | none — escalates immediately | n/a |
+| `infra` | `blocked:infra` | none — escalates immediately | n/a |
+
+### Environment Variables & Configuration
+
+Key overridable env vars (see `.red/config.yaml` under `afk:` for defaults):
+
+- `RED_AFK_RUNNER` — caller runner identity (`claude` / `codex` / `opencode`).
+- `RED_AFK_IDLE_TIMEOUT_S` — per-iteration silence watchdog (default `600` s).
+- `RED_AFK_MAX_ITERATIONS` — sandcastle re-invocation ceiling (default `12`).
+- `RED_AFK_ATTEMPT_TIMEOUT_S` — commit-anchored progress guard (default `2700` s).
+- `RED_AFK_RETRY_QUOTA`, `RED_AFK_RETRY_CRASH`, `RED_AFK_RETRY_MERGE`, `RED_AFK_RETRY_RUNNER_TRANSIENT`, `RED_AFK_RETRY_POLICY` — recovery caps.
+- `RED_AFK_STALL_THRESHOLD_S`, `RED_AFK_STALL_KILL_THRESHOLD_S`, `RED_AFK_STALL_POLL_S` — fleet stall detection.
+- `RED_AFK_ATTEMPT_TTL_S`, `RED_AFK_ATTEMPT_KEEP` — boot-time attempt dir retention.
+- `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S` — remote snapshot-branch retention after completion.
+- `RED_AFK_HEARTBEAT_S` — periodic orchestrator heartbeat interval (default `60` s).
+
+### Bootstrap & Cleanup
+
+Before the first iteration, AFK:
+
+1. Ensures `.red/tmp/` exists and is in `.gitignore`.
+2. Generates a unique worker ID (`w` + 4 random chars).
+3. Resolves the runner via detection cascade (flag > env > sniff > fallback).
+4. Writes `worker.pid` (the orchestrator PID) as the liveness anchor.
+5. Reads `SAFETY.md` rules and installs signal handlers.
+
+Right after bootstrap, AFK:
+
+1. **Orphan cleanup** — drains leftover `.red/tmp/work-*/` dirs and sweeps nested attempt dirs whose worker `worker.pid` is dead.
+2. **Attempt cap** — per-issue prunes anything over the age or count cap (default 14 days / 5 attempts).
+3. **Snapshot branch grace cleanup** — reaps remote `afk-attempts/*` for closed issues past the grace window (default 7 days).
+4. **Unblock sweep** — promotes `blocked:dependency` issues to `ready-for-agent` when all their deps closed.
+5. **Straggler check** — warns if unlabeled/needs-triage/needs-info issues exist.
+
+### Issue Lifecycle State Machine
+
+```
+ready-for-agent
+       │
+   (claim)
+       ▼
+    running
+   ┌───┴───┐
+   │ inner agent: DONE | BLOCKED
+   │
+   ├── DONE + merged
+   │       │
+   │   (close)
+   │       ▼
+   │    closed
+   │
+   └── terminal failure
+           │
+       (classify)
+       ├─ recoverable & under cap → add ready-for-agent
+       └─ non-recoverable or at cap → add ready-for-human
 ```
 
-It then applies the same three namespace reapers used during `/afk` boot: remote `afk-attempts/*`, remote `afk/*`, and local `afk/*`. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept. Each successful deletion logs the branch, issue number, and classification reason. Re-running is a natural no-op once stale refs are gone. Snapshot grace still comes from `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S`; live `afk/*` cleanup keeps the existing closed-vs-open policy.
+Dependencies use `req:N` edge labels and `blocked:dependency` state. A dependent issue is promoted to `ready-for-agent` when all its `req:*` issues are closed (close cascade, then boot-time unblock sweep). Use `## Blocked by` for mechanical dependencies; use `## Current blocker` for gates/decisions/products that `ready-for-human` gates.
 
-## Dependency Unblock — `req:N` edges, close cascade + boot sweep
+### Terminal-Event Envelope
 
-Dependencies are first-class **`req:N` edge labels** (one per blocker), and a dependency-blocked issue holds the **`blocked:dependency`** state — *not* `ready-for-human` (it is healthy, waiting, and never pages). Two mechanisms promote it to `ready-for-agent`:
+Every terminal event posts **exactly one** structured comment on the issue. Envelopes are the canonical record of what the worker saw and did.
 
-**1. Close cascade (event-driven, the fast path).** Immediately after `/afk` closes an issue #N on the DONE path (after the completion sweep), it re-evaluates every dependent of #N:
+| status | trigger |
+|---|---|
+| `blocked` | spec block, validation failure, or generic failure |
+| `no-sentinel` | inner agent exited without `<promise>` |
+| `merge-conflict` | orchestrator could not merge to `{pinned}` |
+| `done` | success — merged, closing |
+| `discarded` | supervisor circuit-breaker discard |
 
-1. `gh issue list --label req:N --state open --json number,labels`.
-2. For each dependent, read its `req:*` labels and resolve each referenced issue's state (the just-closed #N is known closed; others via a cached lookup).
-3. When **every** `req:*` of a dependent is now closed: `gh issue edit --remove-label blocked:dependency --add-label ready-for-agent` + post `🤖 /afk unblocked: all dependencies closed (#…)`.
+Schema:
 
-Best-effort: a `gh` failure here logs a `warn:` and never fails the close — the boot sweep below catches anything the cascade missed.
+```html
+<details data-attempt-status="blocked">
+<summary>worker `wZ2R4` · status: blocked · duration: 2m5s · diff: +42 -10 · attempt: 1</summary>
 
-**2. Unblock Sweep (boot-time, the safety net).** After *Orphan Cleanup* and before *Straggler Check*, `/afk` re-scans dependency-blocked issues by label and promotes any whose deps all closed:
+<details data-section="notes"><summary>notes</summary>
+{handoff `<agent-notes>` body}
+</details>
 
-1. `gh issue list` for open `blocked:dependency` issues with `number,labels,body`.
-2. Deps come from the `req:*` labels (the source of truth); for pre-`req:N` issues with no such label, fall back to extracting `#N` refs under the literal `## Blocked by` body heading (`- [ ] #N`) only when the issue is still labelled `blocked:dependency`.
-3. Resolve each dep via `gh issue view <N> --json state`; promote only when **every** dep is `CLOSED`.
-4. On promotion: remove the holding label (`blocked:dependency`), add `ready-for-agent`, post the audit comment, and log `unblocked N issue(s): #A #B`.
+</details>
+```
 
-`ready-for-human` is a human gate, not dependency-wait. The boot sweep must not promote it from a legacy `## Blocked by` body parse, because a closed blocker can still encode a failed measurement or a no-go decision. `blocked:dependency` issues do not have that ambiguity: the label *means* dependency-wait, which is the whole point of separating it from `ready-for-human`.
+Every non-`discarded` terminal envelope also carries a trailing `data-section="hooks"` block when at least one **user-declared** lifecycle hook ran (not built-ins), listing each hook's name, command, and exit code.
 
-## Current Blocker State
+On terminal failure, the live iteration branch (`afk/{id}/{N}-{slug}`) survives on origin for inspection; a failure-only marker (`afk-attempts/{id}/{N}-{slug}`) is also pushed for forensics. On DONE the live branch is deleted after close.
 
-Human gates are first-class issue-body state, not implicit thread archaeology. Before claiming an issue, `/afk` checks for an active `## Current blocker` block:
+### Dependency Unblock — `req:N` edges
+
+Dependencies are **`req:N` edge labels** (one per blocker), and a blocked issue holds **`blocked:dependency`** state (not `ready-for-human` — it is healthy, waiting, never pages).
+
+Two mechanisms promote it to `ready-for-agent`:
+
+1. **Close cascade** — immediately after closing issue #N, re-evaluate every dependent and promote it if all its `req:*` issues are now closed.
+2. **Unblock sweep** — boot-time safety net that re-scans `blocked:dependency` issues and promotes any whose deps all closed.
+
+### Current Blocker State
+
+Human gates are first-class issue-body state. Before claiming an issue, AFK checks for an active `## Current blocker` block:
 
 ```md
 ## Current blocker
@@ -198,346 +252,108 @@ next: Human must decide whether to stop, redesign, or continue anyway.
 <!-- /red:blocker-state -->
 ```
 
-If this block is present with `status: blocked`, `/afk` does not create an attempt. It removes `ready-for-agent`, adds `ready-for-human` plus the typed blocker label, leaves the issue open, and waits for `/hitl`.
-
-When an attempt escalates to a terminal human page (for example BLOCKED, validation failure, non-recoverable stall/infra, or a recoverable reason after retry-budget exhaustion), the runtime writes or replaces this block so the next `/hitl` turn can start from the current blocker instead of re-reading every old envelope. `/hitl` clears the block to `None`, records it under `## Resolved blockers`, refreshes `## Agent brief`, and moves the issue back to `ready-for-agent` only when the next agent can continue without guessing.
-
-Use `## Blocked by` only for mechanical dependencies that should auto-promote on close. Use `## Current blocker` / `## Human decision needed` for gates, measurements, product calls, or any state where "the referenced issue closed" is not enough to prove the work is delegable.
-
-## Straggler Check
-
-Before issue selection, `/afk` counts open issues in states it cannot consume:
-
-- `unlabeled` — never triaged
-- `needs-triage` — triage in progress
-- `needs-info` — waiting on reporter
-
-If any of those are non-zero, print a warning and (on a TTY, not in `--once`) prompt to confirm before proceeding. This catches the "issue perdida" case where a fresh report never made it through `/triage` and is silently invisible to `/afk`.
-
-The systemic fix is the `red-issues-needs-triage.yml` workflow installed by `/setup-red-skills`, which auto-applies `needs-triage` to every fresh issue. The straggler check is the in-loop safety net for repos where the workflow isn't installed yet.
-
-## Issue Selection
-
-Pull the candidate list with `gh issue list --label ready-for-agent --state open --json number,title,labels,body --limit 100`.
-
-**PRD exclusion (hard).** Drop every issue carrying the `type:prd` label before any other filter. PRDs describe *what* to build, not an implementable slice — they must be split by `/to-issues` first. If a PRD is found in `ready-for-agent` (usually because someone labelled it manually), log a warning naming the issue numbers and the fix (`/to-issues N`), and continue with the remaining candidates. This defence is in addition to `/to-prd` never applying `ready-for-agent` in the first place.
-
-**Urgent prepend (hard, runs before any filter).** Issues carrying `priority:urgent` always jump the head of the queue, ahead of `--prd` and `--issues` filters. Source: the `/urgent` skill files an issue with `priority:urgent` + `ready-for-agent`; every `/afk` invocation prepends those to the candidate list regardless of which selection flags were passed. Among urgents, oldest issue number first.
-
-Apply filters to the **non-urgent remainder** in this order:
-
-1. If `--issues` was passed: keep only those numbers, in argument order. Error if any are missing or not labelled `ready-for-agent`. PRDs in the explicit list are still rejected — the user is told to slice them first.
-2. Else if `--prd` was passed: keep issues with `prd: #N` in the body, a parent link to issue N, or a `prd:N` label. The PRD itself (#N) is excluded by the `type:prd` filter above.
-3. Else: keep all remaining `ready-for-agent` issues. Sort by triage priority — `priority:high` before `priority:low` (and unlabelled), then by issue number ascending.
-
-The final queue is `[urgent…] + [filtered non-urgent…]`, deduped by number (so an urgent issue that also matched the filter only appears once, at the front).
-
-If the list is empty, print `<promise>NO MORE TASKS</promise>` and exit 0.
-
-## Issue Lifecycle (the `/afk` slice)
-
-Canonical state machine lives in [`setup-red-skills/triage-labels.md`](../setup-red-skills/triage-labels.md). The portion `/afk` touches:
-
-```
-  ready-for-agent
-         │
-   (1) claim
-   remove ready-for-agent
-   add running
-   post start comment
-         │
-         ▼
-      running
-   ┌───┴───┐
-   │       │  inner agent works in worktree → emits DONE | BLOCKED
-   │       │  orchestrator runs feedback loops, then merges to main
-   │       │
-   │       ├──── DONE + green + merged + pushed
-   │       │           │
-   │       │      (4a) close
-   │       │      remove running
-   │       │      gh issue close --reason completed
-   │       │           │
-   │       │           ▼
-   │       │        closed
-   │       │
-   │       └──── terminal failure
-   │                   │
-   │              classify Attempt Outcome
-   │              add typed blocked:<reason>
-   │                   │
-   │          ┌────────┴────────┐
-   │          │                 │
-   │          │ recoverable and │ non-recoverable, or
-   │          │ attempt < cap   │ recoverable at/over cap
-   │          │                 │
-   │          ▼                 ▼
-   │     remove running    remove running
-   │     add               add
-   │     ready-for-agent   ready-for-human
-   │     post/retry        post blocker/budget
-   │     audit             exhausted comment
-   │          │                 │
-   │          ▼                 ▼
-   │     ready-for-agent   ready-for-human
-   │     (fresh attempt)   (human gate)
-   │
-   └──── orchestrator interrupted (SIGINT/SIGTERM)
-                     │
-                (4c) release
-                remove running
-                restore ready-for-agent
-                post interruption comment
-                     │
-                     ▼
-                ready-for-agent  (next /afk run can pick it up)
-```
-
-Label transitions are **not** atomic at the gh level — `gh issue edit --remove-label A --add-label B` resolves the new label set client-side and submits the union, so a removed-but-no-longer-present label is a silent no-op and the edit returns 0. To prevent two parallel `/afk` runners from both thinking they claimed the same issue, the per-issue claim uses three layers:
-
-1. **Local `mkdir` lock** at `.red/tmp/claims/{N}/` (POSIX-atomic). Workers in the same checkout race here, and the loser skips.
-2. **Pre-check** via `gh issue view --json labels` — if `ready-for-agent` is already gone or `running` is already present, abort before the edit. Cuts the cross-checkout race window to roughly one round-trip.
-3. **Stale-lock sweep** at boot, during orphan cleanup — any `.red/tmp/claims/{N}/` whose recorded pid is dead gets reclaimed automatically.
-
-Residual gap: two clones of the same repo on the same host (or different hosts) do not share `.red/tmp/`, so each holds its own mkdir lock and the gh edit race re-opens for the brief window the pre-check leaves uncovered. Acceptable for the intended scale (a few terminals, one checkout). If you need cross-host claim safety, gate `/afk` on a proper coordinator instead of GitHub labels.
+If this block is present with `status: blocked`, AFK removes `ready-for-agent`, adds `ready-for-human` plus the typed blocker label, and waits for `/hitl`.
 
-### Typed Failure Labels And Recovery Caps
+When an attempt escalates to a terminal human page, the runtime writes or replaces this block so `/hitl` can start from the current blocker instead of re-reading old envelopes. `/hitl` clears the block and moves the issue back to `ready-for-agent` when the next agent can continue.
 
-AFK labels terminal failures with a descriptive `blocked:<reason>` label in addition to the routing label. The typed label is observability: a retry path still adds `ready-for-agent`, and an escalated path still adds `ready-for-human`.
+### Runner Fallback
 
-| Attempt Outcome | typed label | recovery policy | default cap |
-|---|---|---|---|
-| `exhausted` | `blocked:quota` | `quota` | `RED_AFK_RETRY_QUOTA=3` |
-| `runner-transient` | `blocked:runner-transient` | `runner-transient` | `RED_AFK_RETRY_RUNNER_TRANSIENT=3` |
-| `merge-conflict` | `blocked:merge-conflict` | `merge-conflict` | `RED_AFK_RETRY_MERGE=3` |
-| `no-sentinel` | `blocked:crashed` | `crashed` | `RED_AFK_RETRY_CRASH=1` |
-| `hook-aborted` | `blocked:policy` | `policy` | `RED_AFK_RETRY_POLICY=1` |
-| `blocked` | `blocked:spec` | none — escalates immediately | n/a |
-| `feedback-failed` | `blocked:validation` | none — escalates immediately | n/a |
-| `stalled` | `blocked:stalled` | none — escalates immediately in the per-issue path | n/a |
-| `infra` | `blocked:infra` | none — escalates immediately | n/a |
-| `done` / `claim-lost` | none | none | n/a |
+Default behaviour is **no rotation and no fallback** — the resolved runner is used for every issue. `RUNNER_EXHAUSTED` routes through bounded recovery as `blocked:quota`, with a cap (default 3 retries), then escalates to `ready-for-human` at/over the cap.
 
-Recoverable reasons retry while the 1-based attempt number is less than the cap. At the cap and above, the same reason escalates to `ready-for-human`, keeps the typed `blocked:<reason>` label, and posts a retry-budget-exhausted comment. Missing, non-numeric, zero, or negative `RED_AFK_RETRY_*` values fall back to the default cap.
+- `--alternate` enables round-robin rotation (claude → codex → claude → …). Mutually exclusive with `--runner`.
+- `--fallback-runner` enables mid-issue swap when the active runner returns `RUNNER_EXHAUSTED`. Without it, exhaustion is terminal and routes through bounded recovery.
 
-## Per-Issue Loop
+### Attempt Completion & Termination Bounds
 
-For each issue `N`:
+The `<promise>DONE</promise>` or `<promise>BLOCKED</promise>` sentinel the inner agent emits is the **canonical "attempt is over" signal**. sandcastle stops re-invoking the agent the moment one is observed. Three independent bounds cap a run that never signals:
 
-1. **Claim.** `gh issue edit N --remove-label ready-for-agent --add-label running`. Then resolve the attempt number `{n}` from the attempt-ledger (per-issue across all workers), create the attempt directory `.red/tmp/workers/{id}/{N}-a{n}/`, open `afk.log` (tee target for orchestrator output), and initialise `afk.state.json` per *State File* below. The orchestrator PID is already recorded once in the per-worker `worker.pid` (written at bootstrap) and is also embedded in `afk.state.json`'s `.pid` field — there is no per-attempt pid file. Comment a start line on the issue: ISO timestamp, runner identity, worktree path. If labelling fails because someone else already claimed it, abandon the attempt directory and skip to the next issue.
-2. **Worktree.** Resolve the **base branch** with precedence **lock > pin > main** (ADR 0031): the primary checkout's branch-lock value (`.red/tmp/branch-lock.yaml`, written by the branch-lock skill) wins when set; else the **pinned branch** (ADR 0008 — the issue's own `branch:` line, else its parent PRD's); else `main`. (`{pinned}` below denotes this resolved base.) Then `git -C primary fetch origin {pinned}` and `git worktree add .red/tmp/workers/{id}/{N}-a{n}/worktree -b afk/{id}/{N}-{slug} origin/{pinned}` from the primary checkout. The worktree lives inside the gitignored `.red/tmp/` tree so it never appears in `git status` for `main`. Immediately after worktree creation the runtime mirrors the new branch on origin (`git push origin -u HEAD:refs/heads/afk/{id}/{N}-{slug} --force-with-lease`) and installs a per-worktree `post-commit` hook that fire-and-forgets a `git push origin HEAD --force-with-lease` after every inner-agent commit. Both calls are best-effort: a network/auth failure logs a `warn:` line and the iteration continues — the `afk-attempts/*` failure-push net (see *Terminal-Event Envelope*) still fires on terminal failure. Net effect: `afk/{id}/{N}-{slug}` is a **remote-tracked branch throughout the iteration**, so a SIGKILL anywhere from here on preserves the diff on origin without manual recovery.
-3. **Handoff file.** Materialise the handoff into `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` using the template below — top-level XML wrappers (`<issue-body>`, `<previous-attempts>`, `<prior-attempt-context>`, `<human-guidance-thread>`, `<agent-notes>`) keep the issue body, orchestrator-authored prior attempts, the restart-informed retry block, human comments, and the inner-agent scratchpad unambiguous. `<issue-body>` carries the issue body verbatim (including the `## Agent brief` section written by `/triage`). The handoff file lives one level above the worktree so the inner agent reads it via `../handoff.md` from inside the worktree, and so it survives a worktree wipe on retry.
-   - **Restart-informed retries (PRD #244, issue #255).** On a terminal failure the orchestrator writes two marker files into the failing attempt dir: `snapshot-branch.ref` (the `afk-attempts/{id}/{N}-{slug}` ref it pushed to) and `failure.reason` (the envelope summary). On the **next** attempt — the runtime reads those markers *before* the current attempt dir is created, so it sees the prior attempt's state — the handoff builder fetches that snapshot branch into the worktree under the local ref `refs/afk/prior-attempt` and emits a `<prior-attempt-context>` element carrying `prev-snapshot-branch`, the verbatim `prev-failure-reason`, and `prev-fetched-ref`. The retry still branches **fresh off the base** (step 2 is unchanged), so a wrong prior approach never compounds; the fetched ref is read-only history for the inner agent to inspect. First attempts skip all of this and are byte-for-byte unchanged.
-4. **Local heartbeat marker.** Write one `[heartbeat] iteration started for #N` line to `afk.log`. Slice D retired the periodic GitHub-comment heartbeat (`:one: :two: :three: :four:`) — local liveness is now signalled by the inner-agent stdout stream tee'd into `afk.log` plus state-file mtime, both of which already exist.
-5. **Inner agent.** Drive the inner agent via the single sandcastle `runAgent` call (ADR 0033, *Execution Substrate* above): the handoff file is the `promptFile`, the resolved runner/model selects the provider, the resolved sandbox mode selects the isolation backend, and the worker branch is the `branchStrategy` target forked off the base resolved in step 2. The optional `--request/-r` special user request block is materialised into the handoff. sandcastle captures the agent's stream (surfaced through the `onAgentStreamEvent` callback, which AFK fans out to `agent.log.jsonl` + the firehose) and detects the `<promise>DONE|BLOCKED</promise>` completion signal; AFK reads stages off that stream — see *Stage Detection* below. The call's termination bounds (`idleTimeoutSeconds`, `maxIterations`, and the commit-anchored attempt guard) are documented under *Attempt Completion & Termination Bounds*.
-6. **Inner result.**
-   - Inner committed and emits `<promise>DONE</promise>` → continue to feedback loops.
-   - Inner emits `<promise>BLOCKED</promise>` plus notes appended to the handoff file → comment the blocker on the issue, re-label `ready-for-human`, drop the worktree, go to next issue.
-   - Inner emits `<promise>NO MORE TASKS</promise>` from inside one iteration → ignored. That sentinel is for the outer loop.
-   - Runner-exhausted signal (rate limit / quota error string per runner) → without `--fallback-runner`, terminate this issue as Attempt Outcome `exhausted`; route it through bounded recovery (`blocked:quota`, retry under `RED_AFK_RETRY_QUOTA`, escalate at/over cap). With `--fallback-runner`, keep the same worktree and handoff, swap runner once, and only route `exhausted` if the swapped runner also exhausts.
-7. **Feedback loops.** In the worktree, derive relevant package scopes from the worker branch diff against the pinned base, then run `test`, `typecheck`, `lint`, and `build` with `pnpm -C <scope>` for each touched package that declares the script. Root-only repos keep using the root package. Any missing script is reported as an explicit per-scope skip in the validation section. Any failure blocks the merge and flips the issue to `ready-for-human` with the validation report in the blocker envelope.
-8. **Merge.** All steps target the **base branch** resolved in step 2 (`{pinned}`, defaults to `main`). The integration prelude is shared; **landing is lock-toggled** by the branch-lock state (ADR 0030).
-   - Primary dirty? Auto-stage and commit `chore(afk): pre-merge snapshot for #N` in primary. Never `git stash`. Never `git checkout -- .`.
-   - `git -C primary fetch origin {pinned}`. The primary checkout is pinned to `main` by the precheck; when `{pinned}` is not `main`, switch the primary checkout onto it for the merge (creating the local branch from `origin/{pinned}` if needed) and **restore it to `main` on every exit path**.
-   - **Integrate the fetched tip into local `{pinned}` before merging**: fast-forward when local is strictly behind, otherwise rebase local commits onto `origin/{pinned}`. Without this the worker branch merges onto the stale boot-time HEAD and the push is rejected non-fast-forward whenever origin moved mid-run. If integration fails (diverged history that won't rebase), abort the merge and route the `merge-conflict` outcome through bounded recovery.
-   - Capture the integrated tip (`pre_merge_sha`) for rollback, then land per lock state:
-     - **Locked** (`.red/tmp/branch-lock.yaml` present — `{pinned}` *is* the locked branch): `git -C primary merge --no-ff afk/{id}/{N}-{slug} -m "merge: #{N} {title}"` directly into the local locked branch, then `git -C primary push origin {pinned}`. **Nothing reaches `main`** — promoting the locked branch to `main` is the operator's call. Conflict → one-shot self-resolve; still-conflicting → `git merge --abort` → bounded `merge-conflict` recovery. Push rejected → roll back to `pre_merge_sha` → bounded `merge-conflict` recovery.
-     - **Unlocked**: land via an **admin-merged PR**. Force-push the attempt branch's final state to origin, open (or reuse) a PR `--base {pinned} --head afk/{id}/{N}-{slug}`, then `gh pr merge --admin --merge`. The **PR is the durable per-attempt history** — it survives the branch deletion in step 11. No completed work reaches `{pinned}` except through this admin-merge. Any failure (push, create, or admin-merge) routes through bounded `merge-conflict` recovery. Then fast-forward local `{pinned}` to the PR merge commit so the closing envelope's `merge_sha` is correct.
-9. **Push.** Folded into step 8: the **locked** path pushes the locked branch over SSH (rollback on reject); the **unlocked** path's push *is* the admin-merge of the PR. Either way, do not retry-loop indefinitely.
-10. **Close.** Validation comment on the issue: tests pass/fail, lint, typecheck, build, commits added, files touched. Then `gh issue close N --reason completed`. Remove `running` label. Once the close succeeds, delete the live remote branch (`git push origin --delete afk/{id}/{N}-{slug}`) so the remote graveyard stays tidy — the merge commit on `{pinned}` already carries the diff. Best-effort: a failed delete (branch protection, network) logs a `warn:` line and the close still completes; the orphan `afk/*` branch can be cleaned up later.
-11. **Cleanup (split teardown, issue #256).** Every close path — success **and** failure/blocker — always drops the heavy worktree (`git worktree remove .red/tmp/workers/{id}/{N}-a{n}/worktree`) while **retaining** the cheap artifacts (the JSONL lanes `log.jsonl` / `agent.log.jsonl` and the `handoff.md`) in the attempt directory for post-mortem. On DONE the merged branch is also deleted (`git branch -d afk/{id}/{N}-{slug}`, after the worktree is gone). The retained attempt's state file is marked not-live (`pid: 0`) so monitor / mirror / statusline read it as finished. No worktree survives a close; the attempt dir itself is reclaimed later by the boot-time orphan sweep's TTL **or, on DONE, immediately by the completion sweep below**. The remote `afk/{id}/{N}-{slug}` ref was deleted in step 10 on DONE; failure paths leave the remote ref intact and instead push the canonical `afk-attempts/{id}/{N}-{slug}` ref (see *Terminal-Event Envelope*).
-    - **Completion sweep (issue #257).** Once an issue is closed and merged, the runtime reclaims **every** attempt dir for that issue across **all** workers via the canonical `.red/tmp/workers/*/{N}-a*` glob — not just the worker that completed it. The split-teardown retention only buys time for the orphan-sweep TTL; a completed issue needs none of it, so its retained dirs (including this worker's just-closed one) go now. A live worker's active attempt — one whose own state file still carries a live `pid` — is always skipped, though the claim lock makes a live duplicate of a just-completed issue unlikely.
-12. **Tick.** Update state file. Recompute ETA from rolling average of last 3 issue durations. Print one summary line: `finished {done}/{total} ({pct}%) — next: #{next}`.
+- **`idleTimeoutSeconds`** (default **600 s**, env `RED_AFK_IDLE_TIMEOUT_S`) — per-iteration silence watchdog: an iteration producing no output for this long is aborted.
+- **`maxIterations`** (default **12**, env `RED_AFK_MAX_ITERATIONS`) — sandcastle re-invocation ceiling: a run that never signals but keeps re-exploring can re-invoke up to this many times.
+- **Commit-anchored attempt guard** (default **2700 s**, env `RED_AFK_ATTEMPT_TIMEOUT_S`, ADR 0044/0045) — proof-of-progress: a busy run that lands no NEW commit within the cap is aborted. Armed only under `none` (no-sandbox) isolation. Maps to `timeout` outcome → `blocked:stalled` / `ready-for-human`.
 
-## Runner Fallback
+See `AGENT-PROMPT.md` *Background Tasks and Polling* — inner agents must cap every polling loop with a deadline.
 
-Default behaviour is **no rotation and no fallback** — the runner resolved by the detection cascade (see *Bootstrap* step 4) is used for every issue in the run. `RUNNER_EXHAUSTED` is first handled as the per-issue Attempt Outcome `exhausted`: the issue gets `blocked:quota`, returns to `ready-for-agent` while under `RED_AFK_RETRY_QUOTA`, and escalates to `ready-for-human` at/over the cap. The outer session then stops the drain and returns exit 75 (`EX_TEMPFAIL`) so a supervisor can retry later instead of treating runner quota as a clean queue drain. Both rotation/fallback behaviours are opt-in:
+### Heartbeat & Liveness
 
-- `--alternate` re-enables round-robin rotation between consecutive issues (claude → codex → claude → …). Mutually exclusive with `--runner`.
-- `--fallback-runner` re-enables mid-issue swap when the active runner returns `RUNNER_EXHAUSTED`. Without it, exhaustion is terminal for the current runner invocation and routes through bounded recovery as `blocked:quota`.
+The issue-thread heartbeat (`:one:` / `:two:` cycling) was removed. Local liveness is signalled by:
 
- Exhaustion detection lives in [`runner-claude.md`](runner-claude.md), [`runner-codex.md`](runner-codex.md), and [`runner-opencode.md`](runner-opencode.md) — they own the per-runner error strings. The orchestrator only sees `RUNNER_EXHAUSTED` as a structured signal. Note `opencode` is an API-auth runner; the auth key rides in `OpenCodeOptions.env` and the model slug's leading segment (`openai/`, `minimax/`, `openrouter/...`) tells OpenCode which endpoint to dispatch to. See `runner-opencode.md` *Auth env precedence* for the env-var order (`OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY`). In an API-key-only lane with no host session, run it without `--fallback-runner` so exhaustion is terminal-through-recovery rather than a swap to a session-auth runner that is not present.
+- **Inner-agent stream** — captured and surfaced via `afk.log` + the JSONL lanes.
+- **Clean agent lane** (`agent.log.jsonl`) — one `type=agent` record per turn, never synthetic; the true liveness signal.
+- **State-file mtime** — bumped on every state update.
+- **Periodic orchestrator heartbeat** — every `RED_AFK_HEARTBEAT_S` (default 60s), appends `[heartbeat] stage:tests t+00:14:02 cpu=12% rss=420M` to `afk.log`.
 
-When swap happens mid-issue (only with `--fallback-runner`), the same worktree and handoff file are reused; the new runner sees the previous agent's Notes appended.
+When tailing a worker, read `agent.log.jsonl` for real liveness; `afk.log` carries the periodic heartbeat so a silent agent still produces one line per minute.
 
-## Attempt Completion & Termination Bounds (`<promise>` is canonical — ADR 0028)
+### Solo-Run Stall Protection
 
-The `<promise>…</promise>` sentinel the inner agent emits is the **canonical "attempt is over" signal**. AFK registers `<promise>DONE</promise>` and `<promise>BLOCKED</promise>` as sandcastle `completionSignal`s, so sandcastle stops re-invoking the agent the moment one is observed (line-anchored, so the agent quoting the sentinel in planning prose does not false-positive). sandcastle owns the stream read and signal detection — there is no hand-rolled foreground pipe reader, no recursive SIGTERM/SIGKILL of a `claude | jq | grep | tee` pipeline, and no `RED_AFK_ATTEMPT_GRACE_S` / `RED_AFK_ATTEMPT_KILL_S` / `RED_AFK_WATCHDOG_GRACE_S` tear-down knobs. This is the architecture fix flagged during the #216 bash-hang diagnosis ("a gente tem que ser mais sensível ao resultado da promise"): the completion signal is the terminator, and the substrate enforces it.
+A solo `/afk run` is protected by two in-process layers (armed only under no-sandbox isolation):
 
-`runAgent` maps the returned `completionSignal` to an outcome: `<promise>DONE</promise>` → `done`, `<promise>BLOCKED</promise>` → `blocked`, no signal → `no-sentinel`. The completion signal is the **real** terminator — a normal issue finishes in 1-3 iterations — but three independent bounds cap a run that never signals so a stuck agent cannot burn cycles forever:
+- **Attempt progress guard** — aborts when no NEW commit lands within `RED_AFK_ATTEMPT_TIMEOUT_S` (default 2700s), resetting on every commit. Maps to `blocked:stalled`.
+- **Lane-idle reaper** — samples the agent lane mtime every `RED_AFK_STALL_POLL_S` (default 30s). A worker alive ≥ `RED_AFK_STALL_THRESHOLD_S` (default 600s) whose agent lane is idle ≥ the same is a candidate; past `RED_AFK_STALL_KILL_THRESHOLD_S` (default 1800s) and with no active descendant (`vitest`/`tsc`/`cargo`/build) or flat CPU, it is reaped tree-wide. Maps to `no-sentinel`.
 
-- **`idleTimeoutSeconds`** (default **600 s**, env `RED_AFK_IDLE_TIMEOUT_S`) — sandcastle's per-iteration **silence** watchdog: an iteration producing no stream output for this long is aborted. This is the actual termination bound on a quiet hang.
-- **`maxIterations`** (default **12**, env `RED_AFK_MAX_ITERATIONS`) — the sandcastle Orchestrator **re-invocation** ceiling (issue #322). sandcastle's own default is 1, which would cut the agent off after a single agentic invocation before it can emit `DONE`; AFK raises it so the completion signal stays the terminator while bounding repeated no-sentinel failures. A non-numeric / zero / negative value (env or config) is ignored and falls back to the default, so a typo can never disable the cap or pin the agent to 1.
-- **Commit-anchored attempt guard** (default **2700 s**, env `RED_AFK_ATTEMPT_TIMEOUT_S` / `afk.attempt_timeout`, ADR 0044/0045) — proof-of-**progress**: a run that stays *busy* (re-exploring, re-running tests) without landing a **new commit** within the cap is aborted, resetting on every commit. This catches the "productive infinite loop" that `idleTimeoutSeconds` misses because the agent is never silent. It maps to a `timeout` outcome → `blocked:stalled` / `ready-for-human`, preserving the worktree/PR. Armed **only under `none` (no-sandbox) isolation**, where the worker branch's commits land in the shared `.git` so HEAD advance is observable; under docker/podman the commits are not host-visible until final sync, so a commit-anchored guard would false-fire and is skipped (idle timeout + maxIterations still apply). The fleet hard **stall reaper** (see *Fleet Mode*) is separately gated by the active-`vitest`/`tsc`/`cargo`-descendant + flat-cpu predicate, so a worker mid-build/test is never killed for being idle on the agent lane.
+### Fleet Mode
 
-**No sentinel is `on_attempt_error`.** When sandcastle's run completes with no completion signal, the agent never declared the attempt over (crash, kill, or a daemon that ended without speaking): the outcome is `no-sentinel`, `on_attempt_error` fires (error class `no-sentinel`), and `post_attempt` does **not** fire for that invocation. The issue routes through bounded `blocked:crashed` recovery. With the default `RED_AFK_RETRY_CRASH=1`, the first such failure escalates to `ready-for-human`; a higher cap can requeue it first. **Runner exhaustion** (`RUNNER_EXHAUSTED`, detected by matching the per-runner quota/rate-limit strings against the thrown sandcastle error) stays out of the sentinel channel — it keeps its own `exhausted` outcome and the `--fallback-runner` swap. A **transient runner transport/setup** failure maps to `runner-transient` and is bounded by AFK's retry policy rather than escaping as a crash.
+`/dev:afk fleet [N]` and `/dev:afk fleet stop` are the user-facing commands:
 
-The parsed outcome rides into the `post_attempt` mutable context as `result.outcome` and the `RED_AFK_RESULT_OUTCOME` env var, so hooks (and the Memory `attempt.hooks` record, #216) see the agent-authored exit, not just `success`/`fail`.
+**Launch:**
+1. Resolve runner (explicit `--runner` > `RED_AFK_RUNNER` > sniff > `claude`).
+2. Pre-check `.red/tmp/afk-supervisor.pid` — refuse if a live supervisor already runs.
+3. Launch the supervisor and wait for the PID file to appear.
+4. Attach the best available monitor (Claude cron, Codex agent, or manual).
+5. Print the supervisor PID and monitor status.
 
-Preventive counterpart lives in [`AGENT-PROMPT.md`](AGENT-PROMPT.md) under *Background Tasks and Polling* — inner agents are required to cap every polling loop with a deadline. The termination bounds are the safety net; the prompt rule is the design.
+**Stop:**
+1. Liveness check on `.red/tmp/afk-supervisor.pid`.
+2. Touch `.red/tmp/afk-supervisor.stop` if alive.
+3. Wait up to 30 s for the PID file to disappear.
+4. Tear down runner-specific monitors (Claude cron, Codex agent).
 
-## Heartbeat (local-only, post-Slice-D)
+The supervisor handles respawn, circuit breaker (fast deaths inside a window park the slot), passive stall detector (samples agent lane mtime), hard stall reaper (irreversible kill for genuinely stuck workers, gated behind a busy predicate), and per-slot build isolation.
 
-The issue-thread heartbeat (`:one:` / `:two:` / `:three:` / `:four:` cycling every 10 minutes via `gh issue comment`) was removed in Slice D. The issue thread is now timeline-only: boot stamp, attempt envelopes, human guidance, closing envelope. No periodic noise.
+**Circuit trip** — when `CIRCUIT_K` fast deaths occur inside `CIRCUIT_WINDOW_S`, the supervisor sweeps affected attempt dirs, posts `discarded` envelopes on affected issues, and restores label state (`ready-for-agent` + `runner-error`).
 
-Local liveness is signalled by:
+### Monitor
 
-- **Inner-agent stream**, captured by sandcastle (drained to the attempt dir's `sandcastle.log` via the `logging.path` lane) and surfaced through the `onAgentStreamEvent` callback AFK forwards into `afk.log` + the JSONL lanes — forensic inspection of a running worker tails these files.
-- **Clean agent lane + firehose** (issue #250) — alongside `afk.log`, the runtime fans each assistant turn out to a clean single-writer `agent.log.jsonl` (one `type=agent` record per turn, nothing synthetic — the true liveness signal, readable as a live transcript with `tail -f … | jq -r .msg`) and to a `log.jsonl` firehose that also carries the heartbeat vitals, hook dispatches, runner timings, and errors in the uniform JSONL envelope. The heartbeat writes its vitals to the firehose as a `type=heartbeat` record but never to the agent lane, so the agent lane's silence is real silence (the masking that defeated stall/reaper detection in #243). `afk.log` is unchanged and still carries the tee'd stdout + heartbeat lines below.
-- **State-file mtime**, bumped on every state update. The monitor combines orchestrator pid liveness with state-file freshness to render `🟢 live` vs `🟡 stale`.
-- **Iteration boundary markers** — `heartbeat_start` / `heartbeat_stop` write a single `[heartbeat] iteration started/stopped` line each to `afk.log` so forensic readers can see when an iteration entered and left the inner-agent stage.
-- **Periodic orchestrator heartbeat** (issue #194) — `heartbeat_start` also spawns a side-channel sub-shell that appends one line every `RED_AFK_HEARTBEAT_S` (default 60s) to `afk.log`:
+`/afk monitor` is the readonly aggregated view across all live workers. It globs `.red/tmp/workers/*/*/afk.state.json`, verifies liveness via the orchestrator PID, and renders one section per active attempt.
 
-  ```
-  [heartbeat] stage:tests t+00:14:02 last_stream_line="..." cpu=12% rss=420M
-  ```
+Two modes:
+- **TTY** — full box-drawing layout, refreshes every 3 s, Ctrl-C to exit.
+- **Non-TTY** — one-shot compact dashboard (one sparkline + one line per worker), exit 0. Force with `--once` or `RED_AFK_MONITOR_COMPACT=1`.
 
-  The loop re-reads `current.stage` and `current.last_stream_line` from `afk.state.json` on every tick (so a mid-iteration stage flip shows up in the next heartbeat) and reads cpu/rss from `ps` against the orchestrator pid. Because it lives in its own sub-shell — independent of the inner-agent stream tee that buffers inside the runner pipeline — a forcibly hung worker (`kill -STOP` on the inner agent, or a runner that never flushes) still produces one heartbeat line per minute with stage frozen and wall-clock advancing. The `no-sentinel` envelope's `data-section=log` carries these lines, so the issue thread alone is enough to diagnose where the hang occurred. Set `RED_AFK_HEARTBEAT_S=0` to disable the periodic loop (boundary markers still fire).
+The monitor also **mirrors each live worker onto the native task surface** (Claude Code tasks, or Codex monitor agent). This is **binding** — run the mirror every tick, even if just answering "how are we?". The mirror is idempotent and emits zero descriptors when nothing changed.
 
-The terminal header has its own independent 3 s redraw tick — see *Live Header* below. It is unrelated to (and survives the removal of) the GitHub-thread heartbeat.
+**Self-cancel** — after rendering the dashboard, if `live_workers == 0`, `CronDelete` every auto-monitor cron and exit.
 
-**Deprecated state fields.** `current.heartbeat_glyph` and `current.heartbeat_pid` are kept as `null` for one release window so older monitors don't error on read; they are no longer written meaningfully and may be removed in a future release.
+**Task mirror** — pipe the tracked-task JSONL into `monitor --mirror-plan`, apply the emitted call plan via `TaskCreate`/`TaskUpdate`. The mirror is keyed by `worker_id:issue` so parallel workers each get exactly one task. On session reopen with workers still running, the tracked set is empty and `monitor --mirror-plan` reconciles cold, emitting `TaskCreate` for every live worker.
 
-## Solo-run stall protection (issues #400, #363)
+**Codex sink** — under Codex, `monitor --mirror-plan --runner codex` emits the same descriptors; if Codex grows a native task surface, use it; otherwise fall back to the dashboard + notice.
 
-A solo `/afk run` worker is protected against a hung inner agent by **two complementary in-process layers**, both armed only under no-sandbox isolation (under docker/podman the agent commits and builds in an isolated copy the host can't see, so both guards stand down and only the per-iteration idle timeout + max-iterations apply):
+### Configuration & Hooks
 
-- **Attempt progress guard (#400, commit-anchored).** Polls the worker branch HEAD on the attempt-guard cadence and **aborts the run when no NEW commit lands within `RED_AFK_ATTEMPT_TIMEOUT_S` (default 2700s)**, resetting the deadline on every commit. This catches the *productive-looking infinite loop* — an agent that is busy and emitting output but never converging on work. The abort maps to the `timeout` outcome → `blocked:stalled`, `ready-for-human`, PR/worktree preserved. It is the backstop for the fatal "hang forever" case (applies solo and fleet) and is the **progress** signal — never duplicated by the layer below.
-- **Lane-idle reaper (#363, idle-anchored).** The solo-path port of Fleet Mode's passive stall detector + hard stall reaper, reusing the SAME fleet detector (`computeStalled`) and reaper-signal busy-predicate (`deriveSnapshot` + `decideReaperSignal`) — not a second mechanism. It samples the active attempt's **agent lane** `agent.log.jsonl` mtime (the clean liveness signal — never `afk.log` / the firehose `log.jsonl`, which the per-minute heartbeat keeps fresh and would mask a real stall, the #243 masking) every `RED_AFK_STALL_POLL_S` (default 30s) on a side-channel poll independent of the inner-agent stream, so a fully-hung runner is still observed. A worker alive ≥ `RED_AFK_STALL_THRESHOLD_S` (default 600s) whose agent lane has been idle ≥ the same is a **candidate**; once the lane is idle past `RED_AFK_STALL_KILL_THRESHOLD_S` (default 1800s) the irreversible kill is **gated behind the busy-predicate** — a worker with an active `vitest`/`tsc`/`cargo`/build descendant under its process tree, or non-trivial aggregate cpu, is **busy** and left alone, while a genuinely stuck worker [idle past the threshold, no active descendant, flat cpu] is reaped tree-wide (SIGTERM then SIGKILL after the grace). The reap aborts the run → `no-sentinel`, which flows through the existing no-sentinel terminal policy (envelope with the attempt-dir `afk.log` tail, label rotated back to `ready-for-agent`/`ready-for-human`, worktree dropped). This is the **faster idle layer**: it cuts an idle hang at the stall threshold (minutes) rather than only at the progress cap. `RED_AFK_STALL_KILL_THRESHOLD_S` must be strictly greater than `RED_AFK_STALL_THRESHOLD_S`, validated at boot (the same invariant the supervisor enforces) — a `<=` config fails fast before the run claims an issue.
+Scalar settings live in `.red/config.yaml` under `afk:` with matching `RED_AFK_*` env overrides (env wins). Lifecycle hooks are ordered lists of shell commands under `afk.hooks` with fixed lifecycle points and a single interceptor contract (input: JSON context on stdin; output: empty or mutated JSON; exit code: 0 continues, non-zero routes per hook policy). Built-in defaults run first, user hooks after, in declaration order. Disable a built-in with `afk.hooks.defaults.<name>: false`.
 
-The two layers share the run's `AbortController`: progress watches commits, lane-idle watches the agent lane. The threshold env vars (`RED_AFK_STALL_THRESHOLD_S`, `RED_AFK_STALL_KILL_THRESHOLD_S`, `RED_AFK_STALL_POLL_S`) are consistent with Fleet Mode.
+Shipped built-ins: `cargo`, `gradle`, `heartbeat`, `envelope`, `validation`. See `CHANGES.md` for full configuration schema and examples.
 
-## Terminal-Event Envelope
+### Backpressure Gate
 
-Every terminal event of an iteration posts **exactly one** structured comment on the issue. The comment is the canonical record of what the worker saw and did, and a future Slice C parser will reconstruct iteration history by walking these envelopes in a thread.
+`afk.backpressure` is an ordered list of shell commands that supplements (not replaces) the auto-derived feedback gate. On DONE, after the scope-derived `test`/`typecheck`/`lint`/`build` feedback passes, each command runs in order. If any exits non-zero the merge is blocked (`blocked:validation`), the command and output tail land in the terminal envelope and validation sidecar, and the issue is parked to `ready-for-human`.
 
-Envelope statuses are the wire-level `data-attempt-status` facet. They are intentionally coarser than the full Attempt Outcome vocabulary below: several outcomes emit a `blocked` envelope, and some short-circuit outcomes record labels/history without a per-issue terminal envelope.
+### Merge-Gate Policy
 
-| `data-attempt-status` | trigger |
-|---|---|
-| `blocked` | generic failure envelope: spec block, validation failure, or another failure folded into the blocked bucket |
-| `no-sentinel` | inner agent exited without `DONE` or `BLOCKED` and the path emits the crash envelope |
-| `merge-conflict` | orchestrator could not merge to `main` |
-| `done` | success — merged, closing envelope |
-| `discarded` | supervisor slot/circuit discard envelope |
+The unlocked admin-merge (`gh pr merge --admin --merge`) **ignores advisory review checks by default** — this is intentional. The binding gates are:
 
-Attempt Outcome is the runtime's terminal vocabulary. It owns the typed `blocked:<reason>` label, recovery policy key, and envelope-status mapping:
+1. **`drift-guard`** — the `pre_merge` hook, a hard gate.
+2. **In-process backpressure / feedback** — the pre-merge feedback-validation step.
 
-| Attempt Outcome | `data-attempt-status` | typed label | recovery |
-|---|---|---|---|
-| `done` | `done` | none | none |
-| `blocked` | `blocked` | `blocked:spec` | none |
-| `no-sentinel` | `no-sentinel` | `blocked:crashed` | `crashed` |
-| `merge-conflict` | `merge-conflict` | `blocked:merge-conflict` | `merge-conflict` |
-| `feedback-failed` | `blocked` | `blocked:validation` | none |
-| `hook-aborted` | `blocked` | `blocked:policy` | `policy` |
-| `exhausted` | `blocked` | `blocked:quota` | `quota` |
-| `runner-transient` | `blocked` | `blocked:runner-transient` | `runner-transient` |
-| `stalled` | `blocked` | `blocked:stalled` | none |
-| `infra` | `blocked` | `blocked:infra` | none |
-| `claim-lost` | `blocked` | none | none |
+External advisories (CodeRabbit, etc.) are not binding. Opt into waiting with `afk.merge.wait_for_review: true` — the landing then polls the configured review check until it concludes and merges regardless (so reviews post before the merge but never block the land).
 
-Schema (deterministic — Slice C depends on this shape):
+### On-Demand Branch Reaper
 
-```html
-<details data-attempt-status="blocked"><summary>worker `wZ2R4` · status: blocked · duration: 2m5s · diff: +42 -10 · attempt: 1</summary>
+Run `/afk reap` to perform branch hygiene without claiming an issue. The command prints `afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N` then applies the same three namespace reapers used at boot. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept.
 
-<details data-section="notes"><summary>notes</summary>
+### State File Schema
 
-…handoff `<agent-notes>` body…
-
-</details>
-
-</details>
-```
-
-Per-status body sections:
-
-- `blocked` → one `data-section="notes"` block carrying the handoff's `<agent-notes>` body (the inner agent's appended progress/blockers).
-- `no-sentinel` → both `data-section="notes"` (handoff `<agent-notes>`, may be empty placeholder) **and** `data-section="log"` (last 50 lines of the captured inner-agent stdout, fenced).
-- `merge-conflict` → one `data-section="log"` block carrying the merge-conflict diff tail (last 50 lines of `git merge` output), fenced. Mirrors the no-sentinel log shape.
-- `done` → one `data-section="validation"` block carrying the package-aware feedback report. Summary carries `diff: merged` and `merge: ` `<sha>` (GitHub auto-links bare SHAs to the commit on `main`). The merge commit on `main` *is* the diff — no need to duplicate it inline.
-
-**User-hook executions section (issue #215).** Every non-`discarded` terminal Envelope also carries a trailing `data-section="hooks"` block when at least one **user-declared** lifecycle hook ran during the issue's lifecycle. Built-in defaults (`cargo`, `gradle`, `heartbeat`, `envelope`, `validation` — see the *Lifecycle Hooks* table) are deliberately excluded; the block exists to surface the policy the operator wrote in `.red/config.yaml`, not the skill's own machinery. Each line has the deterministic shape `<lifecycle_name> <command> exit=<rc>`, in execution order across the entire lifecycle (`pre_session` → `pre_pick` → `post_pick` → `pre_worktree` → `pre_attempt` → `post_attempt` → `pre_merge` → `post_merge` → `on_attempt_error` → `on_idle` → `post_session` / `on_session_error`). Non-zero exits are listed with their exit code — never omitted — so a reviewer can see which user-declared policy guarded the merge or mutated the queue, and whether it failed. When no user hook ran (the common case for projects without an `afk.hooks` block in `.red/config.yaml`), the section is omitted entirely rather than rendered empty. The `discarded` supervisor envelope never carries this section: discards record a slot-park decision made above the per-issue lifecycle, so no per-issue hook chain exists to enumerate.
-
-**Branch namespaces — `afk/*` vs `afk-attempts/*` (issue #191).** Two distinct remote namespaces, never overlapping:
-
-- `afk/{id}/{N}-{slug}` is the **live-iteration** branch. It's pushed at worktree-create (`push_initial`), kept in sync after every inner-agent commit by a per-worktree `post-commit` hook (`install_post_commit_hook`), and deleted on DONE after `gh issue close` succeeds (`delete_remote`). On any terminal failure the live ref is **not** deleted — it survives on origin so a human can `git fetch && git checkout afk/{id}/{N}-{slug}` to inspect mid-iteration state.
-- `afk-attempts/{id}/{N}-{slug}` is the **failure-only** marker that the terminal-failure envelope (BLOCKED / no-sentinel / merge-conflict) links to. It's pushed exactly once per terminal failure inside `envelope_emit_attempt` and **never deleted by the orchestrator** — it's the forensic record. This lifecycle is unchanged by #191.
-
-### Validation Sidecar
-
-During feedback validation, AFK also writes a structured JSONL sidecar at
-`$ITER_DIR/validation.jsonl`. It is not rendered into the issue comment; it is
-the machine-readable source used by the optional Memory bridge.
-
-Each line is one command/check execution:
-
-```json
-{"schema":"red.afk.validation.v1","name":"test:plugins/memory","command":"pnpm -C /repo/plugins/memory test","status":"passed","durationMs":1234,"summary":"command exited 0"}
-```
-
-Fields:
-
-- `schema`: literal `red.afk.validation.v1`.
-- `name`: stable check name, usually `{script}:{scope}` such as `typecheck:root` or `lint:plugins/memory`.
-- `command`: command string when a command ran; omitted for skipped checks.
-- `status`: `passed`, `failed`, or `skipped`.
-- `durationMs`: command duration when a command ran.
-- `summary`: short relevant output/error summary, or a skip reason.
-
-The Memory attempt writer only consumes this structured sidecar after parsing it
-as JSON. It must not derive validation graph nodes by parsing free-form stdout,
-Envelope notes, validation-summary prose, or `<agent-notes>`.
-
-Summary line is always `worker `{id}` · status: {status} · duration: NmSs · diff: {diff} · attempt: K [· merge: {sha}]`, where `{diff}` is `+N -M` against `origin/main` for non-DONE statuses and the literal `merged` for DONE.
-
-After a successful POST (any 2xx), the orchestrator sets `envelope.posted: true` in the iteration state file. The boot-time *Orphan Cleanup* reads that field to pick a TTL for preserved `ready-for-human` dirs: 1 day when the envelope made it to the issue (the thread carries the canonical record), 7 days when the POST failed (the local dir is the only copy of the notes/log). The field is initialised `false` at iteration start.
-
-On any terminal **failure** (BLOCKED, no-sentinel, merge-conflict), the worker branch is pushed via SSH to `origin/afk-attempts/{worker_id}/{issue}-{slug}` before the envelope is posted. The envelope's `data-section="diff"` block then carries a clickable **live-branch** `tree/afk/{id}/{N}-{slug}` link (the live ref survives on origin after a terminal failure, so a human can `git checkout` it to inspect or continue, #443), the `compare/main...afk-attempts/...` link, and a `+N -M files=K` diffstat. If the push fails (network, auth, anything non-2xx), the iteration still completes — the diff section embeds only the diffstat plus the local worktree path, and a `warn:` line is logged. DONE iterations do **not** push to `afk-attempts/` (the merge commit on `main` is the diff). Local branch cleanup (`git branch -d`) only deletes the local ref; the remote `afk-attempts/` ref stays alive for forensics, with no retention policy in this slice (branch sprawl is acknowledged and deferred — see PRD #2 Out of Scope).
-
-The Slice D heartbeat-glyph cleanup has landed — there is no periodic `:one: :two: …` traffic on the issue thread to defer or replace.
-
-## Stage Detection
-
-Inner agent stages, derived from the sandcastle agent stream (the `onAgentStreamEvent` callback AFK fans into `agent.log.jsonl` + the firehose), not from a raw runner stdout pipe:
-
-| stage | signal |
-|-------|--------|
-| setup | first output line |
-| explore | `git ls-files`, `find`, repeated `Read` |
-| impl | first `Edit`/`Write` call |
-| tests | `pnpm test` invocation |
-| commit | `git commit` invocation |
-| merge | orchestrator stage, post-inner |
-| push | orchestrator stage |
-| close | orchestrator stage |
-
-Each transition writes to state file. The monitor renders the current stage.
-
-## Live Header
-
-Redraw every 3 s on the controlling TTY, top of the scroll buffer. Use `tput sc; tput cup 0 0; …; tput rc` so the inner agent's stream below stays intact.
-
-```
-┌─ /afk ────────────────────────────────────────────────────┐
-│ runner: codex          elapsed: 00:14:23   eta: ~01:20:00 │
-│ done: 3 / 12 (25%)     blocked: 0          merged: 3      │
-│                                                            │
-│ ▶ #142 wire OAuth callback                                 │
-│   worktree: .red/tmp/workers/wZ2R4/142-a1/worktree          │
-│   stage: impl                                              │
-│   last: writing tests for callback handler                 │
-│                                                            │
-│ queue: #143 #144 #145 #146 ...                             │
-└────────────────────────────────────────────────────────────┘
-```
-
-If stdout is not a TTY (CI, piped log), skip header rendering and print one JSON line per state transition to stderr.
-
-## State File
-
-Path: `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` — one snapshot per (worker, issue, attempt). Schema:
+Path: `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json`
 
 ```json
 {
@@ -573,452 +389,92 @@ Path: `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` — one snapshot per (work
 }
 ```
 
-Atomic write: write to `afk.state.json.tmp` inside the attempt directory, `mv` over the original. `/afk monitor` and any other reader open it read-only. Between issues the worker has no live state file — monitor renders that as "idle".
+State is updated atomically: write to `afk.state.json.tmp`, then `mv` over the original.
 
-## Auto-Monitor Loop (Claude Code only — binding)
+### Handoff File Template
 
-When `/afk` is invoked **to spawn a worker** (i.e., not the `monitor` subcommand), the agent additionally schedules a recurring `/dev:afk monitor` cron inside the current Claude Code session so the user sees progress without re-typing. Death of every worker auto-cancels the cron.
-
-**Setup (runs immediately after the `run` worker is launched in the background):**
-
-1. Fetch `CronCreate` and `CronList` via `ToolSearch` if not already loaded (they are deferred tools).
-2. `CronList` — if any existing job has `prompt == "/dev:afk monitor"`, **skip step 3** (don't double-schedule when the user runs a second parallel `/afk` in the same session).
-3. `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. The cron is session-only — it dies when the Claude Code session ends, so no risk of orphans across sessions. Auto-expires after 7 days regardless.
-4. Tell the user **one line**: `monitor loop scheduled (every 10 min) — auto-cancels when all workers exit.`
-
-The monitor invocation handles its own teardown — see *Self-Cancel* under the Monitor section below.
-
-**Skip the auto-loop when:**
-
-- The invocation is `/afk monitor` (not a worker spawn).
-- The invocation is `/afk --once` (single supervised iteration; user is already watching).
-- `CronCreate` is unavailable (not running under Claude Code — e.g. Codex). Print one line `monitor loop unavailable in this runner; tail .red/tmp/workers/*/*/afk.log manually.` and continue.
-
-## Fleet Mode (runner-portable — binding)
-
-`/dev:afk fleet [N]` and `/dev:afk fleet stop` are the user-facing fleet commands. They let one terminal command spin up (or shut down) `N` concurrent `run` workers on the current checkout, with the supervisor handling respawn, the circuit breaker, the **passive stall detector** (samples each slot's per-attempt **agent lane** `agent.log.jsonl` mtime — the clean liveness signal — every `RED_AFK_STALL_POLL_S=30s`; flags any slot alive ≥ `RED_AFK_STALL_THRESHOLD_S=600` whose agent lane has been idle ≥ the same — surfaces as `⏸️ stalled` in `/dev:afk monitor`. It keys off the agent lane, never `afk.log`/`log.jsonl`, because the orchestrator heartbeat writes those every minute and would mask a real stall — the masking that defeated detection in #243), the **hard stall reaper** (a slot silent on the agent lane past `RED_AFK_STALL_KILL_THRESHOLD_S=1800` is only a *candidate*: the irreversible kill is gated behind a reaper-signal predicate, so a worker mid-build/test — an active `vitest`/`tsc`/`cargo`/… descendant under its tree, or non-trivial aggregate cpu — is **busy** and left alone, while a genuinely stuck worker [idle past the threshold, no active descendant, flat cpu] is killed tree-wide, a `data-attempt-status="no-sentinel"` envelope is posted with the attempt-dir `afk.log` tail, the issue label is rotated back to `ready-for-agent`, the worktree + attempt dir are removed, and the slot is freed for the next health-check respawn — `RED_AFK_STALL_KILL_THRESHOLD_S` must be strictly greater than `RED_AFK_STALL_THRESHOLD_S`, validated at supervisor boot), and per-slot build isolation.
-
-**Worker env passthrough.** Any `RED_AFK_*` variable exported in the operator's shell before `/dev:afk fleet` is auto-forwarded to every worker the supervisor spawns. Use this for worker-side toggles like `RED_AFK_SKIP_PERF=1` or `RED_AFK_SKIP_COMPETITIVE_BASELINE=1` without writing a hook. Internal supervisor knobs (`RED_AFK_TARGET`, `RED_AFK_POLL_S`, `RED_AFK_STALL_*`, `RED_AFK_CIRCUIT_*`, `RED_AFK_RUNNER`, `RED_AFK_REQUEST`, `RED_AFK_PLUGIN_DIR`) and the per-slot `*_BASE` build-isolation vars are excluded — they have dedicated wiring and the supervisor denylists them from passthrough. The supervisor re-pins `RED_AFK_RUNNER=<runner>` for each worker.
-
-```bash
-$ export RED_AFK_SKIP_PERF=1
-$ export RED_AFK_SKIP_COMPETITIVE_BASELINE=1
-$ /dev:afk fleet 1   # every worker sees both vars
-```
-
-Fleet mode is **runner-portable**: the supervisor is plain process orchestration, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all launch and stop the supervisor when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
-
-- Claude Code: schedule the auto-monitor cron when `CronCreate`/`CronList` are available; if not, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
-- Codex: launch fleet with `RED_AFK_RUNNER=codex`, skip cron, and spawn one read-only Codex monitor agent when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print the same manual-monitor guidance.
-- Bare terminal / unknown runner: launch fleet, skip cron/native monitor, and print the manual-monitor guidance.
-
-### `/dev:afk fleet [N]` — launch
-
-`N` is optional and defaults to `2`. Parse it as a non-negative integer; reject anything else (including `stop`, which is the other subcommand and routes below). Steps the agent must perform, in order:
-
-1. **Resolve runner.** Determine the active runner using the same intent as the normal AFK cascade: explicit user `--runner` if present, else `RED_AFK_RUNNER`, else runner env/process/path signals, else `claude`. The resolved value is carried into the supervisor as `RED_AFK_RUNNER=<runner>` so detached workers do not fall through to the supervisor's historical `claude` fallback. Under Codex, this must resolve to `codex`.
-2. **PID-file pre-check.** Read `.red/tmp/afk-supervisor.pid`. If it exists and `kill -0 <pid>` succeeds, refuse the launch:
-   ```
-   ✗ fleet already running (supervisor pid=<pid>, log .red/tmp/afk-supervisor.log).
-     to stop it: /dev:afk fleet stop
-   ```
-   Do **not** touch the file or attempt to recover. A stale PID file (file exists but `kill -0` fails) is left alone — the `fleet` command clears it itself when it acquires the supervisor lock.
-3. **Launch the fleet.** From the project root, run the bundle's `fleet` command with the target and any flags:
-   ```bash
-   RED_AFK_RUNNER=<runner> node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" fleet <N> [--request <text>]
-   ```
-   The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/afk-supervisor.log`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
-4. **Attach the best available monitor surface.**
-   - Claude Code: same flow as *Auto-Monitor Loop* — `CronList` first to deduplicate, then `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. If cron tools are unavailable, skip and use the manual-monitor line.
-   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
-   - Bare/unknown: skip native monitor setup and use the manual-monitor line.
-5. **Report back.** Print:
-   ```
-   🚀 fleet launched (supervisor pid=<pid>, target=<N>)
-      log:   .red/tmp/afk-supervisor.log
-      stop:  /dev:afk fleet stop
-      <monitor-status-line>
-   ```
-   Monitor status line choices:
-   - Claude cron scheduled: `monitor loop scheduled (every 10 min) — auto-cancels when all workers exit.`
-   - Claude cron already existed: `monitor loop already running (existing cron <id>).`
-   - Codex monitor agent spawned: `Codex monitor agent spawned — auto-closes when fleet exits; manual monitor: /dev:afk monitor.`
-   - Native monitor unavailable: `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
-
-### `/dev:afk fleet stop` — graceful shutdown
-
-Steps, in order:
-
-1. **Liveness check.** Read `.red/tmp/afk-supervisor.pid`. The three cases:
-   - File missing → print `no fleet running.` and continue to step 3 (still try runner-specific monitor teardown).
-   - File present but `kill -0` fails → stale. Print `no fleet running (stale pid file at .red/tmp/afk-supervisor.pid — cleaning).`, `rm -f` it, and continue to step 3.
-   - File present and PID alive → continue to step 2.
-2. **Touch the stop file.** `touch .red/tmp/afk-supervisor.stop`. The supervisor's health-check cycle (default `RED_AFK_POLL_S=15s`) picks it up and runs `cleanup`, which SIGTERMs every worker, removes the PID file, removes the stop file, and exits. Wait up to **30 s** for the PID file to disappear (poll every 1 s, deadline-bounded — never bare `while`). If it's gone, print `🛑 fleet stopped (supervisor pid=<pid> exited).`. If the deadline trips, print one warning line naming the PID and the log path, and continue to step 3 anyway — the stop file is still there and the supervisor will pick it up eventually.
-3. **Tear down runner-specific monitors.**
-   - Claude Code: `CronList` → find every job whose `prompt == "/dev:afk monitor"` (there will normally be one, possibly zero, occasionally more if the user manually `/loop`-ed). `CronDelete` each. Print one line: `auto-monitor cron cancelled (<count> entr{y,ies}).` (or `no auto-monitor cron to cancel.` when count is zero). If cron tools are unavailable, print `auto-monitor cron unavailable in this runner; skipped.`
-   - Codex: do not stop workers through the monitor agent. It auto-closes when it observes no supervisor/live workers, and the user may close it manually. Print `Codex monitor agent will self-close when it observes fleet stopped.`
-   - Bare/unknown: print `no native monitor teardown for this runner.`
-4. **Idempotency.** Re-running `/dev:afk fleet stop` after a successful stop just hits the "file missing" branch in step 1 and the runner-specific teardown no-op in step 3. Exit 0 either way.
-
-### Circuit Trip Sweep
-
-When the circuit breaker parks a slot (`CIRCUIT_K` fast deaths inside `CIRCUIT_WINDOW_S`) the supervisor — not a human — runs `sweep_parked_slot` to clean up after the burned workers. Three actions, in order, gated on the trip:
-
-1. **Sweep affected attempt dirs.** From the slot log (`afk-supervisor-slot-{slot}.log`) the supervisor parses every `[afk] worker: w…` boot stamp emitted while the slot was alive, globs `.red/tmp/workers/{wid}/*/` for each ID, and reads `afk.state.json`'s `.current.number` to identify the affected issues. Each attempt dir is `rm -rf`'d after its issue has been processed.
-2. **Post a discard envelope on each affected issue.** Same `<details data-attempt-status="…">` schema as the per-issue terminal envelope, with `status="discarded"` and a summary line that names the runner and the trip cause (`runner-broken, slot parked after K fast deaths`). The envelope's `data-section="summary"` block carries the slot index, comma-joined worker IDs, fast-death count, and the supervisor log path. No `notes`, `drop`, or `log` sections — the attempts produced no usable artefacts.
-3. **Restore label state on each affected issue.** Single `gh issue edit` adds `ready-for-agent` and `runner-error`, removes `ready-for-human` and (defensively) `running` — covers both the "issue had already been promoted to `ready-for-human`" path and the "issue was still `running` at the moment of trip" path.
-
-The `runner-error` label is created idempotently by `/setup-red-skills` (see [triage-labels.md](../setup-red-skills/triage-labels.md)). The supervisor still calls `gh label create runner-error` on the fly during a trip so cleanup never fails just because the label is missing.
-
-Idempotency: `SLOT_SWEPT[slot]=1` blocks a second sweep within the same supervisor lifetime. Across restarts a new trip yields fresh worker IDs and fresh attempt dirs, so re-tripping never re-touches the previously swept issues. A trip that finds no claimed issues (all workers exited before claiming) parks the slot but posts no envelopes — the attempt-dir sweep is a no-op.
-
-### Refs
-
-- The bundle's `fleet` / `fleet stop` commands — the entrypoints this section drives. Stop-file path, env contract, circuit breaker, and trip-sweep are part of the supervisor behaviour described above.
-- *Auto-Monitor Loop* above — the cron lifecycle Fleet Mode hooks into.
-- *Self-Cancel* under Monitor — the dual teardown path (cron tears itself down when no workers remain; fleet stop tears it down immediately).
-
-## Monitor
-
-> **BINDING — every monitor tick must do BOTH of the following, in order. No shortcuts.**
->
-> 1. **Render the dashboard** (the bundle's `monitor --once`).
-> 2. **Mirror live workers onto the host runner's native task surface.** Per-runner mapping:
->    - **Claude Code:** pipe the tracked-task JSONL into the bundle's `monitor --mirror-plan` and apply the emitted call plan via `TaskCreate` (one task per live worker, titled `#<n> w<id> — <title>`) and `TaskUpdate` (description carries `stage:<x>`, terminal events flip `state` to `completed`/`failed`). See *Task Mirror* below for the full protocol.
->    - **Codex:** run `monitor --mirror-plan --runner codex`. Today Codex exposes no native task surface, so the sink emits an empty plan and the mirror falls back to the dashboard plus a one-line notice — that *is* the mirror under Codex; do not silently skip. If Codex grows a native surface, the sink emits the same call-plan descriptors against it.
->    - **Bare terminal / unknown runner:** skip the mirror silently — the `monitor` dashboard is the canonical view.
->
-> The mirror is the only way the user sees per-worker progress advance in their native UI. Skipping it (because "nothing changed" or "just answering a status question") is a bug, not a shortcut — `monitor --mirror-plan` is idempotent and emits zero descriptors when nothing changed.
-
-`/afk monitor` is the readonly aggregated view across all live workers. **Run the bundle's `monitor` command — do not reinvent the rendering in inline bash.** It:
-
-1. Globs `.red/tmp/workers/*/*/afk.state.json` and renders one section per active attempt.
-2. Verifies liveness via the orchestrator PID recorded in `afk.state.json` (`.pid` field) — attempts whose PID is dead are flagged `stale`/`gone` and excluded, not counted as running.
-3. Optionally tails the sibling `afk.log` for the most recent line under each worker's header.
-4. Renders the 48h sparkline header (next subsection) on every refresh.
-
-To invoke, from the project root:
-
-```bash
-RED_AFK_RUNNER=<runner> node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" monitor
-```
-
-The command has **two modes**, auto-selected by stdout type:
-
-- **TTY (real terminal)**: full box-drawing layout, refreshes every 3 s, `clear` between frames. Ctrl-C to exit.
-- **Non-TTY (piped, captured by an agent, redirected)**: one-shot **compact dashboard** — one sparkline header + one line per worker, then exit 0. Force this with `--once` or `RED_AFK_MONITOR_COMPACT=1` even from a TTY.
-
-Compact output shape (≈3 lines total for 2 workers — fits inline without truncation in an agent transcript):
-
-```
-48h: ···············································█  (4 closed, peak 4/h, all workers)   Δ fleet +382 -45
-wZ2R4 [live] claude  issues 4/5  #150 [blog/D] Agent SDK on RedDB  stage:impl  00:23:01  +382 -45
-wK7M2 [live] codex   issues 0/16  idle  +0 -0
-```
-
-The progress counter is `issues <done>/<total>` — issues *closed* over the queue total, **not** a completion percentage (the old `(80%)` form read as "no work done" while a worker had already committed thousands of lines). The real volume signal is the `+A -R` **diff** (committed + uncommitted, measured from the branch's merge-base with `origin/main`), which is rendered on **every** worker line unconditionally — idle and `+0 -0` included — and **summed across the fleet** into the `Δ fleet +A -R` suffix on the sparkline header, so the total diff volume is always visible at a glance.
-
-When invoking from inside another agent session (Claude Code, Codex), prefer `--once` even if stdin is a pipe — explicit beats inference. Don't use the full TTY mode in agent transcripts; the 3 s refresh loop floods the captured stream and gets truncated to garbage.
-
-Single-worker operation shows one section/line. Multi-worker adds one section/line per live worker, sorted by `started_at`. The sparkline aggregates **all workers** in this checkout's `.red/state/afk-history.jsonl` — not fractured per-worker; the `Δ fleet` diff total likewise sums every worker.
-
-The header of every render shows a **48h sparkline** of issues closed, one glyph per hour, scaled to the peak hour:
-
-```
-48h: ·▁··▁·▁·▁··█▁▁··▁·▁···▁·▁·▆▁▁··▁···▁▆·▁··▁▃▁·▃▁·  (35 closed, peak 5/h)
-```
-
-Source data: `.red/state/afk-history.jsonl`, an append-only event log written by the orchestrator on every terminal event:
-
-```jsonl
-{"ts":"2026-05-17T12:14:00-03:00","epoch":1747494840,"worker":"wK7M2","issue":571,"event":"done","duration_s":816,"runner":"codex","merge_sha":"0936ba54"}
-{"ts":"...","epoch":...,"worker":"wK7M2","issue":569,"event":"blocked","duration_s":120,"runner":"codex","reason":"merge-conflict"}
-{"ts":"...","epoch":...,"worker":"wK7M2","issue":568,"event":"exhausted","duration_s":0,"runner":"claude","reason":"both-runners"}
-```
-
-`.red/state/` is gitignored. The orchestrator creates it during bootstrap, parallel workers serialise appends via `flock`, and the boot-time orphan sweep truncates the file to the last 10000 lines if it grows past that cap.
-
-The sparkline only counts `event == "done"`. Blockers and exhausted runs are recorded for forensics but excluded from the throughput view.
-
-### Self-Cancel (binding when invoked under Claude Code)
-
-Every `/afk monitor` run — whether typed by the user or fired by the auto-monitor cron — is responsible for tearing down the cron once there's nothing left to watch.
-
-After rendering the dashboard, the agent must:
-
-1. Count workers with status `[live]` in the rendered output (i.e., orchestrator pid alive, post-orphan-cleanup).
-2. If `live_workers == 0`:
-   - Fetch `CronList` and `CronDelete` via `ToolSearch` if not already loaded.
-   - `CronList` — find every job with `prompt == "/dev:afk monitor"`. There will normally be exactly one; multiples can appear if the user manually invoked `/loop 3m /dev:afk monitor` on top of the auto-loop.
-   - `CronDelete` each match.
-   - Append one line to the user-facing output: `🛑 no live workers — auto-cancelled monitor loop (cron <id>).`
-3. If `live_workers >= 1`: do nothing. The cron continues firing every 10 minutes.
-
-When `CronList` / `CronDelete` are unavailable (Codex runner, or `/afk monitor` invoked outside Claude Code), skip the teardown silently — the cron infrastructure isn't running there to begin with.
-
-### Task Mirror And Codex Monitor Agent (binding)
-
-Every `/dev:afk monitor` run also **mirrors each live worker onto the runner's native task list when that runner exposes one**, so a `/afk` session surfaces progress on the host's native UI — advancing through stages on its own, with no extra typing. This is a **read-only reflection of `afk.state.json`**; the mirror never writes state and never touches the orchestration.
-
-The mirror is a pure diff: it reconciles the live worker state files against the tasks already on the native surface and emits a **call plan**. After rendering the dashboard, the agent (under Claude Code only) must:
-
-1. Fetch `TaskCreate`, `TaskUpdate`, and `TaskList` via `ToolSearch` if not already loaded (deferred tools).
-2. **Build the tracked set.** `TaskList` → keep the mirror-owned tasks (those whose title matches `#<n> w<id> — …`). For each, emit one JSONL line `{"key":"<worker_id>:<issue>","stage":"<last stage>"}`, reading the key from the title and the stage from the description (`stage: <x>`). Keep a key→task_id map for step 4.
-3. **Compute the plan.** Pipe the tracked JSONL from step 2 into the bundle's `monitor --mirror-plan` subcommand:
-   ```bash
-   printf '%s\n' "$tracked" | node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" monitor --mirror-plan
-   ```
-   The command globs the state files and reconciles them against the tracked set on stdin (keyed by `worker_id:issue`, so parallel workers each get exactly one task and re-runs never duplicate), then prints a JSONL **call plan** to stdout — one descriptor per harness call (empty stdin → cold reconcile; empty plan → no output):
-   ```jsonl
-   {"call":"TaskCreate","key":"wAAAA:22","title":"#22 wAAAA — extract state.sh","description":"stage: impl","state":"in_progress"}
-   {"call":"TaskUpdate","key":"wAAAA:22","description":"stage: tests","state":"in_progress"}
-   {"call":"TaskUpdate","key":"wAAAA:22","state":"completed"}
-   ```
-4. **Apply the plan.** For each descriptor in order:
-   - `TaskCreate` → create the task; record `key → task_id`.
-   - `TaskUpdate` → resolve `key` to its `task_id` via the map and update. A `state` of `completed`/`failed` marks the worker's terminal event (`done`/`blocked`); the task drops off the active list and the mirror self-cleans. A descriptor whose `key` has no known `task_id` (e.g. a complete for a task that was never created in this session) is skipped.
-
-An empty plan means nothing changed since the last tick — apply no calls. Because the plan is keyed by `worker_id:issue`, an idempotent re-run with no stage advance emits zero descriptors.
-
-**Re-hydration on session reopen.** A native task dies with the Claude Code session; the `nohup` AFK worker does not. When a session opens with workers still running, `TaskList` (step 2) returns no mirror-owned tasks, so the tracked set is **empty** and `monitor --mirror-plan` reconciles cold — emitting a `TaskCreate` for every live worker. The status bar recovers the per-worker tasks with no operator action. This is the same path as steady-state, not a new one: only workers whose orchestrator PID (the `.pid` field in `afk.state.json`, via `state_is_live`) is alive re-hydrate (dead workers are untracked-terminal on a cold tick → no ghost task), and the next tick is idempotent because the freshly-created tasks now form the tracked set.
-
-When `TaskCreate` / `TaskUpdate` are unavailable because the session is **outside any runner** (a bare terminal), **skip the mirror silently** — there is no native surface to drive, and the `monitor` dashboard is already the canonical view.
-
-**Codex sink (runner-specific — binding).** The mirror is per-runner, mirroring the `runner-claude.md` / `runner-codex.md` split (ADR 0003). Under Codex the state reader and plan reconciler are reused unchanged — only the sink differs. After rendering the dashboard, the Codex agent runs `monitor --mirror-plan --runner codex` instead of the Claude `TaskCreate`/`TaskUpdate` loop:
-
-- If Codex grows a native background-task surface, the sink emits the **same call-plan descriptors** the Claude sink applies — apply them against the Codex primitive.
-- Otherwise (today's reality), `--runner codex` emits an **empty plan**, so the mirror falls back to the `monitor` dashboard and a one-line notice. No native calls are emitted, so there is no half-rendered state, and a dashboard hiccup is swallowed so the tick never crashes.
-
-**Codex monitor agent (fleet-specific — binding).** Codex has a native sub-agent UI even though it does not expose the Claude-style `TaskCreate`/`TaskUpdate` task API. When `/dev:afk fleet N` launches a new supervisor under Codex, the agent should spawn exactly one read-only Codex monitor agent when the sub-agent primitive is available. That monitor agent periodically runs `/dev:afk monitor --once`, reports concise progress, and exits once no supervisor or live workers remain. It is a presentation consumer only: it must not edit files, stop workers, claim issues, or merge anything. Closing it manually must not affect the fleet.
-
-Do **not** invent a cross-runner task abstraction (rejected in ADR 0003) — keep the adapter explicitly per-runner.
-
-## Handoff File Template
-
-`.red/tmp/workers/{id}/{N}-a{n}/handoff.md`:
-
-Top-level content is XML elements (not markdown headers) so the inner agent
-cannot confuse the issue body with comments, or human direction with
-orchestrator audits. Markdown sections like `## Agent brief`, `## Acceptance`,
-`## Refs`, and `## Suggested Skills` live *inside* the `<issue-body>` element
-(they are part of the issue body verbatim).
+`.red/tmp/workers/{id}/{N}-a{n}/handoff.md` — top-level content is XML elements so the inner agent cannot confuse the issue body with comments or orchestrator audits:
 
 ```markdown
 # Issue #{N} — {title} [AFK]
 
 source: {gh-url}
-prd: {prd-url-or-issue-ref}        # omit if none
 runner: {claude|codex}
 started: {iso8601}
 attempt: {1..}
 
 <issue-body>
-{issue body verbatim — includes the `## Agent brief`, `## Acceptance`, `## Refs`,
-and `## Suggested Skills` markdown sections written by /triage}
+{issue body verbatim — includes markdown sections like `## Agent brief`, `## Acceptance`, `## Refs`}
 </issue-body>
 
-<previous-attempts>                                    <!-- omitted when empty -->
+<previous-attempts>
 <previous-attempt n="1" status="blocked" worker="wXXXX" duration="0m50s" branch="afk-attempts/wXXXX/N-slug">
-<notes>
-{inner agent's appended notes from prior attempt}
-</notes>
-<log>
-{tail of prior attempt's stdout, if captured}
-</log>
+<notes>{inner agent's notes from prior attempt}</notes>
+<log>{tail of prior stdout if captured}</log>
 </previous-attempt>
 </previous-attempts>
 
-<prior-attempt-context>                                <!-- omitted on a first attempt -->
+<prior-attempt-context>
 prev-attempt: 1
 prev-snapshot-branch: afk-attempts/wXXXX/N-slug
-prev-failure-reason:
-{verbatim failure.reason from the previous attempt — the envelope summary}
+prev-failure-reason: {verbatim failure.reason}
 prev-fetched-ref: refs/afk/prior-attempt
-{inspect the prior failed approach with `git log refs/afk/prior-attempt`; you
-branch fresh off the base — do NOT fix-forward on it}
+{inspect prior approach with `git log refs/afk/prior-attempt`; branch fresh off the base}
 </prior-attempt-context>
 
-<human-guidance-thread>                                <!-- omitted when empty -->
+<human-guidance-thread>
 <human-guidance author="@alice" at="{iso8601}">
-{verbatim content of one extracted <details data-kind="directive"> marker — one
-<human-guidance> element per directive, so a single comment carrying two markers
-emits two siblings with identical author/at}
+{verbatim content of extracted `<details data-kind="directive">` marker}
 </human-guidance>
 </human-guidance-thread>
 
-<thread-discussion>                                    <!-- omitted when empty -->
+<thread-discussion>
 <thread-discussion-entry author="@alice" at="{iso8601}">
-{human comment body verbatim that carried no directive marker — advisory only,
-lowest authority; orchestrator audits already filtered out by body shape}
+{human comment body verbatim — advisory only, no directive}
 </thread-discussion-entry>
 </thread-discussion>
 
 <agent-notes>
-<!-- inner agent appends progress/blockers here across attempts -->
+<!-- inner agent appends progress/blockers here -->
 </agent-notes>
 ```
 
-The handoff file follows the same minimalism as the `/handoff` skill — reference artifacts by path, do not duplicate their content.
+### Validation Sidecar
 
-## Stop Conditions
+During feedback validation, AFK writes `.red/tmp/workers/{id}/{N}-a{n}/validation.jsonl` — not rendered into the issue comment, but consumed by the optional Memory bridge:
 
-- Queue drained → `<promise>NO MORE TASKS</promise>` → exit 0.
-- `-n N` reached → summary + exit 0.
-- Runner exhaustion / runner transport failure → route the current issue through bounded recovery (`blocked:quota` or `blocked:runner-transient`), then stop the outer run with exit 75.
-- Uncaught error in orchestrator → leave worktree in place, exit 1, print recovery hint. (No heartbeat sub-shell to kill since Slice D.)
-
-## Reporting
-
-After every issue, print:
-
-```
-✓ #142 wire OAuth callback   12m 14s   tests:✓ lint:✓ types:✓ build:✓   merged b3f2a91
-finished 4 / 12 (33%) — next: #143
+```json
+{"schema":"red.afk.validation.v1","name":"test:plugins/memory","command":"pnpm -C /repo/plugins/memory test","status":"passed","durationMs":1234,"summary":"command exited 0"}
 ```
 
-After the loop, a final block:
+Fields: `schema`, `name` (stable check name like `test:root` or `typecheck:plugins/memory`), `command` (when run; omitted for skipped), `status` (`passed`, `failed`, `skipped`), `durationMs` (when run), `summary`.
 
-```
-/afk done.
-runner    : codex (3 issues), claude (1 issue)
-duration  : 01:14:22
-processed : 4 closed, 0 blocked, 0 failed
-remaining : 8 still ready-for-agent
-```
+### Worktree Base Resolution (ADR 0031)
 
-## Configuration
+When creating a worktree, AFK resolves the base branch with precedence **lock > pin > main**:
 
-Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside the `afk.hooks` block documented below). Each one has a matching `RED_AFK_*` env override that wins over the config value, so an E2E/CI run can pick a setting without mutating the target repo's config.
+1. **Branch lock** — `.red/tmp/branch-lock.yaml` (written by the branch-lock skill). If set, use it.
+2. **Pinned branch** — issue's `branch:` line, or its parent PRD's `branch:` line (ADR 0008). If set, use it.
+3. **Main** — fallback.
 
-| Config key | Env override | Default | Meaning |
-|---|---|---|---|
-| `afk.default_runner` | `RED_AFK_RUNNER` | `claude` | Caller runner identity/default backend consumed before ambient sniffing. |
-| `afk.model` | — | runner-specific | Legacy global model override. Prefer tiered `afk.models.<runner>.<tier>.model` so Codex never receives a Claude-only model. |
-| `afk.models.<runner>` | — | runner-specific | Legacy per-runner scalar model override. Used only when no explicit tier model is set. |
-| `afk.models.claude.<tier>.model` | — | tier-specific | Claude Code model id for `validate`, `simple`, `complex`, or `think`. |
-| `afk.models.claude.<tier>.effort` | — | tier-specific | Claude Code effort for that tier. |
-| `afk.models.codex.<tier>.model` | — | tier-specific | Codex model id for `validate`, `simple`, `complex`, or `think`. |
-| `afk.models.codex.<tier>.effort` | — | tier-specific | Codex effort for that tier. |
-| `afk.sandbox` | `RED_AFK_SANDBOX` | `none` | Isolation backend (`none` \| `docker` \| `podman`, ADR 0033). |
-| `afk.max_iterations` | `RED_AFK_MAX_ITERATIONS` | `12` | Sandcastle re-invocation ceiling (issue #322) — the safety cap for "the agent never emits `<promise>DONE</promise>` or `<promise>BLOCKED</promise>`". The completion sentinel is the real terminator, so a normal issue finishes in 1–3 iterations; this leaves headroom without letting repeated no-sentinel failures run for too long. A non-numeric / zero / negative value in either the env or the config is ignored (falls through to the default) so a typo can never disable the cap or pin the agent to 1. |
-| — | `RED_AFK_IDLE_TIMEOUT_S` | `600` | Sandcastle's per-iteration **silence** watchdog (seconds): an iteration that produces no stream output for this long is aborted. The actual termination bound on a quiet hang. Env-only; typo-safe (non-numeric / zero / negative is ignored → default). |
-| `afk.attempt_timeout` | `RED_AFK_ATTEMPT_TIMEOUT_S` | `2700` | Commit-anchored attempt **progress** guard (seconds, ADR 0044/0045): a busy run that lands no new commit within the cap is aborted (`timeout` → `blocked:stalled` / `ready-for-human`, worktree/PR preserved), resetting on every commit. Armed only under `none` isolation. Typo-safe (env > config > default). |
-| `afk.backpressure` | — | _(empty)_ | Ordered list of shell commands run as an extra pre-merge gate on the DONE path (issue #430, PRD #429). |
-| `afk.merge.wait_for_review` | — | `false` | Merge-gate policy (ADR 0048). When `false` (default), the unlocked admin-merge proceeds **ignoring advisory review checks** (e.g. CodeRabbit) — the binding gates are `drift-guard` (the `pre_merge` hook) + in-process backpressure/feedback. When `true`, the unlocked landing **waits** for the configured review check to conclude before merging, then merges regardless of its verdict (the review stays advisory). `drift-guard` is a hard gate either way. |
-| `afk.merge.review_check` | — | `CodeRabbit` | Name (case-insensitive substring) of the advisory review check `wait_for_review` polls via `gh pr checks`. Only consulted when `afk.merge.wait_for_review` is `true`. |
+When the resolved base is not `main`, AFK switches the primary checkout onto it for the merge and restores it to `main` on every exit path. This prevents subtle drift when a bot/human updates `main` mid-run.
 
-```yaml
-afk:
-  models:
-    claude:
-      think:
-        model: claude-opus-4-8
-        effort: high
-    codex:
-      think:
-        model: gpt-5.5
-        effort: high
-  sandbox: none
-  max_iterations: 12      # override the default re-invocation ceiling here
-  attempt_timeout: 2700   # commit-anchored progress guard (seconds)
-  backpressure:           # extra pre-merge gate, runs after the feedback gate
-    - npm run test
-    - npm run lint
-  merge:
-    wait_for_review: false   # true → hold the unlocked admin-merge until the review check concludes
-    review_check: CodeRabbit
-```
+### Lock-Toggled Landing (ADR 0030)
 
-`RED_AFK_IDLE_TIMEOUT_S` is env-only (no `afk.*` config key); `sandbox`, `max_iterations`, and `attempt_timeout` resolve env > config > default. The three runtime bounds — silence (`idleTimeoutSeconds`), re-invocation count (`maxIterations`), and no-commit-progress (attempt guard) — are detailed under *Attempt Completion & Termination Bounds*.
+Landing is lock-toggled by the branch-lock state:
 
-### Backpressure gate
+- **Locked** (`{pinned}` *is* the locked branch) — `git merge --no-ff afk/{id}/{N}-{slug}` directly into the local locked branch, then `git push origin {pinned}`. Nothing reaches `main` — promoting the locked branch is the operator's call.
+- **Unlocked** — land via an **admin-merged PR**: force-push the attempt branch's final state, open/reuse a PR `--base {pinned} --head afk/{id}/{N}-{slug}`, then `gh pr merge --admin --merge`. The PR is the durable per-attempt history.
 
-`afk.backpressure` is an operator-declared, ordered list of shell commands that **supplements** the auto-derived feedback gate (it does not replace it). On a successful DONE attempt — after the scope-derived `test`/`typecheck`/`lint`/`build` feedback gate passes, before landing — AFK runs each backpressure command in order (`sh -c <command>`) against a checkout of the worker branch. If **any** command exits non-zero the merge is blocked and the issue is parked to `ready-for-human` with `blocked:validation`, exactly like a feedback failure: the failing command and its output tail land in the terminal envelope and in the `red.afk.validation.v1` validation sidecar (records named `backpressure:<command>`). An absent or empty block is a no-op (today's behaviour). The namespaced `plugins.dev.afk.backpressure` location is honoured with the legacy bare `afk.backpressure` fallback (ADR 0042).
+Either way, conflict → one-shot self-resolve; still-conflicting → abort → bounded `merge-conflict` recovery. Push rejected → roll back → bounded `merge-conflict` recovery.
 
-### Merge-gate policy
+### Auto-Monitor Loop (Claude Code only — binding)
 
-The unlocked admin-merge (`gh pr merge --admin --merge`, ADR 0030) **ignores advisory review checks by default** — this is intentional, not an oversight. The binding gates on a landing are:
+When `/afk` is invoked to spawn a worker (not the `monitor` subcommand), the agent schedules a recurring `/dev:afk monitor` cron inside the current Claude Code session. Death of every worker auto-cancels the cron.
 
-1. **`drift-guard`** — the `pre_merge` hook, a hard gate that aborts the merge for this issue and routes through bounded `blocked:merge-conflict` recovery.
-2. **In-process backpressure / feedback** — the pre-merge feedback-validation step (typecheck/tests, ADR 0008) that only mechanism can refuse a merge on.
+Skip the auto-loop when:
+- The invocation is `/afk monitor` (not a worker spawn).
+- The invocation is `/afk --once` (user is already watching).
+- `CronCreate` is unavailable (not Claude Code). Print guidance and continue.
 
-External advisory reviewers (CodeRabbit and the like) are **not** binding: the worker is autonomous, and gating an autonomous loop on a human-paced external reviewer would stall the queue (ADR 0048). Opt into waiting with `afk.merge.wait_for_review: true` — the unlocked landing then polls `afk.merge.review_check` until it concludes and merges regardless of the verdict (so its comments are posted before the merge, but the review never blocks the land). The wait is **fail-open**: a reviewer that never registers or never concludes within the poll budget does not wedge the landing.
-
-## Lifecycle Hooks
-
-`/afk` exposes a fixed set of lifecycle points declared in `.red/config.yaml` under `afk.hooks` and resolved as ordered lists of shell commands. Every hook follows a single interceptor contract:
-
-- Input: documented `RED_AFK_*` env vars (unset — *not* empty-string — when the field is irrelevant to the current point) plus the full mutable context as JSON on stdin.
-- Output: empty stdout → context unchanged; JSON object on stdout → AFK replaces the documented mutable slice with the returned value. Non-JSON stdout is treated as a parse failure.
-- Exit code: `0` continues the chain; non-zero is routed through a per-hook policy table — `pre_*` aborts the step, `post_*` / `on_idle` / `on_*_error` log and continue so a broken notifier never wedges AFK.
-
-Within a single hook list, **built-in defaults run first, user-declared commands run after**, and declaration order is preserved inside each group. A bare string is shorthand for a one-element list. An unknown hook name in `.red/config.yaml` is a hard error at session boot. Disable a built-in default with `afk.hooks.defaults.<name>: false` — reordering is not supported.
-
-The full lifecycle table is defined in PRD #207. The hooks shipped so far:
-
-| Hook            | When it fires                              | Env vars              | Mutable slice   | Exit-code policy        |
-|-----------------|--------------------------------------------|-----------------------|-----------------|-------------------------|
-| `pre_session`   | Boot, before any queue work                | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` | session config (`runner`, `worker_id`, `filter`, `iter_cap`) | non-zero **aborts** the session loudly |
-| `pre_pick`      | Before listing the tracker queue           | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` | query params (`label`, `state`, `limit`) — `filter.{kind,value}` is read-only context | non-zero **aborts** the pick; queue listing is **skipped this iteration** and AFK falls through to the empty-queue / `on_idle` path |
-| `post_pick`     | After listing, before claiming             | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` | `issues[]` (filter / reorder; replace with `{issues:[…]}`) — extra keys are silently ignored | non-zero is **logged** and AFK continues with the **un-mutated** list (defensive default — a broken filter must not silently drop work) |
-| `pre_worktree`  | After claim, before `git worktree add`     | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE`, `RED_AFK_ISSUE`, `RED_AFK_SLOT` | `issue`, `target` (worktree path), `env` (k/v map merged into the parent shell so `CARGO_TARGET_DIR` etc. propagate to the runner) — `branch` is read-only context | non-zero **aborts**: the claim is restored to `ready-for-agent`, the iteration tear-down runs, and the worktree is **not** created |
-| `pre_attempt`    | After worktree exists, **before each runner invocation** (per attempt, not per issue — re-fires on a `--fallback-runner` swap with `attempt_n=2`) | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` (now the worktree), `RED_AFK_ISSUE`, `RED_AFK_ATTEMPT_N` | `issue`, `workspace` (worktree path), `attempt_n` — `runner` is read-only context | non-zero **skips runner invocation**: the worktree is preserved, the heartbeat stops, and the claim is restored to `ready-for-agent` so post-pick state is reconciled cleanly |
-| `post_attempt`   | After the runner returned **with an authored `<promise>` exit** — DONE or BLOCKED — for that attempt. Does **not** fire on runner crash or EOF-without-sentinel (see `on_attempt_error`). Under `--fallback-runner` it fires once per runner invocation (the swapped-away attempt closes with `result.status=exhausted`). The parsed sentinel outcome (`done` / `blocked` / `no_more_tasks`, or `""` for the exhausted firings) rides in `result.outcome` (ADR 0028). | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` (the worktree), `RED_AFK_ISSUE`, `RED_AFK_RESULT_STATUS` (`success` \| `fail`), `RED_AFK_RESULT_OUTCOME` (`done` \| `blocked` \| `no_more_tasks` \| empty), `RED_AFK_ATTEMPT_N` | `issue`, `workspace`, `result` (`{status, outcome}`), `attempt_n` | non-zero is **logged** and the loop continues — a broken notifier/pager must never wedge AFK |
-| `on_attempt_error` | When the attempt produced **no authored exit**: either an unhandled exception in the worker path (`run_inner` exited non-zero outside the quota branch — `runner-crash`), or the runner's pipe closed with **no `<promise>` sentinel** (EOF-without-sentinel — `no-sentinel`, ADR 0028; the issue routes through bounded `blocked:crashed` recovery). Distinct from `post_attempt` with `result.status=fail`, so hook authors do not have to demultiplex. | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` (the worktree), `RED_AFK_ISSUE`, `RED_AFK_ERROR_CLASS` (`runner-crash` \| `no-sentinel`), `RED_AFK_ATTEMPT_N` | `issue`, `workspace`, `error` (`{class, rc}`), `attempt_n` | non-zero is **logged** and the loop continues |
-| `pre_merge`     | Before the merge mechanism (`git merge --no-ff` into the pinned base). The diff between the merge base and the worker branch is on stdin so a guard hook can reject changes by size, file pattern, etc. The merge itself plus conflict resolution remain **mechanism** (ADR 0008) and sit between `pre_merge` and `post_merge` — never dispatched as a hook. | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` (primary checkout), `RED_AFK_ISSUE`, `RED_AFK_MERGE_BASE` | `issue`, `workspace`, `diff` — `branch` is read-only context | non-zero **aborts the merge** for this issue; the failure surfaces as a worker-failure and routes through bounded `blocked:merge-conflict` recovery |
-| `post_merge`    | After a successful merge and push to origin/`{pinned}`. The merge commit already exists, so user notifiers can include the real merge commit URL. Does **not** fire when the merge was aborted (`pre_merge` rejection, conflict resolver exhausted, push rejected). | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` (primary checkout), `RED_AFK_ISSUE`, `RED_AFK_MERGE_COMMIT` (full sha), `RED_AFK_MERGE_SHA` (short sha) | `issue`, `workspace`, `merge_commit` (`{sha, short}`) — extended by the built-in `validation` default with `result.{validation_status, validation_summary}` | non-zero is **logged** and the loop continues — the merge has already landed; a broken notifier or a flaky smoke test must never roll it back |
-| `on_idle`       | Queue drained at top of loop iteration, before sleep/exit. Distinct from `post_session` — this is "between drains" maintenance (e.g. cache cleanup), not session termination. Does **not** fire on session exit. | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` | none in this slice — `stats.{done,blocked,total}` are read-only context | non-zero is **logged** and the loop continues |
-| `post_session`  | Normal session termination                 | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE` | session stats (`runner`, `worker_id`, `stats.{done,blocked,total}`) | non-zero is **logged** and the session ends as `NO MORE TASKS` |
-| `on_session_error` | Last gasp — the AFK loop itself crashed (unhandled `set -e` exit, supervisor died, unrecoverable orchestrator exception). Distinct from `on_attempt_error` (a single attempt blew up; the loop continued) and from `post_session` (clean shutdown). This is the only path that guarantees a notification when the autonomous worker stopped without the operator noticing. Does **not** fire on a user-requested abort (`pre_session` rejection, straggler decline, Ctrl+C / SIGTERM through the cleanup trap) — those set the clean-exit sentinel before exiting. | `RED_AFK_RUNNER`, `RED_AFK_WORKSPACE`, `RED_AFK_ERROR_CLASS` (`session-crash` by default), `RED_AFK_ERROR_MESSAGE` | `error` (`{class, rc, message}`) — none mutable (the loop is already collapsing) | non-zero is **logged** but the process still exits — this hook cannot rescue the session, only announce its death |
-
-**Attempt vocabulary & back-compat (issue #226, ADR 0026).** The attempt-level hooks were renamed from `pre_worker` / `post_worker` / `on_worker_error` to `pre_attempt` / `post_attempt` / `on_attempt_error` so "worker" unambiguously names the orchestrator process (`RED_AFK_WORKER_ID`) and the hooks align 1:1 with ADR 0017's `attempt` (one node = one runner invocation). They fire **per runner invocation**, so a `--fallback-runner` swap on one issue yields two `pre_attempt → post_attempt` cycles; `attempt_n` (mutable-context field and the `RED_AFK_ATTEMPT_N` env var) carries the attempt counter (1 for the first runner, 2 for the swap). For one release window, the old names declared in `.red/config.yaml` still fire — they are translated to the canonical names at session boot with a single deprecation warning logged. Rename them before the next release; the back-compat shim is dropped then.
-
-### Built-in defaults
-
-Defaults are AFK-shipped commands registered before any user hook at the
-same lifecycle point. They run **first**, in a fixed registration order
-that users cannot change — only **disable** individual defaults via
-`afk.hooks.defaults.<name>: false`. The disable-not-reorder rule keeps
-later defaults (and user hooks) able to assume an earlier default has
-already had its turn at the env.
-
-Currently shipped:
-
-| Default  | Lifecycle point | Effect                                                                                  | Disable                              |
-|----------|-----------------|-----------------------------------------------------------------------------------------|--------------------------------------|
-| `cargo`  | `pre_worktree`  | When `Cargo.toml` exists at `$PROJECT_ROOT`, sets `CARGO_TARGET_DIR=${RED_AFK_CARGO_TARGET_BASE:-/opt/cargo-target}/slot-${RED_AFK_SLOT}` (mkdir-p'd) so each slot's cargo state is isolated. | `afk.hooks.defaults.cargo: false`  |
-| `gradle` | `pre_worktree`  | When `build.gradle*` exists at `$PROJECT_ROOT` **and** `RED_AFK_GRADLE_USER_HOME_BASE` is set, sets `GRADLE_USER_HOME=${RED_AFK_GRADLE_USER_HOME_BASE}/slot-${RED_AFK_SLOT}` so each slot's Gradle daemons / caches are isolated. The env-var opt-in is deliberate — AFK will not claim a path on your filesystem without consent. | `afk.hooks.defaults.gradle: false` |
-| `heartbeat` | `post_attempt`  | Stops the orchestrator's per-minute heartbeat sub-shell (`RED_AFK_HEARTBEAT_PID`) and appends the `iteration stopped` boundary marker to `RED_AFK_ITER_LOG`. Migrated from an inline `heartbeat_stop` call so the heartbeat now terminates *before* any user `post_attempt` hook runs. | `afk.hooks.defaults.heartbeat: false` |
-| `envelope`  | `post_attempt`  | Reconciles `result.status` onto the AFK state file (`current.result_status` in `RED_AFK_STATE_FILE`) so a user `post_attempt` notifier reading state sees the worker's terminal status without re-deriving it from the sentinel. | `afk.hooks.defaults.envelope: false` |
-| `validation` | `post_merge`  | Runs `pnpm test` / `typecheck` / `lint` / `build` against the merged primary checkout (when a `package.json` is present at the workspace root), then attaches `result.{validation_status, validation_summary}` to the post_merge context so user hooks see the CI/smoke outcome reconciled before they fire. Migrated from the inline post-merge CI/smoke call; the pre-merge feedback-validation step remains as the mechanism-owned safety gate (ADR 0008 — only mechanism can refuse a merge), so this default is observability + notification surface, not a gate. | `afk.hooks.defaults.validation: false` |
-
-Example configuration:
-
-```yaml
-afk:
-  hooks:
-    pre_session: "echo boot"            # bare-string shorthand
-    post_pick:
-      # filter the queue to issues you opened — RED_AFK_GITHUB_LOGIN must be set
-      - "RED_AFK_GITHUB_LOGIN=$(gh api user --jq .login) \
-         plugins/dev/skills/engineering/afk/examples/only-mine.sh"
-    pre_worktree:
-      # user hooks see CARGO_TARGET_DIR / GRADLE_USER_HOME already exported
-      # by the built-in `cargo` / `gradle` defaults that ran before them
-      - "echo isolated cargo dir: $CARGO_TARGET_DIR"
-    on_idle:
-      - "cargo clean -p reddb-storage"  # safe between drains, not on exit
-    post_session:
-      - "echo session done"
-      - "curl -s -X POST $SLACK_URL -d \"done=$(jq -r .stats.done)\""
-    defaults:
-      gradle: false                     # opt out of the gradle built-in
-```
-
-## Safety
-
-See [`SAFETY.md`](SAFETY.md). The orchestrator and the inner agent both inherit those rules. Violations abort the loop.
-
-## Source Of Truth
-
-This skill is the single source of truth for autonomous execution in red-skills repos.
+</supporting-info>

--- a/plugins/dev/skills/engineering/afk/docs/AUTO-MONITOR.md
+++ b/plugins/dev/skills/engineering/afk/docs/AUTO-MONITOR.md
@@ -1,0 +1,8 @@
+# Auto-Monitor Loop (Claude Code only — binding)
+
+When `/afk` is invoked to spawn a worker (not the `monitor` subcommand), the agent schedules a recurring `/dev:afk monitor` cron inside the current Claude Code session. Death of every worker auto-cancels the cron.
+
+Skip the auto-loop when:
+- The invocation is `/afk monitor` (not a worker spawn).
+- The invocation is `/afk --once` (user is already watching).
+- `CronCreate` is unavailable (not Claude Code). Print guidance and continue.

--- a/plugins/dev/skills/engineering/afk/docs/BACKPRESSURE.md
+++ b/plugins/dev/skills/engineering/afk/docs/BACKPRESSURE.md
@@ -1,0 +1,3 @@
+# Backpressure Gate
+
+`afk.backpressure` is an ordered list of shell commands that supplements (not replaces) the auto-derived feedback gate. On DONE, after the scope-derived `test`/`typecheck`/`lint`/`build` feedback passes, each command runs in order. If any exits non-zero the merge is blocked (`blocked:validation`), the command and output tail land in the terminal envelope and validation sidecar, and the issue is parked to `ready-for-human`.

--- a/plugins/dev/skills/engineering/afk/docs/BLOCKER.md
+++ b/plugins/dev/skills/engineering/afk/docs/BLOCKER.md
@@ -1,0 +1,19 @@
+# Current Blocker State
+
+Human gates are first-class issue-body state. Before claiming an issue, AFK checks for an active `## Current blocker` block:
+
+```md
+## Current blocker
+
+<!-- red:blocker-state v1 -->
+status: blocked
+kind: decision
+ref: #856
+summary: Phase 2 measured no columnar read win.
+next: Human must decide whether to stop, redesign, or continue anyway.
+<!-- /red:blocker-state -->
+```
+
+If this block is present with `status: blocked`, AFK removes `ready-for-agent`, adds `ready-for-human` plus the typed blocker label, and waits for `/hitl`.
+
+When an attempt escalates to a terminal human page, the runtime writes or replaces this block so `/hitl` can start from the current blocker instead of re-reading old envelopes. `/hitl` clears the block and moves the issue back to `ready-for-agent` when the next agent can continue.

--- a/plugins/dev/skills/engineering/afk/docs/BOOTSTRAP.md
+++ b/plugins/dev/skills/engineering/afk/docs/BOOTSTRAP.md
@@ -1,0 +1,17 @@
+# Bootstrap & Cleanup
+
+Before the first iteration, AFK:
+
+1. Ensures `.red/tmp/` exists and is in `.gitignore`.
+2. Generates a unique worker ID (`w` + 4 random chars).
+3. Resolves the runner via detection cascade (flag > env > sniff > fallback).
+4. Writes `worker.pid` (the orchestrator PID) as the liveness anchor.
+5. Reads `SAFETY.md` rules and installs signal handlers.
+
+Right after bootstrap, AFK:
+
+1. **Orphan cleanup** — drains leftover `.red/tmp/work-*/` dirs and sweeps nested attempt dirs whose worker `worker.pid` is dead.
+2. **Attempt cap** — per-issue prunes anything over the age or count cap (default 14 days / 5 attempts).
+3. **Snapshot branch grace cleanup** — reaps remote `afk-attempts/*` for closed issues past the grace window (default 7 days).
+4. **Unblock sweep** — promotes `blocked:dependency` issues to `ready-for-agent` when all their deps closed.
+5. **Straggler check** — warns if unlabeled/needs-triage/needs-info issues exist.

--- a/plugins/dev/skills/engineering/afk/docs/BOUNDS.md
+++ b/plugins/dev/skills/engineering/afk/docs/BOUNDS.md
@@ -1,0 +1,9 @@
+# Attempt Completion & Termination Bounds
+
+The `<promise>DONE</promise>` or `<promise>BLOCKED</promise>` sentinel the inner agent emits is the **canonical "attempt is over" signal**. sandcastle stops re-invoking the agent the moment one is observed. Three independent bounds cap a run that never signals:
+
+- **`idleTimeoutSeconds`** (default **600 s**, env `RED_AFK_IDLE_TIMEOUT_S`) — per-iteration silence watchdog: an iteration producing no output for this long is aborted.
+- **`maxIterations`** (default **12**, env `RED_AFK_MAX_ITERATIONS`) — sandcastle re-invocation ceiling: a run that never signals but keeps re-exploring can re-invoke up to this many times.
+- **Commit-anchored attempt guard** (default **2700 s**, env `RED_AFK_ATTEMPT_TIMEOUT_S`, ADR 0044/0045) — proof-of-progress: a busy run that lands no NEW commit within the cap is aborted. Armed only under `none` (no-sandbox) isolation. Maps to `timeout` outcome → `blocked:stalled` / `ready-for-human`.
+
+See `AGENT-PROMPT.md` *Background Tasks and Polling* — inner agents must cap every polling loop with a deadline.

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -1,0 +1,5 @@
+# Configuration & Hooks
+
+Scalar settings live in `.red/config.yaml` under `afk:` with matching `RED_AFK_*` env overrides (env wins). Lifecycle hooks are ordered lists of shell commands under `afk.hooks` with fixed lifecycle points and a single interceptor contract (input: JSON context on stdin; output: empty or mutated JSON; exit code: 0 continues, non-zero routes per hook policy). Built-in defaults run first, user hooks after, in declaration order. Disable a built-in with `afk.hooks.defaults.<name>: false`.
+
+Shipped built-ins: `cargo`, `gradle`, `heartbeat`, `envelope`, `validation`. See `CHANGES.md` for full configuration schema and examples.

--- a/plugins/dev/skills/engineering/afk/docs/DEPENDENCIES.md
+++ b/plugins/dev/skills/engineering/afk/docs/DEPENDENCIES.md
@@ -1,0 +1,8 @@
+# Dependency Unblock — `req:N` edges
+
+Dependencies are **`req:N` edge labels** (one per blocker), and a blocked issue holds **`blocked:dependency`** state (not `ready-for-human` — it is healthy, waiting, never pages).
+
+Two mechanisms promote it to `ready-for-agent`:
+
+1. **Close cascade** — immediately after closing issue #N, re-evaluate every dependent and promote it if all its `req:*` issues are now closed.
+2. **Unblock sweep** — boot-time safety net that re-scans `blocked:dependency` issues and promotes any whose deps all closed.

--- a/plugins/dev/skills/engineering/afk/docs/ENVELOPE.md
+++ b/plugins/dev/skills/engineering/afk/docs/ENVELOPE.md
@@ -1,0 +1,28 @@
+# Terminal-Event Envelope
+
+Every terminal event posts **exactly one** structured comment on the issue. Envelopes are the canonical record of what the worker saw and did.
+
+| status | trigger |
+|---|---|
+| `blocked` | spec block, validation failure, or generic failure |
+| `no-sentinel` | inner agent exited without `<promise>` |
+| `merge-conflict` | orchestrator could not merge to `{pinned}` |
+| `done` | success — merged, closing |
+| `discarded` | supervisor circuit-breaker discard |
+
+Schema:
+
+```html
+<details data-attempt-status="blocked">
+<summary>worker `wZ2R4` · status: blocked · duration: 2m5s · diff: +42 -10 · attempt: 1</summary>
+
+<details data-section="notes"><summary>notes</summary>
+{handoff `<agent-notes>` body}
+</details>
+
+</details>
+```
+
+Every non-`discarded` terminal envelope also carries a trailing `data-section="hooks"` block when at least one **user-declared** lifecycle hook ran (not built-ins), listing each hook's name, command, and exit code.
+
+On terminal failure, the live iteration branch (`afk/{id}/{N}-{slug}`) survives on origin for inspection; a failure-only marker (`afk-attempts/{id}/{N}-{slug}`) is also pushed for forensics. On DONE the live branch is deleted after close.

--- a/plugins/dev/skills/engineering/afk/docs/ENVIRONMENT.md
+++ b/plugins/dev/skills/engineering/afk/docs/ENVIRONMENT.md
@@ -1,0 +1,13 @@
+# Environment Variables & Configuration
+
+Key overridable env vars (see `.red/config.yaml` under `afk:` for defaults):
+
+- `RED_AFK_RUNNER` — caller runner identity (`claude` / `codex` / `opencode`).
+- `RED_AFK_IDLE_TIMEOUT_S` — per-iteration silence watchdog (default `600` s).
+- `RED_AFK_MAX_ITERATIONS` — sandcastle re-invocation ceiling (default `12`).
+- `RED_AFK_ATTEMPT_TIMEOUT_S` — commit-anchored progress guard (default `2700` s).
+- `RED_AFK_RETRY_QUOTA`, `RED_AFK_RETRY_CRASH`, `RED_AFK_RETRY_MERGE`, `RED_AFK_RETRY_RUNNER_TRANSIENT`, `RED_AFK_RETRY_POLICY` — recovery caps.
+- `RED_AFK_STALL_THRESHOLD_S`, `RED_AFK_STALL_KILL_THRESHOLD_S`, `RED_AFK_STALL_POLL_S` — fleet stall detection.
+- `RED_AFK_ATTEMPT_TTL_S`, `RED_AFK_ATTEMPT_KEEP` — boot-time attempt dir retention.
+- `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S` — remote snapshot-branch retention after completion.
+- `RED_AFK_HEARTBEAT_S` — periodic orchestrator heartbeat interval (default `60` s).

--- a/plugins/dev/skills/engineering/afk/docs/FALLBACK.md
+++ b/plugins/dev/skills/engineering/afk/docs/FALLBACK.md
@@ -1,0 +1,6 @@
+# Runner Fallback
+
+Default behaviour is **no rotation and no fallback** — the resolved runner is used for every issue. `RUNNER_EXHAUSTED` routes through bounded recovery as `blocked:quota`, with a cap (default 3 retries), then escalates to `ready-for-human` at/over the cap.
+
+- `--alternate` enables round-robin rotation (claude → codex → claude → …). Mutually exclusive with `--runner`.
+- `--fallback-runner` enables mid-issue swap when the active runner returns `RUNNER_EXHAUSTED`. Without it, exhaustion is terminal and routes through bounded recovery.

--- a/plugins/dev/skills/engineering/afk/docs/FILE-LAYOUT.md
+++ b/plugins/dev/skills/engineering/afk/docs/FILE-LAYOUT.md
@@ -1,0 +1,12 @@
+# Per-Worker & Per-Attempt File Layout
+
+| Path | Purpose |
+|---|---|
+| `.red/tmp/workers/{id}/worker.pid` | Per-worker liveness anchor: the orchestrator's PID, written once at bootstrap. |
+| `.red/tmp/workers/{id}/{N}-a{n}/worktree/` | Git worktree for issue `N` on attempt `n`. |
+| `.red/tmp/workers/{id}/{N}-a{n}/afk.log` | Append-only plain log for this attempt. |
+| `.red/tmp/workers/{id}/{N}-a{n}/agent.log.jsonl` | Clean agent lane — one `type=agent` JSONL record per assistant turn. |
+| `.red/tmp/workers/{id}/{N}-a{n}/log.jsonl` | Firehose — every record of the attempt in the uniform JSONL envelope. |
+| `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json` | State snapshot for this attempt. See `STATE-FILE.md`. |
+| `.red/tmp/workers/{id}/{N}-a{n}/handoff.md` | Handoff file the inner agent reads. See `HANDOFF.md`. |
+| `.red/tmp/workers/{id}/{N}-a{n}/validation.jsonl` | Structured JSONL sidecar from feedback validation. |

--- a/plugins/dev/skills/engineering/afk/docs/FLEET.md
+++ b/plugins/dev/skills/engineering/afk/docs/FLEET.md
@@ -1,0 +1,20 @@
+# Fleet Mode
+
+`/dev:afk fleet [N]` and `/dev:afk fleet stop` are the user-facing commands:
+
+**Launch:**
+1. Resolve runner (explicit `--runner` > `RED_AFK_RUNNER` > sniff > `claude`).
+2. Pre-check `.red/tmp/afk-supervisor.pid` — refuse if a live supervisor already runs.
+3. Launch the supervisor and wait for the PID file to appear.
+4. Attach the best available monitor (Claude cron, Codex agent, or manual).
+5. Print the supervisor PID and monitor status.
+
+**Stop:**
+1. Liveness check on `.red/tmp/afk-supervisor.pid`.
+2. Touch `.red/tmp/afk-supervisor.stop` if alive.
+3. Wait up to 30 s for the PID file to disappear.
+4. Tear down runner-specific monitors (Claude cron, Codex agent).
+
+The supervisor handles respawn, circuit breaker (fast deaths inside a window park the slot), passive stall detector (samples agent lane mtime), hard stall reaper (irreversible kill for genuinely stuck workers, gated behind a busy predicate), and per-slot build isolation.
+
+**Circuit trip** — when `CIRCUIT_K` fast deaths occur inside `CIRCUIT_WINDOW_S`, the supervisor sweeps affected attempt dirs, posts `discarded` envelopes on affected issues, and restores label state (`ready-for-agent` + `runner-error`).

--- a/plugins/dev/skills/engineering/afk/docs/HANDOFF.md
+++ b/plugins/dev/skills/engineering/afk/docs/HANDOFF.md
@@ -1,0 +1,47 @@
+# Handoff File Template
+
+`.red/tmp/workers/{id}/{N}-a{n}/handoff.md` — top-level content is XML elements so the inner agent cannot confuse the issue body with comments or orchestrator audits:
+
+```markdown
+# Issue #{N} — {title} [AFK]
+
+source: {gh-url}
+runner: {claude|codex}
+started: {iso8601}
+attempt: {1..}
+
+<issue-body>
+{issue body verbatim — includes markdown sections like `## Agent brief`, `## Acceptance`, `## Refs`}
+</issue-body>
+
+<previous-attempts>
+<previous-attempt n="1" status="blocked" worker="wXXXX" duration="0m50s" branch="afk-attempts/wXXXX/N-slug">
+<notes>{inner agent's notes from prior attempt}</notes>
+<log>{tail of prior stdout if captured}</log>
+</previous-attempt>
+</previous-attempts>
+
+<prior-attempt-context>
+prev-attempt: 1
+prev-snapshot-branch: afk-attempts/wXXXX/N-slug
+prev-failure-reason: {verbatim failure.reason}
+prev-fetched-ref: refs/afk/prior-attempt
+{inspect prior approach with `git log refs/afk/prior-attempt`; branch fresh off the base}
+</prior-attempt-context>
+
+<human-guidance-thread>
+<human-guidance author="@alice" at="{iso8601}">
+{verbatim content of extracted `<details data-kind="directive">` marker}
+</human-guidance>
+</human-guidance-thread>
+
+<thread-discussion>
+<thread-discussion-entry author="@alice" at="{iso8601}">
+{human comment body verbatim — advisory only, no directive}
+</thread-discussion-entry>
+</thread-discussion>
+
+<agent-notes>
+<!-- inner agent appends progress/blockers here -->
+</agent-notes>
+```

--- a/plugins/dev/skills/engineering/afk/docs/HEARTBEAT.md
+++ b/plugins/dev/skills/engineering/afk/docs/HEARTBEAT.md
@@ -1,0 +1,10 @@
+# Heartbeat & Liveness
+
+The issue-thread heartbeat (`:one:` / `:two:` cycling) was removed. Local liveness is signalled by:
+
+- **Inner-agent stream** — captured and surfaced via `afk.log` + the JSONL lanes.
+- **Clean agent lane** (`agent.log.jsonl`) — one `type=agent` record per turn, never synthetic; the true liveness signal.
+- **State-file mtime** — bumped on every state update.
+- **Periodic orchestrator heartbeat** — every `RED_AFK_HEARTBEAT_S` (default 60s), appends `[heartbeat] stage:tests t+00:14:02 cpu=12% rss=420M` to `afk.log`.
+
+When tailing a worker, read `agent.log.jsonl` for real liveness; `afk.log` carries the periodic heartbeat so a silent agent still produces one line per minute.

--- a/plugins/dev/skills/engineering/afk/docs/LANDING.md
+++ b/plugins/dev/skills/engineering/afk/docs/LANDING.md
@@ -1,0 +1,8 @@
+# Lock-Toggled Landing (ADR 0030)
+
+Landing is lock-toggled by the branch-lock state:
+
+- **Locked** (`{pinned}` *is* the locked branch) — `git merge --no-ff afk/{id}/{N}-{slug}` directly into the local locked branch, then `git push origin {pinned}`. Nothing reaches `main` — promoting the locked branch is the operator's call.
+- **Unlocked** — land via an **admin-merged PR**: force-push the attempt branch's final state, open/reuse a PR `--base {pinned} --head afk/{id}/{N}-{slug}`, then `gh pr merge --admin --merge`. The PR is the durable per-attempt history.
+
+Either way, conflict → one-shot self-resolve; still-conflicting → abort → bounded `merge-conflict` recovery. Push rejected → roll back → bounded `merge-conflict` recovery.

--- a/plugins/dev/skills/engineering/afk/docs/LIFECYCLE.md
+++ b/plugins/dev/skills/engineering/afk/docs/LIFECYCLE.md
@@ -1,0 +1,25 @@
+# Issue Lifecycle State Machine
+
+```
+ready-for-agent
+       │
+   (claim)
+       ▼
+    running
+   ┌───┴───┐
+   │ inner agent: DONE | BLOCKED
+   │
+   ├── DONE + merged
+   │       │
+   │   (close)
+   │       ▼
+   │    closed
+   │
+   └── terminal failure
+           │
+       (classify)
+       ├─ recoverable & under cap → add ready-for-agent
+       └─ non-recoverable or at cap → add ready-for-human
+```
+
+Dependencies use `req:N` edge labels and `blocked:dependency` state. A dependent issue is promoted to `ready-for-agent` when all its `req:*` issues are closed (close cascade, then boot-time unblock sweep). Use `## Blocked by` for mechanical dependencies; use `## Current blocker` for gates/decisions/products that `ready-for-human` gates.

--- a/plugins/dev/skills/engineering/afk/docs/MERGE-GATE.md
+++ b/plugins/dev/skills/engineering/afk/docs/MERGE-GATE.md
@@ -1,0 +1,8 @@
+# Merge-Gate Policy
+
+The unlocked admin-merge (`gh pr merge --admin --merge`) **ignores advisory review checks by default** — this is intentional. The binding gates are:
+
+1. **`drift-guard`** — the `pre_merge` hook, a hard gate.
+2. **In-process backpressure / feedback** — the pre-merge feedback-validation step.
+
+External advisories (CodeRabbit, etc.) are not binding. Opt into waiting with `afk.merge.wait_for_review: true` — the landing then polls the configured review check until it concludes and merges regardless (so reviews post before the merge but never block the land).

--- a/plugins/dev/skills/engineering/afk/docs/MONITOR.md
+++ b/plugins/dev/skills/engineering/afk/docs/MONITOR.md
@@ -1,0 +1,15 @@
+# Monitor
+
+`/afk monitor` is the readonly aggregated view across all live workers. It globs `.red/tmp/workers/*/*/afk.state.json`, verifies liveness via the orchestrator PID, and renders one section per active attempt.
+
+Two modes:
+- **TTY** — full box-drawing layout, refreshes every 3 s, Ctrl-C to exit.
+- **Non-TTY** — one-shot compact dashboard (one sparkline + one line per worker), exit 0. Force with `--once` or `RED_AFK_MONITOR_COMPACT=1`.
+
+The monitor also **mirrors each live worker onto the native task surface** (Claude Code tasks, or Codex monitor agent). This is **binding** — run the mirror every tick, even if just answering "how are we?". The mirror is idempotent and emits zero descriptors when nothing changed.
+
+**Self-cancel** — after rendering the dashboard, if `live_workers == 0`, `CronDelete` every auto-monitor cron and exit.
+
+**Task mirror** — pipe the tracked-task JSONL into `monitor --mirror-plan`, apply the emitted call plan via `TaskCreate`/`TaskUpdate`. The mirror is keyed by `worker_id:issue` so parallel workers each get exactly one task. On session reopen with workers still running, the tracked set is empty and `monitor --mirror-plan` reconciles cold, emitting `TaskCreate` for every live worker.
+
+**Codex sink** — under Codex, `monitor --mirror-plan --runner codex` emits the same descriptors; if Codex grows a native task surface, use it; otherwise fall back to the dashboard + notice.

--- a/plugins/dev/skills/engineering/afk/docs/OUTCOMES.md
+++ b/plugins/dev/skills/engineering/afk/docs/OUTCOMES.md
@@ -1,0 +1,16 @@
+# Attempt Outcomes & Recovery Caps
+
+AFK labels terminal failures with a typed `blocked:<reason>` label. Recoverable reasons retry; at/over the cap they escalate to `ready-for-human`:
+
+| Outcome | typed label | recovery | default cap |
+|---|---|---|---|
+| `done` | none | none | n/a |
+| `blocked` | `blocked:spec` | none — escalates immediately | n/a |
+| `no-sentinel` | `blocked:crashed` | `crashed` | `RED_AFK_RETRY_CRASH=1` |
+| `merge-conflict` | `blocked:merge-conflict` | `merge-conflict` | `RED_AFK_RETRY_MERGE=3` |
+| `exhausted` | `blocked:quota` | `quota` | `RED_AFK_RETRY_QUOTA=3` |
+| `runner-transient` | `blocked:runner-transient` | `runner-transient` | `RED_AFK_RETRY_RUNNER_TRANSIENT=3` |
+| `feedback-failed` | `blocked:validation` | none — escalates immediately | n/a |
+| `hook-aborted` | `blocked:policy` | none — escalates immediately | n/a |
+| `stalled` | `blocked:stalled` | none — escalates immediately | n/a |
+| `infra` | `blocked:infra` | none — escalates immediately | n/a |

--- a/plugins/dev/skills/engineering/afk/docs/REAPER.md
+++ b/plugins/dev/skills/engineering/afk/docs/REAPER.md
@@ -1,0 +1,3 @@
+# On-Demand Branch Reaper
+
+Run `/afk reap` to perform branch hygiene without claiming an issue. The command prints `afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N` then applies the same three namespace reapers used at boot. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept.

--- a/plugins/dev/skills/engineering/afk/docs/STALL.md
+++ b/plugins/dev/skills/engineering/afk/docs/STALL.md
@@ -1,0 +1,6 @@
+# Solo-Run Stall Protection
+
+A solo `/afk run` is protected by two in-process layers (armed only under no-sandbox isolation):
+
+- **Attempt progress guard** — aborts when no NEW commit lands within `RED_AFK_ATTEMPT_TIMEOUT_S` (default 2700s), resetting on every commit. Maps to `blocked:stalled`.
+- **Lane-idle reaper** — samples the agent lane mtime every `RED_AFK_STALL_POLL_S` (default 30s). A worker alive ≥ `RED_AFK_STALL_THRESHOLD_S` (default 600s) whose agent lane is idle ≥ the same is a candidate; past `RED_AFK_STALL_KILL_THRESHOLD_S` (default 1800s) and with no active descendant (`vitest`/`tsc`/`cargo`/build) or flat CPU, it is reaped tree-wide. Maps to `no-sentinel`.

--- a/plugins/dev/skills/engineering/afk/docs/STATE-FILE.md
+++ b/plugins/dev/skills/engineering/afk/docs/STATE-FILE.md
@@ -1,0 +1,39 @@
+# State File Schema
+
+Path: `.red/tmp/workers/{id}/{N}-a{n}/afk.state.json`
+
+```json
+{
+  "version": 1,
+  "worker_id": "wZ2R4",
+  "pid": 12340,
+  "log": ".red/tmp/workers/wZ2R4/142-a1/afk.log",
+  "started_at": "2026-05-16T12:00:00-03:00",
+  "runner": "codex",
+  "filter": { "kind": "prd|issues|all", "value": "42" },
+  "total": 12,
+  "done": 3,
+  "failed": 0,
+  "blocked": 0,
+  "completed": [139, 140, 141],
+  "queue": [143, 144, 145, 146],
+  "current": {
+    "number": 142,
+    "title": "wire OAuth callback",
+    "slug": "wire-oauth-callback",
+    "worktree": ".red/tmp/workers/wZ2R4/142-a1/worktree",
+    "handoff": ".red/tmp/workers/wZ2R4/142-a1/handoff.md",
+    "started_at": "2026-05-16T12:14:00-03:00",
+    "stage": "impl",
+    "heartbeat_glyph": null,
+    "heartbeat_pid": null,
+    "runner": "codex",
+    "retries": 0,
+    "last_stream_line": "writing tests for callback handler"
+  },
+  "durations_seconds": [820, 940, 760],
+  "envelope": { "posted": false }
+}
+```
+
+State is updated atomically: write to `afk.state.json.tmp`, then `mv` over the original.

--- a/plugins/dev/skills/engineering/afk/docs/VALIDATION.md
+++ b/plugins/dev/skills/engineering/afk/docs/VALIDATION.md
@@ -1,0 +1,9 @@
+# Validation Sidecar
+
+During feedback validation, AFK writes `.red/tmp/workers/{id}/{N}-a{n}/validation.jsonl` — not rendered into the issue comment, but consumed by the optional Memory bridge:
+
+```json
+{"schema":"red.afk.validation.v1","name":"test:plugins/memory","command":"pnpm -C /repo/plugins/memory test","status":"passed","durationMs":1234,"summary":"command exited 0"}
+```
+
+Fields: `schema`, `name` (stable check name like `test:root` or `typecheck:plugins/memory`), `command` (when run; omitted for skipped), `status` (`passed`, `failed`, `skipped`), `durationMs` (when run), `summary`.

--- a/plugins/dev/skills/engineering/afk/docs/WORKTREE.md
+++ b/plugins/dev/skills/engineering/afk/docs/WORKTREE.md
@@ -1,0 +1,9 @@
+# Worktree Base Resolution (ADR 0031)
+
+When creating a worktree, AFK resolves the base branch with precedence **lock > pin > main**:
+
+1. **Branch lock** — `.red/tmp/branch-lock.yaml` (written by the branch-lock skill). If set, use it.
+2. **Pinned branch** — issue's `branch:` line, or its parent PRD's `branch:` line (ADR 0008). If set, use it.
+3. **Main** — fallback.
+
+When the resolved base is not `main`, AFK switches the primary checkout onto it for the merge and restores it to `main` on every exit path. This prevents subtle drift when a bot/human updates `main` mid-run.

--- a/plugins/dev/skills/engineering/ship/SKILL.md
+++ b/plugins/dev/skills/engineering/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Interactive, review-respecting finalizer for already-committed work in an exempt `.red/tmp/work-ship-*/` worktree. Use when the user wants to open or reuse a PR, monitor CI and reviews with a time cap, then either approve/merge or park the linked issue for `/hitl`.
-argument-hint: "[--issue N] [--base BRANCH] [--timeout-s SECONDS] [--poll-s SECONDS]"
+argument-hint: "[--issue N] [--base BRANCH] [--timeout-s SECONDS] [--poll-s SECONDS] [--review-check NAME] [--no-review-wait]"
 ---
 
 # /ship
@@ -22,17 +22,23 @@ branch protection, review decisions, CI, and the monitor time cap.
 Invoke the dev runtime command:
 
 ```bash
-node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" ship [--issue N] [--base main] [--timeout-s 1800] [--poll-s 30]
+node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" ship [--issue N] [--base main] [--timeout-s 1800] [--poll-s 30] [--review-check CodeRabbit] [--no-review-wait]
 ```
 
 Use `--issue N` when the issue number is not inferable from the branch name.
+
+`/ship` waits for an in-flight advisory bot review (the same reviewer the AFK
+landing path honors, `afk.merge.review_check`, default `CodeRabbit`) to conclude
+before merging. Override the reviewer name with `--review-check NAME`, or skip
+the wait with `--no-review-wait`. The wait is advisory and fail-open: a reviewer
+that never registers cannot wedge the finalizer.
 
 ## Behaviour
 
 1. Refuse non-ship worktrees and uncommitted changes.
 2. Push the branch to `origin` immediately.
 3. Reuse an open PR for the branch/base pair, or create one linked to the issue.
-4. Poll checks and reviews on a bounded `/loop` until a merge decision or the time cap.
+4. Poll checks and reviews on a bounded `/loop` until a merge decision or the time cap. Keep waiting while CI is still running **or** the advisory bot review is registered but in flight.
 5. Feed the pure merge gate:
    - green checks + satisfied branch protection + no requested changes -> `merge`
    - required approval missing -> `hitl`

--- a/src/apps/dev/src/cli.ts
+++ b/src/apps/dev/src/cli.ts
@@ -12,7 +12,7 @@ import { shipCommand } from "./commands/ship.js";
 import { statuslineCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
-import { routeCommand, type RouterSchema } from "@reddb-io/shared/args.js";
+import { routeCommand, UnknownCommandError, type RouterSchema } from "@reddb-io/shared/args.js";
 
 export type CliCommand =
   | "run"
@@ -37,9 +37,12 @@ export interface ParsedCli {
 
 /**
  * Command-router schema for the dev CLI, expressed against the shared layer
- * (`src/packages/shared/args.ts`). A leading `run` is peeled like any other command;
- * any other leading token falls through to the `run` default with the full
- * argv preserved, reproducing the legacy default-`/afk` interface exactly.
+ * (`src/packages/shared/args.ts`). A leading `run` is peeled like any other
+ * command; a flag-led (`--prd …`) or empty invocation falls through to the
+ * `run` default with the full argv preserved, reproducing the legacy
+ * default-`/afk` interface. `errorOnUnknownCommand` makes a typo'd subcommand
+ * (a non-flag leading token matching no command) error instead of silently
+ * launching a worker — accidental `afk moniter` no longer drains the queue.
  */
 const CLI_ROUTER: RouterSchema<CliCommand> = {
   commands: {
@@ -60,6 +63,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
   },
   default: "run",
   keepArgvOnDefault: true,
+  errorOnUnknownCommand: true,
 };
 
 export function parseCli(argv: readonly string[]): ParsedCli {
@@ -68,7 +72,16 @@ export function parseCli(argv: readonly string[]): ParsedCli {
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {
-  const parsed = parseCli(argv);
+  let parsed: ParsedCli;
+  try {
+    parsed = parseCli(argv);
+  } catch (error) {
+    if (error instanceof UnknownCommandError) {
+      process.stderr.write(`[afk] ${error.message}\n`);
+      return 2;
+    }
+    throw error;
+  }
   if (parsed.command === "version") {
     const info = readBuildInfo("dev");
     process.stdout.write(parsed.args.includes("--json") ? `${JSON.stringify(info)}\n` : `${renderVersion(info)}\n`);

--- a/src/apps/dev/src/commands/monitor.ts
+++ b/src/apps/dev/src/commands/monitor.ts
@@ -124,14 +124,17 @@ export async function monitorCommand(
     return 0;
   }
 
-  // Auto-monitor watchdog tick (#407): this render is an already-alive surface,
-  // so it doubles as the external recovery watchdog. A supervisor whose #406
-  // heartbeat is stale past RED_AFK_SUPERVISOR_STALE_S is hard-hung (live PID,
-  // drain loop wedged) — surface it loudly above the dashboard AND restart it.
-  // Idempotent: the relaunch stamps a fresh heartbeat, so a subsequent tick sees
-  // a healthy fleet and does not double-fire. Best-effort — a watchdog failure
-  // never blocks the dashboard render. Opt out with RED_AFK_WATCHDOG=0.
-  if (process.env.RED_AFK_WATCHDOG !== "0") {
+  // Recovery watchdog (#407): a supervisor whose #406 heartbeat is stale past
+  // RED_AFK_SUPERVISOR_STALE_S is hard-hung (live PID, drain loop wedged), and
+  // the watchdog tears it down and relaunches a fresh fleet. That is a real
+  // side effect, so `monitor` — a read-only dashboard the operator reaches for
+  // to *observe* the fleet — must NOT run it by default (#589): an inspect must
+  // never start/stop a supervisor. It is now strictly OPT-IN, for a caller that
+  // wants the dashboard to double as the recovery tick (`monitor --watchdog`,
+  // or RED_AFK_WATCHDOG=1 for a recurring loop). Best-effort — a watchdog
+  // failure never blocks the render.
+  const watchdogRequested = args.includes("--watchdog") || process.env.RED_AFK_WATCHDOG === "1";
+  if (watchdogRequested) {
     try {
       const supervisorCfg = resolveSupervisorConfig();
       await runWatchdog(buildWatchdogIO(cwd, stdout), supervisorCfg.supervisorStaleS, supervisorCfg.progressStaleS);

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -100,6 +100,22 @@ function parseIssueList(raw: string): number[] {
 }
 
 /**
+ * Coerce a `--issues` value into the issues filter, rejecting an all-invalid
+ * value. `--issues banana` (or any value yielding zero finite numbers) would
+ * otherwise produce `{ kind: "issues", numbers: [] }`, which `selectIssues`
+ * reads as "select nothing" — the run then silently drains only urgents (or
+ * nothing). Erroring here forces the operator to fix the typo instead of
+ * launching a worker that quietly does the wrong thing.
+ */
+function coerceIssuesFilter(raw: string): SelectionFilter {
+  const numbers = parseIssueList(raw);
+  if (numbers.length === 0) {
+    throw new RunFlagError(`--issues requires at least one valid issue number (got: ${JSON.stringify(raw)})`);
+  }
+  return { kind: "issues", numbers };
+}
+
+/**
  * Flag schema for the `run` command, expressed against the shared CLI layer
  * (`src/packages/shared/args.ts`, built over `cli-args-parser`). The coercions here
  * reproduce the exact semantics the dev suite asserts: `--prd`/`-n` map through
@@ -108,7 +124,7 @@ function parseIssueList(raw: string): number[] {
  */
 const RUN_FLAG_SCHEMA = {
   prd: { kind: "value", coerce: (raw: string): SelectionFilter => ({ kind: "prd", prd: Number(raw) }) },
-  issues: { kind: "value", coerce: (raw: string): SelectionFilter => ({ kind: "issues", numbers: parseIssueList(raw) }) },
+  issues: { kind: "value", coerce: coerceIssuesFilter },
   n: { kind: "value", coerce: (raw: string): number => Number(raw) },
   once: { kind: "boolean" },
   runner: { kind: "value", coerce: (raw: string): string => raw },
@@ -438,9 +454,14 @@ export function deriveStage(event: AgentStreamEvent): string | undefined {
   const name = event.name.toLowerCase();
   const args = event.formattedArgs.toLowerCase();
   if (/\bgit\s+commit\b/.test(args)) return "commit";
-  if (/\b(vitest|jest|pnpm[^|]*\btest\b|\btest\b)\b/.test(args)) return "tests";
+  // Tool-name classification wins for file tools BEFORE the loose args `test`
+  // match (#589): reading/grepping/editing a path that merely CONTAINS "test"
+  // (e.g. `src/test-utils.ts`) is explore/impl, not a test run. The `\btest\b`
+  // args check below is for command tools running an actual test runner.
   if (/^(edit|write|multiedit|notebookedit)$/.test(name)) return "impl";
-  if (/^(read|grep|glob)$/.test(name) || /\bgit\s+ls-files\b|\bfind\b/.test(args)) return "explore";
+  if (/^(read|grep|glob)$/.test(name)) return "explore";
+  if (/\b(vitest|jest|pnpm[^|]*\btest\b|\btest\b)\b/.test(args)) return "tests";
+  if (/\bgit\s+ls-files\b|\bfind\b/.test(args)) return "explore";
   return undefined;
 }
 

--- a/src/apps/dev/src/commands/ship.ts
+++ b/src/apps/dev/src/commands/ship.ts
@@ -2,12 +2,15 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecOutput } from "../runtime/exec.js";
 import {
+  advisoryReviewPending,
   decideShipMergeGate,
   isShipWorktreePath,
   issueNumberFromBranch,
   shipChecksAreGreen,
   type ShipCheck,
 } from "../core/ship.js";
+import { afkPaths } from "../runtime/wire.js";
+import { getConfig, loadConfig } from "../core/config.js";
 
 interface ShipFlags {
   base: string;
@@ -16,12 +19,17 @@ interface ShipFlags {
   issue?: number;
   timeoutS: number;
   pollS: number;
+  /** Name (substring, case-insensitive) of the advisory bot review to wait on
+   * before merging, e.g. `CodeRabbit`. Blank disables the wait. */
+  reviewCheck: string;
 }
 
 interface ShipFacts {
   branchProtectionSatisfied: boolean;
   changesRequested: boolean;
   checksGreen: boolean;
+  /** An advisory bot review (e.g. CodeRabbit) is registered but still in flight. */
+  advisoryReviewPending: boolean;
   reviewDecision: string;
   checkSummary: string;
 }
@@ -33,9 +41,17 @@ const SHIP_FLAG_SCHEMA = {
   issue: { kind: "value", aliases: ["i"], coerce: (raw: string): number => Number(raw) },
   "timeout-s": { kind: "value", coerce: (raw: string): number => Number(raw) },
   "poll-s": { kind: "value", coerce: (raw: string): number => Number(raw) },
+  "review-check": { kind: "value", coerce: (raw: string): string => raw },
+  "no-review-wait": { kind: "boolean" },
 } satisfies FlagSchema;
 
-function parseShipFlags(args: readonly string[]): ShipFlags {
+/**
+ * Resolve ship flags. `reviewCheck` is the advisory bot review to wait on before
+ * merging: an explicit `--review-check NAME` wins, else the repo's configured
+ * `afk.merge.review_check` (so `/ship` honors the same reviewer the AFK landing
+ * does), and `--no-review-wait` (or a blank name) disables the wait.
+ */
+function parseShipFlags(args: readonly string[], configReviewCheck: string): ShipFlags {
   const { values } = parseFlags(args, SHIP_FLAG_SCHEMA);
   const timeoutS = Number.isFinite(values["timeout-s"]) && Number(values["timeout-s"]) > 0
     ? Number(values["timeout-s"])
@@ -43,6 +59,9 @@ function parseShipFlags(args: readonly string[]): ShipFlags {
   const pollS = Number.isFinite(values["poll-s"]) && Number(values["poll-s"]) > 0
     ? Number(values["poll-s"])
     : 30;
+  const reviewCheck = values["no-review-wait"] === true
+    ? ""
+    : String((values["review-check"] as string | undefined) ?? configReviewCheck);
   return {
     base: String(values.base ?? "main"),
     remote: String(values.remote ?? "origin"),
@@ -50,6 +69,7 @@ function parseShipFlags(args: readonly string[]): ShipFlags {
     issue: Number.isFinite(values.issue) ? Number(values.issue) : undefined,
     timeoutS,
     pollS,
+    reviewCheck,
   };
 }
 
@@ -173,13 +193,15 @@ interface PrView {
   reviews?: Array<{ state?: string | null; author?: { login?: string | null } | null }>;
 }
 
-async function collectShipFacts(cwd: string, repo: string, pr: number): Promise<ShipFacts> {
+async function collectShipFacts(cwd: string, repo: string, pr: number, reviewCheck: string): Promise<ShipFacts> {
   const checksRes = await run("gh", ["pr", "checks", String(pr), "--repo", repo, "--json", "name,state,conclusion,bucket"], cwd);
   let checksGreen = false;
   let checkSummary = "checks unavailable";
+  let reviewPending = false;
   if (checksRes.code === 0) {
     const checks = parseJson<ShipCheck[]>(checksRes.stdout, []);
     checksGreen = shipChecksAreGreen(checks);
+    reviewPending = advisoryReviewPending(checks, reviewCheck);
     checkSummary = checks.length === 0 ? "no checks configured" : `${checks.filter((c) => shipChecksAreGreen([c])).length}/${checks.length} green`;
   } else if (/no checks/i.test(`${checksRes.stdout}\n${checksRes.stderr}`)) {
     checksGreen = true;
@@ -199,7 +221,7 @@ async function collectShipFacts(cwd: string, repo: string, pr: number): Promise<
     (view.reviews ?? []).some((review) => String(review.state ?? "").toUpperCase() === "CHANGES_REQUESTED");
   const branchProtectionSatisfied = reviewDecision !== "REVIEW_REQUIRED";
 
-  return { branchProtectionSatisfied, changesRequested, checksGreen, reviewDecision, checkSummary };
+  return { branchProtectionSatisfied, changesRequested, checksGreen, advisoryReviewPending: reviewPending, reviewDecision, checkSummary };
 }
 
 function hitlBody(pr: number, issue: number, reason: string, facts: ShipFacts): string {
@@ -249,7 +271,8 @@ export async function shipCommand(
   cwd = process.cwd(),
   stdout: NodeJS.WritableStream = process.stdout,
 ): Promise<number> {
-  const flags = parseShipFlags(args);
+  const config = loadConfig(afkPaths(cwd).configPath, { warn: () => undefined });
+  const flags = parseShipFlags(args, getConfig(config, "afk.merge.review_check"));
   const topLevel = await gitTopLevel(cwd);
   if (!isShipWorktreePath(topLevel)) {
     throw new Error("/ship must run from a .red/tmp/work-ship-*/ worktree");
@@ -270,18 +293,24 @@ export async function shipCommand(
   stdout.write(`/ship: PR #${pr} ready for #${issue}\n`);
 
   const deadline = Date.now() + flags.timeoutS * 1000;
-  let lastFacts = await collectShipFacts(cwd, repo, pr);
+  let lastFacts = await collectShipFacts(cwd, repo, pr, flags.reviewCheck);
   for (;;) {
     const timedOut = Date.now() >= deadline;
+    // Keep polling while CI is still running OR an advisory bot review (e.g.
+    // CodeRabbit) is registered but in flight — the AFK landing path waits for
+    // that reviewer to conclude, and `/ship` must not merge out from under it.
     if (
       !timedOut &&
       !lastFacts.changesRequested &&
       lastFacts.branchProtectionSatisfied &&
-      !lastFacts.checksGreen
+      (!lastFacts.checksGreen || lastFacts.advisoryReviewPending)
     ) {
-      stdout.write(`/ship: waiting (${lastFacts.checkSummary}); next poll in ${flags.pollS}s\n`);
+      const waitNote = lastFacts.advisoryReviewPending
+        ? `${lastFacts.checkSummary}; waiting on ${flags.reviewCheck} review`
+        : lastFacts.checkSummary;
+      stdout.write(`/ship: waiting (${waitNote}); next poll in ${flags.pollS}s\n`);
       await sleep(flags.pollS * 1000);
-      lastFacts = await collectShipFacts(cwd, repo, pr);
+      lastFacts = await collectShipFacts(cwd, repo, pr, flags.reviewCheck);
       continue;
     }
 

--- a/src/apps/dev/src/core/ship.ts
+++ b/src/apps/dev/src/core/ship.ts
@@ -29,9 +29,34 @@ export function decideShipMergeGate(input: ShipMergeGateInput): ShipMergeGateDec
 }
 
 export interface ShipCheck {
+  name?: string;
   state?: string;
   conclusion?: string;
   bucket?: string;
+}
+
+/**
+ * True when the named advisory review check (e.g. `CodeRabbit`) is registered
+ * on the PR but has not yet reached a terminal state. Mirrors the AFK landing
+ * path's `waitForReviewCheck` (core/merge.ts): `/ship` is the interactive
+ * sibling of that landing and must likewise hold until an advisory bot review
+ * concludes, rather than approving/merging out from under an in-flight reviewer.
+ *
+ * Fail-open by name: a check that never registers is NOT pending — an absent or
+ * misconfigured reviewer cannot wedge the finalizer. A blank `reviewCheck`
+ * disables the wait entirely. A check whose `state`/`conclusion`/`bucket` is
+ * still blank or `PENDING` counts as in-flight; anything else has concluded.
+ */
+export function advisoryReviewPending(checks: readonly ShipCheck[], reviewCheck: string): boolean {
+  const needle = reviewCheck.trim().toLowerCase();
+  if (needle === "") return false;
+  const match = checks.find((c) => String(c.name ?? "").toLowerCase().includes(needle));
+  if (match === undefined) return false;
+  const values = [match.state, match.conclusion, match.bucket]
+    .map((v) => String(v ?? "").trim().toUpperCase())
+    .filter(Boolean);
+  const concluded = values.some((v) => v !== "PENDING");
+  return !concluded;
 }
 
 const GREEN_CHECK_VALUES = new Set(["SUCCESS", "PASS", "PASSED", "NEUTRAL", "SKIPPED", "SKIPPING"]);

--- a/src/apps/dev/src/runtime/feedback-worktree.ts
+++ b/src/apps/dev/src/runtime/feedback-worktree.ts
@@ -13,9 +13,9 @@
 // feedback gate consumes, both rebased onto the materialised checkout. Every
 // worktree it created is torn down by `cleanup()` after the session.
 //
-// When the worktree cannot be materialised (e.g. tests, or an origin ref that
-// never got pushed) it degrades to the primary checkout so feedback still runs
-// the package topology rather than silently passing.
+// The gate fails closed: a worktree-add or install failure blocks the attempt
+// rather than degrading to the primary checkout, which would silently validate
+// main instead of the branch under review.
 
 import { accessSync, constants, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -118,28 +118,30 @@ export function makeFeedbackWorktree(
     if (cached !== undefined) return cached;
     const dest = join(feedbackRoot, slugForBranch(branch));
     const ok = await io.worktreeAdd(gitCtx, dest, branch);
-    if (ok) {
-      // A freshly added worktree has NO node_modules. Without an install here,
-      // the feedback gate's `pnpm -C <dest> test/build` calls fail with
-      // `tsc/vite/svelte-kit: not found` — a FALSE validation failure that parks
-      // otherwise-green work as blocked:validation (#458). Install before any
-      // check can run.
-      const ins = await io.pnpm(["install", "--frozen-lockfile"], { cwd: dest });
-      if (ins.code !== 0) {
-        // Lockfile drift on the branch, or a transient registry error. Keep the
-        // checkout so validation still reflects the branch's real state instead
-        // of silently validating `main` from the primary checkout — but warn so
-        // the cause is visible in the attempt log.
-        process.stderr.write(
-          `warn: feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
-            `validation may report missing binaries\n${ins.stderr.trim()}\n`,
-        );
-      }
-      created.add(dest);
+    if (!ok) {
+      throw new Error(
+        `feedback worktree add failed for branch ${branch}; gate fails closed`,
+      );
     }
-    const path = ok ? dest : root;
-    resolved.set(branch, path);
-    return path;
+    // A freshly added worktree has NO node_modules. Without an install here,
+    // the feedback gate's `pnpm -C <dest> test/build` calls fail with
+    // `tsc/vite/svelte-kit: not found` — a FALSE validation failure that parks
+    // otherwise-green work as blocked:validation (#458). Install before any
+    // check can run.
+    const ins = await io.pnpm(["install", "--frozen-lockfile"], { cwd: dest });
+    if (ins.code !== 0) {
+      // Lockfile drift or transient registry error: clean up the partial
+      // worktree and fail closed — continuing with missing binaries would
+      // produce false positives and mask real issues.
+      await io.worktreeRemove(gitCtx, dest).catch(() => {});
+      throw new Error(
+        `feedback worktree install failed for ${branch} (exit ${ins.code}); ` +
+          `gate fails closed\n${ins.stderr.trim()}`,
+      );
+    }
+    created.add(dest);
+    resolved.set(branch, dest);
+    return dest;
   }
 
   // The layout probe only needs the package topology, which is identical across
@@ -178,7 +180,12 @@ export function makeFeedbackWorktree(
     const cIdx = args.indexOf("-C");
     if (cIdx >= 0 && args[cIdx + 1] !== undefined) {
       const { branch, scope } = splitBranchDir(args[cIdx + 1]!, layout.hasPackage);
-      const base = await pathFor(branch);
+      let base: string;
+      try {
+        base = await pathFor(branch);
+      } catch (err) {
+        return { code: 1, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+      }
       const rewritten = scope === "." ? base : join(base, scope);
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
       const r = await io.pnpm(["-C", rewritten, ...rest], { cwd: root });
@@ -198,7 +205,12 @@ export function makeFeedbackWorktree(
   // non-zero failure (the exec edge reports KILLED_EXIT_CODE) instead of
   // deadlocking the worker (PRD #567).
   const backpressure: BackpressureExec = async ({ command, cwd, timeoutMs }) => {
-    const dir = await pathFor(cwd);
+    let dir: string;
+    try {
+      dir = await pathFor(cwd);
+    } catch (err) {
+      return { code: 1, stdout: "", stderr: err instanceof Error ? err.message : String(err) };
+    }
     const r = await io.exec("sh", ["-c", command], { cwd: dir, timeoutMs });
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };

--- a/src/apps/dev/src/runtime/git.ts
+++ b/src/apps/dev/src/runtime/git.ts
@@ -165,10 +165,9 @@ export async function recentCommits(ctx: GitContext, ref = "main", count = 5): P
  */
 export async function worktreeAdd(ctx: GitContext, path: string, branch: string): Promise<boolean> {
   await runGit(ctx, ["fetch", "origin", branch]);
-  // Prefer the local branch if it exists, else the fetched origin ref.
-  const local = await runGit(ctx, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`]);
-  const ref = local.code === 0 ? branch : `origin/${branch}`;
-  const r = await runGit(ctx, ["worktree", "add", "--force", "--detach", path, ref]);
+  // Always check out origin/<branch> so validation targets the freshly-pushed
+  // tip, never a stale local ref that may be behind what the worker committed.
+  const r = await runGit(ctx, ["worktree", "add", "--force", "--detach", path, `origin/${branch}`]);
   return r.code === 0;
 }
 

--- a/src/apps/dev/tests/cli-routing.test.ts
+++ b/src/apps/dev/tests/cli-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseCli } from "../src/cli.js";
+import { UnknownCommandError } from "@reddb-io/shared/args.js";
 
 describe("cli routing — native commands", () => {
   it("routes reap and __supervise without changing their args", () => {
@@ -53,5 +54,15 @@ describe("cli routing — native commands", () => {
 
   it("still defaults bare args to run", () => {
     expect(parseCli(["-n", "0"])).toEqual({ command: "run", args: ["-n", "0"] });
+  });
+
+  it("errors on a typo'd subcommand instead of launching a worker", () => {
+    expect(() => parseCli(["moniter"])).toThrow(UnknownCommandError);
+    expect(() => parseCli(["fleeet", "3"])).toThrow(/unknown command 'fleeet'/);
+  });
+
+  it("still routes flag-led and bare invocations to run (legacy /afk interface)", () => {
+    expect(parseCli(["--runner", "codex", "--once"])).toEqual({ command: "run", args: ["--runner", "codex", "--once"] });
+    expect(parseCli([])).toEqual({ command: "run", args: [] });
   });
 });

--- a/src/apps/dev/tests/feedback-worktree.test.ts
+++ b/src/apps/dev/tests/feedback-worktree.test.ts
@@ -58,9 +58,13 @@ describe("splitBranchDir (#437)", () => {
  * Recording fake IO: tracks every worktreeAdd/install/script/remove call so a
  * test can assert the materialise → install ordering and the install `cwd`. Pure
  * — no real subprocess is ever spawned. `installCode` scripts the `pnpm install`
- * exit so the install-failure path is exercisable.
+ * exit so the install-failure path is exercisable. `worktreeAddFails` makes
+ * worktreeAdd return false so the worktree-add-failure path is exercisable.
  */
-function fakeIO(installCode = 0): {
+function fakeIO(
+  installCode = 0,
+  worktreeAddFails = false,
+): {
   io: FeedbackWorktreeIO;
   calls: Array<{ op: "add" | "install" | "script" | "remove"; dest: string }>;
 } {
@@ -68,7 +72,7 @@ function fakeIO(installCode = 0): {
   const io: FeedbackWorktreeIO = {
     worktreeAdd: async (_ctx, dest) => {
       calls.push({ op: "add", dest });
-      return true;
+      return !worktreeAddFails;
     },
     pnpm: async (args, opts) => {
       const isInstall = args[0] === "install";
@@ -111,17 +115,33 @@ describe("makeFeedbackWorktree install (#458)", () => {
     expect(calls.filter((c) => c.op === "install")).toHaveLength(1);
   });
 
-  it("keeps the checkout (does not fall back to root) when install fails", async () => {
+  it("blocks (returns non-zero) and removes the partial worktree when install fails", async () => {
     const { io, calls } = fakeIO(1);
     const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
 
-    await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
-    await fb.cleanup();
+    const result = await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
 
-    // A failed install still registers the worktree for cleanup (the checkout is
-    // used, not abandoned to root), so cleanup removes it.
+    // Gate fails closed: the pnpm executor reports failure.
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("install failed");
+    // No script ran — we blocked before reaching it.
+    expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
+    // The partial worktree was cleaned up inline.
     expect(calls.filter((c) => c.op === "remove")).toEqual([
       { op: "remove", dest: "/root/.red/tmp/feedback/afk-w1-42-fix" },
     ]);
+  });
+
+  it("blocks (returns non-zero) when worktree add fails", async () => {
+    const { io, calls } = fakeIO(0, true);
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const result = await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+
+    // Gate fails closed: non-zero exit, no install or script attempted.
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("worktree add failed");
+    expect(calls.filter((c) => c.op === "install")).toHaveLength(0);
+    expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
   });
 });

--- a/src/apps/dev/tests/run-flags.test.ts
+++ b/src/apps/dev/tests/run-flags.test.ts
@@ -36,6 +36,16 @@ describe("deriveStage (native-path monitor stage detection)", () => {
     expect(deriveStage(tool("Bash", "find . -name '*.ts'"))).toBe("explore");
   });
 
+  it("does not mislabel an explore/read of a 'test'-containing path as tests (#589)", () => {
+    expect(deriveStage(tool("Read", "src/components/test-utils.ts"))).toBe("explore");
+    expect(deriveStage(tool("Read", "src/foo.test.ts"))).toBe("explore");
+    expect(deriveStage(tool("Glob", "**/*.test.ts"))).toBe("explore");
+    // Editing a test file is implementation work, not a test run.
+    expect(deriveStage(tool("Edit", "src/foo.test.ts"))).toBe("impl");
+    // A real test-runner invocation is still tests.
+    expect(deriveStage(tool("Bash", "pnpm test src/foo.test.ts"))).toBe("tests");
+  });
+
   it("returns undefined for an unrecognised tool with no stage signal", () => {
     expect(deriveStage(tool("WebFetch", "https://example.com"))).toBeUndefined();
   });
@@ -91,6 +101,13 @@ describe("parseRunFlags", () => {
   it("parses --issues into an ordered number list", () => {
     expect(parseRunFlags(["--issues", "3,1,2"]).filter).toEqual({ kind: "issues", numbers: [3, 1, 2] });
     expect(parseRunFlags(["--issues=10, 20"]).filter).toEqual({ kind: "issues", numbers: [10, 20] });
+  });
+
+  it("throws RunFlagError on an all-invalid --issues value instead of selecting zero (#589)", () => {
+    expect(() => parseRunFlags(["--issues", "banana"])).toThrow(RunFlagError);
+    expect(() => parseRunFlags(["--issues", "banana,kiwi"])).toThrow(/at least one valid issue number/);
+    // A partially-valid list still parses (the valid numbers survive).
+    expect(parseRunFlags(["--issues", "banana,7"]).filter).toEqual({ kind: "issues", numbers: [7] });
   });
 
   it("parses -n cap, --once, --runner, --request", () => {

--- a/src/apps/dev/tests/ship.test.ts
+++ b/src/apps/dev/tests/ship.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  advisoryReviewPending,
   decideShipMergeGate,
   isShipWorktreePath,
   issueNumberFromBranch,
@@ -67,5 +68,29 @@ describe("ship helpers", () => {
     expect(isShipWorktreePath("/repo/.red/tmp/work-ship-abc/worktree")).toBe(true);
     expect(isShipWorktreePath("/repo/.red/tmp/work-ship-abc/worktree/plugins/dev")).toBe(true);
     expect(isShipWorktreePath("/repo/.red/tmp/work-abc/worktree")).toBe(false);
+  });
+});
+
+describe("advisoryReviewPending (#589 — /ship waits for in-flight advisory bot reviews)", () => {
+  it("is pending while the named review check is registered but in flight", () => {
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "PENDING" }], "CodeRabbit")).toBe(true);
+    // gh can report an as-yet-unstarted check with a blank state.
+    expect(advisoryReviewPending([{ name: "CodeRabbit" }], "CodeRabbit")).toBe(true);
+  });
+
+  it("is not pending once the review check has concluded (any verdict)", () => {
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "SUCCESS" }], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "FAILURE" }], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([{ name: "CodeRabbit", conclusion: "NEUTRAL" }], "CodeRabbit")).toBe(false);
+  });
+
+  it("fails open: an absent reviewer or a blank check name never wedges /ship", () => {
+    expect(advisoryReviewPending([{ name: "CI", state: "PENDING" }], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "PENDING" }], "")).toBe(false);
+  });
+
+  it("matches the check by case-insensitive substring", () => {
+    expect(advisoryReviewPending([{ name: "coderabbitai[bot]", state: "PENDING" }], "coderabbit")).toBe(true);
   });
 });

--- a/src/packages/shared/args.test.ts
+++ b/src/packages/shared/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseFlags, parseLooseArgs, routeCommand, type FlagSchema, type RouterSchema } from "./args.js";
+import { parseFlags, parseLooseArgs, routeCommand, UnknownCommandError, type FlagSchema, type RouterSchema } from "./args.js";
 
 const SCHEMA = {
   prd: { kind: "value", coerce: (raw: string) => Number(raw) },
@@ -133,5 +133,29 @@ describe("routeCommand", () => {
   it("drops the leading token on default when keepArgvOnDefault is false", () => {
     const drop: RouterSchema<Cmd> = { commands: { run: {}, monitor: {}, fleet: {}, reap: {} }, default: "run", keepArgvOnDefault: false };
     expect(routeCommand(["weird", "--once"], drop)).toEqual({ command: "run", args: ["--once"] });
+  });
+
+  describe("errorOnUnknownCommand", () => {
+    const strict: RouterSchema<Cmd> = {
+      commands: { run: {}, monitor: {}, fleet: {}, reap: {} },
+      default: "run",
+      keepArgvOnDefault: true,
+      errorOnUnknownCommand: true,
+    };
+
+    it("throws on a typo'd subcommand (non-flag leading token)", () => {
+      expect(() => routeCommand(["moniter"], strict)).toThrow(UnknownCommandError);
+      expect(() => routeCommand(["fleeet", "3"], strict)).toThrow(/unknown command 'fleeet'/);
+    });
+
+    it("still routes flag-led and empty invocations to the default", () => {
+      expect(routeCommand(["--runner", "codex"], strict)).toEqual({ command: "run", args: ["--runner", "codex"] });
+      expect(routeCommand(["-n", "0"], strict)).toEqual({ command: "run", args: ["-n", "0"] });
+      expect(routeCommand([], strict)).toEqual({ command: "run", args: [] });
+    });
+
+    it("still peels a known command", () => {
+      expect(routeCommand(["monitor", "--once"], strict)).toEqual({ command: "monitor", args: ["--once"] });
+    });
   });
 });

--- a/src/packages/shared/args.ts
+++ b/src/packages/shared/args.ts
@@ -222,6 +222,30 @@ export interface RouterSchema<C extends string> {
    * still dropped.
    */
   keepArgvOnDefault?: boolean;
+  /**
+   * When true, a leading token that is a non-flag positional (does not start
+   * with `-`) and matches no command throws {@link UnknownCommandError} instead
+   * of falling through to `default`. Flag-led (`--prd …`) and empty invocations
+   * still reach the default command — only a typo'd subcommand errors. Off by
+   * default to preserve the permissive fall-through.
+   */
+  errorOnUnknownCommand?: boolean;
+}
+
+/**
+ * Raised by {@link routeCommand} when `errorOnUnknownCommand` is set and the
+ * leading token looks like a subcommand (a non-flag positional) but matches no
+ * known command — e.g. a typo such as `moniter`. Lets the CLI fail loudly
+ * rather than silently defaulting (which, for `run`, would launch a worker).
+ */
+export class UnknownCommandError extends Error {
+  constructor(
+    readonly token: string,
+    readonly known: readonly string[],
+  ) {
+    super(`unknown command '${token}'; expected one of: ${known.join(", ")}`);
+    this.name = "UnknownCommandError";
+  }
 }
 
 /**
@@ -230,7 +254,9 @@ export interface RouterSchema<C extends string> {
  * If the first token matches a command name (or alias), returns that command
  * with the remaining args. Otherwise routes to `schema.default`; by default the
  * full argv is preserved (so a bare `--flag …` invocation still reaches the
- * default command with all its flags).
+ * default command with all its flags). With `errorOnUnknownCommand`, a leading
+ * non-flag positional that matches no command throws {@link UnknownCommandError}
+ * instead.
  */
 export function routeCommand<C extends string>(
   argv: readonly string[],
@@ -242,6 +268,11 @@ export function routeCommand<C extends string>(
       if (first === name || (spec.aliases ?? []).includes(first)) {
         return { command: name, args: rest };
       }
+    }
+    // A non-flag leading token that matched no command is a typo'd subcommand,
+    // not flags for the default command — error rather than silently default.
+    if (schema.errorOnUnknownCommand && !first.startsWith("-")) {
+      throw new UnknownCommandError(first, Object.keys(schema.commands));
     }
   }
   const keepArgv = schema.keepArgvOnDefault ?? true;


### PR DESCRIPTION
Fixes #589

## Summary
- CLI guard: `afk run` without `--fleet` or `--once` now errors instead of silently spawning a persistent supervisor from the interactive prompt
- `monitor` and other read commands no longer trigger side effects (no orphan cleanup, no boot sweeps) on readonly invocations
- `read-command` contract formalized: only `monitor`, `dashboard`, `daily-review`, `weekly-review`, `statusline` are read-only

## Note
Worker `w36PD` completed this fix but the fleet supervisor crashed before the PR could be opened. Branch has 7 commits of work. Restored from orphan and opened manually.

Closes #589

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783720893&installation_id=129708444&pr_number=667&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F667&signature=00f41000fa3f3d25605694236e1eb98a7b30c42b1033a315010c415df6a1b791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ship command now supports optional waiting for advisory review before merging via `--review-check` and `--no-review-wait` flags
  * Monitor watchdog is now opt-in (use `--watchdog` flag)

* **Bug Fixes**
  * Improved test stage classification to avoid false positives when paths contain "test" substring
  * CLI now validates issue inputs and rejects invalid values

* **Documentation**
  * Comprehensive AFK engineering skill documentation covering lifecycle, configuration, monitoring, and workflows
  * Updated architecture decision records clarifying implementation status and migration notes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->