### PR TITLE
fix(afk): CLI ergonomics and safety — no accidental worker launch, no read-command side effects

### DIFF
--- a/plugins/dev/skills/engineering/ship/SKILL.md
+++ b/plugins/dev/skills/engineering/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Interactive, review-respecting finalizer for already-committed work in an exempt `.red/tmp/work-ship-*/` worktree. Use when the user wants to open or reuse a PR, monitor CI and reviews with a time cap, then either approve/merge or park the linked issue for `/hitl`.
-argument-hint: "[--issue N] [--base BRANCH] [--timeout-s SECONDS] [--poll-s SECONDS]"
+argument-hint: "[--issue N] [--base BRANCH] [--timeout-s SECONDS] [--poll-s SECONDS] [--review-check NAME] [--no-review-wait]"
 ---
 
 # /ship
@@ -22,17 +22,23 @@ branch protection, review decisions, CI, and the monitor time cap.
 Invoke the dev runtime command:
 
 ```bash
-node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" ship [--issue N] [--base main] [--timeout-s 1800] [--poll-s 30]
+node "$CLAUDE_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" ship [--issue N] [--base main] [--timeout-s 1800] [--poll-s 30] [--review-check CodeRabbit] [--no-review-wait]
 ```
 
 Use `--issue N` when the issue number is not inferable from the branch name.
+
+`/ship` waits for an in-flight advisory bot review (the same reviewer the AFK
+landing path honors, `afk.merge.review_check`, default `CodeRabbit`) to conclude
+before merging. Override the reviewer name with `--review-check NAME`, or skip
+the wait with `--no-review-wait`. The wait is advisory and fail-open: a reviewer
+that never registers cannot wedge the finalizer.
 
 ## Behaviour
 
 1. Refuse non-ship worktrees and uncommitted changes.
 2. Push the branch to `origin` immediately.
 3. Reuse an open PR for the branch/base pair, or create one linked to the issue.
-4. Poll checks and reviews on a bounded `/loop` until a merge decision or the time cap.
+4. Poll checks and reviews on a bounded `/loop` until a merge decision or the time cap. Keep waiting while CI is still running **or** the advisory bot review is registered but in flight.
 5. Feed the pure merge gate:
    - green checks + satisfied branch protection + no requested changes -> `merge`
    - required approval missing -> `hitl`

--- a/src/apps/dev/src/cli.ts
+++ b/src/apps/dev/src/cli.ts
@@ -12,7 +12,7 @@ import { shipCommand } from "./commands/ship.js";
 import { statuslineCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
-import { routeCommand, type RouterSchema } from "@reddb-io/shared/args.js";
+import { routeCommand, UnknownCommandError, type RouterSchema } from "@reddb-io/shared/args.js";
 
 export type CliCommand =
   | "run"
@@ -37,9 +37,12 @@ export interface ParsedCli {
 
 /**
  * Command-router schema for the dev CLI, expressed against the shared layer
- * (`src/packages/shared/args.ts`). A leading `run` is peeled like any other command;
- * any other leading token falls through to the `run` default with the full
- * argv preserved, reproducing the legacy default-`/afk` interface exactly.
+ * (`src/packages/shared/args.ts`). A leading `run` is peeled like any other
+ * command; a flag-led (`--prd …`) or empty invocation falls through to the
+ * `run` default with the full argv preserved, reproducing the legacy
+ * default-`/afk` interface. `errorOnUnknownCommand` makes a typo'd subcommand
+ * (a non-flag leading token matching no command) error instead of silently
+ * launching a worker — accidental `afk moniter` no longer drains the queue.
  */
 const CLI_ROUTER: RouterSchema<CliCommand> = {
   commands: {
@@ -60,6 +63,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
   },
   default: "run",
   keepArgvOnDefault: true,
+  errorOnUnknownCommand: true,
 };
 
 export function parseCli(argv: readonly string[]): ParsedCli {
@@ -68,7 +72,16 @@ export function parseCli(argv: readonly string[]): ParsedCli {
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {
-  const parsed = parseCli(argv);
+  let parsed: ParsedCli;
+  try {
+    parsed = parseCli(argv);
+  } catch (error) {
+    if (error instanceof UnknownCommandError) {
+      process.stderr.write(`[afk] ${error.message}\n`);
+      return 2;
+    }
+    throw error;
+  }
   if (parsed.command === "version") {
     const info = readBuildInfo("dev");
     process.stdout.write(parsed.args.includes("--json") ? `${JSON.stringify(info)}\n` : `${renderVersion(info)}\n`);

--- a/src/apps/dev/src/commands/monitor.ts
+++ b/src/apps/dev/src/commands/monitor.ts
@@ -124,14 +124,17 @@ export async function monitorCommand(
     return 0;
   }
 
-  // Auto-monitor watchdog tick (#407): this render is an already-alive surface,
-  // so it doubles as the external recovery watchdog. A supervisor whose #406
-  // heartbeat is stale past RED_AFK_SUPERVISOR_STALE_S is hard-hung (live PID,
-  // drain loop wedged) — surface it loudly above the dashboard AND restart it.
-  // Idempotent: the relaunch stamps a fresh heartbeat, so a subsequent tick sees
-  // a healthy fleet and does not double-fire. Best-effort — a watchdog failure
-  // never blocks the dashboard render. Opt out with RED_AFK_WATCHDOG=0.
-  if (process.env.RED_AFK_WATCHDOG !== "0") {
+  // Recovery watchdog (#407): a supervisor whose #406 heartbeat is stale past
+  // RED_AFK_SUPERVISOR_STALE_S is hard-hung (live PID, drain loop wedged), and
+  // the watchdog tears it down and relaunches a fresh fleet. That is a real
+  // side effect, so `monitor` — a read-only dashboard the operator reaches for
+  // to *observe* the fleet — must NOT run it by default (#589): an inspect must
+  // never start/stop a supervisor. It is now strictly OPT-IN, for a caller that
+  // wants the dashboard to double as the recovery tick (`monitor --watchdog`,
+  // or RED_AFK_WATCHDOG=1 for a recurring loop). Best-effort — a watchdog
+  // failure never blocks the render.
+  const watchdogRequested = args.includes("--watchdog") || process.env.RED_AFK_WATCHDOG === "1";
+  if (watchdogRequested) {
     try {
       const supervisorCfg = resolveSupervisorConfig();
       await runWatchdog(buildWatchdogIO(cwd, stdout), supervisorCfg.supervisorStaleS, supervisorCfg.progressStaleS);

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -100,6 +100,22 @@ function parseIssueList(raw: string): number[] {
 }
 
 /**
+ * Coerce a `--issues` value into the issues filter, rejecting an all-invalid
+ * value. `--issues banana` (or any value yielding zero finite numbers) would
+ * otherwise produce `{ kind: "issues", numbers: [] }`, which `selectIssues`
+ * reads as "select nothing" — the run then silently drains only urgents (or
+ * nothing). Erroring here forces the operator to fix the typo instead of
+ * launching a worker that quietly does the wrong thing.
+ */
+function coerceIssuesFilter(raw: string): SelectionFilter {
+  const numbers = parseIssueList(raw);
+  if (numbers.length === 0) {
+    throw new RunFlagError(`--issues requires at least one valid issue number (got: ${JSON.stringify(raw)})`);
+  }
+  return { kind: "issues", numbers };
+}
+
+/**
  * Flag schema for the `run` command, expressed against the shared CLI layer
  * (`src/packages/shared/args.ts`, built over `cli-args-parser`). The coercions here
  * reproduce the exact semantics the dev suite asserts: `--prd`/`-n` map through
@@ -108,7 +124,7 @@ function parseIssueList(raw: string): number[] {
  */
 const RUN_FLAG_SCHEMA = {
   prd: { kind: "value", coerce: (raw: string): SelectionFilter => ({ kind: "prd", prd: Number(raw) }) },
-  issues: { kind: "value", coerce: (raw: string): SelectionFilter => ({ kind: "issues", numbers: parseIssueList(raw) }) },
+  issues: { kind: "value", coerce: coerceIssuesFilter },
   n: { kind: "value", coerce: (raw: string): number => Number(raw) },
   once: { kind: "boolean" },
   runner: { kind: "value", coerce: (raw: string): string => raw },
@@ -449,9 +465,14 @@ export function deriveStage(event: AgentStreamEvent): string | undefined {
   const name = event.name.toLowerCase();
   const args = event.formattedArgs.toLowerCase();
   if (/\bgit\s+commit\b/.test(args)) return "commit";
-  if (/\b(vitest|jest|pnpm[^|]*\btest\b|\btest\b)\b/.test(args)) return "tests";
+  // Tool-name classification wins for file tools BEFORE the loose args `test`
+  // match (#589): reading/grepping/editing a path that merely CONTAINS "test"
+  // (e.g. `src/test-utils.ts`) is explore/impl, not a test run. The `\btest\b`
+  // args check below is for command tools running an actual test runner.
   if (/^(edit|write|multiedit|notebookedit)$/.test(name)) return "impl";
-  if (/^(read|grep|glob)$/.test(name) || /\bgit\s+ls-files\b|\bfind\b/.test(args)) return "explore";
+  if (/^(read|grep|glob)$/.test(name)) return "explore";
+  if (/\b(vitest|jest|pnpm[^|]*\btest\b|\btest\b)\b/.test(args)) return "tests";
+  if (/\bgit\s+ls-files\b|\bfind\b/.test(args)) return "explore";
   return undefined;
 }
 

--- a/src/apps/dev/src/commands/ship.ts
+++ b/src/apps/dev/src/commands/ship.ts
@@ -2,12 +2,15 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecOutput } from "../runtime/exec.js";
 import {
+  advisoryReviewPending,
   decideShipMergeGate,
   isShipWorktreePath,
   issueNumberFromBranch,
   shipChecksAreGreen,
   type ShipCheck,
 } from "../core/ship.js";
+import { afkPaths } from "../runtime/wire.js";
+import { getConfig, loadConfig } from "../core/config.js";
 
 interface ShipFlags {
   base: string;
@@ -16,12 +19,17 @@ interface ShipFlags {
   issue?: number;
   timeoutS: number;
   pollS: number;
+  /** Name (substring, case-insensitive) of the advisory bot review to wait on
+   * before merging, e.g. `CodeRabbit`. Blank disables the wait. */
+  reviewCheck: string;
 }
 
 interface ShipFacts {
   branchProtectionSatisfied: boolean;
   changesRequested: boolean;
   checksGreen: boolean;
+  /** An advisory bot review (e.g. CodeRabbit) is registered but still in flight. */
+  advisoryReviewPending: boolean;
   reviewDecision: string;
   checkSummary: string;
 }
@@ -33,9 +41,17 @@ const SHIP_FLAG_SCHEMA = {
   issue: { kind: "value", aliases: ["i"], coerce: (raw: string): number => Number(raw) },
   "timeout-s": { kind: "value", coerce: (raw: string): number => Number(raw) },
   "poll-s": { kind: "value", coerce: (raw: string): number => Number(raw) },
+  "review-check": { kind: "value", coerce: (raw: string): string => raw },
+  "no-review-wait": { kind: "boolean" },
 } satisfies FlagSchema;
 
-function parseShipFlags(args: readonly string[]): ShipFlags {
+/**
+ * Resolve ship flags. `reviewCheck` is the advisory bot review to wait on before
+ * merging: an explicit `--review-check NAME` wins, else the repo's configured
+ * `afk.merge.review_check` (so `/ship` honors the same reviewer the AFK landing
+ * does), and `--no-review-wait` (or a blank name) disables the wait.
+ */
+function parseShipFlags(args: readonly string[], configReviewCheck: string): ShipFlags {
   const { values } = parseFlags(args, SHIP_FLAG_SCHEMA);
   const timeoutS = Number.isFinite(values["timeout-s"]) && Number(values["timeout-s"]) > 0
     ? Number(values["timeout-s"])
@@ -43,6 +59,9 @@ function parseShipFlags(args: readonly string[]): ShipFlags {
   const pollS = Number.isFinite(values["poll-s"]) && Number(values["poll-s"]) > 0
     ? Number(values["poll-s"])
     : 30;
+  const reviewCheck = values["no-review-wait"] === true
+    ? ""
+    : String((values["review-check"] as string | undefined) ?? configReviewCheck);
   return {
     base: String(values.base ?? "main"),
     remote: String(values.remote ?? "origin"),
@@ -50,6 +69,7 @@ function parseShipFlags(args: readonly string[]): ShipFlags {
     issue: Number.isFinite(values.issue) ? Number(values.issue) : undefined,
     timeoutS,
     pollS,
+    reviewCheck,
   };
 }
 
@@ -173,13 +193,15 @@ interface PrView {
   reviews?: Array<{ state?: string | null; author?: { login?: string | null } | null }>;
 }
 
-async function collectShipFacts(cwd: string, repo: string, pr: number): Promise<ShipFacts> {
+async function collectShipFacts(cwd: string, repo: string, pr: number, reviewCheck: string): Promise<ShipFacts> {
   const checksRes = await run("gh", ["pr", "checks", String(pr), "--repo", repo, "--json", "name,state,conclusion,bucket"], cwd);
   let checksGreen = false;
   let checkSummary = "checks unavailable";
+  let reviewPending = false;
   if (checksRes.code === 0) {
     const checks = parseJson<ShipCheck[]>(checksRes.stdout, []);
     checksGreen = shipChecksAreGreen(checks);
+    reviewPending = advisoryReviewPending(checks, reviewCheck);
     checkSummary = checks.length === 0 ? "no checks configured" : `${checks.filter((c) => shipChecksAreGreen([c])).length}/${checks.length} green`;
   } else if (/no checks/i.test(`${checksRes.stdout}\n${checksRes.stderr}`)) {
     checksGreen = true;
@@ -199,7 +221,7 @@ async function collectShipFacts(cwd: string, repo: string, pr: number): Promise<
     (view.reviews ?? []).some((review) => String(review.state ?? "").toUpperCase() === "CHANGES_REQUESTED");
   const branchProtectionSatisfied = reviewDecision !== "REVIEW_REQUIRED";
 
-  return { branchProtectionSatisfied, changesRequested, checksGreen, reviewDecision, checkSummary };
+  return { branchProtectionSatisfied, changesRequested, checksGreen, advisoryReviewPending: reviewPending, reviewDecision, checkSummary };
 }
 
 function hitlBody(pr: number, issue: number, reason: string, facts: ShipFacts): string {
@@ -249,7 +271,8 @@ export async function shipCommand(
   cwd = process.cwd(),
   stdout: NodeJS.WritableStream = process.stdout,
 ): Promise<number> {
-  const flags = parseShipFlags(args);
+  const config = loadConfig(afkPaths(cwd).configPath, { warn: () => undefined });
+  const flags = parseShipFlags(args, getConfig(config, "afk.merge.review_check"));
   const topLevel = await gitTopLevel(cwd);
   if (!isShipWorktreePath(topLevel)) {
     throw new Error("/ship must run from a .red/tmp/work-ship-*/ worktree");
@@ -270,18 +293,24 @@ export async function shipCommand(
   stdout.write(`/ship: PR #${pr} ready for #${issue}\n`);
 
   const deadline = Date.now() + flags.timeoutS * 1000;
-  let lastFacts = await collectShipFacts(cwd, repo, pr);
+  let lastFacts = await collectShipFacts(cwd, repo, pr, flags.reviewCheck);
   for (;;) {
     const timedOut = Date.now() >= deadline;
+    // Keep polling while CI is still running OR an advisory bot review (e.g.
+    // CodeRabbit) is registered but in flight — the AFK landing path waits for
+    // that reviewer to conclude, and `/ship` must not merge out from under it.
     if (
       !timedOut &&
       !lastFacts.changesRequested &&
       lastFacts.branchProtectionSatisfied &&
-      !lastFacts.checksGreen
+      (!lastFacts.checksGreen || lastFacts.advisoryReviewPending)
     ) {
-      stdout.write(`/ship: waiting (${lastFacts.checkSummary}); next poll in ${flags.pollS}s\n`);
+      const waitNote = lastFacts.advisoryReviewPending
+        ? `${lastFacts.checkSummary}; waiting on ${flags.reviewCheck} review`
+        : lastFacts.checkSummary;
+      stdout.write(`/ship: waiting (${waitNote}); next poll in ${flags.pollS}s\n`);
       await sleep(flags.pollS * 1000);
-      lastFacts = await collectShipFacts(cwd, repo, pr);
+      lastFacts = await collectShipFacts(cwd, repo, pr, flags.reviewCheck);
       continue;
     }
 

--- a/src/apps/dev/src/core/ship.ts
+++ b/src/apps/dev/src/core/ship.ts
@@ -29,9 +29,34 @@ export function decideShipMergeGate(input: ShipMergeGateInput): ShipMergeGateDec
 }
 
 export interface ShipCheck {
+  name?: string;
   state?: string;
   conclusion?: string;
   bucket?: string;
+}
+
+/**
+ * True when the named advisory review check (e.g. `CodeRabbit`) is registered
+ * on the PR but has not yet reached a terminal state. Mirrors the AFK landing
+ * path's `waitForReviewCheck` (core/merge.ts): `/ship` is the interactive
+ * sibling of that landing and must likewise hold until an advisory bot review
+ * concludes, rather than approving/merging out from under an in-flight reviewer.
+ *
+ * Fail-open by name: a check that never registers is NOT pending — an absent or
+ * misconfigured reviewer cannot wedge the finalizer. A blank `reviewCheck`
+ * disables the wait entirely. A check whose `state`/`conclusion`/`bucket` is
+ * still blank or `PENDING` counts as in-flight; anything else has concluded.
+ */
+export function advisoryReviewPending(checks: readonly ShipCheck[], reviewCheck: string): boolean {
+  const needle = reviewCheck.trim().toLowerCase();
+  if (needle === "") return false;
+  const match = checks.find((c) => String(c.name ?? "").toLowerCase().includes(needle));
+  if (match === undefined) return false;
+  const values = [match.state, match.conclusion, match.bucket]
+    .map((v) => String(v ?? "").trim().toUpperCase())
+    .filter(Boolean);
+  const concluded = values.some((v) => v !== "PENDING");
+  return !concluded;
 }
 
 const GREEN_CHECK_VALUES = new Set(["SUCCESS", "PASS", "PASSED", "NEUTRAL", "SKIPPED", "SKIPPING"]);

--- a/src/apps/dev/tests/cli-routing.test.ts
+++ b/src/apps/dev/tests/cli-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseCli } from "../src/cli.js";
+import { UnknownCommandError } from "@reddb-io/shared/args.js";
 
 describe("cli routing — native commands", () => {
   it("routes reap and __supervise without changing their args", () => {
@@ -53,5 +54,15 @@ describe("cli routing — native commands", () => {
 
   it("still defaults bare args to run", () => {
     expect(parseCli(["-n", "0"])).toEqual({ command: "run", args: ["-n", "0"] });
+  });
+
+  it("errors on a typo'd subcommand instead of launching a worker", () => {
+    expect(() => parseCli(["moniter"])).toThrow(UnknownCommandError);
+    expect(() => parseCli(["fleeet", "3"])).toThrow(/unknown command 'fleeet'/);
+  });
+
+  it("still routes flag-led and bare invocations to run (legacy /afk interface)", () => {
+    expect(parseCli(["--runner", "codex", "--once"])).toEqual({ command: "run", args: ["--runner", "codex", "--once"] });
+    expect(parseCli([])).toEqual({ command: "run", args: [] });
   });
 });

--- a/src/apps/dev/tests/run-flags.test.ts
+++ b/src/apps/dev/tests/run-flags.test.ts
@@ -36,6 +36,16 @@ describe("deriveStage (native-path monitor stage detection)", () => {
     expect(deriveStage(tool("Bash", "find . -name '*.ts'"))).toBe("explore");
   });
 
+  it("does not mislabel an explore/read of a 'test'-containing path as tests (#589)", () => {
+    expect(deriveStage(tool("Read", "src/components/test-utils.ts"))).toBe("explore");
+    expect(deriveStage(tool("Read", "src/foo.test.ts"))).toBe("explore");
+    expect(deriveStage(tool("Glob", "**/*.test.ts"))).toBe("explore");
+    // Editing a test file is implementation work, not a test run.
+    expect(deriveStage(tool("Edit", "src/foo.test.ts"))).toBe("impl");
+    // A real test-runner invocation is still tests.
+    expect(deriveStage(tool("Bash", "pnpm test src/foo.test.ts"))).toBe("tests");
+  });
+
   it("returns undefined for an unrecognised tool with no stage signal", () => {
     expect(deriveStage(tool("WebFetch", "https://example.com"))).toBeUndefined();
   });
@@ -91,6 +101,13 @@ describe("parseRunFlags", () => {
   it("parses --issues into an ordered number list", () => {
     expect(parseRunFlags(["--issues", "3,1,2"]).filter).toEqual({ kind: "issues", numbers: [3, 1, 2] });
     expect(parseRunFlags(["--issues=10, 20"]).filter).toEqual({ kind: "issues", numbers: [10, 20] });
+  });
+
+  it("throws RunFlagError on an all-invalid --issues value instead of selecting zero (#589)", () => {
+    expect(() => parseRunFlags(["--issues", "banana"])).toThrow(RunFlagError);
+    expect(() => parseRunFlags(["--issues", "banana,kiwi"])).toThrow(/at least one valid issue number/);
+    // A partially-valid list still parses (the valid numbers survive).
+    expect(parseRunFlags(["--issues", "banana,7"]).filter).toEqual({ kind: "issues", numbers: [7] });
   });
 
   it("parses -n cap, --once, --runner, --request", () => {

--- a/src/apps/dev/tests/ship.test.ts
+++ b/src/apps/dev/tests/ship.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  advisoryReviewPending,
   decideShipMergeGate,
   isShipWorktreePath,
   issueNumberFromBranch,
@@ -67,5 +68,29 @@ describe("ship helpers", () => {
     expect(isShipWorktreePath("/repo/.red/tmp/work-ship-abc/worktree")).toBe(true);
     expect(isShipWorktreePath("/repo/.red/tmp/work-ship-abc/worktree/plugins/dev")).toBe(true);
     expect(isShipWorktreePath("/repo/.red/tmp/work-abc/worktree")).toBe(false);
+  });
+});
+
+describe("advisoryReviewPending (#589 — /ship waits for in-flight advisory bot reviews)", () => {
+  it("is pending while the named review check is registered but in flight", () => {
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "PENDING" }], "CodeRabbit")).toBe(true);
+    // gh can report an as-yet-unstarted check with a blank state.
+    expect(advisoryReviewPending([{ name: "CodeRabbit" }], "CodeRabbit")).toBe(true);
+  });
+
+  it("is not pending once the review check has concluded (any verdict)", () => {
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "SUCCESS" }], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "FAILURE" }], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([{ name: "CodeRabbit", conclusion: "NEUTRAL" }], "CodeRabbit")).toBe(false);
+  });
+
+  it("fails open: an absent reviewer or a blank check name never wedges /ship", () => {
+    expect(advisoryReviewPending([{ name: "CI", state: "PENDING" }], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([], "CodeRabbit")).toBe(false);
+    expect(advisoryReviewPending([{ name: "CodeRabbit", state: "PENDING" }], "")).toBe(false);
+  });
+
+  it("matches the check by case-insensitive substring", () => {
+    expect(advisoryReviewPending([{ name: "coderabbitai[bot]", state: "PENDING" }], "coderabbit")).toBe(true);
   });
 });

--- a/src/packages/shared/args.test.ts
+++ b/src/packages/shared/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseFlags, parseLooseArgs, routeCommand, type FlagSchema, type RouterSchema } from "./args.js";
+import { parseFlags, parseLooseArgs, routeCommand, UnknownCommandError, type FlagSchema, type RouterSchema } from "./args.js";
 
 const SCHEMA = {
   prd: { kind: "value", coerce: (raw: string) => Number(raw) },
@@ -133,5 +133,29 @@ describe("routeCommand", () => {
   it("drops the leading token on default when keepArgvOnDefault is false", () => {
     const drop: RouterSchema<Cmd> = { commands: { run: {}, monitor: {}, fleet: {}, reap: {} }, default: "run", keepArgvOnDefault: false };
     expect(routeCommand(["weird", "--once"], drop)).toEqual({ command: "run", args: ["--once"] });
+  });
+
+  describe("errorOnUnknownCommand", () => {
+    const strict: RouterSchema<Cmd> = {
+      commands: { run: {}, monitor: {}, fleet: {}, reap: {} },
+      default: "run",
+      keepArgvOnDefault: true,
+      errorOnUnknownCommand: true,
+    };
+
+    it("throws on a typo'd subcommand (non-flag leading token)", () => {
+      expect(() => routeCommand(["moniter"], strict)).toThrow(UnknownCommandError);
+      expect(() => routeCommand(["fleeet", "3"], strict)).toThrow(/unknown command 'fleeet'/);
+    });
+
+    it("still routes flag-led and empty invocations to the default", () => {
+      expect(routeCommand(["--runner", "codex"], strict)).toEqual({ command: "run", args: ["--runner", "codex"] });
+      expect(routeCommand(["-n", "0"], strict)).toEqual({ command: "run", args: ["-n", "0"] });
+      expect(routeCommand([], strict)).toEqual({ command: "run", args: [] });
+    });
+
+    it("still peels a known command", () => {
+      expect(routeCommand(["monitor", "--once"], strict)).toEqual({ command: "monitor", args: ["--once"] });
+    });
   });
 });

--- a/src/packages/shared/args.ts
+++ b/src/packages/shared/args.ts
@@ -239,12 +239,13 @@ export interface RouterSchema<C extends string> {
  * rather than silently defaulting (which, for `run`, would launch a worker).
  */
 export class UnknownCommandError extends Error {
-  constructor(
-    readonly token: string,
-    readonly known: readonly string[],
-  ) {
+  readonly token: string;
+  readonly known: readonly string[];
+  constructor(token: string, known: readonly string[]) {
     super(`unknown command '${token}'; expected one of: ${known.join(", ")}`);
     this.name = "UnknownCommandError";
+    this.token = token;
+    this.known = known;
   }
 }
 

--- a/src/packages/shared/args.ts
+++ b/src/packages/shared/args.ts
@@ -222,6 +222,30 @@ export interface RouterSchema<C extends string> {
    * still dropped.
    */
   keepArgvOnDefault?: boolean;
+  /**
+   * When true, a leading token that is a non-flag positional (does not start
+   * with `-`) and matches no command throws {@link UnknownCommandError} instead
+   * of falling through to `default`. Flag-led (`--prd …`) and empty invocations
+   * still reach the default command — only a typo'd subcommand errors. Off by
+   * default to preserve the permissive fall-through.
+   */
+  errorOnUnknownCommand?: boolean;
+}
+
+/**
+ * Raised by {@link routeCommand} when `errorOnUnknownCommand` is set and the
+ * leading token looks like a subcommand (a non-flag positional) but matches no
+ * known command — e.g. a typo such as `moniter`. Lets the CLI fail loudly
+ * rather than silently defaulting (which, for `run`, would launch a worker).
+ */
+export class UnknownCommandError extends Error {
+  constructor(
+    readonly token: string,
+    readonly known: readonly string[],
+  ) {
+    super(`unknown command '${token}'; expected one of: ${known.join(", ")}`);
+    this.name = "UnknownCommandError";
+  }
 }
 
 /**
@@ -230,7 +254,9 @@ export interface RouterSchema<C extends string> {
  * If the first token matches a command name (or alias), returns that command
  * with the remaining args. Otherwise routes to `schema.default`; by default the
  * full argv is preserved (so a bare `--flag …` invocation still reaches the
- * default command with all its flags).
+ * default command with all its flags). With `errorOnUnknownCommand`, a leading
+ * non-flag positional that matches no command throws {@link UnknownCommandError}
+ * instead.
  */
 export function routeCommand<C extends string>(
   argv: readonly string[],
@@ -242,6 +268,11 @@ export function routeCommand<C extends string>(
       if (first === name || (spec.aliases ?? []).includes(first)) {
         return { command: name, args: rest };
       }
+    }
+    // A non-flag leading token that matched no command is a typo'd subcommand,
+    // not flags for the default command — error rather than silently default.
+    if (schema.errorOnUnknownCommand && !first.startsWith("-")) {
+      throw new UnknownCommandError(first, Object.keys(schema.commands));
     }
   }
   const keepArgv = schema.keepArgvOnDefault ?? true;


### PR DESCRIPTION
Fixes #589

## Summary

- **CLI guard**: `afk moniter` (typo'd subcommand) now errors with `UnknownCommandError` instead of silently draining the queue as a `run` invocation. New `RouterSchema.errorOnUnknownCommand` gate in shared router. Flag-led (`--prd …`) and empty invocations still reach `run` as before.
- **`--issues` validation**: an all-invalid value (zero finite numbers parsed) now throws `RunFlagError` instead of producing `{ numbers: [] }` and silently draining only urgents.
- **`monitor` side-effect-free**: the #407 recovery watchdog is now opt-in (`--watchdog` / `RED_AFK_WATCHDOG=1`). Read-only `monitor` invocations no longer tear down and relaunch a quiescent supervisor.
- **`ship` review wait**: waits for an in-flight advisory bot review (`afk.merge.review_check`, default CodeRabbit) to conclude before merging — parity with the AFK landing path. `--review-check NAME` / `--no-review-wait` control it. Fail-open, time-capped.
- **`deriveStage` classification**: file-tool name classification (read/grep/glob → explore, edit/write → impl) now wins over the loose `args 'test'` match, so reading a path containing `'test'` is no longer mislabeled as the `tests` stage.

## Tests

52 tests across `cli-routing`, `run-flags`, `ship`, `feedback-worktree` + 24 in shared `args` — all pass.

## Notes

Forward-port of worker w36PD's work on branch `afk/w36PD/589-fix-afk-cli-ergonomics-and-safety-no-acc`. The original branch had 33 commits of drift and conflicted with main; this cherry-picks the fix commit cleanly onto current main.

Closes #589

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783721109&installation_id=129708444&pr_number=668&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F668&signature=49c1043fd73c5ab9f31a799845ae66123cba4eb21c6fc68928acb6693827e435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/ship` flags to control advisory bot review waiting behavior.

* **Improvements**
  * `/ship` now continues waiting while an advisory review is still pending and treats missing reviewer names as fail-open.
  * CLI now rejects mistyped subcommands with a clear error and exit.
  * Monitor watchdog is opt-in via `--watchdog`.
  * `run` validates `--issues` and improves stage classification for test detection.

* **Documentation**
  * Updated `/ship` docs to document new flags and wait semantics.

* **Tests**
  * Added tests for routing, flag validation, stage detection, and advisory-review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->