### PR TITLE
chore(legacy): remove dead exports and orphan build path

### DIFF
--- a/src/apps/dev/package.json
+++ b/src/apps/dev/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "dev": "node --import tsx src/cli.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "compile": "tsc -p tsconfig.build.json",
     "bundle": "node ../../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../../dist/dev.bundle.min.mjs --asset dev.bundle.min.mjs --minify",
     "bundle:red-fetch": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"fetch\"' --outfile=../../../plugins/dev/hooks/red-fetch.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "bundle:entrypoint": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"run:dev\"' --outfile=../../../plugins/dev/skills/engineering/afk/bin/afk.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",

--- a/src/apps/dev/src/core/jsonl-log.ts
+++ b/src/apps/dev/src/core/jsonl-log.ts
@@ -25,12 +25,6 @@ import { dirname } from "node:path";
 /** Canonical envelope field order, mirroring the bash schema exactly. */
 export const ENVELOPE_FIELD_ORDER = ["ts", "lvl", "worker", "issue", "attempt", "type", "msg"] as const;
 
-/**
- * Synthetic record types: orchestrator-authored kinds that must never appear on
- * the agent lane (which carries inner-agent output only).
- */
-export const SYNTHETIC_TYPES = ["boot", "heartbeat", "iteration", "promotion", "envelope", "audit", "stamp"] as const;
-
 /** Keys the caller may never set via the `extra` fields map; the module owns them. */
 const RESERVED_KEYS = new Set(["type", "msg", "ts"]);
 

--- a/src/apps/dev/src/types/state.ts
+++ b/src/apps/dev/src/types/state.ts
@@ -56,4 +56,3 @@ export const AfkStateSchema = z.object({
 });
 
 export type AfkState = z.infer<typeof AfkStateSchema>;
-export type AfkCurrent = z.infer<typeof AfkCurrentSchema>;

--- a/src/apps/dev/tsconfig.build.json
+++ b/src/apps/dev/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": false,
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["src"]
-}


### PR DESCRIPTION
## Summary

- Drop `SYNTHETIC_TYPES` from `jsonl-log.ts` — exported but never imported anywhere
- Drop `AfkCurrent` type from `state.ts` — exported but never imported anywhere  
- Remove `compile` script and `tsconfig.build.json` from dev app — build goes through esbuild bundles, not tsc emit; the compile script was never called by `build`, CI, or any other script

## Acceptance criteria
- [x] `SYNTHETIC_TYPES` and `AfkCurrent` confirmed unreferenced and removed
- [x] Orphan `compile` script + `tsconfig.build.json` removed (rationale: build path is esbuild, not tsc emit)
- [x] Typecheck passes; 83/84 test files pass (1 known OOM in supervisor.test.ts, pre-existing on main)

Closes #598

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783723780&installation_id=129708444&pr_number=669&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F669&signature=584b6444a68d83a1c5d1567122b450b5175133ffd21a3ece9281c3b4b03ffb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed build script and related TypeScript configuration from the development environment
  * Cleaned up internal module exports by removing unused type aliases and constants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->