### PR TITLE
refactor(core): extract triage-labels.ts as single shared vocabulary owner

### DIFF
--- a/src/apps/dev/src/commands/activity-review.ts
+++ b/src/apps/dev/src/commands/activity-review.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { LABEL_HUMAN } from "../core/triage-labels.js";
 import {
   activityReviewInterval,
   buildActivityReviewReport,
@@ -134,7 +135,7 @@ function shouldFetchIssueComments(issue: ActivityReviewIssue, start: Date, end: 
   return (
     dateInRange(issue.createdAt, start, end) ||
     dateInRange(issue.closedAt, start, end) ||
-    labels.includes("ready-for-human") ||
+    labels.includes(LABEL_HUMAN) ||
     labels.some((label) => label.startsWith("blocked:"))
   );
 }

--- a/src/apps/dev/src/commands/run.ts
+++ b/src/apps/dev/src/commands/run.ts
@@ -33,6 +33,7 @@ import {
 import type { LaneIdleStallConfig } from "../core/lane-idle-reaper.js";
 import { workerDir as workerDirPath, workerPidFile } from "../core/worker-paths.js";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { LABEL_HUMAN, LABEL_RUNNING } from "../core/triage-labels.js";
 import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import * as fsx from "../runtime/fs.js";
@@ -416,10 +417,10 @@ async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: numbe
       orphanState: async (issue) => {
         const row = issueStates.get(issue);
         if (!row) return ghx.orphanState(ghCtx, issue);
-        const label = row.labels.includes("ready-for-human")
-          ? "ready-for-human"
-          : row.labels.includes("running")
-            ? "running"
+        const label = row.labels.includes(LABEL_HUMAN)
+          ? LABEL_HUMAN
+          : row.labels.includes(LABEL_RUNNING)
+            ? LABEL_RUNNING
             : null;
         return { ghOk: true, state: row.state, label, envelopePosted: false };
       },

--- a/src/apps/dev/src/commands/ship.ts
+++ b/src/apps/dev/src/commands/ship.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { LABEL_HUMAN } from "../core/triage-labels.js";
 import { execTool, type ExecOutput } from "../runtime/exec.js";
 import {
   advisoryReviewPending,
@@ -240,10 +241,10 @@ function hitlBody(pr: number, issue: number, reason: string, facts: ShipFacts): 
 
 async function markHitl(cwd: string, repo: string, pr: number, issue: number, reason: string, facts: ShipFacts): Promise<void> {
   const body = hitlBody(pr, issue, reason, facts);
-  await run("gh", ["label", "create", "ready-for-human", "--repo", repo, "--color", "FBCA04", "--description", "Waiting for a human decision"], cwd);
+  await run("gh", ["label", "create", LABEL_HUMAN, "--repo", repo, "--color", "FBCA04", "--description", "Waiting for a human decision"], cwd);
   await run("gh", ["issue", "comment", String(issue), "--repo", repo, "--body", body], cwd);
-  await run("gh", ["issue", "edit", String(issue), "--repo", repo, "--add-label", "ready-for-human"], cwd);
-  await run("gh", ["pr", "edit", String(pr), "--repo", repo, "--add-label", "ready-for-human"], cwd);
+  await run("gh", ["issue", "edit", String(issue), "--repo", repo, "--add-label", LABEL_HUMAN], cwd);
+  await run("gh", ["pr", "edit", String(pr), "--repo", repo, "--add-label", LABEL_HUMAN], cwd);
   await run("gh", ["pr", "comment", String(pr), "--repo", repo, "--body", body], cwd);
 }
 

--- a/src/apps/dev/src/core/activity-review.ts
+++ b/src/apps/dev/src/core/activity-review.ts
@@ -1,4 +1,5 @@
 import type { HistoryRecord } from "./history.js";
+import { LABEL_HUMAN } from "./triage-labels.js";
 
 export type ActivityReviewKind = "daily" | "weekly";
 
@@ -163,7 +164,7 @@ function lowerLabels(labels: readonly string[]): string[] {
 
 function isHitlOrBlocked(issue: ActivityReviewIssue): boolean {
   const labels = lowerLabels(issue.labels);
-  if (labels.includes("ready-for-human")) return true;
+  if (labels.includes(LABEL_HUMAN)) return true;
   if (labels.some((label) => label.startsWith("blocked:"))) return true;
   const text = [
     issue.body ?? "",

--- a/src/apps/dev/src/core/attempt-outcome.ts
+++ b/src/apps/dev/src/core/attempt-outcome.ts
@@ -22,6 +22,17 @@
 // envelope status, so the multi-enum-desync bug class becomes impossible.
 
 import type { AttemptStatus } from "./envelope.js";
+import {
+  LABEL_QUOTA,
+  LABEL_RUNNER_TRANSIENT,
+  LABEL_MERGE_CONFLICT,
+  LABEL_SPEC,
+  LABEL_VALIDATION,
+  LABEL_CRASHED,
+  LABEL_POLICY,
+  LABEL_STALLED,
+  LABEL_INFRA,
+} from "./triage-labels.js";
 
 /**
  * Every terminal ending an AFK iteration can have — the UNION of what
@@ -72,23 +83,23 @@ export type RecoveryReason = "quota" | "runner-transient" | "merge-conflict" | "
 export function blockedLabelFor(o: AttemptOutcome): string | null {
   switch (o) {
     case "exhausted":
-      return "blocked:quota";
+      return LABEL_QUOTA;
     case "runner-transient":
-      return "blocked:runner-transient";
+      return LABEL_RUNNER_TRANSIENT;
     case "merge-conflict":
-      return "blocked:merge-conflict";
+      return LABEL_MERGE_CONFLICT;
     case "blocked":
-      return "blocked:spec";
+      return LABEL_SPEC;
     case "feedback-failed":
-      return "blocked:validation";
+      return LABEL_VALIDATION;
     case "no-sentinel":
-      return "blocked:crashed";
+      return LABEL_CRASHED;
     case "hook-aborted":
-      return "blocked:policy";
+      return LABEL_POLICY;
     case "stalled":
-      return "blocked:stalled";
+      return LABEL_STALLED;
     case "infra":
-      return "blocked:infra";
+      return LABEL_INFRA;
     case "done":
     case "claim-lost":
       return null;

--- a/src/apps/dev/src/core/boot-sweep.ts
+++ b/src/apps/dev/src/core/boot-sweep.ts
@@ -26,6 +26,8 @@
 
 /** The literal `## Blocked by` heading line, allowing only trailing whitespace.
  * Mirrors awk `/^## Blocked by[[:space:]]*$/`. */
+import { LABEL_STALLED, LABEL_CRASHED, LABEL_DEPENDENCY } from "./triage-labels.js";
+
 const BLOCKED_BY_HEADING_RE = /^## Blocked by[ \t]*$/;
 /** Any `## ` heading — the awk `/^## /` that closes the Blocked-by section. */
 const ANY_H2_RE = /^## /;
@@ -204,7 +206,7 @@ export async function planUnblockSweep(
   const plans: PromotionPlan[] = [];
   for (const candidate of candidates) {
     const labels = candidate.labels ?? [];
-    if (!labels.includes("blocked:dependency")) continue;
+    if (!labels.includes(LABEL_DEPENDENCY)) continue;
 
     const reqIds = parseReqLabels(labels);
 
@@ -309,7 +311,7 @@ export function findOwnedBranch(branches: readonly string[], issue: number): str
 
 /** The labels that mark a parked-mechanical issue: the attempt-progress guard
  * fired (`blocked:stalled`) or the agent process crashed (`blocked:crashed`). */
-const PARKED_MECHANICAL_LABELS = new Set(["blocked:stalled", "blocked:crashed"]);
+const PARKED_MECHANICAL_LABELS = new Set([LABEL_STALLED, LABEL_CRASHED]);
 
 /**
  * True when the label set carries a parked-mechanical routing label

--- a/src/apps/dev/src/core/boot.ts
+++ b/src/apps/dev/src/core/boot.ts
@@ -41,6 +41,7 @@ import {
   type ReconcileSweepCandidate,
   type ReconcileSweepPlan,
 } from "./boot-sweep.js";
+import { LABEL_READY, LABEL_RUNNING, LABEL_HUMAN, LABEL_DEPENDENCY } from "./triage-labels.js";
 
 // ---------- precheck (hard preconditions) ----------
 
@@ -455,7 +456,7 @@ async function runOrphanCleanup(
         await deps.fs.removeDir(dir.path);
         removed.push(dir.path);
       } else {
-        await deps.gh.editLabels(dir.issue!, ["running"], ["ready-for-agent"]);
+        await deps.gh.editLabels(dir.issue!, [LABEL_RUNNING], [LABEL_READY]);
         await deps.gh.comment(
           dir.issue!,
           "🤖 /afk orchestrator died mid-issue; restoring ready-for-agent.",
@@ -568,8 +569,8 @@ async function runUnblockSweep(
   const promoted: number[] = [];
   for (const p of plans) {
     const held = labelsByIssue.get(p.number) ?? [];
-    const remove = held.includes("blocked:dependency") ? "blocked:dependency" : "ready-for-human";
-    await deps.gh.editLabels(p.number, [remove], ["ready-for-agent"]);
+    const remove = held.includes(LABEL_DEPENDENCY) ? LABEL_DEPENDENCY : LABEL_HUMAN;
+    await deps.gh.editLabels(p.number, [remove], [LABEL_READY]);
     await deps.gh.comment(p.number, p.comment);
     promoted.push(p.number);
   }

--- a/src/apps/dev/src/core/dashboard.ts
+++ b/src/apps/dev/src/core/dashboard.ts
@@ -1,3 +1,5 @@
+import { LABEL_PRD, LABEL_VALIDATION, LABEL_RUNNING } from "./triage-labels.js";
+
 export interface DashboardIssue {
   number: number;
   title: string;
@@ -114,7 +116,7 @@ function hasLabel(issue: DashboardIssue, predicate: (label: string) => boolean):
 
 function isPrd(issue: DashboardIssue): boolean {
   return (
-    hasLabel(issue, (label) => label === "type:prd" || label === "prd") ||
+    hasLabel(issue, (label) => label === LABEL_PRD || label === "prd") ||
     /^prd\b/i.test(issue.title.trim())
   );
 }
@@ -126,7 +128,7 @@ function isFailureLike(issue: DashboardIssue): boolean {
     label === "regression" ||
     label === "incident" ||
     label === "type:incident" ||
-    label === "blocked:validation",
+    label === LABEL_VALIDATION,
   );
 }
 
@@ -201,7 +203,7 @@ export function buildDashboardReport(input: DashboardInput): DashboardReport {
     operations: {
       open_prds: openPrds.length,
       open_issues: openNonPrdIssues.length,
-      global_running_workers: openIssues.filter((issue) => issue.labels.includes("running")).length,
+      global_running_workers: openIssues.filter((issue) => issue.labels.includes(LABEL_RUNNING)).length,
       local_workers: input.localWorkers,
       issues_created_in_period: createdInPeriod.length,
       issues_closed_today: input.issues.filter((issue) => sameUtcDay(parseDate(issue.closedAt), today)).length,

--- a/src/apps/dev/src/core/hitl-resolution-plan.ts
+++ b/src/apps/dev/src/core/hitl-resolution-plan.ts
@@ -1,5 +1,6 @@
 import type { HitlDecisionExtraction } from "./hitl-decision-extraction.js";
 import { clearCurrentBlocker, parseCurrentBlocker, upsertCurrentBlocker } from "./blocker-state.js";
+import { LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
 
 export interface HitlResolutionIssue {
   number: number;
@@ -104,8 +105,8 @@ export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPl
     return {
       commentBody: directiveComment(input),
       bodyUpdate: upsertMarkdownSection(cleared, "Agent brief", input.disposition.agentBrief),
-      addLabels: ["ready-for-agent"],
-      removeLabels: ["ready-for-human", ...staleBlockerLabels(input.issue.labels)],
+      addLabels: [LABEL_READY],
+      removeLabels: [LABEL_HUMAN, ...staleBlockerLabels(input.issue.labels)],
     };
   }
 
@@ -117,7 +118,7 @@ export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPl
       summary: input.decision.kind === "pending-decision" ? input.decision.prompt : input.decision.prompt,
       next: input.disposition.nextPendingDecision,
     }),
-    addLabels: ["ready-for-human"],
+    addLabels: [LABEL_HUMAN],
     removeLabels: [],
   };
 }

--- a/src/apps/dev/src/core/hitl-selection.ts
+++ b/src/apps/dev/src/core/hitl-selection.ts
@@ -10,10 +10,7 @@ export interface HitlSelectionOptions {
   skipped?: readonly number[];
 }
 
-const LABEL_HUMAN = "ready-for-human";
-const LABEL_PRD = "type:prd";
-const LABEL_URGENT = "priority:urgent";
-const LABEL_HIGH = "priority:high";
+import { LABEL_HUMAN, LABEL_PRD, LABEL_URGENT, LABEL_HIGH } from "./triage-labels.js";
 
 function hasLabel(candidate: HitlCandidate, label: string): boolean {
   return candidate.labels.includes(label);

--- a/src/apps/dev/src/core/process-issue.ts
+++ b/src/apps/dev/src/core/process-issue.ts
@@ -400,9 +400,7 @@ export interface ProcessIssueResult {
 
 // ---------- the orchestration ----------
 
-const LABEL_READY = "ready-for-agent";
-const LABEL_RUNNING = "running";
-const LABEL_HUMAN = "ready-for-human";
+import { LABEL_READY, LABEL_RUNNING, LABEL_HUMAN, LABEL_DEPENDENCY } from "./triage-labels.js";
 
 /**
  * The typed `blocked:*` labels present in a label set (#402). Promoting an issue
@@ -1398,7 +1396,7 @@ async function runCloseCascade(deps: ProcessIssueDeps, closedIssue: number): Pro
 
     const plans = planCloseCascade(closedIssue, dependents);
     for (const p of plans) {
-      await deps.gh.editLabels(p.number, ["blocked:dependency"], [LABEL_READY]);
+      await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY], [LABEL_READY]);
       await deps.gh.comment(p.number, p.comment);
     }
   } catch (err) {

--- a/src/apps/dev/src/core/reclaim.ts
+++ b/src/apps/dev/src/core/reclaim.ts
@@ -11,6 +11,7 @@
 // shared worker-paths.ts parser so the nested layout stays single-sourced.
 
 import { parseWorkerAttemptPath } from "./worker-paths.js";
+import { LABEL_HUMAN, LABEL_RUNNING } from "./triage-labels.js";
 
 /** Orphan TTLs (afk.sh TTL_LONG / TTL_SHORT). */
 export const ORPHAN_TTL_LONG_S = 7 * 86400;
@@ -84,13 +85,13 @@ export function decideOrphanFate(input: OrphanInput): OrphanFate {
     };
   }
   if (input.issueState === "CLOSED") return { kind: "remove" };
-  if (input.label === "ready-for-human") {
+  if (input.label === LABEL_HUMAN) {
     return {
       kind: "keep-until",
       ttlS: input.envelopePosted ? ORPHAN_TTL_SHORT_S : ORPHAN_TTL_LONG_S,
     };
   }
-  if (input.label === "running") return { kind: "restore-and-remove" };
+  if (input.label === LABEL_RUNNING) return { kind: "restore-and-remove" };
   return { kind: "remove" };
 }
 

--- a/src/apps/dev/src/core/reconcile.ts
+++ b/src/apps/dev/src/core/reconcile.ts
@@ -48,10 +48,15 @@ import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-
 import type { HistoryClock } from "./history.js";
 import type { Runner } from "../types/runner.js";
 
-const LABEL_READY = "ready-for-agent";
-const LABEL_RUNNING = "running";
-const LABEL_HUMAN = "ready-for-human";
-const LABEL_VALIDATION = "blocked:validation";
+import {
+  LABEL_READY,
+  LABEL_RUNNING,
+  LABEL_HUMAN,
+  LABEL_VALIDATION,
+  LABEL_DEPENDENCY,
+  LABEL_MERGE_CONFLICT,
+  LABEL_SPEC,
+} from "./triage-labels.js";
 
 /**
  * The blocked-failure classes reconcile is allowed to act on: MECHANICAL ones
@@ -68,7 +73,7 @@ const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-conflict"
  * `blocked:validation` means a prior gate already failed for a reason a human
  * must resolve, so re-running the same gate is pointless.
  */
-const NON_MECHANICAL_LABELS = ["blocked:spec", LABEL_VALIDATION];
+const NON_MECHANICAL_LABELS = [LABEL_SPEC, LABEL_VALIDATION];
 
 // ---------- injected IO ----------
 
@@ -391,8 +396,8 @@ async function parkMergeConflict(
   startedEpoch: number,
 ): Promise<ReconcileResult> {
   const { issue, labels } = input;
-  await deps.gh.ensureLabel("blocked:merge-conflict");
-  await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, "blocked:merge-conflict"]);
+  await deps.gh.ensureLabel(LABEL_MERGE_CONFLICT);
+  await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, LABEL_MERGE_CONFLICT]);
   const posted = await emitFailure(deps, input, "merge-conflict", startedEpoch, {
     log: `reconcile land failed: ${reason}`,
   });
@@ -414,7 +419,7 @@ function parkDropLabels(labels: string[]): string[] {
     (l) =>
       l === LABEL_RUNNING ||
       l === LABEL_READY ||
-      (l.startsWith("blocked:") && l !== LABEL_VALIDATION && l !== "blocked:merge-conflict"),
+      (l.startsWith("blocked:") && l !== LABEL_VALIDATION && l !== LABEL_MERGE_CONFLICT),
   );
 }
 
@@ -555,7 +560,7 @@ async function runCloseCascade(deps: ReconcileDeps, closedIssue: number): Promis
     }
 
     for (const p of planCloseCascade(closedIssue, dependents)) {
-      await deps.gh.editLabels(p.number, ["blocked:dependency"], [LABEL_READY]);
+      await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY], [LABEL_READY]);
       await deps.gh.comment(p.number, p.comment);
     }
   } catch (err) {

--- a/src/apps/dev/src/core/retake.ts
+++ b/src/apps/dev/src/core/retake.ts
@@ -1,4 +1,5 @@
 import { issueNumberFromBranch } from "./ship.js";
+import { LABEL_HUMAN } from "./triage-labels.js";
 
 export interface RetakeIssue {
   number: number;
@@ -155,7 +156,7 @@ export function recommendRetake(facts: RetakeFacts): RetakeRecommendation {
   const matchingWorktrees = facts.worktrees.filter((worktree) => worktreeMatchesIssue(worktree, facts.issue.number));
   const dirtyWorktree = matchingWorktrees.find((worktree) => worktree.dirty);
 
-  if (labels.has("ready-for-human")) {
+  if (labels.has(LABEL_HUMAN)) {
     return {
       kind: "resolve-hitl",
       summary: "Issue is waiting for a human decision before agents can continue.",

--- a/src/apps/dev/src/core/session.ts
+++ b/src/apps/dev/src/core/session.ts
@@ -73,10 +73,7 @@ export type SelectionFilter =
   | { kind: "issues"; numbers: number[] }
   | { kind: "prd"; prd: number };
 
-const LABEL_PRD = "type:prd";
-const LABEL_URGENT = "priority:urgent";
-const LABEL_HIGH = "priority:high";
-const LABEL_READY = "ready-for-agent";
+import { LABEL_PRD, LABEL_URGENT, LABEL_HIGH, LABEL_READY } from "./triage-labels.js";
 
 function hasLabel(c: IssueCandidate, label: string): boolean {
   return c.labels.includes(label);

--- a/src/apps/dev/src/core/supervisor.ts
+++ b/src/apps/dev/src/core/supervisor.ts
@@ -18,6 +18,12 @@ import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from ".
 import { buildEnvelope } from "./envelope.js";
 import { blockedLabelFor } from "./attempt-outcome.js";
 import { recoveryCap, recoveryDecision, type RecoveryEnv } from "./recovery.js";
+import {
+  LABEL_READY,
+  LABEL_RUNNING,
+  LABEL_HUMAN,
+  LABEL_RUNNER_ERROR,
+} from "./triage-labels.js";
 
 // ---------- tunables ----------
 
@@ -752,8 +758,8 @@ export async function sweepParkedSlot(
         await deps.gh.comment(pair.issue, body);
         await deps.gh.editLabels(
           pair.issue,
-          ["ready-for-agent", "runner-error"],
-          ["ready-for-human", "running"],
+          [LABEL_READY, LABEL_RUNNER_ERROR],
+          [LABEL_HUMAN, LABEL_RUNNING],
         );
       }
       await deps.fs.removeDir(pair.dir);
@@ -812,14 +818,14 @@ export async function reapStalledSlot(
     const env = deps.recoveryEnv ?? {};
     const decision = recoveryDecision("stalled", info.attempt, env);
     if (decision === "retry") {
-      await deps.gh.editLabels(info.issue, ["ready-for-agent"], ["running"]);
+      await deps.gh.editLabels(info.issue, [LABEL_READY], [LABEL_RUNNING]);
     } else {
       const typed = blockedLabelFor("stalled");
       if (typed !== null) await deps.gh.ensureLabel(typed);
       await deps.gh.editLabels(
         info.issue,
-        typed !== null ? ["ready-for-human", typed] : ["ready-for-human"],
-        ["running", "ready-for-agent"],
+        typed !== null ? [LABEL_HUMAN, typed] : [LABEL_HUMAN],
+        [LABEL_RUNNING, LABEL_READY],
       );
       const cap = recoveryCap("stalled", env);
       if (cap !== null) {

--- a/src/apps/dev/src/core/triage-labels.ts
+++ b/src/apps/dev/src/core/triage-labels.ts
@@ -1,0 +1,32 @@
+// triage-labels — canonical string constants for the GitHub issue triage-label vocabulary.
+//
+// Every module that references a triage label (routing, blocked reason, priority, or
+// type) must import from here. Never redefine these inline or as local consts — doing
+// so creates the drift-prone duplication this module was extracted to eliminate.
+//
+// The authoritative human-readable vocab spec is .red/agents/triage-labels.md.
+
+// Lifecycle routing labels
+export const LABEL_READY = "ready-for-agent";
+export const LABEL_RUNNING = "running";
+export const LABEL_HUMAN = "ready-for-human";
+
+// Priority / type labels
+export const LABEL_PRD = "type:prd";
+export const LABEL_URGENT = "priority:urgent";
+export const LABEL_HIGH = "priority:high";
+
+// Blocked reason labels
+export const LABEL_VALIDATION = "blocked:validation";
+export const LABEL_STALLED = "blocked:stalled";
+export const LABEL_CRASHED = "blocked:crashed";
+export const LABEL_DEPENDENCY = "blocked:dependency";
+export const LABEL_SPEC = "blocked:spec";
+export const LABEL_QUOTA = "blocked:quota";
+export const LABEL_RUNNER_TRANSIENT = "blocked:runner-transient";
+export const LABEL_MERGE_CONFLICT = "blocked:merge-conflict";
+export const LABEL_POLICY = "blocked:policy";
+export const LABEL_INFRA = "blocked:infra";
+
+// Auxiliary labels
+export const LABEL_RUNNER_ERROR = "runner-error";

--- a/src/apps/dev/src/runtime/gh.ts
+++ b/src/apps/dev/src/runtime/gh.ts
@@ -7,6 +7,14 @@
 // Best-effort writes swallow failures (the bash orchestrator's `|| true`).
 
 import { execTool, type ExecOptions, type ExecFn, type ExecOutput } from "./exec.js";
+import {
+  LABEL_READY,
+  LABEL_HUMAN,
+  LABEL_RUNNING,
+  LABEL_DEPENDENCY,
+  LABEL_STALLED,
+  LABEL_CRASHED,
+} from "../core/triage-labels.js";
 import type { IssueCandidate } from "../core/session.js";
 import type { HitlCandidate } from "../core/hitl-selection.js";
 import type { IssueMeta } from "../core/branch-cleanup.js";
@@ -104,7 +112,7 @@ export async function listCandidates(ctx: GhContext): Promise<IssueCandidate[]> 
       "list",
       ...repoArgs(ctx),
       "--label",
-      "ready-for-agent",
+      LABEL_READY,
       "--state",
       "open",
       "--limit",
@@ -140,7 +148,7 @@ export async function listHitlCandidates(ctx: GhContext): Promise<HitlCandidate[
       "list",
       ...repoArgs(ctx),
       "--label",
-      "ready-for-human",
+      LABEL_HUMAN,
       "--state",
       "open",
       "--limit",
@@ -406,10 +414,10 @@ export async function orphanState(
     const parsed = JSON.parse(r.stdout) as { state?: string; labels?: Array<{ name?: string }> };
     const labels = Array.isArray(parsed.labels) ? parsed.labels.map((l) => String(l.name ?? "")) : [];
     // afk.sh checks ready-for-human first, then running.
-    const label = labels.includes("ready-for-human")
-      ? "ready-for-human"
-      : labels.includes("running")
-        ? "running"
+    const label = labels.includes(LABEL_HUMAN)
+      ? LABEL_HUMAN
+      : labels.includes(LABEL_RUNNING)
+        ? LABEL_RUNNING
         : null;
     return { ghOk: true, state: String(parsed.state ?? "OPEN"), label, envelopePosted: false };
   } catch {
@@ -461,12 +469,12 @@ export async function countUnlabeled(ctx: GhContext): Promise<number> {
 
 /** Count open `ready-for-agent` issues (the 📋 statusline queue count). */
 export function countReadyForAgent(ctx: GhContext): Promise<number> {
-  return countIssues(ctx, ["--label", "ready-for-agent"]);
+  return countIssues(ctx, ["--label", LABEL_READY]);
 }
 
 /** Count open `ready-for-human` issues (the 🆘 statusline count). */
 export function countReadyForHuman(ctx: GhContext): Promise<number> {
-  return countIssues(ctx, ["--label", "ready-for-human"]);
+  return countIssues(ctx, ["--label", LABEL_HUMAN]);
 }
 
 /** Count `needs-triage` straggler issues. */
@@ -489,7 +497,7 @@ export async function listUnblockCandidates(ctx: GhContext): Promise<UnblockCand
       "list",
       ...repoArgs(ctx),
       "--label",
-      "blocked:dependency",
+      LABEL_DEPENDENCY,
       "--state",
       "open",
       "--limit",
@@ -566,8 +574,8 @@ export async function listParkedMechanicalCandidates(
   ctx: GhContext,
 ): Promise<ReconcileSweepCandidate[]> {
   const [stalled, crashed] = await Promise.all([
-    listIssuesByLabel(ctx, "blocked:stalled"),
-    listIssuesByLabel(ctx, "blocked:crashed"),
+    listIssuesByLabel(ctx, LABEL_STALLED),
+    listIssuesByLabel(ctx, LABEL_CRASHED),
   ]);
   const seen = new Set<number>();
   const result: ReconcileSweepCandidate[] = [];


### PR DESCRIPTION
## Summary
- Extracts `src/apps/dev/src/core/triage-labels.ts` as the single canonical owner of triage-label string constants
- Removes all duplicated local `LABEL_*` consts from core modules (`process-issue`, `supervisor`, `boot`, `reconcile`, etc.)
- All call sites now import from the shared module

## Related
Closes #599
Parent: #567

## Test plan
- [ ] `pnpm --filter @reddb-io/dev test` passes (1208 tests; one pre-existing supervisor.test.ts OOM unrelated to this change)
- [ ] No local `LABEL_*` const definitions remain outside `triage-labels.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783726712&installation_id=129708444&pr_number=670&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F670&signature=326d485bd2d4d5ee4d660d1a77a56e758466c2eeb4d6a30d6c9da716c56972df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated triage label definitions to a centralized module for consistent usage across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->