### PR TITLE
refactor(core): single shared owner for the triage-label vocabulary

### DIFF
--- a/src/apps/dev/src/runtime/gh.ts
+++ b/src/apps/dev/src/runtime/gh.ts
@@ -14,6 +14,7 @@ import {
   LABEL_DEPENDENCY,
   LABEL_STALLED,
   LABEL_CRASHED,
+  LABEL_RUNNER_ERROR,
 } from "../core/triage-labels.js";
 import type { IssueCandidate } from "../core/session.js";
 import type { HitlCandidate } from "../core/hitl-selection.js";
@@ -289,7 +290,7 @@ export async function ensureRunnerErrorLabel(ctx: GhContext): Promise<void> {
     [
       "label",
       "create",
-      "runner-error",
+      LABEL_RUNNER_ERROR,
       ...repoArgs(ctx),
       "--color",
       "B60205",


### PR DESCRIPTION
## Summary

- Extracts `src/apps/dev/src/core/triage-labels.ts` as the single canonical owner of all triage-label string constants (`LABEL_READY`, `LABEL_RUNNING`, `LABEL_HUMAN`, blocked-reason labels, priority labels, etc.)
- Removes duplicated local `LABEL_*` consts from `hitl-selection`, `process-issue`, `reconcile`, and `session`
- Migrates all remaining inline string literals in `commands/ship.ts`, `commands/run.ts`, `commands/activity-review.ts`, and `runtime/gh.ts` (including `ensureRunnerErrorLabel`) to import from the shared module

Closes #599

## Test plan

- [x] `pnpm tsc --noEmit` — no errors
- [x] `vitest run tests/label-vocabulary-docs.test.ts tests/gh-batch.test.ts tests/gh-auth.test.ts` — 17 tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783728515&installation_id=129708444&pr_number=671&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F671&signature=b85b5439a42698ac2f58e9393f2b071a25dac9c547e5fde99fd0bdd8e5a9a5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal label management to use shared constants for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->