### PR TITLE
feat(afk): repo-portable AFK Actions lane via a composite action (ADR 0062)

### DIFF
--- a/.github/actions/afk-attempt/action.yml
+++ b/.github/actions/afk-attempt/action.yml
@@ -1,0 +1,98 @@
+# Composite action: afk-attempt
+#
+# The repo-portable EXECUTION primitive for the AFK Actions lane (ADR 0059/0062).
+# Runs exactly ONE AFK attempt against an issue in the already-checked-out
+# repository, then exits. No fleet, no admin-merge — the PR is the deliverable.
+#
+# Why a composite action (not just a workspace `node …afk.mjs`): when any repo
+# references `uses: reddb-io/red-skills/.github/actions/afk-attempt@<ref>`, GitHub
+# fetches the red-skills tree at <ref> to run this action. The committed launcher
+# `afk.mjs` and `plugins/dev/.claude-plugin/plugin.json` come along under
+# `${{ github.action_path }}`, so the launcher resolves its version and fetches
+# the matching `dev` bundle from the Release (ADR 0038/0039) — red-castle inlined,
+# no workspace build, no submodule. The action runs against the CALLER's checked-out
+# workspace (the target repo, where the issues/PRs live), while the launcher lives
+# in the action's own red-skills checkout. Reproducible by pinning <ref>.
+#
+# Contract: the CALLER checks out the target repo and grants `contents: write`,
+# `issues: write`, `pull-requests: write`. Secrets are passed as inputs (composite
+# actions cannot read `secrets.*`); the automatic `github.token` is used for gh/git.
+
+name: AFK attempt
+description: Run one AFK attempt against an issue in the checked-out repository (opencode/claude/codex).
+
+inputs:
+  issue:
+    description: "Issue number to process."
+    required: true
+  runner:
+    description: "AFK runner to drive (claude|codex|opencode). CI default is opencode (API-auth, no host session)."
+    required: false
+    default: "opencode"
+  openrouter-api-key:
+    description: "OpenRouter API key (opencode auth; precedence 3)."
+    required: false
+    default: ""
+  minimax-api-key:
+    description: "MiniMax API key (opencode auth; precedence 2)."
+    required: false
+    default: ""
+  openai-api-key:
+    description: "OpenAI API key (opencode auth precedence 1; also the codex CLI key)."
+    required: false
+    default: ""
+  anthropic-api-key:
+    description: "Anthropic API key (claude runner CLI)."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
+    - name: Install the runner CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "${{ inputs.runner }}" in
+          opencode) npm install -g opencode-ai ;;
+          claude)   npm install -g @anthropic-ai/claude-code ;;
+          codex)    npm install -g @openai/codex ;;
+          *) echo "::error::unsupported runner for the Actions lane: '${{ inputs.runner }}'"; exit 1 ;;
+        esac
+        echo "runner '${{ inputs.runner }}' CLI installed"
+
+    - name: Run the AFK attempt
+      shell: bash
+      env:
+        # gh + git operations (label the issue, post the envelope, open the PR).
+        GH_TOKEN: ${{ github.token }}
+        # CI never wants a nested container: force the no-sandbox lane regardless
+        # of the target repo's `afk.sandbox` config (wire.ts precedence).
+        RED_AFK_SANDBOX: none
+        # opencode auth — first set key wins (opencode-env.ts precedence).
+        OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
+        MINIMAX_API_KEY: ${{ inputs.minimax-api-key }}
+        OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        # claude/codex CLIs, when those runners are selected, read these directly.
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+      run: |
+        set -euo pipefail
+        ISSUE="${{ inputs.issue }}"
+        if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+          echo "::error::invalid issue number: '$ISSUE'"; exit 1
+        fi
+        # A committer identity for the worker-branch commits the runner lands.
+        git config --global user.name  "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        # The launcher is resolved from THIS action's red-skills checkout; it
+        # fetches the version-matched dev bundle and runs against the CWD repo.
+        LAUNCHER="${{ github.action_path }}/../../../plugins/dev/skills/engineering/afk/bin/afk.mjs"
+        node "$LAUNCHER" run \
+          --issues "$ISSUE" \
+          --runner "${{ inputs.runner }}" \
+          --once

--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -23,10 +23,12 @@
 # allowlist. The gate is evaluated with `actions/github-script@v7`. Failure →
 # no claim, no PR, logged reason + a comment.
 #
-# Execution: the job checks out the repo, sets up Node, installs the selected
-# runner CLI, then runs the version-pinned AFK launcher (`afk.mjs`), which
-# fetches the prebuilt `dev` bundle from the matching GitHub Release (ADR
-# 0038/0039) — no workspace build, no submodule needed in CI.
+# Execution is delegated to the repo-portable composite action
+# `reddb-io/red-skills/.github/actions/afk-attempt` (ADR 0062): it sets up Node,
+# installs the selected runner CLI, and runs the version-pinned AFK launcher
+# (`afk.mjs`), which fetches the prebuilt `dev` bundle from the matching GitHub
+# Release (ADR 0038/0039) — no workspace build, no submodule needed in CI. This
+# workflow owns only the triggers + the trust gate (the policy layer).
 #
 # Adoption paths:
 #   - Path A (auto, simplest): install this workflow directly into the adopter
@@ -201,55 +203,24 @@ jobs:
             }
 
       # Everything below runs only when the gate admits the claim.
-      - name: Checkout
+      - name: Checkout the target repository
         if: steps.trust.outputs.gate == 'pass' || steps.trust.outputs.gate == 'bypass'
         uses: actions/checkout@v4
 
-      - name: Set up Node
-        if: steps.trust.outputs.gate == 'pass' || steps.trust.outputs.gate == 'bypass'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install the runner CLI
-        if: steps.trust.outputs.gate == 'pass' || steps.trust.outputs.gate == 'bypass'
-        run: |
-          set -euo pipefail
-          case "${RED_AFK_RUNNER}" in
-            opencode) npm install -g opencode-ai ;;
-            claude)   npm install -g @anthropic-ai/claude-code ;;
-            codex)    npm install -g @openai/codex ;;
-            *) echo "::error::unsupported runner for the Actions lane: '${RED_AFK_RUNNER}'"; exit 1 ;;
-          esac
-          echo "runner '${RED_AFK_RUNNER}' CLI installed"
-        shell: bash
-
+      # Execution is the repo-portable composite action (ADR 0062): it sets up
+      # Node, installs the selected runner CLI, and runs the version-pinned
+      # launcher (which fetches the dev bundle from the Release) against this
+      # checkout. The action carries its own red-skills checkout, so the launcher
+      # resolves even when this workflow runs in an adopter repo.
+      # TODO: when #622 lands, the atomic claim CAS replaces the --issues <N>
+      # direct invocation with a server-side claim that can't race a local fleet.
       - name: Run the AFK attempt
         if: steps.trust.outputs.gate == 'pass' || steps.trust.outputs.gate == 'bypass'
-        env:
-          RESOLVED_NUMBER: ${{ steps.resolve.outputs.number }}
-          # gh + git operations (label the issue, post the envelope, open the PR).
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # opencode auth — first set key wins (opencode-env.ts precedence).
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          MINIMAX_API_KEY:    ${{ secrets.MINIMAX_API_KEY }}
-          OPENAI_API_KEY:     ${{ secrets.OPENAI_API_KEY }}
-          # claude/codex CLIs, if those runners are selected, read these directly.
-          ANTHROPIC_API_KEY:  ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          set -euo pipefail
-          ISSUE="${RESOLVED_NUMBER}"
-          if [ -z "${ISSUE}" ]; then
-            echo "::error::missing issue number"
-            exit 1
-          fi
-          # A committer identity for the worker-branch commits the runner lands.
-          git config --global user.name  "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # TODO: when #622 lands, the atomic claim CAS replaces the --issues <N>
-          # direct invocation with a server-side claim that can't race a local fleet.
-          node plugins/dev/skills/engineering/afk/bin/afk.mjs run \
-            --issues "$ISSUE" \
-            --runner "${RED_AFK_RUNNER}" \
-            --once
-        shell: bash
+        uses: reddb-io/red-skills/.github/actions/afk-attempt@main
+        with:
+          issue: ${{ steps.resolve.outputs.number }}
+          runner: ${{ env.RED_AFK_RUNNER }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          minimax-api-key: ${{ secrets.MINIMAX_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.red/adr/0062-afk-actions-lane-is-a-composite-action.md
+++ b/.red/adr/0062-afk-actions-lane-is-a-composite-action.md
@@ -1,0 +1,88 @@
+# The AFK Actions lane is a repo-portable composite action under a thin reusable workflow
+
+## Context
+
+ADR 0059 introduced the AFK Actions lane — running ONE AFK attempt per issue from
+GitHub Actions. The first implementation (`red-afk-attempt.yml`, #665, made
+functional in #675) baked the execution into the reusable workflow: it invoked
+`node plugins/dev/skills/engineering/afk/bin/afk.mjs` as a **workspace-relative
+path**. That only resolves when the checked-out repository *is* red-skills.
+
+When an adopter repo calls the reusable
+(`uses: reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@<ref>`),
+`actions/checkout` checks out the **adopter's** repo (the event's
+`github.repository`), which does not contain `plugins/dev/.../afk.mjs`. So the
+lane worked only for red-skills self-hosting, not for the adopters the lane is
+explicitly meant to serve.
+
+Three concerns were tangled in one file: **triggers** (when), **trust gate**
+(who), and **execution** (how). Execution was the only non-portable part.
+
+## Decision
+
+**Extract execution into a repo-portable composite action; keep the reusable
+workflow as a thin policy layer (triggers + trust gate) on top of it.**
+
+- **`.github/actions/afk-attempt`** (composite action) is the execution
+  PRIMITIVE: set up Node, install the selected runner CLI
+  (`opencode-ai` | `@anthropic-ai/claude-code` | `@openai/codex`), and run the
+  launcher against the already-checked-out workspace.
+
+  *Why a composite action makes it portable:* a `uses:
+  reddb-io/red-skills/.github/actions/afk-attempt@<ref>` causes GitHub to fetch
+  the red-skills tree at `<ref>` to run the action. The committed `afk.mjs`
+  launcher and `plugins/dev/.claude-plugin/plugin.json` ride along under
+  `${{ github.action_path }}`, so the launcher resolves its version and fetches
+  the matching `dev` bundle from the Release (ADR 0038/0039) — red-castle inlined
+  (ADR 0061), no workspace build, no submodule. The action runs against the
+  **caller's** workspace (the target repo), while the launcher lives in the
+  action's own red-skills checkout. The two are independent paths.
+
+- **`red-afk-attempt.yml`** (reusable workflow) keeps the triggers
+  (`issues: labeled`/`opened`, `workflow_dispatch`, `workflow_call`) and the
+  ADR 0056 trust gate, then delegates execution via
+  `uses: …/.github/actions/afk-attempt`. It owns policy, not execution.
+
+- **Two adoption surfaces**, one execution primitive:
+  - *Turnkey*: call the reusable (or install it directly) — triggers + trust gate
+    handled (`examples/red-afk-attempt-caller.yml`).
+  - *Composable*: `uses: …/afk-attempt@v1` in a workflow you control, with your
+    own trigger and gating (`examples/red-afk-attempt-action.yml`).
+
+- **CI invariants baked into the action:** `RED_AFK_SANDBOX=none` (never a nested
+  container in Actions, overriding any target-repo `afk.sandbox` config),
+  `GH_TOKEN = github.token`, a committer identity, and `--once` (one attempt, no
+  fleet, no admin-merge — the PR is the deliverable).
+
+- **Secrets via inputs.** Composite actions can't read `secrets.*`, so auth keys
+  are action inputs the caller wires from its own secrets; `github.token` is read
+  directly. Permissions stay minimal (`contents`/`issues`/`pull-requests: write`).
+
+- **Reproducibility by ref.** Pinning `afk-attempt@v1` (or a SHA) fixes both the
+  action and — through the plugin version in that checkout — the `dev` bundle the
+  launcher fetches. The reusable references the action at `@main` (they ship
+  together in red-skills); adopters wanting strict pinning use the composable path.
+
+## Consequences
+
+- The lane runs in **any** repo, not just red-skills. red-skills dogfoods it
+  (its own `red-afk-attempt.yml` consumes the action).
+- Execution is a testable, independently-versioned unit, decoupled from triggers
+  and gating.
+- No new distribution mechanism: reuses launcher + Release (ADR 0038/0039) and
+  the single execution seam (ADR 0033/0061).
+- Open follow-ups unchanged: #621 (allowlist from `.red/config.yaml`) and #622
+  (atomic claim CAS to avoid racing a local fleet).
+
+## Status
+
+accepted.
+
+## Related
+
+- ADR 0059 — the AFK Actions lane + OpenCode as the API-auth CI runner (this
+  refines its packaging).
+- ADR 0038 / 0039 — the launcher + Release-fetch distribution the action reuses.
+- ADR 0033 / 0061 — the single execution seam; the substrate (`@reddb-io/red-castle`)
+  inlined into the `dev` bundle the launcher fetches.
+- ADR 0056 — the trust gate that stays in the reusable's policy layer.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -50,6 +50,7 @@ stale notes inline.
 - **0051** AFK attempt-progress guard resets on worktree edits, not just commits — stops false-stalling the productive-but-not-committing codex runner *(refines 0044, 0045)*
 - **0054** AFK arms the attempt guard + heartbeat under docker/podman isolation via an attempt-dir bind mount; lane-idle reaper stays host-only *(supersedes 0044 §4 / 0045 §4; relies on 0033; absorbs #284 docker E2E)*
 - **0059** OpenCode is the third AFK runner, addressing OpenRouter through its own `openrouter/<vendor>/<model>` slug + the `OpenCodeOptions.env` auth seam; accepted only as an explicit pin, never auto-sniffed. **Amended (1):** endpoint-agnostic — accepts any `<provider>/<model>` slug, propagates the first-set auth env-var (OPENAI_API_KEY > MINIMAX_API_KEY > OPENROUTER_API_KEY) through `OpenCodeOptions.env`; OpenCode owns endpoint resolution. **Amended (2):** MiniMax subscription API as the concrete case that motivated the endpoint-agnostic property *(follows 0003, 0033, 0049)*
+- **0062** AFK Actions lane is a repo-portable composite action (`.github/actions/afk-attempt`) under a thin reusable workflow (triggers + trust gate); execution carries its own red-skills checkout so the launcher resolves in any adopter repo *(refines 0059; reuses 0038/0039 launcher, 0033/0061 seam, 0056 gate)*
 
 ## Branch lock
 - **0006** Branch lock enforces on the agent only, not the human terminal

--- a/plugins/dev/skills/engineering/afk/examples/red-afk-attempt-action.yml
+++ b/plugins/dev/skills/engineering/afk/examples/red-afk-attempt-action.yml
@@ -1,0 +1,53 @@
+# Example: direct use of the afk-attempt composite action (the COMPOSABLE path).
+#
+# Use this when you want full control over triggers and gating and don't need the
+# turnkey reusable workflow. The composite action is the execution PRIMITIVE
+# (ADR 0062): it sets up Node, installs the runner CLI, and runs ONE AFK attempt
+# against this repo's checkout. You own the trigger and any trust gate.
+#
+# Trade-off vs. the reusable (`red-afk-attempt-caller.yml`): the reusable ships
+# the author/label-actor trust gate (ADR 0056); the raw action does not. For
+# public repos prefer the reusable. For private repos an `if:` on the actor (as
+# below) is usually enough.
+#
+# Pin the action to a tag (`@v1`) for reproducible runs — that ref also fixes the
+# `dev` bundle version the launcher fetches. Copy to `.github/workflows/afk.yml`.
+
+name: afk
+on:
+  issues:
+    types: [labeled, opened]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to process."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  attempt:
+    # Minimal inline gate: a labeled/opened issue carrying `ready-for-agent`,
+    # applied by a trusted actor. EDIT the login list.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(github.event.issue.labels.*.name, 'ready-for-agent') &&
+        contains(fromJSON('["filipeforattini"]'), github.event.sender.login)
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reddb-io/red-skills/.github/actions/afk-attempt@v1
+        with:
+          issue: ${{ github.event.issue.number || inputs.issue }}
+          runner: opencode
+          # Wire whichever key your org provisions (first set wins; see
+          # opencode-env.ts precedence). EDIT.
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          minimax-api-key:    ${{ secrets.MINIMAX_API_KEY }}
+          openai-api-key:     ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Makes the AFK Actions lane **run in any repo**, not just red-skills, by extracting execution into a composite action — the architecture worked out in discussion.

## The problem
The reusable `red-afk-attempt.yml` ran the launcher as a **workspace path** (`node plugins/dev/.../afk.mjs`). That only resolves when the checked-out repo *is* red-skills. An adopter calling the reusable gets `actions/checkout` of **their** repo → the launcher path doesn't exist → broken for adopters (the lane's stated audience).

## The architecture (3 layers)
| Layer | What | Where |
|---|---|---|
| trigger + policy | when + trust gate | reusable workflow |
| **execution** | run one attempt | **composite action (new)** |
| runtime distribution | fetch the versioned bundle | launcher + Release (ADR 0038/0039) |

- **`.github/actions/afk-attempt`** — composite action: setup-node, install the runner CLI (`opencode-ai`/`@anthropic-ai/claude-code`/`@openai/codex`), run the launcher against the caller's checkout. The portability trick: `uses: reddb-io/red-skills/.github/actions/afk-attempt@<ref>` makes GitHub fetch the red-skills tree, so the committed `afk.mjs` + `plugin.json` ride along under `github.action_path` → the launcher resolves its version and fetches the matching `dev` bundle (red-castle inlined) **in any repo**. CI invariants baked in: `RED_AFK_SANDBOX=none`, `GH_TOKEN`, committer identity, `--once`.
- **`red-afk-attempt.yml`** — now thin: triggers (`issues: labeled`/`opened`, dispatch, call) + trust gate, delegating execution to the action. red-skills **dogfoods** it.
- **Two adoption surfaces, one primitive**: turnkey reusable (`examples/red-afk-attempt-caller.yml`) or composable direct-action (`examples/red-afk-attempt-action.yml`).

## Notes
- Secrets are action **inputs** (composite actions can't read `secrets.*`); `github.token` is used directly. Minimal perms.
- Reproducibility by pinning `afk-attempt@v1` (fixes both the action and the bundle version). A `v1` tag will be cut after merge.
- ADR 0062 (refines 0059) + INDEX.
- Open follow-ups unchanged: #621 (allowlist from config), #622 (atomic claim CAS vs. local fleet).

## Validation
`actionlint` clean on the workflow + action; all example YAML parses. End-to-end still needs a real issue event (+ API-key secrets configured) — recommend a live smoke after merge + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783740047&installation_id=129708444&pr_number=676&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F676&signature=60684311989ea93cf423f057aad14fe2c3224edffd75c13d24b4a91c89d1c776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable GitHub Action for running automated fix attempts on repository issues, enabling integration across different repositories.

* **Documentation**
  * Added architecture decision record documenting the composite action design, integration patterns, and its role within the automated issue-fixing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->