### PR TITLE
feat(afk): model/effort override via --model/--effort flag + RED_AFK_MODEL/RED_AFK_EFFORT env

### DIFF
--- a/.github/actions/afk-attempt/action.yml
+++ b/.github/actions/afk-attempt/action.yml
@@ -29,6 +29,14 @@ inputs:
     description: "AFK runner to drive (claude|codex|opencode). CI default is opencode (API-auth, no host session)."
     required: false
     default: "opencode"
+  model:
+    description: "Override the model for every tier (e.g. minimax/MiniMax-M2). Empty = .red/config.yaml / defaults. Maps to RED_AFK_MODEL."
+    required: false
+    default: ""
+  effort:
+    description: "Override the reasoning effort/variant (low|medium|high|…). Empty = config. Maps to RED_AFK_EFFORT (still provider-gated)."
+    required: false
+    default: ""
   openrouter-api-key:
     description: "OpenRouter API key (opencode auth; precedence 3)."
     required: false
@@ -74,6 +82,10 @@ runs:
         # CI never wants a nested container: force the no-sandbox lane regardless
         # of the target repo's `afk.sandbox` config (wire.ts precedence).
         RED_AFK_SANDBOX: none
+        # Model/effort override (resolveTier precedence) — empty values are ignored,
+        # so an unset input leaves the target repo's .red/config.yaml in charge.
+        RED_AFK_MODEL: ${{ inputs.model }}
+        RED_AFK_EFFORT: ${{ inputs.effort }}
         # opencode auth — first set key wins (opencode-env.ts precedence).
         OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         MINIMAX_API_KEY: ${{ inputs.minimax-api-key }}

--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -55,8 +55,13 @@ on:
         required: false
         type: string
         default: "opencode"
-      model_slug:
-        description: "Reserved. AFK reads the model from `.red/config.yaml` (`plugins.dev.afk.models.<runner>.<tier>.model`); a per-run override is not yet wired."
+      model:
+        description: "Override the model for every tier (e.g. minimax/MiniMax-M2). Empty = read from `.red/config.yaml` / defaults. Maps to RED_AFK_MODEL."
+        required: false
+        type: string
+        default: ""
+      effort:
+        description: "Override the reasoning effort/variant. Empty = config. Maps to RED_AFK_EFFORT (still provider-gated)."
         required: false
         type: string
         default: ""
@@ -94,6 +99,11 @@ on:
         required: false
         type: string
         default: "opencode"
+      model:
+        description: "Override the model for every tier (e.g. minimax/MiniMax-M2). Empty = config."
+        required: false
+        type: string
+        default: ""
 
   # Auto-trigger: fire when `ready-for-agent` is applied to an issue, or when an
   # issue is opened already carrying it. The `if:` on the job enforces both.
@@ -220,6 +230,10 @@ jobs:
         with:
           issue: ${{ steps.resolve.outputs.number }}
           runner: ${{ env.RED_AFK_RUNNER }}
+          # model/effort are caller inputs (workflow_call/dispatch); empty for the
+          # issues triggers, which leaves the target repo's config in charge.
+          model: ${{ inputs.model }}
+          effort: ${{ inputs.effort }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           minimax-api-key: ${{ secrets.MINIMAX_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -72,6 +72,10 @@ interface ParsedRunFlags {
   iterCap?: number;
   once: boolean;
   runnerFlag?: string;
+  /** --model <slug>: override the resolved tier model for every tier (flag > env > config). */
+  model?: string;
+  /** --effort <e>: override the resolved tier effort (still provider-gated downstream). */
+  effort?: string;
   request?: string;
   /** --alternate: rotate the runner between consecutive issues (claude↔codex). */
   alternate: boolean;
@@ -129,6 +133,8 @@ const RUN_FLAG_SCHEMA = {
   n: { kind: "value", coerce: (raw: string): number => Number(raw) },
   once: { kind: "boolean" },
   runner: { kind: "value", coerce: (raw: string): string => raw },
+  model: { kind: "value", coerce: (raw: string): string => raw },
+  effort: { kind: "value", coerce: (raw: string): string => raw },
   request: { kind: "value", aliases: ["r"], coerce: (raw: string): string => raw },
   alternate: { kind: "boolean" },
   "fallback-runner": { kind: "boolean" },
@@ -175,6 +181,8 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     iterCap: values.n as number | undefined,
     once: values.once === true,
     runnerFlag,
+    model: values.model as string | undefined,
+    effort: values.effort as string | undefined,
     request: values.request as string | undefined,
     alternate,
     fallbackRunner: values["fallback-runner"] === true,
@@ -590,7 +598,7 @@ export function buildProcessDeps(
     runAgent: makeRunAgent(sandbox, process.env, maxIterations, attemptTimeoutSeconds, laneIdle),
     model,
     classifyIssue: makeIssueClassifier(config, runner, ctx.root, exec),
-    resolveTier: (activeRunner, taskClass = "think") => resolveTier(config, activeRunner, taskClass),
+    resolveTier: (activeRunner, taskClass = "think") => resolveTier(config, activeRunner, taskClass, process.env),
     fallbackRunner,
     waitForReview,
     // One-shot merge-conflict resolver (merge_resolve_conflict): re-enter the
@@ -599,7 +607,7 @@ export function buildProcessDeps(
     // verifies git state afterwards, so a non-zero / thrown runner here is
     // swallowed. Mirrors run_claude / run_codex on the conflicted checkout.
     conflictResolver: async (prompt: string, cwd: string) => {
-      const conflictTier = resolveTier(config, runner, "think");
+      const conflictTier = resolveTier(config, runner, "think", process.env);
       const invocation =
         runner === "codex"
           ? codexSpawnArgs({
@@ -804,7 +812,7 @@ function makeIssueClassifier(
   exec?: ExecFn,
 ): (metadata: IssueClassificationMetadata) => Promise<import("../core/config.js").AfkModelTier> {
   return async (metadata) => {
-    const validateTier = resolveTier(config, runner, "validate");
+    const validateTier = resolveTier(config, runner, "validate", process.env);
     return classifyIssue(metadata, async ({ prompt }) => {
       const run = exec ?? (await import("../runtime/exec.js")).execTool;
       const common = { cwd, timeoutMs: 45_000, maxBuffer: 1024 * 1024 };
@@ -1014,6 +1022,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
 
   const flags = parseRunFlags(options.args);
+  // --model / --effort pre-set the env override (flag > env). Setting them on the
+  // process env makes the override flow through both the in-process `--once` path
+  // (resolveTier reads process.env) and the fleet path (buildWorkerEnv passes
+  // RED_AFK_MODEL/RED_AFK_EFFORT through to workers — not in PASSTHROUGH_DENYLIST).
+  if (flags.model) process.env.RED_AFK_MODEL = flags.model;
+  if (flags.effort) process.env.RED_AFK_EFFORT = flags.effort;
   const detection = detectRunner({
     flag: flags.runnerFlag ?? parseRunnerFlag(options.args),
     processTree: callerProcessTreeNative(),

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -298,19 +298,26 @@ function readEffort(raw: string, fallback: AgentEffort): AgentEffort {
 /**
  * Resolve AFK's per-runner model tier (ADR 0049).
  *
- * Precedence for the model:
+ * Precedence for the model (mirrors the runner/sandbox knobs — flag and env beat
+ * the file, ADR 0049):
+ *   0. runtime override: `RED_AFK_MODEL` env (the `--model` run flag pre-sets it).
+ *      Flattens every tier onto one slug — "use this model regardless of tier".
  *   1. explicit tier table entry: `afk.models.<runner>.<tier>.model`
  *   2. legacy runner scalar: `afk.models.<runner>`
  *   3. legacy global scalar: `afk.model`
  *   4. tier-table default
+ * `RED_AFK_EFFORT` overrides effort the same way (still provider-gated downstream).
  *
  * `loadConfig` already folds `plugins.dev.afk.*` over the legacy top-level
- * `afk.*` keys (ADR 0042), so the same reader honours both locations.
+ * `afk.*` keys (ADR 0042), so the same reader honours both locations. `env` is
+ * injected (default empty) so the override is opt-in per call site — the AFK run
+ * path passes `process.env`; the interactive model-tier route does not.
  */
 export function resolveTier(
   values: ConfigValues,
   runner: string,
   taskClass: AfkModelTier = "think",
+  env: NodeJS.ProcessEnv = {},
 ): ResolvedTier {
   // The runner whose tier table to read. claude/codex/opencode each ship a full
   // table (CONFIG_DEFAULTS); any other runner (e.g. the runner-neutral hermes)
@@ -325,12 +332,22 @@ export function resolveTier(
   const scalarRunnerModel = getConfig(values, `afk.models.${tierRunner}`);
   const scalarGlobalModel = getConfig(values, "afk.model");
 
+  // Runtime override: a non-empty RED_AFK_MODEL/RED_AFK_EFFORT wins over the file
+  // (`""` counts as unset, so a placeholder export never flattens the tiers).
+  const modelOverride = (env.RED_AFK_MODEL ?? "").trim();
+  const effortOverride = (env.RED_AFK_EFFORT ?? "").trim();
+
+  const configModel =
+    tierModel && tierModel !== defaultModel
+      ? tierModel
+      : scalarRunnerModel || scalarGlobalModel || tierModel || defaultModel;
+
   return {
-    model:
-      tierModel && tierModel !== defaultModel
-        ? tierModel
-        : scalarRunnerModel || scalarGlobalModel || tierModel || defaultModel,
-    effort: readEffort(getConfig(values, effortKey), defaultEffort),
+    model: modelOverride.length > 0 ? modelOverride : configModel,
+    effort:
+      effortOverride.length > 0
+        ? readEffort(effortOverride, defaultEffort)
+        : readEffort(getConfig(values, effortKey), defaultEffort),
   };
 }
 

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -131,7 +131,9 @@ export function resolveRunSettings(
     : "none";
   const defaultRunner = getConfig(cfg, "afk.default_runner") || "claude";
   const activeRunner = runner ?? (isRunner(defaultRunner) ? defaultRunner : "claude");
-  const tier = resolveTier(cfg, activeRunner, "think");
+  // Pass env so the RED_AFK_MODEL/RED_AFK_EFFORT runtime override (the --model /
+  // --effort flags pre-set them) wins over the file, mirroring the sandbox knob.
+  const tier = resolveTier(cfg, activeRunner, "think", env);
   // Precedence: RED_AFK_MAX_ITERATIONS env > afk.max_iterations config >
   // undefined (→ DEFAULT_MAX_ITERATIONS). parseMaxIterations rejects a
   // non-numeric / zero / negative value from EITHER source, so a typo in the

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -281,6 +281,28 @@ describe("config — AFK model tier table (ADR 0049)", () => {
     expect(resolveTier(values, "codex")).toEqual({ model: "gpt-5.5", effort: "high" });
   });
 
+  it("lets RED_AFK_MODEL / RED_AFK_EFFORT override every tier (flag pre-sets the env)", () => {
+    const values = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });
+    // Override flattens all tiers onto one slug, beating the config/default table.
+    expect(resolveTier(values, "opencode", "simple", { RED_AFK_MODEL: "minimax/MiniMax-M2" })).toEqual({
+      model: "minimax/MiniMax-M2",
+      effort: "high",
+    });
+    expect(
+      resolveTier(values, "opencode", "validate", { RED_AFK_MODEL: "minimax/MiniMax-M2", RED_AFK_EFFORT: "high" }),
+    ).toEqual({ model: "minimax/MiniMax-M2", effort: "high" });
+    // An empty override is treated as unset — config/default stays in charge.
+    expect(resolveTier(values, "opencode", "simple", { RED_AFK_MODEL: "" })).toEqual({
+      model: "openrouter/anthropic/claude-sonnet-4",
+      effort: "high",
+    });
+    // No env arg (e.g. the interactive model-tier route) → never overridden.
+    expect(resolveTier(values, "opencode", "simple")).toEqual({
+      model: "openrouter/anthropic/claude-sonnet-4",
+      effort: "high",
+    });
+  });
+
   it("resolves every Claude tier from the default table", () => {
     const values = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });
     expect(resolveTier(values, "claude", "validate")).toEqual({ model: "claude-haiku-4-5", effort: "low" });

--- a/plugins/dev/skills/engineering/model-tier-policy/SKILL.md
+++ b/plugins/dev/skills/engineering/model-tier-policy/SKILL.md
@@ -7,7 +7,9 @@ description: Use when choosing or explaining the RedSkills dev model tier for va
 
 This is the dev plugin's cross-host policy for why a task uses a given model tier and which tier should run it. It is the human-readable policy from ADR 0049.
 
-The machine source for model ids and effort values is `apps/dev/src/core/config.ts` (`CONFIG_DEFAULTS`), overridden per repository by `.red/config.yaml` at `plugins.dev.afk.models.{claude,codex}.{validate,simple,complex,think}`. The legacy top-level `afk.models...` location remains a fallback. Do not copy this table into executor prompts; point executors here so the classification criterion stays in one place.
+The machine source for model ids and effort values is `apps/dev/src/core/config.ts` (`CONFIG_DEFAULTS`), overridden per repository by `.red/config.yaml` at `plugins.dev.afk.models.{claude,codex,opencode}.{validate,simple,complex,think}`. The legacy top-level `afk.models...` location remains a fallback. Do not copy this table into executor prompts; point executors here so the classification criterion stays in one place.
+
+**Runtime override (flag / env, ADR 0049).** Like `--runner`/`RED_AFK_RUNNER` and `RED_AFK_SANDBOX`, the model and effort are overridable at run time without editing a file — for ad-hoc runs and the CI lane. Precedence: **`--model` flag > `RED_AFK_MODEL` env > `.red/config.yaml` > defaults** (and the same for `--effort` / `RED_AFK_EFFORT`). A non-empty override **flattens every tier** onto the one slug ("use this model regardless of tier"); `""` is treated as unset. The `--model`/`--effort` flags pre-set the env so the override flows through both `--once` and the fleet. Example — drive OpenCode against a MiniMax subscription with no config edit: `MINIMAX_API_KEY=… afk run --runner opencode --model minimax/MiniMax-M2 --issues 42` (the slug's leading segment routes the endpoint; `opencode-env.ts` picks the key). The CI composite action exposes this as the `model`/`effort` inputs.
 
 ## Tier table
 


### PR DESCRIPTION
Closes the gap you flagged: the per-issue model was **config-file-only**, inconsistent with `--runner`/`RED_AFK_RUNNER` and `RED_AFK_SANDBOX` (both flag+env). You couldn't point AFK at a MiniMax subscription (or any model) without editing `.red/config.yaml`.

## What
A runtime override with the same precedence pattern as the other knobs:

```
--model flag  >  RED_AFK_MODEL env  >  .red/config.yaml  >  defaults     (idem --effort / RED_AFK_EFFORT)
```

- **`config.ts` `resolveTier`**: optional `env` param; a non-empty `RED_AFK_MODEL`/`RED_AFK_EFFORT` **flattens every tier** onto one slug (`""` = unset). Opt-in per call site — the AFK run path passes `process.env`; the interactive model-tier route does **not** (so it's unaffected).
- **`run.ts`**: `--model`/`--effort` flags pre-set `process.env.RED_AFK_MODEL/EFFORT` (flag wins over a pre-existing env), so the override flows through both `--once` (in-process) **and** the fleet (`buildWorkerEnv` passes them — not in the denylist).
- **`wire.ts`**: `resolveRunSettings` threads its `env` into `resolveTier`.
- **CI**: the `afk-attempt` composite action **and** the reusable workflow gain `model`/`effort` inputs → `RED_AFK_MODEL`/`RED_AFK_EFFORT` (the reusable's previously-reserved `model_slug` becomes the functional `model`).
- **Docs**: `model-tier-policy/SKILL.md` documents the knob with the MiniMax example.

## Your MiniMax case — now config-free
```bash
# local
MINIMAX_API_KEY=… afk run --runner opencode --model minimax/MiniMax-M2 --issues 42
# or env-only
RED_AFK_RUNNER=opencode RED_AFK_MODEL=minimax/MiniMax-M2 MINIMAX_API_KEY=… afk run --issues 42
```
```yaml
# CI (composable action)
- uses: reddb-io/red-skills/.github/actions/afk-attempt@v1
  with: { issue: …, runner: opencode, model: minimax/MiniMax-M2, minimax-api-key: ${{ secrets.MINIMAX_API_KEY }} }
```
The slug's leading segment routes the endpoint; `opencode-env.ts` picks the matching key.

## Validation
- `resolveTier` override unit test (config.test.ts **41/41**), run-flags **18/18**, dev typecheck clean, dev bundle builds, actionlint clean.
- Runtime proof: `RED_AFK_MODEL=minimax/MiniMax-M2` → `resolveTier` returns it; `""` ignored; no-env arg → default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783741670&installation_id=129708444&pr_number=677&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F677&signature=37704cc88f4e1748c77f6087594f7746603ce016f288cf3635ffe93d8ef5637a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--model` and `--effort` CLI flags to override tier configuration at runtime.
  * GitHub Actions workflows now support caller-provided model and effort input overrides for per-run customization.
  * Runtime overrides take precedence over default configurations.

* **Documentation**
  * Updated documentation describing runtime override behavior and configuration precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->