### PR TITLE
docs(afk): consolidate the Actions-lane / reusable-workflow docs into one adopter guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,11 @@ afk:
 
 Defaults are runner- and tier-specific. Until classification lands, AFK uses the `think` tier by default: Codex defaults to `gpt-5.5`/`high`; Claude Code defaults to `claude-opus-4-8`/`high`. The legacy `afk.model` and `afk.models.<runner>` scalar keys are still accepted as fallback model overrides, but tiered `afk.models.<runner>.<tier>.{model,effort}` is safer for mixed Claude/Codex fleets.
 
-The cross-host tier table, deterministic-first validation rule, simple-vs-complex criterion, escalation policy, and executor map live in [`model-tier-policy`](./plugins/dev/skills/engineering/model-tier-policy/SKILL.md). The single machine source for defaults remains `CONFIG_DEFAULTS` in [`config.ts`](./apps/dev/src/core/config.ts).
+The cross-host tier table, deterministic-first validation rule, simple-vs-complex criterion, escalation policy, and executor map live in [`model-tier-policy`](./plugins/dev/skills/engineering/model-tier-policy/SKILL.md). The single machine source for defaults remains `CONFIG_DEFAULTS` in [`config.ts`](./apps/dev/src/core/config.ts). The runner and model are also overridable at run time without editing config — `--runner`/`RED_AFK_RUNNER` and `--model`/`RED_AFK_MODEL` (plus `--effort`/`RED_AFK_EFFORT`), flag beating env beating file.
+
+#### Running `/afk` from GitHub Actions
+
+The **AFK Actions lane** runs one attempt per issue from CI in any repo — a reusable workflow (triggers + trust gate) over a repo-portable composite action (`reddb-io/red-skills/.github/actions/afk-attempt@v1`), reusing the launcher + Release bundle (no workspace build, no submodule). It depends only on GitHub-official actions plus our own. Drive it on a label (`ready-for-agent`), on pre-labeled issue creation, manually, or via `workflow_call`, with the OpenCode runner pointed at OpenAI / MiniMax / OpenRouter through the model slug + matching key. **Full adopter guide: [`afk/actions-lane.md`](./plugins/dev/skills/engineering/afk/actions-lane.md)** (ADR 0059/0062).
 
 <details>
 <summary><strong>Alternatives — no auto-update</strong></summary>

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -58,92 +58,32 @@ AFK drives the sandcastle Orchestrator through **injected providers** (`Sandcast
 - `/afk fleet stop` — gracefully shut down a running fleet supervisor and cancel its auto-monitor cron.
 - `/afk reap` — run branch hygiene without starting a worker: one count line for remote `afk/*`, remote `afk-attempts/*`, and local `afk/*`, then the same safe reapers used at boot.
 
-### Running `/afk` in an execution environment (GitHub Actions / k8s)
+### Running `/afk` in an execution environment (GitHub Actions)
 
-The same `/afk --issues N --runner opencode --once` command runs unchanged
-in a GitHub Actions runner or a k8s pod — it is the canonical
-**execution-environment** invocation. The runtime contract is identical to
-the local one (one attempt, one issue, one PR per invocation, no fleet
-semantics); only the trigger and the secret-injection surface differ.
+The same `/afk --issues N --runner opencode --once` command runs unchanged in a
+GitHub Actions runner — one attempt, one issue, one PR per invocation, no fleet,
+no admin-merge. Only the trigger and the secret-injection surface differ.
 
-The published reusable workflow (`.github/workflows/red-afk-attempt.yml`
-in `reddb-io/red-skills`) is the single entry point for any adopting
-repository. It listens to **three triggers in the same file**:
+The lane is packaged as three layers (ADR 0059/0062): the reusable workflow
+`.github/workflows/red-afk-attempt.yml` (triggers + trust gate) → the composite
+action `.github/actions/afk-attempt` (execution) → the `afk.mjs` launcher +
+Release bundle (runtime). Two adoption paths: **turnkey** (call the reusable) or
+**composable** (`uses: reddb-io/red-skills/.github/actions/afk-attempt@v1` with
+your own triggers/gate). Pin `@v1`/SHA for reproducibility. The composite action
+carries its own red-skills checkout, so the launcher resolves in any adopter repo
+— no workspace build, no submodule.
 
-1. `workflow_call` — direct invocation by a thin caller the adopter
-   drops in their own `.github/workflows/` (template at
-   `plugins/dev/skills/engineering/afk/examples/red-afk-attempt-caller.yml`).
-2. `workflow_dispatch` — manual run from the Actions UI with an
-   `issue_number` input. Useful for one-off retries.
-3. `issues: types: [labeled]` — auto-trigger when the
-   `ready-for-agent` label is applied to any issue (the job's `if:`
-   filter restricts to exactly that label; the `actions/github-script`
-   step then evaluates the trust gate). Useful when a triage bot or a
-   human wants the lane to fire the moment an issue is delegable,
-   without spinning up a caller workflow.
+Triggers: `issues: labeled`/`opened` (on `ready-for-agent`), `workflow_dispatch`,
+`workflow_call`. Trust gate (ADR 0056): author + label-actor must both be
+allowlisted. Runner: opencode (API-auth); point it at OpenAI/MiniMax/OpenRouter
+by wiring the matching key + a `<provider>/<model>` slug via the `model` input.
 
-The trust gate is **rigorous by default** in the Actions lane: the
-reusable refuses to claim an issue whose author
-(`issue.user.login`) is NOT in the caller-supplied
-`allowlist_authors` CSV OR whose label-applier
-(`sender.login` from the `labeled` event) is NOT in the
-`allowlist_label_actors` CSV. Both checks pass → claim proceeds.
-Either fails → logged, no claim, no PR. Until issue #621 (the runtime
-trust-gate predicate) lands, the allowlist is hard-coded to the
-reddb-io maintainers for the auto-trigger path; the caller-supplied
-allowlist is honoured for `workflow_call` and the manual path.
+**→ Full adopter guide:
+[`actions-lane.md`](./actions-lane.md)** (architecture, both examples, all
+inputs, triggers, trust gate, auth precedence, the MiniMax recipe, permissions).
 
-The k8s job manifest (container `Dockerfile` + `job.yaml`) and the
-real-environment E2E test are tracked as
+The k8s job manifest + real-environment E2E remain tracked as
 [#631](https://github.com/reddb-io/red-skills/issues/631) (ADR 0059).
-Until the k8s piece lands, an adopter running on a cluster can wire
-the same `node plugins/dev/skills/engineering/afk/bin/afk.mjs run
---issues N --runner opencode --once` command line — the command is
-stable:
-
-```bash
-# GHA reusable workflow body, or k8s container CMD
-export RED_AFK_RUNNER=opencode
-# One of the precedence env-vars, set from a secret:
-export MINIMAX_API_KEY="${{ secrets.MINIMAX_API_KEY }}"   # or OPENAI_API_KEY / OPENROUTER_API_KEY
-node plugins/dev/skills/engineering/afk/bin/afk.mjs run --issues "$ISSUE_NUMBER" --runner opencode --once
-```
-
-```bash
-# GHA reusable workflow body, or k8s container CMD
-export RED_AFK_RUNNER=opencode
-# One of the precedence env-vars, set from a secret:
-export MINIMAX_API_KEY="${{ secrets.MINIMAX_API_KEY }}"   # or OPENAI_API_KEY / OPENROUTER_API_KEY
-node plugins/dev/skills/engineering/afk/bin/afk.mjs run --issues "$ISSUE_NUMBER" --runner opencode --once
-```
-
-What the runtime does (and what is the caller's job):
-
-| step | runtime (`/afk`) | caller (GHA / k8s) |
-|---|---|---|
-| checkout the repo | — | yes — `actions/checkout@v4` or initContainer with the same git ref |
-| install pnpm | — | yes — `pnpm/action-setup@v4` or baked into the image |
-| install workspace deps | — | yes — `pnpm install --frozen-lockfile` |
-| expose the API key | env-precedence resolver reads `OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY` from `process.env` | yes — wire the secret into the env (Actions: `${{ secrets.* }}`; k8s: `envFrom: secretRef`) |
-| resolve the model slug | `afk.models.opencode.<tier>.model` from the repo's `.red/config.yaml` | — |
-| run one attempt | `run --issues N --runner opencode --once` | — |
-| claim the issue | ADR 0056 GitHub-native CAS (when #622 lands) | — |
-| enforce the trust gate | predicate on author + label-actor (when #621 lands) | — |
-| push the worker branch | `git push origin …` | — (the runtime does it; no GITHUB_TOKEN dance required at the caller) |
-| post the terminal envelope | `gh issue comment` on the issue | caller grants `issues: write`; runtime has no `GITHUB_TOKEN` of its own |
-| open the PR | `gh pr create` | caller grants `pull-requests: write` |
-
-The recommended `--permissions:` for the GHA workflow is exactly
-`contents: write, issues: write, pull-requests: write` — no `id-token: write`
-(no OIDC needed for this lane) and no `actions: write` (the workflow does
-not publish actions). The k8s `ServiceAccount` needs the same scope bound
-to the same `GITHUB_TOKEN` Secret.
-
-Trust gate is **rigorous by default** in the Actions lane: the workflow
-refuses to claim an issue whose author or label-actor is not in
-`plugins.dev.afk.trust_gate.allowlist`. The opt-out is
-`enforce-trust-gate: false` on the workflow input — for the red-skills
-team's own private-repo runs, never for an adopting public repo.
 
 ## Parallelization
 

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -1,0 +1,141 @@
+# AFK Actions lane — running `/afk` from GitHub Actions
+
+The **AFK Actions lane** runs one AFK attempt per issue from GitHub Actions, in
+any repository — not just `reddb-io/red-skills`. It is the same per-issue routine
+as a local `/afk --issues N --once`: **one attempt, one issue, one PR per
+invocation, no fleet, no admin-merge.** The PR is the deliverable; the merge
+decision stays human. ADR 0059 (the lane + OpenCode as the CI runner) and ADR
+0062 (the packaging below).
+
+## Architecture — three layers
+
+| Layer | What it owns | Artifact |
+|---|---|---|
+| **Trigger + policy** | *when* it runs + the trust gate | reusable workflow `red-afk-attempt.yml` |
+| **Execution** | run one attempt (Node, runner CLI, launcher) | composite action `.github/actions/afk-attempt` |
+| **Runtime distribution** | fetch the versioned `dev` bundle | the `afk.mjs` launcher + GitHub Release (ADR 0038/0039) |
+
+The composite action is repo-portable: `uses:
+reddb-io/red-skills/.github/actions/afk-attempt@<ref>` makes GitHub fetch the
+red-skills tree to run the action, so the committed `afk.mjs` + `plugin.json`
+ride along and the launcher resolves its version and fetches the matching `dev`
+bundle (red-castle inlined, ADR 0061) — **no workspace build, no submodule, in
+any repo.** Execution runs against the caller's checkout; the launcher lives in
+the action's own checkout. Pin `@v1` (or a SHA) to fix both the action and the
+bundle version.
+
+External dependencies are only **GitHub-official** actions (`actions/checkout`,
+`actions/setup-node`, `actions/github-script`) plus our own action — no
+third-party action repos.
+
+## Two ways to adopt
+
+### A. Turnkey — the reusable workflow (triggers + trust gate included)
+
+Drop the reusable into your repo (or call it). It ships the issue/label triggers
+and the ADR 0056 trust gate. Template:
+[`examples/red-afk-attempt-caller.yml`](./examples/red-afk-attempt-caller.yml).
+
+```yaml
+# .github/workflows/afk.yml in your repo
+jobs:
+  attempt:
+    uses: reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@v1
+    with:
+      issue_number: ${{ inputs.issue_number }}   # or wire your own trigger
+      runner: opencode
+      model: ""                                   # e.g. minimax/MiniMax-M2 (empty = repo config)
+      allowlist_authors: "your-login"
+      allowlist_label_actors: "your-login"
+    secrets:
+      minimax_api_key: ${{ secrets.MINIMAX_API_KEY }}
+```
+
+### B. Composable — the composite action (your triggers + gating)
+
+Use the execution primitive directly and own the trigger/gate. Template:
+[`examples/red-afk-attempt-action.yml`](./examples/red-afk-attempt-action.yml).
+
+```yaml
+on: { issues: { types: [labeled] } }
+permissions: { contents: write, issues: write, pull-requests: write }
+jobs:
+  attempt:
+    if: github.event.label.name == 'ready-for-agent'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reddb-io/red-skills/.github/actions/afk-attempt@v1
+        with:
+          issue: ${{ github.event.issue.number }}
+          runner: opencode
+          model: minimax/MiniMax-M2            # optional override
+          minimax-api-key: ${{ secrets.MINIMAX_API_KEY }}
+```
+
+## Triggers (reusable workflow)
+
+1. `workflow_call` — a thin caller in your repo.
+2. `workflow_dispatch` — manual run from the Actions UI (`issue_number` input).
+3. `issues: labeled` — fires when **`ready-for-agent`** is applied.
+4. `issues: opened` — fires when an issue is **created already carrying**
+   `ready-for-agent` (a pre-delegated issue). Raw label-less issues are NOT run
+   — they fall through to `red-issues-needs-triage` and the labeled path.
+
+## Trust gate (ADR 0056)
+
+The reusable refuses to claim unless the issue **author** AND the
+**label-applier** (the opener, for the `opened` path) are both in the allowlist
+(`allowlist_authors` / `allowlist_label_actors`). A failure logs, comments, and
+exits without a claim or PR. `enforce_trust_gate: "false"` bypasses it — for
+private repos only, never a public one. (Until #621, the auto-trigger path falls
+back to a hard-coded maintainer allowlist.)
+
+## Inputs
+
+| Input | Action | Reusable | Notes |
+|---|---|---|---|
+| `issue` / `issue_number` | ✓ | ✓ | required |
+| `runner` | ✓ | ✓ | `claude` \| `codex` \| `opencode` (CI default `opencode`) |
+| `model` | ✓ | ✓ | override every tier, e.g. `minimax/MiniMax-M2` (empty = repo config) |
+| `effort` | ✓ | ✓ | reasoning effort/variant override |
+| `*-api-key` secrets | ✓ (inputs) | ✓ (secrets) | the auth keys — passed as **action inputs** (composite actions can't read `secrets.*`) |
+| `allowlist_*`, `enforce_trust_gate` | — | ✓ | trust gate (policy layer) |
+
+## Runner + auth
+
+CI uses **opencode** by default — the API-auth runner with no host session (ADR
+0059). It is endpoint-agnostic: the model slug's leading segment routes the
+endpoint, and AFK forwards the first-set auth key. Precedence (first non-empty
+wins; `""` is treated as unset):
+
+| precedence | env / secret | slug prefix | endpoint |
+|---|---|---|---|
+| 1 | `OPENAI_API_KEY` | `openai/…` | OpenAI direct |
+| 2 | `MINIMAX_API_KEY` | `minimax/…` | MiniMax subscription |
+| 3 | `OPENROUTER_API_KEY` | `openrouter/<vendor>/…` | OpenRouter relay |
+
+So to drive a **MiniMax** subscription: wire `minimax-api-key` and set
+`model: minimax/<your-model>` — nothing else. (claude/codex runners need their
+own CLIs + `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`.) Details:
+[`runner-opencode.md`](./runner-opencode.md), and the model tiers/override in
+[`../model-tier-policy/SKILL.md`](../model-tier-policy/SKILL.md).
+
+## CI invariants (baked into the action)
+
+`RED_AFK_SANDBOX=none` (never a nested container, overrides any repo
+`afk.sandbox`), `GH_TOKEN = github.token`, a `github-actions[bot]` committer
+identity, and `--once`. Required permissions: exactly `contents: write`,
+`issues: write`, `pull-requests: write` — no `id-token`, no `actions: write`.
+
+## What it does NOT do
+
+No fleet, no admin-merge, no auto-merge — the human merges the PR. It also does
+not yet claim atomically against a concurrently-running local fleet (#622), and
+the config-sourced allowlist predicate is pending (#621).
+
+## See also
+
+- ADR 0059 (lane + OpenCode runner), ADR 0062 (composite-action packaging),
+  ADR 0038/0039 (launcher + Release distribution), ADR 0056 (trust gate).
+- [`SKILL.md`](./SKILL.md) — the local `/afk` runtime contract this mirrors.

--- a/plugins/dev/skills/engineering/afk/examples/red-afk-attempt-caller.yml
+++ b/plugins/dev/skills/engineering/afk/examples/red-afk-attempt-caller.yml
@@ -12,7 +12,7 @@
 #      `opencode-env.ts` picks the first set; the others are ignored.
 #
 # This file calls the published reusable workflow
-# `reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@main` and
+# `reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@v1` and
 # is the only piece of YAML your repo needs to enable the AFK Actions
 # lane. The reusable itself also auto-triggers on `issues: labeled`
 # when this caller does NOT route through it (e.g. an external
@@ -21,7 +21,7 @@
 #
 # If you don't want this caller to exist at all (i.e. you only want
 # auto-trigger), you don't need this file: install
-# `reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@main`
+# `reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@v1`
 # directly into your `.github/workflows/` and edit the
 # `allowlist_*` inputs there. The `if:` gate on that workflow
 # filters to the `ready-for-agent` label automatically.
@@ -60,7 +60,7 @@ jobs:
   # A reusable workflow is invoked at the JOB level via `uses:` (NOT as a step) —
   # `with:`/`secrets:` are siblings of `uses:`, and the job has no `runs-on`/`steps`.
   attempt:
-    uses: reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@main
+    uses: reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@v1
     with:
       issue_number: ${{ inputs.issue_number }}
       runner: opencode


### PR DESCRIPTION
The reusable workflow + composite action (ADR 0059/0062) were documented only in scattered YAML comments, two examples, and ADRs — and the `afk/SKILL.md` section had gone **stale**: 3 triggers (not 4), a `pnpm install` caller table that no longer applies, no mention of the composite action, and a duplicated code block. README had **zero** mention of the lane.

## What
- **New `plugins/dev/skills/engineering/afk/actions-lane.md`** — the single adopter guide:
  - 3-layer architecture (reusable workflow → composite action → launcher + Release bundle)
  - turnkey (reusable) vs composable (action) adoption, with both example links
  - the 4 triggers, the ADR 0056 trust gate, the full input table
  - opencode auth precedence + the **MiniMax recipe**, the `runner`/`model`/`effort` overrides
  - CI invariants (`RED_AFK_SANDBOX=none`, minimal permissions)
  - notes the lane depends only on **GitHub-official actions + our own**
- **`afk/SKILL.md`** — replaced the stale "execution environment" subsection with a tight, accurate summary pointing to the new guide.
- **`README.md`** — added a "Running /afk from GitHub Actions" pointer + the run-time `--runner`/`--model`/`--effort` override note.
- **caller example** — pinned the reusable to `@v1` (matches the composable example).

Cross-links verified; English-only; no watched memory surfaces (code-only docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783742280&installation_id=129708444&pr_number=678&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F678&signature=6eecb7f5f7c9848bcd86ca992be50820a0d96e70300ac3436def876599ed156e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AFK Actions lane—a new workflow capability for running `/afk` CI attempts directly from GitHub Actions with two flexible adoption approaches.

* **Documentation**
  * Updated `/afk` runner and model configuration guidance with reference to tier policies and validation mapping.
  * Added dedicated AFK Actions lane documentation covering three-layer architecture, adoption paths, and configuration.
  * Pinned workflow example to stable version tag for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->