### PR TITLE
feat(setup): /setup-red-skills installs the autonomous AFK lane (opt-in) + workflow catalogue

### DIFF
--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -81,6 +81,16 @@ Confirm with the user:
 - Does the `blocked:dependency` label exist? If not, create it (`gh label create blocked:dependency --color D4C5F9 --description "Waiting on other issues (req:N edges); auto-unblocks when the last dependency closes"`). `req:N` edge labels are created on demand by `/to-issues` (`gh label create req:<n>`) like `prd:N`, so they need no upfront provisioning.
 - Provision the typed **blocked-reason** labels `/afk` applies to describe *why* an iteration stopped (it falls back to creating each on the fly, so this only keeps colour/description consistent): `gh label create blocked:quota`, `blocked:runner-transient`, `blocked:merge-conflict`, `blocked:spec`, `blocked:validation`, `blocked:crashed`, `blocked:policy`, `blocked:stalled`, `blocked:infra` (suggested colour `E99695`, descriptions per the *Blocked Reasons* table in triage-labels). These are descriptive (added alongside the routing label) — see triage-labels.
 
+**Autonomous AFK execution lane (opt-in — default NO).** Beyond auto-triage, RedSkills can run `/afk` itself **from GitHub Actions** — one attempt per issue, opening a PR with no human at a terminal (the "offline" / headless lane, ADR 0059/0062). This is a bigger commitment than auto-triage, so it is **off by default**. Offer it, defaulting to no:
+
+- Install the AFK Actions lane (`red-afk-attempt.yml`) into `.github/workflows/`? **Default: no.** Explain the prerequisites before a yes:
+  - **Secrets** — an OpenCode auth key as a repo secret (`MINIMAX_API_KEY`, `OPENAI_API_KEY`, or `OPENROUTER_API_KEY`; first set wins). Without one the lane fires but the agent fails auth.
+  - **Trust gate** — only allowlisted issue authors + label-appliers can drive a run (you set the logins). Public repos: keep the allowlist to yourself + your bot.
+  - **Triggers** — fires on `ready-for-agent` (labeled, or an issue opened already carrying it) / manual dispatch.
+  - Full reference: [`../afk/actions-lane.md`](../afk/actions-lane.md).
+
+For the complete `red-*` workflow catalogue (which are adopter-installable vs. red-skills' own CI), see [WORKFLOWS.md](./WORKFLOWS.md).
+
 Future RedSkills workflows will land in this same step. Filename prefix `red-` is mandatory.
 
 **Section E — Token efficiency (strongly recommended).**
@@ -205,6 +215,13 @@ Then write the three docs files using the seed templates in this skill folder as
 - [domain.md](./domain.md) — domain doc consumer rules + layout
 
 If the user accepted Section D, copy each `workflows/red-*.yml` template from this skill folder into `.github/workflows/` of the consumer repo. Don't overwrite existing files with the same name — diff and ask first. Then ensure both `needs-triage` and `runner-error` labels exist via `gh label create` if missing (`gh label create runner-error --color B60205 --description "AFK supervisor circuit-tripped; runner was misconfigured"`).
+
+**If the user opted into the autonomous AFK execution lane** (Section D, default no), additionally:
+
+1. Copy [`../afk/examples/red-afk-attempt-caller.yml`](../afk/examples/red-afk-attempt-caller.yml) to `.github/workflows/red-afk-attempt.yml` in the consumer repo. Don't overwrite an existing file — diff and ask first.
+2. Edit `allowlist_authors` and `allowlist_label_actors` to the maintainer login(s) the user named (the trust gate; keep it short on public repos).
+3. Print the secret-setup guidance — the lane needs one OpenCode auth key as a repo secret; do **not** set it for them (secrets are the user's to provision): `gh secret set MINIMAX_API_KEY` (or `OPENAI_API_KEY` / `OPENROUTER_API_KEY`; first set wins). Point them at [`../afk/actions-lane.md`](../afk/actions-lane.md) for the auth precedence + the `model` slug (e.g. `minimax/MiniMax-M2`).
+4. Note that the lane will not fire until both a secret is set and an issue carries `ready-for-agent` from an allowlisted actor.
 
 Scaffold `.red/config.yaml` (Section G, no user decision):
 

--- a/plugins/dev/skills/engineering/setup-red-skills/WORKFLOWS.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/WORKFLOWS.md
@@ -1,0 +1,35 @@
+# RedSkills GitHub Actions workflows
+
+Every RedSkills workflow is filename-prefixed `red-`. They split into two
+groups: **adopter-installable** (offered by `/setup-red-skills` Section D) and
+**red-skills' own CI** (live in `reddb-io/red-skills`, not copied into adopter
+repos).
+
+## Adopter-installable (offered by `/setup-red-skills`)
+
+| Workflow | Default | Trigger | What it does |
+|---|---|---|---|
+| `red-issues-needs-triage.yml` | **install (yes)** | `issues: opened`/`reopened` | Auto-applies `needs-triage` to any fresh label-less issue, so reports never slip past `/triage` and never sit invisible to `/afk` (which only drains `ready-for-agent`). |
+| `red-afk-attempt.yml` | **opt-in (no)** | `issues: labeled`/`opened` (on `ready-for-agent`), `workflow_dispatch`, `workflow_call` | The **AFK Actions lane** — runs one `/afk` attempt per issue headless from Actions and opens a PR (no fleet, no admin-merge; human merges). Needs an OpenCode auth secret + a trust-gate allowlist. Full guide: [`../afk/actions-lane.md`](../afk/actions-lane.md). |
+
+The AFK lane has two shapes (both in `../afk/examples/`): the **turnkey caller**
+(`red-afk-attempt-caller.yml`, what `/setup-red-skills` installs) and the
+**composable action** (`red-afk-attempt-action.yml`, for your own triggers/gate).
+It depends only on GitHub-official actions plus reddb-io's own composite action.
+
+## red-skills' own CI (NOT installed into adopter repos)
+
+These run in `reddb-io/red-skills` only. Listed so the catalogue is complete.
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `red-release.yml` | push to `main` | Auto-release: conventional-commit version bump, build the per-plugin bundles, publish a GitHub Release with the assets. Defers while a `running` issue (an active fleet) exists. |
+| `red-memory-drift-guard.yml` | `pull_request` | Fails a PR that changes a watched memory surface (`.red/adr/**`, the glossary) without a `Memory-Ingested:`/`Memory-NoIngest:` audit marker. |
+| `red-memory-bench.yml` | `pull_request`, push to `main` | Memory deterministic-core regression gate. |
+| `red-memory-wiki-extract.yml` | PR merge | Extracts LLM-Wiki pages from the merged PR. |
+| `red-upstream-watch.yml` | schedule | Opens a tracking issue when `mattpocock/skills` advances past the recorded `.upstream` SHA. |
+
+## Conventions
+
+- **Prefix `red-`** is mandatory for every RedSkills workflow (easy to spot alongside the host repo's own CI).
+- Adopter-installable workflows are copied by `/setup-red-skills` Section D from this skill folder (`workflows/`) or, for the AFK lane, from `../afk/examples/`.


### PR DESCRIPTION
Answers the gap you flagged: `/setup-red-skills` only installed `red-issues-needs-triage.yml`, so an adopter got auto-triage but **not** the offline/headless AFK execution lane (`red-afk-attempt`) — and the setup skill didn't even mention it.

## What
- **Section D opt-in (default NO): the autonomous AFK execution lane.** Installs `red-afk-attempt.yml` from `../afk/examples/red-afk-attempt-caller.yml`, edits the trust-gate allowlist, and prints secret-setup guidance (`MINIMAX_API_KEY`/`OPENAI_API_KEY`/`OPENROUTER_API_KEY` — the user provisions secrets; setup never sets them). **Off by default** (needs secrets + trust gate + autonomous PRs = deliberate), unlike the on-by-default `needs-triage`.
- **New `WORKFLOWS.md` catalogue** — every `red-*` workflow, split into **adopter-installable** (`needs-triage` default-yes, `afk-attempt` opt-in) vs **red-skills' own CI** (release, drift-guard, bench, wiki-extract, upstream-watch). Linked from Section D.
- The lane template is **referenced from `afk/examples/`** (not duplicated into `setup-red-skills/workflows/`), so the "copy each `red-*.yml`" default set stays `needs-triage`-only and the lane stays opt-in.

## Net effect
A repo running `/setup-red-skills` can now opt into headless AFK execution (issue → autonomous PR via Actions) during onboarding, with clear prerequisites — instead of hand-copying the caller.

## Validation
Links resolve; `scripts/validate-agent-metadata.sh` → `agent metadata ok`; `doctor-docs` + `label-vocabulary-docs` tests green. No watched memory surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783743907&installation_id=129708444&pr_number=680&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F680&signature=7f030f3172bb75cbb555bcb1f0bc9d7dfcfb858d669a174f0a27eb2e2db54d58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added setup instructions for optional autonomous AFK execution with prerequisites, configuration guidance, and workflow templates
* Added workflow reference documentation covering naming conventions, available workflows, and operational details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->