### PR TITLE
docs(adr): correct stale src/apps paths in 9 ADRs + 0059→0062 note (closes #682)

### DIFF
--- a/.red/adr/0027-memory-plugin-closed-loop-via-hooks-and-ci.md
+++ b/.red/adr/0027-memory-plugin-closed-loop-via-hooks-and-ci.md
@@ -17,7 +17,7 @@ those surfaces is **passive in two directions**:
   `Stop`, and `PreCompact` entries that each invoke
   `scripts/bootstrap.mjs hook <event> --runner <r>` with best-effort failure
   handling (`|| printf "{}"`). The dispatcher in
-  `src/apps/memory/src/hook-runtime.ts`
+  `apps/memory/src/hook-runtime.ts`
   routes them to `handleSessionStart` (engine `recall`), `handlePostToolUse`
   (`reindexFiles`), and `handleFlush` (`extractStructuredTranscript` +
   `factsToGraph`, then `PromotionEngine`). `recordLifecycle` writes each
@@ -45,7 +45,7 @@ Two mechanisms cited above were later superseded:
   (resolved under `${CLAUDE_PLUGIN_ROOT}`).
 - **Source location.** **ADR 0034** moved each plugin's implementation out of
   `plugins/<x>/src/` and under a top-level monorepo `src/`; the hook dispatcher
-  now lives at `src/apps/memory/src/hook-runtime.ts` (`plugins/memory/src/` no
+  now lives at `apps/memory/src/hook-runtime.ts` (`plugins/memory/src/` no
   longer holds source). The references below have been updated in place to the
   current paths; ADR 0041 records the pending migration of this code to a
   separate `red-memory` repo.
@@ -99,7 +99,7 @@ symmetrically catches Codex contributors and the human-only
 ### Already implemented or merged
 
 - SessionStart recall, PostToolUse reindex, Stop / PreCompact flush, and
-  lifecycle logging: shipped in `src/apps/memory/src/hook-runtime.ts`
+  lifecycle logging: shipped in `apps/memory/src/hook-runtime.ts`
   (issues #221 and #223 closed as already done).
 - PR-merge → wiki extract Action (#219 — merged).
 - Repo-versioned `MEMORY.md` migration (#220 — merged).

--- a/.red/adr/0036-memory-transports-are-adapters-over-the-operation-registry.md
+++ b/.red/adr/0036-memory-transports-are-adapters-over-the-operation-registry.md
@@ -5,7 +5,7 @@
 Memory exposes ~80 read-only surfaces (the report + viewer pairs in the
 `memory` glossary) over three transports: CLI, MCP, and an optional local HTTP
 server. A seam for these already exists — `MemoryOperation<Input, Output>` in
-`src/apps/memory/src/operations.ts`, indexed by
+`apps/memory/src/operations.ts`, indexed by
 `createReadOnlyMemoryOperationRegistry`, carrying `inputSchema`, `outputSchema`,
 `execute`, and `renderer.{cli,mcp}` metadata.
 

--- a/.red/adr/0038-dev-runtime-ships-as-a-fetched-asset-not-a-committed-bundle.md
+++ b/.red/adr/0038-dev-runtime-ships-as-a-fetched-asset-not-a-committed-bundle.md
@@ -24,7 +24,7 @@ production by a sibling domain:
 - **ADR 0034** generalised the Memory bootstrap into a per-plugin dynamic-fetch
   mechanism: every domain builds to `<plugin>.bundle.min.mjs`, attached to the
   GitHub Release as an asset with a `<plugin>.manifest.json` sha256.
-- `src/packages/shared/bundle-fetch.ts` (pure, unit-tested) + the committed,
+- `packages/shared/bundle-fetch.ts` (pure, unit-tested) + the committed,
   dependency-free `red-fetch.mjs` launcher resolve and verify a bundle into a
   version-keyed cache (`~/.cache/red-skills/bundles/<plugin>-<version>.bundle.min.mjs`).
 - The dev plugin's **SessionStart hook already runs `red-fetch dev <version>`**,
@@ -68,7 +68,7 @@ domain and supersedes ADR 0032.
    existing call sites (`SKILL.md`, statusline hooks) invoke `node bin/afk.mjs`
    unchanged — only the file's *content* shrinks from 2.6 MB to a launcher.
 
-3. **`build` no longer emits a committed bundle.** `src/apps/dev` drops the
+3. **`build` no longer emits a committed bundle.** `apps/dev` drops the
    `bundle:bin` script; `build` = `bundle` (→ `dist/dev.bundle.min.mjs`) +
    `bundle:red-fetch` (→ committed `red-fetch.mjs`). The release workflow stops
    staging/committing `bin/afk.mjs`; it still rebuilds+stages `red-fetch.mjs` (the
@@ -98,7 +98,7 @@ domain and supersedes ADR 0032.
   network. Offline-without-cache fails loudly with build/network guidance.
 - `node` is assumed on the client — unchanged from ADR 0032.
 - The e2e smoke (`scripts/afk-e2e-smoke.sh`) and any direct `node bin/afk.mjs` use
-  now require a resolvable bundle (cache or a local `pnpm -C src/apps/dev bundle`).
+  now require a resolvable bundle (cache or a local `pnpm -C apps/dev bundle`).
 
 ## Status
 

--- a/.red/adr/0039-plugin-entrypoints-share-one-source.md
+++ b/.red/adr/0039-plugin-entrypoints-share-one-source.md
@@ -26,7 +26,7 @@ bootstrap the fetched runtime — it cannot itself be fetched. The question is n
 
 ## Decision
 
-**One source — `src/packages/shared/entrypoint-cli.ts` — is the single entrypoint
+**One source — `packages/shared/entrypoint-cli.ts` — is the single entrypoint
 for every per-plugin bundle. The build emits it to each committed path with a
 `__ENTRYPOINT_ROLE__` esbuild define that selects behaviour.**
 

--- a/.red/adr/0041-red-skills-consumes-red-memory-and-red-ui-mcps.md
+++ b/.red/adr/0041-red-skills-consumes-red-memory-and-red-ui-mcps.md
@@ -8,7 +8,7 @@ The red ecosystem has a dedicated repo per product:
 - `red-memory` — the local-first graph+markdown memory plugin for Claude Code, backed by RedDB (`packages/mcp-server/`, hooks, CLI). Currently **pre-alpha**.
 - `red-ui` — the universal RedDB client, one Svelte source shipped three ways: embeddable web component (`@reddb-io/ui/embed`), an MCP *App* server (`@reddb-io/ui-mcp`, renders the client inside an MCP host), and a Tauri desktop app.
 
-red-skills historically **built** the memory plugin under `src/apps/memory` (mature, ~55k lines) and exposed it as the `memory` MCP — even though `red-memory` is the dedicated home. The mature implementation lived here; the dedicated repo was the empty shell. Separately, the memory MCP name was inconsistent across three surfaces (`memory` registered, but the routing-guide advertised `reddb-memory` + `command: memory-mcp` + `MEMORY_ROOT`, a command/env that does not match the real bootstrap invocation).
+red-skills historically **built** the memory plugin under `apps/memory` (mature, ~55k lines) and exposed it as the `memory` MCP — even though `red-memory` is the dedicated home. The mature implementation lived here; the dedicated repo was the empty shell. Separately, the memory MCP name was inconsistent across three surfaces (`memory` registered, but the routing-guide advertised `reddb-memory` + `command: memory-mcp` + `MEMORY_ROOT`, a command/env that does not match the real bootstrap invocation).
 
 There are two distinct MCPs in play, repeatedly conflated:
 
@@ -17,14 +17,14 @@ There are two distinct MCPs in play, repeatedly conflated:
 
 ## Decision
 
-1. **red-skills is a consumer, not the home, of memory and UI.** The mature `src/apps/memory` **migrates to the `red-memory` repo** (its canonical home), which becomes the source of the memory plugin/MCP. `src/apps/memory` is retired from red-skills after the migration lands.
+1. **red-skills is a consumer, not the home, of memory and UI.** The mature `apps/memory` **migrates to the `red-memory` repo** (its canonical home), which becomes the source of the memory plugin/MCP. `apps/memory` is retired from red-skills after the migration lands.
 
 2. **Canonical MCP names align with their owning repo:**
    - **`red-memory`** — the data/tools MCP (was `memory` / the never-settled `reddb-memory`). Tools keep the `memory_*` prefix; only the server name changes.
    - **`red-ui`** — the visualizer MCP App (was `ui-mcp` / `@reddb-io/ui-mcp`).
    - **`code-nav`** — unchanged; stays built in red-skills under the `dev` plugin. The brand-prefix asymmetry (`code-nav` not `red-code-nav`) is accepted.
 
-3. **red-skills pulls both as bundles from their repos' GitHub releases** (the fetch model of ADR 0029) — one fetch mechanism across the ecosystem, no npm-registry runtime dependency. **Both MCPs live in the memory plugin's `.mcp.json`** — `red-memory` (data) *and* `red-ui` (visualizer) — as consumers; red-skills builds neither. This replaces today's single, standalone-local `memory` server (which runs `scripts/bootstrap.mjs` against the in-repo `src/apps/memory` build). Target shape:
+3. **red-skills pulls both as bundles from their repos' GitHub releases** (the fetch model of ADR 0029) — one fetch mechanism across the ecosystem, no npm-registry runtime dependency. **Both MCPs live in the memory plugin's `.mcp.json`** — `red-memory` (data) *and* `red-ui` (visualizer) — as consumers; red-skills builds neither. This replaces today's single, standalone-local `memory` server (which runs `scripts/bootstrap.mjs` against the in-repo `apps/memory` build). Target shape:
 
    ```jsonc
    // plugins/memory/.mcp.json (end state)
@@ -47,15 +47,15 @@ There are two distinct MCPs in play, repeatedly conflated:
 - red-skills shrinks to the `dev` plugin (code-nav, AFK, skills) plus thin consumption of `red-memory` / `red-ui`. The ~55k-line memory app, its tests, hooks, and memory skills leave for `red-memory`.
 - Per-repo ownership mirrors the product split (reddb / red-memory / red-ui); the visualizer is never duplicated here.
 - `memory` → `red-memory` is a **client-contract rename**: any agent config or doc referencing the `memory` MCP server must update; the routing-guide is fixed to emit the real runnable command.
-- **Large multi-repo migration** — sequenced, not atomic: stand up `red-memory` from the migrated code, bundle + release it, bundle `red-ui`'s `ui-mcp`, then rewire red-skills' `.mcp.json` to fetch both, then retire `src/apps/memory`. Open red-skills issues (#370–#374 and others) that target `src/apps/memory` move with it.
-- **Partially reverses ADR 0034** (which placed memory under `src/apps/memory`) — for memory only; `dev` stays in red-skills.
+- **Large multi-repo migration** — sequenced, not atomic: stand up `red-memory` from the migrated code, bundle + release it, bundle `red-ui`'s `ui-mcp`, then rewire red-skills' `.mcp.json` to fetch both, then retire `apps/memory`. Open red-skills issues (#370–#374 and others) that target `apps/memory` move with it.
+- **Partially reverses ADR 0034** (which placed memory under `apps/memory`) — for memory only; `dev` stays in red-skills.
 
 ## Status
 
-Accepted (direction). The multi-repo migration is large and pending; until it lands, `src/apps/memory` remains the live source.
+Accepted (direction). The multi-repo migration is large and pending; until it lands, `apps/memory` remains the live source.
 
 ## Related
 
 - ADR 0029 — runtime ships as a release-asset bundle fetched by a bootstrap (the fetch model reused here).
-- ADR 0034 — monorepo `src/apps` domains (partially reversed for memory).
+- ADR 0034 — monorepo `apps` domains (partially reversed for memory).
 - `../red-memory`, `../red-ui` — the owning repos.

--- a/.red/adr/0042-plugin-config-unified-under-red-config-yaml.md
+++ b/.red/adr/0042-plugin-config-unified-under-red-config-yaml.md
@@ -4,8 +4,8 @@
 
 Each plugin resolved its own configuration, in its own place, in its own format:
 
-- `dev` reads `.red/config.yaml` (YAML) — `afk.*` and `statusline` keys, hand-authored, read-only to the code (`src/apps/dev/src/core/config.ts`).
-- `memory` read **and wrote** `.red/memory/config.json` (JSON) — `mode`, `hooks`, `notesDir`, `storePath`, `provider`, … (`src/apps/memory/src/config.ts`).
+- `dev` reads `.red/config.yaml` (YAML) — `afk.*` and `statusline` keys, hand-authored, read-only to the code (`apps/dev/src/core/config.ts`).
+- `memory` read **and wrote** `.red/memory/config.json` (JSON) — `mode`, `hooks`, `notesDir`, `storePath`, `provider`, … (`apps/memory/src/config.ts`).
 
 There is no shared config-resolution module; the two formats and locations diverged for no principled reason. A maintainer inspecting a repo sees two unrelated config conventions and cannot answer "where do I set plugin X?" from one place.
 

--- a/.red/adr/0047-afk-salvages-no-sentinel-branch-that-passes-feedback.md
+++ b/.red/adr/0047-afk-salvages-no-sentinel-branch-that-passes-feedback.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-accepted. Complements ADR 0028 (`<promise>` is the canonical attempt-exit). Supersedes the runtime half of the stale PR #335 (`fix/332-afk-salvage-no-sentinel`, ~169 commits behind on the pre-`src/apps` tree); re-implemented here on the current `src/apps/dev/src/core/process-issue.ts`.
+accepted. Complements ADR 0028 (`<promise>` is the canonical attempt-exit). Supersedes the runtime half of the stale PR #335 (`fix/332-afk-salvage-no-sentinel`, ~169 commits behind on a tree predating the monorepo relocation); re-implemented here on the current `apps/dev/src/core/process-issue.ts`.
 
 ## Context
 

--- a/.red/adr/0052-one-bundle-naming-convention-under-dist.md
+++ b/.red/adr/0052-one-bundle-naming-convention-under-dist.md
@@ -9,7 +9,7 @@ accepted. Supersedes the transitional dual-output state described in ADR 0029 (l
 The release shipped two parallel, inconsistent artifact shapes:
 
 - **dev, code-nav, benchmark-\*** → a single minified bundle in `./dist/`: `<app>.bundle.min.mjs` + `<app>.manifest.json`.
-- **memory, brain** → a non-minified pair under `src/apps/<app>/dist-bundle/`: `<app>-cli.mjs` + `<app>-mcp.mjs`, plus `<app>-runtime-manifest.json` written next to the package.
+- **memory, brain** → a non-minified pair under `apps/<app>/dist-bundle/`: `<app>-cli.mjs` + `<app>-mcp.mjs`, plus `<app>-runtime-manifest.json` written next to the package.
 
 The memory/brain build *already* produced the clean `dist/<app>.bundle.min.mjs` + `dist/<app>-mcp.bundle.min.mjs` via `pnpm bundle` — but the release ran `pnpm bundle:legacy` and shipped the `dist-bundle/*-cli.mjs` artifacts instead, leaving the clean bundles built and discarded. The result was incoherent: a `dist-bundle/` directory that shouldn't exist, non-minified 1.8 MB CLIs named `*-cli.mjs` (no `.bundle.min`), manifests outside `dist/`, and two naming schemes for the same concept.
 
@@ -25,7 +25,7 @@ One convention. Every release asset lives under `./dist/` and follows `<app>[-<r
 
 Concretely: drop the `bundle:legacy*` scripts from memory and brain; the release runs `pnpm bundle` and reads/uploads the `dist/` bundles; the runtime manifest's `cli.asset` / `mcp.asset` fields name the `dist/` bundles.
 
-The plugin bootstraps are unaffected at the fetch layer: they read the asset names **from the version-pinned manifest**, so the rename follows automatically and every released version stays internally self-consistent (an old launcher + old tag resolves old names; a new launcher + new tag resolves new names — no cross-version break). Only the dev-checkout *local fallback* path is repointed from `src/apps/<app>/dist-bundle/` to `./dist/`. The version-keyed runtime cache filenames (`<runtimeRoot>/<version>/memory-cli.mjs`) are internal and unchanged, so `memory-bridge.sh` keeps resolving them.
+The plugin bootstraps are unaffected at the fetch layer: they read the asset names **from the version-pinned manifest**, so the rename follows automatically and every released version stays internally self-consistent (an old launcher + old tag resolves old names; a new launcher + new tag resolves new names — no cross-version break). Only the dev-checkout *local fallback* path is repointed from `apps/<app>/dist-bundle/` to `./dist/`. The version-keyed runtime cache filenames (`<runtimeRoot>/<version>/memory-cli.mjs`) are internal and unchanged, so `memory-bridge.sh` keeps resolving them.
 
 ## Consequences
 

--- a/.red/adr/0057-brain-depends-on-fetched-never-vendored-red-hermes-black-box.md
+++ b/.red/adr/0057-brain-depends-on-fetched-never-vendored-red-hermes-black-box.md
@@ -4,7 +4,7 @@
 
 The `brain` plugin reaches external messaging channels (the "channel bridge")
 through **`reddb-io/red-hermes`**, a separate product consumed as an internal
-**black box**. The integration point is `src/apps/brain/src/channel-bridge.ts`
+**black box**. The integration point is `apps/brain/src/channel-bridge.ts`
 (`McpStdioChannelBridge`), which spawns the runtime as a stdio MCP server with
 `command: "hermes"`, `args: ["mcp", "serve"]` and speaks only the MCP tool
 protocol to it — never red-hermes' Python internals, models, or storage.
@@ -38,7 +38,7 @@ coordination, never vendored.
 ## Decision
 
 1. **`red-hermes` is a dependency of the `brain` plugin, not `memory`.** Its only
-   consumer is `src/apps/brain/src/channel-bridge.ts`, and it is reached **only**
+   consumer is `apps/brain/src/channel-bridge.ts`, and it is reached **only**
    via `hermes mcp serve` over stdio MCP. `brain` treats it as a black box: it
    calls the 10-tool surface and never the Python runtime directly.
 
@@ -133,5 +133,5 @@ are downstream, blocked on red-hermes publishing fetchable releases.
   (the sibling consume-don't-build precedent).
 - ADR 0004 — Apache-2.0 relicense with a `NOTICE` for upstream MIT (the
   attribution model extended here).
-- `src/apps/brain/src/channel-bridge.ts` — the `McpStdioChannelBridge` and the
+- `apps/brain/src/channel-bridge.ts` — the `McpStdioChannelBridge` and the
   `HERMES_CHANNEL_BRIDGE_TOOLS` contract.

--- a/.red/adr/0059-opencode-is-the-third-afk-runner-over-openrouter.md
+++ b/.red/adr/0059-opencode-is-the-third-afk-runner-over-openrouter.md
@@ -7,6 +7,9 @@ runner, OpenRouter-only, explicit pin) stands; the amendment extends the
 endpoint surface to any OpenAI-compatible endpoint (OpenAI direct, MiniMax
 subscription, OpenRouter relay) and shifts endpoint resolution into OpenCode.
 
+**Refined by ADR 0062:** the Actions-lane packaging introduced here is now a
+composite action + reusable workflow (the lane's runtime contract is unchanged).
+
 ## Context
 
 AFK ships two inner-agent runners — Claude Code and Codex — each integrated the


### PR DESCRIPTION
Slice 1/3 of PRD #681 (the `/dev:review-adrs` reconciliation). Closes #682.

After ADR 0060 relocated `src/apps/*`→`apps/*` and `src/packages/*`→`packages/*`, nine still-accepted ADRs cited the old paths. This reconciles the **prose** without touching any standing decision.

- **Path swap** `src/apps/`→`apps/`, `src/packages/`→`packages/` in 0027, 0036, 0038, 0039, 0041, 0042, 0047, 0052, 0057.
- **Live-claim fixes** (the judgment bit from Q01): 0041 (`apps/memory` remains the live source) and 0047 (the current `apps/dev/src/core/process-issue.ts`) — both asserted now-wrong live paths.
- **Two bare historical phrases** reworded so no stale literal survives (0041 "monorepo `apps` domains", 0047 "a tree predating the monorepo relocation").
- **0059 Status** gains a "Refined by ADR 0062" note — 0062 already cited 0059, this closes the bidirectional link.

**Gate:** `git grep -lE 'src/apps|src/packages' -- .red/adr/0*.md` now returns only `0034` + `0060` (both legitimately describe the pre-relocation layout with a relocation note). No decision reversed.

Follow-ups in the PRD: #683 (INDEX refresh) and #684 (wiki re-ingest), both `req:682` → auto-promote when this closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783745544&installation_id=129708444&pr_number=685&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F685&signature=503466254bc049c4bed77e339c9edcf1c7083f1e39bcde08a2a303c72f50b05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture documentation to reflect current monorepo structure and organization.
  * Clarified plugin integration patterns and asset delivery processes across multiple architectural decision records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->