### PR TITLE
docs(adr): refresh INDEX — 0058 note + 0059→0062 edge (closes #683)

### DIFF
--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -9,6 +9,9 @@ stale notes inline.
 > **0005** to **0046**.
 > **0043** was reserved/pending for PR #393 ("dev loop / ship") while that PR was
 > in flight; do not reclaim the number.
+> **0058** is held by an unmerged AFK "goal-predicate" branch (commit `daa3cc18`)
+> and never landed on `main`; if that branch is abandoned the number is free,
+> otherwise it lands with it — do not reclaim it blindly.
 
 ## Repo structure & contexts
 - **0021** Multi-context plugin glossaries — *accepted*
@@ -49,7 +52,7 @@ stale notes inline.
 - **0050** AFK salvages an uncommitted worktree when the inner agent emits DONE without committing (codex non-compliance net) *(complements 0047, 0028)*
 - **0051** AFK attempt-progress guard resets on worktree edits, not just commits — stops false-stalling the productive-but-not-committing codex runner *(refines 0044, 0045)*
 - **0054** AFK arms the attempt guard + heartbeat under docker/podman isolation via an attempt-dir bind mount; lane-idle reaper stays host-only *(supersedes 0044 §4 / 0045 §4; relies on 0033; absorbs #284 docker E2E)*
-- **0059** OpenCode is the third AFK runner, addressing OpenRouter through its own `openrouter/<vendor>/<model>` slug + the `OpenCodeOptions.env` auth seam; accepted only as an explicit pin, never auto-sniffed. **Amended (1):** endpoint-agnostic — accepts any `<provider>/<model>` slug, propagates the first-set auth env-var (OPENAI_API_KEY > MINIMAX_API_KEY > OPENROUTER_API_KEY) through `OpenCodeOptions.env`; OpenCode owns endpoint resolution. **Amended (2):** MiniMax subscription API as the concrete case that motivated the endpoint-agnostic property *(follows 0003, 0033, 0049)*
+- **0059** OpenCode is the third AFK runner, addressing OpenRouter through its own `openrouter/<vendor>/<model>` slug + the `OpenCodeOptions.env` auth seam; accepted only as an explicit pin, never auto-sniffed. **Amended (1):** endpoint-agnostic — accepts any `<provider>/<model>` slug, propagates the first-set auth env-var (OPENAI_API_KEY > MINIMAX_API_KEY > OPENROUTER_API_KEY) through `OpenCodeOptions.env`; OpenCode owns endpoint resolution. **Amended (2):** MiniMax subscription API as the concrete case that motivated the endpoint-agnostic property *(follows 0003, 0033, 0049; refined by 0062)*
 - **0062** AFK Actions lane is a repo-portable composite action (`.github/actions/afk-attempt`) under a thin reusable workflow (triggers + trust gate); execution carries its own red-skills checkout so the launcher resolves in any adopter repo *(refines 0059; reuses 0038/0039 launcher, 0033/0061 seam, 0056 gate)*
 
 ## Branch lock


### PR DESCRIPTION
Slice 2/3 of PRD #681. Closes #683 (blocker #682 already landed).

- **0058 held-slot note** in the numbering-collisions block (held by the unmerged `daa3cc18` goal-predicate branch; mirrors the 0043 reservation).
- **0059→0062 refinement edge** added to the 0059 entry (0062 already cited 0059).
- Stale-marker check: the only INDEX `src/apps` is the 0060 entry describing its own relocation — legit, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783745686&installation_id=129708444&pr_number=686&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F686&signature=73473bdb3a4239c94fbfb339b3cb01e0920d996dec162b7c8acc73593c1ca4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision records with refinements to existing references and reservation notes.

**Note:** These changes are internal documentation updates with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->