### PR TITLE
fix(afk): terminal history event appends even when the envelope POST fails (closes #625)

### DIFF
--- a/apps/dev/src/core/envelope-emit.ts
+++ b/apps/dev/src/core/envelope-emit.ts
@@ -315,7 +315,14 @@ export async function emitEnvelope(
   await deps.writePosted(posted);
   if (!posted) {
     warnings.push(`failed to post envelope for #${input.issue} (status=${input.status})`);
-  } else if (input.historyPath && input.historyClock) {
+  }
+  // The local history ledger is independent of the GitHub comment POST (#625).
+  // Append the terminal event whether or not the comment landed — a transient
+  // post failure must not drop the `done`/`blocked` record that feeds the
+  // monitor sparkline and the drain-promotion counters (the 2026-06-09 gap:
+  // three issues landed but produced no `done` records because the append was
+  // gated behind `posted === true`).
+  if (input.historyPath && input.historyClock) {
     const append = deps.historyAppend ?? historyAppend;
     await append(
       input.historyPath,

--- a/apps/dev/tests/envelope-emit.test.ts
+++ b/apps/dev/tests/envelope-emit.test.ts
@@ -325,6 +325,36 @@ describe("emitEnvelope — done", () => {
     expect(event).toBe("done");
     expect(fields).toMatchObject({ worker: "wTEST", issue: 20, runner: "claude" });
   });
+
+  // Regression (#625): the local history ledger is independent of the GitHub
+  // comment POST. A transient post failure must NOT drop the terminal record —
+  // before the fix the append sat in an `else if (posted)` branch, so the
+  // 2026-06-09 gap saw three issues land with no `done` record (frozen sparkline).
+  it("appends the history event even when the comment POST fails (#625)", async () => {
+    const { deps, historyAppend, posted } = makeDeps({ posterOk: false });
+    const res = await emitEnvelope(deps, {
+      status: "done",
+      issue: 21,
+      worker: "wTEST",
+      durationS: 600,
+      branch: "b",
+      attempt: 1,
+      mergeSha: "abcdef1",
+      diff: "merged",
+      historyPath: "/ledger.jsonl",
+      historyClock: { ts: "2026-05-30T00:00:00Z", epoch: 1748563200 },
+      historyFields: { runner: "claude", merge_sha: "abcdef1", duration_s: 600 },
+    });
+    // posted=false is still surfaced (warning + signal), but the ledger append fires anyway.
+    expect(res.posted).toBe(false);
+    expect(posted.writes).toContain(false);
+    expect(res.warnings.some((w) => w.includes("failed to post envelope"))).toBe(true);
+    expect(historyAppend).toHaveBeenCalledTimes(1);
+    const [path, , event, fields] = historyAppend.mock.calls[0]!;
+    expect(path).toBe("/ledger.jsonl");
+    expect(event).toBe("done");
+    expect(fields).toMatchObject({ worker: "wTEST", issue: 21 });
+  });
 });
 
 // ===========================================================================
@@ -392,7 +422,7 @@ describe("emitEnvelope — failure push/markers/posted flow", () => {
     expect(res.warnings.length).toBeGreaterThan(0);
   });
 
-  it("sets posted=false and skips the history append when the post fails", async () => {
+  it("sets posted=false but still appends the history event when the post fails (#625)", async () => {
     const { deps, posted, historyAppend } = makeDeps({ gitCode: 0, posterOk: false });
     const res = await emitEnvelope(deps, {
       status: "blocked",
@@ -413,7 +443,10 @@ describe("emitEnvelope — failure push/markers/posted flow", () => {
     });
     expect(res.posted).toBe(false);
     expect(posted.writes).toEqual([false]);
-    expect(historyAppend).not.toHaveBeenCalled();
+    // #625: the ledger append is independent of the comment POST — a failed
+    // post still surfaces the warning, but the terminal `blocked` record lands.
+    expect(historyAppend).toHaveBeenCalledTimes(1);
+    expect(historyAppend.mock.calls[0]![2]).toBe("blocked");
     expect(res.warnings.some((w) => w.includes("failed to post envelope for #11"))).toBe(true);
   });
 });


### PR DESCRIPTION
Parent PRD #614.

**Root cause:** in `emitEnvelope` the history-ledger append was gated inside the `else if (posted)` branch — a transient `gh issue comment` failure (`posted === false`) silently dropped the `done`/`blocked` record. The 2026-06-09 gap: three issues landed but produced no `done` records, freezing the sparkline + drain-promotion counters.

**Fix:** the local ledger is independent of the GitHub comment — append the terminal event unconditionally (when `historyPath`+`historyClock` are set); the `!posted` warning + `envelope.posted` signal stay separate. flock append + truncation unchanged.

**Tests:** new regression for the post-fails path; the stale test that *encoded the bug* (`historyAppend).not.toHaveBeenCalled()`) flipped to assert the fix. envelope-emit + history green (37/37), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783746230&installation_id=129708444&pr_number=687&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F687&signature=a95956535cbff7123d4a788346986d3bf8dcc3fe3c1dbb2a1f7f0bee16455907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved history record reliability. Records are now properly saved even when background operations fail, ensuring data integrity and preventing information loss.

* **Tests**
  * Added test coverage for history persistence under various operational conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->