### PR TITLE
feat(afk): Actions-lane reusable workflow — add the lanes input (#631 GHA target)

### DIFF
--- a/.github/actions/afk-attempt/action.yml
+++ b/.github/actions/afk-attempt/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Override the reasoning effort/variant (low|medium|high|…). Empty = config. Maps to RED_AFK_EFFORT (still provider-gated)."
     required: false
     default: ""
+  lane:
+    description: "Execution-lane tag (actions|k8s). Surfaced as RED_AFK_LANE for observability; does not change the runtime contract."
+    required: false
+    default: "actions"
   openrouter-api-key:
     description: "OpenRouter API key (opencode auth; precedence 3)."
     required: false
@@ -86,6 +90,8 @@ runs:
         # so an unset input leaves the target repo's .red/config.yaml in charge.
         RED_AFK_MODEL: ${{ inputs.model }}
         RED_AFK_EFFORT: ${{ inputs.effort }}
+        # Execution-lane observability tag (actions|k8s) — informational only.
+        RED_AFK_LANE: ${{ inputs.lane }}
         # opencode auth — first set key wins (opencode-env.ts precedence).
         OPENROUTER_API_KEY: ${{ inputs.openrouter-api-key }}
         MINIMAX_API_KEY: ${{ inputs.minimax-api-key }}

--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -78,6 +78,11 @@ on:
         required: false
         type: string
         default: "true"
+      lanes:
+        description: "Execution-lane tag for this invocation (e.g. actions|k8s). Surfaced as RED_AFK_LANE for observability/forward-compat; does not change the runtime contract (one attempt, one issue, one PR)."
+        required: false
+        type: string
+        default: "actions"
     secrets:
       openrouter_api_key:
         required: false
@@ -234,6 +239,7 @@ jobs:
           # issues triggers, which leaves the target repo's config in charge.
           model: ${{ inputs.model }}
           effort: ${{ inputs.effort }}
+          lane: ${{ github.event_name == 'workflow_call' && inputs.lanes || 'actions' }}
           openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           minimax-api-key: ${{ secrets.MINIMAX_API_KEY }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -99,6 +99,7 @@ back to a hard-coded maintainer allowlist.)
 | `runner` | ✓ | ✓ | `claude` \| `codex` \| `opencode` (CI default `opencode`) |
 | `model` | ✓ | ✓ | override every tier, e.g. `minimax/MiniMax-M2` (empty = repo config) |
 | `effort` | ✓ | ✓ | reasoning effort/variant override |
+| `lanes` | ✓ | ✓ | execution-lane tag (`actions`\|`k8s`), surfaced as `RED_AFK_LANE` for observability; default `actions` |
 | `*-api-key` secrets | ✓ (inputs) | ✓ (secrets) | the auth keys — passed as **action inputs** (composite actions can't read `secrets.*`) |
 | `allowlist_*`, `enforce_trust_gate` | — | ✓ | trust gate (policy layer) |
 


### PR DESCRIPTION
Parent PRD #614. Addresses the **GHA target** of #631 (k8s target deferred — see below).

The reusable workflow already shipped this session (ADR 0062: `red-afk-attempt.yml` + the `afk-attempt` composite action). Verified against #631's GHA acceptance:
- ✅ `workflow_call`, red-prefixed filename
- ✅ inputs: `issue_number`, `runner` (opencode default), `model`, `effort`, `enforce_trust_gate` — **+ `lanes` added here** (the one missing item)
- ✅ secrets: openrouter/minimax/openai/anthropic
- ✅ `permissions:` exactly `contents: write`, `issues: write`, `pull-requests: write`
- ✅ checks out, installs pnpm/runner, exports the key, runs the version-pinned launcher `--once`, posts the envelope

**`lanes`** (default `actions`) threads workflow → composite action `lane` → `RED_AFK_LANE` env. It is an observability/forward-compat tag — there is no `--lanes` runtime flag, so it does not change the one-attempt/one-issue/one-PR contract.

**k8s target deferred:** the job manifest needs cluster specifics (registry, namespace, secret refs) and was explicitly deferred by ADR 0062. **#631 stays open** for that piece; this PR completes the GHA half. Both YAML files parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783746605&installation_id=129708444&pr_number=688&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F688&signature=8b63a91efe1134f8fee255fed3b758455c470a60ed697c15361463d9281fcfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional execution lane selection (actions or k8s) for improved observability capabilities.

* **Documentation**
  * Updated documentation to reflect new execution lane configuration option and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->