### PR TITLE
docs(adr): reconcile the ADR map — 0008→0030, 0053 Status, brain/bash/memory notes (closes #595)

### DIFF
--- a/.red/adr/0008-afk-merges-into-the-pinned-branch.md
+++ b/.red/adr/0008-afk-merges-into-the-pinned-branch.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-accepted.
+accepted. **The merge *mechanism* is superseded by ADR 0030** (AFK landing is
+lock-toggled and the PR carries history): a finished issue no longer does a plain
+`do_merge` into the pinned base — the unlocked path lands via an admin-merged PR,
+the locked path pushes the locked branch over SSH. The **base-resolution decision
+of this ADR (pin > main) stands** and is refined by ADR 0031 (lock > pin > main).
 
 `/afk` historically based every worktree on `origin/main` and merged every
 finished issue back into `main`. PRD #59 (issue #64) introduces the **pinned

--- a/.red/adr/0053-provider-tidy-is-report-only-governance.md
+++ b/.red/adr/0053-provider-tidy-is-report-only-governance.md
@@ -1,5 +1,14 @@
 # Provider tidy is report-only governance until an explicit soft-merge approval
 
+## Status
+
+accepted. Report-only governance: provider tidy never mutates governed recall on
+its own — a recommendation takes effect only behind an explicit, approval-gated
+`SAME_AS`/`MERGED_INTO` Soft-merge edge. Part of the Odysseus-inspired Memory
+governance line (PRD #484).
+
+## Context
+
 Provider-backed tidy may help Memory find duplicate or near-duplicate evidence, but its output is not canonical graph evidence. Memory persists tidy results as non-canonical provider review artifacts keyed by a fingerprint over the relevant nodes/edges plus operation and review-policy version; `memory governance` reports those recommendations read-only and degrades to deterministic output when provider tidy is unavailable. A recommendation affects governed recall only after an explicit mutating workflow accepts it and creates an approval-gated `SAME_AS`/`MERGED_INTO` Soft-merge edge.
 
 This keeps Odysseus-style conservative tidy useful without letting provider output silently collapse the RedDB Memory graph, bypass provenance, or turn governance into a mutating surface.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -14,7 +14,7 @@ stale notes inline.
 > otherwise it lands with it — do not reclaim it blindly.
 
 ## Repo structure & contexts
-- **0021** Multi-context plugin glossaries — *accepted*
+- **0021** Multi-context plugin glossaries — *accepted* (predates the `brain` plugin; the multi-context model now spans `dev`/`memory`/**`brain`** — see the *Brain plugin* section and `.red/contexts/brain/`)
 - **0034** Repo splits DEFINITIONS from IMPLEMENTATION (`apps/…` + `packages/…`) — partially superseded by **0039** (entrypoints fused), **0041** (memory leaves), and **0060** (layout relocated to root with a pnpm catalog)
 - **0041** red-skills consumes `red-memory` + `red-ui` MCPs; stops building memory — partially supersedes 0034 *(renumbered from 0039)*
 - **0060** Workspaces move to root `apps/` + `packages/` with a pnpm `catalog:` for shared versions — relocates 0034's `src/apps`/`src/packages` layout (conventional Turborepo); `@reddb-io/sdk` stays per-app-pinned for the bundler
@@ -32,6 +32,12 @@ stale notes inline.
 - **0052** One bundle-naming convention — all release assets under `./dist/` as `<app>[-<role>].bundle.min.mjs`; legacy `dist-bundle/*-cli.mjs` removed *(supersedes 0029's dual output for memory/brain)*
 
 ## AFK execution & lifecycle
+
+> Many ADRs in this group predate the bash→TypeScript port (ADR 0032/0034 deleted
+> the `scripts/*.sh` runtime). Their references to `*.sh` files (e.g. `supervisor.sh`,
+> `afk.sh`) are **historical parity anchors** — the TS runtime mirrors that behaviour;
+> the shell files no longer exist. The decisions stand; only the implementation moved.
+
 - **0003** Native task surface mirrors AFK worker state
 - **0008** `/afk` merges into the pinned branch, not always main
 - **0015** Fleet supervisor is runner-portable; observability degrades per runner
@@ -60,6 +66,12 @@ stale notes inline.
 - *(see also 0030, 0031)*
 
 ## Memory architecture & graph
+
+> Post-**0041**, the memory runtime is no longer built in red-skills — it lives in the
+> `red-memory` repo and is consumed as a fetched MCP. These ADRs still describe the
+> memory **substrate/domain** (the decisions stand), but their implementation now
+> resides in `red-memory`, not `apps/memory`.
+
 - **0005** Memory plugin: three-layer RedDB architecture, local-first per-repo, MCP+CLI
 - **0007** RedDB graph writes go through multi-model DML, not table inserts
 - **0009** `dev` soft-uses `memory`, one-directional — gate mechanism partially superseded by **0042**; soft-use direction stands


### PR DESCRIPTION
PRD #567 slice. Pure ADR-map reconciliation (no new decision).

- **0008 Status** → records the merge *mechanism* is superseded by **0030** (lock-toggled landing); base-resolution (pin > main) stands, refined by 0031.
- **0053** → gains the missing `## Status` (+ `## Context`).
- **INDEX**: 0021 notes it predates `brain` (multi-context now spans dev/memory/brain); AFK-section note that `*.sh` refs are historical parity anchors post the bash→TS port (0032/0034); Memory-section note that the runtime moved to `red-memory` post-0041.
- **0055** was already in INDEX (finding already satisfied).

The prior AFK attempt only failed on a flaky `test:root` on the old `src/apps` tree — this is done fresh on current main. review-adrs-docs + doctor-docs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783747204&installation_id=129708444&pr_number=689&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F689&signature=bdccac5a73b34d73e7db3b23918f42991e3efae08e37199791ff6928a224a08e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture decision records with status clarifications and governance model refinements
  * Revised ADR index entries to document multi-context model scope, AFK execution references, and memory component organization changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->