### PR TITLE
decision(adr): introduce the brain plugin (ADR 0063) + amend 0021 (closes #596)

### DIFF
--- a/.red/adr/0021-multi-context-plugin-glossaries.md
+++ b/.red/adr/0021-multi-context-plugin-glossaries.md
@@ -6,6 +6,11 @@ accepted.
 
 Supersedes: [ADR 0046](0046-single-global-red-dir.md)
 
+**Amended by [ADR 0063](0063-brain-plugin-is-the-third-red-skills-context.md):** the
+`brain` plugin is a third product context — its glossary lives in
+`.red/contexts/brain/CONTEXT.md` (added to the Decision list below). The
+multi-context model is unchanged; only the context count grew from two to three.
+
 ## Context
 
 ADR 0046 deliberately kept one root `.red/CONTEXT.md` while `memory` was being
@@ -28,6 +33,9 @@ Use a multi-context glossary layout:
 - `.red/contexts/memory/CONTEXT.md` owns `memory` plugin, RedDB graph, reasoning
   memory, validation evidence, skill telemetry evidence, and codebase mapping
   terms.
+- `.red/contexts/brain/CONTEXT.md` owns `brain` plugin terms — project-local
+  RedDB knowledge repository, freeform captures, graph connections, folder-level
+  brains, and the Hermes connector (added by ADR 0063).
 - `.red/CONTEXT.md` remains only as a compatibility pointer to the map.
 - ADRs stay in the single root `.red/adr/` sequence for now; future
   context-specific ADR subtrees require a separate decision.

--- a/.red/adr/0063-brain-plugin-is-the-third-red-skills-context.md
+++ b/.red/adr/0063-brain-plugin-is-the-third-red-skills-context.md
@@ -1,0 +1,56 @@
+# The `brain` plugin is a first-class red-skills plugin and the third multi-context glossary context
+
+## Status
+
+accepted.
+
+Relates: [ADR 0021](0021-multi-context-plugin-glossaries.md) (amended here to enumerate the `brain` context),
+[ADR 0057](0057-brain-depends-on-fetched-never-vendored-red-hermes-black-box.md) (the Hermes connector),
+[ADR 0038](0038-dev-runtime-ships-as-a-fetched-asset-not-a-committed-bundle.md) / [ADR 0040](0040-version-is-single-source-one-writer-version-aware-clis.md) (fetch + version model),
+[ADR 0034](0034-monorepo-src-domains-with-per-plugin-bundles.md) / [ADR 0060](0060-root-apps-packages-with-pnpm-catalog.md) (the `apps/brain` runtime layout),
+[ADR 0041](0041-red-skills-consumes-red-memory-and-red-ui-mcps.md) (the ecosystem-split precedent brain may follow later).
+
+## Context
+
+The `brain` plugin ships in production — its own `plugins/brain/` definition
+(plugin manifests, `.mcp.json`, hooks, the `capture` / `search` / `status` /
+`think` / `view` core skills, a `bootstrap.mjs` fetch launcher), an `apps/brain`
+runtime, a `brain` MCP, and a `.red/contexts/brain/` glossary — but it carried
+**zero decision-record coverage**, and ADR 0021 (multi-context glossaries)
+enumerated only the `dev` and `memory` contexts while `contexts/brain/` already
+existed. The map and the shipped plugin had drifted from the decision record.
+Two calls were open: where `brain` lives long-term, and how 0021 is reconciled.
+
+## Decision
+
+1. **`brain` is a first-class red-skills plugin** alongside `dev` and `memory` —
+   a project-local RedDB knowledge repository for freeform captures and graph
+   connections (folder-level brains; the command-center direction is PRD #463).
+   It follows the established plugin patterns: a fetched, never-committed bundle
+   (ADR 0038), version-pinned to the plugin (ADR 0040), an `apps/brain` runtime
+   under the root monorepo layout (ADR 0034/0060), and Hermes consumed as a
+   fetched, never-vendored black-box connector (ADR 0057). It exposes the `brain`
+   MCP and its `core/` skills, and owns its own glossary context.
+
+2. **`brain` stays in red-skills for now.** Unlike `memory` — which moved out to
+   the `red-memory` repo (ADR 0041) only after it had matured to ~55k lines —
+   `brain` is still actively developed (draft reconstruction in #422, the
+   command-center program in PRD #463). It is premature to split it out. The door
+   stays open: `brain` may follow the ADR 0041 ecosystem split to a dedicated
+   `red-brain` repo (built there, consumed via a fetched MCP) once it matures.
+   That move, if taken, is a future ADR.
+
+3. **ADR 0021 is amended in place** (not superseded) to enumerate the `brain`
+   context. The multi-context-glossary *model* of 0021 still holds — it was only
+   missing the third context.
+
+## Why
+
+- The plugin already exists and is consumed; the decision record must reflect
+  reality so the ADR map and `CONTEXT-MAP.md` are trustworthy.
+- Reusing the existing plugin patterns (fetch/version/runtime/Hermes) keeps
+  `brain` consistent with `dev`/`memory` rather than inventing a parallel shape.
+- Keeping `brain` in red-skills avoids a premature multi-repo migration while it
+  is still a draft; the 0041 precedent makes a later split cheap if warranted.
+- Amending 0021 (vs a successor) is the lighter change because the model did not
+  change — only the context count.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -21,6 +21,7 @@ stale notes inline.
 - **0046** A single global `.red/` shared by all plugins — *superseded by 0021*
 
 ## Brain plugin
+- **0063** The `brain` plugin is a first-class red-skills plugin (RedDB knowledge repo: captures + graph connections, folder-level brains) and the **third** multi-context glossary context; stays in red-skills for now, may follow the 0041 split to a `red-brain` repo when mature *(amends 0021; reuses 0038/0040 fetch+version, 0034/0060 layout, 0057 Hermes)*
 - **0057** `red-hermes` is a fetched, never-vendored black-box dependency of the `brain` plugin — reached via `hermes mcp serve`, fetched as a Release asset (0038 model), version pinned (0040), 10-tool contract; MIT attribution in `NOTICE` (0004) *(downstream fetch/launcher blocked on red-hermes releases, same shape as #378)*
 
 ## Bundle / fetch / release / version


### PR DESCRIPTION
PRD #567 slice. The `brain` plugin shipped in production with **no introducing ADR**, and ADR 0021 (multi-context glossaries) enumerated only dev/memory while `.red/contexts/brain/` already existed. Two human calls were open; **resolved with the maintainer**:

**Q1 — brain's home:** stays in red-skills for now (actively developed — PRD #463 command-center, draft #422), unlike memory which left for `red-memory` (ADR 0041) only after maturing. Door stays open to follow that split later.
**Q2 — ADR 0021:** amended in place (the multi-context model is unchanged; only the context count grew).

Changes:
- **ADR 0063** (new) — brain is a first-class plugin alongside dev/memory; reuses the fetch (0038) / version (0040) / apps-layout (0034/0060) / Hermes (0057) patterns; home + reconciliation decisions recorded.
- **ADR 0021** amended to enumerate the `brain` context (+ an amendment note).
- **INDEX** gains the 0063 entry under the Brain plugin group.

review-adrs-docs + doctor-docs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783747591&installation_id=129708444&pr_number=691&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F691&signature=52c8678617310e635e433e6a40ba288619447f6f11c35f24e967ddc2fd605b21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established the brain plugin as a first-class component within the red-skills system
  * Updated architecture documentation to recognize brain as a third context in the multi-context glossary
  * Documented ownership scope and integration patterns for the brain plugin, including knowledge repository and connector support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->