### PR TITLE
chore(afk): Actions lane is dispatch/call-only — drop the issues auto-trigger until secrets are set

### DIFF
--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -10,13 +10,12 @@
 #
 #   1. `workflow_call`     — direct invocation by a caller workflow.
 #   2. `workflow_dispatch` — manual run from the Actions UI, `issue_number` input.
-#   3. `issues: labeled`   — auto-trigger when the `ready-for-agent` label is
-#                            applied. The `if:` gate filters to that label.
-#   4. `issues: opened`    — auto-trigger when an issue is CREATED already
-#                            carrying `ready-for-agent` (e.g. an automation or a
-#                            maintainer files a pre-delegated issue). Raw issues
-#                            with no label are NOT run — they fall through to
-#                            `red-issues-needs-triage` and the labeled path.
+#
+# The `issues: [labeled, opened]` auto-trigger was intentionally removed so the
+# lane stays dispatch/call-only while no auth secrets are configured (it was
+# firing — and failing at auth — on every `ready-for-agent` issue). Re-add it
+# (the `on:` trigger + the two `issues`-event branches in the job `if:`) once the
+# MINIMAX / OPENAI / OPENROUTER secrets are set.
 #
 # Per ADR 0056, the trust gate is rigorous by default: the issue author AND the
 # label-applier (the opener, for the `opened` path) must both be in the
@@ -110,10 +109,9 @@ on:
         type: string
         default: ""
 
-  # Auto-trigger: fire when `ready-for-agent` is applied to an issue, or when an
-  # issue is opened already carrying it. The `if:` on the job enforces both.
-  issues:
-    types: [labeled, opened]
+  # NOTE: the `issues: [labeled, opened]` auto-trigger was intentionally removed —
+  # the lane is dispatch/call-only until auth secrets are configured (see the job
+  # `if:` below for how to restore auto-firing).
 
 permissions:
   contents: write
@@ -122,15 +120,14 @@ permissions:
 
 jobs:
   attempt:
-    # Trigger sources converge into a single job. The job runs only when:
-    #   - workflow_dispatch / workflow_call (caller-resolved issue), or
-    #   - issues:labeled with label == ready-for-agent, or
-    #   - issues:opened where the issue already carries ready-for-agent.
+    # Manual / programmatic dispatch only. The `issues:` auto-trigger was removed
+    # so the lane no longer fires (and fails) on every `ready-for-agent` issue
+    # while no auth secrets are configured. To restore auto-firing once secrets
+    # (MINIMAX / OPENAI / OPENROUTER) are set: re-add `issues: types: [labeled,
+    # opened]` to `on:` above, and the two `issues`-event branches to this `if:`.
     if: >-
       (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'workflow_call') ||
-      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'ready-for-agent') ||
-      (github.event_name == 'issues' && github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'ready-for-agent'))
+      (github.event_name == 'workflow_call')
     runs-on: ubuntu-latest
     # Resolve the runner once for every step. issues:* events have no host
     # session, so they always use opencode (the API-auth runner, ADR 0059).


### PR DESCRIPTION
Quiets the failing `red-afk-attempt` CI runs. The lane fired on every `ready-for-agent` issue (`issues: [labeled, opened]`) and failed at *Run the AFK attempt* because the repo has **no auth secrets** configured — noise, not a build defect.

- Remove the `issues:` auto-trigger; `on:` is now **`workflow_call` + `workflow_dispatch` only**.
- Simplify the job `if:` to dispatch/call (the two `issues`-event branches removed).
- Header + job comments document how to **restore auto-firing** (re-add the trigger + the two `if:` branches) once MINIMAX/OPENAI/OPENROUTER secrets are set.

No runtime/contract change. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783748559&installation_id=129708444&pr_number=692&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F692&signature=6a5fa16b89f7eb48b48e4edff6c638fa0b01bd251b7f52e86aeff88ac1efd053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration, removing automatic event triggering.

* **Documentation**
  * Added inline documentation clarifying workflow trigger behavior and configuration steps for future restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->