### PR TITLE
feat(afk): per-runner `base` model/effort auto-populates every tier (extends ADR 0049)

### DIFF
--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -303,9 +303,11 @@ function readEffort(raw: string, fallback: AgentEffort): AgentEffort {
  *   0. runtime override: `RED_AFK_MODEL` env (the `--model` run flag pre-sets it).
  *      Flattens every tier onto one slug — "use this model regardless of tier".
  *   1. explicit tier table entry: `afk.models.<runner>.<tier>.model`
- *   2. legacy runner scalar: `afk.models.<runner>`
- *   3. legacy global scalar: `afk.model`
- *   4. tier-table default
+ *   2. per-runner base: `afk.models.<runner>.base.model` (auto-populates every
+ *      tier of the runner; a specialized `.<tier>.model` still wins over it)
+ *   3. legacy runner scalar: `afk.models.<runner>`
+ *   4. legacy global scalar: `afk.model`
+ *   5. tier-table default
  * `RED_AFK_EFFORT` overrides effort the same way (still provider-gated downstream).
  *
  * `loadConfig` already folds `plugins.dev.afk.*` over the legacy top-level
@@ -329,8 +331,17 @@ export function resolveTier(
   const defaultModel = CONFIG_DEFAULTS[modelKey];
   const defaultEffort = CONFIG_DEFAULTS[effortKey] as AgentEffort;
   const tierModel = getConfig(values, modelKey);
+  // Per-runner `base` (model + effort): a structured default that auto-populates
+  // every tier of this runner, so an operator can point the whole runner at one
+  // provider/model with a single line and still specialize a tier by setting its
+  // own `.<tier>.model`. It sits between the explicit tier entry and the legacy
+  // scalars — a tier left at its table default falls back to `base`; an explicitly
+  // set tier overrides it.
+  const baseModel = getConfig(values, `afk.models.${tierRunner}.base.model`);
+  const baseEffort = getConfig(values, `afk.models.${tierRunner}.base.effort`);
   const scalarRunnerModel = getConfig(values, `afk.models.${tierRunner}`);
   const scalarGlobalModel = getConfig(values, "afk.model");
+  const tierEffort = getConfig(values, effortKey);
 
   // Runtime override: a non-empty RED_AFK_MODEL/RED_AFK_EFFORT wins over the file
   // (`""` counts as unset, so a placeholder export never flattens the tiers).
@@ -340,14 +351,18 @@ export function resolveTier(
   const configModel =
     tierModel && tierModel !== defaultModel
       ? tierModel
-      : scalarRunnerModel || scalarGlobalModel || tierModel || defaultModel;
+      : baseModel || scalarRunnerModel || scalarGlobalModel || tierModel || defaultModel;
+  const configEffort =
+    tierEffort && tierEffort !== defaultEffort
+      ? tierEffort
+      : baseEffort || tierEffort || defaultEffort;
 
   return {
     model: modelOverride.length > 0 ? modelOverride : configModel,
     effort:
       effortOverride.length > 0
         ? readEffort(effortOverride, defaultEffort)
-        : readEffort(getConfig(values, effortKey), defaultEffort),
+        : readEffort(configEffort, defaultEffort),
   };
 }
 

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -349,6 +349,30 @@ describe("config — AFK model tier table (ADR 0049)", () => {
     });
   });
 
+  it("auto-populates every tier from `base`, with a specialized tier overriding it", () => {
+    const text =
+      "plugins:\n  dev:\n    afk:\n      models:\n        opencode:\n          base:\n            model: minimax/MiniMax-M2\n            effort: medium\n          think:\n            model: minimax/MiniMax-M2-thinking\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    // base flows to every un-specialized tier (model AND effort)
+    expect(resolveTier(values, "opencode", "validate")).toEqual({ model: "minimax/MiniMax-M2", effort: "medium" });
+    expect(resolveTier(values, "opencode", "simple")).toEqual({ model: "minimax/MiniMax-M2", effort: "medium" });
+    expect(resolveTier(values, "opencode", "complex")).toEqual({ model: "minimax/MiniMax-M2", effort: "medium" });
+    // a specialized tier overrides the base model; its effort still inherits from base
+    expect(resolveTier(values, "opencode", "think")).toEqual({ model: "minimax/MiniMax-M2-thinking", effort: "medium" });
+    // base does not leak across runners — claude keeps its own table
+    expect(resolveTier(values, "claude", "simple")).toEqual({ model: "claude-sonnet-4-6", effort: "high" });
+  });
+
+  it("`base.model` alone uniformly sets the model but leaves each tier's default effort", () => {
+    const text =
+      "plugins:\n  dev:\n    afk:\n      models:\n        opencode:\n          base:\n            model: minimax/MiniMax-M2\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    // model is uniform from base; effort stays at each tier's table default (low/high/medium/high)
+    expect(resolveTier(values, "opencode", "validate")).toEqual({ model: "minimax/MiniMax-M2", effort: "low" });
+    expect(resolveTier(values, "opencode", "complex")).toEqual({ model: "minimax/MiniMax-M2", effort: "medium" });
+    expect(resolveTier(values, "opencode", "think")).toEqual({ model: "minimax/MiniMax-M2", effort: "high" });
+  });
+
   it("lets explicit tier entries override legacy scalar model keys", () => {
     const text =
       "afk:\n  model: shared-model\n  models:\n    claude:\n      think:\n        model: claude-tier-model\n        effort: max\n";

--- a/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
+++ b/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
@@ -30,6 +30,12 @@
 #       think:
 #         model: gpt-5.5
 #         effort: high
+#     opencode:                   # ADR 0059 — endpoint-agnostic; slug = <provider>/<model>
+#       base:                     # auto-populates EVERY tier of this runner. Set the model
+#         model: minimax/MiniMax-M2   # once to point the whole runner at one provider/model;
+#         effort: medium          # `base.effort` is optional (omit it to keep per-tier defaults).
+#       think:                    # specialize a single tier — overrides `base` for that tier only
+#         model: minimax/MiniMax-M2
 #   fleet:
 #     target: 2                   # default supervisor worker target
 #   backpressure:                 # extra merge gates run on every successful


### PR DESCRIPTION
Set `afk.models.<runner>.base.model` (+ optional `base.effort`) **once** to point a whole runner at one provider/model — every tier inherits it — and still specialize a single tier with `.<tier>.model`, which overrides the base. Exactly the OpenCode/MiniMax case (no more repeating `minimax/MiniMax-M2` under validate/simple/complex/think).

**Precedence (model):** flag / `RED_AFK_MODEL` → explicit `.<tier>.model` → **`base.model` (new)** → legacy runner scalar → legacy global scalar → tier default. Effort mirrors it via `base.effort` (optional — omit to keep each tier's default effort). A tier left at its table default falls back to `base`; an explicitly set tier wins.

- `config.ts` — base folded into the model + effort resolution + precedence doc.
- `config.test.ts` — base auto-populates all tiers; specialized tier overrides; no cross-runner leak; `base.model`-only keeps per-tier efforts. **43/43**, typecheck clean.
- `config-template.yaml` — documents the opencode `base` block (MiniMax recipe).

Extends ADR 0049 (model-tier routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772655&installation_id=129708444&pr_number=694&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F694&signature=e4c928477f36df220ff09a12093597ddfa887119ed5b67a9964ee925f9b02fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new base tier configuration system enabling centralized model and effort defaults that intelligently cascade to individual runner tiers with support for selective overrides and runtime environment variable precedence.

* **Documentation**
  * Added configuration template examples demonstrating opencode runner setup with base tier settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->