### PR TITLE
feat(afk): fleet supervisor owns the boot sweeps — workers boot bootstrap+claim only (#623)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -24,6 +24,8 @@ import {
   collectPrecheckFacts,
   collectBootOptions,
   collectMonitorInputs,
+  buildBootDeps,
+  buildMinimalBootDeps,
   makeRunAgent,
   resolveRepoContext,
   resolveRunSettings,
@@ -33,7 +35,6 @@ import {
 import type { LaneIdleStallConfig } from "../core/lane-idle-reaper.js";
 import { workerDir as workerDirPath, workerPidFile } from "../core/worker-paths.js";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
-import { LABEL_HUMAN, LABEL_RUNNING } from "../core/triage-labels.js";
 import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import * as fsx from "../runtime/fs.js";
@@ -189,36 +190,6 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     bootOnly: values["boot-only"] === true,
     reconcileIssue,
   };
-}
-
-/** Pre-resolve the gh issue-state cache the branch-cleanup reapers + orphan
- * lookup read synchronously. Mirrors collectReapInputs' eager resolution, but
- * sources every issue's meta from the SINGLE batched `listIssueStates` map
- * instead of a per-issue `gh issue view` storm. A map miss (issue beyond the
- * --limit window / just-created / transient list failure) falls back to the
- * live `ghx.issueMeta` so closedAt-grace classification stays exact. */
-async function resolveBranchIssueCache(
-  ghCtx: GhContext,
-  options: BootOptions,
-  states: Map<number, import("../runtime/gh.js").IssueStateRow>,
-): Promise<Map<number, import("../core/branch-cleanup.js").IssueMeta | null | undefined>> {
-  const { liveIssueFromBranch, attemptIssueFromBranch } = await import("../core/branch-cleanup.js");
-  const issues = new Set<number>();
-  for (const r of options.branches.snapshotRefs) {
-    const n = attemptIssueFromBranch(r.branch);
-    if (n !== null) issues.add(n);
-  }
-  for (const r of [...options.branches.remoteLiveRefs, ...options.branches.localLiveRefs]) {
-    const n = liveIssueFromBranch(r.branch);
-    if (n !== null) issues.add(n);
-  }
-  const cache = new Map<number, import("../core/branch-cleanup.js").IssueMeta | null | undefined>();
-  for (const n of issues) {
-    const row = states.get(n);
-    if (row) cache.set(n, { state: row.state, closedAt: row.closedAt });
-    else cache.set(n, await ghx.issueMeta(ghCtx, n));
-  }
-  return cache;
 }
 
 /** Build the boot reconcile runner (step 7, ADR 0055). The runner closes over
@@ -385,67 +356,6 @@ async function runReconcileWorker(
   }
 
   return 0;
-}
-
-async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: number): Promise<BootDeps> {
-  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
-  const gitCtx: GitContext = { cwd: ctx.root };
-  // ONE batched issue-state fetch backs every per-issue boot lookup below.
-  const issueStates = await ghx.listIssueStates(ghCtx);
-  const branchCache = await resolveBranchIssueCache(ghCtx, options, issueStates);
-  return {
-    fs: {
-      ensureDir: fsx.ensureDir,
-      ensureGitignoreLine: fsx.ensureGitignoreLine,
-      writeWorkerPid: fsx.writeWorkerPid,
-      removeDir: fsx.removeDir,
-    },
-    gh: {
-      editLabels: async (issue, remove, add) => {
-        await ghx.editLabels(ghCtx, issue, remove, add);
-      },
-      comment: (issue, body) => ghx.comment(ghCtx, issue, body),
-    },
-    git: {
-      deleteRemoteBranch: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),
-      deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
-    },
-    lookups: {
-      // Live-claim ownership for the orphan sweep (#644): a dead attempt dir
-      // naming an issue whose claims/{N}/pid is a LIVE process is claim-race
-      // debris, not a mid-issue crash — the sweep removes it without touching
-      // the winner's `running` label.
-      claimHolderAlive: (issue) => fsx.claimPathHeldByLivePid(join(afkPaths(ctx.root).tmpDir, "claims", String(issue))),
-      // Orphan state pairs gh issue state/label with the attempt dir's
-      // envelope.posted flag (read from the state file, not gh). Derived from
-      // the batched map, preserving ghx.orphanState's exact label/state →
-      // verdict mapping (ready-for-human > running > null). On a map MISS the
-      // issue isn't in the list window — fall back to the live read so a
-      // truncated/just-created/transient issue still classifies correctly.
-      orphanState: async (issue) => {
-        const row = issueStates.get(issue);
-        if (!row) return ghx.orphanState(ghCtx, issue);
-        const label = row.labels.includes(LABEL_HUMAN)
-          ? LABEL_HUMAN
-          : row.labels.includes(LABEL_RUNNING)
-            ? LABEL_RUNNING
-            : null;
-        return { ghOk: true, state: row.state, label, envelopePosted: false };
-      },
-      branchIssue: (issue) => branchCache.get(issue),
-      // Blocker state from the batched map: row.state ("OPEN"/"CLOSED") or
-      // undefined on a miss. undefined-on-miss exactly matches the prior
-      // 404→undefined→not-closed semantics — a missing blocker stays
-      // "open-or-unknown" and the dependent issue is NOT promoted.
-      blockerState: async (issue) => issueStates.get(issue)?.state,
-      straggler: {
-        unlabeled: () => ghx.countUnlabeled(ghCtx),
-        needsTriage: () => ghx.countNeedsTriage(ghCtx),
-        needsInfo: () => ghx.countNeedsInfo(ghCtx),
-      },
-    },
-    nowS,
-  };
 }
 
 /**
@@ -1058,6 +968,13 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const facts = await collectPrecheckFacts(ctx);
   const nowS = Math.floor(Date.now() / 1000);
 
+  // Fleet supervisor owns the boot (#623): a worker spawned by the supervisor
+  // carries RED_AFK_SWEEPS_DONE, signalling the shared sweeps already ran once
+  // pre-spawn. Such a worker boots bootstrap+claim only — it skips every sweep
+  // (cheap respawns; no race over `.red/tmp`). A solo `run` has no marker and
+  // runs the full sweep suite exactly as before.
+  const sweepsDone = process.env.RED_AFK_SWEEPS_DONE === "1";
+
   const sessionCtx: SessionContext = {
     runner,
     workerId,
@@ -1066,6 +983,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
     filter: flags.filter,
     alternate: flags.alternate,
     bootOnly: flags.bootOnly,
+    // Reported by the --boot-only line so the dry-run states whether this worker
+    // ran the sweeps or inherited them from the supervisor.
+    sweepsSkipped: sweepsDone,
     issueTemplate: {
       tmpDir: paths.tmpDir,
       repo: ctx.repo,
@@ -1091,8 +1011,25 @@ export async function runCommand(options: RunOptions): Promise<number> {
   let bootOptions: BootOptions;
   let bootDeps: BootDeps;
   try {
-    bootOptions = await collectBootOptions(ctx, facts, bootstrap, nowS);
-    bootDeps = await buildBootDeps(ctx, bootOptions, nowS);
+    if (sweepsDone) {
+      // Supervisor-owned boot (#623): skip the expensive discovery (branch
+      // listings, orphan walk, unblock-candidate + parked-mechanical gh probes)
+      // AND the sweep work itself. The minimal options carry empty sweep inputs
+      // + skipSweeps:true; the minimal deps wire only the bootstrap fs calls.
+      bootOptions = {
+        precheck: facts,
+        bootstrap,
+        orphans: [],
+        attemptCap: { byIssue: new Map() },
+        branches: { snapshotRefs: [], remoteLiveRefs: [], localLiveRefs: [] },
+        unblockCandidates: [],
+        skipSweeps: true,
+      };
+      bootDeps = buildMinimalBootDeps(ctx, nowS);
+    } else {
+      bootOptions = await collectBootOptions(ctx, facts, bootstrap, nowS);
+      bootDeps = await buildBootDeps(ctx, bootOptions, nowS);
+    }
   } catch (err) {
     await recordBootError(bootstrap.workerDir, "boot-error", err).catch(() => {
       process.stderr.write(`[afk] boot-error: ${err instanceof Error ? err.message : String(err)}\n`);
@@ -1103,8 +1040,13 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Feedback worktree manager — checks out the worker branch for the gate.
   const feedback = makeFeedbackWorktree(ctx.root, join(paths.tmpDir, "feedback"));
 
-  // Wire the boot reconcile runner into bootDeps (step 7, ADR 0055).
-  bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
+  // Wire the boot reconcile runner into bootDeps (step 7, ADR 0055). A
+  // supervisor-owned boot skips every sweep (including reconcile) and the fleet
+  // dispatches reconcile per-tick instead, so the runner is wired only on the
+  // solo / sweep-running path.
+  if (!sweepsDone) {
+    bootDeps = { ...bootDeps, reconcileRunner: makeBootReconcileRunner(ctx, paths, workerId, runner, feedback) };
+  }
 
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
   // over; buildProcessInput resets it before each processIssue call.

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -17,7 +17,15 @@ import {
   type SupervisorDeps,
 } from "../core/supervisor.js";
 import { appendRecord } from "../core/jsonl-log.js";
-import { afkPaths, resolveRepoSlug } from "../runtime/wire.js";
+import {
+  afkPaths,
+  resolveRepoSlug,
+  collectPrecheckFacts,
+  collectBootOptions,
+  buildBootDeps,
+  type RepoContext,
+} from "../runtime/wire.js";
+import { runBoot, type BootResult, type BootstrapInput } from "../core/boot.js";
 import { inspectProcessTreeNative } from "../runtime/proc-tree.js";
 import {
   agentLaneMtimeFor,
@@ -84,6 +92,11 @@ export const PASSTHROUGH_DENYLIST: readonly string[] = [
   "RED_AFK_TARGET",
   "RED_AFK_REQUEST",
   "RED_AFK_RUNNER",
+  // #623: the supervisor sets this explicitly on every spawned worker (below) so
+  // the worker boots bootstrap+claim only. Deny it from the inherited passthrough
+  // so an operator's stray `export RED_AFK_SWEEPS_DONE=1` can never reach a worker
+  // by accident — only the supervisor's own re-pin grants it.
+  "RED_AFK_SWEEPS_DONE",
   "RED_AFK_POLL_S",
   "RED_AFK_STALL_POLL_S",
   "RED_AFK_STALL_THRESHOLD_S",
@@ -131,6 +144,12 @@ export function buildWorkerEnv(
     out[key] = val;
   }
   out.RED_AFK_RUNNER = runner;
+  // Fleet supervisor owns the boot (#623): mark every spawned worker so it boots
+  // bootstrap+claim only (skips the shared sweeps the supervisor already ran
+  // pre-spawn). Read by `run`'s runCommand → BootOptions.skipSweeps. The marker
+  // is the sole grant — it is in PASSTHROUGH_DENYLIST so it can't leak in from
+  // the operator env, exactly mirroring how RED_AFK_RUNNER is re-pinned above.
+  out.RED_AFK_SWEEPS_DONE = "1";
   return out;
 }
 
@@ -195,6 +214,69 @@ export function slotFilterArgs(args: readonly string[]): string[] {
 }
 
 /**
+ * Render a one-line summary of a {@link BootResult} for the supervisor log
+ * (#623). A precheck failure is reported as such (workers still run their own);
+ * otherwise the per-sweep counts are listed so an operator can confirm the
+ * fleet's single boot did its work. Pure over the result.
+ */
+export function formatBootSweepResult(result: BootResult): string {
+  if (!result.precheck.ok) {
+    return `boot sweeps: precheck FAILED (${result.precheck.failed}) — workers will run their own precheck`;
+  }
+  const oc = result.orphanCleanup;
+  const ac = result.attemptCap;
+  const bc = result.branchCleanup;
+  const us = result.unblockSweep;
+  const st = result.straggler;
+  return (
+    "boot sweeps complete: " +
+    `orphans removed=${oc?.removed.length ?? 0} restored=${oc?.restored.length ?? 0} kept=${oc?.kept.length ?? 0}` +
+    ` | attempt-cap reclaimed=${ac?.reclaimed.length ?? 0}` +
+    ` | branches snapshot=${bc?.snapshotReaped.length ?? 0} remote=${bc?.remoteLiveReaped.length ?? 0} local=${bc?.localLiveReaped.length ?? 0}` +
+    ` | unblocked=${us?.promoted.length ?? 0}` +
+    ` | stragglers unlabeled=${st?.counts.unlabeled ?? 0} triage=${st?.counts.needsTriage ?? 0} info=${st?.counts.needsInfo ?? 0}`
+  );
+}
+
+/**
+ * Build the supervisor's pre-spawn boot closure (#623). Runs the FULL shared
+ * sweep suite a single time — precheck, bootstrap, orphan cleanup, attempt cap,
+ * branch cleanup, unblock sweep, straggler check — over real IO, then logs the
+ * result via `log`. The reconcile sweep (boot step 7) is intentionally NOT wired
+ * (no reconcileRunner): the fleet dispatches reconcile per-tick instead, so
+ * landing parked branches at boot would duplicate that path. A throw propagates
+ * to runSupervisor, which logs it and spawns workers anyway.
+ *
+ * The bootstrap writes a supervisor-scoped `afk-supervisor-boot.pid` alongside
+ * the supervisor pid file (NOT a worker dir), so it is never mistaken for a live
+ * worker by the monitor or a later orphan sweep.
+ */
+export function buildSupervisorBootSweeps(
+  root: string,
+  repo: string,
+  log: (line: string) => void,
+): () => Promise<void> {
+  const ctx: RepoContext = { root, repo, remote: "origin" };
+  const paths = afkPaths(root);
+  return async (): Promise<void> => {
+    const nowS = Math.floor(Date.now() / 1000);
+    const facts = await collectPrecheckFacts(ctx);
+    const bootstrap: BootstrapInput = {
+      tmpDir: paths.tmpDir,
+      stateDir: paths.stateDir,
+      gitignorePath: paths.gitignorePath,
+      workerDir: paths.tmpDir,
+      workerPidFile: join(paths.tmpDir, "afk-supervisor-boot.pid"),
+      workerPid: process.pid,
+    };
+    const options = await collectBootOptions(ctx, facts, bootstrap, nowS);
+    const bootDeps = await buildBootDeps(ctx, options, nowS);
+    const result = await runBoot(bootDeps, options);
+    log(formatBootSweepResult(result));
+  };
+}
+
+/**
  * Build SupervisorDeps backed by REAL process / filesystem / gh IO. Every
  * closure mirrors a supervisor.sh function (see runtime/proc-tree.ts +
  * runtime/supervisor-fs.ts) and is best-effort: a failed ps / stat / gh degrades
@@ -217,6 +299,15 @@ function buildSupervisorDeps(
 ): SupervisorDeps {
   const bundle = process.argv[1];
   const now = () => Math.floor(Date.now() / 1000);
+  // Per-tick / boot liveness line into afk-supervisor.log (best-effort). Shared
+  // by `log` and the pre-spawn boot sweeps so both land in the supervisor log.
+  const logLine = (line: string): void => {
+    try {
+      writeSync(logFd, `[${new Date().toISOString()}] ${line}\n`);
+    } catch {
+      // best-effort: a log-write failure must never affect the loop.
+    }
+  };
   // slot index → live orchestrator pid (SLOT_PIDS parity).
   const slotPids = new Map<number, number>();
   // slot index → exit code of the most recent worker for that slot.
@@ -362,13 +453,11 @@ function buildSupervisorDeps(
     recoveryEnv: process.env,
     // Per-tick liveness line into afk-supervisor.log (best-effort). Makes a
     // healthy fleet's heartbeat — and a wedged one's silence — observable.
-    log: (line) => {
-      try {
-        writeSync(logFd, `[${new Date().toISOString()}] ${line}\n`);
-      } catch {
-        // best-effort: a log-write failure must never affect the loop.
-      }
-    },
+    log: logLine,
+    // Fleet supervisor owns the boot (#623): runSupervisor calls this ONCE before
+    // the initial spawn. Runs the full shared sweep suite over real IO and logs
+    // the result; each worker then boots bootstrap+claim only.
+    bootSweeps: buildSupervisorBootSweeps(root, ghCtx.repo, logLine),
     emitFleetHeartbeat: async (hb) => {
       try {
         writeFleetStateAtomic(statePath, hb);

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -267,6 +267,16 @@ export interface BootOptions {
    * reconcile sweep (step 7) will attempt to validate-and-land. When absent the
    * sweep is a no-op. Optional for back-compat. */
   reconcileSweepCandidates?: readonly ReconcileSweepCandidate[];
+  /**
+   * Skip every shared boot sweep (#623). When true, `runBoot` runs precheck +
+   * bootstrap only and returns before orphan cleanup / attempt cap / branch
+   * cleanup / unblock sweep / reconcile sweep / straggler check. The fleet
+   * supervisor sets this on each worker (via the `RED_AFK_SWEEPS_DONE` marker)
+   * because it already ran the sweeps once, pre-spawn — so a supervised worker
+   * boots bootstrap+claim only and never races peers over shared `.red/tmp`
+   * state. A solo `run` (no marker) leaves this false and runs every sweep.
+   */
+  skipSweeps?: boolean;
 }
 
 // ---------- per-step results (for parity assertions / logging) ----------
@@ -347,6 +357,11 @@ export interface BootResult {
  * Steps 3-8 run only after a passing precheck, mirroring the bash `die`/`set -e`
  * abort. The TTY "proceed anyway?" prompt is the caller's: this returns the
  * straggler warn flag, it does not block.
+ *
+ * When `options.skipSweeps` is set (#623, a supervised worker carrying the
+ * `RED_AFK_SWEEPS_DONE` marker) the sequence stops after step 2: the supervisor
+ * already ran every shared sweep once, pre-spawn, so the worker boots
+ * bootstrap+claim only and never races peers over `.red/tmp` / branch / gh state.
  */
 export async function runBoot(deps: BootDeps, options: BootOptions): Promise<BootResult> {
   // ---- 1. precheck ----
@@ -361,6 +376,16 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   await deps.fs.ensureGitignoreLine(b.gitignorePath, ".red/state/");
   await deps.fs.ensureDir(b.workerDir);
   await deps.fs.writeWorkerPid(b.workerPidFile, b.workerPid);
+
+  // ---- 2a. supervisor-owned-sweeps short-circuit (#623) ----
+  // Under the fleet supervisor the shared sweeps already ran once, pre-spawn.
+  // A supervised worker boots bootstrap+claim only: return here so it touches no
+  // shared `.red/tmp` / branch / gh state below (no orphan cleanup, attempt cap,
+  // branch cleanup, unblock sweep, reconcile sweep, or straggler check). This is
+  // what makes a respawn cheap and keeps peers from racing over boot state.
+  if (options.skipSweeps) {
+    return { precheck: pre, bootstrap: { ok: true } };
+  }
 
   // ---- 3. orphan cleanup ----
   const orphanCleanup = await runOrphanCleanup(deps, options);

--- a/apps/dev/src/core/session.ts
+++ b/apps/dev/src/core/session.ts
@@ -202,6 +202,14 @@ export interface SessionContext {
    * processing — a dry-run for inspecting the boot, never spawns an agent.
    */
   bootOnly?: boolean;
+  /**
+   * The fleet supervisor already ran the shared boot sweeps before spawning this
+   * worker (#623, `RED_AFK_SWEEPS_DONE`): the worker booted bootstrap+claim only.
+   * Purely informational — it only shapes the `--boot-only` line so the dry-run
+   * reports the sweeps as supervisor-owned rather than worker-run. The actual
+   * skip is driven by `BootOptions.skipSweeps` in `runBoot`, not here.
+   */
+  sweepsSkipped?: boolean;
 }
 
 /** Toggle a runner to the other backend (claude↔codex). */
@@ -410,7 +418,11 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
   // ---- 1a. --boot-only: dry-run. The boot sweeps ran above; return before
   // any selection/claim/processing so no agent is ever spawned. ----
   if (ctx.bootOnly) {
-    deps.emit("boot complete (--boot-only): sweeps ran, no issues processed");
+    deps.emit(
+      ctx.sweepsSkipped
+        ? "boot complete (--boot-only): sweeps skipped (supervisor-owned), no issues processed"
+        : "boot complete (--boot-only): sweeps ran, no issues processed",
+    );
     return { ...empty, boot };
   }
 

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -528,6 +528,19 @@ export interface SupervisorDeps {
    * throws out of the loop.
    */
   emitFleetHeartbeat?(heartbeat: FleetHeartbeat): void | Promise<void>;
+  /**
+   * Run the shared boot sweeps ONCE before the initial fleet spawn (#623). The
+   * fleet supervisor owns the boot: it runs orphan cleanup / attempt cap /
+   * branch cleanup / unblock sweep / straggler check a single time, pre-spawn,
+   * and every worker it then spawns carries the `RED_AFK_SWEEPS_DONE` marker so
+   * it boots bootstrap+claim only — respawns are cheap and workers never race
+   * peers over shared `.red/tmp` state. Called exactly once per supervisor
+   * lifetime (never on a respawn, which happens inside the tick loop). The
+   * closure itself logs its sweep results via {@link SupervisorDeps.log}.
+   * Best-effort: a throw is caught and logged, never aborting the fleet. Absent
+   * in tests / non-fleet contexts → no boot runs (back-compat).
+   */
+  bootSweeps?(): Promise<void>;
 }
 
 // ---------- per-slot runtime state ----------
@@ -1155,6 +1168,22 @@ export async function runSupervisor(
   // The progress-stale check (#579) must fire strictly after the heartbeat-stale
   // check, so its threshold must be greater.
   validateSupervisorProgressThreshold(config);
+
+  // Fleet supervisor owns the boot (#623): run the shared sweeps ONCE, pre-spawn,
+  // so every worker the fleet spawns boots bootstrap+claim only and never races
+  // peers over `.red/tmp` state. This is the ONLY call site — a respawn after a
+  // worker exit happens inside the tick loop below and never re-enters here, so
+  // the sweeps run exactly once per supervisor lifetime. Best-effort: a boot
+  // failure is logged, not fatal (each worker still runs its own precheck).
+  if (deps.bootSweeps) {
+    try {
+      await deps.bootSweeps();
+    } catch (err) {
+      deps.log?.(
+        `boot sweeps failed: ${err instanceof Error ? err.message : String(err)} — spawning workers anyway`,
+      );
+    }
+  }
 
   // Spawn the initial fleet to target.
   for (let i = 0; i < state.slots.length; i += 1) {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -651,8 +651,10 @@ export async function collectReapInputs(ctx: RepoContext): Promise<ReapInputs> {
 
 // ---------- precheck facts ----------
 
-import type { PrecheckFacts, BootOptions, BootstrapInput, OrphanDir } from "../core/boot.js";
+import type { PrecheckFacts, BootOptions, BootDeps, BootstrapInput, OrphanDir } from "../core/boot.js";
 import type { AttemptDir } from "../core/reclaim.js";
+import type { IssueStateRow } from "./gh.js";
+import { LABEL_HUMAN, LABEL_RUNNING } from "../core/triage-labels.js";
 import { parseWorkerAttemptPath } from "../core/worker-paths.js";
 
 /**
@@ -754,5 +756,150 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     currentBranch,
     lockedBranch,
     pnpmInstalled,
+  };
+}
+
+// ---------- boot deps ----------
+
+/** Pre-resolve the gh issue-state cache the branch-cleanup reapers + orphan
+ * lookup read synchronously. Mirrors collectReapInputs' eager resolution, but
+ * sources every issue's meta from the SINGLE batched `listIssueStates` map
+ * instead of a per-issue `gh issue view` storm. A map miss (issue beyond the
+ * --limit window / just-created / transient list failure) falls back to the
+ * live `ghx.issueMeta` so closedAt-grace classification stays exact. */
+async function resolveBranchIssueCache(
+  ghCtx: GhContext,
+  options: BootOptions,
+  states: Map<number, IssueStateRow>,
+): Promise<Map<number, IssueMeta | null | undefined>> {
+  const { liveIssueFromBranch, attemptIssueFromBranch } = await import("../core/branch-cleanup.js");
+  const issues = new Set<number>();
+  for (const r of options.branches.snapshotRefs) {
+    const n = attemptIssueFromBranch(r.branch);
+    if (n !== null) issues.add(n);
+  }
+  for (const r of [...options.branches.remoteLiveRefs, ...options.branches.localLiveRefs]) {
+    const n = liveIssueFromBranch(r.branch);
+    if (n !== null) issues.add(n);
+  }
+  const cache = new Map<number, IssueMeta | null | undefined>();
+  for (const n of issues) {
+    const row = states.get(n);
+    if (row) cache.set(n, { state: row.state, closedAt: row.closedAt });
+    else cache.set(n, await issueMeta(ghCtx, n));
+  }
+  return cache;
+}
+
+/**
+ * Build the real {@link BootDeps} for a full boot run — the fs/gh/git side
+ * effects + per-issue lookups every sweep composes. ONE batched
+ * `listIssueStates` fetch backs every per-issue boot lookup (orphan state,
+ * branch state, blocker state); a map miss falls back to a live read so the
+ * classification stays exact. Used by a solo `run` (sweeps run) and by the fleet
+ * supervisor's pre-spawn boot (#623).
+ */
+export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: number): Promise<BootDeps> {
+  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  const gitCtx: gitx.GitContext = { cwd: ctx.root };
+  // ONE batched issue-state fetch backs every per-issue boot lookup below.
+  const issueStates = await ghx.listIssueStates(ghCtx);
+  const branchCache = await resolveBranchIssueCache(ghCtx, options, issueStates);
+  return {
+    fs: {
+      ensureDir: fsx.ensureDir,
+      ensureGitignoreLine: fsx.ensureGitignoreLine,
+      writeWorkerPid: fsx.writeWorkerPid,
+      removeDir: fsx.removeDir,
+    },
+    gh: {
+      editLabels: async (issue, remove, add) => {
+        await ghx.editLabels(ghCtx, issue, remove, add);
+      },
+      comment: (issue, body) => ghx.comment(ghCtx, issue, body),
+    },
+    git: {
+      deleteRemoteBranch: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),
+      deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
+    },
+    lookups: {
+      // Live-claim ownership for the orphan sweep (#644): a dead attempt dir
+      // naming an issue whose claims/{N}/pid is a LIVE process is claim-race
+      // debris, not a mid-issue crash — the sweep removes it without touching
+      // the winner's `running` label.
+      claimHolderAlive: (issue) => fsx.claimPathHeldByLivePid(join(afkPaths(ctx.root).tmpDir, "claims", String(issue))),
+      // Orphan state pairs gh issue state/label with the attempt dir's
+      // envelope.posted flag (read from the state file, not gh). Derived from
+      // the batched map, preserving ghx.orphanState's exact label/state →
+      // verdict mapping (ready-for-human > running > null). On a map MISS the
+      // issue isn't in the list window — fall back to the live read so a
+      // truncated/just-created/transient issue still classifies correctly.
+      orphanState: async (issue) => {
+        const row = issueStates.get(issue);
+        if (!row) return ghx.orphanState(ghCtx, issue);
+        const label = row.labels.includes(LABEL_HUMAN)
+          ? LABEL_HUMAN
+          : row.labels.includes(LABEL_RUNNING)
+            ? LABEL_RUNNING
+            : null;
+        return { ghOk: true, state: row.state, label, envelopePosted: false };
+      },
+      branchIssue: (issue) => branchCache.get(issue),
+      // Blocker state from the batched map: row.state ("OPEN"/"CLOSED") or
+      // undefined on a miss. undefined-on-miss exactly matches the prior
+      // 404→undefined→not-closed semantics — a missing blocker stays
+      // "open-or-unknown" and the dependent issue is NOT promoted.
+      blockerState: async (issue) => issueStates.get(issue)?.state,
+      straggler: {
+        unlabeled: () => ghx.countUnlabeled(ghCtx),
+        needsTriage: () => ghx.countNeedsTriage(ghCtx),
+        needsInfo: () => ghx.countNeedsInfo(ghCtx),
+      },
+    },
+    nowS,
+  };
+}
+
+/**
+ * Build a MINIMAL {@link BootDeps} for a supervised worker whose boot skips
+ * every shared sweep (#623, `RED_AFK_SWEEPS_DONE`). `runBoot` with
+ * `skipSweeps:true` touches only `deps.fs` (the bootstrap mkdir / gitignore /
+ * worker.pid writes) and `deps.nowS` before returning, so the gh/git/lookup
+ * closures are never reached — they are present only to satisfy the type and
+ * throw if ever called, which would surface a regression that let a skip-boot
+ * fall through into a sweep. This deliberately AVOIDS the batched
+ * `listIssueStates` + branch-cache resolution {@link buildBootDeps} pays, which
+ * is the whole point: a respawned worker's boot must be cheap.
+ */
+export function buildMinimalBootDeps(ctx: RepoContext, nowS: number): BootDeps {
+  const unreachable = (): never => {
+    throw new Error("buildMinimalBootDeps: sweep IO invoked on a skip-sweeps boot (#623)");
+  };
+  return {
+    fs: {
+      ensureDir: fsx.ensureDir,
+      ensureGitignoreLine: fsx.ensureGitignoreLine,
+      writeWorkerPid: fsx.writeWorkerPid,
+      removeDir: fsx.removeDir,
+    },
+    gh: {
+      editLabels: async () => unreachable(),
+      comment: async () => unreachable(),
+    },
+    git: {
+      deleteRemoteBranch: async () => unreachable(),
+      deleteLocalBranch: async () => unreachable(),
+    },
+    lookups: {
+      orphanState: async () => unreachable(),
+      branchIssue: () => unreachable(),
+      blockerState: async () => unreachable(),
+      straggler: {
+        unlabeled: async () => unreachable(),
+        needsTriage: async () => unreachable(),
+        needsInfo: async () => unreachable(),
+      },
+    },
+    nowS,
   };
 }

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -251,6 +251,57 @@ describe("runBoot bootstrap", () => {
   });
 });
 
+describe("runBoot skipSweeps — supervisor-owned boot (#623)", () => {
+  it("runs precheck + bootstrap then returns before every sweep", async () => {
+    const { deps, calls, fsCalls } = makeDeps();
+    // Provide sweep INPUTS that would normally trigger work, to prove they are
+    // ignored once skipSweeps is set: an orphan dir, an attempt-cap group, a
+    // reapable branch, and an unblock candidate.
+    const result = await runBoot(
+      deps,
+      options({
+        skipSweeps: true,
+        orphans: [{ path: "/d/orphan", issue: 7, ageS: 999_999 }],
+        attemptCap: { byIssue: new Map([[7, [attempt(7, 1, 999_999)]]]) },
+        branches: { snapshotRefs: [{ branch: "afk-attempts/7-x" }], remoteLiveRefs: [], localLiveRefs: [] },
+        unblockCandidates: [{ number: 9, body: "", labels: ["blocked:dependency", "req:1"] }],
+      }),
+    );
+
+    // Bootstrap still ran (dirs + gitignore + worker.pid).
+    expect(fsCalls.ensureDir).toEqual([
+      "/p/.red/tmp",
+      "/p/.red/state",
+      "/p/.red/tmp/workers/wAAA",
+    ]);
+    expect(fsCalls.workerPid).toHaveLength(1);
+    // …but NOTHING else: no removeDir, no gh, no git — every sweep was skipped.
+    expect(fsCalls.removeDir).toEqual([]);
+    expect(calls.filter((c) => c.startsWith("gh.") || c.startsWith("git."))).toEqual([]);
+
+    // The result carries only precheck + bootstrap; every sweep field is absent.
+    expect(result.precheck.ok).toBe(true);
+    expect(result.bootstrap).toEqual({ ok: true });
+    expect(result.orphanCleanup).toBeUndefined();
+    expect(result.attemptCap).toBeUndefined();
+    expect(result.branchCleanup).toBeUndefined();
+    expect(result.unblockSweep).toBeUndefined();
+    expect(result.reconcileSweep).toBeUndefined();
+    expect(result.straggler).toBeUndefined();
+  });
+
+  it("still aborts on a precheck failure before bootstrap", async () => {
+    const { deps, calls } = makeDeps();
+    const result = await runBoot(
+      deps,
+      options({ skipSweeps: true, precheck: facts({ ghInstalled: false }) }),
+    );
+    expect(result.precheck).toEqual({ ok: false, failed: "gh-missing" });
+    expect(result.bootstrap).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+});
+
 describe("runBoot orphan cleanup applies each fate", () => {
   it("removes a CLOSED-issue orphan dir", async () => {
     const orphanState: BootDeps["lookups"]["orphanState"] = async () => ({

--- a/apps/dev/tests/session.test.ts
+++ b/apps/dev/tests/session.test.ts
@@ -183,6 +183,8 @@ interface RunHarnessOptions {
   throwOnProcess?: boolean;
   /** --boot-only: run the boot then return before selection/processing. */
   bootOnly?: boolean;
+  /** #623: the supervisor already ran the sweeps; shape the boot-only line. */
+  sweepsSkipped?: boolean;
   /** Runners whose shared circuit is already open before the next claim. */
   circuitOpenFor?: Runner[];
 }
@@ -298,6 +300,7 @@ function makeSession(opts: RunHarnessOptions = {}): {
     once: opts.once,
     alternate: opts.alternate,
     bootOnly: opts.bootOnly,
+    sweepsSkipped: opts.sweepsSkipped,
     filter: opts.filter ?? { kind: "all" },
     issueTemplate: {
       tmpDir: "/tmp/afk",
@@ -442,6 +445,22 @@ describe("runSession — --boot-only dry-run", () => {
     // A single informational line is emitted, never the NO MORE TASKS sentinel.
     expect(trace.emitted).not.toContain(NO_MORE_TASKS);
     expect(trace.emitted).toEqual(["boot complete (--boot-only): sweeps ran, no issues processed"]);
+  });
+
+  it("reports the sweeps as supervisor-owned when sweepsSkipped is set (#623)", async () => {
+    const { deps, ctx, trace } = makeSession({
+      candidates: [cand(1), cand(2)],
+      bootOnly: true,
+      sweepsSkipped: true,
+    });
+    const summary = await runSession(deps, ctx);
+    // Still a dry-run: no selection / processing, just the supervisor-owned line.
+    expect(trace.listCandidatesCalls).toBe(0);
+    expect(trace.processedOrder).toEqual([]);
+    expect(trace.emitted).toEqual([
+      "boot complete (--boot-only): sweeps skipped (supervisor-owned), no issues processed",
+    ]);
+    expect(summary.drained).toBe(false);
   });
 });
 

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -5,7 +5,9 @@ import {
   buildWorkerEnv,
   buildSlotEnv,
   slotFilterArgs,
+  formatBootSweepResult,
 } from "../src/commands/supervise.js";
+import type { BootResult } from "../src/core/boot.js";
 
 describe("buildWorkerEnv / passthroughKeys (gap 4: passthrough denylist)", () => {
   it("forwards operator RED_AFK_* vars but strips internal supervisor knobs", () => {
@@ -26,12 +28,16 @@ describe("buildWorkerEnv / passthroughKeys (gap 4: passthrough denylist)", () =>
     // every internal knob is stripped
     for (const denied of PASSTHROUGH_DENYLIST) {
       if (denied === "RED_AFK_RUNNER") continue; // re-pinned below
+      if (denied === "RED_AFK_SWEEPS_DONE") continue; // re-pinned below (#623)
       expect(env[denied]).toBeUndefined();
     }
     expect(env.RED_AFK_TARGET).toBeUndefined();
     expect(env.RED_AFK_POLL_S).toBeUndefined();
     // runner is re-pinned to the supervisor's runner
     expect(env.RED_AFK_RUNNER).toBe("codex");
+    // #623: every supervised worker is marked sweeps-done so it boots
+    // bootstrap+claim only (skips the sweeps the supervisor already ran).
+    expect(env.RED_AFK_SWEEPS_DONE).toBe("1");
   });
 
   it("strips per-slot _BASE build-isolation vars (handled per slot, not forwarded)", () => {
@@ -133,5 +139,30 @@ describe("slotFilterArgs (gap 5: supervised fleet forwards the filter)", () => {
 
   it("returns [] for an empty arg list", () => {
     expect(slotFilterArgs([])).toEqual([]);
+  });
+});
+
+describe("formatBootSweepResult — supervisor boot log shape (#623)", () => {
+  it("summarises each sweep's counts on a passing precheck", () => {
+    const result: BootResult = {
+      precheck: { ok: true, warnings: [] },
+      bootstrap: { ok: true },
+      orphanCleanup: { removed: ["a", "b"], restored: [7], kept: ["c"], legacyWiped: [], claimsReleased: [] },
+      attemptCap: { reclaimed: ["x"] },
+      branchCleanup: { snapshotReaped: ["s1"], remoteLiveReaped: [], localLiveReaped: ["l1", "l2"] },
+      unblockSweep: { promoted: [9] },
+      straggler: { counts: { unlabeled: 2, needsTriage: 1, needsInfo: 0 }, warn: true },
+    };
+    expect(formatBootSweepResult(result)).toBe(
+      "boot sweeps complete: orphans removed=2 restored=1 kept=1 | attempt-cap reclaimed=1 | " +
+        "branches snapshot=1 remote=0 local=2 | unblocked=1 | stragglers unlabeled=2 triage=1 info=0",
+    );
+  });
+
+  it("reports a precheck failure (workers fall back to their own precheck)", () => {
+    const result: BootResult = { precheck: { ok: false, failed: "not-on-main", detail: "feat/x" } };
+    expect(formatBootSweepResult(result)).toBe(
+      "boot sweeps: precheck FAILED (not-on-main) — workers will run their own precheck",
+    );
   });
 });

--- a/apps/dev/tests/supervisor-boot.test.ts
+++ b/apps/dev/tests/supervisor-boot.test.ts
@@ -1,0 +1,143 @@
+// supervisor-boot.test.ts — the fleet supervisor owns the boot (#623).
+//
+// runSupervisor runs the injected `bootSweeps` ONCE, before the initial fleet
+// spawn, and never again for the rest of its lifetime (a worker death + respawn
+// inside the tick loop must not re-trigger the sweeps). A bootSweeps throw is
+// caught and logged; the fleet still spawns. Kept in its own small file so it
+// runs without the environmental heap pressure of the full supervisor suite.
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  runSupervisor,
+  initSupervisorState,
+  SUPERVISOR_DEFAULTS,
+  type SupervisorConfig,
+  type SupervisorDeps,
+} from "../src/core/supervisor.js";
+import type { ProcessSnapshotEntry } from "../src/core/reaper-signal.js";
+
+const NOW = 1_000_000;
+
+function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
+  return { ...SUPERVISOR_DEFAULTS, ...over };
+}
+
+interface DepsOverrides {
+  isAlive?: () => boolean;
+  lastExitCode?: () => number | null;
+  readyQueueDepth?: () => Promise<number>;
+  bootSweeps?: (() => Promise<void>) | undefined;
+}
+
+/** A minimal real-shaped SupervisorDeps with every closure spied. The `sleep`
+ * resolves on a macrotask (setTimeout 0) — NOT immediately — so guardedTick's
+ * race lets the real tick win and `stopped` propagates (avoids the #446 spin). */
+function makeDeps(over: DepsOverrides = {}): {
+  deps: SupervisorDeps;
+  spawnSlot: ReturnType<typeof vi.fn>;
+  bootSweeps: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.fn>;
+  order: string[];
+} {
+  let nextPid = 2000;
+  const order: string[] = [];
+  const hasBoot = !("bootSweeps" in over) || over.bootSweeps !== undefined;
+  const bootSweeps = vi.fn(
+    over.bootSweeps ??
+      (async () => {
+        order.push("boot");
+      }),
+  );
+  const spawnSlot = vi.fn(async () => {
+    order.push("spawn");
+    return { pid: ++nextPid, spawnEpoch: NOW };
+  });
+  const log = vi.fn();
+  const deps: SupervisorDeps = {
+    proc: {
+      spawnSlot,
+      isAlive: vi.fn(over.isAlive ?? (() => true)),
+      killTree: vi.fn(async () => {}),
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
+      sleep: vi.fn((_ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 0))),
+      lastExitCode: vi.fn(over.lastExitCode ?? (() => null as number | null)),
+    },
+    fs: {
+      agentLaneMtime: vi.fn(() => 0),
+      resolveIterDir: vi.fn(() => null),
+      teardownIterDir: vi.fn(async () => {}),
+      parkedSlotWork: vi.fn(() => ({ workers: [], supervisorLogPath: ".red/tmp/afk-supervisor.log" })),
+      removeDir: vi.fn(async () => {}),
+    },
+    gh: {
+      comment: vi.fn(async () => {}),
+      editLabels: vi.fn(async () => {}),
+      ensureRunnerErrorLabel: vi.fn(async () => {}),
+      ensureLabel: vi.fn(async () => {}),
+      readyQueueDepth: vi.fn(over.readyQueueDepth ?? (async () => 0)),
+    },
+    now: vi.fn(() => NOW),
+    log,
+    ...(hasBoot ? { bootSweeps } : {}),
+  };
+  return { deps, spawnSlot, bootSweeps, log, order };
+}
+
+describe("runSupervisor — supervisor owns the boot (#623)", () => {
+  it("runs bootSweeps exactly once, before the initial fleet spawn", async () => {
+    const { deps, spawnSlot, bootSweeps, order } = makeDeps();
+    const state = initSupervisorState(2);
+
+    await runSupervisor(state, deps, config({ target: 2 }), () => true);
+
+    expect(bootSweeps).toHaveBeenCalledTimes(1);
+    expect(spawnSlot).toHaveBeenCalledTimes(2);
+    // The single boot strictly precedes every spawn.
+    expect(order).toEqual(["boot", "spawn", "spawn"]);
+  });
+
+  it("does not re-run bootSweeps when a worker dies and the slot respawns", async () => {
+    // Slot worker pid is reported dead from tick 1 onward → handleDeadSlot
+    // respawns it (clean queue has work). bootSweeps must NOT fire again.
+    const { deps, spawnSlot, bootSweeps } = makeDeps({
+      isAlive: vi.fn(() => false),
+      lastExitCode: vi.fn(() => 0), // clean exit + queue>0 → respawn, not park.
+      readyQueueDepth: vi.fn(async () => 3),
+    });
+    const state = initSupervisorState(1);
+
+    // Stop on the 2nd probe: tick 1 respawns the dead slot, then stop.
+    let probes = 0;
+    const stop = () => ++probes >= 2;
+
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15 }), stop);
+
+    // Boot ran once for the whole lifetime; the slot spawned initial + respawn.
+    expect(bootSweeps).toHaveBeenCalledTimes(1);
+    expect(spawnSlot.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("spawns the fleet even when bootSweeps throws (best-effort, logged)", async () => {
+    const { deps, spawnSlot, log } = makeDeps({
+      bootSweeps: vi.fn(async () => {
+        throw new Error("gh down");
+      }),
+    });
+    const state = initSupervisorState(1);
+
+    await runSupervisor(state, deps, config({ target: 1 }), () => true);
+
+    expect(spawnSlot).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls.some((c) => String(c[0]).includes("boot sweeps failed"))).toBe(true);
+  });
+
+  it("spawns normally when no bootSweeps is wired (back-compat)", async () => {
+    const { deps, spawnSlot, bootSweeps } = makeDeps({ bootSweeps: undefined });
+    const state = initSupervisorState(1);
+
+    await runSupervisor(state, deps, config({ target: 1 }), () => true);
+
+    expect(bootSweeps).not.toHaveBeenCalled();
+    expect(spawnSlot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -8,8 +8,10 @@ import {
   collectMonitorInputs,
   readFleetState,
   resolveAttemptGuardArming,
+  buildMinimalBootDeps,
   withTimeout,
 } from "../src/runtime/wire.js";
+import { runBoot } from "../src/core/boot.js";
 
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), "afk-wire-"));
@@ -308,5 +310,57 @@ describe("withTimeout — bounded cold-cache refresh", () => {
     const result = await withTimeout(lateRejecting.catch(() => -1), 20, -1);
     lateReject(new Error("network gone"));
     expect(result).toBe(-1);
+  });
+});
+
+describe("buildMinimalBootDeps — supervisor-owned-sweeps worker boot (#623)", () => {
+  it("drives a real skipSweeps runBoot: bootstrap on disk, no sweep IO", async () => {
+    const dir = scratch();
+    try {
+      const tmpDir = join(dir, ".red", "tmp");
+      const deps = buildMinimalBootDeps({ root: dir, repo: "o/r", remote: "origin" }, 1_700_000_000);
+      const result = await runBoot(deps, {
+        precheck: {
+          ghInstalled: true,
+          ghAuthenticated: true,
+          isGitRepo: true,
+          remoteUrls: ["git@github.com:o/r.git"],
+          hasMainBranch: true,
+          currentBranch: "main",
+          pnpmInstalled: true,
+        },
+        bootstrap: {
+          tmpDir,
+          stateDir: join(dir, ".red", "state"),
+          gitignorePath: join(dir, ".gitignore"),
+          workerDir: join(tmpDir, "workers", "wAAAA"),
+          workerPidFile: join(tmpDir, "workers", "wAAAA", "worker.pid"),
+          workerPid: 4242,
+        },
+        orphans: [],
+        attemptCap: { byIssue: new Map() },
+        branches: { snapshotRefs: [], remoteLiveRefs: [], localLiveRefs: [] },
+        unblockCandidates: [],
+        skipSweeps: true,
+      });
+      // Boot ran precheck + bootstrap then short-circuited; no sweep fields.
+      expect(result.precheck.ok).toBe(true);
+      expect(result.bootstrap).toEqual({ ok: true });
+      expect(result.orphanCleanup).toBeUndefined();
+      expect(result.straggler).toBeUndefined();
+      // Bootstrap really wrote to disk (the real fs closures are wired).
+      const { existsSync } = await import("node:fs");
+      expect(existsSync(join(tmpDir, "workers", "wAAAA", "worker.pid"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws if any sweep IO closure is invoked (guards a skip-boot regression)", async () => {
+    const deps = buildMinimalBootDeps({ root: "/x", repo: "o/r", remote: "origin" }, 0);
+    await expect(deps.gh.comment(1, "x")).rejects.toThrow(/skip-sweeps/);
+    await expect(deps.lookups.blockerState(1)).rejects.toThrow(/skip-sweeps/);
+    await expect(deps.lookups.straggler.unlabeled()).rejects.toThrow(/skip-sweeps/);
+    expect(() => deps.lookups.branchIssue(1)).toThrow(/skip-sweeps/);
   });
 });

--- a/plugins/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
+++ b/plugins/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
@@ -49,3 +49,11 @@ afk branch counts: remote-afk=N remote-afk-attempts=N local-afk=N
 
 It then applies the same three namespace reapers used during `/afk` boot: remote `afk-attempts/*`, remote `afk/*`, and local `afk/*`. Open issues and transiently unclassified issues are kept; local branches checked out by any worktree are kept. Each successful deletion logs the branch, issue number, and classification reason. Re-running is a natural no-op once stale refs are gone. Snapshot grace still comes from `RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S`; live `afk/*` cleanup keeps the existing closed-vs-open policy.
 
+## Fleet mode: the supervisor owns the boot (issue #623)
+
+The sweeps above (*Orphan Cleanup*, *Attempt Cap*, *Snapshot Branch Grace Cleanup*, the *Unblock Sweep*, and the *Straggler Check*) all read and mutate **shared** `.red/tmp` / branch / `gh` state. When several workers boot at once they would race over that state — the observed failure mode was a fleet collapsing to a single live worker because peers fast-died in their boot sweeps.
+
+So in **fleet mode** the **supervisor** runs the full sweep suite **exactly once, before it spawns any worker**, and logs the result to `.red/tmp/afk-supervisor.log` (`boot sweeps complete: orphans … | attempt-cap … | branches … | unblocked … | stragglers …`). Every worker the supervisor spawns carries a `RED_AFK_SWEEPS_DONE=1` marker; a marked worker's boot is **bootstrap + claim only** — it ensures its dirs/gitignore/`worker.pid` and goes straight to claiming an issue, skipping every shared sweep. This makes respawns cheap and keeps workers from racing each other over boot state. The supervisor runs the sweeps a single time per lifetime: a worker that exits and is respawned does **not** re-trigger them.
+
+A **solo** `/afk run` (no supervisor, no marker) is unchanged — it runs the full sweep suite itself, exactly as described above. `/afk run --boot-only` reports which path it took: `sweeps ran` for a solo boot, `sweeps skipped (supervisor-owned)` for a marked worker.
+


### PR DESCRIPTION
Closes #623. Landed manually via admin-merge: the AFK worker wSC3A completed the work (commit 329a9480, 124/124 tests pass, typecheck clean) but looped without emitting the DONE sentinel. Work verified complete on the branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772886&installation_id=129708444&pr_number=695&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F695&signature=ee01342d9e40f59555cbaf60e9e0d381e6d0bc350145ae529ad7b65c4535ff8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Supervisor now executes shared boot sweeps once before spawning workers in fleet mode.
  * Workers in fleet mode skip redundant sweeps, improving startup time.
  * Boot logging indicates supervisor-owned vs. worker-performed sweeps.

* **Documentation**
  * Added fleet mode boot behavior documentation explaining supervisor sweep execution and worker boot process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->