### PR TITLE
fix(config): fold plugins.dev.<key> onto dev.* so dev settings stay namespaced (extends ADR 0042)

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -10,16 +10,14 @@
 #       cargo: true               # ship cargo isolation on Rust projects
 #       gradle: true              # ship gradle isolation when GRADLE_USER_HOME_BASE is set
 
-# Active: default the OpenCode/Actions lane to MiniMax M3 for every tier.
-# `base` auto-populates validate/simple/complex/think; specialize a single tier
-# with plugins.dev.afk.models.opencode.<tier>.model to override just that one.
+# Active dev-plugin settings, all namespaced under `plugins.dev.*` (the root
+# stays sacred). `base` auto-populates every opencode tier (validate/simple/
+# complex/think); specialize one with plugins.dev.afk.models.opencode.<tier>.model.
 plugins:
   dev:
+    lock-primary-branch: true       # primary-checkout branch-switch guard
     afk:
       models:
         opencode:
           base:
             model: minimax/MiniMax-M3
-
-dev:
-  lock-primary-branch: true

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -271,12 +271,19 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
   }
 
   // Copy raw parsed keys (forward compatibility), then fold the namespaced
-  // `plugins.dev.*` block down to the bare accessor keys so the new location
-  // wins over the legacy top-level one (ADR 0042).
+  // `plugins.dev.*` block down to the accessor keys so the new location wins over
+  // the legacy top-level one (ADR 0042).
   for (const [key, value] of Object.entries(parsed)) values[key] = value;
   for (const [key, value] of Object.entries(parsed)) {
     const m = /^plugins\.dev\.(.+)$/.exec(key);
-    if (m) values[m[1]!] = value;
+    if (!m) continue;
+    const rest = m[1]!;
+    // The dev plugin's AFK settings flatten to the bare `afk.*` accessor
+    // (historical, shared with the legacy top-level `afk:` block); every other
+    // dev-plugin key keeps the `dev.*` accessor — so
+    // `plugins.dev.lock-primary-branch` folds to `dev.lock-primary-branch`, not a
+    // bare `lock-primary-branch` the loader never reads.
+    values[rest === "afk" || rest.startsWith("afk.") ? rest : `dev.${rest}`] = value;
   }
   return values;
 }

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -97,6 +97,24 @@ describe("config", () => {
     expect(getConfig(values, "dev.lock-primary-branch")).toBe("true");
   });
 
+  it("folds the namespaced `plugins.dev.lock-primary-branch` onto `dev.lock-primary-branch`", () => {
+    // The root-sacred convention: dev-plugin keys nest under `plugins.dev.*` and
+    // fold to the `dev.*` accessor (afk keeps its bare `afk.*` accessor).
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => "plugins:\n  dev:\n    lock-primary-branch: true\n",
+    });
+    expect(getConfig(values, "dev.lock-primary-branch")).toBe("true");
+  });
+
+  it("folds `plugins.dev` dev-keys and afk-keys to their distinct accessors at once", () => {
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () =>
+        "plugins:\n  dev:\n    lock-primary-branch: true\n    afk:\n      default_runner: codex\n",
+    });
+    expect(getConfig(values, "dev.lock-primary-branch")).toBe("true");
+    expect(getConfig(values, "afk.default_runner")).toBe("codex");
+  });
+
   it("nested override leaves siblings untouched", async () => {
     const path = await writeConfig(
       `afk:\n  hooks:\n    defaults:\n      cargo: false\n`,


### PR DESCRIPTION
Fixes the inconsistency you spotted: `lock-primary-branch` was stuck at top-level `dev:` instead of nesting under `plugins.dev` like the rest.

**Root cause:** the ADR 0042 fold stripped `plugins.dev.` whole — `plugins.dev.afk.*` → `afk.*` worked, but `plugins.dev.lock-primary-branch` → bare `lock-primary-branch`, a key the loader never reads (it reads `dev.lock-primary-branch`). Namespacing it silently flipped the branch guard off.

**Fix:** the dev plugin's AFK subtree keeps the bare `afk.*` accessor (historical, shared with the legacy `afk:` block); every other `plugins.dev.<key>` now folds onto `dev.<key>`. So `plugins.dev.lock-primary-branch` → `dev.lock-primary-branch`.

- `config.ts` — afk-vs-dev accessor split in the fold.
- `config.test.ts` — namespaced `plugins.dev.lock-primary-branch` resolves; mixed dev+afk under one `plugins.dev` block both land. **45/45**, typecheck clean.
- `.red/config.yaml` — `lock-primary-branch` moved under `plugins.dev`; the repo config is now **fully namespaced (root sacred)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783773501&installation_id=129708444&pr_number=697&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F697&signature=8679de476870e6f50c22d17810b37e0f3c9bbb27313e7da9777a6cc56c40c21c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration structure and validation for improved organization.
  * Enhanced configuration key mapping tests to ensure correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->