### PR TITLE
feat(afk): enrich the proof-of-life heartbeat with stream-activity metrics

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -60,6 +60,7 @@ import { join } from "node:path";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
 import { initState, updateState } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
+import { createActivityMeter } from "../core/activity-meter.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
 import type { AgentStreamEvent } from "../core/execution.js";
 
@@ -425,6 +426,11 @@ export function buildProcessDeps(
   const iterMax = maxIterations ?? DEFAULT_MAX_ITERATIONS;
   let lastIter = 0;
   let lastIterDir = "";
+  // Per-attempt stream-activity meter (slice 1 liveness metrics): counts
+  // toolCall/text events and derives waiting windows. Re-created when the
+  // attempt dir changes so counts never bleed across the attempt boundary.
+  let activityMeter = createActivityMeter();
+  let activityMeterDir = "";
 
   // ---- lifecycle hooks: load config + resolve built-in defaults + real exec ----
   const config = loadConfig(paths.configPath, { warn: () => undefined });
@@ -616,6 +622,12 @@ export function buildProcessDeps(
         lastIterDir = dir0;
         lastIter = 0; // new attempt → fresh iteration count
       }
+      // New attempt → fresh activity meter (counts must not bleed across attempts).
+      if (dir0 !== activityMeterDir) {
+        activityMeterDir = dir0;
+        activityMeter = createActivityMeter();
+      }
+      activityMeter.record(event);
       if (event.iteration !== lastIter) {
         const emit = (line: string, phase: string, n: number): void => {
           void fsx.appendLine(join(dir0, "afk.log"), line);
@@ -681,12 +693,17 @@ export function buildProcessDeps(
         const { added, removed } = await gitx
           .diffstatShortstat({ cwd: worktree }, baseRef)
           .catch(() => ({ added: 0, removed: 0 }));
+        // Close this heartbeat window on the meter — derives the waiting count
+        // (a window with no new stream events) and snapshots the cumulative
+        // tool/text counts to fold into the record + state.
+        const activity = activityMeter.snapshotWindow();
         const hb = buildProgressHeartbeat({
           secsSinceProgress: secs,
           lastProgressAt,
           head,
           added,
           removed,
+          activity,
         });
         await appendRecord(join(current.attemptDir, "log.jsonl"), "heartbeat", hb.msg, {
           ts,

--- a/apps/dev/src/core/activity-meter.ts
+++ b/apps/dev/src/core/activity-meter.ts
@@ -1,0 +1,85 @@
+// activity-meter — a tiny per-attempt counter over the agent's normalised
+// stream events, surfaced into the proof-of-life heartbeat so liveness is
+// readable at a glance rather than inferred from cpu/rss alone.
+//
+// red-castle's public `AgentStreamEvent` carries only `text` and `toolCall`
+// today (the raw per-CLI streams also carry reasoning/usage, but the parsers
+// drop them — extending that is a separate red-castle change). So this meter
+// counts exactly what the three runners (claude / codex / opencode) already
+// deliver identically:
+//
+//   - tools_called_count — cumulative `toolCall` events this attempt
+//   - text_chunk_count   — cumulative `text` events this attempt
+//   - waiting_count      — cumulative heartbeat WINDOWS (≈ one per guard poll)
+//     in which the agent emitted ZERO new stream events. A window with no
+//     output means the agent produced nothing between two ticks — it was
+//     blocked/waiting (on a tool result, an API round-trip, or genuinely hung).
+//     Distinct from cpu/rss (a wedged subprocess still burns cpu) and from the
+//     line-diff (which only moves on a commit), so a rising waiting_count with a
+//     flat diff is the cleanest "stuck vs working" signal we can derive without
+//     touching red-castle.
+//
+// Pure and deterministic: no clock, no IO. The caller stamps timestamps. The
+// per-window bookkeeping is driven by `snapshotWindow()`, called once per
+// heartbeat tick.
+
+/** The minimal shape this meter reads off a normalised stream event. */
+export interface StreamEventLike {
+  readonly type: "text" | "toolCall";
+}
+
+/** The counters surfaced into a heartbeat tick. All cumulative for the attempt. */
+export interface ActivitySnapshot {
+  /** Cumulative `toolCall` events observed this attempt. */
+  readonly toolsCalled: number;
+  /** Cumulative `text` events observed this attempt. */
+  readonly textChunks: number;
+  /** Cumulative heartbeat windows with no new stream event (waiting/blocked). */
+  readonly waiting: number;
+  /** New stream events since the previous `snapshotWindow()` (0 → a waiting window). */
+  readonly eventsThisWindow: number;
+}
+
+export interface ActivityMeter {
+  /** Record one normalised stream event (call from the agent-event sink). */
+  record(event: StreamEventLike): void;
+  /**
+   * Close the current heartbeat window and open the next. Increments `waiting`
+   * when no events arrived since the previous call. Returns the cumulative
+   * snapshot to fold into the heartbeat record. Idempotent only across distinct
+   * ticks — each call advances the window boundary.
+   */
+  snapshotWindow(): ActivitySnapshot;
+  /** Read the cumulative counters without advancing the window (for tests/state reads). */
+  peek(): ActivitySnapshot;
+}
+
+/**
+ * Create a fresh meter for one attempt. A new attempt gets a new meter so the
+ * counts never bleed across the per-issue attempt boundary.
+ */
+export function createActivityMeter(): ActivityMeter {
+  let toolsCalled = 0;
+  let textChunks = 0;
+  let waiting = 0;
+  // Total events at the last window boundary, to derive per-window deltas.
+  let eventsAtLastWindow = 0;
+
+  const total = (): number => toolsCalled + textChunks;
+
+  return {
+    record(event) {
+      if (event.type === "toolCall") toolsCalled += 1;
+      else if (event.type === "text") textChunks += 1;
+    },
+    snapshotWindow() {
+      const eventsThisWindow = total() - eventsAtLastWindow;
+      if (eventsThisWindow <= 0) waiting += 1;
+      eventsAtLastWindow = total();
+      return { toolsCalled, textChunks, waiting, eventsThisWindow: Math.max(0, eventsThisWindow) };
+    },
+    peek() {
+      return { toolsCalled, textChunks, waiting, eventsThisWindow: total() - eventsAtLastWindow };
+    },
+  };
+}

--- a/apps/dev/src/core/heartbeat.ts
+++ b/apps/dev/src/core/heartbeat.ts
@@ -131,6 +131,23 @@ export interface ProgressHeartbeatInput {
   added: number;
   /** Removed lines vs the same base. */
   removed: number;
+  /**
+   * Optional per-attempt stream-activity counters (the activity-meter snapshot).
+   * Omitted on callers/tests that don't observe the stream — when absent the
+   * heartbeat is byte-for-byte the pre-metrics record. When present each count
+   * rides the firehose `extra` (string-valued) and is mirrored into
+   * `current.*_count` so the monitor/statusline can read liveness at a glance.
+   */
+  activity?: {
+    /** Cumulative `toolCall` events this attempt. */
+    toolsCalled: number;
+    /** Cumulative `text` events this attempt. */
+    textChunks: number;
+    /** Cumulative heartbeat windows with no new stream event (waiting/blocked). */
+    waiting: number;
+    /** New stream events in the window this tick closes (0 → a waiting window). */
+    eventsThisWindow: number;
+  };
 }
 
 export interface ProgressHeartbeat {
@@ -155,21 +172,50 @@ export interface ProgressHeartbeat {
 export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressHeartbeat {
   const diff = formatDiffVolume(input.added, input.removed);
   const headShort = input.head ? ` @ ${input.head.slice(0, 8)}` : "";
-  const msg = `progress: ${input.secsSinceProgress}s since last commit${headShort} · ${diff}`;
+  const locAdded = input.added > 0 ? input.added : 0;
+  const locRemoved = input.removed > 0 ? input.removed : 0;
+  const a = input.activity;
+  // Append a compact activity tail to the human line so a `tail -f afk.log`
+  // shows liveness without opening the firehose. Only when observed.
+  const activityTail = a
+    ? ` · tools:${a.toolsCalled} text:${a.textChunks} wait:${a.waiting}${a.eventsThisWindow === 0 ? " (idle window)" : ""}`
+    : "";
+  const msg = `progress: ${input.secsSinceProgress}s since last commit${headShort} · ${diff}${activityTail}`;
   return {
     msg,
     extra: {
       secs_since_progress: String(input.secsSinceProgress),
       last_progress_at: input.lastProgressAt,
       head: input.head,
-      diff_added: String(input.added > 0 ? input.added : 0),
-      diff_removed: String(input.removed > 0 ? input.removed : 0),
+      diff_added: String(locAdded),
+      diff_removed: String(locRemoved),
       diff: diff,
+      // The user-facing metric names (aliases of diff_*) so consumers can key on
+      // loc_* directly. Kept alongside diff_* for monitor back-compat.
+      loc_added: String(locAdded),
+      loc_removed: String(locRemoved),
+      ...(a
+        ? {
+            tools_called_count: String(a.toolsCalled),
+            text_chunk_count: String(a.textChunks),
+            waiting_count: String(a.waiting),
+            events_this_window: String(a.eventsThisWindow),
+          }
+        : {}),
     },
     statePatch: {
       "current.last_progress_at": input.lastProgressAt,
-      "current.diff_added": input.added > 0 ? input.added : 0,
-      "current.diff_removed": input.removed > 0 ? input.removed : 0,
+      "current.diff_added": locAdded,
+      "current.diff_removed": locRemoved,
+      "current.loc_added": locAdded,
+      "current.loc_removed": locRemoved,
+      ...(a
+        ? {
+            "current.tools_called_count": a.toolsCalled,
+            "current.text_chunk_count": a.textChunks,
+            "current.waiting_count": a.waiting,
+          }
+        : {}),
     },
   };
 }

--- a/apps/dev/tests/activity-meter.test.ts
+++ b/apps/dev/tests/activity-meter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createActivityMeter } from "../src/core/activity-meter.js";
+
+describe("createActivityMeter", () => {
+  it("counts toolCall and text events independently", () => {
+    const m = createActivityMeter();
+    m.record({ type: "toolCall" });
+    m.record({ type: "text" });
+    m.record({ type: "toolCall" });
+    const s = m.peek();
+    expect(s.toolsCalled).toBe(2);
+    expect(s.textChunks).toBe(1);
+  });
+
+  it("a window with new events does NOT increment waiting", () => {
+    const m = createActivityMeter();
+    m.record({ type: "toolCall" });
+    const s = m.snapshotWindow();
+    expect(s.eventsThisWindow).toBe(1);
+    expect(s.waiting).toBe(0);
+    expect(s.toolsCalled).toBe(1);
+  });
+
+  it("a window with ZERO new events increments waiting (the blocked/hung signal)", () => {
+    const m = createActivityMeter();
+    m.record({ type: "text" });
+    m.snapshotWindow(); // window 1: 1 event → not waiting
+    const s2 = m.snapshotWindow(); // window 2: no new events → waiting
+    expect(s2.eventsThisWindow).toBe(0);
+    expect(s2.waiting).toBe(1);
+    const s3 = m.snapshotWindow(); // window 3: still nothing → waiting again
+    expect(s3.waiting).toBe(2);
+  });
+
+  it("waiting only counts windows, not events: a busy window resets the streak", () => {
+    const m = createActivityMeter();
+    m.snapshotWindow(); // empty → waiting 1
+    m.record({ type: "toolCall" });
+    const busy = m.snapshotWindow(); // has an event → waiting stays 1
+    expect(busy.waiting).toBe(1);
+    expect(busy.eventsThisWindow).toBe(1);
+    const idle = m.snapshotWindow(); // empty again → waiting 2
+    expect(idle.waiting).toBe(2);
+  });
+
+  it("cumulative counts survive across windows", () => {
+    const m = createActivityMeter();
+    m.record({ type: "toolCall" });
+    m.snapshotWindow();
+    m.record({ type: "toolCall" });
+    m.record({ type: "text" });
+    const s = m.snapshotWindow();
+    expect(s.toolsCalled).toBe(2);
+    expect(s.textChunks).toBe(1);
+    expect(s.eventsThisWindow).toBe(2);
+  });
+
+  it("peek does not advance the window boundary", () => {
+    const m = createActivityMeter();
+    m.record({ type: "text" });
+    expect(m.peek().eventsThisWindow).toBe(1);
+    expect(m.peek().eventsThisWindow).toBe(1); // unchanged — peek is read-only
+    expect(m.peek().waiting).toBe(0);
+  });
+});

--- a/apps/dev/tests/heartbeat.test.ts
+++ b/apps/dev/tests/heartbeat.test.ts
@@ -222,7 +222,12 @@ describe("buildProgressHeartbeat (#448)", () => {
       "current.last_progress_at": "2026-06-03T12:00:00.000Z",
       "current.diff_added": 382,
       "current.diff_removed": 45,
+      "current.loc_added": 382,
+      "current.loc_removed": 45,
     });
+    // no activity snapshot → no activity fields, no msg tail (back-compat)
+    expect(hb.extra.tools_called_count).toBeUndefined();
+    expect(hb.msg.includes("tools:")).toBe(false);
   });
 
   it("omits the head fragment when HEAD is unresolved and clamps the diff", () => {
@@ -236,5 +241,37 @@ describe("buildProgressHeartbeat (#448)", () => {
     expect(hb.msg).toBe("progress: 0s since last commit · +0 -0");
     expect(hb.statePatch["current.diff_added"]).toBe(0);
     expect(hb.statePatch["current.diff_removed"]).toBe(0);
+  });
+
+  it("folds the activity-meter snapshot into the msg tail, extra, and state", () => {
+    const hb = buildProgressHeartbeat({
+      secsSinceProgress: 75,
+      lastProgressAt: "2026-06-03T12:00:00.000Z",
+      head: "40ac9326",
+      added: 382,
+      removed: 45,
+      activity: { toolsCalled: 12, textChunks: 7, waiting: 2, eventsThisWindow: 3 },
+    });
+    expect(hb.msg).toBe("progress: 75s since last commit @ 40ac9326 · +382 -45 · tools:12 text:7 wait:2");
+    expect(hb.extra.tools_called_count).toBe("12");
+    expect(hb.extra.text_chunk_count).toBe("7");
+    expect(hb.extra.waiting_count).toBe("2");
+    expect(hb.extra.loc_added).toBe("382");
+    expect(hb.extra.loc_removed).toBe("45");
+    expect(hb.statePatch["current.tools_called_count"]).toBe(12);
+    expect(hb.statePatch["current.waiting_count"]).toBe(2);
+    expect(hb.statePatch["current.loc_added"]).toBe(382);
+  });
+
+  it("marks an idle window (no new stream events) in the msg tail", () => {
+    const hb = buildProgressHeartbeat({
+      secsSinceProgress: 130,
+      lastProgressAt: "t",
+      head: "",
+      added: 0,
+      removed: 0,
+      activity: { toolsCalled: 5, textChunks: 3, waiting: 4, eventsThisWindow: 0 },
+    });
+    expect(hb.msg).toContain("wait:4 (idle window)");
   });
 });


### PR DESCRIPTION
## What

Slice 1 of richer liveness observability, **entirely in the dev CLI — no red-castle change**. A per-attempt activity meter counts the normalised stream events red-castle already exposes (`toolCall` / `text` via `onAgentStreamEvent`) and derives a *waiting* count. The proof-of-life heartbeat (each ~60s attempt-guard poll) now carries:

- `loc_added` / `loc_removed` — aliases of the existing diff volume
- `tools_called_count` — cumulative `toolCall` events this attempt
- `text_chunk_count` — cumulative `text` events
- `waiting_count` — cumulative heartbeat windows with **zero** new stream events (the agent was blocked/waiting). Rising `waiting` with a flat diff = stuck; rising `tools` = working.

These ride the firehose record `extra`, mirror into `current.*_count` in `afk.state.json`, and append a compact `tools:N text:N wait:N` tail to the `afk.log` line so `tail -f` shows liveness without opening the firehose.

## CLI coverage

Works identically for **claude / codex / opencode** because it consumes the already-normalised `AgentStreamEvent` (text|toolCall) — the same for all three runners. `loc_*` is git-based (CLI-agnostic).

## Deferred to a red-castle slice

`thinking_called_count` and token counts: the raw per-CLI streams carry reasoning/usage but the parsers drop them. Extending the normalised `AgentStreamEvent` is a substrate change (done once for all three runners) — that's slice 2.

## Design note

All fields are additive/optional — a caller that does not observe the stream emits the byte-for-byte pre-metrics record. The heartbeat lives in `apps/dev` (not red-castle) because it is an AFK-policy/observability concern: its inputs (the issue's git base, `afk.state.json`, the attempt-progress guard poll, the firehose) all live AFK-side; red-castle only needs to expose the normalised stream, which it already does.

## Verification

`apps/dev` typecheck clean. 1244/1244 tests pass (85 files; `supervisor.test.ts` excluded for the known environmental OOM). New `activity-meter.test.ts` (6) + heartbeat activity tests (3).

Refs #623

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783774998&installation_id=129708444&pr_number=699&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F699&signature=71e29af3a0f52e1e40a3c7cee59d5d11456b5bb69ef65eebae68592d2abe6356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress heartbeats now include per-attempt activity metrics, displaying tool calls executed, text chunks generated, and idle periods for enhanced visibility into agent execution.

* **Tests**
  * Added comprehensive test coverage for activity tracking and heartbeat enrichment functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->