### PR TITLE
feat(afk): dev.lock.branch static base lock — runtime > config > pin > main (stage 2, extends ADR 0031)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -206,6 +206,8 @@ function makeBootReconcileRunner(
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: GitContext = { cwd: ctx.root };
   const lockPath = branchLockPath(ctx.root);
+  const configLockedBranch =
+    getConfig(loadConfig(paths.configPath, { warn: () => undefined }), "dev.lock.branch") || undefined;
 
   return async (plan: ReconcileSweepPlan) => {
     // Acquire the per-issue claim before validating/landing so a concurrent live
@@ -281,7 +283,11 @@ function makeBootReconcileRunner(
       // never the trunk (#568, trunk safety). Mirrors the per-issue base lookup.
       const base = await resolveBase(
         { issueBody: plan.body },
-        { readLockedBranch: () => readLockedBranch(lockPath), fetchIssueBody: (n) => ghx.issueBody(ghCtx, n) },
+        {
+          readLockedBranch: () => readLockedBranch(lockPath),
+          configLockedBranch,
+          fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
+        },
       );
 
       const reconcileInput: ReconcileInput = {
@@ -560,6 +566,7 @@ export function buildProcessDeps(
     lookups: {
       base: {
         readLockedBranch: () => readLockedBranch(lockPath),
+        configLockedBranch: getConfig(config, "dev.lock.branch") || undefined,
         fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
       },
       isLocked: () => isLocked(lockPath),

--- a/apps/dev/src/core/base-resolver.ts
+++ b/apps/dev/src/core/base-resolver.ts
@@ -30,6 +30,13 @@ export interface ResolveBaseDeps {
    * unlocked). Wraps the branch-lock skill's `lock_store_read`.
    */
   readLockedBranch: () => Promise<string | undefined>;
+  /**
+   * Static config default branch lock (`dev.lock.branch`), used when the runtime
+   * branch-lock file is absent/unset. The runtime lock still overrides it, so the
+   * `/branch-lock` skill can re-lock dynamically per session. Empty/undefined =
+   * no config-level lock.
+   */
+  configLockedBranch?: string;
   /** Fetch the raw body for issue/PRD number `n`, or `undefined` if missing. */
   fetchIssueBody: (n: number) => Promise<string | undefined>;
 }
@@ -37,16 +44,20 @@ export interface ResolveBaseDeps {
 export type ResolveBaseInput = ResolvePinInput;
 
 /**
- * Resolve the effective base branch by the fixed precedence lock > pin > main:
- *   the locked branch if present, else the resolved pin, else `main`.
+ * Resolve the effective base branch by the fixed precedence
+ * runtime-lock > config-lock > pin > main:
+ *   the runtime branch-lock if present, else the static `dev.lock.branch` config
+ *   default, else the resolved pin, else `main`.
  *
- * The lock value is read via the injected `readLockedBranch`; the pin is
- * delegated to pin-reader's `resolvePin` (composed with the injected
- * `fetchIssueBody`). A whitespace-only lock counts as "not set".
+ * The runtime lock is read via the injected `readLockedBranch`; `configLockedBranch`
+ * is the static `dev.lock.branch` value; the pin is delegated to pin-reader's
+ * `resolvePin`. A whitespace-only value counts as "not set".
  */
 export async function resolveBase(input: ResolveBaseInput, deps: ResolveBaseDeps): Promise<string> {
   const locked = await deps.readLockedBranch();
   if (isSet(locked)) return locked.trim();
+
+  if (isSet(deps.configLockedBranch)) return deps.configLockedBranch.trim();
 
   const pinned = await resolvePin(input, { fetchIssueBody: deps.fetchIssueBody });
   if (isSet(pinned)) return pinned;

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -75,6 +75,11 @@ export const CONFIG_DEFAULTS = {
   "afk.merge.wait_for_review": "false",
   "afk.merge.review_check": "CodeRabbit",
   "dev.lock.primary-branch": "false",
+  // NOTE: `dev.lock.branch` (the static base lock — ADR 0031) is intentionally
+  // NOT in this table. Its "default" is *unset* (no config-level lock), and
+  // `getConfig` already returns "" for an absent key, so adding a "" default
+  // here would only break the "every default is non-empty" invariant. It is read
+  // via `getConfig(values, "dev.lock.branch")` and documented in config-template.yaml.
 } as const;
 
 export type ConfigKey = keyof typeof CONFIG_DEFAULTS;

--- a/apps/dev/tests/base-resolver.test.ts
+++ b/apps/dev/tests/base-resolver.test.ts
@@ -50,6 +50,28 @@ describe("resolveBase", () => {
     expect(deps.fetchCalls).toEqual([59]);
   });
 
+  // dev.lock.branch (config-level static lock) — precedence runtime > config > pin > main.
+  it("uses the config lock (dev.lock.branch) when the runtime lock is unset", async () => {
+    const deps = { ...depsFor(undefined, { 59: prdWithPin }), configLockedBranch: "config/branch" };
+    expect(await resolveBase({ issueBody: issueWithPin }, deps)).toBe("config/branch");
+    expect(deps.fetchCalls).toEqual([]); // config lock short-circuits pin resolution
+  });
+
+  it("lets the runtime lock override the config lock", async () => {
+    const deps = { ...depsFor("runtime/branch"), configLockedBranch: "config/branch" };
+    expect(await resolveBase({ issueBody: issueWithPin }, deps)).toBe("runtime/branch");
+  });
+
+  it("config lock wins over a pin", async () => {
+    const deps = { ...depsFor(undefined), configLockedBranch: "config/branch" };
+    expect(await resolveBase({ issueBody: issueWithPin }, deps)).toBe("config/branch");
+  });
+
+  it("an empty config lock falls through to the pin", async () => {
+    const deps = { ...depsFor(undefined), configLockedBranch: "" };
+    expect(await resolveBase({ issueBody: issueWithPin }, deps)).toBe("feature/some-pin");
+  });
+
   it("defaults to main when neither a lock nor a pin is set", async () => {
     const deps = depsFor(undefined);
     expect(await resolveBase({ issueBody: "## What to build\nno pin, no parent" }, deps)).toBe(DEFAULT_BRANCH);

--- a/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
+++ b/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
@@ -52,3 +52,5 @@
 # dev:
 #   lock:
 #     primary-branch: true        # activate the primary-checkout branch-switch guard
+#     branch: my-branch           # static base lock: AFK bases/merges here (ADR 0031);
+#                                 # the runtime `/branch-lock` overrides it per session


### PR DESCRIPTION
Stage 2 of the lock redesign (stage 1 = #700). `dev.lock.branch` is a **static, committed base lock**: when set, AFK bases/merges on that branch. It slots into the ADR 0031 precedence:

```
runtime .red/tmp/branch-lock.yaml  >  config dev.lock.branch  >  pin  >  main
```

Your decision: **config = default, runtime overrides** — the `/branch-lock` skill still re-locks dynamically per session (runtime wins), but a repo can commit a default base lock.

- `base-resolver.ts` — `configLockedBranch` dep in the precedence.
- `run.ts` — both `resolveBase` sites (boot-reconcile + per-issue `buildProcessDeps`) read `dev.lock.branch`.
- `config-template.yaml` documents it.
- Deliberately **not** in CONFIG_DEFAULTS (default is *unset*; `getConfig` returns "" for an absent key, preserving the every-default-non-empty invariant).

Tests: runtime overrides config; config wins over pin (short-circuits resolution); empty falls through. **62/62**, typecheck clean.

Now the full shape works:
```yaml
plugins:
  dev:
    lock:
      primary-branch: true
      branch: my-branch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783775659&installation_id=129708444&pr_number=701&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F701&signature=ece3fb1a17ca96709a86fc69a803bb0ad3bb328e60fa3483468fa69011a7bbb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable default locked branch via `dev.lock.branch` in configuration files. When set, this value serves as a fallback for branch resolution when no runtime lock is active, with runtime locks maintaining priority. Configuration template updated with usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->