### PR TITLE
feat(afk): count model reasoning in the heartbeat across claude/codex/opencode (slice 2)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -648,7 +648,14 @@ export function buildProcessDeps(
         emit(formatIterationMarker(lastIter, "started", iterMax), "started", lastIter);
         void updateState(join(dir0, "afk.state.json"), { "current.iteration": String(lastIter) }).catch(() => {});
       }
-      const msg = event.type === "text" ? event.message : `→ ${event.name} ${event.formattedArgs}`;
+      const msg =
+        event.type === "text"
+          ? event.message
+          : event.type === "reasoning"
+            ? `🧠 reasoning${
+                event.tokens ? ` (${event.tokens} tok)` : event.message ? `: ${event.message.slice(0, 80)}` : ""
+              }`
+            : `→ ${event.name} ${event.formattedArgs}`;
       void appendAgentRecord(join(current.attemptDir, "agent.log.jsonl"), msg, {
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },

--- a/apps/dev/src/core/activity-meter.ts
+++ b/apps/dev/src/core/activity-meter.ts
@@ -25,7 +25,9 @@
 
 /** The minimal shape this meter reads off a normalised stream event. */
 export interface StreamEventLike {
-  readonly type: "text" | "toolCall";
+  readonly type: "text" | "toolCall" | "reasoning";
+  /** Reasoning token count, when the runner exposes it (codex/opencode). */
+  readonly tokens?: number;
 }
 
 /** The counters surfaced into a heartbeat tick. All cumulative for the attempt. */
@@ -34,6 +36,19 @@ export interface ActivitySnapshot {
   readonly toolsCalled: number;
   /** Cumulative `text` events observed this attempt. */
   readonly textChunks: number;
+  /**
+   * Cumulative `reasoning` events. claude streams one per thinking block;
+   * codex/opencode emit one per reasoning-bearing turn/step. The unit differs
+   * per runner, but a non-zero value always means the model is actively
+   * reasoning — present on all three CLIs.
+   */
+  readonly reasoningCount: number;
+  /**
+   * Cumulative reasoning TOKENS, summed from events that carry a count
+   * (codex/opencode). claude folds thinking tokens into output and does not
+   * break them out, so a claude attempt accrues `reasoningCount` but 0 tokens.
+   */
+  readonly reasoningTokens: number;
   /** Cumulative heartbeat windows with no new stream event (waiting/blocked). */
   readonly waiting: number;
   /** New stream events since the previous `snapshotWindow()` (0 → a waiting window). */
@@ -61,25 +76,45 @@ export interface ActivityMeter {
 export function createActivityMeter(): ActivityMeter {
   let toolsCalled = 0;
   let textChunks = 0;
+  let reasoningCount = 0;
+  let reasoningTokens = 0;
   let waiting = 0;
   // Total events at the last window boundary, to derive per-window deltas.
   let eventsAtLastWindow = 0;
 
-  const total = (): number => toolsCalled + textChunks;
+  const total = (): number => toolsCalled + textChunks + reasoningCount;
 
   return {
     record(event) {
       if (event.type === "toolCall") toolsCalled += 1;
       else if (event.type === "text") textChunks += 1;
+      else if (event.type === "reasoning") {
+        reasoningCount += 1;
+        if (typeof event.tokens === "number" && event.tokens > 0) reasoningTokens += event.tokens;
+      }
     },
     snapshotWindow() {
       const eventsThisWindow = total() - eventsAtLastWindow;
       if (eventsThisWindow <= 0) waiting += 1;
       eventsAtLastWindow = total();
-      return { toolsCalled, textChunks, waiting, eventsThisWindow: Math.max(0, eventsThisWindow) };
+      return {
+        toolsCalled,
+        textChunks,
+        reasoningCount,
+        reasoningTokens,
+        waiting,
+        eventsThisWindow: Math.max(0, eventsThisWindow),
+      };
     },
     peek() {
-      return { toolsCalled, textChunks, waiting, eventsThisWindow: total() - eventsAtLastWindow };
+      return {
+        toolsCalled,
+        textChunks,
+        reasoningCount,
+        reasoningTokens,
+        waiting,
+        eventsThisWindow: total() - eventsAtLastWindow,
+      };
     },
   };
 }

--- a/apps/dev/src/core/heartbeat.ts
+++ b/apps/dev/src/core/heartbeat.ts
@@ -143,6 +143,10 @@ export interface ProgressHeartbeatInput {
     toolsCalled: number;
     /** Cumulative `text` events this attempt. */
     textChunks: number;
+    /** Cumulative `reasoning` events this attempt (all three CLIs). */
+    reasoningCount: number;
+    /** Cumulative reasoning tokens (codex/opencode; 0 for claude). */
+    reasoningTokens: number;
     /** Cumulative heartbeat windows with no new stream event (waiting/blocked). */
     waiting: number;
     /** New stream events in the window this tick closes (0 → a waiting window). */
@@ -177,8 +181,11 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
   const a = input.activity;
   // Append a compact activity tail to the human line so a `tail -f afk.log`
   // shows liveness without opening the firehose. Only when observed.
+  const reasonFrag = a
+    ? ` think:${a.reasoningCount}${a.reasoningTokens > 0 ? `/${a.reasoningTokens}tok` : ""}`
+    : "";
   const activityTail = a
-    ? ` · tools:${a.toolsCalled} text:${a.textChunks} wait:${a.waiting}${a.eventsThisWindow === 0 ? " (idle window)" : ""}`
+    ? ` · tools:${a.toolsCalled} text:${a.textChunks}${reasonFrag} wait:${a.waiting}${a.eventsThisWindow === 0 ? " (idle window)" : ""}`
     : "";
   const msg = `progress: ${input.secsSinceProgress}s since last commit${headShort} · ${diff}${activityTail}`;
   return {
@@ -198,6 +205,8 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
         ? {
             tools_called_count: String(a.toolsCalled),
             text_chunk_count: String(a.textChunks),
+            thinking_called_count: String(a.reasoningCount),
+            reasoning_tokens: String(a.reasoningTokens),
             waiting_count: String(a.waiting),
             events_this_window: String(a.eventsThisWindow),
           }
@@ -213,6 +222,8 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
         ? {
             "current.tools_called_count": a.toolsCalled,
             "current.text_chunk_count": a.textChunks,
+            "current.thinking_called_count": a.reasoningCount,
+            "current.reasoning_tokens": a.reasoningTokens,
             "current.waiting_count": a.waiting,
           }
         : {}),

--- a/apps/dev/tests/activity-meter.test.ts
+++ b/apps/dev/tests/activity-meter.test.ts
@@ -12,6 +12,32 @@ describe("createActivityMeter", () => {
     expect(s.textChunks).toBe(1);
   });
 
+  it("counts reasoning events and sums their tokens (codex/opencode style)", () => {
+    const m = createActivityMeter();
+    m.record({ type: "reasoning", tokens: 13 });
+    m.record({ type: "reasoning", tokens: 21 });
+    const s = m.peek();
+    expect(s.reasoningCount).toBe(2);
+    expect(s.reasoningTokens).toBe(34);
+  });
+
+  it("counts a token-less reasoning event (claude thinking block) without adding tokens", () => {
+    const m = createActivityMeter();
+    m.record({ type: "reasoning" });
+    m.record({ type: "reasoning" });
+    const s = m.peek();
+    expect(s.reasoningCount).toBe(2);
+    expect(s.reasoningTokens).toBe(0);
+  });
+
+  it("reasoning events count as activity (a reasoning-only window is not waiting)", () => {
+    const m = createActivityMeter();
+    m.record({ type: "reasoning", tokens: 5 });
+    const s = m.snapshotWindow();
+    expect(s.eventsThisWindow).toBe(1);
+    expect(s.waiting).toBe(0);
+  });
+
   it("a window with new events does NOT increment waiting", () => {
     const m = createActivityMeter();
     m.record({ type: "toolCall" });

--- a/apps/dev/tests/heartbeat.test.ts
+++ b/apps/dev/tests/heartbeat.test.ts
@@ -250,17 +250,36 @@ describe("buildProgressHeartbeat (#448)", () => {
       head: "40ac9326",
       added: 382,
       removed: 45,
-      activity: { toolsCalled: 12, textChunks: 7, waiting: 2, eventsThisWindow: 3 },
+      activity: { toolsCalled: 12, textChunks: 7, reasoningCount: 4, reasoningTokens: 130, waiting: 2, eventsThisWindow: 3 },
     });
-    expect(hb.msg).toBe("progress: 75s since last commit @ 40ac9326 · +382 -45 · tools:12 text:7 wait:2");
+    expect(hb.msg).toBe(
+      "progress: 75s since last commit @ 40ac9326 · +382 -45 · tools:12 text:7 think:4/130tok wait:2",
+    );
     expect(hb.extra.tools_called_count).toBe("12");
     expect(hb.extra.text_chunk_count).toBe("7");
+    expect(hb.extra.thinking_called_count).toBe("4");
+    expect(hb.extra.reasoning_tokens).toBe("130");
     expect(hb.extra.waiting_count).toBe("2");
     expect(hb.extra.loc_added).toBe("382");
     expect(hb.extra.loc_removed).toBe("45");
     expect(hb.statePatch["current.tools_called_count"]).toBe(12);
+    expect(hb.statePatch["current.thinking_called_count"]).toBe(4);
+    expect(hb.statePatch["current.reasoning_tokens"]).toBe(130);
     expect(hb.statePatch["current.waiting_count"]).toBe(2);
     expect(hb.statePatch["current.loc_added"]).toBe(382);
+  });
+
+  it("reasoning with no tokens (claude-style) shows think:N without /tok", () => {
+    const hb = buildProgressHeartbeat({
+      secsSinceProgress: 10,
+      lastProgressAt: "t",
+      head: "",
+      added: 1,
+      removed: 0,
+      activity: { toolsCalled: 0, textChunks: 2, reasoningCount: 3, reasoningTokens: 0, waiting: 0, eventsThisWindow: 5 },
+    });
+    expect(hb.msg).toContain("think:3 ");
+    expect(hb.msg).not.toContain("tok");
   });
 
   it("marks an idle window (no new stream events) in the msg tail", () => {
@@ -270,7 +289,7 @@ describe("buildProgressHeartbeat (#448)", () => {
       head: "",
       added: 0,
       removed: 0,
-      activity: { toolsCalled: 5, textChunks: 3, waiting: 4, eventsThisWindow: 0 },
+      activity: { toolsCalled: 5, textChunks: 3, reasoningCount: 1, reasoningTokens: 0, waiting: 4, eventsThisWindow: 0 },
     });
     expect(hb.msg).toContain("wait:4 (idle window)");
   });


### PR DESCRIPTION
## What

Slice 2 of the richer liveness heartbeat. Consumes red-castle's new normalised `reasoning` stream event (submodule `34b5bfa`→`6406bcb`, reddb-io/red-castle#4) so the proof-of-life heartbeat carries a **cross-runner** reasoning signal:

- `thinking_called_count` — cumulative reasoning events (claude: one per thinking block; codex/opencode: one per reasoning-bearing turn/step)
- `reasoning_tokens` — summed reasoning tokens (codex/opencode; 0 for claude, which folds thinking tokens into output)
- `afk.log` tail gains a `think:N[/Ntok]` fragment

## Why it works on all 3 CLIs (confirmed by live capture)

| CLI | reasoning in stream | how we count it |
|---|---|---|
| claude | discrete `thinking` content blocks | one event each (text-bearing) |
| codex | **no** discrete item — only `turn.completed.usage.reasoning_output_tokens` (verified live: a trivial prompt → `reasoning_output_tokens:13`) | token-bearing event |
| opencode | **no** discrete part — only `step_finish.part.tokens.reasoning` (per the committed reference capture) | token-bearing event |

So a uniform *event count* isn't possible — the metric is defined semantically ("is the model reasoning, and how much") and each runner populates it from its confirmed real shape. Additive: a claude-only attempt accrues counts but 0 tokens; an attempt with no reasoning accrues neither.

## Submodule bump also strips red-castle's standalone machinery

red-castle is vendored source consumed as `workspace:*`, never published to npm / never tagged (the pin is the SHA). The bump pulls in the removal of its CI/release/changeset/agent workflows + a rewritten CLAUDE.md documenting the vendored-source model.

## Verification

red-castle: 383 tests green (8 new reasoning parser tests). apps/dev: 1253 tests green (new reasoning meter/heartbeat tests). Typecheck clean both sides.

Refs #623

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776931&installation_id=129708444&pr_number=702&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F702&signature=6ce08a96b16bb50fe0e86a1386e8d42b1d52913dfb1869150b60621103e8a320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event message formatting with visual indicators and token counts for reasoning operations.
  * Extended activity tracking to monitor reasoning events and token consumption.
  * Updated heartbeat reporting to include reasoning count and token usage metrics.

* **Tests**
  * Added comprehensive test coverage for reasoning event handling and metrics.

* **Chores**
  * Updated subproject dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->