### PR TITLE
feat(afk): deliver the exit-protocol as a system prompt, not a handoff footer (slice 4)

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -159,6 +159,14 @@ export interface RunAgentInput {
   effort?: AgentEffort;
   /** Path to the materialised handoff file used as the agent prompt. */
   handoffPath: string;
+  /**
+   * The AFK exit-protocol contract, delivered as a system prompt rather than
+   * appended to the handoff body. red-castle picks the per-CLI delivery: claude
+   * `--append-system-prompt` (a real system prompt, out of the user turn);
+   * codex/opencode prepend it to the handoff content (no flag exists). Omitted →
+   * no contract delivered.
+   */
+  systemPrompt?: string;
   /** The worker branch sandcastle commits land on (afk/{id}/{N}-{slug}). */
   branch: string;
   /**
@@ -587,6 +595,7 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
     // root. Omitted → sandcastle defaults to process.cwd().
     ...(input.cwd ? { cwd: input.cwd } : {}),
     promptFile: input.handoffPath,
+    ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
     branchStrategy,
     completionSignal: [...COMPLETION_SIGNALS],
     // sandcastle defaults maxIterations to 1, which stops the agent before it

--- a/apps/dev/src/core/handoff.ts
+++ b/apps/dev/src/core/handoff.ts
@@ -268,23 +268,22 @@ export function buildHandoff(input: HandoffInput): string {
   lines.push("<!-- inner agent appends progress/blockers here across attempts -->");
   lines.push("</agent-notes>");
 
-  lines.push("");
-  lines.push(EXIT_PROTOCOL);
-
   return lines.join("\n") + "\n";
 }
 
 /**
- * Exit-protocol footer appended to every handoff. The agent's prompt is this
- * handoff file alone (sandcastle `promptFile`); red-castle deliberately does not
- * inject completion instructions — `run()` requires the caller to instruct the
- * agent to emit the configured completion signal. Without this block the agent
- * receives only the issue body and never learns that `<promise>DONE</promise>`
- * is the required terminator, so it writes a prose "Done." and the orchestrator
- * (matching the literal sentinel) re-invokes it until the attempt guard reaps it
- * — most visibly on the "work already committed by a prior attempt" path, where
- * a re-spawned agent re-verifies a finished branch every iteration. The
- * already-done short-circuit is the fix for that class.
+ * The AFK exit-protocol contract. The agent receives it as a **system prompt**
+ * (not appended to the handoff body): the runtime passes it as
+ * `RunAgentInput.systemPrompt`, and red-castle delivers it per-CLI — claude via
+ * `--append-system-prompt` (kept out of the user turn), codex/opencode prepended
+ * to the handoff content (no flag exists). red-castle deliberately does not
+ * inject completion instructions itself (`run()` requires the caller to instruct
+ * the agent to emit the configured signal), so without delivering this the agent
+ * would only see the issue body and never learn that `<promise>DONE</promise>`
+ * is the required terminator — it would write a prose "Done." and the
+ * orchestrator (matching the literal sentinel) would re-invoke it until the
+ * attempt guard reaps it, worst on the "work already committed by a prior
+ * attempt" path. The already-done short-circuit is the fix for that class.
  */
 export const EXIT_PROTOCOL = [
   "<exit-protocol>",

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -26,7 +26,7 @@ import {
   slugifyRef,
   type GitExec,
 } from "./remote-branch.js";
-import { buildHandoff, type HandoffComment } from "./handoff.js";
+import { buildHandoff, EXIT_PROTOCOL, type HandoffComment } from "./handoff.js";
 import {
   type AgentOutcome,
   type AgentEffort,
@@ -669,6 +669,7 @@ export async function processIssue(
       model: initialTier.model,
       effort: initialTier.effort,
       handoffPath,
+      systemPrompt: EXIT_PROTOCOL,
       branch,
       base,
       cwd: input.attemptDir,
@@ -735,6 +736,7 @@ export async function processIssue(
         model: fallbackTier.model,
         effort: fallbackTier.effort,
         handoffPath,
+        systemPrompt: EXIT_PROTOCOL,
         branch,
         base,
         cwd: input.attemptDir,

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -92,6 +92,16 @@ describe("buildRunOptions", () => {
     expect(opts.prompt).toBeUndefined();
   });
 
+  it("threads systemPrompt into RunOptions when present, omits it otherwise", () => {
+    const withSys = buildRunOptions(makeDeps(async () => fakeResult()), {
+      ...baseInput,
+      systemPrompt: "RULE: emit DONE last.",
+    });
+    expect(withSys.systemPrompt).toBe("RULE: emit DONE last.");
+    const without = buildRunOptions(makeDeps(async () => fakeResult()), baseInput);
+    expect(without.systemPrompt).toBeUndefined();
+  });
+
   it("selects the agent provider from runner+model+effort", () => {
     const opts = buildRunOptions(makeDeps(async () => fakeResult()), baseInput);
     expect(opts.agent).toEqual({ __agent: "claude:claude-opus-4-8:high" });

--- a/apps/dev/tests/handoff.test.ts
+++ b/apps/dev/tests/handoff.test.ts
@@ -6,6 +6,7 @@ import {
   buildHumanGuidance,
   buildPreviousAttempts,
   buildThreadDiscussion,
+  EXIT_PROTOCOL,
   type HandoffComment,
 } from "../src/core/handoff.js";
 
@@ -262,17 +263,20 @@ describe("buildHandoff", () => {
     expect(out).toContain("<agent-notes>");
   });
 
-  it("exit protocol: every handoff ends with the sentinel contract + already-done short-circuit", () => {
+  it("exit protocol is delivered as a system prompt, NOT baked into the handoff body", () => {
     const out = base({ title: "Anything" });
-    // the agent's only prompt is this handoff; the exit protocol must be in it
-    expect(out).toContain("<exit-protocol>");
-    expect(out).toContain("<promise>DONE</promise>");
-    expect(out).toContain("<promise>BLOCKED</promise>");
-    expect(out).toContain("ALREADY-DONE SHORT-CIRCUIT");
-    // it sits after agent-notes so it reads as the final standing instruction
-    expect(out.indexOf("<agent-notes>")).toBeLessThan(out.indexOf("<exit-protocol>"));
-    // a prose "done" is explicitly rejected as a non-sentinel
-    expect(out).toContain("prose");
+    // The contract now rides RunAgentInput.systemPrompt (red-castle delivers it
+    // per-CLI), so the handoff body is back to pure issue data — no footer.
+    expect(out).not.toContain("<exit-protocol>");
+    expect(out).toContain("<agent-notes>");
+  });
+
+  it("EXIT_PROTOCOL constant still carries the sentinel contract + already-done short-circuit", () => {
+    expect(EXIT_PROTOCOL).toContain("<exit-protocol>");
+    expect(EXIT_PROTOCOL).toContain("<promise>DONE</promise>");
+    expect(EXIT_PROTOCOL).toContain("<promise>BLOCKED</promise>");
+    expect(EXIT_PROTOCOL).toContain("ALREADY-DONE SHORT-CIRCUIT");
+    expect(EXIT_PROTOCOL).toContain("prose");
   });
 
   it("case5: malformed envelope → no previous-attempts, no human-guidance, surfaces in discussion", () => {


### PR DESCRIPTION
Consumes red-castle's new `RunOptions.systemPrompt` (submodule `6406bcb`→`bb1b1445`, reddb-io/red-castle#5) to deliver the AFK exit-protocol contract as a **system prompt** instead of a handoff-body footer.

- claude (the dominant runner): `--append-system-prompt` — a real appended system prompt, kept out of the user turn / cached separately.
- codex / opencode (no per-invocation flag exists — verified via `--help`): red-castle prepends the contract to the handoff content.
- `buildHandoff` no longer appends the footer — the handoff body is back to pure issue data; `EXIT_PROTOCOL` stays exported and is now the `systemPrompt` payload passed on both runAgent calls.

The substrate owns the per-CLI 'how'; AFK passes the contract once. Typecheck clean; 1255 apps/dev + 388 red-castle tests green.

Refs #623

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783778690&installation_id=129708444&pr_number=703&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F703&signature=017a0f4dd6e0aa5a8fe713370ae087b9b3b1ecb178ee072cde709ede9c2a8608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced agent protocol delivery mechanism by restructuring how exit and termination instructions are communicated, improving consistency across retry and fallback execution flows.

* **Tests**
  * Added comprehensive test coverage for protocol handling integration and updated validation of handoff generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->