### PR TITLE
feat(afk): canonicalize worker-vitals names + last_event_at liveness clock (S1 #708)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -655,7 +655,11 @@ export function buildProcessDeps(
             ? `🧠 reasoning${
                 event.tokens ? ` (${event.tokens} tok)` : event.message ? `: ${event.message.slice(0, 80)}` : ""
               }`
-            : `→ ${event.name} ${event.formattedArgs}`;
+            : event.type === "usage"
+              ? `💰 usage (in:${event.inputTokens} out:${event.outputTokens}${
+                  event.reasoningTokens ? ` reason:${event.reasoningTokens}` : ""
+                })`
+              : `→ ${event.name} ${event.formattedArgs}`;
       void appendAgentRecord(join(current.attemptDir, "agent.log.jsonl"), msg, {
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },
@@ -671,11 +675,16 @@ export function buildProcessDeps(
       // Advance the monitor's state view on recognised tool-call transitions
       // (bounded write rate vs every text chunk — the lane mtime above is the
       // stall-detector's liveness signal; this is the dashboard's stage/last).
+      // `last_event_at` (the honest liveness clock, ADR 0065) is stamped on every
+      // DISCRETE event — tool/reasoning/usage, not per-text-chunk — so it advances
+      // every few seconds for an active worker even between commits.
       const stage = deriveStage(event);
-      if (stage) {
+      const discrete =
+        event.type === "toolCall" || event.type === "reasoning" || event.type === "usage";
+      if (stage || discrete) {
         void updateState(join(current.attemptDir, "afk.state.json"), {
-          "current.stage": stage,
-          "current.last_stream_line": msg.slice(0, 200),
+          ...(stage ? { "current.stage": stage, "current.last_stream_line": msg.slice(0, 200) } : {}),
+          "current.last_event_at": ts,
         }).catch(() => {});
       }
     },

--- a/apps/dev/src/core/activity-meter.ts
+++ b/apps/dev/src/core/activity-meter.ts
@@ -25,7 +25,10 @@
 
 /** The minimal shape this meter reads off a normalised stream event. */
 export interface StreamEventLike {
-  readonly type: "text" | "toolCall" | "reasoning";
+  /** `usage` is accepted so the sink can forward every stream event unfiltered,
+   * but it is a cost meta-event (ADR 0065 cost group) — `record()` does not count
+   * it as a tool/text/reasoning liveness unit. */
+  readonly type: "text" | "toolCall" | "reasoning" | "usage";
   /** Reasoning token count, when the runner exposes it (codex/opencode). */
   readonly tokens?: number;
 }

--- a/apps/dev/src/core/heartbeat.ts
+++ b/apps/dev/src/core/heartbeat.ts
@@ -192,37 +192,40 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
     msg,
     extra: {
       secs_since_progress: String(input.secsSinceProgress),
-      last_progress_at: input.lastProgressAt,
+      // Canonical WorkerVitals names (ADR 0065). The legacy keys below are kept
+      // ONLY in the firehose `extra` (append-only history read by post-mortem
+      // tooling) for one release; the live state (`statePatch`) is canonical-only.
+      last_commit_at: input.lastProgressAt,
       head: input.head,
-      diff_added: String(locAdded),
-      diff_removed: String(locRemoved),
-      diff: diff,
-      // The user-facing metric names (aliases of diff_*) so consumers can key on
-      // loc_* directly. Kept alongside diff_* for monitor back-compat.
       loc_added: String(locAdded),
       loc_removed: String(locRemoved),
+      diff: diff,
+      // Deprecated legacy aliases — remove one release after S1.
+      last_progress_at: input.lastProgressAt,
+      diff_added: String(locAdded),
+      diff_removed: String(locRemoved),
       ...(a
         ? {
             tools_called_count: String(a.toolsCalled),
             text_chunk_count: String(a.textChunks),
-            thinking_called_count: String(a.reasoningCount),
+            reasoning_events: String(a.reasoningCount),
             reasoning_tokens: String(a.reasoningTokens),
             waiting_count: String(a.waiting),
             events_this_window: String(a.eventsThisWindow),
+            // Deprecated legacy alias — remove one release after S1.
+            thinking_called_count: String(a.reasoningCount),
           }
         : {}),
     },
     statePatch: {
-      "current.last_progress_at": input.lastProgressAt,
-      "current.diff_added": locAdded,
-      "current.diff_removed": locRemoved,
+      "current.last_commit_at": input.lastProgressAt,
       "current.loc_added": locAdded,
       "current.loc_removed": locRemoved,
       ...(a
         ? {
             "current.tools_called_count": a.toolsCalled,
             "current.text_chunk_count": a.textChunks,
-            "current.thinking_called_count": a.reasoningCount,
+            "current.reasoning_events": a.reasoningCount,
             "current.reasoning_tokens": a.reasoningTokens,
             "current.waiting_count": a.waiting,
           }

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -6,8 +6,30 @@ export function defaultState(): AfkState {
   return AfkStateSchema.parse({});
 }
 
+/**
+ * One-release back-compat read shim (ADR 0065): map legacy worker-vitals keys on
+ * `current` onto their canonical names when the canonical key is absent, so a NEW
+ * bundle reads an OLD afk.state.json without losing the value. The state file is
+ * ephemeral (rewritten each ~60s heartbeat), so this only bridges the upgrade
+ * window. Remove the shim — and the legacy keys — one release after S1 lands.
+ */
+function migrateLegacyCurrentKeys(data: unknown): unknown {
+  if (typeof data !== "object" || data === null) return data;
+  const cur = (data as Record<string, unknown>).current;
+  if (typeof cur !== "object" || cur === null) return data;
+  const c = cur as Record<string, unknown>;
+  const alias = (canon: string, legacy: string): void => {
+    if (c[canon] === undefined && c[legacy] !== undefined) c[canon] = c[legacy];
+  };
+  alias("loc_added", "diff_added");
+  alias("loc_removed", "diff_removed");
+  alias("reasoning_events", "thinking_called_count");
+  alias("last_commit_at", "last_progress_at");
+  return data;
+}
+
 export function parseState(data: unknown): AfkState {
-  return AfkStateSchema.parse(data ?? {});
+  return AfkStateSchema.parse(migrateLegacyCurrentKeys(data ?? {}));
 }
 
 export async function readState(path: string): Promise<AfkState> {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -398,8 +398,8 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
     // are 0 (same logic as collectStatuslineAfk). Always populated — the dashboard
     // renders the +A -R volume unconditionally (idle / zero included) and sums it
     // into the fleet header, so it is never suppressed.
-    let added = state.current.diff_added;
-    let removed = state.current.diff_removed;
+    let added = state.current.loc_added;
+    let removed = state.current.loc_removed;
     if (added === 0 && removed === 0 && state.current.worktree) {
       const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
       const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
@@ -541,8 +541,8 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     // fleet and shown as 💤N so a wedged-but-not-dead worker is visible.
     waiting += state.current.waiting_count;
 
-    let a = state.current.diff_added;
-    let r = state.current.diff_removed;
+    let a = state.current.loc_added;
+    let r = state.current.loc_removed;
     if (a === 0 && r === 0 && state.current.worktree) {
       // Fallback: compute the diffstat from the worktree like statusline.sh.
       const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -17,15 +17,21 @@ export const AfkCurrentSchema = z.object({
   heartbeat_pid: z.union([z.string(), z.number(), z.null()]).optional().default(""),
   runner: z.string().default(""),
   retries: z.number().default(0),
-  diff_added: z.number().default(0),
-  diff_removed: z.number().default(0),
   last_stream_line: z.string().default(""),
   run_mode: z.string().default(""),
-  /** ISO timestamp of the last observed progress — the last new commit on the
-   * worker branch, or attempt start. Written each attempt-guard poll (PR-B) so an
-   * external monitor reading afk.state.json sees liveness/progress, not just a
-   * stale stream line. Empty until the guard arms (no-sandbox runs). */
-  last_progress_at: z.string().default(""),
+  /** ISO timestamp of the last observed COMMIT on the worker branch (or attempt
+   * start). Written each attempt-guard poll. The guard's ABORT logic is anchored
+   * on this (commit-anchored stall detection, ADR 0044) — NOT on stream activity,
+   * so a worker streaming forever without committing is still stalled work.
+   * Renamed from `last_progress_at` (which mislabeled "commit" as "progress");
+   * read-shimmed from the old key for one release. See ADR 0065. */
+  last_commit_at: z.string().default(""),
+  /** ISO timestamp of the last observed STREAM event (any agent text/tool/
+   * reasoning chunk), stamped in `recordAgentEvent`. The honest liveness clock:
+   * an exploring worker advances this every few seconds even when it has not
+   * committed, so `silent_for_s` (now − last_event_at) is the true stuck signal,
+   * distinct from `last_commit_at`. See ADR 0065. */
+  last_event_at: z.string().default(""),
   /** Current sandcastle agentic-iteration number (1..maxIterations), advanced
    * each time the inner agent's re-invocation count ticks. Lets the monitor show
    * "iter N/max" and surfaces a run burning through iterations re-validating. */
@@ -34,17 +40,18 @@ export const AfkCurrentSchema = z.object({
    * first heartbeat so the monitor/statusline fallback diffstat uses the correct
    * ref instead of hardcoding origin/main. */
   base: z.string().default(""),
-  /** Per-attempt stream-activity counters, mirrored from the proof-of-life
-   * heartbeat's `statePatch` (core/heartbeat.ts → buildProgressHeartbeat) each
-   * ~60s poll. These MUST be declared here: `updateState` round-trips the whole
-   * state through this schema before writing, so an undeclared key is silently
-   * stripped on BOTH write and read — the counters would never survive in
-   * afk.state.json. The monitor/statusline read them straight off `current` to
-   * show liveness (is the agent actually streaming) without opening the firehose.
-   * `loc_added`/`loc_removed` are user-facing aliases of `diff_added`/`diff_removed`. */
+  /** Per-attempt stream-activity counters (the WorkerVitals activity + progress
+   * groups, ADR 0065), mirrored from the proof-of-life heartbeat's `statePatch`
+   * (core/heartbeat.ts → buildProgressHeartbeat) each ~60s poll. These MUST be
+   * declared here: `updateState` round-trips the whole state through this schema
+   * before writing, so an undeclared key is silently stripped on BOTH write and
+   * read. The monitor/statusline read them straight off `current` to show
+   * liveness without opening the firehose. Canonical names — `reasoning_events`
+   * (was `thinking_called_count`) and `loc_added`/`loc_removed` (was `diff_*`);
+   * the legacy keys are read-shimmed in `parseState` for one release. */
   tools_called_count: z.number().default(0),
   text_chunk_count: z.number().default(0),
-  thinking_called_count: z.number().default(0),
+  reasoning_events: z.number().default(0),
   reasoning_tokens: z.number().default(0),
   waiting_count: z.number().default(0),
   loc_added: z.number().default(0),

--- a/apps/dev/tests/heartbeat.test.ts
+++ b/apps/dev/tests/heartbeat.test.ts
@@ -218,13 +218,14 @@ describe("buildProgressHeartbeat (#448)", () => {
     expect(hb.extra.diff_removed).toBe("45");
     expect(hb.extra.secs_since_progress).toBe("75");
     // state patch persists the volume the monitor prefers over a live git diff.
+    // Canonical-only (ADR 0065): last_commit_at + loc_* — no legacy diff_* in state.
     expect(hb.statePatch).toEqual({
-      "current.last_progress_at": "2026-06-03T12:00:00.000Z",
-      "current.diff_added": 382,
-      "current.diff_removed": 45,
+      "current.last_commit_at": "2026-06-03T12:00:00.000Z",
       "current.loc_added": 382,
       "current.loc_removed": 45,
     });
+    // firehose extra keeps the legacy diff_* alias for one release (asserted above).
+    expect(hb.extra.last_commit_at).toBe("2026-06-03T12:00:00.000Z");
     // no activity snapshot → no activity fields, no msg tail (back-compat)
     expect(hb.extra.tools_called_count).toBeUndefined();
     expect(hb.msg.includes("tools:")).toBe(false);
@@ -239,8 +240,8 @@ describe("buildProgressHeartbeat (#448)", () => {
       removed: -2,
     });
     expect(hb.msg).toBe("progress: 0s since last commit · +0 -0");
-    expect(hb.statePatch["current.diff_added"]).toBe(0);
-    expect(hb.statePatch["current.diff_removed"]).toBe(0);
+    expect(hb.statePatch["current.loc_added"]).toBe(0);
+    expect(hb.statePatch["current.loc_removed"]).toBe(0);
   });
 
   it("folds the activity-meter snapshot into the msg tail, extra, and state", () => {
@@ -257,13 +258,17 @@ describe("buildProgressHeartbeat (#448)", () => {
     );
     expect(hb.extra.tools_called_count).toBe("12");
     expect(hb.extra.text_chunk_count).toBe("7");
+    // canonical reasoning_events + legacy thinking_called_count alias (firehose).
+    expect(hb.extra.reasoning_events).toBe("4");
     expect(hb.extra.thinking_called_count).toBe("4");
     expect(hb.extra.reasoning_tokens).toBe("130");
     expect(hb.extra.waiting_count).toBe("2");
     expect(hb.extra.loc_added).toBe("382");
     expect(hb.extra.loc_removed).toBe("45");
     expect(hb.statePatch["current.tools_called_count"]).toBe(12);
-    expect(hb.statePatch["current.thinking_called_count"]).toBe(4);
+    // canonical name in state — no legacy thinking_called_count in statePatch.
+    expect(hb.statePatch["current.reasoning_events"]).toBe(4);
+    expect(hb.statePatch["current.thinking_called_count"]).toBeUndefined();
     expect(hb.statePatch["current.reasoning_tokens"]).toBe(130);
     expect(hb.statePatch["current.waiting_count"]).toBe(2);
     expect(hb.statePatch["current.loc_added"]).toBe(382);

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -30,5 +30,36 @@ describe("state", () => {
     expect(isStateLive({ pid: 0 }, () => true)).toBe(false);
     expect(isStateLive({ pid: 123 }, (pid) => pid === 123)).toBe(true);
     expect(isStateLive({ pid: 123 }, () => false)).toBe(false);
+  });
+
+  it("read-shims legacy worker-vitals keys onto their canonical names (ADR 0065)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+    // An OLD afk.state.json written by a pre-S1 bundle: legacy keys only.
+    const legacy = {
+      version: 1,
+      current: {
+        diff_added: 120,
+        diff_removed: 7,
+        thinking_called_count: 5,
+        last_progress_at: "2026-06-11T00:00:00.000Z",
+      },
+    };
+    await writeFile(path, JSON.stringify(legacy), "utf8");
+    const state = await readState(path);
+    // Canonical names carry the legacy values — nothing is lost on read.
+    expect(state.current.loc_added).toBe(120);
+    expect(state.current.loc_removed).toBe(7);
+    expect(state.current.reasoning_events).toBe(5);
+    expect(state.current.last_commit_at).toBe("2026-06-11T00:00:00.000Z");
+  });
+
+  it("prefers the canonical key over the legacy alias when both are present", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+    const both = { version: 1, current: { loc_added: 99, diff_added: 1 } };
+    await writeFile(path, JSON.stringify(both), "utf8");
+    const state = await readState(path);
+    expect(state.current.loc_added).toBe(99);
   });
 });


### PR DESCRIPTION
Closes #708. Slice S1 of PRD #706 (WorkerVitals canonical vocabulary, ADR 0065) — the heart of the rename.

## Renames (one-release back-compat read shim in `parseState`)
- `thinking_called_count` → **`reasoning_events`**
- `diff_added`/`diff_removed` collapsed into **`loc_added`/`loc_removed`** (single canonical name)
- `last_progress_at` → **`last_commit_at`** (it tracks commits, not generic progress)

## New: the honest liveness clock
- **`last_event_at`** — stamped on every DISCRETE stream event (tool/reasoning/usage, not per-text-chunk) in `recordAgentEvent`. Advances every few seconds for an exploring-but-not-committing worker, so `silent_for_s` (now − last_event_at) is the true stuck signal, distinct from `last_commit_at`. The attempt-progress guard's **ABORT** logic stays commit-anchored (ADR 0044) — only the displayed clock changes.

## S2 usage integration (forced, necessary)
S1 branches from main-with-S2, so apps/dev's re-exported `AgentStreamEvent` now includes the `usage` variant. The sink integrates it minimally (msg formatting, activity-meter accepts-but-ignores it as a cost meta-event, `last_event_at`) so the bundle **typechecks** against the usage-emitting red-castle. `core-regression-gate` runs vitest (no tsc), so this was a latent typecheck break. Full cost persistence is **S3 (#709)**.

## Back-compat
- `parseState` maps legacy keys → canonical on read (state file is ephemeral; bridges the upgrade window). Removed one release after this.
- statePatch (live state) is **canonical-only**; the firehose `extra` keeps legacy aliases for one release.

## Tests
Updated heartbeat statePatch/extra assertions; +2 new state shim tests (legacy→canonical read, canonical-wins). Full apps/dev suite green (1235 pass; the lone `args.test.ts` failure is the pre-existing `cli-args-parser` worktree-resolution artifact, unrelated).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783784613&installation_id=129708444&pr_number=712&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F712&signature=e963bb700a9434667a757e134d210e8d659756a8e463a503254c0a10d2803247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced activity monitoring with improved tracking of reasoning and usage events.
  * Refined liveness timing updates across different event types for more accurate monitoring.
  * Standardized metric naming and fields for better consistency in telemetry data.

* **Bug Fixes**
  * Added legacy data migration to ensure smooth compatibility with previous state formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->