### PR TITLE
feat(afk): persist + surface per-worker cost vitals (S3 #709)

### DIFF
--- a/apps/dev/src/core/activity-meter.ts
+++ b/apps/dev/src/core/activity-meter.ts
@@ -25,12 +25,17 @@
 
 /** The minimal shape this meter reads off a normalised stream event. */
 export interface StreamEventLike {
-  /** `usage` is accepted so the sink can forward every stream event unfiltered,
-   * but it is a cost meta-event (ADR 0065 cost group) — `record()` does not count
-   * it as a tool/text/reasoning liveness unit. */
+  /** `usage` is accepted so the sink can forward every stream event unfiltered.
+   * It is not counted as a tool/text/reasoning liveness unit, but it DOES feed
+   * the cumulative cost group (ADR 0065) via the fields below. */
   readonly type: "text" | "toolCall" | "reasoning" | "usage";
   /** Reasoning token count, when the runner exposes it (codex/opencode). */
   readonly tokens?: number;
+  /** Cost group, present on `usage` events only — per-turn/step token spend that
+   * `record()` sums into the cumulative attempt totals. */
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly costUsd?: number;
 }
 
 /** The counters surfaced into a heartbeat tick. All cumulative for the attempt. */
@@ -56,6 +61,14 @@ export interface ActivitySnapshot {
   readonly waiting: number;
   /** New stream events since the previous `snapshotWindow()` (0 → a waiting window). */
   readonly eventsThisWindow: number;
+  /** Cost group (ADR 0065) — cumulative token spend summed from `usage` events.
+   * Fed live by codex/opencode (per-turn/step usage); claude's usage arrives at
+   * the iteration boundary, not the stream, so a pure-claude attempt accrues 0
+   * here (its cost is a follow-up). */
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  /** Cumulative USD cost when the runner reports it directly, else 0. */
+  readonly costUsd: number;
 }
 
 export interface ActivityMeter {
@@ -82,16 +95,25 @@ export function createActivityMeter(): ActivityMeter {
   let reasoningCount = 0;
   let reasoningTokens = 0;
   let waiting = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let costUsd = 0;
   // Total events at the last window boundary, to derive per-window deltas.
   let eventsAtLastWindow = 0;
 
+  // `usage` is deliberately excluded — it is a cost meta-event, not a liveness
+  // unit, so it never resets the waiting window.
   const total = (): number => toolsCalled + textChunks + reasoningCount;
 
   return {
     record(event) {
       if (event.type === "toolCall") toolsCalled += 1;
       else if (event.type === "text") textChunks += 1;
-      else if (event.type === "reasoning") {
+      else if (event.type === "usage") {
+        if (typeof event.inputTokens === "number") inputTokens += event.inputTokens;
+        if (typeof event.outputTokens === "number") outputTokens += event.outputTokens;
+        if (typeof event.costUsd === "number") costUsd += event.costUsd;
+      } else if (event.type === "reasoning") {
         reasoningCount += 1;
         if (typeof event.tokens === "number" && event.tokens > 0) reasoningTokens += event.tokens;
       }
@@ -107,6 +129,9 @@ export function createActivityMeter(): ActivityMeter {
         reasoningTokens,
         waiting,
         eventsThisWindow: Math.max(0, eventsThisWindow),
+        inputTokens,
+        outputTokens,
+        costUsd,
       };
     },
     peek() {
@@ -117,6 +142,9 @@ export function createActivityMeter(): ActivityMeter {
         reasoningTokens,
         waiting,
         eventsThisWindow: total() - eventsAtLastWindow,
+        inputTokens,
+        outputTokens,
+        costUsd,
       };
     },
   };

--- a/apps/dev/src/core/heartbeat.ts
+++ b/apps/dev/src/core/heartbeat.ts
@@ -151,6 +151,10 @@ export interface ProgressHeartbeatInput {
     waiting: number;
     /** New stream events in the window this tick closes (0 → a waiting window). */
     eventsThisWindow: number;
+    /** Cost group (ADR 0065): cumulative token spend / USD from `usage` events. */
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
   };
 }
 
@@ -184,8 +188,13 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
   const reasonFrag = a
     ? ` think:${a.reasoningCount}${a.reasoningTokens > 0 ? `/${a.reasoningTokens}tok` : ""}`
     : "";
+  // Cost tail: shown only when the runner streamed token usage (codex/opencode).
+  const costFrag =
+    a && (a.inputTokens > 0 || a.outputTokens > 0)
+      ? ` tok:${a.inputTokens}/${a.outputTokens}${a.costUsd > 0 ? ` $${a.costUsd.toFixed(2)}` : ""}`
+      : "";
   const activityTail = a
-    ? ` · tools:${a.toolsCalled} text:${a.textChunks}${reasonFrag} wait:${a.waiting}${a.eventsThisWindow === 0 ? " (idle window)" : ""}`
+    ? ` · tools:${a.toolsCalled} text:${a.textChunks}${reasonFrag} wait:${a.waiting}${costFrag}${a.eventsThisWindow === 0 ? " (idle window)" : ""}`
     : "";
   const msg = `progress: ${input.secsSinceProgress}s since last commit${headShort} · ${diff}${activityTail}`;
   return {
@@ -212,6 +221,9 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
             reasoning_tokens: String(a.reasoningTokens),
             waiting_count: String(a.waiting),
             events_this_window: String(a.eventsThisWindow),
+            input_tokens: String(a.inputTokens),
+            output_tokens: String(a.outputTokens),
+            cost_usd: String(a.costUsd),
             // Deprecated legacy alias — remove one release after S1.
             thinking_called_count: String(a.reasoningCount),
           }
@@ -228,6 +240,9 @@ export function buildProgressHeartbeat(input: ProgressHeartbeatInput): ProgressH
             "current.reasoning_events": a.reasoningCount,
             "current.reasoning_tokens": a.reasoningTokens,
             "current.waiting_count": a.waiting,
+            "current.input_tokens": a.inputTokens,
+            "current.output_tokens": a.outputTokens,
+            "current.cost_usd": a.costUsd,
           }
         : {}),
     },

--- a/apps/dev/src/core/monitor.ts
+++ b/apps/dev/src/core/monitor.ts
@@ -22,6 +22,12 @@ export interface CompactCurrent {
   stage: string;
   /** Per-iteration start (current.started_at), an ISO/RFC string or "". */
   started_at: string;
+  /** Cost group (ADR 0065) — cumulative per-worker token spend / USD. Optional so
+   * the dashboard's compact-current constructor and fixtures stay terse; absent
+   * reads as 0. */
+  input_tokens?: number;
+  output_tokens?: number;
+  cost_usd?: number;
 }
 
 /** The subset of afk.state.json the compact line reads. */
@@ -152,11 +158,18 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
 
   const diff = `  ${formatDiff(worker.diffAdded ?? 0, worker.diffRemoved ?? 0)}`;
 
+  // Cost group (ADR 0065): per-worker token spend, shown only when the runner
+  // streamed usage (codex/opencode). `$cost` only when the runner reports USD.
+  const it = state.current.input_tokens ?? 0;
+  const ot = state.current.output_tokens ?? 0;
+  const cu = state.current.cost_usd ?? 0;
+  const costFrag = it > 0 || ot > 0 ? `  tok:${it}/${ot}${cu > 0 ? ` $${cu.toFixed(2)}` : ""}` : "";
+
   let cur: string;
   if (!isNoIssue(state.current.number)) {
     const title = state.current.title.slice(0, TITLE_MAX);
     const elapsed = formatElapsed(elapsedSeconds(state, now));
-    cur = `  #${state.current.number} ${title}  stage:${state.current.stage}  ${elapsed}${diff}`;
+    cur = `  #${state.current.number} ${title}  stage:${state.current.stage}  ${elapsed}${diff}${costFrag}`;
   } else {
     cur = `  idle${diff}`;
   }

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -55,6 +55,12 @@ export interface AfkInput {
    * across live workers. A rising value between glances is the clean
    * stuck-vs-working signal (silent agent), so it is shown only when > 0. */
   waiting?: number;
+  /** 🪙 — summed token spend (input + output) across live workers (ADR 0065 cost
+   * group). Humanized (e.g. `🪙12k`); shown only when > 0. */
+  tokens?: number;
+  /** 💵 — summed USD cost across live workers, shown only when > 0 (most runners
+   * report tokens but not cost, so this is frequently absent). */
+  costUsd?: number;
   /** #N issue numbers for the in-progress workers, in order. */
   issues: ReadonlyArray<number | string>;
   /** Per-issue `current.stage` aligned by index with {@link issues}. When a
@@ -137,6 +143,8 @@ export function renderAfkBlock(afk: AfkInput | undefined): string | null {
   if (afk.added > 0) tokens.push(`+${afk.added}`);
   if (afk.removed > 0) tokens.push(`-${afk.removed}`);
   if (afk.waiting !== undefined && afk.waiting > 0) tokens.push(`💤${afk.waiting}`);
+  if (afk.tokens !== undefined && afk.tokens > 0) tokens.push(`🪙${humanizeTokens(afk.tokens)}`);
+  if (afk.costUsd !== undefined && afk.costUsd > 0) tokens.push(`💵$${afk.costUsd.toFixed(2)}`);
   afk.issues.forEach((issue, i) => {
     const stage = afk.stages?.[i];
     tokens.push(stage ? `#${issue}·${stage}` : `#${issue}`);

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -422,6 +422,9 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
           title: state.current.title,
           stage: state.current.stage,
           started_at: state.current.started_at,
+          input_tokens: state.current.input_tokens,
+          output_tokens: state.current.output_tokens,
+          cost_usd: state.current.cost_usd,
         },
       },
       live: isStateLive(state),
@@ -520,6 +523,8 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   let added = 0;
   let removed = 0;
   let waiting = 0;
+  let tokens = 0;
+  let costUsd = 0;
   const issues: Array<number | string> = [];
   const stages: Array<string | undefined> = [];
 
@@ -540,6 +545,9 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     // event, persisted on `current` (see AfkCurrentSchema). Summed across the
     // fleet and shown as 💤N so a wedged-but-not-dead worker is visible.
     waiting += state.current.waiting_count;
+    // Cost group (ADR 0065): per-worker token spend + USD, summed for the fleet.
+    tokens += state.current.input_tokens + state.current.output_tokens;
+    costUsd += state.current.cost_usd;
 
     let a = state.current.loc_added;
     let r = state.current.loc_removed;
@@ -592,7 +600,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     void refresh().catch(() => undefined);
   }
 
-  return { workers, queue, human, blocked, added, removed, waiting, issues, stages };
+  return { workers, queue, human, blocked, added, removed, waiting, tokens, costUsd, issues, stages };
 }
 
 // ---------- reap inputs ----------

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -56,6 +56,13 @@ export const AfkCurrentSchema = z.object({
   waiting_count: z.number().default(0),
   loc_added: z.number().default(0),
   loc_removed: z.number().default(0),
+  /** Cost group (ADR 0065) — cumulative per-worker token spend, summed from the
+   * runner's `usage` stream events (codex/opencode live; claude at iteration
+   * boundary, a follow-up). `cost_usd` is populated only when the runner reports
+   * cost directly. */
+  input_tokens: z.number().default(0),
+  output_tokens: z.number().default(0),
+  cost_usd: z.number().default(0),
 });
 
 export const AfkStateSchema = z.object({

--- a/apps/dev/tests/activity-meter.test.ts
+++ b/apps/dev/tests/activity-meter.test.ts
@@ -12,6 +12,26 @@ describe("createActivityMeter", () => {
     expect(s.textChunks).toBe(1);
   });
 
+  it("sums usage events into the cost group without counting them as liveness units", () => {
+    const m = createActivityMeter();
+    m.record({ type: "toolCall" });
+    m.record({ type: "usage", inputTokens: 1500, outputTokens: 320, costUsd: 0.04 });
+    m.record({ type: "usage", inputTokens: 800, outputTokens: 120, costUsd: 0.02 });
+    const s = m.peek();
+    expect(s.inputTokens).toBe(2300);
+    expect(s.outputTokens).toBe(440);
+    expect(s.costUsd).toBeCloseTo(0.06);
+    expect(s.toolsCalled).toBe(1);
+    expect(s.textChunks).toBe(0);
+    expect(s.reasoningCount).toBe(0);
+  });
+
+  it("treats a usage-only window as a waiting window (usage is not a liveness event)", () => {
+    const m = createActivityMeter();
+    m.record({ type: "usage", inputTokens: 100, outputTokens: 10 });
+    expect(m.snapshotWindow().waiting).toBe(1);
+  });
+
   it("counts reasoning events and sums their tokens (codex/opencode style)", () => {
     const m = createActivityMeter();
     m.record({ type: "reasoning", tokens: 13 });

--- a/apps/dev/tests/heartbeat.test.ts
+++ b/apps/dev/tests/heartbeat.test.ts
@@ -251,10 +251,10 @@ describe("buildProgressHeartbeat (#448)", () => {
       head: "40ac9326",
       added: 382,
       removed: 45,
-      activity: { toolsCalled: 12, textChunks: 7, reasoningCount: 4, reasoningTokens: 130, waiting: 2, eventsThisWindow: 3 },
+      activity: { toolsCalled: 12, textChunks: 7, reasoningCount: 4, reasoningTokens: 130, waiting: 2, eventsThisWindow: 3, inputTokens: 1500, outputTokens: 320, costUsd: 0.04 },
     });
     expect(hb.msg).toBe(
-      "progress: 75s since last commit @ 40ac9326 · +382 -45 · tools:12 text:7 think:4/130tok wait:2",
+      "progress: 75s since last commit @ 40ac9326 · +382 -45 · tools:12 text:7 think:4/130tok wait:2 tok:1500/320 $0.04",
     );
     expect(hb.extra.tools_called_count).toBe("12");
     expect(hb.extra.text_chunk_count).toBe("7");
@@ -265,6 +265,10 @@ describe("buildProgressHeartbeat (#448)", () => {
     expect(hb.extra.waiting_count).toBe("2");
     expect(hb.extra.loc_added).toBe("382");
     expect(hb.extra.loc_removed).toBe("45");
+    // cost group (ADR 0065)
+    expect(hb.extra.input_tokens).toBe("1500");
+    expect(hb.extra.output_tokens).toBe("320");
+    expect(hb.extra.cost_usd).toBe("0.04");
     expect(hb.statePatch["current.tools_called_count"]).toBe(12);
     // canonical name in state — no legacy thinking_called_count in statePatch.
     expect(hb.statePatch["current.reasoning_events"]).toBe(4);
@@ -272,6 +276,9 @@ describe("buildProgressHeartbeat (#448)", () => {
     expect(hb.statePatch["current.reasoning_tokens"]).toBe(130);
     expect(hb.statePatch["current.waiting_count"]).toBe(2);
     expect(hb.statePatch["current.loc_added"]).toBe(382);
+    expect(hb.statePatch["current.input_tokens"]).toBe(1500);
+    expect(hb.statePatch["current.output_tokens"]).toBe(320);
+    expect(hb.statePatch["current.cost_usd"]).toBe(0.04);
   });
 
   it("reasoning with no tokens (claude-style) shows think:N without /tok", () => {
@@ -281,7 +288,7 @@ describe("buildProgressHeartbeat (#448)", () => {
       head: "",
       added: 1,
       removed: 0,
-      activity: { toolsCalled: 0, textChunks: 2, reasoningCount: 3, reasoningTokens: 0, waiting: 0, eventsThisWindow: 5 },
+      activity: { toolsCalled: 0, textChunks: 2, reasoningCount: 3, reasoningTokens: 0, waiting: 0, eventsThisWindow: 5, inputTokens: 0, outputTokens: 0, costUsd: 0 },
     });
     expect(hb.msg).toContain("think:3 ");
     expect(hb.msg).not.toContain("tok");
@@ -294,7 +301,7 @@ describe("buildProgressHeartbeat (#448)", () => {
       head: "",
       added: 0,
       removed: 0,
-      activity: { toolsCalled: 5, textChunks: 3, reasoningCount: 1, reasoningTokens: 0, waiting: 4, eventsThisWindow: 0 },
+      activity: { toolsCalled: 5, textChunks: 3, reasoningCount: 1, reasoningTokens: 0, waiting: 4, eventsThisWindow: 0, inputTokens: 0, outputTokens: 0, costUsd: 0 },
     });
     expect(hb.msg).toContain("wait:4 (idle window)");
   });

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -58,6 +58,29 @@ describe("monitor — compact line", () => {
     );
   });
 
+  it("appends per-worker token spend (and $cost when reported) when usage streamed", () => {
+    const base = baseWorker();
+    const withCost = baseWorker({
+      state: {
+        ...base.state,
+        current: { ...base.state.current, input_tokens: 15479, output_tokens: 184, cost_usd: 0.07 },
+      },
+    });
+    expect(renderWorkerCompactLine(withCost, 1780140600)).toContain("tok:15479/184 $0.07");
+    // no cost reported → tokens only, no $ fragment
+    const noUsd = baseWorker({
+      state: {
+        ...base.state,
+        current: { ...base.state.current, input_tokens: 100, output_tokens: 20, cost_usd: 0 },
+      },
+    });
+    const line = renderWorkerCompactLine(noUsd, 1780140600);
+    expect(line).toContain("tok:100/20");
+    expect(line).not.toContain("$");
+    // no usage at all → no cost fragment (back-compat with the documented shape)
+    expect(renderWorkerCompactLine(base, 1780140600)).not.toContain("tok:");
+  });
+
   it("flags a non-live worker as stale", () => {
     const line = renderWorkerCompactLine(
       baseWorker({ live: false }),

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -177,6 +177,18 @@ describe("statusline — AFK block", () => {
     expect(renderAfkBlock(baseAfk())).not.toContain("💤");
   });
 
+  it("renders 🪙 humanized tokens and 💵 cost after 💤, each only when > 0", () => {
+    expect(renderAfkBlock(baseAfk({ tokens: 12500, costUsd: 0.42 }))).toBe(
+      "🤖1 📋11 🆘3 🚧2 +12 -3 🪙12k 💵$0.42 #17",
+    );
+    // tokens but no cost (the common case — most runners report tokens, not USD)
+    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).toContain("🪙900");
+    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).not.toContain("💵");
+    // neither when zero/absent
+    expect(renderAfkBlock(baseAfk({ tokens: 0, costUsd: 0 }))).not.toMatch(/🪙|💵/);
+    expect(renderAfkBlock(baseAfk())).not.toMatch(/🪙|💵/);
+  });
+
   it("keeps the pre-vitals render byte-for-byte when no waiting/stages are supplied", () => {
     // The new fields are optional: an aggregator that never populates them must
     // produce the exact legacy line, so the upgrade is a no-op for old callers.


### PR DESCRIPTION
Closes #709. Slice S3 of PRD #706 (WorkerVitals canonical vocabulary, ADR 0065).

## What this does
Consumes red-castle's `usage` stream event (delivered by S2 #707) in the apps/dev sink and persists the **WorkerVitals cost group** on `current.*`: `input_tokens`, `output_tokens`, `cost_usd`.

- **activity-meter** sums usage events into cumulative `inputTokens`/`outputTokens`/`costUsd` — usage is summed for cost but **not** counted as a tool/text/reasoning liveness unit (a usage-only window still counts as waiting).
- **heartbeat** persists the cost group on `current.*` + firehose `extra`, and appends `tok:in/out $cost` to the afk.log tail.
- **state schema** gains `input_tokens`/`output_tokens`/`cost_usd`.
- **statusline** renders `🪙<tokens>` (humanized) + `💵$<cost>` (only when the runner reports USD).
- **monitor** per-worker line appends `tok:in/out $cost`.

## Per-runner
codex/opencode feed cost live via the `usage` stream event; claude's usage arrives at the iteration boundary (not the stream), so a pure-claude attempt accrues 0 here — claude live cost is a follow-up.

## Tests
+2 activity-meter cases (usage accumulation; usage-only window is waiting), +1 statusline case (🪙/💵 render), +1 monitor case (per-worker spend); heartbeat fixtures assert the cost group. Full apps/dev suite green (1241 pass; the lone `args.test.ts` failure is the pre-existing `cli-args-parser` worktree-resolution artifact, unrelated).

After this, **S4 (#710)** — the shared `WorkerVitals` type + drift-guard contract test — is the last slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783788168&installation_id=129708444&pr_number=713&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F713&signature=78a1171a2ca66aac658835ea5c237aaa1372ab85902adbfc1597211c51bb4618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token usage tracking and cost metrics across monitoring dashboards
  * Per-worker token counts (input/output) and USD costs now displayed in real-time views
  * Fleet-wide aggregated token spend and cost reporting added to status monitoring
  * Token and cost information conditionally rendered in activity displays when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->