### PR TITLE
feat(afk): shared WorkerVitals type + drift-guard contract test (S4 #710)

### DIFF
--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -330,6 +330,7 @@ export function makeRunAgent(
 
 import type { CompactWorker, FleetState } from "../core/monitor.js";
 import { parseState, isStateLive } from "../core/state.js";
+import type { WorkerVitals } from "../types/state.js";
 import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
 
 export interface MonitorInputs {
@@ -541,16 +542,19 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
 
     workers += 1;
     blocked += state.blocked;
+    // Read the worker's signals through the canonical WorkerVitals contract
+    // (ADR 0065) rather than ad-hoc field access — `current` satisfies it.
+    const vitals: WorkerVitals = state.current;
     // Silent-agent signal: cumulative heartbeat windows with no new stream
-    // event, persisted on `current` (see AfkCurrentSchema). Summed across the
-    // fleet and shown as 💤N so a wedged-but-not-dead worker is visible.
-    waiting += state.current.waiting_count;
-    // Cost group (ADR 0065): per-worker token spend + USD, summed for the fleet.
-    tokens += state.current.input_tokens + state.current.output_tokens;
-    costUsd += state.current.cost_usd;
+    // event. Summed across the fleet and shown as 💤N so a wedged-but-not-dead
+    // worker is visible.
+    waiting += vitals.waiting_count;
+    // Cost group: per-worker token spend + USD, summed for the fleet.
+    tokens += vitals.input_tokens + vitals.output_tokens;
+    costUsd += vitals.cost_usd;
 
-    let a = state.current.loc_added;
-    let r = state.current.loc_removed;
+    let a = vitals.loc_added;
+    let r = vitals.loc_removed;
     if (a === 0 && r === 0 && state.current.worktree) {
       // Fallback: compute the diffstat from the worktree like statusline.sh.
       const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -85,3 +85,49 @@ export const AfkStateSchema = z.object({
 });
 
 export type AfkState = z.infer<typeof AfkStateSchema>;
+
+/** The full `current` sub-state of a running attempt (issue identity + worktree
+ * bookkeeping + the WorkerVitals signals). */
+export type AfkCurrent = z.infer<typeof AfkCurrentSchema>;
+
+/**
+ * The canonical worker-vitals contract (ADR 0065) — the observable signals a
+ * running AFK worker emits, one name per signal, grouped by the question each
+ * group answers. This is the single shape consumers (statusline, monitor,
+ * dashboard) read; `AfkCurrent` (the persisted `current.*`) is a superset of it,
+ * enforced by the `_AfkCurrentSatisfiesWorkerVitals` assertion below — so adding
+ * or renaming a vital is one declaration here + the schema, and a drift between
+ * the two fails to compile. The red-castle stream-event → field map is pinned by
+ * the contract test in `tests/worker-vitals.contract.test.ts`.
+ */
+export interface WorkerVitals {
+  // identity
+  number: number | string;
+  runner: string;
+  retries: number;
+  // lifecycle
+  stage: string;
+  iteration: number | string;
+  // progress
+  loc_added: number;
+  loc_removed: number;
+  last_commit_at: string;
+  // activity
+  tools_called_count: number;
+  text_chunk_count: number;
+  reasoning_events: number;
+  reasoning_tokens: number;
+  last_event_at: string;
+  // liveness
+  waiting_count: number;
+  // cost
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+}
+
+/** Compile-time guarantee that the persisted `current.*` satisfies the canonical
+ * WorkerVitals contract. If a vital is renamed on the schema without updating
+ * {@link WorkerVitals} (or vice-versa), this assignment fails to compile. */
+const _AfkCurrentSatisfiesWorkerVitals: WorkerVitals = undefined as unknown as AfkCurrent;
+void _AfkCurrentSatisfiesWorkerVitals;

--- a/apps/dev/tests/worker-vitals.contract.test.ts
+++ b/apps/dev/tests/worker-vitals.contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { AgentStreamEvent } from "../src/core/execution.js";
+import { AfkCurrentSchema, type WorkerVitals } from "../src/types/state.js";
+
+// The contract test (ADR 0065): pin the red-castle stream-event type -> canonical
+// WorkerVitals field map so a future per-CLI parser change cannot silently
+// reintroduce name drift across the chain. This guards TWO directions at once:
+//
+//  1. COMPLETENESS (compile-time): the `satisfies Record<AgentStreamEvent["type"],
+//     ...>` makes TypeScript fail to compile if red-castle adds a new
+//     AgentStreamEvent variant without an entry here.
+//  2. VALIDITY (compile-time): each mapped target is `keyof WorkerVitals`, so a
+//     typo or a renamed vital that no longer exists fails to compile.
+//  3. PERSISTENCE (runtime): every mapped field is actually present on the parsed
+//     `current.*`, i.e. the schema persists it (the lesson from S1/PR #705 —
+//     undeclared keys are stripped by updateState's schema round-trip).
+const EVENT_TO_VITALS = {
+  text: ["text_chunk_count"],
+  toolCall: ["tools_called_count"],
+  reasoning: ["reasoning_events", "reasoning_tokens"],
+  usage: ["input_tokens", "output_tokens", "cost_usd"],
+} satisfies Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]>;
+
+describe("WorkerVitals contract (ADR 0065)", () => {
+  it("maps every red-castle stream-event type to canonical current.* fields that are persisted", () => {
+    const current = AfkCurrentSchema.parse({});
+    for (const [eventType, fields] of Object.entries(EVENT_TO_VITALS)) {
+      for (const field of fields) {
+        // The mapped vital must survive a schema round-trip (be persisted),
+        // not just exist as a TypeScript key.
+        expect(current, `${eventType} -> ${field} must be a persisted current.* field`).toHaveProperty(
+          field,
+        );
+        expect(typeof (current as Record<string, unknown>)[field]).toBe("number");
+      }
+    }
+  });
+
+  it("covers every AgentStreamEvent variant (no unmapped event type)", () => {
+    // Runtime mirror of the compile-time `satisfies` completeness check: the set
+    // of mapped event types is exactly what we expect. If red-castle adds a
+    // variant, the `satisfies` above fails to compile first; this keeps the
+    // expectation visible to a human reviewer too.
+    expect(Object.keys(EVENT_TO_VITALS).sort()).toEqual(["reasoning", "text", "toolCall", "usage"]);
+  });
+
+  it("rejects a map that omits a known event type (compile-time guard demonstrated)", () => {
+    // A map missing the `usage` variant must NOT satisfy the Record over
+    // AgentStreamEvent["type"]. The @ts-expect-error fails the BUILD if the
+    // completeness guard ever stops working (an unused directive is itself an error).
+    // prettier-ignore
+    // @ts-expect-error missing `usage` key
+    const _incomplete: Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]> = { text: ["text_chunk_count"], toolCall: ["tools_called_count"], reasoning: ["reasoning_events"] };
+    void _incomplete;
+    expect(true).toBe(true);
+  });
+
+  it("rejects a map pointing at a non-vital field (compile-time guard demonstrated)", () => {
+    // `thinking_called_count` was renamed to reasoning_events, so it is no longer
+    // a keyof WorkerVitals — pointing a mapping at it must fail to compile.
+    // prettier-ignore
+    // @ts-expect-error `thinking_called_count` is not a keyof WorkerVitals
+    const _wrongField: Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]> = { text: ["text_chunk_count"], toolCall: ["tools_called_count"], reasoning: ["reasoning_events", "reasoning_tokens"], usage: ["thinking_called_count"] };
+    void _wrongField;
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #710. **Final slice (S4)** of PRD #706 — completes the WorkerVitals canonical vocabulary (ADR 0065).

## What this does
- **Shared `WorkerVitals` type** next to `AfkCurrentSchema`, grouping the canonical signals (identity / lifecycle / progress / activity / liveness / cost). A compile-time assertion guarantees `current.*` (`AfkCurrent`) satisfies it — rename a vital on one but not the other and it **fails to compile**.
- **A consumer reads via the contract**: `collectStatuslineAfk` now reads the fleet's signals through a `WorkerVitals`-typed binding instead of ad-hoc field access.
- **Capstone contract test** (`worker-vitals.contract.test.ts`) pinning the red-castle stream-event type → canonical `current.*` field map, guarding three ways:
  - **completeness** (compile): a new `AgentStreamEvent` variant without a map entry fails the `satisfies Record<AgentStreamEvent["type"], …>`
  - **validity** (compile): each mapped target is `keyof WorkerVitals` — a renamed/typo'd field fails; proven by two `@ts-expect-error` fixtures (e.g. `thinking_called_count` no longer compiles)
  - **persistence** (runtime/CI): every mapped field survives the schema round-trip, catching an accidental schema rename in vitest/CI

## Note on CI coverage
The **persistence** guard runs in CI (vitest). The **compile-time** guards (`satisfies` + `@ts-expect-error`) need `tsc`, which `core-regression-gate` does not run — the same gap that let S1's usage-variant typecheck break land silently. Recommend a follow-up adding an `apps/dev` typecheck job to CI so the full contract is enforced automatically; out of scope here.

## Tests
+4 contract-test cases; full apps/dev suite green (1245 pass; the lone `args.test.ts` failure is the pre-existing `cli-args-parser` worktree-resolution artifact, unrelated).

After this merges, **PRD #706 is fully delivered** (S1+S2+S3+S4).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783789543&installation_id=129708444&pr_number=714&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F714&signature=ff2a92e5bf05af5ac0d549b616ba49f6f3f7cfa378fadac0a4bb5e26e0c4736c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized access to worker status and performance metrics through a canonical contract interface, improving code consistency and maintainability.

* **Tests**
  * Added contract test to validate complete and correct mapping between system events and worker status metrics with compile-time type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->