### PR TITLE
fix(afk): claude cost vitals + honest [live] badge + pre-merge typecheck gate

### DIFF
--- a/.github/workflows/red-workspace-typecheck.yml
+++ b/.github/workflows/red-workspace-typecheck.yml
@@ -1,0 +1,45 @@
+name: red-workspace-typecheck
+
+# Pre-merge typecheck gate. Until this existed, `pnpm typecheck` ran ONLY in
+# red-release.yml on push-to-main — i.e. AFTER merge — so a type break landed
+# silently on a PR and only surfaced at release time (the WorkerVitals S2 `usage`
+# variant break, ADR 0065). This job runs the same workspace typecheck on every
+# pull request so the break is caught before merge. Test execution is deliberately
+# NOT added here yet: the suite carries a known supervisor.test.ts OOM (#446) that
+# would red-flag unrelated PRs; gating tests in CI is a separate effort.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # red-castle submodule must exist so the workspace pnpm install and the
+          # apps/* typecheck resolve @reddb-io/red-castle from source.
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install red binary for SDK
+        uses: ./.github/actions/install-red-binary
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck workspace (apps + packages, excludes red-castle)
+        run: pnpm typecheck

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -83,6 +83,50 @@ export function isStateLive(state: Pick<AfkState, "pid">, kill: (pid: number, si
   return Number.isInteger(state.pid) && state.pid > 0 && kill(state.pid, 0);
 }
 
+/**
+ * Wall-clock staleness ceiling for the per-worker "live" badge. A worker whose
+ * most-recent activity timestamp is older than this is treated as NOT live even
+ * when its recorded pid still resolves — the pid can belong to the shared
+ * supervisor, or be recycled by the OS after the worker exits, both of which
+ * made a finished worker render as `[live]` on the monitor/statusline. Generous
+ * on purpose: a working agent advances `last_event_at` every few seconds and
+ * commits/heartbeats well inside this window, so a real-but-briefly-quiet worker
+ * is never mis-flagged stale (the monitor false-negative this must avoid).
+ */
+export const WORKER_LIVE_MAX_AGE_S = 180;
+
+/** Most-recent activity instant (ms) across a worker's vitals timestamps, or 0
+ * when none parse. `last_event_at` is the honest liveness clock (ADR 0065);
+ * `last_commit_at` and `started_at` are fallbacks so a committing-but-quiet or
+ * just-started worker still reads as fresh. */
+function latestActivityMs(state: Pick<AfkState, "current">): number {
+  let latest = 0;
+  for (const ts of [state.current.last_event_at, state.current.last_commit_at, state.current.started_at]) {
+    const t = ts ? Date.parse(ts) : Number.NaN;
+    if (Number.isFinite(t) && t > latest) latest = t;
+  }
+  return latest;
+}
+
+/**
+ * True when a worker is BOTH process-live (its pid resolves) AND recently active
+ * (latest activity within {@link WORKER_LIVE_MAX_AGE_S}). This is what the
+ * monitor/statusline use for the `[live]` badge: `isStateLive` alone (pid only)
+ * renders a finished worker as live whenever its pid is shared with the
+ * supervisor or recycled by the OS. Reaper/cap logic deliberately keeps using
+ * the pid-only `isStateLive` so a slow worker is never reaped on freshness.
+ */
+export function isStateActive(
+  state: Pick<AfkState, "pid" | "current">,
+  nowMs: number = Date.now(),
+  kill: (pid: number, signal?: 0) => boolean = defaultKill0,
+  maxAgeS: number = WORKER_LIVE_MAX_AGE_S,
+): boolean {
+  if (!isStateLive(state, kill)) return false;
+  const latest = latestActivityMs(state);
+  return latest > 0 && nowMs - latest <= maxAgeS * 1000;
+}
+
 function defaultKill0(pid: number): boolean {
   try {
     process.kill(pid, 0);

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -329,7 +329,7 @@ export function makeRunAgent(
 // ---------- monitor inputs ----------
 
 import type { CompactWorker, FleetState } from "../core/monitor.js";
-import { parseState, isStateLive } from "../core/state.js";
+import { parseState, isStateLive, isStateActive } from "../core/state.js";
 import type { WorkerVitals } from "../types/state.js";
 import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
 
@@ -428,7 +428,9 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
           cost_usd: state.current.cost_usd,
         },
       },
-      live: isStateLive(state),
+      // Display liveness requires BOTH a resolving pid AND recent activity, so a
+      // finished worker whose pid is shared/recycled stops rendering as `[live]`.
+      live: isStateActive(state),
       diffAdded: added,
       diffRemoved: removed,
     });
@@ -538,7 +540,9 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     } catch {
       continue;
     }
-    if (!isStateLive(state)) continue;
+    // Statusline counts only genuinely-active workers (pid-live AND fresh), so a
+    // finished worker with a stale state file no longer inflates the 🤖N badge.
+    if (!isStateActive(state)) continue;
 
     workers += 1;
     blocked += state.blocked;

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -2,7 +2,15 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { initState, isStateLive, readState, updateState } from "../src/core/state.js";
+import {
+  initState,
+  isStateActive,
+  isStateLive,
+  readState,
+  updateState,
+  WORKER_LIVE_MAX_AGE_S,
+} from "../src/core/state.js";
+import { AfkStateSchema } from "../src/types/state.js";
 
 describe("state", () => {
   it("default-parses missing or malformed state files", async () => {
@@ -30,6 +38,36 @@ describe("state", () => {
     expect(isStateLive({ pid: 0 }, () => true)).toBe(false);
     expect(isStateLive({ pid: 123 }, (pid) => pid === 123)).toBe(true);
     expect(isStateLive({ pid: 123 }, () => false)).toBe(false);
+  });
+
+  it("isStateActive requires BOTH a resolving pid AND recent activity (ADR 0065)", () => {
+    const now = Date.parse("2026-06-11T20:00:00.000Z");
+    const alive = () => true;
+    const fresh = AfkStateSchema.parse({
+      pid: 123,
+      current: { last_event_at: new Date(now - 5_000).toISOString() },
+    });
+    const stale = AfkStateSchema.parse({
+      pid: 123,
+      current: { last_event_at: new Date(now - (WORKER_LIVE_MAX_AGE_S + 60) * 1000).toISOString() },
+    });
+
+    // pid-live + fresh activity → active
+    expect(isStateActive(fresh, now, alive)).toBe(true);
+    // pid-live but activity older than the ceiling → NOT active (the phantom case:
+    // a finished worker whose pid is shared/recycled still resolves).
+    expect(isStateActive(stale, now, alive)).toBe(false);
+    // dead pid is never active regardless of freshness
+    expect(isStateActive(fresh, now, () => false)).toBe(false);
+    // a committing-but-quiet worker (no recent event, recent commit) stays active
+    const committing = AfkStateSchema.parse({
+      pid: 123,
+      current: {
+        last_event_at: new Date(now - (WORKER_LIVE_MAX_AGE_S + 60) * 1000).toISOString(),
+        last_commit_at: new Date(now - 10_000).toISOString(),
+      },
+    });
+    expect(isStateActive(committing, now, alive)).toBe(true);
   });
 
   it("read-shims legacy worker-vitals keys onto their canonical names (ADR 0065)", async () => {


### PR DESCRIPTION
Resolves three follow-ups surfaced while validating the 1.200.x runner (ADR 0065). All found during a live runner check; the WorkerVitals activity/progress lanes already worked end-to-end, these close the remaining gaps.

## 1. Cost vitals populate on claude runs
The cost group (`input_tokens`/`output_tokens`/`cost_usd`) was **zero on every claude run** — claude never streamed a discrete `usage` event the way codex does, so the `activity-meter` consumer (already wired since S3) never received one. red-castle bumped to `207de381`: claude's terminal stream-json `result` line (which carries cumulative `usage` + `total_cost_usd`) now also yields a `usage` event through the existing `onUsage` path. So 🪙/💵 finally light up for claude.

## 2. The `[live]` badge is honest
A finished worker rendered as `[live]` on the monitor and inflated the statusline 🤖N badge. `isStateLive` checks **only the recorded pid**, which can be the shared supervisor's or recycled by the OS after the worker exits. New `isStateActive` requires **pid-live AND** latest activity within `WORKER_LIVE_MAX_AGE_S` (180s), used at the two display sites. Reaper/cap logic keeps the conservative pid-only `isStateLive` so a slow worker is never reaped on freshness; the window is generous so a real-but-quiet worker is never mis-flagged stale.

## 3. Pre-merge typecheck gate
`pnpm typecheck` ran only in `red-release.yml` on push-to-main — **after merge** — so a type break landed silently on a PR and surfaced only at release. That's the path the S2 `usage` variant break slipped through. New `red-workspace-typecheck.yml` runs the same workspace typecheck on every PR. Tests stay out for now (`supervisor.test.ts` OOM, #446).

## Validation
- red-castle: 217 AgentProvider tests pass (incl. 2 new for the result→usage emission); typecheck clean (pre-existing template-only tsgo noise unrelated).
- apps/dev: typecheck clean (only the known environmental `cli-args-parser` worktree artifact, resolves in CI); state/wire/monitor/activity-meter/statusline/worker-vitals tests all green (incl. new isStateActive coverage).

Also done in the same session (operational, not in this PR): killed a stale 1.190.0 orphan fleet and cleaned ~430 stale worker scratch dirs (16M).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783802693&installation_id=129708444&pr_number=715&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F715&signature=fd6f4653d4cb896ecf83ed5974120149e1e258247bb4cd31e9be28e8f2b02bbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced worker activity tracking to distinguish between active and stale workers based on recent activity, improving accuracy of worker status monitoring.

* **Chores**
  * Added automated type checking workflow for continuous validation.

* **Tests**
  * Expanded test coverage for worker activity detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->