### PR TITLE
fix(statusline): anchor to the session project_dir, not the live cwd

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -12,7 +12,8 @@
 // Invocation: `node bin/afk.mjs statusline "<project-root>"` with the payload on
 // stdin. The root arg wins when it is a real directory (wire it as
 // `… statusline "$CLAUDE_PROJECT_DIR"`), else the payload's
-// `.workspace.current_dir // .cwd`, else `process.cwd()`.
+// `.workspace.project_dir` (the fixed session root — survives `cd` into subdirs),
+// else `.workspace.current_dir // .cwd`, else `process.cwd()`.
 
 import { existsSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
@@ -46,7 +47,7 @@ function readStdin(stdin: NodeJS.ReadableStream & { isTTY?: boolean }): Promise<
 }
 
 interface ClaudePayload {
-  workspace?: { current_dir?: string };
+  workspace?: { project_dir?: string; current_dir?: string };
   cwd?: string;
   model?: { display_name?: string };
   effort?: { level?: string };
@@ -72,13 +73,17 @@ function isDir(path: string): boolean {
 }
 
 /**
- * Resolve the project root the same way statusline.sh does: an explicit
- * first-arg directory wins, then the payload's `.workspace.current_dir // .cwd`,
- * then `cwd`.
+ * Resolve the project root: an explicit first-arg directory wins, then the
+ * payload's `.workspace.project_dir` — the directory the Claude Code session was
+ * STARTED in, which stays fixed as you `cd` into subdirectories — then the older
+ * `.workspace.current_dir // .cwd` (which track the live cwd) as fallbacks, then
+ * `cwd`. Preferring `project_dir` keeps the statusline anchored to the project
+ * you opened: the basename, git ref, and AFK worker block (resolved under
+ * `<root>/.red/tmp`) no longer change when you wander into a subdir.
  */
 export function resolveRoot(rootArg: string | undefined, payload: ClaudePayload, fallback: string): string {
   if (rootArg && isDir(rootArg)) return rootArg;
-  const fromPayload = payload.workspace?.current_dir || payload.cwd;
+  const fromPayload = payload.workspace?.project_dir || payload.workspace?.current_dir || payload.cwd;
   if (fromPayload) return fromPayload;
   return fallback;
 }

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -66,6 +66,22 @@ describe("statusline command — pure helpers", () => {
     expect(resolveRoot(undefined, {}, "/fallback")).toBe("/fallback");
   });
 
+  it("resolveRoot prefers the fixed project_dir over the live current_dir (anchors to the project on cd)", () => {
+    // The session was started in /proj but the user cd'd into /proj/apps/dev —
+    // the statusline must stay anchored to /proj, not follow the subdir.
+    expect(
+      resolveRoot(
+        undefined,
+        { workspace: { project_dir: "/proj", current_dir: "/proj/apps/dev" }, cwd: "/proj/apps/dev" },
+        "/fallback",
+      ),
+    ).toBe("/proj");
+    // No project_dir (older host) → fall back to current_dir.
+    expect(
+      resolveRoot(undefined, { workspace: { current_dir: "/proj/apps/dev" } }, "/fallback"),
+    ).toBe("/proj/apps/dev");
+  });
+
   it("statuslineEnabled honours both opt-out shapes", async () => {
     const top = await mkdtemp(join(tmpdir(), "sl-cfg-"));
     await mkdir(join(top, ".red"), { recursive: true });
@@ -99,7 +115,15 @@ describe("statusline command — rendered line", () => {
     // One live worker on #17 with +12 -3, blocked 2; cached 📋11 🆘3.
     await writeWorkerState(root, "wA", "17-a1", {
       blocked: 2,
-      current: { number: 17, diff_added: 12, diff_removed: 3 },
+      // `started_at` (fresh) is what makes isStateActive treat this pid-live worker
+      // as active (ADR 0065): the statusline collector now requires recent activity,
+      // not just a resolving pid. A real worker always stamps started_at.
+      current: {
+        number: 17,
+        diff_added: 12,
+        diff_removed: 3,
+        started_at: new Date().toISOString(),
+      },
     });
     await seedFreshCache(root, 11, 3);
 


### PR DESCRIPTION
## The bug (reported live)
The statusline kept changing the project name as you `cd` into subdirectories — so you lose track of which project you're in. It derived the basename, git ref, AND the AFK worker block (resolved under `<root>/.red/tmp`) from `.workspace.current_dir` (the live cwd), so everything followed you into subdirs and the worker block vanished there.

## Fix
`resolveRoot` now prefers **`.workspace.project_dir`** — the directory the Claude Code session was *started* in, which stays fixed — falling back to `current_dir`/`cwd` for hosts that don't send it. This aligns the code with what the `setup-statusline` skill already documents (it claimed project_dir was used; it wasn't). One-line resolution change + type + a covering test.

## Bonus (a regression CI can't see)
Fixed a `statusline-command` test fixture that omitted a fresh timestamp — its pid-live worker failed the `isStateActive` freshness gate added in v1.200.1 (ADR 0065). The test never went red in CI because **`pnpm test` runs in no workflow** (the #446 OOM blocks adding it). A real worker always stamps `started_at`, so this was a fixture gap, not a product bug — but it's a reminder the test suite isn't gating PRs.

## Validation
- typecheck clean; statusline-command (8) + statusline (29) tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783807716&installation_id=129708444&pr_number=718&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F718&signature=01c1ec0398173ef68ca23e4d3328a59f92761d8175b18c590877e8d8509669f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session project root now resolves to the session's starting directory, remaining stable when navigating subdirectories.

* **Tests**
  * Added comprehensive tests for project root resolution and session activity tracking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->