### PR TITLE
fix(afk): init the red-castle submodule in the feedback-gate worktree (landing blocker)

### DIFF
--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -125,6 +125,24 @@ export function makeFeedbackWorktree(
       resolved.set(branch, null);
       return null;
     }
+    // A freshly added git worktree does NOT populate submodules: packages/red-castle
+    // (the `@reddb-io/red-castle` workspace:* SOURCE, ADR 0061) is an empty dir. The
+    // pnpm install below then cannot resolve that workspace dep, so every gate check
+    // (tsc / build / vitest) fails with `Cannot find module '@reddb-io/red-castle'`
+    // — a FALSE blocked:validation on otherwise-green apps/dev work. CI sidesteps
+    // this with `actions/checkout submodules:recursive`; a local `git worktree add`
+    // has no such convenience, so initialise the submodule into the worktree before
+    // installing. Fails closed, like the install below.
+    const sub = await io.exec("git", ["submodule", "update", "--init", "--recursive"], { cwd: dest });
+    if (sub.code !== 0) {
+      await io.worktreeRemove(gitCtx, dest);
+      process.stderr.write(
+        `error: feedback worktree submodule init failed for ${branch} (exit ${sub.code}); ` +
+          `blocking validation\n${sub.stderr.trim()}\n`,
+      );
+      resolved.set(branch, null);
+      return null;
+    }
     // A freshly added worktree has NO node_modules. Without an install here,
     // the feedback gate's `pnpm -C <dest> test/build` calls fail with
     // `tsc/vite/svelte-kit: not found` — a FALSE validation failure that parks

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -61,11 +61,18 @@ describe("splitBranchDir (#437)", () => {
  * exit so the install-failure path is exercisable. `addOk` controls whether
  * `worktreeAdd` succeeds so the worktree-add-failure path is exercisable.
  */
-function fakeIO(installCode = 0, addOk = true): {
+function fakeIO(
+  installCode = 0,
+  addOk = true,
+  submoduleCode = 0,
+): {
   io: FeedbackWorktreeIO;
-  calls: Array<{ op: "add" | "install" | "script" | "remove"; dest: string }>;
+  calls: Array<{ op: "add" | "submodule" | "install" | "script" | "remove"; dest: string }>;
 } {
-  const calls: Array<{ op: "add" | "install" | "script" | "remove"; dest: string }> = [];
+  const calls: Array<{
+    op: "add" | "submodule" | "install" | "script" | "remove";
+    dest: string;
+  }> = [];
   const io: FeedbackWorktreeIO = {
     worktreeAdd: async (_ctx, dest) => {
       calls.push({ op: "add", dest });
@@ -77,7 +84,13 @@ function fakeIO(installCode = 0, addOk = true): {
       const code = isInstall ? installCode : 0;
       return { code, stdout: "", stderr: code === 0 ? "" : "boom" };
     },
-    exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+    // The submodule init (git submodule update --init --recursive) runs between
+    // worktreeAdd and install; `submoduleCode` scripts its exit so the
+    // init-failure path is exercisable.
+    exec: async (_cmd, _args, opts) => {
+      calls.push({ op: "submodule", dest: opts.cwd ?? "" });
+      return { code: submoduleCode, stdout: "", stderr: submoduleCode === 0 ? "" : "boom" };
+    },
     worktreeRemove: async (_ctx, dest) => {
       calls.push({ op: "remove", dest });
     },
@@ -94,10 +107,11 @@ describe("makeFeedbackWorktree install (#458)", () => {
     // it must materialise + install the checkout, then run the script there.
     await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
 
-    // add → install BEFORE the script runs, the first two keyed to the worktree.
-    expect(calls.map((c) => c.op)).toEqual(["add", "install", "script"]);
+    // add → submodule init → install BEFORE the script runs, all keyed to the worktree.
+    expect(calls.map((c) => c.op)).toEqual(["add", "submodule", "install", "script"]);
     expect(calls[0]?.dest).toBe("/root/.red/tmp/feedback/afk-w1-42-fix");
     expect(calls[1]?.dest).toBe("/root/.red/tmp/feedback/afk-w1-42-fix");
+    expect(calls[2]?.dest).toBe("/root/.red/tmp/feedback/afk-w1-42-fix");
   });
 
   it("installs the materialised checkout exactly once across reused branches", async () => {
@@ -126,6 +140,25 @@ describe("makeFeedbackWorktree install (#458)", () => {
       { op: "remove", dest: "/root/.red/tmp/feedback/afk-w1-42-fix" },
     ]);
     // The script was never run.
+    expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
+  });
+
+  it("blocks validation (returns exit code 1) when submodule init fails", async () => {
+    const { io, calls } = fakeIO(0, true, 1);
+    const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io);
+
+    const result = await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+    await fb.cleanup();
+
+    // A failed submodule init must block (else @reddb-io/red-castle is unresolved
+    // and the gate fails on every check — a false blocked:validation).
+    expect(result.code).toBe(1);
+    // The partial worktree is torn down immediately, and neither install nor the
+    // script ever runs.
+    expect(calls.filter((c) => c.op === "remove")).toEqual([
+      { op: "remove", dest: "/root/.red/tmp/feedback/afk-w1-42-fix" },
+    ]);
+    expect(calls.filter((c) => c.op === "install")).toHaveLength(0);
     expect(calls.filter((c) => c.op === "script")).toHaveLength(0);
   });
 


### PR DESCRIPTION
## What a live fleet-of-2 exposed
A worker did **correct** work on #583 (4 focused commits, "1262 tests pass, tsc clean") but the orchestrator parked it **blocked:validation**. The gate's `validation.jsonl` failed every check — `test`/`typecheck`/`build` — all with `Cannot find module '@reddb-io/red-castle'`.

## Two environments, one confusion
- **CI/CD is fine** — `actions/checkout` uses `submodules: recursive` + `pnpm install`, so red-castle is present (the #719 `test` job is green).
- **The AFK feedback gate is different** — it materialises its own checkout with **`git worktree add`** (`feedback-worktree.ts`). A fresh git worktree does **NOT** populate submodules: `packages/red-castle` (the `@reddb-io/red-castle` `workspace:*` SOURCE, ADR 0061) is an **empty dir**. The `pnpm install` that follows can't resolve that workspace dep → every gate check fails → a **false blocked:validation** that stranded the entire PRD #567 fix cluster.

This is **not** the supervisor OOM (#446 — fixed; the gate test ran in 44ms not 42s) and **not** CI.

## Fix
Run `git submodule update --init --recursive` in the worktree **between `worktreeAdd` and `pnpm install`** — the convenience CI's `actions/checkout submodules:recursive` gives for free that a local `git worktree add` does not. Fails closed like the install step (#458/#459 precedent). Lives in the **dev plugin** (`apps/dev/src/runtime/feedback-worktree.ts`); red-castle untouched.

## Validation
- typecheck clean; feedback-worktree (11) + feedback (14) tests green, including a new submodule-init-failure test. Happy-path ordering is now `add → submodule → install → script`.
- Real proof comes once released: re-run a worker on a PRD #567 fix and watch it LAND instead of parking blocked:validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783811860&installation_id=129708444&pr_number=720&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F720&signature=e78cbe47701693e81ae177875b8d879173e8802c14f0931f753e5dca67d1e4c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of submodule initialization during development environment setup
  * Setup now properly fails and cleans up when module initialization encounters errors, preventing partial or incomplete states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->