### PR TITLE
fix(afk): seed attempt state synchronously so the worker's identity survives (monitor/statusline ghost)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -58,7 +58,7 @@ import { makeHookExec, makeHookResolveOptions, hookEnv } from "../runtime/hooks.
 import { makeFeedbackWorktree, type FeedbackWorktree } from "../runtime/feedback-worktree.js";
 import { join } from "node:path";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
-import { initState, updateState } from "../core/state.js";
+import { initStateSync, updateState } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { createActivityMeter } from "../core/activity-meter.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
@@ -1170,23 +1170,36 @@ export async function runCommand(options: RunOptions): Promise<number> {
       // pid + current.{number,stage} and its mtime). Restore it: write the
       // initial state with the live orchestrator pid so the worker shows up;
       // recordAgentEvent advances current.stage, and the processIssue wrapper
-      // marks it not-live (pid:0) on terminal. Best-effort — never blocks work.
+      // marks it not-live (pid:0) on terminal.
+      //
+      // SYNCHRONOUS on purpose: the agent-event sink + heartbeat fire async
+      // `updateState` read-modify-writes against this same path. A fire-and-forget
+      // async seed here raced them — a sink write that read the file before the
+      // seed landed got the schema DEFAULT (pid 0, number "", worker_id ""),
+      // patched only its vitals, and wrote that back, stranding the worker with
+      // vitals but NO identity (rendered as a pid-0 `?`/idle ghost in monitor /
+      // statusline). Seeding synchronously guarantees the identity exists before
+      // any updateState runs, so every later read preserves it.
       const statePath = join(attemptDir, "afk.state.json");
       const startedAt = new Date().toISOString();
-      void initState(statePath, {
-        worker_id: c.workerId,
-        pid: process.pid,
-        runner: c.runner,
-        log: join(attemptDir, "afk.log"),
-        started_at: startedAt,
-        "current.number": candidate.number,
-        "current.title": candidate.title,
-        "current.worktree": join(attemptDir, "worktree"),
-        "current.handoff": join(attemptDir, "handoff.md"),
-        "current.started_at": startedAt,
-        "current.runner": c.runner,
-        "current.stage": "setup",
-      }).catch(() => {});
+      try {
+        initStateSync(statePath, {
+          worker_id: c.workerId,
+          pid: process.pid,
+          runner: c.runner,
+          log: join(attemptDir, "afk.log"),
+          started_at: startedAt,
+          "current.number": candidate.number,
+          "current.title": candidate.title,
+          "current.worktree": join(attemptDir, "worktree"),
+          "current.handoff": join(attemptDir, "handoff.md"),
+          "current.started_at": startedAt,
+          "current.runner": c.runner,
+          "current.stage": "setup",
+        });
+      } catch {
+        // Best-effort — a failed seed must never block the worker's actual work.
+      }
       // Append the --request block into the handoff body so the inner agent
       // (which reads handoff.md as its prompt) sees the special request.
       const body = requestBlock ? `${candidate.body}\n\n${requestBlock}` : candidate.body;

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -1,4 +1,5 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { AfkStateSchema, type AfkState } from "../types/state.js";
 
@@ -68,6 +69,30 @@ export async function initState(path: string, updates: Record<string, unknown> =
   for (const [key, value] of Object.entries(updates)) setDotted(state, key, value);
   const parsed = parseState(state);
   await writeStateAtomic(path, parsed);
+  return parsed;
+}
+
+/**
+ * Synchronous {@link initState}. Use this to seed an attempt's state BEFORE any
+ * async `updateState` can run against the same path. The async `initState` was
+ * fire-and-forget at the attempt-start seam (run.ts buildProcessInput), so a
+ * concurrent `updateState` (the agent-event sink / heartbeat) could read the
+ * not-yet-written file, get the schema DEFAULT (empty identity: pid 0, number
+ * "", worker_id ""), patch only its vitals, and write that back — stranding the
+ * worker with vitals but no identity, so `monitor`/`statusline` rendered it as a
+ * pid-0 `?`/idle ghost. A synchronous seed completes before the sink starts, so
+ * every later read-modify-write preserves the identity.
+ */
+export function initStateSync(path: string, updates: Record<string, unknown> = {}): AfkState {
+  const state = defaultState() as unknown as Record<string, unknown>;
+  state.version = 1;
+  state.envelope = { posted: false };
+  for (const [key, value] of Object.entries(updates)) setDotted(state, key, value);
+  const parsed = parseState(state);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.sync`;
+  writeFileSync(tmp, `${JSON.stringify(AfkStateSchema.parse(parsed))}\n`, "utf8");
+  renameSync(tmp, path);
   return parsed;
 }
 

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import {
   initState,
+  initStateSync,
   isStateActive,
   isStateLive,
   readState,
@@ -32,6 +33,33 @@ describe("state", () => {
     expect(state.envelope.posted).toBe(true);
     expect(state.queue).toEqual([2, 3]);
     expect(await readFile(path, "utf8")).toContain('"version":1');
+  });
+
+  it("initStateSync seeds identity synchronously so a later updateState preserves it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+
+    // Synchronous seed — the file MUST exist with full identity the instant the
+    // call returns (the whole point: it beats the async sink's read-modify-write).
+    const seeded = initStateSync(path, {
+      worker_id: "wL30L",
+      pid: 4242,
+      "current.number": 583,
+      "current.stage": "setup",
+    });
+    expect(seeded.pid).toBe(4242);
+    const onDisk = JSON.parse(await readFile(path, "utf8"));
+    expect(onDisk.worker_id).toBe("wL30L");
+    expect(onDisk.current.number).toBe(583);
+
+    // A subsequent vitals patch must NOT clobber the identity (the bug was the
+    // sink seeding from DEFAULT and stranding the worker with no pid/number).
+    const after = await updateState(path, { "current.cost_usd": 4.01, "current.stage": "tests" });
+    expect(after.pid).toBe(4242);
+    expect(after.worker_id).toBe("wL30L");
+    expect(after.current.number).toBe(583);
+    expect(after.current.cost_usd).toBe(4.01);
+    expect(after.current.stage).toBe("tests");
   });
 
   it("checks liveness via the injected kill -0 predicate", () => {


### PR DESCRIPTION
## What a live fleet exposed
Worker wL30L's #583 attempt state had every **vital** (cost $4.01, loc +151/-21, stage) but **empty identity** — `pid=0`, `worker_id=''`, `current.number=''`, `started_at=''`. So:
- the monitor rendered it as a `? [stale] … idle issues 0/0` ghost,
- the statusline dropped it entirely (the `isStateActive` filter needs a live pid),
- and the $4.01 cost existed on disk but was visible nowhere.

Its sibling #585 attempt was perfectly populated — a **non-deterministic race**.

## Root cause
`buildProcessInput` seeded the attempt state with a **fire-and-forget async `initState`**, while the agent-event sink + heartbeat fire async `updateState` read-modify-writes against the **same path**. When a sink write read the file *before* the seed landed, it got the schema **DEFAULT** (empty identity), patched only its vitals, and wrote that back. Every later read then preserved the empty identity — vitals accrue, identity stays blank.

## Fix
New **`initStateSync`** (synchronous `writeFileSync`+rename) seeds the identity **before any `updateState` can run**, so reads always see pid/number/worker_id. Wrapped best-effort so a seed failure never blocks the worker. One `void initState` → `initStateSync` at the attempt-start seam; red-castle untouched.

This is the single root cause of three reported symptoms: **empty `current.number`**, **`pid=0` during the run**, and the monitor **`? idle` ghost**.

## Validation
- typecheck clean; state tests green incl. a new seed→patch test proving identity survives.

## Note on the '2nd slot' observation
The same fleet run showed wL30L draining #583 **and** #585 sequentially (two attempt dirs, one worker) — not a second concurrent worker. That points to the GitHub search-index propagation lag at boot (the queue read 0-ready right after labeling), so the supervisor spawned for the one visible issue. Operational (wait for propagation before launching) rather than a code defect; to be confirmed on the next fleet run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783812672&installation_id=129708444&pr_number=721&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F721&signature=2536253e87ba31386ddd5d16eec899de258844a6b3cc761b74c31e491ea678cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a race condition where concurrent operations could access the application state before it was fully initialized, potentially resulting in incomplete or missing identity data being persisted. State initialization now completes synchronously before other operations can proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->