### PR TITLE
feat(afk): enable the GHA AFK lane on red-skills (submodule checkout + rs-* self-caller)

### DIFF
--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -218,6 +218,13 @@ jobs:
       - name: Checkout the target repository
         if: steps.trust.outputs.gate == 'pass' || steps.trust.outputs.gate == 'bypass'
         uses: actions/checkout@v4
+        with:
+          # Pull submodules so a repo that vendors one as a workspace dependency
+          # (e.g. red-skills' public `packages/red-castle`, ADR 0061) resolves in
+          # the feedback gate's `pnpm` build. A no-op for adopter repos with no
+          # submodule. actions/checkout rewrites `git@github.com:` submodule URLs
+          # to token-https; a PUBLIC submodule then needs no extra credential.
+          submodules: recursive
 
       # Execution is the repo-portable composite action (ADR 0062): it sets up
       # Node, installs the selected runner CLI, and runs the version-pinned

--- a/.github/workflows/rs-afk-attempt.yml
+++ b/.github/workflows/rs-afk-attempt.yml
@@ -1,0 +1,54 @@
+# rs-afk-attempt — red-skills' OWN caller for the AFK Actions lane.
+#
+# Naming convention (ADR pending): RedSkills ships its reusable workflows under
+# `red-*` (here, the reusable `red-afk-attempt.yml`). A workflow INSTALLED into a
+# target repo to drive that lane is prefixed `rs-*` ("RedSkills-installed in this
+# repo"). This file is red-skills self-hosting its own lane, so it is `rs-*` too.
+#
+# It calls the LOCAL reusable (`./.github/workflows/red-afk-attempt.yml`) — the
+# same one adopters reference as `reddb-io/red-skills/.github/workflows/red-afk-attempt.yml@v1`.
+#
+# Auth: opencode + the org-level `MINIMAX_API_KEY` secret. Model: minimax/MiniMax-M3.
+# Trust gate: only issues authored AND labelled by an allowlisted login run.
+#
+# Runner: the reusable runs on `ubuntu-latest` today. To move execution onto
+# Blacksmith, swap the reusable's `runs-on:` to `blacksmith-2vcpu-ubuntu-2404`
+# once the Blacksmith GitHub App is installed on the org (a one-line change; a
+# Blacksmith label with no app installed leaves the job queued forever).
+
+name: rs-afk-attempt
+
+on:
+  # Manual: process a specific issue from the Actions UI.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to process (e.g. 631)."
+        required: true
+        type: string
+  # Auto: fire when an issue gains the ready-for-agent label.
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  attempt:
+    # Dispatch always runs; the issues event only when the applied label is
+    # exactly ready-for-agent (so other label edits do not spawn attempts).
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' && github.event.label.name == 'ready-for-agent')
+    uses: ./.github/workflows/red-afk-attempt.yml
+    with:
+      issue_number: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number || github.event.issue.number }}
+      runner: opencode
+      model: minimax/MiniMax-M3
+      enforce_trust_gate: "true"
+      allowlist_authors: "filipeforattini"
+      allowlist_label_actors: "filipeforattini"
+    secrets:
+      minimax_api_key: ${{ secrets.MINIMAX_API_KEY }}


### PR DESCRIPTION
## Goal
Make red-skills run its **own** AFK lane from GitHub Actions — the first step toward 'GHA coding for us'. Two changes:

### 1. Recursive submodule checkout in the reusable
`red-afk-attempt.yml` now checks out with **`submodules: recursive`**. red-skills' `apps/dev` imports `@reddb-io/red-castle` (a `workspace:*` git submodule, ADR 0061), so the feedback gate's `pnpm` build needs it. **No-op for adopter repos** (no submodule). 

**No deploy key / PAT needed** — `packages/red-castle` is a **public** repo (verified: an unauthenticated `git ls-remote` reaches it), so the default `GITHUB_TOKEN` clones it; `actions/checkout` rewrites the `git@github.com:` submodule URL to token-https automatically.

### 2. `rs-afk-attempt.yml` — red-skills' own caller (the `rs-*` convention)
Naming convention this PR introduces: our **reusable** workflows ship as **`red-*`** (`red-afk-attempt.yml`); a workflow **INSTALLED into a target repo** to drive the lane is **`rs-*`** ('RedSkills-installed-here'). red-skills self-hosting is `rs-*` too.

- Calls the **local** reusable (`./.github/workflows/red-afk-attempt.yml`).
- **Dispatch** (manual issue number) **+ auto-trigger** on the `ready-for-agent` label.
- opencode + **`minimax/MiniMax-M3`** via the org **`MINIMAX_API_KEY`** secret.
- Trust gate limited to `filipeforattini`.

Runner stays `ubuntu-latest`; the **Blacksmith** swap (`runs-on: blacksmith-2vcpu-ubuntu-2404`) is a one-line follow-up once the Blacksmith GitHub App is installed on the org.

## Follow-up (separate PR)
The full `red-* → rs-*` convention in the skills: `/setup-red-skills` installs adopter workflows renamed to `rs-*` (asking which + configs), `/doctor` audits `rs-*` adoption, `WORKFLOWS.md` documents the split.

## Test plan
After merge: `gh workflow run rs-afk-attempt.yml -f issue_number=<N>` on a small issue → watch opencode code it + open a PR in the cloud (clean, submodule-provisioned env — none of the local-worktree gate holes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783818324&installation_id=129708444&pr_number=722&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F722&signature=5757365bd094987fb9f19103c4de0ba337579520f5283b352e21ec7e77d70caf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflows to enhance repository checkout handling during automated processes.
  * Added new workflow automation to support manual and label-triggered attempt triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->