### PR TITLE
fix(afk): GHA trust gate resolves issue author on dispatch + unpin model from config

### DIFF
--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -162,6 +162,7 @@ jobs:
           ENFORCE_TRUST_GATE: ${{ github.event_name == 'workflow_call' && inputs.enforce_trust_gate || 'true' }}
           ALLOWLIST_AUTHORS: ${{ github.event_name == 'workflow_call' && inputs.allowlist_authors || '' }}
           ALLOWLIST_LABEL_ACTORS: ${{ github.event_name == 'workflow_call' && inputs.allowlist_label_actors || '' }}
+          ISSUE_NUMBER: ${{ steps.resolve.outputs.number }}
         with:
           script: |
             const enforce = (process.env.ENFORCE_TRUST_GATE || 'true').toLowerCase() !== 'false';
@@ -180,12 +181,27 @@ jobs:
             }
 
             const eventName = context.eventName;
-            const issue = context.payload.issue;
-            const sender = context.payload.sender;
-            const author = issue?.user?.login;
+            const sender = context.payload.sender?.login;
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER, 10);
+            // The author is in the payload ONLY for the `issues` event. For
+            // workflow_dispatch / workflow_call there is no payload.issue, so fetch
+            // the issue by its resolved number to read the author — without this a
+            // dispatched run failed the gate with author=undefined.
+            let author;
+            if (eventName === 'issues') {
+              author = context.payload.issue?.user?.login;
+            } else {
+              const { data } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              author = data.user?.login;
+            }
             // issues:opened — the opener is the de-facto label-applier (the issue
-            // was filed pre-labeled), so the sender (== author) is the actor.
-            const labelActor = eventName === 'issues' ? sender?.login : (sender?.login || author);
+            // was filed pre-labeled), so the sender (== author) is the actor. For a
+            // manual dispatch the human who triggered the run is the actor.
+            const labelActor = eventName === 'issues' ? sender : (sender || author);
 
             const authorOk = authors.includes(author);
             const actorOk  = labelActors.includes(labelActor);
@@ -206,7 +222,7 @@ jobs:
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo:  context.repo.repo,
-                  issue_number: parseInt(context.payload.issue.number, 10),
+                  issue_number: issueNumber,
                   body: `🤖 /afk trust gate refused to claim this issue: ${reason}. See #621 for the allowlist predicate.`,
                 });
               } catch (e) {

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -11,14 +11,10 @@
 #       gradle: true              # ship gradle isolation when GRADLE_USER_HOME_BASE is set
 
 # Active dev-plugin settings, all namespaced under `plugins.dev.*` (the root
-# stays sacred). `base` auto-populates every opencode tier (validate/simple/
-# complex/think); specialize one with plugins.dev.afk.models.opencode.<tier>.model.
+# stays sacred). The AFK opencode model is NOT pinned here — the GHA lane sets it
+# (rs-afk-attempt.yml passes `model: minimax/MiniMax-M3` via RED_AFK_MODEL), so
+# the workflow is the single source of truth for the cloud runner's model.
 plugins:
   dev:
     lock:
       primary-branch: true       # primary-checkout branch-switch guard
-    afk:
-      models:
-        opencode:
-          base:
-            model: minimax/MiniMax-M3


### PR DESCRIPTION
Two follow-ups from the first live GHA run of the AFK lane (#722):

## 1. Trust gate failed on the dispatch path
A `workflow_dispatch` run failed the trust gate with **`author=undefined`** (and couldn't post the refusal comment): the gate read the author from `context.payload.issue`, which exists **only for the `issues` event**. On `workflow_dispatch`/`workflow_call` the issue arrives as an input — no `payload.issue`.

Fix: when the event is not `issues`, **fetch the issue by its resolved number** (`steps.resolve.outputs.number` → `ISSUE_NUMBER` env) to read the author; the refusal comment uses the same number. The `issues` path is unchanged.

## 2. Unpin the model from `.red/config.yaml`
`rs-afk-attempt.yml` already passes `model: minimax/MiniMax-M3`. Dropped the duplicate `plugins.dev.afk.models.opencode.base` pin so the **workflow is the single source of truth** for the cloud runner's model (kept `lock.primary-branch`).

After merge: re-dispatch `rs-afk-attempt.yml` on #585 → the gate should pass and opencode should code + open a PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783818725&installation_id=129708444&pr_number=723&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F723&signature=912bec1caf0ef7348a2c6d55967c1cc3cc47d8593377baea6989158f40baadd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated workflow logic for correctly identifying issue authors and actors across different trigger mechanisms.

* **Chores**
  * Refactored configuration to simplify model selection management, now controlled via workflow environment variables rather than inline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->