### PR TITLE
fix(afk): allow the https remote in the CI lane (precheck killed every GHA attempt)

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -77,6 +77,15 @@ export interface PrecheckFacts {
    */
   lockedBranch?: string;
   pnpmInstalled: boolean;
+  /**
+   * Relax the SSH-only remote rule. "Reject https remote" is a LOCAL-dev safety
+   * net (don't drive autonomous runs through a token-in-URL https remote). In a
+   * CI lane (GitHub Actions: `RED_AFK_LANE=actions` / `GITHUB_ACTIONS`),
+   * `actions/checkout` configures an https remote whose auth is the ephemeral
+   * `GITHUB_TOKEN` — exactly the intended setup — so the rule must NOT fire there.
+   * Set by the runtime facts-builder from the environment.
+   */
+  allowHttpsRemote?: boolean;
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and
@@ -95,9 +104,11 @@ export function precheck(facts: PrecheckFacts): PrecheckResult {
   if (!facts.ghInstalled) return { ok: false, failed: "gh-missing" };
   if (!facts.ghAuthenticated) return { ok: false, failed: "gh-unauthenticated" };
   if (!facts.isGitRepo) return { ok: false, failed: "not-a-git-repo" };
-  for (const url of facts.remoteUrls) {
-    if (url.startsWith("https://")) {
-      return { ok: false, failed: "https-remote-forbidden", detail: url };
+  if (!facts.allowHttpsRemote) {
+    for (const url of facts.remoteUrls) {
+      if (url.startsWith("https://")) {
+        return { ok: false, failed: "https-remote-forbidden", detail: url };
+      }
     }
   }
   if (!facts.hasMainBranch) return { ok: false, failed: "no-main-branch" };

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -783,6 +783,10 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     currentBranch,
     lockedBranch,
     pnpmInstalled,
+    // CI lanes (the GHA Actions lane) check out an https remote token-authed by
+    // GITHUB_TOKEN — the intended setup — so the SSH-only rule must not fire there.
+    allowHttpsRemote:
+      process.env.RED_AFK_LANE === "actions" || process.env.GITHUB_ACTIONS === "true",
   };
 }
 

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -66,6 +66,19 @@ describe("precheck", () => {
     });
   });
 
+  it("allows an https remote in a CI lane (allowHttpsRemote) — GHA checkout is token-https", () => {
+    // The Actions lane checks out an https remote authed by GITHUB_TOKEN; the
+    // SSH-only rule must not fire there or every cloud attempt dies at precheck.
+    expect(
+      precheck(
+        facts({
+          remoteUrls: ["https://github.com/reddb-io/red-skills.git"],
+          allowHttpsRemote: true,
+        }),
+      ),
+    ).toEqual({ ok: true, warnings: [] });
+  });
+
   it("fails no-main-branch", () => {
     expect(precheck(facts({ hasMainBranch: false }))).toEqual({
       ok: false,


### PR DESCRIPTION
## The blocker (live GHA run)
The first real GHA run of the AFK lane on #585 got past the trust gate AND the submodule checkout, then died at:
```
[afk] precheck failed: https-remote-forbidden
```
The **SSH-only** hard precondition is a *local-dev* safety net (don't drive autonomous runs through a token-in-URL https remote). But `actions/checkout` configures an **https** remote authed by the ephemeral `GITHUB_TOKEN` — exactly the intended CI setup. So the rule must NOT fire in the lane, or every cloud attempt dies at precheck.

## Fix
New `allowHttpsRemote` fact on `PrecheckFacts`; the runtime facts-builder sets it from `RED_AFK_LANE=actions || GITHUB_ACTIONS=true`; `precheck` skips the https rejection when set. **Local dev unchanged** (those env vars are absent there). Covered with a test.

## Still needed for the lane to fully run (your infra)
The same run also showed `MINIMAX_API_KEY:` **empty** — the **org secret isn't reaching red-skills**. red-skills is a **public** repo, and **org secrets are NOT shared with public repos by default**. Enable **Public repositories** access on the `MINIMAX_API_KEY` org secret (or add it as a repo secret). Then the lane has both halves: a passing precheck (this PR) + a real auth key.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783819247&installation_id=129708444&pr_number=724&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F724&signature=392c19e1a8553b7c6a2950ae8dcde5636e3c202f855e085989e9005d29fa73e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTPS remote URLs in CI/GitHub Actions environments through optional configuration flag.

* **Bug Fixes**
  * HTTPS remotes are now automatically allowed when running in GitHub Actions or CI pipelines, removing the previous blanket rejection.

* **Tests**
  * Added test coverage for HTTPS remote validation in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->