### PR TITLE
feat(afk): Blacksmith runner for rs-* + Closes #N auto-close on AFK PRs

### DIFF
--- a/.github/actions/afk-attempt/action.yml
+++ b/.github/actions/afk-attempt/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: "opencode"
   model:
-    description: "Override the model for every tier (e.g. minimax/MiniMax-M2). Empty = .red/config.yaml / defaults. Maps to RED_AFK_MODEL."
+    description: "Override the model for every tier (e.g. minimax/MiniMax-M3). Empty = .red/config.yaml / defaults. Maps to RED_AFK_MODEL."
     required: false
     default: ""
   effort:

--- a/.github/workflows/red-afk-attempt.yml
+++ b/.github/workflows/red-afk-attempt.yml
@@ -55,7 +55,7 @@ on:
         type: string
         default: "opencode"
       model:
-        description: "Override the model for every tier (e.g. minimax/MiniMax-M2). Empty = read from `.red/config.yaml` / defaults. Maps to RED_AFK_MODEL."
+        description: "Override the model for every tier (e.g. minimax/MiniMax-M3). Empty = read from `.red/config.yaml` / defaults. Maps to RED_AFK_MODEL."
         required: false
         type: string
         default: ""
@@ -64,6 +64,11 @@ on:
         required: false
         type: string
         default: ""
+      runs_on:
+        description: "Runner label for the attempt job. Default ubuntu-latest (GitHub-hosted). Set e.g. blacksmith-2vcpu-ubuntu-2404 to run on Blacksmith (the GitHub App must be installed on the org, else the job queues forever)."
+        required: false
+        type: string
+        default: "ubuntu-latest"
       allowlist_authors:
         description: "CSV of GitHub logins allowed as issue author."
         required: true
@@ -104,10 +109,15 @@ on:
         type: string
         default: "opencode"
       model:
-        description: "Override the model for every tier (e.g. minimax/MiniMax-M2). Empty = config."
+        description: "Override the model for every tier (e.g. minimax/MiniMax-M3). Empty = config."
         required: false
         type: string
         default: ""
+      runs_on:
+        description: "Runner label for the attempt job (e.g. ubuntu-latest or blacksmith-2vcpu-ubuntu-2404)."
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
   # NOTE: the `issues: [labeled, opened]` auto-trigger was intentionally removed —
   # the lane is dispatch/call-only until auth secrets are configured (see the job
@@ -128,7 +138,7 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'workflow_call')
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on || 'ubuntu-latest' }}
     # Resolve the runner once for every step. issues:* events have no host
     # session, so they always use opencode (the API-auth runner, ADR 0059).
     env:

--- a/.github/workflows/rs-afk-attempt.yml
+++ b/.github/workflows/rs-afk-attempt.yml
@@ -11,10 +11,11 @@
 # Auth: opencode + the org-level `MINIMAX_API_KEY` secret. Model: minimax/MiniMax-M3.
 # Trust gate: only issues authored AND labelled by an allowlisted login run.
 #
-# Runner: the reusable runs on `ubuntu-latest` today. To move execution onto
-# Blacksmith, swap the reusable's `runs-on:` to `blacksmith-2vcpu-ubuntu-2404`
-# once the Blacksmith GitHub App is installed on the org (a one-line change; a
-# Blacksmith label with no app installed leaves the job queued forever).
+# Runner: Blacksmith. We pass `runs_on: blacksmith-2vcpu-ubuntu-2404` (the
+# smallest Blacksmith tier — there is no "nano"; 2vcpu is the floor) to the
+# reusable, which exposes a `runs_on` input defaulting to `ubuntu-latest` for
+# adopters without Blacksmith. The Blacksmith GitHub App is installed on the org;
+# without it a Blacksmith label leaves the job queued forever.
 
 name: rs-afk-attempt
 
@@ -47,6 +48,7 @@ jobs:
       issue_number: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_number || github.event.issue.number }}
       runner: opencode
       model: minimax/MiniMax-M3
+      runs_on: blacksmith-2vcpu-ubuntu-2404
       enforce_trust_gate: "true"
       allowlist_authors: "filipeforattini"
       allowlist_label_actors: "filipeforattini"

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -318,7 +318,11 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
       "--title",
       `merge: #${n} ${title}`,
       "--body",
-      `${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the \`afk-attempts/*\` snapshot branches.`,
+      // `Closes #${n}` links the PR to the issue and lets GitHub auto-close it
+      // when the PR is merged into the default branch — the lane where a human
+      // merges the PR (GitHub Actions / no admin-merge). The admin-merge path
+      // also closes the issue itself; both are idempotent.
+      `${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the \`afk-attempts/*\` snapshot branches.\n\nCloses #${n}`,
     ]);
     if (create.code !== 0) return { ok: false };
     prNumber = await listOpenPr(exec, repo, branch, target);

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -104,8 +104,26 @@ back to a hard-coded maintainer allowlist.)
 | `model` | ✓ | ✓ | override every tier, e.g. `minimax/MiniMax-M3` (empty = repo config) |
 | `effort` | ✓ | ✓ | reasoning effort/variant override |
 | `lanes` | ✓ | ✓ | execution-lane tag (`actions`\|`k8s`), surfaced as `RED_AFK_LANE` for observability; default `actions` |
+| `runs_on` | — | ✓ | runner label for the attempt job; default `ubuntu-latest`. Set e.g. `blacksmith-2vcpu-ubuntu-2404` to run on Blacksmith (see below). Composable path: set the job's own `runs-on:` directly. |
 | `*-api-key` secrets | ✓ (inputs) | ✓ (secrets) | the auth keys — passed as **action inputs** (composite actions can't read `secrets.*`) |
 | `allowlist_*`, `enforce_trust_gate` | — | ✓ | trust gate (policy layer) |
+
+## Runner host — GitHub-hosted or Blacksmith
+
+The attempt job runs on `ubuntu-latest` (GitHub-hosted) by default. To run it on
+[Blacksmith](https://blacksmith.sh) managed runners — a drop-in, faster, cheaper
+host — pass the `runs_on` input the matching label:
+
+```yaml
+with:
+  runs_on: blacksmith-2vcpu-ubuntu-2404   # smallest Blacksmith tier
+```
+
+`blacksmith-2vcpu-ubuntu-2404` is the **smallest** Blacksmith shape — there is no
+"nano"; 2 vCPU is the floor (other shapes: `-4vcpu-`, `-8vcpu-`, …). The
+**Blacksmith GitHub App must be installed on the org/repo** first — a Blacksmith
+label with no app installed leaves the job **queued forever**. red-skills' own
+`rs-afk-attempt.yml` caller runs on `blacksmith-2vcpu-ubuntu-2404`.
 
 ## Runner + auth
 
@@ -168,11 +186,19 @@ the runner plus `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`. The CI default is
 identity, and `--once`. Required permissions: exactly `contents: write`,
 `issues: write`, `pull-requests: write` — no `id-token`, no `actions: write`.
 
+## Issue ↔ PR link (auto-close on merge)
+
+The PR body carries `Closes #<issue>`, so GitHub links the PR to the issue and
+**auto-closes the issue when the PR is merged** into the default branch — the
+human just merges, no separate close step. (The local admin-merge lane closes the
+issue itself; both are idempotent.)
+
 ## What it does NOT do
 
-No fleet, no admin-merge, no auto-merge — the human merges the PR. It also does
-not yet claim atomically against a concurrently-running local fleet (#622), and
-the config-sourced allowlist predicate is pending (#621).
+No fleet, no admin-merge, no auto-merge — the human merges the PR (merging
+auto-closes the linked issue, above). It also does not yet claim atomically
+against a concurrently-running local fleet (#622), and the config-sourced
+allowlist predicate is pending (#621).
 
 ## See also
 


### PR DESCRIPTION
## What

Two AFK Actions-lane improvements, packaged together.

### 1. Run the lane on Blacksmith
- The reusable `red-afk-attempt.yml` gains a **`runs_on`** input (default `ubuntu-latest`, so **adopters are unchanged**); `runs-on:` resolves `${{ inputs.runs_on || 'ubuntu-latest' }}`.
- red-skills' own `rs-afk-attempt.yml` caller passes **`runs_on: blacksmith-2vcpu-ubuntu-2404`** — the **smallest** Blacksmith tier (there is no "nano"; 2 vCPU is the floor). The Blacksmith GitHub App is installed on the org.

### 2. Auto-close the issue when the PR merges (issue ↔ PR link)
- The AFK PR body (`merge.ts` `landPr`) now carries **`Closes #N`**, so a human-merged GHA-lane PR **auto-closes the linked issue** natively. `/ship` already did this; the local admin-merge path closes the issue itself — both idempotent.

### Also
- `MiniMax-M2` → `M3` in the reusable + composite-action input descriptions.
- Docs in `actions-lane.md`: `runs_on` input row, a "Runner host — GitHub-hosted or Blacksmith" section, and an "Issue ↔ PR link (auto-close on merge)" section.

## Notes
- No test asserts the AFK PR body, so the `Closes #N` append is safe; the CI `test` job covers `merge.ts`.
- Both workflow files YAML-validated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783822277&installation_id=129708444&pr_number=726&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F726&signature=37d807a948f8b96876321f4a3952cc5a88846227d37e03b118b07ce82731b015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom runner selection via new `runs_on` parameter in workflows.
  * PRs now automatically close linked issues when merged.

* **Documentation**
  * Updated workflow and action documentation to reflect model references and runner configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->