### PR TITLE
feat(afk-lane): dispatch with no issue auto-picks the oldest ready-for-agent

### DIFF
--- a/.github/workflows/red-skills-afk-attempt.yml
+++ b/.github/workflows/red-skills-afk-attempt.yml
@@ -20,13 +20,15 @@
 name: red-skills-afk-attempt
 
 on:
-  # Manual: process a specific issue from the Actions UI.
+  # Manual: process a specific issue from the Actions UI, OR leave it empty to
+  # auto-pick the oldest open ready-for-agent issue.
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to process (e.g. 631)."
-        required: true
+        description: "Issue number to process (e.g. 631). Leave EMPTY to auto-pick the oldest open ready-for-agent issue."
+        required: false
         type: string
+        default: ""
   # Auto: fire when an issue gains the ready-for-agent label.
   issues:
     types: [labeled]

--- a/.github/workflows/reusable-afk-attempt.yml
+++ b/.github/workflows/reusable-afk-attempt.yml
@@ -45,7 +45,7 @@ on:
   workflow_call:
     inputs:
       issue_number:
-        description: "Issue number to process. Empty string = no-op."
+        description: "Issue number to process. Empty = auto-pick the oldest open ready-for-agent issue (no-op if none)."
         required: false
         type: string
         default: ""
@@ -100,9 +100,10 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to process (e.g. 631)."
-        required: true
+        description: "Issue number to process (e.g. 631). Leave EMPTY to auto-pick the oldest open ready-for-agent issue."
+        required: false
         type: string
+        default: ""
       runner:
         description: "AFK runner to drive (claude|codex|opencode)."
         required: false
@@ -152,12 +153,36 @@ jobs:
             const eventName = context.eventName;
             let issueNumber = '';
             if (eventName === 'workflow_dispatch') {
-              issueNumber = context.payload.inputs.issue_number;
+              issueNumber = context.payload.inputs.issue_number || '';
             } else if (eventName === 'workflow_call') {
               issueNumber = context.payload.inputs.issue_number || context.payload.issue_number || '';
             } else if (eventName === 'issues') {
               issueNumber = String(context.payload.issue.number);
             }
+
+            // Auto-pick: a dispatch / call with no issue number drains the queue
+            // head — the OLDEST open `ready-for-agent` issue (PRs excluded). No
+            // such issue ⇒ a clean no-op (empty output; downstream steps skip).
+            if (!issueNumber && (eventName === 'workflow_dispatch' || eventName === 'workflow_call')) {
+              const candidates = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'ready-for-agent',
+                sort: 'created',
+                direction: 'asc',
+                per_page: 100,
+              });
+              const oldest = candidates.find(i => !i.pull_request);
+              if (!oldest) {
+                core.info('auto-pick: no open ready-for-agent issue — nothing to do');
+                core.setOutput('number', '');
+                return;
+              }
+              issueNumber = String(oldest.number);
+              core.info(`auto-pick: oldest open ready-for-agent issue is #${issueNumber}`);
+            }
+
             if (!/^[0-9]+$/.test(issueNumber)) {
               core.setFailed(`invalid issue number: ${JSON.stringify(issueNumber)}`);
               return;
@@ -167,6 +192,7 @@ jobs:
 
       - name: Evaluate the trust gate
         id: trust
+        if: steps.resolve.outputs.number != ''
         uses: actions/github-script@v7
         env:
           ENFORCE_TRUST_GATE: ${{ github.event_name == 'workflow_call' && inputs.enforce_trust_gate || 'true' }}

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -80,7 +80,7 @@ jobs:
 ## Triggers (reusable workflow)
 
 1. `workflow_call` — a thin caller in your repo.
-2. `workflow_dispatch` — manual run from the Actions UI (`issue_number` input).
+2. `workflow_dispatch` — manual run from the Actions UI. Pass an `issue_number`, **or leave it empty to auto-pick the oldest open `ready-for-agent` issue** (the queue head). If the queue is empty the run is a clean no-op.
 3. `issues: labeled` — fires when **`ready-for-agent`** is applied.
 4. `issues: opened` — fires when an issue is **created already carrying**
    `ready-for-agent` (a pre-delegated issue). Raw label-less issues are NOT run
@@ -99,7 +99,7 @@ back to a hard-coded maintainer allowlist.)
 
 | Input | Action | Reusable | Notes |
 |---|---|---|---|
-| `issue` / `issue_number` | ✓ | ✓ | required |
+| `issue` / `issue_number` | ✓ | ✓ | the reusable accepts it **empty** on `workflow_dispatch`/`workflow_call` → auto-picks the oldest open `ready-for-agent` issue (no-op if none); the composite action needs an explicit number |
 | `runner` | ✓ | ✓ | `claude` \| `codex` \| `opencode` (CI default `opencode`) |
 | `model` | ✓ | ✓ | override every tier, e.g. `minimax/MiniMax-M3` (empty = repo config) |
 | `effort` | ✓ | ✓ | reasoning effort/variant override |

--- a/plugins/dev/skills/engineering/afk/examples/red-skills-afk-attempt.yml
+++ b/plugins/dev/skills/engineering/afk/examples/red-skills-afk-attempt.yml
@@ -49,9 +49,10 @@ on:
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "Issue number to process (e.g. 631)."
-        required: true
+        description: "Issue number to process (e.g. 631). Leave EMPTY to auto-pick the oldest open ready-for-agent issue."
+        required: false
         type: string
+        default: ""
 
 permissions:
   contents: write


### PR DESCRIPTION
## What

You can now **dispatch the AFK lane with no issue number** — hit *Run workflow*, leave `issue_number` empty, and it grabs the **oldest open `ready-for-agent` issue** (the queue head) and runs it. If the queue is empty, the run is a **clean no-op**.

## How

The reusable's "Resolve the issue number" step (github-script) now, when `issue_number` is empty on `workflow_dispatch` / `workflow_call`, queries `issues.listForRepo({ labels: 'ready-for-agent', state: 'open', sort: 'created', direction: 'asc' })`, skips PRs, and takes the first. No match → empty output + the trust gate and downstream steps skip (`if: steps.resolve.outputs.number != ''`).

## Changes
- **`reusable-afk-attempt.yml`** — `issue_number` optional on dispatch; auto-pick logic; trust gate gated on a non-empty resolved number.
- **`red-skills-afk-attempt.yml`** (our caller) + **example caller** — dispatch `issue_number` now optional (empty = auto-pick).
- **`actions-lane.md`** — documented on the dispatch trigger + the Inputs row.

## Notes
- Workflow-only; no runtime change.
- The trust gate still runs on the auto-picked issue (author from the issue, label-actor = the dispatcher).
- `#622` (atomic server-side claim) will later prevent racing a concurrent local fleet; until then the runtime's own claim handles dedup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783823896&installation_id=129708444&pr_number=728&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F728&signature=4340c8ee1f5f151e9a3e548d533d54e31d37037874cedc28fe786a92adbc9305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows now support making the issue number input optional, with smart auto-selection of the oldest open ready-for-agent issue when left empty.
  * Improved handling when no suitable issue is available, resulting in clean no-op behavior.

* **Documentation**
  * Updated workflow documentation and examples to clarify the new auto-selection behavior and optional input requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->