### PR TITLE
feat(afk): trust gate — executable-issue check over author × label-actor × allowlist (#621)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -475,6 +475,10 @@ export function buildProcessDeps(
       close: (issue) => ghx.closeIssue(ghCtx, issue),
       listByLabel: (label) => ghx.listByLabel(ghCtx, label),
       issueClosed: (n) => ghx.issueClosed(ghCtx, n),
+      // Trust-gate provenance (#621): author + ready-for-agent label actor, read
+      // from the issue timeline. Consulted at claim time only when an allowlist
+      // is configured (plugins.dev.afk.trust-gate.allowlist).
+      issueTrust: (issue) => ghx.issueTrust(ghCtx, issue),
     },
     claimGh: {
       // ADR 0066: the atomic GitHub-native claim arbiter. Numeric comment ids

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -70,6 +70,7 @@ import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sw
 import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
 import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
 import { parseCurrentBlocker, upsertCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
+import { parseTrustPolicy, evaluateTrustGate, type TrustProvenance } from "./trust-gate.js";
 import type { AfkModelTier, ConfigValues } from "./config.js";
 import {
   buildIssueClassificationMetadata,
@@ -104,6 +105,14 @@ export interface ProcessGh {
   /** Resolve whether issue `n` is CLOSED. Resolves the cascade's per-dependency
    * `req:*` closed-states. A 404 / transient failure resolves to false. */
   issueClosed(n: number): Promise<boolean>;
+  /**
+   * Trust-gate provenance (#621, ADR 0056): the issue author + the actor who
+   * applied `ready-for-agent`, read from the issue TIMELINE — never inferred from
+   * the mutable label set. Consulted at claim time ONLY when an allowlist is
+   * configured. Optional → absent callers/tests degrade to permissive (the gate
+   * never fires), preserving today's behaviour.
+   */
+  issueTrust?(issue: number): Promise<TrustProvenance>;
 }
 
 /** Claim-lock side effects (the local mkdir lock at .red/tmp/claims/{N}/). */
@@ -600,6 +609,31 @@ export async function processIssue(
       preserved: false,
       swept: false,
     };
+  }
+
+  // ---- trust gate (#621, ADR 0056) ----
+  // The "executable issue" predicate, evaluated BEFORE the promotion-to-running
+  // edit and before ANY worktree/handoff work: an issue is executable only when
+  // its author is a trusted identity AND `ready-for-agent` was applied by an
+  // allowlisted actor. Provenance is read from the issue TIMELINE + author field
+  // (deps.gh.issueTrust), never inferred from the mutable label set. When no
+  // allowlist is configured the policy is permissive (enabled:false) and this is
+  // a no-op — today's single-maintainer behaviour, preserved exactly. A refusal
+  // releases the claim and abandons the attempt (claim-lost) with a clear log
+  // line; the session loop then skips to the next candidate. The stripping of the
+  // non-allowlisted `ready-for-agent` itself is the sweep's job (planTrustStrip),
+  // not the claim's.
+  const trustPolicy = parseTrustPolicy(deps.hooks.config);
+  if (trustPolicy.enabled && deps.gh.issueTrust) {
+    const provenance = await deps.gh.issueTrust(issue);
+    const verdict = evaluateTrustGate(trustPolicy, provenance);
+    if (!verdict.executable) {
+      deps.appendIterLog(
+        `🤖 /afk trust gate refused #${issue}: ${verdict.reason} — not claimed; no worktree/handoff materialised.`,
+      );
+      await deps.claimLock.release(issue);
+      return claimLost(issue, hooksFired);
+    }
   }
 
   // Project the `running` label, shedding any stale `blocked:*` reason in the same

--- a/apps/dev/src/core/trust-gate.ts
+++ b/apps/dev/src/core/trust-gate.ts
@@ -1,0 +1,150 @@
+// trust-gate — the AFK "executable issue" trust gate (ADR 0056, issue #621).
+//
+// A PURE predicate over three inputs resolved at claim time:
+//   - the issue AUTHOR (the `gh issue view --json author` login),
+//   - the ACTOR who applied `ready-for-agent` (read from the issue TIMELINE —
+//     never inferred from the mutable label set),
+//   - the per-repo ALLOWLIST from plugin config (`plugins.dev.afk.trust-gate.*`,
+//     folded to the bare `afk.trust-gate.*` accessor per ADR 0042).
+//
+// An issue is EXECUTABLE only when BOTH hold:
+//   1. the author is a trusted identity (in the allowlist), AND
+//   2. `ready-for-agent` was applied by an allowlisted actor (in the allowlist).
+//
+// When no allowlist is configured the gate is PERMISSIVE — it returns executable
+// for everything, preserving today's single-maintainer behaviour EXACTLY.
+// Configuring the allowlist switches the repo to strict mode. A `ready-for-agent`
+// applied by a non-allowlisted actor (an automation bot, an untrusted reporter)
+// is ignored by selection/claim and may be stripped by a sweep with an audit
+// comment (`planTrustStrip`).
+//
+// IO-free: the runtime resolves the provenance (author + label actor) through gh
+// and passes it in; this module only DECIDES.
+
+import type { ConfigValues } from "./config.js";
+import { getConfig } from "./config.js";
+
+/** The accessor key the allowlist lives under (folded from
+ * `plugins.dev.afk.trust-gate.allowlist`, ADR 0042). Intentionally NOT in
+ * `CONFIG_DEFAULTS`: its default is *unset* (absent → permissive), and a "" entry
+ * there would break the "every default is non-empty" invariant — same treatment
+ * as `dev.lock.branch`. */
+export const TRUST_ALLOWLIST_KEY = "afk.trust-gate.allowlist";
+
+/** The parsed per-repo trust policy. `enabled` is DERIVED: the gate is active
+ * only when the allowlist is non-empty (absent config → permissive). */
+export interface TrustPolicy {
+  /** True when an allowlist is configured (strict mode). */
+  enabled: boolean;
+  /** The set of trusted GitHub logins — both the author AND the label actor are
+   * checked against this single list. */
+  allowlist: readonly string[];
+}
+
+/** Provenance resolved from gh at claim time. Either field may be undefined when
+ * the gh read failed or the timeline carried no `labeled` event for the label. */
+export interface TrustProvenance {
+  /** Issue author login (`gh issue view --json author`). */
+  author?: string;
+  /** Login of the actor who applied `ready-for-agent`, read from the timeline. */
+  readyForAgentActor?: string;
+}
+
+/** The gate verdict. `reason` is set only when NOT executable (for the log line
+ * and the sweep's audit comment). */
+export interface TrustVerdict {
+  executable: boolean;
+  reason?: string;
+}
+
+/** Parse a comma / whitespace / newline-separated login list into a trimmed,
+ * de-duped set. A leading `@` (how logins are often written in issues) is dropped
+ * so `@alice` and `alice` collapse to one entry. */
+function parseLogins(raw: string): string[] {
+  const seen = new Set<string>();
+  for (const part of raw.split(/[,\s]+/)) {
+    const login = part.trim().replace(/^@/, "");
+    if (login) seen.add(login);
+  }
+  return [...seen];
+}
+
+/**
+ * Read the trust policy from the loaded config map. An empty / absent allowlist
+ * yields `enabled:false` → permissive (today's behaviour).
+ */
+export function parseTrustPolicy(values: ConfigValues): TrustPolicy {
+  const allowlist = parseLogins(getConfig(values, TRUST_ALLOWLIST_KEY));
+  return { enabled: allowlist.length > 0, allowlist };
+}
+
+/**
+ * The pure gate predicate. PERMISSIVE when the policy is disabled (no allowlist);
+ * otherwise BOTH the author and the label actor must be in the allowlist. The
+ * author is checked first, so a trusted author promoted by an automation/untrusted
+ * actor is reported against the actor, and an untrusted author against the author.
+ */
+export function evaluateTrustGate(policy: TrustPolicy, provenance: TrustProvenance): TrustVerdict {
+  if (!policy.enabled) return { executable: true };
+
+  const allow = new Set(policy.allowlist);
+  const author = (provenance.author ?? "").trim();
+  const actor = (provenance.readyForAgentActor ?? "").trim();
+
+  if (!author || !allow.has(author)) {
+    return {
+      executable: false,
+      reason: `untrusted author ${author ? `'${author}'` : "(unknown)"} — not in the trust-gate allowlist`,
+    };
+  }
+  if (!actor || !allow.has(actor)) {
+    return {
+      executable: false,
+      reason: `ready-for-agent applied by ${actor ? `'${actor}'` : "an unknown actor"} — not in the trust-gate allowlist`,
+    };
+  }
+  return { executable: true };
+}
+
+/** A `ready-for-agent` candidate the strip sweep examines: its number + the
+ * provenance resolved from gh. */
+export interface TrustSweepCandidate {
+  number: number;
+  provenance: TrustProvenance;
+}
+
+/** A planned strip: remove `ready-for-agent` from `number` and post `comment`. */
+export interface TrustStripPlan {
+  number: number;
+  reason: string;
+  /** The audit comment body explaining the strip. */
+  comment: string;
+}
+
+/**
+ * Plan the trust-gate STRIP sweep. For each candidate whose provenance fails the
+ * gate, emit a plan to remove `ready-for-agent` and post an audit comment. A
+ * no-op (empty plan) when the policy is permissive — a repo with no allowlist
+ * never strips anything, preserving today's behaviour. PURE: the caller applies
+ * the label edit + comment through gh.
+ */
+export function planTrustStrip(
+  policy: TrustPolicy,
+  candidates: readonly TrustSweepCandidate[],
+): TrustStripPlan[] {
+  if (!policy.enabled) return [];
+  const plans: TrustStripPlan[] = [];
+  for (const c of candidates) {
+    const verdict = evaluateTrustGate(policy, c.provenance);
+    if (verdict.executable) continue;
+    const reason = verdict.reason ?? "not an executable issue";
+    plans.push({
+      number: c.number,
+      reason,
+      comment:
+        `🤖 /afk trust gate: stripped \`ready-for-agent\` — ${reason}. ` +
+        `Re-author this through triage (a maintainer must re-create or promote it) to make it executable.`,
+    });
+  }
+  return plans;
+}

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -685,6 +685,72 @@ async function listIssuesByLabel(ctx: GhContext, label: string): Promise<Reconci
   }
 }
 
+/**
+ * Trust-gate provenance for one issue (#621, ADR 0056): the author login + the
+ * actor who applied `ready-for-agent`, read from the issue TIMELINE (never
+ * inferred from the mutable label set). Two best-effort gh reads:
+ *   - `gh issue view --json author` → author login;
+ *   - `gh api repos/{owner}/{repo}/issues/{n}/timeline` → the LAST `labeled`
+ *     event for `ready-for-agent`, whose `actor.login` is the promoter.
+ * The `{owner}`/`{repo}` placeholders resolve from the current repo, so an empty
+ * `ctx.repo` (worker's own checkout) still works. Either field is `undefined`
+ * when its read fails — the gate treats unknown provenance as untrusted.
+ */
+export async function issueTrust(
+  ctx: GhContext,
+  issue: number,
+): Promise<{ author?: string; readyForAgentActor?: string }> {
+  const [author, actor] = await Promise.all([
+    issueAuthorLogin(ctx, issue),
+    readyForAgentActor(ctx, issue),
+  ]);
+  return { author, readyForAgentActor: actor };
+}
+
+/** `gh issue view --json author` → the author login, or undefined on failure. */
+async function issueAuthorLogin(ctx: GhContext, issue: number): Promise<string | undefined> {
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "author"]);
+  if (r.code !== 0) return undefined;
+  try {
+    const login = (JSON.parse(r.stdout) as { author?: { login?: string } }).author?.login;
+    return login ? String(login) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the login of the actor who applied `ready-for-agent` from the issue
+ * timeline (REST `…/issues/{n}/timeline`). Returns the MOST RECENT `labeled`
+ * event for the label — a re-applied label reflects the latest promoter.
+ * undefined when the read fails or no such event exists. */
+async function readyForAgentActor(ctx: GhContext, issue: number): Promise<string | undefined> {
+  const r = await runGh(ctx, [
+    "api",
+    `repos/{owner}/{repo}/issues/${issue}/timeline`,
+    "--paginate",
+    "-H",
+    "Accept: application/vnd.github+json",
+  ]);
+  if (r.code !== 0) return undefined;
+  try {
+    // `--paginate` concatenates pages; tolerate either one array or several.
+    const text = r.stdout.trim();
+    const events = text.startsWith("[")
+      ? (JSON.parse(text) as unknown[])
+      : (JSON.parse(`[${text.replace(/\]\s*\[/g, ",")}]`) as unknown[]);
+    let actor: string | undefined;
+    for (const ev of events) {
+      const e = ev as { event?: string; label?: { name?: string }; actor?: { login?: string } };
+      if (e.event === "labeled" && e.label?.name === LABEL_READY && e.actor?.login) {
+        actor = String(e.actor.login); // keep the last (most recent) match
+      }
+    }
+    return actor;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Branch-cleanup IssueLookup payload: gh issue view --json state,closedAt.
  * Returns null for a definitive 404, undefined for a transient failure. */
 export async function issueMeta(ctx: GhContext, issue: number): Promise<IssueMeta | null | undefined> {

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -68,6 +68,9 @@ interface HarnessOptions {
   backpressureOk?: boolean;
   locked?: boolean;
   config?: ConfigValues;
+  /** Trust-gate provenance (#621) returned by gh.issueTrust. When set, the port
+   * is registered; absent → no port (gate never fires). */
+  trust?: { author?: string; readyForAgentActor?: string };
   abortHook?: HookName;
   /** FIX J: when set, a pre_worktree hook command emits this env as the mutated
    * context's `{env:{…}}` slice — proving it threads onto the runAgent input. */
@@ -186,6 +189,9 @@ function harness(opts: HarnessOptions = {}): {
       async issueClosed(n) {
         return (opts.closedIssues ?? []).includes(n);
       },
+      // Trust-gate provenance port (#621): registered only when the test opts in,
+      // so legacy-shaped tests omit it and the gate never fires (permissive).
+      issueTrust: opts.trust ? async () => opts.trust! : undefined,
     },
     claimGh: opts.claim
       ? {
@@ -1116,6 +1122,63 @@ describe("processIssue — goal predicate (ADR 0057)", () => {
     const { deps, input, trace } = harness({ outcome: "goal-moot", branchMerged: false });
     await processIssue(deps, input);
     expect(typeof trace.runAgentCalls[0]?.goalProbe).toBe("function");
+  });
+});
+
+describe("processIssue — trust gate (#621)", () => {
+  const ALLOW: ConfigValues = { "afk.trust-gate.allowlist": "alice,bob" };
+
+  it("refuses a non-executable issue BEFORE any claim edit / worktree, with a clear log line", async () => {
+    const { deps, input, trace } = harness({
+      config: ALLOW,
+      trust: { author: "stranger", readyForAgentActor: "alice" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    // No promotion edit, no agent spawn — refused before any work.
+    expect(trace.labelEdits).toEqual([]);
+    expect(trace.runAgentCalls).toEqual([]);
+    // Claim lock released so the slot is not leaked.
+    expect(trace.released).toEqual([9]);
+    // A clear, attributable log line names the gate + the reason.
+    expect(trace.iterLogs.some((l) => /trust gate refused #9.*untrusted author 'stranger'/.test(l))).toBe(true);
+  });
+
+  it("refuses when ready-for-agent was applied by a non-allowlisted actor", async () => {
+    const { deps, input, trace } = harness({
+      config: ALLOW,
+      trust: { author: "alice", readyForAgentActor: "github-actions[bot]" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    expect(trace.runAgentCalls).toEqual([]);
+    expect(trace.iterLogs.some((l) => /trust gate refused.*github-actions\[bot\]/.test(l))).toBe(true);
+  });
+
+  it("claims normally when author AND label actor are both allowlisted", async () => {
+    const { deps, input, trace } = harness({
+      config: ALLOW,
+      outcome: "done",
+      feedbackOk: true,
+      trust: { author: "alice", readyForAgentActor: "bob" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    // The promotion-to-running claim edit ran (the gate passed).
+    expect(trace.labelEdits[0]!.add).toEqual(["running"]);
+    expect(trace.runAgentCalls).toHaveLength(1);
+  });
+
+  it("is permissive when no allowlist is configured — the gate never fires even with an untrusted author", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      trust: { author: "stranger", readyForAgentActor: "anybody" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.iterLogs.some((l) => /trust gate/.test(l))).toBe(false);
   });
 });
 

--- a/apps/dev/tests/trust-gate.test.ts
+++ b/apps/dev/tests/trust-gate.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseTrustPolicy,
+  evaluateTrustGate,
+  planTrustStrip,
+  TRUST_ALLOWLIST_KEY,
+  type TrustPolicy,
+  type TrustProvenance,
+} from "../src/core/trust-gate.js";
+import type { ConfigValues } from "../src/core/config.js";
+
+// trust-gate is the PURE "executable issue" predicate (ADR 0056, #621). The
+// acceptance criterion is an exhaustive matrix over
+//   author (trusted / untrusted)
+//     × label-actor (allowlisted / non-allowlisted / automation)
+//       × config (present / absent).
+
+const ALLOW = ["alice", "bob"];
+const policy: TrustPolicy = { enabled: true, allowlist: ALLOW };
+const permissive: TrustPolicy = { enabled: false, allowlist: [] };
+
+function prov(author?: string, actor?: string): TrustProvenance {
+  return { author, readyForAgentActor: actor };
+}
+
+describe("parseTrustPolicy", () => {
+  it("is permissive (disabled) when the allowlist key is absent", () => {
+    const p = parseTrustPolicy({} as ConfigValues);
+    expect(p.enabled).toBe(false);
+    expect(p.allowlist).toEqual([]);
+  });
+
+  it("is permissive when the allowlist value is empty/whitespace", () => {
+    expect(parseTrustPolicy({ [TRUST_ALLOWLIST_KEY]: "   " }).enabled).toBe(false);
+  });
+
+  it("parses a comma-separated allowlist into a trimmed, @-stripped, de-duped set", () => {
+    const p = parseTrustPolicy({ [TRUST_ALLOWLIST_KEY]: " alice, @bob ,alice,  " });
+    expect(p.enabled).toBe(true);
+    expect(p.allowlist).toEqual(["alice", "bob"]);
+  });
+
+  it("accepts whitespace/newline separators too", () => {
+    const p = parseTrustPolicy({ [TRUST_ALLOWLIST_KEY]: "alice\nbob carol" });
+    expect(p.allowlist).toEqual(["alice", "bob", "carol"]);
+  });
+});
+
+describe("evaluateTrustGate — absent config (permissive)", () => {
+  it("executes everything, even an unknown author + unknown actor", () => {
+    expect(evaluateTrustGate(permissive, prov(undefined, undefined)).executable).toBe(true);
+    expect(evaluateTrustGate(permissive, prov("stranger", "github-actions[bot]")).executable).toBe(true);
+  });
+});
+
+describe("evaluateTrustGate — strict mode matrix", () => {
+  it("trusted author + allowlisted actor → executable", () => {
+    expect(evaluateTrustGate(policy, prov("alice", "bob")).executable).toBe(true);
+  });
+
+  it("untrusted author + allowlisted actor → blocked (on the author)", () => {
+    const v = evaluateTrustGate(policy, prov("stranger", "alice"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("untrusted author 'stranger'");
+  });
+
+  it("trusted author + non-allowlisted actor → blocked (on the actor)", () => {
+    const v = evaluateTrustGate(policy, prov("alice", "stranger"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("applied by 'stranger'");
+  });
+
+  it("trusted author + AUTOMATION actor (bot, not in allowlist) → blocked", () => {
+    const v = evaluateTrustGate(policy, prov("alice", "github-actions[bot]"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("github-actions[bot]");
+  });
+
+  it("untrusted author + non-allowlisted actor → blocked (author reported first)", () => {
+    const v = evaluateTrustGate(policy, prov("stranger", "intruder"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("untrusted author");
+  });
+
+  it("unknown author (gh read failed) → blocked", () => {
+    const v = evaluateTrustGate(policy, prov(undefined, "alice"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("(unknown)");
+  });
+
+  it("trusted author + unknown actor (no labeled event found) → blocked", () => {
+    const v = evaluateTrustGate(policy, prov("alice", undefined));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("unknown actor");
+  });
+});
+
+describe("planTrustStrip", () => {
+  it("is a no-op under a permissive policy (no allowlist → strips nothing)", () => {
+    const plans = planTrustStrip(permissive, [{ number: 1, provenance: prov("stranger", "bot") }]);
+    expect(plans).toEqual([]);
+  });
+
+  it("strips only the non-executable candidates and emits an audit comment", () => {
+    const plans = planTrustStrip(policy, [
+      { number: 10, provenance: prov("alice", "bob") }, // executable → kept
+      { number: 11, provenance: prov("stranger", "bob") }, // untrusted author → strip
+      { number: 12, provenance: prov("alice", "github-actions[bot]") }, // bot actor → strip
+    ]);
+    expect(plans.map((p) => p.number)).toEqual([11, 12]);
+    expect(plans[0]!.comment).toContain("stripped `ready-for-agent`");
+    expect(plans[0]!.comment).toContain("Re-author");
+    expect(plans[0]!.comment).toContain("untrusted author 'stranger'");
+  });
+});

--- a/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
+++ b/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
@@ -48,6 +48,17 @@
 #     defaults:
 #       cargo: true               # ship cargo isolation on Rust projects
 #       gradle: true              # ship gradle isolation when GRADLE_USER_HOME_BASE is set
+#   trust-gate:                   # "executable issue" trust gate (#621, ADR 0056)
+#     allowlist: alice,bob        # comma/space-separated GitHub logins. An issue is
+#                                 # executable only when its AUTHOR is in this list AND
+#                                 # `ready-for-agent` was applied by a listed actor
+#                                 # (read from the issue timeline, not the label set).
+#                                 # ABSENT/empty (the default) → PERMISSIVE: the gate
+#                                 # never fires and every ready-for-agent issue is
+#                                 # claimable, exactly as today. Setting it switches the
+#                                 # repo to STRICT mode; a ready-for-agent applied by a
+#                                 # non-listed actor is skipped at claim and may be
+#                                 # stripped by a sweep with an audit comment.
 
 # dev:
 #   lock:


### PR DESCRIPTION
Closes #621

## Summary

- `core/trust-gate.ts` — pure IO-free predicate: `parseTrustPolicy` (absent allowlist → permissive), `evaluateTrustGate` (author AND label-actor must both be allowlisted), `planTrustStrip` (sweep with audit comment)
- `core/process-issue.ts` — claim-time enforcement before any worktree/handoff; no-op when permissive
- `runtime/gh.ts` — `issueTrust` reads author + `ready-for-agent` label actor from the issue timeline
- `commands/run.ts` — wires `issueTrust` into the per-issue claim deps
- `tests/trust-gate.test.ts` + `tests/process-issue.test.ts` — full author × actor × allowlist matrix, claim-path refusal, permissive-default
- `config-template.yaml` — documents `afk.trust-gate.allowlist` (absent = permissive)

Rebased cleanly onto current `origin/main` (resolving the `process-issue.ts` conflict against the ADR 0066 atomic-claim architecture). 1447/1447 tests pass, tsc clean.

> Branch pointer fix: inner agent rebased correctly inside sandcastle worktree; the outer AFK live branch pointer (`afk/wWH31/621-...`) was never updated, causing the feedback gate to run on the stale pre-rebase branch. This PR is off the properly rebased snapshot (`afk-attempts/wWH31/621-...`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783869023&installation_id=129708444&pr_number=734&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F734&signature=2215959ca89324ad73a66d2969b5299f50e4c74739786daeb36d6f2f7adbaaa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added executable issue trust gate: when configured with an allowlist of GitHub logins, only issues authored by and promoted to `ready-for-agent` by allowlisted users will be claimed and executed. Without configuration, all issues are allowed (permissive mode).

* **Configuration**
  * Added trust gate allowlist configuration option in setup templates to enable strict issue execution policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->