### PR TITLE
feat(afk): monitor renders parked slots — parked:N and per-slot TTY detail

### DIFF
--- a/apps/dev/src/core/monitor.ts
+++ b/apps/dev/src/core/monitor.ts
@@ -57,6 +57,19 @@ export interface CompactWorker {
   diffRemoved?: number;
 }
 
+/** Per-slot visibility record for a non-closed supervisor slot, sourced from the
+ * supervisor-published state file (never from the supervisor log). Closed slots
+ * are omitted; only the slots needing operator attention carry a record. */
+export interface SlotDetail {
+  index: number;
+  /** "open" = circuit tripped, awaiting half-open cooldown
+   *  "half-open" = probe worker spawned, awaiting success/failure verdict
+   *  "idle-parked" = clean drain with empty queue; auto-unparks on next work */
+  status: "open" | "half-open" | "idle-parked";
+  /** Epoch seconds when the half-open probe is scheduled (open slots only). */
+  retryAt?: number;
+}
+
 export interface FleetState {
   ts: string;
   epoch: number;
@@ -74,6 +87,9 @@ export interface FleetState {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  /** Per-slot details for non-closed slots. Absent/empty = all slots closed.
+   * Absent on state files written before this field was added (#630). */
+  slotDetails?: SlotDetail[];
 }
 
 export const FLEET_STALE_AFTER_S = 180;
@@ -110,7 +126,7 @@ export function renderFleetLine(fleet: FleetState, now: number): string {
   return (
     `fleet [${status}] last ticked ${formatElapsed(age)} ago` +
     `  ready:${fleet.readyForAgent}` +
-    `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree}` +
+    `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}` +
     `  spawns:${fleet.spawnsThisTick}`
   );
 }
@@ -177,6 +193,33 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
   return `${workerId} [${tag}] ${runner}  issues ${done}/${total}${flags}${cur}`;
 }
 
+/**
+ * Renders per-slot detail lines for any non-closed slot in the fleet.
+ * Returns one line per non-closed slot:
+ *   open      → "  slot N open  retry in HH:MM:SS"
+ *   half-open → "  slot N half-open  (probing)"
+ *   idle-parked → "  slot N idle-parked  (queue empty)"
+ * Returns an empty array when all slots are closed or slotDetails is absent.
+ * `now` is epoch seconds.
+ */
+export function renderSlotDetails(fleet: FleetState, now: number): string[] {
+  if (!fleet.slotDetails || fleet.slotDetails.length === 0) return [];
+  return fleet.slotDetails.map((d) => {
+    if (d.status === "half-open") {
+      return `  slot ${d.index} half-open  (probing)`;
+    }
+    if (d.status === "idle-parked") {
+      return `  slot ${d.index} idle-parked  (queue empty)`;
+    }
+    // open: show next retry countdown
+    if (d.retryAt !== undefined) {
+      const waitS = Math.max(0, d.retryAt - now);
+      return `  slot ${d.index} open  retry in ${formatElapsed(waitS)}`;
+    }
+    return `  slot ${d.index} open`;
+  });
+}
+
 /** Stable sort key — the worker-process start, oldest first (the bash glob is
  * lexical over the worker dirs; we order by started_at for determinism). */
 function startedAtKey(worker: CompactWorker): string {
@@ -205,7 +248,16 @@ export function renderCompactDashboard(
     removed += w.diffRemoved ?? 0;
   }
   const header = `${buildSparkline(events, now).line}   Δ fleet ${formatDiff(added, removed)}`;
-  const prefix = fleet ? `${header}\n${renderFleetLine(fleet, now)}` : header;
+  let prefix: string;
+  if (fleet) {
+    const fleetLine = renderFleetLine(fleet, now);
+    const details = renderSlotDetails(fleet, now);
+    prefix = details.length > 0
+      ? `${header}\n${fleetLine}\n${details.join("\n")}`
+      : `${header}\n${fleetLine}`;
+  } else {
+    prefix = header;
+  }
   if (workers.length === 0) {
     return `${prefix}\nworkers: (none — /afk not running here)`;
   }

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -460,6 +460,20 @@ export interface SupervisorGh {
   findReconcileCandidate?(): Promise<ReconcileCandidate | null>;
 }
 
+/** Per-slot visibility record for non-closed slots in the heartbeat.
+ * Closed slots (pid running, not parked) are omitted — only non-closed slots
+ * carry a record so the monitor can show per-slot state without parsing logs. */
+export interface HeartbeatSlotDetail {
+  index: number;
+  /** "open" = circuit tripped, awaiting cooldown before next probe
+   *  "half-open" = probe worker spawned, waiting for its verdict
+   *  "idle-parked" = clean drain with empty queue; auto-unparks on next work */
+  status: "open" | "half-open" | "idle-parked";
+  /** Epoch when the half-open probe is scheduled (open slots only). Absent for
+   * half-open (already probing) and idle-parked (no scheduled retry). */
+  retryAt?: number;
+}
+
 export interface FleetHeartbeat {
   /** ISO-8601 timestamp for the supervisor tick. */
   ts: string;
@@ -482,6 +496,8 @@ export interface FleetHeartbeat {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  /** Per-slot details for non-closed slots. Empty array when all slots are closed. */
+  slotDetails: HeartbeatSlotDetail[];
 }
 
 /** The slot's current iteration, resolved from the filesystem. Mirrors the
@@ -726,11 +742,34 @@ function isoFromEpoch(epoch: number): string {
   return new Date(epoch * 1000).toISOString();
 }
 
+function buildSlotDetails(
+  state: SupervisorState,
+  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS">,
+): HeartbeatSlotDetail[] {
+  const details: HeartbeatSlotDetail[] = [];
+  for (let i = 0; i < state.slots.length; i++) {
+    const slot = state.slots[i]!;
+    if (slot.idleParked) {
+      details.push({ index: i, status: "idle-parked" });
+    } else if (slot.parked && slot.halfOpen) {
+      details.push({ index: i, status: "half-open" });
+    } else if (slot.parked) {
+      const retryAt =
+        slot.tripEpoch > 0
+          ? slot.tripEpoch + computeHalfOpenBackoff(slot.backoffStep, config)
+          : undefined;
+      details.push({ index: i, status: "open", ...(retryAt !== undefined ? { retryAt } : {}) });
+    }
+  }
+  return details;
+}
+
 async function emitFleetHeartbeat(
   state: SupervisorState,
   deps: SupervisorDeps,
   result: TickResult,
   runner: string,
+  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS">,
 ): Promise<FleetHeartbeat> {
   // Queue depth was fetched once by superviseTick at the start of this tick
   // and stored in result.queueDepth — reuse it here so there is exactly one
@@ -745,6 +784,7 @@ async function emitFleetHeartbeat(
     readyForAgent,
     ...fleetSlotCounts(state),
     spawnsThisTick: result.respawned.length,
+    slotDetails: buildSlotDetails(state, config),
   };
   try {
     await deps.emitFleetHeartbeat?.(heartbeat);
@@ -1309,7 +1349,7 @@ export async function runSupervisor(
     if (!result.abandoned) {
       state.lastProgressEpoch = deps.now();
     }
-    const heartbeat = await emitFleetHeartbeat(state, deps, result, config.runner);
+    const heartbeat = await emitFleetHeartbeat(state, deps, result, config.runner, config);
     deps.log?.(
       `tick: slots=${state.slots.length} respawned=${result.respawned.length} ` +
         `deaths=${result.deaths.length} parked=${result.parked.length} idle-parked=${result.idleParked.length} ` +

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -328,7 +328,7 @@ export function makeRunAgent(
 
 // ---------- monitor inputs ----------
 
-import type { CompactWorker, FleetState } from "../core/monitor.js";
+import type { CompactWorker, FleetState, SlotDetail } from "../core/monitor.js";
 import { parseState, isStateLive, isStateActive } from "../core/state.js";
 import type { WorkerVitals } from "../types/state.js";
 import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
@@ -338,6 +338,8 @@ export interface MonitorInputs {
   events: Array<Pick<HistoryRecord, "event" | "epoch">>;
   fleet: FleetState | null;
 }
+
+const SLOT_STATUSES = new Set<SlotDetail["status"]>(["open", "half-open", "idle-parked"]);
 
 function parseFleetState(raw: unknown): FleetState | null {
   if (raw === null || typeof raw !== "object") return null;
@@ -349,10 +351,28 @@ function parseFleetState(raw: unknown): FleetState | null {
     ready_for_agent?: unknown;
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
     spawns_this_tick?: unknown;
+    slot_details?: unknown;
   };
   const epoch = Number(rec.epoch ?? 0);
   if (!Number.isFinite(epoch) || epoch <= 0) return null;
   const rawProgress = Number(rec.last_progress_epoch ?? 0);
+
+  let slotDetails: SlotDetail[] | undefined;
+  if (Array.isArray(rec.slot_details)) {
+    slotDetails = [];
+    for (const d of rec.slot_details as unknown[]) {
+      if (d === null || typeof d !== "object") continue;
+      const entry = d as { index?: unknown; status?: unknown; retry_at?: unknown };
+      const idx = Number(entry.index ?? -1);
+      if (!Number.isFinite(idx) || idx < 0) continue;
+      const status = entry.status;
+      if (typeof status !== "string" || !SLOT_STATUSES.has(status as SlotDetail["status"])) continue;
+      const rawRetry = entry.retry_at !== undefined ? Number(entry.retry_at) : undefined;
+      const retryAt = rawRetry !== undefined && Number.isFinite(rawRetry) ? rawRetry : undefined;
+      slotDetails.push({ index: idx, status: status as SlotDetail["status"], ...(retryAt !== undefined ? { retryAt } : {}) });
+    }
+  }
+
   return {
     ts: typeof rec.ts === "string" ? rec.ts : "",
     epoch,
@@ -364,6 +384,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     slotsTotal: Number(rec.slots?.total ?? 0) || 0,
     slotsParked: Number(rec.slots?.parked ?? 0) || 0,
     spawnsThisTick: Number(rec.spawns_this_tick ?? 0) || 0,
+    ...(slotDetails !== undefined ? { slotDetails } : {}),
   };
 }
 

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   renderCompactDashboard,
   renderFleetLine,
+  renderSlotDetails,
   renderWorkerCompactLine,
   type FleetState,
   type CompactWorker,
@@ -230,7 +231,7 @@ describe("monitor — compact dashboard", () => {
   it("surfaces a healthy idle fleet last-tick line", () => {
     const out = renderCompactDashboard([], events, 1780138815, baseFleet());
     expect(out.split("\n")[1]).toBe(
-      "fleet [idle] last ticked 00:00:15 ago  ready:0  slots busy:0 free:2  spawns:0",
+      "fleet [idle] last ticked 00:00:15 ago  ready:0  slots busy:0 free:2 parked:0  spawns:0",
     );
   });
 
@@ -239,13 +240,74 @@ describe("monitor — compact dashboard", () => {
     expect(line).toContain("fleet [wedged]");
     expect(line).toContain("last ticked 00:03:21 ago");
     expect(line).toContain("ready:7");
+    expect(line).toContain("parked:0");
   });
 
   it("shows a non-stale fleet with queued or busy work as draining", () => {
     const line = renderFleetLine(baseFleet({ readyForAgent: 7, slotsBusy: 1, slotsFree: 1, spawnsThisTick: 1 }), 1780138815);
     expect(line).toBe(
-      "fleet [draining] last ticked 00:00:15 ago  ready:7  slots busy:1 free:1  spawns:1",
+      "fleet [draining] last ticked 00:00:15 ago  ready:7  slots busy:1 free:1 parked:0  spawns:1",
     );
+  });
+
+  it("carries parked:N unconditionally — zero when all slots closed", () => {
+    const line = renderFleetLine(baseFleet(), 1780138815);
+    expect(line).toContain("parked:0");
+  });
+
+  it("carries parked:2 for a degraded fleet with two tripped slots", () => {
+    const line = renderFleetLine(
+      baseFleet({ slotsBusy: 1, slotsFree: 0, slotsTotal: 3, slotsParked: 2 }),
+      1780138815,
+    );
+    expect(line).toContain("parked:2");
+  });
+
+  it("renders per-slot state for an open (circuit-tripped) slot with retry countdown", () => {
+    const fleet = baseFleet({
+      slotsParked: 1,
+      slotDetails: [{ index: 1, status: "open", retryAt: 1780138815 + 83 }],
+    });
+    const lines = renderSlotDetails(fleet, 1780138815);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe("  slot 1 open  retry in 00:01:23");
+  });
+
+  it("renders per-slot state for a half-open slot (probe running)", () => {
+    const fleet = baseFleet({
+      slotsParked: 1,
+      slotDetails: [{ index: 0, status: "half-open" }],
+    });
+    const lines = renderSlotDetails(fleet, 1780138815);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe("  slot 0 half-open  (probing)");
+  });
+
+  it("renders per-slot state for an idle-parked slot", () => {
+    const fleet = baseFleet({
+      slotsParked: 1,
+      slotDetails: [{ index: 2, status: "idle-parked" }],
+    });
+    const lines = renderSlotDetails(fleet, 1780138815);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe("  slot 2 idle-parked  (queue empty)");
+  });
+
+  it("returns no slot-detail lines when all slots are closed", () => {
+    expect(renderSlotDetails(baseFleet(), 1780138815)).toHaveLength(0);
+    expect(renderSlotDetails(baseFleet({ slotDetails: [] }), 1780138815)).toHaveLength(0);
+  });
+
+  it("compact dashboard includes slot details after the fleet line when slots are parked", () => {
+    const fleet = baseFleet({
+      slotsParked: 1,
+      slotDetails: [{ index: 0, status: "open", retryAt: 1780138815 + 60 }],
+    });
+    const out = renderCompactDashboard([], events, 1780138815, fleet);
+    const lines = out.split("\n");
+    const fleetIdx = lines.findIndex((l) => l.startsWith("fleet "));
+    expect(fleetIdx).toBeGreaterThanOrEqual(0);
+    expect(lines[fleetIdx + 1]).toBe("  slot 0 open  retry in 00:01:00");
   });
 });
 


### PR DESCRIPTION
Closes #630

## Summary

- `supervisor.ts`: Added `HeartbeatSlotDetail` type + `slotDetails` field to `FleetHeartbeat`; `buildSlotDetails()` computes per-slot state (open/half-open/idle-parked with `retryAt` epoch for open slots); passes `config` to `emitFleetHeartbeat`
- `monitor.ts`: Added `SlotDetail` interface; `renderFleetLine` now includes `parked:N` unconditionally; new `renderSlotDetails()` renders one line per non-closed slot (open→retry countdown, half-open→probing, idle-parked→queue empty); `renderCompactDashboard` appends slot detail lines after the fleet line
- `wire.ts`: `parseFleetState` parses the new `slot_details` array from the supervisor heartbeat JSON, never the log
- `tests/monitor.test.ts`: Updated two exact-match fleet line snapshots for `parked:N`; added 9 new tests

## Test plan

- [ ] pnpm -C apps/dev test — 1458 tests pass
- [ ] pnpm typecheck — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783870776&installation_id=129708444&pr_number=735&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F735&signature=21faece898510e7d15c50376e30b96115739014ae358e16438fc81d0fbb6744c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced dashboard now displays per-slot visibility details for supervisor slots, including individual status (open, half-open, idle-parked) and retry countdown information.
* Fleet status line now includes parked slot count for improved monitoring clarity.
* Detailed slot-level information is propagated through fleet heartbeat telemetry for comprehensive observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->