### PR TITLE
feat(afk): cross-host stale-claim recovery — a dead worker's claim no longer blocks the queue

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -64,6 +64,8 @@ import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat
 import { createActivityMeter } from "../core/activity-meter.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
 import type { AgentStreamEvent } from "../core/execution.js";
+import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../core/claim-staleness.js";
+import { renderClaimComment } from "../core/claim.js";
 
 export interface RunOptions {
   args: string[];
@@ -492,7 +494,24 @@ export function buildProcessDeps(
           // best-effort: a failed concede ages out via the staleness predicate.
         }
       },
+      // One human-visible audit comment when we recover a stale cross-host claim
+      // (#627). Best-effort: a failed audit never abandons the won claim.
+      audit: async (issue, body) => {
+        try {
+          await ghx.comment(ghCtx, issue, body);
+        } catch {
+          // best-effort observability; the claim is already won.
+        }
+      },
     },
+    // Cross-host stale-claim recovery (#627, ADR 0066): a claim whose owner
+    // stopped refreshing past `cadence × (tolerance + 1)` is presumed dead and
+    // released by this sweep. The clock is sampled once per issue at deps build;
+    // the policy comes from RED_AFK_CLAIM_REFRESH_S / RED_AFK_CLAIM_STALE_TOLERANCE.
+    claimStale: makeStaleClaimPredicate(
+      Math.floor(Date.now() / 1000),
+      resolveClaimStalenessConfig(process.env),
+    ),
     claimLock: {
       // Atomic POSIX mkdir lock (#434): a non-recursive mkdir that fails EEXIST,
       // so two simultaneous boots cannot both claim the same issue. The prior

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -41,6 +41,12 @@ import {
   type ReconcileSweepCandidate,
   type ReconcileSweepPlan,
 } from "./boot-sweep.js";
+import {
+  planStaleClaimSweep,
+  renderStaleClaimSweepAudit,
+  resolveClaimStalenessConfig,
+  type ClaimedIssue,
+} from "./claim-staleness.js";
 import { LABEL_READY, LABEL_RUNNING, LABEL_HUMAN, LABEL_DEPENDENCY } from "./triage-labels.js";
 
 // ---------- precheck (hard preconditions) ----------
@@ -179,6 +185,12 @@ export interface BootLookups {
    * a claim-race loser's debris dir can never clobber the live winner's
    * `running` label back to ready-for-agent. */
   claimHolderAlive?: (issue: number) => Promise<boolean>;
+  /** Cross-host stale-claim sweep input (#627): every currently-claimed issue
+   * (projected `running`) with its parsed claim marker records. Optional: absent
+   * → the sweep is a no-op (the same-host orphan sweep still covers local dead
+   * workers). When present, `runBoot` releases any issue held only by a claim
+   * whose owner stopped refreshing past the staleness window, cross-host. */
+  claimedIssues?: () => Promise<ClaimedIssue[]>;
 }
 
 /** Outcome of one boot reconcile run — a coarser view of `ReconcileResult`
@@ -322,6 +334,12 @@ export interface StragglerResult {
   warn: boolean;
 }
 
+export interface StaleClaimSweepResult {
+  /** Issues released back to the executable pool because their cross-host owner
+   * stopped refreshing past the staleness window. */
+  released: number[];
+}
+
 export interface ReconcileSweepResult {
   /** Issues successfully validated-green and landed without re-running the agent. */
   landed: number[];
@@ -340,6 +358,7 @@ export interface BootResult {
   attemptCap?: AttemptCapResult;
   branchCleanup?: BranchCleanupResult;
   unblockSweep?: UnblockSweepResult;
+  staleClaimSweep?: StaleClaimSweepResult;
   reconcileSweep?: ReconcileSweepResult;
   straggler?: StragglerResult;
 }
@@ -360,6 +379,9 @@ export interface BootResult {
  *   5. branch cleanup       — planAttemptSnapshotCleanup, planLiveBranchCleanup,
  *                             planLocalBranchCleanup; delete reaped refs (git).
  *   6. unblock sweep        — planUnblockSweep; edit labels + audit comment (gh).
+ *   6a. stale-claim sweep   — planStaleClaimSweep; release each issue held only by
+ *                             a cross-host claim that stopped refreshing (#627).
+ *                             No-op when `claimedIssues` is absent.
  *   7. reconcile sweep      — planReconcileSweep; validate-and-land each owned
  *                             parked-mechanical branch without re-running the agent
  *                             (ADR 0055). No-op when reconcileRunner is absent.
@@ -410,6 +432,9 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   // ---- 6. unblock sweep ----
   const unblockSweep = await runUnblockSweep(deps, options.unblockCandidates);
 
+  // ---- 6a. cross-host stale-claim sweep (#627) ----
+  const staleClaimSweep = await runStaleClaimSweep(deps);
+
   // ---- 7. reconcile sweep (ADR 0055) ----
   const reconcileSweep = await runReconcileSweep(deps, options);
 
@@ -423,9 +448,43 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
     attemptCap,
     branchCleanup,
     unblockSweep,
+    staleClaimSweep,
     reconcileSweep,
     straggler,
   };
+}
+
+/** Step 6a: cross-host stale-claim sweep (#627). List the currently-claimed
+ * issues + their claim markers, plan a release for any held ONLY by a claim
+ * whose owner stopped refreshing past the staleness window, and apply it: strip
+ * `running`, restore `ready-for-agent`, and post one audit comment. A no-op when
+ * `claimedIssues` is not wired (the same-host orphan sweep still covers local
+ * dead workers). A live-but-slow worker is never released — the planner only
+ * releases an issue with no live claim. Sequenced AFTER the unblock sweep and
+ * BEFORE the reconcile sweep so a freshly-released issue rejoins the executable
+ * pool for the next drain. */
+async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult> {
+  if (!deps.lookups.claimedIssues) return { released: [] };
+  let claimed: ClaimedIssue[];
+  try {
+    claimed = await deps.lookups.claimedIssues();
+  } catch {
+    // Best-effort: a failed listing skips the sweep this boot, never aborting it.
+    return { released: [] };
+  }
+  const config = resolveClaimStalenessConfig(deps.env ?? process.env);
+  const plans = planStaleClaimSweep(claimed, deps.nowS, config);
+  const released: number[] = [];
+  for (const p of plans) {
+    try {
+      await deps.gh.editLabels(p.issue, [LABEL_RUNNING], [LABEL_READY]);
+      await deps.gh.comment(p.issue, renderStaleClaimSweepAudit(p.staleOwners));
+      released.push(p.issue);
+    } catch {
+      // Best-effort: a failed release leaves the issue for the next boot's sweep.
+    }
+  }
+  return { released };
 }
 
 /** Step 3: decideOrphanFate per dir, then apply the fate via gh + fs. Mirrors

--- a/apps/dev/src/core/claim-staleness.ts
+++ b/apps/dev/src/core/claim-staleness.ts
@@ -1,0 +1,271 @@
+// Cross-host stale-claim recovery: the PURE classification function (claim
+// record + clock → fresh | stale) that drives the claim reconciler's injected
+// `isStale` predicate (core/claim.ts, ADR 0066, issue #627, PRD #614).
+//
+// The atomic GitHub-native claim substrate already arbitrates a single winner
+// across hosts via server-ordered claim comments, and leaves liveness as a pure
+// injection point (`reconcileClaim(records, self, { isStale })`). This module is
+// that injected fact: it decides whether a claim record's owner has stopped
+// refreshing long enough to be presumed dead — WITHOUT any I/O. The reconciler
+// then drops stale contenders before the first-claim-wins ordering, so a claim
+// held by a worker that died on another machine is released by ANY other
+// worker's sweep, no human hunting required.
+//
+// A live worker keeps its claim fresh by re-posting its claim marker on a
+// cadence (the substrate already orders by EARLIEST claim id and reads staleness
+// off the LATEST marker, so a refresh never improves the worker's queue position
+// but does reset its liveness clock). The staleness WINDOW is deliberately a
+// generous multiple of that refresh cadence — `cadence × (tolerance + 1)` — so a
+// live-but-slow worker that merely missed a few refreshes is NEVER robbed; only a
+// worker silent past the whole window is reclaimed.
+//
+// Everything here is pure with an injected clock (`nowS`, epoch seconds), so the
+// classification is unit-testable without a real clock or network.
+
+import type { ClaimRecord } from "./claim.js";
+
+/** Default seconds between a live worker's claim refreshes. Coarser than the
+ * heartbeat (60s) so refresh re-posts do not flood the issue thread, yet far
+ * tighter than any realistic attempt duration. */
+export const DEFAULT_CLAIM_REFRESH_S = 300;
+
+/** Default count of consecutive missed refreshes tolerated before a claim is
+ * presumed stale. The window then spans `cadence × (tolerance + 1)` so a worker
+ * can miss this many refreshes (transient gh failure, GC pause, slow step) and
+ * still hold its claim. */
+export const DEFAULT_CLAIM_STALE_TOLERANCE = 3;
+
+/** Staleness policy: the refresh cadence a live worker is expected to keep, and
+ * how many consecutive missed refreshes are tolerated before the claim is stale. */
+export interface ClaimStalenessConfig {
+  /** Seconds between a live worker's claim refreshes. */
+  refreshCadenceS: number;
+  /** Consecutive missed refreshes tolerated before the claim is presumed stale. */
+  tolerance: number;
+}
+
+export const DEFAULT_CLAIM_STALENESS: ClaimStalenessConfig = {
+  refreshCadenceS: DEFAULT_CLAIM_REFRESH_S,
+  tolerance: DEFAULT_CLAIM_STALE_TOLERANCE,
+};
+
+export type ClaimFreshness = "fresh" | "stale";
+
+/**
+ * The staleness window in seconds — the maximum age a claim record may reach
+ * before its owner is presumed dead. `cadence × (tolerance + 1)`: at cadence the
+ * worker refreshes once, so toleration of N missed refreshes means surviving up
+ * to (N+1) cadences of silence. Comfortably exceeds the refresh cadence by
+ * construction, which is what keeps a live-but-slow worker from being robbed.
+ */
+export function staleWindowS(config: ClaimStalenessConfig = DEFAULT_CLAIM_STALENESS): number {
+  return config.refreshCadenceS * (config.tolerance + 1);
+}
+
+/** Parse a claim record's ISO timestamp to epoch seconds, or null when absent /
+ * unparseable. A null age means "unknown" and is treated as FRESH downstream —
+ * the conservative choice that never robs a claim whose age we cannot establish. */
+function recordEpochS(record: ClaimRecord): number | null {
+  if (!record.createdAt) return null;
+  const ms = Date.parse(record.createdAt);
+  if (Number.isNaN(ms)) return null;
+  return Math.floor(ms / 1000);
+}
+
+/**
+ * Classify a single claim record against an injected clock. PURE — the entire
+ * point of issue #627's testable acceptance criterion.
+ *
+ *   - No / unparseable timestamp        → fresh (never rob an unknown-age claim)
+ *   - timestamp in the future (skew)    → fresh
+ *   - age ≤ staleWindowS                → fresh
+ *   - age >  staleWindowS               → stale (owner presumed dead, recoverable)
+ *
+ * @param nowS injected current epoch seconds.
+ */
+export function classifyClaim(
+  record: ClaimRecord,
+  nowS: number,
+  config: ClaimStalenessConfig = DEFAULT_CLAIM_STALENESS,
+): ClaimFreshness {
+  const ts = recordEpochS(record);
+  if (ts === null) return "fresh";
+  const ageS = nowS - ts;
+  if (ageS <= staleWindowS(config)) return "fresh";
+  return "stale";
+}
+
+/**
+ * Build the `isStale` predicate the claim reconciler injects. Binds the injected
+ * clock + policy once and returns `record → boolean`, returning true only for a
+ * record classified `stale`. This is the single seam between the pure classifier
+ * and `reconcileClaim(records, self, { isStale })`.
+ */
+export function makeStaleClaimPredicate(
+  nowS: number,
+  config: ClaimStalenessConfig = DEFAULT_CLAIM_STALENESS,
+): (record: ClaimRecord) => boolean {
+  return (record) => classifyClaim(record, nowS, config) === "stale";
+}
+
+// ---------- cross-host stale-claim sweep (pure planner) ----------
+//
+// The claim-time `isStale` injection only re-examines a claim when a worker
+// SELECTS the issue to claim it. A worker that died on another host leaves its
+// issue projected as `running` (out of the ready pool), so no other worker ever
+// re-selects it — the claim would strand forever. This planner closes that gap:
+// it sweeps the currently-claimed issues directly, classifies each issue's claim,
+// and plans a release for any issue held ONLY by a stale (dead-owner) claim. The
+// boot orchestrator applies the plan — restore `ready-for-agent`, strip
+// `running`, post one audit comment — returning the issue to the executable pool.
+
+/** The folded claim state of a single issue. */
+export interface IssueClaimState {
+  /** The live winning worker — the earliest non-conceded, non-stale claim — or
+   * null when no live claim holds the issue. */
+  liveOwner: string | null;
+  /** Active (non-conceded) claimants whose LATEST marker classified stale. */
+  staleOwners: string[];
+}
+
+/**
+ * Fold an issue's claim records into its live owner + stale owners (pure). A
+ * worker's latest marker decides whether it still contends (a `concede` withdraws
+ * it); its earliest `claim` id is its order key. The live owner is the lowest
+ * order key among contenders the predicate deems fresh; stale contenders are
+ * reported separately so the sweep can audit exactly who it released.
+ */
+export function classifyIssueClaims(
+  records: readonly ClaimRecord[],
+  isStale: (record: ClaimRecord) => boolean,
+): IssueClaimState {
+  interface Fold {
+    earliestClaimId: number | null;
+    latestId: number;
+    latestKind: "claim" | "concede";
+    latestRecord: ClaimRecord;
+  }
+  const folds = new Map<string, Fold>();
+  for (const r of records) {
+    if (!Number.isFinite(r.commentId) || r.worker === "") continue;
+    const f = folds.get(r.worker);
+    if (f === undefined) {
+      folds.set(r.worker, {
+        earliestClaimId: r.kind === "claim" ? r.commentId : null,
+        latestId: r.commentId,
+        latestKind: r.kind,
+        latestRecord: r,
+      });
+      continue;
+    }
+    if (r.kind === "claim" && (f.earliestClaimId === null || r.commentId < f.earliestClaimId)) {
+      f.earliestClaimId = r.commentId;
+    }
+    if (r.commentId >= f.latestId) {
+      f.latestId = r.commentId;
+      f.latestKind = r.kind;
+      f.latestRecord = r;
+    }
+  }
+
+  let liveOwner: string | null = null;
+  let liveOwnerId = Infinity;
+  const staleOwners: string[] = [];
+  for (const [worker, f] of folds) {
+    if (f.latestKind === "concede") continue; // withdrew
+    if (f.earliestClaimId === null) continue; // only ever conceded — not a claim
+    if (isStale(f.latestRecord)) {
+      staleOwners.push(worker);
+      continue;
+    }
+    if (f.earliestClaimId < liveOwnerId) {
+      liveOwnerId = f.earliestClaimId;
+      liveOwner = worker;
+    }
+  }
+  staleOwners.sort();
+  return { liveOwner, staleOwners };
+}
+
+/** One claimed issue handed to the sweep: the issue number + its parsed claim
+ * marker records (from `parseClaimRecords`). */
+export interface ClaimedIssue {
+  issue: number;
+  records: readonly ClaimRecord[];
+}
+
+/** A planned release: the issue to return to the executable pool + the stale
+ * owners whose dead claim it recovered (for the audit comment). */
+export interface StaleClaimRelease {
+  issue: number;
+  staleOwners: string[];
+}
+
+/** Render the single audit comment the boot sweep posts when it releases an
+ * issue whose owner died on another host (#627) — the visible record that the
+ * issue returned to the executable pool. */
+export function renderStaleClaimSweepAudit(staleOwners: readonly string[]): string {
+  const who = staleOwners.map((w) => `\`${w}\``).join(", ");
+  return (
+    `🤖 AFK cross-host stale-claim sweep: released this issue back to \`ready-for-agent\` — ` +
+    `${staleOwners.length === 1 ? "the claim" : "the claims"} held by ${who} stopped refreshing ` +
+    `past the staleness window (owner presumed dead on another host).`
+  );
+}
+
+/**
+ * Plan which claimed issues to release back to the executable pool (pure). An
+ * issue is released ONLY when it has at least one stale claim AND no LIVE claim
+ * holds it — so a live-but-slow worker (its claim still within the window) is
+ * never robbed, and an issue with a live contender is left to that contender.
+ * The boot orchestrator applies each release: restore `ready-for-agent`, strip
+ * `running`, and post one audit comment naming the recovered stale owners.
+ */
+export function planStaleClaimSweep(
+  claimed: readonly ClaimedIssue[],
+  nowS: number,
+  config: ClaimStalenessConfig = DEFAULT_CLAIM_STALENESS,
+): StaleClaimRelease[] {
+  const isStale = makeStaleClaimPredicate(nowS, config);
+  const releases: StaleClaimRelease[] = [];
+  for (const c of claimed) {
+    const state = classifyIssueClaims(c.records, isStale);
+    if (state.liveOwner === null && state.staleOwners.length > 0) {
+      releases.push({ issue: c.issue, staleOwners: state.staleOwners });
+    }
+  }
+  return releases;
+}
+
+const POSITIVE_INT_RE = /^[0-9]+$/;
+
+function resolvePositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw !== undefined && POSITIVE_INT_RE.test(raw)) {
+    const n = Number(raw);
+    if (n > 0) return n;
+  }
+  return fallback;
+}
+
+function resolveNonNegativeInt(raw: string | undefined, fallback: number): number {
+  if (raw !== undefined && POSITIVE_INT_RE.test(raw)) {
+    return Number(raw);
+  }
+  return fallback;
+}
+
+/**
+ * Resolve the staleness policy from the environment. `RED_AFK_CLAIM_REFRESH_S`
+ * (positive int, default 300) and `RED_AFK_CLAIM_STALE_TOLERANCE` (non-negative
+ * int, default 3). A missing / non-numeric / non-positive cadence falls back to
+ * the default so an operator typo can never collapse the window to zero and rob
+ * live claims; tolerance accepts 0 (window = exactly one cadence).
+ */
+export function resolveClaimStalenessConfig(
+  env: Record<string, string | undefined> = process.env,
+): ClaimStalenessConfig {
+  return {
+    refreshCadenceS: resolvePositiveInt(env.RED_AFK_CLAIM_REFRESH_S, DEFAULT_CLAIM_REFRESH_S),
+    tolerance: resolveNonNegativeInt(env.RED_AFK_CLAIM_STALE_TOLERANCE, DEFAULT_CLAIM_STALE_TOLERANCE),
+  };
+}

--- a/apps/dev/src/core/claim.ts
+++ b/apps/dev/src/core/claim.ts
@@ -76,6 +76,11 @@ export interface ClaimDecision {
   winner: string | null;
   /** One-line rationale, for logs. */
   reason: string;
+  /** Stale cross-host claimants this decision RECOVERED — workers whose latest
+   * marker `isStale` rejected and who would otherwise have held an earlier claim
+   * than the winner. Empty unless a stale claim was superseded. Drives the single
+   * audit comment the orchestrator posts on a recovery (issue #627). */
+  recovered: string[];
 }
 
 export interface ClaimReconcileOptions {
@@ -99,6 +104,17 @@ function escapeField(value: string): string {
   // characters that would break parsing; identities are already constrained to
   // host/worker charsets, this is defence-in-depth against a forged title.
   return value.replace(/[\s>]/g, "_");
+}
+
+/** Render the one-line audit comment posted when a claim recovered a stale
+ * cross-host claim — the visible record that the issue returned to the
+ * executable pool because an owner stopped refreshing (#627). */
+export function renderRecoveryAudit(self: { worker: string }, recovered: readonly string[]): string {
+  const who = recovered.map((w) => `\`${w}\``).join(", ");
+  return (
+    `🤖 AFK cross-host recovery: worker \`${self.worker}\` released ${recovered.length === 1 ? "a stale claim" : "stale claims"} ` +
+    `held by ${who} (owner stopped refreshing past the staleness window) and re-claimed this issue.`
+  );
 }
 
 /** Render the structured claim/concede marker comment a claimant posts. The
@@ -252,19 +268,33 @@ export function reconcileClaim(
   });
 
   const contenders: Contender[] = [];
+  // Stale claimants that would have out-ordered us, captured so the orchestrator
+  // can post one audit comment recording the cross-host recovery (#627).
+  const stale: Contender[] = [];
   for (const [worker, f] of folds) {
     if (f.latestKind === "concede") continue; // withdrew
     if (f.earliestClaimId === null) continue; // only ever conceded — not a claim
-    if (isStale(f.latestRecord)) continue; // dead/expired — recovered
+    if (isStale(f.latestRecord)) {
+      stale.push({ worker, claimId: f.earliestClaimId }); // dead/expired — recovered
+      continue;
+    }
     contenders.push({ worker, claimId: f.earliestClaimId });
   }
 
   if (contenders.length === 0) {
-    return { verdict: "lost", winner: null, reason: "no live claim contends" };
+    return { verdict: "lost", winner: null, reason: "no live claim contends", recovered: [] };
   }
 
   contenders.sort((a, b) => a.claimId - b.claimId || (a.worker < b.worker ? -1 : 1));
   const winner = contenders[0];
+
+  // A recovery is real only when we WIN and a stale claimant out-ordered us —
+  // i.e. it would have beaten the winner had it not aged out. A stale claim that
+  // posted AFTER the winner never held the issue, so it is not "recovered".
+  const recovered =
+    winner.worker === self.worker
+      ? stale.filter((s) => s.claimId < winner.claimId).map((s) => s.worker).sort()
+      : [];
 
   if (winner.worker === self.worker) {
     return {
@@ -274,12 +304,14 @@ export function reconcileClaim(
         contenders.length === 1
           ? "solo claim"
           : `earliest of ${contenders.length} live claims (id ${winner.claimId})`,
+      recovered,
     };
   }
   return {
     verdict: "lost",
     winner: winner.worker,
     reason: `worker ${winner.worker} holds earlier claim (id ${winner.claimId} < our ${self.commentId})`,
+    recovered: [],
   };
 }
 
@@ -295,6 +327,10 @@ export interface ClaimGh {
   /** Post a concede marker (best-effort; a failed concede is non-fatal — our
    * claim simply ages out via staleness). */
   concede(issue: number, body: string): Promise<void>;
+  /** Post the single human-visible audit comment when this claim RECOVERED a
+   * stale cross-host claim (#627). Optional + best-effort: a failed audit does
+   * not abandon the won claim. Omitted by legacy callers (no audit posted). */
+  audit?(issue: number, body: string): Promise<void>;
 }
 
 export interface AcquireClaimOptions extends ClaimReconcileOptions {
@@ -327,6 +363,15 @@ export async function acquireClaim(
       issue,
       renderClaimComment({ worker: self.worker, runner: self.runner }, "concede"),
     );
+  }
+  // One audit comment when we won by recovering a stale cross-host claim (#627).
+  // Best-effort: a failed audit never abandons the won claim.
+  if (decision.verdict === "won" && decision.recovered.length > 0 && gh.audit) {
+    try {
+      await gh.audit(issue, renderRecoveryAudit({ worker: self.worker }, decision.recovered));
+    } catch {
+      // best-effort observability; the claim is already won.
+    }
   }
   return decision;
 }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -683,6 +683,7 @@ import type { AttemptDir } from "../core/reclaim.js";
 import type { IssueStateRow } from "./gh.js";
 import { LABEL_HUMAN, LABEL_RUNNING } from "../core/triage-labels.js";
 import { parseWorkerAttemptPath } from "../core/worker-paths.js";
+import { parseClaimRecords } from "../core/claim.js";
 
 /**
  * Discover every per-step input boot's sweeps consume, replacing the empty
@@ -885,6 +886,24 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
         unlabeled: () => ghx.countUnlabeled(ghCtx),
         needsTriage: () => ghx.countNeedsTriage(ghCtx),
         needsInfo: () => ghx.countNeedsInfo(ghCtx),
+      },
+      // Cross-host stale-claim sweep input (#627): every OPEN issue projected as
+      // `running` (a held claim) with its parsed claim marker records. Derived
+      // from the batched issue-state map; the claim comments are read per-issue.
+      // A per-issue read failure drops that issue from the sweep (best-effort).
+      claimedIssues: async () => {
+        const claimed = [];
+        for (const [issue, row] of issueStates) {
+          if (row.state !== "OPEN") continue;
+          if (!row.labels.includes(LABEL_RUNNING)) continue;
+          try {
+            const comments = await ghx.listClaimComments(ghCtx, issue);
+            claimed.push({ issue, records: parseClaimRecords(comments) });
+          } catch {
+            // best-effort: skip an issue whose claim comments cannot be read.
+          }
+        }
+        return claimed;
       },
     },
     nowS,

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -134,6 +134,7 @@ function makeDeps(over: Partial<{
   blockerState: BootDeps["lookups"]["blockerState"];
   straggler: BootDeps["lookups"]["straggler"];
   claimHolderAlive: BootDeps["lookups"]["claimHolderAlive"];
+  claimedIssues: BootDeps["lookups"]["claimedIssues"];
   env: Record<string, string | undefined>;
   reconcileRunner: ReconcileBootRunner;
 }> = {}) {
@@ -205,6 +206,7 @@ function makeDeps(over: Partial<{
           needsInfo: async () => 0,
         },
       ...(over.claimHolderAlive ? { claimHolderAlive: over.claimHolderAlive } : {}),
+      ...(over.claimedIssues ? { claimedIssues: over.claimedIssues } : {}),
     },
     nowS: NOW,
     env: over.env ?? {},
@@ -614,6 +616,67 @@ describe("runBoot unblock sweep promotes + comments", () => {
       { issue: 100, body: "🤖 /afk unblocked: all dependencies closed (#10, #11)." },
     ]);
     expect(r.unblockSweep).toEqual({ promoted: [100] });
+  });
+});
+
+describe("runBoot cross-host stale-claim sweep (#627)", () => {
+  // A claim record from `worker` whose latest refresh was `ageS` ago.
+  const claim = (commentId: number, worker: string, ageS: number) => ({
+    commentId,
+    worker,
+    kind: "claim" as const,
+    createdAt: new Date((NOW - ageS) * 1000).toISOString(),
+  });
+
+  it("is a no-op when claimedIssues is not wired", async () => {
+    const { deps, ghCalls } = makeDeps();
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [] });
+    expect(ghCalls.editLabels).toEqual([]);
+  });
+
+  it("releases a cross-host stale claim back to ready-for-agent with one audit comment", async () => {
+    const claimedIssues = async () => [{ issue: 42, records: [claim(10, "host1:wXY", 99999)] }];
+    const { deps, ghCalls } = makeDeps({ claimedIssues });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [42] });
+    expect(ghCalls.editLabels).toEqual([
+      { issue: 42, remove: ["running"], add: ["ready-for-agent"] },
+    ]);
+    expect(ghCalls.comment).toHaveLength(1);
+    expect(ghCalls.comment[0].issue).toBe(42);
+    expect(ghCalls.comment[0].body).toContain("host1:wXY");
+    expect(ghCalls.comment[0].body).toContain("cross-host stale-claim sweep");
+  });
+
+  it("never releases an issue still held by a live worker", async () => {
+    const claimedIssues = async () => [{ issue: 42, records: [claim(10, "host1:wXY", 120)] }];
+    const { deps, ghCalls } = makeDeps({ claimedIssues });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [] });
+    expect(ghCalls.editLabels).toEqual([]);
+    expect(ghCalls.comment).toEqual([]);
+  });
+
+  it("honours RED_AFK_CLAIM_REFRESH_S / tolerance from env", async () => {
+    // 700s old: stale under the default 1200s window? no. Tighten the window to
+    // 60×(1+0)=60s via env → 700s is now stale.
+    const claimedIssues = async () => [{ issue: 7, records: [claim(10, "h:w", 700)] }];
+    const { deps } = makeDeps({
+      claimedIssues,
+      env: { RED_AFK_CLAIM_REFRESH_S: "60", RED_AFK_CLAIM_STALE_TOLERANCE: "0" },
+    });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [7] });
+  });
+
+  it("tolerates a claimedIssues listing failure (best-effort no-op)", async () => {
+    const claimedIssues = async () => {
+      throw new Error("gh down");
+    };
+    const { deps } = makeDeps({ claimedIssues });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [] });
   });
 });
 

--- a/apps/dev/tests/claim-staleness.test.ts
+++ b/apps/dev/tests/claim-staleness.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CLAIM_REFRESH_S,
+  DEFAULT_CLAIM_STALE_TOLERANCE,
+  DEFAULT_CLAIM_STALENESS,
+  classifyClaim,
+  classifyIssueClaims,
+  makeStaleClaimPredicate,
+  planStaleClaimSweep,
+  resolveClaimStalenessConfig,
+  staleWindowS,
+  type ClaimStalenessConfig,
+} from "../src/core/claim-staleness.js";
+import type { ClaimRecord } from "../src/core/claim.js";
+
+// A claim record whose owner last refreshed at ISO `ts` (epoch seconds → ISO).
+function recAt(epochS: number, worker = "dead:host"): ClaimRecord {
+  return { commentId: 1, worker, kind: "claim", createdAt: new Date(epochS * 1000).toISOString() };
+}
+
+// A claim record at `commentId` from `worker`, last-refreshed `ageS` ago.
+function claimAt(commentId: number, worker: string, ageS: number, nowS = T0): ClaimRecord {
+  return {
+    commentId,
+    worker,
+    kind: "claim",
+    createdAt: new Date((nowS - ageS) * 1000).toISOString(),
+  };
+}
+
+const T0 = 1_700_000_000; // a fixed injected clock anchor (epoch seconds)
+
+describe("staleWindowS", () => {
+  it("is cadence × (tolerance + 1) — comfortably exceeds the refresh cadence", () => {
+    const cfg: ClaimStalenessConfig = { refreshCadenceS: 300, tolerance: 3 };
+    expect(staleWindowS(cfg)).toBe(1200);
+    // The window strictly exceeds the cadence for any tolerance ≥ 0.
+    expect(staleWindowS(cfg)).toBeGreaterThan(cfg.refreshCadenceS);
+    expect(staleWindowS({ refreshCadenceS: 60, tolerance: 0 })).toBe(60);
+  });
+
+  it("defaults to 300 × 4 = 1200s", () => {
+    expect(staleWindowS()).toBe(DEFAULT_CLAIM_REFRESH_S * (DEFAULT_CLAIM_STALE_TOLERANCE + 1));
+    expect(staleWindowS(DEFAULT_CLAIM_STALENESS)).toBe(1200);
+  });
+});
+
+describe("classifyClaim (pure, injected clock)", () => {
+  const cfg: ClaimStalenessConfig = { refreshCadenceS: 300, tolerance: 3 };
+
+  it("a just-refreshed claim is fresh", () => {
+    expect(classifyClaim(recAt(T0), T0, cfg)).toBe("fresh");
+  });
+
+  it("a claim within the window (missed a few refreshes) is still fresh — never robbed", () => {
+    // 900s old < 1200s window: missed 2 refreshes, tolerated.
+    expect(classifyClaim(recAt(T0 - 900), T0, cfg)).toBe("fresh");
+  });
+
+  it("a claim exactly at the window boundary is fresh (inclusive)", () => {
+    expect(classifyClaim(recAt(T0 - 1200), T0, cfg)).toBe("fresh");
+  });
+
+  it("a claim past the window is stale — owner presumed dead, recoverable", () => {
+    expect(classifyClaim(recAt(T0 - 1201), T0, cfg)).toBe("stale");
+    expect(classifyClaim(recAt(T0 - 99999), T0, cfg)).toBe("stale");
+  });
+
+  it("a claim with no timestamp is fresh (unknown age never robs)", () => {
+    expect(classifyClaim({ commentId: 1, worker: "h:w", kind: "claim" }, T0, cfg)).toBe("fresh");
+  });
+
+  it("a claim with an unparseable timestamp is fresh", () => {
+    expect(classifyClaim({ commentId: 1, worker: "h:w", kind: "claim", createdAt: "not-a-date" }, T0, cfg)).toBe(
+      "fresh",
+    );
+  });
+
+  it("a future-dated claim (clock skew) is fresh, never stale", () => {
+    expect(classifyClaim(recAt(T0 + 5000), T0, cfg)).toBe("fresh");
+  });
+});
+
+describe("makeStaleClaimPredicate", () => {
+  it("returns true only for records past the window — the reconciler's isStale seam", () => {
+    const isStale = makeStaleClaimPredicate(T0, { refreshCadenceS: 300, tolerance: 3 });
+    expect(isStale(recAt(T0 - 100))).toBe(false);
+    expect(isStale(recAt(T0 - 5000))).toBe(true);
+    expect(isStale({ commentId: 9, worker: "h:w", kind: "claim" })).toBe(false);
+  });
+});
+
+describe("resolveClaimStalenessConfig", () => {
+  it("defaults when env is empty", () => {
+    expect(resolveClaimStalenessConfig({})).toEqual(DEFAULT_CLAIM_STALENESS);
+  });
+
+  it("reads RED_AFK_CLAIM_REFRESH_S and RED_AFK_CLAIM_STALE_TOLERANCE", () => {
+    expect(
+      resolveClaimStalenessConfig({ RED_AFK_CLAIM_REFRESH_S: "600", RED_AFK_CLAIM_STALE_TOLERANCE: "5" }),
+    ).toEqual({ refreshCadenceS: 600, tolerance: 5 });
+  });
+
+  it("tolerates a zero tolerance (window = exactly one cadence)", () => {
+    const cfg = resolveClaimStalenessConfig({ RED_AFK_CLAIM_STALE_TOLERANCE: "0" });
+    expect(cfg.tolerance).toBe(0);
+    expect(staleWindowS(cfg)).toBe(DEFAULT_CLAIM_REFRESH_S);
+  });
+
+  it("falls back to the default cadence on a non-positive / non-numeric value — never robs", () => {
+    expect(resolveClaimStalenessConfig({ RED_AFK_CLAIM_REFRESH_S: "0" }).refreshCadenceS).toBe(
+      DEFAULT_CLAIM_REFRESH_S,
+    );
+    expect(resolveClaimStalenessConfig({ RED_AFK_CLAIM_REFRESH_S: "abc" }).refreshCadenceS).toBe(
+      DEFAULT_CLAIM_REFRESH_S,
+    );
+  });
+});
+
+describe("classifyIssueClaims", () => {
+  const isStale = makeStaleClaimPredicate(T0, { refreshCadenceS: 300, tolerance: 3 });
+
+  it("a single fresh claim is the live owner, no stale owners", () => {
+    const st = classifyIssueClaims([claimAt(10, "live:host", 60)], isStale);
+    expect(st).toEqual({ liveOwner: "live:host", staleOwners: [] });
+  });
+
+  it("a single aged-out claim has no live owner and one stale owner", () => {
+    const st = classifyIssueClaims([claimAt(10, "dead:host", 9999)], isStale);
+    expect(st).toEqual({ liveOwner: null, staleOwners: ["dead:host"] });
+  });
+
+  it("a live contender holds the issue even when an older claim went stale", () => {
+    const st = classifyIssueClaims(
+      [claimAt(10, "dead:host", 9999), claimAt(20, "live:host", 30)],
+      isStale,
+    );
+    expect(st.liveOwner).toBe("live:host");
+    expect(st.staleOwners).toEqual(["dead:host"]);
+  });
+
+  it("the earliest live claim wins as the owner", () => {
+    const st = classifyIssueClaims(
+      [claimAt(30, "b:host", 30), claimAt(10, "a:host", 30)],
+      isStale,
+    );
+    expect(st.liveOwner).toBe("a:host");
+  });
+
+  it("a worker that conceded after a stale claim is not counted", () => {
+    const records: ClaimRecord[] = [
+      claimAt(10, "gone:host", 9999),
+      { commentId: 40, worker: "gone:host", kind: "concede" },
+    ];
+    const st = classifyIssueClaims(records, isStale);
+    expect(st).toEqual({ liveOwner: null, staleOwners: [] });
+  });
+});
+
+describe("planStaleClaimSweep", () => {
+  const cfg: ClaimStalenessConfig = { refreshCadenceS: 300, tolerance: 3 };
+
+  it("releases an issue held only by a stale claim", () => {
+    const releases = planStaleClaimSweep(
+      [{ issue: 7, records: [claimAt(10, "dead:host", 9999)] }],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([{ issue: 7, staleOwners: ["dead:host"] }]);
+  });
+
+  it("never releases an issue with a live owner — a slow worker is not robbed", () => {
+    const releases = planStaleClaimSweep(
+      [{ issue: 7, records: [claimAt(10, "live:host", 200)] }],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([]);
+  });
+
+  it("never releases when a live claim coexists with a stale one", () => {
+    const releases = planStaleClaimSweep(
+      [{ issue: 7, records: [claimAt(10, "dead:host", 9999), claimAt(20, "live:host", 30)] }],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([]);
+  });
+
+  it("releases only the dead-held issues across a mixed set", () => {
+    const releases = planStaleClaimSweep(
+      [
+        { issue: 1, records: [claimAt(10, "dead:1", 9999)] },
+        { issue: 2, records: [claimAt(10, "live:2", 30)] },
+        { issue: 3, records: [claimAt(10, "dead:3", 5000)] },
+        { issue: 4, records: [] },
+      ],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([
+      { issue: 1, staleOwners: ["dead:1"] },
+      { issue: 3, staleOwners: ["dead:3"] },
+    ]);
+  });
+});

--- a/apps/dev/tests/claim.test.ts
+++ b/apps/dev/tests/claim.test.ts
@@ -4,6 +4,7 @@ import {
   parseClaimRecords,
   reconcileClaim,
   renderClaimComment,
+  renderRecoveryAudit,
   type ClaimGh,
   type ClaimRecord,
   type ClaimSelf,
@@ -140,17 +141,70 @@ describe("reconcileClaim stale-claim recovery (injected liveness)", () => {
     const d = reconcileClaim(records, self("h:me", 50), { isStale: () => false });
     expect(d.verdict).toBe("won");
   });
+
+  it("reports the recovered stale worker that out-ordered us (#627 audit input)", () => {
+    const records = [rec(10, "dead:host"), rec(50, "h:me")];
+    const d = reconcileClaim(records, self("h:me", 50), { isStale: (r) => r.worker === "dead:host" });
+    expect(d.verdict).toBe("won");
+    expect(d.recovered).toEqual(["dead:host"]);
+  });
+
+  it("does not report a stale claim posted AFTER our claim as recovered", () => {
+    // dead:host's earliest claim (id 80) is LATER than ours (id 50): it never
+    // held the issue, so superseding it is not a recovery.
+    const records = [rec(50, "h:me"), rec(80, "dead:host")];
+    const d = reconcileClaim(records, self("h:me", 50), { isStale: (r) => r.worker === "dead:host" });
+    expect(d.verdict).toBe("won");
+    expect(d.recovered).toEqual([]);
+  });
+
+  it("reports no recovery when we lose", () => {
+    const records = [rec(10, "live:host"), rec(20, "dead:host"), rec(50, "h:me")];
+    const d = reconcileClaim(records, self("h:me", 50), { isStale: (r) => r.worker === "dead:host" });
+    expect(d.verdict).toBe("lost");
+    expect(d.winner).toBe("live:host");
+    expect(d.recovered).toEqual([]);
+  });
+
+  it("the returning stale owner concedes — the staleness predicate resolves the race", () => {
+    // B (h:me) recovered A (dead:host) and now holds the live claim. When A
+    // returns and reconciles WITHOUT refreshing, its own latest marker is still
+    // stale, so A is dropped and B (the live claim) wins — A concedes. This is
+    // the race resolved by the claim primitive itself.
+    const records = [rec(10, "dead:host"), rec(50, "h:me")];
+    const fromOwner = reconcileClaim(records, self("dead:host", 10), {
+      isStale: (r) => r.worker === "dead:host",
+    });
+    expect(fromOwner.verdict).toBe("lost");
+    expect(fromOwner.winner).toBe("h:me");
+  });
+});
+
+describe("renderRecoveryAudit", () => {
+  it("names the releasing worker and the recovered claimants", () => {
+    const one = renderRecoveryAudit({ worker: "h:me" }, ["dead:host"]);
+    expect(one).toContain("h:me");
+    expect(one).toContain("dead:host");
+    expect(one).toContain("a stale claim");
+    const many = renderRecoveryAudit({ worker: "h:me" }, ["a:1", "b:2"]);
+    expect(many).toContain("stale claims");
+    expect(many).toContain("`a:1`, `b:2`");
+  });
 });
 
 // ---- orchestrator (injected IO) ----
 
-function fakeGh(existing: RawClaimComment[]): ClaimGh & { posted: string[]; conceded: string[] } {
+function fakeGh(
+  existing: RawClaimComment[],
+): ClaimGh & { posted: string[]; conceded: string[]; audited: string[] } {
   let nextId = (existing.at(-1)?.id ?? 0) + 1;
   const posted: string[] = [];
   const conceded: string[] = [];
+  const audited: string[] = [];
   return {
     posted,
     conceded,
+    audited,
     async postClaim(_issue, body) {
       const id = nextId++;
       posted.push(body);
@@ -162,6 +216,9 @@ function fakeGh(existing: RawClaimComment[]): ClaimGh & { posted: string[]; conc
     },
     async concede(_issue, body) {
       conceded.push(body);
+    },
+    async audit(_issue, body) {
+      audited.push(body);
     },
   };
 }
@@ -190,5 +247,28 @@ describe("acquireClaim orchestration", () => {
     const d = await acquireClaim(gh, { worker: "h:me" }, 5, { suppressConcede: true });
     expect(d.verdict).toBe("lost");
     expect(gh.conceded).toHaveLength(0);
+  });
+
+  it("recovers a stale cross-host claim and posts exactly one audit comment (#627)", async () => {
+    // A dead worker holds an earlier claim (id 1); our post gets id 2. We win
+    // only because the staleness predicate drops the dead claim — and one audit
+    // comment records the recovery.
+    const gh = fakeGh([{ id: 1, body: renderClaimComment({ worker: "dead:host" }) }]);
+    const d = await acquireClaim(gh, { worker: "h:me", runner: "claude" }, 5, {
+      isStale: (r) => r.worker === "dead:host",
+    });
+    expect(d.verdict).toBe("won");
+    expect(d.recovered).toEqual(["dead:host"]);
+    expect(gh.audited).toHaveLength(1);
+    expect(gh.audited[0]).toContain("cross-host recovery");
+    expect(gh.audited[0]).toContain("dead:host");
+    expect(gh.conceded).toHaveLength(0);
+  });
+
+  it("posts no audit comment on an ordinary solo win", async () => {
+    const gh = fakeGh([]);
+    const d = await acquireClaim(gh, { worker: "h:me" }, 5);
+    expect(d.verdict).toBe("won");
+    expect(gh.audited).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #627

## Summary

- `core/claim-staleness.ts` (new): `classifyClaim(record, nowS, config) → fresh|stale`; staleness window `cadence × (tolerance + 1)` comfortably exceeds the refresh cadence and tolerates N missed refreshes. Plus `makeStaleClaimPredicate` (the reconciler's `isStale` seam), `classifyIssueClaims`, `planStaleClaimSweep`, audit renderers, and `RED_AFK_CLAIM_REFRESH_S` / `RED_AFK_CLAIM_STALE_TOLERANCE` env resolver.
- `core/claim.ts`: reconciler reports `recovered` stale claimants; `acquireClaim` posts exactly one audit comment on a recovered win.
- `core/boot.ts` (step 6a) + `runtime/wire.ts`: boot sweep lists `running` issues, releases any held only by a dead cross-host claim → restore `ready-for-agent`, strip `running`, post one audit comment. No-op when the lookup is absent.
- `commands/run.ts`: injects the staleness predicate + audit method so a simultaneous claim race also drops a stale cross-host winner.

## Acceptance criteria

- ✅ cross-host stale release via boot sweep
- ✅ live-slow worker never robbed (window math + "no live owner" release rule)
- ✅ restore-to-pool + one audit comment
- ✅ pure classifier unit-tested with injected clock
- ✅ returning owner concedes via the reconciler (`isStale` drops it before id-ordering)

## Test plan

- [ ] pnpm -C apps/dev test — 1482 tests pass
- [ ] pnpm typecheck — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783871483&installation_id=129708444&pr_number=736&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F736&signature=026bd536c6f9e31253881e45931b5ea27a8efb830fbe99700d4e0a8b5b63fbee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic stale-claim recovery during boot initialization to detect and release inactive claims across hosts
  * Issues with stale claims now transition to "ready-for-agent" status for reassignment
  * Recovery operations include audit comments for visibility and transparency
  * Staleness detection parameters are configurable via environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->