### PR TITLE
fix(actions): rewrite git@github.com SSH URLs to HTTPS (#738)

### DIFF
--- a/.github/actions/afk-attempt/action.yml
+++ b/.github/actions/afk-attempt/action.yml
@@ -107,6 +107,12 @@ runs:
         # A committer identity for the worker-branch commits the runner lands.
         git config --global user.name  "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        # Rewrite SSH git@github.com: URLs to HTTPS with token auth. Required because:
+        # (a) the feedback gate runs `git submodule update --init` which hits the SSH URL
+        #     in .gitmodules — Actions runners have no SSH key, so it fails; and
+        # (b) AFK worker-branch pushes go to the same SSH remote, failing the same way.
+        # github.token (GH_TOKEN) has `contents: write` so HTTPS push to worker branches works.
+        git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
         # The launcher is resolved from THIS action's red-skills checkout; it
         # fetches the version-matched dev bundle and runs against the CWD repo.
         LAUNCHER="${{ github.action_path }}/../../../plugins/dev/skills/engineering/afk/bin/afk.mjs"


### PR DESCRIPTION
## Problem

The AFK Actions lane fails on GitHub Actions runners in two ways:

1. **Submodule SSH failure** — the bundle's feedback gate runs `git submodule update --init --recursive` in the feedback worktree. The `.gitmodules` URL for red-castle is SSH (`git@github.com:reddb-io/red-castle.git`). Actions runners have no SSH key → `Permission denied (publickey)`.

2. **Worker-branch push failure** — AFK pushes worker branches (`git push origin afk/<id>/…`) to the SSH remote, same failure.

Broken in [run #27428579555](https://github.com/reddb-io/red-skills/actions/runs/27428579555).

## Fix

One line in `.github/actions/afk-attempt/action.yml`, added after the git identity config:

```bash
git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
```

This rewrites all `git@github.com:` → HTTPS-with-token for the duration of the action run, enabling both submodule init and worker-branch push. `GH_TOKEN` is already set from `github.token`. The workflow already declares `permissions: contents: write` — **no PAT needed**.

## Test plan

- [ ] Trigger `workflow_dispatch` on a `ready-for-agent` issue after merge
- [ ] Confirm feedback worktree setup succeeds (no SSH permission error)
- [ ] Confirm worker-branch push completes and PR is opened

Closes #738.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783875954&installation_id=129708444&pr_number=739&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F739&signature=1a3e453f6c2405ec74a6a39b1d03c9f66a698e1f79ecf54e90dad62715551e9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of Git operations in automated workflows with enhanced credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->