### PR TITLE
fix(afk): resolveTier — explicit pin equal to default beats legacy scalar (#583)

### DIFF
--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -278,7 +278,16 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
   // Copy raw parsed keys (forward compatibility), then fold the namespaced
   // `plugins.dev.*` block down to the accessor keys so the new location wins over
   // the legacy top-level one (ADR 0042).
-  for (const [key, value] of Object.entries(parsed)) values[key] = value;
+  // Track which accessor keys the user explicitly set — needed by resolveTier to
+  // distinguish "user pinned a tier to the same value as the default" (should win
+  // over legacy scalars) from "tier is just the CONFIG_DEFAULTS value" (should fall
+  // through to base/scalar fallbacks). Stored as a null-byte-keyed side-channel
+  // that can never originate from YAML (null bytes are invalid YAML key chars).
+  const explicitAccessorKeys = new Set<string>();
+  for (const [key, value] of Object.entries(parsed)) {
+    values[key] = value;
+    explicitAccessorKeys.add(key);
+  }
   for (const [key, value] of Object.entries(parsed)) {
     const m = /^plugins\.dev\.(.+)$/.exec(key);
     if (!m) continue;
@@ -288,7 +297,12 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
     // dev-plugin key keeps the `dev.*` accessor — so
     // `plugins.dev.lock.primary-branch` folds to `dev.lock.primary-branch`, not a
     // bare `lock.primary-branch` the loader never reads.
-    values[rest === "afk" || rest.startsWith("afk.") ? rest : `dev.${rest}`] = value;
+    const accessorKey = rest === "afk" || rest.startsWith("afk.") ? rest : `dev.${rest}`;
+    values[accessorKey] = value;
+    explicitAccessorKeys.add(accessorKey);
+  }
+  if (explicitAccessorKeys.size > 0) {
+    values["\0explicit"] = Array.from(explicitAccessorKeys).join("\x01");
   }
   return values;
 }
@@ -355,19 +369,28 @@ export function resolveTier(
   const scalarGlobalModel = getConfig(values, "afk.model");
   const tierEffort = getConfig(values, effortKey);
 
+  // The set of accessor keys the user explicitly wrote in their YAML (tracked by
+  // loadConfig). Needed to distinguish "user pinned a tier to the same value as the
+  // CONFIG_DEFAULT" (must win over legacy scalars — bug #583) from "tier is just the
+  // CONFIG_DEFAULT" (should fall through to base/scalar fallbacks).
+  const explicitKeys = new Set<string>((values["\0explicit"] ?? "").split("\x01").filter(Boolean));
+
   // Runtime override: a non-empty RED_AFK_MODEL/RED_AFK_EFFORT wins over the file
   // (`""` counts as unset, so a placeholder export never flattens the tiers).
   const modelOverride = (env.RED_AFK_MODEL ?? "").trim();
   const effortOverride = (env.RED_AFK_EFFORT ?? "").trim();
 
+  // An explicit tier pin wins when it is non-empty AND either differs from the
+  // default (clearly user-set) or is known to have been user-set (even when it
+  // equals the default — an explicit pin must beat legacy scalars per bug #583).
   const configModel =
-    tierModel && tierModel !== defaultModel
+    tierModel && (tierModel !== defaultModel || explicitKeys.has(modelKey))
       ? tierModel
-      : baseModel || scalarRunnerModel || scalarGlobalModel || tierModel || defaultModel;
+      : baseModel || scalarRunnerModel || scalarGlobalModel || defaultModel;
   const configEffort =
-    tierEffort && tierEffort !== defaultEffort
+    tierEffort && (tierEffort !== defaultEffort || explicitKeys.has(effortKey))
       ? tierEffort
-      : baseEffort || tierEffort || defaultEffort;
+      : baseEffort || defaultEffort;
 
   return {
     model: modelOverride.length > 0 ? modelOverride : configModel,

--- a/apps/dev/src/core/model-tier-route.ts
+++ b/apps/dev/src/core/model-tier-route.ts
@@ -156,9 +156,9 @@ export function routeModelTier(
     return { kind: "audit", tier, model: resolved.model, reason };
   }
 
-  // path (a): rewrite. Preserve the full original input, override only model.
+  // path (a): rewrite. Preserve the full original input, override model and effort.
   const original = input.tool_input ?? {};
-  const updatedInput: Record<string, unknown> = { ...original, model: resolved.model };
+  const updatedInput: Record<string, unknown> = { ...original, model: resolved.model, effort: resolved.effort };
   return {
     kind: "rewrite",
     tier,

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -398,6 +398,24 @@ describe("config — AFK model tier table (ADR 0049)", () => {
     expect(resolveTier(values, "claude", "think")).toEqual({ model: "claude-tier-model", effort: "max" });
   });
 
+  it("an explicit tier pin equal to the default beats a stale legacy scalar (bug #583)", () => {
+    // simple tier default = claude-sonnet-4-6; legacy afk.model = custom-model.
+    // An explicit simple.model = claude-sonnet-4-6 (same as the default) must
+    // still win — the old tierModel !== defaultModel guard silently dropped it.
+    const text = "afk:\n  model: custom-model\n  models:\n    claude:\n      simple:\n        model: claude-sonnet-4-6\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(resolveTier(values, "claude", "simple")).toEqual({ model: "claude-sonnet-4-6", effort: "high" });
+  });
+
+  it("an explicit tier effort pin equal to the default beats a base effort override (bug #583)", () => {
+    // validate tier default effort = low; base effort = medium.
+    // An explicit validate.effort = low (same as the default) must still win.
+    const text =
+      "plugins:\n  dev:\n    afk:\n      models:\n        claude:\n          base:\n            effort: medium\n          validate:\n            effort: low\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(resolveTier(values, "claude", "validate")).toEqual({ model: "claude-haiku-4-5", effort: "low" });
+  });
+
   it("falls back to legacy per-runner and global scalar model keys", () => {
     const values = loadConfig("/x/.red/config.yaml", {
       read: () => "afk:\n  model: shared-model\n  models:\n    codex: gpt-custom\n",

--- a/apps/dev/tests/model-tier-route.test.ts
+++ b/apps/dev/tests/model-tier-route.test.ts
@@ -82,8 +82,8 @@ describe("routeModelTier — rewrite (path a)", () => {
     expect(action.tier).toBe("validate");
     expect(action.model).toBe("claude-haiku-4-5");
     expect(action.effort).toBe("low");
-    // full input preserved, only model overridden
-    expect(action.updatedInput).toEqual({ subagent_type: "validate", model: "claude-haiku-4-5", prompt: "p" });
+    // full input preserved, model and effort overridden
+    expect(action.updatedInput).toEqual({ subagent_type: "validate", model: "claude-haiku-4-5", prompt: "p", effort: "low" });
   });
 
   it("injects the config model when a tier-agent dispatch leaves model unset", () => {
@@ -97,6 +97,26 @@ describe("routeModelTier — rewrite (path a)", () => {
   it("clamps simple-code dispatched on opus down to the simple tier (savings enforced)", () => {
     const action = routeModelTier(task({ subagent_type: "simple-code", model: "claude-opus-4-8" }), defaults());
     expect(action.kind === "rewrite" && action.model).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("routeModelTier — explicit pin vs legacy scalar", () => {
+  it("does not upgrade a correctly-cheap dispatch when an explicit tier pin equals the default", () => {
+    // validate tier default = claude-haiku-4-5; legacy afk.model = claude-sonnet-4-6.
+    // An explicit validate.model = claude-haiku-4-5 must beat the legacy scalar
+    // (resolveTier bug #583), so a haiku dispatch to validate remains a noop.
+    const config = loadConfig("/x/.red/config.yaml", {
+      read: () =>
+        "afk:\n  model: claude-sonnet-4-6\n  models:\n    claude:\n      validate:\n        model: claude-haiku-4-5\n",
+    });
+    expect(routeModelTier(task({ subagent_type: "validate", model: "haiku" }), config)).toEqual({ kind: "noop" });
+  });
+
+  it("enforces the resolved effort in updatedInput alongside the model", () => {
+    const action = routeModelTier(task({ subagent_type: "validate", model: "opus" }), defaults());
+    expect(action.kind).toBe("rewrite");
+    if (action.kind !== "rewrite") return;
+    expect(action.updatedInput).toMatchObject({ effort: "low" });
   });
 });
 


### PR DESCRIPTION
## Summary

Three bugs in the model-tier routing pipeline:

1. **`resolveTier` explicit-pin precedence** — an explicit tier pin whose value equals the CONFIG_DEFAULT was incorrectly treated as "not set" and fell through to legacy scalar keys (e.g. `afk.model: claude-sonnet-4-6` won over an explicit `validate.model: claude-haiku-4-5` even though they were equal). Root cause: the `tierModel !== defaultModel` guard couldn't distinguish "user-set to same value as default" from "just the CONFIG_DEFAULT". Fix: `loadConfig` now stores the set of user-explicitly-written accessor keys in a null-byte-keyed side-channel (`\0explicit`). `resolveTier` reads it: a pin wins when it differs from the default OR when the user explicitly wrote it.

2. **Same bug for effort** — explicit tier effort pins were ignored when equal to the default; they now win over `base.effort` overrides the same way.

3. **Effort missing from `updatedInput`** — the `routeModelTier` rewrite path (path a) preserved the original dispatch input and overrode `model`, but forgot `effort`. Fixed by spreading `effort: resolved.effort` alongside `model`.

## Test plan

- [x] `pnpm -C apps/dev test --run` — all 1493 tests pass
- [x] Two new regression tests in `config.test.ts` (explicit-pin-equals-default for model and effort)
- [x] Updated `model-tier-route.test.ts` to assert `effort` in `updatedInput` + new describe block for explicit-pin-vs-scalar

Closes #583.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783875972&installation_id=129708444&pr_number=740&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F740&signature=76dc8edbb9660c71da99f800b281ec7f383f398eb2a5f6a03bb01132c979a2f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed configuration precedence handling to ensure explicitly set tier values (model and effort) are properly respected and not overridden by defaults when the explicit value equals the default (Issue `#583`)
* Improved model tier routing to consistently apply and preserve effort values throughout the rewrite process
* Configuration system now correctly distinguishes between explicitly configured values and default-derived values for accurate precedence resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->