### PR TITLE
fix(afk): restore PRD 567 blocked slices on current main

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -598,7 +598,7 @@ export function buildProcessDeps(
       config,
       resolveOptions,
       exec: makeHookExec(ctx.root),
-      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT)),
+      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
     },
     lookups: {
       base: {
@@ -1194,7 +1194,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       config: loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined }),
       resolveOptions: makeHookResolveOptions(ctx.root),
       exec: makeHookExec(ctx.root),
-      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT)),
+      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
     },
     runnerCircuit: {
       isOpen: (r) => runnerCircuitOpen(paths.tmpDir, r, Math.floor(Date.now() / 1000)),

--- a/apps/dev/src/core/history.ts
+++ b/apps/dev/src/core/history.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 // Port of lib/history.sh — the afk-history.jsonl ledger. The pure parts (the
@@ -151,7 +151,11 @@ export function parseHistoryLines(text: string): HistoryRecord[] {
   for (const raw of text.split("\n")) {
     const line = raw.trim();
     if (!line) continue;
-    out.push(JSON.parse(line) as HistoryRecord);
+    try {
+      out.push(JSON.parse(line) as HistoryRecord);
+    } catch {
+      continue;
+    }
   }
   return out;
 }
@@ -179,7 +183,9 @@ export const defaultHistoryIO: HistoryIO = {
     }
   },
   async write(path, text) {
-    await writeFile(path, text, "utf8");
+    const tmp = `${path}.tmp`;
+    await writeFile(tmp, text, "utf8");
+    await rename(tmp, path);
   },
 };
 

--- a/apps/dev/src/core/hook-dispatcher.ts
+++ b/apps/dev/src/core/hook-dispatcher.ts
@@ -133,10 +133,68 @@ function isJsonObject(trimmed: string): boolean {
 }
 
 export interface DispatchHooksOptions {
-  /** The documented RED_AFK_* env passed to every command in this point. */
+  /**
+   * The base RED_AFK_* env passed to every command in this point. Per-event vars
+   * derived from the mutable context are layered on top.
+   */
   env?: Record<string, string>;
   /** Sink for the dispatcher's log lines (defaults to a no-op). */
   log?: (message: string) => void;
+}
+
+/**
+ * Derive the documented per-event RED_AFK_* env from a hook's mutable context.
+ * Irrelevant fields stay unset instead of being exported as empty strings.
+ */
+export function deriveHookEnv(base: Record<string, string>, contextJson: string): Record<string, string> {
+  const env: Record<string, string> = { ...base };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contextJson);
+  } catch {
+    return env;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return env;
+  const ctx = parsed as Record<string, unknown>;
+
+  const set = (key: string, value: unknown): void => {
+    if (typeof value === "string") {
+      if (value.length > 0) env[key] = value;
+    } else if (typeof value === "number" && Number.isFinite(value)) {
+      env[key] = String(value);
+    }
+  };
+  const obj = (value: unknown): Record<string, unknown> | undefined =>
+    typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : undefined;
+
+  set("RED_AFK_ISSUE", obj(ctx.issue)?.number);
+  set("RED_AFK_WORKSPACE", ctx.workspace);
+  set("RED_AFK_RUNNER", ctx.runner);
+  set("RED_AFK_ATTEMPT_N", ctx.attempt_n);
+  set("RED_AFK_MERGE_BASE", ctx.merge_base);
+
+  const result = obj(ctx.result);
+  if (result) {
+    set("RED_AFK_RESULT_STATUS", result.status);
+    set("RED_AFK_RESULT_OUTCOME", result.outcome);
+  }
+
+  const error = obj(ctx.error);
+  if (error) {
+    set("RED_AFK_ERROR_CLASS", error.class);
+    set("RED_AFK_ERROR_MESSAGE", error.message);
+  }
+
+  const mergeCommit = obj(ctx.merge_commit);
+  if (mergeCommit) {
+    set("RED_AFK_MERGE_COMMIT", mergeCommit.sha);
+    set("RED_AFK_MERGE_SHA", mergeCommit.short);
+  }
+
+  return env;
 }
 
 /**
@@ -160,7 +218,7 @@ export async function dispatchHooks(
 ): Promise<HookDispatchResult> {
   if (!HOOK_NAME_SET.has(name)) throw new UnknownLifecyclePointError(name);
 
-  const env = options.env ?? {};
+  const env = deriveHookEnv(options.env ?? {}, context);
   const log = options.log ?? (() => {});
   const policy = HOOK_EXIT_POLICY[name];
 

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -96,7 +96,7 @@ export interface LandingInput {
  * exact JSON shape stays defined once, next to the other hook contexts). */
 export interface LandingHookContexts {
   preMerge(): string;
-  postMerge(): string;
+  postMerge(mergeSha?: string): string;
 }
 
 /** Result of a landing. On success the caller closes; `mergeSha` carries the
@@ -152,7 +152,7 @@ export async function doLanding(
 
   // post_merge hook (best-effort; an abort here does not unwind the landing,
   // matching the prior behaviour which never branched on its result).
-  await deps.fireHook("post_merge", hooks.postMerge());
+  await deps.fireHook("post_merge", hooks.postMerge(landed.mergeSha));
   return landed;
 }
 

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1157,8 +1157,16 @@ export async function processIssue(
       title: input.title,
     },
     {
-      preMerge: () => hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch }),
-      postMerge: () => hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch }),
+      preMerge: () =>
+        hookContext({ issue, title: input.title, workspace: input.repoDir, branch: workerBranch, merge_base: base }),
+      postMerge: (mergeSha?: string) =>
+        hookContext({
+          issue,
+          title: input.title,
+          workspace: input.repoDir,
+          branch: workerBranch,
+          merge_commit: mergeSha ? { sha: mergeSha, short: mergeSha.slice(0, 7) } : undefined,
+        }),
     },
   );
   if (!landing.ok) {

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -446,6 +446,8 @@ function blockedLabelsIn(labels: string[]): string[] {
   return labels.filter((l) => l.startsWith("blocked:"));
 }
 
+const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-conflict"]);
+
 /**
  * ADDITIVE typed-blocked observability tag. Apply the routing label transition
  * (remove → add) and, ALONGSIDE it in the SAME editLabels call, the DESCRIPTIVE
@@ -595,7 +597,7 @@ export async function processIssue(
   }
 
   const activeBlocker = parseCurrentBlocker(input.body);
-  if (activeBlocker) {
+  if (activeBlocker && !MECHANICAL_BLOCKER_KINDS.has(activeBlocker.kind)) {
     await editLabelsTagged(deps, issue, [LABEL_READY], [LABEL_HUMAN], "blocked");
     await deps.gh.comment(
       issue,

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -295,8 +295,8 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       title: input.title,
     },
     {
-      preMerge: () => landingHookContext(input, branch),
-      postMerge: () => landingHookContext(input, branch),
+      preMerge: () => landingHookContext(input, branch, { mergeBase: input.base }),
+      postMerge: (mergeSha?: string) => landingHookContext(input, branch, { mergeSha }),
     },
   );
   if (!landing.ok) {
@@ -573,10 +573,17 @@ async function runCloseCascade(deps: ReconcileDeps, closedIssue: number): Promis
 // ---------- hook context ----------
 
 /** The pre_merge / post_merge hook context JSON, matching process-issue's shape. */
-function landingHookContext(input: ReconcileInput, branch: string): string {
-  return JSON.stringify({
+function landingHookContext(
+  input: ReconcileInput,
+  branch: string,
+  opts: { mergeBase?: string; mergeSha?: string } = {},
+): string {
+  const out: Record<string, unknown> = {
     issue: { number: input.issue, title: input.title },
     workspace: input.repoDir,
     branch,
-  });
+  };
+  if (opts.mergeBase) out.merge_base = opts.mergeBase;
+  if (opts.mergeSha) out.merge_commit = { sha: opts.mergeSha, short: opts.mergeSha.slice(0, 7) };
+  return JSON.stringify(out);
 }

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -54,6 +54,8 @@ import {
   LABEL_HUMAN,
   LABEL_VALIDATION,
   LABEL_DEPENDENCY,
+  LABEL_POLICY,
+  LABEL_INFRA,
   LABEL_MERGE_CONFLICT,
   LABEL_SPEC,
 } from "./triage-labels.js";
@@ -71,9 +73,10 @@ const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-conflict"
  * Labels that DISQUALIFY an issue from reconcile outright — the human-decision
  * blocked classes. `blocked:spec` is the boundary the ADR calls out explicitly;
  * `blocked:validation` means a prior gate already failed for a reason a human
- * must resolve, so re-running the same gate is pointless.
+ * must resolve, `blocked:dependency` is a dependency wait, and policy/infra
+ * blocks need operator action outside the worker branch.
  */
-const NON_MECHANICAL_LABELS = [LABEL_SPEC, LABEL_VALIDATION];
+const NON_MECHANICAL_LABELS = [LABEL_SPEC, LABEL_VALIDATION, LABEL_DEPENDENCY, LABEL_POLICY, LABEL_INFRA];
 
 // ---------- injected IO ----------
 
@@ -330,8 +333,9 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
 /**
  * The reason an issue is NOT a mechanical reconcile candidate, or null when it
  * is. Disqualified when it carries a human-decision blocked label
- * (`blocked:spec` / `blocked:validation`), or an ACTIVE `## Current blocker`
- * whose kind is not mechanical (stalled / crashed / merge-conflict). A stalled /
+ * (`blocked:spec` / `blocked:validation` / `blocked:dependency` /
+ * `blocked:policy` / `blocked:infra`), or an ACTIVE `## Current blocker` whose
+ * kind is not mechanical (stalled / crashed / merge-conflict). A stalled /
  * crashed blocker is mechanical and therefore allowed — it is exactly the parked
  * state reconcile exists to clear.
  */

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -216,7 +216,9 @@ export async function writeEnvelopePosted(attemptDir: string, posted: boolean): 
   env.posted = posted;
   obj.envelope = env;
   await mkdir(attemptDir, { recursive: true });
-  await writeFile(statePath, `${JSON.stringify(obj)}\n`, "utf8");
+  const tmp = `${statePath}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(obj)}\n`, "utf8");
+  await rename(tmp, statePath);
 }
 
 /** Read the `envelope.posted` flag from an attempt state file (false when

--- a/apps/dev/src/runtime/hooks.ts
+++ b/apps/dev/src/runtime/hooks.ts
@@ -55,12 +55,19 @@ export function makeHookResolveOptions(root: string): ResolveHooksOptions {
   return { defaultCommand: scriptDefaultResolver(defaultsDir, existsSync) };
 }
 
-/** The RED_AFK_* env handed to every hook command. */
-export function hookEnv(repo: string, root: string, slot?: number): Record<string, string> {
+/**
+ * The base RED_AFK_* env handed to every hook command. Event-specific context
+ * can override RED_AFK_WORKSPACE when dispatchHooks layers per-hook variables.
+ */
+export function hookEnv(repo: string, root: string, slot?: number, runner?: string): Record<string, string> {
   const env: Record<string, string> = {
     RED_AFK_REPO: repo,
     RED_AFK_ROOT: root,
+    RED_AFK_WORKSPACE: root,
   };
+  if (runner !== undefined && runner.length > 0) {
+    env.RED_AFK_RUNNER = runner;
+  }
   if (slot !== undefined) {
     env.RED_AFK_SLOT = String(slot);
   }

--- a/apps/dev/tests/fs-envelope.test.ts
+++ b/apps/dev/tests/fs-envelope.test.ts
@@ -1,0 +1,19 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readEnvelopePosted, writeEnvelopePosted } from "../src/runtime/fs.js";
+
+describe("envelope posted state persistence", () => {
+  it("preserves the original state when the atomic temp write fails", async () => {
+    const attemptDir = await mkdtemp(join(tmpdir(), "afk-envelope-"));
+    const statePath = join(attemptDir, "afk.state.json");
+    const original = `${JSON.stringify({ pid: 123, envelope: { posted: false }, current: { stage: "impl" } })}\n`;
+    await writeFile(statePath, original, "utf8");
+    await mkdir(`${statePath}.tmp`);
+
+    await expect(writeEnvelopePosted(attemptDir, true)).rejects.toThrow();
+    expect(await readFile(statePath, "utf8")).toBe(original);
+    expect(await readEnvelopePosted(attemptDir)).toBe(false);
+  });
+});

--- a/apps/dev/tests/history.test.ts
+++ b/apps/dev/tests/history.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -135,6 +135,19 @@ describe("history append", () => {
     expect(total).toBe(1);
   });
 
+  it("skips malformed JSONL lines while keeping valid monitor history", () => {
+    const records = parseHistoryLines(
+      [
+        JSON.stringify({ ts: "t1", epoch: 1, worker: "wA", issue: 1, event: "done", duration_s: 0, runner: "codex" }),
+        "{not-json",
+        "",
+        JSON.stringify({ ts: "t2", epoch: 2, worker: "wB", issue: 2, event: "blocked", duration_s: 3, runner: "claude" }),
+      ].join("\n"),
+    );
+
+    expect(records.map((record) => record.issue)).toEqual([1, 2]);
+  });
+
   it("rejects an empty event", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
     const path = join(dir, "afk-history.jsonl");
@@ -170,5 +183,18 @@ describe("history trim", () => {
   it("is a silent no-op for a missing file", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
     expect(await historyTrim(join(dir, "missing.jsonl"), 5)).toBeNull();
+  });
+
+  it("preserves the original ledger when the atomic temp write fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
+    const path = join(dir, "afk-history.jsonl");
+    const original = [1, 2, 3]
+      .map((epoch) => JSON.stringify({ ts: "t", epoch, worker: "", issue: 0, event: "done", duration_s: 0, runner: "" }))
+      .join("\n") + "\n";
+    await writeFile(path, original, "utf8");
+    await mkdir(`${path}.tmp`);
+
+    await expect(historyTrim(path, 2)).rejects.toThrow();
+    expect(await readFile(path, "utf8")).toBe(original);
   });
 });

--- a/apps/dev/tests/hook-dispatcher.test.ts
+++ b/apps/dev/tests/hook-dispatcher.test.ts
@@ -5,6 +5,7 @@ import {
   type ResolvedHooks,
 } from "../src/core/hook-config.js";
 import {
+  deriveHookEnv,
   dispatchHooks,
   HOOK_EXIT_POLICY,
   UnknownLifecyclePointError,
@@ -288,6 +289,92 @@ describe("hook-dispatcher executions list shape", () => {
       { env: { RED_AFK_RUNNER: "claude" } },
     );
     expect(calls[0]!.env).toEqual({ RED_AFK_RUNNER: "claude" });
+  });
+});
+
+describe("deriveHookEnv (documented per-event RED_AFK_* contract)", () => {
+  const base = { RED_AFK_REPO: "owner/repo", RED_AFK_ROOT: "/repo", RED_AFK_WORKSPACE: "/repo" };
+
+  it("returns the base env unchanged for empty and non-object contexts", () => {
+    expect(deriveHookEnv(base, "{}")).toEqual(base);
+    expect(deriveHookEnv(base, "[]")).toEqual(base);
+    expect(deriveHookEnv(base, "not json")).toEqual(base);
+  });
+
+  it("derives the pre_attempt env from issue, workspace, runner, and attempt_n", () => {
+    const env = deriveHookEnv(
+      base,
+      JSON.stringify({
+        issue: { number: 585, title: "fix env contract" },
+        workspace: "/repo/.red/tmp/worktree",
+        runner: "codex",
+        attempt_n: 2,
+      }),
+    );
+
+    expect(env).toEqual({
+      RED_AFK_REPO: "owner/repo",
+      RED_AFK_ROOT: "/repo",
+      RED_AFK_WORKSPACE: "/repo/.red/tmp/worktree",
+      RED_AFK_ISSUE: "585",
+      RED_AFK_RUNNER: "codex",
+      RED_AFK_ATTEMPT_N: "2",
+    });
+  });
+
+  it("derives result, error, and merge vars when those event fields are present", () => {
+    const env = deriveHookEnv(
+      base,
+      JSON.stringify({
+        issue: { number: 7 },
+        result: { status: "success", outcome: "done" },
+        error: { class: "session-crash", message: "boom" },
+        merge_base: "main",
+        merge_commit: { sha: "abc123456", short: "abc1234" },
+        attempt_n: 1,
+      }),
+    );
+
+    expect(env.RED_AFK_ISSUE).toBe("7");
+    expect(env.RED_AFK_RESULT_STATUS).toBe("success");
+    expect(env.RED_AFK_RESULT_OUTCOME).toBe("done");
+    expect(env.RED_AFK_ERROR_CLASS).toBe("session-crash");
+    expect(env.RED_AFK_ERROR_MESSAGE).toBe("boom");
+    expect(env.RED_AFK_MERGE_BASE).toBe("main");
+    expect(env.RED_AFK_MERGE_COMMIT).toBe("abc123456");
+    expect(env.RED_AFK_MERGE_SHA).toBe("abc1234");
+    expect(env.RED_AFK_ATTEMPT_N).toBe("1");
+  });
+
+  it("leaves irrelevant or empty fields unset", () => {
+    const env = deriveHookEnv(base, JSON.stringify({ result: { status: "fail", outcome: "" } }));
+
+    expect(env.RED_AFK_RESULT_STATUS).toBe("fail");
+    expect("RED_AFK_RESULT_OUTCOME" in env).toBe(false);
+    expect("RED_AFK_ISSUE" in env).toBe(false);
+    expect("RED_AFK_RUNNER" in env).toBe(false);
+  });
+});
+
+describe("dispatchHooks layers the per-event env onto the base env", () => {
+  it("a pre_attempt command receives the documented RED_AFK_* vars for its event", async () => {
+    const calls: Array<{ command: string; stdin: string; env: Record<string, string> }> = [];
+    await dispatchHooks(
+      "pre_attempt",
+      ["notify"],
+      JSON.stringify({ issue: { number: 585 }, workspace: "/wt", runner: "codex", attempt_n: 1 }),
+      fakeExec({ notify: { code: 0, stdout: "" } }, calls),
+      { env: { RED_AFK_REPO: "o/r", RED_AFK_ROOT: "/repo", RED_AFK_WORKSPACE: "/repo" } },
+    );
+
+    expect(calls[0]!.env).toEqual({
+      RED_AFK_REPO: "o/r",
+      RED_AFK_ROOT: "/repo",
+      RED_AFK_WORKSPACE: "/wt",
+      RED_AFK_ISSUE: "585",
+      RED_AFK_RUNNER: "codex",
+      RED_AFK_ATTEMPT_N: "1",
+    });
   });
 });
 

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -815,6 +815,28 @@ describe("processIssue — active Current blocker preflight", () => {
     expect(trace.comments[0]?.body).toContain("active Current blocker (decision)");
     expect(trace.released).toEqual([9]);
   });
+
+  it("does not escalate a mechanical Current blocker before reconcile can handle it", async () => {
+    const body = upsertCurrentBlocker("## Agent brief\nDo it.", {
+      status: "blocked",
+      kind: "stalled",
+      summary: "Worker stopped after pushing a branch.",
+      next: "Reconcile the owned branch.",
+    });
+    const { deps, input, trace } = harness({
+      body,
+      labels: ["ready-for-agent", "blocked:stalled"],
+      outcome: "done",
+      feedbackOk: true,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls.length).toBe(1);
+    expect(labelTrace(trace)[0]).toBe("-ready-for-agent+blocked:stalled|+running");
+    expect(trace.comments.map((c) => c.body).some((body) => body.includes("preflight stopped"))).toBe(false);
+    expect(trace.ensuredLabels).not.toContain("blocked:spec");
+  });
 });
 
 describe("processIssue — feedback fail", () => {

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -389,6 +389,9 @@ describe("mechanicalDisqualifier", () => {
   it("flags human-decision blocked labels", () => {
     expect(mechanicalDisqualifier(["blocked:spec"], "x")).toBe("not-mechanical");
     expect(mechanicalDisqualifier(["blocked:validation"], "x")).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:dependency"], "x")).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:policy"], "x")).toBe("not-mechanical");
+    expect(mechanicalDisqualifier(["blocked:infra"], "x")).toBe("not-mechanical");
   });
 
   it("flags an active non-mechanical Current blocker", () => {

--- a/apps/dev/tests/runtime-hooks.test.ts
+++ b/apps/dev/tests/runtime-hooks.test.ts
@@ -75,10 +75,15 @@ describe("makeHookResolveOptions (gap 6: built-in defaults anchor on the plugin)
 });
 
 describe("hookEnv (per-slot RED_AFK_SLOT in hook environment)", () => {
-  it("includes RED_AFK_REPO and RED_AFK_ROOT always", () => {
+  it("includes RED_AFK_REPO, RED_AFK_ROOT, and RED_AFK_WORKSPACE always", () => {
     const env = hookEnv("owner/repo", "/repo");
     expect(env.RED_AFK_REPO).toBe("owner/repo");
     expect(env.RED_AFK_ROOT).toBe("/repo");
+    expect(env.RED_AFK_WORKSPACE).toBe("/repo");
+  });
+
+  it("includes RED_AFK_RUNNER when the caller supplies the resolved runner", () => {
+    expect(hookEnv("owner/repo", "/repo", undefined, "codex").RED_AFK_RUNNER).toBe("codex");
   });
 
   it("omits RED_AFK_SLOT when no slot is given", () => {

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -620,7 +620,7 @@ remaining : 8 still ready-for-agent
 
 ## Configuration & lifecycle hooks
 
-All `.red/config.yaml` knobs + `RED_AFK_*` env overrides (sandbox, runner, model/effort, timeouts, retry caps, stall thresholds, backpressure) and the lifecycle-hook contract live in [`docs/CONFIG.md`](./docs/CONFIG.md). Runner/model resolution policy: [`../model-tier-policy/SKILL.md`](../model-tier-policy/SKILL.md).
+All `.red/config.yaml` knobs + `RED_AFK_*` env overrides (sandbox, runner, model/effort, timeouts, retry caps, stall thresholds, backpressure) and the lifecycle-hook contract live in [`docs/CONFIG.md`](./docs/CONFIG.md). The runtime supplies the documented base env (`RED_AFK_REPO`, `RED_AFK_ROOT`, `RED_AFK_WORKSPACE`, `RED_AFK_RUNNER`, optional `RED_AFK_SLOT`) and layers each hook event's documented `RED_AFK_*` variables from that event's JSON context. Runner/model resolution policy: [`../model-tier-policy/SKILL.md`](../model-tier-policy/SKILL.md).
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Restores and lands the preserved AFK attempt commits for PRD #567 children:
- Closes #584
- Closes #585
- Closes #587

The prior AFK attempts were parked by validation against a stale local base where apps/dev's full Vitest suite OOMed in tests/supervisor.test.ts. This branch reapplies the preserved attempt commits onto current origin/main, where the supervisor suite fix is present.

## Validation

- pnpm -C apps/dev exec vitest run tests/history.test.ts tests/fs-envelope.test.ts tests/hook-dispatcher.test.ts tests/runtime-hooks.test.ts tests/process-issue.test.ts tests/reconcile.test.ts
- pnpm -C apps/dev typecheck
- pnpm -C apps/dev test (96 files, 1533 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783977541&installation_id=129708444&pr_number=741&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F741&signature=0317fd6930fc93ae7ef5f69a905cf4ba66b74dc6abf3c9690b4cae75753aa430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->