### PR TITLE
feat(brain): add daily dashboard

### DIFF
--- a/apps/brain/src/cli.ts
+++ b/apps/brain/src/cli.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readFile, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { AddressInfo } from "node:net";
 import { McpStdioChannelBridge } from "./channel-bridge.js";
 import { handleHook, type Runner } from "./hook-runtime.js";
 import { ingestEvents } from "./ingest-events.js";
 import { withBrainRuntime } from "./runtime.js";
 import { brainAct } from "./brain-act.js";
+import { buildBrainDashboard, buildBrainDashboardArtifact, serveBrainDashboardHtml } from "./dashboard.js";
 import { ARTIFACT_KINDS, CONNECTION_KINDS } from "./schema.js";
 import { loadIngestionState, saveIngestionState, scheduledIngest } from "./scheduled-ingestion.js";
 import type { KpiGroupBy, KpiInterval, KpiTimeField } from "./kpi-query.js";
@@ -63,6 +65,9 @@ async function main(): Promise<void> {
     case "kpi":
     case "kpis":
       await kpis(args);
+      return;
+    case "dashboard":
+      await dashboard(args);
       return;
     default:
       throw new Error(`unknown brain command: ${command}`);
@@ -211,6 +216,45 @@ async function kpis(args: string[]): Promise<void> {
   });
 }
 
+async function dashboard(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const rendered = await withBrainRuntime(async ({ config, store, project }) => {
+    const dashboard = await buildBrainDashboard(store, {
+      project,
+      rootDir: config.rootDir,
+    });
+    return {
+      dashboard,
+      artifact: buildBrainDashboardArtifact(dashboard),
+      defaultOut: join(config.rootDir, ".red", "brain", "dashboard.html"),
+    };
+  });
+
+  if (flags.json === true) {
+    printJson(rendered.dashboard);
+    return;
+  }
+
+  if (flags.serve === true) {
+    const host = stringFlag(flags, "host") ?? "127.0.0.1";
+    const port = numberFlag(flags, "port") ?? 4738;
+    const server = await serveBrainDashboardHtml(rendered.artifact.html, { host, port });
+    const address = server.address() as AddressInfo;
+    console.log(`brain: dashboard serving at http://${address.address}:${address.port}/`);
+    await new Promise<void>((resolve) => {
+      const stop = () => server.close(() => resolve());
+      process.once("SIGINT", stop);
+      process.once("SIGTERM", stop);
+    });
+    return;
+  }
+
+  const out = stringFlag(flags, "out") ?? rendered.defaultOut;
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, rendered.artifact.html, "utf8");
+  console.log(`brain: dashboard written ${out}`);
+}
+
 async function act(args: string[]): Promise<void> {
   const flags = parseFlags(args);
   const target = stringFlag(flags, "target") ?? flags._[0];
@@ -292,6 +336,7 @@ function printHelp(): void {
   ingest-events [--after-cursor N] [--session-key KEY] [--limit N]
   schedule-ingest [--session-key KEY] [--limit N] [--state PATH]
   kpi [--interval hour|day|week|month] [--group-by platform|event_type|target] [--time-field event|ingested] [--from T] [--to T] [--platform P] [--event-type T] [--target T]
+  dashboard [--out PATH] [--json] [--serve] [--host 127.0.0.1] [--port 4738]
 `);
 }
 

--- a/apps/brain/src/dashboard.ts
+++ b/apps/brain/src/dashboard.ts
@@ -1,0 +1,490 @@
+import { createServer, type Server } from "node:http";
+import type { KpiResult } from "./kpi-query.js";
+import type { StoredBrainArtifact, StoredBrainConnection } from "./schema.js";
+import type { BrainStore } from "./store.js";
+
+export interface BrainDashboardOptions {
+  project: string;
+  rootDir: string;
+  now?: number;
+  decisionLimit?: number;
+  connectionLimit?: number;
+}
+
+export interface BrainDashboard {
+  schema_version: "brain.dashboard.v1";
+  generated_at: string;
+  project: string;
+  root: string;
+  stats: {
+    artifacts: number;
+    connections: number;
+    decisions: number;
+    events: number;
+    supports: number;
+    contradicts: number;
+    depends_on: number;
+  };
+  kpis: {
+    events_daily: KpiResult;
+    events_by_platform: KpiResult;
+    events_by_type: KpiResult;
+  };
+  recent_decisions: BrainDashboardDecision[];
+  recent_connections: BrainDashboardConnection[];
+  attribution: {
+    red_hermes: string;
+  };
+}
+
+export interface BrainDashboardDecision {
+  rid: number;
+  id: string;
+  title: string;
+  updated_at: string;
+  tags: string[];
+  connection_counts: {
+    supports: number;
+    contradicts: number;
+    depends_on: number;
+    related_to: number;
+  };
+  excerpt: string;
+}
+
+export interface BrainDashboardConnection {
+  rid: number;
+  kind: string;
+  from: { rid: number; title: string };
+  to: { rid: number; title: string };
+  created_at: string;
+  reason: string | null;
+}
+
+export interface BrainDashboardArtifact {
+  contract: {
+    name: "brain.dashboard.viewer";
+    version: "brain.dashboard.viewer.v1";
+    consumes: "brain.dashboard.v1";
+  };
+  html: string;
+}
+
+export async function buildBrainDashboard(
+  store: BrainStore,
+  options: BrainDashboardOptions,
+): Promise<BrainDashboard> {
+  const artifacts = await store.listArtifacts();
+  const connections = await store.listConnections();
+  const artifactsByRid = new Map(artifacts.map((artifact) => [artifact.rid, artifact]));
+  const eventsDaily = await store.eventKpis({ interval: "day" });
+  const eventsByPlatform = await store.eventKpis({ interval: "day", groupBy: "platform" });
+  const eventsByType = await store.eventKpis({ interval: "day", groupBy: "event_type" });
+  const decisionLimit = options.decisionLimit ?? 8;
+  const connectionLimit = options.connectionLimit ?? 12;
+
+  return {
+    schema_version: "brain.dashboard.v1",
+    generated_at: new Date(options.now ?? Date.now()).toISOString(),
+    project: options.project,
+    root: options.rootDir,
+    stats: {
+      artifacts: artifacts.length,
+      connections: connections.length,
+      decisions: artifacts.filter((artifact) => artifact.kind === "decision").length,
+      events: eventsDaily.total,
+      supports: countConnections(connections, "supports"),
+      contradicts: countConnections(connections, "contradicts"),
+      depends_on: countConnections(connections, "depends_on"),
+    },
+    kpis: {
+      events_daily: eventsDaily,
+      events_by_platform: eventsByPlatform,
+      events_by_type: eventsByType,
+    },
+    recent_decisions: artifacts
+      .filter((artifact) => artifact.kind === "decision")
+      .sort((a, b) => b.properties.updated_at - a.properties.updated_at || b.rid - a.rid)
+      .slice(0, decisionLimit)
+      .map((artifact) => summarizeDecision(artifact, connections)),
+    recent_connections: connections
+      .filter((connection) => artifactsByRid.has(connection.from_rid) && artifactsByRid.has(connection.to_rid))
+      .sort((a, b) => b.properties.created_at - a.properties.created_at || b.rid - a.rid)
+      .slice(0, connectionLimit)
+      .map((connection) => summarizeConnection(connection, artifactsByRid)),
+    attribution: {
+      red_hermes:
+        "Dashboard layout and command-center interaction model are adapted from the red-hermes web surface; NOTICE records the MIT attribution.",
+    },
+  };
+}
+
+export function buildBrainDashboardArtifact(dashboard: BrainDashboard): BrainDashboardArtifact {
+  return {
+    contract: {
+      name: "brain.dashboard.viewer",
+      version: "brain.dashboard.viewer.v1",
+      consumes: "brain.dashboard.v1",
+    },
+    html: renderBrainDashboardHtml(dashboard),
+  };
+}
+
+export async function serveBrainDashboardHtml(
+  html: string,
+  options: { host?: string; port?: number } = {},
+): Promise<Server> {
+  const host = options.host ?? "127.0.0.1";
+  const port = options.port ?? 4738;
+  const server = createServer((req, res) => {
+    const url = req.url ?? "/";
+    if (url === "/" || url === "/dashboard") {
+      res.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      });
+      res.end(html);
+      return;
+    }
+    res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    res.end("not found\n");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+function summarizeDecision(
+  artifact: StoredBrainArtifact,
+  connections: StoredBrainConnection[],
+): BrainDashboardDecision {
+  const related = connections.filter((connection) => (
+    connection.from_rid === artifact.rid || connection.to_rid === artifact.rid
+  ));
+  return {
+    rid: artifact.rid,
+    id: artifact.properties.id,
+    title: artifact.properties.title,
+    updated_at: new Date(artifact.properties.updated_at).toISOString(),
+    tags: artifact.properties.tags,
+    connection_counts: {
+      supports: related.filter((connection) => connection.kind === "supports").length,
+      contradicts: related.filter((connection) => connection.kind === "contradicts").length,
+      depends_on: related.filter((connection) => connection.kind === "depends_on").length,
+      related_to: related.filter((connection) => connection.kind === "related_to").length,
+    },
+    excerpt: excerpt(artifact.properties.content),
+  };
+}
+
+function summarizeConnection(
+  connection: StoredBrainConnection,
+  artifactsByRid: Map<number, StoredBrainArtifact>,
+): BrainDashboardConnection {
+  const from = artifactsByRid.get(connection.from_rid);
+  const to = artifactsByRid.get(connection.to_rid);
+  if (!from || !to) {
+    throw new Error(`connection ${connection.rid} references missing artifacts`);
+  }
+  return {
+    rid: connection.rid,
+    kind: connection.kind,
+    from: { rid: from.rid, title: from.properties.title },
+    to: { rid: to.rid, title: to.properties.title },
+    created_at: new Date(connection.properties.created_at).toISOString(),
+    reason: connection.properties.reason ?? null,
+  };
+}
+
+function renderBrainDashboardHtml(dashboard: BrainDashboard): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Brain Dashboard</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17202a;
+      --muted: #667085;
+      --line: #d8dee8;
+      --surface: #ffffff;
+      --band: #f6f7f9;
+      --accent: #2f6f73;
+      --accent-2: #8b5f2a;
+      --risk: #9f3a38;
+      --good: #2f7d56;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--band);
+      color: var(--ink);
+      letter-spacing: 0;
+    }
+    header {
+      display: grid;
+      gap: 12px;
+      padding: 28px clamp(18px, 4vw, 48px) 18px;
+      border-bottom: 1px solid var(--line);
+      background: var(--surface);
+    }
+    h1 {
+      margin: 0;
+      font-size: 30px;
+      line-height: 1.1;
+      font-weight: 720;
+    }
+    h2 {
+      margin: 0 0 12px;
+      font-size: 16px;
+      line-height: 1.2;
+    }
+    .meta {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+    main {
+      display: grid;
+      gap: 18px;
+      padding: 18px clamp(18px, 4vw, 48px) 48px;
+    }
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 10px;
+    }
+    .metric, section {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: 0 1px 2px rgba(23, 32, 42, 0.04);
+    }
+    .metric {
+      min-height: 92px;
+      padding: 14px;
+      display: grid;
+      align-content: space-between;
+      gap: 10px;
+    }
+    .metric strong {
+      display: block;
+      font-size: 26px;
+      line-height: 1;
+      font-weight: 760;
+    }
+    .metric span {
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+    }
+    section { padding: 16px; }
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(280px, .8fr);
+      gap: 18px;
+      align-items: start;
+    }
+    .bars {
+      display: grid;
+      gap: 8px;
+      margin-top: 10px;
+    }
+    .bar {
+      display: grid;
+      grid-template-columns: 120px minmax(0, 1fr) 42px;
+      gap: 10px;
+      align-items: center;
+      font-size: 13px;
+    }
+    .track {
+      height: 10px;
+      border-radius: 999px;
+      background: #e8edf2;
+      overflow: hidden;
+    }
+    .fill {
+      height: 100%;
+      background: var(--accent);
+    }
+    .feed {
+      display: grid;
+      gap: 10px;
+    }
+    .item {
+      border-top: 1px solid var(--line);
+      padding-top: 10px;
+    }
+    .item:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+    .item h3 {
+      margin: 0 0 5px;
+      font-size: 14px;
+      line-height: 1.3;
+    }
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 8px;
+    }
+    .tag {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      color: var(--muted);
+      background: #fbfcfd;
+    }
+    .edge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 22px;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      color: #fff;
+      background: var(--accent-2);
+    }
+    .edge.supports { background: var(--good); }
+    .edge.contradicts { background: var(--risk); }
+    .empty {
+      color: var(--muted);
+      border-top: 1px solid var(--line);
+      padding-top: 10px;
+      font-size: 13px;
+    }
+    footer {
+      padding: 0 clamp(18px, 4vw, 48px) 28px;
+    }
+    @media (max-width: 780px) {
+      .grid { grid-template-columns: 1fr; }
+      .bar { grid-template-columns: 86px minmax(0, 1fr) 34px; }
+      h1 { font-size: 24px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>${escapeHtml(dashboard.project)} Brain Dashboard</h1>
+    <div class="meta">${escapeHtml(dashboard.root)} - ${escapeHtml(dashboard.generated_at)}</div>
+  </header>
+  <main>
+    <div class="metrics">
+      ${metric("Artifacts", dashboard.stats.artifacts, "captured knowledge")}
+      ${metric("Decisions", dashboard.stats.decisions, "curated choices")}
+      ${metric("Events", dashboard.stats.events, "KpiQuery total")}
+      ${metric("Connections", dashboard.stats.connections, "typed graph edges")}
+      ${metric("Supports", dashboard.stats.supports, "positive evidence")}
+      ${metric("Contradicts", dashboard.stats.contradicts, "open tension")}
+    </div>
+    <div class="grid">
+      <section>
+        <h2>Event KPIs</h2>
+        <div class="meta">Derived from kind:event artifacts through KpiQuery. No separate metrics store.</div>
+        ${kpiBars(dashboard.kpis.events_by_platform, "Platform")}
+        ${kpiBars(dashboard.kpis.events_by_type, "Event type")}
+      </section>
+      <section>
+        <h2>Recent Decisions</h2>
+        <div class="feed">
+          ${dashboard.recent_decisions.length === 0 ? empty("No decision artifacts captured yet.") : dashboard.recent_decisions.map(decisionItem).join("")}
+        </div>
+      </section>
+    </div>
+    <section>
+      <h2>Recent Connections</h2>
+      <div class="feed">
+        ${dashboard.recent_connections.length === 0 ? empty("No graph connections captured yet.") : dashboard.recent_connections.map(connectionItem).join("")}
+      </div>
+    </section>
+  </main>
+  <footer class="meta">${escapeHtml(dashboard.attribution.red_hermes)}</footer>
+  <script id="brain-dashboard-data" type="application/json">${jsonForScript(dashboard)}</script>
+</body>
+</html>`;
+}
+
+function metric(label: string, value: number, note: string): string {
+  return `<div class="metric"><span>${escapeHtml(label)}</span><strong>${value}</strong><div class="meta">${escapeHtml(note)}</div></div>`;
+}
+
+function kpiBars(kpi: KpiResult, title: string): string {
+  const grouped = kpi.series.filter((series) => series.group != null);
+  if (grouped.length === 0) return `<div class="empty">No ${escapeHtml(title.toLowerCase())} split available.</div>`;
+  const max = Math.max(...grouped.map((series) => series.total), 1);
+  return `<div class="bars" aria-label="${escapeHtml(title)}">${grouped.map((series) => {
+    const label = series.group ?? "all";
+    const width = Math.round((series.total / max) * 100);
+    return `<div class="bar"><div class="meta">${escapeHtml(label)}</div><div class="track"><div class="fill" style="width:${width}%"></div></div><strong>${series.total}</strong></div>`;
+  }).join("")}</div>`;
+}
+
+function decisionItem(decision: BrainDashboardDecision): string {
+  const counts = decision.connection_counts;
+  const tags = decision.tags.length === 0
+    ? ""
+    : `<div class="tags">${decision.tags.slice(0, 6).map((tag) => `<span class="tag">${escapeHtml(tag)}</span>`).join("")}</div>`;
+  return `<article class="item">
+    <h3>${escapeHtml(decision.title)}</h3>
+    <div class="meta">#${decision.rid} - ${escapeHtml(decision.updated_at)} - supports ${counts.supports}, contradicts ${counts.contradicts}, depends_on ${counts.depends_on}, related_to ${counts.related_to}</div>
+    <p class="meta">${escapeHtml(decision.excerpt)}</p>
+    ${tags}
+  </article>`;
+}
+
+function connectionItem(connection: BrainDashboardConnection): string {
+  return `<article class="item">
+    <h3><span class="edge ${escapeHtml(connection.kind)}">${escapeHtml(connection.kind)}</span> ${escapeHtml(connection.from.title)} -> ${escapeHtml(connection.to.title)}</h3>
+    <div class="meta">#${connection.rid} - ${escapeHtml(connection.created_at)}${connection.reason ? ` - ${escapeHtml(connection.reason)}` : ""}</div>
+  </article>`;
+}
+
+function empty(text: string): string {
+  return `<div class="empty">${escapeHtml(text)}</div>`;
+}
+
+function countConnections(connections: StoredBrainConnection[], kind: string): number {
+  return connections.filter((connection) => connection.kind === kind).length;
+}
+
+function excerpt(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "\"":
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}
+
+function jsonForScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}

--- a/apps/brain/tests/dashboard.test.ts
+++ b/apps/brain/tests/dashboard.test.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildBrainDashboard, buildBrainDashboardArtifact, serveBrainDashboardHtml } from "../src/dashboard.js";
+import { BrainStore } from "../src/store.js";
+
+const TIMEOUT = 40_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "brain-dashboard-"));
+  roots.push(root);
+  await mkdir(join(root, ".red", "brain"), { recursive: true });
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function runBrain(args: string[], root: string) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    env: { ...process.env, RED_BRAIN_ROOT: root },
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+async function seedBrain(root: string): Promise<void> {
+  const store = await BrainStore.open({ uri: `file://${join(root, ".red", "brain", "brain.rdb")}` });
+  try {
+    const decision = await store.capture({
+      title: "Use channel bridge",
+      kind: "decision",
+      tags: ["dashboard"],
+      content: "Use the channel bridge behind Brain instead of exposing raw messaging tools.",
+    });
+    const event = await store.capture({
+      title: "Slack release event",
+      kind: "event",
+      tags: ["channel-event"],
+      content: "Release train is green.",
+      metadata: {
+        timestamp: "2026-06-01T08:00:00.000Z",
+        platform: "slack",
+        event_type: "message",
+        target: "#eng",
+      },
+    });
+    await store.link({
+      from: event.rid,
+      to: decision.rid,
+      kind: "supports",
+      reason: "The event supports the dashboard decision.",
+    });
+  } finally {
+    await store.close();
+  }
+}
+
+describe("Brain dashboard", () => {
+  it("builds a curated daily-driver model over KPIs, decisions, and graph edges", async () => {
+    const root = await tempRoot();
+    await seedBrain(root);
+    const store = await BrainStore.open({ uri: `file://${join(root, ".red", "brain", "brain.rdb")}` });
+    try {
+      const dashboard = await buildBrainDashboard(store, {
+        project: "brain-dashboard-test",
+        rootDir: root,
+        now: Date.UTC(2026, 5, 13, 12),
+      });
+
+      expect(dashboard).toMatchObject({
+        schema_version: "brain.dashboard.v1",
+        generated_at: "2026-06-13T12:00:00.000Z",
+        project: "brain-dashboard-test",
+        stats: {
+          decisions: 1,
+          events: 1,
+          supports: 1,
+        },
+        kpis: {
+          events_daily: { total: 1 },
+          events_by_platform: { total: 1 },
+          events_by_type: { total: 1 },
+        },
+      });
+      expect(dashboard.recent_decisions[0]).toMatchObject({
+        title: "Use channel bridge",
+        connection_counts: { supports: 1 },
+      });
+      expect(dashboard.recent_connections[0]).toMatchObject({
+        kind: "supports",
+        from: { title: "Slack release event" },
+        to: { title: "Use channel bridge" },
+      });
+
+      const artifact = buildBrainDashboardArtifact(dashboard);
+      expect(artifact.contract).toEqual({
+        name: "brain.dashboard.viewer",
+        version: "brain.dashboard.viewer.v1",
+        consumes: "brain.dashboard.v1",
+      });
+      expect(artifact.html).toContain("Brain Dashboard");
+      expect(artifact.html).toContain("Event KPIs");
+      expect(artifact.html).toContain("Recent Decisions");
+      expect(artifact.html).toContain('id="brain-dashboard-data"');
+      expect(artifact.html).toContain("red-hermes web surface");
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("CLI writes self-contained HTML and emits dashboard JSON", async () => {
+    const root = await tempRoot();
+    await seedBrain(root);
+
+    const out = join(root, "brain-dashboard.html");
+    const html = runBrain(["dashboard", "--out", out], root);
+    expect(html.status, html.stderr).toBe(0);
+    expect(html.stdout).toContain("brain: dashboard written");
+    const content = await readFile(out, "utf8");
+    expect(content).toContain("brain-dashboard-data");
+
+    const json = runBrain(["dashboard", "--json"], root);
+    expect(json.status, json.stderr).toBe(0);
+    expect(JSON.parse(json.stdout)).toMatchObject({
+      schema_version: "brain.dashboard.v1",
+      stats: { events: 1, decisions: 1 },
+    });
+  });
+
+  it("serves the dashboard on a loopback URL", async () => {
+    const server = await serveBrainDashboardHtml("<!doctype html><title>Brain Dashboard</title>", {
+      port: 0,
+    });
+    try {
+      const address = server.address();
+      if (address == null || typeof address === "string") throw new Error("expected TCP server address");
+      const response = await fetch(`http://127.0.0.1:${address.port}/`);
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toContain("Brain Dashboard");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+});

--- a/plugins/brain/README.md
+++ b/plugins/brain/README.md
@@ -62,3 +62,10 @@ Core skills: [capture](./skills/core/capture/SKILL.md),
 [status](./skills/core/status/SKILL.md), and
 [view](./skills/core/view/SKILL.md). `view` opens `brain.rdb` in red-ui for
 graph/connection exploration.
+
+`brain dashboard` generates the separate daily-driver surface: a self-contained
+HTML overview with KpiQuery-backed event metrics, recent decisions, and recent
+typed connections. It is intentionally not a node-link graph and does not reuse
+the Memory Workbench. Use `brain dashboard --out dashboard.html` for a file,
+`brain dashboard --json` for the underlying `brain.dashboard.v1` contract, or
+`brain dashboard --serve --port 4738` for a loopback local URL.


### PR DESCRIPTION
## Summary

Closes #478.

Adds the Brain daily-driver dashboard as a curated local surface distinct from the red-ui graph explorer:
- `brain dashboard --out <path>` writes a self-contained HTML overview
- `brain dashboard --json` emits the `brain.dashboard.v1` contract
- `brain dashboard --serve --port <n>` serves the same view on loopback
- dashboard content is backed by existing Brain artifacts/connections plus KpiQuery event metrics
- README documents the command and keeps Memory Workbench out of scope

## Validation

- pnpm -C apps/brain exec vitest run tests/dashboard.test.ts tests/kpi-query.test.ts tests/store.test.ts
- pnpm -C apps/brain typecheck
- pnpm -C apps/brain test
- pnpm -C apps/brain build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783979147&installation_id=129708444&pr_number=742&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F742&signature=e9189d4514b72717306f8a424fe09fe984b243396e8d4230f18ab15efb3ef3fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->