### PR TITLE
feat(brain): add dashboard and cited think answers

### DIFF
--- a/.red/contexts/brain/CONTEXT.md
+++ b/.red/contexts/brain/CONTEXT.md
@@ -70,6 +70,19 @@ _Avoid_: automatic cache, search result, folder listing
 A derived view or cache that summarizes a slice of the Brain until a human or agent curates it into a **Brain index**.
 _Avoid_: canonical artifact, promoted knowledge, durable decision
 
+**Brain cited answer**:
+The deterministic `brain think` response that turns Brain search hits into a
+user-facing answer with stable citations, confidence, and evidence gaps. It is
+grounded in Brain artifacts and their RedDB graph signals; it must not fill gaps
+from uncited model knowledge.
+_Avoid_: uncited synthesis, freeform answer, hallucinated recall
+
+**Brain evidence gap**:
+An explicit `missing_evidence` item in a Brain cited answer, used when the Brain
+has no hits, weak hits, only one citation, or artifacts missing captured source
+provenance.
+_Avoid_: silent uncertainty, generic disclaimer, confidence padding
+
 **Brain capture**:
 The ingestion act that creates or updates a Brain artifact.
 _Avoid_: memory store, transcript logging

--- a/apps/brain/src/mcp-server.ts
+++ b/apps/brain/src/mcp-server.ts
@@ -73,7 +73,8 @@ const TOOLS = [
   },
   {
     name: "brain_think",
-    description: "Return a deterministic synthesis over Brain search hits.",
+    description:
+      "Return a deterministic cited synthesis over Brain search hits, including citations, confidence, and missing evidence.",
     inputSchema: zodShape(SearchInput),
   },
   {

--- a/apps/brain/src/store.ts
+++ b/apps/brain/src/store.ts
@@ -65,6 +65,35 @@ export interface SearchOptions {
 
 export interface ThinkOptions extends SearchOptions {}
 
+export type BrainThinkConfidence = "none" | "low" | "medium" | "high";
+
+export interface BrainCitationSource {
+  path?: string;
+  session?: string;
+  agent?: string;
+  runner?: string;
+}
+
+export interface BrainCitation {
+  ref: string;
+  rid: number;
+  id: string;
+  title: string;
+  kind: ArtifactKind;
+  score: number;
+  score_breakdown: SearchScoreBreakdown;
+  excerpt: string;
+  source?: BrainCitationSource;
+}
+
+export interface BrainThinkResult {
+  answer: string;
+  hits: SearchHit[];
+  citations: BrainCitation[];
+  confidence: BrainThinkConfidence;
+  missing_evidence: string[];
+}
+
 export class BrainStore {
   private db!: RedDB;
   private artifactCache: StoredBrainArtifact[] | null = null;
@@ -266,12 +295,11 @@ export class BrainStore {
     return new KpiQuery(artifacts).events(input);
   }
 
-  async think(query: string, limit = 8, options: ThinkOptions = {}): Promise<{ answer: string; hits: SearchHit[] }> {
-    const hits = await this.search(query, limit, options);
-    return {
-      hits,
-      answer: renderThinkAnswer(query, hits),
-    };
+  async think(query: string, limit = 8, options: ThinkOptions = {}): Promise<BrainThinkResult> {
+    const hits = (await this.search(query, Math.max(limit * 2, limit + 5), options))
+      .filter((hit) => !isDerivedArtifact(hit.artifact))
+      .slice(0, limit);
+    return renderThinkResult(query, hits);
   }
 
   async deriveAutoLinks(artifact: StoredBrainArtifact): Promise<AppliedBrainAutoLink[]> {
@@ -337,7 +365,7 @@ export class BrainStore {
       const request: BrainAutoLinkRequest = {
         newArtifact: artifactToAutoLinkArtifact(artifact),
         candidates,
-        think: { query, answer: renderThinkAnswer(query, think.hits) },
+        think: { query, answer: think.answer },
         allowedKinds: AUTO_LINK_CONNECTION_KINDS,
       };
       const proposals = await this.opts.autoLinker.deriveConnections(request);
@@ -554,18 +582,126 @@ function excerpt(content: string, terms: string[]): string {
   return `${start > 0 ? "..." : ""}${content.slice(start, start + 220)}${start + 220 < content.length ? "..." : ""}`;
 }
 
-function renderThinkAnswer(query: string, hits: SearchHit[]): string {
-  const lines = hits.map((hit, index) => {
-    const artifact = hit.artifact;
-    const signals = Object.entries(hit.score_breakdown)
+function renderThinkResult(query: string, hits: SearchHit[]): BrainThinkResult {
+  const citations = hits.map(hitToCitation);
+  const confidence = classifyThinkConfidence(hits);
+  const missingEvidence = thinkMissingEvidence(query, citations, confidence);
+  return {
+    hits,
+    citations,
+    confidence,
+    missing_evidence: missingEvidence,
+    answer: renderThinkAnswer(query, citations, confidence, missingEvidence),
+  };
+}
+
+function hitToCitation(hit: SearchHit, index: number): BrainCitation {
+  const artifact = hit.artifact;
+  const source: BrainCitationSource = {};
+  if (artifact.properties.source_path) source.path = artifact.properties.source_path;
+  if (artifact.properties.source_session) source.session = artifact.properties.source_session;
+  if (artifact.properties.source_agent) source.agent = artifact.properties.source_agent;
+  if (artifact.properties.source_runner) source.runner = artifact.properties.source_runner;
+  return {
+    ref: `B${index + 1}`,
+    rid: artifact.rid,
+    id: artifact.properties.id,
+    title: artifact.properties.title,
+    kind: artifact.kind,
+    score: hit.score,
+    score_breakdown: hit.score_breakdown,
+    excerpt: hit.excerpt,
+    source: Object.keys(source).length > 0 ? source : undefined,
+  };
+}
+
+function classifyThinkConfidence(hits: SearchHit[]): BrainThinkConfidence {
+  const top = hits[0];
+  if (!top) return "none";
+  const signalCount = Object.entries(top.score_breakdown)
+    .filter(([key, value]) => key !== "total" && value > 0)
+    .length;
+  if (top.score >= 8 || (top.score >= 5 && signalCount >= 2)) return "high";
+  if (top.score >= 3) return "medium";
+  return "low";
+}
+
+function thinkMissingEvidence(
+  query: string,
+  citations: BrainCitation[],
+  confidence: BrainThinkConfidence,
+): string[] {
+  if (citations.length === 0) {
+    return [`No Brain artifacts matched "${query}". Capture or ingest cited artifacts before relying on Brain for this answer.`];
+  }
+  const gaps: string[] = [];
+  if (confidence === "low") {
+    gaps.push("Only low-scoring deterministic matches were found; open the cited artifacts before treating this as settled.");
+  }
+  if (citations.length === 1) {
+    gaps.push("Only one cited artifact matched; missing context or contradictions may not be visible yet.");
+  }
+  if (citations.every((citation) => citation.source == null)) {
+    gaps.push("The matched artifacts do not carry source path, session, agent, or runner provenance.");
+  }
+  return gaps;
+}
+
+function renderThinkAnswer(
+  query: string,
+  citations: BrainCitation[],
+  confidence: BrainThinkConfidence,
+  missingEvidence: string[],
+): string {
+  if (citations.length === 0) {
+    return [
+      `Brain has no cited evidence for "${query}".`,
+      "",
+      "Missing evidence:",
+      ...missingEvidence.map((gap) => `- ${gap}`),
+    ].join("\n");
+  }
+
+  const evidenceLines = citations.slice(0, 5).map((citation) => {
+    return `- ${citation.title}: ${citation.excerpt} [${citation.ref}]`;
+  });
+  const citationLines = citations.map((citation) => {
+    const signals = Object.entries(citation.score_breakdown)
       .filter(([key, value]) => key !== "total" && value > 0)
       .map(([key, value]) => `${key} ${value}`)
       .join(", ");
-    return `[${index + 1}] ${artifact.properties.title} (${artifact.kind}, rid ${artifact.rid}, score ${hit.score})${signals ? ` [${signals}]` : ""}: ${hit.excerpt}`;
+    return `[${citation.ref}] ${citation.title} (${citation.kind}, rid ${citation.rid}, score ${citation.score})${signals ? ` [${signals}]` : ""}; ${renderCitationSource(citation)}`;
   });
-  return lines.length > 0
-    ? `Deterministic Brain synthesis for "${query}":\n\n${lines.join("\n")}`
-    : `No Brain artifacts matched "${query}".`;
+  const gaps =
+    missingEvidence.length > 0
+      ? missingEvidence.map((gap) => `- ${gap}`)
+      : ["- No deterministic evidence gap detected in the returned Brain citations."];
+
+  return [
+    `Brain answer for "${query}"`,
+    "",
+    `Confidence: ${confidence}`,
+    "",
+    "Best cited evidence:",
+    ...evidenceLines,
+    "",
+    "Missing evidence:",
+    ...gaps,
+    "",
+    "Citations:",
+    ...citationLines,
+  ].join("\n");
+}
+
+function renderCitationSource(citation: BrainCitation): string {
+  if (!citation.source) return `source: Brain artifact ${citation.id}`;
+  const parts = [
+    citation.source.path ? `path ${citation.source.path}` : null,
+    citation.source.session ? `session ${citation.source.session}` : null,
+    citation.source.agent ? `agent ${citation.source.agent}` : null,
+    citation.source.runner ? `runner ${citation.source.runner}` : null,
+  ].filter(notNull);
+  return `source: ${parts.length > 0 ? parts.join(", ") : `Brain artifact ${citation.id}`}`;
 }
 
 function artifactHashKey(hash: string): string {

--- a/apps/brain/tests/store.test.ts
+++ b/apps/brain/tests/store.test.ts
@@ -96,15 +96,56 @@ describe("BrainStore hybrid search", () => {
         kind: "decision",
         tags: ["brain"],
         content: "Keep Brain storage local by default.",
+        sourceAgent: "codex",
+        sourceRunner: "brain-test",
+        sourceSession: "session-123",
+        sourcePath: "/repo/notes/brain.md",
       });
 
       const result = await store.think("brain decision");
 
+      expect(result.confidence).toBe("high");
+      expect(result.citations[0]).toEqual(expect.objectContaining({
+        ref: "B1",
+        title: "Use local Brain",
+        kind: "decision",
+        score: result.hits[0]?.score,
+        source: expect.objectContaining({
+          path: "/repo/notes/brain.md",
+          agent: "codex",
+          runner: "brain-test",
+          session: "session-123",
+        }),
+      }));
+      expect(result.missing_evidence).toEqual(["Only one cited artifact matched; missing context or contradictions may not be visible yet."]);
+      expect(result.answer).toContain("Brain answer");
+      expect(result.answer).toContain("Confidence: high");
+      expect(result.answer).toContain("Citations:");
+      expect(result.answer).toContain("[B1]");
       expect(result.answer).toContain("score");
       expect(result.answer).toContain("lexical");
       expect(result.answer).toContain("tags");
       expect(result.answer).toContain("kind");
       expect(result.hits[0]?.score_breakdown.total).toBe(result.hits[0]?.score);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("admits when think has no cited evidence", async () => {
+    const root = await tempRoot();
+    const store = await BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+    try {
+      const result = await store.think("quantum roadmap");
+
+      expect(result.hits).toEqual([]);
+      expect(result.citations).toEqual([]);
+      expect(result.confidence).toBe("none");
+      expect(result.missing_evidence).toEqual([
+        'No Brain artifacts matched "quantum roadmap". Capture or ingest cited artifacts before relying on Brain for this answer.',
+      ]);
+      expect(result.answer).toContain('Brain has no cited evidence for "quantum roadmap".');
+      expect(result.answer).toContain("Missing evidence:");
     } finally {
       await store.close();
     }

--- a/plugins/brain/README.md
+++ b/plugins/brain/README.md
@@ -50,6 +50,13 @@ matches, artifact kind matches, and graph connections all contribute to each
 hit's `score_breakdown`. The contract already reserves a `vector` score slot, but
 embeddings are not required for the local Brain MVP.
 
+`brain think` turns that ranking into a cited Brain answer. It returns the
+original hits plus stable `citations`, a deterministic `confidence` label, and a
+`missing_evidence` list so the Brain can say when it has weak or absent evidence
+instead of fabricating certainty. Citations point back to the Brain artifact rid,
+kind, id, score signals, excerpt, and any captured source path/session/agent
+provenance.
+
 Brain can also act on a channel. `brain_act` (MCP) and `brain act --target
 <channel> --message <text>` (CLI) post a message to a channel target through the
 Channel bridge in outbound-only mode: the bridge sends standalone using

--- a/plugins/brain/skills/core/think/SKILL.md
+++ b/plugins/brain/skills/core/think/SKILL.md
@@ -8,5 +8,17 @@ description: Synthesize an answer from the project Brain.
 Use this when the user asks what the project Brain knows, what changed, what
 supports or contradicts an idea, or how captured knowledge connects.
 
-Call `brain_think` when MCP is available. The MVP synthesis is deterministic
-over Brain search results; LLM enrichment is a later asynchronous layer.
+Call `brain_think` when MCP is available. The synthesis is deterministic over
+Brain search results and returns:
+
+- `answer` - a concise cited answer suitable for the user.
+- `citations` - stable refs back to Brain artifact rid/id/kind, score signals,
+  excerpts, and captured source provenance.
+- `confidence` - `none`, `low`, `medium`, or `high`, derived from the returned
+  ranking signals.
+- `missing_evidence` - explicit gaps when Brain has no hits, weak hits, only one
+  citation, or artifacts without source provenance.
+
+Prefer the cited answer over freeform synthesis. If `confidence` is `none` or
+`missing_evidence` is non-empty, say what Brain does not know instead of filling
+the gap from general model knowledge.


### PR DESCRIPTION
## Summary

- add the Brain daily dashboard surface over KPIs, recent decisions, and typed connections
- enrich `brain think` with structured citations, deterministic confidence, and explicit missing evidence
- keep synthesis grounded by filtering derived tag artifacts out of cited Brain answers

## Validation

- `pnpm -C apps/brain test`
- `pnpm -C apps/brain typecheck`
- `pnpm -C apps/brain build`

Related: #478

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784074643&installation_id=129708444&pr_number=743&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F743&signature=3b0459332f660c31018ba875b1e884242b35084230a0f96d50557127aabbadc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `brain think` now returns structured responses with citations, confidence levels (none/low/medium/high), and explicitly identifies missing evidence gaps.
  * Citations include source attribution and relevance scores.

* **Documentation**
  * Updated plugin and skill documentation to describe the new citation, confidence, and missing evidence output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->