### PR TITLE
chore(red-castle): bump submodule to sandcastle 0.11.0

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -661,6 +661,19 @@ export function buildProcessDeps(
     // break a run (sandcastle also swallows any throw from this callback).
     recordAgentEvent: (event) => {
       const ts = new Date().toISOString();
+      // Raw stdout lines (sandcastle 0.11.0 verbose stream `{type:"raw"}`) are
+      // noisy per-line output, not assistant turns. Fan them to the FIREHOSE only
+      // so a stuck/silent agent stays diagnosable, while the clean agent lane keeps
+      // its one-record-per-turn invariant. Not a liveness/activity unit, so skip
+      // the meter + iteration markers. Returning here also narrows `event` to the
+      // non-raw variants for the rest of the handler.
+      if (event.type === "raw") {
+        void appendRecord(join(current.attemptDir, "log.jsonl"), "raw", event.line, {
+          ts,
+          fields: { extra: { kind: "raw", iteration: String(event.iteration) } },
+        }).catch(() => {});
+        return;
+      }
       // Agentic-iteration boundary markers (synthetic — afk.log + firehose, NEVER
       // the agent lane). Emit "iteration N ended" + "iteration N+1 started" when
       // sandcastle's re-invocation count advances, so a run burning through

--- a/apps/dev/tests/worker-vitals.contract.test.ts
+++ b/apps/dev/tests/worker-vitals.contract.test.ts
@@ -19,6 +19,9 @@ const EVENT_TO_VITALS = {
   toolCall: ["tools_called_count"],
   reasoning: ["reasoning_events", "reasoning_tokens"],
   usage: ["input_tokens", "output_tokens", "cost_usd"],
+  // `raw` (sandcastle 0.11.0 verbose stdout stream) is firehose-only diagnostics,
+  // not an assistant turn — it maps to no WorkerVitals field.
+  raw: [],
 } satisfies Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]>;
 
 describe("WorkerVitals contract (ADR 0065)", () => {
@@ -41,7 +44,7 @@ describe("WorkerVitals contract (ADR 0065)", () => {
     // of mapped event types is exactly what we expect. If red-castle adds a
     // variant, the `satisfies` above fails to compile first; this keeps the
     // expectation visible to a human reviewer too.
-    expect(Object.keys(EVENT_TO_VITALS).sort()).toEqual(["reasoning", "text", "toolCall", "usage"]);
+    expect(Object.keys(EVENT_TO_VITALS).sort()).toEqual(["raw", "reasoning", "text", "toolCall", "usage"]);
   });
 
   it("rejects a map that omits a known event type (compile-time guard demonstrated)", () => {


### PR DESCRIPTION
Bumps `packages/red-castle` to `1bb39a4` — our fork rebased onto sandcastle **0.11.0** (PR reddb-io/red-castle#6).

Preserves our reasoning/cost stream events + systemPrompt; unlocks maxRetries, warm-container resume/fork, raw/verbose logging, permissionMode. red-castle: typecheck clean, 1431 tests pass. This PR's CI is the gate that the dev bundle builds against 0.11.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784463486&installation_id=129708444&pr_number=754&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F754&signature=e568b5394c16369922b8474ef0c0fade7364ca283a3ccef8947a2cd418b93256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->