### PR TITLE
fix(test): harden the AFK feedback gate against two known flakes

### DIFF
--- a/apps/brain/vitest.config.ts
+++ b/apps/brain/vitest.config.ts
@@ -4,5 +4,13 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // dashboard.test.ts spawns the brain CLI via `tsx` (compile + store open +
+    // HTML build), bounded by its own 40s subprocess `TIMEOUT`. Vitest's default
+    // 5s per-test timeout trips first under load (e.g. an AFK feedback-gate run
+    // sharing the box with a live agent), false-failing a healthy test. Give the
+    // test body more room than the subprocess so the subprocess timeout is the
+    // real bound; pure-unit tests still finish in ms.
+    testTimeout: 45_000,
+    hookTimeout: 45_000,
   },
 });

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -12,7 +12,7 @@
     "bundle:red-fetch": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"fetch\"' --outfile=../../plugins/dev/hooks/red-fetch.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "bundle:entrypoint": "esbuild ../../packages/shared/entrypoint-cli.ts --bundle --minify --platform=node --format=esm --target=node22 --define:__ENTRYPOINT_ROLE__='\"run:dev\"' --outfile=../../plugins/dev/skills/engineering/afk/bin/afk.mjs --banner:js=\"import { createRequire as __cr } from 'node:module'; const require = __cr(import.meta.url);\"",
     "build": "pnpm run bundle && pnpm run bundle:red-fetch && pnpm run bundle:entrypoint",
-    "test": "vitest run"
+    "test": "NODE_OPTIONS=--max-old-space-size=6144 vitest run"
   },
   "dependencies": {
     "@reddb-io/build-info": "workspace:*",


### PR DESCRIPTION
The whole-workspace AFK feedback gate (`turbo run test`) false-failed both #746 attempts on environmental flakes that only show under local AFK machine load (CI is clean):

- **brain/dashboard.test.ts** — CLI tests spawn `tsx` (40s subprocess TIMEOUT) but the test body used vitest's 5s default → trips first under load. → `testTimeout/hookTimeout: 45_000`.
- **dev** — `supervisor.test.ts` OOMs the vitest worker (known). → test heap bumped to `--max-old-space-size=6144`.

Pure config, no behaviour change. Unblocks every workspace-touching AFK attempt (#746/#747 can then drain clean).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784470305&installation_id=129708444&pr_number=755&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F755&signature=a417c2c8d4b25ddff829eeeb16d6f24c35b6034ce31c06006b9941f9d45346bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->