### PR TITLE
fix(review): route advisory PR review through MiniMax-M3 + MiniMax-only auth (#748)

### DIFF
--- a/.github/workflows/red-pr-review.yml
+++ b/.github/workflows/red-pr-review.yml
@@ -51,12 +51,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           # CI never wants a nested container: force the no-sandbox lane.
           RED_AFK_SANDBOX: none
-          # OpenCode auth — first set key wins (opencode-env.ts precedence). The
-          # cloud lane is non-resumable, so the review's structured-output
-          # `maxRetries` resolves to 0 and the advisory path runs single-attempt.
+          # Route the review through the MiniMax-M3 subscription (#748). The
+          # review command resolves the opencode `complex` tier; RED_AFK_MODEL
+          # overrides it to a `minimax/...` slug so OpenCode dispatches to the
+          # MiniMax endpoint (config.ts resolveTier precedence: env wins).
+          RED_AFK_MODEL: minimax/MiniMax-M3
+          # OpenCode auth — first-set-key wins (opencode-env.ts precedence:
+          # OPENAI_API_KEY > MINIMAX_API_KEY > OPENROUTER_API_KEY). Expose ONLY
+          # MINIMAX_API_KEY so a stray/empty OPENAI/OPENROUTER secret cannot
+          # shadow it (#748 acceptance criterion). The cloud lane is
+          # non-resumable, so the review's structured-output `maxRetries`
+          # resolves to 0 and the advisory path runs single-attempt.
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           PR="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Refs #748 (PRD #745 keystone). The agent-doable wiring half — the human still provisions the secret + validates.

## What this fixes
`red-pr-review.yml` had two gaps that would stop a MiniMax review from ever firing:
1. **Model:** `dev review` resolves the opencode `complex` tier, which **defaults to `openrouter/anthropic/claude-opus-4`** — it would route to OpenRouter, not your MiniMax subscription.
2. **Auth shadowing:** it exported all three `*_API_KEY` secrets. Per the first-set-wins precedence (`OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY`), an empty/stray `OPENAI_API_KEY` would **shadow MiniMax** — exactly the gotcha documented on #748.

## Change (single file)
- `RED_AFK_MODEL: minimax/MiniMax-M3` → review dispatches to the MiniMax endpoint (`resolveTier` honors the env override over the file default, config.ts:392).
- Expose **only** `MINIMAX_API_KEY` (drop OPENAI/OPENROUTER) → satisfies the #748 criterion *"runner env exposes MINIMAX_API_KEY only"*, mirroring the proven `red-skills-afk-attempt.yml` minimax-only wiring.

No `.red/config.yaml` edit: per the existing convention, **the workflow is the single source of truth for the cloud runner's model**.

## Still requires you (the HITL remainder of #748)
1. Provision the `MINIMAX_API_KEY` repo secret (`gh secret set MINIMAX_API_KEY --repo reddb-io/red-skills`).
2. Label a real PR `ready-for-review` → confirm the advisory review posts via a MiniMax-routed run.
3. Record the go/no-go on the auth mechanism in ADR 0064.

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784552807&installation_id=129708444&pr_number=760&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F760&signature=f4683113f1e45daf4d67c5c15361178acb45bfcdd220a3abadba070dee37f050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->