### PR TITLE
docs(wiki): mark 727 naming page superseded by ADR 0067

### DIFF
--- a/.red/wiki/pages/727-chore-workflows-reusable-red-skills-red-three-prefix-naming.md
+++ b/.red/wiki/pages/727-chore-workflows-reusable-red-skills-red-three-prefix-naming.md
@@ -11,6 +11,12 @@ merge_sha: b0b20ff278740e586b0c4316c02d702e706797f0
 
 # chore(workflows): reusable-* / red-skills-* / red-* three-prefix naming scheme
 
+> **Superseded by [ADR 0067](../../adr/0067-workflow-naming-three-prefix-rs-caller.md).**
+> The caller prefix `red-skills-*` was later renamed to **`rs-*`** (caller =
+> instantiation of a reusable, one per reusable adopted), and copy-installables
+> (e.g. needs-triage) now keep their `red-*` name on install. This page is kept
+> as the dated record of the original scheme.
+
 - **PR:** [#727](https://github.com/reddb-io/red-skills/pull/727)
 - **Author:** @filipeforattini
 - **Merge SHA:** `b0b20ff278740e586b0c4316c02d702e706797f0`


### PR DESCRIPTION
Small doc tidy: adds a supersede banner to the `727` wiki page pointing at ADR 0067 (the `red-skills-*` → `rs-*` caller rename).

**Also serves as the live validation PR for #748** — labeling it `ready-for-review` fires `red-pr-review.yml` end-to-end (MiniMax-M3 via the repo `MINIMAX_API_KEY` secret), proving headless auth resolution + advisory review posting in a GitHub-hosted runner.

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784565304&installation_id=129708444&pr_number=762&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F762&signature=a82f05881214a536793ce7ccee53a3d841f74fc109fb9c3ec2c400fdd4e76bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->