### PR TITLE
docs(adr): GO on MiniMax-in-CI auth — ADR 0064 Amendment 1 (closes #748)

### DIFF
--- a/.red/adr/0064-cloud-agent-interaction-extends-the-afk-actions-lane-to-pr-and-comment-surfaces.md
+++ b/.red/adr/0064-cloud-agent-interaction-extends-the-afk-actions-lane-to-pr-and-comment-surfaces.md
@@ -5,6 +5,27 @@
 proposed. Captured from a `/start` grilling session (2026-06-18). The load-bearing
 decisions are stable; two implementation leaves stay open (see *Open questions*).
 
+## Amendment 1 — MiniMax-in-CI auth validated (GO, #748)
+
+The open leaf "the credential-into-CI mechanism is unverified" is **closed: GO**.
+Validated live on 2026-06-20 — labeling a real PR `ready-for-review` fired
+`red-pr-review.yml`, which resolved the `MINIMAX_API_KEY` repo secret
+**headlessly** in a GitHub-hosted runner and posted a substantive MiniMax-M3
+advisory review (run succeeded in ~1m44s, single-attempt).
+
+The durable mechanism (per ADR 0059 Amendment 1):
+
+- Auth is a **repo/org secret → worker env**, never an interactive session and
+  never committed. OpenCode picks the endpoint from the model slug's leading
+  segment (`minimax/MiniMax-M3` → MiniMax).
+- The lane **must expose only `MINIMAX_API_KEY`** — env precedence is
+  first-set-wins (`OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY`), so
+  a stray/empty competing key would shadow MiniMax. `red-pr-review.yml` sets
+  `RED_AFK_MODEL=minimax/MiniMax-M3` and exports MiniMax only (#748 / PR #760).
+- Secret scope: **org-level** is preferred so every org repo's lane resolves it;
+  a public repo needs the org secret's Repository-access to include it (else it
+  resolves empty). red-skills currently carries it repo-level.
+
 ## Context
 
 `mattpocock/sandcastle` ships a label-driven cloud agent loop: applying an


### PR DESCRIPTION
Closes #748 — the last item (record the go/no-go). Validated live (run [27877311306](https://github.com/reddb-io/red-skills/actions/runs/27877311306): MiniMax-M3 advisory review posted headlessly on #762). Records ADR 0064 Amendment 1 with the durable mechanism. **PRD #745 → 7/7.**

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784565865&installation_id=129708444&pr_number=763&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F763&signature=915f8aaa494899a9df7fd512e81fc1f4b7a47a0e73922094cd94e5c685f0566f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->