### PR TITLE
docs(afk): org-vs-repo secret + public-repo Repository-access gotcha

### DIFF
--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -156,6 +156,14 @@ precedence above decide.
 | OpenAI | `OPENAI_API_KEY` | `openai/<model>` | `secrets: { openai_api_key: ${{ secrets.OPENAI_API_KEY }} }` |
 | OpenRouter | `OPENROUTER_API_KEY` | `openrouter/<vendor>/<model>` | `secrets: { openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }} }` |
 
+**Repo vs org secret.** A **repo** secret is the simplest. An **org** secret is
+preferred when several org repos run the lane (set it once). The public-repo
+gotcha: an org secret resolves to **empty** in a public repo unless that repo is
+in the secret's **Repository access** list — so an org secret looks "set" yet the
+review no-ops at auth. Include every repo that runs the lane in Repository
+access. Don't keep both a repo and an org secret of the same name on one repo —
+the repo one wins and the two can silently drift.
+
 Set the key (the value is yours to provision — RedSkills never sets it for you):
 
 ```bash

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -156,13 +156,11 @@ precedence above decide.
 | OpenAI | `OPENAI_API_KEY` | `openai/<model>` | `secrets: { openai_api_key: ${{ secrets.OPENAI_API_KEY }} }` |
 | OpenRouter | `OPENROUTER_API_KEY` | `openrouter/<vendor>/<model>` | `secrets: { openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }} }` |
 
-**Repo vs org secret.** A **repo** secret is the simplest. An **org** secret is
-preferred when several org repos run the lane (set it once). The public-repo
-gotcha: an org secret resolves to **empty** in a public repo unless that repo is
-in the secret's **Repository access** list — so an org secret looks "set" yet the
-review no-ops at auth. Include every repo that runs the lane in Repository
-access. Don't keep both a repo and an org secret of the same name on one repo —
-the repo one wins and the two can silently drift.
+**Repo vs org secret.** A **repo** secret is simplest; an **org** secret is
+preferred when several org repos run the lane (set it once — mind the public-repo
+*Repository access* caveat in the gotcha below). Don't keep both a repo **and** an
+org secret of the **same name** on one repo: the repo secret wins, so the two can
+silently drift — pick one.
 
 Set the key (the value is yours to provision — RedSkills never sets it for you):
 


### PR DESCRIPTION
Documents the org-secret behavior we hit wiring #748 org-level. Also the **live test** that the org `MINIMAX_API_KEY` resolves for red-skills (repo-level secret removed first, so only the org one is in play).

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784567976&installation_id=129708444&pr_number=764&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F764&signature=35afccf8bad98dc616fa41272921c11a33a5fbe3dca6fefc778f60362b69c7a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->