### PR TITLE
docs(agents): mirror '## Agent skills' into AGENTS.md (doctor parity 1/1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,24 @@
+## Agent skills
+
+### Wiki
+
+Incremental LLM Wiki for accumulating knowledge about `RedSkills, agents, skills, memory instrumentation, and engineering automation patterns`. Schema at `.red/agents/wiki.md`. Use `/wiki` for ingest, query, and lint.
+
+### Issue tracker
+
+GitHub Issues on `reddb-io/red-skills`. See `.red/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical kebab-case / `prefix:value` vocab — labels match their canonical role names. See `.red/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context — start at `.red/CONTEXT-MAP.md`, then read the owning glossary in
+`.red/contexts/{dev,memory,brain}/CONTEXT.md`. `.red/CONTEXT.md` is a
+compatibility pointer only. ADRs remain in the single root `.red/adr/` sequence
+for now. See `.red/agents/domain.md`.
+
 ## Development workflow
 
 - Work in an isolated worktree; do not change the primary checkout's branch for task work.


### PR DESCRIPTION
Closes the only adoption gap from `/dev:doctor` on red-skills: AGENTS≡CLAUDE **Agent-skills parity 1/0** → **1/1**. AGENTS.md (Codex/other-runner rules) now carries the same `## Agent skills` pointers (wiki / issue-tracker / triage-labels / domain docs) CLAUDE.md has. The `inject-development-workflow` injector only covers the Development-workflow block, so this block is mirrored by hand.

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784568676&installation_id=129708444&pr_number=765&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F765&signature=c7c198f4b5d90a0b85f64ecfd084d624b78d1cf766d7d2be212de3cbfe93cba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agent skills section documenting agent capabilities across Wiki, Issue tracker, Triage labels, and Domain docs with guidance on accessing these resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->