### PR TITLE
fix(afk): classify provider 529/overload as runner-transient (no orchestrator crash)

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -678,7 +678,17 @@ export function isExhaustionError(error: unknown): boolean {
 /**
  * True when a sandcastle failure looks like a transient runner transport/setup
  * failure rather than agent-authored work. These should be bounded by AFK's
- * retry policy, not escape as raw worker crashes.
+ * retry policy (cooldown circuit + capped retries → exit 75), not escape as raw
+ * worker crashes that kill the orchestrator and orphan the issue in `running`.
+ *
+ * Covers two families: (a) Codex transport/setup hiccups (websocket, thread
+ * start, spawn/cwd); and (b) **provider server-side overload** — a `529
+ * Overloaded` / `overloaded_error` (Anthropic) or `503 Service Unavailable`,
+ * which is temporary and server-side, not your code or your quota. Before this,
+ * a 529 matched neither the exhaustion nor the transient pattern, so it hit the
+ * `throw error` fall-through and crashed the whole drain (observed on the reddb
+ * AFK lane: a sustained 529 killed the orchestrator mid-drain, orphaning the
+ * claimed issue in `running`).
  */
 export function isTransientRunnerError(error: unknown): boolean {
   if (error === null || error === undefined) return false;
@@ -688,7 +698,7 @@ export function isTransientRunnerError(error: unknown): boolean {
 }
 
 const runnerTransientPattern =
-  /failed to connect to websocket|HTTP error:\s*502 Bad Gateway|wss:\/\/chatgpt\.com\/backend-api\/codex\/responses|thread\/start failed|failed to load configuration|spawn sh ENOENT|cwd does not exist/i;
+  /failed to connect to websocket|HTTP error:\s*502 Bad Gateway|HTTP error:\s*503 Service Unavailable|\b529\b|overloaded|wss:\/\/chatgpt\.com\/backend-api\/codex\/responses|thread\/start failed|failed to load configuration|spawn sh ENOENT|cwd does not exist/i;
 
 /** Recursively gather string values reachable from an error-ish value, bounded
  * by depth and a visited set so cyclic Effect `Cause` graphs terminate. */

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -686,9 +686,34 @@ describe("isTransientRunnerError", () => {
     expect(isTransientRunnerError(new Error("cwd does not exist: /tmp/.red/tmp/workers/wAAAA/17-a1"))).toBe(true);
   });
 
+  it("matches provider server-side overload (529 / overloaded_error / 503) — temporary, not a crash", () => {
+    expect(
+      isTransientRunnerError(
+        new Error("claude-code exited with code 1: API Error: 529 Overloaded. This is a server-side issue, usually temporary"),
+      ),
+    ).toBe(true);
+    expect(isTransientRunnerError(new Error('{"type":"error","error":{"type":"overloaded_error"}}'))).toBe(true);
+    expect(isTransientRunnerError(new Error("HTTP error: 503 Service Unavailable"))).toBe(true);
+  });
+
   it("does not match ordinary agent/work failures", () => {
     expect(isTransientRunnerError(new Error("worktree add failed: fatal"))).toBe(false);
     expect(isTransientRunnerError(new Error("tests failed: 2 failing"))).toBe(false);
+    // A 529 elsewhere in unrelated prose is overwhelmingly the status code; a
+    // bare number like 5290 must NOT match (word-boundary guard).
+    expect(isTransientRunnerError(new Error("processed 5290 records"))).toBe(false);
+  });
+});
+
+describe("runAgent — server overload (529) is transient, never a crash", () => {
+  it("maps a thrown 529 Overloaded to runner-transient (not a rethrow/no-sentinel)", async () => {
+    const r = await runAgent(
+      makeDeps(async () => {
+        throw new Error("claude-code exited with code 1: API Error: 529 Overloaded. This is a server-side issue, usually temporary");
+      }),
+      baseInput,
+    );
+    expect(r.outcome).toBe("runner-transient");
   });
 });
 


### PR DESCRIPTION
## The bug (observed live on the reddb AFK lane)
A `529 Overloaded` (Anthropic server-side overload) crashed the **whole orchestrator** mid-drain and orphaned the claimed issue in `running` — twice in a row.

**Root cause** — `runAgent`'s catch (`execution.ts`) classifies a thrown error as `exhausted` (quota/rate-limit) or `runner-transient` (502/websocket/spawn), else `throw error`. A 529 matches **neither** pattern → hits the `throw` → propagates uncaught → orchestrator dies. It's an AFK **classifier blind spot**, not red-castle (which correctly surfaces the 529 text on the error).

## The fix
A 529 is temporary + server-side (not your code, not your quota) → it belongs in the **transient** lane. Extend `runnerTransientPattern` with `529` (word-bounded), `overloaded` (covers `Overloaded` + `overloaded_error`), `503 Service Unavailable`. Now: 529 → `runner-transient` → cooldown circuit (300s) + capped retries → exit 75 so a supervisor/`/loop` retries later. **No crash, no orphan.**

## Tests
+ 529 / `overloaded_error` / 503 classify transient; bare `5290` does **not** (word-boundary); `runAgent` maps a thrown 529 → `runner-transient`. Full `execution.test.ts` = **95 passing**.

## Follow-up (not in this PR)
The deeper hardening — *any* truly-unknown uncaught runner error should park the issue gracefully (restore the label) instead of orphaning it in `running` + crashing the drain. This PR fixes the known-common 529; the generic catch-all is worth a separate slice.

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784569660&installation_id=129708444&pr_number=766&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F766&signature=91a65f5f7229df71fbebc3567f2d60c91be39766f6ae5dc70d9a19be5473e426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->