### PR TITLE
feat(afk): unclassified runner error → no-sentinel, never crash the drain (#767)

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -869,8 +869,11 @@ export function startAttemptGuard(opts: {
  * sandcastle's `run()` can signal exhaustion two ways: by throwing an error
  * whose message matches the exhaustion patterns (the common case — the provider
  * raises on a 429 / usage-limit), or by completing with exhaustion text on
- * stdout. Both map to the `exhausted` outcome (no commits, no sentinel). Any
- * other thrown error propagates unchanged.
+ * stdout. Both map to the `exhausted` outcome (no commits, no sentinel). A
+ * transient transport / server-overload error maps to `runner-transient`; any
+ * OTHER thrown error maps to `no-sentinel` (a recoverable crash) rather than
+ * propagating — so an unrecognized runner failure never kills the drain or
+ * orphans the issue in `running` (#767).
  *
  * When `attemptTimeoutSeconds` + `headProbe` are supplied, an attempt progress
  * guard runs alongside: if no new commit lands within the cap, the run is
@@ -1027,7 +1030,21 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
         stdout: error instanceof Error ? error.message : String(error),
       };
     }
-    throw error;
+    // Any OTHER thrown runner error (an error class we don't yet recognize):
+    // do NOT rethrow. A rethrow propagates uncaught past the per-issue loop,
+    // kills the whole orchestrator mid-drain, and leaves the claimed issue
+    // orphaned in `running` (the failure mode behind #766's 529 incident). Map
+    // it to `no-sentinel` instead — the same outcome a crashed agent produces —
+    // so the per-issue loop runs its graceful recovery: it posts a crash
+    // envelope carrying this error text, rotates the label off `running`, and
+    // pages `ready-for-human` (bounded by RED_AFK_RETRY_CRASH). The drain
+    // survives every runner error class, known or not. (#767)
+    return {
+      outcome: "no-sentinel",
+      branch: input.branch,
+      commits: [],
+      stdout: error instanceof Error ? error.message : String(error),
+    };
   } finally {
     guard?.stop();
     laneReaper?.stop();

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -717,6 +717,19 @@ describe("runAgent — server overload (529) is transient, never a crash", () =>
   });
 });
 
+describe("runAgent — unclassified runner error never crashes the drain (#767)", () => {
+  it("maps any other thrown error to no-sentinel (recoverable crash), not a rethrow", async () => {
+    const r = await runAgent(
+      makeDeps(async () => {
+        throw new Error("some unrecognized runner failure nobody has a pattern for yet");
+      }),
+      baseInput,
+    );
+    expect(r.outcome).toBe("no-sentinel");
+    expect(r.stdout).toContain("unrecognized runner failure");
+  });
+});
+
 describe("runAgent — exhaustion", () => {
   it("maps a thrown exhaustion error to the exhausted outcome (no commits, no sentinel)", async () => {
     const r = await runAgent(
@@ -739,15 +752,18 @@ describe("runAgent — exhaustion", () => {
     expect(r.outcome).toBe("exhausted");
   });
 
-  it("re-throws a non-exhaustion sandcastle error unchanged", async () => {
-    await expect(
-      runAgent(
-        makeDeps(async () => {
-          throw new Error("worktree add failed: fatal");
-        }),
-        baseInput,
-      ),
-    ).rejects.toThrow("worktree add failed");
+  it("maps a non-exhaustion, non-transient error to no-sentinel (never rethrows — #767)", async () => {
+    // Previously this rethrew, killing the orchestrator + orphaning the issue
+    // in `running`. Now any unclassified runner error becomes a recoverable
+    // no-sentinel crash so the drain survives.
+    const r = await runAgent(
+      makeDeps(async () => {
+        throw new Error("worktree add failed: fatal");
+      }),
+      baseInput,
+    );
+    expect(r.outcome).toBe("no-sentinel");
+    expect(r.stdout).toContain("worktree add failed");
   });
 });
 


### PR DESCRIPTION
Closes #767 — the generic safety net behind the #766 / 529 incident.

**Before:** `runAgent`'s catch (`execution.ts`) → `exhausted` (quota) / `runner-transient` (502/websocket/529) / **`throw error`** for anything else. That rethrow propagated uncaught, killed the orchestrator mid-drain, and orphaned the claimed issue in `running`.

**After:** any *other* thrown runner error → **`no-sentinel`** (a recoverable crash). The per-issue loop already handles it gracefully — posts a crash envelope with the error text, rotates the label off `running`, pages `ready-for-human` (bounded by `RED_AFK_RETRY_CRASH`). **The drain survives every runner error class, known or not**; the failure is surfaced as a page, never a silent orphan + dead drain.

Design note: resolved via the *classify-recoverable* approach (vs the brief's finally-release) — simpler, lower-risk, and the no-sentinel path is already battle-tested. A real AFK bug still surfaces (as a `blocked:crashed` page), just without taking down the whole drain.

**Tests:** unclassified error → `no-sentinel` (not a throw); the old "re-throws unchanged" test updated to the new contract. `execution.test.ts` = **96 passing**.

This is the **feat** that cuts the **minor** (v1.218.0).

https://claude.ai/code/session_01PTMupX7PaPvHmptGp1cghA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784570385&installation_id=129708444&pr_number=768&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F768&signature=9aa59f15ac68512a35194c3498f9b48b768268b7c05d9d302029454487f033d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->