### PR TITLE
docs(adr): reverse ADR 0041 — memory stays in red-skills as the local red-memory MCP

### DIFF
--- a/.red/adr/0041-red-skills-consumes-red-memory-and-red-ui-mcps.md
+++ b/.red/adr/0041-red-skills-consumes-red-memory-and-red-ui-mcps.md
@@ -1,5 +1,13 @@
 # red-skills consumes `red-memory` and `red-ui` MCPs; it stops building the memory plugin
 
+> **⚠️ REVERSED by Amendment 1 (2026-06-20).** The core decision below — migrate
+> `apps/memory` out to a separate `red-memory` repo and consume it as a fetched
+> release bundle — is **cancelled**. Memory **stays in red-skills**; `red-memory`
+> is the **local** MCP already wired in `plugins/memory/.mcp.json` (it execs the
+> in-repo `apps/memory` build, RedDB-backed via `@reddb-io/sdk`). The only part
+> of this ADR that survives is the `memory` → `red-memory` **server rename**,
+> which is already applied. Read [Amendment 1](#amendment-1-2026-06-20--reversed-memory-stays-in-red-skills) for the current decision; the body below is kept for history.
+
 ## Context
 
 The red ecosystem has a dedicated repo per product:
@@ -52,10 +60,69 @@ There are two distinct MCPs in play, repeatedly conflated:
 
 ## Status
 
-Accepted (direction). The multi-repo migration is large and pending; until it lands, `apps/memory` remains the live source.
+**Reversed by Amendment 1 (2026-06-20).** The original direction (migrate memory
+to a separate `red-memory` repo, consume via release fetch, retire `apps/memory`)
+is cancelled. Memory stays in red-skills as the local `red-memory` MCP; the only
+surviving change is the `memory` → `red-memory` server rename, already applied.
+
+## Amendment 1 (2026-06-20) — REVERSED: memory stays in red-skills
+
+The core decision of this ADR — migrate `apps/memory` out to a dedicated
+`red-memory` repo and have red-skills consume it as a fetched release bundle — is
+**reversed**. It was scaffolded (`reddb-io/red-memory` was created 2026-06-08) but
+never delivered: that repo is an empty skeleton with **zero releases** and no
+activity since creation, so the "consume a fetched `red-memory` bundle / retire
+`apps/memory`" path has been blocking #378 indefinitely on a prerequisite that is
+not coming. Memory has run from the in-repo build the entire time and is fully
+functional, so there is no operational reason to keep waiting on the split.
+
+**New decision:**
+
+- **Memory stays in red-skills.** `apps/memory` (`@reddb-io/memory`) remains the
+  live, in-repo source of the memory plugin and is **not** retired; red-skills
+  keeps building it.
+- **`red-memory` is a local MCP, not a repo.** The memory MCP is the `red-memory`
+  server already wired in `plugins/memory/.mcp.json`, which execs the in-repo
+  `scripts/bootstrap.mjs mcp` (built from `apps/memory`). It is RedDB-backed
+  (`@reddb-io/sdk`) and exposes the `memory_*` tool surface locally. There is no
+  fetch-from-release for memory.
+- **No `red-memory` GitHub repo dependency.** The `reddb-io/red-memory` scaffold
+  is abandoned and should be archived (or left dormant). No red-skills surface
+  fetches from it.
+
+**What survives from the original decision:**
+
+- The **server rename `memory` → `red-memory`** in `plugins/memory/.mcp.json`
+  (decision item 2) — already applied and kept; a good name independent of where
+  the code lives.
+- **`red-ui` as a consumed visualizer MCP** — kept (today wired via
+  `npx @reddb-io/ui@latest`).
+- **`code-nav` stays in the `dev` plugin** — unchanged.
+
+**What is cancelled:**
+
+- Decision item 1 (migrate `apps/memory` → `red-memory` repo; retire it here).
+- Decision item 3's "fetch the `red-memory` bundle from its repo's release" —
+  memory runs from the local build; only `red-ui` remains a fetched/external
+  consumer.
+- Decision item 4's `red-memory` release prerequisite.
+
+**Consequences of the reversal:**
+
+- **#378** (the tracking issue for this migration) is **moot** and is closed as
+  not-planned — the migration it tracked is cancelled.
+- The partial reversal of ADR 0034 no longer applies to memory: `apps/memory`
+  stays under the root `apps/` layout (ADR 0060).
+- INDEX.md cross-references that read "post-0041, the memory runtime is fetched
+  from `red-memory`" / "no longer built in red-skills" are corrected in this
+  change.
+- `/dev:doctor` check 6 (which flags the standalone-local `memory`/`red-memory`
+  server as drift from the consumer shape) must be updated so the **local** shape
+  is the intended one, not drift. Tracked as a follow-up.
 
 ## Related
 
-- ADR 0029 — runtime ships as a release-asset bundle fetched by a bootstrap (the fetch model reused here).
-- ADR 0034 — monorepo `apps` domains (partially reversed for memory).
-- `../red-memory`, `../red-ui` — the owning repos.
+- ADR 0029 — runtime ships as a release-asset bundle fetched by a bootstrap (the fetch model the original decision reused; no longer applied to memory).
+- ADR 0034 — monorepo `apps` domains (memory stays under `apps/`, per this reversal + ADR 0060).
+- ADR 0060 — root `apps/` + `packages/` layout that `apps/memory` keeps.
+- `../red-ui` — the owning repo for the visualizer MCP (still external). `reddb-io/red-memory` is an abandoned scaffold, not a dependency.

--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -17,7 +17,7 @@ stale notes inline.
 ## Repo structure & contexts
 - **0021** Multi-context plugin glossaries — *accepted* (predates the `brain` plugin; the multi-context model now spans `dev`/`memory`/**`brain`** — see the *Brain plugin* section and `.red/contexts/brain/`)
 - **0034** Repo splits DEFINITIONS from IMPLEMENTATION (`apps/…` + `packages/…`) — partially superseded by **0039** (entrypoints fused), **0041** (memory leaves), and **0060** (layout relocated to root with a pnpm catalog)
-- **0041** red-skills consumes `red-memory` + `red-ui` MCPs; stops building memory — partially supersedes 0034 *(renumbered from 0039)*
+- **0041** red-skills consumes `red-memory` + `red-ui` MCPs; stops building memory — partially supersedes 0034 *(renumbered from 0039; **REVERSED by Amendment 1, 2026-06-20 — memory stays in red-skills as the local `red-memory` MCP; the repo split is cancelled**)*
 - **0060** Workspaces move to root `apps/` + `packages/` with a pnpm `catalog:` for shared versions — relocates 0034's `src/apps`/`src/packages` layout (conventional Turborepo); `@reddb-io/sdk` stays per-app-pinned for the bundler
 - **0046** A single global `.red/` shared by all plugins — *superseded by 0021*
 
@@ -26,7 +26,7 @@ stale notes inline.
 - **0057** `red-hermes` is a fetched, never-vendored black-box dependency of the `brain` plugin — reached via `hermes mcp serve`, fetched as a Release asset (0038 model), version pinned (0040), 10-tool contract; MIT attribution in `NOTICE` (0004) *(downstream fetch/launcher blocked on red-hermes releases, same shape as #378)*
 
 ## Bundle / fetch / release / version
-- **0029** Runtime ships as esbuild bundle + `red` binary, fetched post-install by a bootstrap — post-0041, the memory runtime is fetched from the `red-memory` repo rather than built in red-skills
+- **0029** Runtime ships as esbuild bundle + `red` binary, fetched post-install by a bootstrap — the fetch model for the `dev`/`code-nav` bundles (0041's memory-fetch was reversed 2026-06-20; memory runs from the in-repo `apps/memory` build)
 - **0032** AFK ships as a committed dependency-free bundle — *shipping detail superseded by 0038; location by 0034*
 - **0038** Dev runtime ships as a fetched Release asset, not a committed bundle — supersedes 0032's committed-bundle model
 - **0039** Plugin entrypoints share one source, selected by a build role (unifies red-fetch/afk/code-nav/memory launchers)
@@ -72,10 +72,11 @@ stale notes inline.
 
 ## Memory architecture & graph
 
-> Post-**0041**, the memory runtime is no longer built in red-skills — it lives in the
-> `red-memory` repo and is consumed as a fetched MCP. These ADRs still describe the
-> memory **substrate/domain** (the decisions stand), but their implementation now
-> resides in `red-memory`, not `apps/memory`.
+> **0041's memory-to-separate-repo split was reversed (Amendment 1, 2026-06-20).**
+> The memory runtime stays in red-skills — it is built from `apps/memory` and
+> served by the local `red-memory` MCP (`plugins/memory/.mcp.json`). These ADRs
+> describe the memory **substrate/domain** and their decisions stand; their
+> implementation lives in `apps/memory`, not a separate `red-memory` repo.
 
 - **0005** Memory plugin: three-layer RedDB architecture, local-first per-repo, MCP+CLI
 - **0007** RedDB graph writes go through multi-model DML, not table inserts
@@ -103,7 +104,7 @@ stale notes inline.
 - *(see also 0035)*
 
 ## Skill curation & telemetry
-- **0014** Memory owns skill telemetry and report-only curation — post-0041 runtime moves to `red-memory`; ownership/report-only boundary stands
+- **0014** Memory owns skill telemetry and report-only curation — runtime stays in `apps/memory` (0041 split reversed 2026-06-20); ownership/report-only boundary stands
 - **0016** `dev` owns the mutating Skill curator — post-0041 it consumes report-only curator output through `red-memory` MCP, not an in-repo `memory` CLI
 
 ## Licensing


### PR DESCRIPTION
## What

Reverses **ADR 0041** (red-skills migrates `apps/memory` to a separate `red-memory` repo and consumes it via release fetch). Adds a reversal banner + **Amendment 1 (2026-06-20)** to the ADR, and corrects the now-false `INDEX.md` cross-references.

## Why

The split was scaffolded (`reddb-io/red-memory` created 2026-06-08) but **never delivered** — that repo has **zero releases** and no activity since, so #378 has been parked indefinitely waiting on a `red-memory` release bundle that is not coming. Meanwhile memory has run from the in-repo `apps/memory` build the entire time and is fully functional. The maintainer's call: `red-memory` should be a **local MCP here** (RedDB-backed search/governed memory), not a separate repo.

## Decision (Amendment 1)

- **Memory stays in red-skills** — `apps/memory` is the live source, not retired; red-skills keeps building it.
- **`red-memory` is the local MCP** already wired in `plugins/memory/.mcp.json` (execs `apps/memory`, `@reddb-io/sdk` → RedDB), exposing the `memory_*` tools. No fetch-from-release for memory.
- **Survives:** the `memory` → `red-memory` server rename, `red-ui` as a consumed visualizer MCP, `code-nav` in `dev`.
- **Cancelled:** the migration, the release-fetch of memory, the `red-memory` release prerequisite.

## Follow-ups (not in this PR)

- Close **#378** as not-planned (migration cancelled).
- Update **`/dev:doctor` check 6** so the local `red-memory` MCP shape is the intended one, not flagged as drift.
- Archive the abandoned `reddb-io/red-memory` scaffold.

Docs-only change.

https://claude.ai/code/session_01SaovzktnT2tmAac6Chfwey

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784594357&installation_id=129708444&pr_number=771&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F771&signature=26640268541cd8cee212ae7691cc91e403cc06f54c538e621fcc1bf2e1c20033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->