### PR TITLE
feat(ff): two-step interactive flow — choose framing, then dispatch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@694fa30311e02c2639942308513555e61ee84a6f` (see
 
 ---
 
+## ff (productivity) — two-step interactive flow: choose framing, then dispatch prompt
+
+- **status**: modified
+- **upstream**: —
+- **why**: The old `/ff` dumped all seven framings at once and made dispatch an invocation-time flag. The desired UX is two sequential questions with user interaction between them — pick the framing first, then decide whether to execute the single rewrite.
+- **what changed**: Restructured the skill into two steps. **Step 1** asks `How do you want to rewrite your content?` and presents the framing menu (a–g) with one recommendation, then stops — no rewrite generated yet; the user picks by label. **Step 2** generates only the chosen framing's rewrite, prints `Result: {result}`, and asks `Would you like to dispatch it? Yes/no` — Yes adopts the rewrite as the active message and executes the underlying task, No hands it back and stops. `--dispatch`/`-d` is kept as an auto-yes shortcut that skips the Step 2 question. Dropped the all-previews-at-once output and the compare/mix affordance (conscious trade-off for a cleaner flow). Restructured the body into `<what-to-do>` / `<supporting-info>` and updated the frontmatter `description`. README, productivity bucket README updated to match.
+
 ## branch-lock (misc) + dev codex hooks — extend the ADR 0067 gate to the non-launcher hook surface
 
 - **status**: modified

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Composable. Boring on purpose where boring is enough. Sharp where it matters.
 | Skill | What it does |
 |-------|--------------|
 | **[reflect](./plugins/dev/skills/productivity/reflect/SKILL.md)** | Interviews you until every branch of the decision tree is resolved. |
-| **[ff](./plugins/dev/skills/productivity/ff/SKILL.md)** | Fast-forward clarity: reframes the latest user message into multiple plausible interpretations or next replies, then recommends one. |
+| **[ff](./plugins/dev/skills/productivity/ff/SKILL.md)** | Fast-forward clarity: asks which framing you want, rewrites your message into that one framing, then asks whether to dispatch (execute) it. |
 | **[handoff](./plugins/dev/skills/productivity/handoff/SKILL.md)** | Compacts the current conversation into a handoff doc for the next agent. |
 | **[write-a-skill](./plugins/dev/skills/productivity/write-a-skill/SKILL.md)** | Scaffolds new skills with proper structure and progressive disclosure. |
 

--- a/plugins/dev/skills/productivity/README.md
+++ b/plugins/dev/skills/productivity/README.md
@@ -3,6 +3,6 @@
 General workflow tools, not code-specific.
 
 - **[reflect](./reflect/SKILL.md)** — Get relentlessly interviewed about a plan or design until every branch of the decision tree is resolved.
-- **[ff](./ff/SKILL.md)** — Fast-forward clarity: reframe the latest user message into multiple preview versions with a recommendation.
+- **[ff](./ff/SKILL.md)** — Fast-forward clarity: pick a framing, get your message rewritten into it, then choose whether to dispatch (execute) it.
 - **[handoff](./handoff/SKILL.md)** — Compact the current conversation into a handoff document so another agent can continue the work.
 - **[write-a-skill](./write-a-skill/SKILL.md)** — Create new skills with proper structure, progressive disclosure, and bundled resources.

--- a/plugins/dev/skills/productivity/ff/SKILL.md
+++ b/plugins/dev/skills/productivity/ff/SKILL.md
@@ -1,71 +1,80 @@
 ---
 name: ff
-description: Reframes the user's latest message into several useful versions with short previews and one explicit recommendation, then hands the chosen rewrite back to the user — it does NOT execute the underlying task unless invoked with `--dispatch`/`-d`. Use when the user invokes `/ff`, says fast-forward, asks to rewrite their own message, or wants to clarify intent before acting.
+description: Reframes the user's message into one chosen framing through a two-step interaction — first asks which framing to rewrite into, then generates that single rewrite and asks whether to dispatch (execute) it. Use when the user invokes `/ff`, says fast-forward, asks to rewrite their own message, or wants to clarify intent before acting.
 argument-hint: "[--dispatch|-d] [text to reframe]"
 ---
 
 # /ff
 
 Fast-forward clarity. Reframe the user's latest message, or the text passed after
-`/ff`, into multiple preview versions so the user can pick the framing they want.
+`/ff`, into **one** chosen framing — through two sequential questions, asked one
+at a time with the user's interaction between them.
 
-By default `/ff` **ends by handing the chosen rewrite back to the user** — it does
-not start executing the underlying task. Pass `--dispatch` (or `-d`) to have `/ff`
-reframe, let the user pick a format, and **then run** the task with that framing.
+`/ff` does NOT dump every framing at once. It asks which framing the user wants
+first, generates only that one rewrite, then asks whether to dispatch it.
 
-## Modes
+<what-to-do>
 
-- **`/ff <text>`** (default — reframe only): present the previews, and once the
-  user picks a framing, output the finalized rewrite and **stop**. That rewritten
-  prompt is the deliverable; the user takes it and decides what to do next. Never
-  continue a paused workflow or execute the underlying task.
-- **`/ff --dispatch <text>`** / **`/ff -d <text>`** (reframe then run): present the
-  previews exactly the same way; once the user picks a framing, adopt that rewrite
-  as the active message and **immediately carry out the underlying task**.
+Run these two steps in order. Ask one question, wait for the answer, then proceed
+to the next. Never skip ahead.
 
-`--dispatch`/`-d` may appear anywhere in the arguments; strip it before reframing
-the remaining text.
+### Step 1 — choose the framing
 
-## Contract (both modes)
-
-- While presenting previews, reframe only: do not solve the underlying task, do
-  not edit files or run commands, and do not continue a paused `/start`,
-  `/diagnose`, `/afk`, or implementation task.
-- Return previews for every option below, then stop and wait for the user's pick.
-- Start with one recommendation in this exact spirit: `I think you want (x), because ...`
-- Keep each preview short by default: 3-8 lines, or a compact summary when the
-  source text is long.
-
-## Output
-
-Use this shape:
+Present the framing menu with a single recommendation, then **stop and wait**. Do
+not generate any rewrite yet — the user picks by label, before seeing any output.
 
 ```md
-I think you want (a), because ...
+How do you want to rewrite your content?
+
+I think you want (x), because ...
 
 (a) For a junior dev
-...
-
 (b) For a 10-year-old
-...
-
 (c) For a senior dev
-...
-
 (d) As an improved prompt
-...
-
 (e) As an implementable issue
-...
-
 (f) As a decision request
-...
-
 (g) Short and direct
-...
 ```
 
-## Option Semantics
+The user picks with phrases like `d`, `use a`, or `go with that one`.
+
+### Step 2 — generate, then ask to dispatch
+
+Produce **only** the chosen framing's rewrite and present it, then ask whether to
+dispatch:
+
+```md
+Result:
+{result}
+
+Would you like to dispatch it? Yes/no
+```
+
+- **Yes** → adopt `{result}` as the active message and **carry out the underlying
+  task** immediately.
+- **No** → hand `{result}` back and **stop**. Do not execute anything.
+
+**`--dispatch`/`-d` shortcut**: if the flag was passed in the invocation, **skip
+the Yes/no question** — present the `Result:` and immediately dispatch (auto-yes).
+The flag may appear anywhere in the arguments; strip it before reframing the
+remaining text.
+
+### Hard rules
+
+- ✅ Generate exactly **one** rewrite — the chosen framing. Never preview all of them.
+- ✅ In Step 1, reframe only: do not solve the task, edit files, run commands, or
+  continue a paused `/start`, `/diagnose`, `/afk`, or implementation task.
+- ✅ Keep the rewrite tight: a few lines, or a compact summary when the source is long.
+- ❌ Do not execute anything until the user answers Yes in Step 2 (or passed `-d`).
+- ❌ Do not collapse the two steps into one turn — the menu and the result are
+  separate questions.
+
+</what-to-do>
+
+<supporting-info>
+
+## Framing semantics
 
 - **(a) For a junior dev**: precise but simple technical language, minimal jargon, practical examples.
 - **(b) For a 10-year-old**: plain language, one analogy if useful, no patronizing tone.
@@ -75,11 +84,12 @@ I think you want (a), because ...
 - **(f) As a decision request**: decision needed, options, tradeoffs, recommendation, and what answer unblocks.
 - **(g) Short and direct**: the shortest clear version.
 
-## When the user picks a framing
+## Why two steps
 
-The user picks with phrases like `use a`, `mix a with d`, or `go with that one`.
+The user picks the framing by label *before* any rewrite is generated. This is
+cheaper and cleaner than producing all seven previews up front, at the cost of
+not comparing finished rewrites side by side or mixing two framings. The Step 2
+Yes/no makes dispatch an explicit, per-invocation choice; `-d` is the shortcut
+for users who already know they want to execute.
 
-- **Default mode** (no `--dispatch`): produce the finalized rewrite from the chosen
-  option(s) and **stop**. Hand that rewritten prompt back — do not start executing it.
-- **`--dispatch` mode**: produce the finalized rewrite from the chosen option(s),
-  adopt it as the active message, and **proceed to carry out the underlying task**.
+</supporting-info>


### PR DESCRIPTION
Restructures `/ff` into two sequential questions asked one at a time:

- **Step 1** presents the framing menu (a–g) + one recommendation and stops — no rewrite yet; user picks by label.
- **Step 2** generates only the chosen framing's rewrite, prints `Result: {result}`, and asks `dispatch it? Yes/no` — Yes adopts it as the active message and executes, No hands it back and stops.
- `-d`/`--dispatch` stays as an auto-yes shortcut that skips Step 2.

Drops the all-previews-at-once output and the compare/mix affordance (conscious trade-off). Propagates to README, productivity bucket README, and CHANGES.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784597903&installation_id=129708444&pr_number=774&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F774&signature=b5108d9f123fd03cf4d69110b1a0fc8521183dd40272c3f32bd32c66026fb894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->