### PR TITLE
docs: SKILL.md writing convention — 8 techniques in write-a-skill + CLAUDE.md (#777)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@694fa30311e02c2639942308513555e61ee84a6f` (see
 
 ---
 
+## write-a-skill (productivity) — document the eight-technique SKILL.md writing convention + dogfood it
+
+- **status**: modified
+- **upstream**: —
+- **why**: RedSkills had a *section-level* SKILL.md convention (`<what-to-do>`/`<supporting-info>`) but no *sentence-level* writing guidance, so skill authors had no canonical reference for how each sentence should read. PRD #776 / #777 establishes the eight sentence-level techniques borrowed from `anthropics/launch-your-agent` and makes them discoverable.
+- **what changed**: Added a "SKILL.md writing style" section to `write-a-skill` enumerating all eight techniques (bold lead-in + gloss; maxim/slogan compression; prohibition + reason inline; literal phrasing in quotes; vocabulary hygiene; numbered taxonomy; self-demonstrating voice; precondition-carrying headers), each with a one-line before → after. Rewrote the skill's own body to follow the convention (imperative bold lead-ins, prohibitions carrying their reason, precondition in the Review header) so the generator both teaches and follows the style. Added a sentence-level pointer to `CLAUDE.md` beside the existing "SKILL.md body convention" section, framed as additive (it complements, does not replace, the section-level split). Docs-only — no behavioural/runtime change to any bundle, hook, or CLI.
+
 ## doctor (engineering) — enforce `plugins.dev.*` config namespacing + migrate legacy top-level keys
 
 - **status**: modified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,10 @@ If a skill has only one of the two sections, the whole body is the primary direc
 
 Never reorder priorities so that documentation/side-effect work in `<supporting-info>` competes with the interview / implementation / review loop defined in `<what-to-do>`.
 
+### SKILL.md writing style (sentence-level)
+
+The body convention above is **section-level** — it decides *where* a sentence goes. Underneath it sits the **sentence-level** writing convention: eight techniques (bold lead-in + gloss; maxim/slogan compression; prohibition + reason inline; literal phrasing in quotes; vocabulary hygiene; numbered taxonomy; self-demonstrating voice; precondition-carrying headers) that decide *how each sentence reads*. It is **additive — it complements the `<what-to-do>`/`<supporting-info>` split, it does not replace it.** When writing or editing any RedSkills SKILL.md, apply both. The full list with before → after examples lives in the `write-a-skill` skill's "SKILL.md writing style" section.
+
 ## Agent skills
 
 ### Wiki

--- a/plugins/dev/skills/productivity/write-a-skill/SKILL.md
+++ b/plugins/dev/skills/productivity/write-a-skill/SKILL.md
@@ -7,34 +7,33 @@ description: Create new agent skills with proper structure, progressive disclosu
 
 ## Process
 
-1. **Gather requirements** - ask user about:
-   - What task/domain does the skill cover?
-   - What specific use cases should it handle?
-   - Does it need executable scripts or just instructions?
-   - Any reference materials to include?
+1. **Gather requirements** — ask the user, before drafting anything:
+   - What task or domain does the skill cover?
+   - Which specific use cases must it handle?
+   - Does it need executable scripts, or just instructions?
+   - Any reference material to bundle?
 
-2. **Draft the skill** - create:
-   - SKILL.md with concise instructions
-   - Additional reference files if content exceeds 500 lines
-   - Utility scripts if deterministic operations needed
+2. **Draft the skill** — produce:
+   - A SKILL.md with concise, imperative instructions.
+   - Extra reference files only when content would push SKILL.md past ~100 lines.
+   - Utility scripts only when a deterministic operation repeats.
 
-3. **Review with user** - present draft and ask:
-   - Does this cover your use cases?
-   - Anything missing or unclear?
-   - Should any section be more/less detailed?
+3. **Review with the user** — present the draft and ask whether it covers the
+   use cases, what is missing or unclear, and which section needs more or less
+   detail. Do not ship before this loop closes.
 
-## Skill Structure
+## Skill structure
 
 ```
 skill-name/
 ├── SKILL.md           # Main instructions (required)
-├── REFERENCE.md       # Detailed docs (if needed)
-├── EXAMPLES.md        # Usage examples (if needed)
-└── scripts/           # Utility scripts (if needed)
+├── REFERENCE.md       # Detailed docs (only if needed)
+├── EXAMPLES.md        # Usage examples (only if needed)
+└── scripts/           # Utility scripts (only if needed)
     └── helper.js
 ```
 
-## SKILL.md Template
+## SKILL.md template
 
 ```md
 ---
@@ -57,61 +56,100 @@ description: Brief description of capability. Use when [specific triggers].
 [Link to separate files: See [REFERENCE.md](REFERENCE.md)]
 ```
 
-## Description Requirements
+## Description requirements
 
-The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
+The description is **the only thing the agent sees before loading the skill** —
+write it for the picker, not the reader. It is surfaced in the system prompt
+beside every other installed skill, and the agent chooses from those lines
+alone.
 
-**Goal**: Give your agent just enough info to know:
-
-1. What capability this skill provides
-2. When/why to trigger it (specific keywords, contexts, file types)
+Give the agent just enough to know two things: what the capability is, and
+when to trigger it (keywords, contexts, file types).
 
 **Format**:
 
-- Max 1024 chars
-- Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+- Max 1024 chars.
+- Third person.
+- First sentence: what it does.
+- Second sentence: starts with the literal `"Use when"` so the trigger is
+  matchable verbatim.
 
-**Good example**:
+**Good** — distinguishes itself from every other document skill:
 
 ```
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example**:
+**Bad** — gives the agent no way to pick it:
 
 ```
 Helps with documents.
 ```
 
-The bad example gives your agent no way to distinguish this from other document skills.
+## When to add scripts
 
-## When to Add Scripts
+Add a utility script when the operation is deterministic (validation,
+formatting), when the same code would be generated repeatedly, or when errors
+need explicit handling. Scripts save tokens and beat generated code on
+reliability.
 
-Add utility scripts when:
+## When to split files
 
-- Operation is deterministic (validation, formatting)
-- Same code would be generated repeatedly
-- Errors need explicit handling
+Split into a separate file when SKILL.md exceeds ~100 lines, when content spans
+distinct domains (finance vs sales schemas), or when advanced features are
+rarely needed — keep references one level deep so the agent never chases a chain.
 
-Scripts save tokens and improve reliability vs generated code.
+## SKILL.md writing style
 
-## When to Split Files
+Section structure (`<what-to-do>` / `<supporting-info>`) decides *where* a
+sentence goes; this section decides *how the sentence reads*. Apply these eight
+sentence-level techniques — borrowed from `anthropics/launch-your-agent` — when
+writing any RedSkills SKILL.md. Each carries a one-line before → after.
 
-Split into separate files when:
+1. **Bold lead-in + gloss** — open a step with the imperative in bold, then
+   explain it.
+   - Before: `You should gather the requirements from the user first.`
+   - After: `**Gather requirements** — ask the user what task the skill covers.`
 
-- SKILL.md exceeds 100 lines
-- Content has distinct domains (finance vs sales schemas)
-- Advanced features are rarely needed
+2. **Maxim/slogan compression** — fold a rule into one memorable line.
+   - Before: `The description matters because it is what the agent uses to decide whether to load the skill.`
+   - After: `The description is the only thing the agent sees before loading — write it for the picker, not the reader.`
 
-## Review Checklist
+3. **Prohibition + reason inline (em-dash consequence)** — state the ban and its
+   cost on one line.
+   - Before: `Do not exceed 100 lines. Long skills are hard to read.`
+   - After: `Never exceed ~100 lines — past that the agent skims and drops steps.`
 
-After drafting, verify:
+4. **Literal phrasing in quotes** — quote the exact words the agent must emit or
+   match.
+   - Before: `End the description with a phrase about when to use it.`
+   - After: `End the description with "Use when …" so the trigger is matchable verbatim.`
 
-- [ ] Description includes triggers ("Use when...")
-- [ ] SKILL.md under 100 lines
-- [ ] No time-sensitive info
-- [ ] Consistent terminology
-- [ ] Concrete examples included
-- [ ] References one level deep
+5. **Vocabulary hygiene (real term, ban synonym)** — name a thing once, forbid
+   its synonyms.
+   - Before: `Put your docs / guidance / instructions in the file.`
+   - After: `Call it the SKILL.md — never "the doc", "the manifest", or "the guide".`
+
+6. **Numbered taxonomy when concepts blur** — number a set whose members are
+   easily conflated.
+   - Before: `Add scripts for deterministic work and split files for big skills.`
+   - After: `Two distinct moves: (1) add a script for deterministic work; (2) split a file once SKILL.md passes ~100 lines.`
+
+7. **Self-demonstrating voice** — write the instruction in the style it teaches.
+   - Before: `Instructions should be concise and imperative.`
+   - After: `Write every step imperative and bold-led — like this one.`
+
+8. **Phase/step header carries its precondition** — fold the precondition into
+   the header instead of a trailing aside.
+   - Before: `## Review` followed by `(Only do this after the draft is complete.)`
+   - After: `## Review (after the draft compiles and runs)`
+
+## Review checklist (run after the draft compiles)
+
+- [ ] Description ends with the literal `"Use when …"` trigger.
+- [ ] SKILL.md stays under ~100 lines (excluding this meta-skill).
+- [ ] No time-sensitive info.
+- [ ] One term per concept — no synonym drift.
+- [ ] Concrete before → after or input → output examples included.
+- [ ] References stay one level deep.
+- [ ] Steps read imperative and bold-led — the skill follows its own style.


### PR DESCRIPTION
Closes #777 · PRD #776

## What

The foundational slice of PRD #776 (SKILL.md writing convention). Docs-only:

- **`write-a-skill/SKILL.md`** — new "SKILL.md writing style" section enumerating the eight sentence-level techniques (bold lead-in + gloss; maxim compression; prohibition + reason inline; literal phrasing; vocabulary hygiene; numbered taxonomy; self-demonstrating voice; precondition-carrying header), each with a one-line before→after. The skill's own body rewritten to follow the convention (dogfood).
- **`CLAUDE.md`** — pointer beside the existing "SKILL.md body convention" section, framed as additive (sentence-level complement to the section-level `<what-to-do>`/`<supporting-info>` split).
- **`CHANGES.md`** — records the `write-a-skill` divergence (status: modified, docs-only).

## Why a manual PR (not auto-merged)

The AFK worker (`w6F9S`) completed the work and emitted DONE, but the whole-workspace feedback gate flaked on an **unrelated** test — `apps/memory tests/public-docs-claims.test.ts` (RedDB-backed, timing-sensitive). That test passes clean on primary (799/799). #777 touches no runtime code, so the failure is not caused by this slice. Opening as a normal PR for human review (the convention is the ruler the rest of PRD #776 imitates).

No behavioural/runtime change to any bundle, hook, or CLI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784601903&installation_id=129708444&pr_number=787&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F787&signature=8c4cfd05ed59f74a8147d6285793dc53119c41b03eaddba69e9d5fea2cabebec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->