### PR TITLE
fix(brain): state Personal-facts boundary verbatim in capture SKILL.md (unblocks PRD #788 gate)

### DIFF
--- a/plugins/brain/skills/core/capture/SKILL.md
+++ b/plugins/brain/skills/core/capture/SKILL.md
@@ -36,7 +36,7 @@ When unsure, use `note`. Do not invent kinds outside the Brain vertex vocabulary
 
 ## 2. Check the Brain-vs-Memory boundary
 
-Before capturing, confirm the content belongs in Brain:
+**Use Brain, not Memory, for Personal facts.** Before capturing, confirm the content belongs in Brain:
 
 - **Belongs in Brain**: biographical details, identity context, personal preferences, contact information, durable human decisions, knowledge about people and organizations, long-lived ideas, plans, and questions — anything the user wants to recall across sessions as human-facing knowledge.
 - **Belongs in Memory** (route to `/memory:store`): short operational facts from the current work session — a gotcha encountered, a why-note for a code decision, a validated approach, a scoped reminder for the agent.


### PR DESCRIPTION
`memory-brain-boundary-docs.test.ts` asserts the brain capture skill contains the literal `Use Brain, not Memory, for Personal facts`. The expanded capture skill documented the boundary in prose but dropped that verbatim token, so the test was **red on origin/main** and failed the apps/dev feedback gate for every PRD #788 slice (#793/#794 hit `blocked:validation` on it).

Adds the maxim lead-in to section 2 (SKILL.md house style). Test now green (2 passed).

https://claude.ai/code/session_012HdByUsz8cJN2zqUS1MT5k

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784642891&installation_id=129708444&pr_number=797&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F797&signature=d4d7b56d1bc5e109f6eab077fd43d69b9b9bc702db54f470a441d53a609950f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->