### PR TITLE
fix(afk): claude-minimax pins API-key auth via CLAUDE_CODE_SIMPLE=1 (no OAuth fallthrough)

### DIFF
--- a/apps/dev/src/core/minimax-env.ts
+++ b/apps/dev/src/core/minimax-env.ts
@@ -32,26 +32,41 @@ export const MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic";
 export const MINIMAX_M3_MODEL = "MiniMax-M3";
 
 /**
+ * Forces the Claude Code CLI down its API-key auth path instead of resolving a
+ * host OAuth/keychain session. Without it, a host already logged into a real
+ * Claude account would send that OAuth token to the MiniMax base URL — which
+ * MiniMax rejects (401), or worse, silently routes the inner agent to real
+ * Anthropic. `CLAUDE_CODE_SIMPLE=1` makes the injected `ANTHROPIC_API_KEY` the
+ * sole credential, so the lane is deterministic regardless of host login state.
+ */
+export const CLAUDE_CODE_SIMPLE_ENV = "1";
+
+/**
  * The inner-spawn env block delivered to the claude-code provider: the MiniMax
- * key under Anthropic's `ANTHROPIC_API_KEY` plus the hardcoded MiniMax
- * `ANTHROPIC_BASE_URL`.
+ * key under Anthropic's `ANTHROPIC_API_KEY`, the hardcoded MiniMax
+ * `ANTHROPIC_BASE_URL`, and `CLAUDE_CODE_SIMPLE=1` to pin the API-key auth path.
  */
 export type MiniMaxClaudeEnv = {
   ANTHROPIC_API_KEY: string;
   ANTHROPIC_BASE_URL: string;
+  CLAUDE_CODE_SIMPLE: string;
 };
 
 /**
- * Map `MINIMAX_API_KEY` → `{ ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL }` for the
- * inner claude-code spawn, or `undefined` when no key is set (lane unusable).
- * Pure — the env is injected. An empty-string value counts as unset (operators
- * sometimes export an empty placeholder in shared rc files; we never want to
- * spawn against MiniMax with no real key).
+ * Map `MINIMAX_API_KEY` → `{ ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL,
+ * CLAUDE_CODE_SIMPLE }` for the inner claude-code spawn, or `undefined` when no
+ * key is set (lane unusable). Pure — the env is injected. An empty-string value
+ * counts as unset (operators sometimes export an empty placeholder in shared rc
+ * files; we never want to spawn against MiniMax with no real key).
  */
 export function resolveMiniMaxClaudeEnv(env: NodeJS.ProcessEnv): MiniMaxClaudeEnv | undefined {
   const key = env[MINIMAX_API_KEY_ENV];
   if (typeof key === "string" && key.length > 0) {
-    return { ANTHROPIC_API_KEY: key, ANTHROPIC_BASE_URL: MINIMAX_ANTHROPIC_BASE_URL };
+    return {
+      ANTHROPIC_API_KEY: key,
+      ANTHROPIC_BASE_URL: MINIMAX_ANTHROPIC_BASE_URL,
+      CLAUDE_CODE_SIMPLE: CLAUDE_CODE_SIMPLE_ENV,
+    };
   }
   return undefined;
 }

--- a/apps/dev/tests/minimax-env.test.ts
+++ b/apps/dev/tests/minimax-env.test.ts
@@ -11,6 +11,7 @@ describe("resolveMiniMaxClaudeEnv", () => {
     expect(resolveMiniMaxClaudeEnv({ [MINIMAX_API_KEY_ENV]: "mm-key-123" })).toEqual({
       ANTHROPIC_API_KEY: "mm-key-123",
       ANTHROPIC_BASE_URL: MINIMAX_ANTHROPIC_BASE_URL,
+      CLAUDE_CODE_SIMPLE: "1",
     });
   });
 


### PR DESCRIPTION
The claude-minimax lane injects `MINIMAX_API_KEY`→`ANTHROPIC_API_KEY` + the MiniMax `ANTHROPIC_BASE_URL` into the inner Claude Code spawn. On a host already logged into a real Claude account, Claude Code can prefer its **OAuth/keychain** session over the injected key — sending the Claude token to MiniMax's endpoint (401) or silently routing the agent to **real Anthropic** instead of M3.

Adds `CLAUDE_CODE_SIMPLE=1` to `resolveMiniMaxClaudeEnv`'s returned env so the injected key is the sole credential. Matches the operator's verified manual `minimax` wrapper. Test updated (5 pass).

https://claude.ai/code/session_012HdByUsz8cJN2zqUS1MT5k

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784645590&installation_id=129708444&pr_number=798&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F798&signature=748f9666c666bbe389143c83fb9f1db4a7c6933d849f8e588c0c55828f0d5ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->