### PR TITLE
fix(ci): drop red-release contract-fixture tests for the retired .red/contracts (unblocks release)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -61,22 +61,6 @@ jobs:
         if: steps.fleet.outputs.running == '0'
         run: scripts/test-validate-agent-metadata.sh
 
-      - name: Test AFK task contract fixtures
-        if: steps.fleet.outputs.running == '0'
-        run: scripts/test-validate-afk-task-contract.sh
-
-      - name: Test issue-analyzer contract fixtures
-        if: steps.fleet.outputs.running == '0'
-        run: scripts/test-validate-issue-analyzer-contract.sh
-
-      - name: Test task-executor contract fixtures
-        if: steps.fleet.outputs.running == '0'
-        run: scripts/test-validate-task-executor-contract.sh
-
-      - name: Test quality-gate contract fixtures
-        if: steps.fleet.outputs.running == '0'
-        run: scripts/test-validate-quality-gate-contract.sh
-
       - name: Decide bump kind
         id: bump
         if: steps.fleet.outputs.running == '0'


### PR DESCRIPTION
The single-root `.red` cleanup removed `.red/contracts/` (schema + fixtures), but `red-release.yml` still ran `test-validate-{afk-task,issue-analyzer,task-executor,quality-gate}-contract.sh` which read the deleted `.red/contracts/fixtures/*` → **every release fails** at the first contract step. The contracts are retired + unused by the runtime, so the 4 test steps are removed. 'agent metadata fixtures' stays. Orphaned `scripts/*-contract.sh` left for a follow-up cleanup.

https://claude.ai/code/session_012HdByUsz8cJN2zqUS1MT5k

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784648396&installation_id=129708444&pr_number=799&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F799&signature=543c6311c99b6f703897abc6d0e4b30b50f35042480d4c185aeb664f87b476bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->