### PR TITLE
docs(afk): correct CLAUDE_CODE_SIMPLE comment — no-op, not an OAuth bypass (forward-fix of #798)

### DIFF
--- a/apps/dev/src/core/minimax-env.ts
+++ b/apps/dev/src/core/minimax-env.ts
@@ -32,19 +32,22 @@ export const MINIMAX_ANTHROPIC_BASE_URL = "https://api.minimax.io/anthropic";
 export const MINIMAX_M3_MODEL = "MiniMax-M3";
 
 /**
- * Forces the Claude Code CLI down its API-key auth path instead of resolving a
- * host OAuth/keychain session. Without it, a host already logged into a real
- * Claude account would send that OAuth token to the MiniMax base URL — which
- * MiniMax rejects (401), or worse, silently routes the inner agent to real
- * Anthropic. `CLAUDE_CODE_SIMPLE=1` makes the injected `ANTHROPIC_API_KEY` the
- * sole credential, so the lane is deterministic regardless of host login state.
+ * Mirrors the operator's manual `minimax` wrapper, which exports
+ * `CLAUDE_CODE_SIMPLE=1`. NOTE: the Claude Code CLI does **not** read this var
+ * today — verified zero references in the v2.1.185 binary, so it is a **no-op**.
+ * What actually pins the inner spawn to MiniMax is `ANTHROPIC_BASE_URL` +
+ * `ANTHROPIC_API_KEY` (below): a non-default base URL with an explicit API key
+ * routes there without sending a host OAuth/keychain token. We still inject this
+ * var for parity with the wrapper and as a forward-compatible hint should Claude
+ * Code adopt a "simple/API-key-only" switch; it never harms the spawn.
  */
 export const CLAUDE_CODE_SIMPLE_ENV = "1";
 
 /**
  * The inner-spawn env block delivered to the claude-code provider: the MiniMax
  * key under Anthropic's `ANTHROPIC_API_KEY`, the hardcoded MiniMax
- * `ANTHROPIC_BASE_URL`, and `CLAUDE_CODE_SIMPLE=1` to pin the API-key auth path.
+ * `ANTHROPIC_BASE_URL` (these two are what actually route to MiniMax), plus the
+ * parity-only `CLAUDE_CODE_SIMPLE` (a no-op in current Claude Code — see above).
  */
 export type MiniMaxClaudeEnv = {
   ANTHROPIC_API_KEY: string;


### PR DESCRIPTION
#798 documented `CLAUDE_CODE_SIMPLE=1` as forcing the API-key auth path / bypassing host OAuth. **That's false** — the Claude Code CLI (v2.1.185) has **0 references** to `CLAUDE_CODE_SIMPLE` (vs 100+ for `ANTHROPIC_API_KEY`); it never reads it. The real routing to MiniMax is `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY`.

Forward-fix (not a revert, per operator): keep injecting the var (parity with the manual `minimax` wrapper + forward-compat), but the docstrings now tell the truth — it's a no-op today. Comments-only; behavior + test unchanged.

https://claude.ai/code/session_012HdByUsz8cJN2zqUS1MT5k

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784655076&installation_id=129708444&pr_number=800&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F800&signature=3891c30f59e8a42357e65116575f2e4cdca7c847f1c0847563b736cc6acdb3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for environment variable handling and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->