### PR TITLE
ship: #801 Statusline high-tech theme: wine-red line, mnemonic KPIs, black-chipped numbers

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -17,7 +17,8 @@
 
 import { existsSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
-import { renderStatusline, type ClaudeInput, type ProjectInput } from "../core/statusline.js";
+import { type ClaudeInput, type ProjectInput } from "../core/statusline.js";
+import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
 import { collectStatuslineAfk } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
@@ -153,7 +154,10 @@ export async function statuslineCommand(
   // from the project root and let gh infer the repo from cwd (repo slug "").
   const afk = (await collectStatuslineAfk({ root, repo: "", remote: "origin" })) ?? undefined;
 
-  const line = renderStatusline({ project, claude, afk });
+  // Theme on by default (the high-tech wine line with chipped KPI numbers);
+  // honour NO_COLOR for plain consumers, matching the de-facto colour opt-out.
+  const color = !process.env.NO_COLOR;
+  const line = renderStatuslineThemed({ project, claude, afk }, color);
   stdout.write(`${line}\n`);
   return 0;
 }

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -1,0 +1,78 @@
+// core/statusline-style.ts — the ANSI styling slice for the /afk statusline.
+//
+// core/statusline.ts is deliberately PURE plain-text. This sibling adds the
+// optional "high-tech" theme the pure renderer leaves out: the whole line on a
+// wine-red background in white, with every AFK KPI *number* drawn as a black
+// chip (black background, white text) so the live counts pop against the wine.
+//
+// The chip is the terminal-feasible stand-in for a bordered badge: ANSI cannot
+// draw a box around inline characters, so a reversed-contrast black chip is the
+// closest "negative" highlight. Labels (wk/rq/#/…) stay on the wine field; only
+// the value the eye tracks gets the chip.
+//
+// Everything here is PURE (input object → string). The IO half
+// (commands/statusline.ts) decides whether to call this (colour on) or the
+// plain renderProjectBlock/renderStatusline path (colour off, e.g. NO_COLOR).
+
+import {
+  afkTokens,
+  renderContextBlock,
+  renderModelBlock,
+  renderProjectBlock,
+  renderStatusline,
+  type AfkInput,
+  type StatuslineInput,
+} from "./statusline.js";
+
+/** Truecolor SGR helpers. Wine-red is `#722F37`; chips are pure black. */
+const WINE_BG = "\x1b[48;2;114;47;55m";
+const BLACK_BG = "\x1b[48;2;0;0;0m";
+const WHITE_FG = "\x1b[38;2;255;255;255m";
+const RESET = "\x1b[0m";
+
+/**
+ * Wrap a KPI value as a black chip, then restore the wine field so following
+ * text stays on the line background. The foreground is already white from the
+ * line wrapper, so the chip only toggles the background.
+ */
+function chip(value: string): string {
+  return `${BLACK_BG}${value}${WINE_BG}`;
+}
+
+/**
+ * The AFK block with each KPI value chipped. Shares {@link afkTokens} with the
+ * plain renderer, so the mnemonics and emit order never drift. Empty string
+ * when there are no live workers (caller drops the section).
+ */
+export function styleAfkBlock(afk: AfkInput | undefined): string {
+  const tokens = afkTokens(afk);
+  if (tokens.length === 0) return "";
+  return tokens.map((t) => `${t.label}${chip(t.value)}${t.suffix}`).join(" ");
+}
+
+/**
+ * Assemble the full statusline with the high-tech theme: project / model /
+ * context blocks plain on the wine field, the AFK block with chipped KPI
+ * numbers, joined by ` · ` and wrapped in one wine-red/white run terminated by
+ * a reset. Block presence and order match {@link renderStatusline} exactly, so
+ * colour only ever changes how the line looks, never which sections appear.
+ */
+export function styleStatusline(input: StatuslineInput): string {
+  const sections: string[] = [renderProjectBlock(input.project)];
+  const model = renderModelBlock(input.claude);
+  if (model !== null) sections.push(model);
+  const context = renderContextBlock(input.claude);
+  if (context !== null) sections.push(context);
+  const afk = styleAfkBlock(input.afk);
+  if (afk !== "") sections.push(afk);
+  return `${WINE_BG}${WHITE_FG}${sections.join(" · ")}${RESET}`;
+}
+
+/**
+ * Render the statusline, themed or plain. `color` is the single switch: true →
+ * {@link styleStatusline} (ANSI), false → {@link renderStatusline} (the exact
+ * plain line, for NO_COLOR / non-terminal consumers).
+ */
+export function renderStatuslineThemed(input: StatuslineInput, color: boolean): string {
+  return color ? styleStatusline(input) : renderStatusline(input);
+}

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -3,7 +3,11 @@
 // model, effort, context window) and combines it with live /afk worker state
 // from <root>/.red/tmp/workers/*/* to emit ONE compact line like:
 //
-//   red-skills · Opus·high · 47k 24% · 🤖4 📋1 🆘11 🚧10 +12 -3 #17
+//   red-skills · Opus·high · 47k 24% · wk4 rq1 rh11 bk10 ad12 rm3 #17
+//
+// The AFK KPIs use two-letter mnemonics (wk/rq/rh/bk/ad/rm/wt/tk/$) instead of
+// emojis; the optional ANSI theming (wine-red line, black-chipped KPI numbers)
+// lives in the sibling style module, not here.
 //
 // The render here is PURE — no stdin parse, no filesystem, no git/gh, no cache,
 // no ANSI. The caller injects the already-resolved inputs (project basename +
@@ -39,26 +43,26 @@ export interface ClaudeInput {
 
 /** The block-4 aggregated worker counts, already summed across live workers. */
 export interface AfkInput {
-  /** 🤖 — number of live workers. */
+  /** `wk` — number of live workers. */
   workers: number;
-  /** 📋 — cached ready-for-agent (queue) count. */
+  /** `rq` — cached ready-for-agent (queue) count. */
   queue: number;
-  /** 🆘 — cached ready-for-human count. */
+  /** `rh` — cached ready-for-human count. */
   human: number;
-  /** 🚧 — summed blocked count. */
+  /** `bk` — summed blocked count. */
   blocked: number;
-  /** +N — summed insertions. */
+  /** `adN` — summed insertions. */
   added: number;
-  /** -N — summed deletions. */
+  /** `rmN` — summed deletions. */
   removed: number;
-  /** 💤 — summed `waiting_count` (heartbeat windows with zero new stream events)
+  /** `wt` — summed `waiting_count` (heartbeat windows with zero new stream events)
    * across live workers. A rising value between glances is the clean
    * stuck-vs-working signal (silent agent), so it is shown only when > 0. */
   waiting?: number;
-  /** 🪙 — summed token spend (input + output) across live workers (ADR 0065 cost
-   * group). Humanized (e.g. `🪙12k`); shown only when > 0. */
+  /** `tk` — summed token spend (input + output) across live workers (ADR 0065 cost
+   * group). Humanized (e.g. `tk12k`); shown only when > 0. */
   tokens?: number;
-  /** 💵 — summed USD cost across live workers, shown only when > 0 (most runners
+  /** `$` — summed USD cost across live workers, shown only when > 0 (most runners
    * report tokens but not cost, so this is frequently absent). */
   costUsd?: number;
   /** #N issue numbers for the in-progress workers, in order. */
@@ -127,30 +131,60 @@ export function renderContextBlock(claude: ClaudeInput | undefined): string | nu
 }
 
 /**
- * Block 4: the space-joined AFK token run. Each emoji+number is emitted only
- * when its count is > 0, in the fixed order 🤖 📋 🆘 🚧 +N -N 💤N, followed by the
- * `#N` issue numbers (always emitted, in order, each with an optional `·stage`
- * suffix). Null when there are no live workers, matching the bash
- * `(( total_workers > 0 ))` gate around the block.
+ * One AFK token, split so the styling slice can paint the numeric VALUE
+ * independently of its label. `label` is the leading two-letter mnemonic (`wk`,
+ * `rq`, …) or sigil (`#`, `$`); `value` is the number/humanized count the chip
+ * highlights; `suffix` is any trailing non-numeric text (the `·stage` on an
+ * issue token). Plain render = `label + value + suffix`; styled render chips
+ * only `value`. See {@link renderAfkBlock} (plain) and the style module.
  */
-export function renderAfkBlock(afk: AfkInput | undefined): string | null {
-  if (!afk || afk.workers <= 0) return null;
-  const tokens: string[] = [];
-  if (afk.workers > 0) tokens.push(`🤖${afk.workers}`);
-  if (afk.queue > 0) tokens.push(`📋${afk.queue}`);
-  if (afk.human > 0) tokens.push(`🆘${afk.human}`);
-  if (afk.blocked > 0) tokens.push(`🚧${afk.blocked}`);
-  if (afk.added > 0) tokens.push(`+${afk.added}`);
-  if (afk.removed > 0) tokens.push(`-${afk.removed}`);
-  if (afk.waiting !== undefined && afk.waiting > 0) tokens.push(`💤${afk.waiting}`);
-  if (afk.tokens !== undefined && afk.tokens > 0) tokens.push(`🪙${humanizeTokens(afk.tokens)}`);
-  if (afk.costUsd !== undefined && afk.costUsd > 0) tokens.push(`💵$${afk.costUsd.toFixed(2)}`);
+export interface AfkToken {
+  label: string;
+  value: string;
+  suffix: string;
+}
+
+/**
+ * The ordered AFK token model behind block 4. Each KPI is emitted only when its
+ * count is > 0, in the fixed order workers `wk`, queue `rq`, human `rh`, blocked
+ * `bk`, added `ad`, removed `rm`, waiting `wt`, tokens `tk`, cost `$`, followed
+ * by the `#N` issue tokens (always emitted, in order, each carrying an optional
+ * `·stage` suffix). Empty when there are no live workers. Two-letter mnemonics
+ * replace the legacy emojis (🤖📋🆘🚧+−💤🪙💵) so the line is emoji-free and the
+ * style slice can chip each numeric value.
+ */
+export function afkTokens(afk: AfkInput | undefined): AfkToken[] {
+  if (!afk || afk.workers <= 0) return [];
+  const tokens: AfkToken[] = [];
+  const kpi = (label: string, value: string): void => {
+    tokens.push({ label, value, suffix: "" });
+  };
+  if (afk.workers > 0) kpi("wk", String(afk.workers));
+  if (afk.queue > 0) kpi("rq", String(afk.queue));
+  if (afk.human > 0) kpi("rh", String(afk.human));
+  if (afk.blocked > 0) kpi("bk", String(afk.blocked));
+  if (afk.added > 0) kpi("ad", String(afk.added));
+  if (afk.removed > 0) kpi("rm", String(afk.removed));
+  if (afk.waiting !== undefined && afk.waiting > 0) kpi("wt", String(afk.waiting));
+  if (afk.tokens !== undefined && afk.tokens > 0) kpi("tk", humanizeTokens(afk.tokens));
+  if (afk.costUsd !== undefined && afk.costUsd > 0) kpi("$", afk.costUsd.toFixed(2));
   afk.issues.forEach((issue, i) => {
     const stage = afk.stages?.[i];
-    tokens.push(stage ? `#${issue}·${stage}` : `#${issue}`);
+    tokens.push({ label: "#", value: String(issue), suffix: stage ? `·${stage}` : "" });
   });
+  return tokens;
+}
+
+/**
+ * Block 4: the space-joined AFK token run in plain text. Null when there are no
+ * live workers, matching the bash `(( total_workers > 0 ))` gate around the
+ * block. The ANSI-painted variant lives in the style module and shares the
+ * {@link afkTokens} model, so plain and styled never drift.
+ */
+export function renderAfkBlock(afk: AfkInput | undefined): string | null {
+  const tokens = afkTokens(afk);
   if (tokens.length === 0) return null;
-  return tokens.join(" ");
+  return tokens.map((t) => `${t.label}${t.value}${t.suffix}`).join(" ");
 }
 
 /**

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -553,7 +553,7 @@ function writeStatuslineCacheAtomic(path: string, cache: StatuslineCache): void 
  * collect the in-progress issue numbers in directory order. Returns null when
  * there are no live workers, so the caller drops the whole AFK block.
  *
- * The 📋 ready-for-agent / 🆘 ready-for-human counts are GitHub-derived and
+ * The `rq` ready-for-agent / `rh` ready-for-human counts are GitHub-derived and
  * cached for {@link STATUSLINE_CACHE_TTL_S} seconds in
  * `.red/tmp/statusline-cache.json`: a cold cache refreshes synchronously, a
  * fresh cache is read as-is, and a stale cache is read AND refreshed in the
@@ -584,7 +584,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
       continue;
     }
     // Statusline counts only genuinely-active workers (pid-live AND fresh), so a
-    // finished worker with a stale state file no longer inflates the 🤖N badge.
+    // finished worker with a stale state file no longer inflates the wkN badge.
     if (!isStateActive(state)) continue;
 
     workers += 1;
@@ -593,7 +593,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     // (ADR 0065) rather than ad-hoc field access — `current` satisfies it.
     const vitals: WorkerVitals = state.current;
     // Silent-agent signal: cumulative heartbeat windows with no new stream
-    // event. Summed across the fleet and shown as 💤N so a wedged-but-not-dead
+    // event. Summed across the fleet and shown as wtN so a wedged-but-not-dead
     // worker is visible.
     waiting += vitals.waiting_count;
     // Cost group: per-worker token spend + USD, summed for the fleet.

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -9,6 +9,12 @@ import {
   statuslineEnabled,
 } from "../src/commands/statusline.js";
 
+/** Strip ANSI SGR escapes so assertions read the plain rendered text. The
+ * command now themes the line (wine background + black-chipped KPI numbers);
+ * stripping recovers the exact plain content the renderer produced. */
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
 /** A non-TTY readable carrying the Claude Code payload on stdin. */
 function fakeStdin(text: string): NodeJS.ReadableStream & { isTTY?: boolean } {
   const stream = Readable.from([text]) as Readable & { isTTY?: boolean };
@@ -112,7 +118,7 @@ describe("statusline command — rendered line", () => {
   });
 
   it("emits the full block run from a payload + live workers + cached counts", async () => {
-    // One live worker on #17 with +12 -3, blocked 2; cached 📋11 🆘3.
+    // One live worker on #17 with ad12 rm3, blocked 2; cached rq11 rh3.
     await writeWorkerState(root, "wA", "17-a1", {
       blocked: 2,
       // `started_at` (fresh) is what makes isStateActive treat this pid-live worker
@@ -131,11 +137,13 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
 
-    const line = out.text().trim();
+    const line = stripAnsi(out.text().trim());
     // basename(root) (branch may or may not resolve) · Opus·high · 47k 24% · AFK run.
     expect(line).toContain("Opus·high");
     expect(line).toContain("47k 24%");
-    expect(line).toContain("🤖1 📋11 🆘3 🚧2 +12 -3 #17");
+    expect(line).toContain("wk1 rq11 rh3 bk2 ad12 rm3 #17");
+    // The raw output carries the wine-red background SGR (theme on by default).
+    expect(out.text()).toContain("\x1b[48;2;114;47;55m");
   });
 
   it("drops the AFK block when there are no live workers", async () => {
@@ -143,10 +151,10 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
 
-    const line = out.text().trim();
+    const line = stripAnsi(out.text().trim());
     expect(line).toContain("Opus·high");
     expect(line).toContain("47k 24%");
-    expect(line).not.toContain("🤖");
+    expect(line).not.toContain("wk");
   });
 
   it("renders only the project block outside Claude Code (empty stdin)", async () => {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { renderStatusline, type AfkInput, type StatuslineInput } from "../src/core/statusline.js";
+import {
+  renderStatuslineThemed,
+  styleAfkBlock,
+  styleStatusline,
+} from "../src/core/statusline-style.js";
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+const WINE_BG = "\x1b[48;2;114;47;55m";
+const BLACK_BG = "\x1b[48;2;0;0;0m";
+const WHITE_FG = "\x1b[38;2;255;255;255m";
+const RESET = "\x1b[0m";
+
+const afk: AfkInput = { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] };
+const input: StatuslineInput = {
+  project: { basename: "red-skills", branch: "main" },
+  claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
+  afk,
+};
+
+describe("statusline style — AFK chips", () => {
+  it("chips every KPI value in black and leaves the label on the wine field", () => {
+    const block = styleAfkBlock(input.afk);
+    // The worker label sits outside the chip; its value is wrapped black→wine.
+    expect(block).toContain(`wk${BLACK_BG}4${WINE_BG}`);
+    expect(block).toContain(`ad${BLACK_BG}12${WINE_BG}`);
+    expect(block).toContain(`#${BLACK_BG}17${WINE_BG}`);
+    // Stripped, the styled block equals the plain initials run.
+    expect(stripAnsi(block)).toBe("wk4 rq1 rh11 bk10 ad12 rm3 #17");
+  });
+
+  it("chips only the numeric value of an issue, leaving its ·stage on the field", () => {
+    const block = styleAfkBlock({
+      workers: 1,
+      queue: 0,
+      human: 0,
+      blocked: 0,
+      added: 0,
+      removed: 0,
+      issues: [17],
+      stages: ["impl"],
+    });
+    expect(block).toContain(`#${BLACK_BG}17${WINE_BG}·impl`);
+  });
+
+  it("is empty when there are no live workers", () => {
+    expect(styleAfkBlock(undefined)).toBe("");
+    expect(styleAfkBlock({ ...afk, workers: 0 })).toBe("");
+  });
+});
+
+describe("statusline style — full themed line", () => {
+  it("wraps the whole line in wine + white and resets at the end", () => {
+    const line = styleStatusline(input);
+    expect(line.startsWith(`${WINE_BG}${WHITE_FG}`)).toBe(true);
+    expect(line.endsWith(RESET)).toBe(true);
+  });
+
+  it("changes only appearance — stripped, it equals the plain render exactly", () => {
+    expect(stripAnsi(styleStatusline(input))).toBe(renderStatusline(input));
+  });
+
+  it("renderStatuslineThemed switches between styled and plain on the color flag", () => {
+    expect(renderStatuslineThemed(input, true)).toBe(styleStatusline(input));
+    expect(renderStatuslineThemed(input, false)).toBe(renderStatusline(input));
+    // The plain path carries no escape sequences at all.
+    expect(renderStatuslineThemed(input, false)).not.toContain("\x1b");
+  });
+});

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -108,24 +108,24 @@ describe("statusline — context block", () => {
 
 describe("statusline — AFK block", () => {
   it("renders the full token run in the fixed order", () => {
-    // case 3: one live worker on #17 with +12 -3, blocked 2, cached 📋11 🆘3.
-    expect(renderAfkBlock(baseAfk())).toBe("🤖1 📋11 🆘3 🚧2 +12 -3 #17");
+    // case 3: one live worker on #17 with ad12 rm3, blocked 2, cached rq11 rh3.
+    expect(renderAfkBlock(baseAfk())).toBe("wk1 rq11 rh3 bk2 ad12 rm3 #17");
   });
 
   it("sums diffstats and lists both issues for two workers", () => {
-    // case 4: 🤖2, +42 -10, 🚧5, both #17 and #20.
+    // case 4: wk2, ad42 rm10, bk5, both #17 and #20.
     const out = renderAfkBlock(
       baseAfk({ workers: 2, added: 42, removed: 10, blocked: 5, issues: [17, 20] }),
     );
-    expect(out).toContain("🤖2");
-    expect(out).toContain("+42 -10");
+    expect(out).toContain("wk2");
+    expect(out).toContain("ad42 rm10");
     expect(out).toContain("#17");
     expect(out).toContain("#20");
-    expect(out).toContain("🚧5");
+    expect(out).toContain("bk5");
   });
 
   it("drops the block when there are no live workers", () => {
-    // case 1 / case 2: empty .red/tmp => no 🤖 block.
+    // case 1 / case 2: empty .red/tmp => no wk block.
     expect(renderAfkBlock({ ...baseAfk(), workers: 0 })).toBeNull();
     expect(renderAfkBlock(undefined)).toBeNull();
   });
@@ -134,10 +134,10 @@ describe("statusline — AFK block", () => {
     const out = renderAfkBlock(
       baseAfk({ queue: 0, human: 0, blocked: 0, added: 5, removed: 2, issues: [17] }),
     );
-    expect(out).toBe("🤖1 +5 -2 #17");
-    expect(out).not.toContain("📋");
-    expect(out).not.toContain("🆘");
-    expect(out).not.toContain("🚧");
+    expect(out).toBe("wk1 ad5 rm2 #17");
+    expect(out).not.toContain("rq");
+    expect(out).not.toContain("rh");
+    expect(out).not.toContain("bk");
   });
 
   it("renders only the worker count when everything else is zero and no issues", () => {
@@ -151,7 +151,7 @@ describe("statusline — AFK block", () => {
         removed: 0,
         issues: [],
       }),
-    ).toBe("🤖1");
+    ).toBe("wk1");
   });
 
   it("suffixes each issue with its stage when present, aligned by index", () => {
@@ -171,28 +171,28 @@ describe("statusline — AFK block", () => {
     expect(out).not.toContain("#20·");
   });
 
-  it("renders 💤N after the diff only when waiting > 0", () => {
-    expect(renderAfkBlock(baseAfk({ waiting: 4 }))).toBe("🤖1 📋11 🆘3 🚧2 +12 -3 💤4 #17");
-    expect(renderAfkBlock(baseAfk({ waiting: 0 }))).not.toContain("💤");
-    expect(renderAfkBlock(baseAfk())).not.toContain("💤");
+  it("renders wtN after the diff only when waiting > 0", () => {
+    expect(renderAfkBlock(baseAfk({ waiting: 4 }))).toBe("wk1 rq11 rh3 bk2 ad12 rm3 wt4 #17");
+    expect(renderAfkBlock(baseAfk({ waiting: 0 }))).not.toContain("wt");
+    expect(renderAfkBlock(baseAfk())).not.toContain("wt");
   });
 
-  it("renders 🪙 humanized tokens and 💵 cost after 💤, each only when > 0", () => {
+  it("renders tk humanized tokens and $ cost after wt, each only when > 0", () => {
     expect(renderAfkBlock(baseAfk({ tokens: 12500, costUsd: 0.42 }))).toBe(
-      "🤖1 📋11 🆘3 🚧2 +12 -3 🪙12k 💵$0.42 #17",
+      "wk1 rq11 rh3 bk2 ad12 rm3 tk12k $0.42 #17",
     );
     // tokens but no cost (the common case — most runners report tokens, not USD)
-    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).toContain("🪙900");
-    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).not.toContain("💵");
+    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).toContain("tk900");
+    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).not.toContain("$");
     // neither when zero/absent
-    expect(renderAfkBlock(baseAfk({ tokens: 0, costUsd: 0 }))).not.toMatch(/🪙|💵/);
-    expect(renderAfkBlock(baseAfk())).not.toMatch(/🪙|💵/);
+    expect(renderAfkBlock(baseAfk({ tokens: 0, costUsd: 0 }))).not.toMatch(/tk|\$/);
+    expect(renderAfkBlock(baseAfk())).not.toMatch(/tk|\$/);
   });
 
   it("keeps the pre-vitals render byte-for-byte when no waiting/stages are supplied", () => {
     // The new fields are optional: an aggregator that never populates them must
     // produce the exact legacy line, so the upgrade is a no-op for old callers.
-    expect(renderAfkBlock(baseAfk())).toBe("🤖1 📋11 🆘3 🚧2 +12 -3 #17");
+    expect(renderAfkBlock(baseAfk())).toBe("wk1 rq11 rh3 bk2 ad12 rm3 #17");
   });
 });
 
@@ -204,7 +204,7 @@ describe("statusline — full assembly", () => {
       afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
     };
     expect(renderStatusline(input)).toBe(
-      "red-skills (main) · Opus·high · 47k 24% · 🤖4 📋1 🆘11 🚧10 +12 -3 #17",
+      "red-skills (main) · Opus·high · 47k 24% · wk4 rq1 rh11 bk10 ad12 rm3 #17",
     );
   });
 
@@ -213,7 +213,7 @@ describe("statusline — full assembly", () => {
       project: { basename: "c3" },
       afk: baseAfk(),
     });
-    expect(out).toBe("c3 · 🤖1 📋11 🆘3 🚧2 +12 -3 #17");
+    expect(out).toBe("c3 · wk1 rq11 rh3 bk2 ad12 rm3 #17");
     expect(out).not.toContain("Opus");
     expect(out).not.toContain("%");
   });
@@ -224,7 +224,7 @@ describe("statusline — full assembly", () => {
       claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
     });
     expect(out).toBe("c1 · Opus·high · 47k 24%");
-    expect(out).not.toContain("🤖");
+    expect(out).not.toContain("wk");
     expect(out).toContain("c1");
   });
 


### PR DESCRIPTION
Interactive /ship landing for #801.

Closes #801

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784677155&installation_id=129708444&pr_number=802&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F802&signature=c2a688248bc874b4dc87efffc251db39e36c4606ecf5f6bac622c78b9fd1c2b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now supports themed colored output, respecting the `NO_COLOR` environment variable for plain-text mode.
  * AFK worker metrics now use concise text mnemonics (wk, rq, rh, bk, ad, rm) instead of emoji formatting.
  * Numeric values in the AFK block display with distinct styled chips when color output is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->