### PR TITLE
ship: #803 Statusline v2: two-line powerline layout, width-aware via $COLUMNS

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -154,10 +154,17 @@ export async function statuslineCommand(
   // from the project root and let gh infer the repo from cwd (repo slug "").
   const afk = (await collectStatuslineAfk({ root, repo: "", remote: "origin" })) ?? undefined;
 
-  // Theme on by default (the high-tech wine line with chipped KPI numbers);
-  // honour NO_COLOR for plain consumers, matching the de-facto colour opt-out.
+  // Theme on by default (the two-line powerline wine layout with chipped KPI
+  // numbers); honour NO_COLOR for plain consumers, matching the de-facto colour
+  // opt-out. Claude Code exports $COLUMNS (v2.1.153+) so the AFK line fits its
+  // issue list to the terminal width; absent/unparseable → fixed-cap fallback.
   const color = !process.env.NO_COLOR;
-  const line = renderStatuslineThemed({ project, claude, afk }, color);
+  const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
+  const line = renderStatuslineThemed(
+    { project, claude, afk },
+    color,
+    Number.isFinite(columns) && columns > 0 ? columns : undefined,
+  );
   stdout.write(`${line}\n`);
   return 0;
 }

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -1,78 +1,168 @@
 // core/statusline-style.ts — the ANSI styling slice for the /afk statusline.
 //
 // core/statusline.ts is deliberately PURE plain-text. This sibling adds the
-// optional "high-tech" theme the pure renderer leaves out: the whole line on a
-// wine-red background in white, with every AFK KPI *number* drawn as a black
-// chip (black background, white text) so the live counts pop against the wine.
+// "high-tech" theme: a TWO-LINE powerline layout where each semantic group sits
+// on its own wine-red background block (the block-to-block background SHIFT is
+// the separator — no `/` or `|` glyphs, so it needs no powerline/Nerd font), and
+// every KPI *number* is drawn as a black chip (black bg, white text) for
+// contrast.
 //
-// The chip is the terminal-feasible stand-in for a bordered badge: ANSI cannot
-// draw a box around inline characters, so a reversed-contrast black chip is the
-// closest "negative" highlight. Labels (wk/rq/#/…) stay on the wine field; only
-// the value the eye tracks gets the chip.
+//   line 1 (header, always): » <project> | <model·effort> | ctx<n>
+//   line 2 (AFK, when workers>0): <rq rh bk backlog> | <wk ad rm #issues active>
 //
-// Everything here is PURE (input object → string). The IO half
-// (commands/statusline.ts) decides whether to call this (colour on) or the
-// plain renderProjectBlock/renderStatusline path (colour off, e.g. NO_COLOR).
+// Width-aware: Claude Code exports $COLUMNS to the statusline command (v2.1.153+),
+// so line 2 fits its issue list to the budget and collapses the rest into `+N`.
+// Without COLUMNS it falls back to a fixed 3-issue cap. Per the Claude Code docs,
+// each line ends with a reset so the block background never bleeds.
+//
+// Everything here is PURE (inputs → string). The IO half
+// (commands/statusline.ts) decides colour (NO_COLOR → the plain renderer) and
+// passes the COLUMNS budget.
 
 import {
-  afkTokens,
-  renderContextBlock,
-  renderModelBlock,
-  renderProjectBlock,
+  humanizeTokens,
   renderStatusline,
   type AfkInput,
+  type ClaudeInput,
+  type ProjectInput,
   type StatuslineInput,
 } from "./statusline.js";
 
-/** Truecolor SGR helpers. Wine-red is `#722F37`; chips are pure black. */
-const WINE_BG = "\x1b[48;2;114;47;55m";
-const BLACK_BG = "\x1b[48;2;0;0;0m";
-const WHITE_FG = "\x1b[38;2;255;255;255m";
+/** Truecolor SGR helpers. WINE/WINE2 are the two block shades; chips are black. */
+const WINE = "\x1b[48;2;114;47;55m";
+const WINE2 = "\x1b[48;2;88;36;42m";
+const BLACK = "\x1b[48;2;0;0;0m";
+const WHITE = "\x1b[38;2;255;255;255m";
+const DIM = "\x1b[38;2;201;150;158m";
+const GOLD = "\x1b[38;2;240;200;120m";
+const BOLD = "\x1b[1m";
+const NOBOLD = "\x1b[22m";
 const RESET = "\x1b[0m";
 
-/**
- * Wrap a KPI value as a black chip, then restore the wine field so following
- * text stays on the line background. The foreground is already white from the
- * line wrapper, so the chip only toggles the background.
- */
-function chip(value: string): string {
-  return `${BLACK_BG}${value}${WINE_BG}`;
+const BRANCH_MAX = 28;
+/** Issue cap when no COLUMNS budget is available. */
+const ISSUE_CAP_NO_WIDTH = 3;
+/** Reserve columns for Claude Code's right-side notifications when budgeting. */
+const WIDTH_MARGIN = 6;
+/** Per-issue `·stage` suffixes only render at or below this worker count, so a
+ * crowded fleet shows bare `#N` and stays narrow. */
+const STAGE_MAX_WORKERS = 2;
+
+/** Visible width of an ANSI string (escapes stripped). */
+// eslint-disable-next-line no-control-regex
+const vlen = (s: string): number => s.replace(/\x1b\[[0-9;]*m/g, "").length;
+
+/** A KPI number as a black chip; `blockBg` restores the block background after. */
+const chip = (value: string, blockBg: string): string => `${BLACK}${WHITE}${value}${blockBg}`;
+/** A dim two-letter label sitting on the block field. */
+const label = (text: string): string => `${DIM}${text}${WHITE}`;
+
+/** Block 1 content: `» bold-project dim-(branch)`. Branch truncated like the
+ * plain renderer (27 chars + ellipsis). */
+function projectContent(project: ProjectInput): string {
+  let ref = "";
+  if (project.branch) {
+    const b = project.branch.length > BRANCH_MAX ? `${project.branch.slice(0, 27)}…` : project.branch;
+    ref = ` ${DIM}(${b})${WHITE}`;
+  } else if (project.detachedSha) {
+    ref = ` ${DIM}(detached ${project.detachedSha})${WHITE}`;
+  }
+  return `${GOLD}»${WHITE} ${BOLD}${project.basename}${NOBOLD}${ref}`;
 }
 
-/**
- * The AFK block with each KPI value chipped. Shares {@link afkTokens} with the
- * plain renderer, so the mnemonics and emit order never drift. Empty string
- * when there are no live workers (caller drops the section).
- */
-export function styleAfkBlock(afk: AfkInput | undefined): string {
-  const tokens = afkTokens(afk);
-  if (tokens.length === 0) return "";
-  return tokens.map((t) => `${t.label}${chip(t.value)}${t.suffix}`).join(" ");
+/** Block 2 content: `model·effort`, or null when there is no model. */
+function modelContent(claude: ClaudeInput | undefined): string | null {
+  if (!claude || !claude.model) return null;
+  return claude.effort ? `${claude.model}${DIM}·${WHITE}${claude.effort}` : claude.model;
 }
 
-/**
- * Assemble the full statusline with the high-tech theme: project / model /
- * context blocks plain on the wine field, the AFK block with chipped KPI
- * numbers, joined by ` · ` and wrapped in one wine-red/white run terminated by
- * a reset. Block presence and order match {@link renderStatusline} exactly, so
- * colour only ever changes how the line looks, never which sections appear.
- */
-export function styleStatusline(input: StatuslineInput): string {
-  const sections: string[] = [renderProjectBlock(input.project)];
-  const model = renderModelBlock(input.claude);
-  if (model !== null) sections.push(model);
-  const context = renderContextBlock(input.claude);
-  if (context !== null) sections.push(context);
-  const afk = styleAfkBlock(input.afk);
-  if (afk !== "") sections.push(afk);
-  return `${WINE_BG}${WHITE_FG}${sections.join(" · ")}${RESET}`;
+/** Block 3 content: `ctx<chip(tokens pct)>`, or null when context is absent. */
+function ctxContent(claude: ClaudeInput | undefined): string | null {
+  if (!claude || !claude.contextTokens) return null;
+  const human = humanizeTokens(claude.contextTokens);
+  const value =
+    claude.contextPercent === undefined ? human : `${human} ${Math.round(claude.contextPercent)}%`;
+  return `${label("ctx")}${chip(value, WINE2)}`;
 }
 
-/**
- * Render the statusline, themed or plain. `color` is the single switch: true →
- * {@link styleStatusline} (ANSI), false → {@link renderStatusline} (the exact
- * plain line, for NO_COLOR / non-terminal consumers).
- */
-export function renderStatuslineThemed(input: StatuslineInput, color: boolean): string {
-  return color ? styleStatusline(input) : renderStatusline(input);
+/** A powerline block: ` content ` painted on `bg`. */
+const block = (bg: string, content: string): string => `${bg} ${content} `;
+
+/** Line 1 — the header. Blocks alternate WINE2 / WINE / WINE2 so the background
+ * shift marks each boundary. Always present (project is always there). */
+export function renderHeaderLine(project: ProjectInput, claude: ClaudeInput | undefined): string {
+  let line = block(WINE2, projectContent(project));
+  const model = modelContent(claude);
+  if (model !== null) line += block(WINE, model);
+  const ctx = ctxContent(claude);
+  if (ctx !== null) line += block(WINE2, ctx);
+  return `${line}${RESET}`;
+}
+
+/** Line 2 — the AFK KPIs, or null when there are no live workers. Backlog block
+ * (rq/rh/bk) on WINE2, active block (wk/ad/rm/wt/tk/$ + issues) on WINE. The
+ * issue list fits the COLUMNS budget (or a 3-issue cap), overflow as `+N`. */
+export function renderAfkLine(afk: AfkInput | undefined, columns: number | undefined): string | null {
+  if (!afk || afk.workers <= 0) return null;
+
+  const backParts: string[] = [];
+  if (afk.queue > 0) backParts.push(`${label("rq")}${chip(String(afk.queue), WINE2)}`);
+  if (afk.human > 0) backParts.push(`${label("rh")}${chip(String(afk.human), WINE2)}`);
+  if (afk.blocked > 0) backParts.push(`${label("bk")}${chip(String(afk.blocked), WINE2)}`);
+  const backBlock = backParts.length ? block(WINE2, backParts.join(" ")) : "";
+
+  const actParts: string[] = [`${label("wk")}${chip(String(afk.workers), WINE)}`];
+  if (afk.added > 0) actParts.push(`${label("ad")}${chip(String(afk.added), WINE)}`);
+  if (afk.removed > 0) actParts.push(`${label("rm")}${chip(String(afk.removed), WINE)}`);
+  if (afk.waiting !== undefined && afk.waiting > 0)
+    actParts.push(`${label("wt")}${chip(String(afk.waiting), WINE)}`);
+  if (afk.tokens !== undefined && afk.tokens > 0)
+    actParts.push(`${label("tk")}${chip(humanizeTokens(afk.tokens), WINE)}`);
+  if (afk.costUsd !== undefined && afk.costUsd > 0)
+    actParts.push(`${label("$")}${chip(afk.costUsd.toFixed(2), WINE)}`);
+  const actHead = actParts.join(" ");
+
+  const showStage = afk.workers <= STAGE_MAX_WORKERS;
+  const issueTok = (issue: number | string, i: number): string => {
+    const stage = showStage ? afk.stages?.[i] : undefined;
+    const suffix = stage ? `${DIM}·${stage}${WHITE}` : "";
+    return ` ${label("#")}${chip(String(issue), WINE)}${suffix}`;
+  };
+
+  const budget = columns && columns > 0 ? columns - WIDTH_MARGIN : null;
+  const assemble = (issuesStr: string, overflow: number): string => {
+    const over = overflow > 0 ? ` ${DIM}+${overflow}${WHITE}` : "";
+    return `${backBlock}${WINE} ${actHead}${issuesStr}${over} ${RESET}`;
+  };
+
+  let issuesStr = "";
+  let shown = 0;
+  for (let i = 0; i < afk.issues.length; i++) {
+    if (budget === null && shown >= ISSUE_CAP_NO_WIDTH) break;
+    const tok = issueTok(afk.issues[i], i);
+    if (budget !== null && vlen(assemble(issuesStr + tok, afk.issues.length - shown - 1)) > budget) break;
+    issuesStr += tok;
+    shown += 1;
+  }
+  return assemble(issuesStr, afk.issues.length - shown);
+}
+
+/** The full themed statusline: header line, plus the AFK line when workers are
+ * live, joined by a newline (Claude Code renders each as a row). */
+export function styleStatusline(input: StatuslineInput, columns?: number): string {
+  const lines = [renderHeaderLine(input.project, input.claude)];
+  const afk = renderAfkLine(input.afk, columns);
+  if (afk !== null) lines.push(afk);
+  return lines.join("\n");
+}
+
+/** Render the statusline, themed or plain. `color` is the switch: true → the
+ * powerline {@link styleStatusline}; false → the plain {@link renderStatusline}
+ * (single line, no escapes) for NO_COLOR / non-terminal consumers. */
+export function renderStatuslineThemed(
+  input: StatuslineInput,
+  color: boolean,
+  columns?: number,
+): string {
+  return color ? styleStatusline(input, columns) : renderStatusline(input);
 }

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -137,11 +137,13 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
 
-    const line = stripAnsi(out.text().trim());
-    // basename(root) (branch may or may not resolve) · Opus·high · 47k 24% · AFK run.
-    expect(line).toContain("Opus·high");
-    expect(line).toContain("47k 24%");
-    expect(line).toContain("wk1 rq11 rh3 bk2 ad12 rm3 #17");
+    // Two powerline rows: header (project/model/ctx) + AFK (backlog + active).
+    const rows = out.text().trimEnd().split("\n");
+    expect(rows).toHaveLength(2);
+    expect(stripAnsi(rows[0])).toContain("Opus·high");
+    expect(stripAnsi(rows[0])).toContain("47k 24%");
+    expect(stripAnsi(rows[1])).toContain("rq11 rh3 bk2"); // backlog block
+    expect(stripAnsi(rows[1])).toContain("wk1 ad12 rm3 #17"); // active block
     // The raw output carries the wine-red background SGR (theme on by default).
     expect(out.text()).toContain("\x1b[48;2;114;47;55m");
   });

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -1,72 +1,114 @@
 import { describe, expect, it } from "vitest";
 import { renderStatusline, type AfkInput, type StatuslineInput } from "../src/core/statusline.js";
 import {
+  renderAfkLine,
+  renderHeaderLine,
   renderStatuslineThemed,
-  styleAfkBlock,
   styleStatusline,
 } from "../src/core/statusline-style.js";
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+// eslint-disable-next-line no-control-regex
+const vlen = (s: string): number => stripAnsi(s).length;
 
-const WINE_BG = "\x1b[48;2;114;47;55m";
-const BLACK_BG = "\x1b[48;2;0;0;0m";
-const WHITE_FG = "\x1b[38;2;255;255;255m";
+const WINE = "\x1b[48;2;114;47;55m";
+const WINE2 = "\x1b[48;2;88;36;42m";
+const BLACK = "\x1b[48;2;0;0;0m";
 const RESET = "\x1b[0m";
 
-const afk: AfkInput = { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] };
+const afk: AfkInput = { workers: 1, queue: 11, human: 3, blocked: 2, added: 12, removed: 3, issues: [17] };
 const input: StatuslineInput = {
   project: { basename: "red-skills", branch: "main" },
   claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
   afk,
 };
 
-describe("statusline style — AFK chips", () => {
-  it("chips every KPI value in black and leaves the label on the wine field", () => {
-    const block = styleAfkBlock(input.afk);
-    // The worker label sits outside the chip; its value is wrapped black→wine.
-    expect(block).toContain(`wk${BLACK_BG}4${WINE_BG}`);
-    expect(block).toContain(`ad${BLACK_BG}12${WINE_BG}`);
-    expect(block).toContain(`#${BLACK_BG}17${WINE_BG}`);
-    // Stripped, the styled block equals the plain initials run.
-    expect(stripAnsi(block)).toBe("wk4 rq1 rh11 bk10 ad12 rm3 #17");
+describe("statusline style — header line", () => {
+  it("is one powerline row: » bold project, model·effort, ctx — ending in a reset", () => {
+    const h = renderHeaderLine(input.project, input.claude);
+    expect(h).not.toContain("\n");
+    expect(h.endsWith(RESET)).toBe(true);
+    expect(h).toContain(WINE2); // project + ctx blocks
+    expect(h).toContain(WINE); // model block
+    expect(stripAnsi(h)).toContain("» red-skills (main)");
+    expect(stripAnsi(h)).toContain("Opus·high");
+    expect(stripAnsi(h)).toContain("ctx47k 24%");
   });
 
-  it("chips only the numeric value of an issue, leaving its ·stage on the field", () => {
-    const block = styleAfkBlock({
-      workers: 1,
-      queue: 0,
-      human: 0,
-      blocked: 0,
-      added: 0,
-      removed: 0,
-      issues: [17],
-      stages: ["impl"],
-    });
-    expect(block).toContain(`#${BLACK_BG}17${WINE_BG}·impl`);
-  });
-
-  it("is empty when there are no live workers", () => {
-    expect(styleAfkBlock(undefined)).toBe("");
-    expect(styleAfkBlock({ ...afk, workers: 0 })).toBe("");
+  it("drops the model and ctx blocks outside Claude Code", () => {
+    const h = renderHeaderLine({ basename: "c3" }, undefined);
+    expect(stripAnsi(h)).toBe(" » c3 ");
+    expect(h).not.toContain(WINE); // only the WINE2 project block remains
   });
 });
 
-describe("statusline style — full themed line", () => {
-  it("wraps the whole line in wine + white and resets at the end", () => {
-    const line = styleStatusline(input);
-    expect(line.startsWith(`${WINE_BG}${WHITE_FG}`)).toBe(true);
-    expect(line.endsWith(RESET)).toBe(true);
+describe("statusline style — AFK line", () => {
+  it("chips each KPI number and splits backlog (WINE2) from active (WINE)", () => {
+    const line = renderAfkLine(afk, undefined);
+    expect(line).not.toBeNull();
+    expect(line!.endsWith(RESET)).toBe(true);
+    expect(line).toContain(BLACK); // numbers are drawn as black chips
+    expect(line).toContain(WINE2); // backlog block
+    expect(line).toContain(WINE); // active block
+    expect(stripAnsi(line!)).toContain("rq11 rh3 bk2");
+    expect(stripAnsi(line!)).toContain("wk1 ad12 rm3 #17");
   });
 
-  it("changes only appearance — stripped, it equals the plain render exactly", () => {
-    expect(stripAnsi(styleStatusline(input))).toBe(renderStatusline(input));
+  it("is null when there are no live workers", () => {
+    expect(renderAfkLine(undefined, undefined)).toBeNull();
+    expect(renderAfkLine({ ...afk, workers: 0 }, undefined)).toBeNull();
   });
 
-  it("renderStatuslineThemed switches between styled and plain on the color flag", () => {
+  it("shows the ·stage suffix only at or below two workers", () => {
+    const few = renderAfkLine({ ...afk, workers: 2, issues: [17, 20], stages: ["impl", "tests"] }, undefined);
+    expect(stripAnsi(few!)).toContain("#17·impl");
+    expect(stripAnsi(few!)).toContain("#20·tests");
+
+    const many = renderAfkLine({ ...afk, workers: 5, issues: [17, 20], stages: ["impl", "tests"] }, undefined);
+    expect(stripAnsi(many!)).not.toContain("·impl");
+    expect(stripAnsi(many!)).toContain("#17");
+  });
+
+  it("caps the issue list at 3 with a +N overflow when no COLUMNS budget", () => {
+    const line = renderAfkLine({ ...afk, workers: 5, issues: [17, 20, 21, 22, 23] }, undefined);
+    const txt = stripAnsi(line!);
+    expect(txt).toContain("#17");
+    expect(txt).toContain("#21");
+    expect(txt).not.toContain("#22");
+    expect(txt).toContain("+2");
+  });
+
+  it("fits the issue list to the COLUMNS budget, collapsing the rest into +N", () => {
+    const wide = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 200);
+    expect(stripAnsi(wide!)).not.toContain("+"); // all six fit in 200 cols
+    const narrow = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 40);
+    const ntxt = stripAnsi(narrow!);
+    expect(vlen(narrow!)).toBeLessThanOrEqual(40);
+    expect(ntxt).toMatch(/\+\d/); // overflow marker present
+  });
+});
+
+describe("statusline style — full themed assembly", () => {
+  it("emits two rows (header + AFK) when workers are live, each reset-terminated", () => {
+    const out = styleStatusline(input);
+    const rows = out.split("\n");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].endsWith(RESET)).toBe(true);
+    expect(rows[1].endsWith(RESET)).toBe(true);
+    expect(stripAnsi(rows[0])).toContain("» red-skills");
+    expect(stripAnsi(rows[1])).toContain("wk1");
+  });
+
+  it("emits only the header row when there are no live workers", () => {
+    const out = styleStatusline({ project: input.project, claude: input.claude });
+    expect(out).not.toContain("\n");
+    expect(stripAnsi(out)).toContain("Opus·high");
+  });
+
+  it("renderStatuslineThemed switches between powerline and plain on the color flag", () => {
     expect(renderStatuslineThemed(input, true)).toBe(styleStatusline(input));
     expect(renderStatuslineThemed(input, false)).toBe(renderStatusline(input));
-    // The plain path carries no escape sequences at all.
     expect(renderStatuslineThemed(input, false)).not.toContain("\x1b");
   });
 });


### PR DESCRIPTION
Interactive /ship landing for #803.

Closes #803

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784685227&installation_id=129708444&pr_number=804&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F804&signature=2b3ca5882f6bf22604260e1ec4300f2f6de2e3f6f457fa945861b38331137209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now displays as two formatted lines for improved information organization
  * Terminal width awareness allows dynamic adaptation to available screen space
  * Issue lists intelligently truncate with overflow indicators when space is limited

<!-- end of auto-generated comment: release notes by coderabbit.ai -->