### PR TITLE
ship: #805 Statusline v3: repo-global header stats + AFK runner/resolved (line-1/line-2 data model)

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -20,7 +20,7 @@ import { join, basename } from "node:path";
 import { type ClaudeInput, type ProjectInput } from "../core/statusline.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
-import { collectStatuslineAfk } from "../runtime/wire.js";
+import { collectStatuslineAfk, collectStatuslineRepo } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
 
 /** Read the entire stdin stream as a UTF-8 string (empty when there is none). */
@@ -150,9 +150,13 @@ export async function statuslineCommand(
   const project = await resolveProject(root);
   const claude = resolveClaude(payload);
 
-  // No `gh repo view` round-trip: like statusline.sh, the gh count probes run
-  // from the project root and let gh infer the repo from cwd (repo slug "").
-  const afk = (await collectStatuslineAfk({ root, repo: "", remote: "origin" })) ?? undefined;
+  // No `gh repo view` round-trip: like statusline.sh, the gh probes run from the
+  // project root and let gh infer the repo from cwd (repo slug ""). The repo
+  // header stats (line 1) render ALWAYS; the AFK block (line 2) only with live
+  // workers, so both collectors run every render (each cheap + cached).
+  const repoCtx = { root, repo: "", remote: "origin" };
+  const repo = await collectStatuslineRepo(repoCtx);
+  const afk = (await collectStatuslineAfk(repoCtx)) ?? undefined;
 
   // Theme on by default (the two-line powerline wine layout with chipped KPI
   // numbers); honour NO_COLOR for plain consumers, matching the de-facto colour
@@ -161,7 +165,7 @@ export async function statuslineCommand(
   const color = !process.env.NO_COLOR;
   const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
   const line = renderStatuslineThemed(
-    { project, claude, afk },
+    { project, claude, repo, afk },
     color,
     Number.isFinite(columns) && columns > 0 ? columns : undefined,
   );

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -4,16 +4,16 @@
 // "high-tech" theme: a TWO-LINE powerline layout where each semantic group sits
 // on its own wine-red background block (the block-to-block background SHIFT is
 // the separator — no `/` or `|` glyphs, so it needs no powerline/Nerd font), and
-// every KPI *number* is drawn as a black chip (black bg, white text) for
-// contrast.
+// every KPI *number* is drawn as a black chip (black bg, white text).
 //
-//   line 1 (header, always): » <project> | <model·effort> | ctx<n>
-//   line 2 (AFK, when workers>0): <rq rh bk backlog> | <wk ad rm #issues active>
+//   line 1 (header, always): » project | model·effort | ctx | pr/is | +local/-local
+//   line 2 (AFK, workers>0): runner | wk/res | ad/rm | rq/rh/bk/wt/tk/$ | #issues
 //
-// Width-aware: Claude Code exports $COLUMNS to the statusline command (v2.1.153+),
-// so line 2 fits its issue list to the budget and collapses the rest into `+N`.
-// Without COLUMNS it falls back to a fixed 3-issue cap. Per the Claude Code docs,
-// each line ends with a reset so the block background never bleeds.
+// Block shades alternate WINE2/WINE in EMITTED order, so dropping an absent block
+// never collapses the shift. Width-aware: Claude Code exports $COLUMNS to the
+// statusline command (v2.1.153+), so line 2 fits its issue list to the budget and
+// collapses the rest into `+N` (fixed 3-issue cap without COLUMNS). Each line ends
+// with a reset so the block background never bleeds (per the Claude Code docs).
 //
 // Everything here is PURE (inputs → string). The IO half
 // (commands/statusline.ts) decides colour (NO_COLOR → the plain renderer) and
@@ -25,6 +25,7 @@ import {
   type AfkInput,
   type ClaudeInput,
   type ProjectInput,
+  type RepoInput,
   type StatuslineInput,
 } from "./statusline.js";
 
@@ -54,11 +55,36 @@ const vlen = (s: string): number => s.replace(/\x1b\[[0-9;]*m/g, "").length;
 
 /** A KPI number as a black chip; `blockBg` restores the block background after. */
 const chip = (value: string, blockBg: string): string => `${BLACK}${WHITE}${value}${blockBg}`;
-/** A dim two-letter label sitting on the block field. */
+/** A dim label sitting on the block field. */
 const label = (text: string): string => `${DIM}${text}${WHITE}`;
 
-/** Block 1 content: `» bold-project dim-(branch)`. Branch truncated like the
- * plain renderer (27 chars + ellipsis). */
+/** A block content builder: given its background shade, return the painted
+ * content, or null/"" to drop the block entirely. */
+type Block = (bg: string) => string | null;
+
+/**
+ * Assemble present blocks into a powerline run: each block ` content ` on a
+ * shade that alternates WINE2 / WINE in EMITTED order (absent blocks never
+ * consume a shade slot, so the shift stays visible). `startIdx` seeds the
+ * alternation; the returned `nextIdx` lets a caller continue it (the AFK line's
+ * width-budgeted issue block picks up where the fixed blocks left off).
+ */
+function assemble(blocks: Block[], startIdx = 0): { text: string; nextIdx: number } {
+  let text = "";
+  let idx = startIdx;
+  for (const b of blocks) {
+    const bg = idx % 2 === 0 ? WINE2 : WINE;
+    const content = b(bg);
+    if (content === null || content === "") continue;
+    text += `${bg} ${content} `;
+    idx += 1;
+  }
+  return { text, nextIdx: idx };
+}
+
+// ---------- line 1: header ----------
+
+/** `» bold-project dim-(branch)`. Branch truncated like the plain renderer. */
 function projectContent(project: ProjectInput): string {
   let ref = "";
   if (project.branch) {
@@ -70,87 +96,136 @@ function projectContent(project: ProjectInput): string {
   return `${GOLD}»${WHITE} ${BOLD}${project.basename}${NOBOLD}${ref}`;
 }
 
-/** Block 2 content: `model·effort`, or null when there is no model. */
+/** `model·effort`, or null when there is no model. */
 function modelContent(claude: ClaudeInput | undefined): string | null {
   if (!claude || !claude.model) return null;
   return claude.effort ? `${claude.model}${DIM}·${WHITE}${claude.effort}` : claude.model;
 }
 
-/** Block 3 content: `ctx<chip(tokens pct)>`, or null when context is absent. */
-function ctxContent(claude: ClaudeInput | undefined): string | null {
+/** `ctx<chip(tokens pct)>`, or null when context is absent. */
+function ctxContent(claude: ClaudeInput | undefined, bg: string): string | null {
   if (!claude || !claude.contextTokens) return null;
   const human = humanizeTokens(claude.contextTokens);
   const value =
     claude.contextPercent === undefined ? human : `${human} ${Math.round(claude.contextPercent)}%`;
-  return `${label("ctx")}${chip(value, WINE2)}`;
+  return `${label("ctx")}${chip(value, bg)}`;
 }
 
-/** A powerline block: ` content ` painted on `bg`. */
-const block = (bg: string, content: string): string => `${bg} ${content} `;
-
-/** Line 1 — the header. Blocks alternate WINE2 / WINE / WINE2 so the background
- * shift marks each boundary. Always present (project is always there). */
-export function renderHeaderLine(project: ProjectInput, claude: ClaudeInput | undefined): string {
-  let line = block(WINE2, projectContent(project));
-  const model = modelContent(claude);
-  if (model !== null) line += block(WINE, model);
-  const ctx = ctxContent(claude);
-  if (ctx !== null) line += block(WINE2, ctx);
-  return `${line}${RESET}`;
+/** `pr<chip> is<chip>` repo-global counts, or null when both are absent/zero
+ * (a both-zero read is also how a gh failure surfaces, so it stays hidden). */
+function repoCountsContent(repo: RepoInput | undefined, bg: string): string | null {
+  if (!repo) return null;
+  const parts: string[] = [];
+  if (repo.openPrs && repo.openPrs > 0) parts.push(`${label("pr")}${chip(String(repo.openPrs), bg)}`);
+  if (repo.openIssues && repo.openIssues > 0)
+    parts.push(`${label("is")}${chip(String(repo.openIssues), bg)}`);
+  return parts.length ? parts.join(" ") : null;
 }
 
-/** Line 2 — the AFK KPIs, or null when there are no live workers. Backlog block
- * (rq/rh/bk) on WINE2, active block (wk/ad/rm/wt/tk/$ + issues) on WINE. The
- * issue list fits the COLUMNS budget (or a 3-issue cap), overflow as `+N`. */
+/** `+<chip> -<chip>` LOCAL branch diff, or null when the branch is clean. */
+function localDiffContent(repo: RepoInput | undefined, bg: string): string | null {
+  if (!repo) return null;
+  const parts: string[] = [];
+  if (repo.localAdded && repo.localAdded > 0) parts.push(`${label("+")}${chip(String(repo.localAdded), bg)}`);
+  if (repo.localRemoved && repo.localRemoved > 0)
+    parts.push(`${label("-")}${chip(String(repo.localRemoved), bg)}`);
+  return parts.length ? parts.join(" ") : null;
+}
+
+/** Line 1 — the header powerline. Always present (project is always there). */
+export function renderHeaderLine(
+  project: ProjectInput,
+  claude: ClaudeInput | undefined,
+  repo: RepoInput | undefined,
+): string {
+  const { text } = assemble([
+    () => projectContent(project),
+    () => modelContent(claude),
+    (bg) => ctxContent(claude, bg),
+    (bg) => repoCountsContent(repo, bg),
+    (bg) => localDiffContent(repo, bg),
+  ]);
+  return `${text}${RESET}`;
+}
+
+// ---------- line 2: AFK ----------
+
+/** `wk<chip>` plus `res<chip>` when the supervisor has closed any issue. */
+function workersContent(afk: AfkInput, bg: string): string {
+  let s = `${label("wk")}${chip(String(afk.workers), bg)}`;
+  if (afk.resolved !== undefined && afk.resolved > 0)
+    s += ` ${label("res")}${chip(String(afk.resolved), bg)}`;
+  return s;
+}
+
+/** `ad<chip> rm<chip>` in-transit worker diff, or null when nothing moved. */
+function transitContent(afk: AfkInput, bg: string): string | null {
+  const parts: string[] = [];
+  if (afk.added > 0) parts.push(`${label("ad")}${chip(String(afk.added), bg)}`);
+  if (afk.removed > 0) parts.push(`${label("rm")}${chip(String(afk.removed), bg)}`);
+  return parts.length ? parts.join(" ") : null;
+}
+
+/** `rq rh bk wt tk $` pipeline + cost, each only when > 0; null when all zero. */
+function pipelineContent(afk: AfkInput, bg: string): string | null {
+  const parts: string[] = [];
+  if (afk.queue > 0) parts.push(`${label("rq")}${chip(String(afk.queue), bg)}`);
+  if (afk.human > 0) parts.push(`${label("rh")}${chip(String(afk.human), bg)}`);
+  if (afk.blocked > 0) parts.push(`${label("bk")}${chip(String(afk.blocked), bg)}`);
+  if (afk.waiting !== undefined && afk.waiting > 0)
+    parts.push(`${label("wt")}${chip(String(afk.waiting), bg)}`);
+  if (afk.tokens !== undefined && afk.tokens > 0)
+    parts.push(`${label("tk")}${chip(humanizeTokens(afk.tokens), bg)}`);
+  if (afk.costUsd !== undefined && afk.costUsd > 0)
+    parts.push(`${label("$")}${chip(afk.costUsd.toFixed(2), bg)}`);
+  return parts.length ? parts.join(" ") : null;
+}
+
+/** Line 2 — the AFK KPIs, or null when there are no live workers. */
 export function renderAfkLine(afk: AfkInput | undefined, columns: number | undefined): string | null {
   if (!afk || afk.workers <= 0) return null;
 
-  const backParts: string[] = [];
-  if (afk.queue > 0) backParts.push(`${label("rq")}${chip(String(afk.queue), WINE2)}`);
-  if (afk.human > 0) backParts.push(`${label("rh")}${chip(String(afk.human), WINE2)}`);
-  if (afk.blocked > 0) backParts.push(`${label("bk")}${chip(String(afk.blocked), WINE2)}`);
-  const backBlock = backParts.length ? block(WINE2, backParts.join(" ")) : "";
+  const fixed = assemble([
+    () => (afk.runner ? `${GOLD}${afk.runner}${WHITE}` : null),
+    (bg) => workersContent(afk, bg),
+    (bg) => transitContent(afk, bg),
+    (bg) => pipelineContent(afk, bg),
+  ]);
 
-  const actParts: string[] = [`${label("wk")}${chip(String(afk.workers), WINE)}`];
-  if (afk.added > 0) actParts.push(`${label("ad")}${chip(String(afk.added), WINE)}`);
-  if (afk.removed > 0) actParts.push(`${label("rm")}${chip(String(afk.removed), WINE)}`);
-  if (afk.waiting !== undefined && afk.waiting > 0)
-    actParts.push(`${label("wt")}${chip(String(afk.waiting), WINE)}`);
-  if (afk.tokens !== undefined && afk.tokens > 0)
-    actParts.push(`${label("tk")}${chip(humanizeTokens(afk.tokens), WINE)}`);
-  if (afk.costUsd !== undefined && afk.costUsd > 0)
-    actParts.push(`${label("$")}${chip(afk.costUsd.toFixed(2), WINE)}`);
-  const actHead = actParts.join(" ");
+  if (afk.issues.length === 0) return `${fixed.text}${RESET}`;
 
+  const issuesBg = fixed.nextIdx % 2 === 0 ? WINE2 : WINE;
   const showStage = afk.workers <= STAGE_MAX_WORKERS;
   const issueTok = (issue: number | string, i: number): string => {
     const stage = showStage ? afk.stages?.[i] : undefined;
     const suffix = stage ? `${DIM}·${stage}${WHITE}` : "";
-    return ` ${label("#")}${chip(String(issue), WINE)}${suffix}`;
+    return `${label("#")}${chip(String(issue), issuesBg)}${suffix}`;
   };
 
   const budget = columns && columns > 0 ? columns - WIDTH_MARGIN : null;
-  const assemble = (issuesStr: string, overflow: number): string => {
+  const wrap = (inner: string, overflow: number): string => {
     const over = overflow > 0 ? ` ${DIM}+${overflow}${WHITE}` : "";
-    return `${backBlock}${WINE} ${actHead}${issuesStr}${over} ${RESET}`;
+    return `${fixed.text}${issuesBg} ${inner}${over} ${RESET}`;
   };
 
-  let issuesStr = "";
+  const toks: string[] = [];
   let shown = 0;
   for (let i = 0; i < afk.issues.length; i++) {
     if (budget === null && shown >= ISSUE_CAP_NO_WIDTH) break;
-    const tok = issueTok(afk.issues[i], i);
-    if (budget !== null && vlen(assemble(issuesStr + tok, afk.issues.length - shown - 1)) > budget) break;
-    issuesStr += tok;
+    const next = [...toks, issueTok(afk.issues[i], i)].join(" ");
+    if (budget !== null && vlen(wrap(next, afk.issues.length - shown - 1)) > budget) break;
+    toks.push(issueTok(afk.issues[i], i));
     shown += 1;
   }
-  return assemble(issuesStr, afk.issues.length - shown);
+  return wrap(toks.join(" "), afk.issues.length - shown);
 }
+
+// ---------- assembly ----------
 
 /** The full themed statusline: header line, plus the AFK line when workers are
  * live, joined by a newline (Claude Code renders each as a row). */
 export function styleStatusline(input: StatuslineInput, columns?: number): string {
-  const lines = [renderHeaderLine(input.project, input.claude)];
+  const lines = [renderHeaderLine(input.project, input.claude, input.repo)];
   const afk = renderAfkLine(input.afk, columns);
   if (afk !== null) lines.push(afk);
   return lines.join("\n");

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -65,6 +65,13 @@ export interface AfkInput {
   /** `$` — summed USD cost across live workers, shown only when > 0 (most runners
    * report tokens but not cost, so this is frequently absent). */
   costUsd?: number;
+  /** The fleet runner (`claude` / `codex` / `minimax` / …); first non-empty
+   * across live workers. Rendered as a literal label leading the AFK line.
+   * Themed line 2 only; absent on pre-runner state files. */
+  runner?: string;
+  /** `res` — issues the current supervisor has closed this session (the worker
+   * state's `done`, the monitor's `issues done/total`). Themed line 2 only. */
+  resolved?: number;
   /** #N issue numbers for the in-progress workers, in order. */
   issues: ReadonlyArray<number | string>;
   /** Per-issue `current.stage` aligned by index with {@link issues}. When a
@@ -75,10 +82,24 @@ export interface AfkInput {
   stages?: ReadonlyArray<string | undefined>;
 }
 
+/** Repo-global header inputs (themed line 1, always rendered). Independent of
+ * live AFK workers: it shows where the repo stands even when nothing is running. */
+export interface RepoInput {
+  /** `pr` — open pull-request count (repo-global, GitHub-derived). */
+  openPrs?: number;
+  /** `is` — open issue count (repo-global, GitHub-derived). */
+  openIssues?: number;
+  /** `+N` — LOCAL branch insertions (committed + uncommitted vs origin/main). */
+  localAdded?: number;
+  /** `-N` — LOCAL branch deletions (committed + uncommitted vs origin/main). */
+  localRemoved?: number;
+}
+
 /** All the resolved inputs for one statusline render. */
 export interface StatuslineInput {
   project: ProjectInput;
   claude?: ClaudeInput;
+  repo?: RepoInput;
   afk?: AfkInput;
 }
 

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -545,6 +545,37 @@ export function countNeedsTriage(ctx: GhContext): Promise<number> {
   return countIssues(ctx, ["--label", "needs-triage"]);
 }
 
+/** Count ALL open issues — the repo-global `is` statusline count (no label
+ * filter). Capped at 500 like {@link countIssues}; a busier repo undercounts,
+ * which is acceptable for a glanceable badge. */
+export function countOpenIssues(ctx: GhContext): Promise<number> {
+  return countIssues(ctx, []);
+}
+
+/** Count open pull requests — the repo-global `pr` statusline count. Mirrors
+ * {@link countIssues} against `gh pr list`. Returns 0 on any gh/auth/parse
+ * failure so the statusline stays fail-open. */
+export async function countOpenPrs(ctx: GhContext): Promise<number> {
+  const r = await runGh(ctx, [
+    "pr",
+    "list",
+    ...repoArgs(ctx),
+    "--state",
+    "open",
+    "--limit",
+    "500",
+    "--json",
+    "number",
+  ]);
+  if (r.code !== 0) return 0;
+  try {
+    const parsed = JSON.parse(r.stdout) as unknown[];
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 /** Count `needs-info` straggler issues. */
 export function countNeedsInfo(ctx: GhContext): Promise<number> {
   return countIssues(ctx, ["--label", "needs-info"]);

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -487,7 +487,7 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
 
 // ---------- statusline inputs ----------
 
-import type { AfkInput } from "../core/statusline.js";
+import type { AfkInput, RepoInput } from "../core/statusline.js";
 
 /** The TTL (seconds) of the GitHub-derived queue/human counts cache, matching
  * statusline.sh's 60 s window. */
@@ -571,6 +571,12 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   let waiting = 0;
   let tokens = 0;
   let costUsd = 0;
+  // `runner` is the fleet runner (first non-empty across live workers — a fleet
+  // is single-runner in practice). `resolved` is the supervisor's issues-closed
+  // count, already persisted as `state.done` (the same field the monitor renders
+  // as `issues done/total`), maxed across workers since they all mirror it.
+  let runner = "";
+  let resolved = 0;
   const issues: Array<number | string> = [];
   const stages: Array<string | undefined> = [];
 
@@ -589,6 +595,8 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
 
     workers += 1;
     blocked += state.blocked;
+    if (runner === "" && state.runner) runner = state.runner;
+    if (state.done > resolved) resolved = state.done;
     // Read the worker's signals through the canonical WorkerVitals contract
     // (ADR 0065) rather than ad-hoc field access — `current` satisfies it.
     const vitals: WorkerVitals = state.current;
@@ -651,7 +659,78 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     void refresh().catch(() => undefined);
   }
 
-  return { workers, queue, human, blocked, added, removed, waiting, tokens, costUsd, issues, stages };
+  return { workers, queue, human, blocked, added, removed, waiting, tokens, costUsd, runner, resolved, issues, stages };
+}
+
+interface RepoStatsCache {
+  openPrs: number;
+  openIssues: number;
+  ts: number;
+}
+
+function readRepoStatsCache(path: string): RepoStatsCache | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<RepoStatsCache>;
+    return {
+      openPrs: Number(parsed.openPrs ?? 0),
+      openIssues: Number(parsed.openIssues ?? 0),
+      ts: Number(parsed.ts ?? 0),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
+  try {
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(cache), "utf8");
+    renameSync(tmp, path);
+  } catch {
+    // best-effort, like the bash `|| true`
+  }
+}
+
+/**
+ * Repo-global statusline header inputs (line 1, ALWAYS rendered — unlike the
+ * AFK block these show with no live workers): open-PR / open-issue counts from
+ * GitHub (cached for {@link STATUSLINE_CACHE_TTL_S} seconds in
+ * `.red/tmp/statusline-repo-cache.json`, same cold-bounded / stale-background
+ * discipline as the AFK queue/human cache), plus the LOCAL branch diffstat
+ * (committed + uncommitted vs origin/main) measured live at the project root.
+ * Every field is fail-open: any gh/git error leaves it 0.
+ */
+export async function collectStatuslineRepo(ctx: RepoContext): Promise<RepoInput> {
+  const paths = afkPaths(ctx.root);
+  const cachePath = join(paths.tmpDir, "statusline-repo-cache.json");
+  const nowS = Math.floor(Date.now() / 1000);
+  const cached = readRepoStatsCache(cachePath);
+  let openPrs = cached?.openPrs ?? 0;
+  let openIssues = cached?.openIssues ?? 0;
+
+  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  const refresh = async (): Promise<void> => {
+    const [p, i] = await Promise.all([ghx.countOpenPrs(ghCtx), ghx.countOpenIssues(ghCtx)]);
+    openPrs = p;
+    openIssues = i;
+    writeRepoStatsCacheAtomic(cachePath, { openPrs: p, openIssues: i, ts: nowS });
+  };
+  if (!cached) {
+    await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
+  } else if (nowS - cached.ts >= STATUSLINE_CACHE_TTL_S) {
+    void refresh().catch(() => undefined);
+  }
+
+  // Local branch diff (committed + uncommitted) vs origin/main, bounded so a slow
+  // git can never wedge the render. diffstatShortstat resolves the merge-base, so
+  // this counts every commit on the branch plus the dirty worktree.
+  const diff = await withTimeout(
+    gitx.diffstatShortstat({ cwd: ctx.root }, "origin/main"),
+    STATUSLINE_GH_COLD_TIMEOUT_MS,
+    { added: 0, removed: 0 },
+  ).catch(() => ({ added: 0, removed: 0 }));
+
+  return { openPrs, openIssues, localAdded: diff.added, localRemoved: diff.removed };
 }
 
 // ---------- reap inputs ----------

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -54,6 +54,14 @@ async function seedFreshCache(root: string, queue: number, human: number): Promi
   await writeFile(join(dir, "statusline-cache.json"), JSON.stringify({ queue, human, ts }), "utf8");
 }
 
+/** Pre-seed a FRESH repo-stats cache so collectStatuslineRepo never calls gh. */
+async function seedFreshRepoCache(root: string, openPrs: number, openIssues: number): Promise<void> {
+  const dir = join(root, ".red", "tmp");
+  await mkdir(dir, { recursive: true });
+  const ts = Math.floor(Date.now() / 1000);
+  await writeFile(join(dir, "statusline-repo-cache.json"), JSON.stringify({ openPrs, openIssues, ts }), "utf8");
+}
+
 const PAYLOAD = JSON.stringify({
   model: { display_name: "Opus" },
   effort: { level: "high" },
@@ -118,8 +126,11 @@ describe("statusline command — rendered line", () => {
   });
 
   it("emits the full block run from a payload + live workers + cached counts", async () => {
-    // One live worker on #17 with ad12 rm3, blocked 2; cached rq11 rh3.
+    // One live worker on #17 with ad12 rm3, blocked 2, runner claude, done 7;
+    // cached rq11 rh3; repo cache pr3 is24.
     await writeWorkerState(root, "wA", "17-a1", {
+      runner: "claude",
+      done: 7,
       blocked: 2,
       // `started_at` (fresh) is what makes isStateActive treat this pid-live worker
       // as active (ADR 0065): the statusline collector now requires recent activity,
@@ -132,23 +143,33 @@ describe("statusline command — rendered line", () => {
       },
     });
     await seedFreshCache(root, 11, 3);
+    await seedFreshRepoCache(root, 3, 24);
 
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
 
-    // Two powerline rows: header (project/model/ctx) + AFK (backlog + active).
+    // Two powerline rows: header (project/model/ctx/pr·is) + AFK (runner/wk·res/
+    // in-transit/pipeline/issues).
     const rows = out.text().trimEnd().split("\n");
     expect(rows).toHaveLength(2);
-    expect(stripAnsi(rows[0])).toContain("Opus·high");
-    expect(stripAnsi(rows[0])).toContain("47k 24%");
-    expect(stripAnsi(rows[1])).toContain("rq11 rh3 bk2"); // backlog block
-    expect(stripAnsi(rows[1])).toContain("wk1 ad12 rm3 #17"); // active block
+    const l1 = stripAnsi(rows[0]);
+    const l2 = stripAnsi(rows[1]);
+    expect(l1).toContain("Opus·high");
+    expect(l1).toContain("47k 24%");
+    expect(l1).toContain("pr3");
+    expect(l1).toContain("is24");
+    expect(l2).toContain("claude"); // runner
+    expect(l2).toContain("wk1 res7"); // workers + resolved
+    expect(l2).toContain("ad12 rm3"); // in-transit
+    expect(l2).toContain("rq11 rh3 bk2"); // pipeline
+    expect(l2).toContain("#17");
     // The raw output carries the wine-red background SGR (theme on by default).
     expect(out.text()).toContain("\x1b[48;2;114;47;55m");
   });
 
   it("drops the AFK block when there are no live workers", async () => {
+    await seedFreshRepoCache(root, 0, 0);
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
@@ -160,6 +181,7 @@ describe("statusline command — rendered line", () => {
   });
 
   it("renders only the project block outside Claude Code (empty stdin)", async () => {
+    await seedFreshRepoCache(root, 0, 0);
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(""));
     expect(code).toBe(0);

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { renderStatusline, type AfkInput, type StatuslineInput } from "../src/core/statusline.js";
+import {
+  renderStatusline,
+  type AfkInput,
+  type RepoInput,
+  type StatuslineInput,
+} from "../src/core/statusline.js";
 import {
   renderAfkLine,
   renderHeaderLine,
@@ -9,50 +14,80 @@ import {
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
-// eslint-disable-next-line no-control-regex
 const vlen = (s: string): number => stripAnsi(s).length;
 
 const WINE = "\x1b[48;2;114;47;55m";
 const WINE2 = "\x1b[48;2;88;36;42m";
 const BLACK = "\x1b[48;2;0;0;0m";
+const GOLD = "\x1b[38;2;240;200;120m";
 const RESET = "\x1b[0m";
 
 const afk: AfkInput = { workers: 1, queue: 11, human: 3, blocked: 2, added: 12, removed: 3, issues: [17] };
+const repo: RepoInput = { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 };
 const input: StatuslineInput = {
   project: { basename: "red-skills", branch: "main" },
   claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
+  repo,
   afk,
 };
 
 describe("statusline style — header line", () => {
-  it("is one powerline row: » bold project, model·effort, ctx — ending in a reset", () => {
-    const h = renderHeaderLine(input.project, input.claude);
+  it("powerlines » project, model·effort, ctx, pr/is, +local/-local — reset-terminated", () => {
+    const h = renderHeaderLine(input.project, input.claude, repo);
     expect(h).not.toContain("\n");
     expect(h.endsWith(RESET)).toBe(true);
-    expect(h).toContain(WINE2); // project + ctx blocks
-    expect(h).toContain(WINE); // model block
-    expect(stripAnsi(h)).toContain("» red-skills (main)");
-    expect(stripAnsi(h)).toContain("Opus·high");
-    expect(stripAnsi(h)).toContain("ctx47k 24%");
+    expect(h).toContain(WINE2);
+    expect(h).toContain(WINE);
+    expect(h).toContain(BLACK); // chips
+    const t = stripAnsi(h);
+    expect(t).toContain("» red-skills (main)");
+    expect(t).toContain("Opus·high");
+    expect(t).toContain("ctx47k 24%");
+    expect(t).toContain("pr3");
+    expect(t).toContain("is24");
+    expect(t).toContain("+142");
+    expect(t).toContain("-36");
   });
 
-  it("drops the model and ctx blocks outside Claude Code", () => {
-    const h = renderHeaderLine({ basename: "c3" }, undefined);
+  it("drops the repo blocks when counts are zero / a clean branch", () => {
+    const h = renderHeaderLine(input.project, input.claude, {
+      openPrs: 0,
+      openIssues: 0,
+      localAdded: 0,
+      localRemoved: 0,
+    });
+    const t = stripAnsi(h);
+    expect(t).not.toContain("pr");
+    expect(t).not.toContain("is");
+    expect(t).not.toContain("+");
+  });
+
+  it("drops model/ctx/repo outside Claude Code with no repo stats", () => {
+    const h = renderHeaderLine({ basename: "c3" }, undefined, undefined);
     expect(stripAnsi(h)).toBe(" » c3 ");
-    expect(h).not.toContain(WINE); // only the WINE2 project block remains
+    expect(h).not.toContain(WINE);
   });
 });
 
 describe("statusline style — AFK line", () => {
-  it("chips each KPI number and splits backlog (WINE2) from active (WINE)", () => {
-    const line = renderAfkLine(afk, undefined);
+  it("chips KPI numbers across the runner/workers/transit/pipeline blocks", () => {
+    const line = renderAfkLine({ ...afk, runner: "claude", resolved: 7 }, undefined);
     expect(line).not.toBeNull();
     expect(line!.endsWith(RESET)).toBe(true);
-    expect(line).toContain(BLACK); // numbers are drawn as black chips
-    expect(line).toContain(WINE2); // backlog block
-    expect(line).toContain(WINE); // active block
-    expect(stripAnsi(line!)).toContain("rq11 rh3 bk2");
-    expect(stripAnsi(line!)).toContain("wk1 ad12 rm3 #17");
+    expect(line).toContain(BLACK);
+    expect(line).toContain(GOLD); // runner label
+    const t = stripAnsi(line!);
+    expect(t).toContain("claude"); // runner
+    expect(t).toContain("wk1 res7"); // workers + resolved
+    expect(t).toContain("ad12 rm3"); // in-transit
+    expect(t).toContain("rq11 rh3 bk2"); // pipeline
+    expect(t).toContain("#17");
+  });
+
+  it("omits runner and res when absent / zero", () => {
+    const t = stripAnsi(renderAfkLine(afk, undefined)!);
+    expect(t).not.toContain("res");
+    expect(t.startsWith(" wk1")).toBe(true); // first block is workers, no runner
   });
 
   it("is null when there are no live workers", () => {
@@ -83,9 +118,8 @@ describe("statusline style — AFK line", () => {
     const wide = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 200);
     expect(stripAnsi(wide!)).not.toContain("+"); // all six fit in 200 cols
     const narrow = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 40);
-    const ntxt = stripAnsi(narrow!);
     expect(vlen(narrow!)).toBeLessThanOrEqual(40);
-    expect(ntxt).toMatch(/\+\d/); // overflow marker present
+    expect(stripAnsi(narrow!)).toMatch(/\+\d/);
   });
 });
 
@@ -97,13 +131,15 @@ describe("statusline style — full themed assembly", () => {
     expect(rows[0].endsWith(RESET)).toBe(true);
     expect(rows[1].endsWith(RESET)).toBe(true);
     expect(stripAnsi(rows[0])).toContain("» red-skills");
+    expect(stripAnsi(rows[0])).toContain("pr3");
     expect(stripAnsi(rows[1])).toContain("wk1");
   });
 
   it("emits only the header row when there are no live workers", () => {
-    const out = styleStatusline({ project: input.project, claude: input.claude });
+    const out = styleStatusline({ project: input.project, claude: input.claude, repo });
     expect(out).not.toContain("\n");
     expect(stripAnsi(out)).toContain("Opus·high");
+    expect(stripAnsi(out)).toContain("pr3");
   });
 
   it("renderStatuslineThemed switches between powerline and plain on the color flag", () => {


### PR DESCRIPTION
Interactive /ship landing for #805.

Closes #805

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784686486&installation_id=129708444&pr_number=806&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F806&signature=1a806ec2385a2061ffe03217d5c1aba45dfa1a38e29a0d202e6a1ae90a1fc2eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->