### PR TITLE
ship: #813 Statusline: show the running red-skills plugin version on line 1

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -17,6 +17,7 @@
 
 import { existsSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
+import { readBuildInfo } from "@reddb-io/build-info";
 import { type ClaudeInput, type ProjectInput } from "../core/statusline.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
@@ -103,15 +104,18 @@ export function statuslineEnabled(root: string): boolean {
   return true;
 }
 
-/** The block-1 project input: basename plus the resolved git ref (branch or
- * detached short sha), like statusline.sh's block 1. */
+/** The block-1 project input: basename, the resolved git ref (branch or detached
+ * short sha), and the running `dev` plugin version (build-info → dim `v<version>`
+ * tag on the themed header). */
 async function resolveProject(root: string): Promise<ProjectInput> {
   const ctx: gitx.GitContext = { cwd: root };
+  const version = readBuildInfo("dev").version;
+  const base: ProjectInput = { basename: basename(root), version };
   const branch = await gitx.currentBranch(ctx);
-  if (branch) return { basename: basename(root), branch };
+  if (branch) return { ...base, branch };
   const sha = await gitx.headShortSha(ctx);
-  if (sha) return { basename: basename(root), detachedSha: sha };
-  return { basename: basename(root) };
+  if (sha) return { ...base, detachedSha: sha };
+  return base;
 }
 
 /** Project the Claude Code payload into the renderer's block-2/3 input. */

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -93,7 +93,8 @@ function projectContent(project: ProjectInput): string {
   } else if (project.detachedSha) {
     ref = ` ${DIM}(detached ${project.detachedSha})${WHITE}`;
   }
-  return `${GOLD}»${WHITE} ${BOLD}${project.basename}${NOBOLD}${ref}`;
+  const ver = project.version ? ` ${DIM}v${project.version}${WHITE}` : "";
+  return `${GOLD}»${WHITE} ${BOLD}${project.basename}${NOBOLD}${ref}${ver}`;
 }
 
 /** `model·effort`, or null when there is no model. */

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -27,6 +27,10 @@ export interface ProjectInput {
   branch?: string;
   /** `git rev-parse --short HEAD` when detached (used only when branch is absent). */
   detachedSha?: string;
+  /** Running `dev` plugin/bundle version (e.g. `1.233.0`), from build-info.
+   * Rendered as a dim `v<version>` tag on the themed header line so the user can
+   * see which RedSkills version is producing the statusline. Themed line only. */
+  version?: string;
 }
 
 /** The block-2/3 Claude Code payload inputs. */

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -25,7 +25,7 @@ const RESET = "\x1b[0m";
 const afk: AfkInput = { workers: 1, queue: 11, human: 3, blocked: 2, added: 12, removed: 3, issues: [17] };
 const repo: RepoInput = { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 };
 const input: StatuslineInput = {
-  project: { basename: "red-skills", branch: "main" },
+  project: { basename: "red-skills", branch: "main", version: "1.2.3" },
   claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
   repo,
   afk,
@@ -41,6 +41,7 @@ describe("statusline style — header line", () => {
     expect(h).toContain(BLACK); // chips
     const t = stripAnsi(h);
     expect(t).toContain("» red-skills (main)");
+    expect(t).toContain("v1.2.3"); // fixed fixture version — proves the renderer echoes whatever version it is handed (not the live build version)
     expect(t).toContain("Opus·high");
     expect(t).toContain("ctx47k 24%");
     expect(t).toContain("pr3");


### PR DESCRIPTION
Interactive /ship landing for #813.

Closes #813

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784696616&installation_id=129708444&pr_number=814&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F814&signature=46c46074dc05f635000dbffc5027af5d31f1e0444e1e39313e923ec05f8a446b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now displays the project's dev plugin/bundle version alongside the project name, rendered as a dim version tag for enhanced visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->