### PR TITLE
feat(statusline): short wine identity zone + transparent key=value tail (3-letter)

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -1,19 +1,24 @@
 // core/statusline-style.ts — the ANSI styling slice for the /afk statusline.
 //
 // core/statusline.ts is deliberately PURE plain-text. This sibling adds the
-// "high-tech" theme: a TWO-LINE powerline layout where each semantic group sits
-// on its own wine-red background block (the block-to-block background SHIFT is
-// the separator — no `/` or `|` glyphs, so it needs no powerline/Nerd font), and
-// every KPI *number* is drawn as a black chip (black bg, white text).
+// theme: a TWO-LINE layout where only the leading IDENTITY ZONE (project +
+// model·effort) carries a wine-red BACKGROUND. Everything after it — the rest of
+// line 1 and ALL of line 2 — is background-transparent, so no red block ever
+// appears past the model. In the transparent zone each KPI is a `key=value`
+// pair: the KEY is a very-light, high-contrast red (≈ white), the VALUE is the
+// terminal's default foreground; every other glyph (runner, the `#` sigil, the
+// `·stage` suffix) uses a softer, lighter red. Abbreviations are always THREE
+// letters (wrk/rdy/hmn/blk/loc/wai/tok/usd; ctx/prs/iss); a diff is one
+// `loc=+A -R` pair, so the signed `+A -R` is the default-fg VALUE.
 //
-//   line 1 (header, always): » project | model·effort | ctx | pr/is | +local/-local
-//   line 2 (AFK, workers>0): runner | wk/res | ad/rm | rq/rh/bk/wt/tk/$ | #issues
+//   line 1 (header, always): [wine » project (branch) v· model·effort] ctx=… prs=… iss=… loc=+A -R
+//   line 2 (AFK, workers>0):  runner wrk=… res=… loc=+A -R rdy=… hmn=… blk=… wai=… tok=… usd=… #issues
 //
-// Block shades alternate WINE2/WINE in EMITTED order, so dropping an absent block
-// never collapses the shift. Width-aware: Claude Code exports $COLUMNS to the
-// statusline command (v2.1.153+), so line 2 fits its issue list to the budget and
-// collapses the rest into `+N` (fixed 3-issue cap without COLUMNS). Each line ends
-// with a reset so the block background never bleeds (per the Claude Code docs).
+// The identity zone keeps the two wine shades (WINE2 project, WINE model) so a
+// faint block separator survives between them; the shift to transparent IS the
+// separator from the model onward. Width-aware: Claude Code exports $COLUMNS, so
+// line 2 fits its issue list to the budget and collapses the rest into `+N`.
+// Each line ends with a reset so the background never bleeds.
 //
 // Everything here is PURE (inputs → string). The IO half
 // (commands/statusline.ts) decides colour (NO_COLOR → the plain renderer) and
@@ -29,13 +34,16 @@ import {
   type StatuslineInput,
 } from "./statusline.js";
 
-/** Truecolor SGR helpers. WINE/WINE2 are the two block shades; chips are black. */
-const WINE = "\x1b[48;2;114;47;55m";
-const WINE2 = "\x1b[48;2;88;36;42m";
-const BLACK = "\x1b[48;2;0;0;0m";
-const WHITE = "\x1b[38;2;255;255;255m";
-const DIM = "\x1b[38;2;201;150;158m";
-const GOLD = "\x1b[38;2;240;200;120m";
+/** Truecolor SGR helpers. */
+const WINE = "\x1b[48;2;114;47;55m"; // identity-zone bg (model block)
+const WINE2 = "\x1b[48;2;88;36;42m"; // identity-zone bg (project block)
+const NOBG = "\x1b[49m"; // drop background → terminal default (the transparent zone)
+const WHITE = "\x1b[38;2;255;255;255m"; // identity-zone text
+const KEY = "\x1b[38;2;255;214;214m"; // transparent-zone KEY: very light red ≈ white, high contrast
+const VAL = "\x1b[39m"; // transparent-zone VALUE: terminal default foreground
+const SOFT = "\x1b[38;2;224;138;148m"; // transparent-zone general font: a lighter red (runner, +/-/# sigils, ·stage)
+const DIM = "\x1b[38;2;201;150;158m"; // identity-zone branch/version
+const GOLD = "\x1b[38;2;240;200;120m"; // » accent
 const BOLD = "\x1b[1m";
 const NOBOLD = "\x1b[22m";
 const RESET = "\x1b[0m";
@@ -45,46 +53,28 @@ const BRANCH_MAX = 28;
 const ISSUE_CAP_NO_WIDTH = 3;
 /** Reserve columns for Claude Code's right-side notifications when budgeting. */
 const WIDTH_MARGIN = 6;
-/** Per-issue `·stage` suffixes only render at or below this worker count, so a
- * crowded fleet shows bare `#N` and stays narrow. */
+/** Per-issue `·stage` suffixes only render at or below this worker count. */
 const STAGE_MAX_WORKERS = 2;
 
 /** Visible width of an ANSI string (escapes stripped). */
 // eslint-disable-next-line no-control-regex
 const vlen = (s: string): number => s.replace(/\x1b\[[0-9;]*m/g, "").length;
 
-/** A KPI number as a black chip; `blockBg` restores the block background after. */
-const chip = (value: string, blockBg: string): string => `${BLACK}${WHITE}${value}${blockBg}`;
-/** A dim label sitting on the block field. */
-const label = (text: string): string => `${DIM}${text}${WHITE}`;
+/** A transparent-zone `key=value`: light-red KEY, default-fg VALUE, back to SOFT. */
+const kv = (key: string, value: string): string => `${KEY}${key}=${VAL}${value}${SOFT}`;
 
-/** A block content builder: given its background shade, return the painted
- * content, or null/"" to drop the block entirely. */
-type Block = (bg: string) => string | null;
-
-/**
- * Assemble present blocks into a powerline run: each block ` content ` on a
- * shade that alternates WINE2 / WINE in EMITTED order (absent blocks never
- * consume a shade slot, so the shift stays visible). `startIdx` seeds the
- * alternation; the returned `nextIdx` lets a caller continue it (the AFK line's
- * width-budgeted issue block picks up where the fixed blocks left off).
- */
-function assemble(blocks: Block[], startIdx = 0): { text: string; nextIdx: number } {
-  let text = "";
-  let idx = startIdx;
-  for (const b of blocks) {
-    const bg = idx % 2 === 0 ? WINE2 : WINE;
-    const content = b(bg);
-    if (content === null || content === "") continue;
-    text += `${bg} ${content} `;
-    idx += 1;
-  }
-  return { text, nextIdx: idx };
+/** The `+A -R` signed-pair value (a zero side is omitted), or null when both are
+ * zero. Rendered as the VALUE of a `loc=` pair, so the `+`/`-` are default-fg. */
+function signedDiff(added: number | undefined, removed: number | undefined): string | null {
+  const parts: string[] = [];
+  if (added && added > 0) parts.push(`+${added}`);
+  if (removed && removed > 0) parts.push(`-${removed}`);
+  return parts.length ? parts.join(" ") : null;
 }
 
-// ---------- line 1: header ----------
+// ---------- identity zone (wine background) ----------
 
-/** `» bold-project dim-(branch)`. Branch truncated like the plain renderer. */
+/** `» bold-project dim-(branch) dim-vX`. Branch truncated like the plain renderer. */
 function projectContent(project: ProjectInput): string {
   let ref = "";
   if (project.branch) {
@@ -103,110 +93,91 @@ function modelContent(claude: ClaudeInput | undefined): string | null {
   return claude.effort ? `${claude.model}${DIM}·${WHITE}${claude.effort}` : claude.model;
 }
 
-/** `ctx<chip(tokens pct)>`, or null when context is absent. */
-function ctxContent(claude: ClaudeInput | undefined, bg: string): string | null {
+// ---------- line 1: header ----------
+
+/** `ctx=<tokens pct>` in the transparent zone, or null when context is absent. */
+function ctxKv(claude: ClaudeInput | undefined): string | null {
   if (!claude || !claude.contextTokens) return null;
   const human = humanizeTokens(claude.contextTokens);
   const value =
     claude.contextPercent === undefined ? human : `${human} ${Math.round(claude.contextPercent)}%`;
-  return `${label("ctx")}${chip(value, bg)}`;
+  return kv("ctx", value);
 }
 
-/** `pr<chip> is<chip>` repo-global counts, or null when both are absent/zero
- * (a both-zero read is also how a gh failure surfaces, so it stays hidden). */
-function repoCountsContent(repo: RepoInput | undefined, bg: string): string | null {
-  if (!repo) return null;
+/** `prs=<n> iss=<n>` repo-global counts, each only when > 0. */
+function repoCountsKv(repo: RepoInput | undefined): string[] {
+  if (!repo) return [];
   const parts: string[] = [];
-  if (repo.openPrs && repo.openPrs > 0) parts.push(`${label("pr")}${chip(String(repo.openPrs), bg)}`);
-  if (repo.openIssues && repo.openIssues > 0)
-    parts.push(`${label("is")}${chip(String(repo.openIssues), bg)}`);
-  return parts.length ? parts.join(" ") : null;
+  if (repo.openPrs && repo.openPrs > 0) parts.push(kv("prs", String(repo.openPrs)));
+  if (repo.openIssues && repo.openIssues > 0) parts.push(kv("iss", String(repo.openIssues)));
+  return parts;
 }
 
-/** `+<chip> -<chip>` LOCAL branch diff, or null when the branch is clean. */
-function localDiffContent(repo: RepoInput | undefined, bg: string): string | null {
-  if (!repo) return null;
-  const parts: string[] = [];
-  if (repo.localAdded && repo.localAdded > 0) parts.push(`${label("+")}${chip(String(repo.localAdded), bg)}`);
-  if (repo.localRemoved && repo.localRemoved > 0)
-    parts.push(`${label("-")}${chip(String(repo.localRemoved), bg)}`);
-  return parts.length ? parts.join(" ") : null;
+/** `loc=+A -R` LOCAL branch diff (committed + uncommitted vs origin/main), or
+ * empty when the branch is clean. */
+function localDiffKv(repo: RepoInput | undefined): string[] {
+  if (!repo) return [];
+  const value = signedDiff(repo.localAdded, repo.localRemoved);
+  return value ? [kv("loc", value)] : [];
 }
 
-/** Line 1 — the header powerline. Always present (project is always there). */
+/** Line 1 — wine identity zone (project + model) then a transparent KPI tail. */
 export function renderHeaderLine(
   project: ProjectInput,
   claude: ClaudeInput | undefined,
   repo: RepoInput | undefined,
 ): string {
-  const { text } = assemble([
-    () => projectContent(project),
-    () => modelContent(claude),
-    (bg) => ctxContent(claude, bg),
-    (bg) => repoCountsContent(repo, bg),
-    (bg) => localDiffContent(repo, bg),
-  ]);
-  return `${text}${RESET}`;
+  let s = `${WINE2}${WHITE} ${projectContent(project)} `;
+  const model = modelContent(claude);
+  if (model !== null) s += `${WINE}${WHITE} ${model} `;
+  // Drop the background: from here on the line is transparent.
+  s += `${NOBG}${SOFT}`;
+  const tail = [ctxKv(claude), ...repoCountsKv(repo), ...localDiffKv(repo)].filter(
+    (x): x is string => x !== null,
+  );
+  if (tail.length) s += ` ${tail.join("  ")}`;
+  return `${s}${RESET}`;
 }
 
-// ---------- line 2: AFK ----------
+// ---------- line 2: AFK (fully transparent) ----------
 
-/** `wk<chip>` plus `res<chip>` when the supervisor has closed any issue. */
-function workersContent(afk: AfkInput, bg: string): string {
-  let s = `${label("wk")}${chip(String(afk.workers), bg)}`;
-  if (afk.resolved !== undefined && afk.resolved > 0)
-    s += ` ${label("res")}${chip(String(afk.resolved), bg)}`;
-  return s;
-}
-
-/** `ad<chip> rm<chip>` in-transit worker diff, or null when nothing moved. */
-function transitContent(afk: AfkInput, bg: string): string | null {
-  const parts: string[] = [];
-  if (afk.added > 0) parts.push(`${label("ad")}${chip(String(afk.added), bg)}`);
-  if (afk.removed > 0) parts.push(`${label("rm")}${chip(String(afk.removed), bg)}`);
-  return parts.length ? parts.join(" ") : null;
-}
-
-/** `rq rh bk wt tk $` pipeline + cost, each only when > 0; null when all zero. */
-function pipelineContent(afk: AfkInput, bg: string): string | null {
-  const parts: string[] = [];
-  if (afk.queue > 0) parts.push(`${label("rq")}${chip(String(afk.queue), bg)}`);
-  if (afk.human > 0) parts.push(`${label("rh")}${chip(String(afk.human), bg)}`);
-  if (afk.blocked > 0) parts.push(`${label("bk")}${chip(String(afk.blocked), bg)}`);
-  if (afk.waiting !== undefined && afk.waiting > 0)
-    parts.push(`${label("wt")}${chip(String(afk.waiting), bg)}`);
-  if (afk.tokens !== undefined && afk.tokens > 0)
-    parts.push(`${label("tk")}${chip(humanizeTokens(afk.tokens), bg)}`);
-  if (afk.costUsd !== undefined && afk.costUsd > 0)
-    parts.push(`${label("$")}${chip(afk.costUsd.toFixed(2), bg)}`);
-  return parts.length ? parts.join(" ") : null;
-}
-
-/** Line 2 — the AFK KPIs, or null when there are no live workers. */
+/** Line 2 — the AFK KPIs, transparent background, or null when no live workers. */
 export function renderAfkLine(afk: AfkInput | undefined, columns: number | undefined): string | null {
   if (!afk || afk.workers <= 0) return null;
 
-  const fixed = assemble([
-    () => (afk.runner ? `${GOLD}${afk.runner}${WHITE}` : null),
-    (bg) => workersContent(afk, bg),
-    (bg) => transitContent(afk, bg),
-    (bg) => pipelineContent(afk, bg),
-  ]);
+  const groups: string[] = [];
+  if (afk.runner) groups.push(`${SOFT}${afk.runner}${VAL}`);
 
-  if (afk.issues.length === 0) return `${fixed.text}${RESET}`;
+  let workers = kv("wrk", String(afk.workers));
+  if (afk.resolved !== undefined && afk.resolved > 0) workers += ` ${kv("res", String(afk.resolved))}`;
+  groups.push(workers);
 
-  const issuesBg = fixed.nextIdx % 2 === 0 ? WINE2 : WINE;
+  const diff = signedDiff(afk.added, afk.removed);
+  if (diff) groups.push(kv("loc", diff));
+
+  const pipe: string[] = [];
+  if (afk.queue > 0) pipe.push(kv("rdy", String(afk.queue)));
+  if (afk.human > 0) pipe.push(kv("hmn", String(afk.human)));
+  if (afk.blocked > 0) pipe.push(kv("blk", String(afk.blocked)));
+  if (afk.waiting !== undefined && afk.waiting > 0) pipe.push(kv("wai", String(afk.waiting)));
+  if (afk.tokens !== undefined && afk.tokens > 0) pipe.push(kv("tok", humanizeTokens(afk.tokens)));
+  if (afk.costUsd !== undefined && afk.costUsd > 0) pipe.push(kv("usd", afk.costUsd.toFixed(2)));
+  if (pipe.length) groups.push(pipe.join(" "));
+
+  const fixed = `${NOBG}${SOFT} ${groups.join("  ")}`;
+  if (afk.issues.length === 0) return `${fixed} ${RESET}`;
+
   const showStage = afk.workers <= STAGE_MAX_WORKERS;
   const issueTok = (issue: number | string, i: number): string => {
     const stage = showStage ? afk.stages?.[i] : undefined;
-    const suffix = stage ? `${DIM}·${stage}${WHITE}` : "";
-    return `${label("#")}${chip(String(issue), issuesBg)}${suffix}`;
+    const suffix = stage ? `${SOFT}·${stage}` : "";
+    return `${SOFT}#${VAL}${issue}${suffix}`;
   };
 
   const budget = columns && columns > 0 ? columns - WIDTH_MARGIN : null;
   const wrap = (inner: string, overflow: number): string => {
-    const over = overflow > 0 ? ` ${DIM}+${overflow}${WHITE}` : "";
-    return `${fixed.text}${issuesBg} ${inner}${over} ${RESET}`;
+    const over = overflow > 0 ? ` ${SOFT}+${overflow}` : "";
+    return `${fixed}  ${inner}${over} ${RESET}`;
   };
 
   const toks: string[] = [];
@@ -233,7 +204,7 @@ export function styleStatusline(input: StatuslineInput, columns?: number): strin
 }
 
 /** Render the statusline, themed or plain. `color` is the switch: true → the
- * powerline {@link styleStatusline}; false → the plain {@link renderStatusline}
+ * themed {@link styleStatusline}; false → the plain {@link renderStatusline}
  * (single line, no escapes) for NO_COLOR / non-terminal consumers. */
 export function renderStatuslineThemed(
   input: StatuslineInput,

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -3,11 +3,12 @@
 // model, effort, context window) and combines it with live /afk worker state
 // from <root>/.red/tmp/workers/*/* to emit ONE compact line like:
 //
-//   red-skills · Opus·high · 47k 24% · wk4 rq1 rh11 bk10 ad12 rm3 #17
+//   red-skills · Opus·high · 47k 24% · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17
 //
-// The AFK KPIs use two-letter mnemonics (wk/rq/rh/bk/ad/rm/wt/tk/$) instead of
-// emojis; the optional ANSI theming (wine-red line, black-chipped KPI numbers)
-// lives in the sibling style module, not here.
+// The AFK KPIs use three-letter `key=value` mnemonics
+// (wrk/rdy/hmn/blk/loc/wai/tok/usd) instead of emojis; the optional ANSI
+// theming (a short wine identity zone, then a transparent key=value tail) lives
+// in the sibling style module, not here.
 //
 // The render here is PURE — no stdin parse, no filesystem, no git/gh, no cache,
 // no ANSI. The caller injects the already-resolved inputs (project basename +
@@ -184,15 +185,17 @@ export function afkTokens(afk: AfkInput | undefined): AfkToken[] {
   const kpi = (label: string, value: string): void => {
     tokens.push({ label, value, suffix: "" });
   };
-  if (afk.workers > 0) kpi("wk", String(afk.workers));
-  if (afk.queue > 0) kpi("rq", String(afk.queue));
-  if (afk.human > 0) kpi("rh", String(afk.human));
-  if (afk.blocked > 0) kpi("bk", String(afk.blocked));
-  if (afk.added > 0) kpi("ad", String(afk.added));
-  if (afk.removed > 0) kpi("rm", String(afk.removed));
-  if (afk.waiting !== undefined && afk.waiting > 0) kpi("wt", String(afk.waiting));
-  if (afk.tokens !== undefined && afk.tokens > 0) kpi("tk", humanizeTokens(afk.tokens));
-  if (afk.costUsd !== undefined && afk.costUsd > 0) kpi("$", afk.costUsd.toFixed(2));
+  if (afk.workers > 0) kpi("wrk=", String(afk.workers));
+  if (afk.queue > 0) kpi("rdy=", String(afk.queue));
+  if (afk.human > 0) kpi("hmn=", String(afk.human));
+  if (afk.blocked > 0) kpi("blk=", String(afk.blocked));
+  const diff: string[] = [];
+  if (afk.added > 0) diff.push(`+${afk.added}`);
+  if (afk.removed > 0) diff.push(`-${afk.removed}`);
+  if (diff.length) kpi("loc=", diff.join(" "));
+  if (afk.waiting !== undefined && afk.waiting > 0) kpi("wai=", String(afk.waiting));
+  if (afk.tokens !== undefined && afk.tokens > 0) kpi("tok=", humanizeTokens(afk.tokens));
+  if (afk.costUsd !== undefined && afk.costUsd > 0) kpi("usd=", afk.costUsd.toFixed(2));
   afk.issues.forEach((issue, i) => {
     const stage = afk.stages?.[i];
     tokens.push({ label: "#", value: String(issue), suffix: stage ? `·${stage}` : "" });

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -157,12 +157,12 @@ describe("statusline command — rendered line", () => {
     const l2 = stripAnsi(rows[1]);
     expect(l1).toContain("Opus·high");
     expect(l1).toContain("47k 24%");
-    expect(l1).toContain("pr3");
-    expect(l1).toContain("is24");
+    expect(l1).toContain("prs=3");
+    expect(l1).toContain("iss=24");
     expect(l2).toContain("claude"); // runner
-    expect(l2).toContain("wk1 res7"); // workers + resolved
-    expect(l2).toContain("ad12 rm3"); // in-transit
-    expect(l2).toContain("rq11 rh3 bk2"); // pipeline
+    expect(l2).toContain("wrk=1 res=7"); // workers + resolved
+    expect(l2).toContain("loc=+12 -3"); // in-transit diff
+    expect(l2).toContain("rdy=11 hmn=3 blk=2"); // pipeline
     expect(l2).toContain("#17");
     // The raw output carries the wine-red background SGR (theme on by default).
     expect(out.text()).toContain("\x1b[48;2;114;47;55m");

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -18,8 +18,8 @@ const vlen = (s: string): number => stripAnsi(s).length;
 
 const WINE = "\x1b[48;2;114;47;55m";
 const WINE2 = "\x1b[48;2;88;36;42m";
-const BLACK = "\x1b[48;2;0;0;0m";
-const GOLD = "\x1b[38;2;240;200;120m";
+const NOBG = "\x1b[49m";
+const SOFT = "\x1b[38;2;224;138;148m";
 const RESET = "\x1b[0m";
 
 const afk: AfkInput = { workers: 1, queue: 11, human: 3, blocked: 2, added: 12, removed: 3, issues: [17] };
@@ -36,18 +36,17 @@ describe("statusline style — header line", () => {
     const h = renderHeaderLine(input.project, input.claude, repo);
     expect(h).not.toContain("\n");
     expect(h.endsWith(RESET)).toBe(true);
-    expect(h).toContain(WINE2);
-    expect(h).toContain(WINE);
-    expect(h).toContain(BLACK); // chips
+    expect(h).toContain(WINE2); // project block bg
+    expect(h).toContain(WINE); // model block bg
+    expect(h).toContain(NOBG); // background drops to transparent after the model
     const t = stripAnsi(h);
     expect(t).toContain("» red-skills (main)");
     expect(t).toContain("v1.2.3"); // fixed fixture version — proves the renderer echoes whatever version it is handed (not the live build version)
     expect(t).toContain("Opus·high");
-    expect(t).toContain("ctx47k 24%");
-    expect(t).toContain("pr3");
-    expect(t).toContain("is24");
-    expect(t).toContain("+142");
-    expect(t).toContain("-36");
+    expect(t).toContain("ctx=47k 24%");
+    expect(t).toContain("prs=3");
+    expect(t).toContain("iss=24");
+    expect(t).toContain("loc=+142 -36");
   });
 
   it("drops the repo blocks when counts are zero / a clean branch", () => {
@@ -58,9 +57,9 @@ describe("statusline style — header line", () => {
       localRemoved: 0,
     });
     const t = stripAnsi(h);
-    expect(t).not.toContain("pr");
-    expect(t).not.toContain("is");
-    expect(t).not.toContain("+");
+    expect(t).not.toContain("prs=");
+    expect(t).not.toContain("iss=");
+    expect(t).not.toContain("loc=");
   });
 
   it("drops model/ctx/repo outside Claude Code with no repo stats", () => {
@@ -75,20 +74,21 @@ describe("statusline style — AFK line", () => {
     const line = renderAfkLine({ ...afk, runner: "claude", resolved: 7 }, undefined);
     expect(line).not.toBeNull();
     expect(line!.endsWith(RESET)).toBe(true);
-    expect(line).toContain(BLACK);
-    expect(line).toContain(GOLD); // runner label
+    expect(line).toContain(NOBG); // line 2 is fully transparent — no red block
+    expect(line).toContain(SOFT); // softer red for the runner / sigils
+    expect(line).not.toContain(WINE); // never a wine background on line 2
     const t = stripAnsi(line!);
     expect(t).toContain("claude"); // runner
-    expect(t).toContain("wk1 res7"); // workers + resolved
-    expect(t).toContain("ad12 rm3"); // in-transit
-    expect(t).toContain("rq11 rh3 bk2"); // pipeline
+    expect(t).toContain("wrk=1 res=7"); // workers + resolved
+    expect(t).toContain("loc=+12 -3"); // in-transit diff
+    expect(t).toContain("rdy=11 hmn=3 blk=2"); // pipeline
     expect(t).toContain("#17");
   });
 
   it("omits runner and res when absent / zero", () => {
     const t = stripAnsi(renderAfkLine(afk, undefined)!);
     expect(t).not.toContain("res");
-    expect(t.startsWith(" wk1")).toBe(true); // first block is workers, no runner
+    expect(t.startsWith(" wrk=1")).toBe(true); // first group is workers, no runner
   });
 
   it("is null when there are no live workers", () => {
@@ -117,10 +117,16 @@ describe("statusline style — AFK line", () => {
 
   it("fits the issue list to the COLUMNS budget, collapsing the rest into +N", () => {
     const wide = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 200);
-    expect(stripAnsi(wide!)).not.toContain("+"); // all six fit in 200 cols
-    const narrow = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 40);
-    expect(vlen(narrow!)).toBeLessThanOrEqual(40);
-    expect(stripAnsi(narrow!)).toMatch(/\+\d/);
+    expect(stripAnsi(wide!)).toContain("#6"); // all six issues fit in 200 cols (none collapsed)
+    // The verbose key=value KPI run is wider than the old 2-letter chips, so the
+    // fixed groups alone are ~40 cols for a busy fleet; the budget can only trim
+    // ISSUES. 56 is the realistic narrow floor where collapsing is exercised.
+    // (We assert collapse via a dropped #N, not a bare "+", since the loc=+A -R
+    // diff value also contains a "+".)
+    const narrow = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 56);
+    expect(vlen(narrow!)).toBeLessThanOrEqual(56);
+    expect(stripAnsi(narrow!)).not.toContain("#6"); // tail issues collapsed into +N
+    expect(stripAnsi(narrow!)).toMatch(/ \+\d/); // the +N overflow marker is present
   });
 });
 
@@ -132,15 +138,15 @@ describe("statusline style — full themed assembly", () => {
     expect(rows[0].endsWith(RESET)).toBe(true);
     expect(rows[1].endsWith(RESET)).toBe(true);
     expect(stripAnsi(rows[0])).toContain("» red-skills");
-    expect(stripAnsi(rows[0])).toContain("pr3");
-    expect(stripAnsi(rows[1])).toContain("wk1");
+    expect(stripAnsi(rows[0])).toContain("prs=3");
+    expect(stripAnsi(rows[1])).toContain("wrk=1");
   });
 
   it("emits only the header row when there are no live workers", () => {
     const out = styleStatusline({ project: input.project, claude: input.claude, repo });
     expect(out).not.toContain("\n");
     expect(stripAnsi(out)).toContain("Opus·high");
-    expect(stripAnsi(out)).toContain("pr3");
+    expect(stripAnsi(out)).toContain("prs=3");
   });
 
   it("renderStatuslineThemed switches between powerline and plain on the color flag", () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -109,7 +109,7 @@ describe("statusline — context block", () => {
 describe("statusline — AFK block", () => {
   it("renders the full token run in the fixed order", () => {
     // case 3: one live worker on #17 with ad12 rm3, blocked 2, cached rq11 rh3.
-    expect(renderAfkBlock(baseAfk())).toBe("wk1 rq11 rh3 bk2 ad12 rm3 #17");
+    expect(renderAfkBlock(baseAfk())).toBe("wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 #17");
   });
 
   it("sums diffstats and lists both issues for two workers", () => {
@@ -117,11 +117,11 @@ describe("statusline — AFK block", () => {
     const out = renderAfkBlock(
       baseAfk({ workers: 2, added: 42, removed: 10, blocked: 5, issues: [17, 20] }),
     );
-    expect(out).toContain("wk2");
-    expect(out).toContain("ad42 rm10");
+    expect(out).toContain("wrk=2");
+    expect(out).toContain("loc=+42 -10");
     expect(out).toContain("#17");
     expect(out).toContain("#20");
-    expect(out).toContain("bk5");
+    expect(out).toContain("blk=5");
   });
 
   it("drops the block when there are no live workers", () => {
@@ -134,10 +134,10 @@ describe("statusline — AFK block", () => {
     const out = renderAfkBlock(
       baseAfk({ queue: 0, human: 0, blocked: 0, added: 5, removed: 2, issues: [17] }),
     );
-    expect(out).toBe("wk1 ad5 rm2 #17");
-    expect(out).not.toContain("rq");
-    expect(out).not.toContain("rh");
-    expect(out).not.toContain("bk");
+    expect(out).toBe("wrk=1 loc=+5 -2 #17");
+    expect(out).not.toContain("rdy");
+    expect(out).not.toContain("hmn");
+    expect(out).not.toContain("blk");
   });
 
   it("renders only the worker count when everything else is zero and no issues", () => {
@@ -151,7 +151,7 @@ describe("statusline — AFK block", () => {
         removed: 0,
         issues: [],
       }),
-    ).toBe("wk1");
+    ).toBe("wrk=1");
   });
 
   it("suffixes each issue with its stage when present, aligned by index", () => {
@@ -172,27 +172,29 @@ describe("statusline — AFK block", () => {
   });
 
   it("renders wtN after the diff only when waiting > 0", () => {
-    expect(renderAfkBlock(baseAfk({ waiting: 4 }))).toBe("wk1 rq11 rh3 bk2 ad12 rm3 wt4 #17");
-    expect(renderAfkBlock(baseAfk({ waiting: 0 }))).not.toContain("wt");
-    expect(renderAfkBlock(baseAfk())).not.toContain("wt");
+    expect(renderAfkBlock(baseAfk({ waiting: 4 }))).toBe(
+      "wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 wai=4 #17",
+    );
+    expect(renderAfkBlock(baseAfk({ waiting: 0 }))).not.toContain("wai");
+    expect(renderAfkBlock(baseAfk())).not.toContain("wai");
   });
 
   it("renders tk humanized tokens and $ cost after wt, each only when > 0", () => {
     expect(renderAfkBlock(baseAfk({ tokens: 12500, costUsd: 0.42 }))).toBe(
-      "wk1 rq11 rh3 bk2 ad12 rm3 tk12k $0.42 #17",
+      "wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 tok=12k usd=0.42 #17",
     );
     // tokens but no cost (the common case — most runners report tokens, not USD)
-    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).toContain("tk900");
-    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).not.toContain("$");
+    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).toContain("tok=900");
+    expect(renderAfkBlock(baseAfk({ tokens: 900 }))).not.toContain("usd");
     // neither when zero/absent
-    expect(renderAfkBlock(baseAfk({ tokens: 0, costUsd: 0 }))).not.toMatch(/tk|\$/);
-    expect(renderAfkBlock(baseAfk())).not.toMatch(/tk|\$/);
+    expect(renderAfkBlock(baseAfk({ tokens: 0, costUsd: 0 }))).not.toMatch(/tok=|usd=/);
+    expect(renderAfkBlock(baseAfk())).not.toMatch(/tok=|usd=/);
   });
 
   it("keeps the pre-vitals render byte-for-byte when no waiting/stages are supplied", () => {
     // The new fields are optional: an aggregator that never populates them must
     // produce the exact legacy line, so the upgrade is a no-op for old callers.
-    expect(renderAfkBlock(baseAfk())).toBe("wk1 rq11 rh3 bk2 ad12 rm3 #17");
+    expect(renderAfkBlock(baseAfk())).toBe("wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 #17");
   });
 });
 
@@ -204,7 +206,7 @@ describe("statusline — full assembly", () => {
       afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
     };
     expect(renderStatusline(input)).toBe(
-      "red-skills (main) · Opus·high · 47k 24% · wk4 rq1 rh11 bk10 ad12 rm3 #17",
+      "red-skills (main) · Opus·high · 47k 24% · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
     );
   });
 
@@ -213,7 +215,7 @@ describe("statusline — full assembly", () => {
       project: { basename: "c3" },
       afk: baseAfk(),
     });
-    expect(out).toBe("c3 · wk1 rq11 rh3 bk2 ad12 rm3 #17");
+    expect(out).toBe("c3 · wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 #17");
     expect(out).not.toContain("Opus");
     expect(out).not.toContain("%");
   });
@@ -224,7 +226,7 @@ describe("statusline — full assembly", () => {
       claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
     });
     expect(out).toBe("c1 · Opus·high · 47k 24%");
-    expect(out).not.toContain("wk");
+    expect(out).not.toContain("wrk");
     expect(out).toContain("c1");
   });
 


### PR DESCRIPTION
Restyle the two-line statusline (friend's design):

- Wine background **only** on the identity zone (`» project (branch) v· model·effort`); everything after — rest of line 1 + all of line 2 — is **transparent**.
- Transparent zone is `key=value`: **key** = very-light high-contrast red ≈ white (255,214,214), **value** = terminal default fg. Runner / `+`/`-`/`#` sigils / `·stage` = softer lighter red (224,138,148). Black KPI chips removed.
- **3-letter** abbreviations everywhere: wrk rdy hmn blk add rem wai tok usd; ctx prs iss. `+`/`-`/`#` kept as sigils.

Plain (NO_COLOR) renderer adopts the same labels so the two never drift. COLUMNS-budget test floor 40→56 (verbose key=value run is wider; budget trims issues). 49 statusline tests pass locally.

https://claude.ai/code/session_0184ni9ZeDwtk3ictGpacxuj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784725753&installation_id=129708444&pr_number=821&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F821&signature=96f983b293bc36fb928458f61f81ef75202775692f186209c4bc698e02962d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned statusline visual layout from block-based to transparent styling for improved clarity
  * Updated KPI metric labels to use explicit `key=value` format (e.g., `wrk=`, `rdy=`, `hmn=`, `add=`, `rem=`) for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->