### PR TITLE
fix(statusline): keep AFK line 2 alive for pid-live workers during quiet phases

### DIFF
--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -785,29 +785,24 @@ export async function reconcileDeadWorkerClaim(
     await deps.gh.comment(info.issue, buildCrashEnvelope(info));
   }
 
-  // 2. Bounded blocked:crashed recovery, mirroring the stall-reaper (#402).
-  const env = deps.recoveryEnv ?? {};
-  const decision = recoveryDecision("crashed", info.attempt, env);
-  if (decision === "retry") {
-    await deps.gh.editLabels(info.issue, [LABEL_READY], [LABEL_RUNNING]);
+  // 2. Bounded blocked:crashed recovery via the disposition composer (#402,
+  // #822), mirroring the stall-reaper path below. The death-without-envelope
+  // outcome is "no-sentinel" → recovery reason `crashed` + label `blocked:crashed`;
+  // dispose() owns the retry/escalate decision, label sets, and the budget-
+  // exhausted page comment. (Completes #822: this crash path still called the
+  // un-imported recoveryDecision/blockedLabelFor/recoveryCap after the stall path
+  // was converted, breaking the apps/dev typecheck.)
+  const disp = dispose("no-sentinel", info.attempt, deps.recoveryEnv ?? {});
+  if (disp.decision === "retry") {
+    // CLEAN re-queue: no blocked:* tag rides a re-queued issue.
+    await deps.gh.editLabels(info.issue, disp.addLabels, disp.removeLabels);
   } else {
-    // The recovery REASON is "crashed" (recovery.ts cap table), but the
-    // descriptive `blocked:crashed` label is keyed off the matching terminal
-    // OUTCOME — "no-sentinel" (attempt-outcome.ts), the death-without-envelope
-    // class this reconcile recovers.
-    const typed = blockedLabelFor("no-sentinel");
-    if (typed !== null) await deps.gh.ensureLabel(typed);
-    await deps.gh.editLabels(
-      info.issue,
-      typed !== null ? [LABEL_HUMAN, typed] : [LABEL_HUMAN],
-      [LABEL_RUNNING, LABEL_READY],
-    );
-    const cap = recoveryCap("crashed", env);
-    if (cap !== null) {
-      await deps.gh.comment(
-        info.issue,
-        `🤖 /afk escalating to ready-for-human: blocked:crashed retry budget exhausted (attempt ${info.attempt}/${cap}).`,
-      );
+    if (disp.typedLabel !== null) await deps.gh.ensureLabel(disp.typedLabel);
+    // Escalation also sheds any stale ready-for-agent — the crashed slot was
+    // `running`, never re-queue it (matches the reaper path).
+    await deps.gh.editLabels(info.issue, disp.addLabels, [...disp.removeLabels, LABEL_READY]);
+    if (disp.escalationComment !== null) {
+      await deps.gh.comment(info.issue, disp.escalationComment);
     }
   }
   return info.issue;

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -577,10 +577,17 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   const issues: Array<number | string> = [];
   const stages: Array<string | undefined> = [];
 
-  for (const { state, active } of records) {
-    // Statusline counts only genuinely-active workers (pid-live AND fresh), so a
-    // finished worker with a stale state file no longer inflates the wkN badge.
-    if (!active) continue;
+  for (const { state, live } of records) {
+    // Statusline line 2 counts every pid-live worker (the orchestrator process is
+    // alive), NOT only "fresh" ones (#836). The agent stream legitimately goes
+    // silent for minutes during the feedback gate / long builds — the per-minute
+    // heartbeat even stops at post_attempt — so an `active` (180s freshness) gate
+    // dropped a busy worker and made line 2 VANISH mid-test, reading as "fleet
+    // died." A finished worker sets pid:0 (split teardown) and its dir is reclaimed
+    // by the completion sweep, so it still drops here; only a SIGKILL'd worker with
+    // an OS-recycled pid can briefly ghost (bounded by the boot sweep). The record's
+    // `active` flag stays available for a future per-worker quiet badge.
+    if (!live) continue;
 
     workers += 1;
     blocked += state.blocked;

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -132,9 +132,9 @@ describe("statusline command — rendered line", () => {
       runner: "claude",
       done: 7,
       blocked: 2,
-      // `started_at` (fresh) is what makes isStateActive treat this pid-live worker
-      // as active (ADR 0065): the statusline collector now requires recent activity,
-      // not just a resolving pid. A real worker always stamps started_at.
+      // A real worker stamps started_at; the statusline collector counts any
+      // pid-live worker (#836) — freshness is not required, so a worker quiet on
+      // the agent lane during a long test/build still renders on line 2.
       current: {
         number: 17,
         diff_added: 12,

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -551,6 +551,47 @@ describe("collectStatuslineAfk — cache discipline", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("counts a pid-live worker even when its activity is stale (#836)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      // Fresh gh cache → collectStatuslineAfk makes no gh call.
+      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 0, human: 0, ts: nowS() }), "utf8");
+
+      // A worker whose orchestrator process is ALIVE (pid resolves) but whose
+      // agent-stream activity froze long ago — exactly a long feedback-gate /
+      // build phase, after the heartbeat stops at post_attempt. Pre-#836 this was
+      // dropped (isStateActive freshness gate) and line 2 vanished mid-test.
+      const stale = new Date(Date.now() - 2 * 3600 * 1000).toISOString();
+      const dir = join(tmpDir, "workers", "wQ", "55-a1");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "afk.state.json"),
+        JSON.stringify({
+          pid: process.pid, // alive
+          current: {
+            number: 55,
+            stage: "tests",
+            started_at: stale,
+            last_event_at: stale,
+            last_commit_at: stale,
+            loc_added: 5, // non-zero → no live git diffstat fallback (hermetic)
+            loc_removed: 1,
+          },
+        }),
+        "utf8",
+      );
+
+      const result = await collectStatuslineAfk({ root, repo: "", remote: "origin" });
+      expect(result).not.toBeNull(); // pid-live worker keeps line 2 alive despite stale activity
+      expect(result!.workers).toBe(1);
+      expect(result!.issues).toContain(55);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Line 2 vanished when a worker went quiet on the agent stream >180s — normal during the feedback gate / long builds (heartbeat stops at post_attempt). `collectStatuslineAfk` counted via `isStateActive` (pid + 180s freshness), dropping a busy-but-quiet worker → line 2 disappeared mid-test, reading as "fleet died."

Fix: count line 2 by `isStateLive` (pid-only). Worker renders while the orchestrator process is alive, across all phases. Finished workers set `pid:0` (split teardown) so they still drop; only a SIGKILL'd + recycled-pid worker can briefly ghost (bounded by boot sweep). `active` stays on the record for a future quiet badge; the monitor already keeps quiet workers (badges, never drops).

Regression test added (pid-live + stale activity → still counted). 89 statusline/wire tests pass locally.

Closes #836.

https://claude.ai/code/session_0184ni9ZeDwtk3ictGpacxuj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784732055&installation_id=129708444&pr_number=837&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F837&signature=fbbbab272ea1700b09ca9b8d61c21a2ace44e3452742fc98b48fe971494da8f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statusline AFK block accuracy to include running workers regardless of activity staleness.

* **Tests**
  * Added test coverage for worker counting with stale activity timestamps.
  * Updated test documentation to clarify worker state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->