### PR TITLE
Fix setup-red-skills frontmatter YAML

### DIFF
--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: setup-red-skills
-description: The one authorized creator of a repo's `.red/` directory and the only way to enable RedSkills plugins (dev, memory, brain) in a project (ADR 0067). RedSkills hooks are installed globally on every agent but stay fully inert in any directory without a `.red/config.yaml` whose `plugins.<name>.enabled: true` opts that plugin in. This skill prompts which plugins to enable, creates `.red/`, writes the activation flags, and sets up `## Agent skills`/`## Development workflow` blocks in AGENTS.md/CLAUDE.md plus `.red/agents/`. Run to turn RedSkills on in a repo, to enable/disable a plugin, before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`, or `/ship`, or if those skills appear to be missing context.
+description: >-
+  The one authorized creator of a repo's `.red/` directory and the only way to
+  enable RedSkills plugins (dev, memory, brain) in a project (ADR 0067).
+  RedSkills hooks are installed globally on every agent but stay fully inert in
+  any directory without a `.red/config.yaml` whose
+  `plugins.<name>.enabled: true` opts that plugin in. This skill prompts which
+  plugins to enable, creates `.red/`, writes the activation flags, and sets up
+  `## Agent skills`/`## Development workflow` blocks in AGENTS.md/CLAUDE.md plus
+  `.red/agents/`. Run to turn RedSkills on in a repo, to enable/disable a
+  plugin, before first use of `to-issues`, `to-prd`, `triage`, `diagnose`,
+  `tdd`, `improve-codebase-architecture`, `zoom-out`, or `/ship`, or if those
+  skills appear to be missing context.
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary
- Convert setup-red-skills frontmatter description to a folded YAML scalar so the embedded `enabled: true` text is parsed as content, not a mapping.

## Validation
- `ruby -ryaml` parsed the updated SKILL.md frontmatter.
- `scripts/validate-install-metadata.sh`
- `codex debug prompt-input "startup probe" >/dev/null`
- MCP SDK handshakes for code-nav and raffel succeeded locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784764691&installation_id=129708444&pr_number=846&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F846&signature=dbf4ece826df6a03119e1d0ef209038170e9eb7afad3ea272c9ed1d1a1020380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->