### PR TITLE
fix(ci): skip SDK postinstall in release install

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -123,6 +123,12 @@ jobs:
 
       - name: Install workspace dependencies
         if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
+        env:
+          # The release job builds JS bundles and manifests; it does not execute
+          # the @reddb-io/sdk-backed memory/brain runtimes during install. Skip
+          # the SDK postinstall binary download so release is not blocked when
+          # the matching reddb binary asset is unavailable.
+          REDDB_SKIP_POSTINSTALL: "1"
         run: pnpm install --frozen-lockfile
 
       # ADR 0032: AFK ships as a committed, dependency-free bundle. Rebuild it


### PR DESCRIPTION
The v1.240.1 release attempt failed during `pnpm install` because @reddb-io/sdk postinstall tried to download the missing reddb v1.7.0 binary asset.\n\nThis release job only installs dependencies to build JS bundles/manifests; it does not execute the SDK-backed memory/brain runtimes during install. Set `REDDB_SKIP_POSTINSTALL=1` for that install step so patch releases can complete.\n\nThis is a patch-class fix via conventional commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784776943&installation_id=129708444&pr_number=851&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F851&signature=3b20b96909981eaac69f741e88b60bbe6b5044f13aeeae709ea0c214512b2230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->