### PR TITLE
fix(release): reuse published red asset checksums

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -272,12 +272,29 @@ jobs:
             'macos-aarch64': 'red-macos-aarch64',
             'windows-x86_64': 'red-windows-x86_64.exe',
           };
+          async function previousRedAssets() {
+            const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/memory-runtime-manifest.json';
+            const response = await fetch(url, { redirect: 'follow' });
+            if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
+            const previous = await response.json();
+            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) {
+              throw new Error(`latest memory runtime manifest points at ${previous?.reddb?.tag ?? 'unknown'} / ${previous?.reddb?.sdk ?? 'unknown'}, expected ${reddb.tag} / ${sdk}`);
+            }
+            return previous.reddb.assets ?? {};
+          }
+          const fallbackAssets = await previousRedAssets();
           const redAssets = {};
           for (const [platform, asset] of Object.entries(assetNames)) {
             const url = `https://github.com/${reddb.repo}/releases/download/${reddb.tag}/${asset}.sha256`;
             const response = await fetch(url, { redirect: 'follow' });
-            if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
-            const sha256 = (await response.text()).match(/\b[0-9a-f]{64}\b/i)?.[0]?.toLowerCase();
+            let sha256 = "";
+            if (response.ok) {
+              sha256 = (await response.text()).match(/\b[0-9a-f]{64}\b/i)?.[0]?.toLowerCase() ?? "";
+            } else {
+              const fallback = fallbackAssets[platform];
+              if (fallback?.asset !== asset || !fallback?.sha256) throw new Error(`GET ${url} -> ${response.status}`);
+              sha256 = fallback.sha256;
+            }
             if (!sha256) throw new Error(`invalid sha256 file for ${asset}`);
             redAssets[platform] = { asset, sha256 };
           }
@@ -329,12 +346,29 @@ jobs:
             'macos-aarch64': 'red-macos-aarch64',
             'windows-x86_64': 'red-windows-x86_64.exe',
           };
+          async function previousRedAssets() {
+            const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/brain-runtime-manifest.json';
+            const response = await fetch(url, { redirect: 'follow' });
+            if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
+            const previous = await response.json();
+            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) {
+              throw new Error(`latest brain runtime manifest points at ${previous?.reddb?.tag ?? 'unknown'} / ${previous?.reddb?.sdk ?? 'unknown'}, expected ${reddb.tag} / ${sdk}`);
+            }
+            return previous.reddb.assets ?? {};
+          }
+          const fallbackAssets = await previousRedAssets();
           const redAssets = {};
           for (const [platform, asset] of Object.entries(assetNames)) {
             const url = `https://github.com/${reddb.repo}/releases/download/${reddb.tag}/${asset}.sha256`;
             const response = await fetch(url, { redirect: 'follow' });
-            if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
-            const sha256 = (await response.text()).match(/\b[0-9a-f]{64}\b/i)?.[0]?.toLowerCase();
+            let sha256 = "";
+            if (response.ok) {
+              sha256 = (await response.text()).match(/\b[0-9a-f]{64}\b/i)?.[0]?.toLowerCase() ?? "";
+            } else {
+              const fallback = fallbackAssets[platform];
+              if (fallback?.asset !== asset || !fallback?.sha256) throw new Error(`GET ${url} -> ${response.status}`);
+              sha256 = fallback.sha256;
+            }
             if (!sha256) throw new Error(`invalid sha256 file for ${asset}`);
             redAssets[platform] = { asset, sha256 };
           }


### PR DESCRIPTION
The v1.240.1 release retry reached memory manifest generation, then failed because the reddb v1.7.0 checksum asset URL currently returns 404.\n\nThe latest red-skills release already carries the SDK/tag-matched red asset checksums in memory/brain runtime manifests. Reuse those checksums as a fallback when the external asset checksum is unavailable, while still validating the SDK and tag match.\n\nPatch-class release workflow fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784777168&installation_id=129708444&pr_number=852&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F852&signature=3051ef3a572d41782a1cfe4bc6c9deb1e08e9e36a4ef9684fea69b3b078d7701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->