### PR TITLE
ship: #853 Codex/OpenCode should not skip setup-red-skills due invalid frontmatter

### DIFF
--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "esbuild": "catalog:",
+    "js-yaml": "^4.1.0",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/apps/dev/tests/manifest-parity.test.ts
+++ b/apps/dev/tests/manifest-parity.test.ts
@@ -1,12 +1,27 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const ROOT = join(import.meta.dirname, "..", "..", "..");
+const require = createRequire(import.meta.url);
+const yaml = require("js-yaml") as { load(input: string): unknown };
 
 async function readCodexManifest(): Promise<{ skills: string[] }> {
   const raw = await readFile(join(ROOT, "plugins/dev/.codex-plugin/plugin.json"), "utf8");
   return JSON.parse(raw) as { skills: string[] };
+}
+
+async function listSkillFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return listSkillFiles(path);
+      return entry.isFile() && entry.name === "SKILL.md" ? [path] : [];
+    }),
+  );
+  return files.flat().sort();
 }
 
 describe("dev plugin manifest + frontmatter hygiene", () => {
@@ -19,6 +34,23 @@ describe("dev plugin manifest + frontmatter hygiene", () => {
     const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
     expect(frontmatter, "SKILL.md must open with a YAML frontmatter block").not.toBeNull();
     expect(frontmatter![1]).toMatch(/^name:\s*model-tier-policy\s*$/m);
+  });
+
+  it("published SKILL.md frontmatter parses as YAML", async () => {
+    const manifest = await readCodexManifest();
+    const skillRoots = manifest.skills.map((path) =>
+      join(ROOT, "plugins/dev", path.replace(/^\.\//, "")),
+    );
+    const skillFiles = (await Promise.all(skillRoots.map(listSkillFiles))).flat();
+
+    expect(skillFiles.length).toBeGreaterThan(0);
+
+    for (const path of skillFiles) {
+      const skill = await readFile(path, "utf8");
+      const frontmatter = skill.match(/^---\n([\s\S]*?)\n---/);
+      expect(frontmatter, `${path} must open with a YAML frontmatter block`).not.toBeNull();
+      expect(() => yaml.load(frontmatter![1]), `${path} frontmatter must parse`).not.toThrow();
+    }
   });
 
   it("Codex dev manifest enumerates only published buckets (no in-progress/)", async () => {

--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: setup-red-skills
-description: The one authorized creator of a repo's `.red/` directory and the only way to enable RedSkills plugins (dev, memory, brain) in a project (ADR 0067). RedSkills hooks are installed globally on every agent but stay fully inert in any directory without a `.red/config.yaml` whose `plugins.<name>.enabled: true` opts that plugin in. This skill prompts which plugins to enable, creates `.red/`, writes the activation flags, and sets up `## Agent skills`/`## Development workflow` blocks in AGENTS.md/CLAUDE.md plus `.red/agents/`. Run to turn RedSkills on in a repo, to enable/disable a plugin, before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`, or `/ship`, or if those skills appear to be missing context.
+description: >-
+  The one authorized creator of a repo's `.red/` directory and the only way to
+  enable RedSkills plugins (dev, memory, brain) in a project (ADR 0067).
+  RedSkills hooks are installed globally on every agent but stay fully inert in
+  any directory without a `.red/config.yaml` whose
+  `plugins.<name>.enabled: true` opts that plugin in. This skill prompts which
+  plugins to enable, creates `.red/`, writes the activation flags, and sets up
+  `## Agent skills`/`## Development workflow` blocks in AGENTS.md/CLAUDE.md plus
+  `.red/agents/`. Run to turn RedSkills on in a repo, to enable/disable a
+  plugin, before first use of `to-issues`, `to-prd`, `triage`, `diagnose`,
+  `tdd`, `improve-codebase-architecture`, `zoom-out`, or `/ship`, or if those
+  skills appear to be missing context.
 disable-model-invocation: true
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       esbuild:
         specifier: 'catalog:'
         version: 0.24.2
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.2.0
       tsx:
         specifier: 'catalog:'
         version: 4.22.4


### PR DESCRIPTION
Interactive /ship landing for #853.

Closes #853

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784804962&installation_id=129708444&pr_number=854&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F854&signature=76664292efa51dd13fa1bc0985a29bdf93269d7ec8883b9371722b216e31b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced validation testing to verify skill documentation structure and formatting integrity.

* **Documentation**
  * Updated skill documentation formatting for consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->