### PR TITLE
fix(release): advance major action tags

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -12,6 +12,8 @@ name: red-release
 #   3. Sync plugins/dev/.claude-plugin/plugin.json `version` field.
 #   4. Commit the bump back to main (marker `[skip release]` to avoid loop).
 #   5. Create the git tag and a GitHub Release with auto-generated notes.
+#   6. Move the matching major tag (for example `v1`) to the same commit so
+#      reusable workflows and actions pinned to `@v1` keep receiving releases.
 
 on:
   push:
@@ -501,6 +503,9 @@ jobs:
           PREVIOUS: ${{ steps.bump.outputs.previous }}
         run: |
           set -euo pipefail
+          major="v${NEXT#v}"
+          major="${major%%.*}"
+
           git tag -a "$NEXT" -m "Release $NEXT"
           git push origin "$NEXT"
           assets=(
@@ -530,3 +535,8 @@ jobs:
               --title "$NEXT" \
               --generate-notes
           fi
+
+          # `vX.Y.Z` is immutable release history; `vX` is the moving major ref
+          # GitHub reusable workflows/actions consume via `uses: ...@vX`.
+          git tag -f "$major" HEAD
+          git push --force origin "refs/tags/$major:refs/tags/$major"

--- a/plugins/dev/skills/engineering/afk/actions-lane.md
+++ b/plugins/dev/skills/engineering/afk/actions-lane.md
@@ -21,8 +21,8 @@ red-skills tree to run the action, so the committed `afk.mjs` + `plugin.json`
 ride along and the launcher resolves its version and fetches the matching `dev`
 bundle (red-castle inlined, ADR 0061) — **no workspace build, no submodule, in
 any repo.** Execution runs against the caller's checkout; the launcher lives in
-the action's own checkout. Pin `@v1` (or a SHA) to fix both the action and the
-bundle version.
+the action's own checkout. Pin `@v1` to track the latest compatible v1 release,
+or pin a SHA when the caller needs a fully immutable action/runtime pair.
 
 External dependencies are only **GitHub-official** actions (`actions/checkout`,
 `actions/setup-node`, `actions/github-script`) plus our own action — no


### PR DESCRIPTION
## Summary
- move the matching major tag (for example `v1`) after each successful `vX.Y.Z` release
- document that `@v1` tracks the latest compatible v1 release while SHA pins stay immutable

## Validation
- `actionlint .github/workflows/red-release.yml`
- `git diff --check`
- shell smoke test for `vX.Y.Z -> vX` major tag extraction

## Notes
`/ship` was not used because its contract requires a `.red/tmp/work-ship-*` worktree; this change was made in an isolated non-primary worktree and pushed normally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784822735&installation_id=129708444&pr_number=864&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F864&signature=5dcc538ae2095a2c5daeba8d1d5e10ce97554691b52445321f6e369c69cc21b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->