### PR TITLE
merge: #867 Implement CLI governed write for low-risk validation evidence

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -233,6 +233,12 @@ import { buildMemoryHealthViewerArtifact } from "./memory-health-viewer.js";
 import { buildMemoryDecayReport } from "./memory-decay.js";
 import { buildMemoryDecayViewerArtifact } from "./memory-decay-viewer.js";
 import {
+  memoryStoreEvidence,
+  rejectMemoryStoreEvidence,
+  type GovernedWriteResult,
+  type MemoryStoreEvidenceInput,
+} from "./governed-write.js";
+import {
   buildMemoryMergePassReport,
   executeMemoryMergeBatch,
   unmergeMemoryMergeBatch,
@@ -317,6 +323,7 @@ over the same evidence store.
 Usage:
   memory init [--mode markdown-only|graph] [--hooks] [--skill-telemetry] [--event-retention-days N] [--root <dir>] [--yes]
   memory store <fact...>            [--root <dir>] [--scope project|repo|branch|worktree|session|agent-run|user] [--scope-id ID]
+  memory store-evidence             [--root <dir>] --claim <text> --source-ref <ref> --citation-excerpt <text> --intent <text> --observer <id> [--json]
   memory inbox quarantine <fact...> [--root <dir>] --reason <text> --evidence <summary> [--confidence EXTRACTED|INFERRED|AMBIGUOUS] [--source-kind manual|hook|derived|system] [--writer <name>] [--command <cmd>] [--hook <event>] [--json]
   memory inbox list                 [--root <dir>] [--status quarantined|approved|rejected|promoted|all] [--json]
   memory inbox inspect <id>         [--root <dir>] [--json]
@@ -705,6 +712,33 @@ async function runStore(args: ParsedArgs): Promise<void> {
   });
   console.log(`memory: stored ${note.id}`);
   console.log(`  ${note.path}`);
+}
+
+async function runStoreEvidence(args: ParsedArgs): Promise<void> {
+  const rootDir = rootOf(args.flags);
+  const input: MemoryStoreEvidenceInput = {
+    claim: stringFlag(args.flags, "claim") ?? args.positional.join(" "),
+    sourceRef: stringFlag(args.flags, "source-ref") ?? stringFlag(args.flags, "source"),
+    citationExcerpt:
+      stringFlag(args.flags, "citation-excerpt") ?? stringFlag(args.flags, "citation"),
+    intent: stringFlag(args.flags, "intent"),
+    observer: stringFlag(args.flags, "observer") ?? stringFlag(args.flags, "writer"),
+  };
+
+  const config = await readConfig(rootDir);
+  if (!config || config.mode !== "graph") {
+    const rejected = rejectMemoryStoreEvidence(input, "graph_mode_required");
+    printGovernedWriteResult(rejected, args.flags.json === true);
+    return;
+  }
+
+  const store = await MemoryStore.open({ uri: resolveStoreUri(rootDir, config) });
+  try {
+    const result = await memoryStoreEvidence(store, input);
+    printGovernedWriteResult(result, args.flags.json === true);
+  } finally {
+    await store.close();
+  }
 }
 
 async function runCommit(args: ParsedArgs): Promise<void> {
@@ -1137,6 +1171,23 @@ function printEvidenceResult(action: string, card: EvidenceCard, json: boolean):
   }
   console.log(`memory evidence: ${action} ${card.id}`);
   console.log(`  status: ${card.status}`);
+}
+
+function printGovernedWriteResult(
+  result: GovernedWriteResult,
+  json: boolean,
+): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(`memory store-evidence: ${result.outcome}`);
+  console.log(`  reason: ${result.reason}`);
+  if (result.memory.urn) console.log(`  memory: ${result.memory.urn}`);
+  if (result.provenance.source_ref) console.log(`  source: ${result.provenance.source_ref}`);
+  if (result.provenance.citation_excerpt) {
+    console.log(`  citation: ${result.provenance.citation_excerpt}`);
+  }
 }
 
 function printLinkedEvidenceResult(action: string, card: LinkedEvidenceReviewResult, json: boolean): void {
@@ -7821,6 +7872,8 @@ async function main(): Promise<void> {
       return runInit(args);
     case "store":
       return runStore(args);
+    case "store-evidence":
+      return runStoreEvidence(args);
     case "commit":
       return runCommit(args);
     case "inbox":

--- a/apps/memory/src/governed-write.ts
+++ b/apps/memory/src/governed-write.ts
@@ -1,0 +1,136 @@
+import type { MemoryStore } from "./graph-store.js";
+import type { MemoryProvenance } from "./schema.js";
+import { slugify } from "./store.js";
+
+export type GovernedWriteOutcome = "stored" | "rejected";
+
+export interface MemoryStoreEvidenceInput {
+  claim?: string;
+  sourceRef?: string;
+  citationExcerpt?: string;
+  intent?: string;
+  observer?: string;
+}
+
+export interface GovernedWriteResult {
+  schema_version: "memory.governed_write.v1";
+  operation: "memory_store_evidence";
+  outcome: GovernedWriteOutcome;
+  reason: string;
+  policy: {
+    reason: string;
+    risk: "low" | "unknown";
+    mode_required: "graph";
+  };
+  provenance: {
+    source_kind: MemoryProvenance["source_kind"];
+    writer: string | null;
+    evidence: string[];
+    citation_excerpt: string | null;
+    source_ref: string | null;
+  };
+  memory: {
+    id: number | null;
+    urn: string | null;
+  };
+}
+
+const REQUIRED_FIELDS = ["claim", "sourceRef", "citationExcerpt", "intent", "observer"] as const;
+
+export function rejectMemoryStoreEvidence(
+  input: MemoryStoreEvidenceInput,
+  reason: string,
+): GovernedWriteResult {
+  return governedWriteResult("rejected", reason, input, null);
+}
+
+export async function memoryStoreEvidence(
+  store: MemoryStore,
+  input: MemoryStoreEvidenceInput,
+): Promise<GovernedWriteResult> {
+  const missing = REQUIRED_FIELDS.filter((field) => !nonEmpty(input[field]));
+  if (missing.length > 0) {
+    return rejectMemoryStoreEvidence(input, `missing_required_fields:${missing.join(",")}`);
+  }
+
+  const normalized = normalizeInput(input);
+  const rid = await store.upsertNode({
+    label: slugify(normalized.claim).slice(0, 96),
+    node_type: "validation",
+    properties: {
+      title: normalized.claim,
+      content: normalized.claim,
+      summary: normalized.claim,
+      confidence: "EXTRACTED",
+      source: normalized.sourceRef,
+      tags: ["operational-evidence", "validation"],
+      tier: "durable",
+      layer: "L3",
+      intent: normalized.intent,
+      observer: normalized.observer,
+      citation_excerpt: normalized.citationExcerpt,
+      provenance: {
+        source_kind: "manual",
+        writer: normalized.observer,
+        command: "memory store-evidence",
+        confidence: "EXTRACTED",
+        evidence: [normalized.sourceRef, normalized.citationExcerpt],
+      },
+    },
+  });
+
+  return governedWriteResult(
+    "stored",
+    "low_risk_validation_evidence_stored",
+    normalized,
+    rid,
+  );
+}
+
+function governedWriteResult(
+  outcome: GovernedWriteOutcome,
+  reason: string,
+  input: MemoryStoreEvidenceInput,
+  rid: number | null,
+): GovernedWriteResult {
+  const normalized = normalizeInput(input);
+  return {
+    schema_version: "memory.governed_write.v1",
+    operation: "memory_store_evidence",
+    outcome,
+    reason,
+    policy: {
+      reason,
+      risk: outcome === "stored" ? "low" : "unknown",
+      mode_required: "graph",
+    },
+    provenance: {
+      source_kind: "manual",
+      writer: normalized.observer || null,
+      evidence:
+        normalized.sourceRef && normalized.citationExcerpt
+          ? [normalized.sourceRef, normalized.citationExcerpt]
+          : [],
+      citation_excerpt: normalized.citationExcerpt || null,
+      source_ref: normalized.sourceRef || null,
+    },
+    memory: {
+      id: rid,
+      urn: rid == null ? null : `memory_nodes:${rid}`,
+    },
+  };
+}
+
+function normalizeInput(input: MemoryStoreEvidenceInput): Required<MemoryStoreEvidenceInput> {
+  return {
+    claim: input.claim?.trim() ?? "",
+    sourceRef: input.sourceRef?.trim() ?? "",
+    citationExcerpt: input.citationExcerpt?.trim() ?? "",
+    intent: input.intent?.trim() ?? "",
+    observer: input.observer?.trim() ?? "",
+  };
+}
+
+function nonEmpty(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/apps/memory/tests/governed-write-cli.test.ts
+++ b/apps/memory/tests/governed-write-cli.test.ts
@@ -1,0 +1,206 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import { MemoryStore } from "../src/graph-store.js";
+import { initGraph, initMarkdownOnly } from "../src/init.js";
+import { memoryStoreEvidence } from "../src/governed-write.js";
+
+const TIMEOUT = 40_000;
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, "..");
+
+const roots: string[] = [];
+const stores: MemoryStore[] = [];
+
+async function tempRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "memory-governed-write-"));
+  roots.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: PLUGIN_ROOT,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+describe("memory_store_evidence governed write", () => {
+  test(
+    "stores low-risk validation evidence with normalized provenance",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+      const store = await MemoryStore.open({ uri: storeUri, project: "test" });
+      stores.push(store);
+
+      const result = await memoryStoreEvidence(store, {
+        claim: "Validation proves the CLI governed write stores graph evidence.",
+        sourceRef: "tests/governed-write-cli.test.ts",
+        citationExcerpt: "stores low-risk validation evidence",
+        intent: "validation",
+        observer: "unit-test",
+      });
+
+      expect(result).toMatchObject({
+        outcome: "stored",
+        reason: "low_risk_validation_evidence_stored",
+        provenance: {
+          source_ref: "tests/governed-write-cli.test.ts",
+          citation_excerpt: "stores low-risk validation evidence",
+          evidence: [
+            "tests/governed-write-cli.test.ts",
+            "stores low-risk validation evidence",
+          ],
+        },
+      });
+      expect(result.memory.id).toEqual(expect.any(Number));
+      const node = await store.getNode(result.memory.id!);
+      expect(node).toMatchObject({
+        node_type: "validation",
+        properties: {
+          provenance: {
+            writer: "unit-test",
+            evidence: [
+              "tests/governed-write-cli.test.ts",
+              "stores low-risk validation evidence",
+            ],
+          },
+        },
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "CLI stores evidence and recall/search returns provenance",
+    async () => {
+      const root = await tempRoot();
+      await initGraph(root);
+
+      const write = runMemory([
+        "store-evidence",
+        "--root",
+        root,
+        "--claim",
+        "Graph recall can find governed validation evidence.",
+        "--source-ref",
+        "docs/validation.md:12",
+        "--citation-excerpt",
+        "Graph recall can find governed validation evidence.",
+        "--intent",
+        "validation",
+        "--observer",
+        "cli-test",
+        "--json",
+      ]);
+      expect(write.status, write.stderr).toBe(0);
+      const body = JSON.parse(write.stdout) as {
+        outcome: string;
+        reason: string;
+        memory: { id: number; urn: string };
+        provenance: { source_ref: string; citation_excerpt: string; evidence: string[] };
+      };
+      expect(body.outcome).toBe("stored");
+      expect(body.memory.urn).toBe(`memory_nodes:${body.memory.id}`);
+      expect(body.provenance).toMatchObject({
+        source_ref: "docs/validation.md:12",
+        citation_excerpt: "Graph recall can find governed validation evidence.",
+      });
+
+      const provenance = runMemory(["provenance", String(body.memory.id), "--root", root, "--json"]);
+      expect(provenance.status, provenance.stderr).toBe(0);
+      const provenanceBody = JSON.parse(provenance.stdout) as {
+        provenance: { evidence: string[]; writer: string };
+      };
+      expect(provenanceBody.provenance).toMatchObject({
+        writer: "cli-test",
+        evidence: [
+          "docs/validation.md:12",
+          "Graph recall can find governed validation evidence.",
+        ],
+      });
+
+      const search = runMemory(["search", "governed validation", "--root", root]);
+      expect(search.status, search.stderr).toBe(0);
+      expect(search.stdout).toContain(String(body.memory.id));
+      expect(search.stdout).toContain("Graph recall can find governed validation evidence.");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "CLI rejects missing provenance fields without durable graph memory",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+
+      const result = runMemory([
+        "store-evidence",
+        "--root",
+        root,
+        "--claim",
+        "Missing citation should not write memory.",
+        "--intent",
+        "validation",
+        "--observer",
+        "cli-test",
+        "--json",
+      ]);
+      expect(result.status, result.stderr).toBe(0);
+      const body = JSON.parse(result.stdout) as { outcome: string; reason: string; memory: { id: null } };
+      expect(body).toMatchObject({
+        outcome: "rejected",
+        reason: "missing_required_fields:sourceRef,citationExcerpt",
+        memory: { id: null },
+      });
+
+      const store = await MemoryStore.open({ uri: storeUri, project: "test" });
+      stores.push(store);
+      expect(await store.listNodes()).toEqual([]);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "CLI rejects markdown-only mode instead of falling back to notes",
+    async () => {
+      const root = await tempRoot();
+      await initMarkdownOnly(root);
+
+      const result = runMemory([
+        "store-evidence",
+        "--root",
+        root,
+        "--claim",
+        "Markdown-only mode cannot store graph evidence.",
+        "--source-ref",
+        "source.md",
+        "--citation-excerpt",
+        "Markdown-only mode cannot store graph evidence.",
+        "--intent",
+        "validation",
+        "--observer",
+        "cli-test",
+        "--json",
+      ]);
+      expect(result.status, result.stderr).toBe(0);
+      const body = JSON.parse(result.stdout) as { outcome: string; reason: string; memory: { id: null } };
+      expect(body).toMatchObject({
+        outcome: "rejected",
+        reason: "graph_mode_required",
+        memory: { id: null },
+      });
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
Automated AFK landing for #867. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #867

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784840551&installation_id=129708444&pr_number=875&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F875&signature=c7a7860ecc634669f84ccf78605a101ec0bfcbdd99ace7b428794a73ecd44e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `memory store-evidence` CLI command for storing evidence claims with associated metadata (source references, citations, intent, and observer details).
  * Implemented governed write framework with built-in validation and policy enforcement, supporting both interactive and JSON output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->