### PR TITLE
merge: #868 Add Memory capsule CLI packaging over context-pack and handoff

### DIFF
--- a/apps/memory/src/capsule.ts
+++ b/apps/memory/src/capsule.ts
@@ -1,0 +1,198 @@
+import {
+  buildContextPack,
+  type ContextPack,
+  type ContextPackOptions,
+  type ContextPackStore,
+} from "./context-pack.js";
+import { buildMemoryHandoff, type MemoryHandoffReport } from "./handoff.js";
+import type { MemoryStore } from "./graph-store.js";
+import type { SkillRollup } from "./skill-events.js";
+
+export type MemoryCapsuleSourceKind = "context-pack" | "handoff";
+
+export interface MemoryCapsuleCitation {
+  marker: string | null;
+  urn: string;
+  rid: number;
+  source: string | null;
+}
+
+export interface MemoryCapsuleSource {
+  kind: MemoryCapsuleSourceKind;
+  schema_version: "memory.context_pack.v1" | "memory.handoff.v1";
+  status: string;
+}
+
+export interface MemoryCapsule {
+  schema_version: "memory.capsule.v1";
+  read_only: true;
+  source_read_only: true;
+  goal: string;
+  source: MemoryCapsuleSource;
+  budget_chars: number;
+  used_chars: number;
+  status: "ready" | "insufficient-context" | "empty";
+  citations: MemoryCapsuleCitation[];
+  markdown: string;
+}
+
+export interface MemoryCapsuleOptions {
+  source?: MemoryCapsuleSourceKind;
+  budgetChars?: number;
+  limit?: number;
+  depth?: number;
+  scope?: ContextPackOptions["scope"];
+  skillRollups?: SkillRollup[];
+}
+
+const DEFAULT_BUDGET_CHARS = 4_000;
+
+export async function buildMemoryCapsule(
+  store: MemoryStore & ContextPackStore,
+  goal: string,
+  options: MemoryCapsuleOptions = {},
+): Promise<MemoryCapsule> {
+  const normalizedGoal = goal.trim();
+  if (!normalizedGoal) throw new Error("nothing to package — pass a goal: memory capsule <goal>");
+  const budgetChars = Math.max(0, options.budgetChars ?? DEFAULT_BUDGET_CHARS);
+  const sourceKind = options.source ?? "context-pack";
+  if (sourceKind === "handoff") {
+    const handoff = await buildMemoryHandoff(store, {
+      focus: normalizedGoal,
+      limit: options.limit,
+    });
+    return capsuleFromHandoff(normalizedGoal, handoff, budgetChars);
+  }
+
+  const pack = await buildContextPack(store, normalizedGoal, {
+    budgetChars,
+    limit: options.limit,
+    depth: options.depth,
+    scope: options.scope,
+    skillRollups: options.skillRollups,
+  });
+  return capsuleFromContextPack(normalizedGoal, pack, budgetChars);
+}
+
+function capsuleFromContextPack(
+  goal: string,
+  pack: ContextPack,
+  budgetChars: number,
+): MemoryCapsule {
+  const citations = pack.entries.map((entry) => ({
+    marker: entry.citation.marker,
+    urn: entry.citation.urn,
+    rid: entry.citation.rid,
+    source: entry.citation.source,
+  }));
+  const status = pack.status === "ok" ? "ready" : "insufficient-context";
+  const markdown = renderCapsuleMarkdown({
+    goal,
+    sourceLabel: "Memory context pack",
+    sourceStatus: pack.status,
+    sourceMarkdown: pack.markdown,
+    citations,
+    budgetChars,
+  });
+  return {
+    schema_version: "memory.capsule.v1",
+    read_only: true,
+    source_read_only: true,
+    goal,
+    source: {
+      kind: "context-pack",
+      schema_version: "memory.context_pack.v1",
+      status: pack.status,
+    },
+    budget_chars: budgetChars,
+    used_chars: markdown.length,
+    status,
+    citations,
+    markdown,
+  };
+}
+
+function capsuleFromHandoff(
+  goal: string,
+  handoff: MemoryHandoffReport,
+  budgetChars: number,
+): MemoryCapsule {
+  const citations = handoff.sections.flatMap((section) =>
+    section.items.map((item) => ({
+      marker: null,
+      urn: item.citation,
+      rid: item.rid,
+      source: item.source,
+    })),
+  );
+  const markdown = renderCapsuleMarkdown({
+    goal,
+    sourceLabel: "Memory handoff",
+    sourceStatus: handoff.status,
+    sourceMarkdown: handoff.markdown,
+    citations,
+    budgetChars,
+  });
+  return {
+    schema_version: "memory.capsule.v1",
+    read_only: true,
+    source_read_only: handoff.read_only,
+    goal,
+    source: {
+      kind: "handoff",
+      schema_version: handoff.schema_version,
+      status: handoff.status,
+    },
+    budget_chars: budgetChars,
+    used_chars: markdown.length,
+    status: handoff.status === "ready" ? "ready" : "empty",
+    citations,
+    markdown,
+  };
+}
+
+function renderCapsuleMarkdown(input: {
+  goal: string;
+  sourceLabel: string;
+  sourceStatus: string;
+  sourceMarkdown: string;
+  citations: MemoryCapsuleCitation[];
+  budgetChars: number;
+}): string {
+  const citationSummary =
+    input.citations.length === 0
+      ? "Citations: none"
+      : `Citations: ${input.citations.map((citation) => citation.marker ?? citation.urn).join(", ")}`;
+  const prefix = [
+    `# Memory capsule: ${input.goal}`,
+    "",
+    "Ready-to-inject context.",
+    `Source: ${input.sourceLabel}`,
+    `Source status: ${input.sourceStatus}`,
+    "Storage: none; this capsule packages read-only Memory evidence.",
+    citationSummary,
+    "",
+    "## Packaged evidence",
+    "",
+  ].join("\n");
+  const suffix = input.citations.length > 0 ? `\n\n## Provenance\n\n${renderCitations(input.citations)}` : "";
+  return fitToBudget(`${prefix}${input.sourceMarkdown}${suffix}`, input.budgetChars);
+}
+
+function renderCitations(citations: MemoryCapsuleCitation[]): string {
+  return citations
+    .map((citation) => {
+      const marker = citation.marker ? `${citation.marker} ` : "";
+      const source = citation.source ? `; source: ${citation.source}` : "";
+      return `- ${marker}${citation.urn}${source}`;
+    })
+    .join("\n");
+}
+
+function fitToBudget(markdown: string, budgetChars: number): string {
+  if (markdown.length <= budgetChars) return markdown;
+  if (budgetChars <= 0) return "";
+  const marker = "\n\n[...capsule truncated to fit budget...]";
+  if (budgetChars <= marker.length) return marker.slice(0, budgetChars);
+  return `${markdown.slice(0, budgetChars - marker.length).trimEnd()}${marker}`;
+}

--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -23,6 +23,7 @@ import {
   restoreMemoryBackup,
 } from "./backup.js";
 import { buildMemoryCapabilityCatalog } from "./capability-catalog.js";
+import { buildMemoryCapsule, type MemoryCapsuleSourceKind } from "./capsule.js";
 import { buildMemoryAssetInventory } from "./asset-inventory.js";
 import { buildMemoryAssetInventoryViewerArtifact } from "./asset-inventory-viewer.js";
 import { buildMemoryAgentIntegrationStatus } from "./agent-integration-status.js";
@@ -310,7 +311,7 @@ Common workflows:
   remember one fact          memory store "Decision: ..."
   get context before acting  memory recall "topic"
   map code before reading    memory map-context "who calls token refresh?"
-  prepare another agent      memory context-pack "goal"  | memory handoff "focus"
+  prepare another agent      memory capsule "goal"       | memory context-pack "goal"
   decide if safe to proceed  memory readiness "goal"     | memory claim-check "assertion"
   search every surface       memory smart-search "query"
   operate/debug Memory       memory workbench             | memory health-viewer | memory governance
@@ -341,6 +342,7 @@ Usage:
   memory whatif                     [--root <dir>] --change "<descriptor>" [--change "<descriptor>" ...] [--limit N] [--json]
   memory autocure                   [--root <dir>] [--apply] [--stale-days N] [--json]
   memory smart-search <query...>    [--root <dir>] [--limit N] [--depth N] [--json]
+  memory capsule <goal...>          [--root <dir>] [--source context-pack|handoff] [--budget N] [--limit N] [--json] [--scope ...] [--scope-id ID] [--include-narrower-scopes]
   memory smart-search-viewer <query...> [--root <dir>] [--limit N] [--depth N] [--out <file>]
   memory context-pack <goal...>     [--root <dir>] [--budget N] [--limit N] [--json] [--scope ...] [--scope-id ID] [--include-narrower-scopes]
   memory context-pack-viewer <goal...> [--root <dir>] [--budget N] [--limit N] [--depth N] [--out <file>] [--scope ...] [--scope-id ID] [--include-narrower-scopes]
@@ -1690,6 +1692,37 @@ async function runContextPack(args: ParsedArgs): Promise<void> {
   } finally {
     await store.close();
   }
+}
+
+async function runCapsule(args: ParsedArgs): Promise<void> {
+  const goal = args.positional.join(" ").trim();
+  if (!goal) throw new Error("nothing to package — pass a goal: memory capsule <goal>");
+  const { store } = await openGraphStore(args);
+  try {
+    const source = capsuleSourceFlag(args.flags);
+    const skillRollups = source === "context-pack" ? await readSkillRollups(store) : [];
+    const capsule = await buildMemoryCapsule(store, goal, {
+      source,
+      budgetChars: intFlag(args.flags, "budget"),
+      limit: intFlag(args.flags, "limit"),
+      depth: intFlag(args.flags, "depth"),
+      scope: scopeFlags(args.flags),
+      skillRollups,
+    });
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(capsule, null, 2));
+      return;
+    }
+    process.stdout.write(capsule.markdown);
+  } finally {
+    await store.close();
+  }
+}
+
+function capsuleSourceFlag(flags: ParsedArgs["flags"]): MemoryCapsuleSourceKind {
+  const source = stringFlag(flags, "source") ?? "context-pack";
+  if (source === "context-pack" || source === "handoff") return source;
+  throw new Error(`invalid capsule source "${source}" — expected context-pack or handoff`);
 }
 
 async function runContextPackViewer(args: ParsedArgs): Promise<void> {
@@ -7896,6 +7929,8 @@ async function main(): Promise<void> {
       return runAutocure(args);
     case "smart-search-viewer":
       return runSmartSearchViewer(args);
+    case "capsule":
+      return runCapsule(args);
     case "context-pack":
       return runContextPack(args);
     case "context-pack-viewer":

--- a/apps/memory/tests/capsule-cli.test.ts
+++ b/apps/memory/tests/capsule-cli.test.ts
@@ -1,0 +1,159 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { MemoryStore } from "../src/graph-store.js";
+import { initGraph } from "../src/init.js";
+
+const TIMEOUT = 40_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "memory-capsule-cli-"));
+  roots.push(root);
+  return root;
+}
+
+async function seedCapsuleStore(root: string): Promise<void> {
+  await initGraph(root);
+  const store = await MemoryStore.open({ uri: `file://${join(root, ".red/memory/graph.rdb")}` });
+  try {
+    await store.upsertNode({
+      label: "jwt-docs-decision",
+      node_type: "decision",
+      properties: {
+        title: "JWT docs decision",
+        content: "Decision: JWT token changes must update docs/security.md.",
+        source: "manual",
+        confidence: "EXTRACTED",
+        importance: 0.9,
+        created_at: 1_700_000_000_000,
+      },
+    });
+    await store.upsertNode({
+      label: "jwt-cache-risk",
+      node_type: "problem",
+      properties: {
+        title: "JWT cache risk",
+        content: "Risk: cache TTL can outlive rotated JWT signing material.",
+        source: "manual",
+        confidence: "INFERRED",
+        importance: 0.7,
+        created_at: 1_700_000_100_000,
+      },
+    });
+  } finally {
+    await store.close();
+  }
+}
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+describe("memory capsule CLI", () => {
+  test(
+    "packages a context-pack capsule with preserved citations and no capsule storage",
+    async () => {
+      const root = await tempRoot();
+      await seedCapsuleStore(root);
+
+      const result = runMemory([
+        "capsule",
+        "jwt token work",
+        "--root",
+        root,
+        "--budget",
+        "1600",
+        "--source",
+        "context-pack",
+        "--json",
+      ]);
+
+      expect(result.status, result.stderr).toBe(0);
+      const capsule = JSON.parse(result.stdout) as {
+        schema_version: string;
+        read_only: boolean;
+        source: { kind: string; schema_version: string; status: string };
+        budget_chars: number;
+        used_chars: number;
+        markdown: string;
+        citations: Array<{ marker: string | null; urn: string; source: string | null }>;
+      };
+
+      expect(capsule).toMatchObject({
+        schema_version: "memory.capsule.v1",
+        read_only: true,
+        source: {
+          kind: "context-pack",
+          schema_version: "memory.context_pack.v1",
+          status: "ok",
+        },
+      });
+      expect(capsule.used_chars).toBeLessThanOrEqual(capsule.budget_chars);
+      expect(capsule.markdown).toContain("Ready-to-inject context");
+      expect(capsule.markdown).toContain("## Packaged evidence");
+      expect(capsule.citations[0]).toMatchObject({
+        marker: "[M1]",
+        urn: expect.stringMatching(/^memory_nodes:/),
+        source: "manual",
+      });
+      expect(capsule.markdown).toContain("urn: memory_nodes:");
+
+      const memoryFiles = await readdir(join(root, ".red/memory"));
+      expect(memoryFiles.some((name) => name.includes("capsule"))).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "packages a handoff capsule over the read-only handoff report",
+    async () => {
+      const root = await tempRoot();
+      await seedCapsuleStore(root);
+
+      const result = runMemory([
+        "capsule",
+        "jwt",
+        "--root",
+        root,
+        "--source",
+        "handoff",
+        "--json",
+      ]);
+
+      expect(result.status, result.stderr).toBe(0);
+      const capsule = JSON.parse(result.stdout) as {
+        source: { kind: string; schema_version: string; status: string };
+        source_read_only: boolean;
+        citations: Array<{ marker: string | null; urn: string; rid: number }>;
+        markdown: string;
+      };
+
+      expect(capsule.source).toMatchObject({
+        kind: "handoff",
+        schema_version: "memory.handoff.v1",
+        status: "ready",
+      });
+      expect(capsule.source_read_only).toBe(true);
+      expect(capsule.citations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ marker: null, urn: expect.stringMatching(/^decision:jwt-docs-decision#/) }),
+        ]),
+      );
+      expect(capsule.markdown).toContain("# Memory capsule: jwt");
+      expect(capsule.markdown).toContain("Memory handoff");
+    },
+    TIMEOUT,
+  );
+});

--- a/apps/memory/vitest.suites.ts
+++ b/apps/memory/vitest.suites.ts
@@ -33,6 +33,7 @@ export const INTEGRATION_TESTS: readonly string[] = [
   "as-of-recall.test.ts",
   "backup.test.ts",
   "capability-catalog.test.ts",
+  "capsule-cli.test.ts",
   "claim-check-cli.test.ts",
   "classify-cli.test.ts",
   "code-drift-cli.test.ts",


### PR DESCRIPTION
Automated AFK landing for #868. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #868

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784841748&installation_id=129708444&pr_number=876&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F876&signature=f092e4ce8285da431b54caaccb6c52cdf4f3aeeeebdf750eb605a80626b1a121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->