### PR TITLE
Improve Codex AFK visibility diagnostics

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { fleetCommand } from "./commands/fleet.js";
 import { activityReviewCommand } from "./commands/activity-review.js";
+import { codexStatuslineCommand } from "./commands/codex-statusline.js";
 import { dashboardCommand } from "./commands/dashboard.js";
 import { injectDevelopmentWorkflowCommand } from "./commands/inject-development-workflow.js";
 import { monitorCommand } from "./commands/monitor.js";
@@ -32,6 +33,7 @@ export type CliCommand =
   | "respond"
   | "ship"
   | "triage"
+  | "codex-statusline"
   | "route-model-tier"
   | "statusline"
   | "inject-development-workflow"
@@ -67,6 +69,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     respond: {},
     ship: {},
     triage: {},
+    "codex-statusline": {},
     "route-model-tier": {},
     statusline: {},
     "inject-development-workflow": {},
@@ -111,6 +114,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "respond") return respondCommand(parsed.args);
   if (parsed.command === "ship") return shipCommand(parsed.args);
   if (parsed.command === "triage") return triageCommand(parsed.args);
+  if (parsed.command === "codex-statusline") return codexStatuslineCommand(parsed.args);
   if (parsed.command === "route-model-tier") return routeModelTierCommand(parsed.args);
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);
   if (parsed.command === "inject-development-workflow") return injectDevelopmentWorkflowCommand(parsed.args);

--- a/apps/dev/src/commands/codex-statusline.ts
+++ b/apps/dev/src/commands/codex-statusline.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  CODEX_STATUSLINE_RECOMMENDED,
+  ensureCodexTaskProgress,
+  formatCodexStatusLine,
+  inspectCodexStatuslineConfig,
+  type CodexStatuslineInspection,
+} from "../core/codex-statusline.js";
+
+export interface CodexStatuslineCommandOptions {
+  configPath?: string;
+  json?: boolean;
+  fix?: boolean;
+}
+
+function parseArgs(args: readonly string[]): CodexStatuslineCommandOptions {
+  const out: CodexStatuslineCommandOptions = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--fix") {
+      out.fix = true;
+    } else if (arg === "--config") {
+      const value = args[++i];
+      if (!value) throw new Error("codex-statusline --config requires a path");
+      out.configPath = value;
+    } else if (arg.startsWith("--config=")) {
+      out.configPath = arg.slice("--config=".length);
+    } else {
+      throw new Error(`unknown codex-statusline argument '${arg}'`);
+    }
+  }
+  return out;
+}
+
+function defaultConfigPath(): string {
+  return join(homedir(), ".codex", "config.toml");
+}
+
+function writeAtomic(path: string, text: string): void {
+  const tmp = `${path}.redskills.tmp`;
+  writeFileSync(tmp, text);
+  renameSync(tmp, path);
+}
+
+function statusWord(inspection: CodexStatuslineInspection): "ok" | "warn" {
+  return inspection.problem === null ? "ok" : "warn";
+}
+
+function renderPlain(path: string, inspection: CodexStatuslineInspection, changed: boolean): string {
+  const lines = [
+    `codex-statusline: ${statusWord(inspection)}`,
+    `config: ${path}`,
+  ];
+  if (changed) lines.push("updated: added task-progress to tui.status_line");
+  if (inspection.statusLine !== null) {
+    lines.push(`current: ${formatCodexStatusLine(inspection.statusLine)}`);
+  } else {
+    lines.push("current: <unset>");
+  }
+  lines.push(`recommended: ${formatCodexStatusLine(CODEX_STATUSLINE_RECOMMENDED)}`);
+  if (inspection.parseError) lines.push(`parse-error: ${inspection.parseError}`);
+  if (inspection.problem === "hidden") {
+    lines.push("note: status_line is [], so the Codex footer is intentionally hidden.");
+  } else if (inspection.problem === "missing-task-progress") {
+    lines.push("note: task-progress is missing, so Codex cannot show native task/subagent progress in the footer.");
+    lines.push("fix: afk codex-statusline --fix");
+  } else if (inspection.problem === "missing-tui" || inspection.problem === "missing-status-line") {
+    lines.push("note: Codex will use its built-in default footer, which does not include task-progress.");
+    lines.push("fix: afk codex-statusline --fix");
+  }
+  lines.push("boundary: Codex supports built-in footer IDs only; use /afk monitor for rich AFK worker state.");
+  lines.push("opencode: AFK API-auth runner only; no interactive host footer/plugin UI.");
+  return `${lines.join("\n")}\n`;
+}
+
+export async function codexStatuslineCommand(
+  args: string[],
+  stdout: NodeJS.WritableStream = process.stdout,
+): Promise<number> {
+  const options = parseArgs(args);
+  const path = options.configPath ?? defaultConfigPath();
+
+  if (!existsSync(path)) {
+    const payload = {
+      status: "warn",
+      config: path,
+      exists: false,
+      recommended: CODEX_STATUSLINE_RECOMMENDED,
+    };
+    stdout.write(options.json ? `${JSON.stringify(payload)}\n` : `codex-statusline: warn\nconfig: ${path}\ncurrent: <missing file>\nrecommended: ${formatCodexStatusLine(CODEX_STATUSLINE_RECOMMENDED)}\nfix: create ${path} or run Codex once, then afk codex-statusline --fix\n`);
+    return 0;
+  }
+
+  const before = readFileSync(path, "utf8");
+  let changed = false;
+  let text = before;
+  if (options.fix) {
+    text = ensureCodexTaskProgress(before);
+    changed = text !== before;
+    if (changed) writeAtomic(path, text);
+  }
+  const inspection = inspectCodexStatuslineConfig(text);
+
+  if (options.json) {
+    stdout.write(`${JSON.stringify({
+      status: statusWord(inspection),
+      config: path,
+      changed,
+      ...inspection,
+      recommended: CODEX_STATUSLINE_RECOMMENDED,
+    })}\n`);
+    return 0;
+  }
+
+  stdout.write(renderPlain(path, inspection, changed));
+  return 0;
+}

--- a/apps/dev/src/core/codex-statusline.ts
+++ b/apps/dev/src/core/codex-statusline.ts
@@ -1,0 +1,161 @@
+export const CODEX_STATUSLINE_RECOMMENDED = [
+  "project",
+  "git-branch",
+  "model-with-reasoning",
+  "context-remaining",
+  "task-progress",
+] as const;
+
+export interface CodexStatuslineInspection {
+  statusLine: string[] | null;
+  hidden: boolean;
+  hasTaskProgress: boolean;
+  problem: "missing-tui" | "missing-status-line" | "hidden" | "missing-task-progress" | null;
+  parseError?: string;
+}
+
+function splitLines(text: string): string[] {
+  return text.split(/\n/);
+}
+
+function findTuiSection(lines: readonly string[]): { header: number; end: number } | null {
+  let header = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*\[tui\]\s*(#.*)?$/.test(lines[i])) {
+      header = i;
+      break;
+    }
+  }
+  if (header < 0) return null;
+  let end = lines.length;
+  for (let i = header + 1; i < lines.length; i++) {
+    if (/^\s*\[/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return { header, end };
+}
+
+function stripTomlComment(value: string): string {
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "\"") {
+      inString = !inString;
+      continue;
+    }
+    if (ch === "#" && !inString) return value.slice(0, i).trimEnd();
+  }
+  return value.trimEnd();
+}
+
+function findStatusLine(lines: readonly string[], section: { header: number; end: number }): number {
+  for (let i = section.header + 1; i < section.end; i++) {
+    if (/^\s*status_line\s*=/.test(lines[i])) return i;
+  }
+  return -1;
+}
+
+function parseStatusLineValue(line: string): { value: string[] | null; parseError?: string } {
+  const eq = line.indexOf("=");
+  if (eq < 0) return { value: null, parseError: "missing '=' in status_line" };
+  const raw = stripTomlComment(line.slice(eq + 1).trim());
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((item): item is string => typeof item === "string")
+    ) {
+      return { value: parsed };
+    }
+    return { value: null, parseError: "status_line must be an array of strings" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { value: null, parseError: message };
+  }
+}
+
+export function inspectCodexStatuslineConfig(text: string): CodexStatuslineInspection {
+  const lines = splitLines(text);
+  const section = findTuiSection(lines);
+  if (section === null) {
+    return {
+      statusLine: null,
+      hidden: false,
+      hasTaskProgress: false,
+      problem: "missing-tui",
+    };
+  }
+  const statusLineIdx = findStatusLine(lines, section);
+  if (statusLineIdx < 0) {
+    return {
+      statusLine: null,
+      hidden: false,
+      hasTaskProgress: false,
+      problem: "missing-status-line",
+    };
+  }
+  const parsed = parseStatusLineValue(lines[statusLineIdx]);
+  if (parsed.value === null) {
+    return {
+      statusLine: null,
+      hidden: false,
+      hasTaskProgress: false,
+      problem: "missing-task-progress",
+      parseError: parsed.parseError,
+    };
+  }
+  const hidden = parsed.value.length === 0;
+  const hasTaskProgress = parsed.value.includes("task-progress");
+  return {
+    statusLine: parsed.value,
+    hidden,
+    hasTaskProgress,
+    problem: hidden ? "hidden" : hasTaskProgress ? null : "missing-task-progress",
+  };
+}
+
+export function formatCodexStatusLine(items: readonly string[]): string {
+  return `[${items.map((item) => JSON.stringify(item)).join(", ")}]`;
+}
+
+export function ensureCodexTaskProgress(text: string): string {
+  const lines = splitLines(text);
+  const section = findTuiSection(lines);
+  if (section === null) {
+    const out = [...lines];
+    if (out.length > 0 && out[out.length - 1] !== "") out.push("");
+    out.push("[tui]", `status_line = ${formatCodexStatusLine(CODEX_STATUSLINE_RECOMMENDED)}`, "");
+    return out.join("\n");
+  }
+
+  const statusLineIdx = findStatusLine(lines, section);
+  if (statusLineIdx < 0) {
+    const out = [...lines];
+    out.splice(section.header + 1, 0, `status_line = ${formatCodexStatusLine(CODEX_STATUSLINE_RECOMMENDED)}`);
+    return out.join("\n");
+  }
+
+  const parsed = parseStatusLineValue(lines[statusLineIdx]);
+  const current = parsed.value;
+  if (current === null || current.length === 0 || current.includes("task-progress")) return text;
+
+  const next = [...current];
+  const afterCurrentDir = next.indexOf("current-dir");
+  next.splice(afterCurrentDir >= 0 ? afterCurrentDir + 1 : next.length, 0, "task-progress");
+
+  const indent = lines[statusLineIdx].match(/^\s*/)?.[0] ?? "";
+  const out = [...lines];
+  out[statusLineIdx] = `${indent}status_line = ${formatCodexStatusLine(next)}`;
+  return out.join("\n");
+}

--- a/apps/dev/tests/cli-routing.test.ts
+++ b/apps/dev/tests/cli-routing.test.ts
@@ -34,6 +34,13 @@ describe("cli routing — native commands", () => {
     expect(parseCli(["statusline", "/repo"])).toEqual({ command: "statusline", args: ["/repo"] });
   });
 
+  it("routes codex-statusline with its config/fix flags preserved", () => {
+    expect(parseCli(["codex-statusline", "--config", "/tmp/config.toml", "--fix"])).toEqual({
+      command: "codex-statusline",
+      args: ["--config", "/tmp/config.toml", "--fix"],
+    });
+  });
+
   it("routes dashboard with reporting flags preserved", () => {
     expect(parseCli(["dashboard", "--period", "14d", "--json"])).toEqual({
       command: "dashboard",

--- a/apps/dev/tests/codex-statusline.test.ts
+++ b/apps/dev/tests/codex-statusline.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  ensureCodexTaskProgress,
+  formatCodexStatusLine,
+  inspectCodexStatuslineConfig,
+} from "../src/core/codex-statusline.js";
+import { codexStatuslineCommand } from "../src/commands/codex-statusline.js";
+
+function sink(): { stream: NodeJS.WritableStream; text: () => string } {
+  let buf = "";
+  const stream = {
+    write(chunk: string | Uint8Array): boolean {
+      buf += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+      return true;
+    },
+  } as unknown as NodeJS.WritableStream;
+  return { stream, text: () => buf };
+}
+
+describe("codex statusline config inspection", () => {
+  it("detects a custom footer that omits task-progress", () => {
+    const out = inspectCodexStatuslineConfig(`
+[tui]
+status_line = ["model-with-reasoning", "context-remaining", "current-dir"]
+`);
+    expect(out.problem).toBe("missing-task-progress");
+    expect(out.hasTaskProgress).toBe(false);
+    expect(out.statusLine).toEqual(["model-with-reasoning", "context-remaining", "current-dir"]);
+  });
+
+  it("reports ok when task-progress is present", () => {
+    const out = inspectCodexStatuslineConfig(`
+[tui]
+status_line = ["model-with-reasoning", "task-progress"]
+`);
+    expect(out.problem).toBeNull();
+    expect(out.hasTaskProgress).toBe(true);
+  });
+
+  it("treats an empty footer as an intentional hide", () => {
+    const out = inspectCodexStatuslineConfig(`
+[tui]
+status_line = []
+`);
+    expect(out.problem).toBe("hidden");
+    expect(out.hidden).toBe(true);
+  });
+
+  it("appends task-progress after current-dir without changing other widgets", () => {
+    const text = `
+[tui]
+status_line = ["model-with-reasoning", "context-remaining", "current-dir", "used-tokens"]
+`;
+    expect(ensureCodexTaskProgress(text)).toContain(
+      'status_line = ["model-with-reasoning", "context-remaining", "current-dir", "task-progress", "used-tokens"]',
+    );
+  });
+
+  it("inserts a recommended footer when the tui table has no status_line", () => {
+    const text = `
+[tui]
+notifications = false
+`;
+    const next = ensureCodexTaskProgress(text);
+    expect(next).toContain("notifications = false");
+    expect(next).toContain(`status_line = ${formatCodexStatusLine([
+      "project",
+      "git-branch",
+      "model-with-reasoning",
+      "context-remaining",
+      "task-progress",
+    ])}`);
+  });
+});
+
+describe("codex-statusline command", () => {
+  it("prints a warning and can fix a missing task-progress footer", async () => {
+    const root = await mkdtemp(join(tmpdir(), "codex-statusline-"));
+    const config = join(root, "config.toml");
+    await writeFile(config, '[tui]\nstatus_line = ["model-with-reasoning", "current-dir"]\n', "utf8");
+    try {
+      const warn = sink();
+      await codexStatuslineCommand(["--config", config], warn.stream);
+      expect(warn.text()).toContain("codex-statusline: warn");
+      expect(warn.text()).toContain("task-progress is missing");
+
+      const fixed = sink();
+      await codexStatuslineCommand(["--config", config, "--fix"], fixed.stream);
+      expect(fixed.text()).toContain("codex-statusline: ok");
+      expect(fixed.text()).toContain("updated: added task-progress");
+      expect(await readFile(config, "utf8")).toContain('"task-progress"');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -87,9 +87,21 @@ is a personal host preference, not repo state. There is no command hook, so the
 shared RedSkills `statusline` producer cannot be injected into the footer yet.
 
 Codex has a native `/statusline` command for picking and reordering these
-footer items and persisting them to `config.toml`. If the user already has a
-custom `tui.status_line`, preserve it; that custom value is the operator's host
-preference, not repo state.
+footer items and persisting them to `config.toml`. The dev bundle also exposes
+an explicit inspector/fixer:
+
+```bash
+node "$CODEX_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" codex-statusline
+node "$CODEX_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" codex-statusline --fix
+```
+
+The inspector reports the active `tui.status_line`, flags a missing
+`task-progress` widget, prints the recommended order, and reminds the operator
+that rich AFK worker state still lives in `/afk monitor`. `--fix` is explicit:
+it appends `task-progress` to an existing visible footer or installs the
+recommended footer when `status_line` is absent. If the user already has a
+custom `tui.status_line`, preserve it unless they explicitly ask for `--fix`;
+that custom value is the operator's host preference, not repo state.
 
 Offer to set a useful footer (note: this is **global** Codex config, not
 per-repo like the Claude path):
@@ -120,6 +132,15 @@ spawns a read-only monitor agent; otherwise it falls back to the monitor
 dashboard). When Codex ships a command-backed statusline (openai/codex#17827 /
 #20244), this skill can add a `{ type = "command", command = … }` entry pointing
 at the same AFK bundle so the line matches Claude Code's.
+
+## OpenCode
+
+OpenCode is not a Codex/Claude-style host UI in RedSkills. It is the AFK
+API-auth runner lane selected explicitly with `--runner opencode` or
+`RED_AFK_RUNNER=opencode`; AFK observes it through the same GitHub envelopes,
+worker logs, `/afk monitor`, `/afk dashboard`, and Actions output as any other
+runner. There is no OpenCode footer/statusline adapter to install here because
+there is no interactive RedSkills-hosted OpenCode plugin surface.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

- Add `codex-statusline` to the dev/AFK CLI to inspect Codex `tui.status_line` and flag a missing `task-progress` widget.
- Add explicit `--fix` behavior that appends `task-progress` or installs the recommended footer only when the operator asks for it.
- Update `setup-statusline` docs to explain Codex's built-in footer boundary and OpenCode's role as an AFK API-auth runner, not an interactive host UI.

Refs #877

## Validation

- `pnpm -C apps/dev exec vitest run tests/codex-statusline.test.ts tests/cli-routing.test.ts`
- `pnpm -C apps/dev exec tsc -p tsconfig.json --noEmit`
- `pnpm -C apps/dev exec tsx src/cli.ts codex-statusline --config /home/cyber/.codex/config.toml`
- `pnpm -C apps/dev exec tsx src/cli.ts codex-statusline --config /home/cyber/.codex/config.toml --json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784854887&installation_id=129708444&pr_number=878&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F878&signature=a5122342133832ad119627e6983a14dedf39dd31fe719a994efc3f49e3861bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `codex-statusline` CLI command to inspect and fix Codex statusline configuration, including automatic detection of missing `task-progress` entries and auto-repair via `--fix` flag.
  * Supports `--json` output format for programmatic use.

* **Documentation**
  * Updated statusline setup guidance with host-specific configuration instructions for Codex and OpenCode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->