### PR TITLE
Add Codex AFK monitor agent prompt

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { fleetCommand } from "./commands/fleet.js";
 import { activityReviewCommand } from "./commands/activity-review.js";
+import { codexMonitorAgentCommand } from "./commands/codex-monitor-agent.js";
 import { codexStatuslineCommand } from "./commands/codex-statusline.js";
 import { dashboardCommand } from "./commands/dashboard.js";
 import { injectDevelopmentWorkflowCommand } from "./commands/inject-development-workflow.js";
@@ -33,6 +34,7 @@ export type CliCommand =
   | "respond"
   | "ship"
   | "triage"
+  | "codex-monitor-agent"
   | "codex-statusline"
   | "route-model-tier"
   | "statusline"
@@ -69,6 +71,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     respond: {},
     ship: {},
     triage: {},
+    "codex-monitor-agent": {},
     "codex-statusline": {},
     "route-model-tier": {},
     statusline: {},
@@ -114,6 +117,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "respond") return respondCommand(parsed.args);
   if (parsed.command === "ship") return shipCommand(parsed.args);
   if (parsed.command === "triage") return triageCommand(parsed.args);
+  if (parsed.command === "codex-monitor-agent") return codexMonitorAgentCommand(parsed.args);
   if (parsed.command === "codex-statusline") return codexStatuslineCommand(parsed.args);
   if (parsed.command === "route-model-tier") return routeModelTierCommand(parsed.args);
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);

--- a/apps/dev/src/commands/codex-monitor-agent.ts
+++ b/apps/dev/src/commands/codex-monitor-agent.ts
@@ -1,0 +1,77 @@
+import { renderCodexMonitorAgentPrompt, type CodexMonitorAgentMode } from "../core/codex-monitor-agent.js";
+
+export interface CodexMonitorAgentCommandOptions {
+  projectRoot?: string;
+  mode?: CodexMonitorAgentMode;
+  intervalSeconds?: number;
+  json?: boolean;
+}
+
+function parseMode(value: string): CodexMonitorAgentMode {
+  if (value === "run" || value === "fleet") return value;
+  throw new Error(`codex-monitor-agent --mode must be one of: run, fleet`);
+}
+
+function parsePositiveInteger(flag: string, value: string | undefined): number {
+  if (!value) throw new Error(`codex-monitor-agent ${flag} requires a value`);
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`codex-monitor-agent ${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(args: readonly string[]): CodexMonitorAgentCommandOptions {
+  const out: CodexMonitorAgentCommandOptions = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--project-root") {
+      const value = args[++i];
+      if (!value) throw new Error("codex-monitor-agent --project-root requires a path");
+      out.projectRoot = value;
+    } else if (arg.startsWith("--project-root=")) {
+      out.projectRoot = arg.slice("--project-root=".length);
+    } else if (arg === "--mode") {
+      const value = args[++i];
+      if (!value) throw new Error("codex-monitor-agent --mode requires a value");
+      out.mode = parseMode(value);
+    } else if (arg.startsWith("--mode=")) {
+      out.mode = parseMode(arg.slice("--mode=".length));
+    } else if (arg === "--interval-seconds") {
+      out.intervalSeconds = parsePositiveInteger("--interval-seconds", args[++i]);
+    } else if (arg.startsWith("--interval-seconds=")) {
+      out.intervalSeconds = parsePositiveInteger("--interval-seconds", arg.slice("--interval-seconds=".length));
+    } else {
+      throw new Error(`unknown codex-monitor-agent argument '${arg}'`);
+    }
+  }
+  return out;
+}
+
+export async function codexMonitorAgentCommand(
+  args: string[],
+  stdout: NodeJS.WritableStream = process.stdout,
+): Promise<number> {
+  const options = parseArgs(args);
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const prompt = renderCodexMonitorAgentPrompt({
+    projectRoot,
+    mode: options.mode,
+    intervalSeconds: options.intervalSeconds,
+  });
+
+  if (options.json) {
+    stdout.write(`${JSON.stringify({
+      projectRoot,
+      mode: options.mode ?? "run",
+      intervalSeconds: options.intervalSeconds,
+      prompt,
+    })}\n`);
+    return 0;
+  }
+
+  stdout.write(prompt);
+  return 0;
+}

--- a/apps/dev/src/core/codex-monitor-agent.ts
+++ b/apps/dev/src/core/codex-monitor-agent.ts
@@ -1,0 +1,83 @@
+export type CodexMonitorAgentMode = "run" | "fleet";
+export type CodexMonitorAgentLaunchCommand = CodexMonitorAgentMode | "monitor" | "dashboard" | "statusline" | "other";
+
+export type CodexMonitorAgentDecisionReason =
+  | "spawn"
+  | "not-codex-runner"
+  | "subagent-unavailable"
+  | "command-does-not-launch-worker"
+  | "single-supervised-run"
+  | "boot-only";
+
+export interface CodexMonitorAgentDecisionInput {
+  runner: string;
+  command: CodexMonitorAgentLaunchCommand;
+  subagentAvailable: boolean;
+  once?: boolean;
+  bootOnly?: boolean;
+}
+
+export interface CodexMonitorAgentDecision {
+  spawn: boolean;
+  reason: CodexMonitorAgentDecisionReason;
+}
+
+export interface CodexMonitorAgentPromptOptions {
+  projectRoot: string;
+  mode?: CodexMonitorAgentMode;
+  intervalSeconds?: number;
+  monitorCommand?: string;
+}
+
+export const DEFAULT_CODEX_MONITOR_INTERVAL_SECONDS = 30;
+
+export const DEFAULT_CODEX_MONITOR_COMMAND =
+  'rtk env RED_AFK_RUNNER=codex node "$CODEX_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" monitor --once';
+
+function normalizedRunner(runner: string): string {
+  return runner.trim().toLowerCase();
+}
+
+export function decideCodexMonitorAgent(input: CodexMonitorAgentDecisionInput): CodexMonitorAgentDecision {
+  if (normalizedRunner(input.runner) !== "codex") return { spawn: false, reason: "not-codex-runner" };
+  if (!input.subagentAvailable) return { spawn: false, reason: "subagent-unavailable" };
+  if (input.command !== "run" && input.command !== "fleet") {
+    return { spawn: false, reason: "command-does-not-launch-worker" };
+  }
+  if (input.once) return { spawn: false, reason: "single-supervised-run" };
+  if (input.bootOnly) return { spawn: false, reason: "boot-only" };
+  return { spawn: true, reason: "spawn" };
+}
+
+export function renderCodexMonitorAgentPrompt(options: CodexMonitorAgentPromptOptions): string {
+  const mode = options.mode ?? "run";
+  const intervalSeconds = options.intervalSeconds ?? DEFAULT_CODEX_MONITOR_INTERVAL_SECONDS;
+  const monitorCommand = options.monitorCommand ?? DEFAULT_CODEX_MONITOR_COMMAND;
+
+  return [
+    "You are the read-only Codex AFK monitor agent.",
+    "",
+    `Project root: ${options.projectRoot}`,
+    `AFK launch mode: ${mode}`,
+    "",
+    "Purpose: keep AFK progress visible in the Codex UI while the main session continues working.",
+    "",
+    "Loop:",
+    `1. Every ${intervalSeconds} seconds, from the project root, run:`,
+    `   ${monitorCommand}`,
+    "2. Report a concise progress update when live worker state changes, when a worker becomes stale/wedged, or at least every five minutes.",
+    "3. Exit once there is no live .red/tmp/afk-supervisor.pid and the monitor output has no [live] workers.",
+    "4. If the monitor command fails three times in a row, report the failure and exit.",
+    "",
+    "Hard read-only rules:",
+    "- Do not edit files.",
+    "- Do not run /dev:afk run, /dev:afk fleet, /dev:afk fleet stop, /dev:afk reap, /dev:afk requeue, /ship, /hitl, or /triage.",
+    "- Do not claim issues, edit labels, comment on issues, open PRs, merge, push, run validation suites, or stop workers.",
+    "- Do not repair state. Only observe and report.",
+    "",
+    "Allowed actions:",
+    "- Run the AFK monitor command above.",
+    "- Use read-only process/file checks such as ps, test -f, cat, tail, and ls when needed to decide whether to exit.",
+    "- Summarize worker id, issue number, runner, stage, live/stale/wedged state, duration, and diffstat.",
+  ].join("\n") + "\n";
+}

--- a/apps/dev/tests/cli-routing.test.ts
+++ b/apps/dev/tests/cli-routing.test.ts
@@ -41,6 +41,13 @@ describe("cli routing — native commands", () => {
     });
   });
 
+  it("routes codex-monitor-agent with prompt flags preserved", () => {
+    expect(parseCli(["codex-monitor-agent", "--project-root", "/repo", "--mode", "fleet"])).toEqual({
+      command: "codex-monitor-agent",
+      args: ["--project-root", "/repo", "--mode", "fleet"],
+    });
+  });
+
   it("routes dashboard with reporting flags preserved", () => {
     expect(parseCli(["dashboard", "--period", "14d", "--json"])).toEqual({
       command: "dashboard",

--- a/apps/dev/tests/codex-monitor-agent.test.ts
+++ b/apps/dev/tests/codex-monitor-agent.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { codexMonitorAgentCommand } from "../src/commands/codex-monitor-agent.js";
+import {
+  decideCodexMonitorAgent,
+  renderCodexMonitorAgentPrompt,
+} from "../src/core/codex-monitor-agent.js";
+
+function sink(): { stream: NodeJS.WritableStream; text: () => string } {
+  let buf = "";
+  const stream = {
+    write(chunk: string | Uint8Array): boolean {
+      buf += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+      return true;
+    },
+  } as unknown as NodeJS.WritableStream;
+  return { stream, text: () => buf };
+}
+
+describe("codex monitor agent decision", () => {
+  it("spawns for Codex run/fleet launches when a subagent primitive exists", () => {
+    expect(decideCodexMonitorAgent({
+      runner: "codex",
+      command: "run",
+      subagentAvailable: true,
+    })).toEqual({ spawn: true, reason: "spawn" });
+    expect(decideCodexMonitorAgent({
+      runner: "CODEX",
+      command: "fleet",
+      subagentAvailable: true,
+    })).toEqual({ spawn: true, reason: "spawn" });
+  });
+
+  it("does not spawn for supervised, dry-run, non-Codex, or non-launch commands", () => {
+    expect(decideCodexMonitorAgent({
+      runner: "claude",
+      command: "run",
+      subagentAvailable: true,
+    }).reason).toBe("not-codex-runner");
+    expect(decideCodexMonitorAgent({
+      runner: "codex",
+      command: "run",
+      subagentAvailable: false,
+    }).reason).toBe("subagent-unavailable");
+    expect(decideCodexMonitorAgent({
+      runner: "codex",
+      command: "run",
+      subagentAvailable: true,
+      once: true,
+    }).reason).toBe("single-supervised-run");
+    expect(decideCodexMonitorAgent({
+      runner: "codex",
+      command: "run",
+      subagentAvailable: true,
+      bootOnly: true,
+    }).reason).toBe("boot-only");
+    expect(decideCodexMonitorAgent({
+      runner: "codex",
+      command: "monitor",
+      subagentAvailable: true,
+    }).reason).toBe("command-does-not-launch-worker");
+  });
+});
+
+describe("codex monitor agent prompt", () => {
+  it("renders a read-only monitor contract for the spawned presentation agent", () => {
+    const prompt = renderCodexMonitorAgentPrompt({
+      projectRoot: "/repo",
+      mode: "fleet",
+      intervalSeconds: 10,
+    });
+    expect(prompt).toContain("Project root: /repo");
+    expect(prompt).toContain("AFK launch mode: fleet");
+    expect(prompt).toContain("Every 10 seconds");
+    expect(prompt).toContain("monitor --once");
+    expect(prompt).toContain("Do not edit files.");
+    expect(prompt).toContain("Do not run /dev:afk run");
+    expect(prompt).toContain("Do not repair state. Only observe and report.");
+    expect(prompt).toContain("Exit once there is no live .red/tmp/afk-supervisor.pid");
+  });
+
+  it("prints prompt JSON for host-layer spawn tooling", async () => {
+    const out = sink();
+    await codexMonitorAgentCommand([
+      "--project-root",
+      "/repo",
+      "--mode",
+      "run",
+      "--interval-seconds",
+      "15",
+      "--json",
+    ], out.stream);
+    const payload = JSON.parse(out.text()) as {
+      projectRoot: string;
+      mode: string;
+      intervalSeconds: number;
+      prompt: string;
+    };
+    expect(payload.projectRoot).toBe("/repo");
+    expect(payload.mode).toBe("run");
+    expect(payload.intervalSeconds).toBe(15);
+    expect(payload.prompt).toContain("read-only Codex AFK monitor agent");
+  });
+});

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -24,7 +24,7 @@ The invoking LLM is responsible for setting `RED_AFK_RUNNER` to its own host run
 
 `afk.mjs` is a **dedicated forwarder** (ADR 0039 entrypoint, build role `run:dev`): every argument is passed straight to the `dev` bundle, whose own command surface (`run`, `monitor`, `fleet`, …) is documented below. So `… afk.mjs run --once`, `… afk.mjs monitor`, and the bare `… afk.mjs --issues 42` all reach the orchestrator. The generic entrypoint verbs (`run <plugin>` / `fetch`) belong to `red-fetch.mjs`, not to this launcher — they do **not** shadow the bundle's commands (#434).
 
-Commands and their parameters are documented in *When To Use* below — that section is authoritative for the CLI surface. The commands are `run` (the default — a bare token routes here with argv preserved), `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, `fleet`, `reap`, `statusline` (the shared RedSkills statusline producer for command-backed host adapters; reads the host payload on stdin and resolves the project root from `$1` or the payload), and the hidden `__supervise` (the fleet supervisor entrypoint; never invoked by hand). `run` accepts `--prd`, `--issues`, `--runner`, `--alternate`, `--fallback-runner`, `--request`/`-r`, `-n`, `--once`, and `--boot-only`; `monitor` accepts `--once`; `dashboard` accepts `--period N|Nd` and `--json`; `daily-review` and `weekly-review` accept `--json`; `retake` accepts `#ISSUE`, `--apply`, `--json`, `--repo OWNER/REPO`, and `--pr-limit N`; `fleet` accepts an optional numeric target `N`, the `stop` subcommand, `--request`/`-r`, and `--runner`; `reap` takes no flags; `statusline` accepts an optional project-root path as `$1`.
+Commands and their parameters are documented in *When To Use* below — that section is authoritative for the CLI surface. The commands are `run` (the default — a bare token routes here with argv preserved), `monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, `fleet`, `reap`, `codex-statusline` (inspect/fix Codex's native footer widgets), `codex-monitor-agent` (emit the read-only Codex monitor-agent prompt for host-layer spawning), `statusline` (the shared RedSkills statusline producer for command-backed host adapters; reads the host payload on stdin and resolves the project root from `$1` or the payload), and the hidden `__supervise` (the fleet supervisor entrypoint; never invoked by hand). `run` accepts `--prd`, `--issues`, `--runner`, `--alternate`, `--fallback-runner`, `--request`/`-r`, `-n`, `--once`, and `--boot-only`; `monitor` accepts `--once`; `dashboard` accepts `--period N|Nd` and `--json`; `daily-review` and `weekly-review` accept `--json`; `retake` accepts `#ISSUE`, `--apply`, `--json`, `--repo OWNER/REPO`, and `--pr-limit N`; `fleet` accepts an optional numeric target `N`, the `stop` subcommand, `--request`/`-r`, and `--runner`; `reap` takes no flags; `codex-statusline` accepts `--config`, `--fix`, and `--json`; `codex-monitor-agent` accepts `--project-root`, `--mode run|fleet`, `--interval-seconds`, and `--json`; `statusline` accepts an optional project-root path as `$1`.
 
 The bundle is a single self-contained build (one file, one inlined runtime dependency, no `node_modules`, no install step) and is the public entrypoint. Every command — orchestration, supervisor, statusline, and hooks — executes natively in the bundle; the legacy shell orchestrator under `scripts/` has been removed (ADR 0032, ADR 0034). Treat this `SKILL.md` as the contract: run the bundle, don't read its source.
 
@@ -379,6 +379,38 @@ The monitor invocation handles its own teardown — see *Self-Cancel* under the 
 - The invocation is `/afk --once` (single supervised iteration; user is already watching).
 - `CronCreate` is unavailable (not running under Claude Code — e.g. Codex). Print one line `monitor loop unavailable in this runner; tail .red/tmp/workers/*/*/afk.log manually.` and continue.
 
+## Codex Monitor Agent (Codex only — binding)
+
+Codex does not expose Claude Code's `TaskCreate` / `TaskUpdate` task surface, and
+its `tui.status_line` only renders built-in footer widgets. It does expose a
+native sub-agent UI in hosts where the sub-agent primitive is available. For
+Codex runs, use that sub-agent UI as a read-only presentation layer over the
+canonical `/afk monitor` dashboard.
+
+When `/afk` launches a normal detached worker under Codex (`run`, not
+`monitor`, not `--once`, not `--boot-only`):
+
+1. Fetch a sub-agent spawn primitive via `ToolSearch` (query:
+   `spawn agent background monitor`).
+2. If unavailable, continue the worker launch and print:
+   `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/workers/*/*/afk.log manually.`
+3. If available, emit the canonical prompt from the bundle:
+   ```bash
+   RED_AFK_RUNNER=codex node "$CODEX_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" codex-monitor-agent --project-root "$PWD" --mode run
+   ```
+   Spawn exactly one monitor agent with that prompt. The monitor agent is a
+   presentation consumer only: it periodically runs `/dev:afk monitor --once`,
+   reports concise progress in the Codex UI, and exits once no supervisor or
+   live workers remain.
+4. Tell the user one line:
+   `Codex monitor agent spawned — auto-closes when AFK exits; manual monitor: /dev:afk monitor.`
+
+Hard boundaries for the monitor agent are non-negotiable: it must never edit
+files, claim issues, change labels, comment, stop workers, run validation, push,
+merge, `/ship`, `/hitl`, `/triage`, `/afk run`, `/afk fleet`, `/afk fleet stop`,
+`/afk reap`, or `/afk requeue`. Closing it manually must not affect the AFK
+worker.
+
 ## Fleet Mode (runner-portable — binding)
 
 `/dev:afk fleet [N]` and `/dev:afk fleet stop` are the user-facing fleet commands. They let one terminal command spin up (or shut down) `N` concurrent `run` workers on the current checkout, with the supervisor handling respawn, the circuit breaker, the **passive stall detector** (samples each slot's per-attempt **agent lane** `agent.log.jsonl` mtime — the clean liveness signal — every `RED_AFK_STALL_POLL_S=30s`; flags any slot alive ≥ `RED_AFK_STALL_THRESHOLD_S=600` whose agent lane has been idle ≥ the same — surfaces as `⏸️ stalled` in `/dev:afk monitor`. It keys off the agent lane, never `afk.log`/`log.jsonl`, because the orchestrator heartbeat writes those every minute and would mask a real stall — the masking that defeated detection in #243), the **hard stall reaper** (a slot silent on the agent lane past `RED_AFK_STALL_KILL_THRESHOLD_S=1800` is only a *candidate*: the irreversible kill is gated behind a reaper-signal predicate, so a worker mid-build/test — an active `vitest`/`tsc`/`cargo`/… descendant under its tree, or non-trivial aggregate cpu — is **busy** and left alone, while a genuinely stuck worker [idle past the threshold, no active descendant, flat cpu] is killed tree-wide, a `data-attempt-status="no-sentinel"` envelope is posted with the attempt-dir `afk.log` tail, the issue label is rotated back to `ready-for-agent`, the worktree + attempt dir are removed, and the slot is freed for the next health-check respawn — `RED_AFK_STALL_KILL_THRESHOLD_S` must be strictly greater than `RED_AFK_STALL_THRESHOLD_S`, validated at supervisor boot), and per-slot build isolation.
@@ -394,7 +426,7 @@ $ /dev:afk fleet 1   # every worker sees both vars
 Fleet mode is **runner-portable**: the supervisor is plain process orchestration, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all launch and stop the supervisor when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
 
 - Claude Code: schedule the auto-monitor cron when `CronCreate`/`CronList` are available; if not, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
-- Codex: launch fleet with `RED_AFK_RUNNER=codex`, skip cron, and spawn one read-only Codex monitor agent when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print the same manual-monitor guidance.
+- Codex: launch fleet with `RED_AFK_RUNNER=codex`, skip cron, and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print the same manual-monitor guidance.
 - Bare terminal / unknown runner: launch fleet, skip cron/native monitor, and print the manual-monitor guidance.
 
 ### `/dev:afk fleet [N]` — launch
@@ -415,7 +447,7 @@ Fleet mode is **runner-portable**: the supervisor is plain process orchestration
    The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/afk-supervisor.log`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**
    - Claude Code: same flow as *Auto-Monitor Loop* — `CronList` first to deduplicate, then `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. If cron tools are unavailable, skip and use the manual-monitor line.
-   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
+   - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex node "$CODEX_PLUGIN_ROOT/skills/engineering/afk/bin/afk.mjs" codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
    - Bare/unknown: skip native monitor setup and use the manual-monitor line.
 5. **Report back.** Print:
    ```
@@ -580,7 +612,7 @@ When `TaskCreate` / `TaskUpdate` are unavailable because the session is **outsid
 - If Codex grows a native background-task surface, the sink emits the **same call-plan descriptors** the Claude sink applies — apply them against the Codex primitive.
 - Otherwise (today's reality), `--runner codex` emits an **empty plan**, so the mirror falls back to the `monitor` dashboard and a one-line notice. No native calls are emitted, so there is no half-rendered state, and a dashboard hiccup is swallowed so the tick never crashes.
 
-**Codex monitor agent (fleet-specific — binding).** Codex has a native sub-agent UI even though it does not expose the Claude-style `TaskCreate`/`TaskUpdate` task API. When `/dev:afk fleet N` launches a new supervisor under Codex, the agent should spawn exactly one read-only Codex monitor agent when the sub-agent primitive is available. That monitor agent periodically runs `/dev:afk monitor --once`, reports concise progress, and exits once no supervisor or live workers remain. It is a presentation consumer only: it must not edit files, stop workers, claim issues, or merge anything. Closing it manually must not affect the fleet.
+**Codex monitor agent (Codex-only — binding).** Codex has a native sub-agent UI even though it does not expose the Claude-style `TaskCreate`/`TaskUpdate` task API. When `/dev:afk run` launches a normal detached worker under Codex, or `/dev:afk fleet N` launches a new supervisor under Codex, the agent should spawn exactly one read-only Codex monitor agent when the sub-agent primitive is available. Generate its prompt with `codex-monitor-agent --mode run|fleet` so the read-only rules stay identical across single-worker and fleet launches. That monitor agent periodically runs `/dev:afk monitor --once`, reports concise progress, and exits once no supervisor or live workers remain. It is a presentation consumer only: it must not edit files, stop workers, claim issues, run validation, push, merge, or repair state. Closing it manually must not affect the worker or fleet.
 
 Do **not** invent a cross-runner task abstraction (rejected in ADR 0003) — keep the adapter explicitly per-runner.
 

--- a/plugins/dev/skills/engineering/afk/runner-codex.md
+++ b/plugins/dev/skills/engineering/afk/runner-codex.md
@@ -90,24 +90,39 @@ differs. The Codex sink:
 This is an explicit per-runner adapter, not a cross-runner abstraction (rejected
 in ADR 0003).
 
-## Fleet Monitor Agent
+## Monitor Agent
 
 Codex does expose a native sub-agent UI, but that is not the same as Claude
-Code's `TaskCreate` / `TaskUpdate` task surface. `/afk fleet` therefore keeps
-the actual workers as supervised OS processes and uses one optional Codex
-monitor agent only for presentation.
+Code's `TaskCreate` / `TaskUpdate` task surface. `/afk run` and `/afk fleet`
+therefore keep the actual workers as supervised OS processes and use one
+optional Codex monitor agent only for presentation.
+
+When a Codex session launches a normal detached `/dev:afk run` worker:
+
+- skip the monitor agent for `--once` and `--boot-only`, because no background
+  worker needs a separate presentation surface;
+- fetch a sub-agent spawn primitive when the host exposes one;
+- generate the monitor-agent prompt with:
+  `afk codex-monitor-agent --project-root "$PWD" --mode run`;
+- spawn at most one read-only monitor agent for the newly-started worker;
+- have that monitor agent periodically run `/dev:afk monitor --once`, report
+  concise progress, and exit once no supervisor or live workers remain;
+- never let the monitor agent edit files, claim issues, stop workers, run
+  validation, merge, push, or repair state.
 
 When a Codex session launches `/dev:afk fleet N`:
 
 - launch `/dev:afk fleet N --runner codex` or invoke the bundle with
   `RED_AFK_RUNNER=codex` so detached workers stay on the Codex runner
   deterministically;
-- spawn at most one read-only monitor agent for the newly-started supervisor
-  when the sub-agent primitive is available;
+- generate the monitor-agent prompt with:
+  `afk codex-monitor-agent --project-root "$PWD" --mode fleet`;
+- spawn at most one read-only monitor agent for the newly-started supervisor when
+  the sub-agent primitive is available;
 - have that monitor agent periodically run `/dev:afk monitor --once`, report
   concise progress, and exit once no supervisor or live workers remain;
 - never let the monitor agent edit files, claim issues, stop workers, run
-  validation, merge, or push.
+  validation, merge, push, or repair state.
 
 If the sub-agent primitive is unavailable, launch the supervisor anyway and
 tell the user to run `/dev:afk monitor` or tail `.red/tmp/afk-supervisor.log`.

--- a/plugins/dev/skills/engineering/model-tier-policy/SKILL.md
+++ b/plugins/dev/skills/engineering/model-tier-policy/SKILL.md
@@ -56,7 +56,14 @@ Start with the cheapest capable tier, but escalate immediately when evidence sho
 
 ## Codex interactive
 
-Interactive Codex runs a **single session model** — it exposes no per-task subagent-with-model primitive analogous to Claude's Task/Agent tool (every `.codex-plugin/plugin.json` ships `agents: none`, and there is no interactive subagent dispatch surface), so an interactive session cannot pin a per-call model/effort. The model tier still applies to Codex through **AFK tier-routing**: the codex runner adapter (#455) resolves the per-issue tier into the sandcastle spawn's `--model`/`--effort`. Spike finding for #457; see ADR 0049.
+Interactive Codex runs a **single session model** for the main session and any
+host-level presentation subagents. Even when a Codex host exposes a native
+sub-agent UI, RedSkills does not yet have a per-task subagent-with-model
+primitive analogous to Claude's tiered `Task`/`Agent` wrappers, so an
+interactive session cannot pin a per-call model/effort. The model tier still
+applies to Codex through **AFK tier-routing**: the codex runner adapter (#455)
+resolves the per-issue tier into the sandcastle spawn's `--model`/`--effort`.
+Spike finding for #457; see ADR 0049.
 
 ## Executors
 

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -127,11 +127,14 @@ effects on the repo's `.red/config.yaml` `plugins.dev.enabled: true` flag. That
 keeps the installed plugin available everywhere but inert outside opted-in
 repos, matching the rest of the RedSkills hook model.
 
-For live AFK visibility under Codex, point the user at `/afk monitor` (fleet
-spawns a read-only monitor agent; otherwise it falls back to the monitor
-dashboard). When Codex ships a command-backed statusline (openai/codex#17827 /
-#20244), this skill can add a `{ type = "command", command = … }` entry pointing
-at the same AFK bundle so the line matches Claude Code's.
+For live AFK visibility under Codex, `/afk monitor` remains the canonical
+dashboard. Normal `/afk run` launches and `/afk fleet` launches also try to
+attach one read-only Codex monitor agent when the host exposes a sub-agent
+primitive; the prompt comes from `afk codex-monitor-agent --mode run|fleet`.
+When the primitive is unavailable, Codex falls back to the monitor dashboard.
+When Codex ships a command-backed statusline (openai/codex#17827 / #20244), this
+skill can add a `{ type = "command", command = … }` entry pointing at the same
+AFK bundle so the line matches Claude Code's.
 
 ## OpenCode
 


### PR DESCRIPTION
## Summary

- Adds `afk codex-monitor-agent`, a first-party prompt generator for spawning a read-only Codex monitor agent over `/afk monitor`.
- Extends the AFK/Codex docs so normal Codex `/afk run` and `/afk fleet` launches can attach one presentation-only monitor agent when the host subagent primitive exists.
- Keeps the Claude TaskCreate/TaskUpdate mirror and Codex fallback boundaries explicit; OpenCode remains documented as a runner lane, not an interactive host UI.

Refs #877.

## Validation

- `pnpm -C apps/dev exec vitest run tests/codex-monitor-agent.test.ts tests/cli-routing.test.ts tests/codex-statusline.test.ts`
- `pnpm -C apps/dev exec vitest run tests/runner-spec.test.ts tests/doctor-docs.test.ts tests/label-vocabulary-docs.test.ts tests/skill-paths.test.ts`
- `pnpm -C apps/dev exec tsc -p tsconfig.json --noEmit`
- `pnpm -C apps/dev run build`
- `env -u NO_COLOR pnpm -C apps/dev exec vitest run`

Note: the full suite fails under this shell when `NO_COLOR=1` because `statusline-command.test.ts` expects the two-line themed renderer; rerunning with `NO_COLOR` unset passes all 2157 tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784856244&installation_id=129708444&pr_number=879&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F879&signature=e2348aec5f95a64c038427db35b16c9dc5b17930bdb0f0e504f40da89a8793d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->