### PR TITLE
ship: #869 Route risky governed writes to Evidence cards

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -324,7 +324,7 @@ over the same evidence store.
 Usage:
   memory init [--mode markdown-only|graph] [--hooks] [--skill-telemetry] [--event-retention-days N] [--root <dir>] [--yes]
   memory store <fact...>            [--root <dir>] [--scope project|repo|branch|worktree|session|agent-run|user] [--scope-id ID]
-  memory store-evidence             [--root <dir>] --claim <text> --source-ref <ref> --citation-excerpt <text> --intent <text> --observer <id> [--json]
+  memory store-evidence             [--root <dir>] --claim <text> --source-ref <ref> --citation-excerpt <text> --intent <text> --observer <id> [--blast-radius low|medium|high] [--route <target>] [--confidence EXTRACTED|INFERRED|AMBIGUOUS] [--json]
   memory inbox quarantine <fact...> [--root <dir>] --reason <text> --evidence <summary> [--confidence EXTRACTED|INFERRED|AMBIGUOUS] [--source-kind manual|hook|derived|system] [--writer <name>] [--command <cmd>] [--hook <event>] [--json]
   memory inbox list                 [--root <dir>] [--status quarantined|approved|rejected|promoted|all] [--json]
   memory inbox inspect <id>         [--root <dir>] [--json]
@@ -725,6 +725,12 @@ async function runStoreEvidence(args: ParsedArgs): Promise<void> {
       stringFlag(args.flags, "citation-excerpt") ?? stringFlag(args.flags, "citation"),
     intent: stringFlag(args.flags, "intent"),
     observer: stringFlag(args.flags, "observer") ?? stringFlag(args.flags, "writer"),
+    blastRadius: stringFlag(args.flags, "blast-radius"),
+    route: stringFlag(args.flags, "route"),
+    confidence: parseConfidence(args.flags.confidence),
+    proposalKind: stringFlag(args.flags, "proposal-kind"),
+    proposalId: stringFlag(args.flags, "proposal-id"),
+    proposalPath: stringFlag(args.flags, "proposal-path"),
   };
 
   const config = await readConfig(rootDir);
@@ -736,7 +742,7 @@ async function runStoreEvidence(args: ParsedArgs): Promise<void> {
 
   const store = await MemoryStore.open({ uri: resolveStoreUri(rootDir, config) });
   try {
-    const result = await memoryStoreEvidence(store, input);
+    const result = await memoryStoreEvidence(store, input, { rootDir });
     printGovernedWriteResult(result, args.flags.json === true);
   } finally {
     await store.close();
@@ -1186,6 +1192,10 @@ function printGovernedWriteResult(
   console.log(`memory store-evidence: ${result.outcome}`);
   console.log(`  reason: ${result.reason}`);
   if (result.memory.urn) console.log(`  memory: ${result.memory.urn}`);
+  if (result.review_artifact) {
+    console.log(`  review: ${result.review_artifact.kind}:${result.review_artifact.id}`);
+    console.log(`  path: ${result.review_artifact.path}`);
+  }
   if (result.provenance.source_ref) console.log(`  source: ${result.provenance.source_ref}`);
   if (result.provenance.citation_excerpt) {
     console.log(`  citation: ${result.provenance.citation_excerpt}`);

--- a/apps/memory/src/governed-write.ts
+++ b/apps/memory/src/governed-write.ts
@@ -1,8 +1,10 @@
 import type { MemoryStore } from "./graph-store.js";
-import type { MemoryProvenance } from "./schema.js";
+import type { Confidence, MemoryProvenance } from "./schema.js";
 import { slugify } from "./store.js";
+import { createEvidenceCard, writeEvidenceCard } from "./evidence-card.js";
 
-export type GovernedWriteOutcome = "stored" | "rejected";
+export type GovernedWriteOutcome = "stored" | "rejected" | "proposed";
+export type GovernedWriteRisk = "low" | "medium" | "high" | "unknown";
 
 export interface MemoryStoreEvidenceInput {
   claim?: string;
@@ -10,6 +12,17 @@ export interface MemoryStoreEvidenceInput {
   citationExcerpt?: string;
   intent?: string;
   observer?: string;
+  blastRadius?: string;
+  confidence?: Confidence;
+  route?: string;
+  proposalKind?: string;
+  proposalId?: string;
+  proposalPath?: string;
+}
+
+export interface MemoryStoreEvidenceOptions {
+  rootDir?: string;
+  now?: Date;
 }
 
 export interface GovernedWriteResult {
@@ -19,8 +32,8 @@ export interface GovernedWriteResult {
   reason: string;
   policy: {
     reason: string;
-    risk: "low" | "unknown";
-    mode_required: "graph";
+    risk: GovernedWriteRisk;
+    mode_required: "graph" | "evidence_review";
   };
   provenance: {
     source_kind: MemoryProvenance["source_kind"];
@@ -33,6 +46,11 @@ export interface GovernedWriteResult {
     id: number | null;
     urn: string | null;
   };
+  review_artifact: {
+    kind: "evidence_card";
+    id: string;
+    path: string;
+  } | null;
 }
 
 const REQUIRED_FIELDS = ["claim", "sourceRef", "citationExcerpt", "intent", "observer"] as const;
@@ -47,6 +65,7 @@ export function rejectMemoryStoreEvidence(
 export async function memoryStoreEvidence(
   store: MemoryStore,
   input: MemoryStoreEvidenceInput,
+  options: MemoryStoreEvidenceOptions = {},
 ): Promise<GovernedWriteResult> {
   const missing = REQUIRED_FIELDS.filter((field) => !nonEmpty(input[field]));
   if (missing.length > 0) {
@@ -54,6 +73,75 @@ export async function memoryStoreEvidence(
   }
 
   const normalized = normalizeInput(input);
+  const policy = governedWritePolicy(normalized);
+  if (policy.risk !== "low") {
+    if (!options.rootDir) {
+      return governedWriteResult("rejected", "evidence_review_root_required", normalized, null, {
+        risk: "unknown",
+      });
+    }
+
+    const card = await createEvidenceCard(
+      options.rootDir,
+      {
+        source: {
+          kind: "governed-write",
+          ref: normalized.sourceRef,
+          collected_at: options.now?.toISOString(),
+        },
+        summary: normalized.claim,
+        citations: [
+          {
+            label: normalized.sourceRef,
+            quote: normalized.citationExcerpt,
+          },
+        ],
+        proposedLesson: {
+          text: normalized.claim,
+          scope: normalized.blastRadius || undefined,
+        },
+        route: {
+          target: normalized.route || "evidence_review",
+          rationale: policy.reason,
+        },
+        confidence: normalized.confidence,
+        blastRadius: {
+          scope: normalized.blastRadius || policy.risk,
+          rationale: blastRadiusRationale(policy.risk),
+        },
+        privacyNotes: ["Review before promoting this governed write into durable Memory."],
+        judge: {
+          score: policy.risk === "medium" ? 0.62 : 0.38,
+          rationale: policy.reason,
+        },
+        proposalLink: {
+          kind: normalized.proposalKind || "governed-write",
+          id: normalized.proposalId || undefined,
+          path: normalized.proposalPath || undefined,
+          apply_state: "pending",
+        },
+      },
+      options.now,
+    );
+    const linkedCard = {
+      ...card,
+      proposal_link: {
+        ...card.proposal_link,
+        id: card.proposal_link.id ?? card.id,
+      },
+    };
+    await writeEvidenceCard(options.rootDir, linkedCard);
+
+    return governedWriteResult("proposed", policy.reason, normalized, null, {
+      risk: policy.risk,
+      reviewArtifact: {
+        kind: "evidence_card",
+        id: linkedCard.id,
+        path: `.red/memory/inbox/evidence/${linkedCard.id}.yaml`,
+      },
+    });
+  }
+
   const rid = await store.upsertNode({
     label: slugify(normalized.claim).slice(0, 96),
     node_type: "validation",
@@ -92,8 +180,13 @@ function governedWriteResult(
   reason: string,
   input: MemoryStoreEvidenceInput,
   rid: number | null,
+  extra: {
+    risk?: GovernedWriteRisk;
+    reviewArtifact?: GovernedWriteResult["review_artifact"];
+  } = {},
 ): GovernedWriteResult {
   const normalized = normalizeInput(input);
+  const risk = extra.risk ?? (outcome === "stored" ? "low" : "unknown");
   return {
     schema_version: "memory.governed_write.v1",
     operation: "memory_store_evidence",
@@ -101,8 +194,8 @@ function governedWriteResult(
     reason,
     policy: {
       reason,
-      risk: outcome === "stored" ? "low" : "unknown",
-      mode_required: "graph",
+      risk,
+      mode_required: outcome === "proposed" ? "evidence_review" : "graph",
     },
     provenance: {
       source_kind: "manual",
@@ -118,6 +211,7 @@ function governedWriteResult(
       id: rid,
       urn: rid == null ? null : `memory_nodes:${rid}`,
     },
+    review_artifact: extra.reviewArtifact ?? null,
   };
 }
 
@@ -128,9 +222,43 @@ function normalizeInput(input: MemoryStoreEvidenceInput): Required<MemoryStoreEv
     citationExcerpt: input.citationExcerpt?.trim() ?? "",
     intent: input.intent?.trim() ?? "",
     observer: input.observer?.trim() ?? "",
+    blastRadius: input.blastRadius?.trim().toLowerCase() ?? "",
+    confidence: input.confidence ?? "EXTRACTED",
+    route: input.route?.trim() ?? "",
+    proposalKind: input.proposalKind?.trim() ?? "",
+    proposalId: input.proposalId?.trim() ?? "",
+    proposalPath: input.proposalPath?.trim() ?? "",
   };
 }
 
 function nonEmpty(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function governedWritePolicy(input: Required<MemoryStoreEvidenceInput>): {
+  risk: Exclude<GovernedWriteRisk, "unknown">;
+  reason: string;
+} {
+  if (input.blastRadius === "high") {
+    return { risk: "high", reason: "risk_requires_evidence_review:high_blast_radius" };
+  }
+  if (input.blastRadius === "medium") {
+    return { risk: "medium", reason: "risk_requires_evidence_review:medium_blast_radius" };
+  }
+
+  const text = `${input.claim}\n${input.citationExcerpt}\n${input.intent}`.toLowerCase();
+  if (/\b(user preference|personal fact|personal context|human-facing|biographical|identity context)\b/.test(text)) {
+    return { risk: "high", reason: "risk_requires_evidence_review:personal_or_human_context" };
+  }
+  if (/\b(always|never|must|should|do not|don't|remember to|instruction|agent rule)\b/.test(text)) {
+    return { risk: "high", reason: "risk_requires_evidence_review:instruction_like_memory" };
+  }
+
+  return { risk: "low", reason: "low_risk_validation_evidence_stored" };
+}
+
+function blastRadiusRationale(risk: Exclude<GovernedWriteRisk, "unknown" | "low">): string {
+  return risk === "medium"
+    ? "Medium blast-radius governed writes require Evidence review before promotion."
+    : "High blast-radius governed writes require Evidence review before promotion.";
 }

--- a/apps/memory/tests/governed-write-cli.test.ts
+++ b/apps/memory/tests/governed-write-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import { MemoryStore } from "../src/graph-store.js";
 import { initGraph, initMarkdownOnly } from "../src/init.js";
 import { memoryStoreEvidence } from "../src/governed-write.js";
+import { evidenceInboxRoot, parseEvidenceCardYaml } from "../src/evidence-card.js";
 
 const TIMEOUT = 40_000;
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -167,6 +168,84 @@ describe("memory_store_evidence governed write", () => {
       const store = await MemoryStore.open({ uri: storeUri, project: "test" });
       stores.push(store);
       expect(await store.listNodes()).toEqual([]);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "proposes risky evidence as a redacted Evidence card without durable graph memory",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+      const store = await MemoryStore.open({ uri: storeUri, project: "test" });
+      stores.push(store);
+      const token = "sk-test_1234567890abcdefghijklmnopqrstuv";
+
+      const result = await memoryStoreEvidence(
+        store,
+        {
+          claim: `User preference: do not store deployment token ${token} as a durable Memory fact.`,
+          sourceRef: "agent transcript:42",
+          citationExcerpt: `The human-facing note mentioned ${token}.`,
+          intent: "personal-context",
+          observer: "unit-test",
+          blastRadius: "medium",
+        },
+        { rootDir: root, now: new Date("2026-06-24T01:00:00.000Z") },
+      );
+
+      expect(result).toMatchObject({
+        outcome: "proposed",
+        reason: "risk_requires_evidence_review:medium_blast_radius",
+        policy: {
+          reason: "risk_requires_evidence_review:medium_blast_radius",
+          risk: "medium",
+          mode_required: "evidence_review",
+        },
+        memory: { id: null, urn: null },
+        review_artifact: {
+          kind: "evidence_card",
+          id: expect.stringMatching(/^evidence-[a-f0-9]{12}$/),
+          path: expect.stringMatching(/^\.red\/memory\/inbox\/evidence\/evidence-[a-f0-9]{12}\.yaml$/),
+        },
+      });
+
+      expect(await store.listNodes()).toEqual([]);
+
+      const files = await readdir(evidenceInboxRoot(root));
+      expect(files).toEqual([`${result.review_artifact!.id}.yaml`]);
+      const raw = await readFile(join(evidenceInboxRoot(root), files[0]), "utf8");
+      expect(raw).not.toContain(token);
+      expect(raw).toContain("[REDACTED:openai-token]");
+
+      const card = parseEvidenceCardYaml(raw);
+      expect(card).toMatchObject({
+        id: result.review_artifact!.id,
+        source: {
+          kind: "governed-write",
+          ref: "agent transcript:42",
+        },
+        route: {
+          target: "evidence_review",
+          rationale: "risk_requires_evidence_review:medium_blast_radius",
+        },
+        confidence: "EXTRACTED",
+        blast_radius: {
+          scope: "medium",
+          rationale: "Medium blast-radius governed writes require Evidence review before promotion.",
+        },
+        proposal_link: {
+          kind: "governed-write",
+          id: result.review_artifact!.id,
+          apply_state: "pending",
+        },
+      });
+      expect(card.privacy.redacted).toBe(true);
+      expect(card.citations[0]).toMatchObject({
+        label: "agent transcript:42",
+        quote: "The human-facing note mentioned [REDACTED:openai-token].",
+      });
+      expect(card.proposed_lesson.text).toContain("[REDACTED:openai-token]");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
Interactive /ship landing for #869.

Closes #869

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784859028&installation_id=129708444&pr_number=880&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F880&signature=6970712debda42efdd4591e1a9f8cc7aeea67d7e276d99bc6bd930e87d15844b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI flags (`--blast-radius`, `--route`, `--confidence`, `--proposal-*`) to the `memory store-evidence` command for richer evidence submission.
  * Introduced risk-based evidence review workflow; high-risk evidence now generates review artifacts for validation instead of direct storage.
  * Enhanced output now displays evidence review information and generated review cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->