### PR TITLE
ship: #870 Expose MCP memory_store_evidence through the shared governed write path

### DIFF
--- a/apps/memory/src/mcp-server.ts
+++ b/apps/memory/src/mcp-server.ts
@@ -32,6 +32,10 @@ import { runAutoCure } from "./auto-curation.js";
 import { neighbors, path, recall, search, traverse } from "./engine.js";
 import { resolveProvider } from "./extract-conversation.js";
 import { exportGraph, toEdge } from "./export.js";
+import {
+  memoryStoreEvidence,
+  type GovernedWriteResult,
+} from "./governed-write.js";
 import { buildGraphContract } from "./graph-contract.js";
 import { MemoryStore, factToNode } from "./graph-store.js";
 import { HistoricalMemoryStore } from "./historical-memory-store.js";
@@ -41,7 +45,7 @@ import {
   type ReadOnlyMemoryOperation,
 } from "./operations.js";
 import { runPromote } from "./promote.js";
-import type { EdgeLabel, MemoryScope, NodeType } from "./schema.js";
+import type { Confidence, EdgeLabel, MemoryScope, NodeType } from "./schema.js";
 import {
   current as sessionCurrent,
   end as sessionEnd,
@@ -113,6 +117,20 @@ const StoreInput = z.object({
       }),
     )
     .default([]),
+});
+
+const StoreEvidenceInput = z.object({
+  claim: z.string().optional(),
+  source_ref: z.string().optional(),
+  citation_excerpt: z.string().optional(),
+  intent: z.string().optional(),
+  observer: z.string().optional(),
+  blast_radius: z.string().optional(),
+  confidence: z.enum(["EXTRACTED", "INFERRED", "AMBIGUOUS"]).optional(),
+  route: z.string().optional(),
+  proposal_kind: z.string().optional(),
+  proposal_id: z.string().optional(),
+  proposal_path: z.string().optional(),
 });
 
 const SearchInput = z.object({
@@ -296,6 +314,30 @@ async function main(): Promise<void> {
           );
         }
         return text(`stored rid=${rid}, edges=${edges.length}`, { rid, edges });
+      }
+      case "memory_store_evidence": {
+        const input = StoreEvidenceInput.parse(args);
+        const result = await memoryStoreEvidence(
+          store,
+          {
+            claim: input.claim,
+            sourceRef: input.source_ref,
+            citationExcerpt: input.citation_excerpt,
+            intent: input.intent,
+            observer: input.observer,
+            blastRadius: input.blast_radius,
+            confidence: input.confidence as Confidence | undefined,
+            route: input.route,
+            proposalKind: input.proposal_kind,
+            proposalId: input.proposal_id,
+            proposalPath: input.proposal_path,
+          },
+          { rootDir: root },
+        );
+        return text(
+          JSON.stringify(result, null, 2),
+          governedWriteStructuredContent(result),
+        );
       }
       case "memory_search": {
         const input = SearchInput.parse(args);
@@ -528,6 +570,12 @@ const MANUAL_TOOLS = [
     inputSchema: zodToSchema(StoreInput),
   },
   {
+    name: "memory_store_evidence",
+    description:
+      "MUTATING governed write: submit operational evidence through the shared Memory write policy. Returns stored, proposed, or rejected depending on governance review requirements.",
+    inputSchema: zodToSchema(StoreEvidenceInput),
+  },
+  {
     name: "memory_search",
     description: "Direct full-text search over node titles and content.",
     inputSchema: zodToSchema(SearchInput),
@@ -628,6 +676,30 @@ const OPERATION_BY_TOOL_NAME = new Map<string, ReadOnlyMemoryOperation>(
     operation,
   ]),
 );
+
+function governedWriteStructuredContent(
+  result: GovernedWriteResult,
+): Record<string, unknown> {
+  const artifactId =
+    result.review_artifact?.id ??
+    result.memory.urn ??
+    (result.memory.id == null ? null : String(result.memory.id));
+  return {
+    operation: result.operation,
+    schema_version: result.schema_version,
+    outcome: result.outcome,
+    reason: result.reason,
+    policy_reason: result.policy.reason,
+    policy: result.policy,
+    artifact_id: artifactId,
+    artifact_path: result.review_artifact?.path ?? null,
+    provenance: result.provenance,
+    memory_id: result.memory.id,
+    memory_urn: result.memory.urn,
+    review_artifact_id: result.review_artifact?.id ?? null,
+    review_artifact_path: result.review_artifact?.path ?? null,
+  };
+}
 
 async function operationStructuredContent(
   operationId: string,

--- a/apps/memory/tests/mcp-server.test.ts
+++ b/apps/memory/tests/mcp-server.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -15,6 +15,7 @@ import {
 const TIMEOUT = 40_000;
 
 const pkgRoot = resolve(__dirname, "..");
+const pluginRoot = resolve(pkgRoot, "..", "..", "plugins", "memory");
 const tsx = join(pkgRoot, "node_modules", ".bin", "tsx");
 const serverEntry = join(pkgRoot, "src", "mcp-server.ts");
 
@@ -116,6 +117,15 @@ async function seedConfiguredStore(): Promise<{ uri: string; root: string }> {
     ),
     "utf8",
   );
+  return { uri, root: dir };
+}
+
+async function seedWritableStore(): Promise<{ uri: string; root: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "memory-mcp-writable-"));
+  roots.push(dir);
+  const uri = `file://${join(dir, "graph.rdb")}`;
+  const store = await MemoryStore.open({ uri, project: "test" });
+  await store.close();
   return { uri, root: dir };
 }
 
@@ -232,6 +242,8 @@ describe("MCP server over stdio", () => {
           "memory_layers_viewer",
           "memory_lint",
           "memory_map_context",
+          "memory_map_contract",
+          "memory_map_freshness",
           "memory_merge_pass",
           "memory_neighbors",
           "memory_onboarding_map",
@@ -260,6 +272,7 @@ describe("MCP server over stdio", () => {
           "memory_smart_search_viewer",
           "memory_stats",
           "memory_store",
+          "memory_store_evidence",
           "memory_structural_impact",
           "memory_structural_impact_viewer",
           "memory_supersede",
@@ -287,9 +300,125 @@ describe("MCP server over stdio", () => {
         expect(tool?.inputSchema).toEqual(expect.objectContaining({ type: "object" }));
       }
       const storeTool = tools.find((tool) => tool.name === "memory_store");
+      const storeEvidenceTool = tools.find((tool) => tool.name === "memory_store_evidence");
       const supersedeTool = tools.find((tool) => tool.name === "memory_supersede");
       expect(storeTool?.description?.toLowerCase()).toContain("mutating");
+      expect(storeEvidenceTool?.description?.toLowerCase()).toContain("mutating");
+      expect(storeEvidenceTool?.description?.toLowerCase()).toContain("governed");
+      expect(storeEvidenceTool?.description?.toLowerCase()).toContain("stored");
+      expect(storeEvidenceTool?.description?.toLowerCase()).toContain("proposed");
+      expect(storeEvidenceTool?.description?.toLowerCase()).toContain("rejected");
       expect(supersedeTool?.description?.toLowerCase()).toContain("mutating");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "memory_store_evidence returns stored, proposed, and rejected governed-write outcomes",
+    async () => {
+      const { uri, root } = await seedWritableStore();
+      const client = await connect(uri, { MEMORY_ROOT: root });
+
+      const storedRes = (await client.callTool({
+        name: "memory_store_evidence",
+        arguments: {
+          claim: "MCP governed evidence stores low-risk validation facts.",
+          source_ref: "tests/mcp-server.test.ts",
+          citation_excerpt: "stores low-risk validation facts",
+          intent: "validation",
+          observer: "mcp-test",
+        },
+      })) as ToolResult;
+      const stored = JSON.parse(storedRes.content[0]?.text ?? "{}") as {
+        outcome: string;
+        memory: { id: number; urn: string };
+        provenance: { source_ref: string; citation_excerpt: string; evidence: string[] };
+      };
+      expect(stored).toMatchObject({
+        outcome: "stored",
+        provenance: {
+          source_ref: "tests/mcp-server.test.ts",
+          citation_excerpt: "stores low-risk validation facts",
+          evidence: ["tests/mcp-server.test.ts", "stores low-risk validation facts"],
+        },
+      });
+      expect(stored.memory.urn).toBe(`memory_nodes:${stored.memory.id}`);
+      expect(storedRes.structuredContent).toMatchObject({
+        outcome: "stored",
+        artifact_id: stored.memory.urn,
+        artifact_path: null,
+        policy_reason: "low_risk_validation_evidence_stored",
+        provenance: {
+          source_ref: "tests/mcp-server.test.ts",
+          citation_excerpt: "stores low-risk validation facts",
+        },
+      });
+
+      const proposedRes = (await client.callTool({
+        name: "memory_store_evidence",
+        arguments: {
+          claim: "Always remember this human-facing deployment preference.",
+          source_ref: "agent transcript:9",
+          citation_excerpt: "The instruction-like claim should route through review.",
+          intent: "instruction capture",
+          observer: "mcp-test",
+          blast_radius: "medium",
+        },
+      })) as ToolResult;
+      const proposed = JSON.parse(proposedRes.content[0]?.text ?? "{}") as {
+        outcome: string;
+        memory: { id: null; urn: null };
+        review_artifact: { id: string; path: string };
+      };
+      expect(proposed).toMatchObject({
+        outcome: "proposed",
+        memory: { id: null, urn: null },
+        review_artifact: {
+          id: expect.stringMatching(/^evidence-[a-f0-9]{12}$/),
+          path: expect.stringMatching(/^\.red\/memory\/inbox\/evidence\/evidence-[a-f0-9]{12}\.yaml$/),
+        },
+      });
+      expect(proposedRes.structuredContent).toMatchObject({
+        outcome: "proposed",
+        artifact_id: proposed.review_artifact.id,
+        artifact_path: proposed.review_artifact.path,
+        policy_reason: "risk_requires_evidence_review:medium_blast_radius",
+      });
+      await expect(readFile(join(root, proposed.review_artifact.path), "utf8")).resolves.toContain(
+        proposed.review_artifact.id,
+      );
+
+      const rejectedRes = (await client.callTool({
+        name: "memory_store_evidence",
+        arguments: {
+          claim: "Missing provenance must return a governed rejection.",
+          intent: "validation",
+          observer: "mcp-test",
+        },
+      })) as ToolResult;
+      const rejected = JSON.parse(rejectedRes.content[0]?.text ?? "{}") as {
+        outcome: string;
+        reason: string;
+        memory: { id: null; urn: null };
+        review_artifact: null;
+      };
+      expect(rejected).toMatchObject({
+        outcome: "rejected",
+        reason: "missing_required_fields:sourceRef,citationExcerpt",
+        memory: { id: null, urn: null },
+        review_artifact: null,
+      });
+      expect(rejectedRes.structuredContent).toMatchObject({
+        outcome: "rejected",
+        artifact_id: null,
+        artifact_path: null,
+        policy_reason: "missing_required_fields:sourceRef,citationExcerpt",
+        provenance: {
+          source_ref: null,
+          citation_excerpt: null,
+          evidence: [],
+        },
+      });
     },
     TIMEOUT,
   );
@@ -1672,7 +1801,11 @@ describe("MCP server over stdio", () => {
     "memory_hook_coverage exposes read-only runner manifest and config coverage",
     async () => {
       const seeded = await seedConfiguredStore();
-      const client = await connect(seeded.uri, { MEMORY_ROOT: seeded.root });
+      const client = await connect(seeded.uri, {
+        MEMORY_ROOT: seeded.root,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        CODEX_PLUGIN_ROOT: pluginRoot,
+      });
 
       const result = (await client.callTool({
         name: "memory_hook_coverage",

--- a/apps/memory/tests/operations-registry.test.ts
+++ b/apps/memory/tests/operations-registry.test.ts
@@ -220,6 +220,7 @@ describe("read-only Memory operations registry", () => {
     expect(operations.every((op) => op.safetyClass === "read-only")).toBe(true);
     expect(operations.map((op) => op.sideEffectClass)).not.toContain("writes-memory");
     expect(operations.map((op) => op.id)).not.toContain("memory.store");
+    expect(operations.map((op) => op.id)).not.toContain("memory.store-evidence");
     expect(operations.map((op) => op.id)).not.toContain("memory.supersede");
 
     expect(getReadOnlyMemoryOperation("memory.readiness").outputSchema.parse).toBeTypeOf(


### PR DESCRIPTION
Interactive /ship landing for #870.

Closes #870

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784861186&installation_id=129708444&pr_number=881&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F881&signature=7fd31ffb18fb70af883898a1af1d814030cbdc288eb0b4db69fbf1aefdab4497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->