### PR TITLE
merge: #871 Add deterministic cross-agent Memory smoke test

### DIFF
--- a/apps/memory/tests/governed-write-cli.test.ts
+++ b/apps/memory/tests/governed-write-cli.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import { MemoryStore } from "../src/graph-store.js";
+import { graphRecall } from "../src/graph-recall.js";
 import { initGraph, initMarkdownOnly } from "../src/init.js";
 import { memoryStoreEvidence } from "../src/governed-write.js";
 import { evidenceInboxRoot, parseEvidenceCardYaml } from "../src/evidence-card.js";
@@ -74,6 +75,88 @@ describe("memory_store_evidence governed write", () => {
             evidence: [
               "tests/governed-write-cli.test.ts",
               "stores low-risk validation evidence",
+            ],
+          },
+        },
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "smoke: stores validation evidence as one runner and recalls it as another",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+      const writerStore = await MemoryStore.open({
+        uri: storeUri,
+        project: "claude-smoke-runner",
+      });
+      stores.push(writerStore);
+
+      const result = await memoryStoreEvidence(writerStore, {
+        claim: "Validation smoke proves cross-agent governed Memory recall.",
+        sourceRef: "issue-871-cross-agent-memory-smoke.md:17",
+        citationExcerpt: "Validation smoke proves cross-agent governed Memory recall.",
+        intent: "validation",
+        observer: "claude-smoke-runner",
+      });
+
+      expect(result).toMatchObject({
+        operation: "memory_store_evidence",
+        outcome: "stored",
+        reason: "low_risk_validation_evidence_stored",
+        policy: {
+          reason: "low_risk_validation_evidence_stored",
+          risk: "low",
+          mode_required: "graph",
+        },
+        provenance: {
+          writer: "claude-smoke-runner",
+          source_ref: "issue-871-cross-agent-memory-smoke.md:17",
+          citation_excerpt: "Validation smoke proves cross-agent governed Memory recall.",
+        },
+      });
+      expect(result.memory.id).toEqual(expect.any(Number));
+
+      await writerStore.close();
+      stores.splice(stores.indexOf(writerStore), 1);
+
+      const readerStore = await MemoryStore.open({
+        uri: storeUri,
+        project: "codex-smoke-runner",
+      });
+      stores.push(readerStore);
+
+      const hits = await graphRecall(
+        readerStore,
+        "cross-agent governed Memory recall validation smoke",
+        5,
+      );
+      expect(hits).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rid: result.memory.id,
+            node_type: "validation",
+            excerpt: expect.stringContaining(
+              "Validation smoke proves cross-agent governed Memory recall.",
+            ),
+          }),
+        ]),
+      );
+
+      const recalled = await readerStore.getNode(result.memory.id!);
+      expect(recalled).toMatchObject({
+        node_type: "validation",
+        properties: {
+          intent: "validation",
+          observer: "claude-smoke-runner",
+          provenance: {
+            writer: "claude-smoke-runner",
+            command: "memory store-evidence",
+            evidence: [
+              "issue-871-cross-agent-memory-smoke.md:17",
+              "Validation smoke proves cross-agent governed Memory recall.",
             ],
           },
         },


### PR DESCRIPTION
Automated AFK landing for #871. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #871

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784861736&installation_id=129708444&pr_number=882&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F882&signature=fd6e0dc3aef54085df704cbfe39c03a2b63104b84aedfa0bd37190e291acf108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->