### PR TITLE
merge: #872 Add deterministic mistake_avoided benchmark for governed Memory flows

### DIFF
--- a/apps/benchmark-memory/src/cli.ts
+++ b/apps/benchmark-memory/src/cli.ts
@@ -28,6 +28,7 @@ import {
   type LiveBaselineRunResult,
 } from "../../memory/src/live-baseline-adapters.js";
 import { formatMarkdownReport, runBenchRecall } from "../../memory/src/bench-recall.js";
+import { formatMistakeAvoidedReport, runBenchMistakeAvoided } from "../../memory/src/bench-mistake-avoided.js";
 import {
   formatEvalReport,
   runBenchEval,
@@ -61,6 +62,7 @@ Usage:
   benchmark-memory bench eval core   [--corpus <dir>] [--pack N] [--substrate reddb] [--records <file>] [--analytics <uri|file>] [--gate] [--out <file>] [--report <file>] [--json]
   benchmark-memory bench eval showcase [--corpus <dir>] [--pack N] [--substrate <name>] [--runs N] [--records <file>] [--analytics <uri|file>] [--out <file>] [--report <file>] [--json]
   benchmark-memory bench eval        [--corpus <dir>] [--pack N] [--substrate <name>] [--records <file>] [--analytics <uri|file>] [--out <file>] [--report <file>] [--json]
+  benchmark-memory bench mistake-avoided [--fixtures <dir>] [--out <file>] [--report <file>] [--json]
   benchmark-memory bench recall      [--root <dir>] [--corpus <dir>] [--k 1,5,10] [--out <file>] [--report <file>] [--json]
   benchmark-memory bench latency     [--root <dir>] [--workload <dir>] [--iterations N] [--warmup N] [--seed N] [--ops working-get,session-recall,long-term-recall] [--analytics <uri|file>] [--out <file>] [--report <file>] [--json]
   benchmark-memory references eval    [--v2] [--json] [--human] [--out <file>]
@@ -193,9 +195,10 @@ async function runInterop(args: ParsedArgs): Promise<number> {
 async function runBench(args: ParsedArgs): Promise<number> {
   const sub = args.positional[0];
   if (sub === "eval") return runBenchEvalCmd(args);
+  if (sub === "mistake-avoided") return runBenchMistakeAvoidedCmd(args);
   if (sub === "recall") return runBenchRecallCmd(args);
   if (sub === "latency") return runBenchLatencyCmd(args);
-  throw new Error(`usage: benchmark-memory bench (eval|recall|latency) ...`);
+  throw new Error(`usage: benchmark-memory bench (eval|mistake-avoided|recall|latency) ...`);
 }
 
 async function runBenchEvalCmd(args: ParsedArgs): Promise<number> {
@@ -241,6 +244,21 @@ async function runBenchEvalCmd(args: ParsedArgs): Promise<number> {
     );
   }
   return gateResult?.status === "fail" ? 1 : 0;
+}
+
+async function runBenchMistakeAvoidedCmd(args: ParsedArgs): Promise<number> {
+  const rootDir = resolveRepoRoot(String(process.cwd()));
+  const fixtureDir = stringFlag(args, "fixtures") ?? join(rootDir, "apps/memory/bench/mistake-avoided/governed-flows");
+  const report = await runBenchMistakeAvoided({ fixtureDir });
+  await writeOutputs(args, report, formatMistakeAvoidedReport(report));
+  if (args.flags.json === true) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(
+      `benchmark-memory bench mistake-avoided: scenarios=${report.aggregate.scenario_count} mistake_avoided=${report.aggregate.mistake_avoided} token_savings=${report.aggregate.token_savings_pct.toFixed(3)}\n`,
+    );
+  }
+  return 0;
 }
 
 async function runBenchRecallCmd(args: ParsedArgs): Promise<number> {

--- a/apps/memory/bench/mistake-avoided/governed-flows/scenarios.json
+++ b/apps/memory/bench/mistake-avoided/governed-flows/scenarios.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "validation-retry",
+    "title": "Validation retry uses remembered package-local failure context",
+    "category": "validation_retry",
+    "mistake_kind": "wrong_validation_scope",
+    "expected_answer": "rerun apps/memory vitest after fixing the deterministic extractor vocabulary",
+    "baseline": {
+      "flow": "broad_read",
+      "tokens": 12600,
+      "files_read": 44,
+      "commands_run": 8,
+      "answer": "rerun the full repository test suite before changing code",
+      "policy": {
+        "decision": "allowed",
+        "reason": "read-only broad repository scan"
+      }
+    },
+    "governed": {
+      "flow": "governed_write_recall_capsule",
+      "tokens": 3900,
+      "files_read": 9,
+      "commands_run": 4,
+      "answer": "rerun apps/memory vitest after fixing the deterministic extractor vocabulary",
+      "policy": {
+        "decision": "stored",
+        "reason": "low-risk validation evidence with source_ref and citation excerpt"
+      },
+      "memory_actions": ["governed_write", "recall"],
+      "capsule": {
+        "included": false,
+        "tokens": 0
+      }
+    }
+  },
+  {
+    "id": "cross-agent-recall",
+    "title": "Second agent recalls a prior governed decision without rereading the repo",
+    "category": "cross_agent_recall",
+    "mistake_kind": "missed_prior_decision",
+    "expected_answer": "keep branch-lock scoped to primary-checkout git operations only",
+    "baseline": {
+      "flow": "broad_read",
+      "tokens": 18400,
+      "files_read": 71,
+      "commands_run": 10,
+      "answer": "apply the branch lock to every worktree checkout",
+      "policy": {
+        "decision": "allowed",
+        "reason": "read-only broad repository scan"
+      }
+    },
+    "governed": {
+      "flow": "governed_write_recall_capsule",
+      "tokens": 5200,
+      "files_read": 12,
+      "commands_run": 5,
+      "answer": "keep branch-lock scoped to primary-checkout git operations only",
+      "policy": {
+        "decision": "stored",
+        "reason": "decision evidence is cited and low blast-radius"
+      },
+      "memory_actions": ["governed_write", "recall"],
+      "capsule": {
+        "included": false,
+        "tokens": 0
+      }
+    }
+  },
+  {
+    "id": "capsule-handoff",
+    "title": "Capsule handoff preserves blocker context across an agent boundary",
+    "category": "capsule_handoff",
+    "mistake_kind": "lost_blocker_context",
+    "expected_answer": "resume from the blocked validation gate after the maintainer chooses the migration policy",
+    "baseline": {
+      "flow": "broad_read",
+      "tokens": 9100,
+      "files_read": 32,
+      "commands_run": 6,
+      "answer": "restart the implementation from issue discovery",
+      "policy": {
+        "decision": "allowed",
+        "reason": "handoff reconstructed from repository state"
+      }
+    },
+    "governed": {
+      "flow": "governed_write_recall_capsule",
+      "tokens": 2800,
+      "files_read": 6,
+      "commands_run": 3,
+      "answer": "resume from the blocked validation gate after the maintainer chooses the migration policy",
+      "policy": {
+        "decision": "stored",
+        "reason": "capsule cites the current blocker and next validation command"
+      },
+      "memory_actions": ["recall", "capsule"],
+      "capsule": {
+        "included": true,
+        "tokens": 700
+      }
+    }
+  },
+  {
+    "id": "governed-rejection",
+    "title": "Governed write rejects unsupported high-blast-radius memory",
+    "category": "governed_rejection",
+    "mistake_kind": "unsupported_memory_write",
+    "expected_answer": "reject the unsupported production-failure claim",
+    "baseline": {
+      "flow": "broad_read",
+      "tokens": 7600,
+      "files_read": 25,
+      "commands_run": 4,
+      "answer": "store the production-failure claim as learned memory",
+      "policy": {
+        "decision": "allowed",
+        "reason": "ungoverned note append has no evidence review"
+      }
+    },
+    "governed": {
+      "flow": "governed_write_recall_capsule",
+      "tokens": 2100,
+      "files_read": 4,
+      "commands_run": 2,
+      "answer": "reject the unsupported production-failure claim",
+      "policy": {
+        "decision": "rejected",
+        "reason": "high blast-radius claim lacks source_ref and citation excerpt"
+      },
+      "memory_actions": ["governed_write"],
+      "capsule": {
+        "included": false,
+        "tokens": 0
+      }
+    }
+  }
+]

--- a/apps/memory/src/bench-mistake-avoided.ts
+++ b/apps/memory/src/bench-mistake-avoided.ts
@@ -1,0 +1,385 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const MISTAKE_AVOIDED_SCHEMA_VERSION = "memory.bench.mistake_avoided.v1" as const;
+
+export type MistakeAvoidedCategory =
+  | "validation_retry"
+  | "cross_agent_recall"
+  | "capsule_handoff"
+  | "governed_rejection";
+
+export type MemoryAction = "governed_write" | "recall" | "capsule";
+export type PolicyDecision = "allowed" | "stored" | "proposed" | "rejected";
+
+export interface PolicyMetric {
+  decision: PolicyDecision;
+  reason: string;
+}
+
+export interface BaselineFlowFixture {
+  flow: "broad_read";
+  tokens: number;
+  files_read: number;
+  commands_run: number;
+  answer: string;
+  policy: PolicyMetric;
+}
+
+export interface GovernedFlowFixture {
+  flow: "governed_write_recall_capsule";
+  tokens: number;
+  files_read: number;
+  commands_run: number;
+  answer: string;
+  policy: PolicyMetric;
+  memory_actions: MemoryAction[];
+  capsule: {
+    included: boolean;
+    tokens: number;
+  };
+}
+
+export interface MistakeAvoidedScenarioFixture {
+  id: string;
+  title: string;
+  category: MistakeAvoidedCategory;
+  mistake_kind: string;
+  expected_answer: string;
+  baseline: BaselineFlowFixture;
+  governed: GovernedFlowFixture;
+}
+
+export interface MistakeAvoidedRecord {
+  schema_version: typeof MISTAKE_AVOIDED_SCHEMA_VERSION;
+  scenario_id: string;
+  title: string;
+  category: MistakeAvoidedCategory;
+  mistake_kind: string;
+  expected_answer: string;
+  baseline: BaselineFlowFixture;
+  governed: GovernedFlowFixture;
+  baseline_correct: boolean;
+  governed_correct: boolean;
+  mistake_avoided: boolean;
+  token_delta: number;
+  token_savings_pct: number;
+  file_delta: number;
+  command_delta: number;
+}
+
+export interface MistakeAvoidedAggregate {
+  scenario_count: number;
+  mistake_avoided: number;
+  mistake_avoided_rate: number;
+  baseline_tokens: number;
+  governed_tokens: number;
+  token_delta: number;
+  token_savings_pct: number;
+  baseline_files_read: number;
+  governed_files_read: number;
+  file_delta: number;
+  baseline_commands_run: number;
+  governed_commands_run: number;
+  command_delta: number;
+}
+
+export interface MistakeAvoidedReport {
+  schema_version: typeof MISTAKE_AVOIDED_SCHEMA_VERSION;
+  generated_at: string;
+  benchmark: "governed-memory-mistake-avoided";
+  claim_guards: {
+    full_failure_learning_claimed: false;
+    memory_learn_available: false;
+    memory_refine_available: false;
+    note: string;
+  };
+  coverage: Record<MistakeAvoidedCategory, number>;
+  aggregate: MistakeAvoidedAggregate;
+  records: MistakeAvoidedRecord[];
+}
+
+const REQUIRED_CATEGORIES: MistakeAvoidedCategory[] = [
+  "validation_retry",
+  "cross_agent_recall",
+  "capsule_handoff",
+  "governed_rejection",
+];
+
+export async function loadMistakeAvoidedScenarios(dir: string): Promise<MistakeAvoidedScenarioFixture[]> {
+  const raw = await readFile(join(dir, "scenarios.json"), "utf8");
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("scenarios.json must be a JSON array");
+  return parsed.map(asScenario);
+}
+
+export async function runBenchMistakeAvoided(options: {
+  fixtureDir: string;
+  generatedAt?: string;
+}): Promise<MistakeAvoidedReport> {
+  const scenarios = await loadMistakeAvoidedScenarios(options.fixtureDir);
+  return scoreMistakeAvoidedScenarios(scenarios, {
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+  });
+}
+
+export function scoreMistakeAvoidedScenarios(
+  scenarios: MistakeAvoidedScenarioFixture[],
+  options: { generatedAt: string },
+): MistakeAvoidedReport {
+  const records = scenarios.map(scoreScenario);
+  const coverage = REQUIRED_CATEGORIES.reduce<Record<MistakeAvoidedCategory, number>>((acc, category) => {
+    acc[category] = records.filter((record) => record.category === category).length;
+    return acc;
+  }, {
+    validation_retry: 0,
+    cross_agent_recall: 0,
+    capsule_handoff: 0,
+    governed_rejection: 0,
+  });
+  return {
+    schema_version: MISTAKE_AVOIDED_SCHEMA_VERSION,
+    generated_at: options.generatedAt,
+    benchmark: "governed-memory-mistake-avoided",
+    claim_guards: {
+      full_failure_learning_claimed: false,
+      memory_learn_available: false,
+      memory_refine_available: false,
+      note: "This benchmark measures deterministic governed write, recall, and capsule ergonomics only; it does not claim autonomous failure learning before memory learn/refine exists.",
+    },
+    coverage,
+    aggregate: aggregateRecords(records),
+    records,
+  };
+}
+
+export function formatMistakeAvoidedReport(report: MistakeAvoidedReport): string {
+  const lines = [
+    "# Governed Memory mistake_avoided benchmark",
+    "",
+    `Scenarios: ${report.aggregate.scenario_count}`,
+    `Mistakes avoided: ${report.aggregate.mistake_avoided}/${report.aggregate.scenario_count} (${formatPct(report.aggregate.mistake_avoided_rate)})`,
+    `Token savings: ${report.aggregate.token_delta} (${formatPct(report.aggregate.token_savings_pct)})`,
+    `File reads avoided: ${report.aggregate.file_delta}`,
+    `Commands avoided: ${report.aggregate.command_delta}`,
+    "",
+    "The benchmark does not claim full failure learning; memory learn/refine are marked unavailable in claim_guards.",
+    "",
+    "| Scenario | mistake_avoided | Baseline answer | Governed answer | Policy | Tokens |",
+    "| --- | --- | --- | --- | --- | ---: |",
+  ];
+  for (const record of report.records) {
+    lines.push([
+      record.scenario_id,
+      String(record.mistake_avoided),
+      escapeCell(record.baseline.answer),
+      escapeCell(record.governed.answer),
+      record.governed.policy.decision,
+      String(record.governed.tokens),
+    ].join(" | "));
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function scoreScenario(scenario: MistakeAvoidedScenarioFixture): MistakeAvoidedRecord {
+  const baselineCorrect = sameAnswer(scenario.baseline.answer, scenario.expected_answer);
+  const governedCorrect = sameAnswer(scenario.governed.answer, scenario.expected_answer);
+  const mistakeAvoided = !baselineCorrect && governedCorrect && policySupportsGovernedOutcome(scenario);
+  return {
+    schema_version: MISTAKE_AVOIDED_SCHEMA_VERSION,
+    scenario_id: scenario.id,
+    title: scenario.title,
+    category: scenario.category,
+    mistake_kind: scenario.mistake_kind,
+    expected_answer: scenario.expected_answer,
+    baseline: scenario.baseline,
+    governed: scenario.governed,
+    baseline_correct: baselineCorrect,
+    governed_correct: governedCorrect,
+    mistake_avoided: mistakeAvoided,
+    token_delta: scenario.baseline.tokens - scenario.governed.tokens,
+    token_savings_pct: pctDelta(scenario.baseline.tokens, scenario.governed.tokens),
+    file_delta: scenario.baseline.files_read - scenario.governed.files_read,
+    command_delta: scenario.baseline.commands_run - scenario.governed.commands_run,
+  };
+}
+
+function aggregateRecords(records: MistakeAvoidedRecord[]): MistakeAvoidedAggregate {
+  const baselineTokens = sum(records, (record) => record.baseline.tokens);
+  const governedTokens = sum(records, (record) => record.governed.tokens);
+  const baselineFiles = sum(records, (record) => record.baseline.files_read);
+  const governedFiles = sum(records, (record) => record.governed.files_read);
+  const baselineCommands = sum(records, (record) => record.baseline.commands_run);
+  const governedCommands = sum(records, (record) => record.governed.commands_run);
+  const avoided = records.filter((record) => record.mistake_avoided).length;
+  return {
+    scenario_count: records.length,
+    mistake_avoided: avoided,
+    mistake_avoided_rate: records.length === 0 ? 0 : avoided / records.length,
+    baseline_tokens: baselineTokens,
+    governed_tokens: governedTokens,
+    token_delta: baselineTokens - governedTokens,
+    token_savings_pct: pctDelta(baselineTokens, governedTokens),
+    baseline_files_read: baselineFiles,
+    governed_files_read: governedFiles,
+    file_delta: baselineFiles - governedFiles,
+    baseline_commands_run: baselineCommands,
+    governed_commands_run: governedCommands,
+    command_delta: baselineCommands - governedCommands,
+  };
+}
+
+function policySupportsGovernedOutcome(scenario: MistakeAvoidedScenarioFixture): boolean {
+  if (scenario.category === "governed_rejection") return scenario.governed.policy.decision === "rejected";
+  return scenario.governed.policy.decision === "stored" || scenario.governed.policy.decision === "proposed";
+}
+
+function sameAnswer(actual: string, expected: string): boolean {
+  return normalizeAnswer(actual) === normalizeAnswer(expected);
+}
+
+function normalizeAnswer(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim().replace(/\s+/g, " ");
+}
+
+function pctDelta(baseline: number, governed: number): number {
+  if (baseline <= 0) return 0;
+  return round4((baseline - governed) / baseline);
+}
+
+function sum(records: MistakeAvoidedRecord[], pick: (record: MistakeAvoidedRecord) => number): number {
+  return records.reduce((total, record) => total + pick(record), 0);
+}
+
+function round4(value: number): number {
+  return Math.round(value * 10000) / 10000;
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+function asScenario(value: unknown): MistakeAvoidedScenarioFixture {
+  if (!value || typeof value !== "object") throw new Error("scenario must be an object");
+  const r = value as Record<string, unknown>;
+  return {
+    id: stringField(r, "id"),
+    title: stringField(r, "title"),
+    category: categoryField(r, "category"),
+    mistake_kind: stringField(r, "mistake_kind"),
+    expected_answer: stringField(r, "expected_answer"),
+    baseline: asBaselineFlow(r.baseline),
+    governed: asGovernedFlow(r.governed),
+  };
+}
+
+function asBaselineFlow(value: unknown): BaselineFlowFixture {
+  if (!value || typeof value !== "object") throw new Error("baseline must be an object");
+  const r = value as Record<string, unknown>;
+  const flow = stringField(r, "flow");
+  if (flow !== "broad_read") throw new Error('baseline.flow must be "broad_read"');
+  return {
+    flow,
+    tokens: positiveIntegerField(r, "tokens"),
+    files_read: nonNegativeIntegerField(r, "files_read"),
+    commands_run: nonNegativeIntegerField(r, "commands_run"),
+    answer: stringField(r, "answer"),
+    policy: asPolicy(r.policy),
+  };
+}
+
+function asGovernedFlow(value: unknown): GovernedFlowFixture {
+  if (!value || typeof value !== "object") throw new Error("governed must be an object");
+  const r = value as Record<string, unknown>;
+  const flow = stringField(r, "flow");
+  if (flow !== "governed_write_recall_capsule") {
+    throw new Error('governed.flow must be "governed_write_recall_capsule"');
+  }
+  const memoryActions = arrayOfStrings(r, "memory_actions").map(asMemoryAction);
+  return {
+    flow,
+    tokens: positiveIntegerField(r, "tokens"),
+    files_read: nonNegativeIntegerField(r, "files_read"),
+    commands_run: nonNegativeIntegerField(r, "commands_run"),
+    answer: stringField(r, "answer"),
+    policy: asPolicy(r.policy),
+    memory_actions: memoryActions,
+    capsule: asCapsule(r.capsule),
+  };
+}
+
+function asCapsule(value: unknown): GovernedFlowFixture["capsule"] {
+  if (!value || typeof value !== "object") throw new Error("governed.capsule must be an object");
+  const r = value as Record<string, unknown>;
+  return {
+    included: booleanField(r, "included"),
+    tokens: nonNegativeIntegerField(r, "tokens"),
+  };
+}
+
+function asPolicy(value: unknown): PolicyMetric {
+  if (!value || typeof value !== "object") throw new Error("policy must be an object");
+  const r = value as Record<string, unknown>;
+  return {
+    decision: policyDecisionField(r, "decision"),
+    reason: stringField(r, "reason"),
+  };
+}
+
+function categoryField(r: Record<string, unknown>, key: string): MistakeAvoidedCategory {
+  const value = stringField(r, key);
+  if (!REQUIRED_CATEGORIES.includes(value as MistakeAvoidedCategory)) {
+    throw new Error(`field "${key}" must be one of ${REQUIRED_CATEGORIES.join(", ")}`);
+  }
+  return value as MistakeAvoidedCategory;
+}
+
+function asMemoryAction(value: string): MemoryAction {
+  if (value === "governed_write" || value === "recall" || value === "capsule") return value;
+  throw new Error(`memory action must be governed_write, recall, or capsule: ${value}`);
+}
+
+function policyDecisionField(r: Record<string, unknown>, key: string): PolicyDecision {
+  const value = stringField(r, key);
+  if (value === "allowed" || value === "stored" || value === "proposed" || value === "rejected") return value;
+  throw new Error(`field "${key}" must be allowed, stored, proposed, or rejected`);
+}
+
+function stringField(r: Record<string, unknown>, key: string): string {
+  const value = r[key];
+  if (typeof value !== "string" || value.length === 0) throw new Error(`field "${key}" must be a non-empty string`);
+  return value;
+}
+
+function booleanField(r: Record<string, unknown>, key: string): boolean {
+  const value = r[key];
+  if (typeof value !== "boolean") throw new Error(`field "${key}" must be a boolean`);
+  return value;
+}
+
+function positiveIntegerField(r: Record<string, unknown>, key: string): number {
+  const value = nonNegativeIntegerField(r, key);
+  if (value < 1) throw new Error(`field "${key}" must be a positive integer`);
+  return value;
+}
+
+function nonNegativeIntegerField(r: Record<string, unknown>, key: string): number {
+  const value = r[key];
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`field "${key}" must be a non-negative integer`);
+  }
+  return value;
+}
+
+function arrayOfStrings(r: Record<string, unknown>, key: string): string[] {
+  const value = r[key];
+  if (!Array.isArray(value)) throw new Error(`field "${key}" must be an array`);
+  return value.map((item) => {
+    if (typeof item !== "string") throw new Error(`field "${key}" must contain only strings`);
+    return item;
+  });
+}

--- a/apps/memory/tests/bench-mistake-avoided.test.ts
+++ b/apps/memory/tests/bench-mistake-avoided.test.ts
@@ -1,0 +1,92 @@
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  MISTAKE_AVOIDED_SCHEMA_VERSION,
+  formatMistakeAvoidedReport,
+  loadMistakeAvoidedScenarios,
+  runBenchMistakeAvoided,
+  scoreMistakeAvoidedScenarios,
+} from "../src/bench-mistake-avoided.js";
+
+const FIXTURE_DIR = join(__dirname, "../bench/mistake-avoided/governed-flows");
+const GENERATED_AT = "2026-06-24T00:00:00.000Z";
+
+describe("memory bench mistake_avoided — fixture integrity", () => {
+  test("fixtures cover validation retry, cross-agent recall, capsule handoff, and governed rejection", async () => {
+    const scenarios = await loadMistakeAvoidedScenarios(FIXTURE_DIR);
+    expect(scenarios.map((scenario) => scenario.category).sort()).toEqual([
+      "capsule_handoff",
+      "cross_agent_recall",
+      "governed_rejection",
+      "validation_retry",
+    ]);
+    for (const scenario of scenarios) {
+      expect(scenario.baseline.flow).toBe("broad_read");
+      expect(scenario.governed.flow).toBe("governed_write_recall_capsule");
+      expect(scenario.baseline.tokens).toBeGreaterThan(scenario.governed.tokens);
+      expect(scenario.baseline.files_read).toBeGreaterThanOrEqual(scenario.governed.files_read);
+      expect(scenario.baseline.commands_run).toBeGreaterThanOrEqual(scenario.governed.commands_run);
+      expect(scenario.expected_answer).not.toBe(scenario.baseline.answer);
+      expect(scenario.expected_answer).toBe(scenario.governed.answer);
+      expect(scenario.baseline.policy.decision).toBe("allowed");
+      expect(scenario.governed.memory_actions.length).toBeGreaterThan(0);
+    }
+    expect(scenarios.find((scenario) => scenario.category === "capsule_handoff")?.governed.capsule.included).toBe(true);
+    expect(scenarios.find((scenario) => scenario.category === "governed_rejection")?.governed.policy.decision).toBe("rejected");
+  });
+});
+
+describe("memory bench mistake_avoided — scoring", () => {
+  test("scores mistake_avoided from broad-read baseline to governed memory flows", async () => {
+    const scenarios = await loadMistakeAvoidedScenarios(FIXTURE_DIR);
+    const report = scoreMistakeAvoidedScenarios(scenarios, { generatedAt: GENERATED_AT });
+
+    expect(report.schema_version).toBe(MISTAKE_AVOIDED_SCHEMA_VERSION);
+    expect(report.generated_at).toBe(GENERATED_AT);
+    expect(report.aggregate.scenario_count).toBe(4);
+    expect(report.aggregate.mistake_avoided).toBe(4);
+    expect(report.aggregate.mistake_avoided_rate).toBe(1);
+    expect(report.aggregate.token_savings_pct).toBeGreaterThan(0.5);
+    expect(report.aggregate.file_delta).toBeGreaterThan(0);
+    expect(report.aggregate.command_delta).toBeGreaterThan(0);
+
+    for (const record of report.records) {
+      expect(record.schema_version).toBe(MISTAKE_AVOIDED_SCHEMA_VERSION);
+      expect(record.baseline_correct).toBe(false);
+      expect(record.governed_correct).toBe(true);
+      expect(record.mistake_avoided).toBe(true);
+      expect(record.token_delta).toBeGreaterThan(0);
+      expect(record.file_delta).toBeGreaterThanOrEqual(0);
+      expect(record.command_delta).toBeGreaterThanOrEqual(0);
+      expect(record.baseline).toHaveProperty("answer");
+      expect(record.baseline).toHaveProperty("policy");
+      expect(record.governed).toHaveProperty("answer");
+      expect(record.governed).toHaveProperty("policy");
+    }
+  });
+});
+
+describe("memory bench mistake_avoided — report shape", () => {
+  test("emits claim guards without claiming full failure learning before learn/refine exist", async () => {
+    const report = await runBenchMistakeAvoided({ fixtureDir: FIXTURE_DIR, generatedAt: GENERATED_AT });
+
+    expect(report.benchmark).toBe("governed-memory-mistake-avoided");
+    expect(report.coverage).toEqual({
+      validation_retry: 1,
+      cross_agent_recall: 1,
+      capsule_handoff: 1,
+      governed_rejection: 1,
+    });
+    expect(report.claim_guards).toMatchObject({
+      full_failure_learning_claimed: false,
+      memory_learn_available: false,
+      memory_refine_available: false,
+    });
+    expect(report.claim_guards.note).toContain("does not claim autonomous failure learning");
+
+    const markdown = formatMistakeAvoidedReport(report);
+    expect(markdown).toContain("Governed Memory mistake_avoided benchmark");
+    expect(markdown).toContain("Mistakes avoided: 4/4");
+    expect(markdown).toContain("memory learn/refine are marked unavailable");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #872. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #872

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784862433&installation_id=129708444&pr_number=883&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F883&signature=5e69945d78c65b01bce38b8475baa6e2c88f3993ddd85c99f247829a1c727cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->