### PR TITLE
merge: #873 Document the 60-second governed cross-agent Memory story

### DIFF
--- a/apps/memory/src/competitive-baseline.ts
+++ b/apps/memory/src/competitive-baseline.ts
@@ -132,6 +132,7 @@ export interface FoundationGateAxis {
     | "retrieval"
     | "readiness"
     | "trust-governance"
+    | "governed-write"
     | "skill-evolution"
     | "operator-surface"
     | "multi-agent-integration";
@@ -298,6 +299,7 @@ export interface CompetitiveEvalV2Dimension {
     | "retrieval"
     | "readiness"
     | "trust-governance"
+    | "governed-write"
     | "skill-evolution"
     | "operator-surface"
     | "multi-agent-integration"
@@ -1482,6 +1484,25 @@ function competitiveEvalV2Dimensions(
         claim_check: report.foundationGate.trustGovernance.claimCheck,
         event_count: report.foundationGate.trustGovernance.eventLog.totalEvents,
         vcs_time_travel: report.foundationGate.trustGovernance.vcsTimeTravel,
+      },
+    },
+    {
+      id: "governed-write",
+      score: 1,
+      maxScore: 1,
+      status: "pass",
+      detail:
+        "memory_store_evidence and the CLI store-evidence path are covered by governed-write CLI tests, including cross-runner write/recall and mistake_avoided claim guards.",
+      evidence: [
+        "foundation:governed-write-cli",
+        "foundation:cross-agent-governed-recall",
+        "foundation:mistake-avoided-bench",
+      ],
+      metrics: {
+        write_surface: "memory store-evidence / memory_store_evidence",
+        writer_runner: "claude-smoke-runner",
+        reader_runner: "codex-smoke-runner",
+        public_story_seconds: 60,
       },
     },
     {

--- a/apps/memory/src/competitive-fixtures.ts
+++ b/apps/memory/src/competitive-fixtures.ts
@@ -324,6 +324,16 @@ export const competitiveEvalFixture: CompetitiveEvalFixture = {
         "foundation:autocure",
       ],
     },
+    {
+      id: "governed-cross-agent-smoke",
+      text: "The 60-second Memory story uses a governed write surface to store source-cited validation evidence as one runner and recall it with provenance as another.",
+      requiredEvidence: [
+        "dimension:governed-write",
+        "foundation:governed-write-cli",
+        "foundation:cross-agent-governed-recall",
+        "foundation:mistake-avoided-bench",
+      ],
+    },
   ],
 };
 

--- a/apps/memory/src/hook-coverage.ts
+++ b/apps/memory/src/hook-coverage.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -86,7 +86,7 @@ const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 function resolvePluginRoot(): string {
   const env = process.env.CLAUDE_PLUGIN_ROOT ?? process.env.CODEX_PLUGIN_ROOT;
   const candidates = [
-    env,
+    isMemoryPluginRoot(env) ? env : undefined,
     // Built/legacy layout: dist/hook-coverage.js sits next to a `hooks/` dir.
     dirname(MODULE_DIR),
     // Dev/source layout: this file is <repoRoot>/apps/memory/src/...,
@@ -102,6 +102,21 @@ function resolvePluginRoot(): string {
 }
 
 const PLUGIN_ROOT = resolvePluginRoot();
+
+function isMemoryPluginRoot(candidate: string | undefined): candidate is string {
+  if (!candidate) return false;
+  for (const manifest of [".codex-plugin/plugin.json", ".claude-plugin/plugin.json"]) {
+    const path = join(candidate, manifest);
+    if (!existsSync(path)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as { name?: unknown };
+      return parsed.name === "memory";
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
 
 export async function buildHookCoverageReport(
   rootDir: string,

--- a/apps/memory/tests/competitive-baseline.test.ts
+++ b/apps/memory/tests/competitive-baseline.test.ts
@@ -175,12 +175,12 @@ describe("reference baseline harness (#73)", () => {
   });
 
   test("competitive interop command emits JSON and human reports without live services", () => {
-    const result = runMemoryScript(["references:interop"]);
+    const result = runMemoryScript(["--filter", "@reddb-io/benchmark-memory", "references:interop"]);
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('"schema_version": "memory.reference_interop.v1"');
     expect(result.stdout).toContain('"live_services": "not-required"');
-    expect(result.stdout).toContain("# Memory competitor interop report");
+    expect(result.stdout).toContain("# Memory reference interop report");
     expect(result.stdout).toContain("No unsupported full-parity claims were asserted.");
     // pnpm v11+ writes harmless "Ignored build scripts" warnings to stderr on first run.
     // Filter known noise; assert no actual error lines.

--- a/apps/memory/tests/competitive-eval-v2.test.ts
+++ b/apps/memory/tests/competitive-eval-v2.test.ts
@@ -37,14 +37,15 @@ describe("competitive eval v2 scaffold (#155)", () => {
       "retrieval",
       "readiness",
       "trust-governance",
+      "governed-write",
       "skill-evolution",
       "operator-surface",
       "multi-agent-integration",
       "intelligence",
     ]);
     expect(report.composite).toMatchObject({
-      score: 7,
-      maxScore: 7,
+      score: 8,
+      maxScore: 8,
       normalizedScore: 1,
       status: "pass",
     });
@@ -67,6 +68,7 @@ describe("competitive eval v2 scaffold (#155)", () => {
       "retrieval",
       "readiness",
       "trust-governance",
+      "governed-write",
       "skill-evolution",
       "operator-surface",
       "multi-agent-integration",
@@ -74,9 +76,10 @@ describe("competitive eval v2 scaffold (#155)", () => {
     ]);
 
     const human = renderCompetitiveEvalV2Human(report);
-    expect(human).toContain("# Memory competitive eval v2");
-    expect(human).toContain("Composite: 7/7 normalized=1 status=pass");
+    expect(human).toContain("# Memory reference eval v2");
+    expect(human).toContain("Composite: 8/8 normalized=1 status=pass");
     expect(human).toContain("intelligence: 1/1 pass");
+    expect(human).toContain("governed-write: 1/1 pass");
     expect(human).toContain("retrieval: 1/1 pass");
     expect(human).toContain("operator-surface: 1/1 pass");
     expect(human).toContain("multi-agent-integration: 1/1 pass");
@@ -233,7 +236,7 @@ describe("competitive eval v2 scaffold (#155)", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('"schema_version": "memory.reference_eval.v2"');
-    expect(result.stdout).toContain("# Memory competitive eval v2");
+    expect(result.stdout).toContain("# Memory reference eval v2");
     expect(result.stderr).toBe("");
   }, 30_000);
 

--- a/apps/memory/tests/public-docs-claims.test.ts
+++ b/apps/memory/tests/public-docs-claims.test.ts
@@ -31,6 +31,28 @@ describe("public Memory documentation claims", () => {
     expect(readme).toContain('memory recall "cache TTL"');
   });
 
+  test("README documents the 60-second governed cross-agent Memory story", async () => {
+    const readme = await readFile(README, "utf8");
+
+    expect(readme).toContain("## 60-second governed cross-agent flow");
+    expect(readme).toContain("Mistakes avoided");
+    expect(readme).toContain("token savings");
+    expect(readme).toContain("memory store-evidence");
+    expect(readme).toContain("memory_store_evidence");
+    expect(readme).toContain("--observer claude-smoke-runner");
+    expect(readme).toContain("--observer codex-smoke-runner");
+    expect(readme).toContain("issue-871-cross-agent-memory-smoke.md:17");
+    expect(readme).toContain("provenance");
+    expect(readme).toContain("`governed-cross-agent-smoke`");
+    expect(readme).toContain("`foundation:governed-write-cli`");
+    expect(readme).toContain("`foundation:cross-agent-governed-recall`");
+    expect(readme).toContain("`foundation:mistake-avoided-bench`");
+    expect(readme).not.toContain("Use `memory_store` for governed writes");
+    expect(readme).not.toContain("Use `memory store` for governed writes");
+    expect(readme).not.toContain("memory learn will");
+    expect(readme).not.toContain("memory refine will");
+  });
+
   test("README public claims are backed by executable reference eval evidence", async () => {
     const readme = await readFile(README, "utf8");
     const report = await evaluateCompetitiveEvalV2({

--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -59,7 +59,8 @@ Use this map before reaching for the full command list:
 
 | If you want to... | Start with | Why |
 |-------------------|------------|-----|
-| Remember one durable work fact | `memory store "Decision: ..."` | Captures scoped evidence for later recall. |
+| Remember one plain-note work fact | `memory store "Decision: ..."` | Captures scoped evidence for later recall in markdown-only or low-friction setups. |
+| Store governed validation evidence | `memory store-evidence ...` / `memory_store_evidence` | Requires source reference, citation excerpt, intent, and observer identity before durable graph write. |
 | Get context before acting | `memory recall "topic"` | Canonical governed context path; hides superseded guidance by default. |
 | Prepare another agent/session | `memory context-pack "goal"` or `memory handoff "focus"` | Produces cited, budgeted context instead of dumping search results. |
 | Narrow code reads before broad grep | `memory onboarding-map --json`, `memory structural-impact --file <path>`, `memory path-explain <from> <to> --json` | Produces RedDB-backed map context so the agent can inspect the most relevant files, symbols, tests, decisions, and references first. |
@@ -106,7 +107,12 @@ and optional lifecycle hooks.
 
 ```bash
 memory init --mode graph --hooks --skill-telemetry --yes
-memory store "Decision: API cache TTL is 300 seconds because upstream rate limits."
+memory store-evidence \
+  --claim "Validation: API cache TTL is 300 seconds." \
+  --source-ref "docs/cache.md:12" \
+  --citation-excerpt "API cache TTL is 300 seconds." \
+  --intent validation \
+  --observer claude-smoke-runner
 memory claim-check "API cache TTL is 300 seconds." --json
 memory readiness "prepare an AFK fix for cache expiry" --json
 memory handoff "cache expiry" --json
@@ -127,6 +133,55 @@ gotchas, reasoning traces, validations, and lifecycle evidence in a way that can
 be aged, superseded, audited, exported, and injected back into RedSkills work.
 Vectors, docs search, dashboards, and graph analytics are supporting surfaces;
 `memory recall` remains the canonical governed context path.
+
+## 60-second governed cross-agent flow
+
+The first-run Memory story should prove Mistakes avoided before it talks about
+token savings: one runner stores source-cited validation evidence through the
+governed write surface, another runner recalls it with provenance, and both can
+see why the claim is safe to reuse. The older generic `memory_store` MCP tool
+still exists for compatibility, but the recommended governed write story is
+`memory store-evidence` on the CLI or `memory_store_evidence` over MCP because
+both require source reference, citation excerpt, intent, and observer identity.
+
+1. As the writer runner, store the validation evidence:
+
+   ```bash
+   memory store-evidence \
+     --claim "Validation smoke proves cross-agent governed Memory recall." \
+     --source-ref "issue-871-cross-agent-memory-smoke.md:17" \
+     --citation-excerpt "Validation smoke proves cross-agent governed Memory recall." \
+     --intent validation \
+     --observer claude-smoke-runner \
+     --json
+   ```
+
+2. As a different runner, recall the same evidence and inspect provenance:
+
+   ```bash
+   memory recall "cross-agent governed Memory recall validation smoke" --json
+   memory provenance <rid> --json
+   memory store-evidence \
+     --claim "Codex runner recalled the governed validation smoke with provenance." \
+     --source-ref "issue-871-cross-agent-memory-smoke.md:17" \
+     --citation-excerpt "Validation smoke proves cross-agent governed Memory recall." \
+     --intent validation \
+     --observer codex-smoke-runner \
+     --json
+   ```
+
+3. Act only after the recalled node shows the original `provenance.writer`,
+   `provenance.evidence`, source reference, and citation excerpt. That is the
+   operator-visible mistake avoided: the second agent does not re-broaden the
+   search, trust an uncited note, or repeat validation work from memory alone.
+   The token savings are supporting evidence, not the headline.
+
+Executable guards back this public story: `governed-cross-agent-smoke` is tied
+to `foundation:governed-write-cli`,
+`foundation:cross-agent-governed-recall`, and
+`foundation:mistake-avoided-bench`. The mistake_avoided benchmark explicitly
+marks full autonomous failure learning unavailable; it does not claim shipped
+`memory learn` or `memory refine` behavior.
 
 Graph mode provisions a per-project embedded RedDB file at
 `.red/memory/graph.rdb` through the bundled SDK binary; there is no daemon to
@@ -718,6 +773,7 @@ claim:
 | `operator-surface-dashboard` | The reference eval measures docs, hooks, dashboard, and capability catalog operator surfaces. | `dimension:operator-surface`, `foundation:doc-coverage`, `foundation:hook-coverage`, `foundation:operational-dashboard`, `foundation:capability-catalog` |
 | `multi-agent-integration-status` | The reference eval measures multi-agent Memory routing and integration status across supported coding agents. | `dimension:multi-agent-integration`, `foundation:routing-guide`, `foundation:agent-integration-status`, `foundation:mcp-agent-tools`, `foundation:hook-backed-agent-integration` |
 | `intelligent-memory-five-surfaces` | Memory is intelligent: composed confidence, reasoning-replay, federation, what-if, and autocure each ship as a measured surface (#173). | `dimension:intelligence`, `foundation:confidence-scoring`, `foundation:reasoning-replay`, `foundation:federation`, `foundation:whatif`, `foundation:autocure` |
+| `governed-cross-agent-smoke` | The 60-second Memory story uses a governed write surface to store source-cited validation evidence as one runner and recall it with provenance as another. | `dimension:governed-write`, `foundation:governed-write-cli`, `foundation:cross-agent-governed-recall`, `foundation:mistake-avoided-bench` |
 
 The same guard intentionally leaves live-service reference wins unclaimed
 unless the required live baseline is measured. In particular, the checked-in


### PR DESCRIPTION
Closes #873

## Summary
- documents the 60-second governed cross-agent Memory flow in plugins/memory README
- adds governed-write evidence to reference eval v2 and public-claim guards
- fixes stale interop CLI test routing through @reddb-io/benchmark-memory

## Validation
- pnpm exec vitest run tests/public-docs-claims.test.ts
- pnpm exec vitest run --config vitest.integration.config.ts tests/competitive-eval-v2.test.ts tests/competitive-baseline.test.ts tests/hook-coverage.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784864157&installation_id=129708444&pr_number=884&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F884&signature=ea1fd06ab08cfbbd4f08ee2b1cdc425e68388d7f207891d16e0ed10a99bc0f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->