### PR TITLE
merge: #862 Preserve actionable AFK blockers after runner crashes

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1679,6 +1679,21 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
   }
 }
 
+const ACTIONABLE_BLOCKER_KINDS = new Set([
+  "spec",
+  "validation",
+  "merge-conflict",
+  "ci",
+  "stalled",
+  "decision",
+]);
+
+function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
+  if (!existing) return false;
+  if (next.kind !== "runner") return false;
+  return ACTIONABLE_BLOCKER_KINDS.has(existing.kind);
+}
+
 async function writeCurrentBlockerBestEffort(
   deps: ProcessIssueDeps,
   input: ProcessIssueInput,
@@ -1686,7 +1701,9 @@ async function writeCurrentBlockerBestEffort(
 ): Promise<void> {
   if (!blocker || !deps.gh.editBody) return;
   try {
-    await deps.gh.editBody(input.issue, upsertCurrentBlocker(input.body, blocker));
+    const existing = parseCurrentBlocker(input.body);
+    const next = shouldPreserveCurrentBlocker(existing, blocker) ? existing! : blocker;
+    await deps.gh.editBody(input.issue, upsertCurrentBlocker(input.body, next));
   } catch {
     // Best-effort: issue-body state improves resumability, but label routing and
     // the failure envelope remain the canonical fallback if the edit fails.

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -901,6 +901,27 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(trace.released).toEqual([9]);
   });
 
+  it("preserves an earlier actionable blocker when a later empty no-sentinel crashes (#862)", async () => {
+    const body = upsertCurrentBlocker("## Agent brief\nDo it.", {
+      status: "blocked",
+      kind: "merge-conflict",
+      summary: "Attempt 1 preserved a merge-conflict branch.",
+      next: "Resolve the merge conflict or add guidance for the next agent attempt.",
+    });
+    const { deps, input, trace } = harness({ outcome: "no-sentinel", changedFiles: [], body });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("no-sentinel");
+    expect(trace.bodyEdits).toHaveLength(1);
+    expect(parseCurrentBlocker(trace.bodyEdits[0]!.body)).toMatchObject({
+      kind: "merge-conflict",
+      summary: "Attempt 1 preserved a merge-conflict branch.",
+      next: "Resolve the merge conflict or add guidance for the next agent attempt.",
+    });
+    expect(trace.bodyEdits[0]!.body).not.toContain("Review the attempt log and decide whether to retry");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "no-sentinel" }]);
+  });
+
   it("branch carries work + passes feedback → SALVAGE: lands like DONE, closes (issue #332)", async () => {
     // The agent finished + committed but exited without the sentinel (the #300
     // loop). Branch is ahead of base and green → salvage through the same gate.


### PR DESCRIPTION
Closes #862

## Summary
- preserve an existing actionable Current blocker when a later empty no-sentinel/runner crash escalates
- keep the later no-sentinel envelope as audit evidence while leaving the operator-facing blocker on the richer prior state
- add processIssue coverage for the #850 pattern: merge-conflict blocker followed by API/no-sentinel crash

## Validation
- pnpm -C apps/dev exec vitest run tests/process-issue.test.ts -t "#862"
- pnpm -C apps/dev exec vitest run tests/process-issue.test.ts
- pnpm -C apps/dev run typecheck
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784864856&installation_id=129708444&pr_number=885&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F885&signature=4911b6b6cdaa5dbbbe20fa89cb36c5a1dcf76ac0071f88e51f9e29cd1d4ecf7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->