### PR TITLE
merge: #886 Codify Task mirror host capability matrix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,18 @@ Upstream base: `mattpocock/skills@6eeb81b5fcfeeb5bd531dd47ab2f9f2bbea27461` (see
 
 ---
 
+## afk (engineering) — Task mirror host capability matrix codified (issue #886)
+
+- **status**: modified
+- **upstream**: —
+- **why**: The Task mirror's per-host support (Claude Code native task API, Codex monitor-agent fallback, OpenCode headless) was implicit and scattered across ADR 0003/0015 and the runner docs; OpenCode had no explicit Task-mirror decision and `runMirrorPlan` would have routed an `opencode` host down the Claude native path. #886 makes the matrix explicit and test-backed without changing product behavior, preserving the AFK-runner vs interactive-host distinction and the no-cross-runner-abstraction rule.
+- **what changed**:
+  - `core/mirror.ts`: new `taskMirrorCapability(host)` — an explicit per-host switch (not a generic registry) returning a `TaskMirrorCapability` (`surface`: `native-task` | `monitor-agent` | `headless`, plus `agentDriven`/`nativeTaskApi`/operator note). Unknown host throws. The three sinks (`mirrorPlan`, `codexSinkPlan`, headless none) stay separate; the function classifies, it does not dispatch generically.
+  - `commands/monitor.ts`: `runMirrorPlan` now picks the sink by `taskMirrorCapability(host).surface`; `MirrorPlanOptions` gains `host` (`codex` kept as legacy shorthand). `monitor --mirror-plan --runner opencode` resolves to the headless host and emits an empty plan.
+  - SKILL.md: a binding host-capability matrix table in *Task Mirror And Codex Monitor Agent*, stating no parity across hosts.
+  - `runner-opencode.md`: new *Task mirror (headless — no surface)* section.
+  - Tests: `tests/mirror.test.ts` covers the capability decision for all three hosts (distinct surfaces, normalization, loud unknown-host failure); `tests/monitor.test.ts` covers the OpenCode-headless empty plan and the per-host sink routing.
+
 ## requeue (engineering) — narrowed safe requeue for blocked:validation/spec (issue #860)
 
 - **status**: modified

--- a/apps/dev/src/commands/monitor.ts
+++ b/apps/dev/src/commands/monitor.ts
@@ -6,7 +6,9 @@ import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import {
   mirrorPlan,
   codexSinkPlan,
+  taskMirrorCapability,
   type MirrorCall,
+  type TaskMirrorHost,
   type TrackedTask,
   type WorkerRecord,
 } from "../core/mirror.js";
@@ -70,15 +72,23 @@ export function parseTrackedJsonl(text: string): TrackedTask[] {
 }
 
 export interface MirrorPlanOptions {
-  /** Use the Codex sink (codexSinkPlan) instead of the Claude mirrorPlan. */
+  /** The host whose Task-mirror capability picks the sink. Default "claude". */
+  host?: TaskMirrorHost;
+  /** Legacy shorthand for `host: "codex"`; ignored when `host` is set. */
   codex?: boolean;
 }
 
 /**
  * Pure, testable core of `monitor --mirror-plan`: given the live worker inputs,
- * the tracked-task JSONL, and the runner, compute the mirror call plan and emit
+ * the tracked-task JSONL, and the host, compute the mirror call plan and emit
  * it as JSONL (one MirrorCall per line, trailing newline). An empty plan yields
  * the empty string (idempotent: nothing changed → no output).
+ *
+ * The sink is picked by the host's {@link taskMirrorCapability}, keeping each
+ * adapter explicit per runner (issue #886 / ADR 0003) — never a generic merge:
+ *   native-task   (claude)   → mirrorPlan, the host TaskCreate/TaskUpdate sink.
+ *   monitor-agent (codex)    → codexSinkPlan, empty today (dashboard fallback).
+ *   headless      (opencode) → empty plan, no host session to mirror into.
  */
 export function runMirrorPlan(
   workers: readonly CompactWorker[],
@@ -87,9 +97,21 @@ export function runMirrorPlan(
 ): string {
   const desired = workersToDesired(workers);
   const tracked = parseTrackedJsonl(trackedJsonl);
-  const calls: MirrorCall[] = options.codex
-    ? codexSinkPlan(desired, tracked).plan
-    : mirrorPlan(desired, tracked);
+  const host: TaskMirrorHost = options.host ?? (options.codex ? "codex" : "claude");
+  let calls: MirrorCall[];
+  switch (taskMirrorCapability(host).surface) {
+    case "native-task":
+      calls = mirrorPlan(desired, tracked);
+      break;
+    case "monitor-agent":
+      calls = codexSinkPlan(desired, tracked).plan;
+      break;
+    case "headless":
+      // OpenCode is a headless Worker with no in-session surface — no native
+      // calls are ever emitted, so the plan is always empty.
+      calls = [];
+      break;
+  }
   if (calls.length === 0) return "";
   return `${calls.map((c) => JSON.stringify(c)).join("\n")}\n`;
 }
@@ -122,13 +144,16 @@ export async function monitorCommand(
 ): Promise<number> {
   if (args.includes("--mirror-plan")) {
     const runnerIdx = args.indexOf("--runner");
-    const codex =
-      args.includes("--codex") ||
-      args.includes("--runner=codex") ||
-      (runnerIdx !== -1 && args[runnerIdx + 1] === "codex");
+    const runnerFlag = runnerIdx !== -1 ? args[runnerIdx + 1] : undefined;
+    const host: TaskMirrorHost =
+      args.includes("--codex") || args.includes("--runner=codex") || runnerFlag === "codex"
+        ? "codex"
+        : args.includes("--runner=opencode") || runnerFlag === "opencode"
+          ? "opencode"
+          : "claude";
     const { workers } = await collectMonitorInputs(cwd);
     const trackedJsonl = await readStdin(stdin);
-    const out = runMirrorPlan(workers, trackedJsonl, { codex });
+    const out = runMirrorPlan(workers, trackedJsonl, { host });
     if (out !== "") stdout.write(out);
     return 0;
   }

--- a/apps/dev/src/core/mirror.ts
+++ b/apps/dev/src/core/mirror.ts
@@ -298,3 +298,83 @@ export function codexSinkPlan(
   }
   return { plan: [], notice: CODEX_NO_NATIVE_NOTICE };
 }
+
+// --- Host capability matrix (issue #886) -----------------------------------
+//
+// The Task mirror is per-runner by construction (ADR 0003/0015): there is NO
+// shared native task API across the hosts, so a single cross-runner abstraction
+// would be a fiction. `taskMirrorCapability` is a *classification*, not a
+// dispatcher — it states what each host supports today and which explicit sink
+// applies, leaving the three sinks (`mirrorPlan`, `codexSinkPlan`, headless
+// none) separate. Reading the matrix never collapses the adapters into one.
+
+/** The host/runner whose Task-mirror capability is being classified. */
+export type TaskMirrorHost = "claude" | "codex" | "opencode";
+
+/**
+ * The progress surface a host drives today. Deliberately three distinct values,
+ * never a single "supported: boolean", so the matrix cannot imply parity:
+ *   native-task   — a first-class host task API (Claude Code TaskCreate/TaskUpdate).
+ *   monitor-agent — no task API; the dashboard plus one read-only monitor agent.
+ *   headless      — no host session at all; nothing to mirror into.
+ */
+export type TaskMirrorSurface = "native-task" | "monitor-agent" | "headless";
+
+/** One host's Task-mirror capability — what it supports and how it surfaces. */
+export interface TaskMirrorCapability {
+  host: TaskMirrorHost;
+  /** Which surface this host drives (see {@link TaskMirrorSurface}). */
+  surface: TaskMirrorSurface;
+  /** Whether an in-session agent drives the mirror tick at all. False = headless. */
+  agentDriven: boolean;
+  /** Whether the host exposes a native background-task API the mirror writes to. */
+  nativeTaskApi: boolean;
+  /** Operator-facing one-liner, in project vocabulary (Worker / Agent runner / …). */
+  note: string;
+}
+
+/**
+ * Classify a host's Task-mirror capability (issue #886). An explicit per-host
+ * switch — NOT a generic registry — so adding or pretending a host is left an
+ * obvious code edit, and an unknown host fails loudly rather than silently
+ * inheriting the Claude native path. The honest, no-parity matrix:
+ *
+ *   claude   → native-task   — the Claude Code Agent runner drives the Task
+ *                              mirror through TaskCreate / TaskUpdate.
+ *   codex    → monitor-agent — the Codex Agent runner has no task API; the Task
+ *                              mirror falls back to the dashboard plus one
+ *                              read-only Codex monitor agent (see codexSinkPlan).
+ *   opencode → headless      — the OpenCode runner is an API-auth Worker with no
+ *                              host session, so there is no surface to mirror into.
+ */
+export function taskMirrorCapability(host: string): TaskMirrorCapability {
+  const normalized = host.trim().toLowerCase();
+  switch (normalized) {
+    case "claude":
+      return {
+        host: "claude",
+        surface: "native-task",
+        agentDriven: true,
+        nativeTaskApi: true,
+        note: "Claude Code Agent runner: native Task mirror via TaskCreate/TaskUpdate.",
+      };
+    case "codex":
+      return {
+        host: "codex",
+        surface: "monitor-agent",
+        agentDriven: true,
+        nativeTaskApi: false,
+        note: "Codex Agent runner: no task API — dashboard fallback plus one read-only Codex monitor agent.",
+      };
+    case "opencode":
+      return {
+        host: "opencode",
+        surface: "headless",
+        agentDriven: false,
+        nativeTaskApi: false,
+        note: "OpenCode runner: headless API-auth Worker, no host session and no Task mirror surface.",
+      };
+    default:
+      throw new Error(`taskMirrorCapability: unknown host '${host}'`);
+  }
+}

--- a/apps/dev/tests/mirror.test.ts
+++ b/apps/dev/tests/mirror.test.ts
@@ -4,6 +4,7 @@ import {
   mirrorPlan,
   mirrorReconcile,
   mirrorTitle,
+  taskMirrorCapability,
   type MirrorCall,
   type TrackedTask,
   type WorkerRecord,
@@ -231,5 +232,48 @@ describe("codex sink", () => {
     const result = codexSinkPlan(workers, []);
     expect(result.plan).toEqual([]);
     expect(result.notice).toContain("no native task surface");
+  });
+});
+
+describe("task mirror host capability matrix (#886)", () => {
+  it("Claude Code drives the native task surface (TaskCreate/TaskUpdate)", () => {
+    const cap = taskMirrorCapability("claude");
+    expect(cap.surface).toBe("native-task");
+    expect(cap.agentDriven).toBe(true);
+    expect(cap.nativeTaskApi).toBe(true);
+    expect(cap.note).toContain("Agent runner");
+  });
+
+  it("Codex has no task API — monitor-agent fallback, not parity", () => {
+    const cap = taskMirrorCapability("codex");
+    expect(cap.surface).toBe("monitor-agent");
+    expect(cap.agentDriven).toBe(true);
+    expect(cap.nativeTaskApi).toBe(false);
+    expect(cap.note).toContain("Codex monitor agent");
+  });
+
+  it("OpenCode is a headless runner with no host session to mirror into", () => {
+    const cap = taskMirrorCapability("opencode");
+    expect(cap.surface).toBe("headless");
+    expect(cap.agentDriven).toBe(false);
+    expect(cap.nativeTaskApi).toBe(false);
+    expect(cap.note).toContain("OpenCode runner");
+  });
+
+  it("no two hosts claim parity — each surface is distinct", () => {
+    const surfaces = (["claude", "codex", "opencode"] as const).map(
+      (h) => taskMirrorCapability(h).surface,
+    );
+    expect(new Set(surfaces).size).toBe(3);
+    // Exactly one host exposes a native task API; the matrix never implies parity.
+    expect(surfaces.filter((s) => s === "native-task")).toHaveLength(1);
+  });
+
+  it("the host token is normalized (case / whitespace insensitive)", () => {
+    expect(taskMirrorCapability("  Codex \n").surface).toBe("monitor-agent");
+  });
+
+  it("an unknown host fails loudly instead of inheriting the Claude path", () => {
+    expect(() => taskMirrorCapability("gemini")).toThrow(/unknown host 'gemini'/);
   });
 });

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -457,6 +457,30 @@ describe("monitor — mirror plan", () => {
     expect(out).toBe("");
   });
 
+  it("codex host (via host option) falls back to an empty plan", () => {
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "impl")], "", {
+      host: "codex",
+    });
+    expect(out).toBe("");
+  });
+
+  it("opencode is a headless runner: no native task calls are ever emitted", () => {
+    // A fresh live worker would be a TaskCreate under Claude; under the headless
+    // OpenCode runner there is no host session to mirror into, so the plan is empty.
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "impl")], "", {
+      host: "opencode",
+    });
+    expect(out).toBe("");
+  });
+
+  it("claude host emits the native TaskCreate plan (matrix sanity)", () => {
+    const out = runMirrorPlan([liveWorker("wAAAA", 42, "do thing", "impl")], "", {
+      host: "claude",
+    });
+    expect(parse(out)).toHaveLength(1);
+    expect(parse(out)[0]).toMatchObject({ call: "TaskCreate", key: "wAAAA:42" });
+  });
+
   it("workersToDesired omits idle workers and maps liveness", () => {
     const desired = workersToDesired([
       liveWorker("wAAAA", 42, "t", "impl"),

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -581,6 +581,16 @@ When `CronList` / `CronDelete` are unavailable (Codex runner, or `/afk monitor` 
 
 Every `/dev:afk monitor` run also **mirrors each live worker onto the runner's native task list when that runner exposes one**, so a `/afk` session surfaces progress on the host's native UI — advancing through stages on its own, with no extra typing. This is a **read-only reflection of `afk.state.json`**; the mirror never writes state and never touches the orchestration.
 
+**Host capability matrix (binding — no parity).** The Task mirror is per-runner by construction (ADR 0003/0015): there is **no shared native task API** across the hosts, so each runner gets its own explicit adapter, never a generic cross-runner abstraction. The honest matrix — encoded as `taskMirrorCapability(host)` in `core/mirror.ts` and exercised by `tests/mirror.test.ts` — is:
+
+| Host (Agent runner) | Surface | Native task API | Adapter / sink | Today's behavior |
+|---|---|---|---|---|
+| Claude Code | `native-task` | yes | `mirrorPlan` (`TaskCreate`/`TaskUpdate`) | the in-session Agent runner drives the native Task mirror through the host task tools |
+| Codex | `monitor-agent` | no | `codexSinkPlan` | no task API — the mirror falls back to the `monitor` dashboard plus **one read-only Codex monitor agent** |
+| OpenCode runner | `headless` | no | none (empty plan) | a headless API-auth **Worker** with no host session — there is no surface to mirror into, so no native calls are ever emitted |
+
+The three surfaces are deliberately distinct values (never a single `supported: boolean`) so the matrix can **never imply parity**. Exactly one host (Claude Code) exposes a native task API; the other two degrade explicitly, each on its own adapter. An unknown host fails loudly rather than silently inheriting the Claude native path.
+
 The mirror surfaces **two signals on one lifecycle** (issue #811): the task **title** carries the calm **macro phase** — `w<id> [<n>/5 <phase>] #<issue> <slug>` — while the task **description** carries the fine **micro stage** — `stage: <impl|explore|tests|commit>`. The phase vocabulary is the ordered `setup → coding → validating → merging → done` (1-based `n/5`), plus the terminal `blocked` which drops the `n/5` and renders `[blocked]`. The title changes only when the macro phase moves, so it never flickers on every inner-agent tool call.
 
 The mirror is a pure diff: it reconciles the live worker state files against the tasks already on the native surface and emits a **call plan**. After rendering the dashboard, the agent (under Claude Code only) must:

--- a/plugins/dev/skills/engineering/afk/runner-opencode.md
+++ b/plugins/dev/skills/engineering/afk/runner-opencode.md
@@ -109,6 +109,19 @@ in an API-key-only lane with no host session, run OpenCode **without**
 `--fallback-runner` so an exhaustion is terminal-through-recovery rather than a
 swap to an unavailable runner.
 
+## Task mirror (headless — no surface)
+
+OpenCode is the `headless` row of the Task-mirror host capability matrix
+(`taskMirrorCapability("opencode")`, SKILL.md *Task Mirror And Codex Monitor
+Agent*). Because it has **no host session**, there is no native task list and no
+sub-agent UI to mirror worker progress into: the OpenCode runner is not a Claude
+Code-style native-task host, and it is not the Codex monitor-agent fallback
+either. `monitor --mirror-plan --runner opencode` therefore emits an **empty
+plan** — no `TaskCreate`/`TaskUpdate` calls — and the canonical progress surface
+for an OpenCode lane is the `monitor` dashboard read directly from the worker
+state files. This is the honest no-parity position: do not invent a cross-runner
+task abstraction to pretend OpenCode has a surface it does not (ADR 0003).
+
 ## Working Directory
 
 OpenCode runs with the sandcastle-created worktree as its working directory and


### PR DESCRIPTION
Automated AFK landing for #886. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #886

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784890877&installation_id=129708444&pr_number=890&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F890&signature=cda61bc159f235bd5bfaa59863aaa4adb5704a16befd795eceb28e2683bd89f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runner-aware task mirror handling, so plan generation now adapts based on the selected host.
  * Introduced clearer behavior for headless runs, which now emit no native task actions.

* **Bug Fixes**
  * Improved host detection and validation, including consistent handling of mixed-case and spaced host names.
  * Unknown hosts now fail explicitly instead of falling back silently.

* **Documentation**
  * Updated task-mirror guidance to reflect per-runner behavior for Claude, Codex, and OpenCode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->