### PR TITLE
merge: #887 Surface Codex Task mirror fallback in monitor output

### DIFF
--- a/apps/dev/src/commands/monitor.ts
+++ b/apps/dev/src/commands/monitor.ts
@@ -8,6 +8,7 @@ import {
   codexSinkPlan,
   taskMirrorCapability,
   type MirrorCall,
+  type MirrorFallbackNotice,
   type TaskMirrorHost,
   type TrackedTask,
   type WorkerRecord,
@@ -99,21 +100,33 @@ export function runMirrorPlan(
   const tracked = parseTrackedJsonl(trackedJsonl);
   const host: TaskMirrorHost = options.host ?? (options.codex ? "codex" : "claude");
   let calls: MirrorCall[];
+  let notice: string | undefined;
   switch (taskMirrorCapability(host).surface) {
     case "native-task":
       calls = mirrorPlan(desired, tracked);
       break;
-    case "monitor-agent":
-      calls = codexSinkPlan(desired, tracked).plan;
+    case "monitor-agent": {
+      // Codex has no native task API. codexSinkPlan always returns an empty call
+      // plan plus a one-line fallback notice so the operator can see that task
+      // mirroring is intentionally falling back to the dashboard, not silently
+      // doing nothing. The notice is surfaced as a structured JSONL line — it
+      // carries `signal`, never `call`, so it is not a task call descriptor.
+      const sink = codexSinkPlan(desired, tracked);
+      calls = sink.plan;
+      notice = sink.notice;
       break;
+    }
     case "headless":
       // OpenCode is a headless Worker with no in-session surface — no native
       // calls are ever emitted, so the plan is always empty.
       calls = [];
       break;
   }
-  if (calls.length === 0) return "";
-  return `${calls.map((c) => JSON.stringify(c)).join("\n")}\n`;
+  const callsOut =
+    calls.length === 0 ? "" : `${calls.map((c) => JSON.stringify(c)).join("\n")}\n`;
+  if (notice === undefined) return callsOut;
+  const noticeRecord: MirrorFallbackNotice = { signal: "fallback-notice", message: notice };
+  return `${callsOut}${JSON.stringify(noticeRecord)}\n`;
 }
 
 /** Read all of stdin to a string (empty when nothing is piped / TTY). */
@@ -134,7 +147,9 @@ async function readStdin(stdin: NodeJS.ReadableStream): Promise<string> {
  * mode: read the agent's tracked mirror tasks as JSONL from stdin, diff against
  * the live worker state (the same reads the dashboard uses), and emit the mirror
  * call plan as JSONL to stdout for the agent to apply via TaskCreate/TaskUpdate.
- * Renders no dashboard; empty plan → no output.
+ * Renders no dashboard; empty plan → no output. For Codex (monitor-agent surface)
+ * a `{ signal: "fallback-notice" }` line is always written so the operator knows
+ * that native task mirroring is unavailable — never a silent no-op.
  */
 export async function monitorCommand(
   args: string[],

--- a/apps/dev/src/core/mirror.ts
+++ b/apps/dev/src/core/mirror.ts
@@ -280,6 +280,17 @@ export const CODEX_NO_NATIVE_NOTICE =
   "afk: Codex has no native task surface — mirroring via the monitor.sh dashboard instead.";
 
 /**
+ * Structured monitor signal emitted to stdout in the `--mirror-plan` output
+ * when the Codex fallback path is active. Never confused with a task call
+ * descriptor — `signal` is present, `call` is absent — so the consumer can
+ * render it as a plain notice without attempting to apply it to a task surface.
+ */
+export interface MirrorFallbackNotice {
+  signal: "fallback-notice";
+  message: string;
+}
+
+/**
  * Codex half of the runner-specific Task-mirror sink (mirror_sink_codex). The
  * reader + reconciler are reused unchanged; only this sink is runner-specific.
  *

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -8,11 +8,12 @@ import {
   type CompactWorker,
 } from "../src/core/monitor.js";
 import {
+  monitorCommand,
   runMirrorPlan,
   parseTrackedJsonl,
   workersToDesired,
 } from "../src/commands/monitor.js";
-import type { MirrorCall } from "../src/core/mirror.js";
+import type { MirrorCall, MirrorFallbackNotice } from "../src/core/mirror.js";
 
 const baseWorker = (over: Partial<CompactWorker> = {}): CompactWorker => ({
   state: {
@@ -450,18 +451,26 @@ describe("monitor — mirror plan", () => {
     expect(out).toBe("");
   });
 
-  it("codex runner falls back to an empty plan (no native surface)", () => {
+  it("codex runner emits a fallback notice (no native task calls)", () => {
     const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "impl")], "", {
       codex: true,
     });
-    expect(out).toBe("");
+    const lines = out.split("\n").filter((l) => l.trim() !== "");
+    expect(lines).toHaveLength(1);
+    const notice = JSON.parse(lines[0]!) as MirrorFallbackNotice;
+    expect(notice.signal).toBe("fallback-notice");
+    expect(notice.message).toContain("no native task surface");
+    // no task call descriptors — criterion 2
+    expect(notice).not.toHaveProperty("call");
   });
 
-  it("codex host (via host option) falls back to an empty plan", () => {
+  it("codex host (via host option) emits the same fallback notice", () => {
     const out = runMirrorPlan([liveWorker("wAAAA", 42, "t", "impl")], "", {
       host: "codex",
     });
-    expect(out).toBe("");
+    const lines = out.split("\n").filter((l) => l.trim() !== "");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({ signal: "fallback-notice" });
   });
 
   it("opencode is a headless runner: no native task calls are ever emitted", () => {
@@ -505,5 +514,79 @@ describe("monitor — mirror plan", () => {
       { key: "a:1", stage: "impl", phase: "coding" },
       { key: "b:2", stage: "", phase: "" },
     ]);
+  });
+});
+
+// Helpers shared by the monitorCommand integration tests below.
+function makeMockStdout(): { chunks: string[]; stream: NodeJS.WritableStream } {
+  const chunks: string[] = [];
+  const stream = {
+    write(chunk: string | Buffer) {
+      chunks.push(String(chunk));
+      return true;
+    },
+  } as unknown as NodeJS.WritableStream;
+  return { chunks, stream };
+}
+
+// An async-iterable stdin that immediately ends (no piped input).
+const emptyStdin = {
+  async *[Symbol.asyncIterator]() {},
+} as unknown as NodeJS.ReadableStream;
+
+describe("monitorCommand — Codex fallback path (issue #887)", () => {
+  it("--mirror-plan --runner codex writes the fallback notice to stdout", async () => {
+    const { chunks, stream } = makeMockStdout();
+    const code = await monitorCommand(
+      ["--mirror-plan", "--runner", "codex"],
+      "/tmp",
+      stream,
+      emptyStdin,
+    );
+    expect(code).toBe(0);
+    const output = chunks.join("");
+    const lines = output.split("\n").filter((l) => l.trim() !== "");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const records = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+    const notice = records.find((r) => r["signal"] === "fallback-notice");
+    expect(notice).toBeDefined();
+    expect(String(notice!["message"])).toContain("no native task surface");
+  });
+
+  it("--mirror-plan --codex (legacy flag) also writes the fallback notice", async () => {
+    const { chunks, stream } = makeMockStdout();
+    await monitorCommand(["--mirror-plan", "--codex"], "/tmp", stream, emptyStdin);
+    const output = chunks.join("");
+    const records = output
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(records.some((r) => r["signal"] === "fallback-notice")).toBe(true);
+  });
+
+  it("codex fallback notice contains no TaskCreate or TaskUpdate call descriptors", async () => {
+    const { chunks, stream } = makeMockStdout();
+    await monitorCommand(
+      ["--mirror-plan", "--runner", "codex"],
+      "/tmp",
+      stream,
+      emptyStdin,
+    );
+    const output = chunks.join("");
+    const records = output
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const taskCalls = records.filter(
+      (r) => r["call"] === "TaskCreate" || r["call"] === "TaskUpdate",
+    );
+    expect(taskCalls).toHaveLength(0);
+  });
+
+  it("monitor --mirror-plan --runner codex is non-crashing and read-only (exit 0)", async () => {
+    const { stream } = makeMockStdout();
+    await expect(
+      monitorCommand(["--mirror-plan", "--runner", "codex"], "/tmp", stream, emptyStdin),
+    ).resolves.toBe(0);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #887. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #887

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784891664&installation_id=129708444&pr_number=891&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F891&signature=ac4521c9e1a4f6584b41983c45c3d526f1543564ef198af12b8e54d1e1dc168f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->