### PR TITLE
merge: #888 Prototype OpenCode Task mirror sink against server API

### DIFF
--- a/apps/dev/src/core/opencode-host.ts
+++ b/apps/dev/src/core/opencode-host.ts
@@ -1,0 +1,94 @@
+/**
+ * opencode-host.ts — Prototype OpenCode *host* Task-mirror sink (issue #888).
+ *
+ * This is a narrow, reversible prototype that treats OpenCode as an interactive
+ * HOST surface — a server that holds a session's task/progress state — when an
+ * OpenCode server API is configured and reachable. It is NOT the OpenCode
+ * *Agent runner*: that runner stays a headless, API-auth Worker (see
+ * `opencode-env.ts` and `taskMirrorCapability("opencode") === headless` in
+ * `mirror.ts`). Host mirroring is a separate, opt-in surface layered on top; it
+ * changes neither runner selection nor AFK execution semantics.
+ *
+ * The sink is capability-gated by construction:
+ *
+ *   no host client configured        → no-op + NO_SERVER notice (headless path intact)
+ *   client present, server unreachable → no-op + UNREACHABLE notice
+ *   client present, server reachable   → publish the SHARED mirror plan
+ *
+ * The mapping itself is not reinvented: the desired Worker set is reconciled
+ * against the tasks the server already holds via the shared {@link mirrorPlan},
+ * so host mirroring speaks the exact same macro phase (`[n/5 <phase>]`) and micro
+ * stage (`stage: <x>`) vocabulary as the native Claude Task mirror. The OpenCode
+ * server interactions are funnelled through {@link OpenCodeHostClient}, a small
+ * fakeable seam so every branch is testable without a live OpenCode process.
+ */
+
+import { mirrorPlan, type MirrorCall, type TrackedTask, type WorkerRecord } from "./mirror.js";
+
+/**
+ * The minimum OpenCode server interactions the host sink needs, modelled as an
+ * injectable seam so tests fake it (no live OpenCode process). All three calls
+ * are async because real interactions are network round-trips. Implementations
+ * MAY throw on transport failure — the sink treats any throw as "unreachable"
+ * and degrades cleanly, so a host implementation need not swallow its own errors.
+ */
+export interface OpenCodeHostClient {
+  /** Probe whether the host server API is configured AND reachable right now. */
+  available(): Promise<boolean>;
+  /** Read the tasks the server already tracks for a session (for reconcile). */
+  readTasks(sessionId: string): Promise<TrackedTask[]>;
+  /** Publish the reconciled task/progress plan to the session. */
+  publishTasks(sessionId: string, calls: readonly MirrorCall[]): Promise<void>;
+}
+
+/** Outcome of one host-sink tick. */
+export interface OpenCodeHostSinkResult {
+  /** The plan applied to the host (empty when degraded or already steady-state). */
+  plan: MirrorCall[];
+  /** True only when the host server was reached and the plan was published. */
+  mirrored: boolean;
+  /** One-line operator notice, present only on the degraded (no-op) paths. */
+  notice?: string;
+}
+
+export const OPENCODE_HOST_NO_SERVER_NOTICE =
+  "afk: OpenCode host mirroring is off (no host server configured) — the OpenCode Agent runner stays headless; this is separate from running OpenCode as a headless runner.";
+
+export const OPENCODE_HOST_UNREACHABLE_NOTICE =
+  "afk: OpenCode host server is unreachable — falling back to no host mirror; the OpenCode Agent runner is unaffected and keeps running headless.";
+
+/**
+ * OpenCode half of the runner-specific Task-mirror sink, host-surface variant
+ * (issue #888). The reader + reconciler + plan map are reused unchanged through
+ * {@link mirrorPlan}; only the server I/O and the capability gate are new here.
+ *
+ *   client === undefined        → no-op + NO_SERVER notice (host mirroring off).
+ *   client.available() falsy    → no-op + UNREACHABLE notice.
+ *   any client call throws      → no-op + UNREACHABLE notice (clean degrade).
+ *   server reachable            → reconcile vs server-held tasks, publish, mirror.
+ *
+ * Never throws: a host that cannot be reached degrades to the headless behaviour,
+ * it does not fail the run.
+ */
+export async function openCodeHostSinkPlan(
+  desired: readonly WorkerRecord[],
+  client: OpenCodeHostClient | undefined,
+  sessionId: string,
+): Promise<OpenCodeHostSinkResult> {
+  if (client === undefined) {
+    return { plan: [], mirrored: false, notice: OPENCODE_HOST_NO_SERVER_NOTICE };
+  }
+  try {
+    if (!(await client.available())) {
+      return { plan: [], mirrored: false, notice: OPENCODE_HOST_UNREACHABLE_NOTICE };
+    }
+    const tracked = await client.readTasks(sessionId);
+    const plan = mirrorPlan(desired, tracked);
+    if (plan.length > 0) await client.publishTasks(sessionId, plan);
+    return { plan, mirrored: true };
+  } catch {
+    // Transport / server error → degrade to the headless behaviour. The prototype
+    // is reversible by design: a failing host never blocks the Worker.
+    return { plan: [], mirrored: false, notice: OPENCODE_HOST_UNREACHABLE_NOTICE };
+  }
+}

--- a/apps/dev/tests/opencode-host.test.ts
+++ b/apps/dev/tests/opencode-host.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { mirrorPlan, type TrackedTask, type WorkerRecord } from "../src/core/mirror.js";
+import {
+  OPENCODE_HOST_NO_SERVER_NOTICE,
+  OPENCODE_HOST_UNREACHABLE_NOTICE,
+  openCodeHostSinkPlan,
+  type OpenCodeHostClient,
+} from "../src/core/opencode-host.js";
+
+function running(
+  worker_id: string,
+  issue: number,
+  title: string,
+  stage: string,
+  phase = "coding",
+): WorkerRecord {
+  return { worker_id, issue, title, slug: title, stage, phase, started_at: "x", status: "running" };
+}
+
+/** In-memory fake of the minimum OpenCode server interactions (no live process). */
+function fakeClient(
+  opts: {
+    available?: boolean;
+    tracked?: TrackedTask[];
+    throwOn?: "available" | "readTasks" | "publishTasks";
+  } = {},
+): OpenCodeHostClient & { published: { sessionId: string; calls: unknown[] }[] } {
+  const published: { sessionId: string; calls: unknown[] }[] = [];
+  return {
+    published,
+    async available() {
+      if (opts.throwOn === "available") throw new Error("connect ECONNREFUSED");
+      return opts.available ?? true;
+    },
+    async readTasks() {
+      if (opts.throwOn === "readTasks") throw new Error("read failed");
+      return opts.tracked ?? [];
+    },
+    async publishTasks(sessionId, calls) {
+      if (opts.throwOn === "publishTasks") throw new Error("publish failed");
+      published.push({ sessionId, calls: [...calls] });
+    },
+  };
+}
+
+describe("opencode host sink (#888)", () => {
+  const workers: WorkerRecord[] = [running("wAAAA", 22, "extract state.sh", "impl")];
+
+  it("publishes the shared mirror plan when the host server is reachable", async () => {
+    const client = fakeClient({ available: true, tracked: [] });
+    const result = await openCodeHostSinkPlan(workers, client, "sess-1");
+    expect(result.mirrored).toBe(true);
+    expect(result.notice).toBeUndefined();
+    // Same macro/micro vocabulary as the shared Task mirror — not a separate map.
+    expect(result.plan).toEqual(mirrorPlan(workers, []));
+    expect(client.published).toHaveLength(1);
+    expect(client.published[0]!.sessionId).toBe("sess-1");
+    expect(client.published[0]!.calls).toEqual(result.plan);
+  });
+
+  it("reconciles against the tracked tasks the server already holds", async () => {
+    const tracked: TrackedTask[] = [{ key: "wAAAA:22", stage: "impl", phase: "coding" }];
+    const client = fakeClient({ available: true, tracked });
+    const result = await openCodeHostSinkPlan(workers, client, "sess-1");
+    // Already in steady state on the server → no writes, nothing published.
+    expect(result.mirrored).toBe(true);
+    expect(result.plan).toEqual([]);
+    expect(client.published).toEqual([]);
+  });
+
+  it("degrades to a no-op when no host client is configured (headless path preserved)", async () => {
+    const result = await openCodeHostSinkPlan(workers, undefined, "sess-1");
+    expect(result.mirrored).toBe(false);
+    expect(result.plan).toEqual([]);
+    expect(result.notice).toBe(OPENCODE_HOST_NO_SERVER_NOTICE);
+  });
+
+  it("degrades to a no-op when the configured server is unreachable", async () => {
+    const client = fakeClient({ available: false });
+    const result = await openCodeHostSinkPlan(workers, client, "sess-1");
+    expect(result.mirrored).toBe(false);
+    expect(result.plan).toEqual([]);
+    expect(result.notice).toBe(OPENCODE_HOST_UNREACHABLE_NOTICE);
+    expect(client.published).toEqual([]);
+  });
+
+  it("never throws: a server error during probe degrades cleanly", async () => {
+    const client = fakeClient({ throwOn: "available" });
+    const result = await openCodeHostSinkPlan(workers, client, "sess-1");
+    expect(result.mirrored).toBe(false);
+    expect(result.plan).toEqual([]);
+    expect(result.notice).toBe(OPENCODE_HOST_UNREACHABLE_NOTICE);
+  });
+
+  it("never throws: a server error during publish degrades cleanly", async () => {
+    const client = fakeClient({ available: true, throwOn: "publishTasks" });
+    const result = await openCodeHostSinkPlan(workers, client, "sess-1");
+    expect(result.mirrored).toBe(false);
+    expect(result.notice).toBe(OPENCODE_HOST_UNREACHABLE_NOTICE);
+  });
+
+  it("operator notices separate host mirroring from the headless Agent runner", () => {
+    // Both notices must name the headless runner so operators never confuse the
+    // optional host surface with OpenCode-as-Agent-runner.
+    expect(OPENCODE_HOST_NO_SERVER_NOTICE).toContain("headless");
+    expect(OPENCODE_HOST_NO_SERVER_NOTICE).toContain("runner");
+    expect(OPENCODE_HOST_UNREACHABLE_NOTICE).toContain("headless");
+    expect(OPENCODE_HOST_UNREACHABLE_NOTICE).toContain("runner");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #888. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #888

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784892944&installation_id=129708444&pr_number=892&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F892&signature=6e7cc565c47e30b2996b0404ffdab2182a12aa710ed43f4ecbeaa708abc51502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->