### PR TITLE
merge: #889 Add deterministic cross-host Task mirror smoke test

### DIFF
--- a/apps/dev/tests/cross-host-smoke.test.ts
+++ b/apps/dev/tests/cross-host-smoke.test.ts
@@ -1,0 +1,263 @@
+/**
+ * cross-host-smoke.test.ts — deterministic Task-mirror smoke test (issue #889).
+ *
+ * Replays three fixed Worker-state snapshots through the full pipeline:
+ *   readWorkers() → [claude mirrorPlan | codex codexSinkPlan | opencode openCodeHostSinkPlan]
+ *
+ * No live agent, no live OpenCode server, no native Claude/Codex host API.
+ * Run as a quick operator check that parity claims hold and fallbacks degrade cleanly.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  codexSinkPlan,
+  mirrorPlan,
+  readWorkers,
+  taskMirrorCapability,
+  type WorkerStateRead,
+} from "../src/core/mirror.js";
+import {
+  OPENCODE_HOST_NO_SERVER_NOTICE,
+  OPENCODE_HOST_UNREACHABLE_NOTICE,
+  openCodeHostSinkPlan,
+  type OpenCodeHostClient,
+} from "../src/core/opencode-host.js";
+import { AfkStateSchema } from "../src/types/state.js";
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+//
+// Three archetypal Worker snapshots:
+//   wAAAA — live, in the coding phase, micro-stage "impl"
+//   wBBBB — live, in the merging phase, micro-stage "commit"
+//   wCCCC — dead process whose last macro-phase was "blocked" (terminal failure)
+
+function snapshot(
+  worker_id: string,
+  number: number,
+  title: string,
+  slug: string,
+  stage: string,
+  phase: string,
+) {
+  return AfkStateSchema.parse({
+    worker_id,
+    started_at: "2026-06-24T00:00:00Z",
+    current: { number, title, slug, stage, phase },
+  });
+}
+
+const READS: WorkerStateRead[] = [
+  {
+    state: snapshot("wAAAA", 889, "add-deterministic-cross-host-task-mirror", "cross-host-mirror", "impl", "coding"),
+    live: true,
+  },
+  {
+    state: snapshot("wBBBB", 887, "surface-codex-task-mirror-fallback", "codex-fallback", "commit", "merging"),
+    live: true,
+  },
+  {
+    state: snapshot("wCCCC", 885, "old-blocked-slice", "old-blocked", "impl", "blocked"),
+    live: false,
+  },
+];
+
+// The normalized WorkerRecord set shared by all three host sinks below.
+const WORKERS = readWorkers(READS);
+
+// ── fixture normalization ─────────────────────────────────────────────────────
+
+describe("Worker-state fixture normalization (readWorkers)", () => {
+  it("produces three records — two running, one blocked-terminal", () => {
+    expect(WORKERS).toHaveLength(3);
+    expect(WORKERS.find((w) => w.worker_id === "wAAAA")?.status).toBe("running");
+    expect(WORKERS.find((w) => w.worker_id === "wBBBB")?.status).toBe("running");
+    expect(WORKERS.find((w) => w.worker_id === "wCCCC")?.status).toBe("blocked");
+  });
+
+  it("normalizes phase and slug from the raw state", () => {
+    const a = WORKERS.find((w) => w.worker_id === "wAAAA")!;
+    expect(a.phase).toBe("coding");
+    expect(a.slug).toBe("cross-host-mirror");
+    expect(a.issue).toBe(889);
+  });
+});
+
+// ── Claude Code (native-task) ─────────────────────────────────────────────────
+
+describe("Claude Code host (native-task surface)", () => {
+  it("capability: native-task, agent-driven, nativeTaskApi=true", () => {
+    const cap = taskMirrorCapability("claude");
+    expect(cap.surface).toBe("native-task");
+    expect(cap.agentDriven).toBe(true);
+    expect(cap.nativeTaskApi).toBe(true);
+  });
+
+  it("cold plan: two TaskCreate for the running workers; untracked blocked is not mirrored", () => {
+    const plan = mirrorPlan(WORKERS, []);
+    const creates = plan.filter((c) => c.call === "TaskCreate");
+    expect(creates).toHaveLength(2);
+    expect(plan.find((c) => c.key === "wCCCC:885")).toBeUndefined();
+  });
+
+  it("TaskCreate carries macro-phase title (n/5) and micro-stage description", () => {
+    const plan = mirrorPlan(WORKERS, []);
+    const a = plan.find((c) => c.key === "wAAAA:889")!;
+    expect(a.call).toBe("TaskCreate");
+    expect(a.title).toBe("wAAAA [2/5 coding] #889 cross-host-mirror");
+    expect(a.description).toBe("stage: impl");
+    expect(a.state).toBe("in_progress");
+
+    const b = plan.find((c) => c.key === "wBBBB:887")!;
+    expect(b.title).toBe("wBBBB [4/5 merging] #887 codex-fallback");
+    expect(b.description).toBe("stage: commit");
+  });
+
+  it("steady-state: once tracked at the current stage+phase, no ops emitted", () => {
+    const coldPlan = mirrorPlan(WORKERS, []);
+    const tracked = coldPlan
+      .filter((c) => c.call === "TaskCreate")
+      .map((c) => ({
+        key: c.key,
+        stage: c.description!.replace(/^stage: /, ""),
+        phase: c.title!.match(/\[(?:\d+\/5 )?([a-z]+)\]/)![1]!,
+      }));
+    expect(mirrorPlan(WORKERS, tracked)).toEqual([]);
+  });
+
+  it("tracked blocked worker maps to a failed TaskUpdate re-titled [blocked]", () => {
+    const plan = mirrorPlan(WORKERS, [{ key: "wCCCC:885", stage: "impl", phase: "coding" }]);
+    const fail = plan.find((c) => c.key === "wCCCC:885")!;
+    expect(fail.call).toBe("TaskUpdate");
+    expect(fail.state).toBe("failed");
+    expect(fail.title).toBe("wCCCC [blocked] #885 old-blocked");
+  });
+
+  it("tracked worker absent from the live set maps to a completed TaskUpdate", () => {
+    const plan = mirrorPlan(
+      [WORKERS.find((w) => w.worker_id === "wAAAA")!],
+      [{ key: "wBBBB:887", stage: "commit", phase: "merging" }],
+    );
+    const done = plan.find((c) => c.key === "wBBBB:887")!;
+    expect(done.call).toBe("TaskUpdate");
+    expect(done.state).toBe("completed");
+  });
+});
+
+// ── Codex (monitor-agent fallback) ───────────────────────────────────────────
+
+describe("Codex host (monitor-agent fallback — no native task API)", () => {
+  it("capability: monitor-agent, agent-driven, nativeTaskApi=false", () => {
+    const cap = taskMirrorCapability("codex");
+    expect(cap.surface).toBe("monitor-agent");
+    expect(cap.agentDriven).toBe(true);
+    expect(cap.nativeTaskApi).toBe(false);
+  });
+
+  it("default sink: empty plan + dashboard notice (honest no-parity)", () => {
+    const result = codexSinkPlan(WORKERS, []);
+    expect(result.plan).toEqual([]);
+    expect(result.notice).toContain("no native task surface");
+  });
+
+  it("notice is always present regardless of worker set — Codex never silently implies parity", () => {
+    expect(codexSinkPlan([], []).notice).toBeTruthy();
+    expect(codexSinkPlan(WORKERS, []).notice).toBeTruthy();
+  });
+
+  it("when a future native surface is wired in, the shared mirror plan is emitted", () => {
+    const result = codexSinkPlan(WORKERS, [], { nativeTaskAvailable: true });
+    expect(result.notice).toBeUndefined();
+    expect(result.plan).toEqual(mirrorPlan(WORKERS, []));
+  });
+});
+
+// ── OpenCode host adapter (prototype, capability-gated) ──────────────────────
+
+describe("OpenCode host adapter (prototype, capability-gated)", () => {
+  it("capability (runner): headless — no host session to mirror into", () => {
+    const cap = taskMirrorCapability("opencode");
+    expect(cap.surface).toBe("headless");
+    expect(cap.agentDriven).toBe(false);
+    expect(cap.nativeTaskApi).toBe(false);
+  });
+
+  it("no host client configured → no-op + notice (headless path preserved)", async () => {
+    const result = await openCodeHostSinkPlan(WORKERS, undefined, "sess-smoke");
+    expect(result.mirrored).toBe(false);
+    expect(result.plan).toEqual([]);
+    expect(result.notice).toBe(OPENCODE_HOST_NO_SERVER_NOTICE);
+  });
+
+  it("host client reachable → publishes the shared mirror plan (same vocabulary as Claude)", async () => {
+    const published: unknown[][] = [];
+    const client: OpenCodeHostClient = {
+      async available() { return true; },
+      async readTasks() { return []; },
+      async publishTasks(_sid, calls) { published.push([...calls]); },
+    };
+    const result = await openCodeHostSinkPlan(WORKERS, client, "sess-smoke");
+    expect(result.mirrored).toBe(true);
+    expect(result.notice).toBeUndefined();
+    expect(result.plan).toEqual(mirrorPlan(WORKERS, []));
+    expect(published).toHaveLength(1);
+  });
+
+  it("host client unreachable → clean no-op + notice (worker is unaffected)", async () => {
+    const client: OpenCodeHostClient = {
+      async available() { return false; },
+      async readTasks() { return []; },
+      async publishTasks() {},
+    };
+    const result = await openCodeHostSinkPlan(WORKERS, client, "sess-smoke");
+    expect(result.mirrored).toBe(false);
+    expect(result.plan).toEqual([]);
+    expect(result.notice).toBe(OPENCODE_HOST_UNREACHABLE_NOTICE);
+  });
+
+  it("host client throws during probe → degrades to the same no-op path (never throws)", async () => {
+    const client: OpenCodeHostClient = {
+      async available() { throw new Error("ECONNREFUSED"); },
+      async readTasks() { return []; },
+      async publishTasks() {},
+    };
+    await expect(openCodeHostSinkPlan(WORKERS, client, "sess-smoke")).resolves.toMatchObject({
+      mirrored: false,
+      plan: [],
+      notice: OPENCODE_HOST_UNREACHABLE_NOTICE,
+    });
+  });
+
+  it("notices name the headless Agent runner to prevent confusing host surface with runner", () => {
+    expect(OPENCODE_HOST_NO_SERVER_NOTICE).toContain("headless");
+    expect(OPENCODE_HOST_UNREACHABLE_NOTICE).toContain("headless");
+  });
+});
+
+// ── cross-host parity contract ────────────────────────────────────────────────
+
+describe("cross-host parity contract", () => {
+  it("each host drives a distinct progress surface — no two hosts claim parity", () => {
+    const surfaces = (["claude", "codex", "opencode"] as const).map(
+      (h) => taskMirrorCapability(h).surface,
+    );
+    expect(new Set(surfaces).size).toBe(3);
+  });
+
+  it("exactly one host exposes nativeTaskApi=true across the full host matrix", () => {
+    const nativeCount = (["claude", "codex", "opencode"] as const).filter(
+      (h) => taskMirrorCapability(h).nativeTaskApi,
+    ).length;
+    expect(nativeCount).toBe(1);
+  });
+
+  it("the shared mirror plan is identical whether driven by Claude or an OpenCode host with capability", async () => {
+    const claudePlan = mirrorPlan(WORKERS, []);
+    const published: unknown[] = [];
+    const client: OpenCodeHostClient = {
+      async available() { return true; },
+      async readTasks() { return []; },
+      async publishTasks(_sid, calls) { published.push(...calls); },
+    };
+    const { plan: opencodePlan } = await openCodeHostSinkPlan(WORKERS, client, "sess-parity");
+    expect(opencodePlan).toEqual(claudePlan);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #889. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #889

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784894505&installation_id=129708444&pr_number=893&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F893&signature=3cd8b921fb959d8694cc5a3571de3fd651c71e2e92144320d26e124c0a5f1d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a deterministic smoke test for cross-host task mirroring.
  * Covers mirrored task behavior across multiple host surfaces, including success, no-op, and failure cases.
  * Verifies fallback behavior when no client is available or a host is unreachable.
  * Confirms parity between supported host paths and shared mirroring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->