### PR TITLE
Bump red-castle and preserve PR landing work

### DIFF
--- a/apps/brain/tests/config.test.ts
+++ b/apps/brain/tests/config.test.ts
@@ -1,5 +1,6 @@
+import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -20,13 +21,44 @@ async function tempRoot(): Promise<string> {
   return root;
 }
 
+function hasRedAncestor(path: string): boolean {
+  let current = resolve(path);
+  while (true) {
+    if (existsSync(join(current, ".red"))) return true;
+    const parent = dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
+}
+
+async function tempRootWithoutRedAncestor(): Promise<string> {
+  const candidates = new Set(
+    [
+      process.env.RUNNER_TEMP,
+      process.env.TMPDIR,
+      tmpdir(),
+      process.platform === "win32" ? undefined : "/var/tmp",
+      process.platform === "win32" ? undefined : "/dev/shm",
+    ].filter((candidate): candidate is string => Boolean(candidate)),
+  );
+
+  for (const parent of candidates) {
+    if (!existsSync(parent) || hasRedAncestor(parent)) continue;
+    const root = await mkdtemp(join(parent, "brain-config-"));
+    roots.push(root);
+    return root;
+  }
+
+  throw new Error("No temporary parent without a .red ancestor is available");
+}
+
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
 describe("Brain config", () => {
   it("uses the initial directory when no .red ancestor exists", async () => {
-    const root = await tempRoot();
+    const root = await tempRootWithoutRedAncestor();
     await expect(findBrainRoot(root)).resolves.toBe(root);
   });
 

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -733,6 +733,19 @@ export function buildProcessDeps(
         }).catch(() => {});
         return;
       }
+      if (event.type === "sessionId") {
+        void appendRecord(join(current.attemptDir, "log.jsonl"), "session", `session ${event.sessionId}`, {
+          ts,
+          fields: {
+            extra: {
+              kind: "sessionId",
+              iteration: String(event.iteration),
+              session_id: event.sessionId,
+            },
+          },
+        }).catch(() => {});
+        return;
+      }
       // Agentic-iteration boundary markers (synthetic — afk.log + firehose, NEVER
       // the agent lane). Emit "iteration N ended" + "iteration N+1 started" when
       // sandcastle's re-invocation count advances, so a run burning through
@@ -747,7 +760,14 @@ export function buildProcessDeps(
         activityMeterDir = dir0;
         activityMeter = createActivityMeter();
       }
-      activityMeter.record(event);
+      if (
+        event.type === "text" ||
+        event.type === "toolCall" ||
+        event.type === "reasoning" ||
+        event.type === "usage"
+      ) {
+        activityMeter.record(event);
+      }
       if (event.iteration !== lastIter) {
         const emit = (line: string, phase: string, n: number): void => {
           void fsx.appendLine(join(dir0, "afk.log"), line);
@@ -772,7 +792,9 @@ export function buildProcessDeps(
               ? `💰 usage (in:${event.inputTokens} out:${event.outputTokens}${
                   event.reasoningTokens ? ` reason:${event.reasoningTokens}` : ""
                 })`
-              : `→ ${event.name} ${event.formattedArgs}`;
+              : event.type === "result"
+                ? `result: ${event.result}`
+                : `→ ${event.name} ${event.formattedArgs}`;
       void appendAgentRecord(join(current.attemptDir, "agent.log.jsonl"), msg, {
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },
@@ -793,11 +815,14 @@ export function buildProcessDeps(
       // (bounded write rate vs every text chunk — the lane mtime above is the
       // stall-detector's liveness signal; this is the dashboard's stage/last).
       // `last_event_at` (the honest liveness clock, ADR 0065) is stamped on every
-      // DISCRETE event — tool/reasoning/usage, not per-text-chunk — so it advances
+      // DISCRETE event — tool/reasoning/usage/result, not per-text-chunk — so it advances
       // every few seconds for an active worker even between commits.
       const stage = deriveStage(event);
       const discrete =
-        event.type === "toolCall" || event.type === "reasoning" || event.type === "usage";
+        event.type === "toolCall" ||
+        event.type === "reasoning" ||
+        event.type === "usage" ||
+        event.type === "result";
       // A `usage` event is the only carrier of the cost group, and for claude it
       // arrives exactly ONCE — on the terminal result line, AFTER the last
       // heartbeat poll and just before the agent exits. The ~60s heartbeat is

--- a/apps/dev/src/core/activity-meter.ts
+++ b/apps/dev/src/core/activity-meter.ts
@@ -2,11 +2,9 @@
 // stream events, surfaced into the proof-of-life heartbeat so liveness is
 // readable at a glance rather than inferred from cpu/rss alone.
 //
-// red-castle's public `AgentStreamEvent` carries only `text` and `toolCall`
-// today (the raw per-CLI streams also carry reasoning/usage, but the parsers
-// drop them — extending that is a separate red-castle change). So this meter
-// counts exactly what the three runners (claude / codex / opencode) already
-// deliver identically:
+// The caller feeds only the activity/cost-bearing red-castle events here. Raw
+// stdout, terminal result, and session-id metadata are logged elsewhere because
+// they are useful diagnostics but not worker-activity units.
 //
 //   - tools_called_count — cumulative `toolCall` events this attempt
 //   - text_chunk_count   — cumulative `text` events this attempt

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -141,7 +141,14 @@ export type LandingResult =
       // `enforce_admins` base's required checks failed / are still pending. The
       // caller routes them to the distinct `blocked:ci` path (NOT merge-conflict,
       // NOT a full agent re-run), preserving the open PR.
-      reason: "pre_merge-abort" | "integrate-failed" | "land-failed" | "ci-failed" | "ci-pending";
+      reason:
+        | "pre_merge-abort"
+        | "integrate-failed"
+        | "land-failed"
+        | "ci-failed"
+        | "ci-pending"
+        | "pr-conflict"
+        | "pr-merge-failed";
       locked: boolean;
       /** PR number left open for the CI-aware handoff (`ci-failed` / `ci-pending`). */
       prNumber?: number;
@@ -225,7 +232,11 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
   // longer unlocked-only — lock=X + openPr=true also lands through here.
   if (r.reason === "ci-failed") return { ok: false, reason: "ci-failed", locked: input.locked, prNumber: r.prNumber };
   if (r.reason === "ci-pending") return { ok: false, reason: "ci-pending", locked: input.locked, prNumber: r.prNumber };
-  return { ok: false, reason: "land-failed", locked: input.locked };
+  if (r.reason === "conflict") return { ok: false, reason: "pr-conflict", locked: input.locked, prNumber: r.prNumber };
+  if (r.reason === "merge-failed" && r.prNumber !== undefined) {
+    return { ok: false, reason: "pr-merge-failed", locked: input.locked, prNumber: r.prNumber };
+  }
+  return { ok: false, reason: "land-failed", locked: input.locked, prNumber: r.prNumber };
 }
 
 /**

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -558,6 +558,7 @@ async function routeRecovery(
   issue: number,
   reason: AttemptOutcome,
   attemptN: number,
+  opts: { forceDecision?: "retry" | "escalate" } = {},
 ): Promise<"retry" | "escalate"> {
   // The composer owns the retry-vs-escalate decision, the label sets, and the
   // budget-exhausted page comment (core/disposition). This site only APPLIES it:
@@ -573,14 +574,16 @@ async function routeRecovery(
   // on_recovery_decision (#832, MUTABLE): hand the composer's proposed decision
   // to a hook, which may override retry↔escalate via a `{"decision":…}` stdout
   // JSON before any label is applied. An absent / silent hook is a no-op.
-  let decision = disp.decision;
-  const recResult = await fireRecoveryHook(
-    deps,
-    "on_recovery_decision",
-    JSON.stringify({ issue: { number: issue, title: "" }, decision, reason, attempt_n: attemptN }),
-  );
-  const override = parseRecoveryDecision(recResult.context);
-  if (override !== null) decision = override;
+  let decision = opts.forceDecision ?? disp.decision;
+  if (!opts.forceDecision) {
+    const recResult = await fireRecoveryHook(
+      deps,
+      "on_recovery_decision",
+      JSON.stringify({ issue: { number: issue, title: "" }, decision, reason, attempt_n: attemptN }),
+    );
+    const override = parseRecoveryDecision(recResult.context);
+    if (override !== null) decision = override;
+  }
 
   if (decision === "escalate") {
     if (disp.typedLabel !== null) await deps.gh.ensureLabel(disp.typedLabel);
@@ -1485,6 +1488,22 @@ export async function processIssue(
     if (landing.reason === "ci-failed" || landing.reason === "ci-pending") {
       return await ciBlocked(common, landing.reason, landing.prNumber);
     }
+    if (landing.reason === "pr-conflict") {
+      return await prLandingBlocked(
+        common,
+        "merge-conflict",
+        landing.prNumber,
+        `the open PR has merge conflicts and could not be landed`,
+      );
+    }
+    if (landing.reason === "pr-merge-failed") {
+      return await prLandingBlocked(
+        common,
+        "ci-failed",
+        landing.prNumber,
+        `the open PR merge was rejected by GitHub, usually because branch protection or CI is not satisfied`,
+      );
+    }
     return await mergeFailed(common, landing.reason, landing.locked);
   }
 
@@ -1890,6 +1909,50 @@ async function ciBlocked(
   await recordAttemptBestEffort(c, outcome, {
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: reason,
+  });
+  await deps.claimLock.release(input.issue);
+  return {
+    outcome,
+    issue: input.issue,
+    branch: c.branch,
+    base: c.base,
+    hooksFired: c.hooksFired,
+    envelopePosted: posted,
+    preserved: true,
+    swept: false,
+  };
+}
+
+/**
+ * PR landing handoff for failures that happen AFTER a PR exists. At that point
+ * the durable artifact is the open PR, so re-queueing the issue would make the
+ * next worker re-run the agent from scratch and often create competing work.
+ * Preserve the PR/branch and park the issue for a finisher instead.
+ */
+async function prLandingBlocked(
+  c: StageCommon,
+  outcome: "ci-failed" | "merge-conflict",
+  prNumber: number | undefined,
+  reason: string,
+): Promise<ProcessIssueResult> {
+  const { deps, input } = c;
+  const prRef = prNumber !== undefined ? `PR #${prNumber}` : "the open PR";
+  await routeRecovery(deps, input.issue, outcome, input.attempt, { forceDecision: "escalate" });
+  await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, { log: `${prRef}: ${reason}` }));
+  const section = outcome === "merge-conflict" ? "merge-conflict" : "ci";
+  const posted = await emitFailure(c, envelopeStatusFor(outcome), section, {
+    log:
+      `Inner agent completed (DONE, committed) and ${prRef} exists, but ${reason}. ` +
+      `The work is NOT lost — finish and land the existing PR instead of re-running the agent.`,
+  });
+  await deps.gh.comment(
+    input.issue,
+    `🤖 /afk: ${reason} on ${prRef}. Holding for a human / PR finisher to land the existing PR; ` +
+      `the inner agent was NOT re-run.`,
+  );
+  await recordAttemptBestEffort(c, outcome, {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: `${prRef}: ${reason}`,
   });
   await deps.claimLock.release(input.issue);
   return {

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -54,6 +54,8 @@ interface Opts {
   waitForReview?: boolean;
   /** Enable the opt-in CI-aware merge (#812) and drive the `pr view` verdict. */
   ciAware?: "merge" | "ci-failed" | "ci-pending" | "conflict";
+  /** rc the final `gh pr merge` returns (1 → PR exists but merge is rejected). */
+  prMergeCode?: number;
   /** Make the landing-worktree provisioner fail (returns null). */
   noWorktree?: boolean;
   /** Commits ahead of base returned by `git rev-list --count`. Default 3. */
@@ -112,6 +114,9 @@ function harness(opts: Opts = {}): Harness {
           conflict: { mergeStateStatus: "DIRTY", statusCheckRollup: [] },
         };
         return { code: 0, stdout: JSON.stringify(map[opts.ciAware ?? "merge"]), stderr: "" };
+      }
+      if (j.includes("pr merge")) {
+        return { code: opts.prMergeCode ?? 0, stdout: "", stderr: opts.prMergeCode ? "merge rejected" : "" };
       }
       return { code: 0, stdout: "", stderr: "" };
     },
@@ -429,10 +434,16 @@ describe("doLanding — CI-aware merge (#812)", () => {
     expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
   });
 
-  it("a real DIRTY conflict still maps to land-failed (→ merge-conflict), not ci", async () => {
+  it("a real DIRTY conflict preserves the PR number for the caller's merge-conflict handoff", async () => {
     const h = harness({ locked: false, ciAware: "conflict" });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: false, reason: "land-failed", locked: false });
+    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false, prNumber: 42 });
+  });
+
+  it("a rejected admin merge after PR creation preserves the PR instead of collapsing to generic land-failed", async () => {
+    const h = harness({ locked: false, prMergeCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "pr-merge-failed", locked: false, prNumber: 42 });
   });
 });
 

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -139,6 +139,8 @@ interface HarnessOptions {
   /** CI-aware merge (#812). When set, register the `ciAwait` port and drive the
    * `gh pr view` verdict the unlocked landing polls before admin-merging. */
   ciAware?: "merge" | "ci-failed" | "ci-pending" | "conflict";
+  /** Exit code for the final `gh pr merge` command. Defaults to 0. */
+  prMergeCode?: number;
 }
 
 function harness(opts: HarnessOptions = {}): {
@@ -292,6 +294,9 @@ function harness(opts: HarnessOptions = {}): {
           conflict: { mergeStateStatus: "DIRTY", statusCheckRollup: [] },
         };
         return { code: 0, stdout: JSON.stringify(map[opts.ciAware ?? "merge"]), stderr: "" };
+      }
+      if (j.includes("pr merge")) {
+        return { code: opts.prMergeCode ?? 0, stdout: "", stderr: opts.prMergeCode ? "merge rejected" : "" };
       }
       return { code: 0, stdout: "", stderr: "" };
     },
@@ -649,6 +654,23 @@ describe("processIssue — CI-aware unlocked landing (#812)", () => {
 
     expect(result.outcome).toBe("merge-conflict");
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "merge-conflict" }]);
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-agent"))).toBe(false);
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:merge-conflict"))).toBe(true);
+    expect(trace.runAgentCalls.length).toBe(1);
+  });
+
+  it("admin-merge rejected after PR exists parks the PR instead of re-queueing for a fresh agent", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, locked: false, prMergeCode: 1 });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("ci-failed");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-agent"))).toBe(false);
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:ci"))).toBe(true);
+    expect(trace.closed).toEqual([]);
+    expect(trace.deletedRemote).toEqual([]);
+    expect(trace.runAgentCalls.length).toBe(1);
+    expect(trace.released).toEqual([9]);
   });
 });
 

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -116,13 +116,18 @@ describe("statusline command — pure helpers", () => {
 
 describe("statusline command — rendered line", () => {
   let root: string;
+  let oldNoColor: string | undefined;
 
   beforeEach(async () => {
+    oldNoColor = process.env.NO_COLOR;
+    delete process.env.NO_COLOR;
     root = await mkdtemp(join(tmpdir(), "sl-cmd-"));
   });
 
   afterEach(async () => {
     await rm(root, { recursive: true, force: true });
+    if (oldNoColor === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = oldNoColor;
   });
 
   it("emits the full block run from a payload + live workers + cached counts", async () => {

--- a/apps/dev/tests/worker-vitals.contract.test.ts
+++ b/apps/dev/tests/worker-vitals.contract.test.ts
@@ -19,6 +19,11 @@ const EVENT_TO_VITALS = {
   toolCall: ["tools_called_count"],
   reasoning: ["reasoning_events", "reasoning_tokens"],
   usage: ["input_tokens", "output_tokens", "cost_usd"],
+  // Terminal result text is logged as a discrete event, but it is not a
+  // cumulative WorkerVitals counter.
+  result: [],
+  // Session id metadata is firehose-only diagnostics, not worker activity.
+  sessionId: [],
   // `raw` (sandcastle 0.11.0 verbose stdout stream) is firehose-only diagnostics,
   // not an assistant turn — it maps to no WorkerVitals field.
   raw: [],
@@ -44,7 +49,15 @@ describe("WorkerVitals contract (ADR 0065)", () => {
     // of mapped event types is exactly what we expect. If red-castle adds a
     // variant, the `satisfies` above fails to compile first; this keeps the
     // expectation visible to a human reviewer too.
-    expect(Object.keys(EVENT_TO_VITALS).sort()).toEqual(["raw", "reasoning", "text", "toolCall", "usage"]);
+    expect(Object.keys(EVENT_TO_VITALS).sort()).toEqual([
+      "raw",
+      "reasoning",
+      "result",
+      "sessionId",
+      "text",
+      "toolCall",
+      "usage",
+    ]);
   });
 
   it("rejects a map that omits a known event type (compile-time guard demonstrated)", () => {
@@ -53,7 +66,7 @@ describe("WorkerVitals contract (ADR 0065)", () => {
     // completeness guard ever stops working (an unused directive is itself an error).
     // prettier-ignore
     // @ts-expect-error missing `usage` key
-    const _incomplete: Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]> = { text: ["text_chunk_count"], toolCall: ["tools_called_count"], reasoning: ["reasoning_events"] };
+    const _incomplete: Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]> = { text: ["text_chunk_count"], toolCall: ["tools_called_count"], reasoning: ["reasoning_events"], result: [], sessionId: [], raw: [] };
     void _incomplete;
     expect(true).toBe(true);
   });
@@ -63,7 +76,7 @@ describe("WorkerVitals contract (ADR 0065)", () => {
     // a keyof WorkerVitals — pointing a mapping at it must fail to compile.
     // prettier-ignore
     // @ts-expect-error `thinking_called_count` is not a keyof WorkerVitals
-    const _wrongField: Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]> = { text: ["text_chunk_count"], toolCall: ["tools_called_count"], reasoning: ["reasoning_events", "reasoning_tokens"], usage: ["thinking_called_count"] };
+    const _wrongField: Record<AgentStreamEvent["type"], (keyof WorkerVitals)[]> = { text: ["text_chunk_count"], toolCall: ["tools_called_count"], reasoning: ["reasoning_events", "reasoning_tokens"], usage: ["thinking_called_count"], result: [], sessionId: [], raw: [] };
     void _wrongField;
     expect(true).toBe(true);
   });


### PR DESCRIPTION
Summary:
- Bumps packages/red-castle to reddb-io/red-castle d7bf6be, which includes the upstream sandcastle sync and fork-specific improvements.
- Handles new red-castle stream events in AFK worker logging without counting terminal/session metadata as worker activity.
- Stops AFK re-claim churn after a PR already exists: merge conflicts or rejected admin merges now park the existing PR for finishing instead of putting the issue back into ready-for-agent.
- Fixes environment-sensitive brain/statusline tests exposed by the full workspace suite.

Validation:
- red-castle: npm run typecheck
- red-castle: npm test -- src/createSandbox.test.ts
- red-castle: npm test
- red-castle: npm run build:dist
- pnpm --filter @reddb-io/dev exec vitest run tests/process-issue.test.ts
- pnpm --filter @reddb-io/dev run typecheck
- pnpm --filter @reddb-io/dev exec vitest run tests/landing.test.ts tests/merge.test.ts tests/process-issue.test.ts tests/statusline-command.test.ts tests/worker-vitals.contract.test.ts
- pnpm run typecheck
- pnpm run test
- pnpm run build
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785075015&installation_id=129708444&pr_number=898&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F898&signature=727b63e11fcee4907fbf6cd656ab8bc6e1088228d907689224f1fad525db4529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->