### PR TITLE
Refresh RedSkills README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,36 @@
-# RedSkills
+<div align="center">
 
-Agent workflow, governed operational memory, and project-local knowledge for
-Claude Code, Codex, OpenCode, and GitHub Actions.
+<img src="docs/hero.svg" alt="RedSkills - agent workflow, governed Memory, and Brain knowledge for serious engineering agents" width="100%" />
 
-RedSkills is reddb.io's plugin suite for serious agentic engineering work. It
-turns GitHub issues into reviewed PRs, preserves the operational evidence that
-helps agents avoid repeating mistakes, and gives projects a local knowledge
-repository for human-facing context.
+<p>
+  <a href="https://github.com/reddb-io/red-skills/releases"><img src="https://img.shields.io/github/v/release/reddb-io/red-skills?style=for-the-badge&color=ff2056&labelColor=0b0b0d" alt="Release"></a>
+  <a href="https://github.com/reddb-io/red-skills/actions/workflows/red-workspace-ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/reddb-io/red-skills/red-workspace-ci.yml?branch=main&style=for-the-badge&label=CI&labelColor=0b0b0d" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=for-the-badge&labelColor=0b0b0d" alt="License"></a>
+  <img src="https://img.shields.io/badge/Claude%20Code%20%7C%20Codex%20%7C%20OpenCode-555?style=for-the-badge&label=hosts&labelColor=0b0b0d" alt="Hosts">
+</p>
 
-RedSkills started as a reddb.io adaptation of
-[`mattpocock/skills`](https://github.com/mattpocock/skills). The upstream idea is
-still visible: small `SKILL.md` files that teach agents concrete behaviors.
-RedSkills adds the engineering loop, GitHub issue automation, governed Memory,
-Brain, MCP tools, release bundles, and operational guardrails we need for our
-workflows. Attribution is preserved in [NOTICE](./NOTICE).
+<strong>The operating system for agentic engineering work.</strong><br>
+RedSkills turns GitHub issues into reviewed PRs, remembers the operational
+evidence that prevents repeated mistakes, and gives every repo a local knowledge
+surface for Claude Code, Codex, OpenCode, and GitHub Actions.
 
-## Table Of Contents
+</div>
 
-- [What Ships](#what-ships)
-- [Plugin Boundaries](#plugin-boundaries)
-  - [Dev](#dev)
-  - [Memory](#memory)
-  - [Brain](#brain)
-- [Install](#install)
-- [Quick Start](#quick-start)
-- [Development Workflow](#development-workflow)
-- [GitHub Actions Lane](#github-actions-lane)
-- [Repo Layout](#repo-layout)
-- [Configuration](#configuration)
-- [Skill Index](#skill-index)
-- [Development In This Repo](#development-in-this-repo)
-- [License](#license)
+---
 
-## What Ships
+RedSkills is reddb.io's plugin suite for serious code-agent workflows. It
+started as a reddb.io adaptation of
+[`mattpocock/skills`](https://github.com/mattpocock/skills): small `SKILL.md`
+files that teach agents concrete behaviors. RedSkills keeps that core and adds
+the pieces teams need when agents are doing real engineering work: issue
+automation, isolated worktrees, AFK execution, governed Memory, Brain, MCP
+servers, release bundles, status signals, and guardrails.
 
-RedSkills has three plugins. They share repo conventions and an issue-tracker
-vocabulary, but each plugin owns a different product surface.
-
-| Plugin                                            | Job                                                                                                                                             | Use it when                                                                                        |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`dev`](./plugins/dev/.claude-plugin/plugin.json) | Move engineering work through GitHub Issues, isolated worktrees, AFK execution, review-gated PRs, and process dashboards.                       | You want an agent to plan, triage, execute, review, or ship code work.                             |
-| [`memory`](./plugins/memory/README.md)            | Store governed operational evidence for future agents: decisions, validations, reasoning attempts, gotchas, supersession, and readiness checks. | You want agents to stop starting cold after context resets and to verify old claims before acting. |
-| [`brain`](./plugins/brain/README.md)              | Store project-local human knowledge: typed artifacts, personal/project facts, sources, connections, search, cited answers, and dashboards.      | You want to capture durable knowledge the human may ask about later.                               |
-
-The short version:
-
-- **Dev moves work.**
-- **Memory improves agent execution.**
-- **Brain preserves human-facing knowledge.**
-
-## Plugin Boundaries
-
-### Dev
-
-`dev` is the engineering workflow plugin. It owns the issue pipeline, the AFK
-runtime, interactive landing, process visibility, setup/adoption checks, and
-codebase orientation.
-
-Core responsibilities:
-
-- Bootstrap RedSkills into a repo with [`setup-red-skills`](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md).
-- Maintain GitHub Issue state through [`triage`](./plugins/dev/skills/engineering/triage/SKILL.md), [`to-prd`](./plugins/dev/skills/engineering/to-prd/SKILL.md), and [`to-issues`](./plugins/dev/skills/engineering/to-issues/SKILL.md).
-- Execute delegable work with [`afk`](./plugins/dev/skills/engineering/afk/SKILL.md).
-- Land interactive work with [`ship`](./plugins/dev/skills/engineering/ship/SKILL.md).
-- Resolve human gates with [`hitl`](./plugins/dev/skills/engineering/hitl/SKILL.md) or safe validation/spec retries with [`requeue`](./plugins/dev/skills/engineering/requeue/SKILL.md).
-- Diagnose, test-drive, prototype, review ADRs, and explain codebase structure with the engineering skills listed below.
-- Expose the [code-nav MCP server](./apps/code-nav/README.md) for LSP-backed symbol navigation.
-
-Important `dev` boundaries:
-
-- GitHub Issues are the issue tracker. RedSkills does not target a local issue
-  store or another tracker.
-- `ready-for-agent` is the only issue state AFK consumes.
-- `ready-for-human` means a human decision is needed before delegation is safe.
-- `blocked:dependency` waits on `req:N` labels and should not page a human.
-- AFK work happens in isolated worktrees. The primary checkout stays under human
-  branch control.
-
-### Memory
-
-`memory` is governed operational memory for code agents. It stores work evidence
-that can make future agents safer and faster: decisions, root causes, validation
-evidence, reasoning attempts, stale-claim checks, readiness, handoffs, and skill
-telemetry evidence.
-
-Use Memory for:
-
-- `Decision: ...`, `Problem: ...`, `Fix: ...`, and `Validation: ...` facts that
-  future agents should recall.
-- Claim checks before relying on old context.
-- Context packs and handoffs that cite evidence instead of replaying a whole
-  transcript.
-- Graph-backed codebase map context and operational dashboards.
-- Skill telemetry evidence and approval-gated improvement proposals.
-
-Memory modes:
-
-| Mode            | Storage                                               | Best for                                                                                                       |
-| --------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `markdown-only` | Plain notes under `.red/memory/notes/`.               | Low-risk rollout with explicit store/recall only.                                                              |
-| `graph`         | Project-local RedDB store at `.red/memory/graph.rdb`. | Governed recall, provenance, supersession, readiness, context packs, Workbench, MCP/HTTP, and Skill telemetry. |
-
-Memory is not the Personal-fact store.
-Personal facts belong in Brain, not Memory.
-Broad human-facing project knowledge belongs in Brain too.
-
-Start with [plugins/memory/README.md](./plugins/memory/README.md).
-
-### Brain
-
-`brain` is a project-local knowledge repository under `.red/brain/*`. It stores
-typed artifacts and graph connections for later search and cited synthesis.
-
-Use Brain for:
-
-- Personal facts, durable preferences, identity context, relationship notes, and
-  other human-facing context.
-- Project notes, decisions, ideas, questions, sources, bookmarks, references, and
-  meeting residue.
-- `brain think` cited answers with confidence and missing-evidence signals.
-- `brain dashboard` local summaries and KPI-style views.
-- Optional outbound channel actions through the Brain channel bridge.
-
-Brain is separate from Memory. Memory exists to improve agent execution; Brain
-exists to preserve and connect knowledge the human wants available later.
-
-Start with [plugins/brain/README.md](./plugins/brain/README.md).
+Attribution is preserved in [NOTICE](./NOTICE).
 
 ## Install
 
 ### Claude Code
-
-Install the marketplace and the plugins you want:
 
 ```text
 /plugin marketplace add reddb-io/red-skills
@@ -140,7 +39,7 @@ Install the marketplace and the plugins you want:
 /plugin install brain@red-skills
 ```
 
-Common `dev` commands are native slash commands after install:
+Common `dev` commands become native slash commands:
 
 ```text
 /setup-red-skills
@@ -160,7 +59,7 @@ $capture Remember this project decision...
 $think What do we know about the billing migration?
 ```
 
-Refresh or remove:
+Upgrade or remove:
 
 ```text
 /plugin marketplace update red-skills
@@ -172,14 +71,14 @@ Refresh or remove:
 
 ### Codex CLI
 
-Add the marketplace:
-
 ```bash
 codex plugin marketplace add reddb-io/red-skills
+codex plugin marketplace upgrade red-skills
+codex plugin marketplace remove red-skills
 ```
 
-Codex invokes skills with `$<skill>`. Some clients expose plugin skills with the
-plugin namespace; use that form when it appears in the skills list:
+Codex invokes skills with `$<skill>`. Some clients expose plugin skills with
+the plugin namespace; use that form when it appears in the skills list:
 
 ```text
 $dev:setup-red-skills
@@ -191,13 +90,6 @@ $memory:recall cache TTL
 $brain:capture Save this project note...
 ```
 
-Upgrade or remove:
-
-```bash
-codex plugin marketplace upgrade red-skills
-codex plugin marketplace remove red-skills
-```
-
 Codex currently supports built-in footer items through `tui.status_line`, not a
 command-backed statusline. Use `$dev:afk monitor` when the client exposes
 namespace-qualified skills, or `$afk monitor` when it exposes unqualified skill
@@ -205,179 +97,44 @@ names.
 
 ### OpenCode
 
-OpenCode is a **third host** for RedSkills. ADR 0059 already integrates it as
-the third AFK runner; ADR 0075 extends that to the developer-facing opencode
-TUI by materialising the same `.red/config.yaml` block as an `opencode.json`
-`provider>` entry. The adapter lives in
-[`apps/opencode-host/`](./apps/opencode-host/README.md) and ships per-slice.
-
-#### Quick start
-
-Install from a red-skills checkout. The wrapper builds the
-`@reddb-io/red-skills` opencode-host bundle when needed, generates the
-OpenCode surface for the three plugins (`dev`, `memory`, `brain`), and writes
-skills, plugin modules, MCP config, provider config, and TUI attention config
-for OpenCode.
+OpenCode support is generated from the same plugin source tree as Claude Code
+and Codex. The installer writes skills, plugin modules, MCP config, provider
+config, and TUI attention config for OpenCode.
 
 ```bash
-# user-scoped install; recommended for agents that use OpenCode across repos
 git clone git@github.com:reddb-io/red-skills.git ~/code/red-skills
 cd ~/code/red-skills
+
+# user-scoped install into ~/.config/opencode
 scripts/install-opencode.sh --global
 
-# project-local install into $PWD
+# project-local install into the current repo
 scripts/install-opencode.sh
 
-# install into a specific project directory
-scripts/install-opencode.sh /path/to/your-project
-
-# copy SKILL.md instead of symlinking (cross-filesystem safety)
-scripts/install-opencode.sh /path/to/your-project --copy
-
-# user-scoped install (loads in every project the user opens)
-scripts/install-opencode.sh --global
-
-# dry-run — print the steps, do not write
-scripts/install-opencode.sh /path/to/your-project --dry-run
+# inspect without writing
+scripts/install-opencode.sh /path/to/project --dry-run
 ```
 
-After a global install, run OpenCode in any project:
+Then run OpenCode in any configured project:
 
 ```bash
-cd /path/to/your-project
 opencode .
 ```
 
-After a project-local install, run `opencode <target>` or `cd <target> &&
-opencode .`. Use `/connect` inside OpenCode or export one of
-`OPENAI_API_KEY`, `MINIMAX_API_KEY`, or `OPENROUTER_API_KEY`; auth is never
-written into the generated `opencode.json`.
-
-What the script writes (local mode):
-
-```text
-<target>/.opencode/plugin/   ← Slice 2 hook modules (session-start.ts, pre-tool-use.ts)
-<target>/.opencode/skills/   ← Slice 2 skills, flat-symlinked from plugins/<name>/skills/<bucket>/<name>/SKILL.md
-<target>/opencode.json       ← provider + model + MCP servers
-<target>/tui.json            ← attention config for sounds + notifications
-```
-
-What the script writes (global mode):
-
-```text
-~/.config/opencode/plugins/redskills-<plugin>-<event>.ts
-~/.config/opencode/skills/<name>/SKILL.md
-~/.config/opencode/opencode.json(c) ← provider + model + MCP servers; existing config is backed up
-~/.config/opencode/tui.json(c)      ← attention config; existing config is backed up
-```
-
-The opencode TUI auto-loads the `.opencode/` subtree and the 56 skills + 4
-hook modules become available immediately. The provider block tells
-opencode the same model + auth env-var AFK would have picked (back-compat
-with the AFK-only era).
-
-Preconditions:
-
-- `pnpm install` has been run at least once (the script runs it
-  automatically on the first invocation).
-- `.red/config.yaml` exists with `plugins.dev.enabled: true` (ADR 0067
-  strict opt-in). The script aborts if the gate is closed.
-
-The script is idempotent — re-running replaces the install in place.
-See [apps/opencode-host/README.md](./apps/opencode-host/README.md) for
-the lower-level CLI surface (`generate` / `--with-slice-2` / etc.).
-
-- **Slice 1 (this release)** — provider block. Run the generator and the
-  opencode TUI on the same repo picks the same model AFK would have picked,
-  with the same auth env-var (`OPENAI_API_KEY` → `MINIMAX_API_KEY` →
-  `OPENROUTER_API_KEY`).
-
-  ```bash
-  # Local-dev path
-  pnpm --filter @reddb-io/red-skills generate
-
-  # Bundled form (release asset)
-  pnpm --filter @reddb-io/red-skills bundle
-  node ./dist/opencode-host.bundle.min.mjs --config .red/config.yaml --out ./opencode.json
-  ```
-
-  Auth lives in `~/.local/share/opencode/auth.json` (populated by
-  `/connect` inside opencode) and the process env, **not** in the emitted
-  `opencode.json` — that file is safe to commit.
-
-- **Slice 2 (this release)** — skills + hooks. The `--with-slice-2` flag
-  emits a dist tree at `./dist/opencode/<plugin>/` containing:
-
-  - `.opencode/skills/<name>/SKILL.md` — flat-symlinked (or copied with
-    `--copy`) from `plugins/<plugin>/skills/<bucket>/<name>/SKILL.md`.
-    OpenCode discovers these natively; no tool wrapping required.
-  - `.opencode/plugin/session-start.ts` and `.opencode/plugin/pre-tool-use.ts` —
-    one TS module per Claude/Codex event class. The matcher
-    (`Bash`, `Task|Agent`) is translated to an inline `input.tool` regex
-    test, and `${CLAUDE_PLUGIN_ROOT}` / `${CODEX_PLUGIN_ROOT}` are
-    rewritten to the opencode plugin context's `directory`.
-
-  ```bash
-  pnpm --filter @reddb-io/red-skills generate -- --with-slice-2
-  pnpm --filter @reddb-io/red-skills generate -- --with-slice-2 --plugin dev
-  ```
-
-  Skills are validated against opencode's name rule
-  (`^[a-z0-9]+(-[a-z0-9]+)*$`); a bad name is a build error, not a
-  silent skip. Unsupported events (`UserPromptSubmit`, `PostToolUse`,
-  `Stop`, `PreCompact`) are warn-and-continue; the source hooks the user
-  actually depends on are still emitted.
-
-- **Slice 3 (this release)** — MCP passthrough. The standalone
-  `opencode.json` (and the per-plugin dist files) now embed an
-  `mcp:` block alongside the `provider>`. The generator rewrites
-  each `plugins/<name>/.mcp.json` entry (Claude/Codex
-  `mcpServers: { ... }` shape with a `sh -c` body that resolves
-  the plugin root through a chain of env vars) into opencode's
-  `mcp: { <name>: { type: "local", command, environment, cwd? } }`
-  shape — the plugin root is resolved at **build time** and the
-  absolute path baked into the emitted `command` array. A missing
-  bootstrap script is a build warning, not a silent failure.
-  Today the standalone Slice 1+3 file carries four MCPs: `code-nav`
-  (LSP-backed code navigation), `red-memory` (governed operational
-  memory), `brain` (RedDB knowledge repo), and `red-ui` (the
-  reddb.io dashboard). Skills that depend on MCPs (`$recall`,
-  `$store`, `$init`, the entire `memory:core/*` and `brain:core/*`
-  set) now work in the opencode TUI the same way they work in
-  Claude Code and Codex.
-
-- **Slice 4 (this release)** — statusline + toasts. The dev plugin
-  ships a `session-status.ts` opencode plugin module that
-  capitalises on the AFK statusline subcommand
-  (`apps/dev/src/commands/statusline.ts`) via four opencode
-  events: `session.idle` (toast the live statusline after
-  every LLM turn), `session.error` (toast the error),
-  `session.created` (suggest `/afk monitor` to the user), and
-  `experimental.session.compacting` (inject the live worker
-  state into the compaction prompt so the LLM sees it after
-  `/compact`). The install script also writes a `tui.json`
-  with `attention.enabled: true` so the built-in `done` /
-  `error` / `permission` / `question` / `subagent_done` sounds
-  + notifications fire by default. Together: the opencode
-  TUI shows a toast with the live worker state after every
-  turn, the user hears the `done` sound when a turn finishes,
-  and the LLM has fresh AFK context after a compaction.
-
-- **Slice 5 (next)** — remote install (`opencode --plugin
-  <github-release-url>` without `git clone`). The Slice 1 + 2 +
-  3 + 4 contract is stable; Slice 5 changes the release pipeline
-  (the dist tree ships as a GitHub Release asset) and adds a
-  `--remote` flag to `scripts/install-opencode.sh`.
+Use `/connect` inside OpenCode or export one of `OPENAI_API_KEY`,
+`MINIMAX_API_KEY`, or `OPENROUTER_API_KEY`. Generated config never stores auth
+secrets. Details live in [apps/opencode-host](./apps/opencode-host/README.md).
 
 ### No Marketplace
 
-Use these paths for older agents, local hacking, or Gemini-style skill loading:
+Older agents, local hacking, or Gemini-style skill loading can install from a
+checkout:
 
 ```bash
 npx skills@latest add reddb-io/red-skills
 ```
 
-For a local checkout with symlinked skills:
+For local symlinks:
 
 ```bash
 git clone git@github.com:reddb-io/red-skills.git ~/code/red-skills
@@ -398,6 +155,71 @@ Before a release, or after upgrading Claude Code/Codex, run:
 It checks plugin metadata, shell syntax, runner flags used by `/afk`, Codex
 marketplace registration in a temporary home, and manual skill-link installs.
 
+---
+
+## What Makes It Different
+
+**Issue to PR is the product.** RedSkills treats GitHub Issues as the work
+queue, not a side note. `/triage`, `/to-prd`, `/to-issues`, `/afk`, `/ship`,
+`/hitl`, and `/requeue` all speak the same issue-state vocabulary.
+
+**Agents work in disposable worktrees.** AFK execution and interactive landing
+keep the primary checkout under human branch control. Work is prepared,
+validated, committed, pushed, reviewed, and merged through explicit gates.
+
+**Memory is evidence, not vibes.** The Memory plugin stores decisions, root
+causes, validation records, reasoning attempts, supersession, freshness, and
+readiness signals so future agents can verify old claims before acting.
+
+**Brain is for human-facing knowledge.** Brain captures project notes, personal
+facts, sources, questions, bookmarks, typed artifacts, and cited synthesis under
+`.red/brain/*`.
+
+**One source tree, several hosts.** Claude Code, Codex, OpenCode, GitHub Actions,
+and MCP servers are generated from the same plugin definitions and runtime apps.
+
+---
+
+## The Loop
+
+```text
+Plan -> PRD -> sliced issues -> ready-for-agent -> isolated worktree
+  -> validation -> PR -> review/checks -> merge -> Memory evidence
+```
+
+The issue lifecycle is intentionally boring:
+
+```text
+needs-triage -> /triage -> ready-for-agent -> /afk -> PR/merge -> closed
+                                |
+                                +---- blocked/spec/validation/etc.
+                                      -> ready-for-human -> /hitl or /requeue
+```
+
+Important states:
+
+| State | Meaning |
+| --- | --- |
+| `ready-for-agent` | The only issue state AFK consumes. |
+| `running` | Timeline state while a worker owns the issue. Live state is local. |
+| `ready-for-human` | A human decision is needed before delegation is safe. |
+| `blocked:dependency` | Waits on `req:N` labels and should not page a human. |
+| `blocked:validation` / `blocked:spec` | Can be requeued only after retry guidance is already decided. |
+
+## What Ships
+
+| Plugin | Job | Use it when |
+| --- | --- | --- |
+| [`dev`](./plugins/dev/.claude-plugin/plugin.json) | Engineering workflow: issue triage, AFK execution, worktree safety, review-gated landing, process dashboards, runner policy, and codebase orientation. | You want an agent to plan, execute, review, or ship code work. |
+| [`memory`](./plugins/memory/README.md) | Governed operational memory: decisions, validations, reasoning attempts, stale-claim checks, context packs, and skill telemetry evidence. | You want agents to stop repeating old mistakes after context resets. |
+| [`brain`](./plugins/brain/README.md) | Project-local knowledge: typed artifacts, personal/project facts, sources, graph connections, search, cited answers, and dashboards. | You want durable knowledge the human may ask about later. |
+
+The short version:
+
+- **Dev moves work.**
+- **Memory improves agent execution.**
+- **Brain preserves human-facing knowledge.**
+
 ## Quick Start
 
 ### 1. Bootstrap A Repo
@@ -410,8 +232,7 @@ Run this inside a target repository:
 
 It creates and wires the RedSkills operating surface:
 
-- `.red/config.yaml` with explicit `plugins.<name>.enabled: true` activation
-  flags.
+- `.red/config.yaml` with explicit `plugins.<name>.enabled: true` flags.
 - GitHub issue labels such as `needs-triage`, `ready-for-agent`,
   `ready-for-human`, `running`, `blocked:*`, `blocked:dependency`, and `req:N`.
 - Domain docs under `.red/CONTEXT-MAP.md`, `.red/contexts/*/CONTEXT.md`, and
@@ -456,63 +277,76 @@ $think question
 Use Memory for operational evidence that helps future agents act. Use Brain for
 knowledge the human wants preserved, searched, and cited later.
 
-## Development Workflow
+## Host Support
 
-RedSkills teaches and enforces one interactive development loop:
+| Host | Surface | Notes |
+| --- | --- | --- |
+| Claude Code | Marketplace plugins, slash commands, skills, hooks, MCP servers | Primary interactive host. |
+| Codex CLI | Marketplace plugins, `$skill` invocation, MCP servers, footer integration | Namespace-qualified skill names may appear depending on client version. |
+| OpenCode | Generated `.opencode/skills`, plugin modules, MCP config, provider config, TUI attention config | Installed through `scripts/install-opencode.sh`. |
+| GitHub Actions | Reusable AFK attempt workflow and composable action | Runs one AFK attempt per issue in adopter repos. |
 
-1. Keep the **primary checkout** on `main`; only the human switches it.
-2. Do task work in an isolated worktree, normally under `.red/tmp/work-ship-*`
-   when you intend to use `/ship`.
-3. Commit the worktree.
-4. Push the branch early.
-5. Run `/ship` from the committed worktree to open or reuse a PR.
-6. Let `/ship` monitor checks and reviews with a time cap.
-7. `/ship` merges normally when checks are green, branch protection is satisfied,
-   and no reviewer requested changes.
-8. If review, CI, branch protection, or the time cap blocks the merge, `/ship`
-   parks the linked issue and PR in `ready-for-human` for `/hitl`.
+## Plugin Boundaries
 
-This is the human-in-the-loop sibling of AFK landing:
+### Dev
 
-| Flow    | Use it when                                                               | Landing behavior                                                                                                             |
-| ------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `/afk`  | Work is already `ready-for-agent` and should be executed autonomously.    | AFK claims the issue, creates its own worktree, validates, posts an envelope, and lands through its autonomous landing path. |
-| `/ship` | A human or interactive agent has already prepared and committed a branch. | `/ship` respects branch protection, reviews, checks, advisory bots, and the time cap.                                        |
+`dev` owns the engineering workflow: issue pipeline, AFK runtime, interactive
+landing, process visibility, setup/adoption checks, codebase orientation, and
+the [code-nav MCP server](./apps/code-nav/README.md).
 
-The issue lifecycle is:
+Core responsibilities:
 
-```text
-needs-triage -> /triage -> ready-for-agent -> /afk -> PR/merge -> closed
-                                |
-                                +---- blocked/spec/validation/etc.
-                                      -> ready-for-human -> /hitl or /requeue
-```
+- Bootstrap RedSkills with [`setup-red-skills`](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md).
+- Maintain issue state with [`triage`](./plugins/dev/skills/engineering/triage/SKILL.md), [`to-prd`](./plugins/dev/skills/engineering/to-prd/SKILL.md), and [`to-issues`](./plugins/dev/skills/engineering/to-issues/SKILL.md).
+- Execute delegable work with [`afk`](./plugins/dev/skills/engineering/afk/SKILL.md).
+- Land interactive work with [`ship`](./plugins/dev/skills/engineering/ship/SKILL.md).
+- Resolve human gates with [`hitl`](./plugins/dev/skills/engineering/hitl/SKILL.md) or safe retries with [`requeue`](./plugins/dev/skills/engineering/requeue/SKILL.md).
 
-Important details:
+### Memory
 
-- `running` is timeline-only. There is no periodic issue-thread heartbeat; live
-  worker state is local (`agent.log.jsonl`, `afk.state.json`, process liveness)
-  and visible through `/afk monitor`.
-- `blocked:dependency` issues wait on `req:N` labels and auto-unblock when the
-  last dependency closes.
-- `blocked:validation` and `blocked:spec` can use `/requeue` only when the retry
-  guidance is already decided; use `/hitl` when the decision still needs to be
-  extracted from the thread.
-- The primary-checkout branch guard is controlled by
-  `plugins.dev.lock.primary-branch` in `.red/config.yaml`.
+`memory` is governed operational memory for code agents. It stores work
+evidence that can make future agents safer and faster: decisions, root causes,
+validation evidence, reasoning attempts, stale-claim checks, readiness,
+handoffs, and skill telemetry evidence.
+
+Memory modes:
+
+| Mode | Storage | Best for |
+| --- | --- | --- |
+| `markdown-only` | Plain notes under `.red/memory/notes/`. | Low-risk rollout with explicit store/recall only. |
+| `graph` | Project-local RedDB store at `.red/memory/graph.rdb`. | Governed recall, provenance, supersession, readiness, context packs, Workbench, MCP/HTTP, and Skill telemetry. |
+
+Memory is not the Personal-fact store. Personal facts belong in Brain, not Memory.
+Broad human-facing project knowledge belongs in Brain too.
+
+Start with [plugins/memory/README.md](./plugins/memory/README.md).
+
+### Brain
+
+`brain` is a project-local knowledge repository under `.red/brain/*`. It stores
+typed artifacts and graph connections for later search and cited synthesis.
+
+Use Brain for:
+
+- Personal facts, durable preferences, identity context, and relationship notes.
+- Project notes, decisions, ideas, questions, sources, bookmarks, and meeting
+  residue.
+- `brain think` cited answers with confidence and missing-evidence signals.
+- `brain dashboard` local summaries and KPI-style views.
+- Optional outbound channel actions through the Brain channel bridge.
+
+Start with [plugins/brain/README.md](./plugins/brain/README.md).
 
 ## GitHub Actions Lane
 
 The AFK Actions lane runs one AFK attempt per issue from GitHub Actions. It is
 for adopter repos that want cloud execution without a local fleet.
 
-Architecture:
-
-| Layer                | Artifact                                                                   | Job                                                                         |
-| -------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Trigger + policy     | [`reusable-afk-attempt.yml`](./.github/workflows/reusable-afk-attempt.yml) | `workflow_call`, manual dispatch, and trust gate.                           |
-| Execution            | [`.github/actions/afk-attempt`](./.github/actions/afk-attempt/action.yml)  | Sets up Node, runner CLI, auth env, and invokes the AFK launcher.           |
-| Runtime distribution | `afk.mjs` + GitHub Release assets                                          | Fetches the versioned `dev` bundle matching the checked-out red-skills ref. |
+| Layer | Artifact | Job |
+| --- | --- | --- |
+| Trigger + policy | [`reusable-afk-attempt.yml`](./.github/workflows/reusable-afk-attempt.yml) | `workflow_call`, manual dispatch, and trust gate. |
+| Execution | [`.github/actions/afk-attempt`](./.github/actions/afk-attempt/action.yml) | Sets up Node, runner CLI, auth env, and invokes the AFK launcher. |
+| Runtime distribution | `afk.mjs` + GitHub Release assets | Fetches the versioned `dev` bundle matching the checked-out red-skills ref. |
 
 Adoption paths:
 
@@ -527,29 +361,29 @@ needs a fully immutable action/runtime pair.
 
 Workflow naming convention:
 
-| Prefix       | Meaning                                                                              |
-| ------------ | ------------------------------------------------------------------------------------ |
+| Prefix | Meaning |
+| --- | --- |
 | `reusable-*` | Reusable `workflow_call` workflow referenced by `uses:`; never copied into adopters. |
-| `rs-*`       | A caller that instantiates a `reusable-*` workflow with concrete triggers/inputs.    |
-| `red-*`      | Standalone RedSkills workflow; internal CI or verbatim copy-installable.             |
+| `rs-*` | A caller that instantiates a `reusable-*` workflow with concrete triggers/inputs. |
+| `red-*` | Standalone RedSkills workflow; internal CI or verbatim copy-installable. |
 
 Full guide: [AFK Actions lane](./plugins/dev/skills/engineering/afk/actions-lane.md).
 
 ## Repo Layout
 
-| Path                                       | Purpose                                                                                                   |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| [`plugins/dev`](./plugins/dev)             | Plugin definition, skills, hooks, scripts, MCP config, and docs for engineering workflow.                 |
-| [`plugins/memory`](./plugins/memory)       | Plugin definition and skills for governed operational memory. Runtime source lives in `apps/memory`.      |
-| [`plugins/brain`](./plugins/brain)         | Plugin definition and skills for Brain. Runtime source lives in `apps/brain`.                             |
-| [`apps/dev`](./apps/dev)                   | AFK, ship, dashboard, triage, runner, release/channel, and workflow runtime code.                         |
-| [`apps/memory`](./apps/memory)             | Memory CLI, graph operations, Workbench, MCP/HTTP surfaces, evals, and diagnostics.                       |
-| [`apps/brain`](./apps/brain)               | Brain CLI, store, MCP server, dashboard, channel bridge, and artifact logic.                              |
-| [`apps/code-nav`](./apps/code-nav)         | LSP-backed MCP server used by the `dev` plugin.                                                           |
-| [`apps/opencode-host`](./apps/opencode-host) | Adapter that emits `opencode.json` from `.red/config.yaml` (Slice 1: provider block; Slices 2-5: skills/hooks/MCP/agents). |
-| [`packages/shared`](./packages/shared)     | Shared runtime helpers for plugin gates, bundle fetching, args, logging, and channels.                    |
-| [`.red`](./.red)                           | RedSkills' own project configuration: context map, glossaries, ADRs, issue-tracker docs, and agent rules. |
-| [`.github/workflows`](./.github/workflows) | Release, CI, upstream watch, issue automation, PR review, and reusable AFK attempt workflows.             |
+| Path | Purpose |
+| --- | --- |
+| [`plugins/dev`](./plugins/dev) | Plugin definition, skills, hooks, scripts, MCP config, and docs for engineering workflow. |
+| [`plugins/memory`](./plugins/memory) | Plugin definition and skills for governed operational memory. Runtime source lives in `apps/memory`. |
+| [`plugins/brain`](./plugins/brain) | Plugin definition and skills for Brain. Runtime source lives in `apps/brain`. |
+| [`apps/dev`](./apps/dev) | AFK, ship, dashboard, triage, runner, release/channel, and workflow runtime code. |
+| [`apps/memory`](./apps/memory) | Memory CLI, graph operations, Workbench, MCP/HTTP surfaces, evals, and diagnostics. |
+| [`apps/brain`](./apps/brain) | Brain CLI, store, MCP server, dashboard, channel bridge, and artifact logic. |
+| [`apps/code-nav`](./apps/code-nav) | LSP-backed MCP server used by the `dev` plugin. |
+| [`apps/opencode-host`](./apps/opencode-host) | Adapter that emits OpenCode config, skills, hooks, MCP passthrough, and statusline/toast integration. |
+| [`packages/shared`](./packages/shared) | Shared runtime helpers for plugin gates, bundle fetching, args, logging, and channels. |
+| [`.red`](./.red) | RedSkills' own project configuration: context map, glossaries, ADRs, issue-tracker docs, and agent rules. |
+| [`.github/workflows`](./.github/workflows) | Release, CI, upstream watch, issue automation, PR review, and reusable AFK attempt workflows. |
 
 Installed plugin trees are definitions and launchers. Runtime bundles are built
 from `apps/*` and shipped as GitHub Release assets. Session-start hooks fetch the
@@ -600,104 +434,20 @@ House rules:
 - Do task work in isolated worktrees; the primary checkout's branch is for the
   human to control.
 
-## Skill Index
+## Skill Map
 
-This is a map, not a replacement for the skill files. Open the linked `SKILL.md`
-before using a skill in a new context.
+This is a map, not a replacement for the skill files. Open the linked
+`SKILL.md` before using a skill in a new context.
 
-### Dev: Setup And Issue Flow
-
-| Skill                                                                            | Use it for                                                                                |
-| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| [`setup-red-skills`](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md) | Bootstrap `.red/`, labels, agent rules, workflows, config, and development workflow docs. |
-| [`doctor`](./plugins/dev/skills/engineering/doctor/SKILL.md)                     | Audit RedSkills adoption and optionally fix process drift.                                |
-| [`start`](./plugins/dev/skills/engineering/start/SKILL.md)                       | Stress-test a plan against domain language and ADRs.                                      |
-| [`to-prd`](./plugins/dev/skills/engineering/to-prd/SKILL.md)                     | Turn the current conversation into a PRD issue.                                           |
-| [`to-issues`](./plugins/dev/skills/engineering/to-issues/SKILL.md)               | Slice a plan/PRD into independently grabbable issues.                                     |
-| [`triage`](./plugins/dev/skills/engineering/triage/SKILL.md)                     | Move issues through the triage state machine and write agent briefs.                      |
-| [`report-bug`](./plugins/dev/skills/engineering/report-bug/SKILL.md)             | File a structured `type:bug needs-triage` issue.                                          |
-| [`urgent`](./plugins/dev/skills/engineering/urgent/SKILL.md)                     | Create a `priority:urgent ready-for-agent` issue that jumps the queue.                    |
-
-### Dev: Execution, Landing, And Recovery
-
-| Skill                                                                                              | Use it for                                                                                         |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`afk`](./plugins/dev/skills/engineering/afk/SKILL.md)                                             | Drain `ready-for-agent` issues autonomously.                                                       |
-| [`ship`](./plugins/dev/skills/engineering/ship/SKILL.md)                                           | Finalize committed work through PR checks/reviews.                                                 |
-| [`implement`](./plugins/dev/skills/engineering/implement/SKILL.md)                                 | Interactive, human-guided PRD execution.                                                           |
-| [`tdd`](./plugins/dev/skills/engineering/tdd/SKILL.md)                                             | Red-green-refactor feature or bug work.                                                            |
-| [`diagnose`](./plugins/dev/skills/engineering/diagnose/SKILL.md)                                   | Reproduce, minimize, instrument, fix, and regression-test hard bugs.                               |
-| [`hitl`](./plugins/dev/skills/engineering/hitl/SKILL.md)                                           | Resolve one `ready-for-human` issue and make it delegable again.                                   |
-| [`requeue`](./plugins/dev/skills/engineering/requeue/SKILL.md)                                     | Safely requeue a `blocked:validation`/`blocked:spec` issue when retry guidance is already decided. |
-| [`retake`](./plugins/dev/skills/engineering/retake/SKILL.md)                                       | Reconstruct issue/PR/local state and print the next command.                                       |
-| [`resolving-merge-conflicts`](./plugins/dev/skills/engineering/resolving-merge-conflicts/SKILL.md) | Resolve merge conflicts while preserving both sides' intent.                                       |
-
-### Dev: Operations And Understanding
-
-| Skill                                                                                                      | Use it for                                                             |
-| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| [`dashboard`](./plugins/dev/skills/engineering/dashboard/SKILL.md)                                         | Inspect open PRDs/issues, AFK workers, flow metrics, and DORA proxies. |
-| [`daily-review`](./plugins/dev/skills/engineering/daily-review/SKILL.md)                                   | Produce a daily operational review.                                    |
-| [`weekly-review`](./plugins/dev/skills/engineering/weekly-review/SKILL.md)                                 | Produce a six-day operational review.                                  |
-| [`context`](./plugins/dev/skills/engineering/context/SKILL.md)                                             | Compose the repo context stack before non-trivial work.                |
-| [`zoom-out`](./plugins/dev/skills/engineering/zoom-out/SKILL.md)                                           | Explain codebase structure map-first.                                  |
-| [`improve-codebase-architecture`](./plugins/dev/skills/engineering/improve-codebase-architecture/SKILL.md) | Find architecture deepening opportunities.                             |
-| [`review-adrs`](./plugins/dev/skills/engineering/review-adrs/SKILL.md)                                     | Review ADRs for contradictions, staleness, and missing supersession.   |
-| [`model-tier-policy`](./plugins/dev/skills/engineering/model-tier-policy/SKILL.md)                         | Choose model tier and validation policy across runners.                |
-| [`setup-statusline`](./plugins/dev/skills/engineering/setup-statusline/SKILL.md)                           | Install or inspect Claude/Codex statusline support.                    |
-| [`prototype`](./plugins/dev/skills/engineering/prototype/SKILL.md)                                         | Build a throwaway prototype for state, logic, or UI exploration.       |
-| [`curate`](./plugins/dev/skills/engineering/curate/SKILL.md)                                               | Archive approved curatable skills from Memory recommendations.         |
-
-### Dev: Knowledge, Productivity, And Utilities
-
-| Skill                                                                                         | Use it for                                                          |
-| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| [`wiki-init`](./plugins/dev/skills/knowledge/wiki-init/SKILL.md)                              | Bootstrap `.red/wiki/`.                                             |
-| [`wiki`](./plugins/dev/skills/knowledge/wiki/SKILL.md)                                        | Ingest/query/lint the private LLM Wiki.                             |
-| [`research`](./plugins/dev/skills/knowledge/research/SKILL.md)                                | Save official-source research under `.red/tmp/researches/`.         |
-| [`reflect`](./plugins/dev/skills/productivity/reflect/SKILL.md)                               | Interview through a plan or design until decisions are explicit.    |
-| [`ff`](./plugins/dev/skills/productivity/ff/SKILL.md)                                         | Rewrite a message into a chosen framing and optionally dispatch it. |
-| [`handoff`](./plugins/dev/skills/productivity/handoff/SKILL.md)                               | Compact the current conversation into a handoff document.           |
-| [`write-a-skill`](./plugins/dev/skills/productivity/write-a-skill/SKILL.md)                   | Create a new agent skill with proper structure.                     |
-| [`branch-lock`](./plugins/dev/skills/misc/branch-lock/SKILL.md)                               | Lock an agent to one branch.                                        |
-| [`git-guardrails-claude-code`](./plugins/dev/skills/misc/git-guardrails-claude-code/SKILL.md) | Add Claude Code hooks that block dangerous git commands.            |
-| [`migrate-to-shoehorn`](./plugins/dev/skills/misc/migrate-to-shoehorn/SKILL.md)               | Replace test `as` assertions with `@total-typescript/shoehorn`.     |
-| [`setup-pre-commit`](./plugins/dev/skills/misc/setup-pre-commit/SKILL.md)                     | Configure Husky/lint-staged/typecheck/test pre-commit hooks.        |
-
-### Memory
-
-| Skill                                                                    | Use it for                                                       |
-| ------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| [`init`](./plugins/memory/skills/core/init/SKILL.md)                     | Initialize markdown-only or graph-backed Memory.                 |
-| [`store`](./plugins/memory/skills/core/store/SKILL.md)                   | Save one scoped operational fact.                                |
-| [`recall`](./plugins/memory/skills/core/recall/SKILL.md)                 | Retrieve governed context by relevance.                          |
-| [`ingest`](./plugins/memory/skills/core/ingest/SKILL.md)                 | Index repo files/docs into graph mode.                           |
-| [`extract`](./plugins/memory/skills/core/extract/SKILL.md)               | Extract durable operational facts from a transcript.             |
-| [`context-status`](./plugins/memory/skills/core/context-status/SKILL.md) | Report context stack readiness.                                  |
-| [`skills-status`](./plugins/memory/skills/core/skills-status/SKILL.md)   | Diagnose Skill telemetry and recent usage.                       |
-| [`health`](./plugins/memory/skills/core/health/SKILL.md)                 | Report Memory health and next actions.                           |
-| [`improve-skills`](./plugins/memory/skills/core/improve-skills/SKILL.md) | Create approval-gated Skill improvement proposals from evidence. |
-| [`doctor`](./plugins/memory/skills/core/doctor/SKILL.md)                 | Inspect and prune stale graph nodes after confirmation.          |
-| [`export`](./plugins/memory/skills/core/export/SKILL.md)                 | Export graph artifacts for audit/inspection.                     |
-| [`view`](./plugins/memory/skills/core/view/SKILL.md)                     | Open Memory graph views in red-ui or browser fallback.           |
-
-### Brain
-
-| Skill                                                     | Use it for                                             |
-| --------------------------------------------------------- | ------------------------------------------------------ |
-| [`capture`](./plugins/brain/skills/core/capture/SKILL.md) | Save durable project or personal knowledge into Brain. |
-| [`search`](./plugins/brain/skills/core/search/SKILL.md)   | Search Brain artifacts.                                |
-| [`think`](./plugins/brain/skills/core/think/SKILL.md)     | Produce a cited answer from Brain evidence.            |
-| [`status`](./plugins/brain/skills/core/status/SKILL.md)   | Inspect Brain store status.                            |
-| [`view`](./plugins/brain/skills/core/view/SKILL.md)       | Open Brain graph/connection views in red-ui.           |
-
-### MCP Servers
-
-| Server                                     | Use it for                                                  |
-| ------------------------------------------ | ----------------------------------------------------------- |
-| [`code-nav`](./apps/code-nav/README.md)    | IDE-grade symbol navigation through LSP-backed MCP tools.   |
-| [`memory-mcp`](./plugins/memory/.mcp.json) | Read Memory through MCP surfaces.                           |
-| [`brain`](./plugins/brain/.mcp.json)       | Search, think, inspect, and act through Brain MCP surfaces. |
+| Area | Skills |
+| --- | --- |
+| Dev setup and issue flow | [`setup-red-skills`](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md), [`doctor`](./plugins/dev/skills/engineering/doctor/SKILL.md), [`start`](./plugins/dev/skills/engineering/start/SKILL.md), [`to-prd`](./plugins/dev/skills/engineering/to-prd/SKILL.md), [`to-issues`](./plugins/dev/skills/engineering/to-issues/SKILL.md), [`triage`](./plugins/dev/skills/engineering/triage/SKILL.md), [`report-bug`](./plugins/dev/skills/engineering/report-bug/SKILL.md), [`urgent`](./plugins/dev/skills/engineering/urgent/SKILL.md) |
+| Dev execution and landing | [`afk`](./plugins/dev/skills/engineering/afk/SKILL.md), [`ship`](./plugins/dev/skills/engineering/ship/SKILL.md), [`implement`](./plugins/dev/skills/engineering/implement/SKILL.md), [`tdd`](./plugins/dev/skills/engineering/tdd/SKILL.md), [`diagnose`](./plugins/dev/skills/engineering/diagnose/SKILL.md), [`hitl`](./plugins/dev/skills/engineering/hitl/SKILL.md), [`requeue`](./plugins/dev/skills/engineering/requeue/SKILL.md), [`retake`](./plugins/dev/skills/engineering/retake/SKILL.md), [`resolving-merge-conflicts`](./plugins/dev/skills/engineering/resolving-merge-conflicts/SKILL.md) |
+| Dev operations and understanding | [`dashboard`](./plugins/dev/skills/engineering/dashboard/SKILL.md), [`daily-review`](./plugins/dev/skills/engineering/daily-review/SKILL.md), [`weekly-review`](./plugins/dev/skills/engineering/weekly-review/SKILL.md), [`context`](./plugins/dev/skills/engineering/context/SKILL.md), [`zoom-out`](./plugins/dev/skills/engineering/zoom-out/SKILL.md), [`improve-codebase-architecture`](./plugins/dev/skills/engineering/improve-codebase-architecture/SKILL.md), [`review-adrs`](./plugins/dev/skills/engineering/review-adrs/SKILL.md), [`model-tier-policy`](./plugins/dev/skills/engineering/model-tier-policy/SKILL.md), [`setup-statusline`](./plugins/dev/skills/engineering/setup-statusline/SKILL.md), [`prototype`](./plugins/dev/skills/engineering/prototype/SKILL.md), [`curate`](./plugins/dev/skills/engineering/curate/SKILL.md) |
+| Dev knowledge, productivity, and utilities | [`wiki-init`](./plugins/dev/skills/knowledge/wiki-init/SKILL.md), [`wiki`](./plugins/dev/skills/knowledge/wiki/SKILL.md), [`research`](./plugins/dev/skills/knowledge/research/SKILL.md), [`reflect`](./plugins/dev/skills/productivity/reflect/SKILL.md), [`ff`](./plugins/dev/skills/productivity/ff/SKILL.md), [`handoff`](./plugins/dev/skills/productivity/handoff/SKILL.md), [`write-a-skill`](./plugins/dev/skills/productivity/write-a-skill/SKILL.md), [`branch-lock`](./plugins/dev/skills/misc/branch-lock/SKILL.md), [`git-guardrails-claude-code`](./plugins/dev/skills/misc/git-guardrails-claude-code/SKILL.md), [`migrate-to-shoehorn`](./plugins/dev/skills/misc/migrate-to-shoehorn/SKILL.md), [`setup-pre-commit`](./plugins/dev/skills/misc/setup-pre-commit/SKILL.md) |
+| Memory | [`init`](./plugins/memory/skills/core/init/SKILL.md), [`store`](./plugins/memory/skills/core/store/SKILL.md), [`recall`](./plugins/memory/skills/core/recall/SKILL.md), [`ingest`](./plugins/memory/skills/core/ingest/SKILL.md), [`extract`](./plugins/memory/skills/core/extract/SKILL.md), [`context-status`](./plugins/memory/skills/core/context-status/SKILL.md), [`skills-status`](./plugins/memory/skills/core/skills-status/SKILL.md), [`health`](./plugins/memory/skills/core/health/SKILL.md), [`improve-skills`](./plugins/memory/skills/core/improve-skills/SKILL.md), [`doctor`](./plugins/memory/skills/core/doctor/SKILL.md), [`export`](./plugins/memory/skills/core/export/SKILL.md), [`view`](./plugins/memory/skills/core/view/SKILL.md) |
+| Brain | [`capture`](./plugins/brain/skills/core/capture/SKILL.md), [`search`](./plugins/brain/skills/core/search/SKILL.md), [`think`](./plugins/brain/skills/core/think/SKILL.md), [`status`](./plugins/brain/skills/core/status/SKILL.md), [`view`](./plugins/brain/skills/core/view/SKILL.md) |
+| MCP servers | [`code-nav`](./apps/code-nav/README.md), [`memory-mcp`](./plugins/memory/.mcp.json), [`brain`](./plugins/brain/.mcp.json) |
 
 ## Development In This Repo
 

--- a/docs/hero.svg
+++ b/docs/hero.svg
@@ -1,0 +1,45 @@
+<svg width="1200" height="520" viewBox="0 0 1200 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">RedSkills</title>
+  <desc id="desc">Agent workflow, governed Memory, and Brain knowledge for serious engineering agents.</desc>
+  <rect width="1200" height="520" rx="28" fill="#0B0B0D"/>
+  <path d="M0 342C112 292 205 296 312 330C439 370 529 362 638 304C766 236 900 230 1200 292V520H0V342Z" fill="#16181F"/>
+  <path d="M0 384C123 334 246 347 356 382C490 424 602 394 705 348C836 290 949 286 1200 341V520H0V384Z" fill="#20232D"/>
+  <circle cx="1008" cy="132" r="92" fill="#FF2056" opacity=".18"/>
+  <circle cx="214" cy="420" r="132" fill="#24B47E" opacity=".13"/>
+  <circle cx="1012" cy="406" r="168" fill="#3B82F6" opacity=".12"/>
+  <rect x="55" y="54" width="1090" height="412" rx="22" fill="#101116" stroke="#2A2D38"/>
+  <g filter="url(#shadow)">
+    <rect x="90" y="88" width="318" height="344" rx="18" fill="#15171E" stroke="#313542"/>
+    <rect x="442" y="88" width="318" height="344" rx="18" fill="#15171E" stroke="#313542"/>
+    <rect x="794" y="88" width="316" height="344" rx="18" fill="#15171E" stroke="#313542"/>
+  </g>
+  <text x="120" y="145" fill="#FFFFFF" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="46" font-weight="800" letter-spacing="0">Dev</text>
+  <text x="472" y="145" fill="#FFFFFF" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="46" font-weight="800" letter-spacing="0">Memory</text>
+  <text x="824" y="145" fill="#FFFFFF" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="46" font-weight="800" letter-spacing="0">Brain</text>
+  <text x="120" y="190" fill="#A7AFBF" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="21" font-weight="500" letter-spacing="0">issues to reviewed PRs</text>
+  <text x="472" y="190" fill="#A7AFBF" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="21" font-weight="500" letter-spacing="0">evidence agents can verify</text>
+  <text x="824" y="190" fill="#A7AFBF" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="21" font-weight="500" letter-spacing="0">knowledge humans can recall</text>
+  <g font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="700" letter-spacing="0">
+    <rect x="120" y="238" width="238" height="48" rx="10" fill="#FF2056"/><text x="145" y="269" fill="#FFFFFF">ready-for-agent</text>
+    <rect x="120" y="306" width="238" height="48" rx="10" fill="#232734" stroke="#454B5C"/><text x="145" y="337" fill="#FFFFFF">isolated worktree</text>
+    <rect x="120" y="374" width="238" height="48" rx="10" fill="#232734" stroke="#454B5C"/><text x="145" y="405" fill="#FFFFFF">/ship or /afk</text>
+    <rect x="472" y="238" width="238" height="48" rx="10" fill="#24B47E"/><text x="497" y="269" fill="#06150F">validation evidence</text>
+    <rect x="472" y="306" width="238" height="48" rx="10" fill="#232734" stroke="#454B5C"/><text x="497" y="337" fill="#FFFFFF">claim checks</text>
+    <rect x="472" y="374" width="238" height="48" rx="10" fill="#232734" stroke="#454B5C"/><text x="497" y="405" fill="#FFFFFF">context packs</text>
+    <rect x="824" y="238" width="238" height="48" rx="10" fill="#3B82F6"/><text x="849" y="269" fill="#FFFFFF">project facts</text>
+    <rect x="824" y="306" width="238" height="48" rx="10" fill="#232734" stroke="#454B5C"/><text x="849" y="337" fill="#FFFFFF">cited thinking</text>
+    <rect x="824" y="374" width="238" height="48" rx="10" fill="#232734" stroke="#454B5C"/><text x="849" y="405" fill="#FFFFFF">local dashboard</text>
+  </g>
+  <path d="M407 260H442" stroke="#747B8B" stroke-width="3" stroke-linecap="round"/>
+  <path d="M759 260H794" stroke="#747B8B" stroke-width="3" stroke-linecap="round"/>
+  <path d="M429 247L442 260L429 273" stroke="#747B8B" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M781 247L794 260L781 273" stroke="#747B8B" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="90" y="40" fill="#FF2056" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="800" letter-spacing=".14em">REDSKILLS</text>
+  <text x="90" y="486" fill="#D9DDE7" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="600" letter-spacing="0">Claude Code + Codex + OpenCode + GitHub Actions</text>
+  <text x="797" y="486" fill="#D9DDE7" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="600" letter-spacing="0">agent workflow / governed memory / project brain</text>
+  <defs>
+    <filter id="shadow" x="70" y="74" width="1060" height="384" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#000000" flood-opacity=".28"/>
+    </filter>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add a visual README hero and public-facing badge strip
- tighten the README around install, host support, plugin boundaries, and the issue-to-PR loop
- replace the long OpenCode implementation dump with a concise entry point and link to the adapter README

## Validation
- checked 102 local README links with a Node script
- ran git diff --check

## Notes
- prettier could not run because pnpm tried to install the workspace and failed on missing @reddb-io/red-castle in this checkout
- no XML/SVG validator binary was available on this host

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785181245&installation_id=129708444&pr_number=902&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F902&signature=6494765650a59500ab9fcfe7cb399ed618ab7b66fa33a61d9be7e3d02dfc0b75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->