### PR TITLE
fix(dev): enforce .red tmp worktree boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ for now. See `.red/agents/domain.md`.
 
 ## Development workflow
 
-- Work in an isolated worktree; do not change the primary checkout's branch for task work.
+- Work in an isolated worktree under `.red/tmp/work-*/`; do not create sibling worktrees outside the repo.
+- Create task branches with `git worktree add .red/tmp/work-<slug> -b <branch> origin/main`, not with `git checkout -b` or `git switch -c` in the primary checkout.
 - Commit the worktree, push the branch early, then run `/ship` to open or reuse a PR.
 - Let `/ship` monitor checks and reviews, then either merge the PR or park the issue/PR for `/hitl`.
-- The agent never switches the primary checkout's branch; only the user does. The `dev.lock.primary-branch` flag in `.red/config.yaml` is the kill-switch for the primary-branch guard.
+- The agent never switches the primary checkout's branch; only the user does. With `plugins.dev.enabled: true`, the dev command proxy blocks agent-created worktrees outside `.red/tmp/` and primary-checkout branch movement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,8 @@ for now. See `.red/agents/domain.md`.
 
 ## Development workflow
 
-- Work in an isolated worktree; do not change the primary checkout's branch for task work.
+- Work in an isolated worktree under `.red/tmp/work-*/`; do not create sibling worktrees outside the repo.
+- Create task branches with `git worktree add .red/tmp/work-<slug> -b <branch> origin/main`, not with `git checkout -b` or `git switch -c` in the primary checkout.
 - Commit the worktree, push the branch early, then run `/ship` to open or reuse a PR.
 - Let `/ship` monitor checks and reviews, then either merge the PR or park the issue/PR for `/hitl`.
-- The agent never switches the primary checkout's branch; only the user does. The `dev.lock.primary-branch` flag in `.red/config.yaml` is the kill-switch for the primary-branch guard.
+- The agent never switches the primary checkout's branch; only the user does. With `plugins.dev.enabled: true`, the dev command proxy blocks agent-created worktrees outside `.red/tmp/` and primary-checkout branch movement.

--- a/README.md
+++ b/README.md
@@ -304,14 +304,22 @@ Core responsibilities:
 
 Dev guard rails:
 
-- The primary-checkout branch guard is controlled by
-  `plugins.dev.lock.primary-branch` in `.red/config.yaml`.
+- When `plugins.dev.enabled: true`, the dev PreToolUse proxy enforces the
+  worktree boundary for agent shell commands: `git worktree add` must target a
+  path under `.red/tmp/`, and branch-moving commands in the primary checkout
+  (`git switch`, `git checkout <branch>`, `git checkout -b`, `git switch -c`,
+  `gh pr checkout`) are blocked. Create branches through
+  `git worktree add .red/tmp/work-<slug> -b <branch> ...` instead.
+- `plugins.dev.lock.primary-branch` remains the explicit branch-lock workflow
+  flag that setup writes for compatibility and base-pinning integrations.
 - The dev shell-command guard is controlled by `command_guard` in
   `.red/config.yaml`. It runs from the agent `PreToolUse` hook, stays inert
   unless `plugins.dev.enabled: true`, and blocks matching shell commands before
-  execution. `global` rules apply everywhere, `main` rules apply in the primary
-  session scope (not specifically the Git branch named `main`), and `worktree`
-  rules apply in `/afk` and `/ship` worktrees under `.red/tmp/`. Deny rules
+  execution. These repo-defined rules are **additional** to the built-in
+  `.red/tmp` worktree boundary above. `global` rules apply everywhere, `main`
+  rules apply in the primary session scope (not specifically the Git branch
+  named `main`), and `worktree` rules apply in `/afk` and `/ship` worktrees
+  under `.red/tmp/`. Deny rules
   support `regex:<pattern>`, `prefix:<literal>`, `suffix:<literal>`,
   `exact:<literal>`, and `glob:<pattern>`. Bare entries with `*`, `?`, or `[`
   are Bash globs; other bare entries match the exact command, a command prefix,

--- a/apps/dev/src/core/development-workflow.ts
+++ b/apps/dev/src/core/development-workflow.ts
@@ -2,10 +2,11 @@ export const DEVELOPMENT_WORKFLOW_HEADING = "Development workflow";
 
 export const DEVELOPMENT_WORKFLOW_BLOCK = `## ${DEVELOPMENT_WORKFLOW_HEADING}
 
-- Work in an isolated worktree; do not change the primary checkout's branch for task work.
+- Work in an isolated worktree under \`.red/tmp/work-*/\`; do not create sibling worktrees outside the repo.
+- Create task branches with \`git worktree add .red/tmp/work-<slug> -b <branch> origin/main\`, not with \`git checkout -b\` or \`git switch -c\` in the primary checkout.
 - Commit the worktree, push the branch early, then run \`/ship\` to open or reuse a PR.
 - Let \`/ship\` monitor checks and reviews, then either merge the PR or park the issue/PR for \`/hitl\`.
-- The agent never switches the primary checkout's branch; only the user does. The \`dev.lock.primary-branch\` flag in \`.red/config.yaml\` is the kill-switch for the primary-branch guard.`;
+- The agent never switches the primary checkout's branch; only the user does. With \`plugins.dev.enabled: true\`, the dev command proxy blocks agent-created worktrees outside \`.red/tmp/\` and primary-checkout branch movement.`;
 
 const DEVELOPMENT_WORKFLOW_BODY = DEVELOPMENT_WORKFLOW_BLOCK.replace(/^## [^\n]+\n\n/, "");
 

--- a/apps/dev/tests/development-workflow.test.ts
+++ b/apps/dev/tests/development-workflow.test.ts
@@ -41,13 +41,16 @@ describe("development workflow rules block", () => {
     expect(once).toContain("## Agent skills\n\nExisting.");
   });
 
-  it("documents the loop, primary-branch rule, and kill-switch flag", () => {
+  it("documents the loop and enforced .red/tmp worktree boundary", () => {
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("worktree");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("`.red/tmp/work-*/`");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("git worktree add .red/tmp/work-<slug>");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("not with `git checkout -b` or `git switch -c`");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("push the branch early");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("`/ship`");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("merge the PR or park the issue/PR for `/hitl`");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("The agent never switches the primary checkout's branch; only the user does.");
-    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("`dev.lock.primary-branch`");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("the dev command proxy blocks agent-created worktrees outside `.red/tmp/`");
   });
 
   it("writes both AGENTS.md and CLAUDE.md with identical blocks, then reruns unchanged", async () => {

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -88,15 +88,21 @@ describe("setup-red-skills docs", () => {
 
     expect(skill).toContain("**Section G1 — Command guards");
     expect(skill).toContain("hooks are **proxy guarantees**, not the policy source");
+    expect(skill).toContain("Built-in invariant: when `plugins.dev.enabled: true`");
+    expect(skill).toContain("Agent-created `git worktree add` destinations must resolve under the repo's `.red/tmp/`");
     expect(skill).toContain("Examples are examples only");
     expect(skill).toContain("command_guard.global");
     expect(skill).toContain("command_guard.main");
     expect(skill).toContain("command_guard.worktree");
+    expect(template).toContain("Built-in dev shell guard");
+    expect(template).toContain("agent-created");
+    expect(template).toContain("git worktree add .red/tmp/work-<slug>");
     expect(template).toContain("# command_guard:");
     expect(template).toContain("#   global:");
     expect(template).toContain("#   main:");
     expect(template).toContain("#   worktree:");
     expect(readme).toContain("Example policy, not a default:");
+    expect(readme).toContain("git worktree add .red/tmp/work-<slug>");
   });
 
   it("documents the cross-cli runtime shim instead of global plugin-root env vars", async () => {

--- a/plugins/dev/hooks/command-guard.sh
+++ b/plugins/dev/hooks/command-guard.sh
@@ -17,14 +17,16 @@
 #     dev:
 #       enabled: true
 #
-# The hook is dormant unless plugins.dev.enabled is true. Missing/empty deny
-# rules allow the command. `global` rules apply in every scope, `main` rules
-# apply outside RedSkills runtime worktrees, and `worktree` rules apply inside
-# `/afk` and `/ship` worktrees. Deny rules accept explicit modes:
-# `regex:<pattern>`, `prefix:<literal>`, `suffix:<literal>`, `exact:<literal>`,
-# and `glob:<pattern>`. Bare rules with glob metacharacters are treated as globs;
-# every other bare rule matches the exact command, a command prefix, or a command
-# suffix at a shell-command boundary.
+# The hook is dormant unless plugins.dev.enabled is true. Once enabled, the dev
+# invariant is built in: agent-created git worktrees must live under .red/tmp/,
+# and branch-moving commands are blocked in the primary checkout. Missing/empty
+# deny rules still allow every other command. `global` rules apply in every
+# scope, `main` rules apply outside RedSkills runtime worktrees, and `worktree`
+# rules apply inside `/afk` and `/ship` worktrees. Deny rules accept explicit
+# modes: `regex:<pattern>`, `prefix:<literal>`, `suffix:<literal>`,
+# `exact:<literal>`, and `glob:<pattern>`. Bare rules with glob metacharacters
+# are treated as globs; every other bare rule matches the exact command, a
+# command prefix, or a command suffix at a shell-command boundary.
 
 set -uo pipefail
 
@@ -84,6 +86,7 @@ find_config() {
 
 CONFIG="$(find_config "$ROOT" || true)"
 [[ -n "$CONFIG" ]] || allow
+REPO_ROOT="${CONFIG%/.red/config.yaml}"
 
 trim() {
   local s="$1"
@@ -194,6 +197,216 @@ scope_is_command_guard_worktree() {
 
 COMMAND_GUARD_SCOPE="main"
 scope_is_command_guard_worktree "$ROOT" && COMMAND_GUARD_SCOPE="worktree"
+
+canonical_path() {
+  local base="$1"
+  local path="$2"
+  if [[ "$path" == /* ]]; then
+    realpath -m -- "$path" 2>/dev/null || printf '%s\n' "$path"
+  else
+    realpath -m -- "$base/$path" 2>/dev/null || printf '%s/%s\n' "$base" "$path"
+  fi
+}
+
+git_subcommand_index() {
+  local -n tokens_ref="$1"
+  local git_index="$2"
+  local -n cwd_ref="$3"
+  local k=$((git_index + 1))
+  local len=${#tokens_ref[@]}
+  while ((k < len)); do
+    local tok="${tokens_ref[k]}"
+    case "$tok" in
+      -C)
+        if ((k + 1 < len)); then
+          cwd_ref="$(canonical_path "$cwd_ref" "${tokens_ref[k + 1]}")"
+        fi
+        k=$((k + 2))
+        continue
+        ;;
+      -c|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix)
+        k=$((k + 2))
+        continue
+        ;;
+      --*=*|-*)
+        k=$((k + 1))
+        continue
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  printf '%s\n' "$k"
+}
+
+skip_git_worktree_add_option() {
+  local -n tokens_ref="$1"
+  local -n index_ref="$2"
+  local len=${#tokens_ref[@]}
+  local tok="${tokens_ref[index_ref]}"
+  case "$tok" in
+    -b|-B|--orphan|--reason)
+      index_ref=$((index_ref + 2))
+      return 0
+      ;;
+    --reason=*|--orphan=*)
+      index_ref=$((index_ref + 1))
+      return 0
+      ;;
+    --detach|--checkout|--no-checkout|--guess-remote|--no-guess-remote|--force|-f|--lock)
+      index_ref=$((index_ref + 1))
+      return 0
+      ;;
+    --)
+      index_ref=$((index_ref + 1))
+      return 1
+      ;;
+    --*)
+      index_ref=$((index_ref + 1))
+      return 0
+      ;;
+    -*)
+      # Unknown short option. Treat it as a flag so the destination is still the
+      # first non-option token; if the option actually consumed an argument, the
+      # guard fails closed on a non-.red/tmp "destination".
+      index_ref=$((index_ref + 1))
+      return 0
+      ;;
+    *)
+      ((index_ref < len))
+      return 1
+      ;;
+  esac
+}
+
+worktree_add_destination() {
+  local tokens_name="$1"
+  local -n tokens_ref="$tokens_name"
+  local git_index="$2"
+  local cwd="$ROOT"
+  local s
+  s="$(git_subcommand_index "$tokens_name" "$git_index" cwd)"
+  [[ "${tokens_ref[s]:-}" == "worktree" && "${tokens_ref[s + 1]:-}" == "add" ]] || return 1
+
+  local j=$((s + 2))
+  local len=${#tokens_ref[@]}
+  while ((j < len)); do
+    if skip_git_worktree_add_option "$tokens_name" j; then
+      continue
+    fi
+    [[ -n "${tokens_ref[j]:-}" ]] || return 1
+    printf '%s\t%s\n' "$cwd" "${tokens_ref[j]}"
+    return 0
+  done
+  return 1
+}
+
+primary_branch_movement_reason() {
+  local tokens_name="$1"
+  local -n tokens_ref="$tokens_name"
+  local n=${#tokens_ref[@]}
+  local i j s sub
+
+  for ((i = 0; i < n; i++)); do
+    if [[ "${tokens_ref[i]}" == "gh" && "${tokens_ref[i + 1]:-}" == "pr" && "${tokens_ref[i + 2]:-}" == "checkout" ]]; then
+      printf 'gh pr checkout changes the primary checkout; create or reuse a .red/tmp worktree for the PR branch instead'
+      return 0
+    fi
+
+    [[ "${tokens_ref[i]}" == "git" ]] || continue
+    local cwd="$ROOT"
+    s="$(git_subcommand_index "$tokens_name" "$i" cwd)"
+    sub="${tokens_ref[s]:-}"
+    case "$sub" in
+      checkout|switch)
+        local target="" saw_doubledash=0
+        for ((j = s + 1; j < n; j++)); do
+          local t="${tokens_ref[j]}"
+          case "$t" in
+            --)
+              saw_doubledash=1
+              continue
+              ;;
+            -b|-B|-c|-C|--create|--force-create|--orphan|--track)
+              printf 'git %s creates or checks out a branch in the primary checkout; use git worktree add .red/tmp/work-<slug> -b <branch> ... instead' "$sub"
+              return 0
+              ;;
+            --create=*|--force-create=*|--orphan=*)
+              printf 'git %s creates a branch in the primary checkout; use git worktree add .red/tmp/work-<slug> -b <branch> ... instead' "$sub"
+              return 0
+              ;;
+            -*)
+              continue
+              ;;
+            *)
+              target="$t"
+              break
+              ;;
+          esac
+        done
+        ((saw_doubledash)) && continue
+        [[ -z "$target" || "$target" == "." ]] && continue
+        printf 'git %s changes the primary checkout branch; create or enter a .red/tmp worktree instead' "$sub"
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+enforce_dev_worktree_policy() {
+  local -a tokens
+  read -ra tokens <<<"$COMMAND"
+  local n=${#tokens[@]}
+  ((n > 0)) || return 0
+
+  local i
+  for ((i = 0; i < n; i++)); do
+    [[ "${tokens[i]}" == "git" ]] || continue
+    local pair cwd dest abs allowed_root
+    pair="$(worktree_add_destination tokens "$i" || true)"
+    [[ -n "$pair" ]] || continue
+    cwd="${pair%%$'\t'*}"
+    dest="${pair#*$'\t'}"
+    abs="$(canonical_path "$cwd" "$dest")"
+    allowed_root="$(canonical_path "$REPO_ROOT" ".red/tmp")"
+    case "$abs" in
+      "$allowed_root"/*)
+        ;;
+      *)
+        cat >&2 <<EOF
+BLOCKED by RedSkills dev worktree guard.
+plugins.dev.enabled is true, so agent-created git worktrees must live under .red/tmp/.
+
+Requested worktree path: $dest
+Resolved worktree path:  $abs
+Allowed root:            $allowed_root/
+
+Use: git worktree add .red/tmp/work-<slug> -b <branch> origin/main
+EOF
+        exit 2
+        ;;
+    esac
+  done
+
+  if [[ "$COMMAND_GUARD_SCOPE" == "main" ]]; then
+    local reason
+    reason="$(primary_branch_movement_reason tokens || true)"
+    if [[ -n "$reason" ]]; then
+      cat >&2 <<EOF
+BLOCKED by RedSkills dev primary-checkout guard.
+plugins.dev.enabled is true, so agents must not create or switch branches in the primary checkout.
+
+$reason.
+EOF
+      exit 2
+    fi
+  fi
+}
+
+enforce_dev_worktree_policy
 
 guard_scope_for_path() {
   local path="$1"

--- a/plugins/dev/hooks/tests/command-guard.test.sh
+++ b/plugins/dev/hooks/tests/command-guard.test.sh
@@ -104,6 +104,38 @@ YAML
 result="$(run_hook "$repo" "$(payload "$repo" "sudo make install")")"
 expect_eq "empty deny list: allow" "0" "$(sed -n '1p' <<<"$result")"
 
+result="$(run_hook "$repo" "$(payload "$repo" "git worktree add ../feature-wt -b feat/outside origin/main")")"
+rc="$(sed -n '1p' <<<"$result")"
+stderr="$(sed -n '/---stderr---/,$p' <<<"$result")"
+expect_eq "dev worktree guard: blocks sibling worktree" "2" "$rc"
+expect_contains "dev worktree guard: explains allowed root" "agent-created git worktrees must live under .red/tmp" "$stderr"
+
+result="$(run_hook "$repo" "$(payload "$repo" "rtk proxy git worktree add ../feature-wt -b feat/outside origin/main")")"
+expect_eq "dev worktree guard: blocks rtk-wrapped sibling worktree" "2" "$(sed -n '1p' <<<"$result")"
+
+result="$(run_hook "$repo" "$(payload "$repo" "git worktree add .red/tmp/work-feature -b feat/inside origin/main")")"
+expect_eq "dev worktree guard: allows .red/tmp worktree" "0" "$(sed -n '1p' <<<"$result")"
+
+result="$(run_hook "$repo" "$(payload "$repo" "git -C $repo worktree add .red/tmp/work-feature-c -b feat/inside-c origin/main")")"
+expect_eq "dev worktree guard: allows git -C .red/tmp worktree" "0" "$(sed -n '1p' <<<"$result")"
+
+result="$(run_hook "$repo" "$(payload "$repo" "git switch feature/foo")")"
+expect_eq "primary checkout guard: blocks branch switch" "2" "$(sed -n '1p' <<<"$result")"
+
+result="$(run_hook "$repo" "$(payload "$repo" "git checkout -b feature/foo")")"
+expect_eq "primary checkout guard: blocks branch creation" "2" "$(sed -n '1p' <<<"$result")"
+
+result="$(run_hook "$repo" "$(payload "$repo" "gh pr checkout 123")")"
+expect_eq "primary checkout guard: blocks gh pr checkout" "2" "$(sed -n '1p' <<<"$result")"
+
+result="$(run_hook "$repo" "$(payload "$repo" "git checkout -- README.md")")"
+expect_eq "primary checkout guard: allows file checkout" "0" "$(sed -n '1p' <<<"$result")"
+
+dev_worktree="$repo/.red/tmp/work-manual"
+mkdir -p "$dev_worktree"
+result="$(run_hook "$dev_worktree" "$(payload "$dev_worktree" "git switch feature/foo")")"
+expect_eq "primary checkout guard: allows branch switch inside .red/tmp worktree" "0" "$(sed -n '1p' <<<"$result")"
+
 cat >"$repo/.red/config.yaml" <<'YAML'
 plugins:
   dev:

--- a/plugins/dev/skills/engineering/implement/SKILL.md
+++ b/plugins/dev/skills/engineering/implement/SKILL.md
@@ -16,7 +16,7 @@ disable-model-invocation: true
 |---|---|---|
 | **Driver** | You — interactive, step-by-step | Autonomous fleet, no human in the loop |
 | **Scope** | One PRD / issue set, right now | Drains the full `ready-for-agent` queue |
-| **Worktree** | Your current worktree | Isolated worktree per issue, sandcastle |
+| **Worktree** | Dedicated `.red/tmp/work-*` worktree | Isolated worktree per issue, sandcastle |
 | **Finish** | You run `/ship` when satisfied | Agent merges, closes, claims next issue |
 
 Use `/implement` when you want to implement a PRD or issues yourself — with test-first discipline and review — but need the agent to guide each step. Use `/afk` when you want the fleet to work unsupervised.
@@ -37,7 +37,7 @@ Use `/implement` when you want to implement a PRD or issues yourself — with te
 
 ### Hard rules
 
-- ❌ Do **not** implement on the primary branch — work in an isolated worktree and finish via `/ship`.
+- ❌ Do **not** implement on the primary branch or a sibling checkout — work in `.red/tmp/work-*` and finish via `/ship`.
 - ❌ Do **not** skip `/tdd`; writing code before a failing test is undefined behaviour for this skill.
 - ❌ Do **not** run `/review` while any test is red.
 - ✅ **Do** let `/to-issues` decompose large PRDs before starting — smaller seams mean smaller merge risk.
@@ -61,7 +61,7 @@ Use `/implement` when you want to implement a PRD or issues yourself — with te
 
 ## Worktree convention
 
-All implementation work lives in a dedicated worktree, never on the primary branch. Create one with the dev loop:
+All implementation work lives in a dedicated worktree under `.red/tmp/`, never on the primary branch or in a sibling directory. Create one with the dev loop:
 
 ```
 git worktree add .red/tmp/work-<slug> -b feat/<slug>

--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -29,7 +29,7 @@ Scaffold includes:
 - **Token efficiency** — strongly recommend installing [RTK](https://github.com/rtk-ai/rtk) to cut 60–90% of dev-operation tokens via a transparent CLI proxy
 - **Runtime launcher** — optionally install a host-level `red-skills-dev` shim so Claude Code, Codex, and opencode can invoke the same dev runtime without relying on CLI-specific plugin-root env vars
 - **Command guards** — configure the repo-owned `.red/config.yaml` policy that the globally-installed Claude Code, Codex, and opencode hook proxies enforce
-- **Development workflow** — activate the primary-branch guard, teach agents the isolated-worktree rules, and route interactive landing through `/ship`
+- **Development workflow** — teach agents the `.red/tmp` worktree rules, preserve the primary checkout for the human, and route interactive landing through `/ship`
 
 This is a prompt-driven skill, not a deterministic script. Explore, present what you found, confirm with the user, then write.
 
@@ -44,7 +44,7 @@ Look at the current repo to understand its starting state. Read whatever exists;
 - `.red/CONTEXT.md` and `.red/CONTEXT-MAP.md` at the repo root
 - `.red/adr/` — the single root ADR sequence (there are no nested `.red/` subtrees)
 - `.red/agents/` — does this skill's prior output already exist?
-- `.red/config.yaml` — does it exist? Which plugins are already enabled (`plugins.<name>.enabled: true`)? Is `dev.lock.primary-branch` already set? Is `command_guard` already configured, and under which scopes (`global`, `main`, `worktree`, or legacy `deny`)?
+- `.red/config.yaml` — does it exist? Which plugins are already enabled (`plugins.<name>.enabled: true`)? Is the canonical `plugins.dev.lock.primary-branch` flag already set? Is `command_guard` already configured, and under which scopes (`global`, `main`, `worktree`, or legacy `deny`)?
 - `AGENTS.md` and `CLAUDE.md` — does either already have a `## Development workflow` section?
 
 ### 2. Present findings and ask
@@ -219,7 +219,9 @@ The template carries a **commented `afk.backpressure`** block (#430 / PRD #429):
 
 > Explainer: RedSkills ships the maximum practical shell-command hook coverage for each supported CLI (Claude Code, Codex, and opencode). Those hooks are **proxy guarantees**, not the policy source: they extract the command and cwd, find the repo root, read `.red/config.yaml`, then evaluate `command_guard`. This keeps AFK workers and the main interactive session on the same repo-owned policy, and it keeps per-CLI hook files as thin adapters instead of places where safety rules drift.
 
-Offer to configure `command_guard` now. Default: **no active rules** unless the user confirms specific commands. Examples are examples only — do not write them as defaults.
+Built-in invariant: when `plugins.dev.enabled: true`, the dev proxy always enforces the RedSkills worktree boundary before any repo-authored `command_guard` rule runs. Agent-created `git worktree add` destinations must resolve under the repo's `.red/tmp/`, and branch-moving commands in the primary checkout (`git switch`, `git checkout <branch>`, `git checkout -b`, `git switch -c`, `gh pr checkout`) are blocked so interactive work starts with `git worktree add .red/tmp/work-<slug> -b <branch> ...`. This invariant is not written into `command_guard` and has no example defaults to copy; it is part of enabling `dev`.
+
+Offer to configure additional `command_guard` rules now. Default: **no extra active rules** unless the user confirms specific commands. Examples are examples only — do not write them as defaults.
 
 Explain the scopes:
 
@@ -252,12 +254,12 @@ Do not write the example blindly. The right policy is repo-specific.
 
 **Section H — Development workflow.**
 
-> Explainer: RedSkills' interactive dev loop assumes agents work from isolated worktrees, leave the primary checkout's branch alone, push their branch early, and hand landing to `/ship`. The primary-branch guard already ships dormant; turning on `dev.lock.primary-branch: true` in `.red/config.yaml` activates it. The shared development-workflow injector writes the same `## Development workflow` rules into both `AGENTS.md` and `CLAUDE.md`, updating an existing block in place on rerun.
+> Explainer: RedSkills' interactive dev loop assumes agents work from isolated worktrees, leave the primary checkout's branch alone, push their branch early, and hand landing to `/ship`. With `plugins.dev.enabled: true`, the shell proxy already blocks agent-created worktrees outside `.red/tmp/` and branch movement in the primary checkout. Turning on `plugins.dev.lock.primary-branch: true` in `.red/config.yaml` also activates the branch-lock compatibility flag used by older adapters and base-pinning integrations; the runtime folds it onto the legacy `dev.lock.primary-branch` accessor for back-compat. The shared development-workflow injector writes the same `## Development workflow` rules into both `AGENTS.md` and `CLAUDE.md`, updating an existing block in place on rerun.
 
 Confirm with the user:
 
 - Activate the development workflow? Default: yes.
-- This sets `dev.lock.primary-branch: true` in `.red/config.yaml`.
+- This sets the canonical `plugins.dev.lock.primary-branch: true` flag in `.red/config.yaml`.
 - This writes or updates `## Development workflow` in both `AGENTS.md` and `CLAUDE.md` via the shared injector.
 - Recap that `/ship` is the landing command for interactive work after the branch is pushed.
 
@@ -293,7 +295,7 @@ Show the user a draft of:
 
 - The `## Agent skills` block to add to whichever of `CLAUDE.md` / `AGENTS.md` is being edited (see step 4 for selection rules)
 - The contents of `.red/agents/issue-tracker.md`, `.red/agents/triage-labels.md`, `.red/agents/domain.md`
-- The Section H development-workflow changes: `dev.lock.primary-branch: true` plus the canonical `## Development workflow` block for `AGENTS.md` and `CLAUDE.md`
+- The Section H development-workflow changes: `plugins.dev.lock.primary-branch: true` plus the canonical `## Development workflow` block for `AGENTS.md` and `CLAUDE.md`
 - The Section G1 command-guard changes if the user accepted them: the exact `command_guard` block or scoped entries that will be written to `.red/config.yaml`
 
 Let them edit before writing.
@@ -364,8 +366,8 @@ Scaffold `.red/config.yaml` (Section G), writing the Section A0 activation flags
 
 If the user accepted Section H, activate the development workflow:
 
-1. Invoke the shared injector rather than hand-editing the rules block. From a source checkout, run `pnpm --filter @reddb-io/dev dev inject-development-workflow --root <repo-root>`. From an installed plugin, run the bundled AFK entrypoint with `inject-development-workflow --root <repo-root>` (for example, `node ../afk/bin/afk.mjs inject-development-workflow --root <repo-root>` from this skill folder). The command writes both `AGENTS.md` and `CLAUDE.md`, creates `.red/config.yaml` if still missing, and sets `dev.lock.primary-branch: true`.
-2. If the command is unavailable, make the same changes manually: add or update the top-level `dev:` block in `.red/config.yaml` so `dev.lock.primary-branch` is `true` (nested: `lock:` → `primary-branch: true`), then upsert the canonical `## Development workflow` block in both `AGENTS.md` and `CLAUDE.md`. Never append a duplicate block; update the existing section in place.
+1. Invoke the shared injector rather than hand-editing the rules block. From a source checkout, run `pnpm --filter @reddb-io/dev dev inject-development-workflow --root <repo-root>`. From an installed plugin, run the bundled AFK entrypoint with `inject-development-workflow --root <repo-root>` (for example, `node ../afk/bin/afk.mjs inject-development-workflow --root <repo-root>` from this skill folder). The command writes both `AGENTS.md` and `CLAUDE.md`, creates `.red/config.yaml` if still missing, and sets `plugins.dev.lock.primary-branch: true`.
+2. If the command is unavailable, make the same changes manually: add or update the canonical `plugins:` → `dev:` → `lock:` block in `.red/config.yaml` so `primary-branch` is `true`, then upsert the canonical `## Development workflow` block in both `AGENTS.md` and `CLAUDE.md`. Never append a duplicate block; update the existing section in place. Leave any legacy top-level `dev.lock.*` keys untouched; `/doctor --fix` owns that migration.
 3. In the recap, explicitly point the user at `/ship` as the landing command after an interactive worktree branch has been committed and pushed.
 
 If the user accepted Section F, wire the statusline:

--- a/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
+++ b/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
@@ -10,7 +10,7 @@ plugins:
   dev:
     enabled: true                 # the engineering stack (/afk, /triage, /ship, …)
   #   lock:
-  #     primary-branch: true      # activate the primary-checkout branch-switch guard
+  #     primary-branch: true      # branch-lock compatibility/base-pinning flag
   #                               # (Section H of /setup-red-skills sets this)
   #     branch: my-branch         # static base lock: AFK bases/merges here (ADR 0031);
   #                               # the runtime /branch-lock overrides it per session
@@ -19,9 +19,15 @@ plugins:
   # brain:
   #   enabled: true               # the agentic command-center context
 
+# Built-in dev shell guard: once plugins.dev.enabled is true, agent-created
+# worktrees must live under .red/tmp/, and branch-changing commands in the
+# primary checkout are blocked. Create task branches with:
+#   git worktree add .red/tmp/work-<slug> -b <branch> origin/main
+#
 # Command guard policy. The installed Claude Code, Codex, and opencode hooks are
 # thin proxies: they read this repo-owned policy at runtime and stay inert unless
-# plugins.dev.enabled is true. Uncomment only rules this repo actually wants.
+# plugins.dev.enabled is true. These rules are additional to the built-in
+# .red/tmp worktree boundary above. Uncomment only rules this repo actually wants.
 # command_guard:
 #   global:                       # applies in main sessions and runtime worktrees
 #     - "rm -Rf /*"

--- a/plugins/dev/skills/misc/branch-lock/SKILL.md
+++ b/plugins/dev/skills/misc/branch-lock/SKILL.md
@@ -152,7 +152,7 @@ It allows (exit 0, silent):
 - `git stash list` / `git stash show` — read-only stash
 - `git clean -n` / `--dry-run` — non-destructive clean
 - `git reset --soft` / mixed reset, `git restore --staged <path>` — no working-tree loss
-- `git worktree add …` — worktrees are how `/afk` works
+- `git worktree add .red/tmp/...` — worktrees are how `/afk` and `/ship` work
 - any other command
 
 With `dev.lock.primary-branch: true` and no branch-lock file, the primary guard
@@ -162,6 +162,12 @@ blocks only branch-changing commands in the primary checkout:
   `git checkout -b <new>`, and `git switch -`
 - allows `git commit`, `git worktree add`, `git status` / read-only git,
   targeted path checkout, and every `.red/tmp/work-*/` worktree
+
+The dev command proxy has a stricter host-wide invariant when
+`plugins.dev.enabled: true`: any agent-created `git worktree add` destination
+must resolve under the repo's `.red/tmp/`. Branch-lock allows the command class;
+the dev proxy decides whether the destination path is inside the repo-owned
+runtime area.
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- enforce the dev plugin worktree invariant in the shared command guard: agent-created `git worktree add` destinations must resolve under `.red/tmp/` when `plugins.dev.enabled: true`
- block primary-checkout branch movement from agent shell commands while allowing it inside RedSkills runtime worktrees
- update setup/config/workflow docs so `command_guard` remains additional repo policy, with examples only

## Validation
- `rtk bash -n plugins/dev/hooks/command-guard.sh`
- `rtk bash plugins/dev/hooks/tests/command-guard.test.sh`
- `rtk pnpm --filter @reddb-io/dev test -- development-workflow.test.ts label-vocabulary-docs.test.ts`
- `rtk pnpm --filter ./apps/opencode-host test -- hooks-to-events.test.ts slice-2-e2e.test.ts`
- `rtk proxy git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785267158&installation_id=129708444&pr_number=904&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F904&signature=57bbfb65e7dc03af0bd924a1f78c439ba6529aab808c399333a6505dfda4c64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->