### PR TITLE
feat(install): add universal CLI installer

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -195,6 +195,7 @@ jobs:
             apps/dev/package.json
             apps/memory/package.json
             apps/brain/package.json
+            apps/opencode-host/package.json
             apps/benchmark-memory/package.json
             apps/benchmark-code-understanding/package.json
             apps/code-nav/package.json
@@ -447,6 +448,17 @@ jobs:
           console.log('benchmark-memory bundle manifest:', JSON.stringify(manifest));
           EOF
 
+      - name: Build OpenCode host installer bundle
+        if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
+        working-directory: apps/opencode-host
+        env:
+          RED_BUILD_VERSION: ${{ steps.version.outputs.next }}
+          RED_BUILD_GIT_SHA: ${{ github.sha }}
+          RED_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
+        run: |
+          set -euo pipefail
+          pnpm build
+
       - name: Build benchmark-code-understanding bundle + manifest
         if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
         working-directory: apps/benchmark-code-understanding
@@ -486,6 +498,7 @@ jobs:
             dist/code-nav.manifest.json \
             dist/benchmark-memory.bundle.min.mjs \
             dist/benchmark-memory.manifest.json \
+            dist/opencode-host.bundle.min.mjs \
             dist/benchmark-code-understanding.bundle.min.mjs \
             dist/benchmark-code-understanding.manifest.json \
             dist/memory.bundle.min.mjs \
@@ -515,6 +528,7 @@ jobs:
             dist/code-nav.manifest.json
             dist/benchmark-memory.bundle.min.mjs
             dist/benchmark-memory.manifest.json
+            dist/opencode-host.bundle.min.mjs
             dist/benchmark-code-understanding.bundle.min.mjs
             dist/benchmark-code-understanding.manifest.json
             dist/memory.bundle.min.mjs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,52 @@ Attribution is preserved in [NOTICE](./NOTICE).
 
 ## Install
 
-### Claude Code
+### Universal Installer
+
+Recommended for normal installs and upgrades:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
+```
+
+The installer resolves the latest GitHub Release, stores it under
+`~/.red-skills/versions/<tag>`, updates `~/.red-skills/current`, detects which
+supported CLIs are present (`claude`, `codex`, `opencode`), then installs the
+right surface for each host:
+
+| Host | What the installer does |
+| --- | --- |
+| Claude Code | Registers the RedSkills marketplace and installs `dev`, `memory`, and `brain`. |
+| Codex CLI | Registers the RedSkills marketplace and installs `dev`, `memory`, and `brain`. |
+| OpenCode | Generates and installs OpenCode plugin modules, skills, MCP config, provider config, and TUI attention config. |
+
+OpenCode installs use the published `opencode-host.bundle.min.mjs` asset when
+available, so normal installs need `node` but do not need a local workspace
+build. If that asset is unavailable for a pinned older release, the installer
+falls back to building from source with `pnpm`.
+
+Useful options:
+
+```bash
+# inspect without writing
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --dry-run
+
+# install only one host
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --only opencode
+
+# pin a release
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --version v1.248.1
+
+# force plugin reinstall where the host supports removal
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --force
+```
+
+After installing, restart any already-open CLI sessions so they reload plugin
+manifests. Then run `/setup-red-skills` in a project from Claude Code or
+OpenCode, or `$dev:setup-red-skills` in Codex when the client exposes
+namespace-qualified skills.
+
+### Manual: Claude Code
 
 ```text
 /plugin marketplace add reddb-io/red-skills
@@ -69,11 +114,14 @@ Upgrade or remove:
 /plugin marketplace remove red-skills
 ```
 
-### Codex CLI
+### Manual: Codex CLI
 
 ```bash
 codex plugin marketplace add reddb-io/red-skills
 codex plugin marketplace upgrade red-skills
+codex plugin add dev@red-skills
+codex plugin add memory@red-skills
+codex plugin add brain@red-skills
 codex plugin marketplace remove red-skills
 ```
 
@@ -95,11 +143,13 @@ command-backed statusline. Use `$dev:afk monitor` when the client exposes
 namespace-qualified skills, or `$afk monitor` when it exposes unqualified skill
 names.
 
-### OpenCode
+### Manual: OpenCode
 
 OpenCode support is generated from the same plugin source tree as Claude Code
 and Codex. The installer writes skills, plugin modules, MCP config, provider
-config, and TUI attention config for OpenCode.
+config, and TUI attention config for OpenCode. The universal installer above is
+preferred for normal user-scoped installs; use the direct script when developing
+or when installing a checkout into a specific project.
 
 ```bash
 git clone git@github.com:reddb-io/red-skills.git ~/code/red-skills

--- a/apps/opencode-host/README.md
+++ b/apps/opencode-host/README.md
@@ -53,10 +53,26 @@ pnpm --filter @reddb-io/red-skills bundle
 node ./dist/opencode-host.bundle.min.mjs --with-slice-2 --plugins-root ./plugins
 ```
 
-## Install script (recommended)
+## Universal install (recommended)
+
+For normal user installs, use the root universal installer. It resolves the
+latest RedSkills release, detects `opencode` alongside Claude Code and Codex,
+and invokes the OpenCode adapter when OpenCode is present:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
+```
+
+That path installs OpenCode globally under `~/.config/opencode/` and also keeps
+Claude/Codex marketplace installs in sync when those CLIs are present. It uses
+the published `opencode-host.bundle.min.mjs` release asset when available, so
+normal installs need `node` but do not need a local workspace build.
+
+## Adapter install script
 
 The `scripts/install-opencode.sh` wrapper in the repo root bundles the
-above into one command that handles generation + install:
+above into one command that handles generation + install. Use it directly when
+developing the adapter or when installing a checkout into a specific project:
 
 ```bash
 # global — recommended user-scoped install into ~/.config/opencode/

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -100,25 +100,26 @@ die() { printf 'install-opencode: %s\n' "$*" >&2; exit 1; }
 [ -f "$CONFIG_PATH" ] || die "config not found at $CONFIG_PATH — run from a red-skills clone"
 [ -d "$PLUGINS_ROOT" ] || die "plugins tree not found at $PLUGINS_ROOT"
 
-# 1. pnpm install (first run only)
-if [ ! -d "$REPO_ROOT/node_modules" ] && [ "$DRY_RUN" = "false" ]; then
-  log "running pnpm install (first run)"
-  (cd "$REPO_ROOT" && pnpm install --frozen-lockfile 2>/dev/null || pnpm install) >/dev/null
-fi
-
-# 2. resolve the generator (bundle preferred, tsx fallback)
+# 1. resolve the generator (release bundle preferred, tsx fallback)
 BUNDLE="$REPO_ROOT/dist/opencode-host.bundle.min.mjs"
 if [ "$DRY_RUN" = "true" ]; then
   GENERATOR="(tsx $REPO_ROOT/apps/opencode-host/src/generate.ts)"
 elif [ -f "$BUNDLE" ]; then
   GENERATOR="node $BUNDLE"
 else
+  # Build-from-source fallback for checkout installs. The universal curl
+  # installer downloads the release asset above, so normal user installs do not
+  # need pnpm unless the asset is unavailable.
+  if [ ! -d "$REPO_ROOT/node_modules" ]; then
+    log "running pnpm install (first run)"
+    (cd "$REPO_ROOT" && pnpm install --frozen-lockfile 2>/dev/null || pnpm install) >/dev/null
+  fi
   log "bundle missing — building"
   (cd "$REPO_ROOT" && pnpm --filter @reddb-io/red-skills bundle) >/dev/null
   GENERATOR="node $BUNDLE"
 fi
 
-# 3. generate the dist tree
+# 2. generate the dist tree
 GEN_ARGS=(--config "$CONFIG_PATH" --with-slice-2 --plugins-root "$PLUGINS_ROOT" --out-dir "$OUT_DIR")
 [ "$COPY" = "true" ] && GEN_ARGS+=(--copy)
 
@@ -129,7 +130,7 @@ else
   (cd "$REPO_ROOT" && $GENERATOR "${GEN_ARGS[@]}")
 fi
 
-# 4. discover the plugins that have a dist subtree
+# 3. discover the plugins that have a dist subtree
 PLUGINS=""
 for d in "$OUT_DIR"/*/; do
   [ -d "$d" ] || continue
@@ -138,6 +139,20 @@ for d in "$OUT_DIR"/*/; do
 done
 PLUGINS="${PLUGINS# }"
 [ -n "$PLUGINS" ] || die "no plugin dist trees under $OUT_DIR — the generator emitted nothing"
+
+ORDERED_PLUGINS=""
+for preferred in dev memory brain; do
+  case " $PLUGINS " in
+    *" $preferred "*) ORDERED_PLUGINS="$ORDERED_PLUGINS $preferred" ;;
+  esac
+done
+for plugin in $PLUGINS; do
+  case " $ORDERED_PLUGINS " in
+    *" $plugin "*) ;;
+    *) ORDERED_PLUGINS="$ORDERED_PLUGINS $plugin" ;;
+  esac
+done
+PLUGINS="${ORDERED_PLUGINS# }"
 
 # 5. install into the target
 if [ "$MODE" = "local" ]; then
@@ -211,6 +226,7 @@ else
   GLOBAL_SKILLS_DIR="$XDG_CONFIG_HOME/opencode/skills"
   GLOBAL_CFG="$XDG_CONFIG_HOME/opencode/opencode.json"
   [ -f "$XDG_CONFIG_HOME/opencode/opencode.jsonc" ] && GLOBAL_CFG="$XDG_CONFIG_HOME/opencode/opencode.jsonc"
+  declare -A INSTALLED_SKILLS=()
 
   if [ "$DRY_RUN" = "true" ]; then
     log "(dry-run) flatten each plugin module into $GLOBAL_PLUGINS_DIR/redskills-<plugin>-<event>.ts"
@@ -230,9 +246,14 @@ else
       [ -d "$SRC/skills" ] && for skill_dir in "$SRC/skills"/*/; do
         [ -d "$skill_dir" ] || continue
         skill_name=$(basename "$skill_dir")
+        if [ -n "${INSTALLED_SKILLS[$skill_name]:-}" ]; then
+          log "(note) duplicate skill $skill_name from $plugin skipped; already installed from ${INSTALLED_SKILLS[$skill_name]}"
+          continue
+        fi
         dst="$GLOBAL_SKILLS_DIR/$skill_name"
         rm -rf "$dst"
         cp -R "$skill_dir" "$dst"
+        INSTALLED_SKILLS[$skill_name]="$plugin"
         log "installed skill $skill_name -> $dst"
       done
     done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# Universal RedSkills installer.
+#
+# Intended curl entrypoint:
+#   curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
+#
+# The script resolves the latest GitHub Release by default, installs that source
+# tree under ~/.red-skills, detects supported local CLIs, then wires each host:
+#   - Claude Code: marketplace + plugins
+#   - Codex CLI: marketplace + plugins
+#   - OpenCode: generated plugin/skill/MCP/statusline surface
+
+set -euo pipefail
+
+REPO="${RED_SKILLS_REPO:-reddb-io/red-skills}"
+VERSION="${RED_SKILLS_VERSION:-latest}"
+INSTALL_ROOT="${RED_SKILLS_INSTALL_ROOT:-$HOME/.red-skills}"
+ONLY="${RED_SKILLS_ONLY:-auto}"
+CLAUDE_SCOPE="${RED_SKILLS_CLAUDE_SCOPE:-user}"
+SOURCE_DIR="${RED_SKILLS_SOURCE_DIR:-}"
+FORCE="${RED_SKILLS_FORCE:-false}"
+REFRESH="${RED_SKILLS_REFRESH:-false}"
+DRY_RUN="false"
+OPENCODE_COPY="${RED_SKILLS_OPENCODE_COPY:-false}"
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [options]
+
+Installs RedSkills into every detected supported CLI:
+  claude   -> Claude Code marketplace + dev/memory/brain plugins
+  codex    -> Codex marketplace + dev/memory/brain plugins
+  opencode -> generated OpenCode plugins, skills, MCP config, and TUI config
+
+Options:
+  --version <tag>       Install a specific release tag (default: latest release)
+  --install-root <dir>  Install source cache here (default: ~/.red-skills)
+  --only <list>         Comma list: claude,codex,opencode (default: auto-detect)
+  --claude-scope <s>    Claude install scope: user, project, or local (default: user)
+  --source-dir <dir>    Use an existing red-skills checkout instead of downloading
+  --force               Reinstall plugins where the host supports removal
+  --refresh             Re-download the selected release source
+  --opencode-copy       Copy OpenCode SKILL.md files instead of symlinking
+  --dry-run             Print actions without writing
+  -h, --help            Show this help
+
+Environment:
+  RED_SKILLS_VERSION, RED_SKILLS_INSTALL_ROOT, RED_SKILLS_ONLY,
+  RED_SKILLS_CLAUDE_SCOPE, RED_SKILLS_SOURCE_DIR, RED_SKILLS_FORCE,
+  RED_SKILLS_REFRESH, RED_SKILLS_OPENCODE_COPY, GITHUB_TOKEN.
+EOF
+}
+
+log() { printf 'red-skills install: %s\n' "$*"; }
+warn() { printf 'red-skills install: warn: %s\n' "$*" >&2; }
+die() {
+  printf 'red-skills install: error: %s\n' "$*" >&2
+  exit 1
+}
+
+quote_cmd() {
+  local out="" arg
+  for arg in "$@"; do
+    printf -v arg '%q' "$arg"
+    out="$out $arg"
+  done
+  printf '%s' "$out"
+}
+
+run() {
+  log "+$(quote_cmd "$@")"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+try_run() {
+  log "+$(quote_cmd "$@")"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    return 0
+  fi
+  "$@"
+}
+
+has_target() {
+  local target="$1"
+  if [[ "$ONLY" == "auto" ]]; then
+    command -v "$target" >/dev/null 2>&1
+    return
+  fi
+  case ",$ONLY," in
+    *,"$target",*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+curl_json() {
+  local url="$1"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$url"
+  else
+    curl -fsSL "$url"
+  fi
+}
+
+curl_file() {
+  local url="$1"
+  local out="$2"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$url" -o "$out"
+  else
+    curl -fsSL "$url" -o "$out"
+  fi
+}
+
+latest_release_tag() {
+  local api="https://api.github.com/repos/$REPO/releases/latest"
+  local tag
+  tag="$(curl_json "$api" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [[ -n "$tag" ]] || die "could not resolve latest release from $api"
+  printf '%s\n' "$tag"
+}
+
+safe_release_tag() {
+  local tag="$1"
+  case "$tag" in
+    v[0-9]*.[0-9]*.[0-9]* | [0-9]*.[0-9]*.[0-9]*) printf '%s\n' "$tag" ;;
+    *) die "release tag must look like vX.Y.Z, got '$tag'" ;;
+  esac
+}
+
+download_release_asset_if_available() {
+  local tag="$1"
+  local source="$2"
+  local asset="opencode-host.bundle.min.mjs"
+  local out="$source/dist/$asset"
+  local url="https://github.com/$REPO/releases/download/$tag/$asset"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "would download optional release asset $url"
+    return 0
+  fi
+
+  [[ "$REFRESH" == "true" || ! -f "$out" ]] || return 0
+  mkdir -p "$source/dist"
+  if curl_file "$url" "$out.tmp"; then
+    mv "$out.tmp" "$out"
+    log "downloaded optional release asset $asset"
+  else
+    rm -f "$out.tmp"
+    warn "optional release asset $asset is unavailable for $tag; OpenCode install may build from source"
+  fi
+}
+
+prepare_source() {
+  if [[ -n "$SOURCE_DIR" ]]; then
+    [[ -d "$SOURCE_DIR" ]] || die "--source-dir does not exist: $SOURCE_DIR"
+    SOURCE_DIR="$(cd "$SOURCE_DIR" && pwd)"
+    [[ -f "$SOURCE_DIR/.claude-plugin/marketplace.json" ]] || die "source dir is missing .claude-plugin/marketplace.json"
+    [[ -f "$SOURCE_DIR/.agents/plugins/marketplace.json" ]] || die "source dir is missing .agents/plugins/marketplace.json"
+    log "using local source: $SOURCE_DIR"
+    return 0
+  fi
+
+  require_cmd curl
+  require_cmd tar
+  require_cmd mktemp
+
+  local tag="$VERSION"
+  if [[ "$tag" == "latest" ]]; then
+    tag="$(latest_release_tag)"
+  fi
+  tag="$(safe_release_tag "$tag")"
+  VERSION="$tag"
+
+  local versions_dir="$INSTALL_ROOT/versions"
+  local cache_dir="$INSTALL_ROOT/cache"
+  local dest="$versions_dir/$tag"
+  local current="$INSTALL_ROOT/current"
+  local archive="$cache_dir/$tag.tar.gz"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log "would install $REPO@$tag under $dest"
+    SOURCE_DIR="$current"
+    return 0
+  fi
+
+  mkdir -p "$versions_dir" "$cache_dir"
+  if [[ "$REFRESH" == "true" ]]; then
+    rm -rf "$dest" "$archive"
+  fi
+
+  if [[ ! -d "$dest" ]]; then
+    local url="https://github.com/$REPO/archive/refs/tags/$tag.tar.gz"
+    local tmp extracted
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' RETURN
+    log "downloading $url"
+    curl -fsSL "$url" -o "$archive"
+    tar -xzf "$archive" -C "$tmp"
+    extracted="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+    [[ -n "$extracted" ]] || die "archive did not contain a source directory"
+    rm -rf "$dest.tmp"
+    mv "$extracted" "$dest.tmp"
+    mv "$dest.tmp" "$dest"
+    rm -rf "$tmp"
+    trap - RETURN
+  else
+    log "using cached source $dest"
+  fi
+
+  rm -f "$current"
+  ln -s "$dest" "$current"
+  download_release_asset_if_available "$tag" "$dest"
+  SOURCE_DIR="$current"
+  log "current source -> $dest"
+}
+
+install_claude() {
+  if ! command -v claude >/dev/null 2>&1; then
+    warn "claude not found; skipping Claude Code"
+    return 0
+  fi
+
+  log "installing Claude Code marketplace/plugins from $SOURCE_DIR"
+  if ! try_run claude plugin marketplace add --scope "$CLAUDE_SCOPE" "$SOURCE_DIR"; then
+    warn "Claude marketplace add failed; replacing existing red-skills marketplace source"
+    try_run claude plugin marketplace remove red-skills || true
+    try_run claude plugin marketplace add --scope "$CLAUDE_SCOPE" "$SOURCE_DIR" || die "Claude marketplace add failed"
+  fi
+  try_run claude plugin marketplace update red-skills || warn "Claude marketplace update failed; continuing"
+
+  local plugin
+  for plugin in dev memory brain; do
+    if [[ "$FORCE" == "true" ]]; then
+      try_run claude plugin remove --scope "$CLAUDE_SCOPE" --keep-data "$plugin" || true
+    fi
+    if ! try_run claude plugin install --scope "$CLAUDE_SCOPE" "$plugin@red-skills"; then
+      warn "Claude install for $plugin failed; trying update"
+      try_run claude plugin update --scope "$CLAUDE_SCOPE" "$plugin" || die "Claude plugin $plugin install/update failed"
+    fi
+  done
+}
+
+install_codex() {
+  if ! command -v codex >/dev/null 2>&1; then
+    warn "codex not found; skipping Codex CLI"
+    return 0
+  fi
+
+  log "installing Codex marketplace/plugins from $SOURCE_DIR"
+  if ! try_run codex plugin marketplace add "$SOURCE_DIR"; then
+    warn "Codex marketplace add failed; replacing existing red-skills marketplace source"
+    try_run codex plugin marketplace remove red-skills || true
+    try_run codex plugin marketplace add "$SOURCE_DIR" || die "Codex marketplace add failed"
+  fi
+  try_run codex plugin marketplace upgrade red-skills || warn "Codex marketplace upgrade failed; continuing"
+
+  local plugin
+  for plugin in dev memory brain; do
+    # Codex currently has marketplace upgrade but no plugin update command.
+    # Remove/re-add to make a rerun converge on the selected release source.
+    try_run codex plugin remove "$plugin@red-skills" || true
+    if ! try_run codex plugin add "$plugin@red-skills"; then
+      die "Codex plugin $plugin install failed"
+    fi
+  done
+}
+
+install_opencode() {
+  if ! command -v opencode >/dev/null 2>&1; then
+    warn "opencode not found; skipping OpenCode"
+    return 0
+  fi
+
+  if [[ "$DRY_RUN" != "true" ]]; then
+    [[ -x "$SOURCE_DIR/scripts/install-opencode.sh" ]] || die "source is missing executable scripts/install-opencode.sh"
+    require_cmd node
+    if [[ ! -f "$SOURCE_DIR/dist/opencode-host.bundle.min.mjs" ]]; then
+      require_cmd pnpm
+    fi
+  fi
+
+  local args=("$SOURCE_DIR/scripts/install-opencode.sh" "--global")
+  [[ "$OPENCODE_COPY" == "true" ]] && args+=("--copy")
+  log "installing OpenCode generated plugin surface from $SOURCE_DIR"
+  run "${args[@]}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version|--ref)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      VERSION="$2"
+      shift 2
+      ;;
+    --install-root)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      INSTALL_ROOT="$2"
+      shift 2
+      ;;
+    --only)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      ONLY="$2"
+      shift 2
+      ;;
+    --claude-scope)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      CLAUDE_SCOPE="$2"
+      shift 2
+      ;;
+    --source-dir)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      SOURCE_DIR="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE="true"
+      shift
+      ;;
+    --refresh)
+      REFRESH="true"
+      shift
+      ;;
+    --opencode-copy)
+      OPENCODE_COPY="true"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "$CLAUDE_SCOPE" in
+  user|project|local) ;;
+  *) die "--claude-scope must be user, project, or local" ;;
+esac
+
+case "$ONLY" in
+  auto) ;;
+  *)
+    IFS=',' read -r -a requested_targets <<<"$ONLY"
+    for target in "${requested_targets[@]}"; do
+      case "$target" in
+        claude|codex|opencode) ;;
+        *) die "--only contains unsupported target '$target'" ;;
+      esac
+    done
+    ;;
+esac
+
+prepare_source
+
+installed_any="false"
+if has_target claude; then
+  install_claude
+  installed_any="true"
+fi
+if has_target codex; then
+  install_codex
+  installed_any="true"
+fi
+if has_target opencode; then
+  install_opencode
+  installed_any="true"
+fi
+
+if [[ "$installed_any" != "true" ]]; then
+  warn "no supported CLIs detected (claude, codex, opencode)"
+fi
+
+log "done"
+log "restart open CLI sessions so they reload plugin manifests"
+log "inside each repo, run /setup-red-skills (Claude/OpenCode) or \$dev:setup-red-skills (Codex when namespace-qualified)"

--- a/scripts/validate-install-metadata.sh
+++ b/scripts/validate-install-metadata.sh
@@ -14,6 +14,9 @@ command -v jq >/dev/null || fail "jq is required"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+bash -n scripts/install.sh || fail "scripts/install.sh has invalid bash syntax"
+bash -n scripts/install-opencode.sh || fail "scripts/install-opencode.sh has invalid bash syntax"
+
 # Validate one plugin's install metadata: Claude skill list matches the SKILL.md
 # tree on disk, Claude/Codex versions agree, and the Codex plugin exposes the
 # whole skills/ tree under the right name.


### PR DESCRIPTION
## Summary
- add a curl-friendly universal RedSkills installer that resolves the latest GitHub release, caches it under ~/.red-skills, detects claude/codex/opencode, and installs each supported host surface
- update OpenCode installation to prefer the published host bundle before falling back to a source build
- publish the OpenCode host bundle as a release asset and refresh README installation docs

## Validation
- rtk bash -n scripts/install.sh
- rtk bash -n scripts/install-opencode.sh
- rtk ./scripts/validate-install-metadata.sh
- rtk ./scripts/install.sh --dry-run --source-dir "$PWD" --only claude,codex,opencode --opencode-copy
- rtk ./scripts/install.sh --dry-run --version v1.248.1 --install-root /tmp/red-skills-installer-test --only codex
- rtk ./scripts/install.sh --dry-run --version v1.248.1 --install-root /tmp/red-skills-installer-dry --only opencode
- rtk pnpm --filter @reddb-io/red-skills bundle
- rtk pnpm --filter ./apps/opencode-host test -- generate-cli.test.ts slice-2-e2e.test.ts
- rtk proxy git diff --check

Latest release before merge was verified as v1.248.1. This PR adds the installer path and release asset for the next release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785269403&installation_id=129708444&pr_number=905&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F905&signature=026929b7e173a5a05d63c61252522309510fd63b676a72918b0acdf53fa7839b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->