### PR TITLE
feat(afk): per-attempt budget guard (#788 antidote) — token/cost + runner-agnostic proxy ceiling

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -71,7 +71,7 @@ import { initStateSync, readPidStartTime, updateState } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { createActivityMeter } from "../core/activity-meter.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
-import type { AgentStreamEvent } from "../core/execution.js";
+import type { AgentStreamEvent, AttemptBudget } from "../core/execution.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../core/claim-staleness.js";
 import { renderClaimComment } from "../core/claim.js";
 
@@ -438,6 +438,7 @@ export function buildProcessDeps(
   maxIterations?: number,
   attemptTimeoutSeconds?: number,
   laneIdle?: LaneIdleStallConfig,
+  attemptBudget?: AttemptBudget,
 ): ProcessIssueDeps {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
   const gitCtx: GitContext = { cwd: ctx.root, exec };
@@ -609,7 +610,19 @@ export function buildProcessDeps(
     // shell commands run against the same worker-branch checkout after feedback.
     backpressure: feedback.backpressure,
     backpressureCommands: readBackpressure(config),
-    runAgent: makeRunAgent(sandbox, process.env, maxIterations, attemptTimeoutSeconds, laneIdle),
+    // #908: thread the resolved budget + a LIVE usage probe off this attempt's
+    // activity meter (late-bound — `activityMeter` is reassigned per attempt dir,
+    // and `peek()` returns a superset of AttemptBudgetUsage). makeRunAgent only
+    // wires it when the progress guard is armed.
+    runAgent: makeRunAgent(
+      sandbox,
+      process.env,
+      maxIterations,
+      attemptTimeoutSeconds,
+      laneIdle,
+      attemptBudget,
+      () => activityMeter.peek(),
+    ),
     model,
     classifyIssue: makeIssueClassifier(config, runner, ctx.root, exec),
     resolveTier: (activeRunner, taskClass = "think") => resolveTier(config, activeRunner, taskClass, process.env),
@@ -1339,7 +1352,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }).catch(() => {});
       return result;
     },
-    processDeps: buildProcessDeps(ctx, settings.model, settings.sandbox, feedback, current, flags.fallbackRunner, runner, undefined, settings.maxIterations, settings.attemptTimeoutSeconds, settings.laneIdle),
+    processDeps: buildProcessDeps(ctx, settings.model, settings.sandbox, feedback, current, flags.fallbackRunner, runner, undefined, settings.maxIterations, settings.attemptTimeoutSeconds, settings.laneIdle, settings.attemptBudget),
     // Session-scoped lifecycle hooks (PRD #207): compose the same config /
     // resolver / exec / env the process deps use, so session + per-issue points
     // share one dispatcher rather than duplicating the wiring.

--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -34,6 +34,7 @@ import {
   LABEL_POLICY,
   LABEL_STALLED,
   LABEL_INFRA,
+  LABEL_BUDGET,
 } from "./triage-labels.js";
 
 /**
@@ -71,6 +72,11 @@ export type AttemptOutcome =
   | "exhausted"
   | "runner-transient"
   | "stalled"
+  // AFK runner improvement (#908): the per-attempt resource budget guard aborted
+  // the attempt (token / cost / tool-call / waiting-window ceiling). Partial work
+  // is salvaged through the same feedback gate, then parked for a human — NOT
+  // auto-recovered (a runaway is not a transient flake to blind-retry).
+  | "budget-exceeded"
   | "infra";
 
 /**
@@ -123,6 +129,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_POLICY;
     case "stalled":
       return LABEL_STALLED;
+    case "budget-exceeded":
+      return LABEL_BUDGET;
     case "infra":
       return LABEL_INFRA;
     case "done":
@@ -176,6 +184,7 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     case "runner-transient":
     case "claim-lost":
     case "stalled":
+    case "budget-exceeded":
     case "infra":
     // review-requested is a handoff, not a failure: the per-issue lifecycle
     // emits no terminal failure envelope for it (it parks the issue + opens the
@@ -230,6 +239,10 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     case "blocked":
     case "feedback-failed":
     case "stalled":
+    // #908: a budget abort is NOT auto-recoverable — re-running the inner agent
+    // on a runaway just re-spends the budget. Escalate to a human with the
+    // salvaged partial work intact.
+    case "budget-exceeded":
     case "infra":
     case "done":
     case "claim-lost":

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -61,6 +61,7 @@ export type AgentOutcome =
   | "exhausted"
   | "runner-transient"
   | "timeout"
+  | "budget-exceeded"
   | "goal-moot";
 
 /** AFK's canonical sentinels, registered as sandcastle completion signals. */
@@ -331,6 +332,16 @@ export interface RunAgentInput {
    * Only fires when the guard is armed (cap + headProbe present).
    */
   onHeartbeat?: (info: AttemptProgressInfo) => void;
+  /**
+   * Per-attempt resource budget (#908). When supplied alongside `budgetUsage`,
+   * the attempt guard aborts with the `budget-exceeded` outcome once any ceiling
+   * is breached. Rides the existing guard poll, so it is active whenever the
+   * progress guard is armed (cap + headProbe). Omitted → no budget cap.
+   */
+  budget?: AttemptBudget;
+  /** Sync probe returning the attempt's cumulative usage (the activity meter's
+   * `peek()`), read each guard poll to evaluate `budget`. */
+  budgetUsage?: () => AttemptBudgetUsage;
   /**
    * Goal predicate (ADR 0057): reads the claimed issue's CLOSED state on the
    * existing attempt-guard poll (one issue-state read per tick). When it resolves
@@ -793,6 +804,59 @@ export interface AttemptProgressInfo {
   base?: string;
 }
 
+/**
+ * Per-attempt resource budget (GNHF Track A, #908). Optional ceilings the
+ * attempt guard enforces ALONGSIDE the commit-anchored wall-clock cap. Any unset
+ * field is ignored, so an empty budget is a no-op (today's behaviour). The point
+ * is to stop a runaway BEFORE it burns the whole token allowance — the #788
+ * failure (2.1M tokens on one slice, never emitted DONE, 0 closed).
+ */
+export interface AttemptBudget {
+  /** Abort once cumulative (input+output) tokens reach this. Lives only for
+   * runners that stream usage on the wire (codex/opencode); a pure-claude
+   * attempt accrues 0 live tokens (usage folds in at the iteration boundary),
+   * so for claude/minimax the PROXY ceilings below carry the protection. */
+  maxTotalTokens?: number;
+  /** Abort once cumulative USD cost reaches this (runners that report cost). */
+  maxCostUsd?: number;
+  /** Runner-agnostic proxy: abort once this many tool calls have been made.
+   * Accrues live for ALL runners (incl. claude/minimax), so it is the ceiling
+   * that actually covers the #788 runner. */
+  maxToolCalls?: number;
+  /** Runner-agnostic proxy: abort once this many heartbeat windows have passed
+   * with zero new stream events (waiting/blocked) — a long wedged run. */
+  maxWaitingWindows?: number;
+}
+
+/** The cumulative counters the guard reads each poll to evaluate the budget —
+ * exactly the subset of the activity meter's `peek()` snapshot the ceilings
+ * compare against. */
+export interface AttemptBudgetUsage {
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  toolsCalled: number;
+  waiting: number;
+}
+
+/**
+ * Pure budget predicate: is any configured ceiling reached? Returns the breached
+ * ceiling's name (for the abort message / observability) or `undefined`. Unset
+ * ceilings never fire, so an empty budget always returns `undefined`.
+ */
+export function exceedsBudget(
+  usage: AttemptBudgetUsage,
+  budget: AttemptBudget,
+): "tokens" | "cost" | "tool-calls" | "waiting-windows" | undefined {
+  if (budget.maxTotalTokens !== undefined && usage.inputTokens + usage.outputTokens >= budget.maxTotalTokens) {
+    return "tokens";
+  }
+  if (budget.maxCostUsd !== undefined && usage.costUsd >= budget.maxCostUsd) return "cost";
+  if (budget.maxToolCalls !== undefined && usage.toolsCalled >= budget.maxToolCalls) return "tool-calls";
+  if (budget.maxWaitingWindows !== undefined && usage.waiting >= budget.maxWaitingWindows) return "waiting-windows";
+  return undefined;
+}
+
 export function startAttemptGuard(opts: {
   capMs: number;
   intervalMs: number;
@@ -803,7 +867,16 @@ export function startAttemptGuard(opts: {
    * commit-anchored hard cap ("hard-cap", issue #637) and the goal predicate
    * ("goal-moot", ADR 0057 — the claimed issue is already CLOSED). Callbacks that
    * ignore the argument keep the prior behaviour. */
-  abort: (reason: "stalled" | "hard-cap" | "goal-moot") => void;
+  abort: (reason: "stalled" | "hard-cap" | "goal-moot" | "budget") => void;
+  /**
+   * Per-attempt resource budget (#908). When both `budget` and `budgetUsage` are
+   * supplied, the guard reads the cumulative usage each poll and aborts with
+   * reason `"budget"` once any ceiling is breached. Omitted → no budget cap.
+   */
+  budget?: AttemptBudget;
+  /** Sync probe for the cumulative usage this poll (the activity meter's
+   * `peek()`). Read only when `budget` is also set. */
+  budgetUsage?: () => AttemptBudgetUsage;
   /**
    * Goal predicate (ADR 0057): reads the claimed issue's CLOSED state on THIS
    * same poll (one issue-state read per tick — no extra polling loop). Resolves
@@ -827,13 +900,14 @@ export function startAttemptGuard(opts: {
    * heartbeat + on_heartbeat hook ride this same cadence (PR-B). Never throws —
    * the caller wraps its own IO. */
   onTick?: (info: AttemptProgressInfo) => void;
-}): { stop: () => void; firedTimeout: () => boolean; firedGoalMoot: () => boolean } {
+}): { stop: () => void; firedTimeout: () => boolean; firedGoalMoot: () => boolean; firedBudget: () => boolean } {
   let lastProgress = opts.now();
   let lastCommit = opts.now();
   let lastHead: string | undefined;
   let lastVolume: number | undefined;
   let fired = false;
   let goalMoot = false;
+  let budgetFired = false;
   const cancel = opts.schedule(() => {
     void (async () => {
       if (fired) return;
@@ -856,6 +930,19 @@ export function startAttemptGuard(opts: {
           fired = true;
           goalMoot = true;
           opts.abort("goal-moot");
+          return;
+        }
+      }
+      // Resource budget (#908): a runaway is cut on the cumulative-usage ceiling
+      // BEFORE the commit/edit/deadline logic, so a slice that burns tokens (or
+      // spins tool calls / waiting windows) without committing is stopped fast
+      // — the #788 antidote. Pure predicate over the injected usage probe; an
+      // empty budget never fires (today's behaviour).
+      if (opts.budget && opts.budgetUsage) {
+        if (exceedsBudget(opts.budgetUsage(), opts.budget) !== undefined) {
+          fired = true;
+          budgetFired = true;
+          opts.abort("budget");
           return;
         }
       }
@@ -903,7 +990,14 @@ export function startAttemptGuard(opts: {
       opts.onTick?.({ head: head ?? lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
     })();
   }, opts.intervalMs);
-  return { stop: cancel, firedTimeout: () => fired && !goalMoot, firedGoalMoot: () => goalMoot };
+  return {
+    stop: cancel,
+    // firedTimeout EXCLUDES the goal-moot and budget aborts — each has its own
+    // dedicated terminal so they never collide on the shared `fired` flag.
+    firedTimeout: () => fired && !goalMoot && !budgetFired,
+    firedGoalMoot: () => goalMoot,
+    firedBudget: () => budgetFired,
+  };
 }
 
 /**
@@ -951,7 +1045,9 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
   const now = deps.now ?? (() => Date.now());
   const makeController = deps.makeAbortController ?? (() => new AbortController());
   const schedule = deps.schedule ?? defaultSchedule;
-  let guard: { stop: () => void; firedTimeout: () => boolean; firedGoalMoot: () => boolean } | undefined;
+  let guard:
+    | { stop: () => void; firedTimeout: () => boolean; firedGoalMoot: () => boolean; firedBudget: () => boolean }
+    | undefined;
   let laneReaper: { stop: () => void; firedReap: () => boolean } | undefined;
   let controller: AbortController | undefined;
   if (input.attemptTimeoutSeconds && input.attemptTimeoutSeconds > 0 && input.headProbe) {
@@ -968,14 +1064,17 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       now,
       schedule,
       ...(input.goalProbe ? { goalProbe: input.goalProbe } : {}),
+      ...(input.budget && input.budgetUsage ? { budget: input.budget, budgetUsage: input.budgetUsage } : {}),
       abort: (reason) =>
         controller?.abort(
           new Error(
             reason === "goal-moot"
               ? "afk: attempt mooted — the claimed issue is already CLOSED (goal predicate, ADR 0057)"
-              : reason === "hard-cap"
-                ? `afk: attempt aborted — no new commit within ${hardCap}s despite worktree edits (hard cap, stalled)`
-                : `afk: attempt aborted — no new commit within ${cap}s (stalled)`,
+              : reason === "budget"
+                ? "afk: attempt aborted — per-attempt resource budget exceeded (#908)"
+                : reason === "hard-cap"
+                  ? `afk: attempt aborted — no new commit within ${hardCap}s despite worktree edits (hard cap, stalled)`
+                  : `afk: attempt aborted — no new commit within ${cap}s (stalled)`,
           ),
         ),
       // Externalized proof-of-life (PR-B): each poll fires the caller's opaque
@@ -1051,6 +1150,20 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
         branch: input.branch,
         commits: [],
         stdout: "afk: attempt mooted — the claimed issue is already CLOSED (goal predicate, ADR 0057)",
+      };
+    }
+    // The budget guard aborted: the attempt breached a resource ceiling (#908)
+    // — distinct from a stall (it may have been actively working, just too
+    // expensively). Surface the dedicated `budget-exceeded` outcome so
+    // process-issue salvages the partial work and parks it for a human rather
+    // than blind-retrying a runaway. Checked before firedTimeout (firedTimeout
+    // already excludes the budget abort, but order keeps intent explicit).
+    if (guard?.firedBudget()) {
+      return {
+        outcome: "budget-exceeded",
+        branch: input.branch,
+        commits: [],
+        stdout: "afk: attempt aborted — per-attempt resource budget exceeded (#908)",
       };
     }
     // The progress guard aborted: alive but not committing → stalled.

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1066,7 +1066,7 @@ export async function processIssue(
     // clean worktree salvages nothing (count 0).
     if (
       deps.salvageUncommitted &&
-      (run.outcome === "done" || run.outcome === "no-sentinel")
+      (run.outcome === "done" || run.outcome === "no-sentinel" || run.outcome === "budget-exceeded")
     ) {
       const salvagedFiles = await deps.salvageUncommitted(workerBranch).catch(() => 0);
       if (salvagedFiles > 0) {
@@ -1094,6 +1094,23 @@ export async function processIssue(
     // tail the DONE path uses. The feedback gate is load-bearing: it is the only
     // thing that distinguishes "complete prior work" from a half-baked crash-edit.
     // A branch with no work keeps today's terminal `no-sentinel` behaviour.
+    // ---- budget guard fired (#908): the attempt breached a resource ceiling ----
+    // The salvage pass above already committed any dirty worktree paths onto the
+    // worker branch, so the partial work is preserved on the branch/PR ("never
+    // wake up empty-handed"). Park it for a human with `blocked:budget`: a runaway
+    // is NOT auto-retried (recoveryReasonFor → null), and re-running the inner
+    // agent would just re-spend the budget. The salvaged commits stay on the
+    // branch for the human to review, continue with a larger budget, or stop.
+    if (run.outcome === "budget-exceeded") {
+      await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "budget-exceeded", current.attempt));
+      return await terminalFailure(common, "budget-exceeded", "budget", {
+        notes:
+          salvagedUncommittedFiles > 0
+            ? `_(budget guard aborted the attempt; salvaged ${salvagedUncommittedFiles} uncommitted file(s) onto \`${workerBranch}\` — partial work preserved for review)_`
+            : "_(budget guard aborted the attempt; no uncommitted work to salvage)_",
+        log: run.stdout || "afk: attempt aborted — per-attempt resource budget exceeded (#908)",
+      });
+    }
     let salvaged = false;
     if (run.outcome === "no-sentinel") {
       const branchHasWork =
@@ -1701,6 +1718,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         kind: "stalled",
         summary: oneLine(sections.log, "Inner agent made no progress (no new commit) within the attempt wall-clock."),
         next: "Review the work already pushed (branch/PR) and decide whether to continue, re-scope, or stop.",
+      };
+    case "budget-exceeded":
+      return {
+        status: "blocked",
+        kind: "budget",
+        summary: oneLine(sections.log, "Attempt aborted — per-attempt resource budget exceeded (#908)."),
+        next: "Review the salvaged partial work (branch/PR) and decide whether to continue with a larger budget, re-scope, or stop.",
       };
     case "merge-conflict":
       return {

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -58,6 +58,12 @@ export const LABEL_MERGE_CONFLICT = "blocked:merge-conflict";
 export const LABEL_CI = "blocked:ci";
 export const LABEL_POLICY = "blocked:policy";
 export const LABEL_INFRA = "blocked:infra";
+// AFK runner improvement (#908): the per-attempt resource budget guard aborted
+// the attempt — it breached a token/cost/tool-call/waiting-window ceiling before
+// it could finish. Distinct from `blocked:stalled` (a stall is *no* progress;
+// a budget abort may have been actively — and expensively — working). Partial
+// work is salvaged + parked for a human; never blind-retried as a transient.
+export const LABEL_BUDGET = "blocked:budget";
 
 // Auxiliary labels
 export const LABEL_RUNNER_ERROR = "runner-error";

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -13,7 +13,7 @@ import { readFileSync, writeFileSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import type { SandboxMode } from "../core/execution.js";
-import type { AgentEffort, RunAgentInput, RunAgentResult } from "../core/execution.js";
+import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
 // Value import (pure, no sandcastle pull — the providers load lazily via
 // defaultSandcastleDeps' dynamic import) so resolveRunSettings can parse the
 // max-iterations knob from env/config without importing the runtime.
@@ -124,9 +124,52 @@ export interface RunSettings {
    * pinned bases are exactly why the flag defaults off.
    */
   feedbackRebaseBase?: string;
+  /**
+   * Per-attempt resource budget (#908): the optional token / cost / tool-call /
+   * waiting-window ceilings the attempt guard enforces. Every field is optional;
+   * an all-undefined budget is inert (today's behaviour). The #788 antidote —
+   * the proxy ceilings (tool-calls / waiting-windows) fire live even for
+   * claude/minimax, which stream 0 token usage on the wire.
+   */
+  attemptBudget?: AttemptBudget;
 }
 
 const SANDBOX_MODES: readonly SandboxMode[] = ["none", "docker", "podman"];
+
+/** Parse a positive number (int or float) for a budget ceiling; undefined when
+ * unset / non-numeric / non-positive, so a typo can never silently set a 0 cap
+ * that aborts every attempt instantly. */
+function parsePositive(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Resolve the per-attempt budget (#908) from env overrides then `.red/config.yaml`
+ * `plugins.dev.afk.attempt.*` (folded to `afk.attempt.*`). Returns `undefined`
+ * when NO ceiling is set, so makeRunAgent can skip wiring the probe entirely and
+ * the guard stays at today's behaviour.
+ */
+export function resolveAttemptBudget(
+  env: NodeJS.ProcessEnv,
+  getCfg: (key: string) => string,
+): AttemptBudget | undefined {
+  const budget: AttemptBudget = {
+    maxTotalTokens: parsePositive(env.RED_AFK_ATTEMPT_MAX_TOKENS) ?? parsePositive(getCfg("afk.attempt.max_tokens")),
+    maxCostUsd: parsePositive(env.RED_AFK_ATTEMPT_MAX_COST_USD) ?? parsePositive(getCfg("afk.attempt.max_cost_usd")),
+    maxToolCalls:
+      parsePositive(env.RED_AFK_ATTEMPT_MAX_TOOL_CALLS) ?? parsePositive(getCfg("afk.attempt.max_tool_calls")),
+    maxWaitingWindows:
+      parsePositive(env.RED_AFK_ATTEMPT_MAX_WAITING_WINDOWS) ?? parsePositive(getCfg("afk.attempt.max_waiting_windows")),
+  };
+  const anySet =
+    budget.maxTotalTokens !== undefined ||
+    budget.maxCostUsd !== undefined ||
+    budget.maxToolCalls !== undefined ||
+    budget.maxWaitingWindows !== undefined;
+  return anySet ? budget : undefined;
+}
 
 export function resolveRunSettings(
   root: string,
@@ -174,6 +217,9 @@ export function resolveRunSettings(
     (env.RED_AFK_FEEDBACK_REBASE ?? "").trim() === "1" ||
     getConfig(cfg, "afk.feedback.rebase_on_base") === "true";
   const feedbackRebaseBase = rebaseFlag ? getConfig(cfg, "dev.lock.branch") || "main" : undefined;
+  // Per-attempt resource budget (#908) — env > `afk.attempt.*` config; undefined
+  // when no ceiling is set (inert).
+  const attemptBudget = resolveAttemptBudget(env, (key) => getConfig(cfg, key));
   return {
     sandbox,
     defaultRunner,
@@ -183,6 +229,7 @@ export function resolveRunSettings(
     attemptTimeoutSeconds,
     laneIdle,
     feedbackRebaseBase,
+    attemptBudget,
   };
 }
 
@@ -255,6 +302,11 @@ export function makeRunAgent(
   maxIterations?: number,
   attemptTimeoutSeconds?: number,
   laneIdle?: LaneIdleStallConfig,
+  // Per-attempt budget (#908): the resolved ceilings + a live usage probe (the
+  // attempt's activity meter `peek()`). Both must be present to arm the cap; it
+  // rides the existing progress guard, so it is only active when that guard is.
+  attemptBudget?: AttemptBudget,
+  budgetUsage?: () => AttemptBudgetUsage,
 ): (input: RunAgentInput) => Promise<RunAgentResult> {
   let depsPromise: Promise<import("../core/execution.js").SandcastleDeps> | null = null;
   return async (input: RunAgentInput): Promise<RunAgentResult> => {
@@ -334,6 +386,9 @@ export function makeRunAgent(
             },
           }
         : {}),
+      // Per-attempt budget (#908): only wired when the progress guard is armed
+      // (the budget check rides its poll) AND a budget + live usage probe exist.
+      ...(guardArmed && attemptBudget && budgetUsage ? { budget: attemptBudget, budgetUsage } : {}),
       ...(laneArmed && laneAttemptDir
         ? {
             laneIdleThresholdSeconds: laneIdleCfg.stallThresholdS,

--- a/apps/dev/tests/attempt-outcome.test.ts
+++ b/apps/dev/tests/attempt-outcome.test.ts
@@ -44,6 +44,9 @@ const TABLE: Row[] = [
   // non-recoverable so a worker with a real broken test still pages a human.
   { outcome: "feedback-failed-infra", label: "blocked:validation-infra", recovery: "validation-infra" },
   { outcome: "stalled", label: "blocked:stalled", recovery: null },
+  // #908: a budget abort carries the typed `blocked:budget` label and is NOT
+  // auto-recoverable (escalate — a runaway is not a transient flake).
+  { outcome: "budget-exceeded", label: "blocked:budget", recovery: null },
   { outcome: "infra", label: "blocked:infra", recovery: null },
   // no typed label, no recovery (success / abandoned)
   { outcome: "done", label: null, recovery: null },
@@ -75,6 +78,7 @@ describe("attempt-outcome — exhaustive outcome → (label, recovery) table", (
       "exhausted",
       "runner-transient",
       "stalled",
+      "budget-exceeded",
       "infra",
     ];
     const covered = TABLE.map((r) => r.outcome).sort();
@@ -130,6 +134,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
     { outcome: "runner-transient", status: "blocked" },
     { outcome: "claim-lost", status: "blocked" },
     { outcome: "stalled", status: "blocked" },
+    { outcome: "budget-exceeded", status: "blocked" },
     { outcome: "infra", status: "blocked" },
   ];
 
@@ -154,6 +159,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
       "exhausted",
       "runner-transient",
       "stalled",
+      "budget-exceeded",
       "infra",
     ];
     const covered = STATUS_TABLE.map((r) => r.outcome).sort();

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -24,6 +24,9 @@ import {
   parseIdleTimeout,
   parseAttemptTimeout,
   startAttemptGuard,
+  exceedsBudget,
+  type AttemptBudget,
+  type AttemptBudgetUsage,
   DEFAULT_ATTEMPT_TIMEOUT_S,
   type SandcastleDeps,
   type RunAgentInput,
@@ -1089,6 +1092,79 @@ describe("startAttemptGuard — commit-anchored progress watchdog", () => {
     clock = 100;
     await sched.tick(); // 100 >= cap from start → abort
     expect(aborted).toBe(true);
+  });
+});
+
+describe("exceedsBudget — per-attempt budget predicate (#908)", () => {
+  const zero: AttemptBudgetUsage = { inputTokens: 0, outputTokens: 0, costUsd: 0, toolsCalled: 0, waiting: 0 };
+  it("an empty budget never fires (today's behaviour)", () => {
+    expect(exceedsBudget({ ...zero, inputTokens: 9e9, toolsCalled: 9999 }, {})).toBeUndefined();
+  });
+  it("token ceiling fires on input+output total at-or-above the cap", () => {
+    const b: AttemptBudget = { maxTotalTokens: 1000 };
+    expect(exceedsBudget({ ...zero, inputTokens: 600, outputTokens: 399 }, b)).toBeUndefined();
+    expect(exceedsBudget({ ...zero, inputTokens: 600, outputTokens: 400 }, b)).toBe("tokens");
+  });
+  it("cost ceiling fires at-or-above the cap", () => {
+    expect(exceedsBudget({ ...zero, costUsd: 4.99 }, { maxCostUsd: 5 })).toBeUndefined();
+    expect(exceedsBudget({ ...zero, costUsd: 5 }, { maxCostUsd: 5 })).toBe("cost");
+  });
+  it("runner-agnostic proxy ceilings fire with ZERO token usage (the claude/minimax case)", () => {
+    // claude/minimax stream 0 live tokens, so only the proxy ceilings protect them.
+    expect(exceedsBudget({ ...zero, toolsCalled: 200 }, { maxToolCalls: 200 })).toBe("tool-calls");
+    expect(exceedsBudget({ ...zero, waiting: 30 }, { maxWaitingWindows: 30 })).toBe("waiting-windows");
+  });
+});
+
+describe("startAttemptGuard — resource budget (#908)", () => {
+  it("aborts with reason 'budget' once a ceiling is breached, independent of commits", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    let reason: string | undefined;
+    let usage: AttemptBudgetUsage = { inputTokens: 0, outputTokens: 0, costUsd: 0, toolsCalled: 0, waiting: 0 };
+    const g = startAttemptGuard({
+      capMs: 1_000_000, // huge: the wall-clock cap must NOT be what fires
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      now: () => clock,
+      schedule: sched.schedule,
+      budget: { maxToolCalls: 5 },
+      budgetUsage: () => usage,
+      abort: (r) => {
+        reason = r;
+      },
+    });
+    await sched.tick(); // under budget
+    expect(reason).toBeUndefined();
+    clock = 100;
+    usage = { ...usage, toolsCalled: 5 };
+    await sched.tick(); // ceiling reached → abort('budget')
+    expect(reason).toBe("budget");
+    expect(g.firedBudget()).toBe(true);
+    expect(g.firedTimeout()).toBe(false); // a budget abort is NOT a stall
+    expect(g.firedGoalMoot()).toBe(false);
+    g.stop();
+  });
+
+  it("is a no-op when no budget is supplied", async () => {
+    let clock = 0;
+    const sched = manualScheduler();
+    let reason: string | undefined;
+    const g = startAttemptGuard({
+      capMs: 1_000_000,
+      intervalMs: 50,
+      headProbe: async () => "sha-static",
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: (r) => {
+        reason = r;
+      },
+    });
+    clock = 500;
+    await sched.tick();
+    expect(reason).toBeUndefined();
+    expect(g.firedBudget()).toBe(false);
+    g.stop();
   });
 });
 

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -8,6 +8,7 @@ import {
   collectMonitorInputs,
   readFleetState,
   resolveAttemptGuardArming,
+  resolveAttemptBudget,
   buildMinimalBootDeps,
   withTimeout,
   collectStatuslineAfk,
@@ -58,6 +59,36 @@ describe("resolveAttemptGuardArming (issue #405)", () => {
       guardArmed: true,
       laneArmed: false,
     });
+  });
+});
+
+describe("resolveAttemptBudget (#908)", () => {
+  const cfg = (m: Record<string, string>) => (key: string) => m[key] ?? "";
+  it("returns undefined when no ceiling is set anywhere (inert)", () => {
+    expect(resolveAttemptBudget({}, cfg({}))).toBeUndefined();
+  });
+  it("reads ceilings from afk.attempt.* config", () => {
+    const b = resolveAttemptBudget(
+      {},
+      cfg({
+        "afk.attempt.max_tokens": "500000",
+        "afk.attempt.max_cost_usd": "5",
+        "afk.attempt.max_tool_calls": "200",
+        "afk.attempt.max_waiting_windows": "30",
+      }),
+    );
+    expect(b).toEqual({ maxTotalTokens: 500000, maxCostUsd: 5, maxToolCalls: 200, maxWaitingWindows: 30 });
+  });
+  it("env overrides config", () => {
+    const b = resolveAttemptBudget(
+      { RED_AFK_ATTEMPT_MAX_TOOL_CALLS: "150" } as NodeJS.ProcessEnv,
+      cfg({ "afk.attempt.max_tool_calls": "999" }),
+    );
+    expect(b?.maxToolCalls).toBe(150);
+  });
+  it("rejects non-positive / non-numeric ceilings (typo never sets a 0 cap)", () => {
+    expect(resolveAttemptBudget({}, cfg({ "afk.attempt.max_tokens": "0" }))).toBeUndefined();
+    expect(resolveAttemptBudget({}, cfg({ "afk.attempt.max_tool_calls": "abc" }))).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

Per-attempt **resource budget guard** for the AFK worker (GNHF Track A, PRD #907) — the direct antidote to the #788 burn (claude-minimax spent **2.1M tokens on one slice**, never emitted DONE, closed **0**). The attempt guard now aborts when an attempt exceeds a budget, and the partial work is salvaged so we never wake up empty-handed.

Two ceiling families, evaluated on the guard's existing poll:
- **token / cost** — `maxTotalTokens`, `maxCostUsd` (live for codex/opencode).
- **runner-agnostic proxy** — `maxToolCalls`, `maxWaitingWindows`. These accrue **live for every runner including claude/claude-minimax** (which stream 0 live token usage, so a token-only cap would miss the exact #788 runner).

On a budget abort: new `budget-exceeded` terminal outcome → `blocked:budget` label, `blocked` envelope, **no auto-recovery** (escalate — a runaway is not a transient flake to blind-retry). The dirty worktree is salvaged onto the worker branch first, then the issue parks `ready-for-human` with the partial work preserved.

## Config (all optional; unset = today's behaviour, fully inert)

```yaml
# .red/config.yaml
plugins:
  dev:
    afk:
      attempt:
        max_tokens: 800000        # input+output total
        max_cost_usd: 8
        max_tool_calls: 400       # runner-agnostic — covers claude/minimax
        max_waiting_windows: 40   # runner-agnostic
```
Env overrides: `RED_AFK_ATTEMPT_MAX_TOKENS`, `RED_AFK_ATTEMPT_MAX_COST_USD`, `RED_AFK_ATTEMPT_MAX_TOOL_CALLS`, `RED_AFK_ATTEMPT_MAX_WAITING_WINDOWS`.

## How

- `startAttemptGuard` gains an optional `budget` + sync `budgetUsage` probe; `exceedsBudget()` is a pure predicate; abort reason `"budget"` + `firedBudget()`. It rides the existing progress-guard poll.
- `AgentOutcome`/`AttemptOutcome` gain `budget-exceeded`; the single outcome-owner (`attempt-outcome.ts`) maps it to label/envelope/recovery.
- `process-issue` salvages on a budget abort, then parks via the existing `terminalFailure` path.
- Wiring: `resolveAttemptBudget` (env > `afk.attempt.*` config) → `makeRunAgent` → a live `() => activityMeter.peek()` probe. Armed only when the progress guard is armed.

## Tests
- `exceedsBudget` table; guard fires `budget` at **0 token usage** (the claude case) + no-op when unset.
- `attempt-outcome` exhaustive tables cover the new arm.
- `resolveAttemptBudget` env/config precedence + typo-safety (a `0`/non-numeric ceiling never arms an instant-abort cap).
- Full touched-module suites green (execution / attempt-outcome / process-issue / wire), typecheck clean.

## Honesty note
The token/cost ceiling is reliable for codex/opencode; claude folds usage at the iteration boundary (0 live), which is exactly why the **proxy ceilings** exist and carry the protection for claude/minimax.

Part of PRD #907 (kunchenguid/AXI ecosystem absorption). Closes #908.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785386086&installation_id=129708444&pr_number=925&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F925&signature=37c31efb382d69172c4c7d4744c8dac632b9744285fe2047a4a4981cadf62370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->