### PR TITLE
feat(afk): companion-monitor decision core — drift detection + bounded correction (#921)

### DIFF
--- a/apps/dev/src/core/companion.ts
+++ b/apps/dev/src/core/companion.ts
@@ -1,0 +1,174 @@
+// companion — the PURE decision core for the active "Companion mode" monitor
+// (#921, PRD #907). GNHF's monitor is a COMPANION, not just a dashboard: it
+// watches a live worker, and when the worker drifts (churning iterations without
+// producing work, wedged waiting, or sprawling far past the issue's scope) it
+// converts the observation into the NEXT acceptance criteria and re-enqueues the
+// issue with a bounded correction — instead of only reporting.
+//
+// This module owns the DECISION only (no IO): given a worker's vitals + the
+// per-issue intervention budget, decide whether the attempt is drifting, what
+// the correction should say, and — idempotently — whether a correction has
+// already been issued for this exact (issue, attempt, signal). The IO pass
+// (read worker state, write the issue body/comment/labels) lives in
+// runtime/companion-io.ts and the monitor `--companion` flag; both are kept thin
+// so this decision logic is unit-testable with plain values.
+//
+// Safety invariants encoded here (NOT in the IO layer, so they cannot be
+// bypassed):
+//   - an empty/clean verdict yields NO plan (the monitor stays read-only);
+//   - the same (issue, attempt, signal) yields the SAME fingerprint, so a
+//     re-poll never appends a second identical correction (idempotency);
+//   - once the per-issue intervention budget is spent, the plan ESCALATES to a
+//     human instead of injecting yet another correction — a drifting issue can
+//     never loop forever.
+
+/** The subset of a worker's vitals the drift detector reads. Mirrors the
+ * `current.*` fields of WorkerVitals (iteration churn, line volume, waiting
+ * windows) — passed as plain numbers so the detector is pure. */
+export interface CompanionVitals {
+  /** Current sandcastle agentic-iteration number (1..maxIterations). A high
+   * value with little produced work = re-invocation churn. */
+  iteration: number;
+  /** Cumulative lines added on the worker branch this attempt (committed +
+   * uncommitted). The "is it producing work" signal. */
+  locAdded: number;
+  /** Cumulative lines removed. With locAdded, the total churn / scope size. */
+  locRemoved: number;
+  /** Heartbeat windows with zero new stream events (waiting/blocked). A high
+   * value with flat diff = wedged. */
+  waiting: number;
+}
+
+/** Operator-tunable drift thresholds (config `plugins.dev.afk.companion.*`). */
+export interface CompanionThresholds {
+  /** `iteration >= this` AND below the progress floor → iteration-churn. */
+  iterationChurn: number;
+  /** `waiting >= this` AND below the progress floor → stuck-waiting. */
+  waitingWindows: number;
+  /** `locAdded + locRemoved >= this` → scope-creep (sprawling past the issue). */
+  diffDriftLoc: number;
+  /** Below this many added lines a worker has produced ~nothing — the "flat
+   * diff" half of the churn/stuck predicates. */
+  minProgressLoc: number;
+}
+
+/** Sensible defaults — conservative so the companion only fires on clear drift.
+ * All overridable via the config thresholds. */
+export const DEFAULT_COMPANION_THRESHOLDS: CompanionThresholds = {
+  iterationChurn: 8,
+  waitingWindows: 20,
+  diffDriftLoc: 4000,
+  minProgressLoc: 5,
+};
+
+export type DriftSignal = "iteration-churn" | "stuck-waiting" | "scope-creep";
+
+export interface DriftVerdict {
+  /** True when at least one drift signal fired. */
+  drifting: boolean;
+  /** Every signal that fired, in priority order. */
+  signals: DriftSignal[];
+  /** The dominant signal (first in priority order) — the fingerprint key + the
+   * driver of the correction text. Undefined when not drifting. */
+  primary?: DriftSignal;
+}
+
+/**
+ * Pure drift predicate over a single vitals snapshot. Priority order
+ * (scope-creep > iteration-churn > stuck-waiting) is intentional: a worker that
+ * is BOTH churning and sprawling should be corrected on the more dangerous
+ * scope drift first. A worker producing real work (locAdded ≥ minProgressLoc)
+ * is never flagged for churn/stuck — only genuine spin is drift.
+ */
+export function detectDrift(v: CompanionVitals, t: CompanionThresholds): DriftVerdict {
+  const signals: DriftSignal[] = [];
+  const flat = v.locAdded < t.minProgressLoc;
+  if (v.locAdded + v.locRemoved >= t.diffDriftLoc) signals.push("scope-creep");
+  if (flat && v.iteration >= t.iterationChurn) signals.push("iteration-churn");
+  if (flat && v.waiting >= t.waitingWindows) signals.push("stuck-waiting");
+  return { drifting: signals.length > 0, signals, primary: signals[0] };
+}
+
+/**
+ * Stable, deterministic fingerprint for ONE correction. Identical inputs →
+ * identical string, so the IO layer can scan an issue's existing comments for
+ * this marker and skip a duplicate (idempotency). Deliberately readable rather
+ * than hashed — it doubles as the human-visible audit key. No clock / no
+ * randomness (both are unavailable in this codebase's deterministic paths).
+ */
+export function companionFingerprint(issue: number, attempt: number, signal: DriftSignal): string {
+  return `red:companion:${issue}:a${attempt}:${signal}`;
+}
+
+/** A short, bounded "next acceptance criteria" note per drift signal — the
+ * observation converted into a concrete corrective directive the next attempt
+ * reads. Kept terse on purpose: a correction, not an essay. */
+export function buildCorrectionNote(verdict: DriftVerdict): string {
+  switch (verdict.primary) {
+    case "scope-creep":
+      return "This attempt is sprawling far beyond the issue's scope. Stop, re-read the acceptance criteria, and constrain the change to ONLY what the issue asks — revert unrelated edits before continuing.";
+    case "iteration-churn":
+      return "This attempt is burning iterations without producing committed work — likely re-validating the same broken approach. Stop and change strategy: write a failing test that pins the exact gap, then make it pass. Commit each small step.";
+    case "stuck-waiting":
+      return "This attempt appears wedged (many windows with no progress). Stop waiting on the current path. Re-read the issue + recent failures, state your blocker explicitly, and either take a different approach or emit BLOCKED with a concrete question.";
+    default:
+      return "Re-read the acceptance criteria and verify your work against them before continuing.";
+  }
+}
+
+/** What the companion decided to DO for a worker this poll. */
+export type CompanionPlan =
+  | {
+      kind: "correct";
+      fingerprint: string;
+      signal: DriftSignal;
+      /** The bounded correction directive to inject as the next acceptance
+       * criteria (issue body `## Agent brief` + audit comment). */
+      note: string;
+    }
+  | {
+      kind: "escalate";
+      fingerprint: string;
+      signal: DriftSignal;
+      /** Why the companion stopped correcting and handed off to a human. */
+      reason: string;
+    };
+
+export interface CompanionPlanInput {
+  issue: number;
+  attempt: number;
+  vitals: CompanionVitals;
+  thresholds: CompanionThresholds;
+  /** Fingerprints already present on the issue (parsed from prior companion
+   * audit comments) — the idempotency guard. */
+  seenFingerprints: ReadonlySet<string>;
+  /** The per-issue intervention budget (recoveryCap("drift", env)). Once the
+   * attempt count reaches it, the companion escalates instead of correcting. */
+  cap: number;
+}
+
+/**
+ * The companion's per-worker decision. Returns `null` when there is nothing to
+ * do — NOT drifting, or a correction for this exact (issue, attempt, signal)
+ * already exists. Returns an `escalate` plan once the per-issue budget is spent,
+ * else a bounded `correct` plan. PURE: the caller performs the gh writes.
+ */
+export function planCompanionCorrection(input: CompanionPlanInput): CompanionPlan | null {
+  const verdict = detectDrift(input.vitals, input.thresholds);
+  if (!verdict.drifting || verdict.primary === undefined) return null;
+  const signal = verdict.primary;
+  const fingerprint = companionFingerprint(input.issue, input.attempt, signal);
+  // Idempotency: one correction per (issue, attempt, signal). A fresh attempt
+  // (higher `attempt`) gets a fresh fingerprint, so a genuinely new run is still
+  // correctable; a re-poll of the same attempt is a no-op.
+  if (input.seenFingerprints.has(fingerprint)) return null;
+  if (input.attempt >= input.cap) {
+    return {
+      kind: "escalate",
+      fingerprint,
+      signal,
+      reason: `Companion intervention budget spent (attempt ${input.attempt} ≥ cap ${input.cap}); handing off to a human instead of injecting another correction.`,
+    };
+  }
+  return { kind: "correct", fingerprint, signal, note: buildCorrectionNote(verdict) };
+}

--- a/apps/dev/tests/companion.test.ts
+++ b/apps/dev/tests/companion.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectDrift,
+  companionFingerprint,
+  buildCorrectionNote,
+  planCompanionCorrection,
+  DEFAULT_COMPANION_THRESHOLDS,
+  type CompanionVitals,
+  type CompanionThresholds,
+} from "../src/core/companion.js";
+
+const T: CompanionThresholds = DEFAULT_COMPANION_THRESHOLDS;
+const healthy: CompanionVitals = { iteration: 2, locAdded: 120, locRemoved: 30, waiting: 1 };
+
+describe("detectDrift (#921)", () => {
+  it("a productive worker (real diff) never drifts, even at high iteration", () => {
+    const v = { ...healthy, iteration: 99, waiting: 99 };
+    expect(detectDrift(v, T).drifting).toBe(false);
+  });
+
+  it("iteration-churn: high iteration + flat diff", () => {
+    const v: CompanionVitals = { iteration: T.iterationChurn, locAdded: 0, locRemoved: 0, waiting: 0 };
+    const verdict = detectDrift(v, T);
+    expect(verdict.drifting).toBe(true);
+    expect(verdict.primary).toBe("iteration-churn");
+  });
+
+  it("stuck-waiting: many waiting windows + flat diff", () => {
+    const v: CompanionVitals = { iteration: 1, locAdded: 0, locRemoved: 0, waiting: T.waitingWindows };
+    expect(detectDrift(v, T).signals).toContain("stuck-waiting");
+  });
+
+  it("scope-creep: huge churn dominates (priority over churn)", () => {
+    const v: CompanionVitals = {
+      iteration: T.iterationChurn,
+      locAdded: T.diffDriftLoc,
+      locRemoved: 0,
+      waiting: 0,
+    };
+    const verdict = detectDrift(v, T);
+    // locAdded is well above the progress floor, so churn/stuck do NOT fire; only
+    // scope-creep does — and it is primary.
+    expect(verdict.primary).toBe("scope-creep");
+    expect(verdict.signals).toEqual(["scope-creep"]);
+  });
+
+  it("just-below thresholds do not fire", () => {
+    const v: CompanionVitals = {
+      iteration: T.iterationChurn - 1,
+      locAdded: 0,
+      locRemoved: 0,
+      waiting: T.waitingWindows - 1,
+    };
+    expect(detectDrift(v, T).drifting).toBe(false);
+  });
+});
+
+describe("companionFingerprint (#921)", () => {
+  it("is stable for identical inputs and varies by issue/attempt/signal", () => {
+    const a = companionFingerprint(42, 2, "iteration-churn");
+    expect(companionFingerprint(42, 2, "iteration-churn")).toBe(a);
+    expect(companionFingerprint(42, 3, "iteration-churn")).not.toBe(a);
+    expect(companionFingerprint(43, 2, "iteration-churn")).not.toBe(a);
+    expect(companionFingerprint(42, 2, "scope-creep")).not.toBe(a);
+  });
+});
+
+describe("buildCorrectionNote (#921)", () => {
+  it("returns a non-empty directive per signal", () => {
+    for (const signal of ["scope-creep", "iteration-churn", "stuck-waiting"] as const) {
+      const note = buildCorrectionNote({ drifting: true, signals: [signal], primary: signal });
+      expect(note.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe("planCompanionCorrection (#921)", () => {
+  const churnVitals: CompanionVitals = { iteration: T.iterationChurn, locAdded: 0, locRemoved: 0, waiting: 0 };
+  const base = { issue: 7, attempt: 1, vitals: churnVitals, thresholds: T, cap: 2 };
+
+  it("returns null when the worker is not drifting (monitor stays read-only)", () => {
+    expect(planCompanionCorrection({ ...base, vitals: healthy, seenFingerprints: new Set() })).toBeNull();
+  });
+
+  it("returns a bounded correction on first drift", () => {
+    const plan = planCompanionCorrection({ ...base, seenFingerprints: new Set() });
+    expect(plan?.kind).toBe("correct");
+    expect(plan?.signal).toBe("iteration-churn");
+    if (plan?.kind === "correct") expect(plan.note.length).toBeGreaterThan(0);
+  });
+
+  it("is idempotent — the same (issue, attempt, signal) fingerprint is skipped", () => {
+    const fp = companionFingerprint(base.issue, base.attempt, "iteration-churn");
+    expect(planCompanionCorrection({ ...base, seenFingerprints: new Set([fp]) })).toBeNull();
+  });
+
+  it("a fresh attempt gets a fresh correction despite a prior one", () => {
+    const fpA1 = companionFingerprint(base.issue, 1, "iteration-churn");
+    const plan = planCompanionCorrection({ ...base, attempt: 2, cap: 5, seenFingerprints: new Set([fpA1]) });
+    expect(plan?.kind).toBe("correct");
+  });
+
+  it("escalates to a human once the per-issue budget is spent", () => {
+    const plan = planCompanionCorrection({ ...base, attempt: 2, cap: 2, seenFingerprints: new Set() });
+    expect(plan?.kind).toBe("escalate");
+  });
+});


### PR DESCRIPTION
## What

The **pure decision core** for the active "Companion mode" monitor (PRD #907, the GNHF lesson): today `/afk monitor` is a passive dashboard; this is the brain that lets it *intervene* — detect a drifting worker and re-enqueue the issue with a **bounded correction** that becomes the next acceptance criteria, instead of only reporting.

This PR lands the **decision engine only** (no IO), so the hard logic is fully unit-tested with plain values:

- **`detectDrift()`** — `scope-creep` / `iteration-churn` / `stuck-waiting` over a vitals snapshot (iteration, loc±, waiting-windows). A worker producing real diff is **never** flagged — only genuine spin is drift. Priority: scope-creep > churn > stuck.
- **`companionFingerprint()`** — stable, deterministic, human-readable idempotency key per `(issue, attempt, signal)`.
- **`planCompanionCorrection()`** — returns `null` when clean **or** already-corrected (idempotent); a bounded `correct` plan; or **`escalate`** once the per-issue intervention budget is spent, so a drifting issue can never loop forever.

The safety invariants (read-only when clean, idempotent, budget-bounded escalation) live **in this pure module** so the IO layer cannot bypass them.

## Remaining (tracked on #921, follow-up PR)
- `runtime/companion-io.ts` — read worker state + existing fingerprints, write the issue body (`## Agent brief`) + audit comment + `ready-for-agent` via the existing requeue/blocker-state primitives (write-only, works WITH the fleet; never kills a process).
- `commands/monitor.ts` — opt-in `--companion` flag (off = byte-for-byte the current read-only dashboard).
- `core/recovery.ts` — a `drift` cap (`RED_AFK_RETRY_DRIFT`) sourcing the `cap` input.
- config `plugins.dev.afk.companion.*`.

## Tests
12 tests: drift table (productive worker never drifts; each signal; scope-creep priority; sub-threshold no-op), fingerprint stability, idempotency skip, fresh-attempt re-correction, escalate-at-cap. Typecheck clean.

Part of PRD #907. Advances #921 (does not close it — the IO/flag wiring remains).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785408996&installation_id=129708444&pr_number=926&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F926&signature=9a3d066572da307a32e0c61cc31355bc4478259e3512a1726ee7d6bc1b42c4b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added companion drift detection and correction planning for worker activity.
  * Introduced stable correction fingerprints and readable guidance notes for repeatable handling.
  * Added a cap-based escalation path that stops automated corrections and hands off when limits are reached.

* **Tests**
  * Added coverage for drift detection, fingerprint stability, note generation, idempotent corrections, and escalation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->