### PR TITLE
merge: #917 Adopt tasks-axi byte-exact round-trip markdown edits for AFK doc mutations

### DIFF
--- a/apps/dev/src/core/blocker-state.ts
+++ b/apps/dev/src/core/blocker-state.ts
@@ -111,6 +111,35 @@ export function upsertCurrentBlocker(markdown: string, blocker: CurrentBlocker):
   return `${prefix}${prefix.length > 0 ? "\n\n" : ""}${replacement}`;
 }
 
+export interface CurrentBlockerEditResult {
+  /** The body after the surgical edit (unchanged if already correct). */
+  body: string;
+  /** True when the body differs from the input — a no-op is signaled by false. */
+  changed: boolean;
+  /** True when parsing the result body yields the expected blocker state (round-trip integrity). */
+  valid: boolean;
+}
+
+/**
+ * Byte-exact round-trip edit: compute the new body surgically, detect whether it
+ * changed, and confirm the parse-back yields the intended blocker state. Callers
+ * can skip the remote write when `changed` is false and trust the edit was
+ * correctly formed when `valid` is true.
+ */
+export function applyCurrentBlockerEdit(markdown: string, blocker: CurrentBlocker): CurrentBlockerEditResult {
+  const body = upsertCurrentBlocker(markdown, blocker);
+  const changed = body !== markdown;
+  const parsed = parseCurrentBlocker(body);
+  const valid =
+    parsed !== null &&
+    parsed.status === blocker.status &&
+    parsed.kind === blocker.kind &&
+    parsed.summary === blocker.summary &&
+    parsed.next === blocker.next &&
+    parsed.ref === blocker.ref;
+  return { body, changed, valid };
+}
+
 function appendResolvedBlocker(markdown: string, resolved: ResolvedBlocker): string {
   const entry = `- [x] ${safeField(resolved.summary, "Resolved blocker.")} - ${safeField(
     firstLine(resolved.resolution),

--- a/apps/dev/src/core/hitl-resolution-plan.ts
+++ b/apps/dev/src/core/hitl-resolution-plan.ts
@@ -1,5 +1,6 @@
 import type { HitlDecisionExtraction } from "./hitl-decision-extraction.js";
 import { clearCurrentBlocker, parseCurrentBlocker, upsertCurrentBlocker } from "./blocker-state.js";
+import { upsertMarkdownSection } from "./development-workflow.js";
 import { LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
 
 export interface HitlResolutionIssue {
@@ -69,29 +70,6 @@ ${trimBlock(input.answer)}
 Disposition:
 ${input.disposition.kind}${next}
 </details>`;
-}
-
-function upsertMarkdownSection(markdown: string, heading: string, body: string): string {
-  const lines = markdown.split("\n");
-  const headingRe = new RegExp(`^##\\s+${heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "i");
-  const start = lines.findIndex((line) => headingRe.test(line));
-  const replacement = [`## ${heading}`, "", trimBlock(body)];
-
-  if (start === -1) {
-    const prefix = markdown.trimEnd();
-    return `${prefix}${prefix.length > 0 ? "\n\n" : ""}${replacement.join("\n")}\n`;
-  }
-
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i += 1) {
-    if (/^##\s+/.test(lines[i]!)) {
-      end = i;
-      break;
-    }
-  }
-
-  const next = [...lines.slice(0, start), ...replacement, ...lines.slice(end)];
-  return `${next.join("\n").trimEnd()}\n`;
 }
 
 export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPlan {

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -73,7 +73,7 @@ import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
 import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
-import { parseCurrentBlocker, upsertCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
+import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
 import { parseTrustPolicy, evaluateTrustGate, type TrustProvenance } from "./trust-gate.js";
 import type { AfkModelTier, ConfigValues } from "./config.js";
 import {
@@ -1776,7 +1776,9 @@ async function writeCurrentBlockerBestEffort(
   try {
     const existing = parseCurrentBlocker(input.body);
     const next = shouldPreserveCurrentBlocker(existing, blocker) ? existing! : blocker;
-    await deps.gh.editBody(input.issue, upsertCurrentBlocker(input.body, next));
+    const { body, changed } = applyCurrentBlockerEdit(input.body, next);
+    if (!changed) return; // byte-exact no-op: body already reflects the desired blocker state
+    await deps.gh.editBody(input.issue, body);
   } catch {
     // Best-effort: issue-body state improves resumability, but label routing and
     // the failure envelope remain the canonical fallback if the edit fails.

--- a/apps/dev/tests/blocker-state-round-trip.test.ts
+++ b/apps/dev/tests/blocker-state-round-trip.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCurrentBlockerEdit,
+  formatCurrentBlocker,
+  parseCurrentBlocker,
+  upsertCurrentBlocker,
+} from "../src/core/blocker-state.js";
+
+const blocker = {
+  status: "blocked" as const,
+  kind: "validation",
+  summary: "Gate failed on turbo lint step.",
+  next: "Fix the ESLint rule violation and re-enqueue.",
+};
+
+describe("applyCurrentBlockerEdit — byte-exact round-trip", () => {
+  it("returns changed=true and valid=true when the section is newly inserted", () => {
+    const markdown = "## Summary\nContext here.\n";
+    const { body, changed, valid } = applyCurrentBlockerEdit(markdown, blocker);
+
+    expect(changed).toBe(true);
+    expect(valid).toBe(true);
+    expect(body).toContain("## Current blocker");
+    expect(parseCurrentBlocker(body)).toEqual(blocker);
+  });
+
+  it("returns changed=false when the body already contains the exact blocker state", () => {
+    const markdown = upsertCurrentBlocker("## Summary\nContext here.\n", blocker);
+    const { body, changed, valid } = applyCurrentBlockerEdit(markdown, blocker);
+
+    expect(changed).toBe(false);
+    expect(valid).toBe(true);
+    expect(body).toBe(markdown);
+  });
+
+  it("returns changed=true when an existing blocker is replaced with a different one", () => {
+    const stale = {
+      status: "blocked" as const,
+      kind: "decision",
+      summary: "Old question.",
+      next: "Awaiting answer.",
+    };
+    const markdown = upsertCurrentBlocker("## Summary\nContext here.\n", stale);
+    const { body, changed, valid } = applyCurrentBlockerEdit(markdown, blocker);
+
+    expect(changed).toBe(true);
+    expect(valid).toBe(true);
+    expect(parseCurrentBlocker(body)).toEqual(blocker);
+  });
+
+  it("is idempotent: applying the edit twice leaves the body unchanged on the second pass", () => {
+    const markdown = "## Summary\nContext here.\n";
+    const { body: once } = applyCurrentBlockerEdit(markdown, blocker);
+    const { body: twice, changed: secondChanged } = applyCurrentBlockerEdit(once, blocker);
+
+    expect(secondChanged).toBe(false);
+    expect(twice).toBe(once);
+  });
+
+  it("confirms round-trip integrity: parse-back matches the intended blocker", () => {
+    const markdown = "## Summary\nContext.\n## Current blocker\n\n" + formatCurrentBlocker(blocker) + "\n";
+    const { valid } = applyCurrentBlockerEdit(markdown, blocker);
+    expect(valid).toBe(true);
+  });
+
+  it("preserves surrounding sections and does not drop content", () => {
+    const markdown = [
+      "## Summary",
+      "Do this.",
+      "",
+      "## Current blocker",
+      "",
+      "Old text.",
+      "",
+      "## Acceptance",
+      "- [ ] Done",
+      "",
+    ].join("\n");
+
+    const { body, changed } = applyCurrentBlockerEdit(markdown, blocker);
+
+    expect(changed).toBe(true);
+    expect(body).toContain("## Summary\nDo this.");
+    expect(body).toContain("## Acceptance\n- [ ] Done");
+    expect(body).not.toContain("Old text.");
+    expect(parseCurrentBlocker(body)).toEqual(blocker);
+  });
+
+  it("includes the optional ref field in round-trip when present", () => {
+    const withRef = { ...blocker, ref: "#917" };
+    const { body, changed, valid } = applyCurrentBlockerEdit("## Summary\nCtx.\n", withRef);
+
+    expect(changed).toBe(true);
+    expect(valid).toBe(true);
+    expect(parseCurrentBlocker(body)).toEqual(withRef);
+
+    const { changed: noop } = applyCurrentBlockerEdit(body, withRef);
+    expect(noop).toBe(false);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #917. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #917

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785434850&installation_id=129708444&pr_number=951&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F951&signature=dcac6dbec8e66b9a2131bff0dcece2648db777452037472bacd3f42ab3e6a1d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->