### PR TITLE
merge: #927 Actionable decision cards for ready-for-human (wheelhouse IssueOps)

### DIFF
--- a/.github/workflows/red-hitl-card.yml
+++ b/.github/workflows/red-hitl-card.yml
@@ -1,0 +1,146 @@
+# red-hitl-card — actionable decision cards for ready-for-human issues (issue #927).
+#
+# Turns a ready-for-human issue into an IssueOps UI:
+#
+#   render   → fires on `issues.labeled` with ready-for-human: posts the decision
+#              card as an issue comment, showing the pending decision + PR status +
+#              available slash-commands.
+#
+#   act      → fires on `issue_comment.created` when the issue is ready-for-human
+#              and the comment body starts with a recognised slash-command (/approve,
+#              /approve-ci, /reject, /requeue) or plain English the bot can classify.
+#              Trust-gated: only maintainers with write access (or the allowlist) may
+#              act.  Untrusted authors get a ⛔ reply and the action is a no-op.
+#
+#   refresh  → fires on `pull_request.synchronize` for a PR linked to a
+#              ready-for-human issue: updates the card's status section in place.
+#
+# Injection safety (ADR 0073): the slash-command parser only reads the FIRST non-blank
+# line of the comment body. Issue body and PR diff are never interpreted as commands
+# — they are passed as display data only.
+
+name: red-hitl-card
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [synchronize, reopened, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  # ─── render ────────────────────────────────────────────────────────────────
+  # Post the decision card when ready-for-human is applied to an issue.
+  render:
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'ready-for-human'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Render decision card
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RED_AFK_SANDBOX: none
+        run: |
+          set -euo pipefail
+          LAUNCHER="plugins/dev/skills/engineering/afk/bin/afk.mjs"
+          node "$LAUNCHER" hitl-card render \
+            --issue "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}"
+
+  # ─── act ───────────────────────────────────────────────────────────────────
+  # Process a slash-command or plain-English comment on a ready-for-human issue.
+  act:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      !github.event.issue.pull_request &&
+      contains(toJSON(github.event.issue.labels), '"ready-for-human"')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Execute card command
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RED_AFK_SANDBOX: none
+          # Pass via env to avoid shell-injection from public comment text.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          LAUNCHER="plugins/dev/skills/engineering/afk/bin/afk.mjs"
+          node "$LAUNCHER" hitl-card act \
+            --issue "${{ github.event.issue.number }}" \
+            --body "$COMMENT_BODY" \
+            --author "$COMMENT_AUTHOR" \
+            --repo "${{ github.repository }}"
+
+  # ─── refresh ───────────────────────────────────────────────────────────────
+  # Update the card's status section when the linked PR is updated.
+  # Requires finding the associated ready-for-human issue from the PR's body/title.
+  refresh:
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'synchronize' ||
+       github.event.action == 'reopened' ||
+       github.event.action == 'closed')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Refresh card status for linked issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RED_AFK_SANDBOX: none
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LAUNCHER="plugins/dev/skills/engineering/afk/bin/afk.mjs"
+          # Extract all issue numbers referenced in the PR body or title.
+          # Match "Refs #N", "Closes #N", "Fixes #N", "Resolves #N" patterns.
+          ISSUES=$(echo "$PR_BODY $PR_TITLE" | grep -oP '(?:Refs?|Closes?|Fixes?|Resolves?)\s+#\K[0-9]+' || true)
+          if [[ -z "$ISSUES" ]]; then
+            echo "No linked issues found in PR #${PR_NUMBER}; skipping refresh."
+            exit 0
+          fi
+          for ISSUE in $ISSUES; do
+            # Only refresh if the issue is open and has ready-for-human label.
+            STATE=$(gh issue view "$ISSUE" --repo "$REPO" --json state,labels -q '.state + ":" + ([.labels[].name] | join(","))' 2>/dev/null || echo "")
+            if echo "$STATE" | grep -q "^OPEN:.*ready-for-human"; then
+              echo "Refreshing card for issue #${ISSUE}..."
+              node "$LAUNCHER" hitl-card refresh \
+                --issue "$ISSUE" \
+                --repo "$REPO" || true
+            fi
+          done

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ Upstream base: `mattpocock/skills@6eeb81b5fcfeeb5bd531dd47ab2f9f2bbea27461` (see
 
 ---
 
+## hitl-card (engineering) — Actionable decision cards for ready-for-human (issue #927)
+
+- **status**: added
+- **upstream**: —
+- **why**: `ready-for-human` issues previously required the human to act by hand (reading, labelling, posting comments manually). Issue #927 turns them into IssueOps decision cards: a bot comment renders the pending decision + PR status + slash-command menu, and a GitHub Action executes the ticked command.
+- **what changed**:
+  - `apps/dev/src/core/hitl-card.ts`: pure logic — `renderCard`, `updateCardStatus` (idempotent status refresh), `isHitlCard` (card detection), `parseCardCommand` (injection-safe first-line slash-command parser), `classifyNaturalLanguage` (keyword-based NL → action mapping), `parseCiChecks`.
+  - `apps/dev/src/commands/hitl-card.ts`: IO command handler for `dev hitl-card render | refresh | act` — posts/updates the card, trust-gates `act` via the existing `resolveActorTrust`, executes approve/approve-ci/reject/requeue and posts directive comments.
+  - `apps/dev/src/cli.ts`: registers `hitl-card` in the CLI router.
+  - `.github/workflows/red-hitl-card.yml`: three-job workflow — `render` on `issues.labeled=ready-for-human`, `act` on `issue_comment.created`, `refresh` on `pull_request.synchronize/reopened/closed`.
+  - `apps/dev/tests/hitl-card.test.ts`: 37 unit tests covering all pure functions.
+
+---
+
 ## afk (engineering) — Task mirror host capability matrix codified (issue #886)
 
 - **status**: modified

--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { fleetCommand } from "./commands/fleet.js";
 import { activityReviewCommand } from "./commands/activity-review.js";
+import { hitlCardCommand } from "./commands/hitl-card.js";
 import { codexMonitorAgentCommand } from "./commands/codex-monitor-agent.js";
 import { codexStatuslineCommand } from "./commands/codex-statusline.js";
 import { dashboardCommand } from "./commands/dashboard.js";
@@ -32,6 +33,7 @@ export type CliCommand =
   | "retake"
   | "review"
   | "respond"
+  | "hitl-card"
   | "ship"
   | "triage"
   | "codex-monitor-agent"
@@ -69,6 +71,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     retake: {},
     review: {},
     respond: {},
+    "hitl-card": {},
     ship: {},
     triage: {},
     "codex-monitor-agent": {},
@@ -115,6 +118,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "retake") return retakeCommand(parsed.args);
   if (parsed.command === "review") return reviewCommand(parsed.args);
   if (parsed.command === "respond") return respondCommand(parsed.args);
+  if (parsed.command === "hitl-card") return hitlCardCommand(parsed.args);
   if (parsed.command === "ship") return shipCommand(parsed.args);
   if (parsed.command === "triage") return triageCommand(parsed.args);
   if (parsed.command === "codex-monitor-agent") return codexMonitorAgentCommand(parsed.args);

--- a/apps/dev/src/commands/hitl-card.ts
+++ b/apps/dev/src/commands/hitl-card.ts
@@ -1,0 +1,433 @@
+// commands/hitl-card.ts — the IO half of `dev hitl-card` (issue #927).
+//
+// Three subcommands:
+//   render  --issue=N [--repo=R]
+//       Post or update the decision card comment on a ready-for-human issue.
+//   act  --issue=N --body="..." --author="..." [--repo=R]
+//       Parse a human comment as a card command and execute the action.
+//   refresh  --issue=N [--repo=R]
+//       Update the card's status section in place (idempotent).
+//
+// Injection safety: the `--body` flag carries the raw comment text. It is parsed
+// by parseCardCommand (first non-blank line only) and classifyNaturalLanguage
+// (keyword matching). The issue body is never parsed for commands.
+
+import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { execTool, type ExecFn } from "../runtime/exec.js";
+import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
+import { actorTrustSignals, type GhContext } from "../runtime/gh.js";
+import { loadConfig } from "../core/config.js";
+import { resolveConfigPath } from "./route-model-tier.js";
+import { parseCurrentBlocker } from "../core/blocker-state.js";
+import { planRequeue } from "../core/requeue.js";
+import { LABEL_HUMAN } from "../core/triage-labels.js";
+import {
+  renderCard,
+  updateCardStatus,
+  isHitlCard,
+  parseCardCommand,
+  classifyNaturalLanguage,
+  parseCiChecks,
+  type PrStatus,
+  type CardCommand,
+} from "../core/hitl-card.js";
+
+const FLAG_SCHEMA = {
+  issue: { kind: "value", coerce: (raw: string): number => Number(raw) },
+  body: { kind: "value", coerce: (raw: string): string => raw },
+  author: { kind: "value", coerce: (raw: string): string => raw },
+  repo: { kind: "value", aliases: ["R"], coerce: (raw: string): string => raw },
+  root: { kind: "value", coerce: (raw: string): string => raw },
+} satisfies FlagSchema;
+
+type Exec = (args: readonly string[], opts?: { cwd?: string }) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+function makeExec(cwd: string): Exec {
+  const run: ExecFn = (cmd, args, opts) =>
+    execTool(cmd, args, { cwd: opts?.cwd ?? cwd, maxBuffer: 32 * 1024 * 1024 });
+  return (args, opts) => run(args[0]!, args.slice(1), { cwd: opts?.cwd ?? cwd });
+}
+
+async function resolveRepo(exec: Exec, explicit?: string): Promise<string> {
+  if (explicit?.trim()) return explicit.trim();
+  const r = await exec(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]);
+  return r.code === 0 ? r.stdout.trim() : "";
+}
+
+function repoArgs(repo: string): string[] {
+  return repo ? ["--repo", repo] : [];
+}
+
+interface IssueData {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+  comments: Array<{ id: number; body: string; databaseId?: number }>;
+}
+
+async function fetchIssue(exec: Exec, repo: string, issue: number): Promise<IssueData> {
+  const r = await exec([
+    "gh", "issue", "view", String(issue),
+    ...repoArgs(repo),
+    "--json", "number,title,body,labels,comments",
+  ]);
+  if (r.code !== 0) throw new Error(`fetch issue #${issue} failed: ${r.stderr.trim()}`);
+  const raw = JSON.parse(r.stdout) as {
+    number?: number;
+    title?: string;
+    body?: string;
+    labels?: Array<{ name?: string }>;
+    comments?: Array<{ id?: number; body?: string; databaseId?: number }>;
+  };
+  return {
+    number: Number(raw.number ?? issue),
+    title: String(raw.title ?? ""),
+    body: String(raw.body ?? ""),
+    labels: (raw.labels ?? []).map((l) => String(l.name ?? "")).filter(Boolean),
+    comments: (raw.comments ?? []).map((c) => ({
+      id: Number(c.id ?? 0),
+      databaseId: c.databaseId,
+      body: String(c.body ?? ""),
+    })),
+  };
+}
+
+async function fetchPrStatus(exec: Exec, repo: string, prNumber: number): Promise<PrStatus> {
+  const r = await exec([
+    "gh", "pr", "view", String(prNumber),
+    ...repoArgs(repo),
+    "--json", "number,mergeable,statusCheckRollup,headRefOid",
+  ]);
+  if (r.code !== 0) {
+    return { number: prNumber, ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
+  }
+  const raw = JSON.parse(r.stdout) as {
+    number?: number;
+    mergeable?: string;
+    statusCheckRollup?: Array<{ conclusion?: string | null; state?: string | null }>;
+    headRefOid?: string;
+  };
+  const checks = raw.statusCheckRollup ?? [];
+  const ciResult = parseCiChecks(checks);
+  return {
+    number: prNumber,
+    ...ciResult,
+    mergeability: raw.mergeable === "MERGEABLE" ? "MERGEABLE"
+      : raw.mergeable === "CONFLICTING" ? "CONFLICTING"
+      : "UNKNOWN",
+    headSha: raw.headRefOid ? raw.headRefOid.slice(0, 7) : undefined,
+  };
+}
+
+async function findLinkedPr(exec: Exec, repo: string, issueNumber: number, blockerRef?: string): Promise<number | undefined> {
+  if (blockerRef) {
+    const n = Number.parseInt(blockerRef, 10);
+    if (Number.isInteger(n) && n > 0) return n;
+  }
+  // Fallback: search open PRs that mention this issue.
+  const r = await exec([
+    "gh", "pr", "list",
+    ...repoArgs(repo),
+    "--state", "open",
+    "--json", "number,body,title",
+    "--limit", "50",
+  ]);
+  if (r.code !== 0) return undefined;
+  const prs = JSON.parse(r.stdout) as Array<{ number: number; body: string; title: string }>;
+  const pattern = new RegExp(`(?:Refs?|Closes?|Fixes?|Resolves?)\\s+#${issueNumber}\\b`, "i");
+  const match = prs.find((pr) => pattern.test(pr.body ?? "") || pattern.test(pr.title ?? ""));
+  return match?.number;
+}
+
+function findCardComment(comments: IssueData["comments"]): { id: number; databaseId?: number; body: string } | undefined {
+  return comments.find((c) => isHitlCard(c.body));
+}
+
+async function upsertCardComment(exec: Exec, repo: string, issueNumber: number, card: string, existing: { databaseId?: number } | undefined): Promise<void> {
+  if (existing?.databaseId) {
+    // Update existing comment via gh API.
+    await exec([
+      "gh", "api",
+      `repos/{owner}/{repo}/issues/comments/${existing.databaseId}`,
+      "--method", "PATCH",
+      "--field", `body=${card}`,
+      ...repoArgs(repo),
+    ]);
+  } else {
+    await exec(["gh", "issue", "comment", String(issueNumber), ...repoArgs(repo), "--body", card]);
+  }
+}
+
+function nowUtc(): string {
+  return new Date().toISOString().replace("T", " ").slice(0, 16) + " UTC";
+}
+
+// ---------- render ----------
+
+async function cmdRender(
+  exec: Exec,
+  repo: string,
+  issueNumber: number,
+  stdout: NodeJS.WritableStream,
+): Promise<number> {
+  const issue = await fetchIssue(exec, repo, issueNumber);
+  const blocker = parseCurrentBlocker(issue.body);
+  const pendingDecision = blocker?.next ?? blocker?.summary ?? "Human guidance required.";
+
+  const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
+  const prStatus: PrStatus = prNumber
+    ? await fetchPrStatus(exec, repo, prNumber)
+    : { ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
+
+  const updatedAt = nowUtc();
+  const card = renderCard({ issueNumber, pendingDecision, prStatus, updatedAt });
+  const existing = findCardComment(issue.comments);
+  await upsertCardComment(exec, repo, issueNumber, card, existing);
+
+  stdout.write(`hitl-card render #${issueNumber}: card ${existing ? "updated" : "posted"}.\n`);
+  return 0;
+}
+
+// ---------- refresh ----------
+
+async function cmdRefresh(
+  exec: Exec,
+  repo: string,
+  issueNumber: number,
+  stdout: NodeJS.WritableStream,
+): Promise<number> {
+  const issue = await fetchIssue(exec, repo, issueNumber);
+  const existing = findCardComment(issue.comments);
+  if (!existing) {
+    process.stderr.write(`[afk] hitl-card refresh #${issueNumber}: no card comment found — run render first\n`);
+    return 1;
+  }
+
+  const blocker = parseCurrentBlocker(issue.body);
+  const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
+  const prStatus: PrStatus = prNumber
+    ? await fetchPrStatus(exec, repo, prNumber)
+    : { ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
+
+  const updatedAt = nowUtc();
+  const updatedCard = updateCardStatus(existing.body, prStatus, updatedAt);
+  if (updatedCard === existing.body) {
+    stdout.write(`hitl-card refresh #${issueNumber}: status unchanged.\n`);
+    return 0;
+  }
+
+  await upsertCardComment(exec, repo, issueNumber, updatedCard, existing);
+  stdout.write(`hitl-card refresh #${issueNumber}: status section updated.\n`);
+  return 0;
+}
+
+// ---------- act ----------
+
+function directiveComment(action: CardCommand): string {
+  const verb = action.action;
+  const guidance = action.args?.trim() || "(none recorded)";
+  const dispositionLine = verb === "requeue"
+    ? `requeued to ready-for-agent\n\nHuman guidance:\n${guidance}`
+    : verb === "reject"
+    ? `rejected (PR closed without merging)\n\nReason:\n${guidance}`
+    : `approved — PR merged`;
+  return [
+    '<details data-kind="directive">',
+    `<summary>HITL card: ${verb}</summary>`,
+    "",
+    `Action: /${verb}`,
+    "",
+    `Disposition:\n${dispositionLine}`,
+    "</details>",
+  ].join("\n");
+}
+
+async function executeApprove(exec: Exec, repo: string, issue: IssueData, prNumber: number, waitForCi: boolean): Promise<string> {
+  if (waitForCi) {
+    const prStatus = await fetchPrStatus(exec, repo, prNumber);
+    if (prStatus.ci === "fail") return "CI checks failed — cannot approve.";
+    if (prStatus.ci === "pending") return "CI checks are still pending — re-run `/approve-ci` once they complete.";
+  }
+
+  const mergeResult = await exec([
+    "gh", "pr", "merge", String(prNumber),
+    ...repoArgs(repo),
+    "--admin", "--merge",
+  ]);
+  if (mergeResult.code !== 0) {
+    return `PR merge failed: ${mergeResult.stderr.trim() || mergeResult.stdout.trim()}`;
+  }
+
+  await exec(["gh", "issue", "close", String(issue.number), ...repoArgs(repo)]);
+
+  const blockedLabels = issue.labels.filter((l) => l.startsWith("blocked:"));
+  const removeLabels = [LABEL_HUMAN, ...blockedLabels];
+  const editArgs = ["gh", "issue", "edit", String(issue.number), ...repoArgs(repo)];
+  for (const l of removeLabels) editArgs.push("--remove-label", l);
+  await exec(editArgs);
+
+  return `PR #${prNumber} merged and issue #${issue.number} closed.`;
+}
+
+async function executeReject(exec: Exec, repo: string, issue: IssueData, prNumber: number, reason: string): Promise<string> {
+  const closeResult = await exec([
+    "gh", "pr", "close", String(prNumber),
+    ...repoArgs(repo),
+    "--comment", reason ? `Rejected: ${reason}` : "Rejected by maintainer.",
+  ]);
+  if (closeResult.code !== 0) {
+    return `PR close failed: ${closeResult.stderr.trim()}`;
+  }
+
+  // Drop ready-for-human; keep issue open for manual triage.
+  await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--remove-label", LABEL_HUMAN]);
+  return `PR #${prNumber} closed. Issue #${issue.number} is open for manual follow-up.`;
+}
+
+async function executeRequeue(exec: Exec, repo: string, issue: IssueData, guidance: string, cwd: string): Promise<string> {
+  if (!guidance) {
+    return "⚠️ `/requeue` requires guidance text, e.g. `/requeue Please fix the type errors in src/foo.ts`.";
+  }
+
+  const plan = planRequeue({ body: issue.body, labels: issue.labels, guidance });
+  if (!plan.requeueable) {
+    return `Cannot requeue: ${plan.reason}`;
+  }
+
+  // Apply the requeue transition.
+  if (plan.bodyChanged) {
+    await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--body", plan.body]);
+  }
+  const editArgs = ["gh", "issue", "edit", String(issue.number), ...repoArgs(repo)];
+  for (const l of plan.removeLabels) editArgs.push("--remove-label", l);
+  for (const l of plan.addLabels) editArgs.push("--add-label", l);
+  await exec(editArgs);
+
+  return `Issue #${issue.number} requeued to ready-for-agent with guidance.`;
+}
+
+async function cmdAct(
+  exec: Exec,
+  repo: string,
+  issueNumber: number,
+  commentBody: string,
+  commentAuthor: string | undefined,
+  cwd: string,
+  stdout: NodeJS.WritableStream,
+): Promise<number> {
+  // 1. Trust-check the author.
+  const config = loadConfig(resolveConfigPath(cwd), { warn: () => undefined });
+  const policy = parseTrustPolicy(config);
+  const ghCtx: GhContext = { cwd, repo };
+  const trust = await resolveActorTrust(policy, commentAuthor, (login) => actorTrustSignals(ghCtx, login));
+  if (!trust.executable) {
+    await exec([
+      "gh", "issue", "comment", String(issueNumber),
+      ...repoArgs(repo),
+      "--body", `⛔ Action denied: ${trust.reason ?? "you are not a trusted maintainer"}.`,
+    ]);
+    process.stderr.write(`[afk] hitl-card act #${issueNumber}: trust refused — ${trust.reason}\n`);
+    return 1;
+  }
+
+  // 2. Parse the command (injection-safe: only comment body, never issue body).
+  let command = parseCardCommand(commentBody);
+  if (!command) command = classifyNaturalLanguage(commentBody);
+  if (!command) {
+    await exec([
+      "gh", "issue", "comment", String(issueNumber),
+      ...repoArgs(repo),
+      "--body",
+      "🤖 I couldn't identify your intent. Use `/approve`, `/approve-ci`, `/reject [reason]`, or `/requeue <guidance>`.",
+    ]);
+    stdout.write(`hitl-card act #${issueNumber}: unrecognised command (NL classification returned nothing).\n`);
+    return 0;
+  }
+
+  // 3. Fetch issue state and find linked PR.
+  const issue = await fetchIssue(exec, repo, issueNumber);
+  const blocker = parseCurrentBlocker(issue.body);
+  const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
+
+  if ((command.action === "approve" || command.action === "approve-ci" || command.action === "reject") && !prNumber) {
+    await exec([
+      "gh", "issue", "comment", String(issueNumber),
+      ...repoArgs(repo),
+      "--body",
+      `⚠️ Could not find a linked PR for #${issueNumber}. Post the PR number explicitly or use \`/requeue\` to send back to the agent.`,
+    ]);
+    return 1;
+  }
+
+  // 4. Execute the action.
+  let resultMessage: string;
+  if (command.action === "approve") {
+    resultMessage = await executeApprove(exec, repo, issue, prNumber!, false);
+  } else if (command.action === "approve-ci") {
+    resultMessage = await executeApprove(exec, repo, issue, prNumber!, true);
+  } else if (command.action === "reject") {
+    resultMessage = await executeReject(exec, repo, issue, prNumber!, command.args);
+  } else {
+    resultMessage = await executeRequeue(exec, repo, issue, command.args, cwd);
+  }
+
+  // 5. Post directive comment + result.
+  await exec([
+    "gh", "issue", "comment", String(issueNumber),
+    ...repoArgs(repo),
+    "--body", directiveComment(command),
+  ]);
+  await exec([
+    "gh", "issue", "comment", String(issueNumber),
+    ...repoArgs(repo),
+    "--body", `🤖 **${command.action}**: ${resultMessage}`,
+  ]);
+
+  stdout.write(`hitl-card act #${issueNumber}: executed /${command.action} — ${resultMessage}\n`);
+  return 0;
+}
+
+// ---------- entrypoint ----------
+
+/**
+ * `dev hitl-card <render|refresh|act> --issue=N [--body=...] [--author=...] [--repo=R] [--root=R]`
+ */
+export async function hitlCardCommand(
+  args: readonly string[],
+  cwd = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+): Promise<number> {
+  const subcommand = args[0];
+  if (subcommand !== "render" && subcommand !== "refresh" && subcommand !== "act") {
+    process.stderr.write(`[afk] hitl-card requires a subcommand: render | refresh | act\n`);
+    return 2;
+  }
+
+  const { values } = parseFlags(args.slice(1), FLAG_SCHEMA);
+  const issueNumber = Number(values.issue);
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    process.stderr.write("[afk] hitl-card requires --issue <N>\n");
+    return 2;
+  }
+
+  const root = (values.root as string | undefined)?.trim() || cwd;
+  const exec = makeExec(root);
+  const repo = await resolveRepo(exec, values.repo as string | undefined);
+
+  try {
+    if (subcommand === "render") {
+      return await cmdRender(exec, repo, issueNumber, stdout);
+    }
+    if (subcommand === "refresh") {
+      return await cmdRefresh(exec, repo, issueNumber, stdout);
+    }
+    // act
+    const body = (values.body as string | undefined) ?? "";
+    const author = (values.author as string | undefined)?.trim() || undefined;
+    return await cmdAct(exec, repo, issueNumber, body, author, root, stdout);
+  } catch (error) {
+    process.stderr.write(`[afk] hitl-card ${subcommand} failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}

--- a/apps/dev/src/core/hitl-card.ts
+++ b/apps/dev/src/core/hitl-card.ts
@@ -1,0 +1,219 @@
+// hitl-card — pure logic for actionable decision cards (issue #927).
+//
+// Renders and updates the "decision card" comment that turns a ready-for-human
+// issue into an IssueOps UI: the human posts /approve, /approve-ci, /reject, or
+// /requeue (or plain English), and the red-hitl-card Action executes the action.
+//
+// Injection safety: parseCardCommand only reads the FIRST non-blank line of the
+// comment body. The issue body and PR diff are NEVER parsed for commands — they
+// appear in the card render only as display data, not as instruction input.
+
+export const CARD_OPEN = "<!-- red:hitl-card v1 -->";
+export const CARD_CLOSE = "<!-- /red:hitl-card -->";
+export const CARD_STATUS_OPEN = "<!-- red:hitl-card:status -->";
+export const CARD_STATUS_CLOSE = "<!-- /red:hitl-card:status -->";
+
+/** The four human-actionable decisions on a ready-for-human issue. */
+export type CardAction = "approve" | "approve-ci" | "reject" | "requeue";
+
+/** A parsed card command extracted from a human comment. */
+export interface CardCommand {
+  action: CardAction;
+  /** For /reject: optional reason; for /requeue: required guidance text. */
+  args: string;
+}
+
+/** Live PR status used in the card's status section. */
+export interface PrStatus {
+  /** Linked PR number; undefined when no PR was found. */
+  number?: number;
+  /** Aggregated CI check result. */
+  ci: "pass" | "fail" | "pending" | "none";
+  ciPassed: number;
+  ciTotal: number;
+  /** GitHub mergeability state. */
+  mergeability: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  /** Short head commit SHA. */
+  headSha?: string;
+}
+
+/** Options for rendering the full decision card. */
+export interface RenderCardOpts {
+  issueNumber: number;
+  pendingDecision: string;
+  prStatus: PrStatus;
+  /** ISO-8601 or human-readable refresh timestamp shown in the status section. */
+  updatedAt: string;
+}
+
+function ciEmoji(ci: PrStatus["ci"]): string {
+  if (ci === "pass") return "✅";
+  if (ci === "fail") return "❌";
+  if (ci === "pending") return "⏳";
+  return "—";
+}
+
+function ciCell(s: PrStatus): string {
+  if (s.ci === "none") return "—";
+  return `${ciEmoji(s.ci)} ${s.ciPassed}/${s.ciTotal}`;
+}
+
+function mergeCell(s: PrStatus): string {
+  if (s.mergeability === "MERGEABLE") return "✅ MERGEABLE";
+  if (s.mergeability === "CONFLICTING") return "❌ CONFLICTING";
+  return "⏳ UNKNOWN";
+}
+
+function renderStatusSection(prStatus: PrStatus, updatedAt: string): string {
+  const prCell = prStatus.number ? `#${prStatus.number}` : "—";
+  const headCell = prStatus.headSha ? `\`${prStatus.headSha}\`` : "—";
+  return [
+    CARD_STATUS_OPEN,
+    "| PR | CI | Mergeability | Head |",
+    "|----|----|----|------|",
+    `| ${prCell} | ${ciCell(prStatus)} | ${mergeCell(prStatus)} | ${headCell} |`,
+    "",
+    `_Refreshed: ${updatedAt}_`,
+    CARD_STATUS_CLOSE,
+  ].join("\n");
+}
+
+/** Render the full decision card markdown for posting as an issue comment. */
+export function renderCard(opts: RenderCardOpts): string {
+  const { issueNumber, pendingDecision, prStatus, updatedAt } = opts;
+  return [
+    CARD_OPEN,
+    `## Decision card — #${issueNumber}`,
+    "",
+    `> **Pending decision:** ${pendingDecision}`,
+    "",
+    "### Status",
+    "",
+    renderStatusSection(prStatus, updatedAt),
+    "",
+    "### Available actions",
+    "",
+    "Post a comment with one of:",
+    "",
+    "- `/approve` — merge the linked PR and close this issue",
+    "- `/approve-ci` — merge when all CI checks pass (waits if pending)",
+    "- `/reject [reason]` — close the PR without merging; reopen for rework",
+    "- `/requeue <guidance>` — send back to agent with guidance",
+    "",
+    "**Or reply in plain English** — the bot maps your intent to an action.",
+    "Your instructions are processed securely; issue and PR content is treated as untrusted data.",
+    CARD_CLOSE,
+  ].join("\n");
+}
+
+/**
+ * Update the status section inside an existing card comment body, leaving all
+ * other content unchanged. Idempotent — calling with the same status produces
+ * the same output.
+ */
+export function updateCardStatus(cardBody: string, prStatus: PrStatus, updatedAt: string): string {
+  const open = cardBody.indexOf(CARD_STATUS_OPEN);
+  const close = cardBody.indexOf(CARD_STATUS_CLOSE);
+  if (open === -1 || close === -1 || close < open) return cardBody;
+  const before = cardBody.slice(0, open);
+  const after = cardBody.slice(close + CARD_STATUS_CLOSE.length);
+  return before + renderStatusSection(prStatus, updatedAt) + after;
+}
+
+/** True when a comment body is the hitl-card (contains the card open marker). */
+export function isHitlCard(body: string): boolean {
+  return body.includes(CARD_OPEN);
+}
+
+/**
+ * Parse a slash-command from a comment body. Only the FIRST non-blank line is
+ * examined — this is the injection safety boundary: text in later lines (which
+ * might come from quoted issue content) is never interpreted as instructions.
+ *
+ * Recognised commands:
+ *   /approve          → { action: 'approve',    args: '' }
+ *   /approve-ci       → { action: 'approve-ci', args: '' }
+ *   /reject [reason]  → { action: 'reject',     args: reason }
+ *   /requeue <text>   → { action: 'requeue',    args: text }
+ *
+ * Returns undefined when no recognised command is present on the first line.
+ */
+export function parseCardCommand(body: string): CardCommand | undefined {
+  const firstLine = body
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return undefined;
+
+  const lower = firstLine.toLowerCase();
+
+  // /approve-ci must be checked before /approve (prefix match).
+  if (lower.startsWith("/approve-ci")) {
+    return { action: "approve-ci", args: firstLine.slice("/approve-ci".length).trim() };
+  }
+  if (lower.startsWith("/approve")) {
+    return { action: "approve", args: firstLine.slice("/approve".length).trim() };
+  }
+  if (lower.startsWith("/reject")) {
+    return { action: "reject", args: firstLine.slice("/reject".length).trim() };
+  }
+  if (lower.startsWith("/requeue")) {
+    return { action: "requeue", args: firstLine.slice("/requeue".length).trim() };
+  }
+  return undefined;
+}
+
+/**
+ * Classify a plain-English comment body as a card command via keyword matching.
+ * Only called when {@link parseCardCommand} returns undefined (no slash-command).
+ * Returns undefined when the intent is ambiguous or unrecognisable.
+ *
+ * Injection-safe: only the comment body is read, never the issue body or PR diff.
+ * When intent is ambiguous (multiple keywords match), the caller should ask for
+ * clarification rather than guessing.
+ */
+export function classifyNaturalLanguage(body: string): CardCommand | undefined {
+  const lower = body.toLowerCase();
+  const approve = /\b(approve|merge|lgtm|ship\s*it|looks?\s*good|yes\b|go\s*ahead)\b/.test(lower);
+  const reject = /\b(reject|close|no\b|cancel|abort|don.t\s+merge|do\s+not\s+merge)\b/.test(lower);
+  const requeue = /\b(requeue|try\s+again|another\s+pass|rework|redo|retry|send\s+back)\b/.test(lower);
+
+  const matches = [approve, reject, requeue].filter(Boolean).length;
+  if (matches !== 1) return undefined;
+
+  if (requeue) return { action: "requeue", args: body.trim() };
+  if (reject) return { action: "reject", args: body.trim() };
+  if (approve) return { action: "approve", args: "" };
+  return undefined;
+}
+
+/**
+ * Parse CI check results from the GitHub API's `statusCheckRollup` array into a
+ * normalised {@link PrStatus} ci/ciPassed/ciTotal triple.
+ *
+ * GitHub check conclusions: SUCCESS, NEUTRAL, SKIPPED → pass bucket;
+ * FAILURE, ACTION_REQUIRED, CANCELLED, TIMED_OUT → fail bucket;
+ * everything else (IN_PROGRESS, QUEUED, WAITING, PENDING, undefined) → pending.
+ */
+export function parseCiChecks(checks: ReadonlyArray<{ conclusion?: string | null; state?: string | null }>): Pick<PrStatus, "ci" | "ciPassed" | "ciTotal"> {
+  if (checks.length === 0) return { ci: "none", ciPassed: 0, ciTotal: 0 };
+
+  const PASS_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+  const FAIL_CONCLUSIONS = new Set(["FAILURE", "ACTION_REQUIRED", "CANCELLED", "TIMED_OUT"]);
+
+  let passed = 0;
+  let failed = 0;
+  let pending = 0;
+
+  for (const c of checks) {
+    const conclusion = (c.conclusion ?? "").toUpperCase();
+    if (PASS_CONCLUSIONS.has(conclusion)) passed += 1;
+    else if (FAIL_CONCLUSIONS.has(conclusion)) failed += 1;
+    else pending += 1;
+  }
+
+  const total = checks.length;
+  if (failed > 0) return { ci: "fail", ciPassed: passed, ciTotal: total };
+  if (pending > 0) return { ci: "pending", ciPassed: passed, ciTotal: total };
+  return { ci: "pass", ciPassed: passed, ciTotal: total };
+}

--- a/apps/dev/tests/hitl-card.test.ts
+++ b/apps/dev/tests/hitl-card.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import {
+  CARD_OPEN,
+  CARD_CLOSE,
+  CARD_STATUS_OPEN,
+  CARD_STATUS_CLOSE,
+  renderCard,
+  updateCardStatus,
+  isHitlCard,
+  parseCardCommand,
+  classifyNaturalLanguage,
+  parseCiChecks,
+  type PrStatus,
+} from "../src/core/hitl-card.js";
+
+const EMPTY_PR: PrStatus = { ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
+const GREEN_PR: PrStatus = { number: 42, ci: "pass", ciPassed: 4, ciTotal: 4, mergeability: "MERGEABLE", headSha: "abc1234" };
+
+// ---------- renderCard ----------
+
+describe("renderCard", () => {
+  it("wraps output in open/close markers", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "Merge PR #42?", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card.startsWith(CARD_OPEN)).toBe(true);
+    expect(card.endsWith(CARD_CLOSE)).toBe(true);
+  });
+
+  it("includes the pending decision", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "Approve merge of PR #42", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain("Approve merge of PR #42");
+  });
+
+  it("includes status section markers", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain(CARD_STATUS_OPEN);
+    expect(card).toContain(CARD_STATUS_CLOSE);
+  });
+
+  it("shows PR number and head SHA in status table", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain("#42");
+    expect(card).toContain("`abc1234`");
+  });
+
+  it("shows MERGEABLE check emoji", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain("✅ MERGEABLE");
+  });
+
+  it("shows CONFLICTING check emoji", () => {
+    const conflicting: PrStatus = { ...GREEN_PR, mergeability: "CONFLICTING" };
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: conflicting, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain("❌ CONFLICTING");
+  });
+
+  it("shows em-dash when no PR", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: EMPTY_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    // PR cell, CI cell, head cell all —
+    expect(card.match(/—/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("includes all four slash-command options", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: EMPTY_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain("/approve");
+    expect(card).toContain("/approve-ci");
+    expect(card).toContain("/reject");
+    expect(card).toContain("/requeue");
+  });
+});
+
+// ---------- updateCardStatus ----------
+
+describe("updateCardStatus", () => {
+  it("replaces the status section with updated data", () => {
+    const original = renderCard({ issueNumber: 5, pendingDecision: "dec", prStatus: EMPTY_PR, updatedAt: "before" });
+    const updated = updateCardStatus(original, GREEN_PR, "after");
+    expect(updated).toContain("after");
+    expect(updated).toContain("#42");
+    expect(updated).not.toContain("before");
+  });
+
+  it("leaves content outside the status markers unchanged", () => {
+    const original = renderCard({ issueNumber: 5, pendingDecision: "my decision text", prStatus: EMPTY_PR, updatedAt: "before" });
+    const updated = updateCardStatus(original, GREEN_PR, "after");
+    expect(updated).toContain("my decision text");
+    expect(updated.startsWith(CARD_OPEN)).toBe(true);
+    expect(updated.endsWith(CARD_CLOSE)).toBe(true);
+  });
+
+  it("is idempotent — calling twice with same status produces the same output", () => {
+    const original = renderCard({ issueNumber: 5, pendingDecision: "dec", prStatus: EMPTY_PR, updatedAt: "before" });
+    const once = updateCardStatus(original, GREEN_PR, "now");
+    const twice = updateCardStatus(once, GREEN_PR, "now");
+    expect(once).toBe(twice);
+  });
+
+  it("returns the original body when no status markers are found", () => {
+    const body = "some arbitrary comment without markers";
+    expect(updateCardStatus(body, GREEN_PR, "now")).toBe(body);
+  });
+});
+
+// ---------- isHitlCard ----------
+
+describe("isHitlCard", () => {
+  it("returns true for a rendered card", () => {
+    const card = renderCard({ issueNumber: 1, pendingDecision: "x", prStatus: EMPTY_PR, updatedAt: "now" });
+    expect(isHitlCard(card)).toBe(true);
+  });
+
+  it("returns false for a regular comment", () => {
+    expect(isHitlCard("just a regular comment")).toBe(false);
+  });
+
+  it("returns false for an envelope comment", () => {
+    expect(isHitlCard('<details data-attempt-status="blocked">...</details>')).toBe(false);
+  });
+});
+
+// ---------- parseCardCommand ----------
+
+describe("parseCardCommand", () => {
+  it("parses /approve", () => {
+    expect(parseCardCommand("/approve")).toEqual({ action: "approve", args: "" });
+  });
+
+  it("parses /approve-ci (before /approve prefix)", () => {
+    expect(parseCardCommand("/approve-ci")).toEqual({ action: "approve-ci", args: "" });
+  });
+
+  it("parses /reject without reason", () => {
+    expect(parseCardCommand("/reject")).toEqual({ action: "reject", args: "" });
+  });
+
+  it("parses /reject with reason", () => {
+    expect(parseCardCommand("/reject too many lint errors")).toEqual({ action: "reject", args: "too many lint errors" });
+  });
+
+  it("parses /requeue with guidance", () => {
+    expect(parseCardCommand("/requeue fix the type errors in src/foo.ts")).toEqual({
+      action: "requeue",
+      args: "fix the type errors in src/foo.ts",
+    });
+  });
+
+  it("is case-insensitive on the slash verb", () => {
+    expect(parseCardCommand("/APPROVE")?.action).toBe("approve");
+    expect(parseCardCommand("/Reject")?.action).toBe("reject");
+  });
+
+  it("ignores content after the first non-blank line", () => {
+    const body = "/approve\nThis issue has a PR with content:\n/reject me please";
+    expect(parseCardCommand(body)).toEqual({ action: "approve", args: "" });
+  });
+
+  it("skips leading blank lines", () => {
+    expect(parseCardCommand("\n\n/requeue try again")).toEqual({ action: "requeue", args: "try again" });
+  });
+
+  it("returns undefined for unrecognised commands", () => {
+    expect(parseCardCommand("/merge")).toBeUndefined();
+    expect(parseCardCommand("just a comment")).toBeUndefined();
+    expect(parseCardCommand("")).toBeUndefined();
+  });
+
+  it("returns undefined for a blank body", () => {
+    expect(parseCardCommand("   \n  ")).toBeUndefined();
+  });
+});
+
+// ---------- classifyNaturalLanguage ----------
+
+describe("classifyNaturalLanguage", () => {
+  it("maps 'LGTM' to approve", () => {
+    expect(classifyNaturalLanguage("LGTM, looks good to me")?.action).toBe("approve");
+  });
+
+  it("maps 'yes, merge it' to approve", () => {
+    expect(classifyNaturalLanguage("yes, merge it")?.action).toBe("approve");
+  });
+
+  it("maps 'reject this' to reject", () => {
+    expect(classifyNaturalLanguage("please reject this change")?.action).toBe("reject");
+  });
+
+  it("maps 'requeue with another pass' to requeue", () => {
+    const cmd = classifyNaturalLanguage("needs another pass before merging");
+    expect(cmd?.action).toBe("requeue");
+  });
+
+  it("returns undefined when intent is ambiguous (multiple keywords)", () => {
+    expect(classifyNaturalLanguage("approve or reject?")).toBeUndefined();
+  });
+
+  it("returns undefined for unrelated text", () => {
+    expect(classifyNaturalLanguage("what is the status of this PR?")).toBeUndefined();
+  });
+
+  it("preserves the full body as args for requeue", () => {
+    const guidance = "try again with a different approach";
+    const cmd = classifyNaturalLanguage(guidance);
+    expect(cmd?.args).toBe(guidance);
+  });
+});
+
+// ---------- parseCiChecks ----------
+
+describe("parseCiChecks", () => {
+  it("returns none for empty checks", () => {
+    expect(parseCiChecks([])).toEqual({ ci: "none", ciPassed: 0, ciTotal: 0 });
+  });
+
+  it("returns pass when all checks succeed", () => {
+    const checks = [{ conclusion: "SUCCESS" }, { conclusion: "NEUTRAL" }, { conclusion: "SKIPPED" }];
+    expect(parseCiChecks(checks)).toEqual({ ci: "pass", ciPassed: 3, ciTotal: 3 });
+  });
+
+  it("returns fail when any check fails", () => {
+    const checks = [{ conclusion: "SUCCESS" }, { conclusion: "FAILURE" }];
+    expect(parseCiChecks(checks)).toEqual({ ci: "fail", ciPassed: 1, ciTotal: 2 });
+  });
+
+  it("returns pending when checks are in progress", () => {
+    const checks = [{ conclusion: "SUCCESS" }, { conclusion: null }];
+    expect(parseCiChecks(checks)).toEqual({ ci: "pending", ciPassed: 1, ciTotal: 2 });
+  });
+
+  it("prioritises fail over pending", () => {
+    const checks = [{ conclusion: "FAILURE" }, { conclusion: null }];
+    expect(parseCiChecks(checks)).toEqual({ ci: "fail", ciPassed: 0, ciTotal: 2 });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #927. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #927

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785436001&installation_id=129708444&pr_number=954&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F954&signature=a997d60f7380adbde256bcff262393a245242604e88f77a479a47a0b3d0c67eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->