### PR TITLE
merge: #931 S3 — shared gate: closed mechanical allowlist + context-aware escalation

### DIFF
--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -1,0 +1,202 @@
+// shared-gate — closed mechanical allowlist + context-aware escalation (ADR 0081, issue #931).
+//
+// The SINGLE authority for classifying gate findings as mechanical vs. intent,
+// applying mechanical findings in-tree, and routing intent findings to the right
+// escalation sink. Designed to be shared by `/go` (interactive) and `/afk`
+// (headless) without duplicating the classification logic.
+//
+// Two rules drive everything:
+//   1. CLOSED ALLOWLIST — a finding is mechanical only when its kind appears on
+//      the enumerated list below. Anything absent from the list is INTENT by
+//      default. There is no catch-all "other mechanical"; the default is intent.
+//   2. CONTEXT-AWARE SINK — mechanical findings auto-apply + commit (always);
+//      intent findings are handed to the caller-injected EscalationSink, which
+//      differs by context: interactive (/go) = pause and ask; headless (/afk) =
+//      park to ready-for-human.
+//
+// IO-free: every effect (apply, commit, escalate) is injected, so the decision
+// logic, classification, and result shape are fully unit-testable with zero
+// subprocesses or network access.
+
+// ---------- mechanical allowlist ----------
+
+/**
+ * The CLOSED, AUDITABLE set of mechanical finding kinds. A finding whose `kind`
+ * is NOT in this set is classified as INTENT by default — no catch-all.
+ *
+ * ADR 0081 enumerates exactly these kinds. To add a new mechanical kind, amend
+ * this list AND update the ADR. Anything outside this set must go through human
+ * review.
+ */
+export const MECHANICAL_KINDS = [
+  "formatter",
+  "import-organizer",
+  "lint-fix",
+  "comment-typo",
+  "trailing-whitespace",
+  "trailing-newline",
+] as const;
+
+export type MechanicalKind = (typeof MECHANICAL_KINDS)[number];
+
+/** A gate finding — one diagnostic produced by the review/lint/format step. */
+export interface GateFinding {
+  /** The canonical kind. Must be one of {@link MECHANICAL_KINDS} to be auto-applied. */
+  kind: string;
+  /** Human-readable description of the finding (shown in escalation comments). */
+  description: string;
+  /** Optional patch or command to apply the fix. Populated for mechanical findings. */
+  patch?: string;
+}
+
+// ---------- classification ----------
+
+/**
+ * Classify a single gate finding. PURE predicate — no IO.
+ *
+ * Returns `"mechanical"` only when `finding.kind` is a member of the closed
+ * {@link MECHANICAL_KINDS} allowlist. Every other kind is `"intent"` — the safe
+ * default that prevents silent auto-commit of logic changes.
+ */
+export function classifyFinding(finding: GateFinding): "mechanical" | "intent" {
+  const allowed = new Set<string>(MECHANICAL_KINDS);
+  return allowed.has(finding.kind) ? "mechanical" : "intent";
+}
+
+// ---------- escalation sinks ----------
+
+/**
+ * The execution context that selects the escalation sink.
+ *
+ * - `"interactive"` — a human is present (e.g. `/go`). The sink pauses and asks
+ *   the maintainer to approve, fix, or skip each intent finding.
+ * - `"headless"` — no human is present (e.g. `/afk`). The sink parks the issue
+ *   to `ready-for-human` with `blocked:validation` and a comment.
+ */
+export type GateContext = "interactive" | "headless";
+
+/** The outcome of an escalation for a single intent finding. */
+export type EscalationOutcome = "approved" | "skipped" | "parked";
+
+/** An injected escalation action for one intent finding. Returns the outcome. */
+export type EscalationSink = (finding: GateFinding) => Promise<EscalationOutcome>;
+
+/** An injected apply + commit action for one mechanical finding. */
+export type MechanicalApply = (finding: GateFinding) => Promise<void>;
+
+// ---------- result ----------
+
+/** Per-finding resolution recorded in the gate result. */
+export interface FindingResolution {
+  finding: GateFinding;
+  classification: "mechanical" | "intent";
+  /** Set for mechanical findings that were auto-applied. */
+  applied?: true;
+  /** Set for intent findings that were escalated via the sink. */
+  escalationOutcome?: EscalationOutcome;
+}
+
+/**
+ * The result of running the shared gate over a set of findings.
+ *
+ * - `passed` — all findings were either mechanical (auto-applied) or intent
+ *   findings that the maintainer approved. The gate is green.
+ * - `parked` — at least one intent finding was parked (headless sink) or skipped
+ *   and blocked the gate. The caller must not proceed to merge.
+ */
+export interface SharedGateResult {
+  /** True only when every finding resolved without blocking. */
+  passed: boolean;
+  /** Per-finding detail records, in input order. */
+  resolutions: FindingResolution[];
+  /** Total count of mechanical findings that were auto-applied + committed. */
+  mechanicalApplied: number;
+  /** Total count of intent findings that were escalated (any outcome). */
+  intentEscalated: number;
+}
+
+// ---------- gate runner ----------
+
+/**
+ * Dependencies for the shared gate — all effects injected for testability.
+ */
+export interface SharedGateDeps {
+  /** Apply a mechanical finding in-tree and commit it. */
+  applyMechanical: MechanicalApply;
+  /** Escalate one intent finding to the context-appropriate sink. */
+  escalateIntent: EscalationSink;
+}
+
+/**
+ * Run the shared validation gate over `findings`.
+ *
+ * For each finding:
+ *   - **Mechanical** → `deps.applyMechanical(finding)` (auto-apply + commit).
+ *   - **Intent** → `deps.escalateIntent(finding)` (context-aware sink).
+ *
+ * The gate is GREEN (`passed: true`) when every intent finding resolves with
+ * `"approved"`. A single `"parked"` or `"skipped"` (when the caller treats skip
+ * as blocking) outcome makes the gate RED. The convention followed here is:
+ *   - `"approved"` → non-blocking (maintainer accepted the change)
+ *   - `"parked"`   → blocking (headless sink requested human review)
+ *   - `"skipped"`  → blocking (interactive sink: skip = do not land)
+ *
+ * PURE SEQUENCING — no decision logic lives here beyond the classification +
+ * routing; all judgment (interactive prompt wording, park comment text) stays in
+ * the injected sinks.
+ */
+export async function runSharedGate(
+  findings: readonly GateFinding[],
+  deps: SharedGateDeps,
+): Promise<SharedGateResult> {
+  const resolutions: FindingResolution[] = [];
+  let mechanicalApplied = 0;
+  let intentEscalated = 0;
+  let passed = true;
+
+  for (const finding of findings) {
+    const classification = classifyFinding(finding);
+
+    if (classification === "mechanical") {
+      await deps.applyMechanical(finding);
+      resolutions.push({ finding, classification, applied: true });
+      mechanicalApplied++;
+    } else {
+      const escalationOutcome = await deps.escalateIntent(finding);
+      resolutions.push({ finding, classification, escalationOutcome });
+      intentEscalated++;
+      if (escalationOutcome !== "approved") {
+        passed = false;
+      }
+    }
+  }
+
+  return { passed, resolutions, mechanicalApplied, intentEscalated };
+}
+
+// ---------- built-in sink factories ----------
+
+/**
+ * Build the headless escalation sink. Parks on any intent finding: logs the
+ * finding to `parkIntent` (caller handles label/comment write) and returns
+ * `"parked"` — always blocking, always requiring human review.
+ */
+export function makeHeadlessSink(parkIntent: (finding: GateFinding) => Promise<void>): EscalationSink {
+  return async (finding) => {
+    await parkIntent(finding);
+    return "parked";
+  };
+}
+
+/**
+ * Build the interactive escalation sink. Delegates the approve/skip decision to
+ * the injected `promptUser` callback (the CLI prompt or test double). Returns
+ * whatever the prompt returns — the sink itself carries no prompt wording.
+ */
+export function makeInteractiveSink(
+  promptUser: (finding: GateFinding) => Promise<"approved" | "skipped">,
+): EscalationSink {
+  return async (finding) => {
+    return promptUser(finding);
+  };
+}

--- a/apps/dev/tests/shared-gate.test.ts
+++ b/apps/dev/tests/shared-gate.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyFinding,
+  runSharedGate,
+  makeHeadlessSink,
+  makeInteractiveSink,
+  MECHANICAL_KINDS,
+  type EscalationOutcome,
+  type GateFinding,
+  type SharedGateDeps,
+} from "../src/core/shared-gate.js";
+
+// shared-gate — closed mechanical allowlist + context-aware escalation (#931).
+//
+// Acceptance criteria:
+//   1. Mechanical allowlist is closed and auditable — anything not on it is intent.
+//   2. Mechanical findings auto-apply + commit.
+//   3. Intent findings escalate (never auto-committed).
+//   4. Escalation sink switches by context: interactive pause vs headless park.
+//   5. Tests cover both sinks and the "default = intent" boundary.
+
+function finding(kind: string, description = "test finding"): GateFinding {
+  return { kind, description };
+}
+
+function makeDeps(
+  applied: GateFinding[] = [],
+  escalationOutcome: EscalationOutcome = "approved",
+): SharedGateDeps {
+  return {
+    applyMechanical: vi.fn(async (f) => {
+      applied.push(f);
+    }),
+    escalateIntent: vi.fn(async (): Promise<EscalationOutcome> => escalationOutcome),
+  };
+}
+
+// ---------- classifyFinding ----------
+
+describe("classifyFinding — closed allowlist", () => {
+  it("classifies every enumerated mechanical kind as mechanical", () => {
+    for (const kind of MECHANICAL_KINDS) {
+      expect(classifyFinding(finding(kind))).toBe("mechanical");
+    }
+  });
+
+  it("classifies an unknown kind as intent (default = intent)", () => {
+    expect(classifyFinding(finding("logic-change"))).toBe("intent");
+    expect(classifyFinding(finding("type-error"))).toBe("intent");
+    expect(classifyFinding(finding("test-expectation-change"))).toBe("intent");
+    expect(classifyFinding(finding("library-upgrade"))).toBe("intent");
+  });
+
+  it("treats an empty kind as intent (not mechanical)", () => {
+    expect(classifyFinding(finding(""))).toBe("intent");
+  });
+
+  it("is case-sensitive — Formatter is not formatter", () => {
+    expect(classifyFinding(finding("Formatter"))).toBe("intent");
+    expect(classifyFinding(finding("LINT-FIX"))).toBe("intent");
+  });
+});
+
+// ---------- runSharedGate — mechanical path ----------
+
+describe("runSharedGate — mechanical findings", () => {
+  it("auto-applies all mechanical findings and passes", async () => {
+    const applied: GateFinding[] = [];
+    const deps = makeDeps(applied);
+    const findings = [finding("formatter"), finding("trailing-whitespace")];
+
+    const result = await runSharedGate(findings, deps);
+
+    expect(result.passed).toBe(true);
+    expect(result.mechanicalApplied).toBe(2);
+    expect(result.intentEscalated).toBe(0);
+    expect(applied).toHaveLength(2);
+    expect(result.resolutions[0].applied).toBe(true);
+    expect(result.resolutions[1].applied).toBe(true);
+  });
+
+  it("calls applyMechanical once per mechanical finding in order", async () => {
+    const callOrder: string[] = [];
+    const deps: SharedGateDeps = {
+      applyMechanical: vi.fn(async (f) => {
+        callOrder.push(f.kind);
+      }),
+      escalateIntent: vi.fn(async (): Promise<EscalationOutcome> => "approved"),
+    };
+
+    await runSharedGate(
+      [finding("import-organizer"), finding("lint-fix"), finding("comment-typo")],
+      deps,
+    );
+
+    expect(callOrder).toEqual(["import-organizer", "lint-fix", "comment-typo"]);
+  });
+
+  it("never calls escalateIntent for a mechanical finding", async () => {
+    const deps = makeDeps();
+    await runSharedGate([finding("formatter"), finding("trailing-newline")], deps);
+    expect(deps.escalateIntent).not.toHaveBeenCalled();
+  });
+
+  it("passes with no findings (empty set)", async () => {
+    const deps = makeDeps();
+    const result = await runSharedGate([], deps);
+    expect(result.passed).toBe(true);
+    expect(result.mechanicalApplied).toBe(0);
+    expect(result.intentEscalated).toBe(0);
+    expect(result.resolutions).toHaveLength(0);
+  });
+});
+
+// ---------- runSharedGate — intent path ----------
+
+describe("runSharedGate — intent findings", () => {
+  it("escalates an intent finding and passes when approved", async () => {
+    const deps = makeDeps([], "approved");
+    const result = await runSharedGate([finding("logic-change")], deps);
+
+    expect(result.passed).toBe(true);
+    expect(result.intentEscalated).toBe(1);
+    expect(result.mechanicalApplied).toBe(0);
+    expect(result.resolutions[0].escalationOutcome).toBe("approved");
+  });
+
+  it("fails when an intent finding is parked (headless sink)", async () => {
+    const deps = makeDeps([], "parked");
+    const result = await runSharedGate([finding("function-rename")], deps);
+
+    expect(result.passed).toBe(false);
+    expect(result.intentEscalated).toBe(1);
+    expect(result.resolutions[0].escalationOutcome).toBe("parked");
+  });
+
+  it("fails when an intent finding is skipped (interactive sink)", async () => {
+    const deps = makeDeps([], "skipped");
+    const result = await runSharedGate([finding("test-expectation-change")], deps);
+
+    expect(result.passed).toBe(false);
+    expect(result.resolutions[0].escalationOutcome).toBe("skipped");
+  });
+
+  it("never calls applyMechanical for an intent finding", async () => {
+    const deps = makeDeps([], "approved");
+    await runSharedGate([finding("library-upgrade")], deps);
+    expect(deps.applyMechanical).not.toHaveBeenCalled();
+  });
+});
+
+// ---------- runSharedGate — mixed findings ----------
+
+describe("runSharedGate — mixed mechanical + intent", () => {
+  it("auto-applies mechanical and escalates intent in one pass", async () => {
+    const applied: GateFinding[] = [];
+    const deps: SharedGateDeps = {
+      applyMechanical: vi.fn(async (f) => {
+        applied.push(f);
+      }),
+      escalateIntent: vi.fn(async (): Promise<EscalationOutcome> => "approved"),
+    };
+
+    const findings = [
+      finding("formatter"),
+      finding("logic-change"),
+      finding("trailing-whitespace"),
+      finding("type-error"),
+    ];
+
+    const result = await runSharedGate(findings, deps);
+
+    expect(result.passed).toBe(true);
+    expect(result.mechanicalApplied).toBe(2);
+    expect(result.intentEscalated).toBe(2);
+    expect(applied.map((f) => f.kind)).toEqual(["formatter", "trailing-whitespace"]);
+  });
+
+  it("fails when any intent finding blocks even if mechanical ones applied", async () => {
+    const deps: SharedGateDeps = {
+      applyMechanical: vi.fn(async () => {}),
+      escalateIntent: vi.fn(async (): Promise<EscalationOutcome> => "parked"),
+    };
+
+    const result = await runSharedGate(
+      [finding("formatter"), finding("logic-change")],
+      deps,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.mechanicalApplied).toBe(1);
+    expect(result.intentEscalated).toBe(1);
+  });
+});
+
+// ---------- headless sink ----------
+
+describe("makeHeadlessSink — headless escalation", () => {
+  it("always returns parked and calls the park callback", async () => {
+    const parked: GateFinding[] = [];
+    const sink = makeHeadlessSink(async (f) => {
+      parked.push(f);
+    });
+
+    const f = finding("function-rename");
+    const outcome = await sink(f);
+
+    expect(outcome).toBe("parked");
+    expect(parked).toHaveLength(1);
+    expect(parked[0]).toBe(f);
+  });
+
+  it("parks every intent finding in a batch via runSharedGate", async () => {
+    const parked: string[] = [];
+    const sink = makeHeadlessSink(async (f) => {
+      parked.push(f.kind);
+    });
+
+    const deps: SharedGateDeps = {
+      applyMechanical: vi.fn(async () => {}),
+      escalateIntent: sink,
+    };
+
+    const result = await runSharedGate(
+      [finding("logic-a"), finding("logic-b")],
+      deps,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(parked).toEqual(["logic-a", "logic-b"]);
+  });
+});
+
+// ---------- interactive sink ----------
+
+describe("makeInteractiveSink — interactive escalation", () => {
+  it("returns approved when the user approves", async () => {
+    const sink = makeInteractiveSink(async () => "approved");
+    expect(await sink(finding("type-change"))).toBe("approved");
+  });
+
+  it("returns skipped when the user skips", async () => {
+    const sink = makeInteractiveSink(async () => "skipped");
+    expect(await sink(finding("type-change"))).toBe("skipped");
+  });
+
+  it("passes the finding to the prompt callback", async () => {
+    let received: GateFinding | undefined;
+    const sink = makeInteractiveSink(async (f) => {
+      received = f;
+      return "approved";
+    });
+
+    const f = finding("library-upgrade", "bumped react to v19");
+    await sink(f);
+    expect(received).toBe(f);
+  });
+
+  it("marks gate passed when user approves all intent findings", async () => {
+    const sink = makeInteractiveSink(async () => "approved");
+    const deps: SharedGateDeps = {
+      applyMechanical: vi.fn(async () => {}),
+      escalateIntent: sink,
+    };
+
+    const result = await runSharedGate(
+      [finding("logic-change"), finding("function-rename")],
+      deps,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.intentEscalated).toBe(2);
+  });
+
+  it("marks gate failed when user skips an intent finding", async () => {
+    const sink = makeInteractiveSink(async () => "skipped");
+    const deps: SharedGateDeps = {
+      applyMechanical: vi.fn(async () => {}),
+      escalateIntent: sink,
+    };
+
+    const result = await runSharedGate([finding("type-error")], deps);
+
+    expect(result.passed).toBe(false);
+    expect(result.resolutions[0].escalationOutcome).toBe("skipped");
+  });
+});
+
+// ---------- "default = intent" boundary ----------
+
+describe("default = intent boundary", () => {
+  it("a near-miss kind (e.g. 'format' vs 'formatter') is intent", () => {
+    expect(classifyFinding(finding("format"))).toBe("intent");
+    expect(classifyFinding(finding("lint"))).toBe("intent");
+    expect(classifyFinding(finding("whitespace"))).toBe("intent");
+  });
+
+  it("a kind that is a prefix of a mechanical kind is still intent", () => {
+    expect(classifyFinding(finding("trailing"))).toBe("intent");
+    expect(classifyFinding(finding("import"))).toBe("intent");
+  });
+
+  it("a concatenated kind that contains a mechanical substring is intent", () => {
+    expect(classifyFinding(finding("formatter-plus-logic"))).toBe("intent");
+    expect(classifyFinding(finding("custom-lint-fix"))).toBe("intent");
+  });
+
+  it("MECHANICAL_KINDS are all lowercase (no hidden casing exceptions)", () => {
+    for (const kind of MECHANICAL_KINDS) {
+      expect(kind).toBe(kind.toLowerCase());
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #931. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #931

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785436537&installation_id=129708444&pr_number=955&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F955&signature=dc0ef8a9e01b43f9c2bfda395fc77f8afc193db05f92ed7159b1cebeb8129d0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->