### PR TITLE
merge: #930 S2 — origin provenance field + per-source counts in statusline & monitor

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -102,6 +102,10 @@ interface ParsedRunFlags {
    * issue `n` without re-running the agent.
    */
   reconcileIssue?: number;
+  /** --origin <label>: spawn-time provenance stamped on the worker state
+   * (`"afk"` | `"go"` | `"urgent"` | …). Set by each entry point so the
+   * monitor/statusline can render per-source counts. */
+  origin?: string;
 }
 
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
@@ -153,6 +157,7 @@ const RUN_FLAG_SCHEMA = {
   "fallback-runner": { kind: "boolean" },
   "boot-only": { kind: "boolean" },
   "reconcile-issue": { kind: "value", coerce: (raw: string): number => Number(raw) },
+  origin: { kind: "value", coerce: (raw: string): string => raw },
 } satisfies FlagSchema;
 
 /** Parse the `run` flags: --prd N / --issues a,b,c / -n N / --once / --request / --runner. */
@@ -201,6 +206,7 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     fallbackRunner: values["fallback-runner"] === true,
     bootOnly: values["boot-only"] === true,
     reconcileIssue,
+    origin: values.origin as string | undefined,
   };
 }
 
@@ -1395,6 +1401,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
           pid: process.pid,
           pid_start_time: pidStartTime,
           runner: c.runner,
+          // Spawn-time provenance (issue #930): stamped once here, never mutated.
+          // The entry point (`/afk`, `/go`, `/urgent`) passes `--origin <label>`.
+          origin: flags.origin ?? "",
           log: join(attemptDir, "afk.log"),
           started_at: startedAt,
           "current.number": candidate.number,

--- a/apps/dev/src/core/monitor.ts
+++ b/apps/dev/src/core/monitor.ts
@@ -49,6 +49,10 @@ export interface CompactState {
   runner: string;
   /** Worker-process start; the elapsed fallback when current.started_at is "". */
   started_at: string;
+  /** Spawn-time provenance from `state.origin` (e.g. `"afk"` | `"go"`).
+   * Absent / `""` means unknown (pre-field or origin flag not passed). The
+   * dashboard header aggregates non-empty values into per-source counts. */
+  origin?: string;
   total: number;
   done: number;
   blocked: number;
@@ -292,11 +296,25 @@ export function renderCompactDashboard(
 ): string {
   let added = 0;
   let removed = 0;
+  // Per-source counts: aggregate state.origin from all workers (not just live
+  // ones — liveness filtering happens at the collection layer). Only non-empty
+  // origins are counted; both surfaces read from the same state.origin field.
+  const sourceMap = new Map<string, number>();
   for (const w of workers) {
     added += w.diffAdded ?? 0;
     removed += w.diffRemoved ?? 0;
+    const origin = w.state.origin;
+    if (origin) sourceMap.set(origin, (sourceMap.get(origin) ?? 0) + 1);
   }
-  const header = `${buildSparkline(events, now).line}   Δ fleet ${formatDiff(added, removed)}`;
+  const sourceFrag =
+    sourceMap.size > 0
+      ? "  " +
+        [...sourceMap.entries()]
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([o, c]) => `${o}=${c}`)
+          .join(" ")
+      : "";
+  const header = `${buildSparkline(events, now).line}   Δ fleet ${formatDiff(added, removed)}${sourceFrag}`;
   let prefix: string;
   if (fleet) {
     const fleetLine = renderFleetLine(fleet, now);

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -85,6 +85,12 @@ export interface AfkInput {
    * is doing, not just that it exists. Absent/short arrays fall back to bare
    * `#N`, preserving the pre-stage render. */
   stages?: ReadonlyArray<string | undefined>;
+  /** Per-origin worker counts derived from `state.origin` across live workers.
+   * Populated by the IO layer (wire.ts collectStatuslineAfk) reading the SINGLE
+   * `origin` field on each worker state; absent when no live worker has a
+   * non-empty origin. Sorted by origin for a deterministic token order.
+   * Rendered as `go=N afk=M` tokens immediately after `wrk=<total>`. */
+  sourceCounts?: ReadonlyArray<{ origin: string; count: number }>;
 }
 
 /** Repo-global header inputs (themed line 1, always rendered). Independent of
@@ -186,6 +192,9 @@ export function afkTokens(afk: AfkInput | undefined): AfkToken[] {
     tokens.push({ label, value, suffix: "" });
   };
   if (afk.workers > 0) kpi("wrk=", String(afk.workers));
+  if (afk.sourceCounts && afk.sourceCounts.length > 0) {
+    for (const { origin, count } of afk.sourceCounts) kpi(`${origin}=`, String(count));
+  }
   if (afk.queue > 0) kpi("rdy=", String(afk.queue));
   if (afk.human > 0) kpi("hmn=", String(afk.human));
   if (afk.blocked > 0) kpi("blk=", String(afk.blocked));

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -515,6 +515,10 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
         pid: state.pid,
         runner: state.runner,
         started_at: state.started_at,
+        // Spawn-time provenance — passed through from the single state.origin
+        // field so the dashboard derives per-source counts from the same source
+        // as the statusline (issue #930, no independent derivation).
+        origin: state.origin || undefined,
         total: state.total,
         done: state.done,
         blocked: state.blocked,
@@ -648,6 +652,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   let resolved = 0;
   const issues: Array<number | string> = [];
   const stages: Array<string | undefined> = [];
+  const sourceMap = new Map<string, number>();
 
   for (const { state, live } of records) {
     // Statusline line 2 counts every pid-live worker (the orchestrator process is
@@ -665,6 +670,8 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     blocked += state.blocked;
     if (runner === "" && state.runner) runner = state.runner;
     if (state.done > resolved) resolved = state.done;
+    // Per-source count: read origin from the single state field (issue #930).
+    if (state.origin) sourceMap.set(state.origin, (sourceMap.get(state.origin) ?? 0) + 1);
     // Read the worker's signals through the canonical WorkerVitals contract
     // (ADR 0065) rather than ad-hoc field access — `current` satisfies it.
     const vitals: WorkerVitals = state.current;
@@ -729,7 +736,17 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
 
   if (workers <= 0) return null;
 
-  return { workers, queue, human, blocked, added, removed, waiting, tokens, costUsd, runner, resolved, issues, stages };
+  // Build the per-source count array sorted by origin for a deterministic order.
+  // Both statusline and monitor read from state.origin via readWorkerStates —
+  // this is the one derived form; nothing else derives source counts independently.
+  const sourceCounts =
+    sourceMap.size > 0
+      ? [...sourceMap.entries()]
+          .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+          .map(([origin, count]) => ({ origin, count }))
+      : undefined;
+
+  return { workers, queue, human, blocked, added, removed, waiting, tokens, costUsd, runner, resolved, issues, stages, sourceCounts };
 }
 
 interface RepoStatsCache {

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -83,6 +83,13 @@ export const AfkStateSchema = z.object({
   pid_start_time: z.string().default(""),
   log: z.string().default(""),
   started_at: z.string().default(""),
+  /** Spawn-time provenance: the entry point that launched this worker
+   * (`"afk"` | `"go"` | `"urgent"` | `""`). Stamped once at `initStateSync`
+   * via the `--origin` flag and never mutated. Empty means unknown/pre-field
+   * (round-trip safe — out-of-vocab values survive through `updateState`).
+   * The single source of truth both statusline and monitor read for per-source
+   * worker counts; no independent derivation allowed. */
+  origin: z.string().default(""),
   runner: z.string().default(""),
   filter: AfkFilterSchema.default({}),
   total: z.number().default(0),

--- a/apps/dev/tests/origin-provenance.test.ts
+++ b/apps/dev/tests/origin-provenance.test.ts
@@ -1,0 +1,187 @@
+// Tests that the statusline and monitor derive per-source worker counts from
+// the SAME `state.origin` field via the shared read surface (readWorkerStates →
+// WorkerStateRecord.state.origin), with no independent derivation.
+//
+// Acceptance criteria (issue #930 S2):
+//   - origin stamped at spawn (tested in the flag/init path, exercised by e2e)
+//   - one shared read surface: state.origin from AfkStateSchema
+//   - both surfaces show per-source counts that agree
+//   - enum extends cleanly (new origin strings need no render changes)
+
+import { describe, expect, it } from "vitest";
+import { afkTokens, type AfkInput } from "../src/core/statusline.js";
+import { renderCompactDashboard, type CompactWorker } from "../src/core/monitor.js";
+
+// Builds a minimal CompactWorker with a given origin label.
+function makeWorker(origin: string, id: string): CompactWorker {
+  return {
+    state: {
+      worker_id: id,
+      pid: 1,
+      runner: "claude",
+      started_at: "2026-06-30T00:00:00Z",
+      origin,
+      total: 5,
+      done: 1,
+      blocked: 0,
+      failed: 0,
+      current: {
+        number: 42,
+        title: "some issue",
+        stage: "impl",
+        started_at: "2026-06-30T00:00:00Z",
+      },
+    },
+    live: true,
+    liveness: "active",
+  };
+}
+
+// Derives per-source counts from a list of origin labels, mirroring what both
+// collectStatuslineAfk and renderCompactDashboard do from state.origin.
+function buildSourceCounts(origins: string[]): ReadonlyArray<{ origin: string; count: number }> {
+  const m = new Map<string, number>();
+  for (const o of origins) if (o) m.set(o, (m.get(o) ?? 0) + 1);
+  return [...m.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([origin, count]) => ({ origin, count }));
+}
+
+describe("origin provenance — per-source counts", () => {
+  const NOW_EPOCH = 1_751_000_000;
+
+  it("statusline emits per-source tokens from sourceCounts after wrk=N", () => {
+    const afk: AfkInput = {
+      workers: 3,
+      queue: 0,
+      human: 0,
+      blocked: 0,
+      added: 0,
+      removed: 0,
+      issues: [],
+      sourceCounts: [
+        { origin: "afk", count: 1 },
+        { origin: "go", count: 2 },
+      ],
+    };
+    const tokens = afkTokens(afk);
+    const rendered = tokens.map((t) => `${t.label}${t.value}`);
+    // wrk= comes first, then per-source in sorted order
+    expect(rendered[0]).toBe("wrk=3");
+    expect(rendered).toContain("afk=1");
+    expect(rendered).toContain("go=2");
+    // per-source appear right after wrk=
+    const wrkIdx = rendered.indexOf("wrk=3");
+    const afkIdx = rendered.indexOf("afk=1");
+    const goIdx = rendered.indexOf("go=2");
+    expect(afkIdx).toBe(wrkIdx + 1);
+    expect(goIdx).toBe(wrkIdx + 2);
+  });
+
+  it("statusline omits per-source tokens when sourceCounts is absent (back-compat)", () => {
+    const afk: AfkInput = {
+      workers: 2,
+      queue: 0,
+      human: 0,
+      blocked: 0,
+      added: 5,
+      removed: 1,
+      issues: [17],
+    };
+    const tokens = afkTokens(afk);
+    const rendered = tokens.map((t) => `${t.label}${t.value}`);
+    expect(rendered).toEqual(["wrk=2", "loc=+5 -1", "#17"]);
+  });
+
+  it("monitor dashboard header shows per-source counts from state.origin", () => {
+    const workers: CompactWorker[] = [
+      makeWorker("go", "w1"),
+      makeWorker("go", "w2"),
+      makeWorker("afk", "w3"),
+    ];
+    const dashboard = renderCompactDashboard(workers, [], NOW_EPOCH);
+    const header = dashboard.split("\n")[0]!;
+    expect(header).toContain("go=2");
+    expect(header).toContain("afk=1");
+  });
+
+  it("monitor dashboard omits per-source fragment when no worker has an origin", () => {
+    const workers: CompactWorker[] = [
+      makeWorker("", "w1"),
+      makeWorker("", "w2"),
+    ];
+    const dashboard = renderCompactDashboard(workers, [], NOW_EPOCH);
+    const header = dashboard.split("\n")[0]!;
+    // No origin labels in the header
+    expect(header).not.toMatch(/\b\w+=\d+/g.toString().replace("go|afk", ""));
+    // More specifically: the header must not contain origin= style tokens
+    expect(header).not.toContain("=1");
+    expect(header).not.toContain("=2");
+  });
+
+  it("statusline and monitor report identical per-source counts for the same workers", () => {
+    // Simulate the worker origins that readWorkerStates would return
+    const workerOrigins = ["go", "go", "afk", "urgent"];
+
+    // --- Statusline path ---
+    // collectStatuslineAfk builds sourceCounts from state.origin exactly this way
+    const sourceCounts = buildSourceCounts(workerOrigins);
+    const afk: AfkInput = {
+      workers: workerOrigins.length,
+      queue: 0,
+      human: 0,
+      blocked: 0,
+      added: 0,
+      removed: 0,
+      issues: [],
+      sourceCounts,
+    };
+    const statuslineTokens = afkTokens(afk);
+    const statuslineSrc = new Map(
+      statuslineTokens
+        .filter((t) => t.label !== "wrk=" && t.label !== "rdy=" && t.label !== "hmn=" &&
+                       t.label !== "blk=" && t.label !== "loc=" && t.label !== "wai=" &&
+                       t.label !== "tok=" && t.label !== "usd=" && t.label !== "#")
+        .map((t) => [t.label.replace("=", ""), Number(t.value)]),
+    );
+
+    // --- Monitor path ---
+    // collectMonitorInputs passes state.origin through CompactState.origin
+    const workers: CompactWorker[] = workerOrigins.map((o, i) => makeWorker(o, `w${i}`));
+    const dashboard = renderCompactDashboard(workers, [], NOW_EPOCH);
+    const header = dashboard.split("\n")[0]!;
+    // Extract `key=value` pairs from the header (skipping `+N -N` diff format)
+    const monitorSrc = new Map<string, number>();
+    for (const match of header.matchAll(/\b([a-z]+)=(\d+)\b/g)) {
+      monitorSrc.set(match[1]!, Number(match[2]));
+    }
+
+    // Both surfaces must agree on every per-source count
+    for (const [origin, count] of statuslineSrc) {
+      expect(monitorSrc.get(origin)).toBe(count);
+    }
+    for (const [origin, count] of monitorSrc) {
+      expect(statuslineSrc.get(origin)).toBe(count);
+    }
+  });
+
+  it("new origin labels render without touching render code (enum extensibility)", () => {
+    // A previously-unknown origin `urgent` flows through both surfaces unchanged
+    const afk: AfkInput = {
+      workers: 1,
+      queue: 0,
+      human: 0,
+      blocked: 0,
+      added: 0,
+      removed: 0,
+      issues: [],
+      sourceCounts: [{ origin: "urgent", count: 1 }],
+    };
+    const tokens = afkTokens(afk);
+    expect(tokens.find((t) => t.label === "urgent=" && t.value === "1")).toBeDefined();
+
+    const workers: CompactWorker[] = [makeWorker("urgent", "w1")];
+    const dashboard = renderCompactDashboard(workers, [], NOW_EPOCH);
+    expect(dashboard.split("\n")[0]).toContain("urgent=1");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #930. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #930

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785436655&installation_id=129708444&pr_number=957&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F957&signature=23250b194b2c981dd4218d9e2498f2b1cfadd1e21a8c7f87d9c00b82069f2a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->