### PR TITLE
merge: #936 S12 — browser-bridge package + red-browser surface (lavish-half)

### DIFF
--- a/apps/red-browser/package.json
+++ b/apps/red-browser/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@reddb-io/red-browser",
+  "version": "1.252.0",
+  "private": true,
+  "type": "module",
+  "description": "Red Browser CLI surface — opens a local annotation bridge for HTML artifacts, long-polls human feedback, and enforces the layout-audit gate.",
+  "license": "Apache-2.0",
+  "scripts": {
+    "dev": "node --import tsx src/cli.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@reddb-io/browser-bridge": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/red-browser/src/cli.ts
+++ b/apps/red-browser/src/cli.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { annotateCommand } from "./commands/annotate.js";
+
+const [, , cmd, ...rest] = process.argv;
+
+async function main(): Promise<void> {
+  switch (cmd) {
+    case "annotate":
+      await annotateCommand(rest);
+      break;
+    default:
+      process.stderr.write(
+        "Usage: red-browser annotate <html-file> [--timeout <ms>] [--skip-audit]\n",
+      );
+      process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(msg + "\n");
+  process.exit(1);
+});

--- a/apps/red-browser/src/commands/annotate.ts
+++ b/apps/red-browser/src/commands/annotate.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { openBridge } from "@reddb-io/browser-bridge";
+
+export async function annotateCommand(args: string[]): Promise<void> {
+  const filePath = args.find((a) => !a.startsWith("--"));
+  if (!filePath) {
+    process.stderr.write("Error: html-file argument required\n");
+    process.exit(1);
+  }
+
+  const skipAudit = args.includes("--skip-audit");
+  const timeoutIdx = args.indexOf("--timeout");
+  const annotationTimeoutMs =
+    timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1] ?? "60000", 10) : 60_000;
+
+  const html = await readFile(filePath, "utf8");
+  const bridge = await openBridge(html);
+
+  process.stderr.write(`Bridge ready — open in your browser: ${bridge.url}\n`);
+
+  if (!skipAudit) {
+    const audit = await bridge.layoutAudit(30_000);
+    if (!audit.pass) {
+      process.stderr.write(
+        `Layout audit FAILED — fix violations before declaring done:\n`,
+      );
+      for (const v of audit.violations) {
+        process.stderr.write(`  [${v.type}] ${v.selector}: ${v.detail}\n`);
+      }
+      await bridge.close();
+      process.exit(2);
+    }
+    process.stderr.write("Layout audit passed.\n");
+  }
+
+  const annotation = await bridge.waitForAnnotation(annotationTimeoutMs);
+  process.stdout.write(JSON.stringify(annotation, null, 2) + "\n");
+  await bridge.close();
+}

--- a/apps/red-browser/tests/annotation-roundtrip.test.ts
+++ b/apps/red-browser/tests/annotation-roundtrip.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { openBridge, type BrowserBridge } from "@reddb-io/browser-bridge";
+
+const SIMPLE_HTML = `<!DOCTYPE html><html><body><p id="intro">Hello world</p></body></html>`;
+
+describe("annotation round-trip", () => {
+  let bridge: BrowserBridge | undefined;
+
+  afterEach(async () => {
+    await bridge?.close();
+    bridge = undefined;
+  });
+
+  it("waitForAnnotation resolves with the posted element and char range", async () => {
+    bridge = await openBridge(SIMPLE_HTML);
+
+    const payload = {
+      element: { tagName: "P", id: "intro", className: "", xpath: '//*[@id="intro"]' },
+      charRange: { start: 0, end: 5, text: "Hello" },
+      timestamp: new Date().toISOString(),
+    };
+
+    const [received] = await Promise.all([
+      bridge.waitForAnnotation(5_000),
+      fetch(`${bridge.url}/api/annotate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    ]);
+
+    expect(received.element.tagName).toBe("P");
+    expect(received.element.id).toBe("intro");
+    expect(received.element.xpath).toBe('//*[@id="intro"]');
+    expect(received.charRange.start).toBe(0);
+    expect(received.charRange.end).toBe(5);
+    expect(received.charRange.text).toBe("Hello");
+  });
+
+  it("queues multiple annotations when called before waitForAnnotation", async () => {
+    bridge = await openBridge(SIMPLE_HTML);
+
+    const make = (text: string) => ({
+      element: { tagName: "P", id: "intro", className: "", xpath: '//*[@id="intro"]' },
+      charRange: { start: 0, end: text.length, text },
+      timestamp: new Date().toISOString(),
+    });
+
+    await fetch(`${bridge.url}/api/annotate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(make("Hello")),
+    });
+    await fetch(`${bridge.url}/api/annotate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(make("world")),
+    });
+
+    const first = await bridge.waitForAnnotation(5_000);
+    const second = await bridge.waitForAnnotation(5_000);
+
+    expect(first.charRange.text).toBe("Hello");
+    expect(second.charRange.text).toBe("world");
+  });
+
+  it("GET / serves the HTML artifact with the annotation SDK injected", async () => {
+    bridge = await openBridge(SIMPLE_HTML);
+
+    const res = await fetch(`${bridge.url}/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain('<p id="intro">Hello world</p>');
+    expect(html).toContain("/api/annotate");
+    expect(html).toContain("mouseup");
+    expect(html).toContain("charRange");
+  });
+});

--- a/apps/red-browser/tests/layout-audit.test.ts
+++ b/apps/red-browser/tests/layout-audit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { openBridge, type BrowserBridge } from "@reddb-io/browser-bridge";
+
+const HTML = `<!DOCTYPE html><html><body><p>Test</p></body></html>`;
+
+describe("layout-audit gate", () => {
+  let bridge: BrowserBridge | undefined;
+
+  afterEach(async () => {
+    await bridge?.close();
+    bridge = undefined;
+  });
+
+  it("blocks done when overflow violations are present", async () => {
+    bridge = await openBridge(HTML);
+
+    const [result] = await Promise.all([
+      bridge.layoutAudit(5_000),
+      fetch(`${bridge.url}/api/layout-audit-result`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          violations: [
+            {
+              type: "overflow",
+              selector: "div#wrapper",
+              detail: "scrollWidth=300 clientWidth=200",
+            },
+          ],
+        }),
+      }),
+    ]);
+
+    expect(result.pass).toBe(false);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].type).toBe("overflow");
+    expect(result.violations[0].selector).toBe("div#wrapper");
+  });
+
+  it("blocks done when cutoff violations are present", async () => {
+    bridge = await openBridge(HTML);
+
+    const [result] = await Promise.all([
+      bridge.layoutAudit(5_000),
+      fetch(`${bridge.url}/api/layout-audit-result`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          violations: [
+            {
+              type: "cutoff",
+              selector: "section#hero",
+              detail: "scrollWidth=500 clientWidth=320",
+            },
+          ],
+        }),
+      }),
+    ]);
+
+    expect(result.pass).toBe(false);
+    expect(result.violations[0].type).toBe("cutoff");
+  });
+
+  it("blocks done when overlap violations are present", async () => {
+    bridge = await openBridge(HTML);
+
+    const [result] = await Promise.all([
+      bridge.layoutAudit(5_000),
+      fetch(`${bridge.url}/api/layout-audit-result`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          violations: [
+            {
+              type: "overlap",
+              selector: "header + aside",
+              detail: "elements overlap",
+            },
+          ],
+        }),
+      }),
+    ]);
+
+    expect(result.pass).toBe(false);
+    expect(result.violations[0].type).toBe("overlap");
+  });
+
+  it("allows done when there are no violations", async () => {
+    bridge = await openBridge(HTML);
+
+    const [result] = await Promise.all([
+      bridge.layoutAudit(5_000),
+      fetch(`${bridge.url}/api/layout-audit-result`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ violations: [] }),
+      }),
+    ]);
+
+    expect(result.pass).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it("GET / serves the HTML artifact with the layout-audit SDK injected", async () => {
+    bridge = await openBridge(HTML);
+
+    const res = await fetch(`${bridge.url}/`);
+    const html = await res.text();
+
+    expect(html).toContain("/api/layout-audit-result");
+    expect(html).toContain("scrollWidth");
+    expect(html).toContain("getBoundingClientRect");
+  });
+});

--- a/apps/red-browser/tsconfig.json
+++ b/apps/red-browser/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests", "../../packages/browser-bridge/**/*.ts"]
+}

--- a/apps/red-browser/vitest.config.ts
+++ b/apps/red-browser/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    pool: "forks",
+    fileParallelism: false,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/packages/browser-bridge/annotation-sdk.ts
+++ b/packages/browser-bridge/annotation-sdk.ts
@@ -1,0 +1,44 @@
+/**
+ * Client-side annotation SDK injected into HTML artifacts.
+ *
+ * Captures the element and exact character range of any text selection the
+ * human makes, then POSTs the result to the bridge server.  The placeholder
+ * `__BRIDGE_URL__` is replaced at inject-time with the actual server origin.
+ */
+export const ANNOTATION_SDK = `(function(){
+  document.addEventListener("mouseup",function(){
+    var sel=window.getSelection();
+    if(!sel||sel.rangeCount===0||sel.isCollapsed)return;
+    var range=sel.getRangeAt(0);
+    var el=range.commonAncestorContainer;
+    if(el.nodeType===3)el=el.parentElement;
+    if(!el)return;
+    function xpathOf(n){
+      if(!n||n===document.documentElement)return"/html";
+      if(n.id)return'//*[@id="'+n.id+'"]';
+      if(n===document.body)return"/html/body";
+      var i=1,s=n.previousElementSibling;
+      while(s){if(s.tagName===n.tagName)i++;s=s.previousElementSibling;}
+      return xpathOf(n.parentElement)+"/"+n.tagName.toLowerCase()+"["+i+"]";
+    }
+    var pre=document.createRange();
+    pre.selectNodeContents(el);
+    pre.setEnd(range.startContainer,range.startOffset);
+    var start=pre.toString().length;
+    var text=range.toString();
+    fetch("__BRIDGE_URL__/api/annotate",{
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      body:JSON.stringify({
+        element:{
+          tagName:el.tagName,
+          id:el.id||"",
+          className:typeof el.className==="string"?el.className:"",
+          xpath:xpathOf(el)
+        },
+        charRange:{start:start,end:start+text.length,text:text},
+        timestamp:new Date().toISOString()
+      })
+    }).catch(function(){});
+  });
+})();`;

--- a/packages/browser-bridge/index.ts
+++ b/packages/browser-bridge/index.ts
@@ -1,0 +1,8 @@
+export type {
+  AnnotationResult,
+  LayoutViolation,
+  LayoutAuditResult,
+  BrowserBridge,
+} from "./server.js";
+export { openBridge } from "./server.js";
+export { injectBridgeSdk } from "./inject.js";

--- a/packages/browser-bridge/inject.ts
+++ b/packages/browser-bridge/inject.ts
@@ -1,0 +1,23 @@
+import { ANNOTATION_SDK } from "./annotation-sdk.js";
+import { LAYOUT_AUDIT_SDK } from "./layout-audit-sdk.js";
+
+/**
+ * Injects the annotation and layout-audit SDKs into an HTML artifact.
+ *
+ * Scripts are inserted immediately before `</body>` (or appended if the tag is
+ * absent).  The `__BRIDGE_URL__` placeholder in each SDK is replaced with the
+ * actual bridge server origin so fetch calls land on the right host:port.
+ */
+export function injectBridgeSdk(html: string, bridgeUrl: string): string {
+  const annotationScript = ANNOTATION_SDK.replaceAll("__BRIDGE_URL__", bridgeUrl);
+  const auditScript = LAYOUT_AUDIT_SDK.replaceAll("__BRIDGE_URL__", bridgeUrl);
+  const scripts =
+    `<script>\n${annotationScript}\n</script>\n` +
+    `<script>\n${auditScript}\n</script>\n`;
+
+  const closeBody = html.lastIndexOf("</body>");
+  if (closeBody !== -1) {
+    return html.slice(0, closeBody) + scripts + html.slice(closeBody);
+  }
+  return html + scripts;
+}

--- a/packages/browser-bridge/layout-audit-sdk.ts
+++ b/packages/browser-bridge/layout-audit-sdk.ts
@@ -1,0 +1,56 @@
+/**
+ * Client-side layout-audit SDK injected into HTML artifacts.
+ *
+ * Runs on `window.load`, detects overflow, cutoff, and overlapping elements,
+ * then POSTs the violation list to the bridge server.  The placeholder
+ * `__BRIDGE_URL__` is replaced at inject-time with the actual server origin.
+ */
+export const LAYOUT_AUDIT_SDK = `(function(){
+  function detectViolations(){
+    var violations=[];
+    var all=Array.prototype.slice.call(document.querySelectorAll("*"));
+    all.forEach(function(el){
+      if(el===document.documentElement||el===document.body)return;
+      var overflowsX=el.scrollWidth>el.clientWidth+2;
+      var overflowsY=el.scrollHeight>el.clientHeight+2;
+      if(overflowsX||overflowsY){
+        var cs=window.getComputedStyle(el);
+        var ov=[cs.overflow,cs.overflowX,cs.overflowY].join(" ");
+        var sel=el.tagName.toLowerCase()+(el.id?"#"+el.id:"");
+        if(ov.indexOf("hidden")!==-1){
+          violations.push({type:"cutoff",selector:sel,
+            detail:"scrollWidth="+el.scrollWidth+" clientWidth="+el.clientWidth});
+        } else {
+          violations.push({type:"overflow",selector:sel,
+            detail:"scrollWidth="+el.scrollWidth+" clientWidth="+el.clientWidth});
+        }
+      }
+    });
+    var rects=[];
+    all.forEach(function(el){
+      var r=el.getBoundingClientRect();
+      if(r.width>0&&r.height>0)rects.push({el:el,r:r});
+    });
+    for(var i=0;i<rects.length;i++){
+      for(var j=i+1;j<rects.length;j++){
+        var a=rects[i].r,b=rects[j].r;
+        if(a.left<b.right&&a.right>b.left&&a.top<b.bottom&&a.bottom>b.top){
+          if(!rects[i].el.contains(rects[j].el)&&!rects[j].el.contains(rects[i].el)){
+            var sA=rects[i].el.tagName.toLowerCase()+(rects[i].el.id?"#"+rects[i].el.id:"");
+            var sB=rects[j].el.tagName.toLowerCase()+(rects[j].el.id?"#"+rects[j].el.id:"");
+            violations.push({type:"overlap",selector:sA+" + "+sB,detail:"elements overlap"});
+          }
+        }
+      }
+    }
+    return violations;
+  }
+  window.addEventListener("load",function(){
+    var violations=detectViolations();
+    fetch("__BRIDGE_URL__/api/layout-audit-result",{
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      body:JSON.stringify({violations:violations})
+    }).catch(function(){});
+  });
+})();`;

--- a/packages/browser-bridge/package.json
+++ b/packages/browser-bridge/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@reddb-io/browser-bridge",
+  "version": "1.252.0",
+  "private": true,
+  "type": "module",
+  "description": "Local CLI-to-browser annotation bridge: injects an annotation SDK into HTML artifacts, captures element and character-range selections, and delivers feedback to the agent. Includes a layout-audit gate that blocks done on overflow / cutoff / overlap.",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./index.ts"
+  }
+}

--- a/packages/browser-bridge/server.ts
+++ b/packages/browser-bridge/server.ts
@@ -1,0 +1,186 @@
+import http from "node:http";
+import { injectBridgeSdk } from "./inject.js";
+
+export interface AnnotationResult {
+  element: {
+    tagName: string;
+    id: string;
+    className: string;
+    xpath: string;
+  };
+  charRange: {
+    start: number;
+    end: number;
+    text: string;
+  };
+  timestamp: string;
+}
+
+export interface LayoutViolation {
+  type: "overflow" | "cutoff" | "overlap";
+  selector: string;
+  detail: string;
+}
+
+export interface LayoutAuditResult {
+  pass: boolean;
+  violations: LayoutViolation[];
+}
+
+export interface BrowserBridge {
+  /** Full URL of the bridge server, e.g. `http://127.0.0.1:54321`. */
+  url: string;
+  port: number;
+  /**
+   * Resolves with the next annotation the human posts.
+   * Long-polls until the human selects text and the SDK POSTs back.
+   */
+  waitForAnnotation(timeoutMs?: number): Promise<AnnotationResult>;
+  /**
+   * Resolves with the layout-audit result posted by the injected audit SDK
+   * on page load.  Returns `{pass: false, violations: [...]}` when the page
+   * has overflow, cutoff, or overlapping elements.
+   */
+  layoutAudit(timeoutMs?: number): Promise<LayoutAuditResult>;
+  close(): Promise<void>;
+}
+
+class DeferredQueue<T> {
+  private readonly queue: T[] = [];
+  private readonly waiters: Array<{ resolve: (v: T) => void; reject: (e: Error) => void }> = [];
+  private closed = false;
+
+  push(value: T): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve(value);
+    } else {
+      this.queue.push(value);
+    }
+  }
+
+  take(): Promise<T> {
+    if (this.closed) return Promise.reject(new Error("bridge closed"));
+    if (this.queue.length > 0) return Promise.resolve(this.queue.shift()!);
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  drain(err: Error): void {
+    this.closed = true;
+    for (const w of this.waiters) w.reject(err);
+    this.waiters.length = 0;
+  }
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer!: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * Opens a local HTTP bridge server that serves an HTML artifact with the
+ * annotation and layout-audit SDKs injected.  Returns a handle for long-polling
+ * the human's feedback.
+ */
+export async function openBridge(
+  html: string,
+  opts?: { port?: number },
+): Promise<BrowserBridge> {
+  const annotations = new DeferredQueue<AnnotationResult>();
+  const auditResults = new DeferredQueue<LayoutAuditResult>();
+
+  const server = http.createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(opts?.port ?? 0, "127.0.0.1", () => resolve());
+  });
+
+  const addr = server.address() as { port: number };
+  const port = addr.port;
+  const bridgeUrl = `http://127.0.0.1:${port}`;
+  const injectedHtml = injectBridgeSdk(html, bridgeUrl);
+
+  server.on("request", (req, res) => {
+    const url = req.url ?? "/";
+    const method = req.method ?? "GET";
+
+    if (method === "GET" && url === "/") {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(injectedHtml);
+      return;
+    }
+
+    if (method === "POST" && url === "/api/annotate") {
+      readBody(req)
+        .then((body) => {
+          annotations.push(JSON.parse(body) as AnnotationResult);
+          res.writeHead(204);
+          res.end();
+        })
+        .catch(() => {
+          res.writeHead(400);
+          res.end("Bad Request");
+        });
+      return;
+    }
+
+    if (method === "POST" && url === "/api/layout-audit-result") {
+      readBody(req)
+        .then((body) => {
+          const { violations } = JSON.parse(body) as { violations: LayoutViolation[] };
+          auditResults.push({ pass: violations.length === 0, violations });
+          res.writeHead(204);
+          res.end();
+        })
+        .catch(() => {
+          res.writeHead(400);
+          res.end("Bad Request");
+        });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("Not Found");
+  });
+
+  const closeErr = new Error("bridge closed");
+
+  return {
+    url: bridgeUrl,
+    port,
+
+    waitForAnnotation(timeoutMs = 60_000): Promise<AnnotationResult> {
+      return withTimeout(annotations.take(), timeoutMs, "waitForAnnotation");
+    },
+
+    layoutAudit(timeoutMs = 30_000): Promise<LayoutAuditResult> {
+      return withTimeout(auditResults.take(), timeoutMs, "layoutAudit");
+    },
+
+    close(): Promise<void> {
+      annotations.drain(closeErr);
+      auditResults.drain(closeErr);
+      return new Promise((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,27 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.19)
 
+  apps/red-browser:
+    dependencies:
+      '@reddb-io/browser-bridge':
+        specifier: workspace:*
+        version: link:../../packages/browser-bridge
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.19)
+
+  packages/browser-bridge: {}
+
   packages/build-info: {}
 
   packages/red-castle:


### PR DESCRIPTION
Automated AFK landing for #936. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #936

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785437628&installation_id=129708444&pr_number=958&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F958&signature=59fb1dee4059389667ab678262ece0cb358be716d61af584d478ca1a23c76ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool for opening HTML files in a local browser bridge and generating annotations.
  * Added automatic in-page support for capturing text selections and layout checks in the browser.
  * Added support for serving annotated pages with injected browser-side helpers.

* **Bug Fixes**
  * Improved handling of invalid input and unsupported commands with clearer usage output.
  * Added safeguards for timeouts, missing selections, and audit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->