### PR TITLE
merge: #934 S9 — event-driven supervision

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -38,6 +38,7 @@ import * as gitx from "../runtime/git.js";
 import { planReconcileSweep, executeUnblockSweep } from "../core/boot-sweep.js";
 import { removeDir as removeDirNative } from "../runtime/fs.js";
 import { killTreeAndWait } from "../runtime/kill-tree.js";
+import { buildStateChangeWake } from "../runtime/state-watch.js";
 import { resolveFleetHooks } from "../core/fleet-hook-config.js";
 import { dispatchFleetHook } from "../core/fleet-hook-dispatcher.js";
 import { makeHookExec, makeHookResolveOptions } from "../runtime/hooks.js";
@@ -470,6 +471,12 @@ function buildSupervisorDeps(
       },
     },
     now,
+    // Event-driven wake (#934): a recursive fs.watch over the workers root resolves
+    // the supervisor's inter-tick wait the instant a worker rewrites its
+    // afk.state.json (claim / stage / phase / progress transition), so the loop
+    // reacts to a state change immediately instead of waiting out the safety-net
+    // timer. Best-effort: a watch failure degrades to pure-timer polling.
+    wake: buildStateChangeWake(join(tmpDir, "workers")),
     // Env for the bounded stalled re-claim cap (#402): RED_AFK_RETRY_STALLED.
     recoveryEnv: process.env,
     // Per-tick liveness line into afk-supervisor.log (best-effort). Makes a
@@ -560,6 +567,9 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   const stateFile = paths.fleetStatePath;
 
   await import("../runtime/fs.js").then((m) => m.ensureDir(tmp));
+  // Ensure the workers root exists so the event-driven wake's fs.watch (#934) can
+  // attach from boot rather than waiting for the first worker to create it.
+  await import("../runtime/fs.js").then((m) => m.ensureDir(join(tmp, "workers")));
   // single-supervisor lock
   if (existsSync(pidFile)) {
     try {

--- a/apps/dev/src/core/event-wake.ts
+++ b/apps/dev/src/core/event-wake.ts
@@ -1,0 +1,123 @@
+// event-wake — the supervisor's wake source (issue #934). The fleet supervisor's
+// health-check loop historically slept a FIXED poll interval between ticks
+// (`deps.proc.sleep(pollIntervalS)`), so a worker whose state changed the instant
+// after a tick waited a full interval before the supervisor noticed. Event-driven
+// supervision races that timer against a worker-state-change EVENT: whichever
+// fires first wakes the loop, so a state change is reacted to immediately while
+// the timer is retained purely as a safety-net fallback (no regression when an
+// event is missed or no event lane is wired).
+//
+// Everything here is PURE control flow over an injected `sleep` and an injected
+// {@link WakeSource}. The real event source (an fs.watch over the worker state
+// tree) lives in the runtime/command layer; this module never touches the
+// filesystem, so the race + the wake accounting are unit-testable without timers.
+
+/** Which lane woke the supervisor loop this iteration. */
+export type WakeReason = "event" | "timer";
+
+/**
+ * A source of worker state-change events. `waitForEvent` resolves the moment the
+ * next state change is observed (a worker writing its afk.state.json / appending
+ * a heartbeat-firehose record). The `signal` is aborted by {@link waitForNextWake}
+ * when the OTHER lane (the timer) wins the race, so the implementation must tear
+ * down its watcher on abort — never leak an fs.watch per loop iteration. A throw
+ * on setup is swallowed by waitForNextWake and degrades to the timer (safety-net).
+ */
+export interface WakeSource {
+  waitForEvent(signal: AbortSignal): Promise<void>;
+}
+
+/** Injected timer: sleeps `ms`, optionally honouring `signal` so the loser leg is
+ * torn down when the event wins. The supervisor's real `proc.sleep` ignores the
+ * signal (a stray setTimeout settling late is harmless), but a signal-aware sleep
+ * lets a test prove the timer leg is cancelled. */
+export type WakeSleep = (ms: number, signal?: AbortSignal) => Promise<void>;
+
+export interface WaitForNextWakeOptions {
+  /** The safety-net timer interval (ms) — the supervisor's poll cadence. The loop
+   * is GUARANTEED to wake within this bound even if every event is missed. */
+  fallbackMs: number;
+  /** Injected timer. */
+  sleep: WakeSleep;
+  /** The event lane. Absent → pure-timer behaviour (back-compat / safety-net only). */
+  wake?: WakeSource;
+}
+
+/**
+ * Wait for the next supervisor wake, returning which lane fired. Races the
+ * safety-net timer against the worker-state-change event; the loser's
+ * AbortSignal is fired so its watcher/timer is torn down. When no {@link
+ * WakeSource} is wired (or it throws on setup) this collapses to a plain
+ * `sleep(fallbackMs)` and returns `"timer"` — identical to the pre-event loop, so
+ * the timer poll is always retained as a fallback with no regression.
+ */
+export async function waitForNextWake(opts: WaitForNextWakeOptions): Promise<WakeReason> {
+  const { fallbackMs, sleep, wake } = opts;
+
+  if (!wake) {
+    await sleep(fallbackMs);
+    return "timer";
+  }
+
+  // Build the event leg first so a synchronous throw on setup (e.g. fs.watch
+  // unavailable) degrades to the pure timer rather than rejecting the race.
+  const controller = new AbortController();
+  let eventLeg: Promise<void>;
+  try {
+    eventLeg = wake.waitForEvent(controller.signal);
+  } catch {
+    await sleep(fallbackMs);
+    return "timer";
+  }
+
+  const TIMER = Symbol("timer");
+  try {
+    const winner = await Promise.race<symbol | void>([
+      sleep(fallbackMs, controller.signal).then(() => TIMER),
+      eventLeg.then(() => undefined),
+    ]);
+    return winner === TIMER ? "timer" : "event";
+  } finally {
+    // Tear down the losing leg (close the fs.watch, cancel a signal-aware sleep).
+    // A signal-unaware leg is simply left to settle on its own — harmless.
+    controller.abort();
+  }
+}
+
+/**
+ * Cumulative wake accounting, carried on the supervisor runtime so the fleet can
+ * report — and a test can assert — how event-driven the loop actually ran. Pure
+ * data; {@link recordWake} mutates it in place each iteration (matching the
+ * supervisor's in-place slot bookkeeping).
+ */
+export interface WakeStats {
+  /** Total loop wakes observed. */
+  total: number;
+  /** Wakes driven by a worker state-change event. */
+  event: number;
+  /** Wakes driven by the safety-net timer (idle polls under the baseline). */
+  timer: number;
+}
+
+export function freshWakeStats(): WakeStats {
+  return { total: 0, event: 0, timer: 0 };
+}
+
+/** Record one wake by its lane. */
+export function recordWake(stats: WakeStats, reason: WakeReason): void {
+  stats.total += 1;
+  if (reason === "event") stats.event += 1;
+  else stats.timer += 1;
+}
+
+/**
+ * The fraction of wakes that were event-driven (0..1) — the measurable reduction
+ * in idle wake-ups vs the pure-timer baseline. Under the baseline EVERY wake is a
+ * timer poll (many of them idle, finding nothing changed); each event-driven wake
+ * is one that instead fired exactly when a worker's state changed, displacing an
+ * idle poll. So `event / total` is the share of the baseline's idle polls the
+ * event lane eliminated. 0 when no wakes have happened yet (or none were events).
+ */
+export function idleWakeReduction(stats: WakeStats): number {
+  return stats.total === 0 ? 0 : stats.event / stats.total;
+}

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -15,6 +15,13 @@
 // workers own all claim-lock / state / queue semantics (supervisor.sh header).
 
 import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from "./reaper-signal.js";
+import {
+  freshWakeStats,
+  recordWake,
+  waitForNextWake,
+  type WakeSource,
+  type WakeStats,
+} from "./event-wake.js";
 import { buildEnvelope } from "./envelope.js";
 import { dispose } from "./disposition.js";
 import { type RecoveryEnv } from "./recovery.js";
@@ -59,8 +66,24 @@ export interface SupervisorConfig {
    * (RED_AFK_RUNNER, default "claude"). */
   runner: string;
   /** RED_AFK_POLL_S — seconds the health-check loop sleeps between ticks
-   * (default 15, matching supervisor.sh). Prevents the loop from busy-spinning. */
+   * (default 15, matching supervisor.sh). Prevents the loop from busy-spinning.
+   * This is the interval used when NO event lane is wired (`deps.wake` absent) —
+   * the unchanged pre-#934 cadence, so a fleet without event-driven supervision
+   * behaves exactly as before. */
   pollIntervalS: number;
+  /**
+   * RED_AFK_WAKE_FALLBACK_S — the safety-net timer interval (seconds, default 60)
+   * used ONLY when an event lane (`deps.wake`) is wired (#934). With events
+   * driving responsiveness, the loop no longer needs the tight `pollIntervalS`
+   * poll to notice a state change promptly, so the idle timer can relax to this
+   * longer interval — that is the measurable reduction in idle wake-ups: an idle
+   * fleet wakes every `eventFallbackS` instead of every `pollIntervalS`, while a
+   * real state change still wakes it immediately. The threshold-based stall
+   * detector (600s/1800s) is unaffected by the coarser idle cadence. 0 /
+   * non-numeric falls back to the default; values below `pollIntervalS` simply
+   * poll more often (harmless).
+   */
+  eventFallbackS: number;
   /**
    * RED_AFK_TICK_TIMEOUT_S — per-tick wall-clock ceiling (default 120). A single
    * supervise tick should complete in well under a second; if one exceeds this
@@ -125,6 +148,7 @@ export const SUPERVISOR_DEFAULTS = {
   stallKillThresholdS: 1800,
   runner: "claude",
   pollIntervalS: 15,
+  eventFallbackS: 60,
   tickTimeoutS: 120,
   supervisorStaleS: 300,
   progressStaleS: 900,
@@ -159,6 +183,11 @@ export function resolveSupervisorConfig(
     ),
     runner: env.RED_AFK_RUNNER && env.RED_AFK_RUNNER.length > 0 ? env.RED_AFK_RUNNER : SUPERVISOR_DEFAULTS.runner,
     pollIntervalS: num("RED_AFK_POLL_S", SUPERVISOR_DEFAULTS.pollIntervalS),
+    // 0 would make the safety-net fire instantly (busy-spin) — floor it back to
+    // the default so a typo can never disable the relaxed idle cadence.
+    eventFallbackS:
+      num("RED_AFK_WAKE_FALLBACK_S", SUPERVISOR_DEFAULTS.eventFallbackS) ||
+      SUPERVISOR_DEFAULTS.eventFallbackS,
     // 0 is a valid /^[0-9]+$/ match but would abandon every tick instantly, so
     // floor it back to the default — the guard can never be silently disabled.
     tickTimeoutS:
@@ -577,6 +606,17 @@ export interface SupervisorDeps {
   /** Current epoch seconds (date +%s), injected for determinism. */
   now(): number;
   /**
+   * Event-driven wake source (#934): resolves the instant a worker's state
+   * changes (its afk.state.json is rewritten / a heartbeat-firehose record is
+   * appended), letting the health-check loop react WITHOUT waiting out the full
+   * `pollIntervalS` timer. The timer is always retained as the safety-net
+   * fallback — whichever fires first wins the per-iteration race. Absent → the
+   * loop sleeps the plain poll interval exactly as before (back-compat / no
+   * regression when no event lane is wired). The real source is an fs.watch over
+   * the worker state tree, built in commands/supervise.ts.
+   */
+  wake?: WakeSource;
+  /**
    * Env view for the bounded stalled re-claim cap (#402). Read by the stall-reaper
    * to resolve `RED_AFK_RETRY_STALLED` via recovery.ts. Defaults to {} (the
    * built-in cap) when absent, so tests can omit it.
@@ -701,6 +741,13 @@ export interface SupervisorState {
    * queue still self-heals within one interval without a per-tick gh cost.
    */
   lastUnblockSweepEpoch: number;
+  /**
+   * Cumulative wake accounting (#934): how many health-check loop iterations woke
+   * on a worker state-change event vs the safety-net timer. Lets the supervisor
+   * log — and a test assert — the measurable reduction in idle (timer) wake-ups
+   * the event lane delivered. Updated by runSupervisor after each iteration.
+   */
+  wakeStats: WakeStats;
 }
 
 /** Build the initial runtime for `target` slots. */
@@ -709,6 +756,7 @@ export function initSupervisorState(target: number): SupervisorState {
     slots: Array.from({ length: target }, () => freshSlot()),
     lastProgressEpoch: 0,
     lastUnblockSweepEpoch: 0,
+    wakeStats: freshWakeStats(),
   };
 }
 
@@ -1774,7 +1822,24 @@ export async function runSupervisor(
       }
       return;
     }
-    await deps.proc.sleep(config.pollIntervalS * 1000);
+    // Event-driven wake (#934): race the safety-net poll timer against the next
+    // worker-state-change event. Whichever fires first ends the wait, so a state
+    // change is reacted to immediately instead of waiting out the full interval,
+    // while the timer still guarantees a wake within `pollIntervalS` even if every
+    // event is missed. With no `deps.wake` wired this is exactly the old
+    // `sleep(pollIntervalS)` and always returns "timer" (no regression).
+    const fallbackS = deps.wake ? config.eventFallbackS : config.pollIntervalS;
+    const reason = await waitForNextWake({
+      fallbackMs: fallbackS * 1000,
+      sleep: deps.proc.sleep,
+      wake: deps.wake,
+    });
+    recordWake(state.wakeStats, reason);
+    if (reason === "event") {
+      deps.log?.(
+        `wake: event-driven (idle wakes reduced — ${state.wakeStats.event}/${state.wakeStats.total} wakes event-driven)`,
+      );
+    }
   }
 }
 

--- a/apps/dev/src/runtime/state-watch.ts
+++ b/apps/dev/src/runtime/state-watch.ts
@@ -1,0 +1,76 @@
+// runtime/state-watch.ts — the REAL worker-state-change event source backing the
+// supervisor's event-driven wake (#934). A recursive fs.watch over the workers
+// root (.red/tmp/workers) resolves the supervisor's per-iteration wait the moment
+// a worker rewrites its `afk.state.json` (every claim / stage / phase / progress
+// transition writes that file atomically). The supervisor races this against its
+// safety-net timer, so a state change is reacted to immediately while the timer
+// still guarantees a wake if an event is ever missed.
+//
+// Everything here is best-effort: if fs.watch is unavailable or errors, the
+// returned promise only settles on abort (never spuriously), so the supervisor
+// degrades cleanly to pure-timer polling. The pure race/accounting logic lives in
+// core/event-wake.ts; this file is the thin IO adapter that produces its events.
+
+import { watch, type FSWatcher } from "node:fs";
+import type { WakeSource } from "../core/event-wake.js";
+
+/** The worker state file every worker rewrites on each state transition. A watch
+ * event naming this file is a genuine state change worth waking the supervisor
+ * for; events on the noisier log/firehose siblings are ignored so a `tail -f`
+ * churn does not wake the loop. */
+const STATE_FILENAME = "afk.state.json";
+
+/**
+ * Build the supervisor's worker-state-change {@link WakeSource} over a recursive
+ * fs.watch of `workersRoot`. Each `waitForEvent` call installs a fresh watcher
+ * that resolves on the FIRST `afk.state.json` change (then tears itself down) or
+ * on abort (the supervisor's timer won the race). A watch that cannot be
+ * established — directory missing, recursive unsupported, fs error — resolves
+ * only on abort, so the supervisor falls back to its timer with no spurious wakes.
+ */
+export function buildStateChangeWake(workersRoot: string): WakeSource {
+  return {
+    waitForEvent(signal: AbortSignal): Promise<void> {
+      return new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        let watcher: FSWatcher | undefined;
+        let settled = false;
+        const finish = (): void => {
+          if (settled) return;
+          settled = true;
+          signal.removeEventListener("abort", finish);
+          try {
+            watcher?.close();
+          } catch {
+            // best-effort: a close failure must never throw out of the wake.
+          }
+          resolve();
+        };
+        // The timer-wins / shutdown path: abort tears the watcher down.
+        signal.addEventListener("abort", finish, { once: true });
+        try {
+          watcher = watch(
+            workersRoot,
+            { recursive: true, persistent: false },
+            (_event, filename) => {
+              // filename is null on some platforms; only the named state-file
+              // write is a real state change. A null filename is ignored so log
+              // churn under the tree cannot wake the loop (the timer still covers
+              // the worst case).
+              if (filename && filename.toString().endsWith(STATE_FILENAME)) finish();
+            },
+          );
+          // A watcher error (e.g. the dir is removed mid-watch) must not reject —
+          // close it and leave the timer to drive this iteration's wait.
+          watcher.on("error", () => finish());
+        } catch {
+          // fs.watch unavailable / dir missing: never resolve spuriously — the
+          // abort listener above resolves when the supervisor's timer wins.
+        }
+      });
+    },
+  };
+}

--- a/apps/dev/tests/event-wake.test.ts
+++ b/apps/dev/tests/event-wake.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  freshWakeStats,
+  idleWakeReduction,
+  recordWake,
+  waitForNextWake,
+  type WakeSource,
+} from "../src/core/event-wake.js";
+
+/** A never-firing timer: the fallback sleep that only resolves if nobody beats
+ * it. Lets a test prove the EVENT lane wins without waiting any real time. */
+const neverSleep = () => new Promise<void>(() => undefined);
+
+/** An immediate timer: the fallback that always wins (no event source, or a
+ * silent one). */
+const immediateSleep = () => Promise.resolve();
+
+describe("waitForNextWake", () => {
+  it("returns 'timer' when no wake source is wired (pure-timer fallback)", async () => {
+    const reason = await waitForNextWake({ fallbackMs: 5, sleep: immediateSleep });
+    expect(reason).toBe("timer");
+  });
+
+  it("returns 'event' when a state-change event fires before the timer", async () => {
+    // The headline criterion: an event-driven wake fires on state change WITHOUT
+    // waiting for the timer (the fallback here never resolves).
+    const wake: WakeSource = { waitForEvent: () => Promise.resolve() };
+    const reason = await waitForNextWake({ fallbackMs: 999_999, sleep: neverSleep, wake });
+    expect(reason).toBe("event");
+  });
+
+  it("returns 'timer' when the safety-net fires before any event (no regression)", async () => {
+    // A silent worker fleet: the event source never resolves, so the timer is the
+    // only thing that wakes the loop — exactly the pre-event behaviour.
+    const wake: WakeSource = { waitForEvent: () => new Promise<void>(() => undefined) };
+    const reason = await waitForNextWake({ fallbackMs: 1, sleep: immediateSleep, wake });
+    expect(reason).toBe("timer");
+  });
+
+  it("aborts the wake source's watcher once the timer wins (no leak)", async () => {
+    let aborted = false;
+    const wake: WakeSource = {
+      waitForEvent: (signal) =>
+        new Promise<void>(() => {
+          signal.addEventListener("abort", () => {
+            aborted = true;
+          });
+        }),
+    };
+    await waitForNextWake({ fallbackMs: 1, sleep: immediateSleep, wake });
+    expect(aborted).toBe(true);
+  });
+
+  it("aborts the timer leg once an event wins", async () => {
+    let aborted = false;
+    const wake: WakeSource = { waitForEvent: () => Promise.resolve() };
+    await waitForNextWake({
+      fallbackMs: 999_999,
+      sleep: (_ms, signal) =>
+        new Promise<void>(() => {
+          signal?.addEventListener("abort", () => {
+            aborted = true;
+          });
+        }),
+      wake,
+    });
+    expect(aborted).toBe(true);
+  });
+
+  it("falls back to the timer when the wake source throws on setup", async () => {
+    const wake: WakeSource = {
+      waitForEvent: () => {
+        throw new Error("fs.watch unavailable");
+      },
+    };
+    const reason = await waitForNextWake({ fallbackMs: 1, sleep: immediateSleep, wake });
+    expect(reason).toBe("timer");
+  });
+});
+
+describe("wake accounting", () => {
+  it("records event vs timer wakes and reports a measurable idle-wake reduction", () => {
+    const stats = freshWakeStats();
+    expect(idleWakeReduction(stats)).toBe(0); // no data yet
+
+    recordWake(stats, "timer");
+    recordWake(stats, "event");
+    recordWake(stats, "event");
+    recordWake(stats, "timer");
+
+    expect(stats.total).toBe(4);
+    expect(stats.event).toBe(2);
+    expect(stats.timer).toBe(2);
+    // Half the wakes were event-driven — half the timer-baseline's idle polls
+    // were displaced by a wake that fired exactly on a real state change.
+    expect(idleWakeReduction(stats)).toBe(0.5);
+  });
+
+  it("reports zero reduction for a pure-timer baseline (every wake is an idle poll)", () => {
+    const stats = freshWakeStats();
+    recordWake(stats, "timer");
+    recordWake(stats, "timer");
+    expect(idleWakeReduction(stats)).toBe(0);
+  });
+
+  it("reports full reduction when every wake was event-driven", () => {
+    const stats = freshWakeStats();
+    recordWake(stats, "event");
+    recordWake(stats, "event");
+    expect(idleWakeReduction(stats)).toBe(1);
+  });
+});

--- a/apps/dev/tests/fleet-hooks.test.ts
+++ b/apps/dev/tests/fleet-hooks.test.ts
@@ -43,6 +43,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     stallKillThresholdS: 90,
     runner: "claude",
     pollIntervalS: 15,
+    eventFallbackS: 60,
     tickTimeoutS: 120,
     supervisorStaleS: 300,
     progressStaleS: 900,

--- a/apps/dev/tests/state-watch.test.ts
+++ b/apps/dev/tests/state-watch.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildStateChangeWake } from "../src/runtime/state-watch.js";
+
+/** Resolve true if `p` settles before `ms`, false on timeout — lets a test assert
+ * an event DID / DID NOT fire without hanging the suite. */
+function settledWithin(p: Promise<unknown>, ms: number): Promise<boolean> {
+  return Promise.race([
+    p.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), ms)),
+  ]);
+}
+
+describe("buildStateChangeWake", () => {
+  it("resolves when a worker rewrites its afk.state.json (event-driven wake)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "rs-statewatch-"));
+    const workersRoot = join(root, "workers");
+    const workerDir = join(workersRoot, "w1");
+    mkdirSync(workerDir, { recursive: true });
+    try {
+      const wake = buildStateChangeWake(workersRoot);
+      const controller = new AbortController();
+      const fired = wake.waitForEvent(controller.signal);
+      // Give the watcher a beat to attach, then write the state file.
+      await new Promise((r) => setTimeout(r, 20));
+      writeFileSync(join(workerDir, "afk.state.json"), '{"stage":"impl"}');
+      expect(await settledWithin(fired, 1000)).toBe(true);
+      controller.abort();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves on abort when no event ever fires (timer-wins teardown)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "rs-statewatch-"));
+    const workersRoot = join(root, "workers");
+    mkdirSync(workersRoot, { recursive: true });
+    try {
+      const wake = buildStateChangeWake(workersRoot);
+      const controller = new AbortController();
+      const fired = wake.waitForEvent(controller.signal);
+      // No state file is written; only the abort should settle it.
+      expect(await settledWithin(fired, 60)).toBe(false);
+      controller.abort();
+      expect(await settledWithin(fired, 1000)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades to abort-only when the workers root does not exist (timer fallback)", async () => {
+    const wake = buildStateChangeWake(join(tmpdir(), "rs-statewatch-does-not-exist-12345"));
+    const controller = new AbortController();
+    const fired = wake.waitForEvent(controller.signal);
+    // No spurious resolve from a failed watch setup.
+    expect(await settledWithin(fired, 60)).toBe(false);
+    controller.abort();
+    expect(await settledWithin(fired, 1000)).toBe(true);
+  });
+
+  it("resolves immediately when the signal is already aborted", async () => {
+    const wake = buildStateChangeWake(tmpdir());
+    const controller = new AbortController();
+    controller.abort();
+    expect(await settledWithin(wake.waitForEvent(controller.signal), 1000)).toBe(true);
+  });
+});

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -47,6 +47,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     stallKillThresholdS: 90,
     runner: "claude",
     pollIntervalS: 15,
+    eventFallbackS: 60,
     tickTimeoutS: 120,
     supervisorStaleS: 300,
     progressStaleS: 900,
@@ -1248,6 +1249,50 @@ describe("runSupervisor", () => {
 
     expect(io.sleep).toHaveBeenCalledWith(7000);
     expect(io.sleep.mock.calls.filter((c) => c[0] === 7000)).toHaveLength(1);
+  });
+
+  it("wakes on a worker state-change event without waiting the timer, recording it (#934)", async () => {
+    const { deps, io } = makeDeps({ isAlive: vi.fn(() => true) });
+    // A worker-state-change event that fires immediately each time the loop
+    // begins its inter-tick wait — the event lane beats the (never-needed) timer.
+    const waitForEvent = vi.fn(async () => undefined);
+    const depsWithWake = { ...deps, wake: { waitForEvent } };
+    const state = initSupervisorState(1);
+
+    // tick 1 runs (no stop) → the loop waits and the event wakes it → tick 2 stops.
+    let probes = 0;
+    const stop = () => ++probes >= 2;
+
+    await runSupervisor(
+      state,
+      depsWithWake,
+      config({ target: 1, pollIntervalS: 15, eventFallbackS: 60 }),
+      stop,
+    );
+
+    // The inter-tick wait woke on the EVENT lane, not the safety-net timer.
+    expect(waitForEvent).toHaveBeenCalled();
+    expect(state.wakeStats.event).toBe(1);
+    expect(state.wakeStats.timer).toBe(0);
+    // With an event lane wired the idle safety-net relaxes to eventFallbackS (60s);
+    // the tight 15s poll cadence is never used → fewer idle wake-ups.
+    expect(io.sleep.mock.calls.filter((c) => c[0] === 60000)).toHaveLength(1);
+    expect(io.sleep.mock.calls.filter((c) => c[0] === 15000)).toHaveLength(0);
+  });
+
+  it("falls back to the timer cadence when no event lane is wired (no regression)", async () => {
+    const { deps, io } = makeDeps({ isAlive: vi.fn(() => true) });
+    const state = initSupervisorState(1);
+    let probes = 0;
+    const stop = () => ++probes >= 2;
+
+    // No deps.wake → pure-timer loop at the unchanged 15s poll cadence.
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15 }), stop);
+
+    expect(state.wakeStats.timer).toBe(1);
+    expect(state.wakeStats.event).toBe(0);
+    expect(io.sleep.mock.calls.filter((c) => c[0] === 15000)).toHaveLength(1);
+    expect(io.sleep.mock.calls.filter((c) => c[0] === 60000)).toHaveLength(0);
   });
 
   it("emits one structured fleet heartbeat per supervise tick with queue and slot counts", async () => {


### PR DESCRIPTION
Automated AFK landing for #934. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #934

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785437739&installation_id=129708444&pr_number=959&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F959&signature=205ecefe1283f78d10fd967c4edfad766cde29c5763cf7ad56846e1a4be42368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->