### PR TITLE
merge: #939 S5 — /ship retirement → requeue into the no-agent landing lane (ADR 0055)

### DIFF
--- a/apps/dev/node_modules
+++ b/apps/dev/node_modules
@@ -1,0 +1,1 @@
+/home/cyber/Work/reddb.io/red-skills/apps/dev/node_modules

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -9,10 +9,27 @@
 // human guidance as a directive comment. The pure planner lives in
 // `core/requeue.ts`; `/hitl` is the interactive sibling for when the human
 // decision still has to be extracted.
+//
+// ADR 0081 adds an `--adopt-branch BRANCH` mode: when a maintainer has done the
+// work by hand on an existing branch, requeue adopts that branch and routes it
+// through the no-agent landing lane (ADR 0055 reconcile) — gate-only, no agent
+// re-run. The real adopt runner is built here; `RequeueAdoptRunner` is injectable
+// for tests (mirrors how `RequeueGh` is injected).
 
+import { join } from "node:path";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { planRequeue, type RequeuePlan } from "../core/requeue.js";
+import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
+import { makeFeedbackWorktree } from "../runtime/feedback-worktree.js";
+import { afkPaths, resolveRepoSlug } from "../runtime/wire.js";
+import { branchLockPath, isLocked, readLockedBranch } from "../runtime/lock.js";
+import { resolveBase } from "../core/base-resolver.js";
+import * as ghx from "../runtime/gh.js";
+import * as gitx from "../runtime/git.js";
+import type { GhContext } from "../runtime/gh.js";
+import type { GitContext } from "../runtime/git.js";
+import type { Runner } from "../types/runner.js";
 
 export interface RequeueGh {
   view(issue: number): Promise<{ state: string; body: string; labels: string[] }>;
@@ -21,11 +38,30 @@ export interface RequeueGh {
   comment(issue: number, body: string): Promise<void>;
 }
 
+/** Metadata passed to the adopt runner after the requeue transition is applied. */
+export interface RequeueAdoptData {
+  title: string;
+  body: string;
+  labels: readonly string[];
+}
+
+/**
+ * Injectable adopt runner — builds the reconcile deps and calls reconcile()
+ * (ADR 0055 no-agent landing lane) for a hand-done branch. The real runner is
+ * built by `runAdoptLanding`; tests inject a stub. Returns the reconcile outcome.
+ */
+export type RequeueAdoptRunner = (
+  issue: number,
+  branch: string,
+  issueData: RequeueAdoptData,
+) => Promise<"landed" | "parked" | "skipped">;
+
 const REQUEUE_FLAG_SCHEMA = {
   guidance: { kind: "value", coerce: (raw: string): string => raw },
   repo: { kind: "value", aliases: ["R"], coerce: (raw: string): string => raw },
   json: { kind: "boolean" },
   "dry-run": { kind: "boolean" },
+  "adopt-branch": { kind: "value", coerce: (raw: string): string => raw },
 } satisfies FlagSchema;
 
 function parseIssue(raw: string | undefined): number | undefined {
@@ -87,16 +123,138 @@ async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
 }
 
 /**
+ * Build the real adopt runner: wires ReconcileDeps and calls reconcile() (ADR
+ * 0055) for a hand-done branch. Mirrors makeBootReconcileRunner in commands/run.ts
+ * but is scoped to the requeue adopt path — no claim dir, no AFK worker machinery,
+ * no envelope history. Gate authority is the same runFeedback (via feedback worktree).
+ */
+async function runAdoptLanding(
+  issue: number,
+  branch: string,
+  issueData: RequeueAdoptData,
+  cwd: string,
+  repo: string,
+  stdout: NodeJS.WritableStream,
+): Promise<"landed" | "parked" | "skipped"> {
+  const paths = afkPaths(cwd);
+  const ghCtx: GhContext = { cwd, repo };
+  const gitCtx: GitContext = { cwd };
+  const lockPath = branchLockPath(cwd);
+  const feedbackDir = join(paths.tmpDir, "adopt-landing", String(issue));
+  const feedback = makeFeedbackWorktree(cwd, feedbackDir, undefined, {});
+
+  try {
+    const base = await resolveBase(
+      { issueBody: issueData.body },
+      {
+        readLockedBranch: () => readLockedBranch(lockPath),
+        configLockedBranch: undefined,
+        fetchIssueBody: async () => undefined,
+      },
+    );
+
+    // Re-read the issue title for the ReconcileInput — the gh view already gave
+    // us body+labels but not the title. The title is used in landing artifacts.
+    let title = `Issue #${issue}`;
+    try {
+      const r = await execTool("gh", ["issue", "view", String(issue), "--repo", repo, "--json", "title", "-q", ".title"], { cwd });
+      if (r.code === 0 && r.stdout.trim()) title = r.stdout.trim();
+    } catch { /* best-effort */ }
+
+    const reconcileDeps: ReconcileDeps = {
+      gh: {
+        editLabels: async (n, remove, add) => {
+          await ghx.editLabels(ghCtx, n, remove, add);
+          return true;
+        },
+        ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
+        comment: (n, body) => ghx.comment(ghCtx, n, body),
+        close: (n) => ghx.closeIssue(ghCtx, n),
+        listByLabel: (label) => ghx.listByLabel(ghCtx, label),
+        issueClosed: (n) => ghx.issueClosed(ghCtx, n),
+      },
+      git: {
+        headShortSha: () => gitx.headShortSha(gitCtx),
+        deleteLocalBranch: (b) => gitx.deleteLocalBranch(gitCtx, b),
+      },
+      fs: {
+        // Adopt landing has no AFK worker dir to sweep — best-effort no-op.
+        completionSweep: async () => [],
+      },
+      lookups: {
+        changedFiles: (b, bas) => gitx.changedFiles(gitCtx, b, bas),
+        branchPresent: async (b) => {
+          if (await gitx.branchExists(gitCtx, b)) return true;
+          await gitx.fetchBranch(gitCtx, b);
+          return gitx.branchExists(gitCtx, b);
+        },
+        isLocked: () => isLocked(lockPath),
+      },
+      mergeExec: gitx.mergeExec(gitCtx),
+      remoteGit: gitx.gitExec(gitCtx),
+      pnpm: feedback.pnpm,
+      layout: feedback.layout,
+      // Landing worktree for the locked (DIRECT) land path (#572).
+      makeLandingWorktree: async (bas: string) => {
+        const slug = bas.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "base";
+        const dest = join(paths.tmpDir, "landing", `${slug}-adopt-${issue}`);
+        await gitx.worktreeRemove(gitCtx, dest);
+        const ok = await gitx.worktreeAdd(gitCtx, dest, bas);
+        return ok ? dest : null;
+      },
+      removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
+      envelope: {
+        git: gitx.gitExec(gitCtx),
+        poster: async (n, body) => { await ghx.comment(ghCtx, n, body); return true; },
+        // Adopt landing has no attempt marker files — best-effort no-ops.
+        writeMarkers: async () => {},
+        writePosted: async () => {},
+      },
+      nowEpoch: () => Math.floor(Date.now() / 1000),
+      appendIterLog: (line) => { stdout.write(`${line}\n`); },
+      recoveryEnv: process.env,
+    };
+
+    const reconcileInput: ReconcileInput = {
+      issue,
+      title,
+      body: issueData.body,
+      labels: [...issueData.labels],
+      branch,
+      base,
+      repo,
+      repoDir: cwd,
+      remote: "origin",
+      // Synthetic worker identity for logging/envelope — no real AFK worker ran.
+      workerId: "requeue-adopt",
+      attempt: 0,
+      attemptDir: join(paths.tmpDir, "adopt-landing", String(issue)),
+      runner: "claude" as Runner,
+    };
+
+    const result = await reconcile(reconcileDeps, reconcileInput);
+    return result.outcome;
+  } finally {
+    await feedback.cleanup();
+  }
+}
+
+/**
  * `requeue <issue> [--guidance text] [--repo owner/repo] [--json] [--dry-run]`
+ *    `[--adopt-branch BRANCH]`
  * — apply the one-shot requeue transition. A non-parked issue is a no-op (exit
  * 0). `--dry-run` prints the plan without mutating. The `gh` dependency is
- * injectable for tests; production wires the gh CLI.
+ * injectable for tests; production wires the gh CLI. When `--adopt-branch` is
+ * given, the branch is adopted via the no-agent landing lane (ADR 0055
+ * reconcile) after the requeue transition; `adoptRunnerOverride` is injectable
+ * for tests.
  */
 export async function requeueCommand(
   args: readonly string[],
   cwd = process.cwd(),
   stdout: NodeJS.WritableStream = process.stdout,
   ghOverride?: RequeueGh,
+  adoptRunnerOverride?: RequeueAdoptRunner,
 ): Promise<number> {
   const { values, positionals } = parseFlags(args, REQUEUE_FLAG_SCHEMA);
   const issue = parseIssue(positionals[0]);
@@ -107,6 +265,7 @@ export async function requeueCommand(
   const guidance = (values.guidance as string | undefined)?.trim();
   const json = values.json === true;
   const dryRun = values["dry-run"] === true;
+  const adoptBranch = (values["adopt-branch"] as string | undefined)?.trim() || undefined;
 
   if (!guidance) {
     process.stderr.write("[afk] requeue requires --guidance with the retry decision so it can be recorded as Human guidance\n");
@@ -128,27 +287,66 @@ export async function requeueCommand(
       process.stderr.write(`[afk] requeue #${issue}: refused — ${plan.reason}\n`);
       return 1;
     }
-    stdout.write(`Requeue #${issue}: no-op — ${plan.reason}\n`);
-    return 0;
+    // Not parked — no-op for the requeue transition (may still adopt below).
+    if (!adoptBranch) {
+      stdout.write(`Requeue #${issue}: no-op — ${plan.reason}\n`);
+      return 0;
+    }
   }
 
   if (dryRun) {
     stdout.write(
       json
-        ? `${JSON.stringify({ issue, plan }, null, 2)}\n`
-        : `Requeue #${issue} (dry-run): clear blocker=${plan.bodyChanged} remove=[${plan.removeLabels.join(",")}] add=[${plan.addLabels.join(",")}]\n`,
+        ? `${JSON.stringify({ issue, plan, adoptBranch }, null, 2)}\n`
+        : `Requeue #${issue} (dry-run): clear blocker=${plan.bodyChanged} remove=[${plan.removeLabels.join(",")}] add=[${plan.addLabels.join(",")}]${adoptBranch ? ` adopt-branch=${adoptBranch}` : ""}\n`,
     );
     return 0;
   }
 
-  if (plan.bodyChanged) await gh.editBody(issue, plan.body);
-  await gh.comment(issue, directiveComment(plan, guidance));
-  await gh.editLabels(issue, plan.removeLabels, plan.addLabels);
+  // Apply the requeue transition when the issue is parked and requeueable.
+  if (plan.requeueable) {
+    if (plan.bodyChanged) await gh.editBody(issue, plan.body);
+    await gh.comment(issue, directiveComment(plan, guidance));
+    await gh.editLabels(issue, plan.removeLabels, plan.addLabels);
+    stdout.write(
+      json
+        ? `${JSON.stringify({ issue, plan, applied: true }, null, 2)}\n`
+        : `Requeue #${issue}: cleared blocker=${plan.bodyChanged}, removed [${plan.removeLabels.join(",")}], added [${plan.addLabels.join(",")}].\n`,
+    );
+  } else if (!adoptBranch) {
+    stdout.write(`Requeue #${issue}: no-op — ${plan.reason}\n`);
+    return 0;
+  }
 
-  stdout.write(
-    json
-      ? `${JSON.stringify({ issue, plan, applied: true }, null, 2)}\n`
-      : `Requeue #${issue}: cleared blocker=${plan.bodyChanged}, removed [${plan.removeLabels.join(",")}], added [${plan.addLabels.join(",")}].\n`,
-  );
+  // Adopt mode (ADR 0081): route the branch through the no-agent landing lane.
+  if (adoptBranch) {
+    // Post-transition labels/body — pass the reconcile guard the state AFTER
+    // the requeue cleared any blocked:* labels + active blocker.
+    const postLabels = plan.requeueable
+      ? [...issueState.labels.filter((l) => !plan.removeLabels.includes(l)), ...plan.addLabels]
+      : [...issueState.labels];
+    const postBody = plan.requeueable ? plan.body : issueState.body;
+    const adoptData: RequeueAdoptData = { title: "", body: postBody, labels: postLabels };
+
+    stdout.write(`Requeue #${issue}: adopting branch \`${adoptBranch}\` through the no-agent landing lane (ADR 0055)…\n`);
+
+    const runner = adoptRunnerOverride
+      ?? ((n, b, d) => runAdoptLanding(n, b, d, cwd, repo, stdout));
+
+    const outcome = await runner(issue, adoptBranch, adoptData);
+
+    if (outcome === "landed") {
+      stdout.write(`Requeue #${issue}: \`${adoptBranch}\` validated and landed.\n`);
+      return 0;
+    }
+    if (outcome === "parked") {
+      process.stderr.write(`[afk] requeue #${issue}: gate failed — \`${adoptBranch}\` was parked to ready-for-human.\n`);
+      return 1;
+    }
+    // skipped (no-commits, branch-absent, etc.) — not a failure but worth noting.
+    stdout.write(`Requeue #${issue}: adopt skipped (branch carries no work vs base or branch absent).\n`);
+    return 0;
+  }
+
   return 0;
 }

--- a/apps/dev/src/commands/ship.ts
+++ b/apps/dev/src/commands/ship.ts
@@ -1,85 +1,19 @@
-import { setTimeout as sleep } from "node:timers/promises";
-import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
-import { LABEL_HUMAN, LABEL_READY_FOR_REVIEW } from "../core/triage-labels.js";
-import {
-  buildIssueClassificationMetadata,
-  classifyIssue,
-  resolveReviewGate,
-  shouldRequestReview,
-} from "../core/issue-classifier.js";
+// commands/ship.ts — DEPRECATED per ADR 0081.
+//
+// `/ship` is retired. Manual adoption of a hand-done branch now routes through
+// `requeue --adopt-branch BRANCH` into the no-agent landing lane (ADR 0055).
+// `collectShipFacts` is kept (tested by ship-facts.test.ts; may be reused by
+// future callers). `shipCommand` is the backwards-compat alias.
+
 import { execTool, type ExecOutput } from "../runtime/exec.js";
 import {
   advisoryReviewPending,
-  decideShipMergeGate,
-  isShipWorktreePath,
   issueNumberFromBranch,
   normalizeRollupEntry,
   shipChecksAreGreen,
   type ShipCheck,
 } from "../core/ship.js";
-import { afkPaths } from "../runtime/wire.js";
-import { getConfig, loadConfig } from "../core/config.js";
-
-interface ShipFlags {
-  base: string;
-  remote: string;
-  repo?: string;
-  issue?: number;
-  timeoutS: number;
-  pollS: number;
-  /** Name (substring, case-insensitive) of the advisory bot review to wait on
-   * before merging, e.g. `CodeRabbit`. Blank disables the wait. */
-  reviewCheck: string;
-}
-
-interface ShipFacts {
-  branchProtectionSatisfied: boolean;
-  changesRequested: boolean;
-  checksGreen: boolean;
-  /** An advisory bot review (e.g. CodeRabbit) is registered but still in flight. */
-  advisoryReviewPending: boolean;
-  reviewDecision: string;
-  checkSummary: string;
-}
-
-const SHIP_FLAG_SCHEMA = {
-  base: { kind: "value", aliases: ["b"], coerce: (raw: string): string => raw },
-  remote: { kind: "value", coerce: (raw: string): string => raw },
-  repo: { kind: "value", aliases: ["R"], coerce: (raw: string): string => raw },
-  issue: { kind: "value", aliases: ["i"], coerce: (raw: string): number => Number(raw) },
-  "timeout-s": { kind: "value", coerce: (raw: string): number => Number(raw) },
-  "poll-s": { kind: "value", coerce: (raw: string): number => Number(raw) },
-  "review-check": { kind: "value", coerce: (raw: string): string => raw },
-  "no-review-wait": { kind: "boolean" },
-} satisfies FlagSchema;
-
-/**
- * Resolve ship flags. `reviewCheck` is the advisory bot review to wait on before
- * merging: an explicit `--review-check NAME` wins, else the repo's configured
- * `afk.merge.review_check` (so `/ship` honors the same reviewer the AFK landing
- * does), and `--no-review-wait` (or a blank name) disables the wait.
- */
-function parseShipFlags(args: readonly string[], configReviewCheck: string): ShipFlags {
-  const { values } = parseFlags(args, SHIP_FLAG_SCHEMA);
-  const timeoutS = Number.isFinite(values["timeout-s"]) && Number(values["timeout-s"]) > 0
-    ? Number(values["timeout-s"])
-    : 30 * 60;
-  const pollS = Number.isFinite(values["poll-s"]) && Number(values["poll-s"]) > 0
-    ? Number(values["poll-s"])
-    : 30;
-  const reviewCheck = values["no-review-wait"] === true
-    ? ""
-    : String((values["review-check"] as string | undefined) ?? configReviewCheck);
-  return {
-    base: String(values.base ?? "main"),
-    remote: String(values.remote ?? "origin"),
-    repo: values.repo as string | undefined,
-    issue: Number.isFinite(values.issue) ? Number(values.issue) : undefined,
-    timeoutS,
-    pollS,
-    reviewCheck,
-  };
-}
+import { requeueCommand } from "./requeue.js";
 
 async function run(cmd: string, args: readonly string[], cwd: string): Promise<ExecOutput> {
   return execTool(cmd, args, { cwd });
@@ -101,116 +35,13 @@ async function required(cmd: string, args: readonly string[], cwd: string, label
   return r;
 }
 
-async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
-  if (explicit?.trim()) return explicit.trim();
-  const r = await required("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], cwd, "resolve repo");
-  return r.stdout.trim();
-}
-
-async function currentBranch(cwd: string): Promise<string> {
-  const r = await required("git", ["branch", "--show-current"], cwd, "resolve current branch");
-  const branch = r.stdout.trim();
-  if (!branch) throw new Error("/ship requires a named branch, not detached HEAD");
-  return branch;
-}
-
-async function gitTopLevel(cwd: string): Promise<string> {
-  const r = await required("git", ["rev-parse", "--show-toplevel"], cwd, "resolve git worktree");
-  return r.stdout.trim();
-}
-
-async function ensureCommittedWork(cwd: string): Promise<void> {
-  const r = await required("git", ["status", "--porcelain"], cwd, "check git status");
-  if (r.stdout.trim() !== "") {
-    throw new Error("/ship requires committed work; commit or stash the remaining changes first");
-  }
-}
-
-interface IssueMeta {
-  title: string;
-  body: string;
-  labels: string[];
-}
-
-async function issueMeta(cwd: string, repo: string, issue: number): Promise<IssueMeta> {
-  const r = await run(
-    "gh",
-    ["issue", "view", String(issue), "--repo", repo, "--json", "title,body,labels"],
-    cwd,
-  );
-  const fallback: IssueMeta = { title: `Issue #${issue}`, body: "", labels: [] };
-  if (r.code !== 0) return fallback;
-  const parsed = parseJson<{ title?: string; body?: string; labels?: Array<{ name?: string }> }>(r.stdout, {});
-  return {
-    title: parsed.title?.trim() || fallback.title,
-    body: parsed.body ?? "",
-    labels: (parsed.labels ?? []).map((l) => l.name ?? "").filter(Boolean),
-  };
-}
-
-async function pushBranch(cwd: string, remote: string, branch: string): Promise<void> {
-  await required("git", ["push", "-u", remote, `HEAD:refs/heads/${branch}`], cwd, "push branch");
-}
-
-async function findOpenPr(cwd: string, repo: string, branch: string, base: string): Promise<number | undefined> {
-  const r = await required(
-    "gh",
-    [
-      "pr",
-      "list",
-      "--repo",
-      repo,
-      "--head",
-      branch,
-      "--base",
-      base,
-      "--state",
-      "open",
-      "--json",
-      "number",
-      "--jq",
-      ".[0].number // empty",
-    ],
-    cwd,
-    "find open PR",
-  );
-  const n = Number.parseInt(r.stdout.trim(), 10);
-  return Number.isInteger(n) ? n : undefined;
-}
-
-async function openOrReusePr(
-  cwd: string,
-  repo: string,
-  branch: string,
-  base: string,
-  issue: number,
-  title: string,
-): Promise<number> {
-  const existing = await findOpenPr(cwd, repo, branch, base);
-  if (existing !== undefined) return existing;
-
-  await required(
-    "gh",
-    [
-      "pr",
-      "create",
-      "--repo",
-      repo,
-      "--base",
-      base,
-      "--head",
-      branch,
-      "--title",
-      `ship: #${issue} ${title}`,
-      "--body",
-      `Interactive /ship landing for #${issue}.\n\nCloses #${issue}`,
-    ],
-    cwd,
-    "create PR",
-  );
-  const created = await findOpenPr(cwd, repo, branch, base);
-  if (created === undefined) throw new Error("created PR but could not resolve its number");
-  return created;
+interface ShipFacts {
+  branchProtectionSatisfied: boolean;
+  changesRequested: boolean;
+  checksGreen: boolean;
+  advisoryReviewPending: boolean;
+  reviewDecision: string;
+  checkSummary: string;
 }
 
 interface PrView {
@@ -243,8 +74,7 @@ export async function collectShipFacts(cwd: string, repo: string, pr: number, re
   const view = parseJson<PrView>(viewRes.stdout, {});
 
   // When gh pr checks failed but gh pr view returned a populated statusCheckRollup,
-  // use that rollup as the check source so a transient gh-checks API failure does
-  // not falsely report checks as unavailable.
+  // use that rollup as the check source.
   if (checkSummary === "checks unavailable") {
     const rollup = view.statusCheckRollup ?? [];
     if (rollup.length > 0) {
@@ -264,169 +94,55 @@ export async function collectShipFacts(cwd: string, repo: string, pr: number, re
   return { branchProtectionSatisfied, changesRequested, checksGreen, advisoryReviewPending: reviewPending, reviewDecision, checkSummary };
 }
 
-function hitlBody(pr: number, issue: number, reason: string, facts: ShipFacts): string {
-  return [
-    "/ship stopped for human review.",
-    "",
-    `PR: #${pr}`,
-    `Issue: #${issue}`,
-    `Reason: ${reason}`,
-    `Checks: ${facts.checkSummary}`,
-    `Review decision: ${facts.reviewDecision || "none"}`,
-    "",
-    "Next step: run `/dev:hitl` after the human decision is recorded.",
-  ].join("\n");
-}
-
-async function markHitl(cwd: string, repo: string, pr: number, issue: number, reason: string, facts: ShipFacts): Promise<void> {
-  const body = hitlBody(pr, issue, reason, facts);
-  await run("gh", ["label", "create", LABEL_HUMAN, "--repo", repo, "--color", "FBCA04", "--description", "Waiting for a human decision"], cwd);
-  await run("gh", ["issue", "comment", String(issue), "--repo", repo, "--body", body], cwd);
-  await run("gh", ["issue", "edit", String(issue), "--repo", repo, "--add-label", LABEL_HUMAN], cwd);
-  await run("gh", ["pr", "edit", String(pr), "--repo", repo, "--add-label", LABEL_HUMAN], cwd);
-  await run("gh", ["pr", "comment", String(pr), "--repo", repo, "--body", body], cwd);
+/** Scan argv for a `--issue N` or `-i N` value (the only ship flag the alias needs). */
+function parseIssueFlag(args: readonly string[]): number | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    if ((args[i] === "--issue" || args[i] === "-i") && i + 1 < args.length) {
+      const n = Number(args[i + 1]);
+      return Number.isFinite(n) && n > 0 ? n : undefined;
+    }
+  }
+  return undefined;
 }
 
 /**
- * Review-gate handoff for `/ship` (ADR 0064 §10, #749): a non-mechanical change
- * earns a fresh-agent review before merge, so apply `ready-for-review` to the PR
- * (which fires the advisory review) and hold the merge. The label is created
- * best-effort first so a fresh repo never wedges the handoff. Mirrors the AFK
- * landing path's review handoff (process-issue's handoffForReview).
+ * DEPRECATED per ADR 0081. `/ship` is retired; manual branch adoption routes
+ * through `requeue --adopt-branch BRANCH`. This alias prints the deprecation
+ * notice, infers issue + branch from the current context, and delegates to
+ * requeueCommand so callers are redirected rather than broken.
  */
-async function markReviewRequested(cwd: string, repo: string, pr: number, issue: number, taskClass: string): Promise<void> {
-  await run(
-    "gh",
-    ["label", "create", LABEL_READY_FOR_REVIEW, "--repo", repo, "--color", "0E8A16", "--description", "PR awaiting a fresh-agent review"],
-    cwd,
-  );
-  await run("gh", ["pr", "edit", String(pr), "--repo", repo, "--add-label", LABEL_READY_FOR_REVIEW], cwd);
-  await run(
-    "gh",
-    [
-      "pr",
-      "comment",
-      String(pr),
-      "--repo",
-      repo,
-      "--body",
-      `🤖 /ship: non-mechanical change (\`${taskClass}\`) for #${issue} — applied \`${LABEL_READY_FOR_REVIEW}\` for a fresh-agent review before merge. Holding the merge per the review gate (ADR 0064 §10).`,
-    ],
-    cwd,
-  );
-}
-
-async function approveAndMerge(cwd: string, repo: string, pr: number): Promise<boolean> {
-  const approve = await run(
-    "gh",
-    ["pr", "review", String(pr), "--repo", repo, "--approve", "--body", "Approved by /ship after green checks and review-respecting gate."],
-    cwd,
-  );
-  if (approve.code !== 0) return false;
-  const merge = await run("gh", ["pr", "merge", String(pr), "--repo", repo, "--merge"], cwd);
-  return merge.code === 0;
-}
-
-function reasonForHitl(facts: ShipFacts, timedOut: boolean): string {
-  if (timedOut) return "monitor time cap exceeded";
-  if (facts.changesRequested) return "review requested changes";
-  if (!facts.branchProtectionSatisfied) return "branch protection requires approval";
-  if (!facts.checksGreen) return "checks did not become green";
-  return "merge gate requested HITL";
-}
-
 export async function shipCommand(
   args: string[],
   cwd = process.cwd(),
   stdout: NodeJS.WritableStream = process.stdout,
 ): Promise<number> {
-  const config = loadConfig(afkPaths(cwd).configPath, { warn: () => undefined });
-  const flags = parseShipFlags(args, getConfig(config, "afk.merge.review_check"));
-  const topLevel = await gitTopLevel(cwd);
-  if (!isShipWorktreePath(topLevel)) {
-    throw new Error("/ship must run from a .red/tmp/work-ship-*/ worktree");
-  }
-  await ensureCommittedWork(cwd);
+  process.stderr.write(
+    "[afk] /ship is deprecated (ADR 0081). Manual adoption routes through requeue:\n" +
+    "  red-skills-dev requeue #ISSUE --adopt-branch BRANCH --guidance 'reason'\n\n",
+  );
 
-  const repo = await resolveRepo(cwd, flags.repo);
-  const branch = await currentBranch(cwd);
-  const issue = flags.issue ?? issueNumberFromBranch(branch);
-  if (issue === undefined) {
-    throw new Error("/ship could not infer the linked issue; pass --issue N");
-  }
-  const meta = await issueMeta(cwd, repo, issue);
-  const { title } = meta;
+  // Resolve current branch (best-effort).
+  let branch: string | undefined;
+  try {
+    const r = await execTool("git", ["branch", "--show-current"], { cwd });
+    branch = r.code === 0 ? r.stdout.trim() || undefined : undefined;
+  } catch { /* best-effort */ }
 
-  await pushBranch(cwd, flags.remote, branch);
-  stdout.write(`/ship: pushed ${branch} to ${flags.remote}\n`);
-  const pr = await openOrReusePr(cwd, repo, branch, flags.base, issue, title);
-  stdout.write(`/ship: PR #${pr} ready for #${issue}\n`);
+  const issue = parseIssueFlag(args) ?? (branch ? issueNumberFromBranch(branch) : undefined);
 
-  // PR review gate (ADR 0064 §10, #749). When enabled and the change is
-  // NON-mechanical (issue-classifier tier at/above the threshold), `/ship`
-  // applies `ready-for-review` and HOLDS the merge for a fresh-agent review
-  // instead of auto-merging — honouring the same gate as the AFK landing path.
-  // Mechanical/trivial work falls through to the existing review-respecting
-  // merge loop unchanged. The classification is the cheap deterministic pass
-  // (no model call), matching `/ship`'s synchronous, offline-friendly contract.
-  const reviewGate = resolveReviewGate(config);
-  if (reviewGate) {
-    const taskClass = await classifyIssue(
-      buildIssueClassificationMetadata({ issue, title, body: meta.body, labels: meta.labels }),
+  if (!issue || !branch) {
+    process.stderr.write(
+      "[afk] /ship alias: could not infer issue or branch.\n" +
+      "  Run manually: red-skills-dev requeue #ISSUE --adopt-branch BRANCH --guidance 'reason'\n",
     );
-    if (shouldRequestReview(taskClass, reviewGate)) {
-      await markReviewRequested(cwd, repo, pr, issue, taskClass);
-      stdout.write(
-        `/ship: non-mechanical (${taskClass}) — applied ${LABEL_READY_FOR_REVIEW} to PR #${pr}; holding for a fresh-agent review\n`,
-      );
-      return 0;
-    }
+    return 1;
   }
 
-  const deadline = Date.now() + flags.timeoutS * 1000;
-  let lastFacts = await collectShipFacts(cwd, repo, pr, flags.reviewCheck);
-  for (;;) {
-    const timedOut = Date.now() >= deadline;
-    // Keep polling while CI is still running OR an advisory bot review (e.g.
-    // CodeRabbit) is registered but in flight — the AFK landing path waits for
-    // that reviewer to conclude, and `/ship` must not merge out from under it.
-    if (
-      !timedOut &&
-      !lastFacts.changesRequested &&
-      lastFacts.branchProtectionSatisfied &&
-      (!lastFacts.checksGreen || lastFacts.advisoryReviewPending)
-    ) {
-      const waitNote = lastFacts.advisoryReviewPending
-        ? `${lastFacts.checkSummary}; waiting on ${flags.reviewCheck} review`
-        : lastFacts.checkSummary;
-      stdout.write(`/ship: waiting (${waitNote}); next poll in ${flags.pollS}s\n`);
-      await sleep(flags.pollS * 1000);
-      lastFacts = await collectShipFacts(cwd, repo, pr, flags.reviewCheck);
-      continue;
-    }
+  process.stderr.write(`[afk] /ship alias: routing to requeue #${issue} --adopt-branch ${branch}\n`);
 
-    const decision = decideShipMergeGate({
-      branchProtectionSatisfied: lastFacts.branchProtectionSatisfied,
-      changesRequested: lastFacts.changesRequested,
-      checksGreen: lastFacts.checksGreen,
-      timedOut,
-    });
-
-    if (decision === "merge") {
-      if (await approveAndMerge(cwd, repo, pr)) {
-        stdout.write(`/ship: approved and merged PR #${pr}\n`);
-        return 0;
-      }
-      await markHitl(cwd, repo, pr, issue, "approve or merge command failed", lastFacts);
-      stdout.write(`/ship: approve/merge failed; marked #${issue} and PR #${pr} ready-for-human\n`);
-      return 0;
-    }
-
-    if (timedOut || lastFacts.changesRequested || !lastFacts.branchProtectionSatisfied) {
-      const reason = reasonForHitl(lastFacts, timedOut);
-      await markHitl(cwd, repo, pr, issue, reason, lastFacts);
-      stdout.write(`/ship: ${reason}; marked #${issue} and PR #${pr} ready-for-human\n`);
-      return 0;
-    }
-  }
+  return requeueCommand(
+    [String(issue), "--adopt-branch", branch, "--guidance", "Adopted via deprecated /ship alias (ADR 0081). Update guidance if needed."],
+    cwd,
+    stdout,
+  );
 }

--- a/apps/dev/tests/requeue-command.test.ts
+++ b/apps/dev/tests/requeue-command.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Writable } from "node:stream";
 import { formatCurrentBlocker } from "../src/core/blocker-state.js";
 import { isRequeueComplete } from "../src/core/requeue.js";
-import { requeueCommand, type RequeueGh } from "../src/commands/requeue.js";
+import { requeueCommand, type RequeueGh, type RequeueAdoptRunner } from "../src/commands/requeue.js";
 
 function capture(): { stream: Writable; text: () => string; stderr: () => string } {
   let buf = "";
@@ -211,5 +211,129 @@ describe("requeue command — /hitl refusals (exit 1, no mutation)", () => {
     expect(code).toBe(1);
     expect(err.text()).toContain("refused");
     expect(calls.editBody + calls.editLabels + calls.comment).toBe(0);
+  });
+});
+
+// ---------- ADR 0081 — adopt mode (--adopt-branch) ----------
+
+describe("requeue command — adopt mode (--adopt-branch)", () => {
+  it("requires --guidance even in adopt mode", async () => {
+    const { gh } = fakeGh({ state: "OPEN", body: "## Summary\nFoo.\n", labels: [] });
+    const { stream } = capture();
+    const err = captureStderr();
+
+    const code = await requeueCommand(["#42", "--adopt-branch", "my-branch"], "/tmp", stream, gh);
+    err.restore();
+
+    expect(code).toBe(2);
+    expect(err.text()).toContain("--guidance");
+  });
+
+  it("applies requeue transition then calls adopt runner for a parked issue", async () => {
+    const { gh, calls } = fakeGh({
+      state: "OPEN",
+      body: parkedBody,
+      labels: ["ready-for-human", "blocked:validation"],
+    });
+    const { stream, text } = capture();
+    let adoptCalled = false;
+    const runner: RequeueAdoptRunner = async () => { adoptCalled = true; return "landed"; };
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Gate flake fixed.", "--adopt-branch", "my-branch"],
+      "/tmp", stream, gh, runner,
+    );
+
+    expect(code).toBe(0);
+    expect(calls.editBody).toBe(1);
+    expect(calls.editLabels).toBe(1);
+    expect(adoptCalled).toBe(true);
+    expect(text()).toContain("validated and landed");
+  });
+
+  it("calls adopt runner even when issue is not parked (fresh issue, no blockers)", async () => {
+    const { gh, calls } = fakeGh({ state: "OPEN", body: "## Summary\nFoo.\n", labels: [] });
+    const { stream, text } = capture();
+    let adoptCalled = false;
+    const runner: RequeueAdoptRunner = async () => { adoptCalled = true; return "landed"; };
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Adopt hand-done branch.", "--adopt-branch", "my-branch"],
+      "/tmp", stream, gh, runner,
+    );
+
+    expect(code).toBe(0);
+    // No transition applied (issue was not parked)
+    expect(calls.editBody + calls.editLabels + calls.comment).toBe(0);
+    expect(adoptCalled).toBe(true);
+    expect(text()).toContain("validated and landed");
+  });
+
+  it("exits 1 when adopt runner returns parked (gate failed)", async () => {
+    const { gh } = fakeGh({ state: "OPEN", body: "## Summary\nFoo.\n", labels: [] });
+    const { stream } = capture();
+    const err = captureStderr();
+    const runner: RequeueAdoptRunner = async () => "parked";
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Fix tests.", "--adopt-branch", "broken-branch"],
+      "/tmp", stream, gh, runner,
+    );
+    err.restore();
+
+    expect(code).toBe(1);
+    expect(err.text()).toContain("gate failed");
+  });
+
+  it("exits 0 with skip note when adopt runner returns skipped", async () => {
+    const { gh } = fakeGh({ state: "OPEN", body: "## Summary\nFoo.\n", labels: [] });
+    const { stream, text } = capture();
+    const runner: RequeueAdoptRunner = async () => "skipped";
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Adopt.", "--adopt-branch", "empty-branch"],
+      "/tmp", stream, gh, runner,
+    );
+
+    expect(code).toBe(0);
+    expect(text()).toContain("skipped");
+  });
+
+  it("does not call adopt runner when issue has HITL-refuse (mixed blockers)", async () => {
+    const { gh } = fakeGh({
+      state: "OPEN",
+      body: parkedBody,
+      labels: ["ready-for-human", "blocked:validation", "blocked:spec"],
+    });
+    const { stream } = capture();
+    const err = captureStderr();
+    let adoptCalled = false;
+    const runner: RequeueAdoptRunner = async () => { adoptCalled = true; return "landed"; };
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Fixed.", "--adopt-branch", "my-branch"],
+      "/tmp", stream, gh, runner,
+    );
+    err.restore();
+
+    expect(code).toBe(1);
+    expect(adoptCalled).toBe(false);
+  });
+
+  it("dry-run with --adopt-branch does not call adopt runner", async () => {
+    const { gh } = fakeGh({ state: "OPEN", body: "## Summary\nFoo.\n", labels: [] });
+    const { stream, text } = capture();
+    let adoptCalled = false;
+    const runner: RequeueAdoptRunner = async () => { adoptCalled = true; return "landed"; };
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Adopt.", "--adopt-branch", "my-branch", "--dry-run"],
+      "/tmp", stream, gh, runner,
+    );
+
+    expect(code).toBe(0);
+    expect(adoptCalled).toBe(false);
+    expect(text()).toContain("dry-run");
+    expect(text()).toContain("adopt-branch=my-branch");
   });
 });

--- a/plugins/dev/skills/engineering/requeue/SKILL.md
+++ b/plugins/dev/skills/engineering/requeue/SKILL.md
@@ -1,24 +1,50 @@
 ---
 name: requeue
-description: Safely requeue a parked `blocked:validation` or `blocked:spec` issue after a human decision is already made. Clears the active `## Current blocker`, drops stale `ready-for-human`/`blocked:*` labels, and applies `ready-for-agent` as one coherent transition so AFK preflight does not re-park it. Refuses mixed `blocked:*` states and label/body mismatches — use `/hitl` for those.
-argument-hint: "#ISSUE --guidance \"text\" [--repo OWNER/REPO] [--dry-run] [--json]"
+description: Safely requeue a parked issue or adopt a hand-done branch through the no-agent gate. Requeue clears the active `## Current blocker`, drops stale `ready-for-human`/`blocked:*` labels, and applies `ready-for-agent`. With `--adopt-branch BRANCH` it also validates and lands the branch gate-only via the ADR-0055 no-agent landing lane (reconcile → doLanding). Refuses mixed `blocked:*` states and label/body mismatches — use `/hitl` for those.
+argument-hint: "#ISSUE --guidance \"text\" [--adopt-branch BRANCH] [--repo OWNER/REPO] [--dry-run] [--json]"
 ---
 
 # /requeue
 
-**Put a parked `blocked:validation`/`blocked:spec` issue back in the queue as ONE transition — clear the blocker, record the guidance, flip the labels atomically. A label flip alone is a silent no-op loop.**
+**Put a parked issue back in the queue or adopt a hand-done branch through the gate — ONE coherent transition. A label flip alone is a silent no-op loop.**
 
-## Why a label flip alone fails
+## Two modes
 
-A validation or spec failure parks an issue with `ready-for-human`, a `blocked:*` label, and an active `## Current blocker` block in the body. AFK preflight reads that active non-mechanical blocker and **re-parks the issue before any work starts** — so flipping labels back to `ready-for-agent` by hand produces a silent no-op retry loop: the queue shows the issue as queued, but preflight immediately stops it. The blocker must be cleared in the SAME transition that flips the labels (see #850 for the incident evidence).
-
-## Run
+### 1. Requeue a parked issue (existing behavior)
 
 ```bash
 red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the gate flake is fixed."
 ```
 
-`--guidance` is required — it is the Human guidance recorded in an auditable `directive` comment before the transition is applied. The runtime accepts both `123` and `#123`; quote `'#123'` through a shell. Use `--dry-run` to print the planned transition without mutating, and `--json` for structured output.
+Clears the active `## Current blocker`, drops `ready-for-human` + `blocked:*` labels, records the guidance, and applies `ready-for-agent` atomically.
+
+### 2. Adopt a hand-done branch and run gate-only (ADR 0081)
+
+```bash
+red-skills-dev requeue 123 --adopt-branch my-feature-branch --guidance "Manual implementation complete; run gate."
+```
+
+After the requeue transition (clearing any blocker state), requeue adopts the specified branch and routes it through the **no-agent landing lane** (ADR 0055):
+
+1. Validates the branch via the shared feedback gate (`runFeedback` — no agent re-run).
+2. On green: lands via `doLanding` (same path as `/afk`), closes the issue.
+3. On red: parks to `ready-for-human` with `blocked:validation` + the real failing checks.
+4. On skipped (branch has no commits vs base): exits 0 with a note.
+
+This replaces `/ship` for manual work — the adopted branch and an AFK branch go through the same gate authority. `/ship` users should migrate to this form.
+
+## Why a label flip alone fails
+
+A validation or spec failure parks an issue with `ready-for-human`, a `blocked:*` label, and an active `## Current blocker` in the body. AFK preflight reads the active non-mechanical blocker and **re-parks the issue before any work starts** — so flipping labels back to `ready-for-agent` by hand produces a silent no-op retry loop. The blocker must be cleared in the SAME transition that flips the labels (see #850 for the incident evidence).
+
+## Run
+
+```bash
+red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the gate flake is fixed."
+red-skills-dev requeue 123 --adopt-branch my-branch --guidance "Manual impl done."
+```
+
+`--guidance` is required in both modes — it records the Human decision as an auditable `directive` comment. Use `--dry-run` to print the planned transition without mutating, and `--json` for structured output.
 
 ## Behaviour
 
@@ -28,11 +54,14 @@ red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the g
    - the issue carries **mixed `blocked:*` labels** (e.g., both `blocked:validation` and `blocked:spec`);
    - the `blocked:*` label kind does not match the active `## Current blocker` kind in the body (**label/body mismatch**);
    - the blocked kind is not `validation` or `spec` (e.g., `blocked:decision`, `blocked:stalled`).
-4. Refuse (no-op exit 0) any issue that is not parked — no active `## Current blocker`, no `blocked:*` label, no `ready-for-human`.
-5. Otherwise apply the requeue transition atomically:
+4. If the issue is not parked AND `--adopt-branch` is NOT given: no-op exit 0.
+5. If the issue is parked and requeueable: apply the requeue transition atomically:
    - clear/archive the active `## Current blocker` into `## Resolved blockers`;
    - post a `directive` comment recording the human `--guidance`;
    - remove `ready-for-human` and every `blocked:*` label, and add `ready-for-agent`.
+6. If `--adopt-branch` is given (whether or not the issue was parked):
+   - adopt the branch through the no-agent landing lane (ADR 0055 reconcile);
+   - exit 0 on `landed`, exit 1 on `parked` (gate failed), exit 0 on `skipped`.
 
 ## `/requeue` vs `/hitl` — the decision boundary
 
@@ -40,10 +69,18 @@ red-skills-dev requeue 123 --guidance "Retry with the documented guidance; the g
 - The issue is `blocked:validation` or `blocked:spec` (no other `blocked:*` label).
 - The label kind and the active `## Current blocker` kind in the body agree.
 - You already have the retry guidance and do not need an interview to extract it.
+- OR: you have a hand-done branch to adopt (`--adopt-branch`).
 
 **Use `/hitl`** when:
-- The pending human decision still has to be **extracted and answered** — `/hitl` interviews you for the answer, decides whether the issue is delegable, then (when delegable) clears the blocker and requeues.
-- The issue carries **mixed `blocked:*` labels** or a **label/body mismatch** — `/hitl` reconciles ambiguous blocker state before applying any transition.
-- The blocked kind is anything other than `validation` or `spec` (e.g., `blocked:decision`, `blocked:stalled`) — those require the full `/hitl` interview.
+- The pending human decision still has to be **extracted and answered**.
+- The issue carries **mixed `blocked:*` labels** or a **label/body mismatch**.
+- The blocked kind is anything other than `validation` or `spec`.
 
-Both commands end in the same safe state — an issue in `ready-for-agent` with no active non-mechanical blocker. `/requeue` is the focused shortcut for the already-decided case; `/hitl` is the general path for everything else.
+Both commands end in the same safe state. `/requeue` is the focused shortcut; `/hitl` is the general path for everything else.
+
+## See also
+
+- `/dev:ship` — DEPRECATED; was the interactive finalizer; replaced by this command
+- `/dev:hitl` — interactive decision extraction before requeueing
+- ADR 0055 — the no-agent landing lane (reconcile / doLanding)
+- ADR 0081 — command topology: `/ship` retired; requeue is the manual adoption path

--- a/plugins/dev/skills/engineering/ship/SKILL.md
+++ b/plugins/dev/skills/engineering/ship/SKILL.md
@@ -1,50 +1,40 @@
 ---
 name: ship
-description: Interactive, review-respecting finalizer for already-committed work in an exempt `.red/tmp/work-ship-*/` worktree. Use when the user wants to open or reuse a PR, monitor CI and reviews with a time cap, then either approve/merge or park the linked issue for `/hitl`.
-argument-hint: "[--issue N] [--base BRANCH] [--timeout-s SECONDS] [--poll-s SECONDS] [--review-check NAME] [--no-review-wait]"
+description: DEPRECATED (ADR 0081). Use `/dev:requeue #ISSUE --adopt-branch BRANCH --guidance 'reason'` to adopt a hand-done branch through the no-agent gate. This skill is a backwards-compat alias that redirects to requeue.
+argument-hint: "[--issue N] [--base BRANCH]"
 ---
 
-# /ship
+# /ship — DEPRECATED
 
-**Ship committed work through the review gate: open or reuse a PR, wait for CI and the advisory-bot, then merge or park for `/hitl`.**
+**`/ship` is retired (ADR 0081). Use `/dev:requeue` with `--adopt-branch` instead.**
 
-This skill is the interactive sibling of `/afk`'s autonomous admin-merge landing: it respects branch protection, review decisions, CI, and the monitor time cap.
+## What to use instead
 
-## Preconditions
-
-- Run from a committed worktree under `.red/tmp/work-ship-*/` (nested subdirs are fine).
-- The current branch is the work branch to ship.
-- `gh auth status` works and the repo has the `ready-for-human` label.
-- Worktree creation is a separate front step; `/ship` does not create worktrees.
-
-## Run
-
-Invoke the dev runtime command:
+When you have done work by hand on an existing branch and want to run it through
+the gate and land it:
 
 ```bash
-red-skills-dev ship [--issue N] [--base main] [--timeout-s 1800] [--poll-s 30] [--review-check CodeRabbit] [--no-review-wait]
+red-skills-dev requeue #ISSUE --adopt-branch BRANCH --guidance 'reason for adoption'
 ```
 
-Use `--issue N` when the issue number is not inferable from the branch name.
+This routes the branch through the **no-agent landing lane** (ADR 0055 reconcile):
+gate-only validation (no agent re-run), then lands via the shared `doLanding` path.
 
-`/ship` waits for an in-flight advisory bot review (the same reviewer the AFK
-landing path honors, `afk.merge.review_check`, default `CodeRabbit`) to conclude
-before merging. Override the reviewer name with `--review-check NAME`, or skip
-the wait with `--no-review-wait`. The wait is advisory and fail-open: a reviewer
-that never registers cannot wedge the finalizer.
+## Why /ship was retired
 
-## Behaviour
+`/ship` was an orphan command with a fuzzy trigger ("I never know when to call it").
+ADR 0081 dissolved it into requeue so the manual path and the AFK path share the
+same gate and landing logic — one code path, one authority.
 
-1. Refuse non-ship worktrees and uncommitted changes.
-2. Push the branch to `origin` immediately.
-3. Reuse an open PR for the branch/base pair, or create one linked to the issue.
-4. Poll checks and reviews on a bounded `/loop` until a merge decision or the time cap. Keep waiting while CI is still running **or** the advisory bot review is registered but in flight.
-5. Feed the pure merge gate:
-   - green checks + satisfied branch protection + no requested changes -> `merge`
-   - required approval missing -> `hitl`
-   - any human or bot `CHANGES_REQUESTED` review -> `hitl`
-   - time cap exceeded -> `hitl`
-6. On `merge`, approve the PR and merge it normally.
-7. On `hitl`, comment on the linked issue, add `ready-for-human`, mirror the label on the PR, and stop for `/hitl`.
+## Backwards-compat alias
 
-**Do not use `--admin` — it skips the review gate `/ship` enforces.** If approval or merge fails, treat that as HITL and let the runtime park the issue.
+Running `dev ship` still works during rollout: it prints the deprecation notice,
+infers the issue number from the current branch, and delegates to
+`requeue #N --adopt-branch CURRENT_BRANCH --guidance '...'` automatically.
+Update your workflow to call requeue directly.
+
+## See also
+
+- `/dev:requeue` — the replacement for manual branch adoption
+- `/dev:hitl` — when a human decision still needs to be extracted before requeueing
+- ADR 0081 — command topology decision (goal / go / afk; ship retired)


### PR DESCRIPTION
Automated AFK landing for #939. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #939

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785439614&installation_id=129708444&pr_number=963&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F963&signature=92e515127b8afb38c324e967550c8dd009c8ef7d328ee6560b2518c7cef75770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->