### PR TITLE
feat(dev): auto-render HITL decision card on ready-for-human escalation (#935)

### DIFF
--- a/apps/dev/node_modules
+++ b/apps/dev/node_modules
@@ -1,1 +1,0 @@
-/home/cyber/Work/reddb.io/red-skills/apps/dev/node_modules

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -543,6 +543,13 @@ export function buildProcessDeps(
       // from the issue timeline. Consulted at claim time only when an allowlist
       // is configured (plugins.dev.afk.trust-gate.allowlist).
       issueTrust: (issue) => ghx.issueTrust(ghCtx, issue),
+      // HITL decision card (#935, S11a): post/update the card on escalation.
+      // Best-effort: errors are caught in routeRecovery so they never block
+      // the recovery path. Runs in the worktree root so gh resolves the repo.
+      renderDecisionCard: async (issue) => {
+        const { hitlCardCommand } = await import("./hitl-card.js");
+        await hitlCardCommand(["render", `--issue=${issue}`, `--root=${ctx.root}`]);
+      },
     },
     claimGh: {
       // ADR 0066: the atomic GitHub-native claim arbiter. Numeric comment ids

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -120,6 +120,13 @@ export interface ProcessGh {
    * never fires), preserving today's behaviour.
    */
   issueTrust?(issue: number): Promise<TrustProvenance>;
+  /**
+   * Render (or refresh) the HITL decision card on a `ready-for-human` issue
+   * (#935, S11a). Called best-effort after the escalation labels are applied.
+   * Optional → absent callers/tests degrade silently (no card posted, existing
+   * behaviour preserved).
+   */
+  renderDecisionCard?(issue: number): Promise<void>;
 }
 
 /** Claim-lock side effects (the local mkdir lock at .red/tmp/claims/{N}/). */
@@ -607,6 +614,15 @@ async function routeRecovery(
         attempt_n: attemptN,
       }),
     );
+    // Render the HITL decision card (#935, S11a). Best-effort: a card failure
+    // must never block the recovery path — the label transition already happened.
+    if (deps.gh.renderDecisionCard) {
+      try {
+        await deps.gh.renderDecisionCard(issue);
+      } catch {
+        // best-effort: card render failure is non-fatal.
+      }
+    }
   } else {
     // retry → CLEAN promotion: running → ready-for-agent, no blocked:* tag.
     await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_READY]);

--- a/apps/dev/tests/ship-facts.test.ts
+++ b/apps/dev/tests/ship-facts.test.ts
@@ -25,6 +25,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 
 vi.mock("../src/runtime/exec.js", () => ({
   execTool: vi.fn(),
+  pnpm: vi.fn(),
 }));
 
 import { execTool } from "../src/runtime/exec.js";


### PR DESCRIPTION
## Summary

- Adds optional `renderDecisionCard?(issue: number): Promise<void>` to the `ProcessGh` interface (backward-compatible — absent callers/tests degrade silently)
- Calls it best-effort in `routeRecovery` after the `on_blocked` hook fires and label transitions complete; errors are swallowed so a card failure never blocks the recovery path
- Wires the real implementation in `buildProcessDeps` via dynamic import of the existing `hitlCardCommand` with `render --issue=N --root=<ctx.root>`

Closes #935

## Test plan

- [x] `tsc --noEmit` exits 0 (no type errors)
- [x] `vitest run` passes 2388/2389 tests; 1 flake (`agentFor` 5s timeout in `execution.test.ts`) is pre-existing and unrelated to this change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785442782&installation_id=129708444&pr_number=966&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F966&signature=c4e38befa04424459068826e347d43cbba90167ce2d1532af14bc48f4f264584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->