### PR TITLE
fix(afk): fork worker branch from remote-tracking ref, not stale local

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -202,12 +202,13 @@ export interface RunAgentInput {
   /** The worker branch sandcastle commits land on (afk/{id}/{N}-{slug}). */
   branch: string;
   /**
-   * The resolved base branch (lock > pin > main, ADR 0031) the worker branch is
-   * forked from. Passed to sandcastle's NamedBranchStrategy `baseBranch` start
-   * point so the branch's parent is the pinned/locked base, not HEAD. Sandcastle
-   * only honours it when the branch is created new and the caller has made the
-   * ref current (process-issue does a `git fetch origin <base>` first). Defaults
-   * to HEAD when omitted.
+   * The remote-tracking ref for the resolved base (e.g. `origin/main`, ADR 0031)
+   * the worker branch is forked from. Passed to sandcastle's NamedBranchStrategy
+   * `baseBranch` start point so the branch's parent is the freshly-fetched base,
+   * not the potentially-stale local branch. process-issue populates this as
+   * `${remote}/${base}` after calling `fetchBase`, so the ref is guaranteed current.
+   * Sandcastle only honours it when the branch is created new. Defaults to HEAD
+   * when omitted.
    */
   base?: string;
   /** Isolation: "none" (default, node-only) | "docker" | "podman". */

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -901,7 +901,12 @@ export async function processIssue(
   // prompt, detects the DONE/BLOCKED completion signal, and commits on `branch`.
   // Make the resolved base ref current so sandcastle forks the worker branch off
   // it (ADR 0031): the pinned/locked base becomes the branch's parent, not HEAD.
+  // fetchBase runs `git fetch origin <base>` which updates the remote-tracking
+  // ref (origin/main) but NOT the local branch. We therefore pass the
+  // remote-tracking ref to runAgent so sandcastle's baseBranch start point
+  // uses the freshly-fetched ref, not the potentially-stale local branch.
   if (deps.git.fetchBase) await deps.git.fetchBase(base);
+  const baseRef = `${input.remote}/${base}`;
   // Pin to a sandcastle-backed runner. claude/codex/opencode (ADR 0059) +
   // claude-minimax (PRD #788) each map to a first-class provider and pass
   // through; any other value (e.g. the runner-neutral hermes, which has no
@@ -952,7 +957,7 @@ export async function processIssue(
       handoffContent: handoff,
       systemPrompt: EXIT_PROTOCOL,
       branch,
-      base,
+      base: baseRef,
       cwd: input.attemptDir,
       // Native-path liveness + ONE unified human log: point red-castle's file-log
       // at the attempt's `afk.log` (our canonical log, the one `state.log` and

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -1913,8 +1913,9 @@ describe("processIssue — base reaches sandcastle (ADR 0031)", () => {
     expect(result.base).toBe("main");
     // the base ref is fetched current before the run (ADR 0031 caller contract).
     expect(fetchedBases).toEqual(["main"]);
-    // runAgent receives the base as the branch start point.
-    expect(trace.runAgentCalls[0]?.base).toBe("main");
+    // runAgent receives the remote-tracking ref so sandcastle forks from the
+    // freshly-fetched ref, not the potentially-stale local branch.
+    expect(trace.runAgentCalls[0]?.base).toBe("origin/main");
   });
 });
 


### PR DESCRIPTION
## Summary

- `fetchBase` runs `git fetch origin <base>` which updates `origin/main` but NOT the local `main` branch
- Previously `processIssue` passed bare `base` (`"main"`) to `runAgent`, so sandcastle used the local branch as `baseBranch` — potentially stale when a prior worker merged to main
- Fix: after `fetchBase`, compute `baseRef = ${input.remote}/${base}` and pass that to `runAgent`; sandcastle runs `git worktree add -b <branch> <path> origin/main` which is guaranteed current

## Root cause

`WorktreeManager.create` in red-castle:
```
git worktree add -b new-branch <path> main   ← LOCAL main (may be stale)
```

Fix makes it:
```
git worktree add -b new-branch <path> origin/main   ← freshly-fetched ref
```

## Test plan

- [ ] `processIssue — base reaches sandcastle` test updated: `runAgent.base` now asserts `"origin/main"` (was `"main"`)
- [ ] All 107 tests in `process-issue.test.ts` pass
- [ ] The logical `base` (`"main"`) is unchanged for `result.base`, `merge_base`, hooks, and all non-sandcastle operations

https://claude.ai/code/session_01Et1w1hHdr3GThUPc8oW8ZT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785450523&installation_id=129708444&pr_number=967&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F967&signature=f4c3c40617bd095d3163550caf7df0bbea5040882a860df07d31d4050bd94bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->