### PR TITLE
fix(afk): stale-claim sweep must not restore ready-for-agent when issue is already ready-for-human

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -47,7 +47,7 @@ import {
   resolveClaimStalenessConfig,
   type ClaimedIssue,
 } from "./claim-staleness.js";
-import { LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
+import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "./triage-labels.js";
 
 // ---------- precheck (hard preconditions) ----------
 
@@ -150,6 +150,8 @@ export interface BootGh {
   editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
   /** gh issue comment --body … */
   comment(issue: number, body: string): Promise<void>;
+  /** gh issue view --json labels → flat name list. */
+  viewLabels(issue: number): Promise<string[]>;
 }
 
 /** git side effects: delete a remote or local branch ref. Best-effort. The
@@ -477,7 +479,24 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
   const released: number[] = [];
   for (const p of plans) {
     try {
-      await deps.gh.editLabels(p.issue, [LABEL_RUNNING], [LABEL_READY]);
+      // Re-fetch current labels: the batched issueStates snapshot used by
+      // claimedIssues may be stale by now (parallel edits or a preflight-blocker
+      // concede between the batch and this sweep). Two cases warrant a guard:
+      //
+      //   1. running is gone (race): another sweep or recovery already released
+      //      the issue — skip to avoid a spurious ready-for-agent add.
+      //
+      //   2. running + ready-for-human: a crash recovery wrote ready-for-human but
+      //      left the running projection in place. Adding ready-for-agent here
+      //      would re-admit the issue into the agent queue while the human gate is
+      //      active, causing the preflight-blocker spin (#968). Remove running only.
+      const currentLabels = await deps.gh.viewLabels(p.issue);
+      if (!currentLabels.includes(LABEL_RUNNING)) {
+        released.push(p.issue);
+        continue;
+      }
+      const addLabels = currentLabels.includes(LABEL_HUMAN) ? [] : [LABEL_READY];
+      await deps.gh.editLabels(p.issue, [LABEL_RUNNING], addLabels);
       await deps.gh.comment(p.issue, renderStaleClaimSweepAudit(p.staleOwners));
       released.push(p.issue);
     } catch {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1055,6 +1055,7 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
         await ghx.editLabels(ghCtx, issue, remove, add);
       },
       comment: (issue, body) => ghx.comment(ghCtx, issue, body),
+      viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
     },
     git: {
       deleteRemoteBranch: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),
@@ -1141,6 +1142,7 @@ export function buildMinimalBootDeps(ctx: RepoContext, nowS: number): BootDeps {
     gh: {
       editLabels: async () => unreachable(),
       comment: async () => unreachable(),
+      viewLabels: async () => unreachable(),
     },
     git: {
       deleteRemoteBranch: async () => unreachable(),

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -135,6 +135,7 @@ function makeDeps(over: Partial<{
   straggler: BootDeps["lookups"]["straggler"];
   claimHolderAlive: BootDeps["lookups"]["claimHolderAlive"];
   claimedIssues: BootDeps["lookups"]["claimedIssues"];
+  viewLabels: (issue: number) => Promise<string[]>;
   env: Record<string, string | undefined>;
   reconcileRunner: ReconcileBootRunner;
 }> = {}) {
@@ -148,6 +149,7 @@ function makeDeps(over: Partial<{
   const ghCalls = {
     editLabels: [] as Array<{ issue: number; remove: string[]; add: string[] }>,
     comment: [] as Array<{ issue: number; body: string }>,
+    viewLabels: [] as Array<{ issue: number }>,
   };
   const gitCalls = {
     deleteRemote: [] as string[],
@@ -181,6 +183,11 @@ function makeDeps(over: Partial<{
       async comment(issue, body) {
         calls.push(`gh.comment:${issue}`);
         ghCalls.comment.push({ issue, body });
+      },
+      async viewLabels(issue) {
+        calls.push(`gh.viewLabels:${issue}`);
+        ghCalls.viewLabels.push({ issue });
+        return over.viewLabels ? over.viewLabels(issue) : ["running"];
       },
     },
     git: {
@@ -677,6 +684,35 @@ describe("runBoot cross-host stale-claim sweep (#627)", () => {
     const { deps } = makeDeps({ claimedIssues });
     const r = await runBoot(deps, options());
     expect(r.staleClaimSweep).toEqual({ released: [] });
+  });
+
+  it("removes running but does NOT add ready-for-agent when issue already has ready-for-human (#968)", async () => {
+    // Scenario: crash recovery wrote ready-for-human but left the running projection.
+    // The sweep must strip running without routing back to ready-for-agent, otherwise
+    // the next worker's preflight-blocker concede leaves running again → infinite spin.
+    const claimedIssues = async () => [{ issue: 55, records: [claim(10, "host1:wZZ", 99999)] }];
+    const viewLabels = async (_issue: number) => ["running", "ready-for-human", "blocked:crashed"];
+    const { deps, ghCalls } = makeDeps({ claimedIssues, viewLabels });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [55] });
+    expect(ghCalls.editLabels).toEqual([
+      { issue: 55, remove: ["running"], add: [] },
+    ]);
+    expect(ghCalls.comment).toHaveLength(1);
+    expect(ghCalls.comment[0].issue).toBe(55);
+  });
+
+  it("skips (no-op) when running is already gone at viewLabels time (race)", async () => {
+    // Batch fetch returned issue as running, but by the time viewLabels fires
+    // another sweep or recovery already removed running — skip to avoid a
+    // spurious ready-for-agent add.
+    const claimedIssues = async () => [{ issue: 77, records: [claim(10, "host1:wAA", 99999)] }];
+    const viewLabels = async (_issue: number) => ["ready-for-human", "blocked:crashed"];
+    const { deps, ghCalls } = makeDeps({ claimedIssues, viewLabels });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [77] });
+    expect(ghCalls.editLabels).toEqual([]);
+    expect(ghCalls.comment).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- `runStaleClaimSweep` was calling `editLabels([running], [ready-for-agent])` without checking current labels, causing a spin loop when a crash recovery left the issue in `running` + `ready-for-human` state (#968)
- Fix: `viewLabels` the issue before each release; if `ready-for-human` is present, remove `running` only — never add `ready-for-agent`; if `running` is already gone (race), skip entirely
- Added `viewLabels` to `BootGh` interface, wired in both `buildBootDeps` and `buildMinimalBootDeps`
- Two new tests covering the spin scenario and the concurrent-release race

## Test plan

- [ ] `pnpm --filter @reddb-io/dev run test` — 2479 tests pass
- [ ] CI green

Fixes #968

https://claude.ai/code/session_01Et1w1hHdr3GThUPc8oW8ZT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785462815&installation_id=129708444&pr_number=969&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F969&signature=d93a30b1291e191690d46f3fbec9e05dbcf05b61db31a21c7d17ba82d2a7ace2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-claim handling during boot so issues are rechecked before labels are changed, reducing race conditions.
  * Prevented issues from being re-added for automation when a human review label is present.
  * If an issue has already been released, it is now skipped cleanly without extra updates or comments.

* **Tests**
  * Added coverage for label-state race scenarios to verify the new boot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->