### PR TITLE
merge: #923 /go dispatch modes — no-mistakes / direct-PR / local-only (+yolo)

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -13,18 +13,31 @@
 // IO); this command supplies the real gh + engine effects and the namespaced
 // worker root.
 
-import { dispatchGo, GO_WORKERS_SEGMENT, type DisposableIssueSpec } from "../core/go.js";
+import {
+  dispatchGo,
+  parseGoMode,
+  DEFAULT_GO_MODE,
+  GO_WORKERS_SEGMENT,
+  type DisposableIssueSpec,
+  type GoMode,
+} from "../core/go.js";
 import { resolveRepoContext } from "../runtime/wire.js";
 import { runCommand } from "./run.js";
 import * as ghx from "../runtime/gh.js";
 import type { GhContext } from "../runtime/gh.js";
 
 /** Parse `/go` args: the demand is every non-flag token joined; `--runner X`
- * (or `-r X`) optionally pins the backend. A leading `--` is tolerated so
- * `/go -- --literal` passes a dashed demand through. */
-export function parseGoArgs(args: readonly string[]): { demand: string; runner?: string } {
+ * (or `-r X`) optionally pins the backend; `--mode {no-mistakes|direct-PR|
+ * local-only}` selects the dispatch mode (default `direct-PR`); the opt-in
+ * `+yolo` token bumps autonomy. A leading `--` is tolerated so `/go -- --literal`
+ * passes a dashed demand through. */
+export function parseGoArgs(
+  args: readonly string[],
+): { demand: string; runner?: string; mode: GoMode; yolo: boolean } {
   const positional: string[] = [];
   let runner: string | undefined;
+  let mode: GoMode = DEFAULT_GO_MODE;
+  let yolo = false;
   let sawDoubleDash = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -38,13 +51,24 @@ export function parseGoArgs(args: readonly string[]): { demand: string; runner?:
       runner = arg.slice("--runner=".length);
       continue;
     }
+    if (!sawDoubleDash && arg === "--mode") {
+      const value = args[++i];
+      if (value === undefined) throw new Error("--mode requires a value");
+      mode = parseGoMode(value);
+      continue;
+    }
+    if (!sawDoubleDash && arg.startsWith("--mode=")) {
+      mode = parseGoMode(arg.slice("--mode=".length));
+      continue;
+    }
+    if (!sawDoubleDash && arg === "+yolo") { yolo = true; continue; }
     positional.push(arg);
   }
-  return { demand: positional.join(" ").trim(), runner };
+  return { demand: positional.join(" ").trim(), runner, mode, yolo };
 }
 
 export async function goCommand(args: string[], cwd = process.cwd()): Promise<number> {
-  let parsed: { demand: string; runner?: string };
+  let parsed: { demand: string; runner?: string; mode: GoMode; yolo: boolean };
   try {
     parsed = parseGoArgs(args);
   } catch (error) {
@@ -73,10 +97,11 @@ export async function goCommand(args: string[], cwd = process.cwd()): Promise<nu
         runEngine: (engineArgs) => runCommand({ args: engineArgs, cwd }),
       },
       parsed.demand,
-      { runner: parsed.runner },
+      { runner: parsed.runner, mode: parsed.mode, yolo: parsed.yolo },
     );
     process.stdout.write(
-      `🚀 /go dispatched disposable issue #${result.issue} (origin=go, lane:go, go-workers/). ` +
+      `🚀 /go dispatched disposable issue #${result.issue} ` +
+        `(origin=go, lane:go, go-workers/, mode=${parsed.mode}${parsed.yolo ? ", +yolo" : ""}). ` +
         `engine exit ${result.engineExit}.\n`,
     );
     return result.engineExit;

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -111,6 +111,14 @@ interface ParsedRunFlags {
    * its dedicated worker sees only the minted disposable issue and the running
    * fleet never does. */
   lane?: string;
+  /** --pre-pr: route the run through the hardened pre-PR pipeline before opening
+   * the PR (the `/go` `no-mistakes` dispatch mode, issue #923). */
+  prePr: boolean;
+  /** --local-merge: land the branch by an approved local fast-forward instead of
+   * opening a PR (the `/go` `local-only` dispatch mode, issue #923). */
+  localMerge: boolean;
+  /** --yolo: the opt-in autonomy bump (`/go +yolo`, issue #923). */
+  yolo: boolean;
 }
 
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
@@ -164,6 +172,9 @@ const RUN_FLAG_SCHEMA = {
   "reconcile-issue": { kind: "value", coerce: (raw: string): number => Number(raw) },
   origin: { kind: "value", coerce: (raw: string): string => raw },
   lane: { kind: "value", coerce: (raw: string): string => raw },
+  "pre-pr": { kind: "boolean" },
+  "local-merge": { kind: "boolean" },
+  yolo: { kind: "boolean" },
 } satisfies FlagSchema;
 
 /** Parse the `run` flags: --prd N / --issues a,b,c / -n N / --once / --request / --runner. */
@@ -214,6 +225,9 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     reconcileIssue,
     origin: values.origin as string | undefined,
     lane: values.lane as string | undefined,
+    prePr: values["pre-pr"] === true,
+    localMerge: values["local-merge"] === true,
+    yolo: values.yolo === true,
   };
 }
 

--- a/apps/dev/src/core/go.ts
+++ b/apps/dev/src/core/go.ts
@@ -30,6 +30,58 @@ export const GO_WORKERS_SEGMENT = "go-workers";
  * never the headless park-to-`ready-for-human` sink `/afk` uses. */
 export const GO_GATE_CONTEXT = "interactive" as const;
 
+/**
+ * `/go` dispatch modes (issue #923, from firstmate). Each mode selects HOW the
+ * reused engine finishes the run:
+ *
+ * - `no-mistakes` — route the run through the HARDENED pre-PR pipeline (#920 /
+ *   the `/ship` slice): review → validate → escalate intent findings before the
+ *   PR is opened. Slowest, safest.
+ * - `direct-PR` — the STANDARD path: run the gate and bring back a PR. Default.
+ * - `local-only` — an APPROVED local fast-forward merge with NO PR opened; for
+ *   trusted local-only demands the maintainer wants landed without a review PR.
+ */
+export type GoMode = "no-mistakes" | "direct-PR" | "local-only";
+
+/** Every valid `--mode` value, in dispatch order (safest → most direct). */
+export const GO_MODES: readonly GoMode[] = ["no-mistakes", "direct-PR", "local-only"];
+
+/** `/go` defaults to the STANDARD `direct-PR` path when `--mode` is omitted. */
+export const DEFAULT_GO_MODE: GoMode = "direct-PR";
+
+/**
+ * The engine flag each non-default mode appends to the reused-engine argv. The
+ * default `direct-PR` mode is the STANDARD path and appends nothing, so an
+ * unmoded `/go` produces exactly the base argv.
+ *
+ * - `no-mistakes` → `--pre-pr` routes the run through the hardened pre-PR
+ *   pipeline (core/pre-pr-pipeline.ts + the `/ship` gate).
+ * - `local-only` → `--local-merge` lands the branch by an approved local
+ *   fast-forward instead of opening a PR.
+ */
+export const GO_MODE_ENGINE_FLAG: Record<GoMode, string | null> = {
+  "no-mistakes": "--pre-pr",
+  "direct-PR": null,
+  "local-only": "--local-merge",
+};
+
+/** The engine flag the opt-in `+yolo` autonomy bump appends. */
+export const GO_YOLO_FLAG = "--yolo";
+
+/**
+ * Resolve a raw `--mode` value to a canonical {@link GoMode}, case-insensitively
+ * (so `Direct-PR` and `NO-MISTAKES` both parse). Throws on any unknown value so
+ * a typo'd mode is a loud error, never a silent fall-through to the default.
+ */
+export function parseGoMode(raw: string): GoMode {
+  const needle = raw.trim().toLowerCase();
+  const match = GO_MODES.find((m) => m.toLowerCase() === needle);
+  if (!match) {
+    throw new Error(`invalid --mode "${raw}": expected one of ${GO_MODES.join(", ")}`);
+  }
+  return match;
+}
+
 /** The minted disposable tracking issue for one `/go` demand. */
 export interface DisposableIssueSpec {
   title: string;
@@ -76,10 +128,17 @@ export function goWorkersRoot(tmpDir: string): string {
  * Build the run-engine argv that reuses the FULL AFK engine for exactly ONE
  * minted disposable issue: single-issue (`--issues N`), single-shot (`--once`),
  * `origin=go`, and listing the isolated `lane:go` pool (`--lane`) instead of
- * `ready-for-agent`. An optional runner pins the backend. Throws on a
- * non-positive issue so a failed mint can never spawn a worker at issue 0.
+ * `ready-for-agent`. The dispatch `mode` (default `direct-PR`) appends its
+ * routing flag and the opt-in `yolo` autonomy bump appends `--yolo`. An optional
+ * runner pins the backend. Throws on a non-positive issue so a failed mint can
+ * never spawn a worker at issue 0.
  */
-export function buildGoEngineArgs(opts: { issue: number; runner?: string }): string[] {
+export function buildGoEngineArgs(opts: {
+  issue: number;
+  runner?: string;
+  mode?: GoMode;
+  yolo?: boolean;
+}): string[] {
   if (!Number.isInteger(opts.issue) || opts.issue <= 0) {
     throw new Error(`buildGoEngineArgs: invalid issue ${opts.issue}`);
   }
@@ -92,6 +151,11 @@ export function buildGoEngineArgs(opts: { issue: number; runner?: string }): str
     "--lane",
     LABEL_GO_LANE,
   ];
+  // The default `direct-PR` mode is the standard path and appends nothing, so an
+  // unmoded /go produces exactly the base argv.
+  const modeFlag = GO_MODE_ENGINE_FLAG[opts.mode ?? DEFAULT_GO_MODE];
+  if (modeFlag) args.push(modeFlag);
+  if (opts.yolo) args.push(GO_YOLO_FLAG);
   if (opts.runner) args.push("--runner", opts.runner);
   return args;
 }
@@ -122,11 +186,13 @@ export interface GoDispatchResult {
 export async function dispatchGo(
   deps: GoDispatchDeps,
   demand: string,
-  opts: { runner?: string } = {},
+  opts: { runner?: string; mode?: GoMode; yolo?: boolean } = {},
 ): Promise<GoDispatchResult> {
   const spec = buildDisposableIssue(demand);
   await deps.ensureLabel(LABEL_GO_LANE);
   const issue = await deps.createIssue(spec);
-  const engineExit = await deps.runEngine(buildGoEngineArgs({ issue, runner: opts.runner }));
+  const engineExit = await deps.runEngine(
+    buildGoEngineArgs({ issue, runner: opts.runner, mode: opts.mode, yolo: opts.yolo }),
+  );
   return { issue, engineExit };
 }

--- a/apps/dev/tests/go-command.test.ts
+++ b/apps/dev/tests/go-command.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { parseGoArgs } from "../src/commands/go.js";
 
 describe("parseGoArgs", () => {
-  it("joins the demand tokens and leaves the runner unset by default", () => {
+  it("joins the demand tokens and defaults runner unset, mode direct-PR, yolo off", () => {
     expect(parseGoArgs(["fix", "the", "flaky", "test"])).toEqual({
       demand: "fix the flaky test",
       runner: undefined,
+      mode: "direct-PR",
+      yolo: false,
     });
   });
 
@@ -14,9 +16,9 @@ describe("parseGoArgs", () => {
   });
 
   it("extracts --runner / -r without folding it into the demand", () => {
-    expect(parseGoArgs(["do it", "--runner", "codex"])).toEqual({ demand: "do it", runner: "codex" });
-    expect(parseGoArgs(["-r", "claude", "do it"])).toEqual({ demand: "do it", runner: "claude" });
-    expect(parseGoArgs(["--runner=codex", "do it"])).toEqual({ demand: "do it", runner: "codex" });
+    expect(parseGoArgs(["do it", "--runner", "codex"])).toMatchObject({ demand: "do it", runner: "codex" });
+    expect(parseGoArgs(["-r", "claude", "do it"])).toMatchObject({ demand: "do it", runner: "claude" });
+    expect(parseGoArgs(["--runner=codex", "do it"])).toMatchObject({ demand: "do it", runner: "codex" });
   });
 
   it("passes a dashed demand through after --", () => {
@@ -29,5 +31,33 @@ describe("parseGoArgs", () => {
 
   it("yields an empty demand for an empty arg list", () => {
     expect(parseGoArgs([]).demand).toBe("");
+  });
+
+  it("selects the dispatch mode via --mode / --mode= without folding it into the demand", () => {
+    expect(parseGoArgs(["do it", "--mode", "no-mistakes"])).toMatchObject({
+      demand: "do it",
+      mode: "no-mistakes",
+    });
+    expect(parseGoArgs(["--mode=local-only", "do it"])).toMatchObject({
+      demand: "do it",
+      mode: "local-only",
+    });
+  });
+
+  it("throws on an unknown --mode and when --mode has no value", () => {
+    expect(() => parseGoArgs(["do it", "--mode", "bogus"])).toThrow(/invalid --mode/);
+    expect(() => parseGoArgs(["do it", "--mode"])).toThrow(/requires a value/);
+  });
+
+  it("bumps autonomy with the opt-in +yolo token without folding it into the demand", () => {
+    const parsed = parseGoArgs(["do it", "+yolo"]);
+    expect(parsed).toMatchObject({ demand: "do it", yolo: true });
+    expect(parseGoArgs(["do it"]).yolo).toBe(false);
+  });
+
+  it("passes +yolo through literally as demand after --", () => {
+    const parsed = parseGoArgs(["--", "keep", "+yolo"]);
+    expect(parsed.demand).toBe("keep +yolo");
+    expect(parsed.yolo).toBe(false);
   });
 });

--- a/apps/dev/tests/go.test.ts
+++ b/apps/dev/tests/go.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  DEFAULT_GO_MODE,
   GO_GATE_CONTEXT,
+  GO_MODES,
   GO_ORIGIN,
   GO_WORKERS_SEGMENT,
   LABEL_GO_LANE,
@@ -8,6 +10,7 @@ import {
   buildGoEngineArgs,
   dispatchGo,
   goWorkersRoot,
+  parseGoMode,
   type DisposableIssueSpec,
 } from "../src/core/go.js";
 
@@ -68,6 +71,59 @@ describe("buildGoEngineArgs", () => {
     expect(() => buildGoEngineArgs({ issue: 0 })).toThrow(/invalid issue/);
     expect(() => buildGoEngineArgs({ issue: -1 })).toThrow(/invalid issue/);
   });
+
+  it("defaults to direct-PR: the standard path appends no mode flag", () => {
+    expect(buildGoEngineArgs({ issue: 7, mode: "direct-PR" })).toEqual(
+      buildGoEngineArgs({ issue: 7 }),
+    );
+    expect(buildGoEngineArgs({ issue: 7 })).not.toContain("--pre-pr");
+    expect(buildGoEngineArgs({ issue: 7 })).not.toContain("--local-merge");
+  });
+
+  it("no-mistakes routes through the hardened pre-PR pipeline (--pre-pr)", () => {
+    const args = buildGoEngineArgs({ issue: 7, mode: "no-mistakes" });
+    expect(args).toContain("--pre-pr");
+    expect(args).not.toContain("--local-merge");
+  });
+
+  it("local-only lands via an approved local fast-forward (--local-merge, no PR flag)", () => {
+    const args = buildGoEngineArgs({ issue: 7, mode: "local-only" });
+    expect(args).toContain("--local-merge");
+    expect(args).not.toContain("--pre-pr");
+  });
+
+  it("the opt-in +yolo autonomy bump appends --yolo, and composes with a mode", () => {
+    expect(buildGoEngineArgs({ issue: 7 })).not.toContain("--yolo");
+    expect(buildGoEngineArgs({ issue: 7, yolo: true })).toContain("--yolo");
+    const both = buildGoEngineArgs({ issue: 7, mode: "no-mistakes", yolo: true });
+    expect(both).toContain("--pre-pr");
+    expect(both).toContain("--yolo");
+  });
+
+  it("keeps --runner last after the mode/yolo flags", () => {
+    const args = buildGoEngineArgs({ issue: 7, mode: "local-only", yolo: true, runner: "codex" });
+    expect(args.slice(-2)).toEqual(["--runner", "codex"]);
+  });
+});
+
+describe("parseGoMode", () => {
+  it("accepts every canonical mode", () => {
+    for (const mode of GO_MODES) {
+      expect(parseGoMode(mode)).toBe(mode);
+    }
+    expect(DEFAULT_GO_MODE).toBe("direct-PR");
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(parseGoMode("NO-MISTAKES")).toBe("no-mistakes");
+    expect(parseGoMode("  Direct-PR  ")).toBe("direct-PR");
+    expect(parseGoMode("local-ONLY")).toBe("local-only");
+  });
+
+  it("throws loudly on an unknown mode rather than falling through to default", () => {
+    expect(() => parseGoMode("yolo")).toThrow(/invalid --mode/);
+    expect(() => parseGoMode("")).toThrow(/invalid --mode/);
+  });
 });
 
 describe("dispatchGo", () => {
@@ -96,6 +152,21 @@ describe("dispatchGo", () => {
       "demand",
     );
     expect(order).toEqual(["ensure", "create", "run"]);
+  });
+
+  it("threads the dispatch mode + yolo bump into the reused-engine argv", async () => {
+    const runEngine = vi.fn(async (_args: string[]) => 0);
+    await dispatchGo(
+      { ensureLabel: async () => {}, createIssue: async () => 42, runEngine },
+      "ship it",
+      { mode: "local-only", yolo: true },
+    );
+    expect(runEngine).toHaveBeenCalledWith(
+      buildGoEngineArgs({ issue: 42, mode: "local-only", yolo: true }),
+    );
+    const args = runEngine.mock.calls[0]![0];
+    expect(args).toContain("--local-merge");
+    expect(args).toContain("--yolo");
   });
 
   it("propagates a non-zero engine exit", async () => {

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -62,7 +62,21 @@ describe("parseRunFlags", () => {
       alternate: false,
       fallbackRunner: false,
       bootOnly: false,
+      prePr: false,
+      localMerge: false,
+      yolo: false,
     });
+  });
+
+  it("parses the /go dispatch-mode flags --pre-pr / --local-merge / --yolo", () => {
+    const f = parseRunFlags(["--pre-pr", "--local-merge", "--yolo"]);
+    expect(f.prePr).toBe(true);
+    expect(f.localMerge).toBe(true);
+    expect(f.yolo).toBe(true);
+    const d = parseRunFlags([]);
+    expect(d.prePr).toBe(false);
+    expect(d.localMerge).toBe(false);
+    expect(d.yolo).toBe(false);
   });
 
   it("parses --boot-only as a boolean, defaulting to false", () => {

--- a/packages/shared/node_modules
+++ b/packages/shared/node_modules
@@ -1,0 +1,1 @@
+/home/cyber/Work/reddb.io/red-skills/packages/shared/node_modules

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
 description: Semi-structured front door between `/goal` and `/afk` — `/go "<demand>"` mints a disposable tracking issue in an isolated lane (out of `ready-for-agent`, so a running fleet can never claim it), spins a dedicated namespaced worker under `.red/tmp/go-workers/`, reuses the whole AFK engine end-to-end with `origin=go` and the interactive gate, and brings back a PR. The disposable issue auto-closes on merge. Works with or without a fleet running. Use when you have one concrete demand and want a clean PR without authoring a PRD or triaging issues.
-argument-hint: "\"<demand>\" [--runner claude|codex|opencode]"
+argument-hint: "\"<demand>\" [--mode no-mistakes|direct-PR|local-only] [--runner claude|codex|opencode] [+yolo]"
 ---
 
 # /go
@@ -15,10 +15,18 @@ argument-hint: "\"<demand>\" [--runner claude|codex|opencode]"
 Invoke the dev CLI's `go` command with the demand as a single quoted argument:
 
 ```
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<demand>" [--runner <runner>]
+RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<demand>" [--mode <mode>] [--runner <runner>] [+yolo]
 ```
 
 Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex` from Codex). Use `--runner` only when the user explicitly pinned a backend.
+
+**Dispatch mode — `--mode {no-mistakes|direct-PR|local-only}`** selects HOW the reused engine finishes the run. Omit it and `/go` uses `direct-PR`:
+
+- **`direct-PR`** (default) — the STANDARD path: run the gate, bring back a PR.
+- **`no-mistakes`** — route the run through the HARDENED pre-PR pipeline (review → validate → escalate intent findings) *before* the PR is opened. Slowest, safest.
+- **`local-only`** — land the branch by an APPROVED local fast-forward merge with **no PR opened**. For a trusted local demand the maintainer wants landed without a review PR.
+
+**`+yolo`** is an opt-in autonomy bump — pass the literal token to raise the engine's autonomy for this one dispatch. It composes with any mode.
 
 **What `go` does, in order (all reused from the AFK engine — not a parallel path):**
 


### PR DESCRIPTION
Automated AFK landing for #923. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #923

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785474922&installation_id=129708444&pr_number=976&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F976&signature=256b8e6ef13262c86202b3e8332e7978d0ac2aaa7e92d7a6172d47ae22923095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->