### PR TITLE
merge: #924 Intra-attempt notes-loop (opt-in, default off) — incremental commits + carried notes

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -42,6 +42,7 @@ import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { ExecFn } from "../runtime/exec.js";
 import { getConfig, loadConfig, readBackpressure, resolveTier, resolveCiTimeoutSeconds } from "../core/config.js";
+import { resolveNotesLoopConfig } from "../core/notes-loop.js";
 import {
   classifyIssue,
   resolveReviewGate,
@@ -51,7 +52,7 @@ import { LABEL_READY_FOR_REVIEW } from "../core/triage-labels.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
 import { isValidWorkerId } from "../core/worker-paths.js";
-import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../core/runner-spawn.js";
 import { buildWorkerAttemptPath } from "../core/worker-paths.js";
@@ -523,6 +524,11 @@ export function buildProcessDeps(
   // base (ADR 0031). Honours the namespaced + legacy fallback via loadConfig.
   const worktreeLaunchesPr = getConfig(config, "afk.worktree_launches_pull_request") !== "false";
 
+  // Intra-attempt notes-loop (Track C, #924). Default OFF → exactly one agent
+  // call. When enabled, processIssue wraps the inner invocation in a bounded
+  // outer loop carrying an accumulated `notes.md` between iterations.
+  const notesLoop = resolveNotesLoopConfig(config);
+
   return {
     gh: {
       viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
@@ -957,6 +963,19 @@ export function buildProcessDeps(
         loc_added: lastHeartbeatDiff.added,
         loc_removed: lastHeartbeatDiff.removed,
       };
+    },
+    // Intra-attempt notes-loop (Track C, #924). `notesLoop` is the resolved
+    // `afk.notes_loop.*` config (default OFF). `writeNotes` persists the loop's
+    // carried `notes.md` at the attempt dir — outside the worker branch's
+    // worktree, so it is never committed. Best-effort: a write failure must never
+    // fail the attempt.
+    notesLoop,
+    writeNotes: (path, content) => {
+      try {
+        writeFileSync(path, content, "utf8");
+      } catch {
+        /* best-effort: notes are also carried in-process */
+      }
     },
     // Macro-lifecycle phase stamp (issue #811): processIssue calls this at the
     // orchestrator-owned points the agent stream can't see — `validating` at the

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -156,6 +156,25 @@ export const CONFIG_DEFAULTS = {
   "afk.companion.waiting_windows": "20",
   "afk.companion.diff_drift_loc": "4000",
   "afk.companion.min_progress_loc": "5",
+  // Intra-attempt notes-loop (Track C, #924). Opt-in outer loop that wraps the
+  // single inner-agent invocation: each iteration makes one small committed
+  // change, then the loop re-invokes the agent seeded with an accumulated
+  // `notes.md` (carried at the attempt dir, never committed to the worker
+  // branch) until the agent signals DONE or a cap trips (partial work is then
+  // salvaged + landed). OFF by default → exactly one agent call, today's
+  // behaviour. Caps (folded from `plugins.dev.afk.notes_loop.*`, mirror
+  // NOTES_LOOP_DEFAULT_* in core/notes-loop.ts): `max_iterations` = outer
+  // re-invocation ceiling; `inner_max_iterations` = the per-iteration sandcastle
+  // re-invocation ceiling (0 → leave the run's own default); `token_budget` =
+  // cumulative input+output token ceiling checked BETWEEN iterations (0 →
+  // unlimited); `wall_clock_s` = wall-clock ceiling checked between iterations
+  // (0 → unlimited). The between-iteration checks never double-abort with the
+  // per-call attempt guard, which owns aborting a single in-flight iteration.
+  "afk.notes_loop.enabled": "false",
+  "afk.notes_loop.max_iterations": "4",
+  "afk.notes_loop.inner_max_iterations": "0",
+  "afk.notes_loop.token_budget": "0",
+  "afk.notes_loop.wall_clock_s": "0",
   "dev.lock.primary-branch": "false",
   // NOTE: `dev.lock.branch` (the static base lock — ADR 0031) is intentionally
   // NOT in this table. Its "default" is *unset* (no config-level lock), and

--- a/apps/dev/src/core/notes-loop.ts
+++ b/apps/dev/src/core/notes-loop.ts
@@ -1,0 +1,260 @@
+// Intra-attempt notes-loop (Track C, #924). AFK's default attempt is ONE inner
+// agent invocation: sandcastle spawns the agent on the worker branch, the agent
+// works until it emits the completion block / sentinel, and the orchestrator
+// lands the result. This module adds an OPT-IN outer loop around that single
+// invocation. When enabled, each outer iteration makes one small committed
+// change, the loop reads the run's real completion state from the
+// structured-output adapter (ADR 0082), and — if the agent is not done — seeds
+// the NEXT iteration with an accumulated `notes.md` describing prior progress.
+// A `done` outcome short-circuits to land; a cap-hit hands the last partial run
+// straight back so the caller salvages + lands it.
+//
+// Feasibility (GREEN): sandcastle `run()` is re-invokable on the same branch —
+// commits accumulate — so the loop needs no red-castle change; it just calls the
+// existing `runAgent` port N times with a varying handoff. The loop is DEFAULT
+// OFF: `enabled:false` runs `runOnce` exactly once with the base handoff, byte
+// for byte today's behaviour.
+//
+// Caps: `maxIterations` (outer re-invocation ceiling), `innerMaxIterations` (the
+// per-iteration sandcastle ceiling), `tokenBudget`, and `wallClockS`. The two
+// resource caps are checked BETWEEN iterations only — never mid-run — so they
+// can never double-abort with the per-call attempt guard (execution.ts), which
+// solely owns aborting a single in-flight iteration.
+import { getConfig, type ConfigValues } from "./config.js";
+import type { RunAgentResult, AgentOutcome } from "./execution.js";
+
+/** The carried-notes file, materialised at the attempt dir (never committed). */
+export const NOTES_FILE_NAME = "notes.md";
+
+/** Outer re-invocation ceiling — how many agent calls the loop makes at most. */
+export const NOTES_LOOP_DEFAULT_MAX_ITERATIONS = 4;
+/** Per-iteration sandcastle ceiling override; `0` → leave the run's own default. */
+export const NOTES_LOOP_DEFAULT_INNER_MAX_ITERATIONS = 0;
+/** Cumulative token ceiling checked between iterations; `0` → unlimited. */
+export const NOTES_LOOP_DEFAULT_TOKEN_BUDGET = 0;
+/** Wall-clock ceiling (seconds) checked between iterations; `0` → unlimited. */
+export const NOTES_LOOP_DEFAULT_WALL_CLOCK_S = 0;
+
+/** Resolved `afk.notes_loop.*` knobs (ADR 0042 folding handled by loadConfig). */
+export interface NotesLoopConfig {
+  /** Master switch. `false` (default) → exactly one agent call, no notes. */
+  enabled: boolean;
+  /** Outer re-invocation ceiling (>= 1). */
+  maxIterations: number;
+  /** Per-iteration sandcastle re-invocation ceiling; `0` → no override. */
+  innerMaxIterations: number;
+  /** Cumulative input+output token ceiling; `0` → unlimited. */
+  tokenBudget: number;
+  /** Wall-clock ceiling in seconds; `0` → unlimited. */
+  wallClockS: number;
+}
+
+/**
+ * Resolve the notes-loop config from the loaded `.red/config.yaml` values.
+ * Mirrors the typo-safety used elsewhere (worktree-pool): a non-numeric or
+ * negative cap floors back to its default so a config typo can never produce a
+ * zero-iteration loop (which would run nothing) — while `0` stays meaningful for
+ * the two resource caps, where it means "unlimited".
+ */
+export function resolveNotesLoopConfig(values: ConfigValues): NotesLoopConfig {
+  const posInt = (key: string, fallback: number): number => {
+    const raw = getConfig(values, key);
+    if (/^[0-9]+$/.test(raw)) {
+      const n = Number(raw);
+      if (n > 0) return n;
+    }
+    return fallback;
+  };
+  // `0` is a valid value for the resource caps (unlimited); only a non-integer
+  // floors back to the default.
+  const nonNegInt = (key: string, fallback: number): number => {
+    const raw = getConfig(values, key);
+    return /^[0-9]+$/.test(raw) ? Number(raw) : fallback;
+  };
+  return {
+    enabled: getConfig(values, "afk.notes_loop.enabled") === "true",
+    maxIterations: posInt("afk.notes_loop.max_iterations", NOTES_LOOP_DEFAULT_MAX_ITERATIONS),
+    innerMaxIterations: nonNegInt("afk.notes_loop.inner_max_iterations", NOTES_LOOP_DEFAULT_INNER_MAX_ITERATIONS),
+    tokenBudget: nonNegInt("afk.notes_loop.token_budget", NOTES_LOOP_DEFAULT_TOKEN_BUDGET),
+    wallClockS: nonNegInt("afk.notes_loop.wall_clock_s", NOTES_LOOP_DEFAULT_WALL_CLOCK_S),
+  };
+}
+
+/** Absolute path to the attempt's carried-notes file. */
+export function notesPath(attemptDir: string): string {
+  return `${attemptDir}/${NOTES_FILE_NAME}`;
+}
+
+/** Why the loop stopped. */
+export type NotesLoopStop =
+  | "done" // the agent signalled completion (structured success or sentinel)
+  | "blocked" // the agent explicitly declared the work impossible
+  | "terminal" // a per-call terminal outcome (exhausted / timeout / …) — hand back as-is
+  | "max-iterations" // outer re-invocation ceiling reached with partial work
+  | "token-budget" // cumulative token ceiling reached between iterations
+  | "wall-clock"; // wall-clock ceiling reached between iterations
+
+/** The context handed to `runOnce` for a single outer iteration. */
+export interface NotesLoopIteration {
+  /** 1-based iteration index. */
+  iteration: number;
+  /** The handoff for this iteration: base handoff + carried notes (if any). */
+  handoff: string;
+  /** The accumulated `notes.md` content ("" on the first iteration). */
+  notes: string;
+}
+
+export interface NotesLoopDeps {
+  config: NotesLoopConfig;
+  /** The base handoff every iteration starts from (before notes are appended). */
+  baseHandoff: string;
+  /** Run ONE inner-agent iteration and return its normalised result. */
+  runOnce(iteration: NotesLoopIteration): Promise<RunAgentResult>;
+  /** Persist the accumulated notes (the caller writes `notes.md` at attemptDir). */
+  persistNotes?(content: string): void;
+  /** Millisecond clock for the wall-clock cap; defaults to `Date.now`. */
+  now?(): number;
+  /** Cumulative input+output tokens spent this attempt; enables the token cap. */
+  tokensSpent?(): number;
+  /** Optional progress log sink. */
+  log?(message: string): void;
+}
+
+export interface NotesLoopOutcome {
+  /** The final run — the one the caller salvages / lands. */
+  run: RunAgentResult;
+  /** How many agent calls the loop made. */
+  iterations: number;
+  /** Why the loop stopped. */
+  stoppedBy: NotesLoopStop;
+  /** The final accumulated notes (empty when disabled or done on iteration 1). */
+  notes: string;
+}
+
+/**
+ * The only outcome that CONTINUES the loop: the agent ran, likely committed a
+ * small change, but did not signal completion (`no-sentinel`). Every other
+ * non-`done` outcome is terminal for the loop — `blocked` is an explicit
+ * give-up, and the guard/runner outcomes (`exhausted`, `runner-transient`,
+ * `timeout`, `budget-exceeded`, `goal-moot`) are handled by the caller's
+ * existing terminal policy and re-seeding them would not help.
+ */
+function isContinuable(outcome: AgentOutcome): boolean {
+  return outcome === "no-sentinel";
+}
+
+/**
+ * Render the carried-notes preamble prepended to the next iteration's handoff.
+ * It tells the agent to continue from prior progress and to make ONE small
+ * committed change — the notes-loop contract — rather than restarting.
+ */
+export function renderNotesSection(notes: string): string {
+  return [
+    "<carried-notes>",
+    "Prior iterations of THIS attempt (same worker branch, commits accumulate)",
+    "recorded the progress below. Continue from here — do NOT redo completed work.",
+    "Make ONE small, committed change this iteration, then stop. The outer loop",
+    "re-invokes you with updated notes until the whole issue is done; emit the",
+    "completion block ONLY when the entire issue is complete.",
+    "",
+    notes.trim(),
+    "</carried-notes>",
+  ].join("\n");
+}
+
+/**
+ * Append a structured entry for the just-finished iteration to the running
+ * notes. Draws on the run's structured `AgentOutput` (ADR 0082) when present —
+ * its `summary` / `key_changes_made` / `key_learnings` are exactly the
+ * continuity signal the next iteration needs — and always records the outcome +
+ * commit count so a cap-hit audit trail is legible even without a structured
+ * block.
+ */
+export function appendNotesEntry(prior: string, iteration: number, run: RunAgentResult): string {
+  const lines: string[] = [`## Iteration ${iteration}`];
+  lines.push(`- outcome: ${run.outcome}; commits this iteration: ${run.commits.length}`);
+  const out = run.agentOutput;
+  if (out) {
+    if (out.summary.trim()) lines.push(`- summary: ${out.summary.trim()}`);
+    for (const change of out.key_changes_made) lines.push(`- change: ${change}`);
+    for (const learning of out.key_learnings) lines.push(`- learning: ${learning}`);
+  }
+  const entry = lines.join("\n");
+  return prior ? `${prior}\n\n${entry}` : entry;
+}
+
+/**
+ * Run the bounded intra-attempt notes-loop.
+ *
+ * Disabled (`config.enabled === false`): `runOnce` fires exactly once with the
+ * base handoff and no notes — today's single-invocation behaviour, unchanged.
+ *
+ * Enabled: iterate up to `maxIterations`. Each iteration builds a handoff (base
+ * handoff + carried notes), runs the agent, and reads the outcome. `done`
+ * short-circuits to land; a terminal outcome is handed straight back; a
+ * continuable `no-sentinel` accumulates a notes entry, persists it, and seeds
+ * the next iteration. Reaching a cap (iterations / tokens / wall-clock) returns
+ * the last partial run for the caller to salvage + land. The two resource caps
+ * are checked only BETWEEN iterations, so the first iteration always runs and
+ * the caps never race the per-call attempt guard.
+ */
+export async function runNotesLoop(deps: NotesLoopDeps): Promise<NotesLoopOutcome> {
+  const cfg = deps.config;
+
+  // Disabled → exactly one call, base handoff, no notes seeding or persistence.
+  if (!cfg.enabled) {
+    const run = await deps.runOnce({ iteration: 1, handoff: deps.baseHandoff, notes: "" });
+    return { run, iterations: 1, stoppedBy: stopForOutcome(run.outcome), notes: "" };
+  }
+
+  const now = deps.now ?? (() => Date.now());
+  const startMs = now();
+  const cap = Math.max(1, cfg.maxIterations);
+
+  let notes = "";
+  let lastRun: RunAgentResult | undefined;
+  let iteration = 0;
+
+  while (iteration < cap) {
+    // Resource caps are evaluated BETWEEN iterations only — the first iteration
+    // always runs, and a mid-run iteration is never interrupted here (the
+    // per-call attempt guard owns that). This is the "never double-abort"
+    // guarantee.
+    if (iteration > 0) {
+      if (cfg.wallClockS > 0 && (now() - startMs) / 1000 >= cfg.wallClockS) {
+        deps.log?.(`[afk] notes-loop: wall-clock cap ${cfg.wallClockS}s hit after ${iteration} iteration(s)`);
+        return { run: lastRun!, iterations: iteration, stoppedBy: "wall-clock", notes };
+      }
+      if (cfg.tokenBudget > 0 && deps.tokensSpent && deps.tokensSpent() >= cfg.tokenBudget) {
+        deps.log?.(`[afk] notes-loop: token budget ${cfg.tokenBudget} hit after ${iteration} iteration(s)`);
+        return { run: lastRun!, iterations: iteration, stoppedBy: "token-budget", notes };
+      }
+    }
+
+    iteration += 1;
+    const handoff = notes ? `${deps.baseHandoff}\n\n${renderNotesSection(notes)}` : deps.baseHandoff;
+    const run = await deps.runOnce({ iteration, handoff, notes });
+    lastRun = run;
+
+    if (run.outcome === "done") {
+      return { run, iterations: iteration, stoppedBy: "done", notes };
+    }
+    if (!isContinuable(run.outcome)) {
+      return { run, iterations: iteration, stoppedBy: run.outcome === "blocked" ? "blocked" : "terminal", notes };
+    }
+
+    // Continuable: record progress and seed the next iteration.
+    notes = appendNotesEntry(notes, iteration, run);
+    deps.persistNotes?.(notes);
+    deps.log?.(`[afk] notes-loop: iteration ${iteration}/${cap} produced no completion; carrying notes forward`);
+  }
+
+  return { run: lastRun!, iterations: iteration, stoppedBy: "max-iterations", notes };
+}
+
+/** Map a single-run outcome to the disabled-path stop reason. */
+function stopForOutcome(outcome: AgentOutcome): NotesLoopStop {
+  if (outcome === "done") return "done";
+  if (outcome === "blocked") return "blocked";
+  return "terminal";
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -76,6 +76,7 @@ import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.
 import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
 import { parseTrustPolicy, evaluateTrustGate, type TrustProvenance } from "./trust-gate.js";
 import type { AfkModelTier, ConfigValues } from "./config.js";
+import { runNotesLoop, notesPath, type NotesLoopConfig } from "./notes-loop.js";
 import {
   buildIssueClassificationMetadata,
   shouldRequestReview,
@@ -389,6 +390,21 @@ export interface ProcessIssueDeps {
    * context omits `vitals` (byte-for-byte the pre-#832 record).
    */
   heartbeatVitals?(): Record<string, number> | undefined;
+  /**
+   * Intra-attempt notes-loop config (Track C, #924). Resolved from
+   * `afk.notes_loop.*` by the CLI (`resolveNotesLoopConfig`). When enabled, the
+   * single inner-agent invocation is wrapped in a bounded outer loop that carries
+   * an accumulated `notes.md` between iterations. Absent (tests / legacy callers)
+   * or `enabled:false` → exactly one agent call, today's behaviour, unchanged.
+   */
+  notesLoop?: NotesLoopConfig;
+  /**
+   * Persist the notes-loop's carried `notes.md` (Track C, #924). The CLI binds it
+   * to a filesystem writer; the loop calls it with the attempt-dir path (outside
+   * the worker branch's worktree, so it is never committed). Optional → when
+   * absent the notes are carried in-process only.
+   */
+  writeNotes?(path: string, content: string): void;
   /**
    * Stamp the attempt's macro-lifecycle phase (issue #811) — the calm signal the
    * task-mirror title surfaces. processIssue calls it at the orchestrator-owned
@@ -949,7 +965,12 @@ export async function processIssue(
 
   while (true) {
     const initialTier = resolveSpawnTier(deps, activeRunner, activeTaskClass);
-    let run: RunAgentResult = await deps.runAgent({
+    // The base sandcastle input for THIS attempt. When the intra-attempt
+    // notes-loop (#924) is enabled, `runNotesLoop` re-invokes `runAgent` with
+    // this input and a per-iteration `handoffContent` (base handoff + carried
+    // notes) plus the optional inner-ceiling override; when disabled, it fires
+    // exactly once with `handoffContent: handoff` — byte-for-byte today's call.
+    const baseAgentInput: RunAgentInput = {
       runner: activeRunner,
       model: initialTier.model,
       effort: initialTier.effort,
@@ -1004,7 +1025,46 @@ export async function processIssue(
       // FIX J: env computed by the pre_worktree hook (e.g. CARGO_TARGET_DIR per
       // slot) — runAgent applies it to the spawned agent's environment.
       env: agentEnv,
+    };
+
+    // Intra-attempt notes-loop (Track C, #924). Default OFF → `runNotesLoop`
+    // fires the base input exactly once. Enabled → a bounded outer loop makes one
+    // small committed change per iteration, seeds the next with an accumulated
+    // `notes.md` (materialised at the attempt dir, never committed to the worker
+    // branch), short-circuits on DONE, and hands the last partial run back on a
+    // cap-hit so the existing salvage + landing path runs. The loop's resource
+    // caps are checked BETWEEN iterations, so they never double-abort with the
+    // per-call attempt guard inside `runAgent`.
+    const notesLoopCfg: NotesLoopConfig = deps.notesLoop ?? {
+      enabled: false,
+      maxIterations: 1,
+      innerMaxIterations: 0,
+      tokenBudget: 0,
+      wallClockS: 0,
+    };
+    const notesOutcome = await runNotesLoop({
+      config: notesLoopCfg,
+      baseHandoff: handoff,
+      runOnce: ({ handoff: iterationHandoff }) =>
+        deps.runAgent({
+          ...baseAgentInput,
+          handoffContent: iterationHandoff,
+          ...(notesLoopCfg.enabled && notesLoopCfg.innerMaxIterations > 0
+            ? { maxIterations: notesLoopCfg.innerMaxIterations }
+            : {}),
+        }),
+      persistNotes: (content) => deps.writeNotes?.(notesPath(input.attemptDir), content),
+      // Wall-clock cap reasons in ms; the attempt clock is epoch seconds.
+      now: () => deps.nowEpoch() * 1000,
+      // Cumulative input+output tokens for the token cap, read from the live
+      // WorkerVitals (ADR 0065). Absent vitals → 0, so the cap stays inert.
+      tokensSpent: () => {
+        const vitals = deps.heartbeatVitals?.();
+        return vitals ? (vitals.input_tokens ?? 0) + (vitals.output_tokens ?? 0) : 0;
+      },
+      log: (message) => deps.appendIterLog(message),
     });
+    let run: RunAgentResult = notesOutcome.run;
 
     // ---- runner-fallback subsystem (--fallback-runner / runner failure) ----
     // The active runner signalled quota / rate-limit exhaustion OR a transient

--- a/apps/dev/tests/notes-loop.test.ts
+++ b/apps/dev/tests/notes-loop.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveNotesLoopConfig,
+  runNotesLoop,
+  renderNotesSection,
+  appendNotesEntry,
+  notesPath,
+  NOTES_FILE_NAME,
+  NOTES_LOOP_DEFAULT_MAX_ITERATIONS,
+  type NotesLoopConfig,
+  type NotesLoopIteration,
+} from "../src/core/notes-loop.js";
+import type { RunAgentResult, AgentOutcome, AgentOutput } from "../src/core/execution.js";
+
+const cfg = (over: Partial<NotesLoopConfig> = {}): NotesLoopConfig => ({
+  enabled: true,
+  maxIterations: 3,
+  innerMaxIterations: 0,
+  tokenBudget: 0,
+  wallClockS: 0,
+  ...over,
+});
+
+const result = (outcome: AgentOutcome, over: Partial<RunAgentResult> = {}): RunAgentResult => ({
+  outcome,
+  branch: "afk/w/1-x",
+  commits: [],
+  stdout: "",
+  ...over,
+});
+
+const structured = (over: Partial<AgentOutput> = {}): AgentOutput => ({
+  success: false,
+  summary: "made a small change",
+  key_changes_made: ["edited a.ts"],
+  key_learnings: [],
+  should_fully_stop: false,
+  ...over,
+});
+
+describe("resolveNotesLoopConfig", () => {
+  it("defaults to disabled with the documented caps", () => {
+    const c = resolveNotesLoopConfig({});
+    expect(c.enabled).toBe(false);
+    expect(c.maxIterations).toBe(NOTES_LOOP_DEFAULT_MAX_ITERATIONS);
+    expect(c.innerMaxIterations).toBe(0);
+    expect(c.tokenBudget).toBe(0);
+    expect(c.wallClockS).toBe(0);
+  });
+
+  it("reads the folded accessor keys", () => {
+    const c = resolveNotesLoopConfig({
+      "afk.notes_loop.enabled": "true",
+      "afk.notes_loop.max_iterations": "6",
+      "afk.notes_loop.inner_max_iterations": "10",
+      "afk.notes_loop.token_budget": "500000",
+      "afk.notes_loop.wall_clock_s": "3600",
+    });
+    expect(c).toEqual({
+      enabled: true,
+      maxIterations: 6,
+      innerMaxIterations: 10,
+      tokenBudget: 500000,
+      wallClockS: 3600,
+    });
+  });
+
+  it("floors a non-numeric / zero max_iterations back to the default but keeps 0 as unlimited for resource caps", () => {
+    const c = resolveNotesLoopConfig({
+      "afk.notes_loop.max_iterations": "0", // invalid → default (never a zero-iteration loop)
+      "afk.notes_loop.token_budget": "0", // valid → unlimited
+      "afk.notes_loop.wall_clock_s": "nope", // invalid → default 0
+    });
+    expect(c.maxIterations).toBe(NOTES_LOOP_DEFAULT_MAX_ITERATIONS);
+    expect(c.tokenBudget).toBe(0);
+    expect(c.wallClockS).toBe(0);
+  });
+});
+
+describe("notesPath", () => {
+  it("materialises notes.md at the attempt dir", () => {
+    expect(notesPath("/x/.red/tmp/a-1")).toBe(`/x/.red/tmp/a-1/${NOTES_FILE_NAME}`);
+  });
+});
+
+describe("runNotesLoop — disabled (default off)", () => {
+  it("enabled:false runs exactly one agent call with the base handoff and no notes", async () => {
+    const calls: NotesLoopIteration[] = [];
+    const persisted: string[] = [];
+    const out = await runNotesLoop({
+      config: cfg({ enabled: false }),
+      baseHandoff: "BASE",
+      runOnce: (it) => {
+        calls.push(it);
+        return Promise.resolve(result("done", { commits: [{ sha: "a" }] }));
+      },
+      persistNotes: (c) => persisted.push(c),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.handoff).toBe("BASE");
+    expect(calls[0]!.notes).toBe("");
+    expect(persisted).toHaveLength(0);
+    expect(out.iterations).toBe(1);
+    expect(out.stoppedBy).toBe("done");
+  });
+});
+
+describe("runNotesLoop — enabled", () => {
+  it("stops on DONE and short-circuits to land", async () => {
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 5 }),
+      baseHandoff: "BASE",
+      runOnce: () => {
+        n += 1;
+        return Promise.resolve(n < 2 ? result("no-sentinel", { commits: [{ sha: "c1" }] }) : result("done", { commits: [{ sha: "c2" }] }));
+      },
+    });
+    expect(n).toBe(2);
+    expect(out.stoppedBy).toBe("done");
+    expect(out.iterations).toBe(2);
+    expect(out.run.outcome).toBe("done");
+  });
+
+  it("makes N calls when the agent never signals DONE, then caps out", async () => {
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 3 }),
+      baseHandoff: "BASE",
+      runOnce: () => {
+        n += 1;
+        return Promise.resolve(result("no-sentinel", { commits: [{ sha: `c${n}` }] }));
+      },
+    });
+    expect(n).toBe(3);
+    expect(out.iterations).toBe(3);
+    expect(out.stoppedBy).toBe("max-iterations");
+  });
+
+  it("carries prior notes into each subsequent iteration's handoff", async () => {
+    const handoffs: string[] = [];
+    let n = 0;
+    await runNotesLoop({
+      config: cfg({ maxIterations: 3 }),
+      baseHandoff: "BASE",
+      runOnce: (it) => {
+        handoffs.push(it.handoff);
+        n += 1;
+        return Promise.resolve(
+          result("no-sentinel", {
+            commits: [{ sha: `c${n}` }],
+            agentOutput: structured({ summary: `did step ${n}`, key_changes_made: [`change ${n}`] }),
+          }),
+        );
+      },
+    });
+    // First iteration: bare base handoff (no notes yet).
+    expect(handoffs[0]).toBe("BASE");
+    // Second iteration: base handoff PLUS a carried-notes section citing step 1.
+    expect(handoffs[1]).toContain("BASE");
+    expect(handoffs[1]).toContain("<carried-notes>");
+    expect(handoffs[1]).toContain("did step 1");
+    expect(handoffs[1]).toContain("change 1");
+    // Third iteration: notes accumulate — both prior steps present.
+    expect(handoffs[2]).toContain("did step 1");
+    expect(handoffs[2]).toContain("did step 2");
+  });
+
+  it("cap-hit persists notes and hands back the last partial run for salvage + land", async () => {
+    const persisted: string[] = [];
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 2 }),
+      baseHandoff: "BASE",
+      runOnce: () => {
+        n += 1;
+        return Promise.resolve(result("no-sentinel", { commits: [{ sha: `c${n}` }], agentOutput: structured({ summary: `s${n}` }) }));
+      },
+      persistNotes: (c) => persisted.push(c),
+    });
+    expect(out.stoppedBy).toBe("max-iterations");
+    // The returned run is the LAST partial run — with its commits — so the caller
+    // salvages + lands it.
+    expect(out.run.commits.map((c) => c.sha)).toEqual(["c2"]);
+    // Notes were persisted at least once per completed continuable iteration.
+    expect(persisted.length).toBeGreaterThanOrEqual(1);
+    expect(persisted[persisted.length - 1]).toContain("s1");
+  });
+
+  it("treats a blocked outcome as terminal without re-seeding", async () => {
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 5 }),
+      baseHandoff: "BASE",
+      runOnce: () => {
+        n += 1;
+        return Promise.resolve(result("blocked"));
+      },
+    });
+    expect(n).toBe(1);
+    expect(out.stoppedBy).toBe("blocked");
+  });
+
+  it("hands a per-call terminal outcome (exhausted) straight back after one iteration", async () => {
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 5 }),
+      baseHandoff: "BASE",
+      runOnce: () => {
+        n += 1;
+        return Promise.resolve(result("exhausted"));
+      },
+    });
+    expect(n).toBe(1);
+    expect(out.stoppedBy).toBe("terminal");
+    expect(out.run.outcome).toBe("exhausted");
+  });
+
+  it("stops at the wall-clock cap between iterations (never mid-run)", async () => {
+    let clock = 0;
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 10, wallClockS: 5 }),
+      baseHandoff: "BASE",
+      now: () => clock,
+      runOnce: () => {
+        n += 1;
+        clock += 6000; // each iteration advances the wall clock past the 5s cap
+        return Promise.resolve(result("no-sentinel", { commits: [{ sha: `c${n}` }] }));
+      },
+    });
+    // Iteration 1 always runs; the cap is observed BEFORE iteration 2.
+    expect(n).toBe(1);
+    expect(out.stoppedBy).toBe("wall-clock");
+  });
+
+  it("stops at the token budget between iterations", async () => {
+    let spent = 0;
+    let n = 0;
+    const out = await runNotesLoop({
+      config: cfg({ maxIterations: 10, tokenBudget: 100 }),
+      baseHandoff: "BASE",
+      tokensSpent: () => spent,
+      runOnce: () => {
+        n += 1;
+        spent += 200; // blow the budget after the first iteration
+        return Promise.resolve(result("no-sentinel", { commits: [{ sha: `c${n}` }] }));
+      },
+    });
+    expect(n).toBe(1);
+    expect(out.stoppedBy).toBe("token-budget");
+  });
+});
+
+describe("notes formatting helpers", () => {
+  it("renderNotesSection wraps the notes in a carried-notes block with continue guidance", () => {
+    const s = renderNotesSection("## Iteration 1\n- did a thing");
+    expect(s).toContain("<carried-notes>");
+    expect(s).toContain("</carried-notes>");
+    expect(s).toContain("ONE small, committed change");
+    expect(s).toContain("did a thing");
+  });
+
+  it("appendNotesEntry records outcome, commits, and structured signal, accumulating across iterations", () => {
+    const first = appendNotesEntry("", 1, result("no-sentinel", { commits: [{ sha: "a" }], agentOutput: structured({ summary: "step one", key_changes_made: ["c"], key_learnings: ["l"] }) }));
+    expect(first).toContain("## Iteration 1");
+    expect(first).toContain("commits this iteration: 1");
+    expect(first).toContain("summary: step one");
+    expect(first).toContain("change: c");
+    expect(first).toContain("learning: l");
+    const second = appendNotesEntry(first, 2, result("no-sentinel"));
+    expect(second).toContain("## Iteration 1");
+    expect(second).toContain("## Iteration 2");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #924. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #924

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785475167&installation_id=129708444&pr_number=977&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F977&signature=ee443a5fbeeff2f593e5ae96d81a338769457cebb06d5809856b97579c694bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->