### PR TITLE
fix(memory): remove local machine path from competitive-baseline comment

### DIFF
--- a/apps/memory/src/competitive-baseline.ts
+++ b/apps/memory/src/competitive-baseline.ts
@@ -378,8 +378,7 @@ export interface CompetitiveInteropOptions {
 }
 
 /**
- * Checked-in summary derived from
- * `/home/cyber/Work/reddb.io/reddb-benchmark/graphify-out`.
+ * Checked-in summary derived from a local reddb-benchmark graphify export.
  *
  * The full graph export is intentionally not copied here. The competitive
  * harness only needs the stable shape and the path-query timing fixture behind


### PR DESCRIPTION
Removes an absolute path that exposed local machine directory structure from a JSDoc comment in `competitive-baseline.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785497586&installation_id=129708444&pr_number=983&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F983&signature=70a27197baf6a5809789668cbf1c11a1cfb2f8f02bffa7f1ead29cb0039cfd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->