### PR TITLE
fix(ci): remove accidentally tracked node_modules symlink from packages/shared

### DIFF
--- a/packages/shared/node_modules
+++ b/packages/shared/node_modules
@@ -1,1 +1,0 @@
-/home/cyber/Work/reddb.io/red-skills/packages/shared/node_modules


### PR DESCRIPTION
## Root cause

Commit cc6f837b (PR #976, 2026-07-01 02:05) salvaged an uncommitted change and committed `packages/shared/node_modules` as a **symlink** pointing to an absolute local machine path (`/home/cyber/Work/reddb.io/red-skills/packages/shared/node_modules`).

On the CI runner (`ubuntu-latest`), git checkout creates a **broken symlink** at `packages/shared/node_modules`. When `pnpm install --frozen-lockfile` runs, it tries to create `packages/shared/node_modules/` as a directory (for direct dep symlinks like `cli-args-parser`), finds the broken symlink already there, and fails with:

```
[ENOENT] Error while trying to symlink ...node_modules/cli-args-parser to packages/shared/node_modules/cli-args-parser
...mkdir 'packages/shared/node_modules': ENOENT
```

This has blocked **every** `red-workspace-ci` and `red-release` run since PR #976.

## Fix

`git rm packages/shared/node_modules` — removes the symlink from git tracking. The `.gitignore` already covers `node_modules/` so it won't be re-committed.

## Side effect

Also removes the leaked local machine path from the repository.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785500949&installation_id=129708444&pr_number=984&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F984&signature=3b4eba9f9983802f4414337da2148f47112c12cc0efd630862c633c617bd17f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * No user-visible changes were detected in this update.
  * A repository reference was removed, with no impact on app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->