### PR TITLE
merge: #986 feat(afk): Track A — per-attempt budget guard with salvage-on-abort

### DIFF
--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -2346,6 +2346,66 @@ describe("processIssue — timeout (attempt progress guard fired)", () => {
   });
 });
 
+describe("processIssue — budget-exceeded (per-attempt resource guard fired, #908)", () => {
+  it("salvages partial work, then parks ready-for-human + blocked:budget without crashing", async () => {
+    // The attempt guard aborted on a resource ceiling: the inner agent returns
+    // the `budget-exceeded` outcome with dirty worktree paths. Salvage commits
+    // the partial work onto the branch ("never empty-handed"), then the issue
+    // parks for a human — a runaway is never auto-retried (recovery key null).
+    const { deps, input, trace } = harness({
+      outcome: "budget-exceeded",
+      commits: [],
+      salvage: 3,
+      changedFiles: ["packages/x/src/a.ts"],
+    });
+    const result = await processIssue(deps, input);
+
+    // Salvage ran against the live worker branch and committed the partial work.
+    expect(trace.salvageCalls).toHaveLength(1);
+    expect(trace.salvageCalls[0]).toBe(result.branch);
+    expect(trace.iterLogs.some((line) => line.includes("salvaged 3 uncommitted file(s)"))).toBe(true);
+
+    // Terminal budget-exceeded: preserved, never landed/closed.
+    expect(result.outcome).toBe("budget-exceeded");
+    expect(result.preserved).toBe(true);
+    expect(trace.closed).toEqual([]);
+    // The orchestrator did not leave the issue in `running` — it shed running and
+    // escalated to a human with the typed blocked:budget tag.
+    expect(labelTrace(trace)).toEqual([
+      "-ready-for-agent|+running",
+      "-running|+ready-for-human+blocked:budget",
+    ]);
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-human");
+    expect(edit.add).toContain("blocked:budget");
+    expect(trace.ensuredLabels).toContain("blocked:budget");
+    // The failure envelope rides the generic `blocked` status bucket.
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    // on_attempt_error escalates (no auto-recovery); post_attempt never fires on
+    // a budget abort (the attempt did not reach a sentinel-bearing terminal).
+    expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
+  });
+
+  it("a clean worktree (0 salvaged files) still parks ready-for-human + blocked:budget", async () => {
+    // Nothing to salvage (the runaway committed everything or edited nothing),
+    // but the budget abort still parks for a human — no auto-retry, no crash.
+    const { deps, input, trace } = harness({
+      outcome: "budget-exceeded",
+      commits: [],
+      salvage: 0,
+      changedFiles: [],
+    });
+    const result = await processIssue(deps, input);
+
+    expect(trace.salvageCalls).toHaveLength(1);
+    expect(result.outcome).toBe("budget-exceeded");
+    expect(trace.closed).toEqual([]);
+    const edit = trace.labelEdits.at(-1)!;
+    expect(edit.add).toContain("ready-for-human");
+    expect(edit.add).toContain("blocked:budget");
+  });
+});
+
 describe("processIssue — emitHeartbeat receives resolved base (issue #570)", () => {
   it("passes the resolved non-main base to emitHeartbeat when the issue body pins a branch", async () => {
     const heartbeatInfos: AttemptProgressInfo[] = [];


### PR DESCRIPTION
Automated AFK landing for #986. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #986

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785516424&installation_id=129708444&pr_number=999&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F999&signature=eeb359ba01f479535d36740b40f07fdd566c3bcafbc3a6044006619166b12c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->