### PR TITLE
merge: #988 feat(adr): 1C-doc — AXI/TOON doctrine ADR + reference doc

### DIFF
--- a/.red/adr/0082-axi-toon-doctrine-for-agent-facing-clis.md
+++ b/.red/adr/0082-axi-toon-doctrine-for-agent-facing-clis.md
@@ -33,7 +33,7 @@ Every CLI whose primary reader is an agent is designed against these ten princip
 9. **Contextual disclosure** — end each output with a next-step suggestion ("run `X` to …") so the agent needs one fewer guess.
 10. **Consistent way to get help** — a concise per-subcommand reference reachable the same way everywhere.
 
-**These are targets, not a lint.** A surface adopts them incrementally, slice by slice, measured (Decision 4). A CLI is not rejected for missing one; it is scheduled to close the gap.
+**These are targets, not a lint.** A surface adopts them incrementally, slice by slice, measured (Decision 4). A CLI is not rejected for missing one; it is scheduled to close the gap. The [AXI + TOON doctrine doc](../contexts/dev/axi-toon-doctrine.md) restates these ten as a copy-ready checklist for CLI authors.
 
 ### 2. TOON is the output format for list and tabular data
 
@@ -64,6 +64,8 @@ workers[2]{id,issue,state}:
 - **Do not force TOON onto** a single scalar, a one-off nested config object, or free-form prose. TOON's win is tabular; a lone object gains nothing and reads worse. JSON (or plain text) stays correct there.
 - **Human-facing rendering is unaffected.** A CLI may still render a pretty table for a human; the doctrine governs the *agent-facing* serialization path. A `--json` escape hatch stays available for consumers that need raw JSON.
 
+The [doctrine doc](../contexts/dev/axi-toon-doctrine.md) records the concrete TOON line format (delimiters, summary line, human-readability rules) and a TOON-vs-JSON-vs-prose contrast table.
+
 ### 3. Adoption order — the noisiest agent-facing surfaces first
 
 Surfaces adopt AXI + TOON in this order, chosen by how much an agent reads them and how noisy they are today:
@@ -87,7 +89,7 @@ The measurement is a first-class deliverable of the rollout, reported per slice,
 
 ## Consequences
 
-- **New agent-facing CLIs start AXI-shaped.** The ten principles are the checklist a new surface is designed against, not a retrofit. `/write-a-skill` and CLI authorship reference this ADR.
+- **New agent-facing CLIs start AXI-shaped.** The ten principles are the checklist a new surface is designed against, not a retrofit. `/write-a-skill` and CLI authorship reference this ADR and the [doctrine doc](../contexts/dev/axi-toon-doctrine.md).
 - **Existing surfaces converge incrementally.** `monitor` → `dashboard` → `daily-review` → `statusline`, one measured slice at a time (first = #918). No big-bang rewrite; no surface is blocked on the others.
 - **Output shrinks at the source, not only at the proxy.** RTK stays the safety net for output RedSkills does not control (raw `git`, `gh`, `vitest`, `tsc`); AXI removes the need for it on RedSkills' own CLIs. The two do not conflict — a TOON-emitting monitor piped through RTK simply has less left to compress.
 - **Fewer round-trips.** Pre-computed aggregates, definitive empty states, and contextual next-step suggestions each remove a follow-up call the agent would otherwise make — a saving larger than the byte-level TOON win on interactive flows.
@@ -98,6 +100,7 @@ The measurement is a first-class deliverable of the rollout, reported per slice,
 
 - PRD #907 — the parent program that scopes AXI + TOON adoption (Track 1C/F); this ADR is its design-time decision record.
 - Issue #918 — the first application slice (`monitor` → TOON).
+- [AXI + TOON doctrine doc](../contexts/dev/axi-toon-doctrine.md) — the CLI-author-facing checklist, TOON line-format rules, and the TOON-vs-JSON-vs-prose contrast table that this ADR mandates.
 - ADR 0065 — AFK WorkerVitals canonical vocabulary; the `monitor`/`statusline` fields this doctrine serializes read that vocabulary, so minimal-schema selection draws from it.
 - ADR 0053 — provider-tidy is report-only governance; a sibling "measure before you assert" posture (report the delta, do not claim it).
 - `RTK.md` (global) — the after-the-fact compression proxy whose empirical win motivates the design-time spec; AXI is the upstream complement, not a replacement.

--- a/.red/contexts/dev/axi-toon-doctrine.md
+++ b/.red/contexts/dev/axi-toon-doctrine.md
@@ -1,0 +1,59 @@
+# AXI + TOON doctrine — a checklist for agent-facing CLI authors
+
+This is the CLI-author-facing companion to [ADR 0082](../../adr/0082-axi-toon-doctrine-for-agent-facing-clis.md), which is the binding decision. This doc is the practical restatement: a checklist you run against a CLI whose primary reader is an agent, plus the concrete TOON line format and a contrast table showing why TOON beats JSON and prose for that reader.
+
+**AXI = Agent eXperience Interface** — the design-time contract for how a CLI *chooses* to emit output. **TOON = Token-Oriented Object Notation** — the compact serialization that contract mandates for list/tabular data. AXI is the "why is this output big?" spec; RTK is the after-the-fact "shrink what we can't control" proxy. They are complementary, not alternatives — see the ADR's Context section.
+
+## The 10 AXI principles — checklist
+
+Run each item against your CLI's agent-facing output. These are **targets adopted incrementally**, not a lint gate: a surface is scheduled to close a gap, never rejected for one.
+
+- [ ] **1. Token-efficient output** — list/tabular output is TOON, not JSON (~40% fewer tokens; see the format rules below).
+- [ ] **2. Minimal default schemas** — 3–4 fields per list item by default, not 10. Extra fields are opt-in (`--wide`, `--full`), never the default.
+- [ ] **3. Content truncation** — large text is truncated with a size hint (`… +2.1kB, --full`) and a `--full` escape hatch; no unbounded blobs.
+- [ ] **4. Pre-computed aggregates** — the counts and rollup statuses the agent would otherwise compute with a second call are already on the summary line.
+- [ ] **5. Definitive empty states** — an explicit `0 results` with the next command to try, never ambiguous empty output the agent must guess at.
+- [ ] **6. Structured errors & exit codes** — mutations are idempotent, errors carry a structured payload, exit codes are meaningful, and there are no interactive prompts in an agent context.
+- [ ] **7. Ambient context** — install opt-in session integrations first (SessionStart), then offer an on-demand skill; do not force the agent to discover state.
+- [ ] **8. Content first** — running with no arguments shows live data, not help text.
+- [ ] **9. Contextual disclosure** — each output ends with a next-step suggestion (`run X to …`) so the agent needs one fewer guess.
+- [ ] **10. Consistent way to get help** — a concise per-subcommand reference reachable the same way everywhere.
+
+## TOON format rules
+
+TOON encodes the JSON data model — same objects, arrays, primitives — but declares a uniform array's fields once and streams the row values line by line. Concretely, an agent-facing CLI's TOON output obeys:
+
+1. **One structured line per entity.** Each row is a single line; one entity never spans multiple lines. A header declares the array length and field order once: `workers[2]{id,issue,state}:` then one indented line per row.
+2. **Printable ASCII delimiters, human-readable without a JSON parser.** Fields are comma-separated within a row; status tokens use bracketed literals — `[ok]`, `[FAIL]`, `[time]` — and scalar attributes use `key: value`. No quoting ceremony, no braces per row, no trailing-comma bookkeeping. A human skims it; a parser is optional.
+3. **Summary on the last line.** The final line is a pre-computed rollup — totals, counts, elapsed time — so the agent reads the aggregate without a second call: `2 workers · 1 active · 1 merged · [time] 4m12s`.
+4. **Tabular scope only.** TOON is for uniform arrays of objects (roster, issue list, PR list, DORA rows). A lone scalar, a one-off nested config object, or free-form prose is *not* TOON'd — it gains nothing and reads worse; plain `key: value` or JSON stays correct there.
+
+Worked example — a fleet roster the agent reads every tick:
+
+```toon
+workers[2]{id,issue,state}:
+  wEW5N,910,active
+  wBXI6,943,merged
+2 workers · 1 active · 1 merged · [time] 4m12s
+```
+
+The same data as JSON costs the repeated property names (`id`/`issue`/`state`) and brace/quote punctuation on *every* row; TOON pays for them once in the header.
+
+## Contrast — TOON vs JSON vs prose
+
+Why each alternative is inappropriate for agent-facing output:
+
+| Dimension | TOON | JSON | Prose |
+| --- | --- | --- | --- |
+| Tokens on N rows | Field names once in header, then bare values → ~40% fewer | Field names + braces + quotes repeated every row | Verbose, unbounded, filler words |
+| Parse cost for the agent | Read directly; header gives the schema | Must run a JSON parser to act | Must interpret free text, high error rate |
+| Ambiguity | Deterministic columns; explicit empty state | Deterministic but heavy | High — "a few workers are running" is unactionable |
+| Human-readable without a parser | Yes — printable ASCII, `[ok]`/`key: value` | Barely — nested braces obscure the data | Yes, but not machine-actionable |
+| Aggregates | Pre-computed on the summary line | Absent unless separately computed | Sometimes, inconsistently |
+| Best fit | **Agent-facing list/tabular output** | Machine-to-machine APIs; `--json` escape hatch | Human narrative, docs, commit messages |
+
+**Rule of thumb:** JSON is right for a program consuming a program; prose is right for a human reading a story; **TOON is right for an agent reading state it must act on.** Agent-facing CLIs default to TOON and keep a `--json` escape hatch for consumers that genuinely need raw JSON.
+
+## Where this applies
+
+Adoption order (ADR 0082, Decision 3), noisiest agent-read surface first: `monitor` (first slice #918) → `dashboard` → `daily-review` → `statusline`. New agent-facing CLIs start AXI-shaped by running this checklist at design time; existing surfaces converge one measured slice at a time, reporting the token delta per slice.


### PR DESCRIPTION
Automated AFK landing for #988. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #988

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785516441&installation_id=129708444&pr_number=1000&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1000&signature=6c73e8b6534abbb47f4b123698fd1a9977d536911f9223ac60008e3213fdb7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->