### PR TITLE
merge: #989 feat(ship): 2B — ordered pipeline + mechanical/intentional fix split

### DIFF
--- a/apps/dev/src/core/ship.ts
+++ b/apps/dev/src/core/ship.ts
@@ -176,3 +176,100 @@ export function decidePrePrShipGate(input: PrePrShipGateInput): PrePrShipGateDec
   if (!input.feedbackPassed) return "escalate";
   return "push";
 }
+
+// ---------- Track 2B: ordered pipeline + mechanical/intentional fix split ----------
+
+/**
+ * The seven /ship pipeline stages, in mandatory execution order. Each stage must
+ * pass before the next runs; a failure at stage N stops the pipeline at N.
+ *
+ * 1. review — scan the diff for obvious issues
+ * 2. test   — run the full test suite
+ * 3. docs   — verify public API / SKILL.md changes are documented
+ * 4. lint   — run linter / typecheck
+ * 5. push   — push branch to remote
+ * 6. pr     — open or reuse the PR
+ * 7. ci     — wait for CI to pass
+ */
+export const SHIP_PIPELINE_STAGES = [
+  "review",
+  "test",
+  "docs",
+  "lint",
+  "push",
+  "pr",
+  "ci",
+] as const;
+
+export type ShipPipelineStage = (typeof SHIP_PIPELINE_STAGES)[number];
+
+/** Outcome of a single pipeline stage. `reason` explains a failure (or absence). */
+export interface ShipStageOutcome {
+  passed: boolean;
+  reason?: string;
+}
+
+export type ShipPipelineResult =
+  | { status: "passed"; failedStage: null }
+  | { status: "failed"; failedStage: ShipPipelineStage; stageIndex: number; reason: string };
+
+/**
+ * Run the ordered /ship pipeline over per-stage outcomes and return the first
+ * failure (or `passed` when all seven stages are green).
+ *
+ * Evaluation always follows {@link SHIP_PIPELINE_STAGES} order regardless of the
+ * input map's key order, so "stage N must pass before N+1 runs" is enforced
+ * structurally: the first stage that is missing or `passed: false` stops the
+ * pipeline and is reported with its name, zero-based index, and reason. A stage
+ * with no outcome counts as not-run (the pipeline never reached it), which is a
+ * failure at that stage — callers therefore need only provide outcomes up to and
+ * including the first failure.
+ */
+export function runShipPipeline(
+  stages: Partial<Record<ShipPipelineStage, ShipStageOutcome>>,
+): ShipPipelineResult {
+  for (let index = 0; index < SHIP_PIPELINE_STAGES.length; index++) {
+    const stage = SHIP_PIPELINE_STAGES[index]!;
+    const outcome = stages[stage];
+    if (!outcome || !outcome.passed) {
+      return {
+        status: "failed",
+        failedStage: stage,
+        stageIndex: index,
+        reason: outcome?.reason ?? `stage "${stage}" did not run`,
+      };
+    }
+  }
+  return { status: "passed", failedStage: null };
+}
+
+/**
+ * The two fix classes every proposed fix is labelled with before it is applied.
+ * Maps to the existing INFRA/SEMANTIC distinction:
+ * - `mechanical` — cannot change behaviour (formatting, import sort, unused
+ *   variable, trailing whitespace). Auto-applied silently.
+ * - `intentional` — changes a public symbol, contract, or observable behaviour.
+ *   Escalated to the user; never applied silently.
+ */
+export type FixClass = "mechanical" | "intentional";
+
+/**
+ * Label a proposed fix `mechanical` or `intentional`. A fix that cannot be
+ * classified as mechanical with confidence is treated as `intentional` — the
+ * safe default inherited from {@link isPrePrFindingMechanical}, which only
+ * returns `true` for low-severity lint/format/docs findings.
+ */
+export function classifyFix(finding: PrePrFinding): FixClass {
+  return isPrePrFindingMechanical(finding) ? "mechanical" : "intentional";
+}
+
+export type FixApplication = "auto-apply" | "escalate";
+
+/**
+ * Decide how a labelled fix is applied: `mechanical` fixes are auto-applied
+ * silently; `intentional` fixes are escalated to the user (park
+ * `ready-for-human` or prompt interactively) and never silently applied.
+ */
+export function decideFixApplication(finding: PrePrFinding): FixApplication {
+  return classifyFix(finding) === "mechanical" ? "auto-apply" : "escalate";
+}

--- a/apps/dev/tests/ship.test.ts
+++ b/apps/dev/tests/ship.test.ts
@@ -8,6 +8,10 @@ import {
   shipChecksAreGreen,
   decidePrePrShipGate,
   isPrePrFindingMechanical,
+  runShipPipeline,
+  classifyFix,
+  decideFixApplication,
+  SHIP_PIPELINE_STAGES,
   type PrePrFinding,
 } from "../src/core/ship.js";
 
@@ -257,5 +261,116 @@ describe("no-mistakes pre-PR pipeline (#913 — findings classification)", () =>
       timedOut: true,
     };
     expect(decidePrePrShipGate(gateInput)).toBe("escalate");
+  });
+});
+
+describe("ordered ship pipeline (#989 — Track 2B)", () => {
+  const allGreen = {
+    review: { passed: true },
+    test: { passed: true },
+    docs: { passed: true },
+    lint: { passed: true },
+    push: { passed: true },
+    pr: { passed: true },
+    ci: { passed: true },
+  } as const;
+
+  it("declares the seven stages in mandatory order", () => {
+    expect([...SHIP_PIPELINE_STAGES]).toEqual([
+      "review",
+      "test",
+      "docs",
+      "lint",
+      "push",
+      "pr",
+      "ci",
+    ]);
+  });
+
+  it("passes when all seven stages are green", () => {
+    expect(runShipPipeline(allGreen)).toEqual({ status: "passed", failedStage: null });
+  });
+
+  it("stops at stage N and reports the stage name and reason", () => {
+    // Test (stage 2, index 1) fails: the pipeline must stop there and never
+    // consult docs/lint/push/pr/ci, even though later stages would also fail.
+    const result = runShipPipeline({
+      review: { passed: true },
+      test: { passed: false, reason: "3 tests failing" },
+    });
+    expect(result).toEqual({
+      status: "failed",
+      failedStage: "test",
+      stageIndex: 1,
+      reason: "3 tests failing",
+    });
+  });
+
+  it("fails at the earliest failing stage regardless of input key order", () => {
+    // ci is listed first in the object but review (index 0) fails, so review wins.
+    const result = runShipPipeline({
+      ci: { passed: false, reason: "ci red" },
+      review: { passed: false, reason: "obvious bug in diff" },
+      test: { passed: false, reason: "would also fail" },
+    });
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.failedStage).toBe("review");
+      expect(result.stageIndex).toBe(0);
+      expect(result.reason).toBe("obvious bug in diff");
+    }
+  });
+
+  it("treats a missing (not-run) stage as a failure at that stage", () => {
+    const result = runShipPipeline({ review: { passed: true } });
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.failedStage).toBe("test");
+      expect(result.reason).toContain("did not run");
+    }
+  });
+});
+
+describe("mechanical vs intentional fix split (#989 — Track 2B)", () => {
+  const trailingWhitespace: PrePrFinding = {
+    category: "format",
+    severity: "low",
+    file: "src/foo.ts",
+    line: 12,
+    message: "trailing whitespace",
+    suggestion: "remove whitespace",
+  };
+
+  const renamePublicSymbol: PrePrFinding = {
+    category: "semantics",
+    severity: "high",
+    file: "src/foo.ts",
+    line: 40,
+    message: "public symbol should be renamed",
+    suggestion: "rename export",
+  };
+
+  it("labels a mechanical fix and applies it silently; labels an intentional fix and escalates it", () => {
+    // A mechanical fix (trailing whitespace) is labelled and auto-applied.
+    expect(classifyFix(trailingWhitespace)).toBe("mechanical");
+    expect(decideFixApplication(trailingWhitespace)).toBe("auto-apply");
+
+    // An intentional change (renaming a public symbol) is labelled and escalated.
+    expect(classifyFix(renamePublicSymbol)).toBe("intentional");
+    expect(decideFixApplication(renamePublicSymbol)).toBe("escalate");
+  });
+
+  it("treats a fix it cannot classify with confidence as intentional", () => {
+    // A logic finding is not mechanical → default to intentional (escalate).
+    const unclear: PrePrFinding = {
+      category: "logic",
+      severity: "medium",
+      file: "src/bar.ts",
+      line: 3,
+      message: "ambiguous branch",
+      suggestion: "review the condition",
+    };
+    expect(classifyFix(unclear)).toBe("intentional");
+    expect(decideFixApplication(unclear)).toBe("escalate");
   });
 });

--- a/plugins/dev/skills/engineering/ship/SKILL.md
+++ b/plugins/dev/skills/engineering/ship/SKILL.md
@@ -33,6 +33,40 @@ infers the issue number from the current branch, and delegates to
 `requeue #N --adopt-branch CURRENT_BRANCH --guidance '...'` automatically.
 Update your workflow to call requeue directly.
 
+## The ship pipeline (seven ordered stages)
+
+The validation the `/ship` concept always stood for now runs inside the shared
+gate that `/dev:requeue` and `/afk` both invoke. It is an **ordered pipeline** —
+each stage must pass before the next runs, and a failure at stage N stops the
+pipeline at N and reports the stage name and reason (no later stage runs):
+
+1. **Review** — scan the diff for obvious issues
+2. **Test** — run the full test suite
+3. **Docs** — verify public API or SKILL.md changes are documented
+4. **Lint** — run the linter / typecheck
+5. **Push** — push the branch to the remote
+6. **PR** — open or reuse the PR
+7. **CI** — wait for CI to pass
+
+The pipeline order is fixed in `SHIP_PIPELINE_STAGES` (`apps/dev/src/core/ship.ts`)
+and evaluated by `runShipPipeline`, which returns the first failing stage.
+
+## Mechanical vs intentional fix split
+
+Before applying any fix the pipeline proposes, it is **labelled** one of two
+classes (mapping to the existing INFRA/SEMANTIC distinction):
+
+- **Mechanical** — auto-applied silently. A fix is mechanical only when it cannot
+  change behaviour: formatting, import sort, unused variable, trailing
+  whitespace.
+- **Intentional** — escalated to the user (park `ready-for-human` or prompt
+  interactively) and **never** silently applied. A fix is intentional when it
+  changes a public symbol, contract, or observable behaviour.
+
+A fix that cannot be classified as mechanical **with confidence is treated as
+intentional** — the safe default. The classifier is `classifyFix` and the
+per-fix action is `decideFixApplication` (`apps/dev/src/core/ship.ts`).
+
 ## See also
 
 - `/dev:requeue` — the replacement for manual branch adoption


### PR DESCRIPTION
Automated AFK landing for #989. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #989

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785516950&installation_id=129708444&pr_number=1001&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1001&signature=d6af55c09fcdd9d6291302aff4270eb29329299a703203c945c098d5c82b4c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->