### PR TITLE
merge: #991 feat(afk): 3A — scout as native /afk task type (read-only, queueable)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -2,6 +2,7 @@ import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
 import {
   runSession,
+  runModeForCandidate,
   type SessionContext,
   type SessionDeps,
   type SelectionFilter,
@@ -1455,7 +1456,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         repoDir: c.issueTemplate.repoDir,
         remote: c.issueTemplate.remote,
         baseInput: { issueBody: candidate.body },
-        runMode: flags.runMode,
+        runMode: runModeForCandidate(candidate, flags.runMode),
       };
     },
     emit: (line: string) => process.stdout.write(`${line}\n`),

--- a/apps/dev/src/core/session.ts
+++ b/apps/dev/src/core/session.ts
@@ -73,7 +73,7 @@ export type SelectionFilter =
   | { kind: "issues"; numbers: number[] }
   | { kind: "prd"; prd: number };
 
-import { LABEL_PRD, LABEL_URGENT, LABEL_HIGH, LABEL_READY } from "./triage-labels.js";
+import { LABEL_PRD, LABEL_URGENT, LABEL_HIGH, LABEL_READY, LABEL_TYPE_SCOUT } from "./triage-labels.js";
 
 function hasLabel(c: IssueCandidate, label: string): boolean {
   return c.labels.includes(label);
@@ -176,6 +176,17 @@ export function selectIssues(candidates: readonly IssueCandidate[], filter: Sele
   const urgentNumbers = new Set(urgent.map((c) => c.number));
   const tail = filtered.filter((c) => !urgentNumbers.has(c.number));
   return [...urgent, ...tail];
+}
+
+/** Derive the execution run-mode for a fleet candidate from its labels.
+ * A `type:scout` label activates read-only investigation mode — no commits,
+ * no push, no PR. The caller's explicit `flagRunMode` (from `--run-mode`) wins
+ * when both are set, so CLI overrides always take priority. Issues WITHOUT
+ * `type:scout` return `undefined` (normal ship dispatch — unaffected). */
+export function runModeForCandidate(candidate: IssueCandidate, flagRunMode?: string): string | undefined {
+  if (flagRunMode !== undefined) return flagRunMode;
+  if (candidate.labels.includes(LABEL_TYPE_SCOUT)) return "scout";
+  return undefined;
 }
 
 // ---------- the outer session loop ----------

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -77,5 +77,12 @@ export const LABEL_INFRA = "blocked:infra";
 // work is salvaged + parked for a human; never blind-retried as a transient.
 export const LABEL_BUDGET = "blocked:budget";
 
+// Task-type routing labels (fleet-native dispatch)
+// A `ready-for-agent` issue carrying this label is dispatched in read-only
+// investigation mode — no commits, no push, no PR. The orchestrator posts the
+// agent's output as a comment and closes the issue. Regression guard: issues
+// WITHOUT this label are dispatched as normal ship tasks (unaffected).
+export const LABEL_TYPE_SCOUT = "type:scout";
+
 // Auxiliary labels
 export const LABEL_RUNNER_ERROR = "runner-error";

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -4,6 +4,7 @@ import {
   type ProcessIssueDeps,
   type ProcessIssueInput,
 } from "../src/core/process-issue.js";
+import { SCOUT_EXIT_PROTOCOL } from "../src/core/handoff.js";
 import type { HookName } from "../src/core/hook-config.js";
 import type { ConfigValues } from "../src/core/config.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult } from "../src/core/execution.js";
@@ -129,6 +130,8 @@ interface HarnessOptions {
   salvage?: number;
   /** Issue body threaded into processIssue. */
   body?: string;
+  /** Execution mode forwarded to ProcessIssueInput (e.g. `"scout"`). */
+  runMode?: string;
   /** Optional ADR 0049 tier resolver injected by the production wiring. */
   resolveTier?: ProcessIssueDeps["resolveTier"];
   /** Optional ADR 0049 issue classifier injected by the production wiring. */
@@ -505,6 +508,7 @@ function harness(opts: HarnessOptions = {}): {
     remote: "origin",
     baseInput: { issueBody: opts.body ?? "## Agent brief\nDo it." },
     prdRef: undefined,
+    runMode: opts.runMode,
   };
 
   return { deps, input, trace };
@@ -2519,5 +2523,57 @@ describe("processIssue — new lifecycle checkpoints (#832)", () => {
     };
     await processIssue(customDeps, input);
     expect(commands).toContain("blk");
+  });
+});
+
+// ---------- scout mode (fleet-native read-only dispatch, issue #991) ----------
+
+describe("processIssue — scout mode (runMode: 'scout')", () => {
+  it("uses SCOUT_EXIT_PROTOCOL as the system prompt (read-only handoff)", async () => {
+    const { deps, input, trace } = harness({ runMode: "scout", outcome: "done" });
+    await processIssue(deps, input);
+    expect(trace.runAgentCalls[0]?.systemPrompt).toBe(SCOUT_EXIT_PROTOCOL);
+  });
+
+  it("disables continuous push — no-commit sandbox config", async () => {
+    const { deps, input, trace } = harness({ runMode: "scout", outcome: "done" });
+    await processIssue(deps, input);
+    expect(trace.runAgentCalls[0]?.continuousPush).toBe(false);
+  });
+
+  it("posts the agent's text output as a scout report comment and closes the issue", async () => {
+    const { deps, input, trace } = harness({ runMode: "scout", outcome: "done" });
+    await processIssue(deps, input);
+    const report = trace.comments.find((c) => c.issue === 9 && c.body.includes("Scout Report"));
+    expect(report).toBeDefined();
+    expect(trace.closed).toContain(9);
+  });
+
+  it("returns outcome 'done' after a successful scout", async () => {
+    const { deps, input } = harness({ runMode: "scout", outcome: "done" });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(result.issue).toBe(9);
+  });
+
+  it("does not push a branch to the remote (no worker-branch push)", async () => {
+    const { deps, input, trace } = harness({ runMode: "scout", outcome: "done" });
+    await processIssue(deps, input);
+    expect(trace.pushedAttempt).toHaveLength(0);
+  });
+
+  it("releases the claim lock after a scout completion", async () => {
+    const { deps, input, trace } = harness({ runMode: "scout", outcome: "done" });
+    await processIssue(deps, input);
+    expect(trace.released).toContain(9);
+  });
+
+  it("parks the issue as ready-for-human on no-sentinel (no report)", async () => {
+    const { deps, input, trace } = harness({ runMode: "scout", outcome: "no-sentinel", commits: [] });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("no-sentinel");
+    const humanLabel = trace.labelEdits.find((e) => e.add.includes("ready-for-human"));
+    expect(humanLabel).toBeDefined();
+    expect(trace.closed).not.toContain(9);
   });
 });

--- a/apps/dev/tests/session.test.ts
+++ b/apps/dev/tests/session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   genWorkerId,
+  runModeForCandidate,
   selectIssues,
   slugify,
   runSession,
@@ -107,6 +108,33 @@ describe("selectIssues", () => {
     ];
     const out = selectIssues(list, { kind: "prd", prd: 44 });
     expect(out.map((c) => c.number)).toEqual([9, 2]);
+  });
+});
+
+// ---------- runModeForCandidate ----------
+
+describe("runModeForCandidate (type:scout fleet routing)", () => {
+  it("returns undefined for a plain ship candidate (no type:scout label)", () => {
+    expect(runModeForCandidate(cand(1, ["ready-for-agent"]))).toBeUndefined();
+    expect(runModeForCandidate(cand(2, ["ready-for-agent", "priority:high"]))).toBeUndefined();
+  });
+
+  it("returns 'scout' when the candidate carries the type:scout label", () => {
+    expect(runModeForCandidate(cand(3, ["ready-for-agent", "type:scout"]))).toBe("scout");
+  });
+
+  it("the --run-mode flag takes priority over the label", () => {
+    expect(runModeForCandidate(cand(4, ["ready-for-agent", "type:scout"]), "scout")).toBe("scout");
+    expect(runModeForCandidate(cand(5, ["ready-for-agent"]), "scout")).toBe("scout");
+  });
+
+  it("type:scout issues are NOT dropped by selectIssues (fleet-compatible)", () => {
+    const list = [
+      cand(1, ["ready-for-agent"]),
+      cand(2, ["ready-for-agent", "type:scout"]),
+    ];
+    const out = selectIssues(list, { kind: "all" });
+    expect(out.map((c) => c.number)).toEqual([1, 2]);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #991. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #991

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785517391&installation_id=129708444&pr_number=1003&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1003&signature=4e43a9c2b192b36fbcf14327c032530c390b18f51633804713e051cdd2e8e9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->