### PR TITLE
merge: #994 feat(afk): 3E — tasks-axi: byte-exact markdown edits wherever AFK rewrites a doc

### DIFF
--- a/apps/dev/src/core/agent-brief.ts
+++ b/apps/dev/src/core/agent-brief.ts
@@ -1,0 +1,98 @@
+// agent-brief - byte-exact anchored editing for the ## Agent brief section of
+// issue bodies. Mirrors the blocker-state approach: a surgical anchor-based fast
+// path preserves every byte outside the inner region on every subsequent edit;
+// the fallback (no anchors yet) injects the anchors so the next edit is already
+// byte-exact. This eliminates the whole-document whitespace normalisation that
+// upsertMarkdownSection() introduced.
+
+import { readAnchoredRegion, replaceAnchoredRegion } from "./anchored-edit.js";
+
+export const AGENT_BRIEF_HEADING = "Agent brief";
+export const AGENT_BRIEF_OPEN = "<!-- red:agent-brief v1 -->";
+export const AGENT_BRIEF_CLOSE = "<!-- /red:agent-brief -->";
+
+/** The inner content between the anchors: newline-padded brief text. */
+function formatBriefInner(brief: string): string {
+  return `\n${brief.trim()}\n`;
+}
+
+/** Find the byte range of the `## Agent brief` section (heading through the
+ * start of the next ## heading, or the end of the document). */
+function agentBriefSectionRange(markdown: string): { start: number; end: number } | null {
+  const lines = markdown.split("\n");
+  let offset = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    if (new RegExp(`^##\\s+${AGENT_BRIEF_HEADING}\\s*$`, "i").test(line)) {
+      const start = offset;
+      let end = markdown.length;
+      let innerOffset = offset + line.length + 1;
+      for (let j = i + 1; j < lines.length; j += 1) {
+        if (/^##\s+/.test(lines[j]!)) {
+          end = innerOffset;
+          break;
+        }
+        innerOffset += lines[j]!.length + 1;
+      }
+      return { start, end };
+    }
+    offset += line.length + 1;
+  }
+  return null;
+}
+
+/**
+ * Upsert the `## Agent brief` section using byte-exact anchor editing when the
+ * anchors already exist (fast path). When the section exists but lacks anchors,
+ * replaces it with an anchored block so subsequent edits are byte-exact. When
+ * the section is absent, appends it.
+ *
+ * The anchored fast path calls `replaceAnchoredRegion`, which preserves every
+ * byte outside the inner region unchanged — no trailing-whitespace normalisation
+ * of the surrounding document.
+ */
+export function upsertAgentBrief(markdown: string, brief: string): string {
+  const inner = formatBriefInner(brief);
+
+  // Fast path: byte-exact replacement inside the existing anchored region.
+  const anchored = replaceAnchoredRegion(markdown, AGENT_BRIEF_OPEN, AGENT_BRIEF_CLOSE, inner);
+  if (anchored !== null) return anchored;
+
+  // Fallback: no anchors yet — inject the anchored section, replacing the bare
+  // heading block (if present) or appending. The next call takes the fast path.
+  const replacement = `## ${AGENT_BRIEF_HEADING}\n\n${AGENT_BRIEF_OPEN}${inner}${AGENT_BRIEF_CLOSE}\n`;
+  const range = agentBriefSectionRange(markdown);
+  if (range) {
+    return (
+      `${markdown.slice(0, range.start)}${replacement}\n${markdown.slice(range.end).replace(/^\n+/, "")}`.trimEnd() +
+      "\n"
+    );
+  }
+  const prefix = markdown.trimEnd();
+  return `${prefix}${prefix.length > 0 ? "\n\n" : ""}${replacement}`;
+}
+
+export interface AgentBriefEditResult {
+  /** The body after the surgical edit (byte-identical reference when no change). */
+  body: string;
+  /** True when the body differs from the input — a no-op is signaled by false. */
+  changed: boolean;
+  /** True when reading the result back yields the intended brief text (round-trip
+   * integrity). A false `valid` means the anchors were malformed or the brief
+   * could not be written; callers should skip the remote write. */
+  valid: boolean;
+}
+
+/**
+ * Byte-exact round-trip edit: compute the new body surgically, detect whether it
+ * changed, and confirm the parse-back yields the intended brief. Callers can skip
+ * the remote write when `changed` is false and trust the edit was correctly formed
+ * when `valid` is true.
+ */
+export function applyAgentBriefEdit(markdown: string, brief: string): AgentBriefEditResult {
+  const body = upsertAgentBrief(markdown, brief);
+  const changed = body !== markdown;
+  const read = readAnchoredRegion(body, AGENT_BRIEF_OPEN, AGENT_BRIEF_CLOSE);
+  const valid = read !== null && read.trim() === brief.trim();
+  return { body, changed, valid };
+}

--- a/apps/dev/src/core/hitl-resolution-plan.ts
+++ b/apps/dev/src/core/hitl-resolution-plan.ts
@@ -1,6 +1,6 @@
 import type { HitlDecisionExtraction } from "./hitl-decision-extraction.js";
 import { clearCurrentBlocker, parseCurrentBlocker, upsertCurrentBlocker } from "./blocker-state.js";
-import { upsertMarkdownSection } from "./development-workflow.js";
+import { upsertAgentBrief } from "./agent-brief.js";
 import { LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
 
 export interface HitlResolutionIssue {
@@ -82,7 +82,7 @@ export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPl
     });
     return {
       commentBody: directiveComment(input),
-      bodyUpdate: upsertMarkdownSection(cleared, "Agent brief", input.disposition.agentBrief),
+      bodyUpdate: upsertAgentBrief(cleared, input.disposition.agentBrief),
       addLabels: [LABEL_READY],
       removeLabels: [LABEL_HUMAN, ...staleBlockerLabels(input.issue.labels)],
     };

--- a/apps/dev/src/core/hitl-selection.ts
+++ b/apps/dev/src/core/hitl-selection.ts
@@ -1,7 +1,10 @@
 export interface HitlCandidate {
   number: number;
   title: string;
-  body: string;
+  /** Issue body — absent when the candidate was fetched via the routing list
+   * (only labels/number/createdAt are needed for selectHitlQueue). Callers
+   * that need the body use viewIssueFull for the selected issue. */
+  body?: string;
   labels: string[];
   createdAt?: string | null;
 }

--- a/apps/dev/src/runtime/companion-io.ts
+++ b/apps/dev/src/runtime/companion-io.ts
@@ -26,7 +26,7 @@ import * as ghx from "./gh.js";
 import type { GhContext } from "./gh.js";
 import { readWorkerStates, type WorkerStatesReadOpts, type WorkerStateRecord } from "../core/worker-state-reader.js";
 import { parseWorkerAttemptPath } from "../core/worker-paths.js";
-import { upsertMarkdownSection } from "../core/development-workflow.js";
+import { upsertAgentBrief, AGENT_BRIEF_HEADING } from "../core/agent-brief.js";
 import { upsertCurrentBlocker } from "../core/blocker-state.js";
 import { recoveryCap, type RecoveryEnv } from "../core/recovery.js";
 import {
@@ -42,7 +42,7 @@ import type { AfkState } from "../types/state.js";
 
 /** The issue-body section the correction directive lands in — the next attempt's
  * brief. Kept stable so a re-correction REPLACES the section rather than stacking. */
-export const COMPANION_BRIEF_HEADING = "Agent brief";
+export const COMPANION_BRIEF_HEADING = AGENT_BRIEF_HEADING;
 export const LABEL_READY_FOR_AGENT = "ready-for-agent";
 export const LABEL_READY_FOR_HUMAN = "ready-for-human";
 
@@ -127,7 +127,8 @@ function auditComment(plan: CompanionPlan, issue: number, attempt: number): stri
 }
 
 /** Rewrite the issue body for a `correct` plan: replace the `## Agent brief`
- * section with the bounded correction directive the next attempt reads. */
+ * section with the bounded correction directive the next attempt reads. Uses
+ * byte-exact anchor editing so every byte outside the brief block is preserved. */
 export function applyCorrectionBody(body: string, note: string, signal: string): string {
   const brief = [
     "<!-- companion-correction -->",
@@ -136,7 +137,7 @@ export function applyCorrectionBody(body: string, note: string, signal: string):
     "",
     note,
   ].join("\n");
-  return upsertMarkdownSection(body, COMPANION_BRIEF_HEADING, brief);
+  return upsertAgentBrief(body, brief);
 }
 
 /** Rewrite the issue body for an `escalate` plan: open a `## Current blocker`

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -143,9 +143,11 @@ export async function listCandidates(ctx: GhContext, label: string = LABEL_READY
   });
 }
 
-/** List the ready-for-human candidate pool projected to HitlCandidate[]. */
+/** List the ready-for-human candidate pool projected to HitlCandidate[].
+ * Routing (selectHitlQueue) uses only labels/number/createdAt — body is not
+ * fetched here; callers that need it use viewIssueFull for the selected issue. */
 export async function listHitlCandidates(ctx: GhContext): Promise<HitlCandidate[]> {
-  const r = await runGh(ctx, 
+  const r = await runGh(ctx,
     [
       "issue",
       "list",
@@ -157,7 +159,7 @@ export async function listHitlCandidates(ctx: GhContext): Promise<HitlCandidate[
       "--limit",
       "200",
       "--json",
-      "number,title,labels,body,createdAt",
+      "number,title,labels,createdAt",
     ],
   );
   if (r.code !== 0) return [];
@@ -172,14 +174,12 @@ export async function listHitlCandidates(ctx: GhContext): Promise<HitlCandidate[
     const item = row as {
       number?: number;
       title?: string;
-      body?: string;
       createdAt?: string | null;
       labels?: Array<{ name?: string }>;
     };
     return {
       number: Number(item.number ?? 0),
       title: String(item.title ?? ""),
-      body: String(item.body ?? ""),
       createdAt: item.createdAt ?? null,
       labels: Array.isArray(item.labels) ? item.labels.map((l) => String(l.name ?? "")) : [],
     };

--- a/apps/dev/tests/agent-brief.test.ts
+++ b/apps/dev/tests/agent-brief.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_BRIEF_CLOSE,
+  AGENT_BRIEF_OPEN,
+  applyAgentBriefEdit,
+  upsertAgentBrief,
+} from "../src/core/agent-brief.js";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the bytes before and after the anchored region. */
+function outerBytes(markdown: string): { before: string; after: string } {
+  const openIdx = markdown.indexOf(AGENT_BRIEF_OPEN);
+  const closeIdx = markdown.indexOf(AGENT_BRIEF_CLOSE);
+  if (openIdx === -1 || closeIdx === -1) return { before: markdown, after: "" };
+  return {
+    before: markdown.slice(0, openIdx),
+    after: markdown.slice(closeIdx + AGENT_BRIEF_CLOSE.length),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// upsertAgentBrief — fast path (anchors already present)
+// ---------------------------------------------------------------------------
+
+describe("upsertAgentBrief — fast path (anchors present) (#994)", () => {
+  const withAnchors = [
+    "## Summary",
+    "The original summary.",
+    "",
+    "## Agent brief",
+    "",
+    AGENT_BRIEF_OPEN,
+    "Old brief content.",
+    AGENT_BRIEF_CLOSE,
+    "",
+    "## Acceptance criteria",
+    "- [ ] Keep this.",
+    "",
+  ].join("\n");
+
+  it("replaces inner content; bytes outside the anchored region are byte-identical", () => {
+    const before = outerBytes(withAnchors);
+    const out = upsertAgentBrief(withAnchors, "New brief content.");
+    const after = outerBytes(out);
+
+    expect(after.before).toBe(before.before);
+    expect(after.after).toBe(before.after);
+    expect(out).toContain("New brief content.");
+    expect(out).not.toContain("Old brief content.");
+  });
+
+  it("is a no-op (same reference) when the content is already correct", () => {
+    const out = upsertAgentBrief(withAnchors, "Old brief content.");
+    expect(out).toBe(withAnchors);
+  });
+
+  it("preserves the surrounding sections byte-for-byte", () => {
+    const out = upsertAgentBrief(withAnchors, "Changed.");
+    expect(out).toContain("## Summary\nThe original summary.");
+    expect(out).toContain("## Acceptance criteria\n- [ ] Keep this.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertAgentBrief — fallback (no anchors yet)
+// ---------------------------------------------------------------------------
+
+describe("upsertAgentBrief — fallback (no anchors yet) (#994)", () => {
+  it("injects anchors when the section exists but lacks them", () => {
+    const body = "## Summary\nExisting.\n\n## Agent brief\nOld brief.\n\n## Acceptance\n- [ ] Keep.\n";
+    const out = upsertAgentBrief(body, "New brief.");
+    expect(out).toContain(AGENT_BRIEF_OPEN);
+    expect(out).toContain(AGENT_BRIEF_CLOSE);
+    expect(out).toContain("New brief.");
+    expect(out).not.toContain("Old brief.");
+    expect(out.match(/## Agent brief/g)).toHaveLength(1);
+  });
+
+  it("appends an anchored section when no heading exists", () => {
+    const body = "## Summary\nExisting.\n";
+    const out = upsertAgentBrief(body, "New brief.");
+    expect(out).toContain("## Agent brief");
+    expect(out).toContain(AGENT_BRIEF_OPEN);
+    expect(out).toContain("New brief.");
+    expect(out).toContain("## Summary\nExisting.");
+  });
+
+  it("a second call with anchors now in place uses the fast path", () => {
+    const first = upsertAgentBrief("## Summary\nExisting.\n", "Brief v1.");
+    const before = outerBytes(first);
+    const second = upsertAgentBrief(first, "Brief v2.");
+    const after = outerBytes(second);
+
+    expect(second).toContain("Brief v2.");
+    expect(second).not.toContain("Brief v1.");
+    // Bytes outside the anchored region are preserved byte-for-byte on the second call.
+    expect(after.before).toBe(before.before);
+    expect(after.after).toBe(before.after);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyAgentBriefEdit — round-trip validation
+// ---------------------------------------------------------------------------
+
+describe("applyAgentBriefEdit (#994)", () => {
+  it("reports changed=false when the body is already correct", () => {
+    const body = upsertAgentBrief("## Summary\nExisting.\n", "Stable brief.");
+    const result = applyAgentBriefEdit(body, "Stable brief.");
+    expect(result.changed).toBe(false);
+    expect(result.valid).toBe(true);
+    expect(result.body).toBe(body);
+  });
+
+  it("reports changed=true and valid=true for a fresh update", () => {
+    const body = upsertAgentBrief("## Summary\nExisting.\n", "Old brief.");
+    const result = applyAgentBriefEdit(body, "New brief.");
+    expect(result.changed).toBe(true);
+    expect(result.valid).toBe(true);
+    expect(result.body).toContain("New brief.");
+  });
+
+  it("outer bytes are unchanged on fast-path edit", () => {
+    const initial = upsertAgentBrief(
+      "## Summary\nBefore.\n\n## Notes\nAfter.\n",
+      "Initial.",
+    );
+    const before = outerBytes(initial);
+    const { body } = applyAgentBriefEdit(initial, "Updated.");
+    const after = outerBytes(body);
+    expect(after.before).toBe(before.before);
+    expect(after.after).toBe(before.after);
+  });
+});

--- a/apps/dev/tests/companion-io.test.ts
+++ b/apps/dev/tests/companion-io.test.ts
@@ -114,11 +114,28 @@ describe("parseSeenFingerprints (#921)", () => {
 });
 
 describe("body rewrites (#921)", () => {
-  it("correction upserts the ## Agent brief section", () => {
+  it("correction upserts the ## Agent brief section with byte-exact anchors", () => {
     const out = applyCorrectionBody("## Parent\n#1\n", "Stop and change strategy.", "iteration-churn");
     expect(out).toMatch(/## Agent brief/);
+    expect(out).toContain("<!-- red:agent-brief v1 -->");
+    expect(out).toContain("<!-- /red:agent-brief -->");
     expect(out).toContain("Stop and change strategy.");
     expect(out).toContain("## Parent");
+  });
+  it("correction preserves bytes outside the anchored region on re-correction", () => {
+    // First correction plants the anchors.
+    const first = applyCorrectionBody("## Parent\n#1\n\n## Notes\nKeep this.\n", "Stop.", "iteration-churn");
+    const openIdx = first.indexOf("<!-- red:agent-brief v1 -->");
+    const closeIdx = first.indexOf("<!-- /red:agent-brief -->");
+    const before = first.slice(0, openIdx);
+    const after = first.slice(closeIdx + "<!-- /red:agent-brief -->".length);
+    // Second correction reuses the fast path — outer bytes are identical.
+    const second = applyCorrectionBody(first, "Try again.", "iteration-churn");
+    const openIdx2 = second.indexOf("<!-- red:agent-brief v1 -->");
+    const closeIdx2 = second.indexOf("<!-- /red:agent-brief -->");
+    expect(second.slice(0, openIdx2)).toBe(before);
+    expect(second.slice(closeIdx2 + "<!-- /red:agent-brief -->".length)).toBe(after);
+    expect(second).toContain("Try again.");
   });
   it("escalation opens a ## Current blocker with kind drift", () => {
     const out = applyEscalationBody("## Parent\n#1\n", "stuck-waiting", "budget spent.");
@@ -153,6 +170,7 @@ describe("runCompanionPass (#921)", () => {
     expect(outcomes[0]?.disposition).toBe("corrected");
     const body = gh.writes.find((w) => w.kind === "editBody");
     expect(body?.args.join(" ")).toContain("## Agent brief");
+    expect(body?.args.join(" ")).toContain("<!-- red:agent-brief v1 -->");
     const comment = gh.writes.find((w) => w.kind === "comment");
     expect(comment?.args.join(" ")).toContain(companionFingerprint(7, 1, "iteration-churn"));
     const labels = gh.writes.find((w) => w.kind === "editLabels");

--- a/apps/dev/tests/hitl-resolution-plan.test.ts
+++ b/apps/dev/tests/hitl-resolution-plan.test.ts
@@ -34,7 +34,10 @@ describe("planHitlResolution", () => {
     expect(plan.commentBody).toContain("Pending decision:");
     expect(plan.commentBody).toContain("Human answer:");
     expect(plan.commentBody).toContain("Disposition:\ndelegable");
-    expect(plan.bodyUpdate).toContain("## Agent brief\n\nImplement the agreed behavior with tests.");
+    expect(plan.bodyUpdate).toContain("## Agent brief");
+    expect(plan.bodyUpdate).toContain("<!-- red:agent-brief v1 -->");
+    expect(plan.bodyUpdate).toContain("Implement the agreed behavior with tests.");
+    expect(plan.bodyUpdate).toContain("<!-- /red:agent-brief -->");
     expect(plan.addLabels).toEqual(["ready-for-agent"]);
     expect(plan.removeLabels).toEqual(["ready-for-human"]);
   });
@@ -106,7 +109,9 @@ describe("planHitlResolution", () => {
       }),
     );
 
-    expect(plan.bodyUpdate).toContain("## Agent brief\n\nNew brief.\n## Acceptance");
+    expect(plan.bodyUpdate).toContain("## Agent brief");
+    expect(plan.bodyUpdate).toContain("<!-- red:agent-brief v1 -->");
+    expect(plan.bodyUpdate).toContain("New brief.");
     expect(plan.bodyUpdate).not.toContain("Old brief.");
     expect(plan.bodyUpdate?.match(/## Agent brief/g)).toHaveLength(1);
   });


### PR DESCRIPTION
Automated AFK landing for #994. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #994

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785518728&installation_id=129708444&pr_number=1005&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1005&signature=df825a66aa8beb46652d4b8da1ab70a53258c31e6a93444a5f2a4b2d9876f23d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->