### PR TITLE
merge: #1006 feat(afk): pre-merge rebase in doLanding to eliminate false blocked:merge-conflict

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -203,6 +203,15 @@ async function runAdoptLanding(
         return ok ? dest : null;
       },
       removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
+      // Isolated worker-branch worktree for the PR path's pre-merge rebase (#1006).
+      makeRebaseWorktree: async (branch: string) => {
+        const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
+        const dest = join(paths.tmpDir, "rebase", `${slug}-adopt-${issue}`);
+        await gitx.worktreeRemove(gitCtx, dest);
+        const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
+        return ok ? dest : null;
+      },
+      removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
       envelope: {
         git: gitx.gitExec(gitCtx),
         poster: async (n, body) => { await ghx.comment(ghCtx, n, body); return true; },

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -292,6 +292,17 @@ function makeBootReconcileRunner(
         return ok ? dest : null;
       },
       removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
+      // Isolated worker-branch worktree for the PR path's pre-merge rebase (#1006):
+      // fetch base + rebase the branch + force-push run here, never the primary.
+      makeRebaseWorktree: async (branch: string) => {
+        const slot = parseSlot(process.env.RED_AFK_SLOT) ?? 0;
+        const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
+        const dest = join(paths.tmpDir, "rebase", `${slug}-boot-${slot}`);
+        await gitx.worktreeRemove(gitCtx, dest);
+        const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
+        return ok ? dest : null;
+      },
+      removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
       envelope: {
         git: gitx.gitExec(gitCtx),
         poster: async (issue, body) => {
@@ -686,6 +697,17 @@ export function buildProcessDeps(
       return ok ? dest : null;
     },
     removeLandingWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
+    // Isolated worker-branch worktree for the PR path's pre-merge rebase (#1006):
+    // fetch base + rebase the branch + force-push run here, never the primary.
+    makeRebaseWorktree: async (branch: string) => {
+      const slot = parseSlot(process.env.RED_AFK_SLOT) ?? 0;
+      const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "branch";
+      const dest = join(paths.tmpDir, "rebase", `${slug}-${slot}`);
+      await gitx.worktreeRemove(gitCtx, dest);
+      const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
+      return ok ? dest : null;
+    },
+    removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
     hooks: {
       config,
       resolveOptions,

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -30,6 +30,7 @@ import {
   integrateOrigin,
   landMerge,
   landPr,
+  preMergeRebase,
   resolveMergeConflict,
   type ConflictResolver,
   type CiAwaitInput,
@@ -67,6 +68,18 @@ export interface LandingDeps {
   makeLandingWorktree?(base: string): Promise<string | null>;
   /** Tear down a worktree returned by {@link makeLandingWorktree} (best-effort). */
   removeLandingWorktree?(dir: string): Promise<void>;
+  /**
+   * Provision an ISOLATED worktree checked out on the worker `<branch>` for the
+   * PR path's pre-merge rebase (#1006), so the fetch / rebase / force-push run OFF
+   * the primary checkout — the primary branch is sacred (#572). Returns the
+   * worktree dir, or null when one could not be provisioned. Paired with
+   * {@link removeRebaseWorktree}. Absent → the pre-merge rebase is SKIPPED and the
+   * PR lands exactly as before (opt-in). Only the PR path uses it; the direct path
+   * already integrates origin inside its own detached landing worktree.
+   */
+  makeRebaseWorktree?(branch: string): Promise<string | null>;
+  /** Tear down a worktree returned by {@link makeRebaseWorktree} (best-effort). */
+  removeRebaseWorktree?(dir: string): Promise<void>;
   /**
    * Opt-in advisory-review wait for the admin-PR landing
    * (`afk.merge.wait_for_review`, ADR 0048). Present → landPr holds until the
@@ -212,6 +225,16 @@ export async function doLanding(
  * `<base>` state. `locked` is echoed for the caller's result observability.
  */
 async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<LandingResult> {
+  // Pre-merge rebase (#1006): rebase the worker branch onto the fetched base tip
+  // in an ISOLATED worktree and force-push it before opening/merging the PR, so
+  // the admin-merge is never rejected as a stale non-fast-forward and then
+  // false-flagged blocked:merge-conflict. A real rebase conflict — or a
+  // --force-with-lease reject that survives the bounded retry — parks
+  // blocked:merge-conflict through the existing `pr-conflict` route. Opt-in:
+  // without the worktree provisioner the rebase is skipped (today's behaviour).
+  const rebaseFail = await preMergeRebaseInWorktree(deps, input);
+  if (rebaseFail) return rebaseFail;
+
   const r = await landPr(deps.mergeExec, {
     repo: input.repo,
     gitRepo: input.repoDir,
@@ -237,6 +260,39 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     return { ok: false, reason: "pr-merge-failed", locked: input.locked, prNumber: r.prNumber };
   }
   return { ok: false, reason: "land-failed", locked: input.locked, prNumber: r.prNumber };
+}
+
+/**
+ * Pre-merge rebase step for the PR path (#1006). Provision an isolated worktree
+ * on the worker branch and {@link preMergeRebase} it onto the fetched base,
+ * force-pushing the result. Returns a failing {@link LandingResult} to abort the
+ * landing (parked as blocked:merge-conflict via `pr-conflict`) on a real conflict
+ * or an exhausted force-with-lease retry; returns `undefined` — "proceed to the
+ * admin-merge" — on success, when no provisioner is wired (opt-in), or when a
+ * worktree could not be provisioned (skip rather than risk the primary; the
+ * CI-aware poll still catches a genuinely stale base). The worktree is always
+ * torn down.
+ */
+async function preMergeRebaseInWorktree(
+  deps: LandingDeps,
+  input: LandingInput,
+): Promise<LandingResult | undefined> {
+  if (!deps.makeRebaseWorktree) return undefined;
+  const dir = await deps.makeRebaseWorktree(input.branch);
+  if (!dir) return undefined;
+  try {
+    const rebased = await preMergeRebase(deps.mergeExec, {
+      repo: dir,
+      remote: input.remote,
+      base: input.base,
+      branch: input.branch,
+    });
+    if (rebased.ok) return undefined;
+    // Real conflict / exhausted force-with-lease retries → park merge-conflict.
+    return { ok: false, reason: "pr-conflict", locked: input.locked };
+  } finally {
+    await deps.removeRebaseWorktree?.(dir);
+  }
 }
 
 /**

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -82,6 +82,84 @@ export async function integrateOrigin(
   return { ok: true, action: "rebase" };
 }
 
+/** Inputs for the pre-merge rebase, {@link preMergeRebase} (#1006). */
+export interface PreMergeRebaseInput {
+  /** Dir passed to `git -C` — an ISOLATED worktree checked out on the worker
+   * branch (#572), never the primary checkout. */
+  repo: string;
+  /** Remote name (e.g. `origin`). */
+  remote: string;
+  /** Base branch to rebase onto (e.g. `main`). */
+  base: string;
+  /** Worker branch being rebased + force-pushed. */
+  branch: string;
+  /**
+   * Additional force-push attempts after the first, on a `--force-with-lease`
+   * reject (a landing race: the base or the remote head moved under us). Each
+   * retry re-fetches + re-rebases the advanced base before pushing again. Default
+   * 2 — so at most three pushes total before the caller parks merge-conflict.
+   */
+  maxPushRetries?: number;
+}
+
+/** Why a {@link preMergeRebase} did not land the rebased branch on the remote. */
+export type PreMergeRebaseFailReason = "fetch-failed" | "conflict" | "push-rejected";
+
+export interface PreMergeRebaseResult {
+  ok: boolean;
+  /** Set on `ok:false` — the distinct failure mode. */
+  reason?: PreMergeRebaseFailReason;
+}
+
+/**
+ * Pre-merge rebase (#1006): before the PR admin-merge, rebase the worker branch
+ * onto the freshly-fetched `<remote>/<base>` tip inside an ISOLATED worktree and
+ * force-push it, so the merge is never rejected as a stale non-fast-forward and
+ * false-flagged `blocked:merge-conflict`. The whole sequence runs on `repo` — a
+ * throwaway worktree on the worker branch (#572) — so the primary checkout is
+ * never touched. Sequence, mirroring the issue spec:
+ *   1. `git fetch <remote> <base>` then `git rebase <remote>/<base>`;
+ *   2. on a rebase conflict → `git rebase --abort` → `{ ok:false, conflict }`;
+ *   3. `git push <remote> HEAD:refs/heads/<branch> --force-with-lease`;
+ *   4. on a push reject (a landing race), re-fetch + re-rebase the advanced base
+ *      and retry up to `maxPushRetries` times; exhausting them → `push-rejected`.
+ * Both failure modes map to `blocked:merge-conflict` at the caller.
+ */
+export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Promise<PreMergeRebaseResult> {
+  const { repo, remote, base, branch } = input;
+  const maxRetries = input.maxPushRetries ?? 2;
+  const baseRef = `${remote}/${base}`;
+
+  // Fetch the base tip and rebase the worker branch onto it. Reused by the
+  // push-retry loop so a racing base advance is re-integrated before each retry.
+  const rebaseOntoBase = async (): Promise<PreMergeRebaseResult> => {
+    const fetch = await exec(["git", "-C", repo, "fetch", remote, base, "--quiet"]);
+    if (fetch.code !== 0) return { ok: false, reason: "fetch-failed" };
+    const rebase = await exec(["git", "-C", repo, "rebase", baseRef]);
+    if (rebase.code !== 0) {
+      await exec(["git", "-C", repo, "rebase", "--abort"]);
+      return { ok: false, reason: "conflict" };
+    }
+    return { ok: true };
+  };
+
+  const first = await rebaseOntoBase();
+  if (!first.ok) return first;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const push = await exec([
+      "git", "-C", repo, "push", remote, `HEAD:refs/heads/${branch}`, "--force-with-lease",
+    ]);
+    if (push.code === 0) return { ok: true };
+    if (attempt < maxRetries) {
+      // Force-with-lease reject → a race: re-integrate the advanced base, retry.
+      const again = await rebaseOntoBase();
+      if (!again.ok) return again;
+    }
+  }
+  return { ok: false, reason: "push-rejected" };
+}
+
 /** Inputs for the LOCKED landing path, {@link landMerge}. */
 export interface LandMergeInput {
   /** Dir passed to `git -C` — the isolated landing worktree (#572), not the

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -315,6 +315,16 @@ export interface ProcessIssueDeps {
   makeLandingWorktree?(base: string): Promise<string | null>;
   removeLandingWorktree?(dir: string): Promise<void>;
   /**
+   * Provision/tear down an ISOLATED worktree on the worker branch for the PR
+   * path's pre-merge rebase (#1006): fetch base, rebase the branch onto it,
+   * force-push, then admin-merge — so a diverged base can never false-flag the
+   * landing as blocked:merge-conflict. Runs off the primary checkout (#572). The
+   * CLI binds these to `git worktree add --detach origin/<branch>` / `git worktree
+   * remove`; absent → the rebase is skipped and the PR lands as before (opt-in).
+   */
+  makeRebaseWorktree?(branch: string): Promise<string | null>;
+  removeRebaseWorktree?(dir: string): Promise<void>;
+  /**
    * Opt-in advisory-review wait for the admin-PR landing
    * (`afk.merge.wait_for_review`, ADR 0048). Resolved from config by the CLI:
    * present → the landing holds until the configured review check concludes
@@ -1509,6 +1519,8 @@ export async function processIssue(
       ciAwait: deps.ciAwait,
       makeLandingWorktree: deps.makeLandingWorktree,
       removeLandingWorktree: deps.removeLandingWorktree,
+      makeRebaseWorktree: deps.makeRebaseWorktree,
+      removeRebaseWorktree: deps.removeRebaseWorktree,
     },
     {
       openPr,

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -163,6 +163,13 @@ export interface ReconcileDeps {
    */
   makeLandingWorktree?(base: string): Promise<string | null>;
   removeLandingWorktree?(dir: string): Promise<void>;
+  /**
+   * Isolated worker-branch worktree provisioner/teardown for the PR path's
+   * pre-merge rebase (#1006). Threaded from process-issue's deps; absent → the
+   * rebase is skipped and the PR lands as before.
+   */
+  makeRebaseWorktree?(branch: string): Promise<string | null>;
+  removeRebaseWorktree?(dir: string): Promise<void>;
   /** Opt-in advisory-review wait for the admin-PR landing (optional). */
   waitForReview?: WaitForReviewInput;
   /** Envelope-emit IO (poster / marker writer / posted writer / git push). */
@@ -332,6 +339,8 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       waitForReview: deps.waitForReview,
       makeLandingWorktree: deps.makeLandingWorktree,
       removeLandingWorktree: deps.removeLandingWorktree,
+      makeRebaseWorktree: deps.makeRebaseWorktree,
+      removeRebaseWorktree: deps.removeRebaseWorktree,
     },
     {
       openPr,

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -19,6 +19,11 @@ import type { ExecResult } from "../src/core/merge.js";
 // "primary checkout is sacred" suite below.
 const WT = "/wt";
 
+// The isolated worker-branch worktree the PR path's pre-merge rebase runs in
+// (#1006). Distinct from WT so a test can assert the fetch/rebase/force-push
+// never `git -C`'d the primary checkout (`/repo`).
+const RWT = "/rwt";
+
 interface Harness {
   deps: LandingDeps;
   input: LandingInput;
@@ -27,6 +32,7 @@ interface Harness {
   pushedAttempt: string[][];
   firedHooks: string[];
   removedWorktrees: string[];
+  removedRebaseWorktrees: string[];
   /** cwds the conflict resolver was dispatched in. */
   resolverCwds: string[];
 }
@@ -60,6 +66,14 @@ interface Opts {
   noWorktree?: boolean;
   /** Commits ahead of base returned by `git rev-list --count`. Default 3. */
   commitCount?: number;
+  /** Enable the PR-path pre-merge rebase provisioner (#1006). */
+  rebaseWorktree?: boolean;
+  /** The rebase provisioner returns null (could not provision → rebase skipped). */
+  noRebaseWorktree?: boolean;
+  /** rc the rebase in the rebase worktree returns (1 → real conflict → abort). */
+  rebaseCode?: number;
+  /** rc the force-with-lease push returns (1 → reject on every attempt). */
+  rebasePushCode?: number;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -67,6 +81,7 @@ function harness(opts: Opts = {}): Harness {
   const pushedAttempt: string[][] = [];
   const firedHooks: string[] = [];
   const removedWorktrees: string[] = [];
+  const removedRebaseWorktrees: string[] = [];
   const resolverCwds: string[] = [];
   let mergeResolved = false;
 
@@ -74,6 +89,13 @@ function harness(opts: Opts = {}): Harness {
     mergeExec: async (argv): Promise<ExecResult> => {
       mergeCalls.push(argv);
       const j = argv.join(" ");
+      // #1006 pre-merge rebase, in the isolated worker-branch worktree (RWT).
+      if (j === `git -C ${RWT} rebase origin/main`) {
+        return { code: opts.rebaseCode ?? 0, stdout: "", stderr: "" };
+      }
+      if (j.startsWith(`git -C ${RWT} push origin HEAD:refs/heads/`) && j.includes("--force-with-lease")) {
+        return { code: opts.rebasePushCode ?? 0, stdout: "", stderr: "" };
+      }
       if (argv.includes("pr") && argv.includes("list")) {
         return { code: 0, stdout: "42\n", stderr: "" };
       }
@@ -140,6 +162,14 @@ function harness(opts: Opts = {}): Harness {
     removeLandingWorktree: async (dir) => {
       removedWorktrees.push(dir);
     },
+    // #1006: only wired when the test opts in, so the existing PR-path suites keep
+    // skipping the rebase (opt-in — an absent provisioner is a no-op).
+    makeRebaseWorktree: opts.rebaseWorktree ? async () => (opts.noRebaseWorktree ? null : RWT) : undefined,
+    removeRebaseWorktree: opts.rebaseWorktree
+      ? async (dir) => {
+          removedRebaseWorktrees.push(dir);
+        }
+      : undefined,
   };
 
   const input: LandingInput = {
@@ -161,7 +191,17 @@ function harness(opts: Opts = {}): Harness {
     postMerge: () => "post_merge-ctx",
   };
 
-  return { deps, input, hooks, mergeCalls, pushedAttempt, firedHooks, removedWorktrees, resolverCwds };
+  return {
+    deps,
+    input,
+    hooks,
+    mergeCalls,
+    pushedAttempt,
+    firedHooks,
+    removedWorktrees,
+    removedRebaseWorktrees,
+    resolverCwds,
+  };
 }
 
 const joined = (calls: string[][]): string[] => calls.map((c) => c.join(" "));
@@ -444,6 +484,84 @@ describe("doLanding — CI-aware merge (#812)", () => {
     const h = harness({ locked: false, prMergeCode: 1 });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "pr-merge-failed", locked: false, prNumber: 42 });
+  });
+});
+
+describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
+  it("branch diverged by one unrelated commit is rebased in the worktree, force-pushed, then merged cleanly", async () => {
+    const h = harness({ locked: false, rebaseWorktree: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    const j = joined(h.mergeCalls);
+    // The rebase ran in the isolated worker-branch worktree, before the merge.
+    const fetchIdx = j.findIndex((c) => c === `git -C ${RWT} fetch origin main --quiet`);
+    const rebaseIdx = j.findIndex((c) => c === `git -C ${RWT} rebase origin/main`);
+    const pushIdx = j.findIndex(
+      (c) => c === `git -C ${RWT} push origin HEAD:refs/heads/afk/wAAAA/9-fix-the-thing --force-with-lease`,
+    );
+    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --admin --merge"));
+    expect(fetchIdx).toBeGreaterThanOrEqual(0);
+    expect(rebaseIdx).toBeGreaterThan(fetchIdx);
+    expect(pushIdx).toBeGreaterThan(rebaseIdx);
+    expect(mergeIdx).toBeGreaterThan(pushIdx);
+    // Clean rebase → no abort; the primary checkout is never rebased/reset.
+    expect(j.some((c) => c.includes("rebase --abort"))).toBe(false);
+    expect(j.some((c) => c.includes(`git -C /repo rebase`) || c.includes(`git -C /repo reset`))).toBe(false);
+    // The throwaway rebase worktree is torn down.
+    expect(h.removedRebaseWorktrees).toEqual([RWT]);
+  });
+
+  it("a real rebase conflict aborts and parks blocked:merge-conflict (never admin-merges)", async () => {
+    const h = harness({ locked: false, rebaseWorktree: true, rebaseCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    // pr-conflict routes to blocked:merge-conflict at the caller (existing behaviour).
+    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    const j = joined(h.mergeCalls);
+    expect(j).toContain(`git -C ${RWT} rebase --abort`);
+    // Never force-pushed, never admin-merged, post_merge never fired.
+    expect(j.some((c) => c.includes("--force-with-lease"))).toBe(false);
+    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(h.firedHooks).toEqual(["pre_merge"]);
+    // The primary checkout is never touched destructively.
+    expect(j.some((c) => c.includes("git -C /repo reset") || c.includes("git -C /repo rebase"))).toBe(false);
+    // Worktree still torn down on the failure path.
+    expect(h.removedRebaseWorktrees).toEqual([RWT]);
+  });
+
+  it("force-with-lease rejected on every attempt → parks blocked:merge-conflict after the bounded retry", async () => {
+    const h = harness({ locked: false, rebaseWorktree: true, rebasePushCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    const j = joined(h.mergeCalls);
+    // Three force-with-lease pushes (1 + 2 retries) then gives up — never merges.
+    const pushes = j.filter((c) => c.includes("--force-with-lease")).length;
+    expect(pushes).toBe(3);
+    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+  });
+
+  it("no provisioner (opt-out) → rebase skipped, PR lands exactly as before", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    // No rebase touched the worker branch; the admin-merge still ran.
+    expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+  });
+
+  it("worktree could not be provisioned → rebase skipped, PR still lands (never risks the primary)", async () => {
+    const h = harness({ locked: false, rebaseWorktree: true, noRebaseWorktree: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+  });
+
+  it("the DIRECT (non-PR) path ignores the rebase provisioner (it integrates origin itself)", async () => {
+    const h = harness({ locked: false, openPr: false, rebaseWorktree: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
+    // No pre-merge rebase force-push on the direct path.
+    expect(joined(h.mergeCalls).some((c) => c.includes(`git -C ${RWT}`))).toBe(false);
   });
 });
 

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -4,6 +4,7 @@ import {
   landMerge,
   landPr,
   openReviewPr,
+  preMergeRebase,
   resolveMergeConflict,
   buildConflictPrompt,
   waitForReviewCheck,
@@ -736,5 +737,95 @@ describe("resolveMergeConflict (one-shot self-resolver)", () => {
   it("instructs the resolver to commit with --no-verify (bypass consumer hooks, #840)", () => {
     const prompt = buildConflictPrompt(input, "status", "diff");
     expect(prompt).toContain("git commit --no-edit --no-verify");
+  });
+});
+
+describe("preMergeRebase (#1006)", () => {
+  const base = { repo: "/wt", remote: "origin", base: "main", branch: "afk/w/9-x" };
+
+  it("clean rebase → fetches base, rebases, force-pushes the branch, ok", async () => {
+    const { exec, calls } = fakeExec();
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: true });
+    const j = joined(calls);
+    expect(j).toContain("git -C /wt fetch origin main --quiet");
+    expect(j).toContain("git -C /wt rebase origin/main");
+    expect(j).toContain("git -C /wt push origin HEAD:refs/heads/afk/w/9-x --force-with-lease");
+    // A clean rebase never aborts.
+    expect(j.some((c) => c.includes("rebase --abort"))).toBe(false);
+  });
+
+  it("a fetch failure short-circuits before any rebase", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.includes("fetch"), result: { code: 1 } },
+    ]);
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: false, reason: "fetch-failed" });
+    expect(joined(calls).some((c) => c.includes("rebase"))).toBe(false);
+  });
+
+  it("a rebase conflict aborts the rebase and never pushes → conflict", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
+    ]);
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: false, reason: "conflict" });
+    const j = joined(calls);
+    expect(j).toContain("git -C /wt rebase --abort");
+    expect(j.some((c) => c.includes("push"))).toBe(false);
+  });
+
+  it("a force-with-lease reject retries (re-fetch + re-rebase) then succeeds on the 2nd push", async () => {
+    let pushes = 0;
+    const { exec, calls } = fakeExec([
+      {
+        match: (a) => a.includes("push"),
+        result: { code: 1 },
+      },
+    ]);
+    // Wrap to make the 2nd push succeed.
+    const wrapped: typeof exec = async (argv) => {
+      if (argv.includes("push")) {
+        pushes++;
+        return { code: pushes >= 2 ? 0 : 1, stdout: "", stderr: "" };
+      }
+      return exec(argv);
+    };
+    const r = await preMergeRebase(wrapped, base);
+    expect(r).toEqual({ ok: true });
+    expect(pushes).toBe(2);
+    // A retry re-fetches + re-rebases the advanced base between pushes.
+    const fetches = joined(calls).filter((c) => c.includes("fetch")).length;
+    expect(fetches).toBeGreaterThanOrEqual(2);
+  });
+
+  it("force-with-lease rejected on every attempt → retries twice then push-rejected (3 pushes)", async () => {
+    let pushes = 0;
+    const exec: Exec = async (argv) => {
+      if (argv.includes("push")) {
+        pushes++;
+        return { code: 1, stdout: "", stderr: "rejected" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r = await preMergeRebase(exec, { ...base, maxPushRetries: 2 });
+    expect(r).toEqual({ ok: false, reason: "push-rejected" });
+    expect(pushes).toBe(3);
+  });
+
+  it("a re-rebase during retry that conflicts → conflict (bounded, no infinite retry)", async () => {
+    let rebases = 0;
+    const exec: Exec = async (argv) => {
+      const j = argv.join(" ");
+      if (j === "git -C /wt rebase origin/main") {
+        rebases++;
+        // First rebase clean; the retry's re-rebase conflicts.
+        return { code: rebases >= 2 ? 1 : 0, stdout: "", stderr: "" };
+      }
+      if (argv.includes("push")) return { code: 1, stdout: "", stderr: "rejected" };
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: false, reason: "conflict" });
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1006. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1006

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785526389&installation_id=129708444&pr_number=1008&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1008&signature=c936d8a9b0710d15b7c4a77cb74d6c9d631c56176366a9d27138597578862964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->