### PR TITLE
feat(statusline): sticky last-known loc — show ~+A -R when live diff is 0

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -507,6 +507,13 @@ export function buildProcessDeps(
   // provider (#832) can report loc_added/loc_removed alongside the meter's
   // activity counters without re-shelling `git diff`.
   let lastHeartbeatDiff = { added: 0, removed: 0 };
+  // Per-attempt peak diff: the largest diff seen by the heartbeat for this attempt.
+  // Reset at attempt boundaries (same guard as activityMeter). Written to the state
+  // file so the statusline can show a sticky last-known value when the live diff
+  // transiently drops to 0 (e.g. during the feedback gate).
+  let peakLocAdded = 0;
+  let peakLocRemoved = 0;
+  let peakLocDir = "";
 
   // ---- lifecycle hooks: load config + resolve built-in defaults + real exec ----
   const config = loadConfig(paths.configPath, { warn: () => undefined });
@@ -843,6 +850,12 @@ export function buildProcessDeps(
         activityMeterDir = dir0;
         activityMeter = createActivityMeter();
       }
+      // New attempt → reset peak diff (peaks are per-attempt, not per-worker).
+      if (dir0 !== peakLocDir) {
+        peakLocDir = dir0;
+        peakLocAdded = 0;
+        peakLocRemoved = 0;
+      }
       if (
         event.type === "text" ||
         event.type === "toolCall" ||
@@ -965,6 +978,9 @@ export function buildProcessDeps(
           .catch(() => ({ added: 0, removed: 0 }));
         // Remember the volume for the on_heartbeat vitals provider (#832).
         lastHeartbeatDiff = { added, removed };
+        // Update the per-attempt peak diff (only grows; never decreases).
+        if (added > peakLocAdded) peakLocAdded = added;
+        if (removed > peakLocRemoved) peakLocRemoved = removed;
         // Close this heartbeat window on the meter — derives the waiting count
         // (a window with no new stream events) and snapshots the cumulative
         // tool/text counts to fold into the record + state.
@@ -984,6 +1000,8 @@ export function buildProcessDeps(
         await fsx.appendLine(join(current.attemptDir, "afk.log"), `[heartbeat] ${hb.msg}`);
         await updateState(join(current.attemptDir, "afk.state.json"), {
           ...hb.statePatch,
+          "current.loc_peak_added": peakLocAdded,
+          "current.loc_peak_removed": peakLocRemoved,
           "current.worktree": worktree,
           ...(info.base ? { "current.base": info.base } : {}),
         }).catch(() => {});

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -173,7 +173,7 @@ export function renderAfkLine(afk: AfkInput | undefined, columns: number | undef
   groups.push(workers);
 
   const diff = signedDiff(afk.added, afk.removed);
-  if (diff) groups.push(kv("loc", diff));
+  if (diff) groups.push(kv("loc", afk.locIsPeak ? `~${diff}` : diff));
 
   const pipe: string[] = [];
   if (afk.queue > 0) pipe.push(kv("rdy", String(afk.queue)));

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -79,6 +79,11 @@ export interface AfkInput {
   resolved?: number;
   /** #N issue numbers for the in-progress workers, in order. */
   issues: ReadonlyArray<number | string>;
+  /** When true, {@link added}/{@link removed} reflect the per-attempt peak rather
+   * than the live diff (current diff measured 0 but a prior non-zero value was
+   * seen this attempt). The `loc=` token renders with a `~` prefix on its value
+   * (`loc=~+50 -3`) to signal "last known, not current." */
+  locIsPeak?: boolean;
   /** Per-issue `current.stage` aligned by index with {@link issues}. When a
    * stage is present and non-empty it renders as a `·stage` suffix on the
    * matching `#N` token (`#629·impl`), so the block shows WHAT each live worker
@@ -229,7 +234,7 @@ export function afkTokens(afk: AfkInput | undefined): AfkToken[] {
   const diff: string[] = [];
   if (afk.added > 0) diff.push(`+${afk.added}`);
   if (afk.removed > 0) diff.push(`-${afk.removed}`);
-  if (diff.length) kpi("loc=", diff.join(" "));
+  if (diff.length) kpi("loc=", afk.locIsPeak ? `~${diff.join(" ")}` : diff.join(" "));
   if (afk.waiting !== undefined && afk.waiting > 0) kpi("wai=", String(afk.waiting));
   if (afk.tokens !== undefined && afk.tokens > 0) kpi("tok=", humanizeTokens(afk.tokens));
   if (afk.costUsd !== undefined && afk.costUsd > 0) kpi("usd=", afk.costUsd.toFixed(2));

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -642,6 +642,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   let blocked = 0;
   let added = 0;
   let removed = 0;
+  let locIsPeak = false;
   let waiting = 0;
   let tokens = 0;
   let costUsd = 0;
@@ -701,6 +702,18 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
       a = stat.added;
       r = stat.removed;
     }
+    // Sticky fallback: if the live diff is still 0 but a prior non-zero value
+    // was seen this attempt, use the peak so `loc=` stays visible with a `~`
+    // prefix instead of disappearing (which looks alarming even when intact).
+    if (a === 0 && r === 0) {
+      const pa = state.current.loc_peak_added ?? 0;
+      const pr = state.current.loc_peak_removed ?? 0;
+      if (pa > 0 || pr > 0) {
+        a = pa;
+        r = pr;
+        locIsPeak = true;
+      }
+    }
     added += a;
     removed += r;
 
@@ -756,7 +769,9 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
       : undefined;
 
   return {
-    workers, queue, human, blocked, added, removed, waiting, tokens, costUsd,
+    workers, queue, human, blocked, added, removed,
+    locIsPeak: locIsPeak || undefined,
+    waiting, tokens, costUsd,
     runner, resolved, issues, stages,
     aliveMs: aliveMsList.length > 0 ? aliveMsList : undefined,
     model: model || undefined,

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -70,6 +70,13 @@ export const AfkCurrentSchema = z.object({
   waiting_count: z.number().default(0),
   loc_added: z.number().default(0),
   loc_removed: z.number().default(0),
+  /** Last observed non-zero diff for this attempt (monotonically updated by the
+   * heartbeat when `loc_added > loc_peak_added` or `loc_removed > loc_peak_removed`).
+   * The statusline reads this as a sticky fallback when the current diff drops to 0
+   * (e.g. between commits and the next heartbeat) — prevents the `loc=` token from
+   * disappearing mid-attempt, which looks alarming even when the work is intact. */
+  loc_peak_added: z.number().default(0),
+  loc_peak_removed: z.number().default(0),
   /** Cost group (ADR 0065) — cumulative per-worker token spend, summed from the
    * runner's `usage` stream events (codex/opencode live; claude at iteration
    * boundary, a follow-up). `cost_usd` is populated only when the runner reports

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -114,6 +114,12 @@ describe("statusline style — AFK line", () => {
     expect(stripAnsi(line!)).toContain("#17·impl·5m");
   });
 
+  it("renders loc= with a ~ prefix when locIsPeak is true", () => {
+    const t = stripAnsi(renderAfkLine({ ...afk, locIsPeak: true }, undefined)!);
+    expect(t).toContain("loc=~+12 -3");
+    expect(t).not.toContain("loc=+12 -3"); // ~ prefix replaces the plain form
+  });
+
   it("is null when there are no live workers", () => {
     expect(renderAfkLine(undefined, undefined)).toBeNull();
     expect(renderAfkLine({ ...afk, workers: 0 }, undefined)).toBeNull();

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -255,6 +255,17 @@ describe("statusline — AFK block", () => {
     expect(out).toContain("#20·tests·30s");
   });
 
+  it("renders loc= with a ~ prefix when locIsPeak is true", () => {
+    expect(renderAfkBlock(baseAfk({ locIsPeak: true }))).toBe(
+      "wrk=1 rdy=11 hmn=3 blk=2 loc=~+12 -3 #17",
+    );
+  });
+
+  it("renders normal loc= when locIsPeak is false or absent", () => {
+    expect(renderAfkBlock(baseAfk())).toBe("wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 #17");
+    expect(renderAfkBlock(baseAfk({ locIsPeak: false }))).toBe("wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 #17");
+  });
+
   it("keeps the pre-vitals render byte-for-byte when no waiting/stages/aliveMs are supplied", () => {
     // All new fields are optional: an aggregator that never populates them must
     // produce the exact legacy line, so the upgrade is a no-op for old callers.


### PR DESCRIPTION
## Summary

- Adds `loc_peak_added`/`loc_peak_removed` to `AfkCurrentSchema` — the highest diff seen by the heartbeat since the current attempt started.
- Heartbeat writes peak on each tick (only grows; resets at attempt boundaries).
- Statusline wire falls back to peak when live diff is 0 and peak > 0, setting `locIsPeak: true`.
- Both plain and styled renders prefix the value with `~` (`loc=~+50 -3`) to signal "last known, not current."

**Before:** `loc=` disappeared during the feedback gate / between commits / early in explore — looked like a `git clean` had silently erased work.

**After:** `loc=~+50 -3` stays visible with a tilde prefix; `~` is immediately readable as "stale but intact."

Also includes the cherry-picked scout no-sentinel fix (pre-existing CI failure on main).

## Test plan

- [ ] `tests/statusline.test.ts` — two new cases: `~` prefix when `locIsPeak: true`, plain when `locIsPeak` absent
- [ ] `tests/statusline-style.test.ts` — styled render emits `loc=~+12 -3` when `locIsPeak: true`

https://claude.ai/code/session_01Et1w1hHdr3GThUPc8oW8ZT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785601577&installation_id=129708444&pr_number=1012&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1012&signature=2258a1eb208eab2fe59192d8d016232cdbe8795c0afc7256e9ddc372c89f7905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->