### PR TITLE
fix(statusline): runner label — claude-opus max instead of claude opus-max

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -148,7 +148,7 @@ function compactModelName(model: string): string {
   return m ? m[1] : model;
 }
 
-/** Runner label with optional compact model+effort: `claude opus-max`, `codex`. */
+/** Runner label with optional compact model+effort: `claude-opus max`, `codex`. */
 function formatRunnerLabel(
   runner: string | undefined,
   model: string | undefined,
@@ -157,7 +157,7 @@ function formatRunnerLabel(
   if (!runner) return "";
   if (!model) return runner;
   const compact = compactModelName(model);
-  return effort ? `${runner} ${compact}-${effort}` : `${runner} ${compact}`;
+  return effort ? `${runner}-${compact} ${effort}` : `${runner} ${compact}`;
 }
 
 /** Line 2 — the AFK KPIs, transparent background, or null when no live workers. */

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -97,7 +97,7 @@ describe("statusline style — AFK line", () => {
       undefined,
     );
     const t = stripAnsi(line!);
-    expect(t).toContain("claude opus-max");
+    expect(t).toContain("claude-opus max");
     expect(t).not.toContain("claude-opus-4-8"); // always compact
   });
 


### PR DESCRIPTION
## Summary

- Groups runner + model family with a hyphen (`claude-opus`) matching the recognisable model family name
- Separates effort with a space: `claude-opus max`

**Before:** `claude opus-max`
**After:** `claude-opus max`

## Test plan

- [ ] `statusline-style.test.ts` — updated expectation for compact model-effort test

https://claude.ai/code/session_01Et1w1hHdr3GThUPc8oW8ZT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785603223&installation_id=129708444&pr_number=1014&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1014&signature=f24d4b1ddf5709e4b2113274f165797234e044870a70687c4494420678a788ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->