### PR TITLE
merge: #995 feat(afk): 1C-toon — TOON-ify /afk monitor and /afk dashboard output

### DIFF
--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -321,6 +321,19 @@ describe("monitor — compact dashboard", () => {
       expect(out).toContain("  status: idle");
       expect(out).toContain("  ready: 0");
     });
+
+    it("is materially cheaper than JSON for a typical multi-worker board (#995)", () => {
+      // The token win is the whole point of TOON as the default agent-facing
+      // render (#995): the worker table names its 20 columns ONCE, where JSON
+      // repeats every field name on every row. Guard the win so a future change
+      // that regresses the encoder back toward per-row key repetition is caught.
+      const board = Array.from({ length: 6 }, (_, i) =>
+        baseWorker({ state: { ...baseWorker().state, worker_id: `w${i}` } }),
+      );
+      const toon = renderCompactDashboardToon(board, events, 1780140600);
+      const json = JSON.stringify(board);
+      expect(toon.length).toBeLessThan(json.length);
+    });
   });
 
   it("surfaces a healthy idle fleet last-tick line", () => {


### PR DESCRIPTION
Automated AFK landing for #995. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #995

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785606405&installation_id=129708444&pr_number=1039&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1039&signature=ef1c52be5fc2248b7c503aafb98cd362e43a624573e1695828ff747d0a466780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->