### PR TITLE
merge: #1007 feat(afk): cascade rebase on PRD sibling close — keep open branches fresh

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1060,6 +1060,62 @@ export function buildProcessDeps(
     // hop. ALL errors are swallowed (one warn line), so a memory failure can
     // NEVER fail the close.
     recordAttempt: makeRecordAttempt(ctx.root, current, exec),
+    // PRD cascade rebase (issue #1007): after a successful DONE landing, rebase
+    // every open sibling branch (same prd:N, not held by a live worker) onto the
+    // new base HEAD. Best-effort — failures log a warning, never fail the close.
+    // Gated by `afk.landing.cascade_rebase` (default "true", checked in core).
+    cascadeRebase: {
+      async listAFKBranches() {
+        const refs = await gitx.listRemoteBranches(gitCtx, "afk/");
+        return refs.map((r) => r.branch);
+      },
+      isWorkerLive(workerId: string): boolean {
+        try {
+          const pidPath = workerPidFile(paths.tmpDir, workerId);
+          const content = readFileSync(pidPath, "utf8").trim();
+          if (!/^[1-9][0-9]*$/.test(content)) return false;
+          process.kill(Number(content), 0);
+          return true;
+        } catch (err) {
+          return (err as NodeJS.ErrnoException).code === "EPERM";
+        }
+      },
+      async rebaseAndPush(repoDir: string, branch: string, newBase: string) {
+        const slug = branch.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
+        const slot = parseSlot(process.env.RED_AFK_SLOT) ?? 0;
+        const dest = join(paths.tmpDir, "cascade-rebase", `${slug}-${slot}`);
+        try {
+          await gitx.worktreeRemove(gitCtx, dest);
+          const ok = await gitx.worktreeAdd(gitCtx, dest, branch);
+          if (!ok) {
+            return { ok: false, warn: `failed to create worktree for ${branch}` };
+          }
+          const run = exec ?? (await import("../runtime/exec.js")).execTool;
+          const rebaseR = await run("git", ["rebase", `origin/${newBase}`], { cwd: dest });
+          if (rebaseR.code !== 0) {
+            await run("git", ["rebase", "--abort"], { cwd: dest }).catch(() => {});
+            return {
+              ok: false,
+              warn: `rebase of ${branch} onto ${newBase} conflicted: ${rebaseR.stderr.slice(0, 200)}`,
+            };
+          }
+          const pushR = await run(
+            "git",
+            ["push", "origin", `HEAD:refs/heads/${branch}`, "--force-with-lease"],
+            { cwd: dest },
+          );
+          if (pushR.code !== 0) {
+            return {
+              ok: false,
+              warn: `--force-with-lease push rejected for ${branch}: ${pushR.stderr.slice(0, 200)}`,
+            };
+          }
+          return { ok: true };
+        } finally {
+          await gitx.worktreeRemove(gitCtx, dest).catch(() => {});
+        }
+      },
+    },
   };
 }
 

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -175,6 +175,12 @@ export const CONFIG_DEFAULTS = {
   "afk.notes_loop.inner_max_iterations": "0",
   "afk.notes_loop.token_budget": "0",
   "afk.notes_loop.wall_clock_s": "0",
+  // PRD cascade rebase (issue #1007). After a successful DONE landing, rebase
+  // every open sibling branch (same prd:N, not held by a live worker) onto the
+  // new base HEAD so the next worker to pick up a sibling starts from a
+  // near-current base. Best-effort: a per-branch failure is logged as a warning
+  // and never rolls back the primary landing. Set "false" to opt out.
+  "afk.landing.cascade_rebase": "true",
   "dev.lock.primary-branch": "false",
   // NOTE: `dev.lock.branch` (the static base lock — ADR 0031) is intentionally
   // NOT in this table. Its "default" is *unset* (no config-level lock), and

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -75,6 +75,7 @@ import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-
 import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
 import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
 import { parseTrustPolicy, evaluateTrustGate, type TrustProvenance } from "./trust-gate.js";
+import { getConfig } from "./config.js";
 import type { AfkModelTier, ConfigValues } from "./config.js";
 import { runNotesLoop, notesPath, type NotesLoopConfig } from "./notes-loop.js";
 import {
@@ -457,6 +458,39 @@ export interface ProcessIssueDeps {
    * legacy callers omit it (no salvage).
    */
   salvageUncommitted?(branch: string): Promise<number>;
+  /**
+   * Post-merge PRD cascade rebase (issue #1007, `afk.landing.cascade_rebase`).
+   * Provides the IO surface for {@link runCascadeRebase}: after a successful DONE
+   * landing, AFK rebases every open sibling branch (same prd:N label, not held by
+   * a live worker) onto the new base HEAD, keeping PRD siblings fresh between
+   * landings. All three operations are best-effort — a failure logs a warning and
+   * never rolls back the primary landing. Optional: when absent the cascade rebase
+   * is skipped entirely (legacy callers / tests that predate #1007).
+   */
+  cascadeRebase?: CascadeRebasePort;
+}
+
+/** Injectable IO for the post-merge PRD cascade rebase (#1007). */
+export interface CascadeRebasePort {
+  /**
+   * List remote branch names under the `afk/` namespace (e.g.
+   * `["afk/wXXX/42-fix-thing", …]`). Used to find which origin branches belong
+   * to sibling issues.
+   */
+  listAFKBranches(repoDir: string, remote: string): Promise<string[]>;
+  /**
+   * True when the worker process owning `workerId` is still alive. Used to skip
+   * branches currently held by a running worker — rebasing a live worker's branch
+   * would race with its next push.
+   */
+  isWorkerLive(workerId: string): boolean;
+  /**
+   * Rebase `branch` onto `origin/<newBase>` in an isolated worktree and push the
+   * result with `--force-with-lease`. Best-effort: never throws; returns
+   * `{ok:false, warn}` on any failure (rebase conflict, push rejection, worktree
+   * setup error).
+   */
+  rebaseAndPush(repoDir: string, branch: string, newBase: string): Promise<{ ok: boolean; warn?: string }>;
 }
 
 function resolveSpawnTier(
@@ -1699,6 +1733,14 @@ export async function processIssue(
   // run.
   await runCloseCascade(deps, issue);
 
+  // ---- 10. PRD cascade rebase (keep sibling branches fresh) ----
+  // After landing, rebase every open sibling branch (same prd:N, not held by
+  // a live worker) onto the new base HEAD so the next worker to pick up a
+  // sibling starts from a near-current base. Best-effort: per-branch failures
+  // are logged as warnings and never roll back the primary landing.
+  // `labels` was fetched at claim time (step 1) and carries the prd:N labels.
+  await runCascadeRebase(deps, input, issue, base, labels);
+
   return {
     outcome: "done",
     issue,
@@ -2246,6 +2288,85 @@ async function runCloseCascade(deps: ProcessIssueDeps, closedIssue: number): Pro
   } catch (err) {
     deps.appendIterLog(
       `🤖 /afk close-cascade for #${closedIssue} failed (best-effort; boot sweep will retry): ${String(err)}`,
+    );
+  }
+}
+
+// ---------- PRD cascade rebase (issue #1007) ----------
+
+const PRD_LABEL_RE = /^prd:([0-9]+)$/;
+const AFK_BRANCH_RE = /^afk\/([A-Za-z0-9._-]+)\/([0-9]+)-/;
+
+/**
+ * Best-effort post-merge cascade rebase for PRD siblings (issue #1007).
+ * Called after a DONE close when the issue carries a `prd:N` label. Finds every
+ * open issue carrying the same `prd:N` label, locates their live `afk/*` remote
+ * branches, skips any held by a live worker, and rebases the rest onto the new
+ * `base` HEAD with `--force-with-lease`. A per-branch failure is logged as a
+ * warning and never rolls back the primary landing.
+ *
+ * Guarded by `afk.landing.cascade_rebase` (default "true"): setting it to
+ * "false" in the repo config restores the pre-#1007 behaviour.
+ *
+ * @param labels - the claim-time label set of the closed issue (already fetched).
+ */
+async function runCascadeRebase(
+  deps: ProcessIssueDeps,
+  input: ProcessIssueInput,
+  closedIssue: number,
+  base: string,
+  labels: string[],
+): Promise<void> {
+  if (!deps.cascadeRebase) return;
+  if (getConfig(deps.hooks.config, "afk.landing.cascade_rebase") === "false") return;
+
+  try {
+    // Extract prd:N numbers from the claim-time labels.
+    const prdNumbers: number[] = [];
+    for (const l of labels) {
+      const m = PRD_LABEL_RE.exec(l);
+      if (m) prdNumbers.push(Number(m[1]));
+    }
+    if (prdNumbers.length === 0) return;
+
+    // Collect open sibling issue numbers (same prd:N, not the closed issue itself).
+    const siblingNums = new Set<number>();
+    for (const prd of prdNumbers) {
+      const siblings = await deps.gh.listByLabel(`prd:${prd}`);
+      for (const s of siblings) {
+        if (s.number !== closedIssue) siblingNums.add(s.number);
+      }
+    }
+    if (siblingNums.size === 0) return;
+
+    // List remote afk/* branches and rebase those belonging to sibling issues.
+    const remoteBranches = await deps.cascadeRebase.listAFKBranches(input.repoDir, input.remote);
+    for (const branch of remoteBranches) {
+      const m = AFK_BRANCH_RE.exec(branch);
+      if (!m) continue;
+      const workerId = m[1]!;
+      const issueNum = Number(m[2]);
+      if (!siblingNums.has(issueNum)) continue;
+
+      if (deps.cascadeRebase.isWorkerLive(workerId)) {
+        deps.appendIterLog(
+          `🤖 /afk cascade-rebase: skipping ${branch} — worker ${workerId} is alive`,
+        );
+        continue;
+      }
+
+      const r = await deps.cascadeRebase.rebaseAndPush(input.repoDir, branch, base);
+      if (r.ok) {
+        deps.appendIterLog(`🤖 /afk cascade-rebase: rebased ${branch} onto ${base}`);
+      } else {
+        deps.appendIterLog(
+          `🤖 /afk cascade-rebase warning: ${r.warn ?? `failed to rebase ${branch} onto ${base}`}`,
+        );
+      }
+    }
+  } catch (err) {
+    deps.appendIterLog(
+      `🤖 /afk cascade-rebase for #${closedIssue} failed (best-effort): ${String(err)}`,
     );
   }
 }

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -46,6 +46,8 @@ interface Trace {
   classifierCalls: IssueClassificationMetadata[];
   /** Lines appended to the iteration log (deps.appendIterLog). */
   iterLogs: string[];
+  /** Branches for which cascadeRebase.rebaseAndPush was called (#1007). */
+  cascadeRebaseAttempts: string[];
 }
 
 interface HarnessOptions {
@@ -144,6 +146,13 @@ interface HarnessOptions {
   ciAware?: "merge" | "ci-failed" | "ci-pending" | "conflict";
   /** Exit code for the final `gh pr merge` command. Defaults to 0. */
   prMergeCode?: number;
+  /** PRD cascade rebase (#1007): remote afk/* branches returned by
+   * cascadeRebase.listAFKBranches. When set, injects the cascadeRebase port. */
+  siblingBranches?: string[];
+  /** Worker IDs considered live (skipped by cascade rebase). */
+  liveWorkers?: string[];
+  /** When true, cascadeRebase.rebaseAndPush returns ok=false for every branch. */
+  cascadeRebaseFail?: boolean;
 }
 
 function harness(opts: HarnessOptions = {}): {
@@ -170,6 +179,7 @@ function harness(opts: HarnessOptions = {}): {
     salvageCalls: [],
     classifierCalls: [],
     iterLogs: [],
+    cascadeRebaseAttempts: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -482,6 +492,25 @@ function harness(opts: HarnessOptions = {}): {
             trace.salvageCalls.push(branch);
             return opts.salvage as number;
           },
+    // PRD cascade rebase port (#1007): injected when siblingBranches is set.
+    cascadeRebase:
+      opts.siblingBranches !== undefined
+        ? {
+            async listAFKBranches() {
+              return opts.siblingBranches!;
+            },
+            isWorkerLive(workerId) {
+              return (opts.liveWorkers ?? []).includes(workerId);
+            },
+            async rebaseAndPush(_repoDir, branch, _newBase) {
+              trace.cascadeRebaseAttempts.push(branch);
+              if (opts.cascadeRebaseFail) {
+                return { ok: false, warn: `rebase failed for ${branch}` };
+              }
+              return { ok: true };
+            },
+          }
+        : undefined,
   };
 
   // Wire the hook config + abort marker so dispatchHooks has a command to run.
@@ -2636,5 +2665,142 @@ describe("processIssue — scout mode (runMode: 'scout')", () => {
     const humanLabel = trace.labelEdits.find((e) => e.add.includes("ready-for-human"));
     expect(humanLabel).toBeDefined();
     expect(trace.closed).not.toContain(9);
+  });
+});
+
+// ---------- PRD cascade rebase (#1007) ----------
+
+describe("PRD cascade rebase after DONE landing", () => {
+  it("rebases two sibling branches onto main after merge of issue A (prd:42)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      // Issue 9 carries prd:42 — so after close, AFK should rebase prd:42 siblings.
+      labels: ["ready-for-agent", "prd:42"],
+      // Two open issues carry prd:42; they are the siblings.
+      dependentsByLabel: {
+        "prd:42": [
+          { number: 20, labels: ["prd:42", "ready-for-agent"] },
+          { number: 21, labels: ["prd:42", "ready-for-agent"] },
+        ],
+      },
+      // Two remote afk branches, one for each sibling.
+      siblingBranches: [
+        "afk/wBBBB/20-fix-sibling-a",
+        "afk/wCCCC/21-fix-sibling-b",
+      ],
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    // Both sibling branches were rebased.
+    expect(trace.cascadeRebaseAttempts).toEqual([
+      "afk/wBBBB/20-fix-sibling-a",
+      "afk/wCCCC/21-fix-sibling-b",
+    ]);
+    // The prd:42 label lookup fired.
+    expect(trace.listByLabelCalls).toContain("prd:42");
+  });
+
+  it("skips a sibling branch whose worker is still alive", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "prd:42"],
+      dependentsByLabel: {
+        "prd:42": [
+          { number: 20, labels: ["prd:42"] },
+          { number: 21, labels: ["prd:42"] },
+        ],
+      },
+      siblingBranches: [
+        "afk/wBBBB/20-fix-sibling-a",
+        "afk/wCCCC/21-fix-sibling-b",
+      ],
+      // wBBBB is alive — its branch must be skipped.
+      liveWorkers: ["wBBBB"],
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    // Only the dead-worker branch is rebased.
+    expect(trace.cascadeRebaseAttempts).toEqual(["afk/wCCCC/21-fix-sibling-b"]);
+    expect(trace.iterLogs.some((l) => l.includes("wBBBB is alive"))).toBe(true);
+  });
+
+  it("cascade rebase failure is logged as a warning and does not fail the primary landing", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "prd:42"],
+      dependentsByLabel: {
+        "prd:42": [{ number: 20, labels: ["prd:42"] }],
+      },
+      siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+      cascadeRebaseFail: true,
+    });
+    const result = await processIssue(deps, input);
+    // Primary landing is unaffected.
+    expect(result.outcome).toBe("done");
+    // rebaseAndPush was still called (the attempt is recorded).
+    expect(trace.cascadeRebaseAttempts).toEqual(["afk/wBBBB/20-fix-sibling-a"]);
+    // A warning was logged.
+    expect(trace.iterLogs.some((l) => l.includes("cascade-rebase warning"))).toBe(true);
+  });
+
+  it("does not rebase when the issue carries no prd:N label", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent"],
+      siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.cascadeRebaseAttempts).toEqual([]);
+  });
+
+  it("does not rebase when afk.landing.cascade_rebase is false", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "prd:42"],
+      dependentsByLabel: {
+        "prd:42": [{ number: 20, labels: ["prd:42"] }],
+      },
+      siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+      config: { "afk.landing.cascade_rebase": "false" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.cascadeRebaseAttempts).toEqual([]);
+  });
+
+  it("does not run cascade rebase on a non-done outcome (blocked)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "blocked",
+      labels: ["ready-for-agent", "prd:42"],
+      siblingBranches: ["afk/wBBBB/20-fix-sibling-a"],
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("blocked");
+    expect(trace.cascadeRebaseAttempts).toEqual([]);
+  });
+
+  it("skips branches that do not belong to a prd sibling issue", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "prd:42"],
+      dependentsByLabel: {
+        // Only issue 20 is a sibling; issue 99 is not listed.
+        "prd:42": [{ number: 20, labels: ["prd:42"] }],
+      },
+      siblingBranches: [
+        "afk/wBBBB/20-fix-sibling-a",
+        "afk/wCCCC/99-unrelated-branch",
+      ],
+    });
+    await processIssue(deps, input);
+    // Only issue 20's branch is rebased; issue 99's is not a sibling.
+    expect(trace.cascadeRebaseAttempts).toEqual(["afk/wBBBB/20-fix-sibling-a"]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1007. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1007

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785607034&installation_id=129708444&pr_number=1041&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1041&signature=ff659eb913906b09561bab719c9d9cee38be08b2b43d4399ab1e01c951944f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->