### PR TITLE
feat(afk): Trunk — configurable focal branch, single source for base resolution (closes #1017)

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -25,6 +25,7 @@ import { makeFeedbackWorktree } from "../runtime/feedback-worktree.js";
 import { afkPaths, resolveRepoSlug } from "../runtime/wire.js";
 import { branchLockPath, isLocked, readLockedBranch } from "../runtime/lock.js";
 import { resolveBase } from "../core/base-resolver.js";
+import { getConfig, loadConfig } from "../core/config.js";
 import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import type { GhContext } from "../runtime/gh.js";
@@ -149,6 +150,9 @@ async function runAdoptLanding(
       {
         readLockedBranch: () => readLockedBranch(lockPath),
         configLockedBranch: undefined,
+        configTrunk:
+          getConfig(loadConfig(paths.configPath, { warn: () => undefined }), "dev.trunk") ||
+          undefined,
         fetchIssueBody: async () => undefined,
       },
     );

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -253,8 +253,9 @@ function makeBootReconcileRunner(
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: GitContext = { cwd: ctx.root };
   const lockPath = branchLockPath(ctx.root);
-  const configLockedBranch =
-    getConfig(loadConfig(paths.configPath, { warn: () => undefined }), "dev.lock.branch") || undefined;
+  const reconcileConfig = loadConfig(paths.configPath, { warn: () => undefined });
+  const configLockedBranch = getConfig(reconcileConfig, "dev.lock.branch") || undefined;
+  const configTrunk = getConfig(reconcileConfig, "dev.trunk") || undefined;
 
   return async (plan: ReconcileSweepPlan) => {
     // Acquire the per-issue claim before validating/landing so a concurrent live
@@ -348,6 +349,7 @@ function makeBootReconcileRunner(
         {
           readLockedBranch: () => readLockedBranch(lockPath),
           configLockedBranch,
+          configTrunk,
           fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
         },
       );
@@ -753,6 +755,7 @@ export function buildProcessDeps(
       base: {
         readLockedBranch: () => readLockedBranch(lockPath),
         configLockedBranch: getConfig(config, "dev.lock.branch") || undefined,
+        configTrunk: getConfig(config, "dev.trunk") || undefined,
         fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
       },
       isLocked: () => isLocked(lockPath),
@@ -972,7 +975,10 @@ export function buildProcessDeps(
         const worktree =
           (await gitx.worktreePathUnder(gitCtx, current.attemptDir).catch(() => undefined)) ??
           join(current.attemptDir, "worktree");
-        const baseRef = info.base ? `origin/${info.base}` : "origin/main";
+        // Fall back to the configured Trunk (ADR 0083), not a literal "main".
+        const baseRef = info.base
+          ? `origin/${info.base}`
+          : `origin/${getConfig(config, "dev.trunk") || "main"}`;
         const { added, removed } = await gitx
           .diffstatShortstat({ cwd: worktree }, baseRef)
           .catch(() => ({ added: 0, removed: 0 }));

--- a/apps/dev/src/core/base-resolver.ts
+++ b/apps/dev/src/core/base-resolver.ts
@@ -1,16 +1,23 @@
-// base-resolver — resolve the effective base/merge branch for a work item (ADR 0031).
+// base-resolver — resolve the effective base/merge branch for a work item
+// (ADR 0031; Trunk fallback by ADR 0083).
 //
 // AFK bases each worktree on, and merges each finished item back into, a single
-// branch. Three sources can name that branch; this module decides which one wins
-// by a fixed precedence:
+// branch. This module decides which source wins by a fixed precedence
+// (lock > pin > Trunk):
 //
 //   1. the branch-lock value — when the primary checkout is locked to a branch,
 //      the lock is absolute and overrides any pin (the human pinned this
 //      checkout on purpose; the lock comes from the branch-lock skill's
 //      lock_store_read against `.red/tmp/branch-lock.yaml`);
 //   2. else the pinned branch — the issue/PRD `branch:` resolution (pin-reader's
-//      `resolvePin`, which already collapses "no pin" to `main`);
-//   3. else `main` — today's behaviour when nothing is set.
+//      `resolvePin`, which collapses "no pin" to the Trunk);
+//   3. else the Trunk — the repo's configured focal branch
+//      (`plugins.dev.trunk`, default `main`; ADR 0083).
+//
+// The resolver returns a branch NAME. Consumers must read it as its
+// fresh-fetched remote ref (`origin/<branch>` after `fetchBase`), never as the
+// local working-tree branch (ADR 0083 — the local branch may be stale or carry
+// foreign WIP).
 //
 // Pure composition, no side effects of its own: it touches neither git nor the
 // filesystem directly. All real IO (the lock file read, the gh body fetch) is
@@ -37,6 +44,12 @@ export interface ResolveBaseDeps {
    * no config-level lock.
    */
   configLockedBranch?: string;
+  /**
+   * The configured Trunk (`plugins.dev.trunk`, ADR 0083): the branch a work
+   * item bases on and lands to when neither a lock nor a pin names one.
+   * Empty/undefined falls back to `main`, preserving pre-trunk behaviour.
+   */
+  configTrunk?: string;
   /** Fetch the raw body for issue/PRD number `n`, or `undefined` if missing. */
   fetchIssueBody: (n: number) => Promise<string | undefined>;
 }
@@ -45,13 +58,15 @@ export type ResolveBaseInput = ResolvePinInput;
 
 /**
  * Resolve the effective base branch by the fixed precedence
- * runtime-lock > config-lock > pin > main:
+ * runtime-lock > config-lock > pin > Trunk (ADR 0031/0083):
  *   the runtime branch-lock if present, else the static `dev.lock.branch` config
- *   default, else the resolved pin, else `main`.
+ *   default, else the resolved pin, else the configured Trunk
+ *   (`plugins.dev.trunk`, default `main`).
  *
  * The runtime lock is read via the injected `readLockedBranch`; `configLockedBranch`
  * is the static `dev.lock.branch` value; the pin is delegated to pin-reader's
- * `resolvePin`. A whitespace-only value counts as "not set".
+ * `resolvePin` (whose pinless collapse also lands on the Trunk). A
+ * whitespace-only value counts as "not set".
  */
 export async function resolveBase(input: ResolveBaseInput, deps: ResolveBaseDeps): Promise<string> {
   const locked = await deps.readLockedBranch();
@@ -59,8 +74,11 @@ export async function resolveBase(input: ResolveBaseInput, deps: ResolveBaseDeps
 
   if (isSet(deps.configLockedBranch)) return deps.configLockedBranch.trim();
 
-  const pinned = await resolvePin(input, { fetchIssueBody: deps.fetchIssueBody });
+  const pinned = await resolvePin(input, {
+    fetchIssueBody: deps.fetchIssueBody,
+    defaultBranch: deps.configTrunk,
+  });
   if (isSet(pinned)) return pinned;
 
-  return DEFAULT_BRANCH;
+  return isSet(deps.configTrunk) ? deps.configTrunk.trim() : DEFAULT_BRANCH;
 }

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -182,6 +182,14 @@ export const CONFIG_DEFAULTS = {
   // and never rolls back the primary landing. Set "false" to opt out.
   "afk.landing.cascade_rebase": "true",
   "dev.lock.primary-branch": "false",
+  // The Trunk (ADR 0083): the repo's configured focal branch — the default
+  // base every AFK worktree forks from and the default target a landing
+  // integrates into, when neither a branch lock nor a pin names one
+  // (precedence lock > pin > trunk). Always consumed as its fresh-fetched
+  // remote ref (`origin/<trunk>`), never as the local working-tree branch.
+  // Set `plugins.dev.trunk` (folds to this accessor) to move the focal branch
+  // to e.g. `develop` or `workspace/<user>`.
+  "dev.trunk": "main",
   // NOTE: `dev.lock.branch` (the static base lock — ADR 0031) is intentionally
   // NOT in this table. Its "default" is *unset* (no config-level lock), and
   // `getConfig` already returns "" for an absent key, so adding a "" default

--- a/apps/dev/src/core/pin-reader.ts
+++ b/apps/dev/src/core/pin-reader.ts
@@ -63,6 +63,12 @@ export function parseParentPrd(body: string): number | undefined {
 export interface ResolvePinDeps {
   /** Fetch the raw body for issue/PRD number `n`, or `undefined` if missing. */
   fetchIssueBody: (n: number) => Promise<string | undefined>;
+  /**
+   * The branch a pinless item collapses to — the configured Trunk
+   * (`plugins.dev.trunk`, ADR 0083). Empty/undefined falls back to
+   * `DEFAULT_BRANCH` (`main`), preserving pre-trunk behaviour.
+   */
+  defaultBranch?: string;
 }
 
 export interface ResolvePinInput {
@@ -72,7 +78,8 @@ export interface ResolvePinInput {
 
 /**
  * Apply the inheritance chain and always resolve to a branch:
- *   the issue's own pin, else its parent PRD's pin, else `main`.
+ *   the issue's own pin, else its parent PRD's pin, else the Trunk
+ *   (`deps.defaultBranch`, falling back to `main` when unset — ADR 0083).
  *
  * The parent PRD body is fetched lazily via the injected `fetchIssueBody`,
  * keyed off the issue body's `PRD #<n>` reference.
@@ -90,5 +97,6 @@ export async function resolvePin(input: ResolvePinInput, deps: ResolvePinDeps): 
     }
   }
 
-  return DEFAULT_BRANCH;
+  const trunk = deps.defaultBranch?.trim();
+  return trunk !== undefined && trunk.length > 0 ? trunk : DEFAULT_BRANCH;
 }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -210,13 +210,16 @@ export function resolveRunSettings(
   // config so the run fails fast before claiming an issue.
   const laneIdle = resolveLaneIdleStallConfig(env);
   // Feedback-gate base rebase (Pattern 2). Only resolves to a base branch when
-  // the opt-in flag is on; the base is the config-locked branch or "main".
+  // the opt-in flag is on; the base is the config-locked branch or the Trunk
+  // (`dev.trunk`, ADR 0083 — defaults to "main").
   // A RED_AFK_FEEDBACK_REBASE env knob lets an E2E/CI run force it without
   // mutating .red/config.yaml, mirroring the other RED_AFK_* overrides.
   const rebaseFlag =
     (env.RED_AFK_FEEDBACK_REBASE ?? "").trim() === "1" ||
     getConfig(cfg, "afk.feedback.rebase_on_base") === "true";
-  const feedbackRebaseBase = rebaseFlag ? getConfig(cfg, "dev.lock.branch") || "main" : undefined;
+  const feedbackRebaseBase = rebaseFlag
+    ? getConfig(cfg, "dev.lock.branch") || getConfig(cfg, "dev.trunk") || "main"
+    : undefined;
   // Per-attempt resource budget (#908) — env > `afk.attempt.*` config; undefined
   // when no ceiling is set (inert).
   const attemptBudget = resolveAttemptBudget(env, (key) => getConfig(cfg, key));

--- a/apps/dev/tests/base-resolver.test.ts
+++ b/apps/dev/tests/base-resolver.test.ts
@@ -102,4 +102,54 @@ describe("resolveBase", () => {
     const deps = depsFor(" work-branch\n");
     expect(await resolveBase({ issueBody: issueWithPin }, deps)).toBe("work-branch");
   });
+
+  // Trunk (`plugins.dev.trunk`, ADR 0083) — precedence lock > pin > trunk.
+  it("falls through to the configured trunk when neither a lock nor a pin is set", async () => {
+    const deps = { ...depsFor(undefined), configTrunk: "develop" };
+    expect(await resolveBase({ issueBody: "## What to build\nno pin, no parent" }, deps)).toBe(
+      "develop",
+    );
+  });
+
+  it("collapses a pinless parent-PRD chain to the trunk, not to main", async () => {
+    // The issue references a parent PRD, but neither carries a `branch:` pin —
+    // the pin-reader collapse must land on the trunk (ADR 0083), not on `main`.
+    const deps = {
+      ...depsFor(undefined, { 59: "## PRD\nno pin here either" }),
+      configTrunk: "workspace/forattini",
+    };
+    expect(await resolveBase({ issueBody: issueNoPin }, deps)).toBe("workspace/forattini");
+    expect(deps.fetchCalls).toEqual([59]);
+  });
+
+  it("a pin wins over the trunk", async () => {
+    const deps = { ...depsFor(undefined), configTrunk: "develop" };
+    expect(await resolveBase({ issueBody: issueWithPin }, deps)).toBe("feature/some-pin");
+  });
+
+  it("a lock wins over the trunk", async () => {
+    const deps = { ...depsFor("work-branch"), configTrunk: "develop" };
+    expect(await resolveBase({ issueBody: issueNoPin }, deps)).toBe("work-branch");
+  });
+
+  it("the config lock wins over the trunk", async () => {
+    const deps = {
+      ...depsFor(undefined),
+      configLockedBranch: "config/branch",
+      configTrunk: "develop",
+    };
+    expect(await resolveBase({ issueBody: issueNoPin }, deps)).toBe("config/branch");
+  });
+
+  it("an empty/whitespace trunk falls back to main (pre-trunk behaviour)", async () => {
+    const empty = { ...depsFor(undefined), configTrunk: "" };
+    expect(await resolveBase({ issueBody: "no pin" }, empty)).toBe(DEFAULT_BRANCH);
+    const blank = { ...depsFor(undefined), configTrunk: "  \t " };
+    expect(await resolveBase({ issueBody: "no pin" }, blank)).toBe(DEFAULT_BRANCH);
+  });
+
+  it("trims the trunk value", async () => {
+    const deps = { ...depsFor(undefined), configTrunk: " develop\n" };
+    expect(await resolveBase({ issueBody: "no pin" }, deps)).toBe("develop");
+  });
 });

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -237,6 +237,25 @@ describe("config — plugins.dev namespace (ADR 0042)", () => {
   });
 });
 
+describe("config — the Trunk (`plugins.dev.trunk`, ADR 0083)", () => {
+  it("defaults dev.trunk to main when unset", () => {
+    const values = loadConfig("/x/.red/config.yaml", { read: () => undefined });
+    expect(getConfig(values, "dev.trunk")).toBe("main");
+  });
+
+  it("folds plugins.dev.trunk onto the dev.trunk accessor", () => {
+    const text = "plugins:\n  dev:\n    trunk: develop\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "dev.trunk")).toBe("develop");
+  });
+
+  it("accepts a namespaced branch value (e.g. workspace/<user>)", () => {
+    const text = "plugins:\n  dev:\n    trunk: workspace/forattini\n";
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "dev.trunk")).toBe("workspace/forattini");
+  });
+});
+
 describe("config — block sequences (afk.backpressure, #430)", () => {
   it("parses a `- item` sequence into ordered indexed keys", () => {
     const text = "afk:\n  backpressure:\n    - npm run test\n    - npm run lint\n";

--- a/apps/dev/tests/pin-reader.test.ts
+++ b/apps/dev/tests/pin-reader.test.ts
@@ -93,4 +93,27 @@ describe("resolvePin", () => {
     expect(await resolvePin({ issueBody: issueNoPin }, deps)).toBe("main");
     expect(deps.calls).toEqual([59]);
   });
+
+  // Trunk collapse (ADR 0083): a pinless item lands on the configured trunk.
+  it("collapses a pinless item to the injected defaultBranch (the Trunk)", async () => {
+    const deps = { ...fetcherFor({ 59: prdNoPin }), defaultBranch: "develop" };
+    expect(await resolvePin({ issueBody: issueNoPin }, deps)).toBe("develop");
+  });
+
+  it("a real pin still wins over the defaultBranch", async () => {
+    const deps = { ...fetcherFor({}), defaultBranch: "develop" };
+    expect(await resolvePin({ issueBody: issueWithPin }, deps)).toBe("issue/own");
+  });
+
+  it("an empty/whitespace defaultBranch falls back to main", async () => {
+    const empty = { ...fetcherFor({}), defaultBranch: "" };
+    expect(await resolvePin({ issueBody: "no pin" }, empty)).toBe(DEFAULT_BRANCH);
+    const blank = { ...fetcherFor({}), defaultBranch: " \t " };
+    expect(await resolvePin({ issueBody: "no pin" }, blank)).toBe(DEFAULT_BRANCH);
+  });
+
+  it("trims the defaultBranch value", async () => {
+    const deps = { ...fetcherFor({}), defaultBranch: " develop\n" };
+    expect(await resolvePin({ issueBody: "no pin" }, deps)).toBe("develop");
+  });
 });

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -96,6 +96,8 @@ interface HarnessOptions {
   fallbackRunner?: boolean;
   /** Records each git fetch-base call (the ADR 0031 start-point fetch). */
   fetchedBases?: string[];
+  /** The configured Trunk (`plugins.dev.trunk`, ADR 0083) injected into base resolution. */
+  configTrunk?: string;
   /** When set, the locked `git merge --no-ff` returns this rc (1 → conflict). */
   mergeNoFfCode?: number;
   /** When true, register a one-shot conflict resolver that "resolves" the merge
@@ -428,6 +430,7 @@ function harness(opts: HarnessOptions = {}): {
         async readLockedBranch() {
           return opts.locked ? "main" : undefined;
         },
+        configTrunk: opts.configTrunk,
         async fetchIssueBody() {
           return undefined;
         },
@@ -1949,6 +1952,24 @@ describe("processIssue — base reaches sandcastle (ADR 0031)", () => {
     // runAgent receives the remote-tracking ref so sandcastle forks from the
     // freshly-fetched ref, not the potentially-stale local branch.
     expect(trace.runAgentCalls[0]?.base).toBe("origin/main");
+  });
+
+  it("resolves an unlocked, pinless issue to the configured Trunk and forks off origin/<trunk> (ADR 0083)", async () => {
+    const fetchedBases: string[] = [];
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: false,
+      configTrunk: "develop",
+      fetchedBases,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.base).toBe("develop");
+    // the trunk is fetched current before the run — the resolver's value is
+    // only ever consumed as its fresh-fetched remote ref, never the local branch.
+    expect(fetchedBases).toEqual(["develop"]);
+    expect(trace.runAgentCalls[0]?.base).toBe("origin/develop");
   });
 });
 

--- a/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
+++ b/plugins/dev/skills/engineering/setup-red-skills/config-template.yaml
@@ -9,6 +9,11 @@
 plugins:
   dev:
     enabled: true                 # the engineering stack (/afk, /triage, /ship, …)
+  #   trunk: main                 # the Trunk (ADR 0083): the focal branch agent work
+  #                               # bases on and lands to when no lock/pin names one
+  #                               # (precedence lock > pin > trunk). Always consumed
+  #                               # as fresh-fetched origin/<trunk>, never the local
+  #                               # branch. Set e.g. develop or workspace/<user>.
   #   lock:
   #     primary-branch: true      # branch-lock compatibility/base-pinning flag
   #                               # (Section H of /setup-red-skills sets this)


### PR DESCRIPTION
## Summary

Implements **ADR 0083 §1** (slice S1 of PRD #1013): the **Trunk** — `plugins.dev.trunk`, default `main` — becomes the single fallback for base resolution, replacing every hardcoded `main`. Precedence: **Branch lock > Pinned branch > Trunk**.

- `config`: new `dev.trunk` default (`plugins.dev.trunk` folds onto it, ADR 0042)
- `pin-reader`: the pinless collapse lands on the injected Trunk instead of literal `main`
- `base-resolver`: `configTrunk` dep + docs; final fallback is the Trunk
- Consumers wired: per-issue lookups, reconcile boot runner, requeue adopt-landing, heartbeat diffstat `baseRef`, feedback-rebase base (wire)
- `config-template.yaml` documents the key
- The resolver's value is only consumed as fresh-fetched `origin/<trunk>` (`fetchBase` before `runAgent`) — never the local working-tree branch

## Tests

- base-resolver: trunk fallback, pin>trunk, lock>trunk, config-lock>trunk, empty/whitespace trunk → main, trim
- pin-reader: pinless collapse to trunk, pin wins, empty default → main
- config: default, `plugins.dev.trunk` fold, namespaced branch values
- process-issue: unlocked pinless issue resolves to `develop`, fetches it, and forks off `origin/develop`

Full dev suite: 151 files / 2681 tests green. `tsc --noEmit` clean.

## Landing routing

Manual landing per PRD #1013 human decision (claim/landing machinery slice).

Closes #1017

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785608256&installation_id=129708444&pr_number=1042&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1042&signature=bd46a09e66790f2fab8176a98dff0d8a37d996d67122fa6d9f64bb094cbeb596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->