### PR TITLE
docs(doctrine): /go-first for one-off work — retire /ship from every suggestion surface (ADR 0081)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ for now. See `.red/agents/domain.md`.
 
 ## Development workflow
 
-- Work in an isolated worktree under `.red/tmp/work-*/`; do not create sibling worktrees outside the repo.
+- One-off concrete work goes through `/go "<demand>"` (ADR 0081): it mints a disposable `lane:go` issue, works in an isolated worktree under `.red/tmp/go-workers/`, runs the shared gate, and brings back a PR. Route the structured backlog through `/afk`; put a parked issue back in the queue with `/requeue`.
+- When working by hand instead (e.g. a slice the maintainer decided to land manually), work in an isolated worktree under `.red/tmp/work-*/`; do not create sibling worktrees outside the repo.
 - Create task branches with `git worktree add .red/tmp/work-<slug> -b <branch> origin/main`, not with `git checkout -b` or `git switch -c` in the primary checkout.
-- Commit the worktree, push the branch early, then run `/ship` to open or reuse a PR.
-- Let `/ship` monitor checks and reviews, then either merge the PR or park the issue/PR for `/hitl`.
+- Commit the worktree, push the branch early, open a PR, monitor its checks, then merge it or park the issue/PR for `/hitl`.
 - The agent never switches the primary checkout's branch; only the user does. With `plugins.dev.enabled: true`, the dev command proxy blocks agent-created worktrees outside `.red/tmp/` and primary-checkout branch movement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,8 @@ for now. See `.red/agents/domain.md`.
 
 ## Development workflow
 
-- Work in an isolated worktree under `.red/tmp/work-*/`; do not create sibling worktrees outside the repo.
+- One-off concrete work goes through `/go "<demand>"` (ADR 0081): it mints a disposable `lane:go` issue, works in an isolated worktree under `.red/tmp/go-workers/`, runs the shared gate, and brings back a PR. Route the structured backlog through `/afk`; put a parked issue back in the queue with `/requeue`.
+- When working by hand instead (e.g. a slice the maintainer decided to land manually), work in an isolated worktree under `.red/tmp/work-*/`; do not create sibling worktrees outside the repo.
 - Create task branches with `git worktree add .red/tmp/work-<slug> -b <branch> origin/main`, not with `git checkout -b` or `git switch -c` in the primary checkout.
-- Commit the worktree, push the branch early, then run `/ship` to open or reuse a PR.
-- Let `/ship` monitor checks and reviews, then either merge the PR or park the issue/PR for `/hitl`.
+- Commit the worktree, push the branch early, open a PR, monitor its checks, then merge it or park the issue/PR for `/hitl`.
 - The agent never switches the primary checkout's branch; only the user does. With `plugins.dev.enabled: true`, the dev command proxy blocks agent-created worktrees outside `.red/tmp/` and primary-checkout branch movement.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Common `dev` commands become native slash commands:
 /setup-red-skills
 /triage
 /afk --once
-/ship
+/go "one concrete demand"
 /dashboard
 ```
 
@@ -222,7 +222,7 @@ marketplace registration in a temporary home, and manual skill-link installs.
 ## What Makes It Different
 
 **Issue to PR is the product.** RedSkills treats GitHub Issues as the work
-queue, not a side note. `/triage`, `/to-prd`, `/to-issues`, `/afk`, `/ship`,
+queue, not a side note. `/triage`, `/to-prd`, `/to-issues`, `/afk`, `/go`,
 `/hitl`, and `/requeue` all speak the same issue-state vocabulary.
 
 **Agents work in disposable worktrees.** AFK execution and interactive landing
@@ -361,7 +361,7 @@ Core responsibilities:
 - Bootstrap RedSkills with [`setup-red-skills`](./plugins/dev/skills/engineering/setup-red-skills/SKILL.md).
 - Maintain issue state with [`triage`](./plugins/dev/skills/engineering/triage/SKILL.md), [`to-prd`](./plugins/dev/skills/engineering/to-prd/SKILL.md), and [`to-issues`](./plugins/dev/skills/engineering/to-issues/SKILL.md).
 - Execute delegable work with [`afk`](./plugins/dev/skills/engineering/afk/SKILL.md), or dispatch one concrete demand with [`go`](./plugins/dev/skills/engineering/go/SKILL.md).
-- Land interactive work with [`ship`](./plugins/dev/skills/engineering/ship/SKILL.md).
+- Land a hand-worked branch with [`requeue`](./plugins/dev/skills/engineering/requeue/SKILL.md) (the retired `ship` migrated there — ADR 0081).
 - Resolve human gates with [`hitl`](./plugins/dev/skills/engineering/hitl/SKILL.md) or safe retries with [`requeue`](./plugins/dev/skills/engineering/requeue/SKILL.md).
 
 Dev guard rails:
@@ -380,7 +380,7 @@ Dev guard rails:
   execution. These repo-defined rules are **additional** to the built-in
   `.red/tmp` worktree boundary above. `global` rules apply everywhere, `main`
   rules apply in the primary session scope (not specifically the Git branch
-  named `main`), and `worktree` rules apply in `/afk` and `/ship` worktrees
+  named `main`), and `worktree` rules apply in `/afk` and `/go` worktrees
   under `.red/tmp/`. Deny rules
   support `regex:<pattern>`, `prefix:<literal>`, `suffix:<literal>`,
   `exact:<literal>`, and `glob:<pattern>`. Bare entries with `*`, `?`, or `[`

--- a/apps/dev/src/core/development-workflow.ts
+++ b/apps/dev/src/core/development-workflow.ts
@@ -2,10 +2,10 @@ export const DEVELOPMENT_WORKFLOW_HEADING = "Development workflow";
 
 export const DEVELOPMENT_WORKFLOW_BLOCK = `## ${DEVELOPMENT_WORKFLOW_HEADING}
 
-- Work in an isolated worktree under \`.red/tmp/work-*/\`; do not create sibling worktrees outside the repo.
+- One-off concrete work goes through \`/go "<demand>"\` (ADR 0081): it mints a disposable \`lane:go\` issue, works in an isolated worktree under \`.red/tmp/go-workers/\`, runs the shared gate, and brings back a PR. Route the structured backlog through \`/afk\`; put a parked issue back in the queue with \`/requeue\`.
+- When working by hand instead (e.g. a slice the maintainer decided to land manually), work in an isolated worktree under \`.red/tmp/work-*/\`; do not create sibling worktrees outside the repo.
 - Create task branches with \`git worktree add .red/tmp/work-<slug> -b <branch> origin/main\`, not with \`git checkout -b\` or \`git switch -c\` in the primary checkout.
-- Commit the worktree, push the branch early, then run \`/ship\` to open or reuse a PR.
-- Let \`/ship\` monitor checks and reviews, then either merge the PR or park the issue/PR for \`/hitl\`.
+- Commit the worktree, push the branch early, open a PR, monitor its checks, then merge it or park the issue/PR for \`/hitl\`.
 - The agent never switches the primary checkout's branch; only the user does. With \`plugins.dev.enabled: true\`, the dev command proxy blocks agent-created worktrees outside \`.red/tmp/\` and primary-checkout branch movement.`;
 
 const DEVELOPMENT_WORKFLOW_BODY = DEVELOPMENT_WORKFLOW_BLOCK.replace(/^## [^\n]+\n\n/, "");

--- a/apps/dev/tests/development-workflow.test.ts
+++ b/apps/dev/tests/development-workflow.test.ts
@@ -47,10 +47,17 @@ describe("development workflow rules block", () => {
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("git worktree add .red/tmp/work-<slug>");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("not with `git checkout -b` or `git switch -c`");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("push the branch early");
-    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("`/ship`");
-    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("merge the PR or park the issue/PR for `/hitl`");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("merge it or park the issue/PR for `/hitl`");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("The agent never switches the primary checkout's branch; only the user does.");
     expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("the dev command proxy blocks agent-created worktrees outside `.red/tmp/`");
+  });
+
+  it("routes one-off work through /go and never suggests the retired /ship (ADR 0081)", () => {
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain('One-off concrete work goes through `/go "<demand>"`');
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("`.red/tmp/go-workers/`");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("Route the structured backlog through `/afk`");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).toContain("`/requeue`");
+    expect(DEVELOPMENT_WORKFLOW_BLOCK).not.toContain("/ship");
   });
 
   it("writes both AGENTS.md and CLAUDE.md with identical blocks, then reruns unchanged", async () => {

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -73,7 +73,7 @@ describe("setup-red-skills docs", () => {
     expect(skill).toContain("dev.lock.primary-branch: true");
     expect(skill).toContain("inject-development-workflow --root");
     expect(skill).toContain("both `AGENTS.md` and `CLAUDE.md`");
-    expect(skill).toContain("`/ship` as the landing command");
+    expect(skill).toContain("`/go` for one-off concrete work");
     // ADR 0067: the template now carries an active `plugins:` activation block
     // (dev enabled by default) with the dev lock example folded under it.
     expect(template).toContain("plugins:");
@@ -113,7 +113,7 @@ describe("setup-red-skills docs", () => {
 
     expect(skill).toContain("**Section E1 — Runtime launcher");
     expect(skill).toContain("stable command, not a global fake plugin-root variable");
-    expect(skill).toContain("red-skills-dev ship");
+    expect(skill).toContain("red-skills-dev go");
     expect(skill).toContain("Do not export `CLAUDE_PLUGIN_ROOT` or `CODEX_PLUGIN_ROOT` globally");
     expect(script).toContain("RED_SKILLS_DEV_PLUGIN_ROOT");
     expect(script).toContain(".codex/plugins/cache/red-skills/dev");

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -55,7 +55,7 @@ AFK drives the sandcastle Orchestrator through **injected providers** (`Sandcast
 - `/afk dashboard [--period 30d] [--json]` — readonly process dashboard: open PRDs/issues, global `running` issues, local AFK workers on this machine, issue/PR flow metrics, and DORA proxy metrics.
 - `/afk daily-review [--json]` — readonly daily operational review from yesterday local midnight to now: delivery big numbers, local worker attempts/time, token spend when available, HITL/blocker challenges, and issue/PR cycle times.
 - `/afk weekly-review [--json]` — readonly six-day operational review from six-days-ago local midnight to now, with the same sections as `daily-review`.
-- `/afk retake 123 [--apply] [--json]` — issue resumption report: reads the issue, linked PRs, matching local/remote branches, matching local worktrees, HITL state, and prints the next command to continue, fix, recreate a ship worktree, or run `/ship`. With `--apply`, executes only safe local setup `git` operations and still leaves merges/HITL to `/ship` or `/hitl`. The parser accepts `#123` too; quote it when invoking through a shell.
+- `/afk retake 123 [--apply] [--json]` — issue resumption report: reads the issue, linked PRs, matching local/remote branches, matching local worktrees, HITL state, and prints the next command to continue, fix, recreate a work worktree, or run `/requeue`. With `--apply`, executes only safe local setup `git` operations and still leaves merges/HITL to `/requeue` or `/hitl`. The parser accepts `#123` too; quote it when invoking through a shell.
 - `/afk fleet [N]` — launch the supervisor maintaining `N` concurrent workers (default `2`). See *Fleet Mode* below.
 - `/afk fleet stop` — gracefully shut down a running fleet supervisor and cancel its auto-monitor cron.
 - `/afk reap` — run branch hygiene without starting a worker: one count line for remote `afk/*`, remote `afk-attempts/*`, and local `afk/*`, then the same safe reapers used at boot.
@@ -408,7 +408,7 @@ When `/afk` launches a normal detached worker under Codex (`run`, not
 
 Hard boundaries for the monitor agent are non-negotiable: it must never edit
 files, claim issues, change labels, comment, stop workers, run validation, push,
-merge, `/ship`, `/hitl`, `/triage`, `/afk run`, `/afk fleet`, `/afk fleet stop`,
+merge, `/requeue`, `/go`, `/hitl`, `/triage`, `/afk run`, `/afk fleet`, `/afk fleet stop`,
 `/afk reap`, or `/afk requeue`. Closing it manually must not affect the AFK
 worker.
 

--- a/plugins/dev/skills/engineering/hitl/SKILL.md
+++ b/plugins/dev/skills/engineering/hitl/SKILL.md
@@ -142,7 +142,7 @@ If non-delegable:
 
 - Do not select `type:prd` Issues.
 - Do not use historical slice-routing labels; HITL queue membership is `ready-for-human`.
-- Do not do manual implementation as the default path. The goal is decision resolution and delegation.
+- Do not do manual implementation as the default path. The goal is decision resolution and delegation — when the resolution spawns one-off concrete work that needs no queue, dispatch it with `/go "<demand>"` instead of hand-rolling a worktree.
 - Do not update labels or body before showing the mutation plan and receiving explicit approval.
 - Do not treat Thread discussion as authoritative when it conflicts with Human guidance.
 - Do not move an Issue to `ready-for-agent` unless the refreshed `## Agent brief` is sufficient for autonomous execution.

--- a/plugins/dev/skills/engineering/implement/SKILL.md
+++ b/plugins/dev/skills/engineering/implement/SKILL.md
@@ -17,7 +17,7 @@ disable-model-invocation: true
 | **Driver** | You — interactive, step-by-step | Autonomous fleet, no human in the loop |
 | **Scope** | One PRD / issue set, right now | Drains the full `ready-for-agent` queue |
 | **Worktree** | Dedicated `.red/tmp/work-*` worktree | Isolated worktree per issue, sandcastle |
-| **Finish** | You run `/ship` when satisfied | Agent merges, closes, claims next issue |
+| **Finish** | You run `/requeue` when satisfied | Agent merges, closes, claims next issue |
 
 Use `/implement` when you want to implement a PRD or issues yourself — with test-first discipline and review — but need the agent to guide each step. Use `/afk` when you want the fleet to work unsupervised.
 
@@ -33,11 +33,11 @@ Use `/implement` when you want to implement a PRD or issues yourself — with te
 
 5. **Review with `/review`.** When the full suite is green, invoke `/review` to review the work. Address every finding before committing.
 
-6. **Finish with `/ship`.** Commit the work in the worktree (never on the primary branch), push, and run `/ship` to open or reuse a PR, monitor checks and reviews, and land the branch. Close the linked issues when done.
+6. **Finish with `/requeue`.** Commit the work in the worktree (never on the primary branch), push, and run `/requeue` to adopt the branch into the reconcile lane — it validates through the shared gate and lands. Close the linked issues when done. (For a brand-new one-off demand that doesn't need this interactive loop, dispatch `/go "<demand>"` instead — it handles worktree, gate, and PR end-to-end.)
 
 ### Hard rules
 
-- ❌ Do **not** implement on the primary branch or a sibling checkout — work in `.red/tmp/work-*` and finish via `/ship`.
+- ❌ Do **not** implement on the primary branch or a sibling checkout — work in `.red/tmp/work-*` and finish via `/requeue`.
 - ❌ Do **not** skip `/tdd`; writing code before a failing test is undefined behaviour for this skill.
 - ❌ Do **not** run `/review` while any test is red.
 - ✅ **Do** let `/to-issues` decompose large PRDs before starting — smaller seams mean smaller merge risk.
@@ -67,7 +67,7 @@ All implementation work lives in a dedicated worktree under `.red/tmp/`, never o
 git worktree add .red/tmp/work-<slug> -b feat/<slug>
 ```
 
-`/ship` expects the worktree to be under `.red/tmp/work-*/`. After `/ship` lands the branch, the worktree is pruned automatically.
+`/requeue` expects the worktree to be under `.red/tmp/work-*/`. After the adopted branch lands, the worktree is pruned automatically.
 
 ## PRD / issue model
 

--- a/plugins/dev/skills/engineering/retake/SKILL.md
+++ b/plugins/dev/skills/engineering/retake/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "#ISSUE [--apply] [--json] [--repo OWNER/REPO] [--pr-limit N]"
 
 # /retake
 
-**Find where the work lives and print the one next action — `/ship` is the tail command for a committed worktree ready to land.**
+**Find where the work lives and print the one next action — `/requeue` is the tail command for a committed worktree ready to land (the retired `/ship` is never suggested, ADR 0081); brand-new one-off work goes through `/go`.**
 
 ## Run
 
@@ -20,7 +20,7 @@ accepts both `123` and `#123`; quote `'#123'` if invoking it through a shell.
 Use `--apply` to execute only safe local setup steps: create a missing
 `.red/tmp/work-ship-*` worktree, recreate it from a matching branch, or fetch a
 PR head branch and create the ship worktree. `--apply` never merges, closes
-issues, edits labels, runs `/ship`, or changes the primary checkout branch.
+issues, edits labels, runs `/requeue`, or changes the primary checkout branch.
 
 ## Behaviour
 
@@ -32,11 +32,11 @@ issues, edits labels, runs `/ship`, or changes the primary checkout branch.
    - `ready-for-human` issue -> run `/hitl #ISSUE`
    - open PR with failing/pending checks or changes requested -> fix the PR branch
    - dirty matching worktree -> continue in that worktree
-   - clean open PR -> run `/ship --issue ISSUE` from the matching worktree
+   - clean open PR -> run `/requeue ISSUE` to adopt and land it through the reconcile lane
    - matching branch but no worktree -> recreate a `.red/tmp/work-ship-*` worktree
    - no local state -> create a fresh `.red/tmp/work-ship-*` branch from `origin/main`
 6. With `--apply`, run the safe local `git` operations for the selected action
-   and print the next `cd` or `/ship` command.
+   and print the next `cd`, `/requeue`, or `/go` command.
 
 `/retake` is intentionally non-destructive. It does not delete branches, close
 issues, merge PRs, or switch the primary checkout's branch.

--- a/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-red-skills/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   `## Agent skills`/`## Development workflow` blocks in AGENTS.md/CLAUDE.md plus
   `.red/agents/`. Run to turn RedSkills on in a repo, to enable/disable a
   plugin, before first use of `to-issues`, `to-prd`, `triage`, `diagnose`,
-  `tdd`, `improve-codebase-architecture`, `zoom-out`, or `/ship`, or if those
+  `tdd`, `improve-codebase-architecture`, `zoom-out`, or `/go`, or if those
   skills appear to be missing context.
 disable-model-invocation: true
 ---
@@ -29,7 +29,7 @@ Scaffold includes:
 - **Token efficiency** — strongly recommend installing [RTK](https://github.com/rtk-ai/rtk) to cut 60–90% of dev-operation tokens via a transparent CLI proxy
 - **Runtime launcher** — optionally install a host-level `red-skills-dev` shim so Claude Code, Codex, and opencode can invoke the same dev runtime without relying on CLI-specific plugin-root env vars
 - **Command guards** — configure the repo-owned `.red/config.yaml` policy that the globally-installed Claude Code, Codex, and opencode hook proxies enforce
-- **Development workflow** — teach agents the `.red/tmp` worktree rules, preserve the primary checkout for the human, and route interactive landing through `/ship`
+- **Development workflow** — teach agents the `.red/tmp` worktree rules, preserve the primary checkout for the human, and route one-off concrete work through `/go` (the retired `/ship` is never suggested — ADR 0081)
 
 This is a prompt-driven skill, not a deterministic script. Explore, present what you found, confirm with the user, then write.
 
@@ -59,7 +59,7 @@ Assume the user does not know what these terms mean. Each section starts with a 
 
 Ask the user which plugins to enable in this repo (multi-select; `dev` is the usual baseline):
 
-- **dev** — the engineering stack: `/afk`, `/triage`, `/ship`, model-tier routing, branch-lock, statusline. Enabling it is what makes the rest of this setup meaningful; default yes.
+- **dev** — the engineering stack: `/afk`, `/triage`, `/go`, model-tier routing, branch-lock, statusline. Enabling it is what makes the rest of this setup meaningful; default yes.
 - **memory** — governed operational memory (recall/store/graph). After enabling, run `/memory:init` to choose the storage mode. Default no.
 - **brain** — the agentic command-center context. Default no.
 
@@ -158,7 +158,7 @@ Three things to verify after install:
 
 **Section E1 — Runtime launcher (strongly recommended).**
 
-> Explainer: `CLAUDE_PLUGIN_ROOT`, `CODEX_PLUGIN_ROOT`, and similar variables are plugin/hook environment variables. They are not guaranteed in the interactive shell where an agent runs `/afk`, `/ship`, `/dashboard`, or `/requeue`. Setting those names globally is brittle because they point at versioned plugin-cache directories and can become stale after an update. The cross-CLI surface should be a stable command, not a global fake plugin-root variable.
+> Explainer: `CLAUDE_PLUGIN_ROOT`, `CODEX_PLUGIN_ROOT`, and similar variables are plugin/hook environment variables. They are not guaranteed in the interactive shell where an agent runs `/afk`, `/go`, `/dashboard`, or `/requeue`. Setting those names globally is brittle because they point at versioned plugin-cache directories and can become stale after an update. The cross-CLI surface should be a stable command, not a global fake plugin-root variable.
 
 Offer to install the host-level runtime shim:
 
@@ -171,7 +171,7 @@ The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev`. The shim:
 - prefers the active CLI plugin-root env var when the host exposes one;
 - otherwise finds the latest installed dev plugin under `~/.codex/plugins/cache/red-skills/dev/*` or `~/.claude/plugins/cache/red-skills/dev/*`;
 - falls back to the latest warmed dev bundle under `~/.cache/red-skills/bundles/`;
-- forwards all arguments to the dev runtime, so skills can say `red-skills-dev ship ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
+- forwards all arguments to the dev runtime, so skills can say `red-skills-dev go ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
 - stores no secrets and does not replace the `.red/config.yaml` opt-in gate.
 
 After installing, verify:
@@ -225,7 +225,7 @@ Offer to configure additional `command_guard` rules now. Default: **no extra act
 
 Explain the scopes:
 
-- `global` — blocks in both the main session and `/afk`/`/ship` worktrees.
+- `global` — blocks in both the main session and `/afk`/`/go` worktrees.
 - `main` — blocks only in the primary interactive session scope. This does **not** mean the Git branch named `main`.
 - `worktree` — blocks only in RedSkills runtime worktrees under `.red/tmp/`, including AFK workers.
 - `deny` — legacy alias for `global`; keep it readable but prefer writing new config as `global`.
@@ -254,14 +254,14 @@ Do not write the example blindly. The right policy is repo-specific.
 
 **Section H — Development workflow.**
 
-> Explainer: RedSkills' interactive dev loop assumes agents work from isolated worktrees, leave the primary checkout's branch alone, push their branch early, and hand landing to `/ship`. With `plugins.dev.enabled: true`, the shell proxy already blocks agent-created worktrees outside `.red/tmp/` and branch movement in the primary checkout. Turning on `plugins.dev.lock.primary-branch: true` in `.red/config.yaml` also activates the branch-lock compatibility flag used by older adapters and base-pinning integrations; the runtime folds it onto the legacy `dev.lock.primary-branch` accessor for back-compat. The shared development-workflow injector writes the same `## Development workflow` rules into both `AGENTS.md` and `CLAUDE.md`, updating an existing block in place on rerun.
+> Explainer: RedSkills' interactive dev loop assumes agents work from isolated worktrees, leave the primary checkout's branch alone, push their branch early, and land via a PR — with one-off concrete work dispatched through `/go` rather than hand-rolled worktrees. With `plugins.dev.enabled: true`, the shell proxy already blocks agent-created worktrees outside `.red/tmp/` and branch movement in the primary checkout. Turning on `plugins.dev.lock.primary-branch: true` in `.red/config.yaml` also activates the branch-lock compatibility flag used by older adapters and base-pinning integrations; the runtime folds it onto the legacy `dev.lock.primary-branch` accessor for back-compat. The shared development-workflow injector writes the same `## Development workflow` rules into both `AGENTS.md` and `CLAUDE.md`, updating an existing block in place on rerun.
 
 Confirm with the user:
 
 - Activate the development workflow? Default: yes.
 - This sets the canonical `plugins.dev.lock.primary-branch: true` flag in `.red/config.yaml`.
 - This writes or updates `## Development workflow` in both `AGENTS.md` and `CLAUDE.md` via the shared injector.
-- Recap that `/ship` is the landing command for interactive work after the branch is pushed.
+- Recap that one-off concrete work is dispatched with `/go "<demand>"` (worktree + gate + PR handled by the engine), and that hand-worked branches land via a normal PR.
 
 **Section I — Hook scripts from repo signals (offer-only).**
 
@@ -368,7 +368,7 @@ If the user accepted Section H, activate the development workflow:
 
 1. Invoke the shared injector rather than hand-editing the rules block. From a source checkout, run `pnpm --filter @reddb-io/dev dev inject-development-workflow --root <repo-root>`. From an installed plugin, run the bundled AFK entrypoint with `inject-development-workflow --root <repo-root>` (for example, `node ../afk/bin/afk.mjs inject-development-workflow --root <repo-root>` from this skill folder). The command writes both `AGENTS.md` and `CLAUDE.md`, creates `.red/config.yaml` if still missing, and sets `plugins.dev.lock.primary-branch: true`.
 2. If the command is unavailable, make the same changes manually: add or update the canonical `plugins:` → `dev:` → `lock:` block in `.red/config.yaml` so `primary-branch` is `true`, then upsert the canonical `## Development workflow` block in both `AGENTS.md` and `CLAUDE.md`. Never append a duplicate block; update the existing section in place. Leave any legacy top-level `dev.lock.*` keys untouched; `/doctor --fix` owns that migration.
-3. In the recap, explicitly point the user at `/ship` as the landing command after an interactive worktree branch has been committed and pushed.
+3. In the recap, explicitly point the user at `/go` for one-off concrete work, and at a normal PR for a hand-worked worktree branch that is already committed and pushed.
 
 If the user accepted Section F, wire the statusline:
 
@@ -426,4 +426,4 @@ Never close, reassign, or edit issue bodies in this step — labels only.
 
 ### 6. Done
 
-Tell the user the setup is complete, which plugins are now enabled here (and that all other directories stay inert until they run this skill there too), and which engineering skills will now read from these files. If they enabled **memory** or **brain**, point them at the next step — `/memory:init` to pick a storage mode, or the brain setup — since enabling only authorizes the plugin to run; its own init configures it. Mention they can edit `.red/agents/*.md` directly later, and that interactive work should land through `/ship`. Re-run this skill to enable or disable a plugin, switch issue trackers, or restart from scratch.
+Tell the user the setup is complete, which plugins are now enabled here (and that all other directories stay inert until they run this skill there too), and which engineering skills will now read from these files. If they enabled **memory** or **brain**, point them at the next step — `/memory:init` to pick a storage mode, or the brain setup — since enabling only authorizes the plugin to run; its own init configures it. Mention they can edit `.red/agents/*.md` directly later, and that one-off concrete work should be dispatched with `/go` (backlog via `/afk`, parked issues via `/requeue`). Re-run this skill to enable or disable a plugin, switch issue trackers, or restart from scratch.

--- a/plugins/dev/skills/misc/branch-lock/SKILL.md
+++ b/plugins/dev/skills/misc/branch-lock/SKILL.md
@@ -35,7 +35,7 @@ The hook logic is self-contained: it depends on neither the
 `git-guardrails-claude-code` skill nor anything else, and the two stack
 harmlessly if both are installed.
 
-`/afk` and `/ship` worktrees under `.red/tmp/work-*/` are always exempt — the lock protects
+`/afk` and `/go` worktrees under `.red/tmp/` are always exempt — the lock protects
 the interactive primary checkout, never the autonomous loop.
 
 <what-to-do>
@@ -152,7 +152,7 @@ It allows (exit 0, silent):
 - `git stash list` / `git stash show` — read-only stash
 - `git clean -n` / `--dry-run` — non-destructive clean
 - `git reset --soft` / mixed reset, `git restore --staged <path>` — no working-tree loss
-- `git worktree add .red/tmp/...` — worktrees are how `/afk` and `/ship` work
+- `git worktree add .red/tmp/...` — worktrees are how `/afk` and `/go` work
 - any other command
 
 With `dev.lock.primary-branch: true` and no branch-lock file, the primary guard


### PR DESCRIPTION
## Summary

Maintainer directive: **one-off concrete work goes through `/go`** — make it explicit everywhere the workflow is taught, and stop suggesting the retired `/ship` (ADR 0081).

- **Canonical block** (`DEVELOPMENT_WORKFLOW_BLOCK`): new first bullet routes one-off demands through `/go` (disposable `lane:go` issue, `.red/tmp/go-workers/` worktree, shared gate, PR); backlog → `/afk`; parked → `/requeue`; hand-worked branches finish via a plain PR. Setup injector and doctor comparison inherit automatically; doctor now flags the stale `/ship` form as drift.
- **Repo docs**: CLAUDE.md + AGENTS.md blocks updated in parity; README examples and guard-scope text updated.
- **Skills sweep**: setup-red-skills (10 refs), retake (tail command → `/requeue`/`/go`), implement (finish via `/requeue`; new one-off → `/go`), afk (retake text + monitor hard-boundary list), branch-lock (worktree exemptions), hitl (one-off delegable work → `/go`). requeue's migration note kept.
- **Tests**: new assertion — block contains the /go routing and `not.toContain("/ship")`.

Full dev suite green; found via dogfooding (bug #1045 blocked doing this change through /go itself).

Related: #1043 (original /go demand, superseded by this PR), #1045 (/go boot-death bug).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785609827&installation_id=129708444&pr_number=1046&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1046&signature=a880c7de074aa9429eddf2fc6417517a42ae71719c06ab713225743d90907e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->