### PR TITLE
merge: #1024 feat(dev): guard — block git reset and git stash in the primary checkout (agent-only)

### DIFF
--- a/plugins/dev/skills/misc/branch-lock/SKILL.md
+++ b/plugins/dev/skills/misc/branch-lock/SKILL.md
@@ -22,9 +22,18 @@ dev:
 
 the same pre-tool hook blocks the agent from changing the primary checkout's
 branch (`git switch <branch>`, `git checkout <branch>`, `git switch -b <new>`)
-even without a `branch-lock.yaml` file. Missing config or a missing key means
-off. `git commit`, `git worktree add`, read-only git, and `.red/tmp/work-*/`
-worktrees stay allowed.
+even without a `branch-lock.yaml` file. It also blocks the work-destroying
+commands the standing maintainer rules forbid in the primary checkout, because
+parallel human WIP lives there and these have destroyed in-progress work before
+(issue #1024): `git reset` in **any** form (`--hard`/`--soft`/`--mixed`, with or
+without a pathspec), every `git stash` subcommand, and `git rebase --autostash`.
+The refusal points to the sanctioned alternative — do branch work in an isolated
+worktree under `.red/tmp/work-*/`, and if the local trunk diverged from origin,
+leave it alone and base on the fresh remote ref (ADR 0083). Missing config or a
+missing key means off. `git commit`, `git worktree add`, read-only git, and
+`.red/tmp/work-*/` worktrees stay allowed. Inside isolated worktrees the
+reset/stash/autostash commands remain allowed — the guard is about the primary
+checkout only.
 
 Enforcement is **agent-only**, via runner pre-tool hooks — Claude Code
 `PreToolUse(Bash)` and Codex plugin `PreToolUse` — that intercept the agent's own

--- a/plugins/dev/skills/misc/branch-lock/scripts/branch-lock-hook.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/branch-lock-hook.sh
@@ -50,11 +50,18 @@ if dev_config_lock_primary_branch_enabled "$ROOT/.red/config.yaml" &&
   [[ "$(classify_primary_branch_switch_guard "$COMMAND")" == "block" ]]; then
   cat >&2 <<EOF
 BLOCKED by primary branch guard: dev.lock.primary-branch is true.
-The command '$COMMAND' would switch the agent's primary checkout branch.
+The command '$COMMAND' would move the agent's primary checkout branch or
+destroy work in it (branch switch, 'git reset' in any form, 'git stash', or
+'git rebase --autostash'). Parallel human WIP lives in this primary checkout,
+and these commands have destroyed in-progress work before.
+
+Do branch work in an isolated worktree under .red/tmp/work-*/ instead
+('git worktree add .red/tmp/work-<slug> -b <branch> origin/main'). If the local
+trunk diverged from origin, leave it alone and base on the fresh remote ref
+(ADR 0083) — never reset or stash the primary to reconcile it.
 
 Allowed in the primary checkout: git commit, git worktree add, read-only git,
-and non-branch-changing commands. To work on another branch, create/use a
-worktree under .red/tmp/work-*/ or ask the user to change the primary branch.
+and other non-destructive commands. To change the primary branch, ask the user.
 EOF
   exit 2
 fi

--- a/plugins/dev/skills/misc/branch-lock/scripts/lib/git-command-classifier.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/lib/git-command-classifier.sh
@@ -33,10 +33,15 @@
 #     Echoes exactly "block" or "allow" and returns 0.
 #
 #   classify_primary_branch_switch_guard <command>
-#     Echoes exactly "block" for commands that would switch/create/checkout a
-#     branch in the primary checkout, and "allow" otherwise. This is the
-#     config-flag guard from ADR 0043: unlike classify_git_command it has no
-#     lock branch and only cares about branch movement, not work-loss commands.
+#     Echoes exactly "block" for commands that would move or destroy work in the
+#     primary checkout, and "allow" otherwise. This is the config-flag guard
+#     from ADR 0043 (unlike classify_git_command it has no lock branch). It
+#     blocks: branch movement (switch/create/checkout to a branch); `git reset`
+#     in ANY form; every `git stash` subcommand; and `git rebase --autostash`
+#     (issue #1024). Parallel human WIP lives in the primary checkout and these
+#     commands have destroyed in-progress work before; do branch work in an
+#     isolated worktree under .red/tmp/ instead. Worktrees are exempt by scope,
+#     so this classifier only ever runs against the primary checkout.
 
 # _git_subcommand_index <toks-name> <git-index>
 # Given the name of the token array and the index of a `git` token, echoes the
@@ -150,6 +155,26 @@ classify_primary_branch_switch_guard() {
     local sub="${toks[s]:-}"
     case "$sub" in
       worktree)
+        echo "allow"; return 0
+        ;;
+      reset)
+        # `git reset` in ANY form (--hard/--soft/--mixed, with or without a
+        # pathspec) can throw away parallel human WIP in the primary checkout
+        # (issue #1024). All forms blocked; use a worktree for branch work.
+        echo "block"; return 0
+        ;;
+      stash)
+        # `git stash` and every subcommand (push/save/pop/apply/list/show/…)
+        # blocked in the primary checkout (issue #1024) — the whole family
+        # touches or hides the primary's working tree.
+        echo "block"; return 0
+        ;;
+      rebase)
+        # `git rebase --autostash` silently stashes/pops the primary's WIP
+        # around the rebase (issue #1024); a plain rebase is not this vector.
+        for ((j = s + 1; j < n; j++)); do
+          [[ "${toks[j]}" == "--autostash" ]] && { echo "block"; return 0; }
+        done
         echo "allow"; return 0
         ;;
       checkout|switch)

--- a/plugins/dev/skills/misc/branch-lock/scripts/tests/claude-plugin-hook.test.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/tests/claude-plugin-hook.test.sh
@@ -65,6 +65,24 @@ rc=$?
 expect_eq "primary guard: switch is blocked when flag is on" "2" "$rc"
 expect_contains "primary guard: error names config flag" "dev.lock.primary-branch is true" "$(<"$err")"
 
+# issue #1024 — git reset (any form) and git stash (all subcommands) blocked,
+# and the refusal explains the reason + the sanctioned worktree alternative.
+CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PROJECT_DIR="$primary" bash -lc "$manifest_hook" \
+  >"$out" 2>"$err" <<<"$(payload "git reset --hard")"
+rc=$?
+expect_eq "primary guard: reset --hard is blocked when flag is on" "2" "$rc"
+expect_contains "primary guard: reset refusal points to worktree" ".red/tmp/work-" "$(<"$err")"
+
+CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PROJECT_DIR="$primary" bash -lc "$manifest_hook" \
+  >"$out" 2>"$err" <<<"$(payload "git stash")"
+rc=$?
+expect_eq "primary guard: stash is blocked when flag is on" "2" "$rc"
+
+CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PROJECT_DIR="$primary" bash -lc "$manifest_hook" \
+  >"$out" 2>"$err" <<<"$(payload "git rebase --autostash main")"
+rc=$?
+expect_eq "primary guard: rebase --autostash is blocked when flag is on" "2" "$rc"
+
 CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PROJECT_DIR="$primary" bash -lc "$manifest_hook" \
   >"$out" 2>"$err" <<<"$(payload "git commit -m wip")"
 rc=$?

--- a/plugins/dev/skills/misc/branch-lock/scripts/tests/codex-hook.test.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/tests/codex-hook.test.sh
@@ -139,6 +139,26 @@ result="$(run_hook "$primary" "$(payload "$primary" "git checkout feature")")"
 rc="$(sed -n '1p' <<<"$result")"
 expect_eq "primary guard: checkout branch is blocked when flag is on" "2" "$rc"
 
+# issue #1024 — git reset (any form) and git stash (all subcommands) blocked,
+# and the refusal explains the reason + the sanctioned worktree alternative.
+result="$(run_hook "$primary" "$(payload "$primary" "git reset --hard")")"
+rc="$(sed -n '1p' <<<"$result")"
+stderr="$(sed -n '/---stderr---/,$p' <<<"$result")"
+expect_eq "primary guard: reset --hard is blocked when flag is on" "2" "$rc"
+expect_contains "primary guard: reset refusal points to worktree" ".red/tmp/work-" "$stderr"
+
+result="$(run_hook "$primary" "$(payload "$primary" "git reset --soft HEAD~1")")"
+rc="$(sed -n '1p' <<<"$result")"
+expect_eq "primary guard: reset --soft is blocked when flag is on" "2" "$rc"
+
+result="$(run_hook "$primary" "$(payload "$primary" "git stash")")"
+rc="$(sed -n '1p' <<<"$result")"
+expect_eq "primary guard: stash is blocked when flag is on" "2" "$rc"
+
+result="$(run_hook "$primary" "$(payload "$primary" "git rebase --autostash main")")"
+rc="$(sed -n '1p' <<<"$result")"
+expect_eq "primary guard: rebase --autostash is blocked when flag is on" "2" "$rc"
+
 result="$(run_hook "$primary" "$(payload "$primary" "git switch -b new")")"
 rc="$(sed -n '1p' <<<"$result")"
 expect_eq "primary guard: switch -b is blocked when flag is on" "2" "$rc"

--- a/plugins/dev/skills/misc/branch-lock/scripts/tests/git-command-classifier.test.sh
+++ b/plugins/dev/skills/misc/branch-lock/scripts/tests/git-command-classifier.test.sh
@@ -144,6 +144,44 @@ expect_primary_guard "primary/off/switch allowed"            "git switch other" 
 expect_primary_guard "worktree/on/switch allowed"            "git switch other"              worktree on  allow
 expect_primary_guard "worktree/off/switch allowed"           "git switch other"              worktree off allow
 
+# ---------------------------------------------------------------------------
+# issue #1024: block git reset (any form) and git stash (all subcommands),
+# plus git rebase --autostash, in the primary checkout. Parallel human WIP
+# lives there; these commands have destroyed in-progress work before.
+# ---------------------------------------------------------------------------
+expect_primary_guard "primary/on/reset bare blocked"         "git reset"                          primary  on  block
+expect_primary_guard "primary/on/reset --hard blocked"       "git reset --hard"                   primary  on  block
+expect_primary_guard "primary/on/reset --hard HEAD~1 blocked" "git reset --hard HEAD~1"           primary  on  block
+expect_primary_guard "primary/on/reset --soft blocked"       "git reset --soft HEAD~1"            primary  on  block
+expect_primary_guard "primary/on/reset --mixed blocked"      "git reset --mixed"                  primary  on  block
+expect_primary_guard "primary/on/reset pathspec blocked"     "git reset HEAD file.txt"            primary  on  block
+expect_primary_guard "primary/on/-C reset blocked"           "git -C /repo reset --hard"          primary  on  block
+expect_primary_guard "primary/on/compound reset blocked"     "cd repo && git reset --hard"        primary  on  block
+
+expect_primary_guard "primary/on/stash bare blocked"         "git stash"                          primary  on  block
+expect_primary_guard "primary/on/stash push blocked"         "git stash push"                     primary  on  block
+expect_primary_guard "primary/on/stash push paths blocked"   "git stash push -m x src/"           primary  on  block
+expect_primary_guard "primary/on/stash save blocked"         "git stash save wip"                 primary  on  block
+expect_primary_guard "primary/on/stash pop blocked"          "git stash pop"                      primary  on  block
+expect_primary_guard "primary/on/stash apply blocked"        "git stash apply"                    primary  on  block
+expect_primary_guard "primary/on/stash list blocked"         "git stash list"                     primary  on  block
+expect_primary_guard "primary/on/stash show blocked"         "git stash show"                     primary  on  block
+expect_primary_guard "primary/on/-C stash blocked"           "git -C /repo stash"                 primary  on  block
+
+expect_primary_guard "primary/on/rebase autostash blocked"   "git rebase --autostash"             primary  on  block
+expect_primary_guard "primary/on/rebase autostash arg blocked" "git rebase --autostash origin/main" primary on block
+expect_primary_guard "primary/on/rebase main autostash blocked" "git rebase main --autostash"     primary  on  block
+
+# rebase without --autostash is not the work-loss vector this rule targets
+expect_primary_guard "primary/on/rebase plain allowed"       "git rebase main"                    primary  on  allow
+expect_primary_guard "primary/on/rebase --no-autostash allowed" "git rebase --no-autostash main"  primary  on  allow
+
+# worktrees stay exempt (scope), flag-off stays inert — for reset/stash too
+expect_primary_guard "worktree/on/reset allowed"             "git reset --hard"                   worktree on  allow
+expect_primary_guard "worktree/on/stash allowed"             "git stash"                          worktree on  allow
+expect_primary_guard "primary/off/reset allowed"             "git reset --hard"                   primary  off allow
+expect_primary_guard "primary/off/stash allowed"             "git stash"                          primary  off allow
+
 echo
 echo "summary: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Automated AFK landing for #1024. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1024

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785616982&installation_id=129708444&pr_number=1053&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1053&signature=32cf3368c48317fc4b4eaf558a9c84d0ca115d0a4358db9b8919bded24af93e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->