### PR TITLE
merge: #1026 feat(afk): afk stop — safe fleet shutdown verb (kill the right supervisor, reconcile claims)

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -13,6 +13,7 @@ import { reapCommand } from "./commands/reap.js";
 import { requeueCommand } from "./commands/requeue.js";
 import { retakeCommand } from "./commands/retake.js";
 import { reviewCommand } from "./commands/review.js";
+import { stopCommand } from "./commands/stop.js";
 import { respondCommand } from "./commands/respond.js";
 import { routeModelTierCommand } from "./commands/route-model-tier.js";
 import { shipCommand } from "./commands/ship.js";
@@ -26,6 +27,7 @@ export type CliCommand =
   | "run"
   | "monitor"
   | "fleet"
+  | "stop"
   | "go"
   | "dashboard"
   | "daily-review"
@@ -65,6 +67,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     run: {},
     monitor: {},
     fleet: {},
+    stop: {},
     go: {},
     dashboard: {},
     "daily-review": {},
@@ -113,6 +116,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   }
   if (parsed.command === "monitor") return monitorCommand(parsed.args);
   if (parsed.command === "fleet") return fleetCommand(parsed.args);
+  if (parsed.command === "stop") return stopCommand(parsed.args);
   if (parsed.command === "go") return goCommand(parsed.args);
   if (parsed.command === "dashboard") return dashboardCommand(parsed.args);
   if (parsed.command === "daily-review") return activityReviewCommand("daily", parsed.args);

--- a/apps/dev/src/commands/stop.ts
+++ b/apps/dev/src/commands/stop.ts
@@ -1,0 +1,159 @@
+import { Writable } from "node:stream";
+import { readFile } from "node:fs/promises";
+import { isValidWorkerId, workerPidFile } from "../core/worker-paths.js";
+import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
+import { listStaleClaimDirs, removeDir } from "../runtime/fs.js";
+import { afkPaths } from "../runtime/wire.js";
+import { stopFleet, type FleetStopResult } from "./fleet.js";
+import { encodeToon } from "../core/toon.js";
+
+async function readWorkerPid(pidFile: string): Promise<number | null> {
+  try {
+    const raw = (await readFile(pidFile, "utf8")).trim();
+    if (!/^[1-9][0-9]*$/.test(raw)) return null;
+    return Number(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Injectable IO for deterministic testing. */
+export interface StopIO {
+  stopFleet(root: string, out: NodeJS.WritableStream): Promise<FleetStopResult>;
+  listStaleClaimDirs(tmpDir: string): Promise<Array<{ path: string }>>;
+  removeDir(path: string): Promise<void>;
+  readWorkerPid(pidFile: string): Promise<number | null>;
+  isLivePid(pid: number): boolean;
+  killTreeAndWait(pid: number): Promise<boolean>;
+}
+
+const defaultIO: StopIO = {
+  stopFleet,
+  listStaleClaimDirs,
+  removeDir,
+  readWorkerPid,
+  isLivePid,
+  killTreeAndWait,
+};
+
+export interface ParsedStopArgs {
+  /** Worker id from --worker <wid>; null means fleet-level stop. */
+  worker: string | null;
+}
+
+export function parseStopArgs(args: readonly string[]): ParsedStopArgs {
+  let worker: string | null = null;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--worker" || arg === "-w") {
+      worker = args[++i] ?? null;
+      continue;
+    }
+    if (arg.startsWith("--worker=")) {
+      worker = arg.slice("--worker=".length);
+      continue;
+    }
+  }
+  return { worker };
+}
+
+const discardStream = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+
+/**
+ * `afk stop` — safe fleet shutdown verb.
+ *
+ * Without --worker: discover the supervisor via afk-supervisor.pid, SIGTERM it,
+ * wait for the tree to exit (escalating to SIGKILL after the grace), reconcile
+ * stale claim-lock dirs, then emit a TOON summary.
+ *
+ * With --worker <wid>: SIGTERM exactly one worker's process tree (supervisor
+ * notices the empty slot and respawns it) — the sanctioned recycle path.
+ */
+export async function stopCommand(
+  args: readonly string[],
+  cwd = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+  io: StopIO = defaultIO,
+): Promise<number> {
+  const parsed = parseStopArgs(args);
+  const paths = afkPaths(cwd);
+
+  try {
+    if (parsed.worker !== null) {
+      return await stopWorker(parsed.worker, paths.tmpDir, stdout, io);
+    }
+    return await stopFleetWithReconcile(cwd, paths.tmpDir, stdout, io);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[afk stop] ✗ ${message}\n`);
+    return 1;
+  }
+}
+
+async function stopFleetWithReconcile(
+  cwd: string,
+  tmpDir: string,
+  stdout: NodeJS.WritableStream,
+  io: StopIO,
+): Promise<number> {
+  // Suppress stopFleet's prose — all output from this verb is TOON.
+  const fleetResult = await io.stopFleet(cwd, discardStream);
+
+  const stale = await io.listStaleClaimDirs(tmpDir).catch(() => []);
+  let claimsReleased = 0;
+  for (const dir of stale) {
+    await io.removeDir(dir.path).catch(() => {});
+    claimsReleased += 1;
+  }
+
+  stdout.write(
+    encodeToon({
+      op: "stop",
+      supervisor_pid: fleetResult.pid ?? null,
+      supervisor_status: fleetResult.status,
+      claims_released: claimsReleased,
+    }) + "\n",
+  );
+
+  return fleetResult.status === "timeout" ? 1 : 0;
+}
+
+async function stopWorker(
+  workerId: string,
+  tmpDir: string,
+  stdout: NodeJS.WritableStream,
+  io: StopIO,
+): Promise<number> {
+  if (!isValidWorkerId(workerId)) {
+    process.stderr.write(`[afk stop] invalid worker id: ${JSON.stringify(workerId)}\n`);
+    return 1;
+  }
+
+  const pidFile = workerPidFile(tmpDir, workerId);
+  const pid = await io.readWorkerPid(pidFile);
+
+  if (pid === null) {
+    stdout.write(
+      encodeToon({ op: "stop-worker", worker: workerId, worker_pid: null, worker_status: "none" }) + "\n",
+    );
+    return 0;
+  }
+
+  if (!io.isLivePid(pid)) {
+    stdout.write(
+      encodeToon({ op: "stop-worker", worker: workerId, worker_pid: pid, worker_status: "stale" }) + "\n",
+    );
+    return 0;
+  }
+
+  const dead = await io.killTreeAndWait(pid);
+  stdout.write(
+    encodeToon({
+      op: "stop-worker",
+      worker: workerId,
+      worker_pid: pid,
+      worker_status: dead ? "stopped" : "timeout",
+    }) + "\n",
+  );
+  return dead ? 0 : 1;
+}

--- a/apps/dev/tests/stop-command.test.ts
+++ b/apps/dev/tests/stop-command.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+import { Writable } from "node:stream";
+import { parseCli } from "../src/cli.js";
+import { parseStopArgs, stopCommand, type StopIO } from "../src/commands/stop.js";
+
+// ---------- helpers ----------
+
+function capture(): { stream: Writable; text: () => string } {
+  let buf = "";
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      buf += chunk.toString();
+      cb();
+    },
+  });
+  return { stream, text: () => buf };
+}
+
+function captureStderr(): { restore: () => void; text: () => string } {
+  let buf = "";
+  const orig = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk: string | Uint8Array) => {
+    buf += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+    return true;
+  };
+  return { restore: () => { process.stderr.write = orig; }, text: () => buf };
+}
+
+function nullStream(): Writable {
+  return new Writable({ write(_c, _e, cb) { cb(); } });
+}
+
+type FleetStatus = "stopped" | "none" | "stale" | "timeout";
+
+function fakeIO(opts: {
+  fleetStatus?: FleetStatus;
+  fleetPid?: number;
+  staleClaims?: string[];
+  workerPid?: number | null;
+  workerLive?: boolean;
+  workerKillResult?: boolean;
+} = {}): StopIO & { stopFleetCalled: boolean; removedDirs: string[]; workerKillCalled: boolean } {
+  let stopFleetCalled = false;
+  const removedDirs: string[] = [];
+  let workerKillCalled = false;
+
+  const io: StopIO & { stopFleetCalled: boolean; removedDirs: string[]; workerKillCalled: boolean } = {
+    get stopFleetCalled() { return stopFleetCalled; },
+    get removedDirs() { return removedDirs; },
+    get workerKillCalled() { return workerKillCalled; },
+
+    async stopFleet(_root, _out) {
+      stopFleetCalled = true;
+      return { status: opts.fleetStatus ?? "none", pid: opts.fleetPid };
+    },
+    async listStaleClaimDirs(_tmpDir) {
+      return (opts.staleClaims ?? []).map((p) => ({ path: p }));
+    },
+    async removeDir(path) {
+      removedDirs.push(path);
+    },
+    async readWorkerPid(_pidFile) {
+      return opts.workerPid ?? null;
+    },
+    isLivePid(_pid) {
+      return opts.workerLive ?? false;
+    },
+    async killTreeAndWait(_pid) {
+      workerKillCalled = true;
+      return opts.workerKillResult ?? true;
+    },
+  };
+  return io;
+}
+
+// ---------- CLI routing ----------
+
+describe("cli routing — stop", () => {
+  it("routes 'stop' with no args", () => {
+    expect(parseCli(["stop"])).toEqual({ command: "stop", args: [] });
+  });
+
+  it("routes 'stop --worker wXXXX' preserving the flag", () => {
+    expect(parseCli(["stop", "--worker", "wBZ43"])).toEqual({
+      command: "stop",
+      args: ["--worker", "wBZ43"],
+    });
+  });
+});
+
+// ---------- parseStopArgs ----------
+
+describe("parseStopArgs", () => {
+  it("returns worker=null for bare stop", () => {
+    expect(parseStopArgs([])).toEqual({ worker: null });
+  });
+
+  it("parses --worker <wid>", () => {
+    expect(parseStopArgs(["--worker", "wBZ43"])).toEqual({ worker: "wBZ43" });
+  });
+
+  it("parses --worker=<wid> (= form)", () => {
+    expect(parseStopArgs(["--worker=wQYIB"])).toEqual({ worker: "wQYIB" });
+  });
+
+  it("parses -w <wid> short flag", () => {
+    expect(parseStopArgs(["-w", "wABC1"])).toEqual({ worker: "wABC1" });
+  });
+});
+
+// ---------- fleet stop path ----------
+
+describe("stopCommand — fleet stop", () => {
+  it("targets the supervisor from afk-supervisor.pid, not individual workers", async () => {
+    // In fleet mode stopCommand delegates entirely to io.stopFleet (which reads
+    // afk-supervisor.pid). Worker-level kill (io.killTreeAndWait) must NOT fire.
+    const io = fakeIO({ fleetStatus: "none" });
+    const { stream } = capture();
+    await stopCommand([], "/repo", stream, io);
+
+    expect(io.stopFleetCalled).toBe(true);
+    expect(io.workerKillCalled).toBe(false);
+  });
+
+  it("emits TOON with status=none when no fleet is running", async () => {
+    const io = fakeIO({ fleetStatus: "none" });
+    const { stream, text } = capture();
+    const code = await stopCommand([], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    const out = text();
+    expect(out).toContain("op: stop");
+    expect(out).toContain("supervisor_status: none");
+    expect(out).toContain("claims_released: 0");
+  });
+
+  it("emits TOON with status=stopped and supervisor_pid after clean shutdown", async () => {
+    const io = fakeIO({ fleetStatus: "stopped", fleetPid: 1234 });
+    const { stream, text } = capture();
+    const code = await stopCommand([], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    const out = text();
+    expect(out).toContain("op: stop");
+    expect(out).toContain("supervisor_pid: 1234");
+    expect(out).toContain("supervisor_status: stopped");
+  });
+
+  it("reconciles stale claim dirs after stop and reports the count", async () => {
+    const staleDirs = ["/repo/.red/tmp/claims/42", "/repo/.red/tmp/claims/77"];
+    const io = fakeIO({ fleetStatus: "stopped", fleetPid: 5678, staleClaims: staleDirs });
+    const { stream, text } = capture();
+    await stopCommand([], "/repo", stream, io);
+
+    // All stale dirs removed.
+    expect(io.removedDirs).toEqual(staleDirs);
+    expect(text()).toContain("claims_released: 2");
+  });
+
+  it("reconciles zero claims when none are stale", async () => {
+    const io = fakeIO({ fleetStatus: "stale", fleetPid: 9999 });
+    const { stream, text } = capture();
+    await stopCommand([], "/repo", stream, io);
+
+    expect(io.removedDirs).toHaveLength(0);
+    expect(text()).toContain("claims_released: 0");
+  });
+
+  it("returns exit code 1 and timeout status when supervisor survives SIGKILL", async () => {
+    const io = fakeIO({ fleetStatus: "timeout", fleetPid: 4321 });
+    const { stream, text } = capture();
+    const code = await stopCommand([], "/repo", stream, io);
+
+    expect(code).toBe(1);
+    expect(text()).toContain("supervisor_status: timeout");
+  });
+
+  it("output is valid TOON (no JSON braces)", async () => {
+    const io = fakeIO({ fleetStatus: "stopped", fleetPid: 1, staleClaims: ["/c/1"] });
+    const { stream, text } = capture();
+    await stopCommand([], "/repo", stream, io);
+
+    const out = text();
+    // TOON must not contain JSON delimiters.
+    expect(out).not.toContain("{");
+    expect(out).not.toContain("}");
+    expect(out).not.toContain("[{");
+  });
+});
+
+// ---------- --worker recycle path ----------
+
+describe("stopCommand — --worker recycle", () => {
+  it("SIGTERMs exactly one worker and does NOT stop the fleet", async () => {
+    const io = fakeIO({ workerPid: 9000, workerLive: true, workerKillResult: true });
+    const { stream } = capture();
+    await stopCommand(["--worker", "wBZ43"], "/repo", stream, io);
+
+    expect(io.workerKillCalled).toBe(true);
+    expect(io.stopFleetCalled).toBe(false);
+  });
+
+  it("emits TOON with op=stop-worker and worker_status=stopped on success", async () => {
+    const io = fakeIO({ workerPid: 9000, workerLive: true, workerKillResult: true });
+    const { stream, text } = capture();
+    const code = await stopCommand(["--worker", "wBZ43"], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    const out = text();
+    expect(out).toContain("op: stop-worker");
+    expect(out).toContain("worker: wBZ43");
+    expect(out).toContain("worker_pid: 9000");
+    expect(out).toContain("worker_status: stopped");
+  });
+
+  it("reports worker_status=none when the worker has no pid file", async () => {
+    const io = fakeIO({ workerPid: null });
+    const { stream, text } = capture();
+    const code = await stopCommand(["--worker", "wXXXX"], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    expect(text()).toContain("worker_status: none");
+    expect(io.workerKillCalled).toBe(false);
+  });
+
+  it("reports worker_status=stale when the worker pid is not live", async () => {
+    const io = fakeIO({ workerPid: 7777, workerLive: false });
+    const { stream, text } = capture();
+    const code = await stopCommand(["--worker", "wSTAL"], "/repo", stream, io);
+
+    expect(code).toBe(0);
+    expect(text()).toContain("worker_status: stale");
+    expect(io.workerKillCalled).toBe(false);
+  });
+
+  it("returns exit code 1 and worker_status=timeout when the worker survives SIGKILL", async () => {
+    const io = fakeIO({ workerPid: 3333, workerLive: true, workerKillResult: false });
+    const { stream, text } = capture();
+    const code = await stopCommand(["--worker", "wHANG"], "/repo", stream, io);
+
+    expect(code).toBe(1);
+    expect(text()).toContain("worker_status: timeout");
+  });
+
+  it("rejects an invalid worker id and returns exit code 1", async () => {
+    const io = fakeIO();
+    const { stream } = capture();
+    const { restore, text: stderrText } = captureStderr();
+    const code = await stopCommand(["--worker", "bad id!"], "/repo", stream, io);
+    restore();
+
+    expect(code).toBe(1);
+    expect(stderrText()).toContain("invalid worker id");
+  });
+
+  it("output is valid TOON for the worker path (no JSON braces)", async () => {
+    const io = fakeIO({ workerPid: 5555, workerLive: true, workerKillResult: true });
+    const { stream, text } = capture();
+    await stopCommand(["--worker", "wBZ43"], "/repo", stream, io);
+
+    const out = text();
+    expect(out).not.toContain("{");
+    expect(out).not.toContain("}");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1026. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1026

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785617799&installation_id=129708444&pr_number=1056&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1056&signature=f10cf2a39796c5cdc32c02514538bc88b3d23f972504500bc079e40cb34a4e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->