### PR TITLE
merge: #1027 feat(afk): manual /afk run refuses to boot while a live fleet supervisor is draining

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -55,6 +55,7 @@ import { attemptLedgerContext, formatAttemptContext, highestAttempt, type Attemp
 import { isValidWorkerId } from "../core/worker-paths.js";
 import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
+import { isLivePid } from "../runtime/kill-tree.js";
 import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../core/runner-spawn.js";
 import { buildWorkerAttemptPath } from "../core/worker-paths.js";
 import { branchLockPath, readLockedBranch, isLocked } from "../runtime/lock.js";
@@ -126,6 +127,9 @@ interface ParsedRunFlags {
    * no PR, no merge; the agent report is posted as a comment and the disposable
    * issue closes. Additional modes may be added by future dispatch tiers. */
   runMode?: string;
+  /** --force: bypass the live-supervisor boot guard (#1027). Operator accepts
+   * the collision risk; a warning is printed but the run proceeds. */
+  force: boolean;
 }
 
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
@@ -134,6 +138,54 @@ export class RunFlagError extends Error {
     super(message);
     this.name = "RunFlagError";
   }
+}
+
+/**
+ * Probe the fleet supervisor pid file. Returns `{ live: true, pid }` when a
+ * running supervisor is detected, `{ live: false }` otherwise (no file, stale
+ * pid, or invalid content). `checkLivePid` is injectable so tests can provide a
+ * fake process probe without spawning real processes (#1027).
+ */
+export async function probeFleetSupervisor(
+  pidFile: string,
+  checkLivePid: (pid: number) => boolean = isLivePid,
+): Promise<{ live: true; pid: number } | { live: false }> {
+  try {
+    const raw = (await readFile(pidFile, "utf8")).trim();
+    if (!/^\d+$/.test(raw)) return { live: false };
+    const pid = Number(raw);
+    if (!checkLivePid(pid)) return { live: false };
+    return { live: true, pid };
+  } catch {
+    return { live: false };
+  }
+}
+
+/**
+ * Apply the boot guard: refuse to start if a fleet supervisor is already live
+ * (unless `--force` was passed). Returns `"refused"` when the caller should
+ * abort, `"forced"` when the guard was bypassed with a warning, or `"clear"`
+ * when no live supervisor was found.
+ */
+export async function checkBootGuard(
+  pidFile: string,
+  force: boolean,
+  stdout: NodeJS.WritableStream,
+  checkLivePid: (pid: number) => boolean = isLivePid,
+): Promise<"refused" | "forced" | "clear"> {
+  const probe = await probeFleetSupervisor(pidFile, checkLivePid);
+  if (!probe.live) return "clear";
+  if (force) {
+    stdout.write(`warn: --force: fleet supervisor pid=${probe.pid} is still running; collision risk accepted.\n`);
+    return "forced";
+  }
+  stdout.write(
+    `afk: a fleet supervisor is already running (pid=${probe.pid}).\n` +
+      `  monitor the running fleet: /dev:afk fleet\n` +
+      `  stop it first:             afk stop\n` +
+      `  override (risk):           afk run --force\n`,
+  );
+  return "refused";
 }
 
 /** Parse a comma-separated issue list into an ordered, finite number list. */
@@ -183,6 +235,7 @@ const RUN_FLAG_SCHEMA = {
   "local-merge": { kind: "boolean" },
   yolo: { kind: "boolean" },
   "run-mode": { kind: "value", coerce: (raw: string): string => raw },
+  force: { kind: "boolean" },
 } satisfies FlagSchema;
 
 /** Parse the `run` flags: --prd N / --issues a,b,c / -n N / --once / --request / --runner. */
@@ -237,6 +290,7 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     localMerge: values["local-merge"] === true,
     yolo: values.yolo === true,
     runMode: values["run-mode"] as string | undefined,
+    force: values.force === true,
   };
 }
 
@@ -1296,6 +1350,16 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const ctx = await resolveRepoContext(cwd);
   const settings = resolveRunSettings(cwd, process.env, runner);
   const paths = afkPaths(cwd);
+
+  // Boot guard (#1027): refuse to start if a fleet supervisor is already live.
+  // Supervisor-dispatched paths bypass this: --reconcile-issue workers are
+  // spawned by the running supervisor; RED_AFK_SWEEPS_DONE=1 workers are
+  // fleet-owned and the supervisor already holds the pid.
+  if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
+    const pidFile = join(paths.tmpDir, "afk-supervisor.pid");
+    const guard = await checkBootGuard(pidFile, flags.force, process.stdout);
+    if (guard === "refused") return 1;
+  }
 
   // Worker id — probe the workers root for collisions.
   const existing = new Set((await collectMonitorInputs(cwd)).workers.map((w) => w.state.worker_id));

--- a/apps/dev/tests/boot-guard.test.ts
+++ b/apps/dev/tests/boot-guard.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { tmpdir } from "node:os";
+import { writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { probeFleetSupervisor, checkBootGuard } from "../src/commands/run.js";
+
+function tmpPidFile(suffix: string): string {
+  return join(tmpdir(), `afk-boot-guard-test-${suffix}.pid`);
+}
+
+function makeStdout(): { write: (s: string) => boolean; output: string } {
+  const out = { write: (s: string) => { out.output += s; return true; }, output: "" };
+  return out;
+}
+
+describe("probeFleetSupervisor (#1027)", () => {
+  it("returns live:false when the pid file does not exist", async () => {
+    const result = await probeFleetSupervisor(tmpPidFile("no-file"));
+    expect(result.live).toBe(false);
+  });
+
+  it("returns live:false when the pid file contains a non-numeric value", async () => {
+    const f = tmpPidFile("bad-content");
+    await writeFile(f, "not-a-pid", "utf8");
+    try {
+      const result = await probeFleetSupervisor(f);
+      expect(result.live).toBe(false);
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+
+  it("returns live:false when the pid is not live (fake probe returns false)", async () => {
+    const f = tmpPidFile("dead-pid");
+    await writeFile(f, "99999", "utf8");
+    try {
+      const result = await probeFleetSupervisor(f, () => false);
+      expect(result.live).toBe(false);
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+
+  it("returns { live: true, pid } when the pid is live (fake probe returns true)", async () => {
+    const f = tmpPidFile("live-pid");
+    await writeFile(f, "12345", "utf8");
+    try {
+      const result = await probeFleetSupervisor(f, () => true);
+      expect(result).toEqual({ live: true, pid: 12345 });
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+});
+
+describe("checkBootGuard (#1027)", () => {
+  it("returns 'clear' when no supervisor pid file exists", async () => {
+    const stdout = makeStdout();
+    const result = await checkBootGuard(tmpPidFile("guard-no-file"), false, stdout as unknown as NodeJS.WritableStream);
+    expect(result).toBe("clear");
+    expect(stdout.output).toBe("");
+  });
+
+  it("returns 'refused' and prints monitor/stop hints when a live supervisor is detected", async () => {
+    const f = tmpPidFile("guard-live");
+    await writeFile(f, "55555", "utf8");
+    try {
+      const stdout = makeStdout();
+      const result = await checkBootGuard(f, false, stdout as unknown as NodeJS.WritableStream, () => true);
+      expect(result).toBe("refused");
+      expect(stdout.output).toContain("fleet supervisor is already running");
+      expect(stdout.output).toContain("pid=55555");
+      expect(stdout.output).toContain("afk stop");
+      expect(stdout.output).toContain("--force");
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+
+  it("returns 'forced' and prints a warning when --force is passed with a live supervisor", async () => {
+    const f = tmpPidFile("guard-force");
+    await writeFile(f, "77777", "utf8");
+    try {
+      const stdout = makeStdout();
+      const result = await checkBootGuard(f, true, stdout as unknown as NodeJS.WritableStream, () => true);
+      expect(result).toBe("forced");
+      expect(stdout.output).toContain("--force");
+      expect(stdout.output).toContain("pid=77777");
+      expect(stdout.output).toContain("collision risk");
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+
+  it("returns 'clear' when the pid file exists but the pid is dead", async () => {
+    const f = tmpPidFile("guard-dead");
+    await writeFile(f, "44444", "utf8");
+    try {
+      const stdout = makeStdout();
+      const result = await checkBootGuard(f, false, stdout as unknown as NodeJS.WritableStream, () => false);
+      expect(result).toBe("clear");
+      expect(stdout.output).toBe("");
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+});

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -65,6 +65,7 @@ describe("parseRunFlags", () => {
       prePr: false,
       localMerge: false,
       yolo: false,
+      force: false,
     });
   });
 
@@ -148,5 +149,10 @@ describe("parseRunFlags", () => {
 
   it("throws when a value flag is missing its argument", () => {
     expect(() => parseRunFlags(["--prd"])).toThrow();
+  });
+
+  it("parses --force as a boolean, defaulting to false (#1027)", () => {
+    expect(parseRunFlags(["--force"]).force).toBe(true);
+    expect(parseRunFlags([]).force).toBe(false);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1027. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1027

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785618251&installation_id=129708444&pr_number=1057&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1057&signature=1c83593d1099065953ac89c2373780930285cc31d2cad40ad929b77a93f005da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->