### PR TITLE
merge: #1028 feat(afk): honest statusline freshness — live local facts, age-marked TTL cache for remote facts

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -25,6 +25,7 @@
 // passes the COLUMNS budget.
 
 import {
+  formatCacheAge,
   humanizeAlive,
   humanizeTokens,
   renderStatusline,
@@ -105,12 +106,21 @@ function ctxKv(claude: ClaudeInput | undefined): string | null {
   return kv("ctx", value);
 }
 
-/** `prs=<n> iss=<n>` repo-global counts, each only when > 0. */
+/** `prs=<n> iss=<n>` repo-global counts, each only when > 0. When the cache
+ * was served TTL-stale and refresh failed, the first rendered count carries a
+ * soft age suffix so day-old counts are never silently shown as current. */
 function repoCountsKv(repo: RepoInput | undefined): string[] {
   if (!repo) return [];
   const parts: string[] = [];
-  if (repo.openPrs && repo.openPrs > 0) parts.push(kv("prs", String(repo.openPrs)));
-  if (repo.openIssues && repo.openIssues > 0) parts.push(kv("iss", String(repo.openIssues)));
+  const ageStr = repo.cacheAgeS !== undefined ? ` (${formatCacheAge(repo.cacheAgeS)})` : "";
+  if (repo.openPrs && repo.openPrs > 0) {
+    parts.push(kv("prs", String(repo.openPrs)) + ageStr);
+  }
+  if (repo.openIssues && repo.openIssues > 0) {
+    // put age on iss= only when prs= didn't already carry it
+    const issAge = ageStr && (!repo.openPrs || repo.openPrs === 0) ? ageStr : "";
+    parts.push(kv("iss", String(repo.openIssues)) + issAge);
+  }
   return parts;
 }
 
@@ -176,8 +186,14 @@ export function renderAfkLine(afk: AfkInput | undefined, columns: number | undef
   if (diff) groups.push(kv("loc", afk.locIsPeak ? `~${diff}` : diff));
 
   const pipe: string[] = [];
-  if (afk.queue > 0) pipe.push(kv("rdy", String(afk.queue)));
-  if (afk.human > 0) pipe.push(kv("hmn", String(afk.human)));
+  // Age marker: parallel to the plain-render path in afkTokens(); same placement
+  // rule — rdy= gets the mark first, falls to hmn= when queue is 0.
+  const ageStr = afk.cacheAgeS !== undefined ? ` (${formatCacheAge(afk.cacheAgeS)})` : "";
+  if (afk.queue > 0) pipe.push(kv("rdy", String(afk.queue)) + ageStr);
+  if (afk.human > 0) {
+    const hmAge = ageStr && afk.queue === 0 ? ageStr : "";
+    pipe.push(kv("hmn", String(afk.human)) + hmAge);
+  }
   if (afk.blocked > 0) pipe.push(kv("blk", String(afk.blocked)));
   if (afk.waiting !== undefined && afk.waiting > 0) pipe.push(kv("wai", String(afk.waiting)));
   if (afk.tokens !== undefined && afk.tokens > 0) pipe.push(kv("tok", humanizeTokens(afk.tokens)));

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -108,6 +108,12 @@ export interface AfkInput {
    * non-empty origin. Sorted by origin for a deterministic token order.
    * Rendered as `go=N afk=M` tokens immediately after `wrk=<total>`. */
   sourceCounts?: ReadonlyArray<{ origin: string; count: number }>;
+  /** Age in seconds of the queue/human count cache when it was served TTL-stale
+   * AND the background refresh failed or timed out. Absent when the cache was
+   * fresh or the refresh succeeded. When set, the `rdy=` (or `hmn=`) token
+   * carries a compact age suffix — e.g. `rdy=3 (12m)` — so stale counts are
+   * never silently rendered as current. */
+  cacheAgeS?: number;
 }
 
 /** Repo-global header inputs (themed line 1, always rendered). Independent of
@@ -121,6 +127,11 @@ export interface RepoInput {
   localAdded?: number;
   /** `-N` — LOCAL branch deletions (committed + uncommitted vs origin/main). */
   localRemoved?: number;
+  /** Age in seconds of the PR/issue count cache when served TTL-stale and the
+   * refresh failed or timed out. Absent when the cache was fresh or refresh
+   * succeeded. When set, the `prs=` (or `iss=`) token carries a compact age
+   * suffix so stale counts are not silently shown as current. */
+  cacheAgeS?: number;
 }
 
 /** All the resolved inputs for one statusline render. */
@@ -154,6 +165,20 @@ export function humanizeAlive(ms: number): string {
   const m = Math.floor(s / 60);
   const rs = s % 60;
   if (m < 60) return rs > 0 ? `${m}m${rs}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm > 0 ? `${h}h${rm}m` : `${h}h`;
+}
+
+/**
+ * Compact age string for a TTL-stale cache entry: renders seconds as `45s`,
+ * whole minutes as `12m`, and hours as `1h5m` / `2h`. Used as the `(Xm)`
+ * suffix on remote-count tokens when the cache was stale and refresh failed.
+ */
+export function formatCacheAge(ageS: number): string {
+  if (ageS < 60) return `${ageS}s`;
+  const m = Math.floor(ageS / 60);
+  if (m < 60) return `${m}m`;
   const h = Math.floor(m / 60);
   const rm = m % 60;
   return rm > 0 ? `${h}h${rm}m` : `${h}h`;
@@ -228,8 +253,16 @@ export function afkTokens(afk: AfkInput | undefined): AfkToken[] {
   if (afk.sourceCounts && afk.sourceCounts.length > 0) {
     for (const { origin, count } of afk.sourceCounts) kpi(`${origin}=`, String(count));
   }
-  if (afk.queue > 0) kpi("rdy=", String(afk.queue));
-  if (afk.human > 0) kpi("hmn=", String(afk.human));
+  // Age marker: appended to the first rendered remote-count token so stale
+  // data is never silently shown as current. rdy= takes priority; when queue
+  // is 0 the marker falls to hmn= (if present). Zero/zero with a stale cache
+  // shows nothing — 0/0 stale vs 0/0 fresh is indistinguishable in meaning.
+  const ageSuffix = afk.cacheAgeS !== undefined ? ` (${formatCacheAge(afk.cacheAgeS)})` : "";
+  if (afk.queue > 0) tokens.push({ label: "rdy=", value: String(afk.queue), suffix: ageSuffix });
+  if (afk.human > 0) {
+    const hmSuffix = ageSuffix && afk.queue === 0 ? ageSuffix : "";
+    tokens.push({ label: "hmn=", value: String(afk.human), suffix: hmSuffix });
+  }
   if (afk.blocked > 0) kpi("blk=", String(afk.blocked));
   const diff: string[] = [];
   if (afk.added > 0) diff.push(`+${afk.added}`);

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -735,6 +735,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   let human = cached?.human ?? 0;
 
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  let refreshSucceeded = false;
   const refresh = async (): Promise<void> => {
     const [q, h] = await Promise.all([
       ghx.countReadyForAgent(ghCtx),
@@ -742,9 +743,11 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     ]);
     queue = q;
     human = h;
+    refreshSucceeded = true;
     writeStatuslineCacheAtomic(cachePath, { queue: q, human: h, ts: nowS });
   };
 
+  let cacheAgeS: number | undefined;
   if (!cached) {
     // Cold cache: refresh with a bounded deadline so a hanging gh CLI cannot
     // block the statusline render indefinitely. queue/human stay 0/0 on timeout
@@ -752,8 +755,11 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
   } else if (nowS - cached.ts >= STATUSLINE_CACHE_TTL_S) {
     // Stale: await a bounded refresh so the cache is rewritten before the
-    // process exits. Shows the previous value on timeout (fail-open).
+    // process exits. Shows the previous value on timeout (fail-open). When
+    // refresh fails, mark the age so the renderer can signal staleness.
+    const staleAgeS = nowS - cached.ts;
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
+    if (!refreshSucceeded) cacheAgeS = staleAgeS;
   }
 
   if (workers <= 0) return null;
@@ -777,6 +783,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
     model: model || undefined,
     effort: effort || undefined,
     sourceCounts,
+    cacheAgeS,
   };
 }
 
@@ -827,18 +834,24 @@ export async function collectStatuslineRepo(ctx: RepoContext): Promise<RepoInput
   let openIssues = cached?.openIssues ?? 0;
 
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  let repoRefreshSucceeded = false;
   const refresh = async (): Promise<void> => {
     const [p, i] = await Promise.all([ghx.countOpenPrs(ghCtx), ghx.countOpenIssues(ghCtx)]);
     openPrs = p;
     openIssues = i;
+    repoRefreshSucceeded = true;
     writeRepoStatsCacheAtomic(cachePath, { openPrs: p, openIssues: i, ts: nowS });
   };
+  let repoCacheAgeS: number | undefined;
   if (!cached) {
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
   } else if (nowS - cached.ts >= STATUSLINE_CACHE_TTL_S) {
     // Stale: await a bounded refresh so the cache is rewritten before the
-    // process exits. Shows the previous value on timeout (fail-open).
+    // process exits. Shows the previous value on timeout (fail-open). When
+    // refresh fails, mark the age so the renderer can signal staleness.
+    const staleAgeS = nowS - cached.ts;
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
+    if (!repoRefreshSucceeded) repoCacheAgeS = staleAgeS;
   }
 
   // Local branch diff (committed + uncommitted) vs origin/main, bounded so a slow
@@ -850,7 +863,7 @@ export async function collectStatuslineRepo(ctx: RepoContext): Promise<RepoInput
     { added: 0, removed: 0 },
   ).catch(() => ({ added: 0, removed: 0 }));
 
-  return { openPrs, openIssues, localAdded: diff.added, localRemoved: diff.removed };
+  return { openPrs, openIssues, localAdded: diff.added, localRemoved: diff.removed, cacheAgeS: repoCacheAgeS };
 }
 
 // ---------- reap inputs ----------

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Readable } from "node:stream";
@@ -215,5 +215,80 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
     expect(out.text()).toBe("");
+  });
+
+  it("local facts are read live: a mutated state file is reflected on the next render", async () => {
+    // First render: worker on #17 with loc=+12 -3
+    await writeWorkerState(root, "wA", "17-a1", {
+      runner: "claude",
+      done: 0,
+      blocked: 0,
+      current: {
+        number: 17,
+        diff_added: 12,
+        diff_removed: 3,
+        started_at: new Date().toISOString(),
+      },
+    });
+    await seedFreshCache(root, 0, 0);
+    await seedFreshRepoCache(root, 0, 0);
+
+    const out1 = sink();
+    await statuslineCommand([root], root, out1.stream, fakeStdin(PAYLOAD));
+    expect(stripAnsi(out1.text())).toContain("loc=+12 -3");
+    expect(stripAnsi(out1.text())).not.toContain("loc=+99");
+
+    // Mutate in-place: new diff +99 -5 — no process restart; next render reads fresh
+    await writeWorkerState(root, "wA", "17-a1", {
+      runner: "claude",
+      done: 0,
+      blocked: 0,
+      current: {
+        number: 17,
+        diff_added: 99,
+        diff_removed: 5,
+        started_at: new Date().toISOString(),
+      },
+    });
+
+    const out2 = sink();
+    await statuslineCommand([root], root, out2.stream, fakeStdin(PAYLOAD));
+    // Live read: must reflect the mutation without any cache involvement
+    expect(stripAnsi(out2.text())).toContain("loc=+99 -5");
+    expect(stripAnsi(out2.text())).not.toContain("loc=+12");
+  });
+
+  it("idle fleet (workers=0) does not gate remote refresh behind workers>0 check", async () => {
+    // Seed a STALE AFK cache (ts = 10 min ago, well past the 60 s TTL) with
+    // non-zero values.  The command must attempt a refresh and return exit 0
+    // even when no workers are live (regression: the old workers<=0 guard fired
+    // BEFORE the cache block and prevented any refresh).
+    const dir = join(root, ".red", "tmp");
+    await mkdir(dir, { recursive: true });
+    const staleTs = Math.floor(Date.now() / 1000) - 600;
+    await writeFile(
+      join(dir, "statusline-cache.json"),
+      JSON.stringify({ queue: 5, human: 2, ts: staleTs }),
+      "utf8",
+    );
+    await seedFreshRepoCache(root, 0, 0);
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+
+    // No live workers → AFK block must be absent
+    expect(stripAnsi(out.text())).not.toContain("wrk=");
+    // Header still renders, confirming the command ran to completion
+    expect(stripAnsi(out.text())).toContain("Opus·high");
+
+    // The cache file must still exist (not deleted by refresh failure) —
+    // refresh is fire-and-attempt, fail-open.
+    const cacheRaw = await readFile(join(dir, "statusline-cache.json"), "utf8");
+    const cache = JSON.parse(cacheRaw) as { ts: number };
+    // Either a fresh ts (refresh succeeded) or the old stale ts (gh failed —
+    // fail-open). Either way the command ran past the stale check without
+    // crashing, proving the workers<=0 gate does not short-circuit the refresh.
+    expect(typeof cache.ts).toBe("number");
   });
 });

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -49,6 +49,23 @@ describe("statusline style — header line", () => {
     expect(t).toContain("loc=+142 -36");
   });
 
+  it("prs= carries a compact age suffix when repo cacheAgeS is set (stale cache)", () => {
+    const t = stripAnsi(renderHeaderLine(input.project, input.claude, { ...repo, cacheAgeS: 720 }));
+    expect(t).toContain("prs=3 (12m)");
+    expect(t).toContain("iss=24"); // iss= present but no duplicate age mark
+    expect(t.match(/\(12m\)/g)?.length ?? 0).toBe(1); // exactly one annotation
+  });
+
+  it("age suffix moves to iss= when openPrs is 0 and repo cache is stale", () => {
+    const t = stripAnsi(
+      renderHeaderLine(input.project, input.claude, {
+        ...repo, openPrs: 0, cacheAgeS: 720,
+      }),
+    );
+    expect(t).not.toContain("prs=");
+    expect(t).toContain("iss=24 (12m)");
+  });
+
   it("drops the repo blocks when counts are zero / a clean branch", () => {
     const h = renderHeaderLine(input.project, input.claude, {
       openPrs: 0,
@@ -123,6 +140,26 @@ describe("statusline style — AFK line", () => {
   it("is null when there are no live workers", () => {
     expect(renderAfkLine(undefined, undefined)).toBeNull();
     expect(renderAfkLine({ ...afk, workers: 0 }, undefined)).toBeNull();
+  });
+
+  it("fresh cache (no cacheAgeS) renders rdy= with no age annotation", () => {
+    const t = stripAnsi(renderAfkLine(afk, undefined)!);
+    expect(t).toContain("rdy=11");
+    expect(t).not.toContain("(");
+  });
+
+  it("rdy= carries a compact age suffix when cacheAgeS is set (stale cache)", () => {
+    // 720 s = 12 m stale → (12m) appears after the rdy= value
+    const t = stripAnsi(renderAfkLine({ ...afk, cacheAgeS: 720 }, undefined)!);
+    expect(t).toContain("rdy=11 (12m)");
+    expect(t).toContain("hmn=3"); // hmn= is present but carries no second age mark
+    expect(t.match(/\(12m\)/g)?.length ?? 0).toBe(1); // exactly one age annotation
+  });
+
+  it("age suffix moves to hmn= when queue is 0 but human is live", () => {
+    const t = stripAnsi(renderAfkLine({ ...afk, queue: 0, cacheAgeS: 720 }, undefined)!);
+    expect(t).not.toContain("rdy=");
+    expect(t).toContain("hmn=3 (12m)");
   });
 
   it("shows the ·stage suffix only at or below two workers", () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatCacheAge,
   humanizeAlive,
   humanizeTokens,
   renderAfkBlock,
@@ -20,6 +21,29 @@ const baseAfk = (over: Partial<AfkInput> = {}): AfkInput => ({
   removed: 3,
   issues: [17],
   ...over,
+});
+
+describe("statusline — formatCacheAge", () => {
+  it("renders Xs for ages under one minute", () => {
+    expect(formatCacheAge(45)).toBe("45s");
+    expect(formatCacheAge(0)).toBe("0s");
+    expect(formatCacheAge(59)).toBe("59s");
+  });
+
+  it("renders Xm for whole minutes", () => {
+    expect(formatCacheAge(60)).toBe("1m");
+    expect(formatCacheAge(720)).toBe("12m");
+  });
+
+  it("renders XhYm when minutes remain past a full hour", () => {
+    expect(formatCacheAge(3900)).toBe("1h5m");
+    expect(formatCacheAge(3660)).toBe("1h1m");
+  });
+
+  it("renders Xh for whole hours", () => {
+    expect(formatCacheAge(3600)).toBe("1h");
+    expect(formatCacheAge(7200)).toBe("2h");
+  });
 });
 
 describe("statusline — humanizeAlive", () => {
@@ -270,6 +294,30 @@ describe("statusline — AFK block", () => {
     // All new fields are optional: an aggregator that never populates them must
     // produce the exact legacy line, so the upgrade is a no-op for old callers.
     expect(renderAfkBlock(baseAfk())).toBe("wrk=1 rdy=11 hmn=3 blk=2 loc=+12 -3 #17");
+  });
+
+  it("fresh cache (no cacheAgeS) renders plain with no age marker", () => {
+    // cacheAgeS absent → no age annotation on rdy= or hmn=
+    expect(renderAfkBlock(baseAfk())).not.toContain("(");
+  });
+
+  it("rdy= carries a compact age suffix when cacheAgeS is set (stale cache)", () => {
+    // 720 s = 12 min stale → (12m) on the rdy= token
+    expect(renderAfkBlock(baseAfk({ cacheAgeS: 720 }))).toBe(
+      "wrk=1 rdy=11 (12m) hmn=3 blk=2 loc=+12 -3 #17",
+    );
+  });
+
+  it("age suffix moves to hmn= when queue is 0 but human is live", () => {
+    expect(renderAfkBlock(baseAfk({ queue: 0, human: 3, cacheAgeS: 720 }))).toBe(
+      "wrk=1 hmn=3 (12m) blk=2 loc=+12 -3 #17",
+    );
+  });
+
+  it("no age suffix when both queue and human are 0 even if cacheAgeS is set", () => {
+    // 0/0 stale vs 0/0 fresh is indistinguishable in meaning; nothing to annotate
+    const out = renderAfkBlock(baseAfk({ queue: 0, human: 0, cacheAgeS: 720 }));
+    expect(out).not.toContain("(");
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1028. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1028

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785618794&installation_id=129708444&pr_number=1058&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1058&signature=1095b5d2ff5f34071c151d9cb35848be6da8a0971720fd0d946b5253c7e69a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->