### PR TITLE
merge: #1029 feat(afk): monitor/dashboard discover state where the substrate writes it + honest freshness

### DIFF
--- a/apps/dev/src/commands/monitor.ts
+++ b/apps/dev/src/commands/monitor.ts
@@ -1,5 +1,5 @@
-import { renderCompactDashboard, renderCompactDashboardToon, type CompactWorker } from "../core/monitor.js";
-import { collectMonitorInputs, afkPaths, resolveRepoContext } from "../runtime/wire.js";
+import { renderCompactDashboard, renderCompactDashboardToon, type CompactWorker, type MonitorRemote } from "../core/monitor.js";
+import { collectMonitorInputs, afkPaths, resolveRepoContext, STATUSLINE_CACHE_TTL_S } from "../runtime/wire.js";
 import { resolveSupervisorConfig } from "../core/supervisor.js";
 import { runWatchdog } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
@@ -202,13 +202,17 @@ export async function monitorCommand(
     }
   }
 
-  const { workers, events, fleet } = await collectMonitorInputs(cwd);
+  const { workers, events, fleet, remoteQueue, remoteHuman, remoteCacheAgeS } = await collectMonitorInputs(cwd);
   const now = Math.floor(Date.now() / 1000);
+  const remote: MonitorRemote | undefined =
+    remoteQueue !== undefined && remoteHuman !== undefined && remoteCacheAgeS !== undefined
+      ? { queue: remoteQueue, human: remoteHuman, cacheAgeS: remoteCacheAgeS, stale: remoteCacheAgeS >= STATUSLINE_CACHE_TTL_S }
+      : undefined;
   // TOON is the default agent-facing wire format (PRD #928 / ADR 0081); `--plain`
   // restores the legacy compact text dashboard for a human TTY glance.
   const dashboard = args.includes("--plain")
-    ? renderCompactDashboard(workers, events, now, fleet)
-    : renderCompactDashboardToon(workers, events, now, fleet);
+    ? renderCompactDashboard(workers, events, now, fleet, remote)
+    : renderCompactDashboardToon(workers, events, now, fleet, remote);
   stdout.write(`${dashboard}\n`);
 
   // Companion (active) mode (#921, PRD #907). STRICTLY opt-in: without

--- a/apps/dev/src/core/monitor.ts
+++ b/apps/dev/src/core/monitor.ts
@@ -15,6 +15,17 @@
 import { buildSparkline, type HistoryRecord } from "./history.js";
 import { encodeToon, type ToonValue } from "./toon.js";
 
+/** GitHub-derived queue/human counts exposed by the monitor with freshness metadata.
+ * Read passively from the statusline TTL cache; the monitor never refreshes it. */
+export interface MonitorRemote {
+  queue: number;
+  human: number;
+  /** Age of the underlying statusline cache file in seconds. */
+  cacheAgeS: number;
+  /** True when cacheAgeS exceeds the statusline TTL — render shows a stale marker. */
+  stale: boolean;
+}
+
 /** The subset of a worker's current-iteration state the compact line reads. */
 export interface CompactCurrent {
   /** Issue number; "" / "-" / "null" all mean "no issue in progress". */
@@ -299,6 +310,7 @@ export function renderCompactDashboard(
   events: ReadonlyArray<Pick<HistoryRecord, "event" | "epoch">>,
   now: number,
   fleet?: FleetState | null,
+  remote?: MonitorRemote | null,
 ): string {
   let added = 0;
   let removed = 0;
@@ -331,14 +343,20 @@ export function renderCompactDashboard(
   } else {
     prefix = header;
   }
+  // Remote facts (queue/human) with stale marker when the TTL cache is old.
+  const remoteLine = remote
+    ? `\nqueue:${remote.queue} human:${remote.human}${remote.stale ? ` [stale ${formatElapsed(remote.cacheAgeS)} ago]` : ""}`
+    : "";
+  // Standing rule: every tick report states the current wall-clock time.
+  const tickLine = `\ntick at: ${new Date(now * 1000).toISOString()}`;
   if (workers.length === 0) {
-    return `${prefix}\nworkers: (none — /afk not running here)`;
+    return `${prefix}\nworkers: (none — /afk not running here)${remoteLine}${tickLine}`;
   }
   const sorted = [...workers].sort((a, b) =>
     startedAtKey(a) < startedAtKey(b) ? -1 : startedAtKey(a) > startedAtKey(b) ? 1 : 0,
   );
   const lines = sorted.map((w) => renderWorkerCompactLine(w, now));
-  return `${prefix}\n${lines.join("\n")}`;
+  return `${prefix}\n${lines.join("\n")}${remoteLine}${tickLine}`;
 }
 
 /** Per-source counts from `state.origin` across all workers (#930), aggregated
@@ -397,6 +415,7 @@ export function renderCompactDashboardToon(
   events: ReadonlyArray<Pick<HistoryRecord, "event" | "epoch">>,
   now: number,
   fleet?: FleetState | null,
+  remote?: MonitorRemote | null,
 ): string {
   let added = 0;
   let removed = 0;
@@ -438,6 +457,21 @@ export function renderCompactDashboardToon(
       })),
     };
   }
+
+  // Remote facts: GitHub-derived queue/human counts read from the statusline cache.
+  // stale: 1 when the cache age exceeds the TTL — the consumer should treat the
+  // counts as approximate (last known value, not live).
+  if (remote) {
+    root.remote = {
+      queue: remote.queue,
+      human: remote.human,
+      cache_age_s: remote.cacheAgeS,
+      stale: remote.stale ? 1 : 0,
+    };
+  }
+
+  // Standing rule: every tick report states the current wall-clock time.
+  root.tick_at = new Date(now * 1000).toISOString();
 
   const sorted = [...workers].sort((a, b) =>
     startedAtKey(a) < startedAtKey(b) ? -1 : startedAtKey(a) > startedAtKey(b) ? 1 : 0,

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -417,6 +417,13 @@ export interface MonitorInputs {
   workers: CompactWorker[];
   events: Array<Pick<HistoryRecord, "event" | "epoch">>;
   fleet: FleetState | null;
+  /** GitHub queue/human counts read passively from the statusline TTL cache.
+   * Absent when the cache file has never been written (no statusline run yet). */
+  remoteQueue?: number;
+  remoteHuman?: number;
+  /** Age of the statusline cache in seconds. Undefined when no cache file exists.
+   * The monitor render shows a stale marker when this exceeds STATUSLINE_CACHE_TTL_S. */
+  remoteCacheAgeS?: number;
 }
 
 const SLOT_STATUSES = new Set<SlotDetail["status"]>(["open", "half-open", "idle-parked"]);
@@ -500,11 +507,23 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
     // into the fleet header, so it is never suppressed.
     let added = state.current.loc_added;
     let removed = state.current.loc_removed;
-    if (added === 0 && removed === 0 && state.current.worktree) {
+    if (added === 0 && removed === 0) {
+      const attemptDir = dirname(path);
       const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
-      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
-      added = stat.added;
-      removed = stat.removed;
+      // Resolve the real worktree path: the state file carries it after the first
+      // heartbeat tick. Before that (or for sandcastle where the initial seed is the
+      // legacy {attemptDir}/worktree path that never exists), fall back to
+      // worktreePathUnder which probes `git worktree list --porcelain` and resolves
+      // the sandcastle layout ({attemptDir}/.sandcastle/worktrees/{slug}) even before
+      // the heartbeat has had a chance to persist the resolved path.
+      const worktreePath =
+        state.current.worktree ||
+        (await gitx.worktreePathUnder({ cwd: attemptDir }, attemptDir).catch(() => undefined));
+      if (worktreePath) {
+        const stat = await gitx.diffstatShortstat({ cwd: worktreePath }, baseRef);
+        added = stat.added;
+        removed = stat.removed;
+      }
     }
 
     const logPath = state.log || join(dirname(path), "afk.log");
@@ -553,7 +572,18 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
   const histText = await fsx.readText(paths.historyPath);
   const events = histText === null ? [] : parseHistoryLines(histText).map((r) => ({ event: r.event, epoch: r.epoch }));
   const fleet = await readFleetState(paths.fleetStatePath);
-  return { workers, events, fleet };
+
+  // Remote facts: read the statusline TTL cache passively (no refresh — the monitor
+  // is read-only; the statusline owns the cache lifecycle). Include queue/human counts
+  // and the cache age so the render can show a stale marker when the data is old.
+  const cachePath = join(paths.tmpDir, "statusline-cache.json");
+  const cached = readStatuslineCache(cachePath);
+  const nowS = Math.floor(Date.now() / 1000);
+  const remoteExtra = cached !== null
+    ? { remoteQueue: cached.queue, remoteHuman: cached.human, remoteCacheAgeS: nowS - cached.ts }
+    : {};
+
+  return { workers, events, fleet, ...remoteExtra };
 }
 
 // ---------- statusline inputs ----------

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -7,6 +7,7 @@ import {
   renderWorkerCompactLine,
   type FleetState,
   type CompactWorker,
+  type MonitorRemote,
 } from "../src/core/monitor.js";
 import {
   monitorCommand,
@@ -15,6 +16,13 @@ import {
   workersToDesired,
 } from "../src/commands/monitor.js";
 import type { MirrorCall, MirrorFallbackNotice } from "../src/core/mirror.js";
+
+// Shared fixture fixtureEvents used across multiple test suites (tick_at, remote facts).
+const fixtureEvents = [
+  { event: "done" as const, epoch: 1780137000 },
+  { event: "done" as const, epoch: 1780137000 },
+  { event: "blocked" as const, epoch: 1780137000 },
+];
 
 const baseWorker = (over: Partial<CompactWorker> = {}): CompactWorker => ({
   state: {
@@ -217,15 +225,15 @@ describe("monitor — compact line", () => {
 });
 
 describe("monitor — compact dashboard", () => {
-  // now = 1780140600; events one hour earlier are inside the 48h window.
-  const events = [
+  // now = 1780140600; fixtureEvents one hour earlier are inside the 48h window.
+  const fixtureEvents = [
     { event: "done" as const, epoch: 1780137000 },
     { event: "done" as const, epoch: 1780137000 },
     { event: "blocked" as const, epoch: 1780137000 },
   ];
 
   it("emits the 48h sparkline header as the first line", () => {
-    const out = renderCompactDashboard([baseWorker()], events, 1780140600);
+    const out = renderCompactDashboard([baseWorker()], fixtureEvents, 1780140600);
     const lines = out.split("\n");
     expect(lines[0].startsWith("48h:")).toBe(true);
     expect(lines[0]).toContain("(2 closed");
@@ -238,13 +246,13 @@ describe("monitor — compact dashboard", () => {
       diffAdded: 18,
       diffRemoved: 2,
     });
-    const out = renderCompactDashboard([a, b], events, 1780140600);
+    const out = renderCompactDashboard([a, b], fixtureEvents, 1780140600);
     const lines = out.split("\n");
     expect(lines[0]).toContain("Δ fleet +338 -49");
   });
 
   it("renders the fleet total as +0 -0 even with zero workers", () => {
-    const out = renderCompactDashboard([], events, 1780140600);
+    const out = renderCompactDashboard([], fixtureEvents, 1780140600);
     const lines = out.split("\n");
     expect(lines[0]).toContain("Δ fleet +0 -0");
     expect(out).toContain("workers: (none");
@@ -271,7 +279,7 @@ describe("monitor — compact dashboard", () => {
         started_at: "2026-05-30T09:00:00Z",
       },
     });
-    const out = renderCompactDashboard([later, earlier], events, 1780140600);
+    const out = renderCompactDashboard([later, earlier], fixtureEvents, 1780140600);
     const lines = out.split("\n");
     const aIdx = lines.findIndex((l) => l.startsWith("wAAAA"));
     const bIdx = lines.findIndex((l) => l.startsWith("wBBBB"));
@@ -280,7 +288,7 @@ describe("monitor — compact dashboard", () => {
   });
 
   it("renders a (none …) line when there are zero workers", () => {
-    const out = renderCompactDashboard([], events, 1780140600);
+    const out = renderCompactDashboard([], fixtureEvents, 1780140600);
     const lines = out.split("\n");
     expect(lines[0].startsWith("48h:")).toBe(true);
     expect(out).toContain("workers: (none");
@@ -288,7 +296,7 @@ describe("monitor — compact dashboard", () => {
 
   describe("TOON (default agent-facing render)", () => {
     it("renders one worker as a tabular row, preserving aggregates and sparkline", () => {
-      const out = renderCompactDashboardToon([baseWorker()], events, 1780140600);
+      const out = renderCompactDashboardToon([baseWorker()], fixtureEvents, 1780140600);
       expect(out).toContain("sparkline:");
       expect(out).toContain("diff_added: 10");
       expect(out).toContain("diff_removed: 3");
@@ -303,20 +311,20 @@ describe("monitor — compact dashboard", () => {
       const a = baseWorker({ state: { ...baseWorker().state, worker_id: "wA", origin: "afk" } });
       const b = baseWorker({ state: { ...baseWorker().state, worker_id: "wB", origin: "go" } });
       const c = baseWorker({ state: { ...baseWorker().state, worker_id: "wC", origin: "afk" } });
-      const out = renderCompactDashboardToon([a, b, c], events, 1780140600);
+      const out = renderCompactDashboardToon([a, b, c], fixtureEvents, 1780140600);
       expect(out).toContain("sources[2]{origin,count}:");
       expect(out).toContain("  afk,2");
       expect(out).toContain("  go,1");
     });
 
     it("emits a definitive empty state for an empty fleet", () => {
-      const out = renderCompactDashboardToon([], events, 1780140600);
+      const out = renderCompactDashboardToon([], fixtureEvents, 1780140600);
       expect(out).toContain("workers[0]:");
       expect(out).toContain("sources[0]:");
     });
 
     it("includes the fleet status block when a fleet state is present", () => {
-      const out = renderCompactDashboardToon([], events, 1780138815, baseFleet());
+      const out = renderCompactDashboardToon([], fixtureEvents, 1780138815, baseFleet());
       expect(out).toContain("fleet:");
       expect(out).toContain("  status: idle");
       expect(out).toContain("  ready: 0");
@@ -330,14 +338,14 @@ describe("monitor — compact dashboard", () => {
       const board = Array.from({ length: 6 }, (_, i) =>
         baseWorker({ state: { ...baseWorker().state, worker_id: `w${i}` } }),
       );
-      const toon = renderCompactDashboardToon(board, events, 1780140600);
+      const toon = renderCompactDashboardToon(board, fixtureEvents, 1780140600);
       const json = JSON.stringify(board);
       expect(toon.length).toBeLessThan(json.length);
     });
   });
 
   it("surfaces a healthy idle fleet last-tick line", () => {
-    const out = renderCompactDashboard([], events, 1780138815, baseFleet());
+    const out = renderCompactDashboard([], fixtureEvents, 1780138815, baseFleet());
     expect(out.split("\n")[1]).toBe(
       "fleet [idle] last ticked 00:00:15 ago  ready:0  slots busy:0 free:2 parked:0  spawns:0",
     );
@@ -411,7 +419,7 @@ describe("monitor — compact dashboard", () => {
       slotsParked: 1,
       slotDetails: [{ index: 0, status: "open", retryAt: 1780138815 + 60 }],
     });
-    const out = renderCompactDashboard([], events, 1780138815, fleet);
+    const out = renderCompactDashboard([], fixtureEvents, 1780138815, fleet);
     const lines = out.split("\n");
     const fleetIdx = lines.findIndex((l) => l.startsWith("fleet "));
     expect(fleetIdx).toBeGreaterThanOrEqual(0);
@@ -701,5 +709,73 @@ describe("monitorCommand — Codex fallback path (issue #887)", () => {
     await expect(
       monitorCommand(["--mirror-plan", "--runner", "codex"], "/tmp", stream, emptyStdin),
     ).resolves.toBe(0);
+  });
+});
+
+// now = 1780140600 → new Date(1780140600 * 1000).toISOString() = "2026-05-30T11:30:00.000Z"
+const NOW_ISO = "2026-05-30T11:30:00.000Z";
+
+describe("monitor — tick_at (standing wall-clock rule)", () => {
+  it("TOON output includes tick_at with the ISO wall-clock time", () => {
+    const out = renderCompactDashboardToon([], fixtureEvents, 1780140600);
+    // TOON quotes strings that contain ':' — the ISO date is wrapped in quotes.
+    expect(out).toContain(`tick_at: "${NOW_ISO}"`);
+  });
+
+  it("plain output includes tick at line with ISO wall-clock time", () => {
+    const out = renderCompactDashboard([], fixtureEvents, 1780140600);
+    expect(out).toContain(`tick at: ${NOW_ISO}`);
+  });
+
+  it("tick_at reflects the injected now (deterministic, no live clock)", () => {
+    const out1 = renderCompactDashboardToon([], fixtureEvents, 1780138800);
+    const out2 = renderCompactDashboardToon([], fixtureEvents, 1780140600);
+    expect(out1).toContain('"2026-05-30T11:00:00.000Z"');
+    expect(out2).toContain(`"${NOW_ISO}"`);
+  });
+});
+
+describe("monitor — remote facts age markers (#1029)", () => {
+  const freshRemote: MonitorRemote = { queue: 3, human: 1, cacheAgeS: 20, stale: false };
+  const staleRemote: MonitorRemote = { queue: 5, human: 2, cacheAgeS: 90, stale: true };
+
+  it("TOON output includes remote queue/human when provided", () => {
+    const out = renderCompactDashboardToon([baseWorker()], fixtureEvents, 1780140600, null, freshRemote);
+    expect(out).toContain("queue: 3");
+    expect(out).toContain("human: 1");
+    expect(out).toContain("cache_age_s: 20");
+    expect(out).toContain("stale: 0");
+  });
+
+  it("TOON output marks remote as stale when cache age exceeds TTL", () => {
+    const out = renderCompactDashboardToon([baseWorker()], fixtureEvents, 1780140600, null, staleRemote);
+    expect(out).toContain("stale: 1");
+    expect(out).toContain("cache_age_s: 90");
+    expect(out).toContain("queue: 5");
+  });
+
+  it("plain output shows queue/human with stale marker when cache is old", () => {
+    const out = renderCompactDashboard([baseWorker()], fixtureEvents, 1780140600, null, staleRemote);
+    expect(out).toContain("queue:5");
+    expect(out).toContain("human:2");
+    expect(out).toContain("[stale");
+  });
+
+  it("plain output shows queue/human without stale marker when cache is fresh", () => {
+    const out = renderCompactDashboard([baseWorker()], fixtureEvents, 1780140600, null, freshRemote);
+    expect(out).toContain("queue:3");
+    expect(out).toContain("human:1");
+    expect(out).not.toContain("[stale");
+  });
+
+  it("TOON output has no remote block when remote is absent", () => {
+    const out = renderCompactDashboardToon([baseWorker()], fixtureEvents, 1780140600);
+    expect(out).not.toContain("remote:");
+  });
+
+  it("plain output has no queue/human line when remote is absent", () => {
+    const out = renderCompactDashboard([baseWorker()], fixtureEvents, 1780140600);
+    expect(out).not.toContain("queue:");
+    expect(out).not.toContain("human:");
   });
 });

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -677,3 +677,164 @@ describe("collectStatuslineRepo — cache discipline", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// collectMonitorInputs — layout discovery (#1029)
+// Both sandcastle and legacy layouts put afk.state.json at the same path
+// ({workersRoot}/{workerID}/{attemptDir}/afk.state.json) — the difference is
+// where the git worktree lives. This suite verifies both layouts are discovered
+// by the Worker state reader, satisfying the "no monitor-private globbing" contract.
+// ---------------------------------------------------------------------------
+
+describe("collectMonitorInputs — layout discovery (#1029)", () => {
+  it("discovers a sandcastle-layout worker (state at attemptDir/afk.state.json, worktree absent pre-heartbeat)", async () => {
+    const root = scratch();
+    try {
+      // Sandcastle layout: state file at the standard path; worktree field not yet
+      // set (simulates the pre-heartbeat window where current.worktree = "").
+      const attemptDir = join(root, ".red", "tmp", "workers", "wSC", "42-a1");
+      mkdirSync(attemptDir, { recursive: true });
+      writeFileSync(
+        join(attemptDir, "afk.state.json"),
+        JSON.stringify({ worker_id: "wSC", pid: 999999, runner: "claude", total: 5, done: 2 }),
+      );
+      const { workers } = await collectMonitorInputs(root);
+      // The worker must appear in the output — sandcastle layout does not hide the
+      // state file from the Worker state reader.
+      expect(workers).toHaveLength(1);
+      expect(workers[0]!.state.worker_id).toBe("wSC");
+      expect(workers[0]!.state.done).toBe(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers a legacy-layout worker (state at attemptDir/afk.state.json, worktree at attemptDir/worktree)", async () => {
+    const root = scratch();
+    try {
+      const attemptDir = join(root, ".red", "tmp", "workers", "wLG", "7-a1");
+      mkdirSync(attemptDir, { recursive: true });
+      // Legacy layout: current.worktree points to {attemptDir}/worktree (doesn't
+      // exist here; git call fails gracefully, diffstat returns 0,0 safely).
+      writeFileSync(
+        join(attemptDir, "afk.state.json"),
+        JSON.stringify({
+          worker_id: "wLG",
+          pid: 999999,
+          runner: "codex",
+          total: 3,
+          done: 0,
+          current: { worktree: join(attemptDir, "worktree") },
+        }),
+      );
+      const { workers } = await collectMonitorInputs(root);
+      expect(workers).toHaveLength(1);
+      expect(workers[0]!.state.worker_id).toBe("wLG");
+      // Diffstat gracefully returns 0,0 when worktree path does not exist — no crash.
+      expect(workers[0]!.diffAdded).toBe(0);
+      expect(workers[0]!.diffRemoved).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a live worker under the sandcastle layout renders in the dashboard (not 'workers: none')", async () => {
+    const root = scratch();
+    try {
+      // Use process.pid so isStateLive → true (pid is alive).
+      const attemptDir = join(root, ".red", "tmp", "workers", "wLIVE", "99-a1");
+      mkdirSync(attemptDir, { recursive: true });
+      const stateFile = join(attemptDir, "afk.state.json");
+      writeFileSync(
+        stateFile,
+        JSON.stringify({
+          worker_id: "wLIVE",
+          pid: process.pid,
+          runner: "claude",
+          total: 1,
+          done: 0,
+          current: { number: 99, title: "test issue", stage: "impl", started_at: new Date().toISOString(), loc_added: 5 },
+        }),
+      );
+      const { workers } = await collectMonitorInputs(root);
+      // Regression guard: live worker must appear (workers.length > 0), not be hidden.
+      expect(workers.length).toBeGreaterThan(0);
+      const found = workers.find((w) => w.state.worker_id === "wLIVE");
+      expect(found).toBeDefined();
+      // pid-live worker is not dead — the liveness verdict must not be "dead".
+      expect(found!.liveness).not.toBe("dead");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectMonitorInputs — remote facts (TTL cache) (#1029)
+// ---------------------------------------------------------------------------
+
+describe("collectMonitorInputs — remote facts (TTL cache) (#1029)", () => {
+  it("returns no remote facts when the statusline cache is absent", async () => {
+    const root = scratch();
+    try {
+      const result = await collectMonitorInputs(root);
+      expect(result.remoteQueue).toBeUndefined();
+      expect(result.remoteHuman).toBeUndefined();
+      expect(result.remoteCacheAgeS).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exposes queue/human from a fresh statusline cache with low age", async () => {
+    const root = scratch();
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const freshTs = nowS();
+      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 4, human: 2, ts: freshTs }));
+      const result = await collectMonitorInputs(root);
+      expect(result.remoteQueue).toBe(4);
+      expect(result.remoteHuman).toBe(2);
+      expect(result.remoteCacheAgeS).toBeGreaterThanOrEqual(0);
+      // Fresh cache age must be below the TTL.
+      expect(result.remoteCacheAgeS).toBeLessThan(STATUSLINE_CACHE_TTL_S);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a stale age when the cache is older than the TTL", async () => {
+    const root = scratch();
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 30;
+      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 7, human: 1, ts: staleTs }));
+      const result = await collectMonitorInputs(root);
+      expect(result.remoteQueue).toBe(7);
+      expect(result.remoteHuman).toBe(1);
+      // Age must exceed the TTL so the render can show a stale marker.
+      expect(result.remoteCacheAgeS).toBeGreaterThanOrEqual(STATUSLINE_CACHE_TTL_S);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT refresh the cache (monitor is read-only; statusline owns cache lifecycle)", async () => {
+    const root = scratch();
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 30;
+      const cachePath = join(tmpDir, "statusline-cache.json");
+      writeFileSync(cachePath, JSON.stringify({ queue: 9, human: 3, ts: staleTs }));
+      await collectMonitorInputs(root);
+      // The cache timestamp must NOT have changed — the monitor never refreshes it.
+      const after = JSON.parse(readFileSync(cachePath, "utf8")) as { ts: number };
+      expect(after.ts).toBe(staleTs);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1029. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1029

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785620234&installation_id=129708444&pr_number=1059&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1059&signature=244608d8a697bf4779a533277f280da44a054f150a957d4e7c77a54317f1280c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->