### PR TITLE
merge: #1030 feat(memory): memory runtime ships via committed launcher + Release bundle (ADR 0084 tracer)

### DIFF
--- a/apps/memory/tests/bootstrap-launcher.test.ts
+++ b/apps/memory/tests/bootstrap-launcher.test.ts
@@ -1,0 +1,292 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+// @ts-expect-error — the dependency-free .mjs launcher ships without type declarations
+import { platformKey } from "../../../plugins/memory/scripts/bootstrap.mjs";
+
+// End-to-end launcher behaviour for the Memory runtime (ADR 0084 tracer, #1030).
+//
+// These tests spawn the real `bootstrap.mjs` — the committed launcher that
+// marketplace-installed copies run in place of built output — against a local
+// release server, and prove the four distribution guarantees:
+//
+//   1. cache hit         → a warm cache runs REAL runtime from disk, zero network
+//   2. cache miss + fetch → the SessionStart resolve point downloads + delegates
+//   3. gate-inert        → a directory that never opted in makes zero network
+//   4. offline degrade   → a failed first fetch no-ops and leaves a marker
+//   5. ordering          → a render/hot-path hook never fetches on a cold cache
+//
+// The launcher resolves the plugin version from CLAUDE_PLUGIN_ROOT and every
+// asset URL from RED_MEMORY_RELEASE_BASE, so no real network is ever touched.
+
+const BOOTSTRAP = resolve(__dirname, "../../../plugins/memory/scripts/bootstrap.mjs");
+const PLUGIN_ROOT = resolve(__dirname, "../../../plugins/memory");
+const VERSION: string = JSON.parse(
+  readFileSync(resolve(PLUGIN_ROOT, ".claude-plugin/plugin.json"), "utf8"),
+).version;
+const RED_KEY: string = platformKey(process.platform, process.arch);
+
+// A fake runtime that announces itself so a test can prove the real cached
+// runtime — not a no-op — executed.
+const CLI_BODY = `#!/usr/bin/env node
+process.stdout.write("MEMORY-RUNTIME-RAN " + process.argv.slice(2).join(" ") + "\\n");
+`;
+const MCP_BODY = "#!/usr/bin/env node\nprocess.exit(0);\n";
+const RED_BODY = "#!/bin/sh\nexit 0\n";
+
+const sha = (body: string) => createHash("sha256").update(body).digest("hex");
+
+function manifestJson(): string {
+  return JSON.stringify({
+    schema: "red.memory.runtime.v1",
+    version: VERSION,
+    cli: { asset: "memory-cli.mjs", sha256: sha(CLI_BODY) },
+    mcp: { asset: "memory-mcp.mjs", sha256: sha(MCP_BODY) },
+    reddb: {
+      repo: "reddb-io/reddb",
+      tag: "v0.0.0-test",
+      assets: { [RED_KEY]: { asset: `red-${RED_KEY}`, sha256: sha(RED_BODY) } },
+    },
+  });
+}
+
+interface Release {
+  url: string;
+  hits: () => number;
+  close: () => Promise<void>;
+}
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer(handler);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+/** A working release server that serves the fake runtime assets by basename. */
+async function startRelease(): Promise<Release> {
+  let n = 0;
+  const files: Record<string, string> = {
+    "memory-runtime-manifest.json": manifestJson(),
+    "memory-cli.mjs": CLI_BODY,
+    "memory-mcp.mjs": MCP_BODY,
+    [`red-${RED_KEY}`]: RED_BODY,
+  };
+  const { url, close } = await listen((req, res) => {
+    n += 1;
+    const name = (req.url ?? "").split("?")[0].split("/").pop() ?? "";
+    const body = files[name];
+    if (body === undefined) {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    res.statusCode = 200;
+    res.end(body);
+  });
+  return { url, hits: () => n, close };
+}
+
+/** A release server that fails every request — the offline / outage case. */
+async function startFailingRelease(): Promise<Release> {
+  let n = 0;
+  const { url, close } = await listen((_req, res) => {
+    n += 1;
+    res.statusCode = 500;
+    res.end("boom");
+  });
+  return { url, hits: () => n, close };
+}
+
+const scratch: string[] = [];
+afterEach(async () => {
+  await Promise.all(scratch.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+async function makeCacheDir(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "mem-cache-"));
+  scratch.push(d);
+  return d;
+}
+
+async function enabledCwd(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "mem-on-"));
+  scratch.push(d);
+  await mkdir(join(d, ".red"), { recursive: true });
+  await writeFile(join(d, ".red", "config.yaml"), "plugins:\n  memory:\n    enabled: true\n");
+  return d;
+}
+
+async function disabledCwd(): Promise<string> {
+  // A temp dir with no `.red/config.yaml` in any ancestor — the gate (ADR 0067)
+  // treats memory as disabled.
+  const d = await mkdtemp(join(tmpdir(), "mem-off-"));
+  scratch.push(d);
+  return d;
+}
+
+/** Pre-populate the version-keyed cache with the fake runtime (a warm cache). */
+async function warmCache(cacheDir: string): Promise<void> {
+  const dir = join(cacheDir, "reddb-memory", VERSION);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "memory-cli.mjs"), CLI_BODY);
+  await writeFile(join(dir, "memory-mcp.mjs"), MCP_BODY);
+  const red = join(dir, process.platform === "win32" ? "red.exe" : "red");
+  await writeFile(red, RED_BODY);
+  await chmod(red, 0o755);
+}
+
+const cliPath = (cacheDir: string) =>
+  join(cacheDir, "reddb-memory", VERSION, "memory-cli.mjs");
+const markerPath = (cacheDir: string) =>
+  join(cacheDir, "reddb-memory", "runtime-degraded.json");
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function run(
+  args: string[],
+  opts: { cwd: string; cacheDir: string; base: string },
+): Promise<RunResult> {
+  return new Promise((res) => {
+    const child = spawn(process.execPath, [BOOTSTRAP, ...args], {
+      cwd: opts.cwd,
+      env: {
+        ...process.env,
+        RED_MEMORY_CACHE_DIR: opts.cacheDir,
+        RED_MEMORY_RELEASE_BASE: opts.base,
+        CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (code) => res({ code, stdout, stderr }));
+  });
+}
+
+describe("memory launcher distribution (ADR 0084, #1030)", () => {
+  test("cache hit: a warm cache runs the real cached runtime with zero network", async () => {
+    const cacheDir = await makeCacheDir();
+    await warmCache(cacheDir);
+    const cwd = await enabledCwd();
+    const release = await startRelease();
+    try {
+      const r = await run(["hook", "PostToolUse", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+      });
+      expect(r.code).toBe(0);
+      // Proves an installed-copy hook executes REAL runtime from the cache —
+      // the end of the silent no-op class.
+      expect(r.stdout).toContain("MEMORY-RUNTIME-RAN");
+      expect(release.hits()).toBe(0);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("cache miss + fetch: SessionStart resolves the runtime and delegates", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await enabledCwd();
+    const release = await startRelease();
+    try {
+      const r = await run(["hook", "SessionStart", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("MEMORY-RUNTIME-RAN");
+      expect(release.hits()).toBeGreaterThan(0);
+      expect(existsSync(cliPath(cacheDir))).toBe(true);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("gate-inert: a directory that never opted in makes zero network", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await disabledCwd();
+    const release = await startRelease();
+    try {
+      const r = await run(["hook", "PostToolUse", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("{}");
+      expect(release.hits()).toBe(0);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("offline degrade: a failed first fetch no-ops and leaves a machine-readable marker", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await enabledCwd();
+    const release = await startFailingRelease();
+    try {
+      const r = await run(["hook", "SessionStart", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+      });
+      // Never a crash: the hook no-op contract is preserved.
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("{}");
+      // A marker the doctor can later report.
+      expect(existsSync(markerPath(cacheDir))).toBe(true);
+      const marker = JSON.parse(await readFile(markerPath(cacheDir), "utf8"));
+      expect(marker.schema).toBe("red.memory.runtime-degraded.v1");
+      expect(marker.plugin).toBe("memory");
+      expect(marker.version).toBe(VERSION);
+      expect(typeof marker.reason).toBe("string");
+      expect(marker.reason.length).toBeGreaterThan(0);
+      expect(typeof marker.at).toBe("string");
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("ordering: a render/hot-path hook never fetches on a cold cache", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await enabledCwd();
+    const release = await startRelease();
+    try {
+      // PostToolUse fires on every edit — a hot path. On a cold cache it must
+      // no-op and defer to SessionStart, never block on a synchronous fetch
+      // (the statusline-blanking lesson).
+      const r = await run(["hook", "PostToolUse", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("{}");
+      expect(release.hits()).toBe(0);
+      expect(existsSync(cliPath(cacheDir))).toBe(false);
+    } finally {
+      await release.close();
+    }
+  });
+});

--- a/apps/memory/vitest.suites.ts
+++ b/apps/memory/vitest.suites.ts
@@ -32,6 +32,7 @@ export const INTEGRATION_TESTS: readonly string[] = [
   "ask-cli.test.ts",
   "as-of-recall.test.ts",
   "backup.test.ts",
+  "bootstrap-launcher.test.ts",
   "capability-catalog.test.ts",
   "capsule-cli.test.ts",
   "claim-check-cli.test.ts",

--- a/plugins/memory/scripts/bootstrap.mjs
+++ b/plugins/memory/scripts/bootstrap.mjs
@@ -22,7 +22,7 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, readFile, writeFile, chmod, appendFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, chmod, appendFile, unlink } from "node:fs/promises";
 import { homedir, platform, arch } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -45,9 +45,28 @@ export function sha256Hex(buf) {
   return createHash("sha256").update(buf).digest("hex");
 }
 
+/**
+ * Release host. Overridable via RED_MEMORY_RELEASE_BASE so the launcher tests
+ * can point every asset URL at a local server — no real network, ever.
+ */
+const RELEASE_HOST = process.env.RED_MEMORY_RELEASE_BASE || "https://github.com";
+
 /** GitHub release asset URL. */
 export function assetUrl(repo, tag, name) {
-  return `https://github.com/${repo}/releases/download/${tag}/${name}`;
+  return `${RELEASE_HOST}/${repo}/releases/download/${tag}/${name}`;
+}
+
+/**
+ * Which invocations may hit the network on a cache miss. Only the resolve/warm
+ * points do: the once-per-session SessionStart hook, the long-lived mcp server,
+ * and user-invoked CLI commands. The recurring PostToolUse / Stop / PreCompact
+ * hooks are render/hot paths — they must never block on a synchronous fetch
+ * (ADR 0084, the statusline-blanking lesson). On a cold cache they no-op and
+ * let SessionStart warm the cache.
+ */
+export function mayFetchRuntime(argv) {
+  if (argv[0] === "hook") return argv[1] === "SessionStart";
+  return true;
 }
 
 /** Parse the first hex token out of a `*.sha256` file body (`<hex>  <name>`). */
@@ -83,6 +102,44 @@ async function pluginVersion() {
   } catch {
     return null;
   }
+}
+
+/** Machine-readable degrade marker path — the `memory doctor` reads this. */
+export function degradeMarkerPath() {
+  return join(runtimeRoot(), "runtime-degraded.json");
+}
+
+/**
+ * Record an offline / failed-first-fetch degrade as a machine-readable marker
+ * the doctor can later report. Best-effort: writing the marker must never throw,
+ * so a degrade never becomes a crash.
+ */
+async function writeDegradeMarker(version, err, argv) {
+  try {
+    await mkdir(runtimeRoot(), { recursive: true });
+    await writeFile(
+      degradeMarkerPath(),
+      JSON.stringify(
+        {
+          schema: "red.memory.runtime-degraded.v1",
+          plugin: "memory",
+          version: version ?? null,
+          reason: String(err?.message ?? err),
+          argv,
+          at: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    /* marker writing must never throw */
+  }
+}
+
+/** Clear a stale degrade marker once the runtime resolves again. */
+async function clearDegradeMarker() {
+  await unlink(degradeMarkerPath()).catch(() => {});
 }
 
 async function logLine(msg) {
@@ -128,11 +185,25 @@ async function ensureFile(url, dest, expectedSha, { mode } = {}) {
  * cache and return their absolute paths. Throws (caught by main) on any fetch
  * failure.
  */
-async function ensureRuntime(version) {
+async function ensureRuntime(version, { mayFetch } = {}) {
   const dir = join(runtimeRoot(), version);
   const cliPath = join(dir, "memory-cli.mjs");
   const mcpPath = join(dir, "memory-mcp.mjs");
   const redPath = join(dir, process.platform === "win32" ? "red.exe" : "red");
+
+  // Fast path: a fully warm cache delegates with ZERO network. The old code
+  // re-fetched the manifest on *every* invocation to re-verify checksums; that
+  // synchronous network hop on a render/hot path is exactly the
+  // statusline-blanking class (ADR 0084). Once resolved for a version, trust the
+  // cache — the first fetch already verified every checksum.
+  if (existsSync(cliPath) && existsSync(mcpPath) && existsSync(redPath)) {
+    return { cliPath, mcpPath, redPath };
+  }
+
+  // Cold cache on a render/hot path (recurring PostToolUse / Stop / PreCompact
+  // hooks): never fetch. Defer to the SessionStart resolve point and no-op this
+  // call. `null` tells the caller to honour the hook no-op contract.
+  if (!mayFetch) return null;
 
   // 1. manifest — names + checksums for this exact plugin version.
   const tag = `v${version}`;
@@ -322,15 +393,25 @@ async function main() {
     process.stdout.write("{}");
     process.exit(0);
   }
+  let version = null;
   try {
-    const version = await pluginVersion();
+    version = await pluginVersion();
     if (!version) throw new Error("could not resolve plugin version");
-    const runtime = await ensureRuntime(version);
+    const runtime = await ensureRuntime(version, { mayFetch: mayFetchRuntime(argv) });
+    if (!runtime) {
+      // Render/hot-path hook on a cold cache: SessionStart will warm it. No-op.
+      process.stdout.write("{}");
+      process.exit(0);
+    }
+    // The runtime resolved: any earlier degrade is stale.
+    await clearDegradeMarker();
     const code = await delegate(runtime, argv);
     process.exit(code);
   } catch (err) {
-    // Preserve the hooks' no-op contract; make the failure diagnosable.
+    // Preserve the hooks' no-op contract; leave a machine-readable marker the
+    // doctor can report, and make the failure diagnosable in the log.
     await logLine(`${err?.message ?? err} (args: ${argv.join(" ")})`);
+    await writeDegradeMarker(version, err, argv);
     process.stdout.write("{}");
     process.exit(0);
   }


### PR DESCRIPTION
Automated AFK landing for #1030. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1030

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785621576&installation_id=129708444&pr_number=1060&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1060&signature=8f3a89338a15b154d73eb9541c9423a3271b12339989e9f5d1b5ca234c5ccece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->