### PR TITLE
merge: #1031 feat(afk): validation gate runs the change's dependency cone; whole-workspace only for root changes

### DIFF
--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -1,4 +1,7 @@
 // feedback — the AFK pre-merge validation runner (the merge gate of ADR 0008).
+// ValidationScope threading: when `validationScope` is provided in
+// RunFeedbackInput it is stored verbatim in RunFeedbackResult for the caller
+// (process-issue.ts) to include in the Envelope validation section.
 //
 // Ported from the feedback_* helpers + feedback() in afk.sh. Pure scope
 // resolution and result/sidecar shaping over an injected package layout and an
@@ -12,6 +15,8 @@
 // millisecond clock — so the decision logic, the exact argv, and the
 // `red.afk.validation.v1` sidecar record shape are all unit-testable against
 // fixed inputs with no real pnpm ever run.
+
+import { type ValidationScope } from "./validation-scope.js";
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
@@ -251,6 +256,15 @@ export interface RunFeedbackInput {
    * gate FAILED, so the happy path costs nothing.
    */
   baselineWorktree?: string;
+  /**
+   * The computed validation scope (from {@link computeValidationScope}).
+   * When provided, it is recorded verbatim in {@link RunFeedbackResult} so
+   * the caller (process-issue.ts) can include it in the Envelope validation
+   * section — a human reading a blocked:validation park immediately sees
+   * what was actually tested. Optional: absent callers behave exactly as
+   * before (no scope is recorded in the result).
+   */
+  validationScope?: ValidationScope;
 }
 
 export interface RunFeedbackResult {
@@ -269,6 +283,13 @@ export interface RunFeedbackResult {
    * passed when the worker's branch showed red.
    */
   baselineDowngraded: readonly string[];
+  /**
+   * The computed validation scope passed to `runFeedback` via
+   * {@link RunFeedbackInput.validationScope}, or `undefined` when the caller
+   * did not supply one. Surfaced here so callers can include it in the
+   * Envelope without carrying it separately.
+   */
+  validationScope?: ValidationScope;
 }
 
 /** A single check to re-run against the baseline, for the baseline probe. */
@@ -336,7 +357,7 @@ async function runChecksForBaseline(
  * are probed — the happy path costs nothing extra.
  */
 export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<RunFeedbackResult> {
-  const { worktree, scopes, layout, now, baselineWorktree } = input;
+  const { worktree, scopes, layout, now, baselineWorktree, validationScope } = input;
   const checks: FeedbackCheck[] = [];
   const sidecar: string[] = [];
   let failed = false;
@@ -440,8 +461,8 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       }
     }
     failed = checks.some((c) => c.status === "failed");
-    return { ok: !failed, checks, sidecar, baselineDowngraded: downgraded };
+    return { ok: !failed, checks, sidecar, baselineDowngraded: downgraded, validationScope };
   }
 
-  return { ok: !failed, checks, sidecar, baselineDowngraded: [] };
+  return { ok: !failed, checks, sidecar, baselineDowngraded: [], validationScope };
 }

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -45,6 +45,13 @@ import {
   type PackageLayout,
   type RunFeedbackResult,
 } from "./feedback.js";
+import {
+  computeValidationScope,
+  formatValidationScope,
+  scopesForValidationScope,
+  type ValidationScope,
+  type WorkspaceGraph,
+} from "./validation-scope.js";
 import { runBackpressure, type BackpressureExec } from "./backpressure.js";
 import {
   openReviewPr,
@@ -255,6 +262,14 @@ export interface ProcessIssueDeps {
   pnpm: PnpmExec;
   /** Package layout probe for feedback scope resolution. */
   layout: PackageLayout;
+  /**
+   * Workspace dependency graph for dependency-cone scoping (T5, PRD #1013).
+   * When provided, the feedback gate runs the full cone: the changed packages
+   * plus every package that transitively depends on them. When absent (back-compat
+   * for existing callers / tests), the gate falls back to the current
+   * directly-touched-packages behaviour (no cone expansion).
+   */
+  graph?: WorkspaceGraph;
   /**
    * Shell executor for the operator-declared backpressure gate (#430, PRD #429).
    * Runs each `afk.backpressure` command against the worker-branch checkout.
@@ -963,6 +978,7 @@ export async function processIssue(
     startedEpoch,
   };
   let validationSidecar: string[] = [];
+  let lastValidationScope: ValidationScope | undefined = undefined;
   let salvagedUncommittedFiles = 0;
   let salvagedUncommittedOutcome: RunAgentResult["outcome"] | undefined;
   let salvagedRunCommitCount = 0;
@@ -1439,7 +1455,19 @@ export async function processIssue(
     // Macro phase → `validating` (issue #811): the feedback gate is starting.
     deps.markPhase?.("validating");
     const changedFiles = await deps.lookups.changedFiles(workerBranch, base);
-    const feedbackScopes = relevantScopes(deps.layout, changedFiles);
+    // Compute the validation scope: when a workspace graph is injected, expand
+    // to the full dependency cone (touched packages + transitive dependents);
+    // otherwise fall back to the current directly-touched-packages behaviour.
+    // Root-config changes (lockfile, tsconfig, .github/**) always escalate to
+    // whole-workspace regardless of which approach is used.
+    let validationScope: ValidationScope;
+    if (deps.graph) {
+      validationScope = computeValidationScope(changedFiles, deps.layout, deps.graph);
+    } else {
+      const scopes = relevantScopes(deps.layout, changedFiles);
+      validationScope = { type: "cone", packages: scopes, triggerPackages: scopes };
+    }
+    const feedbackScopes = scopesForValidationScope(validationScope);
     // pre_feedback (#832): a pre_* gate around the scope-derived feedback run — a
     // non-zero exit VETOES validation and routes the attempt to the abort-after-
     // claim terminal (the branch/PR is preserved, the issue returns to the queue).
@@ -1457,6 +1485,7 @@ export async function processIssue(
       layout: deps.layout,
       now: deps.nowEpoch,
       baselineWorktree: base,
+      validationScope,
     });
     // on_baseline_probe (#832): the "already failing on main?" probe (ADR 0071)
     // runs ONLY when the gate failed AND a baseline worktree was supplied. Report
@@ -1534,9 +1563,12 @@ export async function processIssue(
       } else {
         notes = "Feedback validation failed after the inner agent emitted DONE. The worker branch was not merged.";
       }
+      const scopeHeader = feedback.validationScope
+        ? `${formatValidationScope(feedback.validationScope)}\n`
+        : "";
       return await terminalFailure(common, outcome, "feedback", {
         notes,
-        validation: feedback.sidecar.join("\n"),
+        validation: `${scopeHeader}${feedback.sidecar.join("\n")}`,
       }, { validationSummary: feedback.sidecar.join("\n") });
     }
 
@@ -1573,6 +1605,7 @@ export async function processIssue(
     }
     // Both gates passed — the close path's sidecar/envelope carries their union.
     validationSidecar = [...feedback.sidecar, ...backpressureSidecar];
+    lastValidationScope = feedback.validationScope;
     break;
   }
 
@@ -1674,7 +1707,7 @@ export async function processIssue(
   // Write the machine-readable validation sidecar ($ITER_DIR/validation.jsonl,
   // SKILL.md) the Memory bridge consumes. Best-effort: never fails the close.
   await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
-  const posted = await emitDone(common, mergeSha, durationS, validationSidecar);
+  const posted = await emitDone(common, mergeSha, durationS, validationSidecar, lastValidationScope);
   // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
   // (done) envelope. Best-effort, gated, no-op when memory is absent.
   await recordAttemptBestEffort(common, "done", {
@@ -1977,14 +2010,18 @@ async function terminalFailure(
 
 /** Emit the done envelope with the merge sha + validation report. The
  * `validationSidecar` is the union of the feedback gate's records and any
- * backpressure-gate records (#430). */
+ * backpressure-gate records (#430). When `validationScope` is provided, a
+ * human-readable scope summary is prepended to the validation section so a
+ * human reading the envelope can see exactly what was tested. */
 async function emitDone(
   c: StageCommon,
   mergeSha: string,
   durationS: number,
   validationSidecar: string[],
+  validationScope?: ValidationScope,
 ): Promise<boolean> {
   const { deps, input } = c;
+  const scopeHeader = validationScope ? `${formatValidationScope(validationScope)}\n` : "";
   const result = await emitEnvelope(deps.envelope, {
     status: "done",
     issue: input.issue,
@@ -1994,7 +2031,7 @@ async function emitDone(
     attempt: input.attempt,
     mergeSha,
     diff: "merged",
-    sections: { validation: validationSidecar.join("\n") },
+    sections: { validation: `${scopeHeader}${validationSidecar.join("\n")}` },
     historyPath: deps.historyPath,
     historyClock: deps.historyClock,
     historyFields: { runner: input.runner, merge_sha: mergeSha },

--- a/apps/dev/src/core/validation-scope.ts
+++ b/apps/dev/src/core/validation-scope.ts
@@ -1,0 +1,199 @@
+// validation-scope — dependency-cone scoping for the AFK feedback gate (T5, PRD #1013).
+//
+// The gate must run the full dependency cone of a change, not just the directly
+// touched packages: if package A depends on package B and the worker edits B, A
+// also needs its tests run (B's change could break A). This module computes the
+// cone as a pure function over an injected workspace graph so the decision logic
+// is unit-testable without a real pnpm workspace.
+//
+// Root-config changes (lockfile, workspace manifest, tsconfig, turbo.json,
+// .github/**) have global blast radius and escalate to whole-workspace mode
+// (scopes = ["."]) so they are never under-validated.
+
+import { type PackageLayout, relevantScopes } from "./feedback.js";
+
+/** A workspace package: its repo-relative dir and the dirs it directly depends on. */
+export interface WorkspacePackage {
+  /** Repo-relative directory, e.g. "apps/dev" or "packages/shared". Never ".". */
+  dir: string;
+  /**
+   * Repo-relative dirs of workspace packages this package directly depends on
+   * (workspace-internal deps only; external npm deps are irrelevant for scoping).
+   */
+  dependsOn: string[];
+}
+
+/**
+ * Injected workspace graph — pure interface for testability. The real
+ * implementation reads pnpm-workspace.yaml and each package.json to resolve
+ * workspace-internal dependency edges.
+ */
+export interface WorkspaceGraph {
+  /** All workspace packages, excluding the workspace root ("."). */
+  packages: WorkspacePackage[];
+}
+
+/**
+ * The computed validation scope — either a filtered cone (touching only the
+ * affected packages and their transitive dependents) or whole-workspace (when a
+ * root-config change has global blast radius). Recorded in the Envelope so a
+ * human reading a blocked:validation park can see exactly what was tested.
+ */
+export type ValidationScope =
+  | {
+      type: "cone";
+      /**
+       * All packages in the scope: directly touched packages plus their
+       * transitive dependents. Sorted (LC_ALL=C byte order). Empty when no
+       * changed file maps to a package.
+       */
+      packages: string[];
+      /**
+       * The subset of packages that changed files mapped to directly (the
+       * "why" of the cone). Useful for audit — "we ran A and B because C
+       * depends on both; the trigger was C."
+       */
+      triggerPackages: string[];
+    }
+  | {
+      type: "whole-workspace";
+      /**
+       * The first changed file that triggered whole-workspace mode. A single
+       * example is enough: it identifies the class of change (lockfile,
+       * tsconfig, .github/workflow) that caused the escalation.
+       */
+      triggerFile: string;
+    };
+
+// Root-config files whose presence in changedFiles triggers whole-workspace
+// validation. Anything outside a package directory has global blast radius
+// and must not be under-validated by cone scoping.
+const ROOT_TRIGGER_FILES = new Set([
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "package.json",
+  "turbo.json",
+  "tsconfig.json",
+  "tsconfig.base.json",
+  ".npmrc",
+  ".nvmrc",
+]);
+
+function stripDotSlash(file: string): string {
+  return file.startsWith("./") ? file.slice(2) : file;
+}
+
+/**
+ * True when `file` is a root-config change that escalates to whole-workspace
+ * validation. Matches root-level known config files and `.github/**` CI configs.
+ * A file inside any package directory (contains at least one "/") never triggers
+ * unless it is also a .github path.
+ */
+export function isRootTrigger(file: string): boolean {
+  const clean = stripDotSlash(file);
+  // GitHub Actions / CI configs — always global blast radius.
+  if (clean.startsWith(".github/")) return true;
+  // Root-level files only (no directory separator = sits directly at repo root).
+  if (!clean.includes("/")) return ROOT_TRIGGER_FILES.has(clean);
+  return false;
+}
+
+/**
+ * Expand a set of directly touched package dirs to the full cone: the touched
+ * packages plus every package that transitively depends on them (reverse-dep BFS).
+ * Returns the cone sorted LC_ALL=C (byte order).
+ */
+function expandToCone(touchedDirs: readonly string[], graph: WorkspaceGraph): string[] {
+  // Build reverse dep map: dir → list of dirs that depend on it (direct edges only;
+  // BFS handles transitivity).
+  const reverseDeps = new Map<string, string[]>();
+  for (const pkg of graph.packages) {
+    for (const dep of pkg.dependsOn) {
+      let list = reverseDeps.get(dep);
+      if (!list) {
+        list = [];
+        reverseDeps.set(dep, list);
+      }
+      list.push(pkg.dir);
+    }
+  }
+
+  const cone = new Set(touchedDirs);
+  const queue = [...touchedDirs];
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    for (const dependent of reverseDeps.get(dir) ?? []) {
+      if (!cone.has(dependent)) {
+        cone.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return [...cone].sort();
+}
+
+/**
+ * Pure function: given changed files, a package layout, and a workspace graph,
+ * compute the validation scope.
+ *
+ * - Any root-config file in `changedFiles` → `whole-workspace` (global blast
+ *   radius; must not under-validate).
+ * - All other changes → `cone` (touched packages + their transitive dependents).
+ * - Empty changed-file set → `cone` with empty packages (gate runs no-package
+ *   skips, matching the current `relevantScopes` fallback).
+ */
+export function computeValidationScope(
+  changedFiles: readonly string[],
+  layout: PackageLayout,
+  graph: WorkspaceGraph,
+): ValidationScope {
+  for (const file of changedFiles) {
+    if (isRootTrigger(file)) {
+      return { type: "whole-workspace", triggerFile: stripDotSlash(file) };
+    }
+  }
+
+  const touchedDirs = relevantScopes(layout, changedFiles);
+  const coneDirs = expandToCone(touchedDirs, graph);
+
+  return {
+    type: "cone",
+    packages: coneDirs,
+    triggerPackages: touchedDirs,
+  };
+}
+
+/**
+ * Resolve the `scopes` array to pass to `runFeedback` from a computed
+ * ValidationScope.
+ * - `cone` → the cone package dirs (touched packages + transitive dependents).
+ * - `whole-workspace` → `["."]` (root scope runs the workspace-wide turbo
+ *   commands via `pnpm -C . <script>`; skips the redundant typecheck:workspace
+ *   check because root already covers the whole tree).
+ */
+export function scopesForValidationScope(scope: ValidationScope): string[] {
+  if (scope.type === "whole-workspace") return ["."];
+  return scope.packages;
+}
+
+/**
+ * Format a ValidationScope as a human-readable summary line for the Envelope
+ * validation section — so a human reading a blocked:validation park immediately
+ * sees what was tested without parsing JSONL.
+ */
+export function formatValidationScope(scope: ValidationScope): string {
+  if (scope.type === "whole-workspace") {
+    return `scope: whole-workspace (trigger: \`${scope.triggerFile}\`)`;
+  }
+  if (scope.packages.length === 0) {
+    return `scope: cone [] (no package found for changed files)`;
+  }
+  const pkgs = scope.packages.map((p) => `\`${p}\``).join(", ");
+  const triggers = scope.triggerPackages.map((p) => `\`${p}\``).join(", ");
+  const extra =
+    scope.triggerPackages.length < scope.packages.length
+      ? ` — expanded from ${triggers}`
+      : "";
+  return `scope: cone [${pkgs}]${extra}`;
+}

--- a/apps/dev/tests/validation-scope.test.ts
+++ b/apps/dev/tests/validation-scope.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeValidationScope,
+  formatValidationScope,
+  isRootTrigger,
+  scopesForValidationScope,
+  type ValidationScope,
+  type WorkspaceGraph,
+  type WorkspacePackage,
+} from "../src/core/validation-scope.js";
+import {
+  runFeedback,
+  type Exec,
+  type ExecResult,
+  type PackageLayout,
+} from "../src/core/feedback.js";
+
+// ---- helpers ----
+
+function fakeLayout(packages: readonly string[]): PackageLayout {
+  const set = new Set(packages);
+  return {
+    hasPackage: (dir) => set.has(dir),
+    hasScript: () => true,
+  };
+}
+
+function fakeGraph(pkgs: WorkspacePackage[]): WorkspaceGraph {
+  return { packages: pkgs };
+}
+
+/**
+ * Build a WorkspaceGraph from a simple adjacency description: each entry is
+ * `[dir, ...dependsOn]`. All dirs that appear (as keys or deps) are included.
+ */
+function graph(...entries: [string, ...string[]][]): WorkspaceGraph {
+  const packages: WorkspacePackage[] = entries.map(([dir, ...deps]) => ({
+    dir,
+    dependsOn: deps,
+  }));
+  return fakeGraph(packages);
+}
+
+// ---- isRootTrigger ----
+
+describe("isRootTrigger", () => {
+  it("matches the lockfile", () => {
+    expect(isRootTrigger("pnpm-lock.yaml")).toBe(true);
+    expect(isRootTrigger("./pnpm-lock.yaml")).toBe(true);
+  });
+
+  it("matches root-level tsconfig and turbo", () => {
+    expect(isRootTrigger("tsconfig.json")).toBe(true);
+    expect(isRootTrigger("tsconfig.base.json")).toBe(true);
+    expect(isRootTrigger("turbo.json")).toBe(true);
+  });
+
+  it("matches root package.json and workspace manifest", () => {
+    expect(isRootTrigger("package.json")).toBe(true);
+    expect(isRootTrigger("pnpm-workspace.yaml")).toBe(true);
+  });
+
+  it("matches .github/** CI configs", () => {
+    expect(isRootTrigger(".github/workflows/ci.yml")).toBe(true);
+    expect(isRootTrigger(".github/CODEOWNERS")).toBe(true);
+  });
+
+  it("does NOT trigger on package-level tsconfig.json", () => {
+    expect(isRootTrigger("apps/dev/tsconfig.json")).toBe(false);
+    expect(isRootTrigger("packages/shared/package.json")).toBe(false);
+  });
+
+  it("does NOT trigger on normal source files", () => {
+    expect(isRootTrigger("apps/dev/src/index.ts")).toBe(false);
+    expect(isRootTrigger("README.md")).toBe(false);
+  });
+});
+
+// ---- computeValidationScope — root trigger ----
+
+describe("computeValidationScope — whole-workspace escalation", () => {
+  const layout = fakeLayout([".", "apps/dev"]);
+  const g = graph(["apps/dev"]);
+
+  it("escalates to whole-workspace on a lockfile change", () => {
+    const scope = computeValidationScope(["pnpm-lock.yaml"], layout, g);
+    expect(scope.type).toBe("whole-workspace");
+    if (scope.type === "whole-workspace") {
+      expect(scope.triggerFile).toBe("pnpm-lock.yaml");
+    }
+  });
+
+  it("escalates to whole-workspace on a .github/ change even when other files are package-local", () => {
+    const scope = computeValidationScope(
+      ["apps/dev/src/index.ts", ".github/workflows/ci.yml"],
+      layout,
+      g,
+    );
+    expect(scope.type).toBe("whole-workspace");
+    if (scope.type === "whole-workspace") {
+      expect(scope.triggerFile).toBe(".github/workflows/ci.yml");
+    }
+  });
+
+  it("strips the leading ./ from the trigger file path", () => {
+    const scope = computeValidationScope(["./pnpm-lock.yaml"], layout, g);
+    expect(scope.type).toBe("whole-workspace");
+    if (scope.type === "whole-workspace") {
+      expect(scope.triggerFile).toBe("pnpm-lock.yaml");
+    }
+  });
+
+  it("regression: whole-workspace behaviour preserved for root changes", () => {
+    // Root changes must ALWAYS run the full workspace. Any cone expansion that
+    // limited the scope to touched packages would under-validate.
+    const scope = computeValidationScope(["turbo.json"], layout, g);
+    expect(scope.type).toBe("whole-workspace");
+    expect(scopesForValidationScope(scope)).toEqual(["."]);
+  });
+});
+
+// ---- computeValidationScope — cone expansion ----
+
+describe("computeValidationScope — cone expansion", () => {
+  it("leaf-package change → exact cone (package only when no dependents)", () => {
+    // packages/shared has no dependents in this graph.
+    const layout = fakeLayout(["packages/shared"]);
+    const g = graph(["packages/shared"]);
+    const scope = computeValidationScope(["packages/shared/src/index.ts"], layout, g);
+
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual(["packages/shared"]);
+      expect(scope.triggerPackages).toEqual(["packages/shared"]);
+    }
+  });
+
+  it("leaf-package change → cone includes direct dependents", () => {
+    // apps/dev depends on packages/shared — changing shared must run apps/dev too.
+    const layout = fakeLayout(["apps/dev", "packages/shared"]);
+    const g = graph(["apps/dev", "packages/shared"], ["packages/shared"]);
+    // Note: first entry "apps/dev" has no dependsOn; second is packages/shared.
+    // Rebuild to express the dependency properly:
+    const g2 = fakeGraph([
+      { dir: "apps/dev", dependsOn: ["packages/shared"] },
+      { dir: "packages/shared", dependsOn: [] },
+    ]);
+    const scope = computeValidationScope(["packages/shared/src/utils.ts"], layout, g2);
+
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual(["apps/dev", "packages/shared"]);
+      expect(scope.triggerPackages).toEqual(["packages/shared"]);
+    }
+  });
+
+  it("leaf-package change → cone includes transitive dependents (BFS)", () => {
+    // apps/ui → apps/dev → packages/shared. Changing shared must reach apps/ui.
+    const layout = fakeLayout(["apps/dev", "apps/ui", "packages/shared"]);
+    const g = fakeGraph([
+      { dir: "apps/dev", dependsOn: ["packages/shared"] },
+      { dir: "apps/ui", dependsOn: ["apps/dev"] },
+      { dir: "packages/shared", dependsOn: [] },
+    ]);
+    const scope = computeValidationScope(["packages/shared/src/index.ts"], layout, g);
+
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual(["apps/dev", "apps/ui", "packages/shared"]);
+      expect(scope.triggerPackages).toEqual(["packages/shared"]);
+    }
+  });
+
+  it("multi-package change → union of cones (sorted LC_ALL=C)", () => {
+    // apps/dev and packages/shared are both touched; apps/ui depends on apps/dev.
+    const layout = fakeLayout(["apps/dev", "apps/ui", "packages/shared"]);
+    const g = fakeGraph([
+      { dir: "apps/dev", dependsOn: [] },
+      { dir: "apps/ui", dependsOn: ["apps/dev"] },
+      { dir: "packages/shared", dependsOn: [] },
+    ]);
+    const scope = computeValidationScope(
+      ["apps/dev/src/x.ts", "packages/shared/src/y.ts"],
+      layout,
+      g,
+    );
+
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      // apps/dev is triggered directly AND via apps/ui's dependency on apps/dev;
+      // packages/shared is touched directly.
+      expect(scope.packages).toEqual(["apps/dev", "apps/ui", "packages/shared"]);
+      expect(scope.triggerPackages.sort()).toEqual(["apps/dev", "packages/shared"]);
+    }
+  });
+
+  it("empty changed-file set → empty cone", () => {
+    const layout = fakeLayout(["apps/dev"]);
+    const g = fakeGraph([{ dir: "apps/dev", dependsOn: [] }]);
+    const scope = computeValidationScope([], layout, g);
+
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual([]);
+      expect(scope.triggerPackages).toEqual([]);
+    }
+  });
+});
+
+// ---- scopesForValidationScope ----
+
+describe("scopesForValidationScope", () => {
+  it("whole-workspace → ['.']", () => {
+    const scope: ValidationScope = { type: "whole-workspace", triggerFile: "turbo.json" };
+    expect(scopesForValidationScope(scope)).toEqual(["."]);
+  });
+
+  it("cone → the cone package dirs", () => {
+    const scope: ValidationScope = {
+      type: "cone",
+      packages: ["apps/dev", "packages/shared"],
+      triggerPackages: ["packages/shared"],
+    };
+    expect(scopesForValidationScope(scope)).toEqual(["apps/dev", "packages/shared"]);
+  });
+
+  it("empty cone → []", () => {
+    const scope: ValidationScope = { type: "cone", packages: [], triggerPackages: [] };
+    expect(scopesForValidationScope(scope)).toEqual([]);
+  });
+});
+
+// ---- formatValidationScope ----
+
+describe("formatValidationScope", () => {
+  it("formats a whole-workspace scope", () => {
+    const scope: ValidationScope = { type: "whole-workspace", triggerFile: "pnpm-lock.yaml" };
+    expect(formatValidationScope(scope)).toBe("scope: whole-workspace (trigger: `pnpm-lock.yaml`)");
+  });
+
+  it("formats a simple cone (no expansion)", () => {
+    const scope: ValidationScope = {
+      type: "cone",
+      packages: ["apps/dev"],
+      triggerPackages: ["apps/dev"],
+    };
+    expect(formatValidationScope(scope)).toBe("scope: cone [`apps/dev`]");
+  });
+
+  it("formats an expanded cone (trigger ≠ cone)", () => {
+    const scope: ValidationScope = {
+      type: "cone",
+      packages: ["apps/dev", "packages/shared"],
+      triggerPackages: ["packages/shared"],
+    };
+    const result = formatValidationScope(scope);
+    expect(result).toContain("scope: cone [`apps/dev`, `packages/shared`]");
+    expect(result).toContain("expanded from");
+    expect(result).toContain("`packages/shared`");
+  });
+
+  it("formats an empty cone", () => {
+    const scope: ValidationScope = { type: "cone", packages: [], triggerPackages: [] };
+    expect(formatValidationScope(scope)).toContain("no package found");
+  });
+});
+
+// ---- gate integration: runFeedback respects the cone scopes ----
+
+describe("gate integration — runFeedback runs the cone", () => {
+  /**
+   * Simulate a fakeExec that records which package dirs were targeted by pnpm.
+   * Returns an object with the accumulated argv list for inspection.
+   */
+  function trackingExec(): { exec: Exec; pnpmCalls: string[][] } {
+    const pnpmCalls: string[][] = [];
+    const exec: Exec = async (args) => {
+      pnpmCalls.push(args);
+      return { code: 0, stdout: "ok", stderr: "" } satisfies ExecResult;
+    };
+    return { exec, pnpmCalls };
+  }
+
+  it("passes cone packages as pnpm -C targets", async () => {
+    // Changed file in packages/shared; apps/dev depends on it → cone = both.
+    const layout = fakeLayout(["apps/dev", "packages/shared"]);
+    const g = fakeGraph([
+      { dir: "apps/dev", dependsOn: ["packages/shared"] },
+      { dir: "packages/shared", dependsOn: [] },
+    ]);
+    const changedFiles = ["packages/shared/src/index.ts"];
+    const scope = computeValidationScope(changedFiles, layout, g);
+    const scopes = scopesForValidationScope(scope);
+
+    const { exec, pnpmCalls } = trackingExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes,
+      layout,
+      now: () => 0,
+      validationScope: scope,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.validationScope).toBe(scope);
+
+    // Gate must have invoked pnpm for BOTH apps/dev and packages/shared.
+    const dirs = new Set(pnpmCalls.map((a) => a[a.indexOf("-C") + 1] ?? ""));
+    expect(dirs.has("/wt/apps/dev")).toBe(true);
+    expect(dirs.has("/wt/packages/shared")).toBe(true);
+  });
+
+  it("whole-workspace trigger passes ['.'] as the only scope", async () => {
+    const layout = fakeLayout([".", "apps/dev"]);
+    const g = fakeGraph([{ dir: "apps/dev", dependsOn: [] }]);
+    const changedFiles = ["pnpm-lock.yaml"];
+    const scope = computeValidationScope(changedFiles, layout, g);
+
+    expect(scope.type).toBe("whole-workspace");
+    const scopes = scopesForValidationScope(scope);
+    expect(scopes).toEqual(["."]);
+
+    const { exec, pnpmCalls } = trackingExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes,
+      layout,
+      now: () => 0,
+      validationScope: scope,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.validationScope?.type).toBe("whole-workspace");
+
+    // All pnpm calls must target the workspace root ("/wt"), never a sub-package.
+    const dirs = pnpmCalls.map((a) => a[a.indexOf("-C") + 1] ?? "");
+    expect(dirs.every((d) => d === "/wt")).toBe(true);
+  });
+
+  it("validationScope is undefined in result when not provided (backwards compat)", async () => {
+    const layout = fakeLayout(["apps/dev"]);
+    const { exec } = trackingExec();
+    const result = await runFeedback(exec, {
+      worktree: "/wt",
+      scopes: ["apps/dev"],
+      layout,
+      now: () => 0,
+    });
+    expect(result.validationScope).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1031. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1031

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785621674&installation_id=129708444&pr_number=1061&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1061&signature=e96f6a8e37cbe723382776c67db5abebccaad3849b2073ff369c31c334190ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->