### PR TITLE
merge: #1023 feat(afk): all liveness consumers read the single red-castle evaluator via the Worker state reader

### DIFF
--- a/apps/dev/src/commands/monitor.ts
+++ b/apps/dev/src/commands/monitor.ts
@@ -37,7 +37,11 @@ export function workersToDesired(workers: readonly CompactWorker[]): WorkerRecor
     const issue = typeof number === "number" ? number : Number(number);
     if (!Number.isFinite(issue)) continue;
     const phase = w.state.current.phase ?? "";
-    const processLive = w.liveness ? w.liveness !== "dead" : (w.pidLive ?? w.live);
+    const processLive = w.livenessVerdict
+      ? w.livenessVerdict.status !== "stalled"
+      : w.liveness
+        ? w.liveness !== "dead"
+        : (w.pidLive ?? w.live);
     out.push({
       worker_id: w.state.worker_id,
       issue,

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -28,7 +28,7 @@ import {
 import { runBoot, type BootResult, type BootstrapInput } from "../core/boot.js";
 import { inspectProcessTreeNative } from "../runtime/proc-tree.js";
 import {
-  agentLaneMtimeFor,
+  workerLivenessFor,
   parkedSlotWorkFor,
   resolveIterDirInfo,
   teardownIterDirNative,
@@ -395,7 +395,8 @@ function buildSupervisorDeps(
       sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     },
     fs: {
-      agentLaneMtime: (slot) => agentLaneMtimeFor(tmpDir, slotPids.get(slot) ?? null),
+      workerLivenessVerdict: (slot, laneIdleMs) =>
+        workerLivenessFor(tmpDir, slotPids.get(slot) ?? null, laneIdleMs),
       resolveIterDir: (slot) => resolveIterDirInfo(tmpDir, slotPids.get(slot) ?? null, now()),
       teardownIterDir: async (info) => {
         await teardownIterDirNative(info, root);

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -12,7 +12,7 @@
 // as sandcastle completion signals, so the existing AGENT-PROMPT contract is
 // unchanged.
 
-import type { AgentStreamEvent, RunOptions, RunResult } from "@reddb-io/red-castle";
+import type { AgentStreamEvent, RunOptions, RunResult, LivenessVerdict } from "@reddb-io/red-castle";
 import { extractAgentOutput } from "@reddb-io/red-castle";
 import { isRunnerExhausted } from "./runner-spawn.js";
 import { startLaneIdleReaper, DEFAULT_STALL_POLL_S } from "./lane-idle-reaper.js";
@@ -379,12 +379,12 @@ export interface RunAgentInput {
    * DEFAULT_STALL_POLL_S. */
   laneIdlePollSeconds?: number;
   /**
-   * Agent-lane (`agent.log.jsonl`) mtime probe in epoch SECONDS, 0 when absent.
-   * The clean liveness signal — never afk.log / the firehose, which the
-   * heartbeat keeps fresh and would mask a real stall (#243). Required to arm
+   * Red-castle liveness evaluator verdict probe (ADR 0083 §3). Returns the
+   * combined lane-recency + process-cross-check verdict from the attempt's
+   * `liveness.lane.jsonl` — the un-poisonable signal (#1022). Required to arm
    * the lane-idle reaper.
    */
-  laneMtimeProbe?: () => number;
+  livenessVerdictProbe?: () => LivenessVerdict | null;
   /**
    * Inner-agent process-tree snapshot for the lane-idle reaper's busy-predicate
    * (reduced by deriveSnapshot). Required to arm the reaper. The real wiring
@@ -1173,7 +1173,7 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
     input.laneIdleThresholdSeconds > 0 &&
     input.laneIdleKillThresholdSeconds &&
     input.laneIdleKillThresholdSeconds > 0 &&
-    input.laneMtimeProbe &&
+    input.livenessVerdictProbe &&
     input.inspectTree
   ) {
     if (!controller) controller = makeController();
@@ -1184,10 +1184,9 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       stallThresholdS: input.laneIdleThresholdSeconds,
       stallKillThresholdS: input.laneIdleKillThresholdSeconds,
       intervalMs: pollS * 1000,
-      laneMtime: input.laneMtimeProbe,
+      livenessVerdict: input.livenessVerdictProbe,
       inspectTree: input.inspectTree,
-      // The lane reaper reasons in epoch SECONDS (lane mtime is seconds); the
-      // shared clock `now` is ms, so divide here.
+      // The lane reaper reasons in epoch SECONDS; the shared clock `now` is ms.
       now: () => Math.floor(now() / 1000),
       schedule,
       abort: () =>

--- a/apps/dev/src/core/lane-idle-reaper.ts
+++ b/apps/dev/src/core/lane-idle-reaper.ts
@@ -9,8 +9,10 @@
 // busy-predicate so a mid-build/test worker is never killed.
 //
 // It is NOT a second mechanism. It REUSES the fleet machinery:
-//   - the fleet stall DETECTOR  — `computeStalled` (supervisor.ts): worker alive
-//     ≥ soft threshold AND agent lane silent ≥ soft threshold;
+//   - the fleet stall DETECTOR  — the red-castle `evaluateLiveness` evaluator
+//     (ADR 0083 §3): lane silent ≥ soft threshold AND (if armed) no live
+//     descendants → stalled. The verdict is injected via `livenessVerdict` so
+//     the reaper is fully testable without a real process tree or lane file.
 //   - the reaper-signal PREDICATE — `deriveSnapshot` + `decideReaperSignal`
 //     (reaper-signal.ts): the irreversible kill is gated on no active build/test
 //     descendant AND flat cpu.
@@ -19,10 +21,12 @@
 // duplicate or re-implement the #400 progress guard — that watches commits; this
 // watches the agent lane.
 //
-// SIGNAL HYGIENE (#243): the liveness signal is the active attempt's agent lane
-// JSONL mtime — never `afk.log` or the firehose `log.jsonl`, which the per-minute
+// SIGNAL HYGIENE (#243 / #1022): the liveness signal is the red-castle
+// `evaluateLiveness` evaluator over the attempt's `liveness.lane.jsonl` —
+// never `afk.log` or the firehose `agent.log.jsonl`, which the per-minute
 // heartbeat keeps fresh and would mask a real stall. The caller wires
-// `laneMtime` to stat the attempt's `agent.log.jsonl`.
+// `livenessVerdict` to a sync probe that reads the liveness lane and calls
+// the evaluator (runtime/wire.ts `agentLivenessVerdictSync`).
 //
 // The reaper runs in a SIDE-CHANNEL (an injected periodic scheduler) independent
 // of the inner-agent stream, so a fully-hung runner is still observed and reaped.
@@ -32,8 +36,9 @@
 // run then flows through the existing no-sentinel terminal policy (envelope +
 // label rotation + worktree teardown).
 
-import { computeStalled, SUPERVISOR_DEFAULTS, validateStallThresholds } from "./supervisor.js";
+import { SUPERVISOR_DEFAULTS, validateStallThresholds } from "./supervisor.js";
 import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from "./reaper-signal.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 
 /** Default agent-lane sampling cadence in seconds (RED_AFK_STALL_POLL_S). Mirrors
  * the fleet passive stall detector's poll cadence so the solo reaper observes a
@@ -85,12 +90,11 @@ export type LaneIdleVerdict = "not-candidate" | "no-kill" | "kill";
 
 /** One poll's observation, surfaced via `onTick` for diagnostics. */
 export interface LaneIdleInfo {
-  /** Agent-lane mtime observed this tick (epoch seconds; 0 when absent). */
-  laneMtime: number;
-  /** Agent-lane idle duration this tick (seconds; 0 when the lane is unseen). */
+  /** Agent-lane idle duration this tick (seconds; 0 when the lane is unseen or
+   * laneAgeMs is unavailable from the verdict). */
   idleSeconds: number;
-  /** True when the fleet detector flags the worker stalled (alive ≥ soft AND
-   * lane silent ≥ soft). */
+  /** True when the evaluator verdict is "stalled" (lane idle ≥ soft threshold
+   * AND cross-check confirms no live descendants). */
   stalled: boolean;
   /** The kill verdict this tick. */
   verdict: LaneIdleVerdict;
@@ -112,10 +116,13 @@ export interface LaneIdleReaperOptions {
   stallKillThresholdS: number;
   /** Poll cadence in milliseconds (RED_AFK_STALL_POLL_S × 1000). */
   intervalMs: number;
-  /** Agent-lane mtime probe (epoch seconds; 0 when the lane does not exist yet).
-   * MUST read the clean agent lane (`agent.log.jsonl`), never afk.log / the
-   * firehose (#243). */
-  laneMtime: () => number;
+  /**
+   * Red-castle liveness evaluator verdict probe (ADR 0083 §3). Returns the
+   * combined lane-recency + process-cross-check verdict, or null when the
+   * attempt dir cannot be resolved (worker between iterations). A null or
+   * non-stalled verdict keeps the worker as a non-candidate this tick.
+   */
+  livenessVerdict: () => LivenessVerdict | null;
   /** Inner-agent process-tree snapshot, reduced by `deriveSnapshot` into the
    * busy signals. Consulted only at the kill escalation so `ps` is not run every
    * poll. A safe-by-default inspector reports a busy snapshot on inspection
@@ -153,13 +160,29 @@ export function startLaneIdleReaper(opts: LaneIdleReaperOptions): {
   const cancel = opts.schedule(() => {
     if (fired) return;
     const now = opts.now();
-    const laneMtime = opts.laneMtime();
-    const stalled = computeStalled(opts.spawnEpoch, laneMtime, now, opts.stallThresholdS);
+
+    // Startup window: skip freshly-spawned workers (same guard as the fleet's
+    // pollStallDetector to prevent reaping a worker before it can write its lane).
+    const workerAgeS = now - opts.spawnEpoch;
+    if (!(opts.spawnEpoch > 0) || !(workerAgeS >= opts.stallThresholdS)) {
+      opts.onTick?.({ idleSeconds: 0, stalled: false, verdict: "not-candidate", nowS: now });
+      return;
+    }
+
+    // The red-castle evaluator (ADR 0083 §3) combines lane recency and process
+    // cross-check into a single verdict. A null probe result means the worker is
+    // between iterations — not a candidate.
+    const lv = opts.livenessVerdict();
+    const stalled = lv !== null && lv.status === "stalled";
+
+    // Lane idle duration from the evaluator's laneAgeMs (ms → s). When
+    // laneAgeMs is absent (lane never written), fall back to worker age so a
+    // stalled-but-never-written worker still escalates past the kill threshold.
+    const idleSeconds = lv?.laneAgeMs !== undefined ? Math.round(lv.laneAgeMs / 1000) : 0;
+
     let verdict: LaneIdleVerdict = "not-candidate";
     if (stalled) {
-      // The lane mtime IS the stall anchor, so idle === now - lastLaneActivity —
-      // exactly the fleet's `now - stallSinceEpoch`.
-      const idle = now - laneMtime;
+      const idle = idleSeconds > 0 ? idleSeconds : workerAgeS;
       if (idle >= opts.stallKillThresholdS) {
         const snapshot = deriveSnapshot(opts.inspectTree());
         const decision = decideReaperSignal({
@@ -178,8 +201,7 @@ export function startLaneIdleReaper(opts: LaneIdleReaperOptions): {
         verdict = "no-kill";
       }
     }
-    const idleSeconds = laneMtime > 0 ? now - laneMtime : 0;
-    opts.onTick?.({ laneMtime, idleSeconds, stalled, verdict, nowS: now });
+    opts.onTick?.({ idleSeconds, stalled, verdict, nowS: now });
   }, opts.intervalMs);
   return { stop: cancel, firedReap: () => fired };
 }

--- a/apps/dev/src/core/monitor.ts
+++ b/apps/dev/src/core/monitor.ts
@@ -14,6 +14,7 @@
 
 import { buildSparkline, type HistoryRecord } from "./history.js";
 import { encodeToon, type ToonValue } from "./toon.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 
 /** The subset of a worker's current-iteration state the compact line reads. */
 export interface CompactCurrent {
@@ -64,13 +65,16 @@ export interface CompactState {
 /** One worker as handed to the pure renderer. */
 export interface CompactWorker {
   state: CompactState;
-  /** Explicit liveness verdict from the shared Worker state reader. Older tests
-   * may omit it and still fall back to `live` / `pidLive`. */
+  /** Red-castle evaluator verdict (ADR 0083 §3). The primary liveness signal for
+   * all rendering surfaces; `liveness`, `live`, and `pidLive` are derived from
+   * it. Older test stubs may omit it — the fallbacks below still apply. */
+  livenessVerdict?: LivenessVerdict;
+  /** Explicit liveness verdict from the shared Worker state reader. Derived from
+   * `livenessVerdict` when present. Older tests may omit it and still fall back
+   * to `live` / `pidLive`. */
   liveness?: "active" | "quiet-but-live" | "dead";
-  /** True when the worker's pid identity matches AND agent-lane activity is fresh
-   * (within {@link WORKER_LIVE_MAX_AGE_S}). Used for the `[live]` badge.
-   * When false but {@link pidLive} is true, the badge renders as `[quiet]`
-   * (pid identity alive, agent lane idle — e.g. mid-gate or post-attempt commit). */
+  /** True when the evaluator says "alive". Used for the `[live]` badge.
+   * When false but {@link pidLive} is true, the badge renders as `[quiet]`. */
   live: boolean;
   /** True when the worker's pid identity matches regardless of freshness.
    * Absent / false collapses to the `[stale]` (dead/finished) badge. */
@@ -192,8 +196,21 @@ function elapsedSeconds(state: CompactState, now: number): number {
  * `+0 -0`) so the diff volume is never hidden. `now` is an epoch in seconds.
  */
 /** The `live` / `quiet` / `stale` liveness badge, shared by the plain and TOON
- * renders so the two never drift. */
+ * renders so the two never drift.
+ *
+ * Primary path: evaluator verdict (`livenessVerdict`) — the single source of
+ * truth (ADR 0083 §3). Fallback chain for older test stubs without the verdict:
+ * `liveness` → `live` / `pidLive`.
+ */
 export function compactWorkerTag(worker: CompactWorker): "live" | "quiet" | "stale" {
+  if (worker.livenessVerdict !== undefined) {
+    const s = worker.livenessVerdict.status;
+    if (s === "alive") {
+      return worker.livenessVerdict.laneFresh ? "live" : "quiet";
+    }
+    if (s === "unknown") return "quiet";
+    return "stale";
+  }
   return worker.liveness === "active"
     ? "live"
     : worker.liveness === "quiet-but-live"

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -15,6 +15,7 @@
 // workers own all claim-lock / state / queue semantics (supervisor.sh header).
 
 import { decideReaperSignal, deriveSnapshot, type ProcessSnapshotEntry } from "./reaper-signal.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 import {
   freshWakeStats,
   recordWake,
@@ -392,23 +393,13 @@ export function recordDeath(
 // ---------- stall candidacy (pure) ----------
 
 /**
- * compute_stalled (supervisor.sh ~551): pure predicate deciding whether a slot
- * meets every passive-stall criterion. The slot is stalled when its worker has
- * been alive at least the threshold AND its agent lane has been silent at least
- * the threshold. A spawn epoch of 0 (uninitialised slot) or a lane mtime of 0
- * (no lane observed yet — normal startup) is never flagged.
- */
-export function computeStalled(
-  spawnEpoch: number,
-  laneMtime: number,
-  now: number,
-  thresholdS: number,
-): boolean {
-  if (!(spawnEpoch > 0)) return false;
-  if (!(now - spawnEpoch >= thresholdS)) return false;
-  if (!(laneMtime > 0)) return false;
-  return now - laneMtime >= thresholdS;
-}
+ * compute_stalled is deleted — stall detection now uses the red-castle
+ * LivenessVerdict from SupervisorFs.workerLivenessVerdict (ADR 0083 §3).
+ * The evaluator combines lane recency with a process cross-check so a worker
+ * that refreshes the firehose but not the liveness lane can no longer defeat
+ * the kill, and a worker with live agent descendants is never falsely reaped.
+ * The spawnEpoch guard (don't flag freshly started workers) is kept inline in
+ * pollStallDetector so the "just spawned" window still applies.
 
 // ---------- injected IO ----------
 
@@ -459,10 +450,14 @@ export interface SupervisorProc {
 
 /** Filesystem side effects. Best-effort, like the bash `|| true` cleanups. */
 export interface SupervisorFs {
-  /** Last-modified epoch (seconds) of the slot's agent lane, or 0 when the lane
-   * does not exist / the worker is between iterations. Mirrors the
-   * `stat -c %Y "$lane"` read in poll_stall_detector. */
-  agentLaneMtime(slot: number): number;
+  /**
+   * Red-castle evaluator verdict for the slot's current attempt (ADR 0083 §3).
+   * The `laneIdleMs` parameter sets the idle threshold so the supervisor can
+   * use its configured stall window rather than the display threshold.
+   * Returns null when no iter dir is found (worker between iterations or died
+   * pre-claim). Replaces the old `agentLaneMtime` firehose-mtime check.
+   */
+  workerLivenessVerdict(slot: number, laneIdleMs: number): LivenessVerdict | null;
   /** Resolve the slot's current iteration dir + the state it carries, or null
    * when the worker is between iterations / died pre-claim. Mirrors
    * find_slot_iter_dir + the jq reads in reap_stalled_slot. */
@@ -1184,15 +1179,24 @@ export async function pollStallDetector(
     const slot = state.slots[i]!;
     if (slot.parked || slot.idleParked) continue;
 
-    const laneMtime = deps.fs.agentLaneMtime(i);
-    const flagged = computeStalled(slot.spawnEpoch, laneMtime, now, config.stallThresholdS);
+    // Skip freshly-spawned slots (startup window: same guard as old computeStalled).
+    if (!(slot.spawnEpoch > 0) || !(now - slot.spawnEpoch >= config.stallThresholdS)) continue;
+
+    // Evaluator verdict: stale lane + no live descendants → stalled. Live
+    // descendants → alive even when the lane is silent (wedged substrate guard).
+    const verdict = deps.fs.workerLivenessVerdict(i, config.stallThresholdS * 1000);
+    const flagged = verdict !== null && verdict.status === "stalled";
 
     if (flagged) {
       if (!slot.stalled) {
         slot.stalled = true;
-        // Anchor the stall window to the last observed lane activity so the
-        // rendered idle duration matches "agent lane idle for N".
-        slot.stallSinceEpoch = laneMtime;
+        // Anchor the stall window to the last observed lane activity. When the
+        // lane record age is known, compute the epoch; otherwise anchor to now.
+        const stallSince =
+          verdict.laneAgeMs !== undefined
+            ? now - Math.round(verdict.laneAgeMs / 1000)
+            : now;
+        slot.stallSinceEpoch = stallSince;
         // Dispatch on_stall_detected on first detection. Best-effort.
         if (deps.dispatchFleetHook) {
           try {
@@ -1201,8 +1205,9 @@ export async function pollStallDetector(
               runner: config.runner,
               slot: i,
               ...(slot.pid !== null ? { pid: slot.pid } : {}),
-              stall_since: laneMtime,
-              idle_seconds: now - laneMtime,
+              stall_since: stallSince,
+              idle_seconds:
+                verdict.laneAgeMs !== undefined ? Math.round(verdict.laneAgeMs / 1000) : 0,
             });
           } catch {
             // best-effort

--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -4,10 +4,7 @@
 // record — the monitor/statusline collectors, the mirror feed, boot facts, and
 // the fleet supervisor's reaper — goes through here, so there is a SINGLE parse
 // path: JSON.parse → `parseState` (schema + the ADR 0065 legacy-key shim) →
-// liveness via the canonical `isStateLive` / `isStateActive`. Before this, the
-// supervisor reaper hand-rolled its own `JSON.parse` and the wire collectors each
-// re-globbed + re-parsed + re-derived liveness independently; a legacy-keyed file
-// could read differently through those bypass paths than through `parseState`.
+// liveness via the red-castle `evaluateLiveness` evaluator (ADR 0083 §3).
 //
 // `readWorkerState(path)` is SYNCHRONOUS on purpose: the supervisor reaper
 // (runtime/supervisor-fs.ts) resolves issue/worker identity from a state file
@@ -15,9 +12,19 @@
 // async fan-out the collectors use (glob → read each).
 
 import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import type { AfkState } from "../types/state.js";
-import { isStateActive, isStateLive, parseState, type PidStartTimeProbe } from "./state.js";
+import { parseState, type PidStartTimeProbe } from "./state.js";
 import { globWorkerStates } from "../runtime/fs.js";
+import {
+  evaluateLiveness,
+  resolveLivenessCrossCheckArming,
+  createProcessDescendantProbe,
+  parseLivenessRecords,
+  LIVENESS_LANE_FILENAME,
+  type LivenessVerdict,
+  type SandboxTag,
+} from "@reddb-io/red-castle";
 
 export type WorkerLivenessVerdict = "active" | "quiet-but-live" | "dead";
 
@@ -28,19 +35,30 @@ export interface WorkerStateRecord {
   /** Parsed state with the schema + ADR 0065 legacy-key shim applied. */
   state: AfkState;
   /**
-   * pid-identity liveness ({@link isStateLive}). The reaper/cap signal: a slow
-   * worker whose pid identity still matches is live even when briefly quiet —
-   * so it is never reaped on freshness.
+   * Process-identity gate (not stalled in evaluator sense). True for "alive" or
+   * "unknown" evaluator status. Used by boot-cap / companion to exclude workers
+   * that may still hold OS resources.
    */
   live: boolean;
   /**
-   * pid identity + recent-activity liveness ({@link isStateActive}). The
-   * display `[live]` badge the monitor/statusline use.
+   * True when the liveness lane is fresh (evaluator "alive" + laneFresh=true).
+   * Quiet-but-live workers (stale lane, live descendants) have `active: false`.
+   * The `[live]` badge the monitor/statusline show.
    */
   active: boolean;
-  /** Explicit verdict derived once from pid identity + activity freshness. */
+  /** Explicit three-way verdict derived from the evaluator:
+   * - `"active"` — lane fresh (evaluator status "alive" + laneFresh=true)
+   * - `"quiet-but-live"` — alive via cross-check, or unknown (container)
+   * - `"dead"` — evaluator status "stalled" */
   liveness: WorkerLivenessVerdict;
+  /** Raw red-castle evaluator verdict (ADR 0083 §3). The single source of truth
+   * every rendering surface and the fleet reaper consume. */
+  livenessVerdict: LivenessVerdict;
 }
+
+/** Display threshold: lane records this old → not "active". Matches the old
+ * WORKER_LIVE_MAX_AGE_S semantics used by the monitor/statusline. */
+export const LIVENESS_LANE_IDLE_MS = 180_000;
 
 /** Liveness injection for {@link readWorkerState} (tests / determinism). */
 export interface WorkerStateReadOpts {
@@ -51,6 +69,45 @@ export interface WorkerStateReadOpts {
   /** pid identity probe. Defaults to Linux `/proc`; empty legacy state falls
    * back to pid-only liveness. */
   pidStartTime?: PidStartTimeProbe;
+  /**
+   * Sandbox provider tag for cross-check arming. Defaults to `"none"` (arms
+   * the descendant probe for local, no-sandbox workers). Pass `"bind-mount"` or
+   * `"isolated"` to disarm it for container workers where the host process tree
+   * is blind to the agent.
+   */
+  sandboxTag?: SandboxTag;
+  /**
+   * Override for the liveness lane newest-record epoch (ms). When provided, the
+   * reader skips the disk read and uses this value directly — useful in tests to
+   * drive the evaluator without writing real lane files.
+   */
+  laneRecencyMs?: number;
+  /**
+   * Override for the `ps -eo pid=,ppid=` snapshot the descendant probe reads.
+   * Injected in tests so the cross-check can be driven without real process
+   * trees.
+   */
+  psSnapshot?: () => string;
+}
+
+/** Sync read of the newest liveness lane record timestamp (epoch-ms), or
+ * `undefined` when the lane file is absent / empty / unreadable. */
+function readLivenessRecencySync(lanePath: string): number | undefined {
+  try {
+    const raw = readFileSync(lanePath, "utf-8");
+    const records = parseLivenessRecords(raw);
+    if (records.length === 0) return undefined;
+    return records.reduce((max, r) => (r.at > max ? r.at : max), records[0]!.at);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Map evaluator status to the three-way `WorkerLivenessVerdict` display field. */
+function verdictToLiveness(v: LivenessVerdict): WorkerLivenessVerdict {
+  if (v.status === "stalled") return "dead";
+  if (v.status === "alive" && v.laneFresh) return "active";
+  return "quiet-but-live";
 }
 
 /**
@@ -76,14 +133,47 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
     return null;
   }
   const nowMs = opts.nowMs ?? Date.now();
-  const live = isStateLive(state, opts.kill, opts.pidStartTime);
-  const active = isStateActive(state, nowMs, opts.kill, undefined, opts.pidStartTime);
+
+  // Liveness lane recency — injected directly in tests, read from disk otherwise.
+  const laneRecencyMs =
+    opts.laneRecencyMs !== undefined
+      ? opts.laneRecencyMs
+      : readLivenessRecencySync(join(dirname(path), LIVENESS_LANE_FILENAME));
+
+  // Cross-check arming: host process tree is visible only for local (no-sandbox) workers.
+  const { crossCheckArmed } = resolveLivenessCrossCheckArming({ sandboxTag: opts.sandboxTag ?? "none" });
+
+  // Descendant probe: armed only when cross-check is enabled and the pid is valid.
+  const hasLiveDescendants =
+    crossCheckArmed && state.pid > 0
+      ? createProcessDescendantProbe({ agentPid: state.pid, snapshot: opts.psSnapshot })
+      : undefined;
+
+  const livenessVerdict = evaluateLiveness({
+    laneRecencyMs,
+    now: nowMs,
+    laneIdleMs: LIVENESS_LANE_IDLE_MS,
+    crossCheckArmed,
+    hasLiveDescendants,
+  });
+
+  const liveness = verdictToLiveness(livenessVerdict);
+  // live: true when the evaluator does NOT say "stalled" (includes "alive" and "unknown"/container).
+  // Replaces the old isStateLive-only pid check; the evaluator's cross-check already reads
+  // the process tree so a pid-alive but descendant-less worker is correctly marked dead.
+  const live = livenessVerdict.status !== "stalled";
+  // active: lane fresh only (laneFresh=true), NOT just any "alive" status. A worker whose lane
+  // is idle but has live descendants is "quiet-but-live" — it holds resources but is not actively
+  // iterating, so surfaces show it as inactive (no [live] badge in the monitor/statusline).
+  const active = liveness === "active";
+
   return {
     path,
     state,
     live,
     active,
-    liveness: active ? "active" : live ? "quiet-but-live" : "dead",
+    liveness,
+    livenessVerdict,
   };
 }
 
@@ -106,7 +196,13 @@ export async function readWorkerStates(root: string, opts: WorkerStatesReadOpts 
   const files = await glob(root);
   const out: WorkerStateRecord[] = [];
   for (const file of files) {
-    const rec = readWorkerState(file, { nowMs, kill: opts.kill, pidStartTime: opts.pidStartTime });
+    const rec = readWorkerState(file, {
+      nowMs,
+      kill: opts.kill,
+      pidStartTime: opts.pidStartTime,
+      sandboxTag: opts.sandboxTag,
+      psSnapshot: opts.psSnapshot,
+    });
     if (rec !== null) out.push(rec);
   }
   return out;

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -4,20 +4,28 @@
 // Mirrors the slot→worker→iter-dir resolution chain in supervisor.sh:
 //   parse_worker_ids_from_log  (slot log → worker IDs)
 //   find_slot_iter_dir         (slot pid → worker dir → newest attempt dir)
-//   find_slot_agent_lane       (iter dir → agent.log.jsonl mtime)
+//   workerLivenessFor          (iter dir → liveness lane → evaluator verdict)
 //   iter_dirs_for_worker       (worker dir → every attempt dir)
 //   iter_dir_issue_number      (afk.state.json → .current.number)
 //   reap_stalled_slot reads    (notes, afk.log tail, duration)
 //
 // Every export is BEST-EFFORT: a failed read / stat / glob degrades to the safe
-// value (mtime 0, null iter dir, empty sweep work) and never throws out of a
-// SupervisorFs closure — the bash `|| true` cleanups.
+// value (null verdict, null iter dir, empty sweep work) and never throws out of
+// a SupervisorFs closure — the bash `|| true` cleanups.
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { IterDirInfo, SweepWork, SweepWorker } from "../core/supervisor.js";
 import { parseWorkerAttemptPath, workerDir } from "../core/worker-paths.js";
 import { readWorkerState } from "../core/worker-state-reader.js";
+import {
+  evaluateLiveness,
+  resolveLivenessCrossCheckArming,
+  createProcessDescendantProbe,
+  parseLivenessRecords,
+  LIVENESS_LANE_FILENAME,
+  type LivenessVerdict,
+} from "@reddb-io/red-castle";
 
 /** Absolute path of a slot's per-worker stdout/stderr log
  * (`afk-supervisor-slot-{slot}.log`). Mirrors spawn_slot's slot_log. */
@@ -136,21 +144,59 @@ export function findSlotIterDir(tmpDir: string, slotPid: number | null): string 
 }
 
 /**
- * agentLaneMtime backing: resolve the slot's live worker via the slot log, then
- * its current attempt's agent.log.jsonl mtime in whole seconds; 0 when absent.
- * Mirrors find_slot_agent_lane + the `stat -c %Y` read. The slot's live pid is
- * the bridge from log-parsed worker IDs to the running worker.pid match — but
- * since the supervisor already holds the slot pid, we resolve the iter dir
- * directly from it (find_slot_iter_dir), which is exactly what bash does. The
- * slot-log parse is retained for sweep work; here pid resolution is enough.
+ * workerLivenessVerdict backing: resolve the slot's iter dir, read the liveness
+ * lane (ADR 0083 §3), and evaluate via the red-castle evaluator. Returns null
+ * when the iter dir cannot be resolved (worker between iterations or pre-claim).
+ * Best-effort: any read/parse failure degrades to null.
  */
-export function agentLaneMtimeFor(tmpDir: string, slotPid: number | null): number {
+export function workerLivenessFor(
+  tmpDir: string,
+  slotPid: number | null,
+  laneIdleMs: number,
+): LivenessVerdict | null {
   const dir = findSlotIterDir(tmpDir, slotPid);
-  if (dir === null) return 0;
+  if (dir === null) return null;
+
+  // Read liveness lane synchronously (mirrors readLivenessRecencySync in worker-state-reader).
+  let laneRecencyMs: number | undefined;
   try {
-    return Math.floor(statSync(join(dir, "agent.log.jsonl")).mtimeMs / 1000);
+    const raw = readFileSync(join(dir, LIVENESS_LANE_FILENAME), "utf-8");
+    const records = parseLivenessRecords(raw);
+    if (records.length > 0) {
+      laneRecencyMs = records.reduce((max, r) => (r.at > max ? r.at : max), records[0]!.at);
+    }
   } catch {
-    return 0;
+    // absent or unreadable → undefined (lane never written or raced away)
+  }
+
+  // Cross-check: armed for local (no-sandbox) workers — container workers use a
+  // different execution path and are not managed by the fleet supervisor.
+  const { crossCheckArmed } = resolveLivenessCrossCheckArming({ sandboxTag: "none" });
+
+  // Worker pid from the state file for the descendant probe.
+  let agentPid = 0;
+  try {
+    const rec = readWorkerState(join(dir, "afk.state.json"));
+    if (rec !== null) agentPid = rec.state.pid;
+  } catch {
+    // best-effort
+  }
+
+  const hasLiveDescendants =
+    crossCheckArmed && agentPid > 0
+      ? createProcessDescendantProbe({ agentPid })
+      : undefined;
+
+  try {
+    return evaluateLiveness({
+      laneRecencyMs,
+      now: Date.now(),
+      laneIdleMs,
+      crossCheckArmed,
+      hasLiveDescendants,
+    });
+  } catch {
+    return null;
   }
 }
 

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -21,6 +21,14 @@ import { parseAttemptTimeout, parseMaxIterations } from "../core/execution.js";
 import { resolveLaneIdleStallConfig, type LaneIdleStallConfig } from "../core/lane-idle-reaper.js";
 import { inspectProcessTreeNative } from "./proc-tree.js";
 import { statSync } from "node:fs";
+import {
+  evaluateLiveness,
+  resolveLivenessCrossCheckArming,
+  createProcessDescendantProbe,
+  parseLivenessRecords,
+  LIVENESS_LANE_FILENAME,
+  type LivenessVerdict,
+} from "@reddb-io/red-castle";
 import type { BranchRef } from "../core/branch-cleanup.js";
 import { isRunner, type Runner } from "../types/runner.js";
 import * as ghx from "./gh.js";
@@ -236,17 +244,40 @@ export function resolveRunSettings(
   };
 }
 
-/** mtime of the solo attempt's agent lane (`agent.log.jsonl`) in whole epoch
- * seconds, 0 when the lane does not exist yet / cannot be stat'd. The clean
- * liveness signal the solo lane-idle reaper keys off — mirrors the fleet
- * `agentLaneMtimeFor` stat, but resolved directly from the attempt dir the solo
- * worker already holds (no slot-pid round-trip). Best-effort: any stat failure
- * degrades to 0 (no lane observed), which computeStalled never flags. */
-export function agentLaneMtimeSeconds(lanePath: string): number {
+/**
+ * Red-castle liveness evaluator verdict for the solo attempt's liveness lane
+ * (`liveness.lane.jsonl`). Reads and parses the lane synchronously, then calls
+ * `evaluateLiveness` with the configured idle threshold and a process cross-check
+ * (no-sandbox only, matching the fleet path). Returns null on any read failure
+ * (lane not yet written degrades gracefully to null → not-candidate this tick).
+ *
+ * Replaces the old `agentLaneMtimeSeconds` firehose-mtime probe (#1022): the
+ * liveness lane is the un-poisonable signal that the substrate's own control
+ * flow refreshes — never afk.log / agent.log.jsonl / the heartbeat (#243).
+ */
+export function agentLivenessVerdictSync(
+  attemptDir: string,
+  laneIdleMs: number,
+): LivenessVerdict | null {
+  const lanePath = join(attemptDir, LIVENESS_LANE_FILENAME);
+  let laneRecencyMs: number | undefined;
   try {
-    return Math.floor(statSync(lanePath).mtimeMs / 1000);
+    const raw = readFileSync(lanePath, "utf-8");
+    const records = parseLivenessRecords(raw);
+    if (records.length > 0) {
+      laneRecencyMs = records.reduce((max, r) => (r.at > max ? r.at : max), records[0]!.at);
+    }
   } catch {
-    return 0;
+    // Lane absent or unreadable → laneRecencyMs stays undefined.
+  }
+  const { crossCheckArmed } = resolveLivenessCrossCheckArming({ sandboxTag: "none" });
+  const hasLiveDescendants = crossCheckArmed
+    ? createProcessDescendantProbe({ agentPid: process.pid })
+    : undefined;
+  try {
+    return evaluateLiveness({ laneRecencyMs, now: Date.now(), laneIdleMs, crossCheckArmed, hasLiveDescendants });
+  } catch {
+    return null;
   }
 }
 
@@ -397,9 +428,10 @@ export function makeRunAgent(
             laneIdleThresholdSeconds: laneIdleCfg.stallThresholdS,
             laneIdleKillThresholdSeconds: laneIdleCfg.stallKillThresholdS,
             laneIdlePollSeconds: laneIdleCfg.stallPollS,
-            // Clean liveness signal: the attempt's agent.log.jsonl mtime in whole
-            // seconds, 0 when absent — NEVER afk.log / the firehose (#243).
-            laneMtimeProbe: () => agentLaneMtimeSeconds(`${laneAttemptDir}/agent.log.jsonl`),
+            // Clean liveness signal: the evaluator over the attempt's
+            // liveness.lane.jsonl — the un-poisonable lane (#1022, ADR 0083 §3).
+            livenessVerdictProbe: () =>
+              agentLivenessVerdictSync(laneAttemptDir, laneIdleCfg.stallThresholdS * 1000),
             // Inner-agent tree is a descendant of this worker process; the native
             // inspector is safe-by-default (a failed ps reports busy, never reaps).
             inspectTree: () => inspectProcessTreeNative(process.pid),
@@ -487,14 +519,13 @@ export async function readFleetState(path: string): Promise<FleetState | null> {
 export async function collectMonitorInputs(root = process.cwd()): Promise<MonitorInputs> {
   const paths = afkPaths(root);
   // The ONE owner reads + normalizes + liveness-tags every worker state file
-  // (core/worker-state-reader). The dashboard's `[live]` badge uses the
-  // pid-identity + freshness verdict (`active`); the `[quiet]` badge falls back
-  // to the pid-identity verdict (`live`, surfaced here as `pidLive`).
+  // (core/worker-state-reader). The single source of liveness truth for all
+  // surfaces is WorkerStateRecord.livenessVerdict (evaluator verdict, ADR 0083 §3).
   const records = await readWorkerStates(paths.workersRoot);
   const logPaths = records.map(({ path, state }) => state.log || join(dirname(path), "afk.log"));
   const logCounts = await collectLogLineCounts(paths.monitorLogCursorPath, logPaths);
   const workers: CompactWorker[] = [];
-  for (const { path, state, active, live: pidLive, liveness } of records) {
+  for (const { path, state, active, live: pidLive, liveness, livenessVerdict } of records) {
     // Diff volume: committed + uncommitted work for the attempt, measured from
     // the branch's merge-base with origin/main. Prefer the state file's persisted
     // counts; fall back to a live `git diff --shortstat` of the worktree when both
@@ -541,10 +572,10 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
         },
       },
       liveness,
-      // active = pid identity matches + agent-lane freshness → [live] badge.
-      // pidLive = pid identity matches regardless of freshness → [quiet] badge
-      // when the agent lane is idle (e.g. post_attempt gate/commit) but the
-      // process still lives.
+      livenessVerdict,
+      // active = evaluator says "alive" → [live] badge.
+      // pidLive kept for backward compat with older test stubs (ignored when
+      // livenessVerdict is present).
       live: active,
       pidLive,
       diffAdded: added,
@@ -661,17 +692,14 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   const aliveMsList: number[] = [];
   const sourceMap = new Map<string, number>();
 
-  for (const { state, live } of records) {
-    // Statusline line 2 counts every pid-live worker (the orchestrator process is
-    // alive), NOT only "fresh" ones (#836). The agent stream legitimately goes
-    // silent for minutes during the feedback gate / long builds — the per-minute
-    // heartbeat even stops at post_attempt — so an `active` (180s freshness) gate
-    // dropped a busy worker and made line 2 VANISH mid-test, reading as "fleet
-    // died." A finished worker sets pid:0 (split teardown) and its dir is reclaimed
-    // by the completion sweep, so it still drops here; only a SIGKILL'd worker with
-    // an OS-recycled pid can briefly ghost (bounded by the boot sweep). The record's
-    // `active` flag stays available for a future per-worker quiet badge.
-    if (!live) continue;
+  for (const { state, livenessVerdict } of records) {
+    // Statusline counts workers the evaluator does not consider stalled. A busy
+    // worker with live agent descendants shows as "alive" even when the liveness
+    // lane is silent (wedged-substrate guard in the evaluator), so a long
+    // build/gate wait no longer makes the AFK block vanish. "unknown" (container
+    // workers) is treated conservatively as live. Only "stalled" (stale lane AND
+    // no live descendants) is excluded.
+    if (livenessVerdict.status === "stalled") continue;
 
     workers += 1;
     blocked += state.blocked;

--- a/apps/dev/tests/companion-io.test.ts
+++ b/apps/dev/tests/companion-io.test.ts
@@ -26,6 +26,7 @@ function record(issue: number, attempt: number, current: Record<string, unknown>
     live,
     active: live,
     liveness: live ? "active" : "dead",
+    livenessVerdict: { status: live ? "alive" : "stalled", laneFresh: live, crossCheckArmed: false, reason: "" },
   };
 }
 

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { RunOptions, RunResult } from "@reddb-io/red-castle";
+import type { RunOptions, RunResult, LivenessVerdict } from "@reddb-io/red-castle";
 import {
   buildRunOptions,
   buildContinuousPushHook,
@@ -1803,6 +1803,15 @@ describe("runAgent — lane-idle reaper wiring", () => {
       schedule: sched.schedule,
       makeAbortController: () => controller,
     };
+    // Probe: lane was last written at spawn (BASE_MS). Returns stalled once
+    // clock passes the stallThresholdS (600s = 600_000ms).
+    const livenessVerdictProbe = (): LivenessVerdict | null => {
+      const idleMs = clock - BASE_MS;
+      if (idleMs >= 600_000) {
+        return { status: "stalled", laneFresh: false, laneAgeMs: idleMs, crossCheckArmed: false, reason: "lane idle" };
+      }
+      return { status: "alive", laneFresh: true, laneAgeMs: idleMs, crossCheckArmed: false, reason: "lane fresh" };
+    };
     const p = runAgent(deps, {
       ...baseInput,
       laneIdleThresholdSeconds: 600,
@@ -1810,7 +1819,7 @@ describe("runAgent — lane-idle reaper wiring", () => {
       laneIdlePollSeconds: 30,
       // Lane last wrote at spawn; a sleep-only inner child — no agent turns, no
       // build/test descendant under the tree, flat cpu.
-      laneMtimeProbe: () => BASE_S,
+      livenessVerdictProbe,
       inspectTree: () => [{ command: "sleep", cpu: 0 }],
     });
     await sched.tick(); // worker age 0 → not yet a candidate
@@ -1833,11 +1842,18 @@ describe("runAgent — lane-idle reaper wiring", () => {
       schedule: sched.schedule,
       makeAbortController: () => controller,
     };
+    const livenessVerdictProbe2 = (): LivenessVerdict | null => {
+      const idleMs = clock - BASE_MS;
+      if (idleMs >= 600_000) {
+        return { status: "stalled", laneFresh: false, laneAgeMs: idleMs, crossCheckArmed: false, reason: "lane idle" };
+      }
+      return { status: "alive", laneFresh: true, laneAgeMs: idleMs, crossCheckArmed: false, reason: "lane fresh" };
+    };
     const p = runAgent(deps, {
       ...baseInput,
       laneIdleThresholdSeconds: 600,
       laneIdleKillThresholdSeconds: 1800,
-      laneMtimeProbe: () => BASE_S,
+      livenessVerdictProbe: livenessVerdictProbe2,
       inspectTree: () => [{ command: "vitest", cpu: 0 }], // a test run mid-flight
     });
     clock = BASE_MS + 9999_000; // idle far past kill, but busy → never reaped

--- a/apps/dev/tests/fleet-hooks.test.ts
+++ b/apps/dev/tests/fleet-hooks.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../src/core/fleet-hook-config.js";
 import type { ProcessSnapshotEntry } from "../src/core/reaper-signal.js";
 import type { HookExec } from "../src/core/hook-dispatcher.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 
 const NOW = 1700000000;
 
@@ -66,7 +67,7 @@ interface FakeIo {
   inspectTree: ReturnType<typeof vi.fn>;
   sleep: ReturnType<typeof vi.fn>;
   lastExitCode: ReturnType<typeof vi.fn>;
-  agentLaneMtime: ReturnType<typeof vi.fn>;
+  workerLivenessVerdict: ReturnType<typeof vi.fn>;
   resolveIterDir: ReturnType<typeof vi.fn>;
   teardownIterDir: ReturnType<typeof vi.fn>;
   parkedSlotWork: ReturnType<typeof vi.fn>;
@@ -96,7 +97,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
     sleep: vi.fn((_ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 0))),
     lastExitCode: vi.fn((_slot: number) => null as number | null),
-    agentLaneMtime: vi.fn(() => 0),
+    workerLivenessVerdict: vi.fn((): LivenessVerdict | null => null),
     resolveIterDir: vi.fn((): IterDirInfo | null => null),
     teardownIterDir: vi.fn(async () => {}),
     parkedSlotWork: vi.fn(
@@ -126,7 +127,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       sleep: io.sleep,
     },
     fs: {
-      agentLaneMtime: io.agentLaneMtime,
+      workerLivenessVerdict: io.workerLivenessVerdict,
       resolveIterDir: io.resolveIterDir,
       teardownIterDir: io.teardownIterDir,
       parkedSlotWork: io.parkedSlotWork,
@@ -441,8 +442,8 @@ describe("supervisor: on_stall_reap veto", () => {
     slot.stallSinceEpoch = NOW - 200; // stalled for 200s > stallKillThresholdS(90)
 
     const cfg = config({ stallThresholdS: 30, stallKillThresholdS: 90 });
-    // agentLaneMtime returns a mtime that keeps stall flagged.
-    io.agentLaneMtime.mockReturnValue(NOW - 200);
+    // workerLivenessVerdict returns stalled to keep the slot flagged.
+    io.workerLivenessVerdict.mockReturnValue({ status: "stalled", laneFresh: false, laneAgeMs: 200_000, crossCheckArmed: true, liveDescendants: false, reason: "lane idle" });
 
     await pollStallDetector(state, deps, cfg);
 
@@ -471,7 +472,7 @@ describe("supervisor: on_stall_reap veto", () => {
     slot.stallSinceEpoch = NOW - 200;
 
     const cfg = config({ stallThresholdS: 30, stallKillThresholdS: 90 });
-    io.agentLaneMtime.mockReturnValue(NOW - 200);
+    io.workerLivenessVerdict.mockReturnValue({ status: "stalled", laneFresh: false, laneAgeMs: 200_000, crossCheckArmed: true, liveDescendants: false, reason: "lane idle" });
 
     const reaped = await pollStallDetector(state, deps, cfg);
 
@@ -495,7 +496,7 @@ describe("supervisor: on_stall_reap veto", () => {
     slot.stallSinceEpoch = NOW - 200;
 
     const cfg = config({ stallThresholdS: 30, stallKillThresholdS: 90 });
-    io.agentLaneMtime.mockReturnValue(NOW - 200);
+    io.workerLivenessVerdict.mockReturnValue({ status: "stalled", laneFresh: false, laneAgeMs: 200_000, crossCheckArmed: true, liveDescendants: false, reason: "lane idle" });
 
     const reaped = await pollStallDetector(state, deps, cfg);
 
@@ -580,7 +581,7 @@ describe("supervisor: on_stall_detected", () => {
     // idleTime = 50s > stallThresholdS(30) → flagged, but 50 < stallKillThresholdS(90)
     // so the first poll detects the stall but does NOT reap, keeping slot.stalled=true
     // across both polls and preventing a second on_stall_detected from firing.
-    io.agentLaneMtime.mockReturnValue(NOW - 50);
+    io.workerLivenessVerdict.mockReturnValue({ status: "stalled", laneFresh: false, laneAgeMs: 50_000, crossCheckArmed: true, liveDescendants: false, reason: "lane idle" });
 
     const cfg = config({ stallThresholdS: 30, stallKillThresholdS: 90 });
 

--- a/apps/dev/tests/lane-idle-reaper.test.ts
+++ b/apps/dev/tests/lane-idle-reaper.test.ts
@@ -6,6 +6,7 @@ import {
   type LaneIdleInfo,
   type LaneIdleReaperOptions,
 } from "../src/core/lane-idle-reaper.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 
 /** A manual scheduler: captures the periodic fn so the test pumps ticks
  * synchronously (the lane reaper's poll body is synchronous — statSync / ps). */
@@ -28,19 +29,54 @@ const SOFT = 600;
 const KILL = 1800;
 // A realistic epoch anchor: the run spawned at BASE and the agent lane was last
 // written at BASE (the fleet detector requires both spawnEpoch > 0 AND
-// laneMtime > 0 — a never-observed lane / uninitialised spawn is never flagged).
+// lane was recently written — a never-observed lane is never flagged as stalled).
 const BASE = 1_000_000;
+
+/**
+ * Build a fake livenessVerdict probe driven by epoch-second lane-time and clock
+ * functions. Mirrors the evaluator's logic without importing it: lane present
+ * and idle ≥ SOFT (no live descendants) → stalled; idle < SOFT → alive. A zero
+ * laneTimeS (unseen lane) → returns null (not-candidate).
+ */
+function makeVerdictFn(
+  laneTimeS: () => number,
+  clockFn: () => number,
+  softS: number,
+): () => LivenessVerdict | null {
+  return (): LivenessVerdict | null => {
+    const lt = laneTimeS();
+    if (lt === 0) return null;
+    const idleMs = (clockFn() - lt) * 1000;
+    if (idleMs >= softS * 1000) {
+      return {
+        status: "stalled",
+        laneFresh: false,
+        laneAgeMs: idleMs,
+        crossCheckArmed: false,
+        reason: "lane idle",
+      };
+    }
+    return {
+      status: "alive",
+      laneFresh: true,
+      laneAgeMs: idleMs,
+      crossCheckArmed: false,
+      reason: "lane fresh",
+    };
+  };
+}
 
 /** Build reaper options anchored at BASE; `over` overrides per test. */
 function makeOpts(over: Partial<LaneIdleReaperOptions> = {}): LaneIdleReaperOptions {
+  const clock = () => BASE;
   return {
     spawnEpoch: BASE,
     stallThresholdS: SOFT,
     stallKillThresholdS: KILL,
     intervalMs: 30_000,
-    laneMtime: () => BASE,
+    livenessVerdict: makeVerdictFn(() => BASE, clock, SOFT),
     inspectTree: () => [],
-    now: () => BASE,
+    now: clock,
     schedule: () => () => {},
     abort: () => {},
     ...over,
@@ -58,7 +94,7 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
     const r = startLaneIdleReaper(
       makeOpts({
         now: () => clock,
-        laneMtime: () => BASE,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [{ command: "sleep", cpu: 0 }], // idle child, flat cpu
         schedule: sched.schedule,
         abort: () => {
@@ -83,7 +119,7 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
     startLaneIdleReaper(
       makeOpts({
         now: () => clock,
-        laneMtime: () => BASE,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [],
         schedule: sched.schedule,
         abort: () => {
@@ -100,11 +136,12 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
   // ---- AC2: an active vitest/tsc descendant past threshold is NOT killed ----
   it("never reaps a worker with an active vitest descendant, even idle past the kill threshold", () => {
     let aborted = false;
+    const clock = BASE + 99_999;
     const sched = manualScheduler();
     const r = startLaneIdleReaper(
       makeOpts({
-        now: () => BASE + 99_999, // idle far past the kill threshold
-        laneMtime: () => BASE,
+        now: () => clock,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [
           { command: "node", cpu: 0 },
           { command: "vitest", cpu: 0 }, // a test run blocked on I/O at ~0% cpu
@@ -122,11 +159,12 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
 
   it("never reaps a worker with an active tsc descendant past the threshold", () => {
     let aborted = false;
+    const clock = BASE + 99_999;
     const sched = manualScheduler();
     startLaneIdleReaper(
       makeOpts({
-        now: () => BASE + 99_999,
-        laneMtime: () => BASE,
+        now: () => clock,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [{ command: "tsc", cpu: 0 }],
         schedule: sched.schedule,
         abort: () => {
@@ -140,11 +178,12 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
 
   it("never reaps a worker showing non-trivial aggregate cpu (busy without a named tool)", () => {
     let aborted = false;
+    const clock = BASE + 99_999;
     const sched = manualScheduler();
     startLaneIdleReaper(
       makeOpts({
-        now: () => BASE + 99_999,
-        laneMtime: () => BASE,
+        now: () => clock,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [{ command: "node", cpu: 73.4 }],
         schedule: sched.schedule,
         abort: () => {
@@ -156,17 +195,18 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
     expect(aborted).toBe(false);
   });
 
-  // ---- candidacy gating (fleet detector reuse) ----
+  // ---- candidacy gating (spawn epoch guard) ----
   it("does not reap a freshly-spawned worker (worker age below the soft threshold)", () => {
     let aborted = false;
     const sched = manualScheduler();
+    const clock = BASE + 100;
     // worker only 100s old (now-spawnEpoch=100 < soft 600) → not a candidate even
-    // though the lane has been idle since spawn.
+    // though the lane is stale; the spawn guard fires before the verdict is consulted.
     startLaneIdleReaper(
       makeOpts({
         spawnEpoch: BASE,
-        now: () => BASE + 100,
-        laneMtime: () => BASE,
+        now: () => clock,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [],
         schedule: sched.schedule,
         abort: () => {
@@ -178,14 +218,15 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
     expect(aborted).toBe(false);
   });
 
-  it("never treats an unseen lane (mtime 0) as a stall", () => {
+  it("never treats an unseen lane (verdict null) as a stall", () => {
     let aborted = false;
     const sched = manualScheduler();
+    const clock = BASE + 99_999;
     startLaneIdleReaper(
       makeOpts({
         spawnEpoch: BASE,
-        now: () => BASE + 99_999,
-        laneMtime: () => 0, // lane never observed → computeStalled returns false
+        now: () => clock,
+        livenessVerdict: makeVerdictFn(() => 0, () => clock, SOFT), // 0 → returns null
         inspectTree: () => [],
         schedule: sched.schedule,
         abort: () => {
@@ -206,7 +247,7 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
       makeOpts({
         spawnEpoch: BASE,
         now: () => clock,
-        laneMtime: () => lane,
+        livenessVerdict: makeVerdictFn(() => lane, () => clock, SOFT),
         inspectTree: () => [],
         schedule: sched.schedule,
         abort: () => {
@@ -234,13 +275,13 @@ describe("startLaneIdleReaper — reuses the fleet detector + reaper-signal pred
       makeOpts({
         spawnEpoch: BASE,
         now: () => clock,
-        laneMtime: () => BASE,
+        livenessVerdict: makeVerdictFn(() => BASE, () => clock, SOFT),
         inspectTree: () => [],
         schedule: sched.schedule,
         onTick: (i) => ticks.push(i),
       }),
     );
-    clock = BASE + 100; // worker age below soft → not-candidate
+    clock = BASE + 100; // worker age below soft → not-candidate (spawn guard)
     sched.tick();
     clock = BASE + 1000; // stalled, idle below kill → no-kill
     sched.tick();

--- a/apps/dev/tests/supervisor-boot.test.ts
+++ b/apps/dev/tests/supervisor-boot.test.ts
@@ -15,6 +15,7 @@ import {
   type SupervisorDeps,
 } from "../src/core/supervisor.js";
 import type { ProcessSnapshotEntry } from "../src/core/reaper-signal.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 
 const NOW = 1_000_000;
 
@@ -63,7 +64,7 @@ function makeDeps(over: DepsOverrides = {}): {
       lastExitCode: vi.fn(over.lastExitCode ?? (() => null as number | null)),
     },
     fs: {
-      agentLaneMtime: vi.fn(() => 0),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict | null => null),
       resolveIterDir: vi.fn(() => null),
       teardownIterDir: vi.fn(async () => {}),
       parkedSlotWork: vi.fn(() => ({ workers: [], supervisorLogPath: ".red/tmp/afk-supervisor.log" })),

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -6,7 +6,6 @@ import {
   buildCrashEnvelope,
   buildDiscardEnvelope,
   buildReaperEnvelope,
-  computeStalled,
   decideCrashReconcile,
   dispatchReconcileIfPossible,
   reconcileDeadWorkerClaim,
@@ -34,8 +33,32 @@ import {
 } from "../src/core/supervisor.js";
 import { parkedSlotWorkFor, slotLogPath } from "../src/runtime/supervisor-fs.js";
 import type { ProcessSnapshotEntry } from "../src/core/reaper-signal.js";
+import type { LivenessVerdict } from "@reddb-io/red-castle";
 
 const NOW = 1700000000;
+
+/** Build a stalled LivenessVerdict with a given lane age in seconds. */
+function stalledVerdict(laneAgeS: number): LivenessVerdict {
+  return {
+    status: "stalled",
+    laneFresh: false,
+    laneAgeMs: laneAgeS * 1000,
+    crossCheckArmed: true,
+    liveDescendants: false,
+    reason: "lane idle and no live agent descendants",
+  };
+}
+
+/** Build an alive LivenessVerdict (lane fresh). */
+function aliveVerdict(): LivenessVerdict {
+  return {
+    status: "alive",
+    laneFresh: true,
+    laneAgeMs: 1000,
+    crossCheckArmed: true,
+    reason: "lane fresh",
+  };
+}
 
 function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
   return {
@@ -77,7 +100,7 @@ interface FakeIo {
   inspectTree: ReturnType<typeof vi.fn>;
   sleep: ReturnType<typeof vi.fn>;
   lastExitCode: ReturnType<typeof vi.fn>;
-  agentLaneMtime: ReturnType<typeof vi.fn>;
+  workerLivenessVerdict: ReturnType<typeof vi.fn>;
   resolveIterDir: ReturnType<typeof vi.fn>;
   teardownIterDir: ReturnType<typeof vi.fn>;
   parkedSlotWork: ReturnType<typeof vi.fn>;
@@ -115,7 +138,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     sleep: vi.fn((_ms: number) => new Promise<void>((resolve) => setTimeout(resolve, 0))),
     // Default: exit code unknown (null) → treated as non-clean → circuit-breaker path.
     lastExitCode: vi.fn((_slot: number) => null as number | null),
-    agentLaneMtime: vi.fn(() => 0),
+    workerLivenessVerdict: vi.fn((): LivenessVerdict | null => null),
     resolveIterDir: vi.fn((): IterDirInfo | null => null),
     teardownIterDir: vi.fn(async () => {}),
     parkedSlotWork: vi.fn(
@@ -146,7 +169,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       sleep: io.sleep,
     },
     fs: {
-      agentLaneMtime: io.agentLaneMtime,
+      workerLivenessVerdict: io.workerLivenessVerdict,
       resolveIterDir: io.resolveIterDir,
       teardownIterDir: io.teardownIterDir,
       parkedSlotWork: io.parkedSlotWork,
@@ -528,26 +551,7 @@ describe("runSupervisor — lastProgressEpoch tracking (#579)", () => {
   });
 });
 
-// ---------- compute_stalled (pure) ----------
-
-describe("computeStalled", () => {
-  const T = 600;
-  it("fresh worker (alive < threshold) → false", () => {
-    expect(computeStalled(NOW - 100, NOW - 9999, NOW, T)).toBe(false);
-  });
-  it("recent lane activity → false", () => {
-    expect(computeStalled(NOW - 3600, NOW - 60, NOW, T)).toBe(false);
-  });
-  it("old + silent lane → true", () => {
-    expect(computeStalled(NOW - 3600, NOW - 700, NOW, T)).toBe(true);
-  });
-  it("no lane observed yet (mtime 0) → false", () => {
-    expect(computeStalled(NOW - 3600, 0, NOW, T)).toBe(false);
-  });
-  it("uninitialised slot (spawn 0) → false", () => {
-    expect(computeStalled(0, NOW - 9999, NOW, T)).toBe(false);
-  });
-});
+// ---------- pollStallDetector: liveness-evaluator stall detection ----------
 
 // ---------- circuit breaker (pure) ----------
 
@@ -785,7 +789,7 @@ describe("pollStallDetector reaper gating", () => {
   it("does NOT reap a busy slot (reaper-signal says busy)", async () => {
     // An active build/test descendant (vitest) → busy → no-kill.
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "vitest", cpu: 0 }]),
     });
     const state = stalledState();
@@ -801,7 +805,7 @@ describe("pollStallDetector reaper gating", () => {
 
   it("retries a genuinely-stalled slot UNDER the cap (kill + envelope + CLEAN re-queue)", async () => {
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       // No build/test descendant, flat cpu → genuinely stuck.
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
       resolveIterDir: vi.fn(
@@ -853,7 +857,7 @@ describe("pollStallDetector reaper gating", () => {
     // labels rotate, but the destructive `rm -rf` teardown is skipped so it can
     // never race a still-live worker still writing into the worktree.
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
       killTree: vi.fn(async () => false),
       resolveIterDir: vi.fn(
@@ -884,7 +888,7 @@ describe("pollStallDetector reaper gating", () => {
 
   it("tears down the worktree when killTree confirms death (#580)", async () => {
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
       killTree: vi.fn(async () => true),
       resolveIterDir: vi.fn(
@@ -909,7 +913,7 @@ describe("pollStallDetector reaper gating", () => {
 
   it("reaps without posting when the worker died pre-claim (no issue)", async () => {
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
       resolveIterDir: vi.fn(
         (): IterDirInfo => ({
@@ -936,7 +940,7 @@ describe("pollStallDetector reaper gating", () => {
 
   it("escalates to ready-for-human once the stalled re-claim cap is exhausted (#402)", async () => {
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
       resolveIterDir: vi.fn(
         (): IterDirInfo => ({
@@ -971,7 +975,7 @@ describe("pollStallDetector reaper gating", () => {
 
   it("honours RED_AFK_RETRY_STALLED to extend the re-claim budget (#402)", async () => {
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 120),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(120)),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
       resolveIterDir: vi.fn(
         (): IterDirInfo => ({
@@ -993,6 +997,75 @@ describe("pollStallDetector reaper gating", () => {
 
     expect(io.ensureLabel).not.toHaveBeenCalled();
     expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent"], ["running"]);
+  });
+});
+
+// ---------- AC3: evaluator cross-check guards the kill ----------
+
+describe("pollStallDetector — live descendants prevent kill (AC3 / ADR 0083)", () => {
+  // Pre-set the slot as stalled past the kill threshold so each test reaches the
+  // kill-gate without needing to test full stall detection.
+  function stalledSlot() {
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.pid = 4242;
+    slot.spawnEpoch = NOW - 9999;
+    slot.stalled = true;
+    slot.stallSinceEpoch = NOW - 120; // 120s > stallKillThresholdS(90)
+    return state;
+  }
+
+  it("stale lane + no live descendants → kill", async () => {
+    const { deps, io } = makeDeps({
+      // Evaluator: stalled (lane idle, no live descendants)
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => ({
+        status: "stalled",
+        laneFresh: false,
+        laneAgeMs: 120_000,
+        crossCheckArmed: true,
+        liveDescendants: false,
+        reason: "lane idle and no live agent descendants",
+      })),
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => [{ command: "node", cpu: 0 }]),
+      resolveIterDir: vi.fn(
+        (): IterDirInfo => ({
+          path: "/w/wTEST/42-a1",
+          issue: 42,
+          workerId: "wTEST",
+          logTail: "stalled",
+          notes: "",
+          durationS: 120,
+          attempt: 1,
+        }),
+      ),
+    });
+    const state = stalledSlot();
+
+    const reaped = await pollStallDetector(state, deps, config());
+
+    expect(reaped).toEqual([0]);
+    expect(io.killTree).toHaveBeenCalledWith(4242);
+  });
+
+  it("live agent descendants → no kill even with a stale lane", async () => {
+    const { deps, io } = makeDeps({
+      // Evaluator: alive via cross-check (wedged substrate but agent still running)
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => ({
+        status: "alive",
+        laneFresh: false,
+        laneAgeMs: 120_000,
+        crossCheckArmed: true,
+        liveDescendants: true,
+        reason: "lane idle but live agent descendants",
+      })),
+      inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
+    });
+    const state = stalledSlot();
+
+    const reaped = await pollStallDetector(state, deps, config());
+
+    expect(reaped).toEqual([]);
+    expect(io.killTree).not.toHaveBeenCalled();
   });
 });
 
@@ -1528,7 +1601,7 @@ describe("idle-drain: exit 0 idle-parks without tripping the circuit breaker", (
     // A slot that idle-parked has no live process; the stall detector must not
     // try to inspect or reap it (it has no pid and no lane to measure).
     const { deps, io } = makeDeps({
-      agentLaneMtime: vi.fn(() => NOW - 9999),
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(9999)),
       readyQueueDepth: vi.fn(async () => 0),
     });
     const state = initSupervisorState(1);
@@ -1751,7 +1824,7 @@ describe("superviseTick — reconciledSlots accounting (#562)", () => {
   function stalledSlotDeps(candidate: ReconcileCandidate | null) {
     return makeDeps({
       isAlive: vi.fn(() => true), // pid alive so step 2 never respawns
-      agentLaneMtime: vi.fn(() => NOW - 1000), // agent lane silent for 1000s
+      workerLivenessVerdict: vi.fn((): LivenessVerdict => stalledVerdict(1000)), // agent lane silent for 1000s
       now: vi.fn(() => NOW),
       inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []), // no active → "kill"
       resolveIterDir: vi.fn(() => null),

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -3,12 +3,27 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { readWorkerState, readWorkerStates } from "../src/core/worker-state-reader.js";
+import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 
 const NOW = Date.UTC(2026, 5, 22, 12, 0, 0);
 const fresh = new Date(NOW - 5_000).toISOString();
 const old = new Date(NOW - 10 * 60_000).toISOString();
-const aliveKill = (): boolean => true;
-const deadKill = (): boolean => false;
+// Lane timestamps: fresh = 5s ago (within LIVENESS_LANE_IDLE_MS=180s),
+// stale = 200s ago (beyond the display threshold).
+const LANE_FRESH_MS = NOW - 5_000;
+const LANE_STALE_MS = NOW - 200_000;
+/** Write a liveness lane file with a single iteration-start record at `atMs`. */
+async function writeLaneLine(dir: string, atMs: number): Promise<void> {
+  await writeFile(
+    join(dir, LIVENESS_LANE_FILENAME),
+    JSON.stringify({ at: atMs, kind: "iteration-start" }) + "\n",
+    "utf8",
+  );
+}
+/** ps snapshot string where `pid` has a child at `childPid`. */
+function psWithChild(pid: number, childPid: number): string {
+  return `1 0\n${pid} 1\n${childPid} ${pid}\n`;
+}
 
 async function writeState(dir: string, raw: unknown): Promise<string> {
   await mkdir(dir, { recursive: true });
@@ -18,14 +33,15 @@ async function writeState(dir: string, raw: unknown): Promise<string> {
 }
 
 describe("worker-state-reader", () => {
-  it("reads a live worker (pid resolves AND recently active)", async () => {
+  it("reads a live worker (fresh liveness lane → active)", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-live-"));
     const path = await writeState(base, {
       worker_id: "wLIVE",
       pid: 4242,
       current: { number: 824, stage: "impl", last_event_at: fresh },
     });
-    const rec = readWorkerState(path, { nowMs: NOW, kill: aliveKill });
+    // Fresh lane → evaluator: "alive", laneFresh: true → "active".
+    const rec = readWorkerState(path, { nowMs: NOW, laneRecencyMs: LANE_FRESH_MS });
     expect(rec).not.toBeNull();
     expect(rec!.state.worker_id).toBe("wLIVE");
     expect(rec!.state.current.number).toBe(824);
@@ -34,29 +50,35 @@ describe("worker-state-reader", () => {
     expect(rec!.liveness).toBe("active");
   });
 
-  it("reads a stale worker as live (pid only) but NOT active (old activity)", async () => {
+  it("reads a stale-lane worker with live descendants as quiet-but-live", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-stale-"));
     const path = await writeState(base, {
       worker_id: "wSTALE",
       pid: 4242,
       current: { number: 7, last_event_at: old },
     });
-    const rec = readWorkerState(path, { nowMs: NOW, kill: aliveKill });
+    // Stale lane (200s > 180s idle) + pid 4242 has a child → "alive" (cross-check).
+    const rec = readWorkerState(path, {
+      nowMs: NOW,
+      laneRecencyMs: LANE_STALE_MS,
+      psSnapshot: () => psWithChild(4242, 9999),
+    });
     expect(rec!.live).toBe(true);
     expect(rec!.active).toBe(false);
     expect(rec!.liveness).toBe("quiet-but-live");
   });
 
-  it("a dead pid is neither live nor active", async () => {
+  it("a worker with a stale lane and no live descendants is dead", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-dead-"));
     const path = await writeState(base, { pid: 4242, current: { last_event_at: fresh } });
-    const rec = readWorkerState(path, { nowMs: NOW, kill: deadKill });
+    // No lane + no descendants → evaluator: "stalled".
+    const rec = readWorkerState(path, { nowMs: NOW, psSnapshot: () => "" });
     expect(rec!.live).toBe(false);
     expect(rec!.active).toBe(false);
     expect(rec!.liveness).toBe("dead");
   });
 
-  it("a recycled pid with a different start time is neither live nor active", async () => {
+  it("a worker whose lane is absent and pid has no descendants is dead (recycled-pid case)", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-reused-pid-"));
     const path = await writeState(base, {
       worker_id: "wOLD",
@@ -64,11 +86,8 @@ describe("worker-state-reader", () => {
       pid_start_time: "old-start",
       current: { last_event_at: fresh },
     });
-    const rec = readWorkerState(path, {
-      nowMs: NOW,
-      kill: aliveKill,
-      pidStartTime: () => "new-start",
-    });
+    // No lane + empty ps snapshot → evaluator: "stalled" regardless of the old pid identity.
+    const rec = readWorkerState(path, { nowMs: NOW, psSnapshot: () => "" });
     expect(rec!.live).toBe(false);
     expect(rec!.active).toBe(false);
     expect(rec!.liveness).toBe("dead");
@@ -90,12 +109,12 @@ describe("worker-state-reader", () => {
         last_progress_at: fresh,
       },
     });
-    const rec = readWorkerState(path, { nowMs: NOW, kill: aliveKill });
+    // Fresh lane → evaluator "alive" so the legacy worker reads active.
+    const rec = readWorkerState(path, { nowMs: NOW, laneRecencyMs: LANE_FRESH_MS });
     expect(rec!.state.current.loc_added).toBe(12);
     expect(rec!.state.current.loc_removed).toBe(3);
     expect(rec!.state.current.reasoning_events).toBe(5);
     expect(rec!.state.current.last_commit_at).toBe(fresh);
-    // last_commit_at is an activity fallback, so the legacy worker still reads active.
     expect(rec!.active).toBe(true);
   });
 
@@ -112,20 +131,26 @@ describe("worker-state-reader", () => {
 
   it("readWorkerStates globs + tags every record, dropping unreadable ones", async () => {
     const root = await mkdtemp(join(tmpdir(), "wsr-many-"));
-    const live = await writeState(join(root, "wA", "1-a1"), {
+    const dirA = join(root, "wA", "1-a1");
+    const dirB = join(root, "wB", "2-a1");
+    const live = await writeState(dirA, {
       worker_id: "wA",
       pid: 1,
       current: { number: 1, last_event_at: fresh },
     });
-    const stale = await writeState(join(root, "wB", "2-a1"), {
+    const stale = await writeState(dirB, {
       worker_id: "wB",
       pid: 2,
       current: { number: 2, last_event_at: old },
     });
+    // Write a fresh liveness lane for wA so it reads "active".
+    await writeLaneLine(dirA, LANE_FRESH_MS);
+    // wB gets a stale lane + a child in the ps snapshot → "quiet-but-live".
+    await writeLaneLine(dirB, LANE_STALE_MS);
     // A bogus path the fake glob yields but that does not exist → dropped.
     const recs = await readWorkerStates(root, {
       nowMs: NOW,
-      kill: aliveKill,
+      psSnapshot: () => psWithChild(2, 9999), // pid 2 has a child → wB is quiet-but-live
       glob: async () => [live, stale, join(root, "ghost", "afk.state.json")],
     });
     expect(recs).toHaveLength(2);


### PR DESCRIPTION
Automated AFK landing for #1023. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1023

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785621880&installation_id=129708444&pr_number=1062&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1062&signature=2cd4dd605584e41ba9d50dc5df3772f942510eb0658020184fd564b3d76122da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->