### PR TITLE
merge: #1032 feat(brain): brain runtime ships via committed launcher + Release bundle (replicates the memory tracer)

### DIFF
--- a/apps/brain/tests/bootstrap-launcher.test.ts
+++ b/apps/brain/tests/bootstrap-launcher.test.ts
@@ -1,0 +1,314 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+// @ts-expect-error — the dependency-free .mjs launcher ships without type declarations
+import { platformKey } from "../../../plugins/brain/scripts/bootstrap.mjs";
+
+// End-to-end launcher behaviour for the Brain runtime (ADR 0084 tracer, #1032).
+//
+// These tests spawn the real `bootstrap.mjs` — the committed launcher that
+// marketplace-installed copies run in place of built output — against a local
+// release server, and prove the distribution guarantees the memory tracer slice
+// established (#1030):
+//
+//   1. cache hit         → a warm cache runs REAL runtime from disk, zero network
+//   2. cache miss + fetch → the SessionStart resolve point downloads + delegates
+//   3. gate-inert        → a directory that never opted in makes zero network
+//   4. offline degrade   → a failed first fetch no-ops and leaves a marker
+//   5. ordering          → a render/hot-path hook never fetches on a cold cache
+//
+// The launcher resolves the plugin version from CLAUDE_PLUGIN_ROOT and every
+// asset URL from RED_BRAIN_RELEASE_BASE, so no real network is ever touched.
+// RED_BRAIN_REPO_ROOT points the dev/pre-release local fallback at an empty dir,
+// so these tests simulate an installed copy with no repo checkout (the only
+// place the release/degrade paths — not the local fallback — apply).
+
+const BOOTSTRAP = resolve(__dirname, "../../../plugins/brain/scripts/bootstrap.mjs");
+const PLUGIN_ROOT = resolve(__dirname, "../../../plugins/brain");
+const VERSION: string = JSON.parse(
+  readFileSync(resolve(PLUGIN_ROOT, ".claude-plugin/plugin.json"), "utf8"),
+).version;
+const RED_KEY: string = platformKey(process.platform, process.arch);
+
+// A fake runtime that announces itself so a test can prove the real cached
+// runtime — not a no-op — executed.
+const CLI_BODY = `#!/usr/bin/env node
+process.stdout.write("BRAIN-RUNTIME-RAN " + process.argv.slice(2).join(" ") + "\\n");
+`;
+const MCP_BODY = "#!/usr/bin/env node\nprocess.exit(0);\n";
+const RED_BODY = "#!/bin/sh\nexit 0\n";
+
+const sha = (body: string) => createHash("sha256").update(body).digest("hex");
+
+function manifestJson(): string {
+  return JSON.stringify({
+    schema: "red.brain.runtime.v1",
+    version: VERSION,
+    cli: { asset: "brain.bundle.min.mjs", sha256: sha(CLI_BODY) },
+    mcp: { asset: "brain-mcp.bundle.min.mjs", sha256: sha(MCP_BODY) },
+    reddb: {
+      repo: "reddb-io/reddb",
+      tag: "v0.0.0-test",
+      assets: { [RED_KEY]: { asset: `red-${RED_KEY}`, sha256: sha(RED_BODY) } },
+    },
+  });
+}
+
+interface Release {
+  url: string;
+  hits: () => number;
+  close: () => Promise<void>;
+}
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer(handler);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+/** A working release server that serves the fake runtime assets by basename. */
+async function startRelease(): Promise<Release> {
+  let n = 0;
+  const files: Record<string, string> = {
+    "brain-runtime-manifest.json": manifestJson(),
+    "brain.bundle.min.mjs": CLI_BODY,
+    "brain-mcp.bundle.min.mjs": MCP_BODY,
+    [`red-${RED_KEY}`]: RED_BODY,
+  };
+  const { url, close } = await listen((req, res) => {
+    n += 1;
+    const name = (req.url ?? "").split("?")[0].split("/").pop() ?? "";
+    const body = files[name];
+    if (body === undefined) {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    res.statusCode = 200;
+    res.end(body);
+  });
+  return { url, hits: () => n, close };
+}
+
+/** A release server that fails every request — the offline / outage case. */
+async function startFailingRelease(): Promise<Release> {
+  let n = 0;
+  const { url, close } = await listen((_req, res) => {
+    n += 1;
+    res.statusCode = 500;
+    res.end("boom");
+  });
+  return { url, hits: () => n, close };
+}
+
+const scratch: string[] = [];
+afterEach(async () => {
+  await Promise.all(scratch.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+async function makeCacheDir(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "brain-cache-"));
+  scratch.push(d);
+  return d;
+}
+
+/** An empty dir the local fallback resolves against — no bundle, no TS source. */
+async function emptyRepoRoot(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "brain-norepo-"));
+  scratch.push(d);
+  return d;
+}
+
+async function enabledCwd(): Promise<string> {
+  const d = await mkdtemp(join(tmpdir(), "brain-on-"));
+  scratch.push(d);
+  await mkdir(join(d, ".red"), { recursive: true });
+  await writeFile(join(d, ".red", "config.yaml"), "plugins:\n  brain:\n    enabled: true\n");
+  return d;
+}
+
+async function disabledCwd(): Promise<string> {
+  // A temp dir with no `.red/config.yaml` in any ancestor — the gate (ADR 0067)
+  // treats brain as disabled.
+  const d = await mkdtemp(join(tmpdir(), "brain-off-"));
+  scratch.push(d);
+  return d;
+}
+
+/** Pre-populate the version-keyed cache with the fake runtime (a warm cache). */
+async function warmCache(cacheDir: string): Promise<void> {
+  const dir = join(cacheDir, "reddb-brain", VERSION);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "brain-cli.mjs"), CLI_BODY);
+  await writeFile(join(dir, "brain-mcp.mjs"), MCP_BODY);
+  const red = join(dir, process.platform === "win32" ? "red.exe" : "red");
+  await writeFile(red, RED_BODY);
+  await chmod(red, 0o755);
+}
+
+const cliPath = (cacheDir: string) =>
+  join(cacheDir, "reddb-brain", VERSION, "brain-cli.mjs");
+const markerPath = (cacheDir: string) =>
+  join(cacheDir, "reddb-brain", "runtime-degraded.json");
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function run(
+  args: string[],
+  opts: { cwd: string; cacheDir: string; base: string; repoRoot: string },
+): Promise<RunResult> {
+  return new Promise((res) => {
+    const child = spawn(process.execPath, [BOOTSTRAP, ...args], {
+      cwd: opts.cwd,
+      env: {
+        ...process.env,
+        RED_BRAIN_CACHE_DIR: opts.cacheDir,
+        RED_BRAIN_RELEASE_BASE: opts.base,
+        RED_BRAIN_REPO_ROOT: opts.repoRoot,
+        CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (code) => res({ code, stdout, stderr }));
+  });
+}
+
+describe("brain launcher distribution (ADR 0084, #1032)", () => {
+  test("cache hit: a warm cache runs the real cached runtime with zero network", async () => {
+    const cacheDir = await makeCacheDir();
+    await warmCache(cacheDir);
+    const cwd = await enabledCwd();
+    const repoRoot = await emptyRepoRoot();
+    const release = await startRelease();
+    try {
+      const r = await run(["hook", "PostToolUse", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+        repoRoot,
+      });
+      expect(r.code).toBe(0);
+      // Proves an installed-copy hook executes REAL runtime from the cache —
+      // the end of the silent no-op class.
+      expect(r.stdout).toContain("BRAIN-RUNTIME-RAN");
+      expect(release.hits()).toBe(0);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("cache miss + fetch: SessionStart resolves the runtime and delegates", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await enabledCwd();
+    const repoRoot = await emptyRepoRoot();
+    const release = await startRelease();
+    try {
+      const r = await run(["hook", "SessionStart", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+        repoRoot,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("BRAIN-RUNTIME-RAN");
+      expect(release.hits()).toBeGreaterThan(0);
+      expect(existsSync(cliPath(cacheDir))).toBe(true);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("gate-inert: a directory that never opted in makes zero network", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await disabledCwd();
+    const repoRoot = await emptyRepoRoot();
+    const release = await startRelease();
+    try {
+      const r = await run(["hook", "PostToolUse", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+        repoRoot,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("{}");
+      expect(release.hits()).toBe(0);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("offline degrade: a failed first fetch no-ops and leaves a machine-readable marker", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await enabledCwd();
+    const repoRoot = await emptyRepoRoot();
+    const release = await startFailingRelease();
+    try {
+      const r = await run(["hook", "SessionStart", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+        repoRoot,
+      });
+      // Never a crash: the hook no-op contract is preserved.
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("{}");
+      // A marker the doctor can later report.
+      expect(existsSync(markerPath(cacheDir))).toBe(true);
+      const marker = JSON.parse(await readFile(markerPath(cacheDir), "utf8"));
+      expect(marker.schema).toBe("red.brain.runtime-degraded.v1");
+      expect(marker.plugin).toBe("brain");
+      expect(marker.version).toBe(VERSION);
+      expect(typeof marker.reason).toBe("string");
+      expect(marker.reason.length).toBeGreaterThan(0);
+      expect(typeof marker.at).toBe("string");
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("ordering: a render/hot-path hook never fetches on a cold cache", async () => {
+    const cacheDir = await makeCacheDir();
+    const cwd = await enabledCwd();
+    const repoRoot = await emptyRepoRoot();
+    const release = await startRelease();
+    try {
+      // PostToolUse fires on every edit — a hot path. On a cold cache it must
+      // no-op and defer to SessionStart, never block on a synchronous fetch
+      // (the statusline-blanking lesson).
+      const r = await run(["hook", "PostToolUse", "--runner", "claude"], {
+        cwd,
+        cacheDir,
+        base: release.url,
+        repoRoot,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("{}");
+      expect(release.hits()).toBe(0);
+      expect(existsSync(cliPath(cacheDir))).toBe(false);
+    } finally {
+      await release.close();
+    }
+  });
+});

--- a/plugins/brain/scripts/bootstrap.mjs
+++ b/plugins/brain/scripts/bootstrap.mjs
@@ -24,7 +24,7 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, readFile, writeFile, chmod, appendFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, chmod, appendFile, unlink } from "node:fs/promises";
 import { homedir, platform, arch } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,7 +33,10 @@ const RED_SKILLS_REPO = "reddb-io/red-skills";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = resolve(HERE, "..");
-const REPO_ROOT = resolve(PLUGIN_ROOT, "..", "..");
+// The dev / pre-release local-fallback root. Derived from this launcher's own
+// location by default; overridable (RED_BRAIN_REPO_ROOT) so the launcher tests
+// can point it at an empty dir and simulate an installed copy with no checkout.
+const REPO_ROOT = process.env.RED_BRAIN_REPO_ROOT || resolve(PLUGIN_ROOT, "..", "..");
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -51,9 +54,28 @@ export function sha256Hex(buf) {
   return createHash("sha256").update(buf).digest("hex");
 }
 
+/**
+ * Release host. Overridable via RED_BRAIN_RELEASE_BASE so the launcher tests
+ * can point every asset URL at a local server — no real network, ever.
+ */
+const RELEASE_HOST = process.env.RED_BRAIN_RELEASE_BASE || "https://github.com";
+
 /** GitHub release asset URL. */
 export function assetUrl(repo, tag, name) {
-  return `https://github.com/${repo}/releases/download/${tag}/${name}`;
+  return `${RELEASE_HOST}/${repo}/releases/download/${tag}/${name}`;
+}
+
+/**
+ * Which invocations may hit the network on a cache miss. Only the resolve/warm
+ * points do: the once-per-session SessionStart hook, the long-lived mcp server,
+ * and user-invoked CLI commands. Recurring render/hot-path hooks (PostToolUse /
+ * Stop / PreCompact) must never block on a synchronous fetch (ADR 0084, the
+ * statusline-blanking lesson). On a cold cache they no-op and let SessionStart
+ * warm the cache.
+ */
+export function mayFetchRuntime(argv) {
+  if (argv[0] === "hook") return argv[1] === "SessionStart";
+  return true;
 }
 
 function normalizeRedAsset(value) {
@@ -98,6 +120,44 @@ async function logLine(msg) {
   }
 }
 
+/** Machine-readable degrade marker path — a `brain doctor` can later read this. */
+export function degradeMarkerPath() {
+  return join(runtimeRoot(), "runtime-degraded.json");
+}
+
+/**
+ * Record an offline / failed-first-fetch degrade as a machine-readable marker
+ * the doctor can later report. Best-effort: writing the marker must never throw,
+ * so a degrade never becomes a crash.
+ */
+async function writeDegradeMarker(version, err, argv) {
+  try {
+    await mkdir(runtimeRoot(), { recursive: true });
+    await writeFile(
+      degradeMarkerPath(),
+      JSON.stringify(
+        {
+          schema: "red.brain.runtime-degraded.v1",
+          plugin: "brain",
+          version: version ?? null,
+          reason: String(err?.message ?? err),
+          argv,
+          at: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+    );
+  } catch {
+    /* marker writing must never throw */
+  }
+}
+
+/** Clear a stale degrade marker once the runtime resolves again. */
+async function clearDegradeMarker() {
+  await unlink(degradeMarkerPath()).catch(() => {});
+}
+
 async function fetchBuffer(url) {
   const res = await fetch(url, { redirect: "follow" });
   if (!res.ok) throw new Error(`GET ${url} -> ${res.status}`);
@@ -126,10 +186,12 @@ async function ensureFile(url, dest, expectedSha, { mode } = {}) {
 
 /**
  * Ensure {brain-cli.mjs, brain-mcp.mjs, red} exist for `version` in the
- * version-keyed cache and return their absolute paths. Throws (caught by the
- * caller, which falls back to local artifacts) on any fetch failure.
+ * version-keyed cache and return their absolute paths. Returns null when a cold
+ * cache is hit on a render/hot path (`mayFetch` false) so the caller can honour
+ * the hook no-op contract. Throws (caught by the caller, which falls back to
+ * local artifacts) on any fetch failure.
  */
-async function ensureRuntime(version) {
+async function ensureRuntime(version, { mayFetch } = {}) {
   const dir = join(runtimeRoot(), version);
   const cliPath = join(dir, "brain-cli.mjs");
   const mcpPath = join(dir, "brain-mcp.mjs");
@@ -144,6 +206,11 @@ async function ensureRuntime(version) {
   if (existsSync(cliPath) && existsSync(mcpPath) && existsSync(redPath)) {
     return { cliPath, mcpPath, redPath };
   }
+
+  // Cold cache on a render/hot path (recurring PostToolUse / Stop / PreCompact
+  // hooks): never fetch. Defer to the SessionStart resolve point and no-op this
+  // call. `null` tells the caller to honour the hook no-op contract.
+  if (!mayFetch) return null;
 
   const tag = `v${version}`;
   const manifest = JSON.parse(
@@ -341,10 +408,19 @@ async function main() {
   const extra = kind === "mcp" ? argv.slice(1) : argv;
 
   // 1. Primary: fetch the release-published runtime into the version-keyed cache.
+  let version = null;
+  let fetchErr = null;
   try {
-    const version = await pluginVersion();
+    version = await pluginVersion();
     if (!version) throw new Error("could not resolve plugin version");
-    const rt = await ensureRuntime(version);
+    const rt = await ensureRuntime(version, { mayFetch: mayFetchRuntime(argv) });
+    if (!rt) {
+      // Render/hot-path hook on a cold cache: SessionStart will warm it. No-op.
+      process.stdout.write("{}");
+      process.exit(0);
+    }
+    // The runtime resolved: any earlier degrade is stale.
+    await clearDegradeMarker();
     const target = kind === "mcp" ? rt.mcpPath : rt.cliPath;
     const code = await run(process.execPath, [target, ...extra], {
       ...process.env,
@@ -352,6 +428,7 @@ async function main() {
     });
     process.exit(code);
   } catch (err) {
+    fetchErr = err;
     await logLine(`release fetch failed (${err?.message ?? err}); trying local checkout`);
   }
 
@@ -367,6 +444,9 @@ async function main() {
     process.exit(code);
   }
 
+  // 3. No runtime at all (installed copy, first fetch offline): honour the hook
+  // no-op contract and leave a machine-readable marker the doctor can report.
+  await writeDegradeMarker(version, fetchErr, argv);
   await logLine("no runnable runtime: release fetch failed and no local bundle/source found");
   process.stdout.write("{}");
   process.exit(0);


### PR DESCRIPTION
Automated AFK landing for #1032. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1032

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785622719&installation_id=129708444&pr_number=1065&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1065&signature=8a5d8e053ec7a4cfb4c9c530bc27837a47f5ed1187ed7dd5e712c5f7ceb7633f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->