### PR TITLE
fix(afk): lane-aware claim preflight — end the silent /go boot death (#1045)

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -66,6 +66,16 @@ export function parseGoArgs(
     }
     if (!sawDoubleDash && arg === "+yolo") { yolo = true; continue; }
     if (!sawDoubleDash && arg === "--scout") { scout = true; continue; }
+    // Unknown `--flag` before the `--` separator is an error, never demand text
+    // (#1045): folding e.g. `--resume 1043` into the demand silently minted a
+    // junk issue about a flag the user meant as a command. A literal dashed
+    // demand still works via the `--` separator (`/go -- --literal`).
+    if (!sawDoubleDash && arg.startsWith("--")) {
+      throw new Error(
+        `unknown flag ${JSON.stringify(arg)}: expected --runner/-r, --mode, --scout, or +yolo. ` +
+          `Pass a literal dashed demand after a "--" separator.`,
+      );
+    }
     positional.push(arg);
   }
   return { demand: positional.join(" ").trim(), runner, mode, yolo, scout };

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1665,6 +1665,12 @@ export async function runCommand(options: RunOptions): Promise<number> {
         remote: c.issueTemplate.remote,
         baseInput: { issueBody: candidate.body },
         runMode: runModeForCandidate(candidate, flags.runMode),
+        // Lane-aware claim preflight (#1045): the pre-claim state-validity recheck
+        // must validate against the label this issue was SELECTED under (the
+        // `--lane` value), not a hardcoded `ready-for-agent`. `flags.lane` is
+        // undefined for `/afk` (→ defaults to `ready-for-agent` in processIssue)
+        // and `lane:go`/`lane:scout` for the isolated `/go`/scout lanes.
+        laneLabel: flags.lane,
       };
     },
     emit: (line: string) => process.stdout.write(`${line}\n`),

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -547,6 +547,16 @@ export interface ProcessIssueInput {
    * posted as a comment and the disposable issue closes. Forwarded from the
    * `--run-mode` flag by `run.ts`/`buildProcessInput`. */
   runMode?: string;
+  /**
+   * The candidate-listing label the session selected this issue under — the
+   * `--lane` value (`ready-for-agent` for `/afk`, `lane:go` for `/go`,
+   * `lane:scout` for scout). The pre-claim state-validity recheck re-reads the
+   * issue's labels and requires THIS label to still be present; a lane-blind
+   * hardcode to `ready-for-agent` made every `/go`/scout dispatch a silent
+   * `claim-lost` (#1045), because those lanes carry the isolated lane label,
+   * never `ready-for-agent`. Absent → defaults to `ready-for-agent`, so the
+   * `/afk` path is byte-for-byte unchanged. */
+  laneLabel?: string;
 }
 
 // ---------- result ----------
@@ -820,10 +830,20 @@ export async function processIssue(
   }
   // State-validity recheck: the issue must still want an agent. This is NOT the
   // contention lock (that is the claim below) — it only rejects an issue that was
-  // closed/blocked/re-triaged out of `ready-for-agent` between selection and now.
+  // closed/blocked/re-triaged out of ITS LANE between selection and now.
   // `running` is deliberately NOT consulted here: it is a projection, not a lock.
+  //
+  // Lane-aware (#1045): the recheck validates against the label the session
+  // SELECTED this issue under (`input.laneLabel`, defaulting to `ready-for-agent`
+  // for `/afk`), never a hardcoded `ready-for-agent`. A `lane:go`/`lane:scout`
+  // issue never carries `ready-for-agent` by design, so the old hardcode fired
+  // `claim-lost` on every `/go` dispatch BEFORE the claim was ever posted — the
+  // silent boot death (no attempt dir, no claim comment, launcher prints
+  // `1/1 (100%) exit 0`). Validating against the selecting lane fixes it while
+  // leaving the `/afk` path byte-for-byte unchanged.
+  const laneLabel = input.laneLabel ?? LABEL_READY;
   const labels = await deps.gh.viewLabels(issue);
-  if (!labels.includes(LABEL_READY)) {
+  if (!labels.includes(laneLabel)) {
     await deps.claimLock.release(issue);
     return claimLost(issue, hooksFired);
   }

--- a/apps/dev/tests/go-command.test.ts
+++ b/apps/dev/tests/go-command.test.ts
@@ -26,6 +26,17 @@ describe("parseGoArgs", () => {
     expect(parseGoArgs(["--", "--literal", "demand"]).demand).toBe("--literal demand");
   });
 
+  // #1045: an unknown `--flag` must error, never fold into the demand. The
+  // original papercut minted a junk issue when `--resume 1043` was swallowed as
+  // demand text; now it fails loudly, and a literal dashed demand still works via
+  // the `--` separator.
+  it("throws on an unknown --flag instead of folding it into the demand (#1045)", () => {
+    expect(() => parseGoArgs(["--resume", "1043"])).toThrow(/unknown flag/);
+    expect(() => parseGoArgs(["do it", "--frobnicate"])).toThrow(/unknown flag/);
+    // …but a genuinely dashed demand still passes through after the `--` separator.
+    expect(parseGoArgs(["--", "--resume", "1043"]).demand).toBe("--resume 1043");
+  });
+
   it("throws when --runner has no value", () => {
     expect(() => parseGoArgs(["do it", "--runner"])).toThrow(/requires a value/);
   });

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -136,6 +136,10 @@ interface HarnessOptions {
   body?: string;
   /** Execution mode forwarded to ProcessIssueInput (e.g. `"scout"`). */
   runMode?: string;
+  /** The candidate-listing lane label forwarded to ProcessIssueInput (`--lane`).
+   * Undefined models the `/afk` default (`ready-for-agent`); `"lane:go"` models a
+   * `/go` dispatch. Drives the lane-aware claim preflight (#1045). */
+  laneLabel?: string;
   /** Optional ADR 0049 tier resolver injected by the production wiring. */
   resolveTier?: ProcessIssueDeps["resolveTier"];
   /** Optional ADR 0049 issue classifier injected by the production wiring. */
@@ -541,6 +545,7 @@ function harness(opts: HarnessOptions = {}): {
     baseInput: { issueBody: opts.body ?? "## Agent brief\nDo it." },
     prdRef: undefined,
     runMode: opts.runMode,
+    laneLabel: opts.laneLabel,
   };
 
   return { deps, input, trace };
@@ -1519,6 +1524,40 @@ describe("processIssue — claim lost", () => {
     // no claim edit submitted; the claim lock was released.
     expect(trace.labelEdits).toEqual([]);
     expect(trace.released).toEqual([9]);
+  });
+
+  // #1045: a `lane:go` issue never carries `ready-for-agent` — the isolated lane
+  // IS its selection label. The pre-claim recheck must validate against the lane
+  // the session selected under, not a hardcoded `ready-for-agent`. Before the
+  // fix, `laneLabel: "lane:go"` fell into the recheck's hardcoded
+  // `ready-for-agent` test, returned `claim-lost` BEFORE the claim was posted,
+  // and the worker died silently while the launcher reported `1/1 exit 0`.
+  it("#1045: a lane:go issue is NOT silently skipped — it proceeds past the preflight and claims", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      claim: { winner: "self" },
+    });
+    const result = await processIssue(deps, input);
+    // The bug returned "claim-lost" here (silent boot death). Fixed: the lane
+    // matches, so the worker proceeds through the claim to a real attempt.
+    expect(result.outcome).not.toBe("claim-lost");
+    expect(result.outcome).toBe("done");
+    // It actually claimed (posted the GitHub-native claim marker) and ran the agent.
+    expect(trace.comments.some((c) => /AFK claim by worker/.test(c.body))).toBe(true);
+    expect(trace.runAgentCalls.length).toBeGreaterThan(0);
+  });
+
+  it("#1045: the lane-aware recheck still guards — a lane:go issue re-triaged out of its lane is claim-lost", async () => {
+    // The issue was selected under lane:go but no longer carries it (e.g. closed
+    // or re-labelled between selection and claim) → correctly abandoned, releasing
+    // the lock, without spawning an agent.
+    const { deps, input, trace } = harness({ labels: ["running"], laneLabel: "lane:go" });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    expect(trace.labelEdits).toEqual([]);
+    expect(trace.released).toEqual([9]);
+    expect(trace.runAgentCalls).toEqual([]);
   });
 
   // ADR 0066: with the GitHub-native arbiter wired, `running` is a projection and


### PR DESCRIPTION
## Root cause (#1045)

The `/go` go-worker was **not crashing** — it cleanly skipped its only issue via a **lane-blind claim preflight**, then reported false success.

`apps/dev/src/core/process-issue.ts`, the pre-claim state-validity recheck:
```ts
const labels = await deps.gh.viewLabels(issue);
if (!labels.includes(LABEL_READY)) {   // LABEL_READY === 'ready-for-agent'
  await deps.claimLock.release(issue);
  return claimLost(issue, hooksFired); // ← always fires for a lane:go issue
}
```
A `lane:go` (and `lane:scout`) issue **never carries `ready-for-agent`** — that isolation is the entire point of the lane. So the recheck returned `claim-lost` on **every** `/go` dispatch, *before* `acquireClaim` was ever reached (hence zero claim comments on the orphaned #1070/#1071). The session loop counts that `claim-lost` as a processed iteration (`progress: 1/1 (100%)`), `--once` doesn't break on `claim-lost`, and the run.ts wrapper deletes the pre-created attempt dir — leaving only a dead `worker.pid` and a false `exit 0`.

Reproduced deterministically 3× (after #1043/#1044). Full forensics on #1045.

## The fix

- **Lane-aware preflight** — thread the label the session *selected* the issue under (`--lane`, default `ready-for-agent`) into `ProcessIssueInput.laneLabel`, and validate the recheck against it: `if (!labels.includes(input.laneLabel ?? LABEL_READY))`. **`/afk` is byte-for-byte unchanged** (`laneLabel` undefined → `ready-for-agent`); `/go`/scout issues now proceed past the preflight and actually claim + spawn the agent.
- **Unknown-flag hardening** (`parseGoArgs`) — an unrecognised `--flag` (e.g. `--resume 1043`) now errors instead of folding into the demand and minting a junk issue; a literal dashed demand still works via the `--` separator.

## Tests (all green: 2837 passing, typecheck clean)

- `lane:go` issue **proceeds past the preflight and claims** (was the silent boot death)
- the recheck **still guards**: a `lane:go` issue re-triaged out of its lane → `claim-lost`
- `parseGoArgs` throws on unknown `--flag`; `--` separator still passes a dashed demand

## Scope / landing

- **PRD #1013 T1 class — AFK-core claim machinery → manual landing.** Please merge by hand; not for the auto-merge fleet.
- No `git reset`/`git stash`/force-push/auto-commit paths touched.

## Known follow-ups (not in this PR)

1. **`/go` fleet-collision refusal** — the shared AFK boot guard (`checkBootGuard`) refuses `/go` while a fleet supervisor is up, contradicting "`/go` works whether or not a fleet is up." `/go` should be exempt (it is namespaced under `go-workers/`). Worked around here by stopping the fleet.
2. **Honest-exit hardening** — a run that processes only `claim-lost` still exits 0; a defensive non-zero exit for a genuine no-op would harden against future silent skips. Moot for the normal path now that the root cause is fixed.

Refs #1045

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785640867&installation_id=129708444&pr_number=1072&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1072&signature=2ba14c1c95148d7a310392056ff0beb9bee2eb49af1c94f76c2bebaed263dfdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command parsing so unknown dashed flags are rejected unless they follow `--`, helping prevent accidental misreads of literal input.
  * Fixed lane-aware issue handling so selected work now stays tied to the lane it was chosen under, reducing false “claim lost” results.
  * Improved claim checks to stop and release work correctly if the issue no longer matches the expected lane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->