### PR TITLE
merge: #1074 /go: Implement issue #1018: add the ADR 0083 landing precondition to the AFK 

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -235,6 +235,9 @@ async function runAdoptLanding(
       labels: [...issueData.labels],
       branch,
       base,
+      // ADR 0083 landing precondition (#1018): the configured Trunk the primary
+      // checkout tracks, for doLanding's local-trunk-divergence guard.
+      trunk: getConfig(loadConfig(paths.configPath, { warn: () => undefined }), "dev.trunk") || "main",
       repo,
       repoDir: cwd,
       remote: "origin",

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -415,6 +415,9 @@ function makeBootReconcileRunner(
         labels: plan.labels,
         branch: plan.branch,
         base,
+        // ADR 0083 landing precondition (#1018): the configured Trunk the primary
+        // checkout tracks, for doLanding's local-trunk-divergence guard.
+        trunk: configTrunk || "main",
         repo: ctx.repo,
         repoDir: ctx.root,
         remote: ctx.remote,

--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -35,6 +35,7 @@ import {
   LABEL_STALLED,
   LABEL_INFRA,
   LABEL_BUDGET,
+  LABEL_TRUNK_DIVERGED,
 } from "./triage-labels.js";
 
 /**
@@ -77,6 +78,15 @@ export type AttemptOutcome =
   // is salvaged through the same feedback gate, then parked for a human — NOT
   // auto-recovered (a runaway is not a transient flake to blind-retry).
   | "budget-exceeded"
+  // ADR 0083 landing precondition (#1018): the Landing aborted because the
+  // primary checkout's LOCAL trunk ref has DIVERGED from `origin/<trunk>` (it
+  // carries commits origin does not). This is NOT a merge conflict and NOT lost
+  // work — the attempt branch is intact; the local repository state a human owns
+  // is out of sync. It carries the distinct `blocked:trunk-diverged` label and is
+  // human-only (never auto-recovered): the Landing refuses to reset / stash /
+  // auto-commit / force-push to repair it, so a bounded retry could only re-hit
+  // the same precondition.
+  | "trunk-diverged"
   | "infra";
 
 /**
@@ -131,6 +141,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_STALLED;
     case "budget-exceeded":
       return LABEL_BUDGET;
+    case "trunk-diverged":
+      return LABEL_TRUNK_DIVERGED;
     case "infra":
       return LABEL_INFRA;
     case "done":
@@ -185,6 +197,10 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     case "claim-lost":
     case "stalled":
     case "budget-exceeded":
+    // trunk-diverged (#1018) folds into the generic `blocked` bucket — the work
+    // is intact on the attempt branch; the local trunk a human owns is out of
+    // sync, so it emits a `blocked` envelope (never `merge-conflict`).
+    case "trunk-diverged":
     case "infra":
     // review-requested is a handoff, not a failure: the per-issue lifecycle
     // emits no terminal failure envelope for it (it parks the issue + opens the
@@ -243,6 +259,10 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     // on a runaway just re-spends the budget. Escalate to a human with the
     // salvaged partial work intact.
     case "budget-exceeded":
+    // trunk-diverged (#1018) is NON-recoverable by construction: a bounded
+    // auto-retry cannot un-diverge the maintainer's local trunk, and the Landing
+    // refuses to repair it — only a human reconciling the local state clears it.
+    case "trunk-diverged":
     case "infra":
     case "done":
     case "claim-lost":

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -125,6 +125,16 @@ export interface LandingInput {
   branch: string;
   /** Resolved base branch (lock > pin > main). */
   base: string;
+  /**
+   * The configured Trunk (`plugins.dev.trunk`, default `main`; ADR 0083) — the
+   * repo's focal branch. The landing precondition ({@link verifyTrunkPrecondition})
+   * verifies the primary checkout's LOCAL `<trunk>` ref has not diverged from its
+   * fresh-fetched `origin/<trunk>` before integrating any attempt branch. This is
+   * distinct from {@link base}: `base` is the resolved landing target (which may be
+   * a lock/pin branch), while the precondition guards the maintainer-owned trunk
+   * the primary checkout tracks.
+   */
+  trunk: string;
   /** Issue number, for the merge/PR message + hook contexts. */
   issue: number;
   /** Issue title, for the merge/PR message + hook contexts. */
@@ -161,10 +171,20 @@ export type LandingResult =
         | "ci-failed"
         | "ci-pending"
         | "pr-conflict"
-        | "pr-merge-failed";
+        | "pr-merge-failed"
+        // ADR 0083 landing precondition (#1018): the primary checkout's LOCAL
+        // `<trunk>` ref has DIVERGED from `origin/<trunk>`. The landing aborted
+        // BEFORE integrating the attempt branch and NEVER repaired the divergence
+        // (no reset / stash / auto-commit / force-push). The caller parks the
+        // issue ready-for-human with a divergence envelope naming the two SHAs.
+        | "trunk-diverged";
       locked: boolean;
       /** PR number left open for the CI-aware handoff (`ci-failed` / `ci-pending`). */
       prNumber?: number;
+      /** ADR 0083 divergence (`trunk-diverged`): the primary's LOCAL `<trunk>` SHA. */
+      localTrunkSha?: string;
+      /** ADR 0083 divergence (`trunk-diverged`): the fresh-fetched `origin/<trunk>` SHA. */
+      originTrunkSha?: string;
     };
 
 /**
@@ -191,12 +211,92 @@ export type LandingResult =
  *   capture the integrated tip → landMerge → one-shot conflict self-resolve →
  *   post_merge.
  */
+/** Result of the ADR 0083 trunk landing precondition. `ok:true` → proceed with
+ * the landing (local trunk absent, an ancestor of origin, or indeterminate);
+ * `ok:false` → the local trunk DIVERGED, carrying both SHAs for the caller's
+ * ready-for-human divergence envelope. */
+type TrunkPreconditionResult = { ok: true } | { ok: false; localSha: string; originSha: string };
+
+/**
+ * ADR 0083 landing precondition (#1018). Verify the primary checkout's LOCAL
+ * `<trunk>` ref has NOT diverged from its fresh-fetched `origin/<trunk>` before
+ * any attempt branch is integrated.
+ *
+ * The trunk is always read as its fresh-fetched remote ref (ADR 0083), so the
+ * check first fetches `origin/<trunk>` (best-effort — an offline fetch must not
+ * fabricate a divergence; the comparison then falls back to the origin ref the
+ * repo already knows). Then:
+ *   - Local `<trunk>` ABSENT (the primary never checked it out) → nothing can
+ *     diverge → `{ ok:true }`.
+ *   - Local trunk is an ANCESTOR of `origin/<trunk>` (behind or equal) → the
+ *     healthy case → `{ ok:true }`.
+ *   - `git merge-base --is-ancestor` returns a definitive `1` (NOT an ancestor —
+ *     the local trunk carries commits origin does not) → DIVERGED →
+ *     `{ ok:false, localSha, originSha }`. Any OTHER non-zero code is a git error
+ *     (e.g. a missing origin ref on a fresh repo), treated as indeterminate →
+ *     `{ ok:true }` so a transient error never blocks a landing.
+ *
+ * READ-ONLY: it runs only `fetch` / `rev-parse` / `merge-base` against the
+ * primary checkout. It NEVER resets, stashes, auto-commits, or force-pushes to
+ * repair a divergence — that repair is a human-only decision (ADR 0083 + the
+ * standing maintainer rules), so none of those verbs exist even as a fallback.
+ */
+async function verifyTrunkPrecondition(
+  exec: MergeExec,
+  input: { repoDir: string; remote: string; trunk: string },
+): Promise<TrunkPreconditionResult> {
+  const { repoDir, remote, trunk } = input;
+
+  // Fresh-fetch the remote trunk so the comparison is against origin's real tip.
+  // Best-effort: a fetch failure (offline) is ignored — we then compare against
+  // whatever `origin/<trunk>` the local repo already knows.
+  await exec(["git", "-C", repoDir, "fetch", remote, trunk, "--quiet"]);
+
+  // Local trunk ABSENT → nothing to diverge; proceed.
+  const local = await exec(["git", "-C", repoDir, "rev-parse", "--verify", "--quiet", "--short", `refs/heads/${trunk}`]);
+  if (local.code !== 0) return { ok: true };
+  const localSha = local.stdout.trim();
+
+  // Local trunk is an ANCESTOR of origin/<trunk> (exit 0) → proceed. Only a
+  // definitive exit 1 (NOT an ancestor) is a divergence; any other code is a git
+  // error → indeterminate → proceed (never block on a transient error).
+  const ancestor = await exec([
+    "git", "-C", repoDir, "merge-base", "--is-ancestor", localSha, `${remote}/${trunk}`,
+  ]);
+  if (ancestor.code !== 1) return { ok: true };
+
+  const origin = await exec(["git", "-C", repoDir, "rev-parse", "--short", `${remote}/${trunk}`]);
+  return { ok: false, localSha, originSha: origin.stdout.trim() };
+}
+
 export async function doLanding(
   deps: LandingDeps,
   input: LandingInput,
   hooks: LandingHookContexts,
 ): Promise<LandingResult> {
   const { locked } = input;
+
+  // 0. ADR 0083 landing precondition (#1018): the primary checkout's LOCAL
+  // `<trunk>` ref must be an ANCESTOR of `origin/<trunk>`. Verified BEFORE any
+  // attempt branch is pushed or integrated so a diverged local trunk fails loud
+  // instead of silently eating the maintainer's work. On divergence the landing
+  // ABORTS and NEVER repairs it (no reset / stash / auto-commit / force-push);
+  // the caller parks the issue ready-for-human with the two SHAs. Local trunk
+  // absent, an ancestor, or an indeterminate git error → proceed unchanged.
+  const trunkCheck = await verifyTrunkPrecondition(deps.mergeExec, {
+    repoDir: input.repoDir,
+    remote: input.remote,
+    trunk: input.trunk,
+  });
+  if (!trunkCheck.ok) {
+    return {
+      ok: false,
+      reason: "trunk-diverged",
+      locked,
+      localTrunkSha: trunkCheck.localSha,
+      originTrunkSha: trunkCheck.originSha,
+    };
+  }
 
   // 1. push the worker branch so landMerge/landPr have a remote ref.
   // NOT best-effort: if the push fails the remote has no commits and any merge

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -934,6 +934,11 @@ export async function processIssue(
     return claimLost(issue, hooksFired);
   }
   const base = await resolveBase(input.baseInput, deps.lookups.base);
+  // ADR 0083 landing precondition (#1018): the configured Trunk (`plugins.dev.trunk`,
+  // default `main`) the primary checkout tracks — distinct from the resolved `base`
+  // (which may be a lock/pin branch). Both the ADR 0055 no-agent reconcile and the
+  // DONE-path doLanding verify the LOCAL trunk has not diverged from `origin/<trunk>`.
+  const trunk = (deps.lookups.base.configTrunk ?? "").trim() || "main";
   const startedAt = deps.nowIso();
 
   // ---- 2. attempt dir + state init ----
@@ -1391,7 +1396,7 @@ export async function processIssue(
       // through the identical gate.)
       const reconciled = await reconcile(
         { ...deps, fireHook },
-        reconcileInputFor(input, current, workerBranch, base, labels, activeRunner),
+        reconcileInputFor(input, current, workerBranch, base, trunk, labels, activeRunner),
       );
       // on_reconcile (#832): the no-agent reconcile (ADR 0055) re-validated the
       // parked mechanical branch and landed / parked / skipped it. Surface the
@@ -1709,6 +1714,7 @@ export async function processIssue(
       remote: input.remote,
       branch: workerBranch,
       base,
+      trunk,
       issue,
       title: input.title,
     },
@@ -1726,6 +1732,19 @@ export async function processIssue(
     },
   );
   if (!landing.ok) {
+    // ADR 0083 landing precondition (#1018): the primary checkout's LOCAL trunk
+    // has DIVERGED from origin/<trunk>. The landing aborted BEFORE integrating the
+    // attempt branch and never repaired the divergence — park ready-for-human with
+    // a divergence envelope naming both SHAs so a human reconciles the local state.
+    if (landing.reason === "trunk-diverged") {
+      return await trunkDivergedBlocked(
+        common,
+        trunk,
+        landing.localTrunkSha ?? "",
+        landing.originTrunkSha ?? "",
+        landing.locked,
+      );
+    }
     // CI-aware landing failures (#812): a completed, MERGEABLE PR the admin-merge
     // could not land because the `enforce_admins` base's required checks failed /
     // are still pending. NOT a merge conflict — preserve the OPEN PR and park to
@@ -1983,6 +2002,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         summary: oneLine(sections.log, "Required status checks were still pending on the completed, mergeable PR."),
         next: "Wait for the required checks to go green, then merge the open PR (no full agent re-run needed).",
       };
+    case "trunk-diverged":
+      return {
+        status: "blocked",
+        kind: "trunk-diverged",
+        summary: oneLine(sections.log, "Local trunk diverged from origin; landing aborted (ADR 0083)."),
+        next: "Reconcile the primary checkout's local trunk with origin (no reset/stash/force-push), then requeue.",
+      };
     default:
       return null;
   }
@@ -1995,6 +2021,7 @@ const ACTIONABLE_BLOCKER_KINDS = new Set([
   "ci",
   "stalled",
   "decision",
+  "trunk-diverged",
 ]);
 
 function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
@@ -2226,6 +2253,55 @@ async function prLandingBlocked(
     issue: input.issue,
     branch: c.branch,
     base: c.base,
+    hooksFired: c.hooksFired,
+    envelopePosted: posted,
+    preserved: true,
+    swept: false,
+  };
+}
+
+/**
+ * ADR 0083 landing-precondition park (#1018). The Landing aborted BEFORE
+ * integrating the attempt branch because the primary checkout's LOCAL `<trunk>`
+ * ref has DIVERGED from `origin/<trunk>` — it carries commits origin does not.
+ * This is NOT a merge conflict and NOT lost work: the attempt branch is intact;
+ * the maintainer-owned local repository state is out of sync. The Landing NEVER
+ * repairs it (no reset / stash / auto-commit / force-push), so park the issue
+ * ready-for-human with a divergence blocker envelope naming both SHAs and a
+ * self-explanatory comment. routeRecovery escalates (trunk-diverged carries no
+ * recovery budget → ready-for-human + `blocked:trunk-diverged`); the attempt dir
+ * and worker branch are preserved so a requeue re-lands once a human reconciles.
+ */
+async function trunkDivergedBlocked(
+  c: StageCommon,
+  trunk: string,
+  localSha: string,
+  originSha: string,
+  locked: boolean,
+): Promise<ProcessIssueResult> {
+  const { deps, input } = c;
+  const detail =
+    `Landing aborted (ADR 0083): the primary checkout's local \`${trunk}\` (${localSha || "unknown"}) has diverged ` +
+    `from \`origin/${trunk}\` (${originSha || "unknown"}) — it carries commits origin does not. The landing will NOT ` +
+    `reset, stash, auto-commit, or force-push to repair this; a human must reconcile the local repository state, then ` +
+    `requeue the issue. The attempt branch is intact — no work was lost.`;
+  // routeRecovery escalates (trunk-diverged is non-recoverable): drop running,
+  // ensure + add ready-for-human + blocked:trunk-diverged.
+  await routeRecovery(deps, input.issue, "trunk-diverged", input.attempt);
+  await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("trunk-diverged", { log: detail }));
+  const posted = await emitFailure(c, envelopeStatusFor("trunk-diverged"), "trunk-diverged", { log: detail });
+  await deps.gh.comment(input.issue, `🤖 /afk: ${detail}`);
+  await recordAttemptBestEffort(c, "trunk-diverged", {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: detail,
+  });
+  await deps.claimLock.release(input.issue);
+  return {
+    outcome: "trunk-diverged",
+    issue: input.issue,
+    branch: c.branch,
+    base: c.base,
+    locked,
     hooksFired: c.hooksFired,
     envelopePosted: posted,
     preserved: true,
@@ -2606,6 +2682,7 @@ function reconcileInputFor(
   current: ProcessIssueInput,
   branch: string,
   base: string,
+  trunk: string,
   claimLabels: string[],
   runner: Runner,
 ): ReconcileInput {
@@ -2620,6 +2697,9 @@ function reconcileInputFor(
     labels: liveLabels,
     branch,
     base,
+    // ADR 0083 landing precondition (#1018): the configured Trunk for doLanding's
+    // local-trunk-divergence guard on the ADR 0055 no-agent reconcile land.
+    trunk,
     repo: input.repo,
     repoDir: input.repoDir,
     remote: input.remote,

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -212,6 +212,13 @@ export interface ReconcileInput {
   branch: string;
   /** Resolved base branch (lock > pin > main). */
   base: string;
+  /**
+   * The configured Trunk (`plugins.dev.trunk`, default `main`; ADR 0083) — the
+   * focal branch the primary checkout tracks. doLanding verifies the LOCAL trunk
+   * has not diverged from `origin/<trunk>` before integrating the branch (#1018);
+   * distinct from {@link base}, which may be a lock/pin branch.
+   */
+  trunk: string;
   repo: string;
   repoDir: string;
   remote: string;
@@ -368,6 +375,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       remote: input.remote,
       branch,
       base,
+      trunk: input.trunk,
       issue,
       title: input.title,
     },

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -70,6 +70,14 @@ export const LABEL_MERGE_CONFLICT = "blocked:merge-conflict";
 export const LABEL_CI = "blocked:ci";
 export const LABEL_POLICY = "blocked:policy";
 export const LABEL_INFRA = "blocked:infra";
+// ADR 0083 landing precondition: the primary checkout's LOCAL trunk ref has
+// DIVERGED from `origin/<trunk>` (it carries commits origin does not). The
+// Landing aborts BEFORE integrating any attempt branch and NEVER repairs the
+// divergence (no reset / stash / auto-commit / force-push) — a human must
+// reconcile the local repository state, so the issue parks with THIS label. It
+// is human-only (non-recoverable): a bounded auto-retry cannot fix a diverged
+// local branch, and re-running the agent would just re-hit the same precondition.
+export const LABEL_TRUNK_DIVERGED = "blocked:trunk-diverged";
 // AFK runner improvement (#908): the per-attempt resource budget guard aborted
 // the attempt — it breached a token/cost/tool-call/waiting-window ceiling before
 // it could finish. Distinct from `blocked:stalled` (a stall is *no* progress;

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -74,6 +74,15 @@ interface Opts {
   rebaseCode?: number;
   /** rc the force-with-lease push returns (1 → reject on every attempt). */
   rebasePushCode?: number;
+  /**
+   * ADR 0083 landing precondition (#1018): drive the local-trunk-vs-origin check.
+   *   - "diverged" → `merge-base --is-ancestor` exits 1 (local trunk carries
+   *     commits origin does not) → the landing aborts with `trunk-diverged`.
+   *   - "absent"   → `rev-parse --verify refs/heads/<trunk>` exits 1 (the primary
+   *     never checked the trunk out) → the precondition proceeds.
+   * Unset → the local trunk reads as an ancestor of origin → proceeds.
+   */
+  trunk?: "diverged" | "absent";
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -89,6 +98,21 @@ function harness(opts: Opts = {}): Harness {
     mergeExec: async (argv): Promise<ExecResult> => {
       mergeCalls.push(argv);
       const j = argv.join(" ");
+      // ADR 0083 landing precondition (#1018), against the primary checkout.
+      // `merge-base --is-ancestor local origin/<trunk>` — exit 1 = diverged.
+      if (j.includes("merge-base --is-ancestor")) {
+        return { code: opts.trunk === "diverged" ? 1 : 0, stdout: "", stderr: "" };
+      }
+      // The primary's LOCAL trunk ref probe — exit 1 = absent (proceed).
+      if (j.includes("rev-parse --verify --quiet --short refs/heads/")) {
+        return opts.trunk === "absent"
+          ? { code: 1, stdout: "", stderr: "" }
+          : { code: 0, stdout: "1oca1sha\n", stderr: "" };
+      }
+      // origin/<trunk> SHA, captured for the divergence envelope.
+      if (j.includes("rev-parse --short origin/")) {
+        return { code: 0, stdout: "0r1g1nsha\n", stderr: "" };
+      }
       // #1006 pre-merge rebase, in the isolated worker-branch worktree (RWT).
       if (j === `git -C ${RWT} rebase origin/main`) {
         return { code: opts.rebaseCode ?? 0, stdout: "", stderr: "" };
@@ -182,6 +206,11 @@ function harness(opts: Opts = {}): Harness {
     remote: "origin",
     branch: "afk/wAAAA/9-fix-the-thing",
     base: "main",
+    // ADR 0083 landing precondition (#1018): the configured Trunk. The default
+    // permissive mergeExec below returns code 0 for the precondition's
+    // fetch/rev-parse/is-ancestor calls, so the local trunk reads as an ancestor
+    // → the precondition proceeds and the existing path assertions are unchanged.
+    trunk: "main",
     issue: 9,
     title: "Fix the thing",
   };
@@ -266,8 +295,81 @@ describe("doLanding — happy paths", () => {
     expect(j.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"))).toBe(true);
     // Push targeted the lock branch (worktree HEAD → refs/heads/<base>), not main.
     expect(j.some((c) => c.includes("push origin HEAD:refs/heads/feature-locked"))).toBe(true);
-    expect(j.some((c) => c.includes("refs/heads/main"))).toBe(false);
+    // The ADR 0083 precondition READS refs/heads/main (the trunk, read-only); the
+    // landing's WRITE ops (merge/push) must never target main.
+    expect(j.some((c) => (c.includes("merge --") || c.includes("push ")) && c.includes("main"))).toBe(false);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+  });
+});
+
+describe("doLanding — ADR 0083 trunk landing precondition (#1018)", () => {
+  it("diverged local trunk → aborts with trunk-diverged BEFORE any push/integrate/land, naming both SHAs", async () => {
+    const h = harness({ locked: false, trunk: "diverged" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({
+      ok: false,
+      reason: "trunk-diverged",
+      locked: false,
+      localTrunkSha: "1oca1sha",
+      originTrunkSha: "0r1g1nsha",
+    });
+    // The abort is loud and EARLY: no attempt-branch push, no hooks, no landing.
+    expect(h.pushedAttempt).toEqual([]);
+    expect(h.firedHooks).toEqual([]);
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(false);
+  });
+
+  it("diverged local trunk on the DIRECT (locked) path also aborts before integrating", async () => {
+    const h = harness({ locked: true, trunk: "diverged" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({
+      ok: false,
+      reason: "trunk-diverged",
+      locked: true,
+      localTrunkSha: "1oca1sha",
+      originTrunkSha: "0r1g1nsha",
+    });
+    const j = joined(h.mergeCalls);
+    // Never provisioned a landing worktree, never integrated origin/<base>.
+    expect(h.removedWorktrees).toEqual([]);
+    expect(j.some((c) => c.includes("merge --ff-only"))).toBe(false);
+    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(false);
+  });
+
+  it("the precondition NEVER resets / stashes / auto-commits / force-pushes to repair the divergence", async () => {
+    const h = harness({ locked: false, trunk: "diverged" });
+    await doLanding(h.deps, h.input, h.hooks);
+    for (const c of h.mergeCalls) {
+      const j = c.join(" ");
+      expect(j.includes("reset")).toBe(false);
+      expect(j.includes("stash")).toBe(false);
+      expect(j.includes("commit")).toBe(false);
+      expect(j.includes("--force")).toBe(false);
+    }
+    // The only primary-checkout touches are the read-only precondition probes.
+    const primaryOps = joined(h.mergeCalls).filter((c) => c.includes("-C /repo"));
+    for (const op of primaryOps) {
+      expect(/fetch|rev-parse|merge-base/.test(op)).toBe(true);
+    }
+  });
+
+  it("absent local trunk → precondition proceeds and lands unchanged", async () => {
+    const h = harness({ locked: false, trunk: "absent" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+  });
+
+  it("ancestor local trunk (default) → precondition proceeds and lands unchanged", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    // The precondition fresh-fetched origin/<trunk> then admin-merged.
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c === "git -C /repo fetch origin main --quiet")).toBe(true);
+    expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
   });
 });
 
@@ -631,7 +733,9 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     // Integrate + push targeted the lock branch, never main.
     expect(j.some((c) => c.includes("merge --ff-only origin/feature-locked"))).toBe(true);
     expect(j).toContain(`git -C ${WT} push origin HEAD:refs/heads/feature-locked`);
-    expect(j.some((c) => c.includes("refs/heads/main"))).toBe(false);
+    // The ADR 0083 precondition READS refs/heads/main (the trunk, read-only); the
+    // landing's WRITE ops (merge/push) must never target main.
+    expect(j.some((c) => (c.includes("merge --") || c.includes("push ")) && c.includes("main"))).toBe(false);
     expect(prMerged(j)).toBe(false);
   });
 

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -188,6 +188,7 @@ function harness(opts: HarnessOptions = {}): {
     labels: opts.labels ?? ["running", "type:feature"],
     branch: "afk/wAAAA/9-fix-the-thing",
     base: "main",
+    trunk: "main",
     repo: "o/r",
     repoDir: "/repo",
     remote: "origin",


### PR DESCRIPTION
Automated AFK landing for #1074. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1074

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785644057&installation_id=129708444&pr_number=1077&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1077&signature=672da00606b42155694e13ea14631579d0a6109fc50f6df240d68e0d95d4710b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->