### PR TITLE
merge: #1052 bug(afk/go): boot sweep deletes maintainer .red/tmp/work-* worktrees — sweeps must be scoped to AFK-owned namespaces

### DIFF
--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -328,12 +328,29 @@ export async function listStaleClaimDirs(tmpDir: string): Promise<StaleClaimDir[
   return out;
 }
 
+/** Pre-cutover legacy relic name: `work-<issue-number>` (digits only). The AFK
+ * orchestrator created these; a maintainer hand-work worktree is `work-<slug>`
+ * (CLAUDE.md Development workflow) and must never match. */
+const LEGACY_WORK_DIR_RE = /^work-[1-9][0-9]*$/;
+
 /**
  * Discover pre-cutover flat `<tmpDir>/work-NNN` relic dirs whose orchestrator is
- * dead. Each carries an `afk.pid` file; a missing/dead pid marks the dir for the
- * unconditional drain-wipe (#252). Mirrors the `for d in work-...` loop at the
- * top of prune_orphans (minus the dangling-worktree removal, which the caller
- * handles via git when needed). A missing tmp dir yields `[]`.
+ * dead, for the unconditional drain-wipe (#252). Two AFK-ownership gates, both
+ * required, so the sweep can only ever touch dirs the orchestrator itself made:
+ *
+ *   1. NAME — `work-<issue-number>` (digits). A maintainer worktree under
+ *      `.red/tmp/work-<slug>` (the sanctioned home for hand work, CLAUDE.md
+ *      Development workflow) is slug-named and is skipped. Guards #1052, where a
+ *      fresh `work-afk-first-doctrine` worktree was silently deleted by a boot
+ *      sweep because the old `startsWith("work-")` match plus "missing pid = wipe"
+ *      treated any non-AFK `work-*` dir as a dead relic.
+ *   2. SENTINEL — an `afk.pid` file must EXIST. Its absence means the dir was
+ *      not created by the orchestrator, so it is not AFK-owned and is left alone.
+ *
+ * Only when both hold and the recorded pid is dead is the dir a reclaimable
+ * relic. Mirrors the `for d in work-...` loop at the top of prune_orphans (minus
+ * the dangling-worktree removal, which the caller handles via git when needed).
+ * A missing tmp dir yields `[]`.
  */
 export async function listLegacyWorkDirs(tmpDir: string): Promise<string[]> {
   let entries: string[];
@@ -344,7 +361,7 @@ export async function listLegacyWorkDirs(tmpDir: string): Promise<string[]> {
   }
   const out: string[] = [];
   for (const entry of entries) {
-    if (!entry.startsWith("work-")) continue;
+    if (!LEGACY_WORK_DIR_RE.test(entry)) continue;
     const dir = join(tmpDir, entry);
     try {
       const st = await stat(dir);
@@ -353,6 +370,9 @@ export async function listLegacyWorkDirs(tmpDir: string): Promise<string[]> {
       continue;
     }
     const raw = await readText(join(dir, "afk.pid"));
+    // No sentinel → not an orchestrator-created relic → untouchable. Present but
+    // dead → reclaimable relic.
+    if (raw === null) continue;
     if (!pidAlive(raw)) out.push(dir);
   }
   return out;

--- a/apps/dev/tests/fs-sweep.test.ts
+++ b/apps/dev/tests/fs-sweep.test.ts
@@ -185,10 +185,10 @@ describe("listLegacyWorkDirs", () => {
     expect(await listLegacyWorkDirs(join(tmpdir(), "does-not-exist-afk-xyz"))).toEqual([]);
   });
 
-  it("wipes a dead-orchestrator work-* dir and ignores other entries", async () => {
+  it("wipes a dead-orchestrator work-NNN relic and ignores other entries", async () => {
     const root = scratch();
     try {
-      const dead = join(root, "work-aaaa");
+      const dead = join(root, "work-1234");
       mkdirSync(dead, { recursive: true });
       writeFileSync(join(dead, "afk.pid"), DEAD_PID);
       // a non-work entry and the nested workers root must be ignored
@@ -201,10 +201,10 @@ describe("listLegacyWorkDirs", () => {
     }
   });
 
-  it("spares a live-orchestrator work-* dir", async () => {
+  it("spares a live-orchestrator work-NNN relic", async () => {
     const root = scratch();
     try {
-      const live = join(root, "work-bbbb");
+      const live = join(root, "work-5678");
       mkdirSync(live, { recursive: true });
       writeFileSync(join(live, "afk.pid"), ALIVE_PID);
       expect(await listLegacyWorkDirs(root)).toEqual([]);
@@ -213,12 +213,46 @@ describe("listLegacyWorkDirs", () => {
     }
   });
 
-  it("wipes a work-* dir with no pid file", async () => {
+  // #1052: the pre-cutover relics were `work-<issue-number>` dirs the AFK
+  // orchestrator itself created, marked by an `afk.pid` sentinel. A maintainer
+  // hand-work worktree under `.red/tmp/work-<slug>` is NOT AFK-owned — it never
+  // carries an afk.pid — and must be untouchable by the boot sweep.
+  it("spares a maintainer work-<slug> worktree with no afk.pid (with or without commits)", async () => {
     const root = scratch();
     try {
-      const orphan = join(root, "work-cccc");
-      mkdirSync(orphan, { recursive: true });
-      expect(await listLegacyWorkDirs(root)).toEqual([orphan]);
+      // fresh, zero commits — just the worktree dir
+      const fresh = join(root, "work-afk-first-doctrine");
+      mkdirSync(fresh, { recursive: true });
+      // one with WIP files present (simulating committed/uncommitted content)
+      const withWip = join(root, "work-statusline-fix");
+      mkdirSync(withWip, { recursive: true });
+      writeFileSync(join(withWip, "README.md"), "wip");
+      expect(await listLegacyWorkDirs(root)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("spares a work-<slug> dir even when it carries an afk.pid file", async () => {
+    // Belt-and-braces: the name must ALSO look like a relic. A slug-named dir is
+    // never an AFK relic regardless of stray sentinel files.
+    const root = scratch();
+    try {
+      const slug = join(root, "work-afk-first-doctrine");
+      mkdirSync(slug, { recursive: true });
+      writeFileSync(join(slug, "afk.pid"), DEAD_PID);
+      expect(await listLegacyWorkDirs(root)).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("spares a work-NNN relic with no afk.pid — absent sentinel means not AFK-owned", async () => {
+    const root = scratch();
+    try {
+      const noSentinel = join(root, "work-4321");
+      mkdirSync(noSentinel, { recursive: true });
+      expect(await listLegacyWorkDirs(root)).toEqual([]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Automated AFK landing for #1052. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1052

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785644410&installation_id=129708444&pr_number=1078&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1078&signature=ee66cb14f28ad73102ca4c7beabbead10b18b90511533ddada6e8d215c5c792b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->