### PR TITLE
merge: #1075 feat(afk): honest observability — statusline/monitor/dashboard must count /go + scout workers (namespace-blind discovery)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -52,7 +52,7 @@ import {
 import { LABEL_READY_FOR_REVIEW } from "../core/triage-labels.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
-import { isValidWorkerId } from "../core/worker-paths.js";
+import { isValidWorkerId, WORKER_NAMESPACES } from "../core/worker-paths.js";
 import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { isLivePid } from "../runtime/kill-tree.js";
@@ -1371,24 +1371,28 @@ async function runnerCircuitOpen(
 }
 
 /** Synchronous next-attempt resolver over the attempt-ledger's pure core, so it
- * can run inside the synchronous `buildProcessInput`. Walks `<tmp>/workers/*`
- * with readdirSync and feeds the pure `highestAttempt`: the next attempt is the
- * highest existing attempt for the issue + 1 (1 when none). Junk dirs never
- * bump the counter. A missing tree yields attempt 1. */
+ * can run inside the synchronous `buildProcessInput`. Namespace-blind: walks
+ * every worker-lane namespace (`workers`, `go-workers`, `scout-workers`) with
+ * readdirSync and feeds the pure `highestAttempt`, so the same issue retried
+ * across lanes never reuses an attempt number. The next attempt is the highest
+ * existing attempt for the issue + 1 (1 when none). Junk dirs never bump the
+ * counter; a missing namespace tree contributes nothing. */
 function nextAttemptSync(tmpDir: string, issue: number): number {
-  let workers: string[];
-  try {
-    workers = readdirSync(join(tmpDir, "workers"));
-  } catch {
-    return 1;
-  }
   const entries: AttemptDirEntry[] = [];
-  for (const worker of workers) {
-    if (!isValidWorkerId(worker)) continue;
+  for (const namespace of WORKER_NAMESPACES) {
+    let workers: string[];
     try {
-      entries.push({ worker, basenames: readdirSync(join(tmpDir, "workers", worker)) });
+      workers = readdirSync(join(tmpDir, namespace));
     } catch {
-      // not a directory / unreadable
+      continue; // namespace dir absent → no attempts from this lane
+    }
+    for (const worker of workers) {
+      if (!isValidWorkerId(worker)) continue;
+      try {
+        entries.push({ worker, basenames: readdirSync(join(tmpDir, namespace, worker)) });
+      } catch {
+        // not a directory / unreadable
+      }
     }
   }
   const best = highestAttempt(tmpDir, issue, entries);

--- a/apps/dev/src/core/worker-paths.ts
+++ b/apps/dev/src/core/worker-paths.ts
@@ -19,6 +19,29 @@ function normalizeRoot(root: string): string {
 }
 
 /**
+ * The canonical worker-lane namespaces under `.red/tmp/`. The `/afk` fleet lives
+ * in `workers`, a `/go` dispatch in `go-workers`, a `--scout` run in
+ * `scout-workers`. Each RUN-TIME write path stays scoped to its single
+ * {@link workersSegment} lane (via `RED_AFK_WORKERS_NAMESPACE`), but the
+ * read-only observability surfaces (statusline/monitor/dashboard) must UNION
+ * over all of these — a live `/go` or `--scout` worker is one more live worker.
+ */
+export const WORKER_NAMESPACES = ["workers", "go-workers", "scout-workers"] as const;
+
+/**
+ * Every per-namespace workers root under a `.red/tmp` dir, for read-only union
+ * discovery. Namespace-blind on purpose: it does NOT consult
+ * `RED_AFK_WORKERS_NAMESPACE`, so an aggregating reader with no env override
+ * still sees all lanes. A namespace whose directory is absent on disk simply
+ * contributes nothing (the caller's glob swallows ENOENT), never an error.
+ */
+export function allWorkersRoots(tmpDir: string): string[] {
+  if (!tmpDir) throw new Error("tmpDir is required");
+  const base = normalizeRoot(tmpDir);
+  return WORKER_NAMESPACES.map((ns) => `${base}/${ns}`);
+}
+
+/**
  * The worker-tree segment under the tmp root. Defaults to `workers` (the `/afk`
  * fleet). A `/go` dispatch sets `RED_AFK_WORKERS_NAMESPACE=go-workers` in its
  * own process so its worker dir + worktree land under `.red/tmp/go-workers/`,

--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -16,6 +16,7 @@ import { join, dirname } from "node:path";
 import type { AfkState } from "../types/state.js";
 import { parseState, type PidStartTimeProbe } from "./state.js";
 import { globWorkerStates } from "../runtime/fs.js";
+import { allWorkersRoots } from "./worker-paths.js";
 import {
   evaluateLiveness,
   resolveLivenessCrossCheckArming,
@@ -204,6 +205,35 @@ export async function readWorkerStates(root: string, opts: WorkerStatesReadOpts 
       psSnapshot: opts.psSnapshot,
     });
     if (rec !== null) out.push(rec);
+  }
+  return out;
+}
+
+/**
+ * Read-only UNION discovery across every worker-lane namespace
+ * ({@link WORKER_NAMESPACES}: `workers`, `go-workers`, `scout-workers`) under a
+ * `.red/tmp` dir. Globs each namespace root through {@link readWorkerStates} and
+ * concatenates every record, so a live `/go` or `--scout` worker counts as one
+ * more live worker on the observability surfaces. A missing namespace directory
+ * contributes nothing (its glob returns `[]`), never an error. Lane provenance
+ * is preserved on each record via `state.origin`, so per-source breakdowns still
+ * render each lane distinctly.
+ *
+ * This is the AGGREGATION seam every read-only surface (statusline/monitor/
+ * dashboard) uses. It is deliberately namespace-blind — it does NOT consult
+ * `RED_AFK_WORKERS_NAMESPACE`, unlike the single-lane {@link readWorkerStates}
+ * that the run-time write paths rely on for isolation. A single `nowMs` is
+ * shared across the whole batch so every record's liveness is measured against
+ * the same instant.
+ */
+export async function readAllWorkerStates(
+  tmpDir: string,
+  opts: WorkerStatesReadOpts = {},
+): Promise<WorkerStateRecord[]> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const out: WorkerStateRecord[] = [];
+  for (const root of allWorkersRoots(tmpDir)) {
+    out.push(...(await readWorkerStates(root, { ...opts, nowMs })));
   }
   return out;
 }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -444,7 +444,7 @@ export function makeRunAgent(
 // ---------- monitor inputs ----------
 
 import type { CompactWorker, FleetState, SlotDetail } from "../core/monitor.js";
-import { readWorkerState, readWorkerStates } from "../core/worker-state-reader.js";
+import { readWorkerState, readAllWorkerStates } from "../core/worker-state-reader.js";
 import type { WorkerVitals } from "../types/state.js";
 import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
 
@@ -528,7 +528,11 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
   // The ONE owner reads + normalizes + liveness-tags every worker state file
   // (core/worker-state-reader). The single source of liveness truth for all
   // surfaces is WorkerStateRecord.livenessVerdict (evaluator verdict, ADR 0083 §3).
-  const records = await readWorkerStates(paths.workersRoot);
+  // Namespace-blind union: aggregate live workers across the fleet, `/go`, and
+  // `--scout` lanes so a `/go`/`--scout` worker appears in the monitor/dashboard,
+  // tagged distinctly by state.origin. (Not the single-lane paths.workersRoot,
+  // which would render only the `.red/tmp/workers` fleet lane.)
+  const records = await readAllWorkerStates(paths.tmpDir);
   const logPaths = records.map(({ path, state }) => state.log || join(dirname(path), "afk.log"));
   const logCounts = await collectLogLineCounts(paths.monitorLogCursorPath, logPaths);
   const workers: CompactWorker[] = [];
@@ -699,7 +703,10 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   const paths = afkPaths(ctx.root);
   // Same single owner as the monitor (core/worker-state-reader).
   const nowMs = Date.now();
-  const records = await readWorkerStates(paths.workersRoot, { nowMs });
+  // Namespace-blind union across the fleet, `/go`, and `--scout` lanes so the
+  // statusline counts a live `/go`/`--scout` worker (rendered per-origin via
+  // state.origin), not only the `.red/tmp/workers` fleet lane.
+  const records = await readAllWorkerStates(paths.tmpDir, { nowMs });
   const gitCtx: gitx.GitContext = { cwd: ctx.root };
 
   let workers = 0;
@@ -826,7 +833,7 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   if (workers <= 0) return null;
 
   // Build the per-source count array sorted by origin for a deterministic order.
-  // Both statusline and monitor read from state.origin via readWorkerStates —
+  // Both statusline and monitor read from state.origin via readAllWorkerStates —
   // this is the one derived form; nothing else derives source counts independently.
   const sourceCounts =
     sourceMap.size > 0

--- a/apps/dev/tests/worker-paths.test.ts
+++ b/apps/dev/tests/worker-paths.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  allWorkersRoots,
   buildWorkerAttemptPath,
   issueAttemptsGlob,
   livePidsGlob,
   parseWorkerAttemptPath,
+  WORKER_NAMESPACES,
   workerDir,
   workerPidFile,
   workersGlob,
@@ -56,5 +58,25 @@ describe("worker paths — /go namespace", () => {
   it("ignores an unsafe namespace value and falls back to `workers`", () => {
     process.env.RED_AFK_WORKERS_NAMESPACE = "../escape";
     expect(workersSegment()).toBe("workers");
+  });
+
+  it("enumerates every worker-lane namespace for read-only union discovery", () => {
+    expect([...WORKER_NAMESPACES]).toEqual(["workers", "go-workers", "scout-workers"]);
+    expect(allWorkersRoots("/repo/.red/tmp/")).toEqual([
+      "/repo/.red/tmp/workers",
+      "/repo/.red/tmp/go-workers",
+      "/repo/.red/tmp/scout-workers",
+    ]);
+  });
+
+  it("allWorkersRoots is namespace-blind (ignores RED_AFK_WORKERS_NAMESPACE)", () => {
+    process.env.RED_AFK_WORKERS_NAMESPACE = "go-workers";
+    // The read-only aggregator must union ALL lanes regardless of the env
+    // override the reader process happens to carry.
+    expect(allWorkersRoots("/repo/.red/tmp")).toEqual([
+      "/repo/.red/tmp/workers",
+      "/repo/.red/tmp/go-workers",
+      "/repo/.red/tmp/scout-workers",
+    ]);
   });
 });

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { readWorkerState, readWorkerStates } from "../src/core/worker-state-reader.js";
+import { readWorkerState, readWorkerStates, readAllWorkerStates } from "../src/core/worker-state-reader.js";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 
 const NOW = Date.UTC(2026, 5, 22, 12, 0, 0);
@@ -158,5 +158,49 @@ describe("worker-state-reader", () => {
     expect(byId.wA!.active).toBe(true);
     expect(byId.wB!.active).toBe(false);
     expect(byId.wB!.live).toBe(true);
+  });
+
+  it("readAllWorkerStates unions every worker-lane namespace under tmp", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "wsr-union-"));
+    // One live worker per lane: fleet, /go, and --scout.
+    await writeState(join(tmp, "workers", "wFLEET", "10-a1"), {
+      worker_id: "wFLEET",
+      pid: 1,
+      origin: "afk",
+      current: { number: 10, last_event_at: fresh },
+    });
+    await writeState(join(tmp, "go-workers", "wGO", "20-a1"), {
+      worker_id: "wGO",
+      pid: 2,
+      origin: "go",
+      current: { number: 20, last_event_at: fresh },
+    });
+    await writeState(join(tmp, "scout-workers", "wSCOUT", "30-a1"), {
+      worker_id: "wSCOUT",
+      pid: 3,
+      origin: "scout",
+      current: { number: 30, last_event_at: fresh },
+    });
+    const recs = await readAllWorkerStates(tmp, { nowMs: NOW });
+    const byId = Object.fromEntries(recs.map((r) => [r.state.worker_id, r]));
+    // All three lanes are discovered, each carrying its own origin provenance.
+    expect(Object.keys(byId).sort()).toEqual(["wFLEET", "wGO", "wSCOUT"]);
+    expect(byId.wFLEET!.state.origin).toBe("afk");
+    expect(byId.wGO!.state.origin).toBe("go");
+    expect(byId.wSCOUT!.state.origin).toBe("scout");
+  });
+
+  it("readAllWorkerStates with only the fleet lane matches today's single-lane read", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "wsr-union-fleet-"));
+    await writeState(join(tmp, "workers", "wFLEET", "11-a1"), {
+      worker_id: "wFLEET",
+      pid: 1,
+      current: { number: 11, last_event_at: fresh },
+    });
+    // No go-workers/ or scout-workers/ dirs → those lanes contribute nothing.
+    const union = await readAllWorkerStates(tmp, { nowMs: NOW });
+    const single = await readWorkerStates(join(tmp, "workers"), { nowMs: NOW });
+    expect(union.map((r) => r.state.worker_id)).toEqual(["wFLEET"]);
+    expect(union.map((r) => r.state.worker_id)).toEqual(single.map((r) => r.state.worker_id));
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1075. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1075

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785645193&installation_id=129708444&pr_number=1079&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1079&signature=f1f0ce05492af5e2f45f9ff6e76bdc35bf4be5500fd61bcdfd6e92ab555da0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker discovery now spans all worker lanes, including `workers`, `go-workers`, and `scout-workers`.
  * Monitor and statusline views now include activity from all supported worker lanes.

* **Bug Fixes**
  * Next attempt numbers are now calculated across all lanes, helping prevent duplicate attempt labels for the same issue.
  * Worker status displays now preserve lane/source provenance for more consistent counts and summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->