### PR TITLE
merge: #1015 AFK: deterministic auto-format (post_attempt mutating hook) before the feedback gate

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -42,7 +42,7 @@ import * as fsx from "../runtime/fs.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { ExecFn } from "../runtime/exec.js";
-import { getConfig, loadConfig, readBackpressure, resolveTier, resolveCiTimeoutSeconds } from "../core/config.js";
+import { getConfig, loadConfig, readBackpressure, readPostAttemptFormat, resolveTier, resolveCiTimeoutSeconds } from "../core/config.js";
 import { resolveNotesLoopConfig } from "../core/notes-loop.js";
 import {
   classifyIssue,
@@ -735,6 +735,10 @@ export function buildProcessDeps(
     // shell commands run against the same worker-branch checkout after feedback.
     backpressure: feedback.backpressure,
     backpressureCommands: readBackpressure(config),
+    // Post-attempt-format step (#1015): operator-declared `afk.post_attempt_format`
+    // commands run BEFORE the feedback gate and auto-commit any formatting delta.
+    postAttemptFormat: feedback.postAttemptFormat,
+    postAttemptFormatCommands: readPostAttemptFormat(config),
     // #908: thread the resolved budget + a LIVE usage probe off this attempt's
     // activity meter (late-bound — `activityMeter` is reassigned per attempt dir,
     // and `peek()` returns a superset of AttemptBudgetUsage). makeRunAgent only

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -545,6 +545,32 @@ export function readBackpressure(values: ConfigValues): string[] {
   return scalar && scalar.trim() !== "" ? [scalar] : [];
 }
 
+/**
+ * Read the operator-declared post-attempt-format command list
+ * (`afk.post_attempt_format`), in declaration order (#1015). The list form
+ *
+ *   afk:
+ *     post_attempt_format:
+ *       - cargo fmt --all
+ *
+ * materialises as the indexed keys `afk.post_attempt_format.0`, … which this
+ * reads back in order until the first gap. The namespaced
+ * `plugins.dev.afk.post_attempt_format.*` location already folds down to the
+ * bare keys in {@link loadConfig} (ADR 0042). A single-line scalar is accepted
+ * as a one-command list. Absent/empty → `[]` (the step is a no-op).
+ */
+export function readPostAttemptFormat(values: ConfigValues): string[] {
+  const indexed: string[] = [];
+  for (let i = 0; ; i++) {
+    const v = values[`afk.post_attempt_format.${i}`];
+    if (v === undefined) break;
+    if (v.trim() !== "") indexed.push(v);
+  }
+  if (indexed.length > 0) return indexed;
+  const scalar = values["afk.post_attempt_format"];
+  return scalar && scalar.trim() !== "" ? [scalar] : [];
+}
+
 /** Default CI-aware merge wait, in seconds (#812) — 30 minutes, generous enough
  * to outlast a slow required-check suite (e.g. reddb's 25 checks / ~25m fuzzer)
  * without wedging the worker forever. */

--- a/apps/dev/src/core/post-attempt-format.ts
+++ b/apps/dev/src/core/post-attempt-format.ts
@@ -1,0 +1,107 @@
+// post-attempt-format — the AFK pre-feedback mutating formatter step (#1015).
+//
+// Runs operator-declared shell commands AFTER the agent's commits and BEFORE
+// the feedback gate. Each command executes in the worker-branch checkout; if it
+// exits 0 and leaves the checkout dirty, the executor stages + commits
+// (`style: <cmd>`) + pushes the delta onto the worker branch so the feedback
+// gate sees a cleanly-formatted branch.
+//
+// Contract:
+//   - commands run in declaration order;
+//   - the first non-zero exit ABORTS the sequence (ok:false);
+//   - a dirty checkout after a successful command triggers an auto-commit+push;
+//   - an empty command list is a no-op (ok:true, committed:false).
+//
+// Unlike backpressure (which runs every command and gates on the union result),
+// this step stops on the first failure — the formatter is a pre_*-style gate.
+
+import { KILLED_EXIT_CODE } from "../runtime/exec.js";
+
+/** Default per-command kill deadline for the post-attempt format step (10 min). */
+export const DEFAULT_POST_ATTEMPT_FORMAT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Injected shell executor for a single post-attempt-format command. Receives
+ * the command string, the worker-branch checkout root (`cwd` is the branch
+ * token — the runtime materialises it to a path), and the per-command kill
+ * deadline. The executor is responsible for:
+ *   1. running the command via `sh -c` in the checkout;
+ *   2. detecting whether the checkout became dirty after exit 0;
+ *   3. if dirty: staging, committing (`style: <cmd>`), and pushing
+ *      `HEAD:<branch>` to origin;
+ *   4. returning `committed:true` when a commit was pushed, `false` otherwise.
+ */
+export type PostAttemptFormatExec = (input: {
+  command: string;
+  /** Branch token — passed as-is to the runtime materialise step. */
+  cwd: string;
+  timeoutMs: number;
+}) => Promise<{ code: number; stdout: string; stderr: string; committed: boolean }>;
+
+export interface RunPostAttemptFormatInput {
+  /** Worker-branch token, passed through to each command's `cwd`. */
+  worktree: string;
+  /** Operator-declared commands (from `afk.post_attempt_format`), in order. */
+  commands: readonly string[];
+  /** Injected millisecond clock — no `Date.now()` at call scope. */
+  now: () => number;
+  /**
+   * Per-command kill deadline. Defaults to
+   * {@link DEFAULT_POST_ATTEMPT_FORMAT_TIMEOUT_MS}; a command that overruns
+   * it is killed and resolves non-zero (via {@link KILLED_EXIT_CODE}), aborting
+   * the sequence.
+   */
+  timeoutMs?: number;
+}
+
+export interface RunPostAttemptFormatResult {
+  /** False when any command exited non-zero — caller routes to abortAfterClaim. */
+  ok: boolean;
+  /** True when at least one command produced a dirty checkout and was committed. */
+  committed: boolean;
+  /** Human-readable log lines (one per command that ran), for appendIterLog. */
+  log: string[];
+}
+
+/**
+ * Run the operator-declared post-attempt-format commands in order against the
+ * worker-branch worktree. For each command: time it with the injected clock,
+ * run it via the injected exec in the worktree checkout, and either commit the
+ * delta (if dirty + exit 0) or abort (if non-zero). Blank/whitespace entries
+ * are skipped. An empty command list is a no-op (`ok:true`, `committed:false`).
+ *
+ * Stops on the FIRST non-zero exit (abort semantics, unlike backpressure which
+ * runs all commands). A command killed by the `timeoutMs` deadline resolves
+ * non-zero (via `KILLED_EXIT_CODE`) and aborts the sequence.
+ */
+export async function runPostAttemptFormat(
+  exec: PostAttemptFormatExec,
+  input: RunPostAttemptFormatInput,
+): Promise<RunPostAttemptFormatResult> {
+  const { worktree, commands, now } = input;
+  const timeoutMs = input.timeoutMs ?? DEFAULT_POST_ATTEMPT_FORMAT_TIMEOUT_MS;
+  let anyCommitted = false;
+  const log: string[] = [];
+
+  for (const raw of commands) {
+    const command = raw.trim();
+    if (command === "") continue;
+
+    const start = now();
+    const result = await exec({ command, cwd: worktree, timeoutMs });
+    const durationMs = now() - start;
+
+    if (result.code !== 0) {
+      const timedOut = result.code === KILLED_EXIT_CODE;
+      const reason = timedOut ? `timed out after ${timeoutMs}ms` : `exited ${result.code}`;
+      log.push(`post_attempt_format: ${command}: ${reason} (${durationMs}ms) — aborting`);
+      return { ok: false, committed: anyCommitted, log };
+    }
+
+    if (result.committed) anyCommitted = true;
+    const action = result.committed ? "formatted + committed" : "clean";
+    log.push(`post_attempt_format: ${command}: ${action} (${durationMs}ms)`);
+  }
+
+  return { ok: true, committed: anyCommitted, log };
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -53,6 +53,7 @@ import {
   type WorkspaceGraph,
 } from "./validation-scope.js";
 import { runBackpressure, type BackpressureExec } from "./backpressure.js";
+import { runPostAttemptFormat, type PostAttemptFormatExec } from "./post-attempt-format.js";
 import {
   openReviewPr,
   type Exec as MergeExec,
@@ -285,6 +286,21 @@ export interface ProcessIssueDeps {
    * scope-derived feedback gate; it does not replace it.
    */
   backpressureCommands?: readonly string[];
+  /**
+   * Shell executor for the post-attempt-format step (#1015): runs each
+   * `afk.post_attempt_format` command in the worker-branch checkout AFTER the
+   * agent's commits and BEFORE the feedback gate; auto-commits any formatting
+   * delta. Optional → when absent (or `postAttemptFormatCommands` is empty) the
+   * step is a no-op. The CLI binds it to the feedback worktree's auto-format
+   * executor.
+   */
+  postAttemptFormat?: PostAttemptFormatExec;
+  /**
+   * Operator-declared post-attempt-format commands (`afk.post_attempt_format`),
+   * in order. Empty/absent → the step is skipped. Non-zero exit aborts and
+   * routes to abortAfterClaim (branch preserved for manual recovery).
+   */
+  postAttemptFormatCommands?: readonly string[];
   /**
    * The sandcastle execution port (ADR 0033): run the inner agent on a worktree,
    * detect the DONE/BLOCKED sentinel, and commit on the worker branch. The CLI
@@ -1501,6 +1517,27 @@ export async function processIssue(
         `🤖 /afk: worker branch \`${workerBranch}\` absent on host — sandcastle commits did not reach the host; escalating.`,
       );
       return await mergeFailed(common, "worker branch absent — sandcastle commits did not reach the host");
+    }
+
+    // ---- 5a'. post_attempt_format (pre-feedback mutating step, #1015) ----
+    // After the agent's commits and before the feedback gate, run any
+    // operator-declared `afk.post_attempt_format` commands in the worker-branch
+    // checkout. If a command exits 0 and leaves the checkout dirty, the executor
+    // stages + commits (`style: <cmd>`) + pushes the delta so the feedback gate
+    // sees a cleanly-formatted branch. A non-zero exit aborts (branch preserved
+    // for manual recovery via abortAfterClaim — same recovery policy as pre_*
+    // hooks). Absent executor or empty command list → no-op.
+    const postAttemptFormatCommands = deps.postAttemptFormatCommands ?? [];
+    if (deps.postAttemptFormat && postAttemptFormatCommands.length > 0) {
+      const pfmt = await runPostAttemptFormat(deps.postAttemptFormat, {
+        worktree: workerBranch,
+        commands: postAttemptFormatCommands,
+        now: deps.nowEpoch,
+      });
+      for (const line of pfmt.log) deps.appendIterLog(`🤖 /afk: ${line}`);
+      if (!pfmt.ok) {
+        return await abortAfterClaim(deps, input, branch, base, hooksFired, "post_attempt_format");
+      }
     }
 
     // ---- 5b. feedback loops (the merge gate, ADR 0008) ----

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -33,6 +33,7 @@ import { accessSync, constants, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Exec as PnpmExec, PackageLayout } from "../core/feedback.js";
 import type { BackpressureExec } from "../core/backpressure.js";
+import type { PostAttemptFormatExec } from "../core/post-attempt-format.js";
 import { execTool, pnpm as runPnpm, type ExecOptions, type ExecOutput } from "./exec.js";
 import * as gitx from "./git.js";
 
@@ -160,6 +161,14 @@ export interface FeedbackWorktree {
    * is the branch token, materialised the same way the pnpm executor does.
    */
   backpressure: BackpressureExec;
+  /**
+   * Shell executor for the post-attempt-format step (#1015): runs an
+   * operator-declared command via `sh -c` at the materialised worker-branch
+   * checkout root, then — if exit 0 left the checkout dirty — stages, commits
+   * (`style: <cmd>`), and pushes `HEAD:<branch>` to origin. `cwd` is the
+   * branch token (materialised the same way as the pnpm/backpressure executors).
+   */
+  postAttemptFormat: PostAttemptFormatExec;
   /** Remove every worktree this manager created in THIS session (best-effort). */
   cleanup(): Promise<void>;
 }
@@ -373,10 +382,59 @@ export function makeFeedbackWorktree(
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 
+  // Post-attempt-format commands run in the worker-branch checkout (same
+  // materialise step as backpressure) but add auto-commit semantics: after a
+  // successful (exit-0) command, inspect git status; if the checkout is dirty,
+  // stage all changes, commit with `style: <cmd>`, and push `HEAD:<branch>` to
+  // origin so the feedback gate runs against the formatted branch. The branch
+  // name doubles as the `cwd` token (the same convention as backpressure). A
+  // worktree setup failure, a dirty-check failure, or a push failure all resolve
+  // non-zero (committed:false) — the caller aborts when code !== 0.
+  const postAttemptFormat: PostAttemptFormatExec = async ({ command, cwd, timeoutMs }) => {
+    const dir = await pathFor(cwd);
+    if (dir === null) {
+      return { code: 1, stdout: "", stderr: `feedback worktree setup failed for ${cwd}; format aborted`, committed: false };
+    }
+
+    const r = await io.exec("sh", ["-c", command], { cwd: dir, timeoutMs });
+    if (r.code !== 0) {
+      return { code: r.code, stdout: r.stdout, stderr: r.stderr, committed: false };
+    }
+
+    // Check if the checkout is dirty after the format command.
+    const statusR = await io.exec("git", ["status", "--porcelain"], { cwd: dir });
+    if (statusR.stdout.trim() === "") {
+      return { code: 0, stdout: r.stdout, stderr: r.stderr, committed: false };
+    }
+
+    // Dirty checkout: stage + commit + push so the feedback gate sees the delta.
+    const addR = await io.exec("git", ["add", "-A"], { cwd: dir });
+    if (addR.code !== 0) {
+      return { code: addR.code, stdout: addR.stdout, stderr: addR.stderr, committed: false };
+    }
+    const commitR = await io.exec(
+      "git",
+      ["commit", "-m", `style: ${command}`],
+      { cwd: dir },
+    );
+    if (commitR.code !== 0) {
+      return { code: commitR.code, stdout: commitR.stdout, stderr: commitR.stderr, committed: false };
+    }
+    // Push: the checkout is detached HEAD (`git worktree add --detach`), so the
+    // refspec must be explicit: HEAD:<branch-name>.
+    const pushR = await io.exec("git", ["push", "origin", `HEAD:${cwd}`], { cwd: dir });
+    if (pushR.code !== 0) {
+      return { code: pushR.code, stdout: pushR.stdout, stderr: pushR.stderr, committed: false };
+    }
+
+    return { code: 0, stdout: r.stdout, stderr: r.stderr, committed: true };
+  };
+
   return {
     pnpm,
     layout,
     backpressure,
+    postAttemptFormat,
     async cleanup() {
       for (const dest of created) {
         await io.worktreeRemove(gitCtx, dest);

--- a/apps/dev/tests/post-attempt-format.test.ts
+++ b/apps/dev/tests/post-attempt-format.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_POST_ATTEMPT_FORMAT_TIMEOUT_MS,
+  runPostAttemptFormat,
+  type PostAttemptFormatExec,
+} from "../src/core/post-attempt-format.js";
+import { KILLED_EXIT_CODE } from "../src/runtime/exec.js";
+
+type ExecCall = { command: string; cwd: string; timeoutMs: number };
+type ExecResult = { code: number; stdout: string; stderr: string; committed: boolean };
+
+function fakeExec(
+  rules: Array<{ match: (command: string) => boolean; result: Partial<ExecResult> }> = [],
+): { exec: PostAttemptFormatExec; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const exec: PostAttemptFormatExec = async ({ command, cwd, timeoutMs }) => {
+    calls.push({ command, cwd, timeoutMs });
+    for (const rule of rules) {
+      if (rule.match(command)) {
+        return { code: 0, stdout: "", stderr: "", committed: false, ...rule.result };
+      }
+    }
+    return { code: 0, stdout: "", stderr: "", committed: false };
+  };
+  return { exec, calls };
+}
+
+function fakeClock(step = 5): () => number {
+  let t = 1000;
+  return () => {
+    const v = t;
+    t += step;
+    return v;
+  };
+}
+
+describe("runPostAttemptFormat", () => {
+  it("is a no-op for an empty command list", async () => {
+    const { exec, calls } = fakeExec();
+    const result = await runPostAttemptFormat(exec, { worktree: "/wt", commands: [], now: fakeClock() });
+
+    expect(result.ok).toBe(true);
+    expect(result.committed).toBe(false);
+    expect(result.log).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  it("skips blank/whitespace entries without running them", async () => {
+    const { exec, calls } = fakeExec();
+    await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["  ", "cargo fmt --all", ""],
+      now: fakeClock(),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe("cargo fmt --all");
+  });
+
+  it("runs each command at the worktree root under the default timeout", async () => {
+    const { exec, calls } = fakeExec();
+    await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all", "gofmt -w ."],
+      now: fakeClock(),
+    });
+
+    expect(calls).toEqual([
+      { command: "cargo fmt --all", cwd: "/wt", timeoutMs: DEFAULT_POST_ATTEMPT_FORMAT_TIMEOUT_MS },
+      { command: "gofmt -w .", cwd: "/wt", timeoutMs: DEFAULT_POST_ATTEMPT_FORMAT_TIMEOUT_MS },
+    ]);
+  });
+
+  it("passes the caller-supplied timeoutMs to the exec", async () => {
+    const { exec, calls } = fakeExec();
+    await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all"],
+      now: fakeClock(),
+      timeoutMs: 30_000,
+    });
+
+    expect(calls[0]?.timeoutMs).toBe(30_000);
+  });
+
+  it("reports ok:true and committed:true when the exec returns committed:true", async () => {
+    const { exec } = fakeExec([
+      { match: (c) => c === "cargo fmt --all", result: { committed: true } },
+    ]);
+    const result = await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all"],
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.committed).toBe(true);
+  });
+
+  it("reports committed:true when any command in the sequence committed", async () => {
+    const { exec } = fakeExec([
+      { match: (c) => c === "cargo fmt --all", result: { committed: true } },
+    ]);
+    const result = await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all", "gofmt -w ."],
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.committed).toBe(true);
+    expect(result.log).toHaveLength(2);
+  });
+
+  it("aborts on the first non-zero exit — ok:false, remaining commands do not run", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (c) => c === "cargo fmt --all", result: { code: 1, stdout: "syntax error" } },
+    ]);
+    const result = await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all", "gofmt -w ."],
+      now: fakeClock(),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(calls).toHaveLength(1);
+    expect(result.log).toHaveLength(1);
+    expect(result.log[0]).toContain("aborting");
+  });
+
+  it("treats KILLED_EXIT_CODE as a timed-out failure (ok:false)", async () => {
+    const { exec } = fakeExec([
+      { match: (c) => c === "cargo fmt --all", result: { code: KILLED_EXIT_CODE } },
+    ]);
+    const result = await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all"],
+      now: fakeClock(),
+      timeoutMs: 1000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.log[0]).toContain("timed out after 1000ms");
+  });
+
+  it("includes duration in log lines", async () => {
+    const clockSeq = [1000, 2234];
+    let idx = 0;
+    const { exec } = fakeExec();
+    const result = await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["cargo fmt --all"],
+      now: () => clockSeq[idx++] ?? 0,
+    });
+
+    expect(result.log[0]).toContain("1234ms");
+  });
+
+  it("trims whitespace from the command string before running and logging", async () => {
+    const { exec, calls } = fakeExec();
+    const result = await runPostAttemptFormat(exec, {
+      worktree: "/wt",
+      commands: ["  cargo fmt --all  "],
+      now: fakeClock(),
+    });
+
+    expect(calls[0]?.command).toBe("cargo fmt --all");
+    expect(result.log[0]).toContain("cargo fmt --all");
+    expect(result.log[0]).not.toMatch(/\s{2,}/);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1015. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1015

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785645747&installation_id=129708444&pr_number=1080&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1080&signature=f7e004524f451512df3ad91d302862bf6c3e7108c7b458722db963d2f90a0b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->