### PR TITLE
merge: #1019 feat(afk): untouchable primary — locked landing writes to origin/<locked-branch>, never to the local branch

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -202,7 +202,9 @@ export type LandingResult =
  *   `<base>`, so there is nothing to integrate locally first; the prior pre-merge
  *   `merge --ff-only origin/<base>` is dropped (it failed the whole landing on a
  *   diverged primary, #572). landPr's own best-effort local fast-forward is the
- *   only primary touch and never gates the land.
+ *   only primary touch, and even that is SKIPPED on a LOCKED landing (ADR 0083
+ *   §2, #1019) — the locked PR path integrates on `origin/<locked-branch>` and
+ *   never writes to the primary at all.
  *
  *   openPr=false → {@link landDirectInWorktree}. The merge / push / rollback run
  *   inside an ISOLATED detached worktree (makeLandingWorktree) at `<base>`, so the
@@ -329,7 +331,9 @@ export async function doLanding(
  * lock. The merge happens remotely on the forge, so no local integrate runs first
  * — that was the only step that could fail the landing on a diverged primary
  * checkout (#572). The landing succeeds independent of the primary's local
- * `<base>` state. `locked` is echoed for the caller's result observability.
+ * `<base>` state. `locked` is echoed for the caller's result observability AND
+ * passed to {@link landPr}: on a LOCKED landing landPr skips its best-effort local
+ * fast-forward so the primary checkout is never written to (ADR 0083 §2, #1019).
  */
 async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<LandingResult> {
   // Pre-merge rebase (#1006): rebase the worker branch onto the fetched base tip
@@ -352,6 +356,12 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     title: input.title,
     waitForReview: deps.waitForReview,
     ciAwait: deps.ciAwait,
+    // Untouchable primary (ADR 0083 §2, #1019): on a LOCKED landing landPr skips
+    // its step-4 local fast-forward, so the integration reaches the maintainer
+    // only via `origin/<locked-branch>` (they promote by pulling). The lock only
+    // resolved `base` (#842); this is the one primary write the locked PR path
+    // still had.
+    locked: input.locked,
   });
   if (r.ok) return { ok: true, locked: input.locked };
   // Route the CI-aware failure modes (#812) distinctly. A failed required check

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -492,6 +492,15 @@ export interface LandPrInput {
   /** Worktree dir to force-push the attempt branch from; skipped when absent. */
   worktree?: string;
   /**
+   * Untouchable primary (ADR 0083 §2, #1019). When the landing is LOCKED, the
+   * primary checkout is read-only with NO exceptions — including the branch-lock
+   * landing — so the step-4 best-effort local fast-forward of `<target>` is
+   * SKIPPED: the integration lands on `origin/<target>` (the admin-merge is
+   * remote) and the maintainer promotes by pulling. Absent/false (the UNLOCKED
+   * default) keeps the local fast-forward unchanged (issue #1019 criterion 3).
+   */
+  locked?: boolean;
+  /**
    * Opt-in advisory-review wait (`afk.merge.wait_for_review`, ADR 0048). When
    * present, the PR is held until the named review check concludes before the
    * admin-merge; the merge then proceeds regardless of the verdict. Absent (the
@@ -541,7 +550,7 @@ const PR_BODY_PREFIX = "Automated AFK landing for #";
  * Idempotent: a re-attempt reuses the open PR rather than creating a second.
  */
 export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResult> {
-  const { repo, gitRepo, remote, branch, target, n, title, worktree, waitForReview, ciAwait } = input;
+  const { repo, gitRepo, remote, branch, target, n, title, worktree, waitForReview, ciAwait, locked } = input;
 
   // 1. Make the attempt branch's origin state certain before opening the PR.
   if (worktree) {
@@ -588,9 +597,16 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   const merge = await exec(["gh", "-R", repo, "pr", "merge", String(prNumber), "--admin", "--merge"]);
   if (merge.code !== 0) return { ok: false, prNumber, reason: "merge-failed" };
 
-  // 4. Fast-forward local <target> to the merge commit (best-effort).
-  await exec(["git", "-C", gitRepo, "fetch", remote, target, "--quiet"]);
-  await exec(["git", "-C", gitRepo, "merge", "--ff-only", `${remote}/${target}`]);
+  // 4. Fast-forward local <target> to the merge commit (best-effort) — UNLOCKED
+  // ONLY. A LOCKED landing must never write to the primary checkout (ADR 0083 §2,
+  // untouchable primary, no exceptions — including the branch-lock landing): the
+  // integration already lives on `origin/<target>` after the remote admin-merge,
+  // and the maintainer promotes by pulling, so the primary's local `<target>` is
+  // left untouched. The UNLOCKED path keeps its fast-forward (issue #1019 crit. 3).
+  if (!locked) {
+    await exec(["git", "-C", gitRepo, "fetch", remote, target, "--quiet"]);
+    await exec(["git", "-C", gitRepo, "merge", "--ff-only", `${remote}/${target}`]);
+  }
 
   return { ok: true, prNumber };
 }

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -751,3 +751,67 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     expect(mergeIdx).toBeGreaterThan(checksIdx);
   });
 });
+
+describe("doLanding — untouchable primary in the LOCKED landing (ADR 0083 §2, #1019)", () => {
+  // ADR 0083 §2: the primary checkout is READ-ONLY for agents, with NO exceptions
+  // — including the branch-lock landing. The integrated result reaches the
+  // maintainer only via `origin/<locked-branch>`; the maintainer promotes by
+  // pulling. So NO landing path may run a git WRITE verb against the primary
+  // (`git -C /repo`). The only legitimate `git -C /repo` touches are the
+  // read-only precondition probes (fetch a remote ref, rev-parse, merge-base).
+  const WRITE_VERBS = new Set(["merge", "reset", "rebase", "checkout", "switch", "commit", "cherry-pick"]);
+  /** Every `git -C /repo …` call carrying a mutating verb (`merge --ff-only`
+   * included; the read-only `merge-base` token is deliberately NOT `merge`). */
+  function primaryWrites(h: Harness): string[] {
+    return h.mergeCalls
+      .filter((argv) => {
+        const i = argv.indexOf("/repo");
+        return i >= 1 && argv[i - 1] === "-C" && argv.some((tok) => WRITE_VERBS.has(tok));
+      })
+      .map((argv) => argv.join(" "));
+  }
+
+  it("locked + PR (default flag) → admin-merges remotely, NEVER fast-forwards the primary's local lock branch", async () => {
+    const h = harness({ locked: true, openPr: true });
+    h.input.base = "feature-locked";
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true });
+    const j = joined(h.mergeCalls);
+    // The PR is admin-merged remotely — the integration lands on origin, not local.
+    expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    // The step-4 best-effort local fast-forward of the primary's lock branch is GONE.
+    expect(j.some((c) => c.includes("git -C /repo merge --ff-only"))).toBe(false);
+    expect(j.some((c) => c.includes("git -C /repo fetch origin feature-locked"))).toBe(false);
+    // No landing path wrote to the primary checkout.
+    expect(primaryWrites(h)).toEqual([]);
+  });
+
+  it("locked + direct → integrates/merges/pushes only in the isolated worktree, primary write-free", async () => {
+    const h = harness({ locked: true, openPr: false });
+    h.input.base = "feature-locked";
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
+    // The integrated result reaches the maintainer on origin/<lock-branch>.
+    expect(joined(h.mergeCalls)).toContain(`git -C ${WT} push origin HEAD:refs/heads/feature-locked`);
+    expect(primaryWrites(h)).toEqual([]);
+  });
+
+  it("locked + direct conflict self-resolve stays in the worktree, primary write-free", async () => {
+    const h = harness({ locked: true, openPr: false, mergeNoFfCode: 1, conflictResolve: "resolve" });
+    h.input.base = "feature-locked";
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
+    // The resolver ran in the worktree, and the resolved lock branch pushed from it.
+    expect(h.resolverCwds).toEqual([WT]);
+    expect(joined(h.mergeCalls)).toContain(`git -C ${WT} push origin HEAD:refs/heads/feature-locked`);
+    expect(primaryWrites(h)).toEqual([]);
+  });
+
+  it("UNLOCKED PR landing is unchanged — still fast-forwards the primary's local main (criterion 3)", async () => {
+    const h = harness({ locked: false, openPr: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    // The unlocked path keeps its best-effort local fast-forward of <target>=main.
+    expect(joined(h.mergeCalls).some((c) => c.includes("git -C /repo merge --ff-only origin/main"))).toBe(true);
+  });
+});

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -270,6 +270,32 @@ describe("landPr (unlocked path)", () => {
     });
     expect(result.ok).toBe(false);
   });
+
+  it("locked → admin-merges but NEVER fast-forwards the primary checkout (ADR 0083 §2, #1019)", async () => {
+    // Untouchable primary: a LOCKED landing integrates on origin/<target> only; the
+    // best-effort local ff of the primary's <target> is skipped so no write touches
+    // the primary checkout. The maintainer promotes by pulling.
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.join(" ").includes("pr list"), result: { stdout: "42\n" } },
+    ]);
+    const result = await landPr(exec, {
+      repo: "reddb-io/red-skills",
+      gitRepo: "/repo",
+      remote: "origin",
+      branch: "afk/wFFFF/9-x",
+      target: "feature-locked",
+      n: 9,
+      title: "t",
+      locked: true,
+    });
+    expect(result.ok).toBe(true);
+    const c = joined(calls);
+    // The admin-merge still ran (the integration lands remotely on origin).
+    expect(c.some((x) => x.includes("pr merge 42 --admin --merge"))).toBe(true);
+    // No local fast-forward, and no `git -C /repo` write op at all.
+    expect(c.some((x) => x.includes("git -C /repo merge --ff-only"))).toBe(false);
+    expect(c.some((x) => x.includes("git -C /repo fetch"))).toBe(false);
+  });
 });
 
 describe("openReviewPr (review-gate handoff, #749)", () => {


### PR DESCRIPTION
Automated AFK landing for #1019. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1019

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785676436&installation_id=129708444&pr_number=1082&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1082&signature=d05343ce4a2a90a565e5b630204b3000615f9357f185469c33626617b1622e79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->