### PR TITLE
merge: #1020 feat(afk): exit barrier — salvage-commit + push + receipt on the DONE path (tracer)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -14,6 +14,7 @@ import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reco
 import { resolveBase } from "../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
+import { passExitBarrier } from "../core/exit-barrier.js";
 import {
   toMemoryPayload,
   resolveMemoryCli,
@@ -727,6 +728,21 @@ export function buildProcessDeps(
     // branch so the feedback gate + landing see the work instead of an empty
     // merge. No-op when the worktree is clean. Best-effort.
     salvageUncommitted: (branch) => gitx.salvageUncommitted(gitCtx, branch, ctx.remote),
+    // ADR 0083 §4 exit barrier (DONE tracer, #1020): the single owner of the DONE
+    // path's terminal exit — salvage-commit dirty worktree paths, push the branch
+    // to origin (retry once), and return the auditable receipt. Bound over the same
+    // GitContext: salvage reuses `salvageUncommitted`, push uses `pushBranch`, and
+    // the head sha is read from the pushed local ref.
+    exitBarrier: (branch) =>
+      passExitBarrier(
+        {
+          salvage: (b) => gitx.salvageUncommitted(gitCtx, b, ctx.remote),
+          push: (b) => gitx.pushBranch(gitCtx, b, ctx.remote),
+          headSha: async (b) => (await gitx.branchHead(gitCtx, b)) ?? "",
+          nowIso: () => new Date().toISOString(),
+        },
+        branch,
+      ),
     // Feedback runs against a checkout of the worker branch — the feedback
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,

--- a/apps/dev/src/core/exit-barrier.ts
+++ b/apps/dev/src/core/exit-barrier.ts
@@ -1,0 +1,125 @@
+// exit-barrier — ADR 0083 §4: "work is saved iff its branch ref is pushed to
+// origin". The single owner of an attempt's terminal exit: it salvage-commits any
+// uncommitted worktree changes, pushes the attempt branch to origin (create or
+// update), and produces an auditable RECEIPT the caller records in the attempt
+// record / Envelope. A terminal path that bypasses this barrier is a bug by
+// definition (ADR 0083).
+//
+// This slice (issue #1020) is the tracer: only the successful-attempt (DONE) path
+// obtains its exit through the barrier. The remaining terminal paths (guard abort,
+// stall-kill, teardown, reconcile) are the follow-up slice — they will call the
+// SAME `passExitBarrier` so the "one owner" guarantee holds without re-derivation.
+//
+// PURE of a concrete git: every git touch is an injected port so unit tests drive
+// salvage / push / head-sha with fakes and never touch an OS git.
+
+/**
+ * The auditable proof that an attempt's work reached origin. The caller records
+ * it in the attempt record / Envelope so "was this work saved?" is answerable
+ * from the record alone, never re-derived from the live repo.
+ */
+export interface ExitReceipt {
+  /** The attempt branch whose ref was pushed. */
+  branch: string;
+  /** The branch head sha AFTER salvage + push (the ref origin now carries). */
+  head: string;
+  /** ISO-8601 timestamp of the successful push. */
+  pushedAt: string;
+  /** True when the barrier created a salvage commit (dirty worktree at exit). */
+  salvaged: boolean;
+  /** Number of files the salvage step committed (0 when the worktree was clean). */
+  salvagedFiles: number;
+}
+
+/** The result of one push attempt through the {@link ExitBarrierPorts.push} port. */
+export interface PushResult {
+  ok: boolean;
+  /** Failure detail surfaced in the thrown error when both attempts fail. */
+  error?: string;
+}
+
+/**
+ * The injected git surface the barrier needs. run.ts binds these to the concrete
+ * `runtime/git.ts` closures over a GitContext; tests bind recording fakes.
+ */
+export interface ExitBarrierPorts {
+  /**
+   * Salvage-commit any uncommitted worktree changes onto `branch`, one commit per
+   * file (the existing salvage convention, `runtime/git.ts::salvageUncommitted`).
+   * Returns the count committed (0 = clean worktree). Best-effort: MUST NOT throw
+   * — a salvage failure never blocks the push, which is the barrier's hard
+   * guarantee.
+   */
+  salvage(branch: string): Promise<number>;
+  /**
+   * Push `branch` to origin (create or update the remote ref). Returns
+   * `{ok:true}` on success; `{ok:false, error}` on a rejected/failed push. MUST
+   * NOT throw — the barrier owns the retry + hard-error policy.
+   */
+  push(branch: string): Promise<PushResult>;
+  /**
+   * Resolve the current head sha of `branch` (after salvage + push). Empty string
+   * when the ref cannot be read.
+   */
+  headSha(branch: string): Promise<string>;
+  /** ISO-8601 timestamp source for the receipt's `pushedAt`. */
+  nowIso(): string;
+}
+
+/**
+ * Thrown when the barrier cannot push the attempt branch after its retry. The
+ * caller MUST treat this as a non-clean termination: an attempt is never reported
+ * as cleanly terminated without a receipt (ADR 0083 §4).
+ */
+export class ExitBarrierError extends Error {
+  readonly branch: string;
+  constructor(branch: string, detail: string) {
+    super(`exit barrier: failed to push attempt branch \`${branch}\` after retry — ${detail}`);
+    this.name = "ExitBarrierError";
+    this.branch = branch;
+  }
+}
+
+/**
+ * Run the exit barrier for a terminating attempt on `branch`:
+ *
+ *   1. Salvage-commit uncommitted worktree changes (best-effort; count captured).
+ *   2. Push the branch to origin — on failure, retry EXACTLY ONCE.
+ *   3. Both attempts failed → throw {@link ExitBarrierError} (attempt NOT clean).
+ *   4. Success → return the {@link ExitReceipt} (branch / head / pushedAt / salvage).
+ *
+ * The salvage step is best-effort by contract (it never blocks the push); the
+ * PUSH is the load-bearing guarantee, so only a push failure aborts the exit.
+ */
+export async function passExitBarrier(ports: ExitBarrierPorts, branch: string): Promise<ExitReceipt> {
+  // 1. Salvage-commit any dirty worktree paths. `salvage` is best-effort and must
+  //    not throw; guard defensively so a misbehaving port can never strand the
+  //    push behind an exception.
+  let salvagedFiles = 0;
+  try {
+    salvagedFiles = await ports.salvage(branch);
+  } catch {
+    // A salvage failure leaves the committed subset intact and is never fatal —
+    // the push below still saves whatever reached the branch ref.
+    salvagedFiles = 0;
+  }
+
+  // 2. Push the branch — retry once on failure, then surface a hard error.
+  const first = await ports.push(branch).catch((err: unknown) => ({ ok: false, error: String(err) }) as PushResult);
+  if (!first.ok) {
+    const retry = await ports.push(branch).catch((err: unknown) => ({ ok: false, error: String(err) }) as PushResult);
+    if (!retry.ok) {
+      throw new ExitBarrierError(branch, retry.error ?? first.error ?? "push rejected");
+    }
+  }
+
+  // 3. Success → assemble the receipt from the pushed ref.
+  const head = await ports.headSha(branch).catch(() => "");
+  return {
+    branch,
+    head,
+    pushedAt: ports.nowIso(),
+    salvaged: salvagedFiles > 0,
+    salvagedFiles,
+  };
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -64,6 +64,7 @@ import {
 } from "./merge.js";
 import { doLanding } from "./landing.js";
 import { reconcile, type ReconcileInput } from "./reconcile.js";
+import { ExitBarrierError, type ExitReceipt } from "./exit-barrier.js";
 import {
   emitEnvelope,
   type EmitEnvelopeDeps,
@@ -491,6 +492,19 @@ export interface ProcessIssueDeps {
    */
   salvageUncommitted?(branch: string): Promise<number>;
   /**
+   * ADR 0083 §4 exit barrier (DONE tracer, #1020). The single owner of an
+   * attempt's terminal exit on the DONE path: salvage-commit any dirty worktree
+   * paths, push the attempt branch to origin (retry once), and return an auditable
+   * {@link ExitReceipt} (branch / head / pushedAt / salvage flag) recorded in the
+   * done ProcessIssueResult + attempt record. Throws {@link ExitBarrierError} when
+   * the push fails after retry — processIssue routes that to a NON-clean terminal
+   * so the attempt is never reported done without a receipt ("work is saved iff
+   * its branch ref is pushed to origin"). Optional → when absent the DONE path
+   * falls back to the legacy salvage-only step (`salvageUncommitted`). The CLI
+   * (run.ts) binds it over the same GitContext; tests inject a fake barrier.
+   */
+  exitBarrier?(branch: string): Promise<ExitReceipt>;
+  /**
    * Post-merge PRD cascade rebase (issue #1007, `afk.landing.cascade_rebase`).
    * Provides the IO surface for {@link runCascadeRebase}: after a successful DONE
    * landing, AFK rebases every open sibling branch (same prd:N label, not held by
@@ -598,6 +612,12 @@ export interface ProcessIssueResult {
   locked?: boolean;
   /** Merge commit sha on a successful done close. */
   mergeSha?: string;
+  /**
+   * ADR 0083 §4 exit-barrier receipt (#1020) — the auditable proof the attempt
+   * branch reached origin (branch / head / pushedAt / salvage flag). Present on
+   * the DONE path when an `exitBarrier` port is wired; undefined otherwise.
+   */
+  exitReceipt?: ExitReceipt;
   /** The lifecycle points that fired, in order — the parity target for tests. */
   hooksFired: HookName[];
   /** True when the terminal envelope was posted. */
@@ -1059,6 +1079,11 @@ export async function processIssue(
   let salvagedUncommittedFiles = 0;
   let salvagedUncommittedOutcome: RunAgentResult["outcome"] | undefined;
   let salvagedRunCommitCount = 0;
+  // ADR 0083 §4 exit-barrier receipt (#1020). Set on the DONE path once the barrier
+  // has salvage-committed + pushed the attempt branch to origin; recorded in the
+  // done ProcessIssueResult + the attempt record so "was this work saved?" is
+  // answerable from the record alone.
+  let exitReceipt: ExitReceipt | undefined;
   // Scout mode: collect the agent's text-chunk events as the report. The
   // orchestrator posts this as a GitHub comment instead of pushing a branch.
   const scoutTextChunks: string[] = [];
@@ -1273,7 +1298,49 @@ export async function processIssue(
     // dirty worktree paths onto the worker branch (one commit per file) so the
     // SAME feedback gate + landing tail validate and merge the complete work. A
     // clean worktree salvages nothing (count 0).
-    if (
+    // ADR 0083 §4 exit barrier (DONE tracer, #1020): on the DONE path, obtain the
+    // attempt's exit through the single barrier — salvage-commit any dirty worktree
+    // paths, push the branch to origin (retry once), and produce an auditable
+    // receipt. "Work is saved iff its branch ref is pushed to origin"; a push
+    // failure after retry throws ExitBarrierError and routes to a NON-clean
+    // terminal (the attempt is never reported done without a receipt). The legacy
+    // salvage-only step below still covers the other salvageable outcomes
+    // (no-sentinel / budget-exceeded), whose barrier wiring is the follow-up slice.
+    if (deps.exitBarrier && run.outcome === "done") {
+      try {
+        exitReceipt = await deps.exitBarrier(workerBranch);
+      } catch (err) {
+        if (err instanceof ExitBarrierError) {
+          // The barrier could not push the attempt branch to origin after its
+          // retry — "work is saved iff its branch ref is pushed" is NOT satisfied,
+          // so the attempt must NOT be reported as cleanly done. Route to the
+          // recoverable merge-conflict terminal (branch preserved, bounded retry
+          // re-pushes next run) with a receipt-absent reason in the envelope.
+          await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "merge-conflict", current.attempt));
+          return await terminalFailure(common, "merge-conflict", "merge-conflict", {
+            notes: `_(exit barrier: could not push the attempt branch \`${workerBranch}\` to origin after retry — work is NOT confirmed saved, so the attempt is not reported as cleanly done)_`,
+            log: String(err),
+          });
+        }
+        throw err;
+      }
+      if (exitReceipt.salvagedFiles > 0) {
+        salvagedUncommittedFiles = exitReceipt.salvagedFiles;
+        salvagedUncommittedOutcome = run.outcome;
+        salvagedRunCommitCount = run.commits.length;
+        const commitFact =
+          run.commits.length === 0
+            ? "committed nothing"
+            : `left dirty worktree paths after ${run.commits.length} commit(s)`;
+        deps.appendIterLog(
+          `🤖 /afk: inner agent emitted done but ${commitFact} — exit barrier salvaged ${exitReceipt.salvagedFiles} uncommitted file(s) onto \`${workerBranch}\` and pushed to origin (receipt head ${exitReceipt.head || "?"}).`,
+        );
+      } else {
+        deps.appendIterLog(
+          `🤖 /afk: exit barrier pushed \`${workerBranch}\` to origin (clean worktree; receipt head ${exitReceipt.head || "?"}).`,
+        );
+      }
+    } else if (
       deps.salvageUncommitted &&
       (run.outcome === "done" || run.outcome === "no-sentinel" || run.outcome === "budget-exceeded")
     ) {
@@ -1833,11 +1900,16 @@ export async function processIssue(
   await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
   const posted = await emitDone(common, mergeSha, durationS, validationSidecar, lastValidationScope);
   // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
-  // (done) envelope. Best-effort, gated, no-op when memory is absent.
+  // (done) envelope. Best-effort, gated, no-op when memory is absent. The ADR 0083
+  // §4 exit-barrier receipt (#1020), when present, rides the attempt record so the
+  // auditable "work reached origin" proof is preserved with the reasoning attempt.
   await recordAttemptBestEffort(common, "done", {
     durationS,
     mergeSha,
     validationSummary: validationSidecar.join("\n"),
+    notes: exitReceipt
+      ? `exit-barrier receipt: branch \`${exitReceipt.branch}\` pushed to origin at ${exitReceipt.pushedAt} (head ${exitReceipt.head || "?"}, salvaged ${exitReceipt.salvagedFiles} file(s)).`
+      : undefined,
   });
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
@@ -1873,6 +1945,7 @@ export async function processIssue(
     mergeSha,
     hooksFired,
     envelopePosted: posted,
+    exitReceipt,
     preserved: true,
     swept: true,
   };

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -411,6 +411,26 @@ export async function salvageUncommitted(ctx: GitContext, branch: string, remote
 }
 
 /**
+ * Push a LOCAL branch ref to `remote` (create or update the remote branch). The
+ * ref lives in the shared `.git`, so this runs from the primary checkout cwd —
+ * no worktree needed. Used by the ADR 0083 §4 exit barrier to guarantee the
+ * attempt branch reached origin before the attempt is allowed to terminate.
+ * Returns `{ok:true}` on a clean push; `{ok:false, error}` (never throws) on a
+ * rejected/failed push so the barrier owns the retry + hard-error policy. Routed
+ * through the same `runGit` seam so tests drive it without an OS git.
+ */
+export async function pushBranch(
+  ctx: GitContext,
+  branch: string,
+  remote = "origin",
+): Promise<{ ok: boolean; error?: string }> {
+  if (!branch) return { ok: false, error: "empty branch" };
+  const r = await runGit(ctx, ["push", remote, `refs/heads/${branch}:refs/heads/${branch}`]);
+  if (r.code === 0) return { ok: true };
+  return { ok: false, error: (r.stderr || r.stdout || `git push exited ${r.code}`).trim() };
+}
+
+/**
  * List origin refs under a namespace ("afk/" | "afk-attempts/") via ls-remote,
  * shaped as BranchRef[]. The optional last-commit epoch is left unset (the
  * snapshot 404 grace falls back to "keep" without it).

--- a/apps/dev/tests/exit-barrier.test.ts
+++ b/apps/dev/tests/exit-barrier.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  passExitBarrier,
+  ExitBarrierError,
+  type ExitBarrierPorts,
+  type PushResult,
+} from "../src/core/exit-barrier.js";
+
+// Everything injected is a fake — no real git ever runs. Each test records the
+// salvage/push call sequence so the barrier's contract (salvage → push → receipt,
+// retry-once, hard-error-on-failure) is asserted as a trace.
+
+interface Trace {
+  salvageCalls: string[];
+  pushCalls: string[];
+  headCalls: string[];
+}
+
+function harness(
+  overrides: Partial<{
+    salvage: (branch: string) => Promise<number>;
+    push: (branch: string) => Promise<PushResult>;
+    headSha: (branch: string) => Promise<string>;
+  }> = {},
+): { ports: ExitBarrierPorts; trace: Trace } {
+  const trace: Trace = { salvageCalls: [], pushCalls: [], headCalls: [] };
+  const ports: ExitBarrierPorts = {
+    salvage: async (branch) => {
+      trace.salvageCalls.push(branch);
+      return overrides.salvage ? overrides.salvage(branch) : 0;
+    },
+    push: async (branch) => {
+      trace.pushCalls.push(branch);
+      return overrides.push ? overrides.push(branch) : { ok: true };
+    },
+    headSha: async (branch) => {
+      trace.headCalls.push(branch);
+      return overrides.headSha ? overrides.headSha(branch) : "deadbeef";
+    },
+    nowIso: () => "2026-07-03T12:00:00Z",
+  };
+  return { ports, trace };
+}
+
+describe("passExitBarrier", () => {
+  it("clean worktree → branch pushed, no salvage commit in the receipt", async () => {
+    const { ports, trace } = harness({ salvage: async () => 0 });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt).toEqual({
+      branch: "afk/w1/42-x",
+      head: "deadbeef",
+      pushedAt: "2026-07-03T12:00:00Z",
+      salvaged: false,
+      salvagedFiles: 0,
+    });
+    // Salvage was attempted (found nothing) and the branch was pushed exactly once.
+    expect(trace.salvageCalls).toEqual(["afk/w1/42-x"]);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("dirty worktree → salvage commit created and pushed, flagged in the receipt", async () => {
+    const { ports, trace } = harness({
+      salvage: async () => 3,
+      headSha: async () => "cafef00d",
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.salvaged).toBe(true);
+    expect(receipt.salvagedFiles).toBe(3);
+    expect(receipt.head).toBe("cafef00d");
+    // Salvage ran before the push so the pushed ref carries the salvage commit.
+    expect(trace.salvageCalls).toEqual(["afk/w1/42-x"]);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("push fails once then succeeds → retried, receipt returned", async () => {
+    let attempts = 0;
+    const { ports, trace } = harness({
+      push: async () => {
+        attempts += 1;
+        return attempts === 1 ? { ok: false, error: "remote rejected" } : { ok: true };
+      },
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.head).toBe("deadbeef");
+    // Pushed twice: the initial rejection, then the successful retry.
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+  });
+
+  it("push fails after retry → throws ExitBarrierError (attempt not clean)", async () => {
+    const { ports, trace } = harness({
+      push: async () => ({ ok: false, error: "remote rejected" }),
+    });
+
+    await expect(passExitBarrier(ports, "afk/w1/42-x")).rejects.toBeInstanceOf(ExitBarrierError);
+    // Exactly two attempts: the initial push and one retry, then it gives up.
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+    // No head sha is read on the failure path — there is no receipt to build.
+    expect(trace.headCalls).toEqual([]);
+  });
+
+  it("the thrown error names the branch and the last push detail", async () => {
+    const { ports } = harness({
+      push: async () => ({ ok: false, error: "non-fast-forward" }),
+    });
+
+    await expect(passExitBarrier(ports, "afk/w1/42-x")).rejects.toMatchObject({
+      branch: "afk/w1/42-x",
+      message: expect.stringContaining("non-fast-forward"),
+    });
+  });
+
+  it("a salvage that throws is swallowed — the push still saves the branch", async () => {
+    const { ports, trace } = harness({
+      salvage: async () => {
+        throw new Error("salvage boom");
+      },
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    // Salvage failure degrades to 0 files, never blocks the load-bearing push.
+    expect(receipt.salvaged).toBe(false);
+    expect(receipt.salvagedFiles).toBe(0);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("a push port that throws is treated as a failed push and retried", async () => {
+    let attempts = 0;
+    const { ports, trace } = harness({
+      push: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("network down");
+        return { ok: true };
+      },
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.head).toBe("deadbeef");
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1020. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1020

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785676514&installation_id=129708444&pr_number=1083&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1083&signature=ea3e04d4fa2a7814073d0ca6b2e109b541a69c638405a63242dcaf0c2778e889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->