### PR TITLE
merge: #1021 feat(afk): exit barrier on every terminal path — abort, stall-kill, teardown, reconcile

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -14,7 +14,7 @@ import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reco
 import { resolveBase } from "../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
-import { passExitBarrier } from "../core/exit-barrier.js";
+import { passExitBarrier, passTerminalBarrier } from "../core/exit-barrier.js";
 import {
   toMemoryPayload,
   resolveMemoryCli,
@@ -735,6 +735,22 @@ export function buildProcessDeps(
     // the head sha is read from the pushed local ref.
     exitBarrier: (branch) =>
       passExitBarrier(
+        {
+          salvage: (b) => gitx.salvageUncommitted(gitCtx, b, ctx.remote),
+          push: (b) => gitx.pushBranch(gitCtx, b, ctx.remote),
+          headSha: async (b) => (await gitx.branchHead(gitCtx, b)) ?? "",
+          nowIso: () => new Date().toISOString(),
+        },
+        branch,
+      ),
+    // ADR 0083 §4 exit barrier (every-terminal, #1021): the FAILURE-terminal
+    // crossing bound over the SAME GitContext as the DONE barrier — guard abort,
+    // stall-kill, crash teardown, and (via reconcile) the no-agent lane all pass
+    // through it. Unlike the DONE barrier it never throws; a rejected push is
+    // recorded in the receipt (`pushed:false`) so the failing attempt still
+    // terminates but the branch state is reported truthfully.
+    terminalExitBarrier: (branch) =>
+      passTerminalBarrier(
         {
           salvage: (b) => gitx.salvageUncommitted(gitCtx, b, ctx.remote),
           push: (b) => gitx.pushBranch(gitCtx, b, ctx.remote),

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -14,6 +14,7 @@ import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reco
 import { resolveBase } from "../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
+import { passExitBarrier } from "../core/exit-barrier.js";
 import {
   toMemoryPayload,
   resolveMemoryCli,
@@ -727,6 +728,21 @@ export function buildProcessDeps(
     // branch so the feedback gate + landing see the work instead of an empty
     // merge. No-op when the worktree is clean. Best-effort.
     salvageUncommitted: (branch) => gitx.salvageUncommitted(gitCtx, branch, ctx.remote),
+    // ADR 0083 §4 exit barrier (DONE tracer, #1020): the single owner of the DONE
+    // path's terminal exit — salvage-commit dirty worktree paths, push the branch
+    // to origin (retry once), and return the auditable receipt. Bound over the same
+    // GitContext: salvage reuses `salvageUncommitted`, push uses `pushBranch`, and
+    // the head sha is read from the pushed local ref.
+    exitBarrier: (branch) =>
+      passExitBarrier(
+        {
+          salvage: (b) => gitx.salvageUncommitted(gitCtx, b, ctx.remote),
+          push: (b) => gitx.pushBranch(gitCtx, b, ctx.remote),
+          headSha: async (b) => (await gitx.branchHead(gitCtx, b)) ?? "",
+          nowIso: () => new Date().toISOString(),
+        },
+        branch,
+      ),
     // Feedback runs against a checkout of the worker branch — the feedback
     // worktree manager materialises it and rebases pnpm/layout onto it.
     pnpm: feedback.pnpm,

--- a/apps/dev/src/core/exit-barrier.ts
+++ b/apps/dev/src/core/exit-barrier.ts
@@ -31,6 +31,23 @@ export interface ExitReceipt {
   salvagedFiles: number;
 }
 
+/**
+ * The terminal-path variant of {@link ExitReceipt}. A FAILURE terminal (guard
+ * abort, stall-kill, crash teardown, reconcile) is ALREADY terminating, so its
+ * barrier crossing never throws on a rejected push — it records whether the
+ * branch actually reached origin in {@link pushed} instead of converting the
+ * failure into a second one. `pushed:false` means the branch could not be saved
+ * (absent / rejected); the caller still terminates but the receipt tells the
+ * truth about whether the work is on origin ("work is saved iff its branch ref
+ * is pushed", ADR 0083 §4).
+ */
+export interface TerminalReceipt extends ExitReceipt {
+  /** True iff the branch ref reached origin (create or update); false on a failed
+   * or skipped push. The {@link ExitReceipt} base always implies a successful
+   * push (it only exists after one); this flag makes the failure case explicit. */
+  pushed: boolean;
+}
+
 /** The result of one push attempt through the {@link ExitBarrierPorts.push} port. */
 export interface PushResult {
   ok: boolean;
@@ -121,5 +138,53 @@ export async function passExitBarrier(ports: ExitBarrierPorts, branch: string): 
     pushedAt: ports.nowIso(),
     salvaged: salvagedFiles > 0,
     salvagedFiles,
+  };
+}
+
+/**
+ * Run the exit barrier for a FAILURE terminal on `branch` — the shared crossing
+ * for every non-DONE terminal path (guard abort, stall-kill, crash teardown,
+ * reconcile). Unlike {@link passExitBarrier} it NEVER throws: a failing attempt
+ * is already terminal, so a rejected push is RECORDED (`pushed:false`) rather
+ * than escalated into a second failure that could strand the terminal handler.
+ *
+ *   1. Salvage-commit uncommitted worktree changes (best-effort; count captured).
+ *   2. Push the branch to origin — on failure, retry EXACTLY ONCE.
+ *   3. Assemble a {@link TerminalReceipt} whose `pushed` flag is the load-bearing
+ *      truth: consumers report the terminal WITH this receipt so "was this work
+ *      saved?" is answerable from the record alone.
+ *
+ * The receipt is the REQUIRED input to terminal-status reporting: a terminal path
+ * obtains its exit through this barrier, then reports its status with the receipt,
+ * so a path that reports a status without a receipt is not representable.
+ */
+export async function passTerminalBarrier(ports: ExitBarrierPorts, branch: string): Promise<TerminalReceipt> {
+  // 1. Salvage-commit any dirty worktree paths (best-effort; never blocks push).
+  let salvagedFiles = 0;
+  try {
+    salvagedFiles = await ports.salvage(branch);
+  } catch {
+    salvagedFiles = 0;
+  }
+
+  // 2. Push the branch — retry once on failure. A still-failing push is NOT fatal
+  //    here (the attempt already failed); it is recorded as `pushed:false` below.
+  const first = await ports.push(branch).catch((err: unknown) => ({ ok: false, error: String(err) }) as PushResult);
+  let pushed = first.ok;
+  if (!pushed) {
+    const retry = await ports.push(branch).catch((err: unknown) => ({ ok: false, error: String(err) }) as PushResult);
+    pushed = retry.ok;
+  }
+
+  // 3. Assemble the terminal receipt. The head sha is only meaningful once the ref
+  //    reached origin; a not-pushed terminal reports an empty head.
+  const head = pushed ? await ports.headSha(branch).catch(() => "") : "";
+  return {
+    branch,
+    head,
+    pushedAt: ports.nowIso(),
+    salvaged: salvagedFiles > 0,
+    salvagedFiles,
+    pushed,
   };
 }

--- a/apps/dev/src/core/exit-barrier.ts
+++ b/apps/dev/src/core/exit-barrier.ts
@@ -29,6 +29,14 @@ export interface ExitReceipt {
   salvaged: boolean;
   /** Number of files the salvage step committed (0 when the worktree was clean). */
   salvagedFiles: number;
+  /**
+   * Whether the branch ref reached origin. The DONE barrier ({@link passExitBarrier})
+   * OMITS this — a DONE receipt only exists after a successful push, so its absence
+   * reads as "pushed". A FAILURE {@link TerminalReceipt} always sets it explicitly
+   * (true/false), because a failing attempt still terminates even when the push is
+   * rejected. Consumers treat `undefined` as pushed.
+   */
+  pushed?: boolean;
 }
 
 /**
@@ -43,8 +51,9 @@ export interface ExitReceipt {
  */
 export interface TerminalReceipt extends ExitReceipt {
   /** True iff the branch ref reached origin (create or update); false on a failed
-   * or skipped push. The {@link ExitReceipt} base always implies a successful
-   * push (it only exists after one); this flag makes the failure case explicit. */
+   * or skipped push. Unlike the optional base field, a terminal receipt ALWAYS
+   * sets this — the whole point of the failure crossing is to report truthfully
+   * whether the work is on origin. */
   pushed: boolean;
 }
 

--- a/apps/dev/src/core/exit-barrier.ts
+++ b/apps/dev/src/core/exit-barrier.ts
@@ -1,0 +1,125 @@
+// exit-barrier — ADR 0083 §4: "work is saved iff its branch ref is pushed to
+// origin". The single owner of an attempt's terminal exit: it salvage-commits any
+// uncommitted worktree changes, pushes the attempt branch to origin (create or
+// update), and produces an auditable RECEIPT the caller records in the attempt
+// record / Envelope. A terminal path that bypasses this barrier is a bug by
+// definition (ADR 0083).
+//
+// This slice (issue #1020) is the tracer: only the successful-attempt (DONE) path
+// obtains its exit through the barrier. The remaining terminal paths (guard abort,
+// stall-kill, teardown, reconcile) are the follow-up slice — they will call the
+// SAME `passExitBarrier` so the "one owner" guarantee holds without re-derivation.
+//
+// PURE of a concrete git: every git touch is an injected port so unit tests drive
+// salvage / push / head-sha with fakes and never touch an OS git.
+
+/**
+ * The auditable proof that an attempt's work reached origin. The caller records
+ * it in the attempt record / Envelope so "was this work saved?" is answerable
+ * from the record alone, never re-derived from the live repo.
+ */
+export interface ExitReceipt {
+  /** The attempt branch whose ref was pushed. */
+  branch: string;
+  /** The branch head sha AFTER salvage + push (the ref origin now carries). */
+  head: string;
+  /** ISO-8601 timestamp of the successful push. */
+  pushedAt: string;
+  /** True when the barrier created a salvage commit (dirty worktree at exit). */
+  salvaged: boolean;
+  /** Number of files the salvage step committed (0 when the worktree was clean). */
+  salvagedFiles: number;
+}
+
+/** The result of one push attempt through the {@link ExitBarrierPorts.push} port. */
+export interface PushResult {
+  ok: boolean;
+  /** Failure detail surfaced in the thrown error when both attempts fail. */
+  error?: string;
+}
+
+/**
+ * The injected git surface the barrier needs. run.ts binds these to the concrete
+ * `runtime/git.ts` closures over a GitContext; tests bind recording fakes.
+ */
+export interface ExitBarrierPorts {
+  /**
+   * Salvage-commit any uncommitted worktree changes onto `branch`, one commit per
+   * file (the existing salvage convention, `runtime/git.ts::salvageUncommitted`).
+   * Returns the count committed (0 = clean worktree). Best-effort: MUST NOT throw
+   * — a salvage failure never blocks the push, which is the barrier's hard
+   * guarantee.
+   */
+  salvage(branch: string): Promise<number>;
+  /**
+   * Push `branch` to origin (create or update the remote ref). Returns
+   * `{ok:true}` on success; `{ok:false, error}` on a rejected/failed push. MUST
+   * NOT throw — the barrier owns the retry + hard-error policy.
+   */
+  push(branch: string): Promise<PushResult>;
+  /**
+   * Resolve the current head sha of `branch` (after salvage + push). Empty string
+   * when the ref cannot be read.
+   */
+  headSha(branch: string): Promise<string>;
+  /** ISO-8601 timestamp source for the receipt's `pushedAt`. */
+  nowIso(): string;
+}
+
+/**
+ * Thrown when the barrier cannot push the attempt branch after its retry. The
+ * caller MUST treat this as a non-clean termination: an attempt is never reported
+ * as cleanly terminated without a receipt (ADR 0083 §4).
+ */
+export class ExitBarrierError extends Error {
+  readonly branch: string;
+  constructor(branch: string, detail: string) {
+    super(`exit barrier: failed to push attempt branch \`${branch}\` after retry — ${detail}`);
+    this.name = "ExitBarrierError";
+    this.branch = branch;
+  }
+}
+
+/**
+ * Run the exit barrier for a terminating attempt on `branch`:
+ *
+ *   1. Salvage-commit uncommitted worktree changes (best-effort; count captured).
+ *   2. Push the branch to origin — on failure, retry EXACTLY ONCE.
+ *   3. Both attempts failed → throw {@link ExitBarrierError} (attempt NOT clean).
+ *   4. Success → return the {@link ExitReceipt} (branch / head / pushedAt / salvage).
+ *
+ * The salvage step is best-effort by contract (it never blocks the push); the
+ * PUSH is the load-bearing guarantee, so only a push failure aborts the exit.
+ */
+export async function passExitBarrier(ports: ExitBarrierPorts, branch: string): Promise<ExitReceipt> {
+  // 1. Salvage-commit any dirty worktree paths. `salvage` is best-effort and must
+  //    not throw; guard defensively so a misbehaving port can never strand the
+  //    push behind an exception.
+  let salvagedFiles = 0;
+  try {
+    salvagedFiles = await ports.salvage(branch);
+  } catch {
+    // A salvage failure leaves the committed subset intact and is never fatal —
+    // the push below still saves whatever reached the branch ref.
+    salvagedFiles = 0;
+  }
+
+  // 2. Push the branch — retry once on failure, then surface a hard error.
+  const first = await ports.push(branch).catch((err: unknown) => ({ ok: false, error: String(err) }) as PushResult);
+  if (!first.ok) {
+    const retry = await ports.push(branch).catch((err: unknown) => ({ ok: false, error: String(err) }) as PushResult);
+    if (!retry.ok) {
+      throw new ExitBarrierError(branch, retry.error ?? first.error ?? "push rejected");
+    }
+  }
+
+  // 3. Success → assemble the receipt from the pushed ref.
+  const head = await ports.headSha(branch).catch(() => "");
+  return {
+    branch,
+    head,
+    pushedAt: ports.nowIso(),
+    salvaged: salvagedFiles > 0,
+    salvagedFiles,
+  };
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -64,7 +64,7 @@ import {
 } from "./merge.js";
 import { doLanding } from "./landing.js";
 import { reconcile, type ReconcileInput } from "./reconcile.js";
-import { ExitBarrierError, type ExitReceipt } from "./exit-barrier.js";
+import { ExitBarrierError, type ExitReceipt, type TerminalReceipt } from "./exit-barrier.js";
 import {
   emitEnvelope,
   type EmitEnvelopeDeps,
@@ -504,6 +504,21 @@ export interface ProcessIssueDeps {
    * (run.ts) binds it over the same GitContext; tests inject a fake barrier.
    */
   exitBarrier?(branch: string): Promise<ExitReceipt>;
+  /**
+   * ADR 0083 §4 exit barrier (every-terminal, #1021). The single owner of an
+   * attempt's terminal exit on EVERY FAILURE path — guard abort, stall-kill, crash
+   * teardown, and (via reconcile) the no-agent lane: salvage-commit dirty worktree
+   * paths + push the attempt branch to origin (retry once) and return a
+   * {@link TerminalReceipt}. Unlike {@link exitBarrier} it NEVER throws — a failing
+   * attempt is already terminal, so a rejected push is RECORDED (`pushed:false`)
+   * not escalated. The receipt is the REQUIRED input to `preservedTerminal`, so a
+   * preserved terminal that reports a status without crossing the barrier is not
+   * representable. Optional → when absent `crossTerminalBarrier` returns a
+   * not-pushed receipt so legacy callers still report (branch state unconfirmed).
+   * run.ts binds it over the same GitContext as {@link exitBarrier}; tests inject
+   * a fake barrier.
+   */
+  terminalExitBarrier?(branch: string): Promise<TerminalReceipt>;
   /**
    * Post-merge PRD cascade rebase (issue #1007, `afk.landing.cascade_rebase`).
    * Provides the IO surface for {@link runCascadeRebase}: after a successful DONE
@@ -2180,6 +2195,58 @@ async function writeCurrentBlockerBestEffort(
 }
 
 /**
+ * Cross the ADR 0083 §4 exit barrier for a FAILURE terminal (#1021): salvage-commit
+ * any dirty worktree paths + push the attempt branch to origin, returning the
+ * auditable {@link TerminalReceipt} every preserved terminal reports with. NEVER
+ * throws — a failing attempt is already terminal, so a barrier fault or a rejected
+ * push degrades to a not-pushed receipt (`pushed:false`) rather than escalating
+ * into a second failure. When no barrier port is wired (legacy caller) it returns
+ * the same not-pushed receipt so {@link preservedTerminal} always has its required
+ * receipt input — the branch state is simply reported as unconfirmed.
+ */
+async function crossTerminalBarrier(deps: ProcessIssueDeps, branch: string): Promise<TerminalReceipt> {
+  if (deps.terminalExitBarrier) {
+    try {
+      return await deps.terminalExitBarrier(branch);
+    } catch {
+      // The barrier port itself faulted — fall through to the not-pushed receipt.
+      // The terminal still reports; the branch simply is not confirmed on origin.
+    }
+  }
+  return { branch, head: "", pushedAt: new Date().toISOString(), salvaged: false, salvagedFiles: 0, pushed: false };
+}
+
+/**
+ * Build a PRESERVED terminal {@link ProcessIssueResult}. The exit-barrier receipt
+ * is a MANDATORY first argument (ADR 0083 §4, #1021): a preserved terminal is
+ * reported iff its branch crossed the barrier, and the only way to obtain a
+ * {@link TerminalReceipt} is {@link crossTerminalBarrier} — so a terminal that
+ * reports a preserved status without first crossing the barrier is not
+ * representable. Every preserved-terminal tail funnels its result shape through
+ * here so the `preserved:true` / `swept:false` / `exitReceipt` invariant is owned
+ * in one place.
+ */
+function preservedTerminal(
+  receipt: TerminalReceipt,
+  fields: {
+    outcome: ProcessOutcome;
+    issue: number;
+    branch: string;
+    base: string;
+    hooksFired: HookName[];
+    envelopePosted?: boolean;
+    locked?: boolean;
+  },
+): ProcessIssueResult {
+  return {
+    ...fields,
+    exitReceipt: receipt,
+    preserved: true,
+    swept: false,
+  };
+}
+
+/**
  * The uniform terminal-FAILURE tail shared by no-sentinel, blocked, feedback,
  * and merge-conflict: route the BOUNDED auto-recovery labels (routeRecovery),
  * emit the failure envelope with the status derived from the outcome
@@ -2210,22 +2277,31 @@ async function terminalFailure(
     notes: record.notes,
     validationSummary: record.validationSummary,
   });
+  // ADR 0083 §4 exit barrier (#1021): before reporting the terminal, obtain its
+  // exit through the single barrier — salvage-commit any dirty worktree paths and
+  // push the attempt branch to origin. This is the ONE writer for guard-abort
+  // (stalled / budget) and the other salvageable failure terminals, so no path
+  // strands uncommitted work ("work is saved iff its branch ref is pushed").
+  const receipt = await crossTerminalBarrier(deps, c.branch);
+  if (receipt.salvagedFiles > 0) {
+    deps.appendIterLog(
+      `🤖 /afk: exit barrier salvaged ${receipt.salvagedFiles} uncommitted file(s) onto \`${c.branch}\` and pushed to origin (${outcome} terminal; receipt head ${receipt.head || "?"}).`,
+    );
+  }
   // Release the per-issue claim before returning. Every other terminal path
   // (mergeFailed/exhausted/abortAfterClaim/runnerRecoverable) releases; this
   // shared tail (no-sentinel / blocked / feedback-failed / stalled) did not, so
   // a retry-routed or human-requeued issue stayed un-claimable until the live
   // worker process exited and boot's stale-claim sweep reclaimed the dir (#568).
   await deps.claimLock.release(input.issue);
-  return {
+  return preservedTerminal(receipt, {
     outcome,
     issue: input.issue,
     branch: c.branch,
     base: c.base,
     hooksFired: c.hooksFired,
     envelopePosted: posted,
-    preserved: true,
-    swept: false,
-  };
+  });
 }
 
 /** Emit the done envelope with the merge sha + validation report. The
@@ -2280,8 +2356,11 @@ async function mergeFailed(c: StageCommon, _reason: string, locked = false): Pro
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: _reason,
   });
+  // ADR 0083 §4 exit barrier (#1021): cross the barrier before reporting the
+  // merge-conflict terminal so the preserved branch is salvaged + on origin.
+  const receipt = await crossTerminalBarrier(deps, c.branch);
   await deps.claimLock.release(input.issue);
-  return {
+  return preservedTerminal(receipt, {
     outcome: "merge-conflict",
     issue: input.issue,
     branch: c.branch,
@@ -2289,9 +2368,7 @@ async function mergeFailed(c: StageCommon, _reason: string, locked = false): Pro
     locked,
     hooksFired: c.hooksFired,
     envelopePosted: posted,
-    preserved: true,
-    swept: false,
-  };
+  });
 }
 
 /**
@@ -2746,16 +2823,20 @@ async function abortAfterClaim(
       `🤖 /afk aborted before runner invocation (${_reason}). Restored \`${LABEL_READY}\`.`,
     );
   }
+  // ADR 0083 §4 exit barrier (#1021): a crash/teardown abort still crosses the
+  // barrier — salvage-commit + push whatever the aborted attempt left on the
+  // branch (e.g. a pre_worktree hook's dirty edits) so no work is stranded. The
+  // branch may not yet exist on origin (nothing committed); the receipt records
+  // that truthfully (`pushed:false`) rather than throwing.
+  const receipt = await crossTerminalBarrier(deps, branch);
   await deps.claimLock.release(input.issue);
-  return {
+  return preservedTerminal(receipt, {
     outcome: "hook-aborted",
     issue: input.issue,
     branch,
     base,
     hooksFired,
-    preserved: true,
-    swept: false,
-  };
+  });
 }
 
 /**

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -64,6 +64,7 @@ import {
 } from "./merge.js";
 import { doLanding } from "./landing.js";
 import { reconcile, type ReconcileInput } from "./reconcile.js";
+import { ExitBarrierError, type ExitReceipt } from "./exit-barrier.js";
 import {
   emitEnvelope,
   type EmitEnvelopeDeps,
@@ -491,6 +492,19 @@ export interface ProcessIssueDeps {
    */
   salvageUncommitted?(branch: string): Promise<number>;
   /**
+   * ADR 0083 §4 exit barrier (DONE tracer, #1020). The single owner of an
+   * attempt's terminal exit on the DONE path: salvage-commit any dirty worktree
+   * paths, push the attempt branch to origin (retry once), and return an auditable
+   * {@link ExitReceipt} (branch / head / pushedAt / salvage flag) recorded in the
+   * done ProcessIssueResult + attempt record. Throws {@link ExitBarrierError} when
+   * the push fails after retry — processIssue routes that to a NON-clean terminal
+   * so the attempt is never reported done without a receipt ("work is saved iff
+   * its branch ref is pushed to origin"). Optional → when absent the DONE path
+   * falls back to the legacy salvage-only step (`salvageUncommitted`). The CLI
+   * (run.ts) binds it over the same GitContext; tests inject a fake barrier.
+   */
+  exitBarrier?(branch: string): Promise<ExitReceipt>;
+  /**
    * Post-merge PRD cascade rebase (issue #1007, `afk.landing.cascade_rebase`).
    * Provides the IO surface for {@link runCascadeRebase}: after a successful DONE
    * landing, AFK rebases every open sibling branch (same prd:N label, not held by
@@ -598,6 +612,12 @@ export interface ProcessIssueResult {
   locked?: boolean;
   /** Merge commit sha on a successful done close. */
   mergeSha?: string;
+  /**
+   * ADR 0083 §4 exit-barrier receipt (#1020) — the auditable proof the attempt
+   * branch reached origin (branch / head / pushedAt / salvage flag). Present on
+   * the DONE path when an `exitBarrier` port is wired; undefined otherwise.
+   */
+  exitReceipt?: ExitReceipt;
   /** The lifecycle points that fired, in order — the parity target for tests. */
   hooksFired: HookName[];
   /** True when the terminal envelope was posted. */
@@ -1059,6 +1079,11 @@ export async function processIssue(
   let salvagedUncommittedFiles = 0;
   let salvagedUncommittedOutcome: RunAgentResult["outcome"] | undefined;
   let salvagedRunCommitCount = 0;
+  // ADR 0083 §4 exit-barrier receipt (#1020). Set on the DONE path once the barrier
+  // has salvage-committed + pushed the attempt branch to origin; recorded in the
+  // done ProcessIssueResult + the attempt record so "was this work saved?" is
+  // answerable from the record alone.
+  let exitReceipt: ExitReceipt | undefined;
   // Scout mode: collect the agent's text-chunk events as the report. The
   // orchestrator posts this as a GitHub comment instead of pushing a branch.
   const scoutTextChunks: string[] = [];
@@ -1273,7 +1298,49 @@ export async function processIssue(
     // dirty worktree paths onto the worker branch (one commit per file) so the
     // SAME feedback gate + landing tail validate and merge the complete work. A
     // clean worktree salvages nothing (count 0).
-    if (
+    // ADR 0083 §4 exit barrier (DONE tracer, #1020): on the DONE path, obtain the
+    // attempt's exit through the single barrier — salvage-commit any dirty worktree
+    // paths, push the branch to origin (retry once), and produce an auditable
+    // receipt. "Work is saved iff its branch ref is pushed to origin"; a push
+    // failure after retry throws ExitBarrierError and routes to a NON-clean
+    // terminal (the attempt is never reported done without a receipt). The legacy
+    // salvage-only step below still covers the other salvageable outcomes
+    // (no-sentinel / budget-exceeded), whose barrier wiring is the follow-up slice.
+    if (deps.exitBarrier && run.outcome === "done") {
+      try {
+        exitReceipt = await deps.exitBarrier(workerBranch);
+      } catch (err) {
+        if (err instanceof ExitBarrierError) {
+          // The barrier could not push the attempt branch to origin after its
+          // retry — "work is saved iff its branch ref is pushed" is NOT satisfied,
+          // so the attempt must NOT be reported as cleanly done. Route to the
+          // recoverable merge-conflict terminal (branch preserved, bounded retry
+          // re-pushes next run) with a receipt-absent reason in the envelope.
+          await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "merge-conflict", current.attempt));
+          return await terminalFailure(common, "merge-conflict", "merge-conflict", {
+            notes: `_(exit barrier: could not push the attempt branch \`${workerBranch}\` to origin after retry — work is NOT confirmed saved, so the attempt is not reported as cleanly done)_`,
+            log: String(err),
+          });
+        }
+        throw err;
+      }
+      if (exitReceipt.salvagedFiles > 0) {
+        salvagedUncommittedFiles = exitReceipt.salvagedFiles;
+        salvagedUncommittedOutcome = run.outcome;
+        salvagedRunCommitCount = run.commits.length;
+        const commitFact =
+          run.commits.length === 0
+            ? "committed nothing"
+            : `left dirty worktree paths after ${run.commits.length} commit(s)`;
+        deps.appendIterLog(
+          `🤖 /afk: inner agent emitted done but ${commitFact} — exit barrier salvaged ${exitReceipt.salvagedFiles} uncommitted file(s) onto \`${workerBranch}\` and pushed to origin (receipt head ${exitReceipt.head || "?"}).`,
+        );
+      } else {
+        deps.appendIterLog(
+          `🤖 /afk: exit barrier pushed \`${workerBranch}\` to origin (clean worktree; receipt head ${exitReceipt.head || "?"}).`,
+        );
+      }
+    } else if (
       deps.salvageUncommitted &&
       (run.outcome === "done" || run.outcome === "no-sentinel" || run.outcome === "budget-exceeded")
     ) {
@@ -1833,11 +1900,16 @@ export async function processIssue(
   await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
   const posted = await emitDone(common, mergeSha, durationS, validationSidecar, lastValidationScope);
   // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
-  // (done) envelope. Best-effort, gated, no-op when memory is absent.
+  // (done) envelope. Best-effort, gated, no-op when memory is absent. The ADR 0083
+  // §4 exit-barrier receipt (#1020), when present, rides the attempt record so the
+  // auditable "work reached origin" proof is preserved with the reasoning attempt.
   await recordAttemptBestEffort(common, "done", {
     durationS,
     mergeSha,
     validationSummary: validationSidecar.join("\n"),
+    notes: exitReceipt
+      ? `exit-barrier receipt: branch \`${exitReceipt.branch}\` pushed to origin at ${exitReceipt.pushedAt} (head ${exitReceipt.head || "?"}, salvaged ${exitReceipt.salvagedFiles} file(s)).`
+      : undefined,
   });
   await deps.gh.close(issue);
   await deps.gh.editLabels(issue, [LABEL_RUNNING], []);
@@ -1873,6 +1945,7 @@ export async function processIssue(
     mergeSha,
     hooksFired,
     envelopePosted: posted,
+    exitReceipt,
     preserved: true,
     swept: true,
   };

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -47,6 +47,7 @@ import { emitEnvelope, type EmitEnvelopeDeps } from "./envelope-emit.js";
 import { parseCurrentBlocker } from "./blocker-state.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
+import type { TerminalReceipt } from "./exit-barrier.js";
 import { type RecoveryEnv } from "./recovery.js";
 import { dispose } from "./disposition.js";
 import type { AttemptStatus } from "./envelope.js";
@@ -185,6 +186,16 @@ export interface ReconcileDeps {
   nowEpoch(): number;
   /** Append one plain line to the iteration's afk.log. */
   appendIterLog(line: string): void;
+  /**
+   * ADR 0083 §4 exit barrier (every-terminal, #1021). The no-agent reconcile lane
+   * obtains its branch-preservation write through the SAME barrier every other
+   * terminal path uses: salvage-commit dirty paths + push the parked branch to
+   * origin (retry once), returning a {@link TerminalReceipt}. Threaded from
+   * process-issue's deps (structural superset). When wired it REPLACES the inline
+   * `pushAttempt` pre-fetch safety push so the barrier is the only writer; when
+   * absent (legacy caller) reconcile falls back to `pushAttempt`.
+   */
+  terminalExitBarrier?(branch: string): Promise<TerminalReceipt>;
   /** AFK→Memory reasoning-attempt recording (best-effort; optional). */
   recordAttempt?(payload: AttemptRecordPayload): Promise<void>;
   /** History ledger path + clock for the terminal envelope (optional). */
@@ -269,15 +280,28 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     return { outcome: "skipped", reason: disqualifier };
   }
 
-  // ---- 1b. pre-fetch safety push ----
-  // Before checking whether the branch is present on the remote, push any
-  // LOCAL-ONLY commits. A worker that hit a continuous-push failure may have
-  // committed work that never reached origin — the branch exists locally (in
-  // .git/refs/heads/) but the remote is at main's HEAD. Pushing here recovers
-  // those commits so the fetch gate and changedFiles() see them. Best-effort:
-  // a failed push is logged and reconcile falls through to the normal fetch gate
-  // (which will then skip with "branch-absent" or "no-commits" as before).
-  {
+  // ---- 1b. pre-fetch safety push (ADR 0083 §4 exit barrier, #1021) ----
+  // Before checking whether the branch is present on the remote, salvage-commit any
+  // dirty paths + push any LOCAL-ONLY commits. A worker that hit a continuous-push
+  // failure may have committed work that never reached origin — the branch exists
+  // locally (in .git/refs/heads/) but the remote is at main's HEAD. Crossing the
+  // exit barrier here recovers those commits so the fetch gate and changedFiles()
+  // see them, and makes the barrier reconcile's ONLY branch-preservation writer
+  // (no inline push). Best-effort: a failed push is logged and reconcile falls
+  // through to the normal fetch gate (which then skips with "branch-absent" /
+  // "no-commits"). Legacy callers with no barrier wired fall back to `pushAttempt`.
+  if (deps.terminalExitBarrier) {
+    const receipt = await deps.terminalExitBarrier(branch).catch(() => null);
+    if (!receipt || !receipt.pushed) {
+      deps.appendIterLog(
+        `🤖 /afk reconcile #${issue}: exit-barrier pre-fetch push did not confirm \`${branch}\` on origin — continuing to fetch gate`,
+      );
+    } else if (receipt.salvagedFiles > 0) {
+      deps.appendIterLog(
+        `🤖 /afk reconcile #${issue}: exit barrier salvaged ${receipt.salvagedFiles} uncommitted file(s) onto \`${branch}\` and pushed to origin (receipt head ${receipt.head || "?"}).`,
+      );
+    }
+  } else {
     const safetyPush = await pushAttempt(deps.remoteGit, input.repoDir, branch, branch);
     if (!safetyPush.ok) {
       deps.appendIterLog(

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -411,6 +411,26 @@ export async function salvageUncommitted(ctx: GitContext, branch: string, remote
 }
 
 /**
+ * Push a LOCAL branch ref to `remote` (create or update the remote branch). The
+ * ref lives in the shared `.git`, so this runs from the primary checkout cwd —
+ * no worktree needed. Used by the ADR 0083 §4 exit barrier to guarantee the
+ * attempt branch reached origin before the attempt is allowed to terminate.
+ * Returns `{ok:true}` on a clean push; `{ok:false, error}` (never throws) on a
+ * rejected/failed push so the barrier owns the retry + hard-error policy. Routed
+ * through the same `runGit` seam so tests drive it without an OS git.
+ */
+export async function pushBranch(
+  ctx: GitContext,
+  branch: string,
+  remote = "origin",
+): Promise<{ ok: boolean; error?: string }> {
+  if (!branch) return { ok: false, error: "empty branch" };
+  const r = await runGit(ctx, ["push", remote, `refs/heads/${branch}:refs/heads/${branch}`]);
+  if (r.code === 0) return { ok: true };
+  return { ok: false, error: (r.stderr || r.stdout || `git push exited ${r.code}`).trim() };
+}
+
+/**
  * List origin refs under a namespace ("afk/" | "afk-attempts/") via ls-remote,
  * shaped as BranchRef[]. The optional last-commit epoch is left unset (the
  * snapshot 404 grace falls back to "keep" without it).

--- a/apps/dev/tests/exit-barrier.test.ts
+++ b/apps/dev/tests/exit-barrier.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   passExitBarrier,
+  passTerminalBarrier,
   ExitBarrierError,
   type ExitBarrierPorts,
   type PushResult,
@@ -144,5 +145,73 @@ describe("passExitBarrier", () => {
 
     expect(receipt.head).toBe("deadbeef");
     expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+  });
+});
+
+// passTerminalBarrier is the FAILURE-terminal crossing (#1021): same salvage →
+// push → receipt contract, but it never throws — a rejected push is recorded as
+// `pushed:false` instead of escalated, because the attempt is already terminal.
+describe("passTerminalBarrier", () => {
+  it("dirty worktree → salvages, pushes, and reports pushed:true with the salvage flag", async () => {
+    const { ports, trace } = harness({ salvage: async () => 2, headSha: async () => "beefcafe" });
+
+    const receipt = await passTerminalBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt).toEqual({
+      branch: "afk/w1/42-x",
+      head: "beefcafe",
+      pushedAt: "2026-07-03T12:00:00Z",
+      salvaged: true,
+      salvagedFiles: 2,
+      pushed: true,
+    });
+    // Salvage ran before the push so the pushed ref carries the salvage commit.
+    expect(trace.salvageCalls).toEqual(["afk/w1/42-x"]);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("push fails after retry → returns pushed:false, NEVER throws (attempt already terminal)", async () => {
+    const { ports, trace } = harness({
+      push: async () => ({ ok: false, error: "remote rejected" }),
+    });
+
+    const receipt = await passTerminalBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.pushed).toBe(false);
+    // No head sha is read when the ref never reached origin.
+    expect(receipt.head).toBe("");
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+    expect(trace.headCalls).toEqual([]);
+  });
+
+  it("push fails once then succeeds → retried, pushed:true", async () => {
+    let attempts = 0;
+    const { ports, trace } = harness({
+      push: async () => {
+        attempts += 1;
+        return attempts === 1 ? { ok: false, error: "lock" } : { ok: true };
+      },
+    });
+
+    const receipt = await passTerminalBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.pushed).toBe(true);
+    expect(receipt.head).toBe("deadbeef");
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+  });
+
+  it("a salvage that throws is swallowed — the push still saves the branch", async () => {
+    const { ports, trace } = harness({
+      salvage: async () => {
+        throw new Error("salvage boom");
+      },
+    });
+
+    const receipt = await passTerminalBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.salvaged).toBe(false);
+    expect(receipt.salvagedFiles).toBe(0);
+    expect(receipt.pushed).toBe(true);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
   });
 });

--- a/apps/dev/tests/exit-barrier.test.ts
+++ b/apps/dev/tests/exit-barrier.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  passExitBarrier,
+  ExitBarrierError,
+  type ExitBarrierPorts,
+  type PushResult,
+} from "../src/core/exit-barrier.js";
+
+// Everything injected is a fake — no real git ever runs. Each test records the
+// salvage/push call sequence so the barrier's contract (salvage → push → receipt,
+// retry-once, hard-error-on-failure) is asserted as a trace.
+
+interface Trace {
+  salvageCalls: string[];
+  pushCalls: string[];
+  headCalls: string[];
+}
+
+function harness(
+  overrides: Partial<{
+    salvage: (branch: string) => Promise<number>;
+    push: (branch: string) => Promise<PushResult>;
+    headSha: (branch: string) => Promise<string>;
+  }> = {},
+): { ports: ExitBarrierPorts; trace: Trace } {
+  const trace: Trace = { salvageCalls: [], pushCalls: [], headCalls: [] };
+  const ports: ExitBarrierPorts = {
+    salvage: async (branch) => {
+      trace.salvageCalls.push(branch);
+      return overrides.salvage ? overrides.salvage(branch) : 0;
+    },
+    push: async (branch) => {
+      trace.pushCalls.push(branch);
+      return overrides.push ? overrides.push(branch) : { ok: true };
+    },
+    headSha: async (branch) => {
+      trace.headCalls.push(branch);
+      return overrides.headSha ? overrides.headSha(branch) : "deadbeef";
+    },
+    nowIso: () => "2026-07-03T12:00:00Z",
+  };
+  return { ports, trace };
+}
+
+describe("passExitBarrier", () => {
+  it("clean worktree → branch pushed, no salvage commit in the receipt", async () => {
+    const { ports, trace } = harness({ salvage: async () => 0 });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt).toEqual({
+      branch: "afk/w1/42-x",
+      head: "deadbeef",
+      pushedAt: "2026-07-03T12:00:00Z",
+      salvaged: false,
+      salvagedFiles: 0,
+    });
+    // Salvage was attempted (found nothing) and the branch was pushed exactly once.
+    expect(trace.salvageCalls).toEqual(["afk/w1/42-x"]);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("dirty worktree → salvage commit created and pushed, flagged in the receipt", async () => {
+    const { ports, trace } = harness({
+      salvage: async () => 3,
+      headSha: async () => "cafef00d",
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.salvaged).toBe(true);
+    expect(receipt.salvagedFiles).toBe(3);
+    expect(receipt.head).toBe("cafef00d");
+    // Salvage ran before the push so the pushed ref carries the salvage commit.
+    expect(trace.salvageCalls).toEqual(["afk/w1/42-x"]);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("push fails once then succeeds → retried, receipt returned", async () => {
+    let attempts = 0;
+    const { ports, trace } = harness({
+      push: async () => {
+        attempts += 1;
+        return attempts === 1 ? { ok: false, error: "remote rejected" } : { ok: true };
+      },
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.head).toBe("deadbeef");
+    // Pushed twice: the initial rejection, then the successful retry.
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+  });
+
+  it("push fails after retry → throws ExitBarrierError (attempt not clean)", async () => {
+    const { ports, trace } = harness({
+      push: async () => ({ ok: false, error: "remote rejected" }),
+    });
+
+    await expect(passExitBarrier(ports, "afk/w1/42-x")).rejects.toBeInstanceOf(ExitBarrierError);
+    // Exactly two attempts: the initial push and one retry, then it gives up.
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+    // No head sha is read on the failure path — there is no receipt to build.
+    expect(trace.headCalls).toEqual([]);
+  });
+
+  it("the thrown error names the branch and the last push detail", async () => {
+    const { ports } = harness({
+      push: async () => ({ ok: false, error: "non-fast-forward" }),
+    });
+
+    await expect(passExitBarrier(ports, "afk/w1/42-x")).rejects.toMatchObject({
+      branch: "afk/w1/42-x",
+      message: expect.stringContaining("non-fast-forward"),
+    });
+  });
+
+  it("a salvage that throws is swallowed — the push still saves the branch", async () => {
+    const { ports, trace } = harness({
+      salvage: async () => {
+        throw new Error("salvage boom");
+      },
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    // Salvage failure degrades to 0 files, never blocks the load-bearing push.
+    expect(receipt.salvaged).toBe(false);
+    expect(receipt.salvagedFiles).toBe(0);
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x"]);
+  });
+
+  it("a push port that throws is treated as a failed push and retried", async () => {
+    let attempts = 0;
+    const { ports, trace } = harness({
+      push: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("network down");
+        return { ok: true };
+      },
+    });
+
+    const receipt = await passExitBarrier(ports, "afk/w1/42-x");
+
+    expect(receipt.head).toBe("deadbeef");
+    expect(trace.pushCalls).toEqual(["afk/w1/42-x", "afk/w1/42-x"]);
+  });
+});

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -42,6 +42,8 @@ interface Trace {
   recordedAttempts: AttemptRecordPayload[];
   /** Worker branches passed to the commit-leftovers salvage port. */
   salvageCalls: string[];
+  /** Worker branches passed to the ADR 0083 §4 terminal exit barrier (#1021). */
+  terminalBarrierCalls: string[];
   /** Metadata handed to the per-issue classifier before runAgent. */
   classifierCalls: IssueClassificationMetadata[];
   /** Lines appended to the iteration log (deps.appendIterLog). */
@@ -132,6 +134,13 @@ interface HarnessOptions {
    * it return this count (files committed). undefined omits the port (legacy
    * caller — no salvage). */
   salvage?: number;
+  /** When set, register the ADR 0083 §4 `terminalExitBarrier` port (#1021). The
+   * fake records the branch and returns a {@link TerminalReceipt} whose
+   * `salvagedFiles` / `pushed` are driven by these fields (defaults: 0 files,
+   * pushed:true). `fault:true` makes the port reject, proving the terminal still
+   * reports (with a not-pushed receipt) when the barrier itself faults. undefined
+   * omits the port (legacy caller — no barrier crossing). */
+  terminalBarrier?: { salvagedFiles?: number; pushed?: boolean; fault?: boolean };
   /** Issue body threaded into processIssue. */
   body?: string;
   /** Execution mode forwarded to ProcessIssueInput (e.g. `"scout"`). */
@@ -178,6 +187,7 @@ function harness(opts: HarnessOptions = {}): {
     envelopeBodies: [],
     released: [],
     runAgentCalls: [],
+    terminalBarrierCalls: [],
     listByLabelCalls: [],
     ensuredLabels: [],
     sidecarWrites: [],
@@ -498,6 +508,26 @@ function harness(opts: HarnessOptions = {}): {
         : async (branch) => {
             trace.salvageCalls.push(branch);
             return opts.salvage as number;
+          },
+    // ADR 0083 §4 terminal exit barrier port (#1021). Records the branch and
+    // returns a scripted TerminalReceipt; `fault` rejects to prove the terminal
+    // still reports when the barrier itself faults.
+    terminalExitBarrier:
+      opts.terminalBarrier === undefined
+        ? undefined
+        : async (branch) => {
+            trace.terminalBarrierCalls.push(branch);
+            if (opts.terminalBarrier!.fault) throw new Error("terminal barrier boom");
+            const salvagedFiles = opts.terminalBarrier!.salvagedFiles ?? 0;
+            const pushed = opts.terminalBarrier!.pushed ?? true;
+            return {
+              branch,
+              head: pushed ? "beefcafe" : "",
+              pushedAt: "2026-07-03T12:00:00Z",
+              salvaged: salvagedFiles > 0,
+              salvagedFiles,
+              pushed,
+            };
           },
     // PRD cascade rebase port (#1007): injected when siblingBranches is set.
     cascadeRebase:
@@ -2964,5 +2994,100 @@ describe("PRD cascade rebase after DONE landing", () => {
     await processIssue(deps, input);
     // Only issue 20's branch is rebased; issue 99's is not a sibling.
     expect(trace.cascadeRebaseAttempts).toEqual(["afk/wBBBB/20-fix-sibling-a"]);
+  });
+});
+
+// ADR 0083 §4 (#1021): the exit barrier is crossed by EVERY terminal path, not
+// just DONE. One named test per terminal path, resilience-suite style — each
+// asserts the SAME three-part invariant: (1) the barrier ran (branch recorded),
+// (2) the branch was pushed (receipt.pushed), (3) a receipt rides the terminal
+// result (result.exitReceipt). A terminal path that bypassed the barrier would
+// carry no `exitReceipt` — so these tests fail on any bypassing path.
+describe("processIssue — exit barrier on every terminal path (#1021)", () => {
+  const BRANCH = "afk/wAAAA/9-fix-the-thing";
+
+  it("guard abort (budget-exceeded) crosses the barrier — branch pushed, receipt on the result", async () => {
+    const { deps, input, trace } = harness({ outcome: "budget-exceeded", terminalBarrier: { pushed: true } });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("budget-exceeded");
+    // (1) barrier ran, (2) branch pushed, (3) receipt on the terminal result.
+    expect(trace.terminalBarrierCalls).toEqual([BRANCH]);
+    expect(result.exitReceipt?.pushed).toBe(true);
+    expect(result.exitReceipt?.branch).toBe(BRANCH);
+  });
+
+  it("stall-kill (attempt-guard timeout → stalled) crosses the barrier with a dirty worktree salvaged and pushed", async () => {
+    // changedFiles:[] → the ADR 0055 reconcile skips (no commits), falling to the
+    // stalled terminalFailure. The worker was killed with a dirty worktree, so the
+    // barrier salvage-commits it (2 files) and pushes before the terminal reports.
+    const { deps, input, trace } = harness({
+      outcome: "timeout",
+      changedFiles: [],
+      terminalBarrier: { salvagedFiles: 2, pushed: true },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("stalled");
+    // The timeout path crosses the barrier twice — once for reconcile's pre-fetch
+    // push, once for the stalled terminal — both on the worker branch.
+    expect(trace.terminalBarrierCalls.length).toBeGreaterThanOrEqual(1);
+    expect(trace.terminalBarrierCalls.every((b) => b === BRANCH)).toBe(true);
+    // dirty-at-kill: the salvage commit exists and was pushed (receipt truthful).
+    expect(result.exitReceipt?.salvaged).toBe(true);
+    expect(result.exitReceipt?.salvagedFiles).toBe(2);
+    expect(result.exitReceipt?.pushed).toBe(true);
+    // The salvage was announced in the iteration log.
+    expect(trace.iterLogs.some((l) => l.includes("exit barrier salvaged 2 uncommitted file(s)"))).toBe(true);
+  });
+
+  it("crash teardown (pre_worktree hook abort) crosses the barrier — no work stranded", async () => {
+    // A pre-runner hook abort tears the attempt down before the agent runs; the
+    // branch may carry a pre_worktree hook's dirty edits, so it still crosses the
+    // barrier (here nothing reached origin → pushed:false, recorded truthfully).
+    const { deps, input, trace } = harness({ abortHook: "pre_worktree", terminalBarrier: { pushed: false } });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("hook-aborted");
+    expect(trace.terminalBarrierCalls).toEqual([BRANCH]);
+    // The terminal reports WITH a receipt even when nothing reached origin.
+    expect(result.exitReceipt).toBeDefined();
+    expect(result.exitReceipt?.pushed).toBe(false);
+  });
+
+  it("merge-conflict terminal crosses the barrier — the preserved branch is salvaged and pushed", async () => {
+    // A locked merge that conflicts and cannot be auto-resolved lands on the
+    // merge-conflict terminal (mergeFailed), which now crosses the barrier too.
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: true,
+      mergeNoFfCode: 1,
+      conflictResolve: "fail",
+      terminalBarrier: { pushed: true },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("merge-conflict");
+    expect(trace.terminalBarrierCalls).toEqual([BRANCH]);
+    expect(result.exitReceipt?.pushed).toBe(true);
+  });
+
+  it("a barrier that faults still reports the terminal — receipt present, pushed:false (never a second crash)", async () => {
+    // The barrier port itself throwing must NOT convert the terminal into an
+    // uncaught crash: crossTerminalBarrier degrades to a not-pushed receipt so the
+    // terminal is still reported (with a receipt — the required input is present).
+    const { deps, input, trace } = harness({ outcome: "budget-exceeded", terminalBarrier: { fault: true } });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("budget-exceeded");
+    expect(trace.terminalBarrierCalls).toEqual([BRANCH]);
+    expect(result.exitReceipt).toBeDefined();
+    expect(result.exitReceipt?.pushed).toBe(false);
   });
 });

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -28,6 +28,8 @@ interface Trace {
   listByLabelCalls: string[];
   firedHooks: string[];
   pnpmCalls: number;
+  /** Branches passed to the ADR 0083 §4 terminal exit barrier (#1021). */
+  terminalBarrierCalls: string[];
 }
 
 interface HarnessOptions {
@@ -45,6 +47,10 @@ interface HarnessOptions {
   closedIssues?: number[];
   withSidecarPort?: boolean;
   recordAttempt?: boolean;
+  /** When set, wire the ADR 0083 §4 `terminalExitBarrier` port (#1021): reconcile
+   * uses it (not `pushAttempt`) for the pre-fetch safety push. The fake records
+   * the branch and returns a receipt driven by these fields. */
+  terminalBarrier?: { salvagedFiles?: number; pushed?: boolean };
 }
 
 function harness(opts: HarnessOptions = {}): {
@@ -67,6 +73,7 @@ function harness(opts: HarnessOptions = {}): {
     listByLabelCalls: [],
     firedHooks: [],
     pnpmCalls: 0,
+    terminalBarrierCalls: [],
   };
 
   const deps: ReconcileDeps = {
@@ -179,6 +186,22 @@ function harness(opts: HarnessOptions = {}): {
           trace.recordedOutcomes.push(payload.status);
         }
       : undefined,
+    terminalExitBarrier:
+      opts.terminalBarrier === undefined
+        ? undefined
+        : async (branch) => {
+            trace.terminalBarrierCalls.push(branch);
+            const salvagedFiles = opts.terminalBarrier!.salvagedFiles ?? 0;
+            const pushed = opts.terminalBarrier!.pushed ?? true;
+            return {
+              branch,
+              head: pushed ? "beefcafe" : "",
+              pushedAt: "2026-07-03T12:00:00Z",
+              salvaged: salvagedFiles > 0,
+              salvagedFiles,
+              pushed,
+            };
+          },
   };
 
   const input: ReconcileInput = {
@@ -440,5 +463,39 @@ describe("mechanicalDisqualifier", () => {
       next: "Human decides scope.",
     });
     expect(mechanicalDisqualifier(["blocked:stalled"], body)).toBe("active-blocker");
+  });
+});
+
+// ADR 0083 §4 (#1021): the no-agent reconcile lane is a terminal path too — its
+// branch-preservation write goes through the SAME exit barrier every other
+// terminal path uses, replacing the inline `pushAttempt` pre-fetch safety push.
+describe("reconcile — exit barrier crossing (#1021)", () => {
+  it("crosses the barrier for the pre-fetch safety push and does NOT use the inline pushAttempt", async () => {
+    // A parked (red) reconcile isolates the pre-fetch safety push — no landing push
+    // muddies the trace. With the barrier wired, the safety push runs THROUGH the
+    // barrier (branch recorded, salvage surfaced), and the inline `pushAttempt` is
+    // never called — the barrier is reconcile's only branch-preservation writer.
+    const { deps, input, trace } = harness({ feedbackOk: false, terminalBarrier: { salvagedFiles: 1, pushed: true } });
+
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("parked");
+    // (1) barrier ran on the worker branch; (2) receipt confirms the push.
+    expect(trace.terminalBarrierCalls).toEqual(["afk/wAAAA/9-fix-the-thing"]);
+    // (3) no inline pushAttempt ran — no bare `push` reached remoteGit.
+    const barePushes = trace.pushedAttempt.filter((argv) => !argv.includes("--delete"));
+    expect(barePushes).toEqual([]);
+  });
+
+  it("falls back to the inline pushAttempt when no barrier is wired (legacy caller)", async () => {
+    // Back-compat: a caller that has not wired the barrier keeps the original
+    // `pushAttempt` pre-fetch safety push, so older wiring never regresses.
+    const { deps, input, trace } = harness({ feedbackOk: false });
+
+    await reconcile(deps, input);
+
+    expect(trace.terminalBarrierCalls).toEqual([]);
+    const barePushes = trace.pushedAttempt.filter((argv) => !argv.includes("--delete"));
+    expect(barePushes.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1021. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1021

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785678396&installation_id=129708444&pr_number=1084&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1084&signature=dd7bc1c630aae118bc46b9c992cfcd82c832dfe89ac55c8939c4f759d0ae89de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-of-process “exit barrier” handling so successful runs and terminal failures now record a clear receipt of what happened.
  * Reconcile now supports the same barrier flow before the safety push, with consistent reporting when a push succeeds or fails.

* **Bug Fixes**
  * Improved retry behavior for push operations.
  * Terminal failure paths now avoid falsely reporting a clean finish when a push did not complete.
  * Uncommitted changes are handled more reliably before exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->