### PR TITLE
merge: #1087 bug(go): /go and --scout must NOT be blocked by the fleet-supervisor boot-guard (isolated namespace, never collide)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -50,7 +50,9 @@ import {
   resolveReviewGate,
   type IssueClassificationMetadata,
 } from "../core/issue-classifier.js";
-import { LABEL_READY_FOR_REVIEW } from "../core/triage-labels.js";
+import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE } from "../core/triage-labels.js";
+import { GO_ORIGIN, GO_WORKERS_SEGMENT } from "../core/go.js";
+import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../core/scout.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
 import { isValidWorkerId, WORKER_NAMESPACES } from "../core/worker-paths.js";
@@ -163,17 +165,45 @@ export async function probeFleetSupervisor(
 }
 
 /**
+ * Detect a `/go` or `--scout` dispatch (#1087). These runs live in their OWN
+ * worker namespace (`go-workers/` / `scout-workers/`), their own lane
+ * (`lane:go` / `lane:scout`, never `ready-for-agent`), and carry `--origin
+ * go`/`--origin scout` — so they can NEVER collide with a fleet's `workers/`
+ * namespace, claims, or lane. The fleet-supervisor boot guard exists ONLY to
+ * stop a second fleet from stomping the first on the shared `workers/`
+ * namespace; it must not apply to these isolated dispatches, which the SKILL.md
+ * contract requires to boot "whether or not a fleet is up". Detected via any of
+ * the three redundant signals threaded through the boot context.
+ */
+export function isNamespacedDispatch(
+  args: { origin?: string; lane?: string },
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (args.origin === GO_ORIGIN || args.origin === SCOUT_ORIGIN) return true;
+  if (args.lane === LABEL_GO_LANE || args.lane === LABEL_SCOUT_LANE) return true;
+  const ns = env.RED_AFK_WORKERS_NAMESPACE;
+  if (ns === GO_WORKERS_SEGMENT || ns === SCOUT_WORKERS_SEGMENT) return true;
+  return false;
+}
+
+/**
  * Apply the boot guard: refuse to start if a fleet supervisor is already live
  * (unless `--force` was passed). Returns `"refused"` when the caller should
  * abort, `"forced"` when the guard was bypassed with a warning, or `"clear"`
  * when no live supervisor was found.
+ *
+ * `exempt` (#1087) skips the `afk-supervisor.pid` check entirely for a
+ * `/go`/`--scout` dispatch — an isolated, namespaced run that cannot collide
+ * with the fleet, so a live supervisor must never block it.
  */
 export async function checkBootGuard(
   pidFile: string,
   force: boolean,
   stdout: NodeJS.WritableStream,
   checkLivePid: (pid: number) => boolean = isLivePid,
+  exempt = false,
 ): Promise<"refused" | "forced" | "clear"> {
+  if (exempt) return "clear";
   const probe = await probeFleetSupervisor(pidFile, checkLivePid);
   if (!probe.live) return "clear";
   if (force) {
@@ -1459,10 +1489,13 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Boot guard (#1027): refuse to start if a fleet supervisor is already live.
   // Supervisor-dispatched paths bypass this: --reconcile-issue workers are
   // spawned by the running supervisor; RED_AFK_SWEEPS_DONE=1 workers are
-  // fleet-owned and the supervisor already holds the pid.
+  // fleet-owned and the supervisor already holds the pid. A `/go`/`--scout`
+  // dispatch (#1087) is exempt too: its isolated namespace/lane/origin can
+  // never collide with the fleet, so it must boot whether or not a fleet is up.
   if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
     const pidFile = join(paths.tmpDir, "afk-supervisor.pid");
-    const guard = await checkBootGuard(pidFile, flags.force, process.stdout);
+    const exempt = isNamespacedDispatch({ origin: flags.origin, lane: flags.lane });
+    const guard = await checkBootGuard(pidFile, flags.force, process.stdout, isLivePid, exempt);
     if (guard === "refused") return 1;
   }
 

--- a/apps/dev/tests/boot-guard.test.ts
+++ b/apps/dev/tests/boot-guard.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { tmpdir } from "node:os";
 import { writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { probeFleetSupervisor, checkBootGuard } from "../src/commands/run.js";
+import { probeFleetSupervisor, checkBootGuard, isNamespacedDispatch } from "../src/commands/run.js";
 
 function tmpPidFile(suffix: string): string {
   return join(tmpdir(), `afk-boot-guard-test-${suffix}.pid`);
@@ -103,5 +103,60 @@ describe("checkBootGuard (#1027)", () => {
     } finally {
       await rm(f, { force: true });
     }
+  });
+
+  it("returns 'clear' without probing when exempt (a /go|/scout dispatch), even with a LIVE supervisor (#1087)", async () => {
+    const f = tmpPidFile("guard-exempt");
+    await writeFile(f, "88888", "utf8");
+    try {
+      const stdout = makeStdout();
+      // checkLivePid always reports live; exempt must skip the check entirely.
+      const result = await checkBootGuard(f, false, stdout as unknown as NodeJS.WritableStream, () => true, true);
+      expect(result).toBe("clear");
+      expect(stdout.output).toBe("");
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+
+  it("still REFUSES a live supervisor when NOT exempt (bare /afk run regression, #1087)", async () => {
+    const f = tmpPidFile("guard-not-exempt");
+    await writeFile(f, "99998", "utf8");
+    try {
+      const stdout = makeStdout();
+      const result = await checkBootGuard(f, false, stdout as unknown as NodeJS.WritableStream, () => true, false);
+      expect(result).toBe("refused");
+      expect(stdout.output).toContain("fleet supervisor is already running");
+    } finally {
+      await rm(f, { force: true });
+    }
+  });
+});
+
+describe("isNamespacedDispatch (#1087)", () => {
+  it("is true for a /go dispatch (origin=go)", () => {
+    expect(isNamespacedDispatch({ origin: "go" }, {})).toBe(true);
+  });
+
+  it("is true for a --scout dispatch (origin=scout)", () => {
+    expect(isNamespacedDispatch({ origin: "scout" }, {})).toBe(true);
+  });
+
+  it("is true when the lane is lane:go or lane:scout", () => {
+    expect(isNamespacedDispatch({ lane: "lane:go" }, {})).toBe(true);
+    expect(isNamespacedDispatch({ lane: "lane:scout" }, {})).toBe(true);
+  });
+
+  it("is true when RED_AFK_WORKERS_NAMESPACE is go-workers or scout-workers", () => {
+    expect(isNamespacedDispatch({}, { RED_AFK_WORKERS_NAMESPACE: "go-workers" })).toBe(true);
+    expect(isNamespacedDispatch({}, { RED_AFK_WORKERS_NAMESPACE: "scout-workers" })).toBe(true);
+  });
+
+  it("is false for a bare /afk run (origin=afk, workers/ namespace)", () => {
+    expect(isNamespacedDispatch({ origin: "afk", lane: "ready-for-agent" }, { RED_AFK_WORKERS_NAMESPACE: "workers" })).toBe(false);
+  });
+
+  it("is false when no dispatch signal is present", () => {
+    expect(isNamespacedDispatch({}, {})).toBe(false);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1087. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1087

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785680990&installation_id=129708444&pr_number=1089&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1089&signature=1cfc5d47accefe2f6247efd6615e391ea95ac5c782191f0cf56a228959c2f2e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->