### PR TITLE
merge: #1085 bug(afk/statusline): workers bar blind to live workers under isolation (afk.state.json.pid stays 0)

### DIFF
--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -12,7 +12,7 @@
 // async fan-out the collectors use (glob → read each).
 
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
 import type { AfkState } from "../types/state.js";
 import { parseState, type PidStartTimeProbe } from "./state.js";
 import { globWorkerStates } from "../runtime/fs.js";
@@ -89,6 +89,15 @@ export interface WorkerStateReadOpts {
    * trees.
    */
   psSnapshot?: () => string;
+  /**
+   * Raw text content of the per-worker `worker.pid` file, for injection in
+   * tests. When omitted and `state.pid === 0`, the reader reads
+   * `{dirname(dirname(path))}/worker.pid` from disk. Only consulted when
+   * `state.pid === 0` and the primary evaluator returns "stalled" — this is
+   * the host-side liveness signal for isolation workers (docker/podman) where
+   * the host's `afk.state.json.pid` is never populated during the run.
+   */
+  workerPidContent?: string;
 }
 
 /** Sync read of the newest liveness lane record timestamp (epoch-ms), or
@@ -158,11 +167,61 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
     hasLiveDescendants,
   });
 
-  const liveness = verdictToLiveness(livenessVerdict);
+  // Isolation fallback: when state.pid is 0 (docker/podman workers never
+  // populate the host-side pid during the run) and the primary evaluator marks
+  // the attempt stalled (empty lane + no descendants), probe the per-worker
+  // worker.pid file instead. The supervisor writes it on the host regardless of
+  // sandbox mode, so it is the reliable host-side liveness signal for isolation
+  // workers even before afk.state.json syncs back at run end.
+  let finalVerdict = livenessVerdict;
+  if (livenessVerdict.status === "stalled" && state.pid === 0) {
+    // worker.pid lives one directory above the attempt dir:
+    // {workersRoot}/{workerId}/{N}-a{n}/afk.state.json → {workersRoot}/{workerId}/worker.pid
+    const workerPidPath = join(dirname(dirname(path)), "worker.pid");
+    let hostPidText: string | null;
+    if (opts.workerPidContent !== undefined) {
+      hostPidText = opts.workerPidContent;
+    } else {
+      try {
+        hostPidText = readFileSync(workerPidPath, "utf8");
+      } catch {
+        hostPidText = null;
+      }
+    }
+    const hostPid = hostPidText ? parseInt(hostPidText.trim(), 10) : NaN;
+    if (Number.isFinite(hostPid) && hostPid > 0) {
+      const killFn = opts.kill ?? ((pid: number) => { process.kill(pid, 0); return true; });
+      let hostPidAlive = false;
+      try {
+        hostPidAlive = killFn(hostPid, 0);
+      } catch {
+        hostPidAlive = false;
+      }
+      if (hostPidAlive) {
+        // Synthesize a "quiet-but-live" verdict: the orchestrator is running on
+        // the host but afk.state.json has not synced yet (isolation pre-sync).
+        finalVerdict = {
+          status: "alive",
+          laneFresh: false,
+          crossCheckArmed: false,
+          reason: `state.pid=0 but worker.pid=${hostPid} is alive (isolation worker)`,
+        };
+        // Derive the issue number from the attempt-dir basename when the state
+        // carries no current.number (the state file is empty pre-sync).
+        if (state.current.number === "" || state.current.number === undefined || state.current.number === null) {
+          const attemptBasename = basename(dirname(path));
+          const m = /^([1-9][0-9]*)-a[1-9][0-9]*$/.exec(attemptBasename);
+          if (m) state.current.number = Number(m[1]);
+        }
+      }
+    }
+  }
+
+  const liveness = verdictToLiveness(finalVerdict);
   // live: true when the evaluator does NOT say "stalled" (includes "alive" and "unknown"/container).
   // Replaces the old isStateLive-only pid check; the evaluator's cross-check already reads
   // the process tree so a pid-alive but descendant-less worker is correctly marked dead.
-  const live = livenessVerdict.status !== "stalled";
+  const live = finalVerdict.status !== "stalled";
   // active: lane fresh only (laneFresh=true), NOT just any "alive" status. A worker whose lane
   // is idle but has live descendants is "quiet-but-live" — it holds resources but is not actively
   // iterating, so surfaces show it as inactive (no [live] badge in the monitor/statusline).
@@ -174,7 +233,7 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
     live,
     active,
     liveness,
-    livenessVerdict,
+    livenessVerdict: finalVerdict,
   };
 }
 
@@ -203,6 +262,7 @@ export async function readWorkerStates(root: string, opts: WorkerStatesReadOpts 
       pidStartTime: opts.pidStartTime,
       sandboxTag: opts.sandboxTag,
       psSnapshot: opts.psSnapshot,
+      workerPidContent: opts.workerPidContent,
     });
     if (rec !== null) out.push(rec);
   }

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -203,4 +203,62 @@ describe("worker-state-reader", () => {
     expect(union.map((r) => r.state.worker_id)).toEqual(["wFLEET"]);
     expect(union.map((r) => r.state.worker_id)).toEqual(single.map((r) => r.state.worker_id));
   });
+
+  // Isolation fallback: worker.pid liveness when afk.state.json.pid === 0
+  it("isolation: live worker.pid + pid:0 state → quiet-but-live, issue derived from path", async () => {
+    // Path must look like {worker}/{N}-a{n}/afk.state.json so issue derivation works.
+    const base = await mkdtemp(join(tmpdir(), "wsr-iso-live-"));
+    const attemptDir = join(base, "wISO", "1085-a1");
+    const path = await writeState(attemptDir, { pid: 0, current: {} });
+    // No liveness lane (empty lane), workerPidContent = live pid, kill returns true.
+    const rec = readWorkerState(path, {
+      nowMs: NOW,
+      workerPidContent: "9876",
+      kill: () => true,
+    });
+    expect(rec).not.toBeNull();
+    // Worker.pid is alive → quiet-but-live (state.pid=0, lane empty, but host pid alive).
+    expect(rec!.live).toBe(true);
+    expect(rec!.active).toBe(false);
+    expect(rec!.liveness).toBe("quiet-but-live");
+    // Issue number derived from the "1085-a1" attempt-dir basename.
+    expect(rec!.state.current.number).toBe(1085);
+    // Evaluator verdict carries the isolation-fallback reason.
+    expect(rec!.livenessVerdict.status).toBe("alive");
+    expect(rec!.livenessVerdict.reason).toContain("worker.pid=9876 is alive");
+  });
+
+  it("isolation: dead worker.pid + pid:0 state → dead", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-iso-dead-"));
+    const attemptDir = join(base, "wISO", "1085-a1");
+    const path = await writeState(attemptDir, { pid: 0, current: {} });
+    // kill returns false → host pid is dead.
+    const rec = readWorkerState(path, {
+      nowMs: NOW,
+      workerPidContent: "9876",
+      kill: () => false,
+    });
+    expect(rec).not.toBeNull();
+    expect(rec!.live).toBe(false);
+    expect(rec!.liveness).toBe("dead");
+  });
+
+  it("regression: normal no-sandbox worker with populated pid + fresh lane renders as active", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-normal-reg-"));
+    const path = await writeState(base, {
+      worker_id: "wNORMAL",
+      pid: 4242,
+      current: { number: 999, stage: "impl", last_event_at: fresh },
+    });
+    // Fresh liveness lane → evaluator "alive", laneFresh=true → "active".
+    const rec = readWorkerState(path, { nowMs: NOW, laneRecencyMs: LANE_FRESH_MS });
+    expect(rec).not.toBeNull();
+    expect(rec!.live).toBe(true);
+    expect(rec!.active).toBe(true);
+    expect(rec!.liveness).toBe("active");
+    // Issue number from state, not derived from path.
+    expect(rec!.state.current.number).toBe(999);
+    // The isolation fallback must NOT have fired (worker.pid check is skipped when state.pid > 0).
+    expect(rec!.livenessVerdict.reason).not.toContain("worker.pid");
+  });
 });


### PR DESCRIPTION
Automated AFK landing for #1085. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1085

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785681532&installation_id=129708444&pr_number=1090&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1090&signature=df7ee1a1378049c55806dd9a818898e788e6ff198d5557579275e8d179bcdcee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->