### PR TITLE
docs(changes): record upstream drift review 21f5976..272f99b (tdd + start, nothing adopted)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,18 @@
 
 Records every change made to skills inherited from [`mattpocock/skills`](https://github.com/mattpocock/skills), plus new skills created by reddb.io. See the rules in [CLAUDE.md](./CLAUDE.md).
 
-Upstream base: `mattpocock/skills@21f59763be7bf734cd4cf138805bb653d9ffebb7` (see `.upstream`).
+Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see `.upstream`).
+
+---
+
+## tdd + start (engineering) — upstream drift review 21f5976..272f99b: nothing adopted
+
+- **status**: reviewed, no change
+- **upstream**: `272f99b`
+- **why**: Reviewed the two Matt-derived skills touched in `21f5976..272f99b`. Neither upstream tweak survived the adoption bar.
+- **what changed**:
+  - `tdd`: upstream renamed the cross-reference from `'review' skill` to `'code-review' skill`. Our version (`plugins/dev/skills/engineering/tdd/SKILL.md`) is heavily diverged and ships both a `/review` and a `/code-review` skill — the right pointer is ambiguous without deeper reading. Conservative bias: skipped.
+  - `start` (maps to upstream `grilling`): upstream added "Do not enact the plan until I confirm we have reached a shared understanding." and changed the frontmatter description. Our `/start` skill already enforces both constraints more explicitly (`shared understanding is the only exit condition`; hard rules banning implementation and artefacts). Nothing new to add.
 
 ---
 


### PR DESCRIPTION
## Summary

- Reviewed the two Matt-derived skills touched between upstream `21f5976..272f99b`: **tdd** and **grilling** (our `/start`).
- Neither upstream tweak cleared the adoption bar — one is ambiguous in our context, the other is already covered more thoroughly by our diverged version.
- `CHANGES.md` updated: upstream base SHA bumped in the header; new review entry added documenting what was examined and why nothing was adopted.

## What was reviewed

**tdd** (`+1/-1`): upstream renamed `'review' skill` → `'code-review' skill` in the "Refactoring is not part of the loop" rule. Our `/tdd` is heavily diverged and ships both a `/review` and `/code-review` skill — the right target is ambiguous without deeper reading. Conservative bias: skipped.

**grilling/start** (`+3/-1`): upstream changed the frontmatter description and added "Do not enact the plan until I confirm we have reached a shared understanding." Our `/start` already enforces both: `shared understanding is the only exit condition` and hard rules banning implementation, code, and artefacts. Nothing new to add.

## Test plan

- [ ] `CHANGES.md` header SHA matches `.upstream` (`272f99b`)
- [ ] New CHANGES.md entry lists both skills, gives reasons for skipping
- [ ] No skill files were modified
- [ ] Repo validation passes (no manifest or README listing changes needed)

Closes #1092

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785687793&installation_id=129708444&pr_number=1093&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1093&signature=6df23a8802965b19c68677bb44a06efd7d3fcb77c36a1fffb1e205d3409c000e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with the latest upstream reference and a new review entry.
  * Noted that no local behavior changes were needed after reviewing upstream updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->