### PR TITLE
merge: #1095 /go: Professionalize AFK merge-conflict landing. Today when the reconcile/lan

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -13,6 +13,11 @@ import { runBoot, type BootDeps, type BootOptions, type BootstrapInput, type Rec
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
 import { resolveBase } from "../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
+import {
+  classifyConflictedFileKind,
+  partitionConflicts,
+  type ConflictFinding,
+} from "../core/merge-conflict-reconcile.js";
 import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
 import { passExitBarrier, passTerminalBarrier } from "../core/exit-barrier.js";
 import {
@@ -50,7 +55,7 @@ import {
   resolveReviewGate,
   type IssueClassificationMetadata,
 } from "../core/issue-classifier.js";
-import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE } from "../core/triage-labels.js";
+import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE, LABEL_MERGE_CONFLICT } from "../core/triage-labels.js";
 import { GO_ORIGIN, GO_WORKERS_SEGMENT } from "../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../core/scout.js";
 import { resolveHooks } from "../core/hook-config.js";
@@ -325,6 +330,51 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
   };
 }
 
+/**
+ * Real mechanical-conflict resolver for the #1095 merge-conflict reland. Bound
+ * to `gitCtx`, returns the port `preMergeRebase` invokes when a rebase onto
+ * fresh trunk CONFLICTS: it lists the conflicted files, classifies each via the
+ * closed mechanical allowlist (`classifyConflictedFileKind`), and auto-resolves
+ * ONLY when EVERY conflict is mechanical (whitespace-only today) — otherwise it
+ * declines so the rebase aborts and the branch re-parks for a human. On the
+ * mechanical path it takes one (whitespace-equivalent) side per file, stages it,
+ * and `git rebase --continue`s (editor suppressed). Any git/read failure → false.
+ */
+function makeMechanicalConflictResolver(gitCtx: GitContext): (repo: string) => Promise<boolean> {
+  const git = gitx.gitExec(gitCtx);
+  return async (repo: string): Promise<boolean> => {
+    const list = await git(["-C", repo, "diff", "--name-only", "--diff-filter=U"]);
+    if (list.code !== 0) return false;
+    const paths = list.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+    if (paths.length === 0) return false;
+
+    const findings: ConflictFinding[] = [];
+    for (const p of paths) {
+      let body: string;
+      try {
+        body = await readFile(join(repo, p), "utf8");
+      } catch {
+        return false;
+      }
+      const kind = classifyConflictedFileKind(body);
+      findings.push({ path: p, kind, description: `${kind} conflict in ${p}` });
+    }
+    // Intent-by-default: a single non-mechanical conflict declines the whole set.
+    if (partitionConflicts(findings).nonMechanical.length > 0) return false;
+
+    for (const p of paths) {
+      // Whitespace-equivalent sides → taking either resolves it; keep the
+      // worker's committed (validated) version, then stage.
+      const checkout = await git(["-C", repo, "checkout", "--theirs", "--", p]);
+      if (checkout.code !== 0) return false;
+      const add = await git(["-C", repo, "add", "--", p]);
+      if (add.code !== 0) return false;
+    }
+    const cont = await git(["-C", repo, "-c", "core.editor=true", "rebase", "--continue"]);
+    return cont.code === 0;
+  };
+}
+
 /** Build the boot reconcile runner (step 7, ADR 0055). The runner closes over
  * the repo context and feedback worktree so each plan invocation has full
  * reconcile deps without re-building them on every call. */
@@ -405,6 +455,11 @@ function makeBootReconcileRunner(
         return ok ? dest : null;
       },
       removeRebaseWorktree: (dir: string) => gitx.worktreeRemove(gitCtx, dir),
+      // #1095: only the merge-conflict reland auto-resolves mechanical rebase
+      // conflicts; stalled/crashed relands keep the abort-on-any-conflict path.
+      resolveMechanicalConflict: plan.labels.includes(LABEL_MERGE_CONFLICT)
+        ? makeMechanicalConflictResolver(gitCtx)
+        : undefined,
       envelope: {
         git: gitx.gitExec(gitCtx),
         poster: async (issue, body) => {
@@ -456,6 +511,12 @@ function makeBootReconcileRunner(
         attempt: 0,
         attemptDir: join(paths.tmpDir, "boot-reconcile", String(plan.number)),
         runner,
+        // #1095: a `blocked:merge-conflict` park carries a branch that already
+        // validated green before a land-time trunk conflict. Trust that prior
+        // validation and skip re-running the local suite — doLanding's #1006
+        // pre-merge rebase re-lands it on FRESH trunk and the PR's CI is the
+        // merge gate. A branch that still conflicts re-parks merge-conflict.
+        trustPriorValidation: plan.labels.includes(LABEL_MERGE_CONFLICT),
       };
 
       const result = await reconcile(reconcileDeps, reconcileInput);

--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -26,7 +26,7 @@
 
 /** The literal `## Blocked by` heading line, allowing only trailing whitespace.
  * Mirrors awk `/^## Blocked by[[:space:]]*$/`. */
-import { LABEL_STALLED, LABEL_CRASHED, LABEL_DEPENDENCY, LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
+import { LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT, LABEL_DEPENDENCY, LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
 
 const BLOCKED_BY_HEADING_RE = /^## Blocked by[ \t]*$/;
 /** Any `## ` heading — the awk `/^## /` that closes the Blocked-by section. */
@@ -358,9 +358,12 @@ export function findOwnedBranch(branches: readonly string[], issue: number): str
   return null;
 }
 
-/** The labels that mark a parked-mechanical issue: the attempt-progress guard
- * fired (`blocked:stalled`) or the agent process crashed (`blocked:crashed`). */
-const PARKED_MECHANICAL_LABELS = new Set([LABEL_STALLED, LABEL_CRASHED]);
+/** The labels that mark a parked-mechanical issue the reconcile sweep can pick
+ * up: the attempt-progress guard fired (`blocked:stalled`), the agent process
+ * crashed (`blocked:crashed`), or a land-time trunk conflict parked the branch
+ * (`blocked:merge-conflict`, issue #1095). All three carry a branch that may
+ * simply need re-landing on fresh trunk — never a human decision. */
+const PARKED_MECHANICAL_LABELS = new Set([LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT]);
 
 /**
  * True when the label set carries a parked-mechanical routing label

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -81,6 +81,16 @@ export interface LandingDeps {
   /** Tear down a worktree returned by {@link makeRebaseWorktree} (best-effort). */
   removeRebaseWorktree?(dir: string): Promise<void>;
   /**
+   * Opt-in mechanical-conflict resolver for the PR path's pre-merge rebase
+   * (issue #1095). When the rebase onto fresh base CONFLICTS, this is invoked
+   * with the rebase worktree dir; it returns true when it auto-resolved EVERY
+   * conflict on the closed mechanical allowlist and `git rebase --continue`d, so
+   * the landing proceeds instead of parking `blocked:merge-conflict`. Returns
+   * false for any non-mechanical conflict → abort as before. Absent (the
+   * default) → every conflict aborts, so existing landings are unchanged.
+   */
+  resolveMechanicalConflict?: (repo: string) => Promise<boolean>;
+  /**
    * Opt-in advisory-review wait for the admin-PR landing
    * (`afk.merge.wait_for_review`, ADR 0048). Present → landPr holds until the
    * named review check concludes before the admin-merge, then merges regardless
@@ -403,6 +413,7 @@ async function preMergeRebaseInWorktree(
       remote: input.remote,
       base: input.base,
       branch: input.branch,
+      resolveMechanical: deps.resolveMechanicalConflict,
     });
     if (rebased.ok) return undefined;
     // Real conflict / exhausted force-with-lease retries → park merge-conflict.

--- a/apps/dev/src/core/merge-conflict-reconcile.ts
+++ b/apps/dev/src/core/merge-conflict-reconcile.ts
@@ -1,0 +1,186 @@
+// merge-conflict-reconcile — the NO-AGENT auto-reconcile route for a
+// `blocked:merge-conflict` park (issue #1095, extends ADR 0055).
+//
+// Today a trunk conflict at land time (`reconcile land failed: pr-conflict`)
+// AFTER a worker already validated its fix green parks the issue
+// `blocked:merge-conflict` + `ready-for-human`, and recovery is a hand-rolled
+// finish-from-branch that re-runs the FULL CI cold and resolves conflicts by
+// hand. This module professionalises that: it routes the park back into the
+// no-agent lane —
+//   1. rebase the parked worker branch onto FRESH `origin/<trunk>`;
+//   2. auto-resolve ONLY conflicts on the CLOSED mechanical allowlist
+//      (shared-gate `MECHANICAL_KINDS`, intent-by-default, no catch-all);
+//   3. reland trusting the PRIOR green validation — NEVER re-running the full
+//      local build/suite; the opened PR's CI gates the merge.
+// A conflict that is genuinely semantic — or mechanical-looking but OUTSIDE the
+// closed allowlist — parks to `ready-for-human` unchanged.
+//
+// PURE SEQUENCING over injected IO, mirroring reconcile.ts / merge.ts: every
+// git / gh / resolve touch is a port, so the whole decision tree is
+// unit-testable with zero subprocesses. The real ports (rebase-in-worktree,
+// mechanical-resolve, reland-via-PR) are wired at the call site.
+
+import { classifyFinding, type GateFinding } from "./shared-gate.js";
+
+// ---------- findings ----------
+
+/**
+ * One conflicted region surfaced by the rebase, tagged with the mechanical
+ * KIND an analyzer inferred for it. Extends the shared {@link GateFinding} shape
+ * so the SAME closed allowlist (`MECHANICAL_KINDS`) classifies it — a merge
+ * conflict is mechanical for exactly the reasons a gate finding is. `path` is
+ * the conflicted file, carried for the park comment / audit trail.
+ */
+export interface ConflictFinding extends GateFinding {
+  /** The conflicted file path (relative to the repo root). */
+  path: string;
+}
+
+/**
+ * Split conflict findings by the closed mechanical allowlist. A finding whose
+ * `kind` is on the allowlist is mechanical (auto-resolvable); everything else is
+ * INTENT by default — no catch-all. PURE.
+ */
+export function partitionConflicts(
+  findings: readonly ConflictFinding[],
+): { mechanical: ConflictFinding[]; nonMechanical: ConflictFinding[] } {
+  const mechanical: ConflictFinding[] = [];
+  const nonMechanical: ConflictFinding[] = [];
+  for (const f of findings) {
+    if (classifyFinding(f) === "mechanical") mechanical.push(f);
+    else nonMechanical.push(f);
+  }
+  return { mechanical, nonMechanical };
+}
+
+// ---------- injected IO ----------
+
+/** The outcome of rebasing the parked worker branch onto fresh `origin/<trunk>`. */
+export type RebaseOutcome =
+  | { status: "clean" }
+  | { status: "conflicted"; findings: ConflictFinding[] }
+  | { status: "error"; detail: string };
+
+/** Why a {@link MergeConflictReconcileDeps.reland} did not land the branch. */
+export type RelandOutcome = { ok: true } | { ok: false; reason: string };
+
+/** Why the auto-reconcile route parked the issue to `ready-for-human`. */
+export type MergeConflictParkReason =
+  // At least one conflict is OUTSIDE the closed mechanical allowlist — it needs
+  // a human (genuinely semantic, or a mechanical-looking kind not on the list).
+  | "semantic-conflict"
+  // Every conflict was mechanical, but applying the resolution / continuing the
+  // rebase failed — bail rather than land a half-resolved tree.
+  | "resolution-failed"
+  // The rebase clean/resolved, but the reland (force-push / open PR) failed.
+  | "reland-failed"
+  // The rebase could not even run (fetch / worktree setup failure).
+  | "rebase-error";
+
+/** All injected IO for one auto-reconcile. */
+export interface MergeConflictReconcileDeps {
+  /**
+   * Fetch fresh `origin/<trunk>` and rebase the parked worker branch onto it in
+   * an ISOLATED worktree (never the primary checkout). Returns the classified
+   * conflict findings when the rebase stops on conflict, `clean` when it applied
+   * with no conflicts, or `error` when it could not run at all.
+   */
+  rebaseOntoTrunk(): Promise<RebaseOutcome>;
+  /**
+   * Apply the resolution for every (already-classified mechanical) finding,
+   * `git add` each, and `git rebase --continue`. Returns false when the
+   * resolution or the continue failed — the caller then aborts + parks.
+   */
+  resolveMechanical(findings: ConflictFinding[]): Promise<boolean>;
+  /** `git rebase --abort` — leaves the parked branch exactly as it was. */
+  abortRebase(): Promise<void>;
+  /**
+   * Force-push the rebased branch and open/merge its PR, trusting the PRIOR
+   * green validation — NO local suite is re-run here; the PR's CI gates the
+   * merge. Returns whether the reland succeeded.
+   */
+  reland(): Promise<RelandOutcome>;
+  /** Park to `ready-for-human` with the reason + the conflict audit. */
+  park(reason: MergeConflictParkReason, findings: ConflictFinding[]): Promise<void>;
+  /** Append one plain line to the iteration's afk.log. */
+  appendIterLog(line: string): void;
+}
+
+// ---------- result ----------
+
+export type MergeConflictReconcileResult =
+  | { outcome: "relanded" }
+  | { outcome: "parked"; reason: MergeConflictParkReason };
+
+// ---------- the orchestration ----------
+
+/**
+ * Rebase a `blocked:merge-conflict`-parked worker branch onto fresh trunk,
+ * auto-resolve ONLY mechanical conflicts, and reland trusting the prior green
+ * validation (issue #1095). Decision tree:
+ *   - rebase clean            → reland.
+ *   - rebase conflicted, ALL mechanical → resolveMechanical → reland (or park
+ *                               `resolution-failed` when the resolve/continue
+ *                               failed).
+ *   - rebase conflicted, ANY non-mechanical (or no classifiable findings)
+ *                             → abort + park `semantic-conflict`.
+ *   - rebase error            → park `rebase-error` (no abort — nothing started).
+ *   - reland failed           → park `reland-failed`.
+ */
+export async function reconcileMergeConflict(
+  deps: MergeConflictReconcileDeps,
+): Promise<MergeConflictReconcileResult> {
+  const rebase = await deps.rebaseOntoTrunk();
+
+  if (rebase.status === "error") {
+    await deps.park("rebase-error", []);
+    deps.appendIterLog(
+      `🤖 /afk merge-conflict reconcile: rebase onto fresh trunk could not run (${rebase.detail}) — parked to ready-for-human.`,
+    );
+    return { outcome: "parked", reason: "rebase-error" };
+  }
+
+  if (rebase.status === "conflicted") {
+    const { mechanical, nonMechanical } = partitionConflicts(rebase.findings);
+
+    // A conflict with NO classifiable findings cannot be proven safe → treat as
+    // semantic (the conservative default the closed allowlist enforces).
+    if (nonMechanical.length > 0 || rebase.findings.length === 0) {
+      await deps.abortRebase();
+      await deps.park("semantic-conflict", nonMechanical);
+      deps.appendIterLog(
+        `🤖 /afk merge-conflict reconcile: ${nonMechanical.length || "un-classifiable"} conflict(s) outside the mechanical allowlist — aborted the rebase and parked to ready-for-human.`,
+      );
+      return { outcome: "parked", reason: "semantic-conflict" };
+    }
+
+    // Every conflict is on the closed mechanical allowlist → auto-resolve.
+    const resolved = await deps.resolveMechanical(mechanical);
+    if (!resolved) {
+      await deps.abortRebase();
+      await deps.park("resolution-failed", mechanical);
+      deps.appendIterLog(
+        `🤖 /afk merge-conflict reconcile: mechanical resolution of ${mechanical.length} conflict(s) failed — aborted the rebase and parked to ready-for-human.`,
+      );
+      return { outcome: "parked", reason: "resolution-failed" };
+    }
+    deps.appendIterLog(
+      `🤖 /afk merge-conflict reconcile: auto-resolved ${mechanical.length} mechanical conflict(s) on the closed allowlist — relanding trusting the prior green validation.`,
+    );
+  }
+
+  // Clean rebase OR all-mechanical resolved → reland trusting prior green. The
+  // opened PR's CI is the merge gate; the local suite is NOT re-run.
+  const relanded = await deps.reland();
+  if (!relanded.ok) {
+    await deps.park("reland-failed", []);
+    deps.appendIterLog(
+      `🤖 /afk merge-conflict reconcile: rebase succeeded but the reland failed (${relanded.reason}) — parked to ready-for-human.`,
+    );
+    return { outcome: "parked", reason: "reland-failed" };
+  }
+  deps.appendIterLog(
+    `🤖 /afk merge-conflict reconcile: rebased onto fresh trunk and relanded without re-running the agent or the local suite.`,
+  );
+  return { outcome: "relanded" };
+}

--- a/apps/dev/src/core/merge-conflict-reconcile.ts
+++ b/apps/dev/src/core/merge-conflict-reconcile.ts
@@ -20,7 +20,106 @@
 // unit-testable with zero subprocesses. The real ports (rebase-in-worktree,
 // mechanical-resolve, reland-via-PR) are wired at the call site.
 
-import { classifyFinding, type GateFinding } from "./shared-gate.js";
+import { classifyFinding, type GateFinding, type MechanicalKind } from "./shared-gate.js";
+
+// ---------- conflict-content analyzer ----------
+//
+// Infers a mechanical KIND for a conflicted file so the orchestrator can decide,
+// via the closed allowlist, whether it is safe to auto-resolve. CONSERVATIVE by
+// construction: it recognises only conflicts whose two sides are provably
+// equivalent, and defaults everything else to a non-mechanical `"semantic"` kind
+// (→ park). Broadening the recognised classes (lockfile regen, append-only
+// changelog union, import-ordering) is deliberate follow-up.
+
+const CONFLICT_START = "<<<<<<<";
+const CONFLICT_MID = "=======";
+const CONFLICT_END = ">>>>>>>";
+
+/** One conflicted hunk extracted from a file carrying git conflict markers: the
+ * two competing versions (`ours` above `=======`, `theirs` below). */
+export interface ConflictHunk {
+  ours: string[];
+  theirs: string[];
+}
+
+/**
+ * Parse the conflict hunks out of a file body carrying `<<<<<<<` / `=======` /
+ * `>>>>>>>` markers. Tolerant: an unterminated hunk (no closing `>>>>>>>`) is
+ * dropped rather than throwing. Returns [] when the body has no conflict
+ * markers. PURE.
+ */
+export function parseConflictHunks(body: string): ConflictHunk[] {
+  const lines = body.split("\n");
+  const hunks: ConflictHunk[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (!lines[i].startsWith(CONFLICT_START)) {
+      i++;
+      continue;
+    }
+    const ours: string[] = [];
+    const theirs: string[] = [];
+    i++;
+    let sawMid = false;
+    let closed = false;
+    for (; i < lines.length; i++) {
+      if (lines[i].startsWith(CONFLICT_MID)) {
+        sawMid = true;
+        continue;
+      }
+      if (lines[i].startsWith(CONFLICT_END)) {
+        i++;
+        closed = true;
+        break;
+      }
+      (sawMid ? theirs : ours).push(lines[i]);
+    }
+    if (closed) hunks.push({ ours, theirs });
+  }
+  return hunks;
+}
+
+/** True when the two sides are identical after stripping trailing whitespace on
+ * every line AND ignoring trailing blank lines — a whitespace-only conflict that
+ * resolves safely to either side. PURE. */
+function whitespaceEquivalent(ours: readonly string[], theirs: readonly string[]): boolean {
+  const norm = (ls: readonly string[]): string[] => {
+    const trimmed = ls.map((l) => l.replace(/\s+$/, ""));
+    while (trimmed.length > 0 && trimmed[trimmed.length - 1] === "") trimmed.pop();
+    return trimmed;
+  };
+  const a = norm(ours);
+  const b = norm(theirs);
+  if (a.length !== b.length) return false;
+  return a.every((l, idx) => l === b[idx]);
+}
+
+/**
+ * Infer the mechanical KIND of a single conflict hunk, or null when it is not
+ * safely mechanical (→ intent). Recognises WHITESPACE-ONLY conflicts today. PURE.
+ */
+export function classifyConflictHunk(hunk: ConflictHunk): MechanicalKind | null {
+  if (whitespaceEquivalent(hunk.ours, hunk.theirs)) return "trailing-whitespace";
+  return null;
+}
+
+/**
+ * Infer the KIND of a whole conflicted file body. A file is mechanical only when
+ * it carries at least one conflict hunk AND every hunk is mechanical; the shared
+ * kind is returned. Any non-mechanical (or unparseable) hunk yields `"semantic"`
+ * — the conservative, non-allowlisted default. PURE.
+ */
+export function classifyConflictedFileKind(body: string): string {
+  const hunks = parseConflictHunks(body);
+  if (hunks.length === 0) return "semantic";
+  let kind: MechanicalKind | null = null;
+  for (const h of hunks) {
+    const k = classifyConflictHunk(h);
+    if (k === null) return "semantic";
+    kind = k;
+  }
+  return kind ?? "semantic";
+}
 
 // ---------- findings ----------
 

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -100,6 +100,17 @@ export interface PreMergeRebaseInput {
    * 2 — so at most three pushes total before the caller parks merge-conflict.
    */
   maxPushRetries?: number;
+  /**
+   * Opt-in mechanical-conflict resolver (issue #1095). On a rebase CONFLICT,
+   * instead of aborting immediately, the resolver is given the rebase worktree
+   * (`repo`) and returns true when it resolved EVERY conflict on the closed
+   * mechanical allowlist + `git rebase --continue`d successfully — the rebase
+   * then proceeds to the force-push. It returns false to decline (a
+   * non-mechanical / unresolvable conflict), and `preMergeRebase` aborts exactly
+   * as before. Absent (the default) → any conflict aborts → `conflict`, so every
+   * existing landing path is byte-identical.
+   */
+  resolveMechanical?: (repo: string) => Promise<boolean>;
 }
 
 /** Why a {@link preMergeRebase} did not land the rebased branch on the remote. */
@@ -137,6 +148,12 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
     if (fetch.code !== 0) return { ok: false, reason: "fetch-failed" };
     const rebase = await exec(["git", "-C", repo, "rebase", baseRef]);
     if (rebase.code !== 0) {
+      // #1095: give the opt-in mechanical resolver a chance to auto-resolve
+      // whitespace-only / allowlisted conflicts + `rebase --continue` before we
+      // abort. It returns false for anything non-mechanical → abort as before.
+      if (input.resolveMechanical && (await input.resolveMechanical(repo))) {
+        return { ok: true };
+      }
       await exec(["git", "-C", repo, "rebase", "--abort"]);
       return { ok: false, reason: "conflict" };
     }

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -151,6 +151,14 @@ export interface ReconcileDeps {
   /** One-shot inner-agent merge-conflict resolver for the DIRECT land (optional). */
   conflictResolver?: ConflictResolver;
   /**
+   * Opt-in mechanical-conflict resolver for the PR path's pre-merge rebase
+   * (issue #1095): auto-resolve whitespace-only / closed-allowlist conflicts
+   * when re-landing a `blocked:merge-conflict` branch on fresh trunk, instead of
+   * parking. Threaded straight into {@link doLanding}'s `resolveMechanicalConflict`.
+   * Absent → any rebase conflict parks `blocked:merge-conflict` as before.
+   */
+  resolveMechanicalConflict?: (repo: string) => Promise<boolean>;
+  /**
    * Landing-mode flag, decoupled from the lock (#842). `true`/undefined → land via
    * an admin-merged PR; `false` → a direct merge. Threaded from process-issue's
    * deps so a reconcile-land honours the same `afk.worktree_launches_pull_request`
@@ -237,6 +245,16 @@ export interface ReconcileInput {
   attempt: number;
   attemptDir: string;
   runner: Runner;
+  /**
+   * Trust the PRIOR green validation and SKIP re-running the scoped feedback
+   * gate (issue #1095). Set by the merge-conflict auto-reconcile route: the
+   * branch already validated green BEFORE the land-time trunk conflict, so the
+   * no-agent reland rebases onto fresh trunk (via doLanding's #1006 pre-merge
+   * rebase) and lands through the PR — whose CI is the merge gate — WITHOUT
+   * re-running the full local suite. Default undefined/false → the standard
+   * reconcile runs the scoped gate as its verdict, unchanged.
+   */
+  trustPriorValidation?: boolean;
 }
 
 // ---------- result ----------
@@ -335,31 +353,50 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   }
 
   // ---- 4. feedback gate (the verdict — SAME authority as the DONE path) ----
-  // AFK runner improvement: pass `base` as the `baselineWorktree` so a pre-existing
-  // failure on the base branch (NOT the worker's fault) is downgraded to
-  // `skipped (pre-existing failure on baseline)` instead of parking the green
-  // branch. Mirrors the DONE path's behaviour exactly.
+  // The merge-conflict reland route (#1095) trusts the prior green validation
+  // and skips the gate; every other reland runs it exactly as the DONE path does.
   const startedEpoch = deps.nowEpoch();
-  const feedback: RunFeedbackResult = await runFeedback(deps.pnpm, {
-    worktree: branch,
-    scopes: relevantScopes(deps.layout, changedFiles),
-    layout: deps.layout,
-    now: deps.nowEpoch,
-    baselineWorktree: input.base,
-  });
-  await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
+  let feedback: RunFeedbackResult;
+  if (input.trustPriorValidation) {
+    // #1095 merge-conflict reland: the branch validated green before the
+    // land-time trunk conflict, so the scoped gate is NOT re-run here — the
+    // opened PR's CI is the merge gate. Stand in a trusted-green result so the
+    // envelope / close cascade below read a coherent (empty) validation summary.
+    deps.appendIterLog(
+      `🤖 /afk reconcile #${issue}: merge-conflict reland — trusting the prior green validation; NOT re-running the local suite (the PR's CI gates the merge).`,
+    );
+    feedback = {
+      ok: true,
+      checks: [],
+      sidecar: ["merge-conflict reland: prior validation trusted; local suite not re-run (#1095)"],
+      baselineDowngraded: [],
+      quarantined: [],
+    };
+  } else {
+    // AFK runner improvement: pass `base` as the `baselineWorktree` so a
+    // pre-existing failure on the base branch (NOT the worker's fault) is
+    // downgraded instead of parking the green branch. Mirrors the DONE path.
+    feedback = await runFeedback(deps.pnpm, {
+      worktree: branch,
+      scopes: relevantScopes(deps.layout, changedFiles),
+      layout: deps.layout,
+      now: deps.nowEpoch,
+      baselineWorktree: input.base,
+    });
+    await writeValidationSidecar(deps, input.attemptDir, feedback.sidecar);
 
-  // ---- 4b. RED → ready-for-human with the real failing checks ----
-  // AFK runner improvement: an INFRA-rooted failure (worktree / submodule /
-  // pnpm install / OOM) is NOT a parked branch — it is a flaky environment
-  // and the recovery policy should retry it (bounded, default cap 2). Skip
-  // the park-to-human path; let `routeRecovery` re-queue or escalate the
-  // same way the DONE path does, so the green branch isn't stranded.
-  if (!feedback.ok && isInfraFeedbackFailure(feedback)) {
-    return await parkInfraRetry(deps, input, feedback, startedEpoch);
-  }
-  if (!feedback.ok) {
-    return await park(deps, input, feedback, startedEpoch);
+    // ---- 4b. RED → ready-for-human with the real failing checks ----
+    // AFK runner improvement: an INFRA-rooted failure (worktree / submodule /
+    // pnpm install / OOM) is NOT a parked branch — it is a flaky environment
+    // and the recovery policy should retry it (bounded, default cap 2). Skip
+    // the park-to-human path; let `routeRecovery` re-queue or escalate the
+    // same way the DONE path does, so the green branch isn't stranded.
+    if (!feedback.ok && isInfraFeedbackFailure(feedback)) {
+      return await parkInfraRetry(deps, input, feedback, startedEpoch);
+    }
+    if (!feedback.ok) {
+      return await park(deps, input, feedback, startedEpoch);
+    }
   }
 
   // ---- 4a-pre. re-verify the issue is still open immediately before landing ----
@@ -385,6 +422,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       remoteGit: deps.remoteGit,
       fireHook: deps.fireHook ?? (async () => true),
       conflictResolver: deps.conflictResolver,
+      resolveMechanicalConflict: deps.resolveMechanicalConflict,
       waitForReview: deps.waitForReview,
       makeLandingWorktree: deps.makeLandingWorktree,
       removeLandingWorktree: deps.removeLandingWorktree,

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -14,6 +14,7 @@ import {
   LABEL_DEPENDENCY,
   LABEL_STALLED,
   LABEL_CRASHED,
+  LABEL_MERGE_CONFLICT,
 } from "../core/triage-labels.js";
 import type { IssueCandidate } from "../core/session.js";
 import type { HitlCandidate } from "../core/hitl-selection.js";
@@ -723,21 +724,23 @@ export async function issueClosed(ctx: GhContext, n: number): Promise<boolean> {
   return (await blockerState(ctx, n)) === "CLOSED";
 }
 
-/** List open issues labelled `blocked:stalled` OR `blocked:crashed` — the
- * parked-mechanical candidates the boot reconcile sweep processes. The two
- * `gh issue list` calls run concurrently and are de-duplicated by issue number.
- * A failed probe for either label returns [] for that label; the surviving set
- * is still processed. */
+/** List open issues labelled `blocked:stalled`, `blocked:crashed`, OR
+ * `blocked:merge-conflict` — the parked-mechanical candidates the boot reconcile
+ * sweep processes (merge-conflict added in #1095: a land-time trunk conflict is
+ * mechanical, not a human decision). The `gh issue list` calls run concurrently
+ * and are de-duplicated by issue number. A failed probe for any label returns []
+ * for that label; the surviving set is still processed. */
 export async function listParkedMechanicalCandidates(
   ctx: GhContext,
 ): Promise<ReconcileSweepCandidate[]> {
-  const [stalled, crashed] = await Promise.all([
+  const [stalled, crashed, mergeConflict] = await Promise.all([
     listIssuesByLabel(ctx, LABEL_STALLED),
     listIssuesByLabel(ctx, LABEL_CRASHED),
+    listIssuesByLabel(ctx, LABEL_MERGE_CONFLICT),
   ]);
   const seen = new Set<number>();
   const result: ReconcileSweepCandidate[] = [];
-  for (const c of [...stalled, ...crashed]) {
+  for (const c of [...stalled, ...crashed, ...mergeConflict]) {
     if (seen.has(c.number)) continue;
     seen.add(c.number);
     result.push(c);

--- a/apps/dev/tests/boot-sweep.test.ts
+++ b/apps/dev/tests/boot-sweep.test.ts
@@ -475,6 +475,10 @@ describe("isParkedMechanical", () => {
     expect(isParkedMechanical(["blocked:crashed"])).toBe(true);
   });
 
+  it("returns true for blocked:merge-conflict (#1095)", () => {
+    expect(isParkedMechanical(["blocked:merge-conflict", "ready-for-human"])).toBe(true);
+  });
+
   it("returns false for non-mechanical labels", () => {
     expect(isParkedMechanical(["blocked:spec", "ready-for-human"])).toBe(false);
     expect(isParkedMechanical(["blocked:validation"])).toBe(false);

--- a/apps/dev/tests/merge-conflict-reconcile.test.ts
+++ b/apps/dev/tests/merge-conflict-reconcile.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  partitionConflicts,
+  reconcileMergeConflict,
+  type ConflictFinding,
+  type MergeConflictReconcileDeps,
+  type RebaseOutcome,
+  type RelandOutcome,
+} from "../src/core/merge-conflict-reconcile.js";
+
+// Everything injected is a fake — no real git / gh / resolve ever runs. The
+// harness records the side-effect sequence (rebase, resolve, abort, reland,
+// park, log) so each test asserts the decision tree as a trace. Mirrors
+// reconcile.test.ts so the two read alike.
+
+interface Trace {
+  rebased: number;
+  resolvedWith: ConflictFinding[][];
+  aborted: number;
+  relanded: number;
+  parked: Array<{ reason: string; findings: ConflictFinding[] }>;
+  logs: string[];
+}
+
+interface HarnessOptions {
+  rebase: RebaseOutcome;
+  /** Whether resolveMechanical succeeds (default true). */
+  resolveOk?: boolean;
+  /** Reland outcome (default ok). */
+  reland?: RelandOutcome;
+}
+
+function mechanical(path: string, kind = "lint-fix"): ConflictFinding {
+  return { path, kind, description: `${kind} conflict in ${path}` };
+}
+
+function semantic(path: string, kind = "logic"): ConflictFinding {
+  return { path, kind, description: `${kind} conflict in ${path}` };
+}
+
+function harness(opts: HarnessOptions): { deps: MergeConflictReconcileDeps; trace: Trace } {
+  const trace: Trace = { rebased: 0, resolvedWith: [], aborted: 0, relanded: 0, parked: [], logs: [] };
+  const deps: MergeConflictReconcileDeps = {
+    rebaseOntoTrunk: async () => {
+      trace.rebased++;
+      return opts.rebase;
+    },
+    resolveMechanical: async (findings) => {
+      trace.resolvedWith.push(findings);
+      return opts.resolveOk ?? true;
+    },
+    abortRebase: async () => {
+      trace.aborted++;
+    },
+    reland: async () => {
+      trace.relanded++;
+      return opts.reland ?? { ok: true };
+    },
+    park: async (reason, findings) => {
+      trace.parked.push({ reason, findings });
+    },
+    appendIterLog: (line) => trace.logs.push(line),
+  };
+  return { deps, trace };
+}
+
+describe("partitionConflicts", () => {
+  it("splits findings by the closed mechanical allowlist (intent-by-default)", () => {
+    const findings = [
+      mechanical("a.ts", "formatter"),
+      semantic("b.ts", "logic"),
+      mechanical("c.ts", "trailing-newline"),
+      semantic("d.ts", "unknown-kind"),
+    ];
+    const { mechanical: mech, nonMechanical } = partitionConflicts(findings);
+    expect(mech.map((f) => f.path)).toEqual(["a.ts", "c.ts"]);
+    expect(nonMechanical.map((f) => f.path)).toEqual(["b.ts", "d.ts"]);
+  });
+
+  it("classifies every allowlisted kind as mechanical", () => {
+    const kinds = [
+      "formatter",
+      "import-organizer",
+      "lint-fix",
+      "comment-typo",
+      "trailing-whitespace",
+      "trailing-newline",
+    ];
+    const { mechanical: mech, nonMechanical } = partitionConflicts(kinds.map((k) => mechanical("f", k)));
+    expect(mech).toHaveLength(kinds.length);
+    expect(nonMechanical).toHaveLength(0);
+  });
+});
+
+describe("reconcileMergeConflict", () => {
+  it("relands directly on a CLEAN rebase, trusting prior green (no resolve, no abort)", async () => {
+    const { deps, trace } = harness({ rebase: { status: "clean" } });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "relanded" });
+    expect(trace.rebased).toBe(1);
+    expect(trace.resolvedWith).toHaveLength(0);
+    expect(trace.aborted).toBe(0);
+    expect(trace.relanded).toBe(1);
+    expect(trace.parked).toHaveLength(0);
+  });
+
+  it("auto-resolves an ALL-mechanical conflict then relands", async () => {
+    const findings = [mechanical("a.ts", "formatter"), mechanical("b.ts", "lint-fix")];
+    const { deps, trace } = harness({ rebase: { status: "conflicted", findings } });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "relanded" });
+    expect(trace.resolvedWith).toEqual([findings]);
+    expect(trace.aborted).toBe(0);
+    expect(trace.relanded).toBe(1);
+    expect(trace.parked).toHaveLength(0);
+  });
+
+  it("aborts + parks semantic-conflict when ANY conflict is outside the allowlist", async () => {
+    const findings = [mechanical("a.ts", "formatter"), semantic("b.ts", "logic")];
+    const { deps, trace } = harness({ rebase: { status: "conflicted", findings } });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "parked", reason: "semantic-conflict" });
+    expect(trace.resolvedWith).toHaveLength(0);
+    expect(trace.aborted).toBe(1);
+    expect(trace.relanded).toBe(0);
+    expect(trace.parked).toEqual([{ reason: "semantic-conflict", findings: [findings[1]] }]);
+  });
+
+  it("aborts + parks resolution-failed when mechanical resolution fails", async () => {
+    const findings = [mechanical("a.ts", "formatter")];
+    const { deps, trace } = harness({ rebase: { status: "conflicted", findings }, resolveOk: false });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "parked", reason: "resolution-failed" });
+    expect(trace.resolvedWith).toEqual([findings]);
+    expect(trace.aborted).toBe(1);
+    expect(trace.relanded).toBe(0);
+    expect(trace.parked).toEqual([{ reason: "resolution-failed", findings }]);
+  });
+
+  it("parks semantic-conflict when the rebase conflicts with NO classifiable findings", async () => {
+    const { deps, trace } = harness({ rebase: { status: "conflicted", findings: [] } });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "parked", reason: "semantic-conflict" });
+    expect(trace.aborted).toBe(1);
+    expect(trace.resolvedWith).toHaveLength(0);
+  });
+
+  it("parks rebase-error when the rebase could not run (no abort attempted)", async () => {
+    const { deps, trace } = harness({ rebase: { status: "error", detail: "fetch-failed" } });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "parked", reason: "rebase-error" });
+    expect(trace.aborted).toBe(0);
+    expect(trace.relanded).toBe(0);
+    expect(trace.parked).toEqual([{ reason: "rebase-error", findings: [] }]);
+  });
+
+  it("parks reland-failed when a clean/resolved rebase cannot reland", async () => {
+    const { deps, trace } = harness({ rebase: { status: "clean" }, reland: { ok: false, reason: "push-rejected" } });
+    const res = await reconcileMergeConflict(deps);
+    expect(res).toEqual({ outcome: "parked", reason: "reland-failed" });
+    expect(trace.relanded).toBe(1);
+    expect(trace.parked).toEqual([{ reason: "reland-failed", findings: [] }]);
+  });
+});

--- a/apps/dev/tests/merge-conflict-reconcile.test.ts
+++ b/apps/dev/tests/merge-conflict-reconcile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  classifyConflictedFileKind,
+  classifyConflictHunk,
+  parseConflictHunks,
   partitionConflicts,
   reconcileMergeConflict,
   type ConflictFinding,
@@ -89,6 +92,71 @@ describe("partitionConflicts", () => {
     const { mechanical: mech, nonMechanical } = partitionConflicts(kinds.map((k) => mechanical("f", k)));
     expect(mech).toHaveLength(kinds.length);
     expect(nonMechanical).toHaveLength(0);
+  });
+});
+
+describe("parseConflictHunks", () => {
+  it("returns [] when there are no conflict markers", () => {
+    expect(parseConflictHunks("just\nsome\nlines\n")).toEqual([]);
+  });
+
+  it("extracts ours/theirs from a conflict hunk", () => {
+    const body = [
+      "before",
+      "<<<<<<< HEAD",
+      "a",
+      "b",
+      "=======",
+      "a ",
+      "b",
+      ">>>>>>> feature",
+      "after",
+    ].join("\n");
+    expect(parseConflictHunks(body)).toEqual([{ ours: ["a", "b"], theirs: ["a ", "b"] }]);
+  });
+
+  it("drops an unterminated hunk", () => {
+    const body = ["<<<<<<< HEAD", "a", "=======", "b"].join("\n");
+    expect(parseConflictHunks(body)).toEqual([]);
+  });
+});
+
+describe("classifyConflictHunk / classifyConflictedFileKind", () => {
+  it("classifies a whitespace-only hunk as mechanical", () => {
+    expect(classifyConflictHunk({ ours: ["const x = 1;"], theirs: ["const x = 1; "] })).toBe(
+      "trailing-whitespace",
+    );
+  });
+
+  it("classifies a trailing-blank-line-only hunk as mechanical", () => {
+    expect(classifyConflictHunk({ ours: ["a", "", ""], theirs: ["a"] })).toBe("trailing-whitespace");
+  });
+
+  it("classifies a real content divergence as non-mechanical (null)", () => {
+    expect(classifyConflictHunk({ ours: ["const x = 1;"], theirs: ["const x = 2;"] })).toBeNull();
+  });
+
+  it("file kind is mechanical only when EVERY hunk is whitespace-only", () => {
+    const mechanical = ["<<<<<<< HEAD", "a", "=======", "a ", ">>>>>>> f"].join("\n");
+    expect(classifyConflictedFileKind(mechanical)).toBe("trailing-whitespace");
+
+    const mixed = [
+      "<<<<<<< HEAD",
+      "a",
+      "=======",
+      "a ",
+      ">>>>>>> f",
+      "<<<<<<< HEAD",
+      "x = 1",
+      "=======",
+      "x = 2",
+      ">>>>>>> f",
+    ].join("\n");
+    expect(classifyConflictedFileKind(mixed)).toBe("semantic");
+  });
+
+  it("file kind is semantic when there are no conflict markers", () => {
+    expect(classifyConflictedFileKind("no markers here")).toBe("semantic");
   });
 });
 

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -801,6 +801,37 @@ describe("preMergeRebase (#1006)", () => {
     expect(j.some((c) => c.includes("push"))).toBe(false);
   });
 
+  it("#1095: an opt-in resolver that resolves the conflict → proceeds to push (no abort)", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
+    ]);
+    let resolverRepo = "";
+    const r = await preMergeRebase(exec, {
+      ...base,
+      resolveMechanical: async (repo) => {
+        resolverRepo = repo;
+        return true;
+      },
+    });
+    expect(r).toEqual({ ok: true });
+    expect(resolverRepo).toBe("/wt");
+    const j = joined(calls);
+    // The resolver handled it → no abort, and the branch is still force-pushed.
+    expect(j.some((c) => c.includes("rebase --abort"))).toBe(false);
+    expect(j).toContain("git -C /wt push origin HEAD:refs/heads/afk/w/9-x --force-with-lease");
+  });
+
+  it("#1095: a resolver that DECLINES → aborts exactly as before → conflict", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
+    ]);
+    const r = await preMergeRebase(exec, { ...base, resolveMechanical: async () => false });
+    expect(r).toEqual({ ok: false, reason: "conflict" });
+    const j = joined(calls);
+    expect(j).toContain("git -C /wt rebase --abort");
+    expect(j.some((c) => c.includes("push"))).toBe(false);
+  });
+
   it("a force-with-lease reject retries (re-fetch + re-rebase) then succeeds on the 2nd push", async () => {
     let pushes = 0;
     const { exec, calls } = fakeExec([

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -252,6 +252,23 @@ describe("reconcile — green → land", () => {
     expect(trace.firedHooks).toEqual(["pre_merge", "post_merge"]);
   });
 
+  it("trusts prior green (#1095): lands WITHOUT re-running the feedback gate", async () => {
+    const { deps, input, trace } = harness({
+      // feedbackOk left unset — the gate must NOT run at all on this path.
+      labels: ["ready-for-human", "blocked:merge-conflict", "priority:high"],
+    });
+    const result = await reconcile(deps, { ...input, trustPriorValidation: true });
+
+    expect(result.outcome).toBe("landed");
+    // The scoped feedback gate was SKIPPED — zero pnpm invocations.
+    expect(trace.pnpmCalls).toBe(0);
+    // Still lands + closes + sheds the merge-conflict blocked label.
+    expect(trace.closed).toEqual([9]);
+    const close = trace.labelEdits.at(-1)!;
+    expect(close.remove).toEqual(["ready-for-human", "blocked:merge-conflict"]);
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "done" }]);
+  });
+
   it("lands a PARKED issue, shedding ready-for-human + the mechanical blocked label", async () => {
     const { deps, input, trace } = harness({
       feedbackOk: true,


### PR DESCRIPTION
Automated AFK landing for #1095. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1095

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785692624&installation_id=129708444&pr_number=1096&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1096&signature=916ee4f385b99a017090639d1193bb3d106171f9254fc6499e285cac8da914c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically relanding issues marked with merge-conflict when the conflict is purely mechanical.
  * Reconcile can now trust prior successful validation for these relands, avoiding an extra local verification run.

* **Bug Fixes**
  * Improved handling of merge-conflict parking so these items are included in the normal parked-item recovery flow.
  * Conflict recovery now stops and asks for human review when conflicts are not clearly mechanical or when relanding fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->