### PR TITLE
merge: #1097 /go: Add an AFK fleet supervisor watchdog. Problem: the fleet supervisor proc

### DIFF
--- a/apps/dev/src/commands/monitor.ts
+++ b/apps/dev/src/commands/monitor.ts
@@ -200,7 +200,10 @@ export async function monitorCommand(
   if (watchdogRequested) {
     try {
       const supervisorCfg = resolveSupervisorConfig();
-      await runWatchdog(buildWatchdogIO(cwd, stdout), supervisorCfg.supervisorStaleS, supervisorCfg.progressStaleS);
+      await runWatchdog(buildWatchdogIO(cwd, stdout), supervisorCfg.supervisorStaleS, supervisorCfg.progressStaleS, {
+        maxRestarts: supervisorCfg.supervisorMaxRestarts,
+        windowS: supervisorCfg.supervisorRestartWindowS,
+      });
     } catch {
       // best-effort: recovery must never break monitoring.
     }

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -138,6 +138,26 @@ export interface SupervisorConfig {
    * a cost guard, not a correctness one. 0 / non-numeric falls back to the default.
    */
   unblockSweepIntervalS: number;
+  /**
+   * RED_AFK_SUPERVISOR_MAX_RESTARTS — crash-loop bound for the dead-supervisor
+   * watchdog (#1097, default 5). When a supervisor is found DEAD (its pid file
+   * points to a no-longer-alive process) with a non-empty `ready-for-agent` queue
+   * and live workers below target, an already-alive surface (the monitor tick)
+   * respawns the fleet and records the restart epoch. Once this many restarts land
+   * inside `supervisorRestartWindowS` the watchdog STOPS respawning and surfaces
+   * the crash loop instead of hiding it behind an endless respawn. 0 / non-numeric
+   * falls back to the default so a typo can never disable the bound (and never
+   * silently turn a bounded safety net into an infinite respawn loop).
+   */
+  supervisorMaxRestarts: number;
+  /**
+   * RED_AFK_SUPERVISOR_RESTART_WINDOW_S — sliding window (seconds, default 300)
+   * for the dead-supervisor restart bound above. Restart epochs older than this
+   * are pruned before the count is compared to `supervisorMaxRestarts`, so a slow
+   * trickle of unrelated respawns never trips the crash-loop guard. 0 / non-numeric
+   * falls back to the default.
+   */
+  supervisorRestartWindowS: number;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -156,6 +176,8 @@ export const SUPERVISOR_DEFAULTS = {
   halfOpenBaseS: SLOT_CIRCUIT_DEFAULTS.halfOpenBaseS,
   halfOpenCapS: SLOT_CIRCUIT_DEFAULTS.halfOpenCapS,
   unblockSweepIntervalS: 60,
+  supervisorMaxRestarts: 5,
+  supervisorRestartWindowS: 300,
 } as const satisfies SupervisorConfig;
 
 /**
@@ -209,6 +231,15 @@ export function resolveSupervisorConfig(
     unblockSweepIntervalS:
       num("RED_AFK_UNBLOCK_SWEEP_INTERVAL_S", SUPERVISOR_DEFAULTS.unblockSweepIntervalS) ||
       SUPERVISOR_DEFAULTS.unblockSweepIntervalS,
+    // 0 would disable the crash-loop bound (endless respawns) — floor back to the
+    // default so a typo can never turn the safety net into an infinite loop.
+    supervisorMaxRestarts:
+      num("RED_AFK_SUPERVISOR_MAX_RESTARTS", SUPERVISOR_DEFAULTS.supervisorMaxRestarts) ||
+      SUPERVISOR_DEFAULTS.supervisorMaxRestarts,
+    // 0 would prune every restart epoch instantly (bound never trips) — floor back.
+    supervisorRestartWindowS:
+      num("RED_AFK_SUPERVISOR_RESTART_WINDOW_S", SUPERVISOR_DEFAULTS.supervisorRestartWindowS) ||
+      SUPERVISOR_DEFAULTS.supervisorRestartWindowS,
   };
 }
 

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -42,8 +42,99 @@ export interface WatchdogIO {
   /** Spawn a fresh `__supervise` and stamp a fresh heartbeat so the next tick is
    * not itself misread as quiescent during the boot window. */
   relaunch(): Promise<void>;
+  /**
+   * Point-in-time signals for the DEAD-supervisor respawn decision (#1097),
+   * gathered only when the supervisor is found dead (pid file present but its pid
+   * no longer alive). Best-effort: a gh failure degrades `readyForAgent` to the
+   * last heartbeat's value, a missing worker dir counts as zero live workers.
+   * Absent → the dead-supervisor safety net never fires (back-compat; a test IO
+   * that omits it keeps the pre-#1097 behaviour).
+   */
+  deadSupervisorSignals?(): Promise<DeadSupervisorSignals>;
+  /** Read the persisted dead-supervisor restart ledger (epoch seconds). Best-effort:
+   * a missing/corrupt ledger reads as an empty list. */
+  readRestartLedger?(): Promise<number[]>;
+  /** Persist the pruned dead-supervisor restart ledger after a respawn. Best-effort. */
+  writeRestartLedger?(epochs: number[]): Promise<void>;
   /** Loud, structured progress line (best-effort). */
   log(line: string): void;
+}
+
+/**
+ * The signals the dead-supervisor safety net (#1097) reads when a supervisor is
+ * found dead. All are point-in-time and best-effort; the pure decider
+ * {@link decideDeadSupervisorRespawn} turns them into a respawn / skip / crash-loop
+ * verdict.
+ */
+export interface DeadSupervisorSignals {
+  /** Current claimable `ready-for-agent` queue depth. */
+  readyForAgent: number;
+  /** Desired worker count (fleet target). */
+  target: number;
+  /** Live worker processes that survived the supervisor's death — detached workers
+   * outlive their supervisor, so "below target" is measured against the real live
+   * count, not the stale heartbeat's slot bookkeeping. */
+  liveWorkers: number;
+  /** True when a graceful `fleet stop` was requested (stop file present) — the
+   * safety net never resurrects a supervisor the operator asked to stop. */
+  stopRequested: boolean;
+}
+
+/** Pure input to {@link decideDeadSupervisorRespawn}. */
+export interface DeadSupervisorRespawnInput {
+  readyForAgent: number;
+  liveWorkers: number;
+  target: number;
+  /** Restart epochs recorded by prior respawns (the crash-loop ledger). */
+  priorRestarts: readonly number[];
+  now: number;
+  /** Sliding window for the crash-loop bound (seconds). */
+  windowS: number;
+  /** Max respawns allowed inside the window before the net suppresses instead. */
+  maxRestarts: number;
+}
+
+export type DeadSupervisorAction = "respawn" | "skip" | "crash-loop-suppressed";
+
+export interface DeadSupervisorDecision {
+  action: DeadSupervisorAction;
+  /** The ledger to persist. On "respawn" it is the pruned prior restarts plus
+   * `now`; otherwise the pruned prior restarts unchanged. */
+  restarts: number[];
+  /** Restart count inside the window — after adding this respawn on "respawn",
+   * or the current count on "crash-loop-suppressed"/"skip". Drives the alert line. */
+  countInWindow: number;
+}
+
+/**
+ * decideDeadSupervisorRespawn — the pure dead-supervisor safety-net decision
+ * (#1097). Called only once the supervisor is already known dead-with-a-recorded-pid
+ * and not stop-requested (those cheaper guards live in {@link runWatchdog} so this
+ * stays a pure function of the observable fleet state). Order:
+ *
+ *   1. Prune the restart ledger to the crash-loop window.
+ *   2. `skip` when nothing is stranded (`readyForAgent <= 0`) or the fleet is not
+ *      actually short-handed (`liveWorkers >= target`). A supervisor that died
+ *      after cleanly draining its queue is NOT a fault condition.
+ *   3. `crash-loop-suppressed` when the pruned restart count already reached
+ *      `maxRestarts` — respawning again would just hide a repeating crash.
+ *   4. `respawn` otherwise, appending `now` to the ledger.
+ *
+ * Clock skew (a future-stamped restart) only makes the window wider, never
+ * narrower, so the bound can never be under-counted by a skewed clock.
+ */
+export function decideDeadSupervisorRespawn(
+  input: DeadSupervisorRespawnInput,
+): DeadSupervisorDecision {
+  const pruned = input.priorRestarts.filter((t) => input.now - t <= input.windowS);
+  if (input.readyForAgent <= 0 || input.liveWorkers >= input.target) {
+    return { action: "skip", restarts: [...pruned], countInWindow: pruned.length };
+  }
+  if (pruned.length >= input.maxRestarts) {
+    return { action: "crash-loop-suppressed", restarts: [...pruned], countInWindow: pruned.length };
+  }
+  const restarts = [...pruned, input.now];
+  return { action: "respawn", restarts, countInWindow: restarts.length };
 }
 
 export interface WatchdogResult {
@@ -54,6 +145,12 @@ export interface WatchdogResult {
   pid: number | null;
   /** Heartbeat age in seconds at detection, when a heartbeat was observed. */
   staleForS: number | null;
+  /** True only when this pass respawned a DEAD supervisor stranding a non-empty
+   * queue (#1097). Distinct from `recovered`, which is the quiescent (#407) path. */
+  respawnedDeadSupervisor: boolean;
+  /** True when a dead supervisor met the respawn condition but the crash-loop
+   * bound was already reached, so the net logged the loop instead of respawning. */
+  crashLoopSuppressed: boolean;
 }
 
 /**
@@ -97,24 +194,52 @@ export async function teardownWedgedSupervisor(io: WatchdogIO, pid: number | nul
  * and relaunch. Idempotent across repeated invocations of an already-alive
  * surface (a monitor cron tick firing every poll): the relaunch stamps a fresh
  * heartbeat, so the very next pass sees "healthy" and does not double-fire while
- * the new supervisor boots. A supervisor that is absent or healthy is left
- * untouched — the launch pre-check handles the "refuse to stack on a healthy
- * fleet" case itself by inspecting the returned `health`.
+ * the new supervisor boots.
+ *
+ * Two independent recovery conditions:
+ *   - QUIESCENT (#407): a live PID whose heartbeat/progress is stale → tear down
+ *     and relaunch (the original path, unchanged).
+ *   - DEAD-with-stranded-work (#1097): the pid file points to a no-longer-alive
+ *     process (a silent mid-drain crash, NOT a graceful `fleet stop` — that removes
+ *     the pid file) while `ready-for-agent` work is stranded and live workers are
+ *     below target → respawn the fleet, bounded by the crash-loop guard so a
+ *     repeating crash surfaces instead of respawning forever.
+ *
+ * A healthy supervisor, or a dead one whose queue is empty / whose workers are at
+ * target, is left untouched — the launch pre-check handles the "refuse to stack on
+ * a healthy fleet" case itself by inspecting the returned `health`.
  */
 export async function runWatchdog(
   io: WatchdogIO,
   staleS: number,
   progressStaleS: number,
+  restartBound: { maxRestarts: number; windowS: number } = { maxRestarts: 5, windowS: 300 },
 ): Promise<WatchdogResult> {
   const now = io.now();
   const liveness = await io.liveness();
   const health = classifySupervisor(liveness, now, staleS, progressStaleS);
   const staleForS = liveness.lastHeartbeatEpoch !== null ? now - liveness.lastHeartbeatEpoch : null;
 
-  if (health !== "quiescent") {
-    return { health, recovered: false, pid: liveness.pid, staleForS };
+  const base: WatchdogResult = {
+    health,
+    recovered: false,
+    pid: liveness.pid,
+    staleForS,
+    respawnedDeadSupervisor: false,
+    crashLoopSuppressed: false,
+  };
+
+  if (health === "healthy") return base;
+
+  if (health === "absent") {
+    // A null pid means the pid file is gone — a graceful `fleet stop` (or a fleet
+    // that never launched). NEVER resurrect that; the safety net only fires for a
+    // crashed supervisor that left its pid file behind pointing at a dead pid.
+    if (liveness.pid === null) return base;
+    return await recoverDeadSupervisor(io, liveness.pid, now, restartBound, base);
   }
 
+  // health === "quiescent"
   const progressStaleForS =
     liveness.lastProgressEpoch !== null ? now - liveness.lastProgressEpoch : null;
   const isProgressQuiescent =
@@ -132,5 +257,98 @@ export async function runWatchdog(
     io.log(`watchdog: relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
   }
   io.log(`watchdog: wedged supervisor recovered — fresh fleet relaunched.`);
-  return { health, recovered: true, pid: liveness.pid, staleForS };
+  return { ...base, recovered: true };
+}
+
+/**
+ * recoverDeadSupervisor — the DEAD-supervisor safety net (#1097). Called only when
+ * the supervisor is classified absent WITH a recorded (dead) pid: a silent
+ * mid-drain crash. Gathers the observable fleet state, runs the pure
+ * {@link decideDeadSupervisorRespawn} decision, and — on "respawn" — records the
+ * restart, clears the stale control files, reconciles stranded claims, and
+ * relaunches. Unlike the quiescent path it does NOT kill workers: detached workers
+ * that outlived the crash are still legitimately draining their claims, so killing
+ * them would throw away in-flight work. Every step is best-effort.
+ *
+ * The respawn is idempotent across monitor ticks: relaunch stamps a fresh
+ * heartbeat + pid, so the next pass sees "healthy" and does not double-fire.
+ */
+async function recoverDeadSupervisor(
+  io: WatchdogIO,
+  pid: number,
+  now: number,
+  bound: { maxRestarts: number; windowS: number },
+  base: WatchdogResult,
+): Promise<WatchdogResult> {
+  // No signal source wired (a pre-#1097 test IO) → the net is inert (back-compat).
+  if (!io.deadSupervisorSignals) return base;
+
+  let signals: DeadSupervisorSignals;
+  try {
+    signals = await io.deadSupervisorSignals();
+  } catch {
+    // Can't assess the fleet → do nothing rather than respawn blind.
+    return base;
+  }
+  // The operator asked to stop — never resurrect a supervisor mid-shutdown.
+  if (signals.stopRequested) return base;
+
+  let ledger: number[] = [];
+  try {
+    ledger = (await io.readRestartLedger?.()) ?? [];
+  } catch {
+    ledger = [];
+  }
+
+  const decision = decideDeadSupervisorRespawn({
+    readyForAgent: signals.readyForAgent,
+    liveWorkers: signals.liveWorkers,
+    target: signals.target,
+    priorRestarts: ledger,
+    now,
+    windowS: bound.windowS,
+    maxRestarts: bound.maxRestarts,
+  });
+
+  if (decision.action === "skip") return base;
+
+  if (decision.action === "crash-loop-suppressed") {
+    io.log(
+      `⛔ watchdog: supervisor pid=${pid} DIED with ${signals.readyForAgent} ready-for-agent ` +
+        `issue(s) stranded and ${signals.liveWorkers}/${signals.target} live worker(s), but ` +
+        `${decision.countInWindow} restart(s) within ${bound.windowS}s hit the max-restarts cap ` +
+        `(${bound.maxRestarts}) — NOT respawning. Investigate the crash loop; delete ` +
+        `.red/tmp/afk-supervisor.restarts.json to reset the bound.`,
+    );
+    return { ...base, crashLoopSuppressed: true };
+  }
+
+  io.log(
+    `⚠️  watchdog: supervisor pid=${pid} DIED with ${signals.readyForAgent} ready-for-agent ` +
+      `issue(s) stranded and only ${signals.liveWorkers}/${signals.target} live worker(s) — ` +
+      `respawning the fleet (restart ${decision.countInWindow}/${bound.maxRestarts} within ${bound.windowS}s).`,
+  );
+
+  try {
+    await io.writeRestartLedger?.(decision.restarts);
+  } catch {
+    // best-effort: a failed ledger write only weakens the crash-loop bound.
+  }
+  try {
+    await io.clearControlFiles();
+  } catch {
+    // best-effort: the stale pid file may already be gone.
+  }
+  try {
+    await io.reconcile();
+  } catch {
+    // best-effort: the relaunched workers' boot sweep also reconciles.
+  }
+  try {
+    await io.relaunch();
+  } catch (err) {
+    io.log(`watchdog: relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  io.log(`watchdog: dead supervisor respawned — fresh fleet relaunched (target ${signals.target}).`);
+  return { ...base, respawnedDeadSupervisor: true };
 }

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -5,13 +5,14 @@
 // never throws out of the closure.
 
 import { constants } from "node:fs";
-import { access, readFile, readdir, rm } from "node:fs/promises";
+import { access, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { closeSync, openSync, writeSync } from "node:fs";
 import { join } from "node:path";
 import type { SupervisorLiveness } from "../core/supervisor.js";
-import type { WatchdogIO } from "../core/watchdog.js";
-import { afkPaths, readFleetState } from "./wire.js";
+import type { DeadSupervisorSignals, WatchdogIO } from "../core/watchdog.js";
+import { afkPaths, readFleetState, resolveRepoSlug } from "./wire.js";
 import { listStaleClaimDirs, removeDir } from "./fs.js";
+import { countReadyForAgent } from "./gh.js";
 import { detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "./caller-process.js";
 import { spawnSupervisor, stampFreshFleetHeartbeat } from "./supervisor-spawn.js";
@@ -56,12 +57,37 @@ export function buildWatchdogIO(
   const pidFile = join(paths.tmpDir, "afk-supervisor.pid");
   const stopFile = join(paths.tmpDir, "afk-supervisor.stop");
   const logFile = join(paths.tmpDir, "afk-supervisor.log");
+  const restartLedgerFile = join(paths.tmpDir, "afk-supervisor.restarts.json");
 
   // Carried from liveness() → relaunch() so a recovered fleet keeps its target
   // and runner. Falls back to a 2-slot, freshly-detected-runner fleet when the
   // wedged supervisor left no usable heartbeat.
   let lastTarget = 2;
   let lastRunner = "";
+
+  // Count worker processes that survived the supervisor's death. Workers are
+  // spawned detached, so they outlive the supervisor; the dead-supervisor net
+  // measures "below target" against this live count, not the stale heartbeat.
+  const liveWorkerCount = async (): Promise<number> => {
+    let workerDirs: string[];
+    try {
+      workerDirs = await readdir(paths.workersRoot);
+    } catch {
+      return 0;
+    }
+    let live = 0;
+    for (const workerDir of workerDirs) {
+      const pidPath = join(paths.workersRoot, workerDir, "worker.pid");
+      try {
+        const raw = (await readFile(pidPath, "utf8")).trim();
+        if (!/^[1-9][0-9]*$/.test(raw)) continue;
+        if (isLivePid(Number(raw))) live += 1;
+      } catch {
+        // best-effort: a missing/bad pid file counts as no live worker.
+      }
+    }
+    return live;
+  };
 
   return {
     now: () => Math.floor(Date.now() / 1000),
@@ -144,6 +170,43 @@ export function buildWatchdogIO(
         stampFreshFleetHeartbeat(paths.fleetStatePath, Math.floor(Date.now() / 1000), runner, lastTarget);
       } catch {
         // best-effort
+      }
+    },
+
+    deadSupervisorSignals: async (): Promise<DeadSupervisorSignals> => {
+      const fleet = await readFleetState(paths.fleetStatePath);
+      const target = fleet && fleet.slotsTotal > 0 ? fleet.slotsTotal : lastTarget;
+      // Prefer a LIVE queue count — a supervisor that died before its last
+      // heartbeat could have new stranded work the stale state never recorded.
+      // Fall back to the last heartbeat's readyForAgent when gh is unreachable.
+      let readyForAgent = fleet?.readyForAgent ?? 0;
+      try {
+        const repo = await resolveRepoSlug(root).catch(() => "");
+        readyForAgent = await countReadyForAgent({ repo, cwd: root });
+      } catch {
+        // best-effort: keep the last-heartbeat fallback.
+      }
+      const liveWorkers = await liveWorkerCount();
+      const stopRequested = await fileExists(stopFile);
+      return { readyForAgent, target, liveWorkers, stopRequested };
+    },
+
+    readRestartLedger: async (): Promise<number[]> => {
+      try {
+        const raw = await readFile(restartLedgerFile, "utf8");
+        const parsed = JSON.parse(raw) as unknown;
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter((n): n is number => typeof n === "number" && Number.isFinite(n));
+      } catch {
+        return [];
+      }
+    },
+
+    writeRestartLedger: async (epochs: number[]): Promise<void> => {
+      try {
+        await writeFile(restartLedgerFile, JSON.stringify(epochs), "utf8");
+      } catch {
+        // best-effort: a failed ledger write only weakens the crash-loop bound.
       }
     },
 

--- a/apps/dev/tests/fleet-hooks.test.ts
+++ b/apps/dev/tests/fleet-hooks.test.ts
@@ -51,6 +51,8 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     halfOpenBaseS: 60,
     halfOpenCapS: 3600,
     unblockSweepIntervalS: 60,
+    supervisorMaxRestarts: 5,
+    supervisorRestartWindowS: 300,
     ...over,
   };
 }

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -77,6 +77,8 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     halfOpenBaseS: 60,
     halfOpenCapS: 3600,
     unblockSweepIntervalS: 60,
+    supervisorMaxRestarts: 5,
+    supervisorRestartWindowS: 300,
     ...over,
   };
 }
@@ -1667,6 +1669,22 @@ describe("resolveSupervisorConfig — supervisor stale knob (#407)", () => {
     expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "0" }).supervisorStaleS).toBe(300);
     expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "900" }).supervisorStaleS).toBe(900);
     expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_STALE_S: "abc" }).supervisorStaleS).toBe(300);
+  });
+});
+
+describe("resolveSupervisorConfig — dead-supervisor crash-loop knobs (#1097)", () => {
+  it("defaults the max-restarts bound and floors a 0/garbage back to the default", () => {
+    expect(resolveSupervisorConfig({}).supervisorMaxRestarts).toBe(5);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_MAX_RESTARTS: "0" }).supervisorMaxRestarts).toBe(5);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_MAX_RESTARTS: "3" }).supervisorMaxRestarts).toBe(3);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_MAX_RESTARTS: "abc" }).supervisorMaxRestarts).toBe(5);
+  });
+
+  it("defaults the restart window and floors a 0/garbage back to the default", () => {
+    expect(resolveSupervisorConfig({}).supervisorRestartWindowS).toBe(300);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_RESTART_WINDOW_S: "0" }).supervisorRestartWindowS).toBe(300);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_RESTART_WINDOW_S: "600" }).supervisorRestartWindowS).toBe(600);
+    expect(resolveSupervisorConfig({ RED_AFK_SUPERVISOR_RESTART_WINDOW_S: "x" }).supervisorRestartWindowS).toBe(300);
   });
 });
 

--- a/apps/dev/tests/watchdog.test.ts
+++ b/apps/dev/tests/watchdog.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { runWatchdog, teardownWedgedSupervisor, type WatchdogIO } from "../src/core/watchdog.js";
+import {
+  decideDeadSupervisorRespawn,
+  runWatchdog,
+  teardownWedgedSupervisor,
+  type DeadSupervisorSignals,
+  type WatchdogIO,
+} from "../src/core/watchdog.js";
 import type { SupervisorLiveness } from "../src/core/supervisor.js";
 
 const NOW = 1700000000;
@@ -14,6 +20,9 @@ interface FakeIo {
   clearControlFiles: ReturnType<typeof vi.fn>;
   reconcile: ReturnType<typeof vi.fn>;
   relaunch: ReturnType<typeof vi.fn>;
+  deadSupervisorSignals: ReturnType<typeof vi.fn>;
+  readRestartLedger: ReturnType<typeof vi.fn>;
+  writeRestartLedger: ReturnType<typeof vi.fn>;
   log: ReturnType<typeof vi.fn>;
 }
 
@@ -28,7 +37,15 @@ function makeLiveness(over: Partial<SupervisorLiveness> = {}): SupervisorLivenes
   };
 }
 
-function makeIo(liveness: SupervisorLiveness): { io: WatchdogIO; fake: FakeIo } {
+function makeSignals(over: Partial<DeadSupervisorSignals> = {}): DeadSupervisorSignals {
+  return { readyForAgent: 0, target: 2, liveWorkers: 0, stopRequested: false, ...over };
+}
+
+function makeIo(
+  liveness: SupervisorLiveness,
+  signals: DeadSupervisorSignals = makeSignals(),
+  ledger: number[] = [],
+): { io: WatchdogIO; fake: FakeIo } {
   const fake: FakeIo = {
     now: vi.fn(() => NOW),
     liveness: vi.fn(async () => liveness),
@@ -37,6 +54,9 @@ function makeIo(liveness: SupervisorLiveness): { io: WatchdogIO; fake: FakeIo } 
     clearControlFiles: vi.fn(async () => {}),
     reconcile: vi.fn(async () => {}),
     relaunch: vi.fn(async () => {}),
+    deadSupervisorSignals: vi.fn(async () => signals),
+    readRestartLedger: vi.fn(async () => ledger),
+    writeRestartLedger: vi.fn(async () => {}),
     log: vi.fn(),
   };
   return { io: fake as unknown as WatchdogIO, fake };
@@ -167,6 +187,169 @@ describe("runWatchdog — quiescent supervisor recovery (#407)", () => {
     expect(result.health).toBe("healthy");
     expect(result.recovered).toBe(false);
     expect(fake.killTree).not.toHaveBeenCalled();
+  });
+});
+
+describe("decideDeadSupervisorRespawn — pure crash-loop-bounded respawn decision (#1097)", () => {
+  const base = { now: NOW, windowS: 300, maxRestarts: 3 };
+
+  it("respawns a dead supervisor with stranded work and workers below target", () => {
+    const d = decideDeadSupervisorRespawn({
+      ...base,
+      readyForAgent: 4,
+      liveWorkers: 1,
+      target: 2,
+      priorRestarts: [],
+    });
+    expect(d.action).toBe("respawn");
+    expect(d.restarts).toEqual([NOW]);
+    expect(d.countInWindow).toBe(1);
+  });
+
+  it("skips when the queue is empty (a supervisor that cleanly drained is not a fault)", () => {
+    const d = decideDeadSupervisorRespawn({
+      ...base,
+      readyForAgent: 0,
+      liveWorkers: 0,
+      target: 2,
+      priorRestarts: [],
+    });
+    expect(d.action).toBe("skip");
+  });
+
+  it("skips when live workers already meet target (not short-handed)", () => {
+    const d = decideDeadSupervisorRespawn({
+      ...base,
+      readyForAgent: 5,
+      liveWorkers: 2,
+      target: 2,
+      priorRestarts: [],
+    });
+    expect(d.action).toBe("skip");
+  });
+
+  it("prunes restart epochs older than the window before counting", () => {
+    // Two ancient restarts (outside window) + one recent → count is 1, well under cap.
+    const d = decideDeadSupervisorRespawn({
+      ...base,
+      readyForAgent: 3,
+      liveWorkers: 0,
+      target: 2,
+      priorRestarts: [NOW - 1000, NOW - 900, NOW - 10],
+    });
+    expect(d.action).toBe("respawn");
+    // Ancient two pruned; kept the recent one + this respawn.
+    expect(d.restarts).toEqual([NOW - 10, NOW]);
+    expect(d.countInWindow).toBe(2);
+  });
+
+  it("suppresses (crash-loop) once the pruned restart count reaches maxRestarts", () => {
+    const d = decideDeadSupervisorRespawn({
+      ...base,
+      readyForAgent: 3,
+      liveWorkers: 0,
+      target: 2,
+      priorRestarts: [NOW - 30, NOW - 20, NOW - 10], // 3 == maxRestarts
+    });
+    expect(d.action).toBe("crash-loop-suppressed");
+    expect(d.countInWindow).toBe(3);
+    // The ledger is not extended on suppression.
+    expect(d.restarts).toEqual([NOW - 30, NOW - 20, NOW - 10]);
+  });
+});
+
+describe("runWatchdog — dead-supervisor safety net (#1097)", () => {
+  const BOUND = { maxRestarts: 3, windowS: 300 };
+  const deadPid = makeLiveness({ pid: 4242, pidAlive: false });
+
+  it("respawns a dead supervisor: records restart, clears files, reconciles, relaunches", async () => {
+    const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }));
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.health).toBe("absent");
+    expect(result.respawnedDeadSupervisor).toBe(true);
+    expect(result.crashLoopSuppressed).toBe(false);
+    expect(result.recovered).toBe(false); // that flag is the quiescent (#407) path
+
+    expect(fake.writeRestartLedger).toHaveBeenCalledWith([NOW]);
+    expect(fake.clearControlFiles).toHaveBeenCalledTimes(1);
+    expect(fake.reconcile).toHaveBeenCalledTimes(1);
+    expect(fake.relaunch).toHaveBeenCalledTimes(1);
+    // The dead-supervisor path must NOT kill the surviving detached workers.
+    expect(fake.killWorkers).not.toHaveBeenCalled();
+    expect(fake.killTree).not.toHaveBeenCalled();
+  });
+
+  it("does NOT resurrect a gracefully stopped fleet (pid file gone → pid null)", async () => {
+    const { io, fake } = makeIo(makeLiveness({ pid: null }), makeSignals({ readyForAgent: 9, liveWorkers: 0 }));
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.health).toBe("absent");
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.deadSupervisorSignals).not.toHaveBeenCalled();
+    expect(fake.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT resurrect when a graceful stop was requested (stop file present)", async () => {
+    const { io, fake } = makeIo(
+      deadPid,
+      makeSignals({ readyForAgent: 5, liveWorkers: 0, target: 2, stopRequested: true }),
+    );
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.relaunch).not.toHaveBeenCalled();
+    expect(fake.writeRestartLedger).not.toHaveBeenCalled();
+  });
+
+  it("skips a dead supervisor whose queue is empty", async () => {
+    const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 0, liveWorkers: 0, target: 2 }));
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("suppresses respawn and emits a loud alert once the crash-loop bound is hit", async () => {
+    const { io, fake } = makeIo(
+      deadPid,
+      makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }),
+      [NOW - 30, NOW - 20, NOW - 10], // 3 == maxRestarts
+    );
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.crashLoopSuppressed).toBe(true);
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.relaunch).not.toHaveBeenCalled();
+    expect(fake.writeRestartLedger).not.toHaveBeenCalled();
+    expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("max-restarts cap"));
+  });
+
+  it("still records the respawn + relaunches even when relaunch throws (logged)", async () => {
+    const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }));
+    fake.relaunch.mockRejectedValueOnce(new Error("spawn failed"));
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.respawnedDeadSupervisor).toBe(true);
+    expect(fake.writeRestartLedger).toHaveBeenCalledWith([NOW]);
+    expect(fake.log).toHaveBeenCalledWith(expect.stringContaining("relaunch failed"));
+  });
+
+  it("is inert when the IO exposes no dead-supervisor signal source (back-compat)", async () => {
+    const { io, fake } = makeIo(deadPid, makeSignals({ readyForAgent: 3, liveWorkers: 0, target: 2 }));
+    // A pre-#1097 IO surface: drop the new closure entirely.
+    delete (io as { deadSupervisorSignals?: unknown }).deadSupervisorSignals;
+
+    const result = await runWatchdog(io, STALE, PROGRESS_STALE, BOUND);
+
+    expect(result.respawnedDeadSupervisor).toBe(false);
+    expect(fake.relaunch).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1097. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1097

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785712532&installation_id=129708444&pr_number=1098&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1098&signature=53e79dbac1d629c76ba068d3f02c2743f87e60b22cd7fcd35603c35b58906129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->