### PR TITLE
merge: #1100 Source-trust classification for the AFK guidance channel

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -49,6 +49,7 @@ import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
 import type { ExecFn } from "../runtime/exec.js";
 import { getConfig, loadConfig, readBackpressure, readPostAttemptFormat, resolveTier, resolveCiTimeoutSeconds } from "../core/config.js";
+import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
 import { resolveNotesLoopConfig } from "../core/notes-loop.js";
 import {
   classifyIssue,
@@ -668,6 +669,8 @@ export function buildProcessDeps(
 
   // ---- lifecycle hooks: load config + resolve built-in defaults + real exec ----
   const config = loadConfig(paths.configPath, { warn: () => undefined });
+  // Trust policy for the guidance-channel source-trust projection (issue #1100).
+  const trustPolicy = parseTrustPolicy(config);
   const resolveOptions = makeHookResolveOptions(ctx.root);
   // resolveHooks runs once here to surface a malformed-hook-name error early;
   // process-issue re-resolves per run from the same config + options.
@@ -943,7 +946,13 @@ export function buildProcessDeps(
         fetchIssueBody: (n) => ghx.issueBody(ghCtx, n),
       },
       isLocked: () => isLocked(lockPath),
-      comments: (issue) => ghx.issueComments(ghCtx, issue),
+      // Source-trust classification for the guidance channel (issue #1100): each
+      // comment's author is resolved through the `resolveActorTrust` primitive so
+      // only a trusted-source directive can become authoritative `<human-guidance>`.
+      comments: (issue) =>
+        ghx.issueComments(ghCtx, issue, (actor) =>
+          resolveActorTrust(trustPolicy, actor, (login) => ghx.actorTrustSignals(ghCtx, login)),
+        ),
       issueUrl: (issue) => ghx.issueUrl(ghCtx, issue),
       // Restart-informed retry block (#255): read the prior attempt's markers
       // (failure.reason / snapshot-branch.ref) via the attempt-ledger.

--- a/apps/dev/src/core/handoff.ts
+++ b/apps/dev/src/core/handoff.ts
@@ -23,6 +23,7 @@
 
 import { AGENT_OUTPUT_TAG } from "@reddb-io/red-castle";
 import { classifyComment, extractDirectives } from "./comment-classification.js";
+import { isTrustedSource, type SourceTrustLevel } from "./source-trust.js";
 
 /** A comment as projected by the orchestrator from `gh issue view --json comments`. */
 export interface HandoffComment {
@@ -31,6 +32,15 @@ export interface HandoffComment {
   author?: string;
   /** ISO-8601 creation timestamp; the `at="…"` attribute is omitted when absent. */
   createdAt?: string;
+  /**
+   * The resolved source-trust level of the author (issue #1100). The projection
+   * populates it for every comment so guidance promotion can gate on SOURCE, not
+   * on directive FORMAT: only a `trusted` directive becomes authoritative
+   * `<human-guidance>`; a `dubious`/`automation` directive is demoted to the
+   * untrusted `<thread-discussion>` block. Undefined is a legacy pass-through
+   * (see {@link isTrustedSource}) — the projection always sets it now.
+   */
+  sourceTrust?: SourceTrustLevel;
 }
 
 export interface HandoffInput {
@@ -197,11 +207,18 @@ export function buildPreviousAttempts(comments: HandoffComment[]): string {
  * extracted directive, in document order within each directive-carrier comment
  * and chronological order across comments. A comment with two markers emits two
  * siblings with identical author/at. Returns "" when no directive exists.
+ *
+ * Authority is granted by SOURCE, never by FORMAT (issue #1100): a directive
+ * comment is promoted ONLY when its resolved source-trust level is `trusted`. A
+ * `dubious`/`automation` directive is skipped here and demoted to the untrusted
+ * `<thread-discussion>` block by {@link buildThreadDiscussion}. An unclassified
+ * (undefined) level is a legacy pass-through — see {@link isTrustedSource}.
  */
 export function buildHumanGuidance(comments: HandoffComment[]): string {
   const blocks: string[] = [];
   for (const comment of comments) {
     if (classifyComment({ body: comment.body }) !== "directive") continue;
+    if (!isTrustedSource(comment.sourceTrust)) continue;
     const author = comment.author && comment.author.length > 0 ? comment.author : "unknown";
     const created = comment.createdAt;
     for (const directive of extractDirectives(comment.body)) {
@@ -216,13 +233,18 @@ export function buildHumanGuidance(comments: HandoffComment[]): string {
 
 /**
  * `<thread-discussion>` inner body: one `<thread-discussion-entry>` per comment
- * classified `discussion` (narrative, no directive marker, not audit noise),
- * wrapping the verbatim body in chronological order. Returns "" when none.
+ * that is either classified `discussion` (narrative, no directive marker, not
+ * audit noise) OR a directive comment demoted here because its source is not
+ * trusted (issue #1100 — an untrusted directive is retained as untrusted data,
+ * never as authoritative guidance). Wraps the verbatim body in chronological
+ * order. Returns "" when none.
  */
 export function buildThreadDiscussion(comments: HandoffComment[]): string {
   const blocks: string[] = [];
   for (const comment of comments) {
-    if (classifyComment({ body: comment.body }) !== "discussion") continue;
+    const category = classifyComment({ body: comment.body });
+    const untrustedDirective = category === "directive" && !isTrustedSource(comment.sourceTrust);
+    if (category !== "discussion" && !untrustedDirective) continue;
     const author = comment.author && comment.author.length > 0 ? comment.author : "unknown";
     const created = comment.createdAt;
     const openTag = isPresent(created)

--- a/apps/dev/src/core/source-trust.ts
+++ b/apps/dev/src/core/source-trust.ts
@@ -1,0 +1,98 @@
+// source-trust — the single source-trust taxonomy for the AFK guidance channel
+// (issue #1100, parent #1099). The guidance channel is the one path rated
+// EXPOSED end-to-end: any GitHub actor can drop a `<details data-kind="directive">`
+// marker on an issue, and the body-shape classifier in comment-classification.ts
+// happily recognises it. Classification decides SHAPE; this module decides
+// AUTHORITY. Authority is granted by SOURCE, never by FORMAT — a directive marker
+// alone must not confer authoritative `<human-guidance>` status.
+//
+// Three levels, mirroring GitHub's own author-association vocabulary plus the
+// bot/app dimension:
+//   - trusted    — author association OWNER / MEMBER / COLLABORATOR, or a
+//                  trust-gate override (allowlist / write-access / CODEOWNERS).
+//   - dubious    — CONTRIBUTOR / FIRST_TIMER / FIRST_TIME_CONTRIBUTOR / NONE, or a
+//                  fork-PR author without write access; the "unknown source" bucket.
+//   - automation — bots and GitHub Apps (their comments never carry human authority).
+//
+// The trusted determination reuses the existing `resolveActorTrust` primitive
+// (trust-gate.ts) rather than a divergent check: its `ActorTrustVerdict` is
+// threaded in as `trustVerdict`. Crucially, the `permissive-default` basis does
+// NOT promote to trusted here — permissive mode trusts everyone for EXECUTION
+// gating, but the guidance channel demands a POSITIVE source signal before it
+// grants authority. Only the three explicit bases (allowlist / write-access /
+// codeowners) count.
+//
+// IO-free: the caller (the handoff comment projection) resolves author
+// association, bot status, and the actor-trust verdict through gh and passes
+// them in; this module only DECIDES.
+
+import type { ActorTrustVerdict } from "./trust-gate.js";
+
+/** The resolved source-trust level of a single comment's author. */
+export type SourceTrustLevel = "trusted" | "dubious" | "automation";
+
+/** GitHub author-association values that confer trusted authority directly,
+ * without a gh trust lookup. Compared upper-cased (gh emits them upper-cased,
+ * but we normalise defensively). */
+export const TRUSTED_ASSOCIATIONS: ReadonlySet<string> = new Set([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
+
+/** The `ActorTrustVerdict.basis` values that count as a POSITIVE trust signal for
+ * the guidance channel. `permissive-default` is deliberately excluded: it means
+ * "no signal available", not "trusted source". */
+const TRUSTED_BASES: ReadonlySet<string> = new Set([
+  "allowlist",
+  "write-access",
+  "codeowners",
+]);
+
+/** The signals the projection resolves for one comment before classification. */
+export interface SourceTrustInput {
+  /** The comment's `authorAssociation` (`gh issue view --json comments`). */
+  authorAssociation?: string;
+  /** True when the author is a bot / GitHub App (`author.is_bot`). */
+  isBot?: boolean;
+  /** The `resolveActorTrust` verdict for the author login, when resolved. Used to
+   * honour the allowlist / write-access / CODEOWNERS overrides for an author whose
+   * association alone does not qualify. */
+  trustVerdict?: ActorTrustVerdict;
+}
+
+/**
+ * Resolve a comment author's source-trust level. Precedence:
+ *   1. bot / app                                   → automation
+ *   2. author association OWNER/MEMBER/COLLABORATOR → trusted
+ *   3. a POSITIVE trust-gate override (allowlist /
+ *      write-access / codeowners)                  → trusted
+ *   4. everything else                             → dubious
+ *
+ * Note `permissive-default` never promotes: the guidance channel requires a
+ * positive source signal, not the absence of one.
+ */
+export function classifySourceTrust(input: SourceTrustInput): SourceTrustLevel {
+  if (input.isBot) return "automation";
+
+  const association = (input.authorAssociation ?? "").trim().toUpperCase();
+  if (TRUSTED_ASSOCIATIONS.has(association)) return "trusted";
+
+  const verdict = input.trustVerdict;
+  if (verdict?.executable && verdict.basis !== undefined && TRUSTED_BASES.has(verdict.basis)) {
+    return "trusted";
+  }
+
+  return "dubious";
+}
+
+/**
+ * Whether a resolved source-trust level grants authoritative-guidance authority.
+ * Only `trusted` promotes. `undefined` is a legacy/unclassified pass-through: a
+ * comment projected before source-trust existed carries no level, so it keeps
+ * today's promote-on-shape behaviour — the projection always populates the level
+ * going forward, so production never relies on this default.
+ */
+export function isTrustedSource(level: SourceTrustLevel | undefined): boolean {
+  return level === undefined || level === "trusted";
+}

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -20,6 +20,8 @@ import type { IssueCandidate } from "../core/session.js";
 import type { HitlCandidate } from "../core/hitl-selection.js";
 import type { IssueMeta } from "../core/branch-cleanup.js";
 import type { HandoffComment } from "../core/handoff.js";
+import { classifySourceTrust, TRUSTED_ASSOCIATIONS } from "../core/source-trust.js";
+import type { ActorTrustVerdict } from "../core/trust-gate.js";
 import type { IssueOpenState } from "../core/reclaim.js";
 import type { UnblockCandidate, ReconcileSweepCandidate } from "../core/boot-sweep.js";
 
@@ -472,24 +474,75 @@ export async function issueUrl(ctx: GhContext, issue: number): Promise<string> {
   }
 }
 
-/** `gh issue view --json comments` → handoff-projected comment list. Each
- * comment carries the author login + body + createdAt the handoff renders. */
-export async function issueComments(ctx: GhContext, issue: number): Promise<HandoffComment[]> {
+/** A `resolveActorTrust`-bound lookup the projection consults for an author whose
+ * association alone does not confer trust (issue #1100). Injected so gh.ts stays
+ * the only IO seam and the source-trust decision stays pure. */
+export type CommentTrustResolver = (actor: string) => Promise<ActorTrustVerdict>;
+
+/** `gh issue view --json comments` → handoff-projected comment list. Each comment
+ * carries the author login + body + createdAt the handoff renders, plus the
+ * resolved source-trust LEVEL (issue #1100) so guidance promotion gates on SOURCE
+ * rather than directive FORMAT. Bot authors resolve to `automation` and
+ * OWNER/MEMBER/COLLABORATOR associations to `trusted` from the projection alone;
+ * every other author is resolved through the injected `resolveTrust` (the
+ * `resolveActorTrust` primitive) so allowlist / write-access / CODEOWNERS
+ * overrides still promote. Results are memoised per login within the call. When
+ * `resolveTrust` is omitted the level is decided from association + bot status
+ * only (a non-collaborator falls to `dubious`). */
+export async function issueComments(
+  ctx: GhContext,
+  issue: number,
+  resolveTrust?: CommentTrustResolver,
+): Promise<HandoffComment[]> {
   const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "comments"]);
   if (r.code !== 0) return [];
+  let parsed: {
+    comments?: Array<{
+      body?: string;
+      author?: { login?: string; is_bot?: boolean };
+      authorAssociation?: string;
+      createdAt?: string;
+    }>;
+  };
   try {
-    const parsed = JSON.parse(r.stdout) as {
-      comments?: Array<{ body?: string; author?: { login?: string }; createdAt?: string }>;
-    };
-    if (!Array.isArray(parsed.comments)) return [];
-    return parsed.comments.map((c): HandoffComment => ({
-      body: String(c.body ?? ""),
-      author: c.author?.login ? String(c.author.login) : undefined,
-      createdAt: c.createdAt ? String(c.createdAt) : undefined,
-    }));
+    parsed = JSON.parse(r.stdout);
   } catch {
     return [];
   }
+  if (!Array.isArray(parsed.comments)) return [];
+
+  // Memoise the (potentially gh-backed) trust verdict per login within this call.
+  const verdicts = new Map<string, ActorTrustVerdict | undefined>();
+  const resolveVerdict = async (login: string | undefined): Promise<ActorTrustVerdict | undefined> => {
+    if (!login || !resolveTrust) return undefined;
+    if (verdicts.has(login)) return verdicts.get(login);
+    let verdict: ActorTrustVerdict | undefined;
+    try {
+      verdict = await resolveTrust(login);
+    } catch {
+      verdict = undefined;
+    }
+    verdicts.set(login, verdict);
+    return verdict;
+  };
+
+  const out: HandoffComment[] = [];
+  for (const c of parsed.comments) {
+    const login = c.author?.login ? String(c.author.login) : undefined;
+    const isBot = c.author?.is_bot === true;
+    const authorAssociation = c.authorAssociation ? String(c.authorAssociation) : undefined;
+    // A bot, or an already-trusted association, needs no gh trust lookup — only an
+    // otherwise-dubious human author is resolved through the trust primitive.
+    const associationTrusted = TRUSTED_ASSOCIATIONS.has((authorAssociation ?? "").trim().toUpperCase());
+    const trustVerdict = isBot || associationTrusted ? undefined : await resolveVerdict(login);
+    out.push({
+      body: String(c.body ?? ""),
+      author: login,
+      createdAt: c.createdAt ? String(c.createdAt) : undefined,
+      sourceTrust: classifySourceTrust({ authorAssociation, isBot, trustVerdict }),
+    });
+  }
+  return out;
 }
 
 /** Orphan-cleanup per-dir lookup (prune_orphans): the issue's open/closed state

--- a/apps/dev/tests/gh-issue-comments-trust.test.ts
+++ b/apps/dev/tests/gh-issue-comments-trust.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { issueComments, type GhContext } from "../src/runtime/gh.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+import type { ActorTrustVerdict } from "../src/core/trust-gate.js";
+
+/**
+ * Source-trust classification for the guidance channel (issue #1100). The comment
+ * projection resolves a source-trust LEVEL for every comment so guidance
+ * promotion can gate on SOURCE, never directive FORMAT. These pin:
+ *   - a bot author → automation (no trust lookup),
+ *   - an OWNER/MEMBER/COLLABORATOR association → trusted (no trust lookup),
+ *   - a non-collaborator with no override → dubious,
+ *   - a non-collaborator promoted through the injected `resolveActorTrust`.
+ */
+
+function ghReturning(stdout: string, code = 0): GhContext {
+  const out: ExecOutput = { code, stdout, stderr: "" };
+  const exec: ExecFn = () => Promise.resolve(out);
+  return { cwd: "/r", repo: "acme/widgets", exec };
+}
+
+const COMMENTS = JSON.stringify({
+  comments: [
+    { body: "bot chatter", author: { login: "dependabot", is_bot: true }, authorAssociation: "NONE" },
+    { body: "owner order", author: { login: "maint", is_bot: false }, authorAssociation: "OWNER" },
+    { body: "collab order", author: { login: "friend", is_bot: false }, authorAssociation: "COLLABORATOR" },
+    { body: "stranger order", author: { login: "stranger", is_bot: false }, authorAssociation: "NONE" },
+    { body: "allowlisted order", author: { login: "trusted-ext", is_bot: false }, authorAssociation: "CONTRIBUTOR" },
+  ],
+});
+
+describe("issueComments — source-trust projection (#1100)", () => {
+  it("classifies bots as automation and trusted associations as trusted without a lookup", async () => {
+    let lookups = 0;
+    const resolveTrust = async (): Promise<ActorTrustVerdict> => {
+      lookups += 1;
+      return { executable: false, reason: "unused" };
+    };
+    const out = await issueComments(ghReturning(COMMENTS), 7, resolveTrust);
+
+    expect(out[0]).toMatchObject({ author: "dependabot", sourceTrust: "automation" });
+    expect(out[1]).toMatchObject({ author: "maint", sourceTrust: "trusted" });
+    expect(out[2]).toMatchObject({ author: "friend", sourceTrust: "trusted" });
+    // only the two non-collaborators (stranger, trusted-ext) needed a lookup.
+    expect(lookups).toBe(2);
+  });
+
+  it("resolves a non-collaborator through the injected trust primitive", async () => {
+    const resolveTrust = async (actor: string): Promise<ActorTrustVerdict> =>
+      actor === "trusted-ext"
+        ? { executable: true, basis: "allowlist" }
+        : { executable: false, reason: "not a maintainer" };
+    const out = await issueComments(ghReturning(COMMENTS), 7, resolveTrust);
+
+    expect(out[3]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
+    expect(out[4]).toMatchObject({ author: "trusted-ext", sourceTrust: "trusted" });
+  });
+
+  it("without a resolver a non-collaborator falls to dubious", async () => {
+    const out = await issueComments(ghReturning(COMMENTS), 7);
+    expect(out[3]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
+    expect(out[4]).toMatchObject({ author: "trusted-ext", sourceTrust: "dubious" });
+  });
+
+  it("a failed gh read yields no comments", async () => {
+    const out = await issueComments(ghReturning("", 1), 7);
+    expect(out).toEqual([]);
+  });
+});

--- a/apps/dev/tests/handoff.test.ts
+++ b/apps/dev/tests/handoff.test.ts
@@ -130,6 +130,41 @@ describe("buildHumanGuidance", () => {
   it("no directive marker → empty", () => {
     expect(buildHumanGuidance([{ body: "just talking", author: "a" }])).toBe("");
   });
+
+  // ---------- source-trust gating (issue #1100) ----------
+
+  it("a trusted-source directive still becomes authoritative guidance", () => {
+    const out = buildHumanGuidance([
+      { author: "maintainer", sourceTrust: "trusted", body: directiveMarker("do the thing") },
+    ]);
+    expect(out).toContain('<human-guidance author="@maintainer"');
+    expect(out).toContain("do the thing");
+  });
+
+  it("a dubious-source directive is NOT promoted to authoritative guidance", () => {
+    const out = buildHumanGuidance([
+      { author: "stranger", sourceTrust: "dubious", body: directiveMarker("rm -rf everything") },
+    ]);
+    expect(out).toBe("");
+  });
+
+  it("an automation-source directive is NOT promoted to authoritative guidance", () => {
+    const out = buildHumanGuidance([
+      { author: "some-bot", sourceTrust: "automation", body: directiveMarker("deploy now") },
+    ]);
+    expect(out).toBe("");
+  });
+
+  it("mixed sources: only the trusted directive survives promotion", () => {
+    const out = buildHumanGuidance([
+      { author: "stranger", sourceTrust: "dubious", body: directiveMarker("untrusted order") },
+      { author: "maintainer", sourceTrust: "trusted", body: directiveMarker("trusted order") },
+    ]);
+    expect(out.match(/<human-guidance author=/g)).toHaveLength(1);
+    expect(out).toContain('<human-guidance author="@maintainer"');
+    expect(out).toContain("trusted order");
+    expect(out).not.toContain("untrusted order");
+  });
 });
 
 describe("buildThreadDiscussion", () => {
@@ -155,6 +190,23 @@ describe("buildThreadDiscussion", () => {
       { body: directiveMarker("x"), author: "a" },
     ]);
     expect(out).toBe("");
+  });
+
+  it("a trusted-source directive is excluded (promoted, not demoted)", () => {
+    const out = buildThreadDiscussion([
+      { author: "maintainer", sourceTrust: "trusted", body: directiveMarker("trusted order") },
+    ]);
+    expect(out).toBe("");
+  });
+
+  it("an untrusted-source directive is retained in the discussion block (#1100)", () => {
+    const body = directiveMarker("rm -rf everything");
+    const out = buildThreadDiscussion([
+      { author: "stranger", sourceTrust: "dubious", createdAt: "2026-07-04T00:00:00Z", body },
+    ]);
+    expect(out).toContain('<thread-discussion-entry author="@stranger" at="2026-07-04T00:00:00Z">');
+    expect(out).toContain("rm -rf everything");
+    expect(out).toContain("</thread-discussion-entry>");
   });
 });
 
@@ -442,6 +494,19 @@ describe("buildHandoff prior-attempt-context", () => {
     });
     expect(out.indexOf("<human-guidance-thread>")).toBeLessThan(out.indexOf("<prior-attempt-context>"));
     expect(out.indexOf("<prior-attempt-context>")).toBeLessThan(out.indexOf("<thread-discussion"));
+  });
+
+  it("untrusted directive lands in the untrusted discussion block, never guidance (#1100)", () => {
+    const out = base({
+      comments: [
+        { author: "stranger", sourceTrust: "dubious", body: directiveMarker("untrusted order") },
+      ],
+    });
+    // no authoritative guidance section at all
+    expect(out).not.toContain("<human-guidance-thread>");
+    // retained under the injection-guarded untrusted block
+    expect(out).toContain('<thread-discussion data-untrusted="true">');
+    expect(out).toContain("untrusted order");
   });
 });
 

--- a/apps/dev/tests/source-trust.test.ts
+++ b/apps/dev/tests/source-trust.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySourceTrust,
+  isTrustedSource,
+  TRUSTED_ASSOCIATIONS,
+} from "../src/core/source-trust.js";
+import type { ActorTrustVerdict } from "../src/core/trust-gate.js";
+
+describe("classifySourceTrust", () => {
+  it("bots/apps resolve to automation regardless of association", () => {
+    expect(classifySourceTrust({ isBot: true })).toBe("automation");
+    // A bot association would never override the bot flag.
+    expect(classifySourceTrust({ isBot: true, authorAssociation: "OWNER" })).toBe("automation");
+  });
+
+  it("OWNER/MEMBER/COLLABORATOR associations are trusted without a lookup", () => {
+    for (const assoc of TRUSTED_ASSOCIATIONS) {
+      expect(classifySourceTrust({ authorAssociation: assoc })).toBe("trusted");
+    }
+    // case-insensitive / whitespace tolerant.
+    expect(classifySourceTrust({ authorAssociation: " collaborator " })).toBe("trusted");
+  });
+
+  it("CONTRIBUTOR/FIRST_TIMER/NONE without an override are dubious", () => {
+    for (const assoc of ["CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "NONE"]) {
+      expect(classifySourceTrust({ authorAssociation: assoc })).toBe("dubious");
+    }
+    // an absent association is the unknown bucket → dubious.
+    expect(classifySourceTrust({})).toBe("dubious");
+  });
+
+  it("a positive trust-gate override promotes a dubious association to trusted", () => {
+    const bases: ActorTrustVerdict["basis"][] = ["allowlist", "write-access", "codeowners"];
+    for (const basis of bases) {
+      const verdict: ActorTrustVerdict = { executable: true, basis };
+      expect(classifySourceTrust({ authorAssociation: "NONE", trustVerdict: verdict })).toBe(
+        "trusted",
+      );
+    }
+  });
+
+  it("permissive-default never promotes — the guidance channel needs a positive signal", () => {
+    const verdict: ActorTrustVerdict = { executable: true, basis: "permissive-default" };
+    expect(classifySourceTrust({ authorAssociation: "NONE", trustVerdict: verdict })).toBe("dubious");
+  });
+
+  it("a refusing verdict leaves the author dubious", () => {
+    const verdict: ActorTrustVerdict = { executable: false, reason: "not a maintainer" };
+    expect(classifySourceTrust({ authorAssociation: "CONTRIBUTOR", trustVerdict: verdict })).toBe(
+      "dubious",
+    );
+  });
+});
+
+describe("isTrustedSource", () => {
+  it("only the trusted level grants authority", () => {
+    expect(isTrustedSource("trusted")).toBe(true);
+    expect(isTrustedSource("dubious")).toBe(false);
+    expect(isTrustedSource("automation")).toBe(false);
+  });
+
+  it("undefined is a legacy pass-through (promotes)", () => {
+    expect(isTrustedSource(undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1100. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1100

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785723351&installation_id=129708444&pr_number=1114&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1114&signature=fa8ba77a570c188290883a7f0fa871cc4f712c60fe8c38e573460b2e9fd15ee9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guidance comments are now evaluated by trust level, so trusted human instructions are surfaced more reliably.
  * Untrusted directives are preserved in thread discussion instead of being treated as authoritative guidance.

* **Bug Fixes**
  * Bot-generated comments no longer count as human guidance.
  * Comments from non-collaborators are handled more consistently, with safer fallback behavior when trust cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->