### PR TITLE
merge: #1101 Fail-closed AFK trust-gate default on public repositories

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -741,8 +741,15 @@ export function buildProcessDeps(
       issueClosed: (n) => ghx.issueClosed(ghCtx, n),
       // Trust-gate provenance (#621): author + ready-for-agent label actor, read
       // from the issue timeline. Consulted at claim time only when an allowlist
-      // is configured (plugins.dev.afk.trust-gate.allowlist).
+      // is configured (plugins.dev.afk.trust-gate.allowlist) or the repo fails
+      // closed (public + no allowlist, #1101).
       issueTrust: (issue) => ghx.issueTrust(ghCtx, issue),
+      // Repository visibility (#1101): folds into the trust policy so a PUBLIC
+      // repo with no allowlist fails closed while a private one stays permissive.
+      repoVisibility: () => ghx.repoVisibility(ghCtx),
+      // Dynamic-base trust signals (write-access / CODEOWNERS) for the fail-closed
+      // default's author + promoter maintainer check (#1101, reusing #747).
+      actorTrustSignals: (actor) => ghx.actorTrustSignals(ghCtx, actor),
       // HITL decision card (#935, S11a): post/update the card on escalation.
       // Best-effort: errors are caught in routeRecovery so they never block
       // the recovery path. Runs in the worktree root so gh resolves the repo.

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -84,7 +84,14 @@ import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sw
 import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
 import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
 import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
-import { parseTrustPolicy, evaluateTrustGate, type TrustProvenance } from "./trust-gate.js";
+import {
+  parseTrustPolicy,
+  evaluateClaimTrust,
+  describeTrustPosture,
+  type TrustProvenance,
+  type RepoVisibility,
+  type ActorTrustSignals,
+} from "./trust-gate.js";
 import { getConfig } from "./config.js";
 import type { AfkModelTier, ConfigValues } from "./config.js";
 import { runNotesLoop, notesPath, type NotesLoopConfig } from "./notes-loop.js";
@@ -132,6 +139,21 @@ export interface ProcessGh {
    * never fires), preserving today's behaviour.
    */
   issueTrust?(issue: number): Promise<TrustProvenance>;
+  /**
+   * Repository visibility (`gh repo view --json visibility`), folded into the
+   * trust policy so the no-allowlist default is visibility-aware (issue #1101): a
+   * PUBLIC repo fails closed, a private/undeterminable one stays permissive.
+   * Optional → absent callers/tests degrade to the permissive default (no
+   * visibility resolved), preserving today's behaviour.
+   */
+  repoVisibility?(): Promise<RepoVisibility | undefined>;
+  /**
+   * Dynamic-base trust signals for one actor (write-access / CODEOWNERS), the
+   * `ActorTrustLookup` the fail-closed default resolves author + promoter trust
+   * over. Optional → absent callers/tests cannot fail closed (the gate degrades to
+   * permissive even on a public repo), preserving today's behaviour.
+   */
+  actorTrustSignals?(actor: string): Promise<ActorTrustSignals>;
   /**
    * Render (or refresh) the HITL decision card on a `ready-for-human` issue
    * (#935, S11a). Called best-effort after the escalation labels are applied.
@@ -938,25 +960,31 @@ export async function processIssue(
     };
   }
 
-  // ---- trust gate (#621, ADR 0056) ----
+  // ---- trust gate (#621, ADR 0056; visibility-aware default #1101) ----
   // The "executable issue" predicate, evaluated BEFORE the promotion-to-running
-  // edit and before ANY worktree/handoff work: an issue is executable only when
-  // its author is a trusted identity AND `ready-for-agent` was applied by an
-  // allowlisted actor. Provenance is read from the issue TIMELINE + author field
-  // (deps.gh.issueTrust), never inferred from the mutable label set. When no
-  // allowlist is configured the policy is permissive (enabled:false) and this is
-  // a no-op — today's single-maintainer behaviour, preserved exactly. A refusal
-  // releases the claim and abandons the attempt (claim-lost) with a clear log
-  // line; the session loop then skips to the next candidate. The stripping of the
-  // non-allowlisted `ready-for-agent` itself is the sweep's job (planTrustStrip),
-  // not the claim's.
-  const trustPolicy = parseTrustPolicy(deps.hooks.config);
-  if (trustPolicy.enabled && deps.gh.issueTrust) {
+  // edit and before ANY worktree/handoff work. Provenance is read from the issue
+  // TIMELINE + author field (deps.gh.issueTrust), never inferred from the mutable
+  // label set. The active POSTURE (folded from the allowlist config + the repo
+  // visibility) decides:
+  //   - STRICT (allowlist configured) → author AND promoter must be allowlisted;
+  //   - FAIL-CLOSED (#1101: public repo, no allowlist) → author AND promoter must
+  //     resolve as maintainers (write-access / CODEOWNERS); otherwise the issue is
+  //     HELD for a maintainer summon (not auto-claimed);
+  //   - PERMISSIVE (private/undeterminable repo, no allowlist) → no-op, today's
+  //     single-maintainer behaviour preserved exactly.
+  // A refusal releases the claim and abandons the attempt (claim-lost) with a
+  // posture-tagged log line; the session loop then skips to the next candidate.
+  const visibility = deps.gh.repoVisibility ? await deps.gh.repoVisibility() : undefined;
+  const trustPolicy = parseTrustPolicy(deps.hooks.config, visibility);
+  const canFailClosed = !!(trustPolicy.failClosed && deps.gh.actorTrustSignals);
+  if ((trustPolicy.enabled || canFailClosed) && deps.gh.issueTrust) {
     const provenance = await deps.gh.issueTrust(issue);
-    const verdict = evaluateTrustGate(trustPolicy, provenance);
+    const signals = deps.gh.actorTrustSignals;
+    const lookup = signals ? (login: string) => signals(login) : async () => ({});
+    const verdict = await evaluateClaimTrust(trustPolicy, provenance, lookup);
     if (!verdict.executable) {
       deps.appendIterLog(
-        `🤖 /afk trust gate refused #${issue}: ${verdict.reason} — not claimed; no worktree/handoff materialised.`,
+        `🤖 /afk trust gate refused #${issue} [${describeTrustPosture(trustPolicy)}]: ${verdict.reason} — not claimed; no worktree/handoff materialised.`,
       );
       await deps.claimLock.release(issue);
       return claimLost(issue, hooksFired);

--- a/apps/dev/src/core/trust-gate.ts
+++ b/apps/dev/src/core/trust-gate.ts
@@ -11,9 +11,16 @@
 //   1. the author is a trusted identity (in the allowlist), AND
 //   2. `ready-for-agent` was applied by an allowlisted actor (in the allowlist).
 //
-// When no allowlist is configured the gate is PERMISSIVE — it returns executable
-// for everything, preserving today's single-maintainer behaviour EXACTLY.
-// Configuring the allowlist switches the repo to strict mode. A `ready-for-agent`
+// When no allowlist is configured the DEFAULT posture is repository-visibility
+// aware (issue #1101, parent #1099):
+//   - PRIVATE / single-collaborator repo → PERMISSIVE: executable for everything,
+//     preserving today's single-maintainer ergonomics EXACTLY.
+//   - PUBLIC repo → FAIL-CLOSED: a `ready-for-agent` from an untrusted author OR
+//     an untrusted promoter is HELD for a maintainer summon rather than auto-claimed.
+//     "Untrusted" reuses the dynamic maintainer signal (`resolveActorTrust`:
+//     write-access / CODEOWNERS / allowlist), not a new trust matrix.
+// Configuring the allowlist switches the repo to STRICT mode on either visibility:
+// BOTH the author and the promoter must be allowlisted. A `ready-for-agent`
 // applied by a non-allowlisted actor (an automation bot, an untrusted reporter)
 // is ignored by selection/claim and may be stripped by a sweep with an audit
 // comment (`planTrustStrip`).
@@ -31,14 +38,42 @@ import { getConfig } from "./config.js";
  * as `dev.lock.branch`. */
 export const TRUST_ALLOWLIST_KEY = "afk.trust-gate.allowlist";
 
+/** GitHub repository visibility, as reported by `gh repo view --json visibility`
+ * (lower-cased). `undefined` when the read failed or was not attempted — treated
+ * as NON-public, so an undeterminable visibility keeps the permissive default. */
+export type RepoVisibility = "public" | "private" | "internal";
+
+/** The active default posture when NO allowlist is configured, surfaced so an
+ * operator can tell at a glance which way the gate leans:
+ *   - `strict`      — an allowlist IS configured (visibility-independent);
+ *   - `fail-closed` — no allowlist + a PUBLIC repo → untrusted work is held;
+ *   - `permissive`  — no allowlist + a private/undeterminable repo → today's default. */
+export type TrustPosture = "strict" | "fail-closed" | "permissive";
+
 /** The parsed per-repo trust policy. `enabled` is DERIVED: the gate is active
- * only when the allowlist is non-empty (absent config → permissive). */
+ * only when the allowlist is non-empty (absent config → visibility-aware default).
+ * `failClosed` is DERIVED: no allowlist AND a public repo (issue #1101). */
 export interface TrustPolicy {
   /** True when an allowlist is configured (strict mode). */
   enabled: boolean;
   /** The set of trusted GitHub logins — both the author AND the label actor are
    * checked against this single list. */
   allowlist: readonly string[];
+  /** Repository visibility folded into the policy (drives `failClosed`). Optional
+   * so legacy callers/tests that predate the visibility dimension omit it → they
+   * default to the permissive posture, preserving today's behaviour EXACTLY. */
+  visibility?: RepoVisibility;
+  /** DERIVED: no allowlist + a PUBLIC repo → the untrusted-default is fail-closed.
+   * Optional/absent → false (permissive), so pre-#1101 `TrustPolicy` literals keep
+   * their exact meaning. */
+  failClosed?: boolean;
+}
+
+/** The active {@link TrustPosture} for a policy — the operator-facing "which way
+ * does the gate lean" descriptor (acceptance: the posture is discernible). */
+export function describeTrustPosture(policy: TrustPolicy): TrustPosture {
+  if (policy.enabled) return "strict";
+  return policy.failClosed ? "fail-closed" : "permissive";
 }
 
 /** Provenance resolved from gh at claim time. Either field may be undefined when
@@ -70,12 +105,18 @@ function parseLogins(raw: string): string[] {
 }
 
 /**
- * Read the trust policy from the loaded config map. An empty / absent allowlist
- * yields `enabled:false` → permissive (today's behaviour).
+ * Read the trust policy from the loaded config map, folding in the repository
+ * `visibility` so the no-allowlist default becomes visibility-aware (issue #1101):
+ *   - allowlist present            → `enabled:true` (strict, either visibility);
+ *   - no allowlist + PUBLIC repo   → `failClosed:true` (untrusted work is held);
+ *   - no allowlist + private/other → permissive (today's behaviour, preserved).
+ * `visibility` is optional — an absent/undeterminable value keeps the permissive
+ * default, so legacy callers that pass no visibility behave exactly as before.
  */
-export function parseTrustPolicy(values: ConfigValues): TrustPolicy {
+export function parseTrustPolicy(values: ConfigValues, visibility?: RepoVisibility): TrustPolicy {
   const allowlist = parseLogins(getConfig(values, TRUST_ALLOWLIST_KEY));
-  return { enabled: allowlist.length > 0, allowlist };
+  const enabled = allowlist.length > 0;
+  return { enabled, allowlist, visibility, failClosed: !enabled && visibility === "public" };
 }
 
 /**
@@ -176,9 +217,11 @@ export async function resolveActorTrust(
   if (signals.inCodeowners) return { executable: true, basis: "codeowners" };
 
   // 3. permissive default — neither a determinable base signal nor an allowlist.
+  // SUPPRESSED under a fail-closed policy (public repo, no allowlist, issue #1101):
+  // there the absence of a positive maintainer signal must HOLD, not wave through.
   const baseAvailable =
     signals.hasWriteAccess !== undefined || signals.inCodeowners !== undefined;
-  if (!baseAvailable && !policy.enabled) {
+  if (!baseAvailable && !policy.enabled && !policy.failClosed) {
     return { executable: true, basis: "permissive-default" };
   }
 
@@ -189,6 +232,41 @@ export async function resolveActorTrust(
       `${login ? `actor '${login}'` : "actor (unknown)"} is not a repository maintainer — ` +
       `no write access, not in CODEOWNERS, and not in the trust-gate allowlist`,
   };
+}
+
+/**
+ * The claim-time trust decision over BOTH provenance signals, dispatched by the
+ * active {@link TrustPosture}:
+ *   - `strict`      → the allowlist gate (`evaluateTrustGate`): author AND promoter
+ *                     must be allowlisted.
+ *   - `permissive`  → today's no-op: executable for everything.
+ *   - `fail-closed` → (public repo, no allowlist, issue #1101) BOTH the author and
+ *                     the `ready-for-agent` promoter must resolve as maintainers
+ *                     via `resolveActorTrust` (write-access / CODEOWNERS / allowlist).
+ *                     The author is checked first; either untrusted → HOLD.
+ * `lookup` is only consulted on the fail-closed path; the strict/permissive paths
+ * never touch gh, so a caller with no `ActorTrustLookup` can pass a stub.
+ */
+export async function evaluateClaimTrust(
+  policy: TrustPolicy,
+  provenance: TrustProvenance,
+  lookup: ActorTrustLookup,
+): Promise<TrustVerdict> {
+  if (policy.enabled) return evaluateTrustGate(policy, provenance);
+  if (!policy.failClosed) return { executable: true };
+
+  const author = await resolveActorTrust(policy, provenance.author, lookup);
+  if (!author.executable) {
+    return { executable: false, reason: `untrusted author — ${author.reason} (held for maintainer summon)` };
+  }
+  const actor = await resolveActorTrust(policy, provenance.readyForAgentActor, lookup);
+  if (!actor.executable) {
+    return {
+      executable: false,
+      reason: `untrusted ready-for-agent promoter — ${actor.reason} (held for maintainer summon)`,
+    };
+  }
+  return { executable: true };
 }
 
 /** A `ready-for-agent` candidate the strip sweep examines: its number + the

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -21,7 +21,7 @@ import type { HitlCandidate } from "../core/hitl-selection.js";
 import type { IssueMeta } from "../core/branch-cleanup.js";
 import type { HandoffComment } from "../core/handoff.js";
 import { classifySourceTrust, TRUSTED_ASSOCIATIONS } from "../core/source-trust.js";
-import type { ActorTrustVerdict } from "../core/trust-gate.js";
+import type { ActorTrustVerdict, RepoVisibility } from "../core/trust-gate.js";
 import type { IssueOpenState } from "../core/reclaim.js";
 import type { UnblockCandidate, ReconcileSweepCandidate } from "../core/boot-sweep.js";
 
@@ -863,6 +863,25 @@ export async function issueTrust(
  * the AUTHOR alone (a `needs-triage` issue has no `ready-for-agent` actor yet). */
 export async function issueAuthor(ctx: GhContext, issue: number): Promise<string | undefined> {
   return issueAuthorLogin(ctx, issue);
+}
+
+/**
+ * `gh repo view --json visibility` → the repository visibility (issue #1101),
+ * lower-cased to the {@link RepoVisibility} union the trust-gate folds into its
+ * fail-closed default. A best-effort read: `undefined` on any failure (gh absent,
+ * unauthenticated, network blip) or an unrecognised value, which the gate treats
+ * as NON-public → the permissive default is preserved when visibility is unknown.
+ */
+export async function repoVisibility(ctx: GhContext): Promise<RepoVisibility | undefined> {
+  const r = await runGh(ctx, ["repo", "view", ...(ctx.repo ? [ctx.repo] : []), "--json", "visibility"]);
+  if (r.code !== 0) return undefined;
+  try {
+    const raw = (JSON.parse(r.stdout) as { visibility?: string }).visibility;
+    const v = String(raw ?? "").trim().toLowerCase();
+    return v === "public" || v === "private" || v === "internal" ? v : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** `gh issue view --json author` → the author login, or undefined on failure. */

--- a/apps/dev/tests/gh-repo-visibility.test.ts
+++ b/apps/dev/tests/gh-repo-visibility.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { repoVisibility, type GhContext } from "../src/runtime/gh.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+/**
+ * Repository visibility read (issue #1101): `gh repo view --json visibility`,
+ * lower-cased into the {@link RepoVisibility} union the trust-gate folds into its
+ * fail-closed default. A best-effort read — any failure or unrecognised value
+ * degrades to `undefined` (treated as NON-public → permissive preserved).
+ */
+
+function ghReturning(stdout: string, code = 0): { ctx: GhContext; calls: string[][] } {
+  const calls: string[][] = [];
+  const out: ExecOutput = { code, stdout, stderr: "" };
+  const exec: ExecFn = (_bin, args) => {
+    calls.push([...args]);
+    return Promise.resolve(out);
+  };
+  return { ctx: { cwd: "/r", repo: "acme/widgets", exec }, calls };
+}
+
+describe("repoVisibility (#1101)", () => {
+  it("reads and lower-cases a PUBLIC repo", async () => {
+    const { ctx, calls } = ghReturning(JSON.stringify({ visibility: "PUBLIC" }));
+    expect(await repoVisibility(ctx)).toBe("public");
+    // Passes the repo slug + the visibility json field.
+    expect(calls[0]).toEqual(["repo", "view", "acme/widgets", "--json", "visibility"]);
+  });
+
+  it("reads a PRIVATE repo", async () => {
+    const { ctx } = ghReturning(JSON.stringify({ visibility: "private" }));
+    expect(await repoVisibility(ctx)).toBe("private");
+  });
+
+  it("reads an INTERNAL repo", async () => {
+    const { ctx } = ghReturning(JSON.stringify({ visibility: "internal" }));
+    expect(await repoVisibility(ctx)).toBe("internal");
+  });
+
+  it("degrades to undefined on a failed gh read", async () => {
+    const { ctx } = ghReturning("", 1);
+    expect(await repoVisibility(ctx)).toBeUndefined();
+  });
+
+  it("degrades to undefined on an unrecognised value", async () => {
+    const { ctx } = ghReturning(JSON.stringify({ visibility: "mystery" }));
+    expect(await repoVisibility(ctx)).toBeUndefined();
+  });
+
+  it("degrades to undefined on malformed JSON", async () => {
+    const { ctx } = ghReturning("not json");
+    expect(await repoVisibility(ctx)).toBeUndefined();
+  });
+
+  it("omits the repo slug when ctx.repo is empty (worker's own checkout)", async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = (_bin, args) => {
+      calls.push([...args]);
+      return Promise.resolve({ code: 0, stdout: JSON.stringify({ visibility: "public" }), stderr: "" });
+    };
+    await repoVisibility({ cwd: "/r", repo: "", exec });
+    expect(calls[0]).toEqual(["repo", "view", "--json", "visibility"]);
+  });
+});

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -83,6 +83,13 @@ interface HarnessOptions {
   /** Trust-gate provenance (#621) returned by gh.issueTrust. When set, the port
    * is registered; absent → no port (gate never fires). */
   trust?: { author?: string; readyForAgentActor?: string };
+  /** Repository visibility (#1101) returned by gh.repoVisibility. When set, the
+   * port is registered and the no-allowlist default becomes visibility-aware. */
+  visibility?: "public" | "private" | "internal";
+  /** Logins that gh.actorTrustSignals reports as write-access maintainers (#1101);
+   * everyone else resolves to determinable-negative signals. When set, the
+   * actorTrustSignals port is registered (enabling the fail-closed path). */
+  maintainers?: string[];
   abortHook?: HookName;
   /** FIX J: when set, a pre_worktree hook command emits this env as the mutated
    * context's `{env:{…}}` slice — proving it threads onto the runAgent input. */
@@ -237,6 +244,15 @@ function harness(opts: HarnessOptions = {}): {
       // Trust-gate provenance port (#621): registered only when the test opts in,
       // so legacy-shaped tests omit it and the gate never fires (permissive).
       issueTrust: opts.trust ? async () => opts.trust! : undefined,
+      // Visibility-aware default ports (#1101): registered only when the test opts
+      // in, so legacy-shaped tests omit them and the default stays permissive.
+      repoVisibility: opts.visibility ? async () => opts.visibility! : undefined,
+      actorTrustSignals: opts.maintainers
+        ? async (actor: string) => ({
+            hasWriteAccess: opts.maintainers!.includes(actor),
+            inCodeowners: false,
+          })
+        : undefined,
     },
     claimGh: opts.claim
       ? {
@@ -1866,6 +1882,66 @@ describe("processIssue — trust gate (#621)", () => {
     expect(result.outcome).toBe("done");
     expect(trace.runAgentCalls).toHaveLength(1);
     expect(trace.iterLogs.some((l) => /trust gate/.test(l))).toBe(false);
+  });
+});
+
+describe("processIssue — visibility-aware default (#1101)", () => {
+  it("PUBLIC repo + no allowlist + untrusted author → held for summon (claim-lost)", async () => {
+    const { deps, input, trace } = harness({
+      visibility: "public",
+      maintainers: ["maint"],
+      trust: { author: "stranger", readyForAgentActor: "maint" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    // No promotion edit, no agent spawn — held before any work.
+    expect(trace.labelEdits).toEqual([]);
+    expect(trace.runAgentCalls).toEqual([]);
+    expect(trace.released).toEqual([9]);
+    expect(
+      trace.iterLogs.some((l) => /trust gate refused #9 \[fail-closed\].*untrusted author/.test(l)),
+    ).toBe(true);
+  });
+
+  it("PUBLIC repo + no allowlist + maintainer author & promoter → claims normally", async () => {
+    const { deps, input, trace } = harness({
+      visibility: "public",
+      maintainers: ["maint", "maint2"],
+      outcome: "done",
+      feedbackOk: true,
+      trust: { author: "maint", readyForAgentActor: "maint2" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.labelEdits[0]!.add).toEqual(["running"]);
+    expect(trace.runAgentCalls).toHaveLength(1);
+  });
+
+  it("PRIVATE repo + no allowlist → permissive default preserved (untrusted author still runs)", async () => {
+    const { deps, input, trace } = harness({
+      visibility: "private",
+      maintainers: ["maint"],
+      outcome: "done",
+      feedbackOk: true,
+      trust: { author: "stranger", readyForAgentActor: "anybody" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.iterLogs.some((l) => /trust gate/.test(l))).toBe(false);
+  });
+
+  it("PUBLIC repo + configured allowlist → strict allowlist gate, not fail-closed", async () => {
+    const { deps, input, trace } = harness({
+      config: { "afk.trust-gate.allowlist": "alice,bob" },
+      visibility: "public",
+      maintainers: ["maint"], // a maintainer NOT in the allowlist is still refused
+      trust: { author: "maint", readyForAgentActor: "maint" },
+    });
+    const result = await processIssue(deps, input);
+    expect(result.outcome).toBe("claim-lost");
+    expect(trace.runAgentCalls).toEqual([]);
+    expect(trace.iterLogs.some((l) => /trust gate refused #9 \[strict\]/.test(l))).toBe(true);
   });
 });
 

--- a/apps/dev/tests/trust-gate.test.ts
+++ b/apps/dev/tests/trust-gate.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   parseTrustPolicy,
   evaluateTrustGate,
+  evaluateClaimTrust,
+  describeTrustPosture,
   planTrustStrip,
   resolveActorTrust,
   TRUST_ALLOWLIST_KEY,
@@ -21,6 +23,8 @@ import type { ConfigValues } from "../src/core/config.js";
 const ALLOW = ["alice", "bob"];
 const policy: TrustPolicy = { enabled: true, allowlist: ALLOW };
 const permissive: TrustPolicy = { enabled: false, allowlist: [] };
+// A public repo with no allowlist: the #1101 fail-closed default posture.
+const failClosed: TrustPolicy = { enabled: false, allowlist: [], visibility: "public", failClosed: true };
 
 function prov(author?: string, actor?: string): TrustProvenance {
   return { author, readyForAgentActor: actor };
@@ -46,6 +50,44 @@ describe("parseTrustPolicy", () => {
   it("accepts whitespace/newline separators too", () => {
     const p = parseTrustPolicy({ [TRUST_ALLOWLIST_KEY]: "alice\nbob carol" });
     expect(p.allowlist).toEqual(["alice", "bob", "carol"]);
+  });
+});
+
+describe("parseTrustPolicy — repository-visibility-aware default (#1101)", () => {
+  it("no allowlist + PUBLIC repo → fail-closed posture", () => {
+    const p = parseTrustPolicy({} as ConfigValues, "public");
+    expect(p.enabled).toBe(false);
+    expect(p.failClosed).toBe(true);
+    expect(p.visibility).toBe("public");
+    expect(describeTrustPosture(p)).toBe("fail-closed");
+  });
+
+  it("no allowlist + PRIVATE repo → permissive (today's behaviour)", () => {
+    const p = parseTrustPolicy({} as ConfigValues, "private");
+    expect(p.enabled).toBe(false);
+    expect(p.failClosed).toBe(false);
+    expect(describeTrustPosture(p)).toBe("permissive");
+  });
+
+  it("no allowlist + INTERNAL repo → permissive (only public fails closed)", () => {
+    expect(parseTrustPolicy({} as ConfigValues, "internal").failClosed).toBe(false);
+  });
+
+  it("no allowlist + UNDETERMINABLE visibility → permissive (unknown ≠ public)", () => {
+    const p = parseTrustPolicy({} as ConfigValues, undefined);
+    expect(p.failClosed).toBe(false);
+    expect(describeTrustPosture(p)).toBe("permissive");
+  });
+
+  it("a configured allowlist stays STRICT on a public repo (visibility does not weaken it)", () => {
+    const p = parseTrustPolicy({ [TRUST_ALLOWLIST_KEY]: "alice" }, "public");
+    expect(p.enabled).toBe(true);
+    expect(p.failClosed).toBe(false);
+    expect(describeTrustPosture(p)).toBe("strict");
+  });
+
+  it("a configured allowlist stays STRICT on a private repo too", () => {
+    expect(describeTrustPosture(parseTrustPolicy({ [TRUST_ALLOWLIST_KEY]: "alice" }, "private"))).toBe("strict");
   });
 });
 
@@ -172,6 +214,81 @@ describe("resolveActorTrust — layered write-access / CODEOWNERS over the allow
     const issueAuthor = await resolveActorTrust(permissive, "carol", gh.lookup);
     expect(commentAuthor.executable).toBe(true);
     expect(issueAuthor.executable).toBe(true);
+  });
+
+  it("SUPPRESSES the permissive default under a fail-closed policy (#1101)", async () => {
+    // Same undeterminable-signal case as the permissive test above, but a public
+    // repo: the absence of a positive maintainer signal now HOLDS instead of waving through.
+    const gh = fakeGh({});
+    const v = await resolveActorTrust(failClosed, "anyone", gh.lookup);
+    expect(v.executable).toBe(false);
+    expect(v.basis).toBeUndefined();
+  });
+
+  it("still trusts a maintainer with write access under a fail-closed policy", async () => {
+    const gh = fakeGh({ hasWriteAccess: true });
+    const v = await resolveActorTrust(failClosed, "maintainer", gh.lookup);
+    expect(v.executable).toBe(true);
+    expect(v.basis).toBe("write-access");
+  });
+});
+
+describe("evaluateClaimTrust — visibility-aware claim decision (#1101)", () => {
+  // A lookup that trusts a fixed set of maintainer logins (write access), and
+  // returns determinable-but-negative signals for everyone else.
+  function maintainerLookup(...maintainers: string[]): ActorTrustLookup {
+    const set = new Set(maintainers);
+    return async (actor: string) => ({ hasWriteAccess: set.has(actor), inCodeowners: false });
+  }
+  const noLookup: ActorTrustLookup = async () => ({});
+
+  it("STRICT policy defers to the allowlist gate (author + actor allowlisted → executable)", async () => {
+    const v = await evaluateClaimTrust(policy, prov("alice", "bob"), noLookup);
+    expect(v.executable).toBe(true);
+  });
+
+  it("STRICT policy blocks a non-allowlisted author regardless of visibility", async () => {
+    const v = await evaluateClaimTrust(policy, prov("stranger", "alice"), noLookup);
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("untrusted author 'stranger'");
+  });
+
+  it("PERMISSIVE (private repo, no allowlist) executes everything — never consults gh", async () => {
+    const calls: string[] = [];
+    const spy: ActorTrustLookup = async (a) => {
+      calls.push(a);
+      return {};
+    };
+    const v = await evaluateClaimTrust(permissive, prov("stranger", "intruder"), spy);
+    expect(v.executable).toBe(true);
+    expect(calls).toEqual([]); // permissive short-circuits before any maintainer lookup
+  });
+
+  it("FAIL-CLOSED (public repo) executes when BOTH author and promoter are maintainers", async () => {
+    const v = await evaluateClaimTrust(failClosed, prov("maint", "maint2"), maintainerLookup("maint", "maint2"));
+    expect(v.executable).toBe(true);
+  });
+
+  it("FAIL-CLOSED holds an untrusted AUTHOR for a maintainer summon", async () => {
+    const v = await evaluateClaimTrust(failClosed, prov("stranger", "maint"), maintainerLookup("maint"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("untrusted author");
+    expect(v.reason).toContain("held for maintainer summon");
+  });
+
+  it("FAIL-CLOSED holds an untrusted PROMOTER even when the author is a maintainer", async () => {
+    const v = await evaluateClaimTrust(failClosed, prov("maint", "intruder"), maintainerLookup("maint"));
+    expect(v.executable).toBe(false);
+    expect(v.reason).toContain("untrusted ready-for-agent promoter");
+  });
+
+  it("FAIL-CLOSED honours an allowlist override even with no dynamic signal", async () => {
+    // A public repo that ALSO configured an allowlist is strict, not fail-closed —
+    // but the allowlist override still trusts a listed login on the fail-closed path
+    // when (hypothetically) failClosed were set alongside a list.
+    const hybrid: TrustPolicy = { enabled: false, allowlist: ["alice"], visibility: "public", failClosed: true };
+    const v = await evaluateClaimTrust(hybrid, prov("alice", "alice"), noLookup);
+    expect(v.executable).toBe(true);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1101. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1101

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785724657&installation_id=129708444&pr_number=1115&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1115&signature=d2f340b65165a8c7b7398c7094dbfcb2f45186b859cbf1fd4761161b2c6e746a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->