### PR TITLE
merge: #1102 Sensitive-path guard in the AFK merge gate

### DIFF
--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -36,6 +36,7 @@ import {
   LABEL_INFRA,
   LABEL_BUDGET,
   LABEL_TRUNK_DIVERGED,
+  LABEL_SENSITIVE_PATH,
 } from "./triage-labels.js";
 
 /**
@@ -94,6 +95,12 @@ export type AttemptOutcome =
   // auto-commit / force-push to repair it, so a bounded retry could only re-hit
   // the same precondition.
   | "trunk-diverged"
+  // Sensitive-path guard (issue #1102): the landing diff touched a CI workflow
+  // file, a package.json lifecycle script, a git hook, or `.red/` trust/gate
+  // configuration. These are intent-class changes that require human review —
+  // auto-landing them would bypass auditability regardless of test/CI status.
+  // Human-only (non-recoverable): a bounded retry does not change the diff.
+  | "sensitive-path"
   | "infra";
 
 /**
@@ -150,6 +157,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_BUDGET;
     case "trunk-diverged":
       return LABEL_TRUNK_DIVERGED;
+    case "sensitive-path":
+      return LABEL_SENSITIVE_PATH;
     case "infra":
       return LABEL_INFRA;
     case "done":
@@ -212,6 +221,9 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     // is intact on the attempt branch; the local trunk a human owns is out of
     // sync, so it emits a `blocked` envelope (never `merge-conflict`).
     case "trunk-diverged":
+    // sensitive-path (#1102) folds into the generic `blocked` bucket — the diff
+    // touched a sensitive path; a human must review it before landing.
+    case "sensitive-path":
     case "infra":
     // review-requested is a handoff, not a failure: the per-issue lifecycle
     // emits no terminal failure envelope for it (it parks the issue + opens the
@@ -279,6 +291,9 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     // auto-retry cannot un-diverge the maintainer's local trunk, and the Landing
     // refuses to repair it — only a human reconciling the local state clears it.
     case "trunk-diverged":
+    // sensitive-path (#1102) is NON-recoverable: a retry runs the same diff and
+    // hits the same guard. Only a human reviewing the sensitive change clears it.
+    case "sensitive-path":
     case "infra":
     case "done":
     case "claim-lost":

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -38,6 +38,7 @@ import {
   type WaitForReviewInput,
 } from "./merge.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
+import { checkSensitivePaths, type SensitivePathHit } from "./shared-gate.js";
 
 /** Everything the landing needs, all side effects injected — mirroring how
  * process-issue called each of these inline. */
@@ -98,6 +99,14 @@ export interface LandingDeps {
    * Ignored on the direct path, which never opens a PR.
    */
   waitForReview?: WaitForReviewInput;
+  /**
+   * Opt-in sensitive-path guard (issue #1102). Present → the landing scans the
+   * branch diff against the closed set of sensitive path patterns before pushing
+   * or integrating; any hit aborts with `sensitive-paths` and pages a human.
+   * Absent (the default) → the guard is skipped (safe for the direct path and
+   * existing callers that have not yet wired the dep).
+   */
+  getDiffPaths?: () => Promise<{ changedFiles: string[]; packageJsonDiff: string }>;
   /**
    * Opt-in CI-aware merge for the UNLOCKED admin-PR landing (#812). Present →
    * landPr polls the PR's merge state and admin-merges only once it is genuinely
@@ -187,7 +196,11 @@ export type LandingResult =
         // BEFORE integrating the attempt branch and NEVER repaired the divergence
         // (no reset / stash / auto-commit / force-push). The caller parks the
         // issue ready-for-human with a divergence envelope naming the two SHAs.
-        | "trunk-diverged";
+        | "trunk-diverged"
+        // Sensitive-path guard (issue #1102): the branch diff touches a CI
+        // workflow file, a package.json lifecycle script, a git hook, or `.red/`
+        // trust/gate configuration. Never auto-lands; pages a human.
+        | "sensitive-paths";
       locked: boolean;
       /** PR number left open for the CI-aware handoff (`ci-failed` / `ci-pending`). */
       prNumber?: number;
@@ -195,6 +208,8 @@ export type LandingResult =
       localTrunkSha?: string;
       /** ADR 0083 divergence (`trunk-diverged`): the fresh-fetched `origin/<trunk>` SHA. */
       originTrunkSha?: string;
+      /** Sensitive-path guard (`sensitive-paths`): the hits that triggered the guard. */
+      sensitivePaths?: SensitivePathHit[];
     };
 
 /**
@@ -287,6 +302,19 @@ export async function doLanding(
   hooks: LandingHookContexts,
 ): Promise<LandingResult> {
   const { locked } = input;
+
+  // 0a. Sensitive-path guard (issue #1102): scan the branch diff for sensitive
+  // path patterns BEFORE any push or git integration. A hit is an intent-class
+  // change (CI workflow, lifecycle script, git hook, .red/ config) that must
+  // never auto-land — abort immediately and page a human. Opt-in: the guard is
+  // skipped when getDiffPaths is absent (backwards-compatible default).
+  if (deps.getDiffPaths) {
+    const { changedFiles, packageJsonDiff } = await deps.getDiffPaths();
+    const hits = checkSensitivePaths(changedFiles, packageJsonDiff);
+    if (hits.length > 0) {
+      return { ok: false, reason: "sensitive-paths", locked, sensitivePaths: hits };
+    }
+  }
 
   // 0. ADR 0083 landing precondition (#1018): the primary checkout's LOCAL
   // `<trunk>` ref must be an ANCESTOR of `origin/<trunk>`. Verified BEFORE any

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -674,6 +674,7 @@ import {
   LABEL_DEPENDENCY,
   LABEL_READY_FOR_REVIEW,
   LABEL_LANDING_MANUAL,
+  LABEL_SENSITIVE_PATH,
 } from "./triage-labels.js";
 
 /**
@@ -1866,6 +1867,25 @@ export async function processIssue(
       removeLandingWorktree: deps.removeLandingWorktree,
       makeRebaseWorktree: deps.makeRebaseWorktree,
       removeRebaseWorktree: deps.removeRebaseWorktree,
+      // Sensitive-path guard (issue #1102): diff the worker branch against the
+      // resolved base before landing. Uses three-dot notation so the diff reflects
+      // only what this branch changed, not the entire base history.
+      getDiffPaths: async () => {
+        const filesRes = await deps.mergeExec([
+          "git", "-C", input.repoDir,
+          "diff", "--name-only",
+          `${input.remote}/${base}...${workerBranch}`,
+        ]);
+        const changedFiles = filesRes.stdout.trim().split("\n").filter(Boolean);
+        const diffRes = await deps.mergeExec([
+          "git", "-C", input.repoDir,
+          "diff",
+          `${input.remote}/${base}...${workerBranch}`,
+          "--",
+          "package.json", "**/package.json",
+        ]);
+        return { changedFiles, packageJsonDiff: diffRes.stdout };
+      },
     },
     {
       openPr,
@@ -1905,6 +1925,11 @@ export async function processIssue(
         landing.originTrunkSha ?? "",
         landing.locked,
       );
+    }
+    // Sensitive-path guard (issue #1102): the diff touched a CI workflow,
+    // lifecycle script, git hook, or .red/ config — pages a human, never retries.
+    if (landing.reason === "sensitive-paths") {
+      return await sensitivePathGuarded(common, landing.sensitivePaths ?? [], landing.locked);
     }
     // CI-aware landing failures (#812): a completed, MERGEABLE PR the admin-merge
     // could not land because the `enforce_admins` base's required checks failed /
@@ -2176,6 +2201,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         summary: oneLine(sections.log, "Local trunk diverged from origin; landing aborted (ADR 0083)."),
         next: "Reconcile the primary checkout's local trunk with origin (no reset/stash/force-push), then requeue.",
       };
+    case "sensitive-path":
+      return {
+        status: "blocked",
+        kind: "sensitive-path",
+        summary: oneLine(sections.log, "Diff touches a sensitive path (CI workflow, lifecycle script, git hook, or .red/ config)."),
+        next: "Review the sensitive change, then requeue if it is safe to land.",
+      };
     case "manual-landing":
       return {
         status: "blocked",
@@ -2196,6 +2228,7 @@ const ACTIONABLE_BLOCKER_KINDS = new Set([
   "stalled",
   "decision",
   "trunk-diverged",
+  "sensitive-path",
 ]);
 
 function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
@@ -2534,6 +2567,48 @@ async function trunkDivergedBlocked(
   await deps.claimLock.release(input.issue);
   return {
     outcome: "trunk-diverged",
+    issue: input.issue,
+    branch: c.branch,
+    base: c.base,
+    locked,
+    hooksFired: c.hooksFired,
+    envelopePosted: posted,
+    preserved: true,
+    swept: false,
+  };
+}
+
+/**
+ * Sensitive-path guard park (issue #1102). The landing diff touched a CI
+ * workflow file, a package.json lifecycle script, a git hook, or `.red/`
+ * trust/gate configuration — an intent-class change that can never auto-land.
+ * Parks the issue ready-for-human with `blocked:sensitive-path` so a human
+ * reviews the change before it reaches the base branch. The attempt branch and
+ * dir are preserved (the work is intact; a human can land it after review).
+ * routeRecovery escalates (sensitive-path is non-recoverable): a bounded retry
+ * runs the same diff and hits the same guard.
+ */
+async function sensitivePathGuarded(
+  c: StageCommon,
+  hits: Array<{ path: string; reason: string }>,
+  locked: boolean,
+): Promise<ProcessIssueResult> {
+  const { deps, input } = c;
+  const hitList = hits.map((h) => `\`${h.path}\` (${h.reason})`).join(", ");
+  const detail =
+    `Landing blocked: the diff touches sensitive path(s) that require human review before auto-landing — ` +
+    `${hitList}. The attempt branch is intact. Requeue after reviewing the change.`;
+  await routeRecovery(deps, input.issue, "sensitive-path", input.attempt);
+  await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("sensitive-path", { log: detail }));
+  const posted = await emitFailure(c, envelopeStatusFor("sensitive-path"), "sensitive-path", { log: detail });
+  await deps.gh.comment(input.issue, `🤖 /afk: ${detail}`);
+  await recordAttemptBestEffort(c, "sensitive-path", {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: detail,
+  });
+  await deps.claimLock.release(input.issue);
+  return {
+    outcome: "sensitive-path",
     issue: input.issue,
     branch: c.branch,
     base: c.base,

--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -174,6 +174,110 @@ export async function runSharedGate(
   return { passed, resolutions, mechanicalApplied, intentEscalated };
 }
 
+// ---------- sensitive-path guard (issue #1102) ----------
+
+/**
+ * The CLOSED, AUDITABLE set of sensitive path patterns. A diff touching ANY
+ * path that matches one of these patterns is an intent-class change that can
+ * never auto-land — it pages ready-for-human regardless of test/CI status.
+ *
+ * Issue #1102 enumerates exactly these patterns. To add a new one, amend this
+ * list AND update the issue. The default is SAFE: anything not on this list
+ * proceeds normally.
+ */
+export const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
+  /^\.github\/workflows\//,     // CI workflow files
+  /(?:^|\/)\.git\/hooks\//,    // git hooks directory
+  /^\.husky\//,                // Husky hooks
+  /^\.githooks\//,             // alternative git hooks directory
+  /^\.red\//,                  // .red/ trust/gate config and gate's own config
+];
+
+/**
+ * The CLOSED set of npm lifecycle script names. A diff that adds or alters any
+ * of these keys inside a `package.json` file is treated as a sensitive change
+ * because lifecycle scripts execute arbitrary code during `npm install`.
+ */
+export const LIFECYCLE_SCRIPT_NAMES: readonly string[] = [
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+  "prepublish",
+  "prepublishOnly",
+  "prepack",
+  "pack",
+  "postpack",
+];
+
+/** A single match produced by the sensitive-path guard. */
+export interface SensitivePathHit {
+  /** The changed file path (or description) that triggered the guard. */
+  path: string;
+  /** Human-readable reason why this path is sensitive. */
+  reason: string;
+}
+
+/**
+ * Return true when `filePath` matches any entry in {@link SENSITIVE_PATH_PATTERNS}.
+ * PURE predicate — no IO.
+ */
+export function isSensitivePath(filePath: string): boolean {
+  return SENSITIVE_PATH_PATTERNS.some((p) => p.test(filePath));
+}
+
+/**
+ * Return true when `diffText` contains any added line (`+` prefix) that sets a
+ * key from {@link LIFECYCLE_SCRIPT_NAMES} inside a `package.json`. Checks only
+ * lines starting with `+` (added/changed) to avoid false-positives on removed
+ * scripts. PURE predicate — no IO.
+ */
+export function hasLifecycleScriptInDiff(diffText: string): boolean {
+  const names = LIFECYCLE_SCRIPT_NAMES.join("|");
+  const re = new RegExp(`^\\+\\s*"(${names})"\\s*:`, "m");
+  return re.test(diffText);
+}
+
+/**
+ * Scan `changedFiles` (repo-relative paths from the branch diff) and
+ * `packageJsonDiff` (unified diff of any `package.json` files in the branch)
+ * for sensitive-path hits. Returns an empty array when the diff is clean.
+ * PURE — no IO.
+ *
+ * Callers provide both inputs from a single `git diff` pass so this function
+ * stays IO-free and fully unit-testable.
+ */
+export function checkSensitivePaths(
+  changedFiles: string[],
+  packageJsonDiff: string,
+): SensitivePathHit[] {
+  const hits: SensitivePathHit[] = [];
+
+  for (const p of changedFiles) {
+    if (isSensitivePath(p)) {
+      hits.push({ path: p, reason: sensitivePathReason(p) });
+    }
+  }
+
+  if (packageJsonDiff && hasLifecycleScriptInDiff(packageJsonDiff)) {
+    const pkgPaths = changedFiles.filter((p) => /(?:^|\/)package\.json$/.test(p));
+    hits.push({
+      path: pkgPaths.length > 0 ? pkgPaths.join(", ") : "package.json",
+      reason: "lifecycle script added or altered in package.json",
+    });
+  }
+
+  return hits;
+}
+
+function sensitivePathReason(filePath: string): string {
+  if (/^\.github\/workflows\//.test(filePath)) return "CI workflow file";
+  if (/(?:^|\/)\.git\/hooks\//.test(filePath) || /^\.husky\//.test(filePath) || /^\.githooks\//.test(filePath))
+    return "git hook";
+  if (/^\.red\//.test(filePath)) return "trust/gate configuration";
+  return "sensitive path";
+}
+
 // ---------- built-in sink factories ----------
 
 /**

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -90,6 +90,11 @@ export const LABEL_INFRA = "blocked:infra";
 // is human-only (non-recoverable): a bounded auto-retry cannot fix a diverged
 // local branch, and re-running the agent would just re-hit the same precondition.
 export const LABEL_TRUNK_DIVERGED = "blocked:trunk-diverged";
+// Sensitive-path guard (issue #1102): the landing diff touched a CI workflow
+// file, a package.json lifecycle script, a git hook, or `.red/` trust/gate
+// configuration — an intent-class change that can never auto-land. A human
+// must review the change before it reaches the base branch.
+export const LABEL_SENSITIVE_PATH = "blocked:sensitive-path";
 // AFK runner improvement (#908): the per-attempt resource budget guard aborted
 // the attempt — it breached a token/cost/tool-call/waiting-window ceiling before
 // it could finish. Distinct from `blocked:stalled` (a stall is *no* progress;

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -83,6 +83,13 @@ interface Opts {
    * Unset → the local trunk reads as an ancestor of origin → proceeds.
    */
   trunk?: "diverged" | "absent";
+  /**
+   * Sensitive-path guard (issue #1102): inject getDiffPaths.
+   *   - undefined → guard not wired (safe default, no-op, existing tests unaffected)
+   *   - "hit"  → getDiffPaths returns a diff that touches .github/workflows/ci.yml
+   *   - "clean"→ getDiffPaths returns a diff with no sensitive paths
+   */
+  sensitivePaths?: "hit" | "clean";
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -193,6 +200,16 @@ function harness(opts: Opts = {}): Harness {
       ? async (dir) => {
           removedRebaseWorktrees.push(dir);
         }
+      : undefined,
+    // #1102: only wired when the test opts in (opt-in — absent → guard skipped).
+    getDiffPaths: opts.sensitivePaths
+      ? async () => ({
+          changedFiles:
+            opts.sensitivePaths === "hit"
+              ? [".github/workflows/ci.yml", "src/index.ts"]
+              : ["src/index.ts", "apps/dev/src/core/landing.ts"],
+          packageJsonDiff: "",
+        })
       : undefined,
   };
 
@@ -370,6 +387,55 @@ describe("doLanding — ADR 0083 trunk landing precondition (#1018)", () => {
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c === "git -C /repo fetch origin main --quiet")).toBe(true);
     expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+  });
+});
+
+describe("doLanding — sensitive-path guard (issue #1102)", () => {
+  it("diff touching .github/workflows → aborts with sensitive-paths BEFORE any push/hook/land", async () => {
+    const h = harness({ locked: false, sensitivePaths: "hit" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("sensitive-paths");
+      expect(r.locked).toBe(false);
+      expect(r.sensitivePaths).toBeDefined();
+      expect(r.sensitivePaths!.length).toBeGreaterThan(0);
+      expect(r.sensitivePaths![0].path).toBe(".github/workflows/ci.yml");
+    }
+    // The abort is early: no push, no hooks, no landing.
+    expect(h.pushedAttempt).toHaveLength(0);
+    expect(h.firedHooks).toHaveLength(0);
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
+    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(false);
+  });
+
+  it("sensitive-paths abort also fires on the DIRECT (locked) path before integrating", async () => {
+    const h = harness({ locked: true, sensitivePaths: "hit" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("sensitive-paths");
+      expect(r.locked).toBe(true);
+    }
+    expect(h.pushedAttempt).toHaveLength(0);
+    expect(h.firedHooks).toHaveLength(0);
+    expect(h.removedWorktrees).toHaveLength(0);
+  });
+
+  it("clean diff with no sensitive paths proceeds to a normal landing", async () => {
+    const h = harness({ locked: false, sensitivePaths: "clean" });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(h.pushedAttempt).toHaveLength(1);
+    expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+  });
+
+  it("absent getDiffPaths dep → guard is skipped, landing proceeds normally", async () => {
+    // sensitivePaths: undefined → getDiffPaths not wired → guard is a no-op.
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
   });
 });
 

--- a/apps/dev/tests/shared-gate.test.ts
+++ b/apps/dev/tests/shared-gate.test.ts
@@ -5,6 +5,11 @@ import {
   makeHeadlessSink,
   makeInteractiveSink,
   MECHANICAL_KINDS,
+  SENSITIVE_PATH_PATTERNS,
+  LIFECYCLE_SCRIPT_NAMES,
+  isSensitivePath,
+  hasLifecycleScriptInDiff,
+  checkSensitivePaths,
   type EscalationOutcome,
   type GateFinding,
   type SharedGateDeps,
@@ -283,6 +288,173 @@ describe("makeInteractiveSink — interactive escalation", () => {
 
     expect(result.passed).toBe(false);
     expect(result.resolutions[0].escalationOutcome).toBe("skipped");
+  });
+});
+
+// ---------- sensitive-path guard (issue #1102) ----------
+
+describe("SENSITIVE_PATH_PATTERNS — closed auditable set", () => {
+  it("covers every enumerated category (CI, hooks, .red/)", () => {
+    expect(SENSITIVE_PATH_PATTERNS.length).toBeGreaterThan(0);
+    // Each pattern is a RegExp instance (not a string).
+    for (const p of SENSITIVE_PATH_PATTERNS) {
+      expect(p).toBeInstanceOf(RegExp);
+    }
+  });
+
+  it("LIFECYCLE_SCRIPT_NAMES are non-empty strings", () => {
+    for (const name of LIFECYCLE_SCRIPT_NAMES) {
+      expect(typeof name).toBe("string");
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("isSensitivePath — path pattern matching", () => {
+  it("flags .github/workflows/* as sensitive", () => {
+    expect(isSensitivePath(".github/workflows/ci.yml")).toBe(true);
+    expect(isSensitivePath(".github/workflows/red-release.yml")).toBe(true);
+  });
+
+  it("flags .git/hooks/* as sensitive", () => {
+    expect(isSensitivePath(".git/hooks/pre-commit")).toBe(true);
+    expect(isSensitivePath(".git/hooks/commit-msg")).toBe(true);
+  });
+
+  it("flags .husky/* as sensitive", () => {
+    expect(isSensitivePath(".husky/pre-commit")).toBe(true);
+    expect(isSensitivePath(".husky/pre-push")).toBe(true);
+  });
+
+  it("flags .githooks/* as sensitive", () => {
+    expect(isSensitivePath(".githooks/pre-commit")).toBe(true);
+  });
+
+  it("flags any file under .red/ as sensitive", () => {
+    expect(isSensitivePath(".red/config.yaml")).toBe(true);
+    expect(isSensitivePath(".red/trust/gate.json")).toBe(true);
+    expect(isSensitivePath(".red/adr/0001-init.md")).toBe(true);
+  });
+
+  it("does NOT flag ordinary source files", () => {
+    expect(isSensitivePath("src/index.ts")).toBe(false);
+    expect(isSensitivePath("apps/dev/src/core/landing.ts")).toBe(false);
+    expect(isSensitivePath("README.md")).toBe(false);
+    expect(isSensitivePath("package.json")).toBe(false);
+    expect(isSensitivePath("pnpm-lock.yaml")).toBe(false);
+  });
+
+  it("does NOT flag a path that merely contains a sensitive segment mid-path", () => {
+    // A path like 'src/.github/workflows/test.yml' should still be flagged
+    // because the pattern anchors at start of string for .github/workflows.
+    // But something like 'docs/red-migration.md' is NOT .red/
+    expect(isSensitivePath("docs/red-migration.md")).toBe(false);
+    expect(isSensitivePath("apps/red-ui/index.ts")).toBe(false);
+  });
+
+  it("flags a nested .git/hooks path", () => {
+    // The pattern uses (?:^|\/) so nested paths also match.
+    expect(isSensitivePath("sub/.git/hooks/post-commit")).toBe(true);
+  });
+});
+
+describe("hasLifecycleScriptInDiff — lifecycle script detection", () => {
+  it("detects preinstall added to package.json", () => {
+    const diff = `@@ -5,0 +5,1 @@\n+    "preinstall": "node setup.js",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(true);
+  });
+
+  it("detects postinstall added to package.json", () => {
+    const diff = `@@ -10,0 +10,1 @@\n+    "postinstall": "patch-package",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(true);
+  });
+
+  it("detects prepare added to package.json", () => {
+    const diff = `\n+    "prepare": "husky install",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(true);
+  });
+
+  it("ignores removed lifecycle script lines (- prefix)", () => {
+    const diff = `-    "preinstall": "old script",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(false);
+  });
+
+  it("ignores context lines (space prefix) with lifecycle script names", () => {
+    const diff = `     "preinstall": "old script",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(false);
+  });
+
+  it("does NOT flag ordinary script additions (start/test/build)", () => {
+    const diff = `+    "build": "tsc",\n+    "test": "vitest",\n+    "start": "node dist/index.js",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(false);
+  });
+
+  it("returns false for an empty diff", () => {
+    expect(hasLifecycleScriptInDiff("")).toBe(false);
+  });
+
+  it("detects prepublishOnly added to package.json", () => {
+    const diff = `+    "prepublishOnly": "pnpm run build",`;
+    expect(hasLifecycleScriptInDiff(diff)).toBe(true);
+  });
+});
+
+describe("checkSensitivePaths — integrated guard", () => {
+  it("returns empty array when nothing is sensitive", () => {
+    const hits = checkSensitivePaths(["src/index.ts", "README.md"], "");
+    expect(hits).toHaveLength(0);
+  });
+
+  it("flags a CI workflow file", () => {
+    const hits = checkSensitivePaths([".github/workflows/ci.yml"], "");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].path).toBe(".github/workflows/ci.yml");
+    expect(hits[0].reason).toMatch(/CI workflow/);
+  });
+
+  it("flags a .red/ config file", () => {
+    const hits = checkSensitivePaths([".red/config.yaml"], "");
+    expect(hits).toHaveLength(1);
+    expect(hits[0].reason).toMatch(/trust\/gate/);
+  });
+
+  it("flags multiple sensitive paths independently", () => {
+    const hits = checkSensitivePaths(
+      [".github/workflows/ci.yml", "src/core/ship.ts", ".husky/pre-commit"],
+      "",
+    );
+    expect(hits).toHaveLength(2);
+    const paths = hits.map((h) => h.path);
+    expect(paths).toContain(".github/workflows/ci.yml");
+    expect(paths).toContain(".husky/pre-commit");
+  });
+
+  it("flags a lifecycle script change in package.json diff", () => {
+    const diff = `+    "preinstall": "node setup.js",`;
+    const hits = checkSensitivePaths(["package.json", "src/index.ts"], diff);
+    expect(hits.some((h) => h.reason.includes("lifecycle script"))).toBe(true);
+  });
+
+  it("does NOT flag a package.json with only non-lifecycle script changes", () => {
+    const diff = `+    "build": "tsc",`;
+    const hits = checkSensitivePaths(["package.json"], diff);
+    expect(hits).toHaveLength(0);
+  });
+
+  it("includes the package.json file path in the hit when package.json is in changedFiles", () => {
+    const diff = `+    "postinstall": "patch-package",`;
+    const hits = checkSensitivePaths(["packages/shared/package.json"], diff);
+    const lifecycleHit = hits.find((h) => h.reason.includes("lifecycle script"));
+    expect(lifecycleHit).toBeDefined();
+    expect(lifecycleHit!.path).toContain("package.json");
+  });
+
+  it("clean diff with only regular changes returns no hits", () => {
+    const hits = checkSensitivePaths(
+      ["apps/dev/src/core/landing.ts", "apps/dev/tests/landing.test.ts"],
+      "",
+    );
+    expect(hits).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1102. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1102

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785726346&installation_id=129708444&pr_number=1116&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1116&signature=545fcf7eb63cf28b0b36cd6bd1d68cd2476bf9ad8290d72843e18ae9b609e4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->