### PR TITLE
merge: #1103 Drop --admin from the default local AFK landing path

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -108,12 +108,11 @@ export interface LandingDeps {
    */
   getDiffPaths?: () => Promise<{ changedFiles: string[]; packageJsonDiff: string }>;
   /**
-   * Opt-in CI-aware merge for the UNLOCKED admin-PR landing (#812). Present →
-   * landPr polls the PR's merge state and admin-merges only once it is genuinely
-   * ready (CLEAN, or blocked only by a review `--admin` waives), routing the
-   * distinct failure modes (`ci-failed` / `ci-pending`) instead of collapsing
-   * them to merge-conflict. Absent (the default) → admin-merge immediately.
-   * Ignored on the locked path, which never opens a PR.
+   * Opt-in CI-aware merge for the UNLOCKED PR landing (#812). Present →
+   * landPr polls the PR's merge state and merges only once it is genuinely
+   * ready (CLEAN), routing the distinct failure modes (`ci-failed` / `ci-pending`)
+   * instead of collapsing them to merge-conflict. Absent (the default) → merge
+   * immediately. Ignored on the locked path, which never opens a PR.
    */
   ciAwait?: CiAwaitInput;
 }
@@ -121,10 +120,10 @@ export interface LandingDeps {
 /** Static per-landing inputs the caller already resolved. */
 export interface LandingInput {
   /**
-   * Landing MODE, decoupled from the lock (#842): `true` → admin-merged PR
-   * (`landPr`) into `base`; `false` → direct merge (`landMerge`) into `base`.
-   * Resolved from `afk.worktree_launches_pull_request` (default `true`). The lock
-   * no longer toggles this — it only resolves `base` (see {@link locked}).
+   * Landing MODE, decoupled from the lock (#842): `true` → PR merge (`landPr`)
+   * into `base`; `false` → direct merge (`landMerge`) into `base`. Resolved from
+   * `afk.worktree_launches_pull_request` (default `true`). The lock no longer
+   * toggles this — it only resolves `base` (see {@link locked}).
    */
   openPr: boolean;
   /**

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -11,9 +11,9 @@
 //   - LOCKED   → merge the attempt directly into the locked branch with
 //                `git merge --no-ff` and push it; a rejected push rolls the
 //                merge commit back to the captured pre_merge_sha.
-//   - UNLOCKED → land via an admin-merged PR into the pinned target (force-push
-//                the attempt branch, open or reuse the PR, `gh pr merge --admin
-//                --merge`), then fast-forward local <target> to the merge commit.
+//   - UNLOCKED → land via a PR into the pinned target (force-push the attempt
+//                branch, open or reuse the PR, `gh pr merge --merge`), then
+//                fast-forward local <target> to the merge commit.
 
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
@@ -341,20 +341,19 @@ export async function waitForReviewCheck(
 
 // ---------- CI-aware merge (#812) ----------
 //
-// An UNLOCKED admin-merge (`gh pr merge --admin --merge`) does NOT bypass
-// required status checks on a base with `enforce_admins=true` (e.g. reddb-io/reddb
-// since #975 / ADR 0059). Admin-merging a just-opened PR whose required checks are
-// still pending is therefore rejected — and historically AFK bucketed that
-// rejection into `merge-conflict`, mislabelling a perfectly MERGEABLE PR and
-// re-running the whole inner agent. CI-aware merge fixes this: poll
-// `mergeStateStatus` + `statusCheckRollup` until the PR settles, then merge only
-// when it is genuinely ready, and DISTINGUISH the failure modes (conflict vs a
-// failed required check vs checks merely pending).
+// A PR merge (`gh pr merge --merge`) does NOT bypass required status checks.
+// Merging a just-opened PR whose required checks are still pending is therefore
+// rejected — and historically AFK bucketed that rejection into `merge-conflict`,
+// mislabelling a perfectly MERGEABLE PR and re-running the whole inner agent.
+// CI-aware merge fixes this: poll `mergeStateStatus` + `statusCheckRollup` until
+// the PR settles, then merge only when it is genuinely ready, and DISTINGUISH the
+// failure modes (conflict vs a failed required check vs checks merely pending).
 
 /**
  * Normalised verdict for the CI-aware merge poll:
- *   - `merge`     — ready to admin-merge (CLEAN, or BLOCKED only by a required
- *                   review which `--admin` waives, or non-required checks flaky).
+ *   - `merge`     — ready to merge (CLEAN, or non-required checks flaky; BLOCKED
+ *                   by a required review is attempted and surfaces as `merge-failed`
+ *                   rather than being bypassed).
  *   - `conflict`  — a real git conflict / DIRTY / BEHIND (non-fast-forward). Maps
  *                   to the existing bounded `merge-conflict` recovery.
  *   - `ci-failed` — a required check FAILED. A distinct outcome so the next
@@ -448,8 +447,10 @@ export function parseMergeStateView(stdout: string): MergeStateView {
  *      BLOCKED — a failed check never clears by waiting).
  *   3. CLEAN → `merge`.
  *   4. any check still running → `pending` (keep waiting).
- *   5. BLOCKED with neither failures nor pending checks → blocked by a required
- *      REVIEW only, which `--admin` waives → `merge`.
+ *   5. BLOCKED with neither failures nor pending checks → likely blocked by a
+ *      required REVIEW; attempts merge, which surfaces as `merge-failed` if the
+ *      repository's branch protection requires a review (correct: honored, not
+ *      bypassed) → `merge`.
  *   6. UNSTABLE / HAS_HOOKS (mergeable; only non-required checks unsettled) → `merge`.
  *   7. UNKNOWN / DRAFT / empty → `pending` (GitHub still computing mergeability).
  */
@@ -556,12 +557,12 @@ export interface LandPrResult {
 const PR_BODY_PREFIX = "Automated AFK landing for #";
 
 /**
- * UNLOCKED landing (ADR 0030): land the attempt via an admin-merged PR into
- * `<target>`. Steps mirror land_pr in afk.sh:
+ * UNLOCKED landing (ADR 0030): land the attempt via a PR into `<target>`. Steps
+ * mirror land_pr in afk.sh:
  *   1. force-push the attempt branch to `<remote>` (when a worktree is given);
  *   2. reuse an open PR for this head/base, else `gh pr create --base <target>
  *      --head <branch>`;
- *   3. `gh pr merge <num> --admin --merge`;
+ *   3. `gh pr merge <num> --merge` (no --admin: branch protection is honored);
  *   4. fast-forward local `<target>` to the merge commit (best-effort) so HEAD
  *      carries the merge for the closing envelope.
  * Idempotent: a re-attempt reuses the open PR rather than creating a second.
@@ -595,14 +596,13 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     await waitForReviewCheck(exec, repo, prNumber, waitForReview);
   }
 
-  // 2c. Opt-in CI-aware merge (#812). An admin-merge does NOT bypass required
-  // status checks on an `enforce_admins` base, so admin-merging a just-opened PR
-  // with checks still pending is rejected. Poll until the PR settles, then route
-  // the distinct failure modes instead of collapsing them to merge-conflict:
+  // 2c. Opt-in CI-aware merge (#812). Merging a just-opened PR with checks still
+  // pending is rejected. Poll until the PR settles, then route the distinct failure
+  // modes instead of collapsing them to merge-conflict:
   //   - conflict   → caller's bounded merge-conflict recovery (correct here).
   //   - ci-failed  → a distinct outcome targeting the failed check, not a re-run.
   //   - ci-pending → timeout: hand off the OPEN, MERGEABLE PR (never re-run the agent).
-  //   - merge      → fall through to the admin-merge below.
+  //   - merge      → fall through to the merge below.
   if (ciAwait) {
     const ready = await waitForMergeReady(exec, repo, prNumber, ciAwait);
     if (ready === "conflict") return { ok: false, prNumber, reason: "conflict" };
@@ -610,14 +610,14 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     if (ready === "pending") return { ok: false, prNumber, reason: "ci-pending" };
   }
 
-  // 3. Admin-merge: the worker is autonomous, so bypass required-review checks.
-  const merge = await exec(["gh", "-R", repo, "pr", "merge", String(prNumber), "--admin", "--merge"]);
+  // 3. Merge: branch protection is honored rather than bypassed (#1103).
+  const merge = await exec(["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"]);
   if (merge.code !== 0) return { ok: false, prNumber, reason: "merge-failed" };
 
   // 4. Fast-forward local <target> to the merge commit (best-effort) — UNLOCKED
   // ONLY. A LOCKED landing must never write to the primary checkout (ADR 0083 §2,
   // untouchable primary, no exceptions — including the branch-lock landing): the
-  // integration already lives on `origin/<target>` after the remote admin-merge,
+  // integration already lives on `origin/<target>` after the remote merge,
   // and the maintainer promotes by pulling, so the primary's local `<target>` is
   // left untouched. The UNLOCKED path keeps its fast-forward (issue #1019 crit. 3).
   if (!locked) {

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -263,7 +263,7 @@ describe("doLanding — happy paths", () => {
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c.includes("pr list"))).toBe(true);
-    expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     // unlocked never merges the attempt branch locally.
     expect(j.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
   });
@@ -274,7 +274,7 @@ describe("doLanding — happy paths", () => {
     expect(r).toEqual({ ok: true, locked: false });
     const j = joined(h.mergeCalls);
     const checksIdx = j.findIndex((c) => c.includes("pr checks"));
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --admin --merge"));
+    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
     expect(checksIdx).toBeGreaterThanOrEqual(0);
     expect(mergeIdx).toBeGreaterThan(checksIdx);
   });
@@ -284,6 +284,15 @@ describe("doLanding — happy paths", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false });
     expect(joined(h.mergeCalls).some((c) => c.includes("pr checks"))).toBe(false);
+  });
+
+  it("default unlocked landing → merge runs without --admin (branch protection is honored, #1103)", async () => {
+    const h = harness({ locked: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    const mergeCall = h.mergeCalls.find((c) => c.join(" ").includes("pr merge"));
+    expect(mergeCall).toBeDefined();
+    expect(mergeCall!.join(" ")).not.toContain("--admin");
   });
 
   it("locked → lands via merge --no-ff into the locked branch + push", async () => {
@@ -376,7 +385,7 @@ describe("doLanding — ADR 0083 trunk landing precondition (#1018)", () => {
     const h = harness({ locked: false, trunk: "absent" });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false });
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 
   it("ancestor local trunk (default) → precondition proceeds and lands unchanged", async () => {
@@ -386,7 +395,7 @@ describe("doLanding — ADR 0083 trunk landing precondition (#1018)", () => {
     // The precondition fresh-fetched origin/<trunk> then admin-merged.
     const j = joined(h.mergeCalls);
     expect(j.some((c) => c === "git -C /repo fetch origin main --quiet")).toBe(true);
-    expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 });
 
@@ -486,7 +495,7 @@ describe("doLanding — abort / failure short-circuits", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false });
     // It still admin-merged the PR.
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     // The primary checkout was never touched by a destructive op (no reset/abort).
     expect(h.mergeCalls.every((c) => !c.includes("reset"))).toBe(true);
   });
@@ -631,7 +640,7 @@ describe("doLanding — CI-aware merge (#812)", () => {
     expect(r).toEqual({ ok: true, locked: false });
     const j = joined(h.mergeCalls);
     const viewIdx = j.findIndex((c) => c.includes("pr view"));
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --admin --merge"));
+    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
     expect(viewIdx).toBeGreaterThanOrEqual(0);
     expect(mergeIdx).toBeGreaterThan(viewIdx);
   });
@@ -677,7 +686,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     const pushIdx = j.findIndex(
       (c) => c === `git -C ${RWT} push origin HEAD:refs/heads/afk/wAAAA/9-fix-the-thing --force-with-lease`,
     );
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --admin --merge"));
+    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
     expect(fetchIdx).toBeGreaterThanOrEqual(0);
     expect(rebaseIdx).toBeGreaterThan(fetchIdx);
     expect(pushIdx).toBeGreaterThan(rebaseIdx);
@@ -723,7 +732,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     expect(r).toEqual({ ok: true, locked: false });
     // No rebase touched the worker branch; the admin-merge still ran.
     expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 
   it("worktree could not be provisioned → rebase skipped, PR still lands (never risks the primary)", async () => {
@@ -731,7 +740,7 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false });
     expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 
   it("the DIRECT (non-PR) path ignores the rebase provisioner (it integrates origin itself)", async () => {
@@ -747,7 +756,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
   // The flag (openPr = afk.worktree_launches_pull_request) chooses PR vs direct;
   // the lock only resolves `base`. Four cells: {no lock, lock=X} × {true, false}.
   // `prMerged` = the admin-PR path ran; `directMerged` = the worktree merge ran.
-  const prMerged = (j: string[]) => j.some((c) => c.includes("pr merge 42 --admin --merge"));
+  const prMerged = (j: string[]) => j.some((c) => c.includes("pr merge 42 --merge"));
   const directMerged = (j: string[]) => j.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"));
 
   it("no lock + true (default) → admin-merged PR into main (today's unlocked)", async () => {
@@ -812,7 +821,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     expect(r).toEqual({ ok: true, locked: true });
     const j = joined(h.mergeCalls);
     const checksIdx = j.findIndex((c) => c.includes("pr checks"));
-    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --admin --merge"));
+    const mergeIdx = j.findIndex((c) => c.includes("pr merge 42 --merge"));
     expect(checksIdx).toBeGreaterThanOrEqual(0);
     expect(mergeIdx).toBeGreaterThan(checksIdx);
   });
@@ -844,7 +853,7 @@ describe("doLanding — untouchable primary in the LOCKED landing (ADR 0083 §2,
     expect(r).toEqual({ ok: true, locked: true });
     const j = joined(h.mergeCalls);
     // The PR is admin-merged remotely — the integration lands on origin, not local.
-    expect(j.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     // The step-4 best-effort local fast-forward of the primary's lock branch is GONE.
     expect(j.some((c) => c.includes("git -C /repo merge --ff-only"))).toBe(false);
     expect(j.some((c) => c.includes("git -C /repo fetch origin feature-locked"))).toBe(false);

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -212,7 +212,7 @@ describe("landPr (unlocked path)", () => {
     expect(
       c.some((x) => x.includes("pr create --base main --head afk/wBBBB/9-x")),
     ).toBe(true);
-    expect(c.some((x) => x.includes("pr merge 77 --admin --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("pr merge 77 --merge"))).toBe(true);
     // Local ff-merge to carry the merge commit for the closing envelope.
     expect(c).toContain("git -C /repo merge --ff-only origin/main");
     // No direct merge of the attempt branch into target.
@@ -235,7 +235,7 @@ describe("landPr (unlocked path)", () => {
     expect(result.ok).toBe(true);
     const c = joined(calls);
     expect(c.some((x) => x.includes("pr create"))).toBe(false);
-    expect(c.some((x) => x.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
   });
 
   it("returns failure when the admin-merge fails", async () => {
@@ -291,7 +291,7 @@ describe("landPr (unlocked path)", () => {
     expect(result.ok).toBe(true);
     const c = joined(calls);
     // The admin-merge still ran (the integration lands remotely on origin).
-    expect(c.some((x) => x.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
     // No local fast-forward, and no `git -C /repo` write op at all.
     expect(c.some((x) => x.includes("git -C /repo merge --ff-only"))).toBe(false);
     expect(c.some((x) => x.includes("git -C /repo fetch"))).toBe(false);
@@ -476,7 +476,7 @@ describe("landPr wait_for_review wiring", () => {
     expect(result.ok).toBe(true);
     expect(checksPolled).toBe(true);
     expect(mergedAfterPoll).toBe(true);
-    expect(calls.some((c) => c.join(" ").includes("pr merge 77 --admin --merge"))).toBe(true);
+    expect(calls.some((c) => c.join(" ").includes("pr merge 77 --merge"))).toBe(true);
   });
 
   it("does NOT poll review checks by default (waitForReview absent)", async () => {
@@ -494,7 +494,7 @@ describe("landPr wait_for_review wiring", () => {
     });
     expect(result.ok).toBe(true);
     expect(joined(calls).some((c) => c.includes("pr checks"))).toBe(false);
-    expect(joined(calls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 });
 
@@ -535,7 +535,7 @@ describe("CI-aware merge classification (#812)", () => {
     expect(classifyMergeState(view("BLOCKED", [{ status: "COMPLETED", conclusion: "" }]))).toBe("pending");
   });
 
-  it("BLOCKED by required REVIEW only (all checks green) → merge (admin waives review)", () => {
+  it("BLOCKED by required REVIEW only (all checks green) → merge (attempt is made; fails if review actually required)", () => {
     const v = view("BLOCKED", [{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }]);
     expect(classifyMergeState(v)).toBe("merge");
   });
@@ -694,7 +694,7 @@ describe("landPr CI-aware wiring (#812)", () => {
     });
     expect(r.ok).toBe(true);
     expect(joined(calls).some((c) => c.includes("pr view"))).toBe(false);
-    expect(joined(calls).some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined(calls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
   });
 });
 

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -858,7 +858,7 @@ describe("processIssue — per-issue manual-landing mode (landing:manual, #1049)
     const joined = calls.map((c) => c.join(" "));
 
     expect(result.outcome).toBe("done");
-    expect(joined.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(trace.closed).toContain(9);
   });
 });
@@ -898,7 +898,7 @@ describe("processIssue — landing mode decoupled from the lock (#842)", () => {
     const joined = calls.map((c) => c.join(" "));
     // landPr reuses the open PR (#42) and admin-merges it.
     expect(joined.some((c) => c.includes("pr list"))).toBe(true);
-    expect(joined.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     // No direct `merge --no-ff` of the attempt branch into the locked target.
     expect(joined.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
   });
@@ -924,7 +924,7 @@ describe("processIssue — landing mode decoupled from the lock (#842)", () => {
     // result.locked still echoes the lock state (observational), not the mode.
     expect(result.locked).toBe(true);
     const joined = calls.map((c) => c.join(" "));
-    expect(joined.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(joined.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
   });
 
@@ -1008,7 +1008,7 @@ describe("processIssue — PR review gate (ADR 0064 §10, #749)", () => {
     const joined = calls.map((c) => c.join(" "));
 
     expect(result.outcome).toBe("done");
-    expect(joined.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(joined.some((c) => c.includes("--add-label ready-for-review"))).toBe(false);
     expect(trace.closed).toContain(9);
   });
@@ -1026,7 +1026,7 @@ describe("processIssue — PR review gate (ADR 0064 §10, #749)", () => {
     const joined = calls.map((c) => c.join(" "));
 
     expect(result.outcome).toBe("done");
-    expect(joined.some((c) => c.includes("pr merge 42 --admin --merge"))).toBe(true);
+    expect(joined.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     expect(joined.some((c) => c.includes("--add-label ready-for-review"))).toBe(false);
     expect(trace.closed).toContain(9);
   });

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -40,7 +40,7 @@ interface HarnessOptions {
   changedFiles?: string[];
   branchPresent?: boolean;
   locked?: boolean;
-  /** When true, the unlocked `gh pr merge --admin` returns non-zero (land fails). */
+  /** When true, the unlocked `gh pr merge` returns non-zero (land fails). */
   landFail?: boolean;
   /** Close-cascade fixture: open dependents returned by gh.listByLabel(req:N). */
   dependentsByLabel?: Record<string, { number: number; labels: string[] }[]>;


### PR DESCRIPTION
Automated AFK landing for #1103. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1103

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785727880&installation_id=129708444&pr_number=1117&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1117&signature=e818abb648942efdc40e82f1a98f84259ed8e886085bd0a4391637044bac445e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PR landing now follows normal branch protection rules instead of bypassing them.
  * CI-aware landing better distinguishes pending, failed, conflicted, and ready-to-merge states.
  * Review-required PRs now wait and report status more accurately during landing.
  * Updated landing behavior so direct merge and PR-based merge are chosen more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->