### PR TITLE
sec: #1106 Fix shell-injection RCE in red-upstream-watch workflow

### DIFF
--- a/.github/workflows/red-upstream-watch.yml
+++ b/.github/workflows/red-upstream-watch.yml
@@ -42,12 +42,13 @@ jobs:
           gh api "repos/$REPO/compare/$OLD...$NEW" \
             --jq '"## Commits\n" + ([.commits[] | "- `\(.sha[0:7])` \(.commit.message | split("\n")[0])"] | join("\n")) + "\n\n## Files\n" + ([.files[] | "- \(.status): `\(.filename)`"] | join("\n"))' \
             > diff.md
+          delimiter="$(uuidgen)"
           {
             echo "old=$OLD"
             echo "new=$NEW"
-            echo 'body<<EOF'
+            printf 'body<<%s\n' "$delimiter"
             cat diff.md
-            echo EOF
+            printf '%s\n' "$delimiter"
           } >> "$GITHUB_OUTPUT"
 
       - name: Open or update issue
@@ -55,25 +56,29 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ steps.pin.outputs.repo }}
+          OLD: ${{ steps.pin.outputs.sha }}
           NEW: ${{ steps.head.outputs.sha }}
+          DIFF_BODY: ${{ steps.diff.outputs.body }}
         run: |
           title="upstream: $REPO advanced to ${NEW:0:7}"
           existing=$(gh issue list --search "upstream: $REPO in:title" --state open --json number --jq '.[0].number')
-          body=$(cat <<EOF
-          Upstream \`$REPO\` moved past pinned SHA.
+          body_file="$(mktemp)"
+          trap 'rm -f "$body_file"' EXIT
 
-          - pinned: \`${{ steps.pin.outputs.sha }}\`
-          - upstream HEAD: \`$NEW\`
-          - compare: https://github.com/$REPO/compare/${{ steps.pin.outputs.sha }}...$NEW
+          {
+            printf 'Upstream `%s` moved past pinned SHA.\n\n' "$REPO"
+            printf -- '- pinned: `%s`\n' "$OLD"
+            printf -- '- upstream HEAD: `%s`\n' "$NEW"
+            printf -- '- compare: https://github.com/%s/compare/%s...%s\n\n' "$REPO" "$OLD" "$NEW"
+            printf '%s\n\n' "$DIFF_BODY"
+            cat <<'BODY_FOOTER'
+---
+Review changes, cherry-pick relevant skills, then bump `sha=` in `.upstream`.
+BODY_FOOTER
+          } > "$body_file"
 
-          ${{ steps.diff.outputs.body }}
-
-          ---
-          Review changes, cherry-pick relevant skills, then bump \`sha=\` in \`.upstream\`.
-          EOF
-          )
           if [ -n "$existing" ]; then
-            gh issue edit "$existing" --title "$title" --body "$body"
+            gh issue edit "$existing" --title "$title" --body-file "$body_file"
           else
-            gh issue create --title "$title" --body "$body" --label upstream-drift
+            gh issue create --title "$title" --body-file "$body_file" --label upstream-drift
           fi

--- a/apps/dev/tests/red-upstream-watch-workflow.test.ts
+++ b/apps/dev/tests/red-upstream-watch-workflow.test.ts
@@ -1,0 +1,41 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+async function readWorkflow(): Promise<string> {
+  return readFile(join(ROOT, ".github/workflows/red-upstream-watch.yml"), "utf8");
+}
+
+function stepBody(workflow: string, name: string): string {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  expect(start, `missing workflow step: ${name}`).toBeGreaterThanOrEqual(0);
+
+  const next = workflow.indexOf("\n      - name: ", start + marker.length);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
+
+describe("red-upstream-watch workflow injection safety", () => {
+  it("does not let upstream diff text forge GITHUB_OUTPUT records", async () => {
+    const compare = stepBody(await readWorkflow(), "Compare");
+
+    expect(compare).not.toContain("body<<EOF");
+    expect(compare).toMatch(/delimiter="\$\(uuidgen\)"/);
+    expect(compare).toContain("printf 'body<<%s\\n' \"$delimiter\"");
+    expect(compare).toContain("printf '%s\\n' \"$delimiter\"");
+  });
+
+  it("passes upstream-controlled body text through env and quoted shell references", async () => {
+    const openIssue = stepBody(await readWorkflow(), "Open or update issue");
+    const runBlock = openIssue.slice(openIssue.indexOf("run: |"));
+
+    expect(openIssue).toContain("OLD: ${{ steps.pin.outputs.sha }}");
+    expect(openIssue).toContain("DIFF_BODY: ${{ steps.diff.outputs.body }}");
+    expect(runBlock).not.toContain("${{ steps.pin.outputs.sha }}");
+    expect(runBlock).not.toContain("${{ steps.diff.outputs.body }}");
+    expect(runBlock).toContain("printf '%s\\n\\n' \"$DIFF_BODY\"");
+    expect(runBlock).toMatch(/<<'BODY_[A-Z_]+'/);
+  });
+});


### PR DESCRIPTION
Human-reviewed and approved (sensitive-path). Closes #1106

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785769332&installation_id=129708444&pr_number=1120&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1120&signature=fcf6f59690fb3860b18f28fd6df32391425d118bc7502e23d62c1e1e263e24b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->