### PR TITLE
sec: #1105 environment: approval gate on the red-release job

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -30,6 +30,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip release]')"
+    # Repository settings protect the red-release environment with required
+    # reviewers. Approval happens before this job can build, publish assets, or
+    # move the matching major tag.
+    environment:
+      name: red-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -589,6 +589,12 @@ publish release assets, update plugin metadata, and move the matching major tag
 such as `v1` to the same release commit so reusable workflows pinned to `@v1`
 keep advancing.
 
+The `release` job runs in the GitHub environment named `red-release`. Repository
+settings must keep that environment protected with required reviewers, because
+approval is the gate before the job publishes release assets or moves the major
+tag. Once an approved reviewer approves the environment deployment, the normal
+release job continues without any extra manual step.
+
 ## License
 
 Apache-2.0. See [LICENSE](./LICENSE). See [NOTICE](./NOTICE) for upstream MIT

--- a/scripts/test-red-release-approval-gate.sh
+++ b/scripts/test-red-release-approval-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Contract test for the red-release publishing approval gate.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+WORKFLOW=".github/workflows/red-release.yml"
+README="README.md"
+ENVIRONMENT_NAME="red-release"
+
+fail_count=0
+pass_count=0
+
+pass() { printf 'PASS  %s\n' "$1"; pass_count=$((pass_count + 1)); }
+fail() { printf 'FAIL  %s\n' "$1" >&2; fail_count=$((fail_count + 1)); }
+
+assert_grep() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qE "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label - pattern not found: $pattern in $file"
+  fi
+}
+
+assert_release_job_environment() {
+  local block
+  block="$(awk '
+    /^  release:/ { in_release = 1 }
+    in_release && /^  [A-Za-z0-9_-]+:/ && !/^  release:/ { exit }
+    in_release { print }
+  ' "$WORKFLOW")"
+
+  if grep -qE '^    environment:' <<<"$block" &&
+     grep -qE "^[[:space:]]+name: ${ENVIRONMENT_NAME}$" <<<"$block"; then
+    pass "release job uses ${ENVIRONMENT_NAME} environment"
+  else
+    fail "release job does not use ${ENVIRONMENT_NAME} environment"
+  fi
+}
+
+assert_release_job_environment
+assert_grep "README documents approval requirement" \
+  "environment.*${ENVIRONMENT_NAME}.*approval|required reviewers" \
+  "$README"
+
+printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
Human-reviewed and approved (sensitive-path). Closes #1105

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785769337&installation_id=129708444&pr_number=1122&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1122&signature=140ca961c2116ecf5fea16ebc236beefab0cbfa04c1888ea8da03e603319406c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->