### PR TITLE
merge: #1111 Maintainer promotion signal for quarantined outside comments

### DIFF
--- a/apps/dev/src/core/source-trust.ts
+++ b/apps/dev/src/core/source-trust.ts
@@ -8,8 +8,9 @@
 //
 // Three levels, mirroring GitHub's own author-association vocabulary plus the
 // bot/app dimension:
-//   - trusted    — author association OWNER / MEMBER / COLLABORATOR, or a
-//                  trust-gate override (allowlist / write-access / CODEOWNERS).
+//   - trusted    — author association OWNER / MEMBER / COLLABORATOR, a
+//                  trust-gate override (allowlist / write-access / CODEOWNERS),
+//                  or a per-comment maintainer 👍 promotion signal.
 //   - dubious    — CONTRIBUTOR / FIRST_TIMER / FIRST_TIME_CONTRIBUTOR / NONE, or a
 //                  fork-PR author without write access; the "unknown source" bucket.
 //   - automation — bots and GitHub Apps (their comments never carry human authority).
@@ -59,6 +60,10 @@ export interface SourceTrustInput {
    * honour the allowlist / write-access / CODEOWNERS overrides for an author whose
    * association alone does not qualify. */
   trustVerdict?: ActorTrustVerdict;
+  /** True when a maintainer applied 👍 to this specific comment. This is a
+   * per-comment promotion signal; it does not change the author's default trust
+   * on any other comment. */
+  maintainerThumbsUp?: boolean;
 }
 
 /**
@@ -67,7 +72,8 @@ export interface SourceTrustInput {
  *   2. author association OWNER/MEMBER/COLLABORATOR → trusted
  *   3. a POSITIVE trust-gate override (allowlist /
  *      write-access / codeowners)                  → trusted
- *   4. everything else                             → dubious
+ *   4. maintainer 👍 on this comment               → trusted
+ *   5. everything else                             → dubious
  *
  * Note `permissive-default` never promotes: the guidance channel requires a
  * positive source signal, not the absence of one.
@@ -82,6 +88,8 @@ export function classifySourceTrust(input: SourceTrustInput): SourceTrustLevel {
   if (verdict?.executable && verdict.basis !== undefined && TRUSTED_BASES.has(verdict.basis)) {
     return "trusted";
   }
+
+  if (input.maintainerThumbsUp) return "trusted";
 
   return "dubious";
 }

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -484,6 +484,10 @@ interface RawGhComment {
   author?: { login?: string; is_bot?: boolean };
   authorAssociation?: string;
   createdAt?: string;
+  reactionGroups?: Array<{
+    content?: string;
+    users?: { nodes?: Array<{ login?: string }> };
+  }>;
 }
 
 function parseJsonLines(stdout: string): unknown[] {
@@ -500,13 +504,34 @@ function parseJsonLines(stdout: string): unknown[] {
   return out;
 }
 
+function thumbsUpReactors(comment: RawGhComment): string[] {
+  const reactors: string[] = [];
+  for (const group of comment.reactionGroups ?? []) {
+    if (String(group.content ?? "").toUpperCase() !== "THUMBS_UP") continue;
+    for (const node of group.users?.nodes ?? []) {
+      const login = String(node.login ?? "").trim();
+      if (login) reactors.push(login);
+    }
+  }
+  return reactors;
+}
+
+function isMaintainerThumbsUp(verdict: ActorTrustVerdict | undefined): boolean {
+  return (
+    verdict?.executable === true &&
+    (verdict.basis === "write-access" || verdict.basis === "codeowners")
+  );
+}
+
 /** Project GitHub comments to handoff comments with the source-trust taxonomy.
  * Bot authors resolve to `automation` and OWNER/MEMBER/COLLABORATOR associations
  * to `trusted` from the projection alone; every other author is resolved through
  * the injected `resolveTrust` primitive so allowlist / write-access / CODEOWNERS
- * overrides still promote. Results are memoised per login within the call. When
- * `resolveTrust` is omitted the level is decided from association + bot status
- * only (a non-collaborator falls to `dubious`). */
+ * overrides still promote. A maintainer's THUMBS_UP reaction promotes only the
+ * reacted comment; it does not change the author's trust on sibling comments.
+ * Results are memoised per login within the call. When `resolveTrust` is omitted
+ * the level is decided from association + bot status only (a non-collaborator
+ * falls to `dubious`, and reaction promotion is unavailable). */
 async function projectComments(
   raw: readonly RawGhComment[],
   resolveTrust?: CommentTrustResolver,
@@ -535,11 +560,19 @@ async function projectComments(
     // otherwise-dubious human author is resolved through the trust primitive.
     const associationTrusted = TRUSTED_ASSOCIATIONS.has((authorAssociation ?? "").trim().toUpperCase());
     const trustVerdict = isBot || associationTrusted ? undefined : await resolveVerdict(login);
+    const maintainerThumbsUp = (
+      await Promise.all(thumbsUpReactors(c).map((actor) => resolveVerdict(actor)))
+    ).some(isMaintainerThumbsUp);
     out.push({
       body: String(c.body ?? ""),
       author: login,
       createdAt: c.createdAt ? String(c.createdAt) : undefined,
-      sourceTrust: classifySourceTrust({ authorAssociation, isBot, trustVerdict }),
+      sourceTrust: classifySourceTrust({
+        authorAssociation,
+        isBot,
+        trustVerdict,
+        maintainerThumbsUp,
+      }),
     });
   }
   return out;
@@ -562,6 +595,7 @@ export async function issueComments(
       author?: { login?: string; is_bot?: boolean };
       authorAssociation?: string;
       createdAt?: string;
+      reactionGroups?: RawGhComment["reactionGroups"];
     }>;
   };
   try {

--- a/apps/dev/tests/gh-issue-comments-trust.test.ts
+++ b/apps/dev/tests/gh-issue-comments-trust.test.ts
@@ -56,6 +56,36 @@ describe("issueComments — source-trust projection (#1100)", () => {
     expect(out[4]).toMatchObject({ author: "trusted-ext", sourceTrust: "trusted" });
   });
 
+  it("promotes only the outside comment with a maintainer thumbs-up reaction", async () => {
+    const comments = JSON.stringify({
+      comments: [
+        {
+          body: "useful outside suggestion",
+          author: { login: "stranger", is_bot: false },
+          authorAssociation: "NONE",
+          reactionGroups: [
+            { content: "THUMBS_UP", users: { nodes: [{ login: "maintainer" }] } },
+          ],
+        },
+        {
+          body: "second outside suggestion",
+          author: { login: "stranger", is_bot: false },
+          authorAssociation: "NONE",
+          reactionGroups: [],
+        },
+      ],
+    });
+    const resolveTrust = async (actor: string): Promise<ActorTrustVerdict> =>
+      actor === "maintainer"
+        ? { executable: true, basis: "write-access" }
+        : { executable: false, reason: "not a maintainer" };
+
+    const out = await issueComments(ghReturning(comments), 7, resolveTrust);
+
+    expect(out[0]).toMatchObject({ author: "stranger", sourceTrust: "trusted" });
+    expect(out[1]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });
+  });
+
   it("without a resolver a non-collaborator falls to dubious", async () => {
     const out = await issueComments(ghReturning(COMMENTS), 7);
     expect(out[3]).toMatchObject({ author: "stranger", sourceTrust: "dubious" });


### PR DESCRIPTION
Automated AFK landing for #1111. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1111

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785770008&installation_id=129708444&pr_number=1125&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1125&signature=7064d406ab13cc30cea34fd6493c421e4f2285302bb26f2ff6142300fbc7d11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->