### PR TITLE
merge: #1112 Force container isolation for untrusted-author AFK issues

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -47,7 +47,7 @@ import * as gitx from "../runtime/git.js";
 import * as fsx from "../runtime/fs.js";
 import type { GhContext } from "../runtime/gh.js";
 import type { GitContext } from "../runtime/git.js";
-import type { ExecFn } from "../runtime/exec.js";
+import { execTool, type ExecFn } from "../runtime/exec.js";
 import { getConfig, loadConfig, readBackpressure, readPostAttemptFormat, resolveTier, resolveCiTimeoutSeconds } from "../core/config.js";
 import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
 import { resolveNotesLoopConfig } from "../core/notes-loop.js";
@@ -885,6 +885,11 @@ export function buildProcessDeps(
       attemptBudget,
       () => activityMeter.peek(),
     ),
+    sandboxMode: sandbox,
+    sandboxAvailable: async (mode) => {
+      const run = exec ?? execTool;
+      return (await run("sh", ["-c", `command -v ${mode}`], { cwd: ctx.root })).code === 0;
+    },
     model,
     classifyIssue: makeIssueClassifier(config, runner, ctx.root, exec),
     resolveTier: (activeRunner, taskClass = "think") => resolveTier(config, activeRunner, taskClass, process.env),

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -36,6 +36,7 @@ import {
   type AttemptProgressInfo,
   type RunAgentInput,
   type RunAgentResult,
+  type SandboxMode,
 } from "./execution.js";
 import {
   relevantScopes,
@@ -87,6 +88,7 @@ import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } fro
 import {
   parseTrustPolicy,
   evaluateClaimTrust,
+  resolveActorTrust,
   describeTrustPosture,
   type TrustProvenance,
   type RepoVisibility,
@@ -105,6 +107,8 @@ import type { AttemptStatus } from "./envelope.js";
 import type { Runner } from "../types/runner.js";
 import { runnerSupportsStructuredOutput, toAgentRunner } from "./runner-spec.js";
 import type { HistoryClock } from "./history.js";
+
+type ContainerSandboxMode = Exclude<SandboxMode, "none">;
 
 // ---------- injected IO ----------
 
@@ -332,6 +336,19 @@ export interface ProcessIssueDeps {
    * a fake returning a scripted RunAgentResult.
    */
   runAgent(input: RunAgentInput): Promise<RunAgentResult>;
+  /**
+   * The operator-configured AFK sandbox mode. Trusted-author work keeps this
+   * unchanged. Untrusted-author work may override it to a container backend.
+   * Optional for legacy tests/callers; absence preserves the historical `none`
+   * default unless untrusted-author policy has enough provenance to engage.
+   */
+  sandboxMode?: SandboxMode;
+  /**
+   * Best-effort backend availability probe for fail-closed untrusted-author
+   * policy. When untrusted work needs a container and no configured container is
+   * available, processIssue refuses before spawning the inner agent.
+   */
+  sandboxAvailable?(mode: ContainerSandboxMode): Promise<boolean>;
   /** Model id passed through to runAgent (provider-specific, e.g. "claude-opus-4-8"). */
   model: string;
   /** Reasoning effort passed through to runAgent; undefined preserves legacy callers. */
@@ -851,6 +868,76 @@ function parseFeedbackClass(contextJson: string): "infra" | "semantic" | null {
   }
 }
 
+interface UntrustedSandboxDecision {
+  sandboxMode: SandboxMode;
+  authorTrusted: boolean;
+  refused: boolean;
+  reason?: string;
+}
+
+async function resolveUntrustedAuthorSandbox(
+  deps: ProcessIssueDeps,
+  trustPolicy: ReturnType<typeof parseTrustPolicy>,
+  provenance: TrustProvenance | undefined,
+): Promise<UntrustedSandboxDecision> {
+  const configured = deps.sandboxMode ?? "none";
+  if (!provenance?.authorSourceTrust) {
+    return { sandboxMode: configured, authorTrusted: true, refused: false };
+  }
+
+  let authorTrusted = provenance.authorSourceTrust === "trusted";
+  if (!authorTrusted && deps.gh.actorTrustSignals) {
+    const verdict = await resolveActorTrust(trustPolicy, provenance.author, (actor) => deps.gh.actorTrustSignals!(actor));
+    authorTrusted = verdict.executable && verdict.basis !== "permissive-default";
+  }
+  if (authorTrusted) return { sandboxMode: configured, authorTrusted: true, refused: false };
+
+  const candidates: ContainerSandboxMode[] =
+    configured === "docker" ? ["docker", "podman"] : configured === "podman" ? ["podman", "docker"] : ["docker", "podman"];
+  for (const mode of candidates) {
+    if (!deps.sandboxAvailable || (await deps.sandboxAvailable(mode))) {
+      return { sandboxMode: mode, authorTrusted: false, refused: false };
+    }
+  }
+
+  return {
+    sandboxMode: configured,
+    authorTrusted: false,
+    refused: true,
+    reason:
+      `untrusted issue author ${provenance.author ? `'${provenance.author}'` : "(unknown)"} requires container isolation, ` +
+      "but no docker/podman sandbox backend is available",
+  };
+}
+
+async function refuseNoSandboxForUntrustedAuthor(
+  deps: ProcessIssueDeps,
+  input: ProcessIssueInput,
+  hooksFired: HookName[],
+  reason: string,
+): Promise<ProcessIssueResult> {
+  await deps.gh.editLabels(input.issue, [LABEL_READY], [LABEL_HUMAN]);
+  await deps.gh.comment(
+    input.issue,
+    `🤖 /afk preflight stopped: ${reason}. Autonomous execution refused; maintainer intervention required.`,
+  );
+  if (deps.gh.renderDecisionCard) {
+    try {
+      await deps.gh.renderDecisionCard(input.issue);
+    } catch {
+      // best-effort: card render failure is non-fatal.
+    }
+  }
+  await deps.claimLock.release(input.issue);
+  return {
+    outcome: "blocked",
+    issue: input.issue,
+    hooksFired,
+    preserved: false,
+    swept: false,
+  };
+}
+
 /**
  * Run the AFK per-issue lifecycle IN ORDER, composing each pure module and
  * applying its plan through injected IO. The SEQUENCE + the label transitions +
@@ -977,9 +1064,12 @@ export async function processIssue(
   // posture-tagged log line; the session loop then skips to the next candidate.
   const visibility = deps.gh.repoVisibility ? await deps.gh.repoVisibility() : undefined;
   const trustPolicy = parseTrustPolicy(deps.hooks.config, visibility);
+  let provenance: TrustProvenance | undefined;
+  if (deps.gh.issueTrust) {
+    provenance = await deps.gh.issueTrust(issue);
+  }
   const canFailClosed = !!(trustPolicy.failClosed && deps.gh.actorTrustSignals);
-  if ((trustPolicy.enabled || canFailClosed) && deps.gh.issueTrust) {
-    const provenance = await deps.gh.issueTrust(issue);
+  if ((trustPolicy.enabled || canFailClosed) && provenance) {
     const signals = deps.gh.actorTrustSignals;
     const lookup = signals ? (login: string) => signals(login) : async () => ({});
     const verdict = await evaluateClaimTrust(trustPolicy, provenance, lookup);
@@ -990,6 +1080,24 @@ export async function processIssue(
       await deps.claimLock.release(issue);
       return claimLost(issue, hooksFired);
     }
+  }
+
+  // ---- untrusted-author sandbox policy (#1112) ----
+  // Source-trust is separate from the executable-issue trust gate: an issue may be
+  // delegable because a maintainer summoned it, while its original author remains
+  // untrusted. In that case the inner agent must never run under host-native
+  // `none`; pick an available container backend or page a human before any
+  // worktree/handoff/agent execution exists.
+  const sandboxDecision = await resolveUntrustedAuthorSandbox(deps, trustPolicy, provenance);
+  if (sandboxDecision.refused) {
+    const reason = sandboxDecision.reason ?? "untrusted issue author requires container isolation";
+    deps.appendIterLog(`🤖 /afk sandbox policy refused #${issue}: ${reason}.`);
+    return refuseNoSandboxForUntrustedAuthor(deps, input, hooksFired, reason);
+  }
+  if (!sandboxDecision.authorTrusted && sandboxDecision.sandboxMode !== (deps.sandboxMode ?? "none")) {
+    deps.appendIterLog(
+      `🤖 /afk sandbox policy: untrusted issue author forced ${sandboxDecision.sandboxMode} isolation for #${issue}.`,
+    );
   }
 
   // Project the `running` label, shedding any stale `blocked:*` reason in the same
@@ -1219,6 +1327,7 @@ export async function processIssue(
       // FIX J: env computed by the pre_worktree hook (e.g. CARGO_TARGET_DIR per
       // slot) — runAgent applies it to the spawned agent's environment.
       env: agentEnv,
+      sandboxMode: sandboxDecision.sandboxMode,
     };
 
     // Intra-attempt notes-loop (Track C, #924). Default OFF → `runNotesLoop`
@@ -1307,6 +1416,7 @@ export async function processIssue(
         goalProbe: () => deps.gh.issueClosed(issue),
         // FIX J: carry the pre_worktree env onto the fallback runner too.
         env: agentEnv,
+        sandboxMode: sandboxDecision.sandboxMode,
       });
       if (isRunnerRecoverableOutcome(run.outcome)) {
         // Both runner invocations failed in a recoverable runner class → close the

--- a/apps/dev/src/core/trust-gate.ts
+++ b/apps/dev/src/core/trust-gate.ts
@@ -30,6 +30,7 @@
 
 import type { ConfigValues } from "./config.js";
 import { getConfig } from "./config.js";
+import type { SourceTrustLevel } from "./source-trust.js";
 
 /** The accessor key the allowlist lives under (folded from
  * `plugins.dev.afk.trust-gate.allowlist`, ADR 0042). Intentionally NOT in
@@ -81,6 +82,12 @@ export function describeTrustPosture(policy: TrustPolicy): TrustPosture {
 export interface TrustProvenance {
   /** Issue author login (`gh issue view --json author`). */
   author?: string;
+  /**
+   * Source-trust level for the issue author (issue #1100 taxonomy). When present,
+   * process-issue can distinguish trusted-author work from untrusted-author work
+   * even when the executable-issue trust gate is permissive.
+   */
+  authorSourceTrust?: SourceTrustLevel;
   /** Login of the actor who applied `ready-for-agent`, read from the timeline. */
   readyForAgentActor?: string;
 }

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -20,7 +20,7 @@ import type { IssueCandidate } from "../core/session.js";
 import type { HitlCandidate } from "../core/hitl-selection.js";
 import type { IssueMeta } from "../core/branch-cleanup.js";
 import type { HandoffComment } from "../core/handoff.js";
-import { classifySourceTrust, TRUSTED_ASSOCIATIONS } from "../core/source-trust.js";
+import { classifySourceTrust, TRUSTED_ASSOCIATIONS, type SourceTrustLevel } from "../core/source-trust.js";
 import type { ActorTrustVerdict, RepoVisibility } from "../core/trust-gate.js";
 import type { IssueOpenState } from "../core/reclaim.js";
 import type { UnblockCandidate, ReconcileSweepCandidate } from "../core/boot-sweep.js";
@@ -941,12 +941,12 @@ async function listIssuesByLabel(ctx: GhContext, label: string): Promise<Reconci
 export async function issueTrust(
   ctx: GhContext,
   issue: number,
-): Promise<{ author?: string; readyForAgentActor?: string }> {
+): Promise<{ author?: string; authorSourceTrust?: SourceTrustLevel; readyForAgentActor?: string }> {
   const [author, actor] = await Promise.all([
-    issueAuthorLogin(ctx, issue),
+    issueAuthorProfile(ctx, issue),
     readyForAgentActor(ctx, issue),
   ]);
-  return { author, readyForAgentActor: actor };
+  return { author: author.login, authorSourceTrust: author.sourceTrust, readyForAgentActor: actor };
 }
 
 /** `gh issue view --json author` → the author login, or undefined on failure.
@@ -977,13 +977,47 @@ export async function repoVisibility(ctx: GhContext): Promise<RepoVisibility | u
 
 /** `gh issue view --json author` → the author login, or undefined on failure. */
 async function issueAuthorLogin(ctx: GhContext, issue: number): Promise<string | undefined> {
-  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "author"]);
-  if (r.code !== 0) return undefined;
+  return (await issueAuthorProfile(ctx, issue)).login;
+}
+
+async function issueAuthorProfile(
+  ctx: GhContext,
+  issue: number,
+): Promise<{ login?: string; sourceTrust?: SourceTrustLevel }> {
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "author,authorAssociation"]);
+  if (r.code !== 0) return issueAuthorProfileLegacy(ctx, issue);
   try {
-    const login = (JSON.parse(r.stdout) as { author?: { login?: string } }).author?.login;
-    return login ? String(login) : undefined;
+    const parsed = JSON.parse(r.stdout) as {
+      author?: { login?: string; is_bot?: boolean; type?: string };
+      authorAssociation?: string;
+    };
+    const login = parsed.author?.login ? String(parsed.author.login) : undefined;
+    if (!login) return issueAuthorProfileLegacy(ctx, issue);
+    const authorType = String(parsed.author?.type ?? "").toLowerCase();
+    const isBot = parsed.author?.is_bot === true || authorType === "bot";
+    return {
+      login,
+      sourceTrust: classifySourceTrust({ authorAssociation: parsed.authorAssociation, isBot }),
+    };
   } catch {
-    return undefined;
+    return issueAuthorProfileLegacy(ctx, issue);
+  }
+}
+
+async function issueAuthorProfileLegacy(
+  ctx: GhContext,
+  issue: number,
+): Promise<{ login?: string; sourceTrust?: SourceTrustLevel }> {
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "author"]);
+  if (r.code !== 0) return {};
+  try {
+    const parsed = JSON.parse(r.stdout) as { author?: { login?: string; is_bot?: boolean; type?: string } };
+    const login = parsed.author?.login ? String(parsed.author.login) : undefined;
+    const authorType = String(parsed.author?.type ?? "").toLowerCase();
+    const isBot = parsed.author?.is_bot === true || authorType === "bot";
+    return { login, sourceTrust: login ? classifySourceTrust({ isBot }) : undefined };
+  } catch {
+    return {};
   }
 }
 

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -7,9 +7,10 @@ import {
 import { SCOUT_EXIT_PROTOCOL } from "../src/core/handoff.js";
 import type { HookName } from "../src/core/hook-config.js";
 import type { ConfigValues } from "../src/core/config.js";
-import type { AgentEffort, RunAgentInput, RunAgentResult } from "../src/core/execution.js";
+import type { AgentEffort, RunAgentInput, RunAgentResult, SandboxMode } from "../src/core/execution.js";
 import type { AttemptRecordPayload } from "../src/core/attempt-record.js";
 import type { IssueClassificationMetadata } from "../src/core/issue-classifier.js";
+import type { TrustProvenance } from "../src/core/trust-gate.js";
 import { parseCurrentBlocker, upsertCurrentBlocker } from "../src/core/blocker-state.js";
 import type { AttemptProgressInfo } from "../src/core/execution.js";
 
@@ -82,7 +83,11 @@ interface HarnessOptions {
   config?: ConfigValues;
   /** Trust-gate provenance (#621) returned by gh.issueTrust. When set, the port
    * is registered; absent → no port (gate never fires). */
-  trust?: { author?: string; readyForAgentActor?: string };
+  trust?: TrustProvenance;
+  /** Operator-configured sandbox mode threaded into processIssue. */
+  sandboxMode?: SandboxMode;
+  /** Container backends considered present by the fail-closed sandbox policy. */
+  availableSandboxes?: SandboxMode[];
   /** Repository visibility (#1101) returned by gh.repoVisibility. When set, the
    * port is registered and the no-allowlist default becomes visibility-aware. */
   visibility?: "public" | "private" | "internal";
@@ -387,6 +392,8 @@ function harness(opts: HarnessOptions = {}): {
       stderr: "",
     }),
     backpressureCommands: opts.backpressureCommands,
+    sandboxMode: opts.sandboxMode ?? "none",
+    sandboxAvailable: async (mode) => (opts.availableSandboxes ?? ["docker", "podman"]).includes(mode),
     // The sandcastle execution port: a fake returning a scripted outcome on the
     // worker branch sandcastle "committed" to. When `outcomes` is set, each call
     // pops the next scripted outcome (for fallback-swap sequences).
@@ -1825,6 +1832,61 @@ describe("processIssue — trust gate (#621)", () => {
     expect(result.outcome).toBe("done");
     expect(trace.runAgentCalls).toHaveLength(1);
     expect(trace.iterLogs.some((l) => /trust gate/.test(l))).toBe(false);
+  });
+});
+
+describe("processIssue — untrusted-author sandbox policy (#1112)", () => {
+  it("forces container isolation for an untrusted author when the configured sandbox is none", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      sandboxMode: "none",
+      availableSandboxes: ["docker"],
+      trust: { author: "stranger", authorSourceTrust: "dubious", readyForAgentActor: "alice" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.runAgentCalls[0]?.sandboxMode).toBe("docker");
+    expect(trace.iterLogs.some((l) => /sandbox policy: untrusted issue author forced docker isolation/.test(l))).toBe(
+      true,
+    );
+  });
+
+  it("refuses untrusted-author execution and pages a human when no container backend is available", async () => {
+    const { deps, input, trace } = harness({
+      sandboxMode: "none",
+      availableSandboxes: [],
+      trust: { author: "stranger", authorSourceTrust: "dubious", readyForAgentActor: "alice" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("blocked");
+    expect(trace.runAgentCalls).toEqual([]);
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+ready-for-human"]);
+    expect(trace.comments.some((c) => /requires container isolation.*no docker\/podman sandbox backend/.test(c.body))).toBe(
+      true,
+    );
+    expect(trace.released).toEqual([9]);
+  });
+
+  it("keeps trusted-author sandbox resolution unchanged", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      sandboxMode: "none",
+      availableSandboxes: ["docker"],
+      trust: { author: "alice", authorSourceTrust: "trusted", readyForAgentActor: "alice" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(1);
+    expect(trace.runAgentCalls[0]?.sandboxMode).toBe("none");
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1112. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1112

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785770967&installation_id=129708444&pr_number=1126&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1126&signature=718aa8e2e91708214be7ba6aa937d0d84b5637ff8bb35212467106af83bc0ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->