### PR TITLE
fix(statusline): humanizeAlive always shows two units (1h0m, 1d10h)

### DIFF
--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -156,18 +156,20 @@ export function humanizeTokens(tokens: number): string {
 
 /**
  * Humanizes an elapsed duration in milliseconds to a compact human-friendly
- * string: `30s`, `5m`, `5m40s`, `1h`, `1h22m`. Seconds are included only
- * under one hour (they become noise at hour scale). Zero/negative → `0s`.
+ * string that always carries the two most-significant units once past the
+ * seconds floor: `10s`, `1m10s`, `1h10m`, `1d10h`. The lower unit is shown even
+ * when zero (`1h` → `1h0m`) so the magnitude never collapses to a lone number.
+ * Only sub-minute values render a single unit. Zero/negative → `0s`.
  */
 export function humanizeAlive(ms: number): string {
   const s = Math.max(0, Math.floor(ms / 1000));
   if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);
-  const rs = s % 60;
-  if (m < 60) return rs > 0 ? `${m}m${rs}s` : `${m}m`;
+  if (m < 60) return `${m}m${s % 60}s`;
   const h = Math.floor(m / 60);
-  const rm = m % 60;
-  return rm > 0 ? `${h}h${rm}m` : `${h}h`;
+  if (h < 24) return `${h}h${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d${h % 24}h`;
 }
 
 /**

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -52,9 +52,9 @@ describe("statusline — humanizeAlive", () => {
     expect(humanizeAlive(59 * 1000 + 999)).toBe("59s");
   });
 
-  it("renders Xm when an exact number of minutes", () => {
-    expect(humanizeAlive(5 * 60 * 1000)).toBe("5m");
-    expect(humanizeAlive(60 * 1000)).toBe("1m");
+  it("always shows seconds at minute scale, even when zero", () => {
+    expect(humanizeAlive(5 * 60 * 1000)).toBe("5m0s");
+    expect(humanizeAlive(60 * 1000)).toBe("1m0s");
   });
 
   it("renders XmYs when seconds remain under an hour", () => {
@@ -62,9 +62,9 @@ describe("statusline — humanizeAlive", () => {
     expect(humanizeAlive((1 * 60 + 1) * 1000)).toBe("1m1s");
   });
 
-  it("renders Xh when an exact number of hours", () => {
-    expect(humanizeAlive(1 * 60 * 60 * 1000)).toBe("1h");
-    expect(humanizeAlive(2 * 60 * 60 * 1000)).toBe("2h");
+  it("always shows minutes at hour scale, even when zero", () => {
+    expect(humanizeAlive(1 * 60 * 60 * 1000)).toBe("1h0m");
+    expect(humanizeAlive(2 * 60 * 60 * 1000)).toBe("2h0m");
   });
 
   it("renders XhYm when minutes remain", () => {
@@ -74,6 +74,12 @@ describe("statusline — humanizeAlive", () => {
 
   it("drops the seconds part at hour scale", () => {
     expect(humanizeAlive((1 * 60 * 60 + 22 * 60 + 45) * 1000)).toBe("1h22m");
+  });
+
+  it("always shows hours at day scale, even when zero", () => {
+    expect(humanizeAlive(24 * 60 * 60 * 1000)).toBe("1d0h");
+    expect(humanizeAlive((25 * 60 * 60 + 30 * 60) * 1000)).toBe("1d1h");
+    expect(humanizeAlive((2 * 24 * 60 * 60 + 10 * 60 * 60) * 1000)).toBe("2d10h");
   });
 
   it("renders 0s for zero or negative input", () => {


### PR DESCRIPTION
Worker alive-duration collapsed to a lone number at exact hour/minute boundaries (`1h`, `5m`), so a multi-hour worker read as "only hours".

**New format** — always the two most-significant units once past the seconds floor, plus a day tier:

| input | before | after |
|---|---|---|
| 10s | `10s` | `10s` |
| 60s | `1m` | `1m0s` |
| 5m40s | `5m40s` | `5m40s` |
| 1h | `1h` | `1h0m` |
| 1h22m | `1h22m` | `1h22m` |
| 25h30m | `25h30m` | `1d1h` |

Tests updated + day-tier cases added; `apps/dev` vitest + tsc green.

https://claude.ai/code/session_01QzbcZiV9mB6jy9keMuG7Pp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785774773&installation_id=129708444&pr_number=1128&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1128&signature=1c973239075d3254a54ecc41cc0e4a2962497d1aa48b4ad756db8c03bd7c31bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration formatting in the status line so larger time values now consistently show the next smaller unit, even when it is zero.
  * Examples now render as `1h0m`, `2h0m`, and multi-day values like `1d0h` instead of dropping the lower unit.
  * Negative durations still display as `0s`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->