### PR TITLE
merge: #1130 Implement /go Definition-of-Done gate (guaranteed termination) — ADR 0081 Amendment 1

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -18,11 +18,13 @@ import {
   parseGoMode,
   DEFAULT_GO_MODE,
   GO_WORKERS_SEGMENT,
+  type GoDodSpec,
   type DisposableIssueSpec,
   type GoMode,
 } from "../core/go.js";
+import { loadConfig, readBackpressure } from "../core/config.js";
 import { dispatchScout, SCOUT_WORKERS_SEGMENT, type ScoutIssueSpec } from "../core/scout.js";
-import { resolveRepoContext } from "../runtime/wire.js";
+import { afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { runCommand } from "./run.js";
 import * as ghx from "../runtime/gh.js";
 import type { GhContext } from "../runtime/gh.js";
@@ -35,12 +37,14 @@ import type { GhContext } from "../runtime/gh.js";
  * demand through. */
 export function parseGoArgs(
   args: readonly string[],
-): { demand: string; runner?: string; mode: GoMode; yolo: boolean; scout?: boolean } {
+): { demand: string; runner?: string; mode: GoMode; yolo: boolean; scout?: boolean; dod?: string; verifyCommand?: string } {
   const positional: string[] = [];
   let runner: string | undefined;
   let mode: GoMode = DEFAULT_GO_MODE;
   let yolo = false;
   let scout = false;
+  let dod: string | undefined;
+  let verifyCommand: string | undefined;
   let sawDoubleDash = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -66,6 +70,24 @@ export function parseGoArgs(
     }
     if (!sawDoubleDash && arg === "+yolo") { yolo = true; continue; }
     if (!sawDoubleDash && arg === "--scout") { scout = true; continue; }
+    if (!sawDoubleDash && arg === "--dod") {
+      dod = args[++i];
+      if (dod === undefined) throw new Error("--dod requires a value");
+      continue;
+    }
+    if (!sawDoubleDash && arg.startsWith("--dod=")) {
+      dod = arg.slice("--dod=".length);
+      continue;
+    }
+    if (!sawDoubleDash && arg === "--verify") {
+      verifyCommand = args[++i];
+      if (verifyCommand === undefined) throw new Error("--verify requires a value");
+      continue;
+    }
+    if (!sawDoubleDash && arg.startsWith("--verify=")) {
+      verifyCommand = arg.slice("--verify=".length);
+      continue;
+    }
     // Unknown `--flag` before the `--` separator is an error, never demand text
     // (#1045): folding e.g. `--resume 1043` into the demand silently minted a
     // junk issue about a flag the user meant as a command. A literal dashed
@@ -73,16 +95,17 @@ export function parseGoArgs(
     if (!sawDoubleDash && arg.startsWith("--")) {
       throw new Error(
         `unknown flag ${JSON.stringify(arg)}: expected --runner/-r, --mode, --scout, or +yolo. ` +
+          `Also accepted for standard /go: --dod and --verify. ` +
           `Pass a literal dashed demand after a "--" separator.`,
       );
     }
     positional.push(arg);
   }
-  return { demand: positional.join(" ").trim(), runner, mode, yolo, scout };
+  return { demand: positional.join(" ").trim(), runner, mode, yolo, scout, dod, verifyCommand };
 }
 
 export async function goCommand(args: string[], cwd = process.cwd()): Promise<number> {
-  let parsed: { demand: string; runner?: string; mode: GoMode; yolo: boolean; scout?: boolean };
+  let parsed: { demand: string; runner?: string; mode: GoMode; yolo: boolean; scout?: boolean; dod?: string; verifyCommand?: string };
   try {
     parsed = parseGoArgs(args);
   } catch (error) {
@@ -100,6 +123,7 @@ export async function goCommand(args: string[], cwd = process.cwd()): Promise<nu
 
   const ctx = await resolveRepoContext(cwd);
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  const configuredBackpressure = readBackpressure(loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined }));
 
   if (parsed.scout) {
     // Scout mode: read-only investigation, no commits / branch / PR / merge.
@@ -141,7 +165,15 @@ export async function goCommand(args: string[], cwd = process.cwd()): Promise<nu
         runEngine: (engineArgs) => runCommand({ args: engineArgs, cwd }),
       },
       parsed.demand,
-      { runner: parsed.runner, mode: parsed.mode, yolo: parsed.yolo },
+      {
+        runner: parsed.runner,
+        mode: parsed.mode,
+        yolo: parsed.yolo,
+        task: parsed.demand,
+        dod: parsed.dod,
+        verifyCommand: parsed.verifyCommand,
+        hasHarness: configuredBackpressure.length > 0,
+      } satisfies { runner?: string; mode: GoMode; yolo: boolean } & GoDodSpec,
     );
     process.stdout.write(
       `🚀 /go dispatched disposable issue #${result.issue} ` +

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -131,6 +131,11 @@ interface ParsedRunFlags {
   localMerge: boolean;
   /** --yolo: the opt-in autonomy bump (`/go +yolo`, issue #923). */
   yolo: boolean;
+  /** --verify <cmd>: one-shot inline command appended to backpressure for a
+   * single `/go` dispatch when no configured harness exists. */
+  verifyCommand?: string;
+  /** --go-verify-retries <n>: bounded post-DONE machine-gate retry cap for `/go`. */
+  goVerifyRetries?: number;
   /** --run-mode <mode>: execution mode modifier forwarded to `processIssue`.
    * `"scout"` activates the read-only investigation path — no commits, no push,
    * no PR, no merge; the agent report is posted as a comment and the disposable
@@ -271,6 +276,8 @@ const RUN_FLAG_SCHEMA = {
   "pre-pr": { kind: "boolean" },
   "local-merge": { kind: "boolean" },
   yolo: { kind: "boolean" },
+  verify: { kind: "value", coerce: (raw: string): string => raw },
+  "go-verify-retries": { kind: "value", coerce: (raw: string): number => Number(raw) },
   "run-mode": { kind: "value", coerce: (raw: string): string => raw },
   force: { kind: "boolean" },
 } satisfies FlagSchema;
@@ -326,6 +333,11 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     prePr: values["pre-pr"] === true,
     localMerge: values["local-merge"] === true,
     yolo: values.yolo === true,
+    verifyCommand: values.verify as string | undefined,
+    goVerifyRetries:
+      typeof values["go-verify-retries"] === "number" && Number.isFinite(values["go-verify-retries"])
+        ? values["go-verify-retries"] as number
+        : undefined,
     runMode: values["run-mode"] as string | undefined,
     force: values.force === true,
   };
@@ -638,6 +650,8 @@ export function buildProcessDeps(
   attemptTimeoutSeconds?: number,
   laneIdle?: LaneIdleStallConfig,
   attemptBudget?: AttemptBudget,
+  inlineVerifyCommand?: string,
+  goVerifyRetries?: number,
 ): ProcessIssueDeps {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
   const gitCtx: GitContext = { cwd: ctx.root, exec };
@@ -722,6 +736,12 @@ export function buildProcessDeps(
   // call. When enabled, processIssue wraps the inner invocation in a bounded
   // outer loop carrying an accumulated `notes.md` between iterations.
   const notesLoop = resolveNotesLoopConfig(config);
+
+  const backpressureCommands = readBackpressure(config);
+  const mergedBackpressureCommands =
+    inlineVerifyCommand && inlineVerifyCommand.trim() !== ""
+      ? [...backpressureCommands, inlineVerifyCommand.trim()]
+      : backpressureCommands;
 
   return {
     gh: {
@@ -867,7 +887,8 @@ export function buildProcessDeps(
     // Backpressure gate (#430, PRD #429): operator-declared `afk.backpressure`
     // shell commands run against the same worker-branch checkout after feedback.
     backpressure: feedback.backpressure,
-    backpressureCommands: readBackpressure(config),
+    backpressureCommands: mergedBackpressureCommands,
+    goVerifyRetries,
     // Post-attempt-format step (#1015): operator-declared `afk.post_attempt_format`
     // commands run BEFORE the feedback gate and auto-commit any formatting delta.
     postAttemptFormat: feedback.postAttemptFormat,
@@ -1737,7 +1758,22 @@ export async function runCommand(options: RunOptions): Promise<number> {
       if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }).catch(() => {});
       return result;
     },
-    processDeps: buildProcessDeps(ctx, settings.model, settings.sandbox, feedback, current, flags.fallbackRunner, runner, undefined, settings.maxIterations, settings.attemptTimeoutSeconds, settings.laneIdle, settings.attemptBudget),
+    processDeps: buildProcessDeps(
+      ctx,
+      settings.model,
+      settings.sandbox,
+      feedback,
+      current,
+      flags.fallbackRunner,
+      runner,
+      undefined,
+      settings.maxIterations,
+      settings.attemptTimeoutSeconds,
+      settings.laneIdle,
+      settings.attemptBudget,
+      flags.verifyCommand,
+      flags.goVerifyRetries,
+    ),
     // Session-scoped lifecycle hooks (PRD #207): compose the same config /
     // resolver / exec / env the process deps use, so session + per-issue points
     // share one dispatcher rather than duplicating the wiring.

--- a/apps/dev/src/core/go.ts
+++ b/apps/dev/src/core/go.ts
@@ -68,6 +68,17 @@ export const GO_MODE_ENGINE_FLAG: Record<GoMode, string | null> = {
 /** The engine flag the opt-in `+yolo` autonomy bump appends. */
 export const GO_YOLO_FLAG = "--yolo";
 
+/** One-shot inline verification command used only when a `/go` confirmation
+ * approved an ephemeral machine gate for a repo with no configured harness. */
+export const GO_VERIFY_FLAG = "--verify";
+
+/** Bounded post-DONE machine-gate retry cap for `/go` dispatches. */
+export const DEFAULT_GO_VERIFY_RETRIES = 2;
+
+/** Tight cap for check-less `/go` dispatches when the maintainer declined an
+ * ephemeral inline check in a repo with no configured harness/backpressure. */
+export const GO_NO_HARNESS_ITER_CAP = 3;
+
 /**
  * Resolve a raw `--mode` value to a canonical {@link GoMode}, case-insensitively
  * (so `Direct-PR` and `NO-MISTAKES` both parse). Throws on any unknown value so
@@ -89,6 +100,17 @@ export interface DisposableIssueSpec {
   labels: string[];
 }
 
+export interface GoDodSpec {
+  /** The maintainer-approved high-detail rewrite of the demand. */
+  task?: string;
+  /** The maintainer-approved semantic Definition of Done. */
+  dod?: string;
+  /** Optional one-shot machine gate appended to backpressure for this dispatch. */
+  verifyCommand?: string;
+  /** True when the repo already has a configured harness/backpressure gate. */
+  hasHarness?: boolean;
+}
+
 function firstLine(s: string): string {
   const nl = s.indexOf("\n");
   return (nl === -1 ? s : s.slice(0, nl)).trim();
@@ -100,14 +122,35 @@ function firstLine(s: string): string {
  * fleet's candidate listing (which lists `ready-for-agent`) can never surface
  * it. Throws on an empty demand so `/go` never mints a contentless issue.
  */
-export function buildDisposableIssue(demand: string): DisposableIssueSpec {
+export function buildDisposableIssue(demand: string, dodSpec: GoDodSpec = {}): DisposableIssueSpec {
   const text = demand.trim();
   if (!text) throw new Error("/go requires a non-empty demand");
   const title = `/go: ${firstLine(text).slice(0, 72) || "dispatch"}`;
+  const task = (dodSpec.task ?? text).trim();
+  const dod = dodSpec.dod?.trim();
+  const verifyCommand = dodSpec.verifyCommand?.trim();
+  const machineGate =
+    verifyCommand && verifyCommand.length > 0
+      ? `Ephemeral inline check for this dispatch: \`${verifyCommand}\`.`
+      : dodSpec.hasHarness === false
+        ? "No configured harness/backpressure was approved for this dispatch; run best-effort under the tightened iteration cap."
+        : "Configured `afk.backpressure` plus the auto-derived feedback gate (`test`/`typecheck`/`lint`/`build`).";
   const body = [
-    "## Demand",
+    dod ? "## Task" : "## Demand",
     "",
-    text,
+    dod ? task : text,
+    ...(dod
+      ? [
+          "",
+          "## Acceptance Criteria",
+          "",
+          dod,
+          "",
+          "## Machine Gate",
+          "",
+          machineGate,
+        ]
+      : []),
     "",
     "---",
     "",
@@ -138,6 +181,9 @@ export function buildGoEngineArgs(opts: {
   runner?: string;
   mode?: GoMode;
   yolo?: boolean;
+  verifyCommand?: string;
+  hasHarness?: boolean;
+  verifyRetries?: number;
 }): string[] {
   if (!Number.isInteger(opts.issue) || opts.issue <= 0) {
     throw new Error(`buildGoEngineArgs: invalid issue ${opts.issue}`);
@@ -156,6 +202,10 @@ export function buildGoEngineArgs(opts: {
   const modeFlag = GO_MODE_ENGINE_FLAG[opts.mode ?? DEFAULT_GO_MODE];
   if (modeFlag) args.push(modeFlag);
   if (opts.yolo) args.push(GO_YOLO_FLAG);
+  const verifyCommand = opts.verifyCommand?.trim();
+  if (verifyCommand) args.push(GO_VERIFY_FLAG, verifyCommand);
+  if (opts.hasHarness === false && !verifyCommand) args.push("-n", String(GO_NO_HARNESS_ITER_CAP));
+  if (opts.verifyRetries !== undefined) args.push("--go-verify-retries", String(opts.verifyRetries));
   if (opts.runner) args.push("--runner", opts.runner);
   return args;
 }
@@ -186,13 +236,20 @@ export interface GoDispatchResult {
 export async function dispatchGo(
   deps: GoDispatchDeps,
   demand: string,
-  opts: { runner?: string; mode?: GoMode; yolo?: boolean } = {},
+  opts: { runner?: string; mode?: GoMode; yolo?: boolean } & GoDodSpec = {},
 ): Promise<GoDispatchResult> {
-  const spec = buildDisposableIssue(demand);
+  const spec = buildDisposableIssue(demand, opts);
   await deps.ensureLabel(LABEL_GO_LANE);
   const issue = await deps.createIssue(spec);
   const engineExit = await deps.runEngine(
-    buildGoEngineArgs({ issue, runner: opts.runner, mode: opts.mode, yolo: opts.yolo }),
+    buildGoEngineArgs({
+      issue,
+      runner: opts.runner,
+      mode: opts.mode,
+      yolo: opts.yolo,
+      verifyCommand: opts.verifyCommand,
+      hasHarness: opts.hasHarness,
+    }),
   );
   return { issue, engineExit };
 }

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -107,6 +107,7 @@ import type { AttemptStatus } from "./envelope.js";
 import type { Runner } from "../types/runner.js";
 import { runnerSupportsStructuredOutput, toAgentRunner } from "./runner-spec.js";
 import type { HistoryClock } from "./history.js";
+import { DEFAULT_GO_VERIFY_RETRIES, LABEL_GO_LANE } from "./go.js";
 
 type ContainerSandboxMode = Exclude<SandboxMode, "none">;
 
@@ -314,6 +315,12 @@ export interface ProcessIssueDeps {
    * scope-derived feedback gate; it does not replace it.
    */
   backpressureCommands?: readonly string[];
+  /**
+   * `/go` only: bounded number of post-DONE machine-gate correction attempts.
+   * The initial DONE validation is not counted; a value of 2 allows two
+   * correct-and-re-verify agent invocations before deterministic escalation.
+   */
+  goVerifyRetries?: number;
   /**
    * Shell executor for the post-attempt-format step (#1015): runs each
    * `afk.post_attempt_format` command in the worker-branch checkout AFTER the
@@ -868,6 +875,40 @@ function parseFeedbackClass(contextJson: string): "infra" | "semantic" | null {
   }
 }
 
+function resolveGoVerifyRetries(deps: ProcessIssueDeps): number {
+  const raw = deps.recoveryEnv?.RED_GO_VERIFY_RETRIES;
+  const parsed = raw === undefined ? NaN : Number(raw);
+  if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+  if (deps.goVerifyRetries !== undefined && Number.isInteger(deps.goVerifyRetries) && deps.goVerifyRetries >= 0) {
+    return deps.goVerifyRetries;
+  }
+  return DEFAULT_GO_VERIFY_RETRIES;
+}
+
+function tailLines(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  return lines.slice(Math.max(0, lines.length - maxLines)).join("\n");
+}
+
+function appendGoVerifyRetryHandoff(
+  handoff: string,
+  opts: { gate: "feedback" | "backpressure"; validation: string; retry: number; cap: number },
+): string {
+  return [
+    handoff.replace(/\n+$/, ""),
+    "",
+    "<go-machine-gate-retry>",
+    `The ${opts.gate} machine gate failed after DONE. This is bounded correction retry ${opts.retry}/${opts.cap}.`,
+    "Fix the failure on the existing branch, run the relevant gate, commit only the needed changes, then emit the required terminal sentinel.",
+    "",
+    "<validation-tail>",
+    tailLines(opts.validation, 80),
+    "</validation-tail>",
+    "</go-machine-gate-retry>",
+    "",
+  ].join("\n");
+}
+
 interface UntrustedSandboxDecision {
   sandboxMode: SandboxMode;
   authorTrusted: boolean;
@@ -1228,6 +1269,8 @@ export async function processIssue(
   };
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
+  let currentHandoff = handoff;
+  let goVerifyRetriesUsed = 0;
   let salvagedUncommittedFiles = 0;
   let salvagedUncommittedOutcome: RunAgentResult["outcome"] | undefined;
   let salvagedRunCommitCount = 0;
@@ -1257,6 +1300,26 @@ export async function processIssue(
         : "backpressure validation failed after the feedback gate passed";
     return `${prefix}; AFK salvaged ${salvagedUncommittedFiles} uncommitted file(s), but ${gateText}. The worker branch was not merged.`;
   };
+  const goVerifyRetryCap = resolveGoVerifyRetries(deps);
+  const retryGoMachineGate = async (gate: "feedback" | "backpressure", validation: string): Promise<boolean> => {
+    if (input.laneLabel !== LABEL_GO_LANE) return false;
+    if (goVerifyRetriesUsed >= goVerifyRetryCap) return false;
+    goVerifyRetriesUsed += 1;
+    attemptN += 1;
+    currentHandoff = appendGoVerifyRetryHandoff(handoff, {
+      gate,
+      validation,
+      retry: goVerifyRetriesUsed,
+      cap: goVerifyRetryCap,
+    });
+    deps.appendIterLog(
+      `🤖 /go: ${gate} machine gate failed after DONE; correction retry ${goVerifyRetriesUsed}/${goVerifyRetryCap}.`,
+    );
+    return await fireHook(
+      "pre_attempt",
+      hookContext({ issue, title: input.title, workspace: branch, runner: activeRunner, attempt_n: attemptN }),
+    );
+  };
 
   while (true) {
     const initialTier = resolveSpawnTier(deps, activeRunner, activeTaskClass);
@@ -1270,7 +1333,7 @@ export async function processIssue(
       model: initialTier.model,
       effort: initialTier.effort,
       handoffPath,
-      handoffContent: handoff,
+      handoffContent: currentHandoff,
       // Structured-output rollout (ADR 0090, #932): a schema-enabled runner gets
       // the AgentOutput emit clause; others keep the text-sentinel-only protocol.
       systemPrompt: exitProtocolFor({
@@ -1347,7 +1410,7 @@ export async function processIssue(
     };
     const notesOutcome = await runNotesLoop({
       config: notesLoopCfg,
-      baseHandoff: handoff,
+      baseHandoff: currentHandoff,
       runOnce: ({ handoff: iterationHandoff }) =>
         deps.runAgent({
           ...baseAgentInput,
@@ -1400,7 +1463,7 @@ export async function processIssue(
         model: fallbackTier.model,
         effort: fallbackTier.effort,
         handoffPath,
-        handoffContent: handoff,
+        handoffContent: currentHandoff,
         systemPrompt: exitProtocolFor({
           runMode: input.runMode,
           structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(other)),
@@ -1885,9 +1948,13 @@ export async function processIssue(
       const scopeHeader = feedback.validationScope
         ? `${formatValidationScope(feedback.validationScope)}\n`
         : "";
+      const validationText = `${scopeHeader}${feedback.sidecar.join("\n")}`;
+      if (!isInfra && await retryGoMachineGate("feedback", validationText)) {
+        continue;
+      }
       return await terminalFailure(common, outcome, "feedback", {
         notes,
-        validation: `${scopeHeader}${feedback.sidecar.join("\n")}`,
+        validation: validationText,
       }, { validationSummary: feedback.sidecar.join("\n") });
     }
 
@@ -1916,10 +1983,14 @@ export async function processIssue(
           salvagedUncommittedFiles > 0
             ? salvagedUncommittedNotes("backpressure")
             : "Backpressure validation failed after the feedback gate passed. The worker branch was not merged.";
+        const validationText = backpressure.sidecar.join("\n");
+        if (await retryGoMachineGate("backpressure", validationText)) {
+          continue;
+        }
         return await terminalFailure(common, "feedback-failed", "feedback", {
           notes,
-          validation: backpressure.sidecar.join("\n"),
-        }, { validationSummary: backpressure.sidecar.join("\n") });
+          validation: validationText,
+        }, { validationSummary: validationText });
       }
     }
     // Both gates passed — the close path's sidecar/envelope carries their union.

--- a/apps/dev/tests/go-command.test.ts
+++ b/apps/dev/tests/go-command.test.ts
@@ -9,6 +9,8 @@ describe("parseGoArgs", () => {
       mode: "direct-PR",
       yolo: false,
       scout: false,
+      dod: undefined,
+      verifyCommand: undefined,
     });
   });
 
@@ -35,6 +37,33 @@ describe("parseGoArgs", () => {
     expect(() => parseGoArgs(["do it", "--frobnicate"])).toThrow(/unknown flag/);
     // …but a genuinely dashed demand still passes through after the `--` separator.
     expect(parseGoArgs(["--", "--resume", "1043"]).demand).toBe("--resume 1043");
+  });
+
+  it("parses --dod without treating it as a demand or skipping confirmation", () => {
+    expect(parseGoArgs(["do it", "--dod", "tests pass and docs updated"])).toMatchObject({
+      demand: "do it",
+      dod: "tests pass and docs updated",
+    });
+    expect(parseGoArgs(["--dod=done means green gate", "do it"])).toMatchObject({
+      demand: "do it",
+      dod: "done means green gate",
+    });
+  });
+
+  it("parses an ephemeral inline --verify command for one dispatch", () => {
+    expect(parseGoArgs(["do it", "--verify", "npm run test -- go"])).toMatchObject({
+      demand: "do it",
+      verifyCommand: "npm run test -- go",
+    });
+    expect(parseGoArgs(["--verify=pnpm test", "do it"])).toMatchObject({
+      demand: "do it",
+      verifyCommand: "pnpm test",
+    });
+  });
+
+  it("throws when --dod or --verify has no value", () => {
+    expect(() => parseGoArgs(["do it", "--dod"])).toThrow(/requires a value/);
+    expect(() => parseGoArgs(["do it", "--verify"])).toThrow(/requires a value/);
   });
 
   it("throws when --runner has no value", () => {

--- a/apps/dev/tests/go.test.ts
+++ b/apps/dev/tests/go.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_GO_MODE,
+  DEFAULT_GO_VERIFY_RETRIES,
+  GO_NO_HARNESS_ITER_CAP,
   GO_GATE_CONTEXT,
   GO_MODES,
   GO_ORIGIN,
@@ -26,6 +28,21 @@ describe("buildDisposableIssue", () => {
     expect(spec.title).toBe("/go: add a retry to the uploader");
     expect(spec.body).toContain("add a retry to the uploader\nwith backoff");
     expect(spec.body).toContain("auto-closes");
+  });
+
+  it("records the approved Task, semantic DoD, and machine gate on the disposable issue", () => {
+    const spec = buildDisposableIssue("short demand", {
+      task: "Detailed approved task with implementation boundaries.",
+      dod: "The command stops once the login retry is implemented and covered by tests.",
+      verifyCommand: "npm run test -- login",
+    });
+
+    expect(spec.body).toContain("## Task");
+    expect(spec.body).toContain("Detailed approved task with implementation boundaries.");
+    expect(spec.body).toContain("## Acceptance Criteria");
+    expect(spec.body).toContain("The command stops once the login retry is implemented");
+    expect(spec.body).toContain("## Machine Gate");
+    expect(spec.body).toContain("npm run test -- login");
   });
 
   it("truncates an overlong title to 72 chars", () => {
@@ -100,6 +117,19 @@ describe("buildGoEngineArgs", () => {
     expect(both).toContain("--yolo");
   });
 
+  it("threads an ephemeral inline verification command into the reused engine", () => {
+    const args = buildGoEngineArgs({ issue: 7, verifyCommand: "npm run test -- login" });
+    expect(args).toContain("--verify");
+    expect(args).toContain("npm run test -- login");
+  });
+
+  it("tightens the iteration cap when no harness exists and no inline check was approved", () => {
+    const args = buildGoEngineArgs({ issue: 7, hasHarness: false });
+    expect(args).toContain("-n");
+    expect(args).toContain(String(GO_NO_HARNESS_ITER_CAP));
+    expect(DEFAULT_GO_VERIFY_RETRIES).toBe(2);
+  });
+
   it("keeps --runner last after the mode/yolo flags", () => {
     const args = buildGoEngineArgs({ issue: 7, mode: "local-only", yolo: true, runner: "codex" });
     expect(args.slice(-2)).toEqual(["--runner", "codex"]);
@@ -167,6 +197,27 @@ describe("dispatchGo", () => {
     const args = runEngine.mock.calls[0]![0];
     expect(args).toContain("--local-merge");
     expect(args).toContain("--yolo");
+  });
+
+  it("mints the issue with the approved Task + DoD before running the reused engine", async () => {
+    const createIssue = vi.fn(async (_spec: DisposableIssueSpec) => 77);
+    const runEngine = vi.fn(async (_args: string[]) => 0);
+    await dispatchGo(
+      { ensureLabel: async () => {}, createIssue, runEngine },
+      "ship it",
+      {
+        task: "Approved detailed task",
+        dod: "Done when the approved acceptance statement is satisfied.",
+        verifyCommand: "npm run test -- go",
+      },
+    );
+
+    const spec = createIssue.mock.calls[0]![0];
+    expect(spec.body).toContain("Approved detailed task");
+    expect(spec.body).toContain("Done when the approved acceptance statement is satisfied.");
+    expect(runEngine).toHaveBeenCalledWith(
+      buildGoEngineArgs({ issue: 77, verifyCommand: "npm run test -- go" }),
+    );
   });
 
   it("propagates a non-zero engine exit", async () => {

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -131,6 +131,8 @@ interface HarnessOptions {
   attempt?: number;
   /** Env view the recovery policy reads RED_AFK_RETRY_* caps from. Defaults to {}. */
   recoveryEnv?: Record<string, string>;
+  /** /go post-DONE machine-gate retry cap injected by run.ts. */
+  goVerifyRetries?: number;
   /** When set, register the ADR 0017 `recordAttempt` port. "throw" makes it
    * reject (proving a memory failure never fails the close); "ok" records the
    * payload; undefined omits the port entirely (older-caller safety). */
@@ -392,6 +394,7 @@ function harness(opts: HarnessOptions = {}): {
       stderr: "",
     }),
     backpressureCommands: opts.backpressureCommands,
+    goVerifyRetries: opts.goVerifyRetries,
     sandboxMode: opts.sandboxMode ?? "none",
     sandboxAvailable: async (mode) => (opts.availableSandboxes ?? ["docker", "podman"]).includes(mode),
     // The sandcastle execution port: a fake returning a scripted outcome on the
@@ -1448,6 +1451,61 @@ describe("processIssue — feedback fail", () => {
       "on_feedback_classify",
     ]);
     expect(trace.pushedAttempt).toEqual([]);
+  });
+
+  it("/go retries a red post-DONE machine gate up to RED_GO_VERIFY_RETRIES, then parks with blocked:validation", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackResults: [false, false],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "1" },
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<go-machine-gate-retry>");
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("bounded correction retry 1/1");
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
+    expect(trace.closed).toEqual([]);
+  });
+
+  it("/go lands when a bounded machine-gate correction makes feedback green", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackResults: [false, true],
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "2" },
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.labelEdits.some((e) => e.add.includes("blocked:validation"))).toBe(false);
+  });
+
+  it("/go also bounds backpressure re-verification and carries the failing output into the retry handoff", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: false,
+      goVerifyRetries: 1,
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    const retryHandoff = trace.runAgentCalls[1]?.handoffContent ?? "";
+    expect(retryHandoff).toContain("<go-machine-gate-retry>");
+    expect(retryHandoff).toContain("backpressure machine gate failed");
+    expect(retryHandoff).toContain("npm run e2e exploded");
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:validation"))).toBe(true);
   });
 
   it("retries a simple-classified feedback failure once on the complex tier, then lands when green", async () => {

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -65,6 +65,8 @@ describe("parseRunFlags", () => {
       prePr: false,
       localMerge: false,
       yolo: false,
+      verifyCommand: undefined,
+      goVerifyRetries: undefined,
       force: false,
     });
   });
@@ -78,6 +80,12 @@ describe("parseRunFlags", () => {
     expect(d.prePr).toBe(false);
     expect(d.localMerge).toBe(false);
     expect(d.yolo).toBe(false);
+  });
+
+  it("parses the /go inline verify command and bounded verify retry cap", () => {
+    const f = parseRunFlags(["--verify", "npm run test -- go", "--go-verify-retries", "3"]);
+    expect(f.verifyCommand).toBe("npm run test -- go");
+    expect(f.goVerifyRetries).toBe(3);
   });
 
   it("parses --boot-only as a boolean, defaulting to false", () => {

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
 description: Semi-structured front door between `/goal` and `/afk` — `/go "<demand>"` mints a disposable tracking issue in an isolated lane (out of `ready-for-agent`, so a running fleet can never claim it), spins a dedicated namespaced worker under `.red/tmp/go-workers/`, reuses the whole AFK engine end-to-end with `origin=go` and the interactive gate, and brings back a PR. Add `--scout "<question>"` for a read-only investigation that posts a report comment and mutates nothing (no branch/PR/merge). Works with or without a fleet running.
-argument-hint: "\"<demand>\" [--mode no-mistakes|direct-PR|local-only] [--runner claude|codex|opencode] [+yolo] | --scout \"<question>\" [--runner ...]"
+argument-hint: "\"<approved-task>\" --dod \"<definition-of-done>\" [--verify \"<cmd>\"] [--mode no-mistakes|direct-PR|local-only] [--runner claude|codex|opencode] [+yolo] | --scout \"<question>\" [--runner ...]"
 ---
 
 # /go
@@ -12,13 +12,31 @@ Add `--scout` to investigate without touching any code: the agent reads the code
 
 <what-to-do>
 
+## Mandatory confirmation gate for code-producing `/go`
+
+For standard `/go` (anything except `--scout`), do **not** dispatch immediately.
+Before invoking the bundle command, draft both:
+
+1. **Task** — rewrite the maintainer's demand in high detail, including scope, boundaries, files/areas likely involved, and what not to do.
+2. **Definition of Done** — the semantic stop condition: what must be true for the work to be considered complete.
+
+Then ask the maintainer exactly: **`Aprovado?`**
+
+Only after the maintainer approves do you run the `go` bundle command. The approved Task becomes the quoted command argument. The approved Definition of Done is passed with `--dod "<condition>"`, so it is recorded on the disposable `lane:go` issue and injected into the worker handoff.
+
+This gate is always required. `+yolo` only raises in-run autonomy; it never skips Task+DoD approval. `--dod "<condition>"` may pre-fill the Definition of Done draft, but it still requires maintainer approval before dispatch.
+
+At approval time, check whether the repo has configured machine validation (`afk.backpressure` / the normal feedback harness). If no harness is configured, offer one ephemeral inline check with `--verify "<cmd>"`; that command runs as backpressure for this single dispatch only. If the maintainer declines an inline check, proceed best-effort; the engine applies a tightened iteration cap so a check-less dispatch fails fast instead of looping.
+
+Scout mode is read-only and report-producing, so this Task+DoD gate does not apply to `/go --scout`.
+
 **Run the bundle — do not read its source.** This SKILL.md is the contract; the `dev` bundle's `go` command is a build artifact.
 
 Invoke the dev CLI's `go` command with the demand as a single quoted argument:
 
 ```
 # Standard /go — ships a PR (direct-PR is the default mode)
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<demand>" [--mode <mode>] [--runner <runner>] [+yolo]
+RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
 
 # Scout mode — read-only investigation, posts a report comment, no branch/PR/merge
 RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go --scout "<question>" [--runner <runner>]
@@ -34,13 +52,18 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 
 **`+yolo`** is an opt-in autonomy bump — pass the literal token to raise the engine's autonomy for this one dispatch. It composes with any mode.
 
+**`--dod "<condition>"`** records the approved semantic Definition of Done on the disposable issue and in the handoff. It is confirmation sugar only; it never bypasses the required approval turn.
+
+**`--verify "<cmd>"`** adds a one-off inline machine check for this dispatch. Use it only when the repo lacks a configured harness/backpressure and the maintainer approved the command during the confirmation gate.
+
 **What standard `/go` does, in order (all reused from the AFK engine — not a parallel path):**
 
-1. **Mints a disposable tracking issue** in the isolated `lane:go` lane — labelled `lane:go` and **never** `ready-for-agent`, so a running fleet's candidate listing can never surface it.
+1. **Mints a disposable tracking issue** in the isolated `lane:go` lane — labelled `lane:go` and **never** `ready-for-agent`, so a running fleet's candidate listing can never surface it. The issue is minted only after Task+DoD approval; its body carries the approved Task, the approved semantic Definition of Done, and the machine gate reference.
 2. **Spins a dedicated namespaced worker** under `.red/tmp/go-workers/` (separate from `/afk`'s `.red/tmp/workers/`) via `RED_AFK_WORKERS_NAMESPACE=go-workers` — no collision with the fleet.
 3. **Processes the issue in an isolated worktree**, stamping `origin=go` on the worker so the monitor/statusline show it as a distinct source.
 4. **Runs the shared validation gate** with the **interactive** (pause/ask) escalation sink: mechanical findings auto-apply + commit; an intent finding pauses and asks you to approve / fix / skip.
-5. **Brings back a PR**; the disposable issue **auto-closes on merge** (the engine's PR body carries `Closes #N`).
+5. **Runs bounded post-DONE machine-gate correction** for `/go`: if feedback/backpressure fails after the inner agent emits DONE, the engine re-seeds the agent with the failing validation tail under a small `RED_GO_VERIFY_RETRIES` cap, then deterministically parks to `ready-for-human` / `blocked:validation` when the cap is exhausted.
+6. **Brings back a PR**; the disposable issue **auto-closes on merge** (the engine's PR body carries `Closes #N`).
 
 **What `--scout` does differently:**
 
@@ -53,11 +76,13 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 **Hard rules:**
 
 - ✅ **Do** pass the demand/question as ONE quoted argument.
+- ✅ **Do** get Task+DoD approval before standard `/go`, then pass the approved DoD with `--dod`.
 - ✅ **Do** use `--scout` when you want an audit, investigation, or read-only analysis — not a code change.
 - ✅ **Do** let `/go` reuse the AFK engine end-to-end. It is the same worker / monitor / heartbeat / envelope path, only namespaced and mode-gated.
 - ✅ **Do** run it whether or not a fleet is up — `/go` is a self-sufficient front door.
 - ❌ Do **not** add `ready-for-agent` to the minted issue — lane isolation breaks.
 - ❌ Do **not** hand-mint the issue or hand-spawn a worker — call `go`, which does the lane + namespace + origin wiring as one unit.
+- ❌ Do **not** treat `+yolo` or a provided `--dod` as approval. The approval question still happens first.
 - ❌ Do **not** reach for `/go` for a directive you keep green conversationally (that is `/goal`) or for a whole backlog (that is a PRD → `/afk`).
 
 </what-to-do>


### PR DESCRIPTION
Automated AFK landing for #1130. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1130

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785781797&installation_id=129708444&pr_number=1131&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1131&signature=44f1c069cd7ab76b18113b934074eeb563761419d70fbb995ab1f88a16bb7901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->