### PR TITLE
merge: #1134 Dev trigger wave: user-only flips (curate, ff, handoff, setup-pre-commit, go) + description budget rewrites

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## setup-pre-commit (misc) — user-only flip: disable-model-invocation (issue #1134)
+
+- **status**: modified
+- **upstream**: `e74f006`
+- **why**: PRD #1132 trigger-wave — `setup-pre-commit` is an operational command always fired explicitly by the user; flipping removes its description from session context.
+- **what changed**: Added `disable-model-invocation: true` to frontmatter.
+
+## handoff (productivity) — user-only flip: disable-model-invocation (issue #1134)
+
+- **status**: modified
+- **upstream**: `b8be62f`
+- **why**: PRD #1132 trigger-wave — `handoff` is an operational command always fired explicitly by the user; flipping removes its description from session context.
+- **what changed**: Added `disable-model-invocation: true` to frontmatter.
+
 ## write-a-skill (productivity) — absorb the four-dimension skill-quality checklist (issue #1133)
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/curate/SKILL.md
+++ b/plugins/dev/skills/engineering/curate/SKILL.md
@@ -2,6 +2,7 @@
 name: curate
 description: Interactive Skill curator. Reads `memory curate skills --json`, groups Curatable-skill candidates by category (`stale`, `abandoned`, `frequently-failing`, `archive`), asks for explicit approval, archives the approved set recoverably with the approving category recorded in the manifest, and reverses any archive with `/curate --restore <name>`. With `--background`, files a single `ready-for-human` Issue listing candidates and never mutates a Skill file.
 argument-hint: "[--restore <skill-name>] [--background] (no arg = interactive curation flow)"
+disable-model-invocation: true
 ---
 
 **Archive Curatable skills recoverably — the engine uses `rename` only; never call `rm`, `unlink`, or `git rm`, because every archive reverses with `--restore <name>`.**

--- a/plugins/dev/skills/engineering/doctor/SKILL.md
+++ b/plugins/dev/skills/engineering/doctor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doctor
-description: Adoption/process doctor — report how fully a repo has adopted the RedSkills engineering stack (triage label vocabulary, AGENTS≡CLAUDE parity, Development-workflow adoption, statusline form, MCP wiring, blocked-label hygiene, `req:<PRD>` dependency-edge audit, version coherence, `.red/config.yaml` `plugins.dev.*` namespacing, `.red/.gitignore` self-ignore, installed `rs-*` workflow adoption, per-plugin runtime distribution health — enabled-vs-runtime, version drift, cache integrity). Read-only by default; `--fix` applies the canonical fix for every finding, gated per hard-to-reverse change. The recurring counterpart to the one-time `/setup-red-skills`. Use when asked "is our process round / is this repo set up right", "red doctor", "check adoption", "doctor --fix", before a large `/afk` drain, or to audit `reddb`/`red-ui`/`red-skills`-style repos against the canonical conventions.
+description: Adoption/process doctor — reports how fully a repo has adopted the RedSkills engineering stack. Read-only by default; `--fix` applies the canonical fix for every finding, gated per hard-to-reverse change. The recurring counterpart to the one-time `/setup-red-skills`. Use when asked "red doctor", "check adoption", before a large `/afk` drain, or to verify a repo against canonical conventions.
 argument-hint: "[--repo <path|owner/name>] [--fix]"
 ---
 

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: go
-description: Semi-structured front door between `/goal` and `/afk` — `/go "<demand>"` mints a disposable tracking issue in an isolated lane (out of `ready-for-agent`, so a running fleet can never claim it), spins a dedicated namespaced worker under `.red/tmp/go-workers/`, reuses the whole AFK engine end-to-end with `origin=go` and the interactive gate, and brings back a PR. Add `--scout "<question>"` for a read-only investigation that posts a report comment and mutates nothing (no branch/PR/merge). Works with or without a fleet running.
+description: Middle tier of the dispatch spectrum — `/goal` → `/go` → `/afk`. Use for genuinely untracked, ad-hoc, one-off demands only; anything that is or should be a tracked issue belongs to `/afk`. Mints a disposable issue, spins a dedicated worker, and brings back a PR. Add `--scout "<question>"` for a read-only investigation that posts a report comment and mutates nothing.
 argument-hint: "\"<approved-task>\" --dod \"<definition-of-done>\" [--verify \"<cmd>\"] [--mode no-mistakes|direct-PR|local-only] [--runner claude|codex|opencode] [+yolo] | --scout \"<question>\" [--runner ...]"
+disable-model-invocation: true
 ---
 
 # /go

--- a/plugins/dev/skills/engineering/hitl/SKILL.md
+++ b/plugins/dev/skills/engineering/hitl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hitl
-description: Resolve one ready-for-human issue by extracting the pending human decision, recording the maintainer answer as Human guidance, and moving the issue back to ready-for-agent when it becomes delegable.
+description: Resolve one ready-for-human issue by extracting the pending human decision, recording the maintainer answer as Human guidance, and moving the issue back to ready-for-agent when it becomes delegable. Use when the queue has ready-for-human issues, when a blocked issue needs a decision from you, or to drain pending human-in-the-loop gates.
 argument-hint: "[--issue N | --skip N,N]"
 ---
 

--- a/plugins/dev/skills/engineering/review-adrs/SKILL.md
+++ b/plugins/dev/skills/engineering/review-adrs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-adrs
-description: Review the `.red/adr/` set for contradictions, missing supersession links, staleness (paths/commands that moved), numbering collisions, and structurally controversial decisions, reconcile each finding with the maintainer through a one-question-at-a-time interview (like `/start`) — reaching agreement before any write — then consolidate every agreement into a single actionable PRD on the issue tracker via `/to-prd`. Use when asked to "review the ADRs", "are any ADRs conflicting / out of date / superseded", after adding or reversing an ADR, or to make a large ADR set navigable and turn its decision debt into scheduled work.
+description: Review the `.red/adr/` set for consistency issues, reconcile each finding with the maintainer through a one-question-at-a-time interview — reaching agreement before any write — then consolidate every agreement into a single actionable PRD on the issue tracker via `/to-prd`. Use when asked to "review the ADRs", after adding or reversing an ADR, or to turn ADR decision debt into scheduled work.
 ---
 
 # Review ADRs (decision-record interview → actionable PRD)

--- a/plugins/dev/skills/engineering/review/SKILL.md
+++ b/plugins/dev/skills/engineering/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Review a generated HTML artifact (plan, dashboard, or prototype) in the browser — opens the file via the annotation bridge, runs the layout-audit gate, long-polls for surgical human feedback (element + character range), and feeds the annotation back so the agent can iterate. Use when you have an HTML artifact ready for human review, want to replace the "screenshot + describe" loop with precise element-level annotations, or need to verify a rendered plan end-to-end.
+description: Human-driven annotation review for HTML artifacts — opens the file via the annotation bridge, long-polls for surgical human feedback (element + character range), and feeds the annotation back so the agent can iterate. Use when you have an HTML artifact ready for human review or want to replace the "screenshot + describe" loop with precise element-level annotations.
 argument-hint: "<html-file>"
 ---
 

--- a/plugins/dev/skills/in-progress/browser-review/SKILL.md
+++ b/plugins/dev/skills/in-progress/browser-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-review
-description: Open a generated HTML artifact (plan, dashboard, report, or built UI) for live human review — a human points at an exact element and character range and sends feedback, the agent polls that feedback back, and a layout-audit gate blocks "done" on a broken render. The human+agent+browser triangle, no cloud. Use when you have produced an HTML artifact and want surgical human annotation instead of "screenshot + describe in prose", or want a ground-truth render check before declaring UI work done.
+description: Open a generated HTML artifact for live human review — the human annotates an exact element and character range, the agent polls that feedback and iterates. A layout-audit gate blocks "done" on a broken render. Use when you want surgical element-level annotation instead of "screenshot + describe in prose", or need a ground-truth render check before declaring UI work done.
 ---
 
 <what-to-do>

--- a/plugins/dev/skills/knowledge/wiki/SKILL.md
+++ b/plugins/dev/skills/knowledge/wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki
-description: Operate the LLM Wiki — ingest a source (URL or file), query the wiki and optionally file the answer back as a page, or lint for contradictions/orphans/stale claims. Requires `/wiki-init` to have run. Routes by natural language ("ingest <url>", "query <question>", "lint") or by the verb at the start of the user's request.
+description: Operate the LLM Wiki — ingest a source (URL or file), query the wiki and optionally file the answer back as a page, or lint for contradictions/orphans/stale claims. Requires `/wiki-init` to have run. Use when ingesting a doc, asking a question against the knowledge base, or checking the wiki for contradictions and orphans.
 ---
 
 # wiki

--- a/plugins/dev/skills/misc/setup-pre-commit/SKILL.md
+++ b/plugins/dev/skills/misc/setup-pre-commit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: setup-pre-commit
 description: Set up Husky pre-commit hooks with lint-staged (Prettier), type checking, and tests in the current repo. Use when user wants to add pre-commit hooks, set up Husky, configure lint-staged, or add commit-time formatting/typechecking/testing.
+disable-model-invocation: true
 ---
 
 # Setup Pre-Commit Hooks

--- a/plugins/dev/skills/productivity/ff/SKILL.md
+++ b/plugins/dev/skills/productivity/ff/SKILL.md
@@ -2,6 +2,7 @@
 name: ff
 description: Reframes the user's message into one chosen framing through a two-step interaction — first asks which framing to rewrite into, then generates that single rewrite and asks whether to dispatch (execute) it. Use when the user invokes `/ff`, says fast-forward, asks to rewrite their own message, or wants to clarify intent before acting.
 argument-hint: "[--dispatch|-d] [text to reframe]"
+disable-model-invocation: true
 ---
 
 # /ff

--- a/plugins/dev/skills/productivity/handoff/SKILL.md
+++ b/plugins/dev/skills/productivity/handoff/SKILL.md
@@ -2,6 +2,7 @@
 name: handoff
 description: Compact the current conversation into a handoff document for another agent to pick up.
 argument-hint: "What will the next session be used for?"
+disable-model-invocation: true
 ---
 
 **Hand over context, not content — reference existing artifacts; do not reproduce them.** The next agent needs enough to continue, not a transcript.


### PR DESCRIPTION
Automated AFK landing for #1134. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785815127&installation_id=129708444&pr_number=1150&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1150&signature=2b9be6f1877350ca5bcdadf3e4f53477a8151f778ed4bf4c85a846bc86fcc1e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->