### PR TITLE
merge: #1135 Memory+brain trigger wave: maintenance-verb flips, brain status rehabilitation, memory health entrypoint normalization

### DIFF
--- a/plugins/brain/skills/core/status/SKILL.md
+++ b/plugins/brain/skills/core/status/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: status
-description: Inspect the project Brain store.
+description: Report the project Brain store's health — whether Brain initialized in this workspace, the resolved connection string, and how many artifacts and connections are stored. Use when the user says "brain status", "is brain set up", "check brain", or wants to confirm Brain is live before capturing or searching.
+disable-model-invocation: true
 ---
 
-# Status Skill
+# brain status
 
-Use this to verify that Brain initialized in the current workspace, show the
-resolved connection string, and count stored artifacts and connections.
+Reports the operational health of the project Brain store (`.red/brain/brain.rdb`): whether Brain initialized in the current workspace, the resolved connection string, and the count of stored artifacts and connections. Read-only — it inspects, never mutates.
 
-Call `brain_status` when MCP is available. Otherwise run:
+<what-to-do>
+
+**Run the status check, then report initialization state, the connection string, and the artifact/connection counts.**
+
+Call the `brain_status` MCP tool when available. Otherwise run:
 
 ```bash
 node "${CODEX_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/bootstrap.mjs" status
 ```
+
+If Brain is not initialized, tell the user to run `brain init` first.
+
+</what-to-do>

--- a/plugins/memory/skills/core/doctor/SKILL.md
+++ b/plugins/memory/skills/core/doctor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: doctor
 description: Inspect and maintain the memory graph — list stale nodes (long-unaccessed and never recalled) and, only after explicit confirmation, prune them. Use when the user says "memory doctor", "clean up memory", "what's stale in memory", "prune old memory", or wants a health check of the graph. Graph mode only.
+disable-model-invocation: true
 ---
 
 # memory doctor
@@ -54,16 +55,6 @@ In a non-interactive shell, `--prune` refuses unless `--yes` is also passed. Pas
 </what-to-do>
 
 <supporting-info>
-
-## Staleness rule
-
-A node is stale when **both** hold:
-
-- it was last accessed more than `--stale-days` (default 90) days ago, and
-- it has never been recalled (`access_count == 0`).
-
-Access is tracked in a KV overlay that `/memory:recall` bumps on every hit, so
-"never recalled" really means cold. Pinned nodes are exempt regardless of age.
 
 ## MCP
 

--- a/plugins/memory/skills/core/export/SKILL.md
+++ b/plugins/memory/skills/core/export/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: export
 description: Export the memory graph to a self-contained, navigable bundle — graph.json (data), graph.html (an interactive node-link view that opens straight from disk), and audit.md (a health summary). Use when the user says "export memory", "visualize the memory graph", "show me the graph", "dump the memory graph", or wants to browse what's stored. Graph mode only.
+disable-model-invocation: true
 ---
 
 # memory export

--- a/plugins/memory/skills/core/health/SKILL.md
+++ b/plugins/memory/skills/core/health/SKILL.md
@@ -14,7 +14,7 @@ Read-only operational healthcheck for the Memory plugin.
 ## 1. Run the healthcheck
 
 ```bash
-memory health --json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" health --json
 ```
 
 Use `--root <dir>` when checking a repository other than the current working directory.
@@ -43,10 +43,10 @@ Read these JSON fields before deciding the next action:
 
 ## DOs / DON'Ts
 
-- ✅ Run this before `memory improve skills --write-proposal` in automated workflows.
+- ✅ Run this before `bootstrap.mjs improve skills --write-proposal` in automated workflows.
 - ✅ Treat `attention` as actionable, not as failure.
 - ✅ Use `recommendedNextActions` rather than inventing recovery steps.
-- ✅ When `pendingProposalFiles > 0`, inspect them with `memory improve proposals list/show --json`; proposal fingerprints let repeated generation refresh existing work instead of creating duplicates.
+- ✅ When `pendingProposalFiles > 0`, inspect them with `bootstrap.mjs improve proposals list/show --json`; proposal fingerprints let repeated generation refresh existing work instead of creating duplicates.
 - ❌ Do not mutate graph, proposal, or Skill files from this healthcheck.
 - ❌ Do not parse human text when `--json` is available.
 

--- a/plugins/memory/skills/core/improve-skills/SKILL.md
+++ b/plugins/memory/skills/core/improve-skills/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: improve-skills
 description: Generate approval-gated Skill improvement proposals from Memory Skill telemetry. Use when repeated failures suggest a skill should be patched, but direct self-modification would be unsafe.
+disable-model-invocation: true
 ---
 
 # memory improve-skills

--- a/plugins/memory/skills/core/view/SKILL.md
+++ b/plugins/memory/skills/core/view/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: view
 description: Open the project Memory graph in red-ui (the visual cluster/query/collections workspace) by pointing the red-ui MCP App at the local RedDB store, falling back to the browser Workbench in terminal hosts. Use when the user wants to SEE the memory graph, clusters, or collections visually rather than recall text.
+disable-model-invocation: true
 ---
 
 # memory view


### PR DESCRIPTION
Automated AFK landing for #1135. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1135

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785815144&installation_id=129708444&pr_number=1151&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1151&signature=4b901e8561025e8a31c3b4bb66fce69dfa423e6215e0dd6018a51f503a012885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->