### PR TITLE
merge: #1136 ship becomes a user-only redirect stub (~15 lines, ADR 0081)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## ship (engineering) — shrunk to a user-only redirect stub (issue #1136)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #1132 trigger-wave — `ship` is retired (ADR 0081); a deprecation alias must cost nothing and teach nothing beyond where to go instead.
+- **what changed**: Cut from ~74 to 20 lines. Added `disable-model-invocation: true` so the dead alias is neither model-reachable nor pays description context. Deleted the seven-stage pipeline and mechanical-vs-intentional fix-split sections (they document the shared gate's internals and cite source symbols — that content lives with `/requeue` and ADRs 0055/0071). Kept the `/requeue` (and `/go`) redirect and the backwards-compat alias note.
+
 ## setup-pre-commit (misc) — user-only flip: disable-model-invocation (issue #1134)
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/ship/SKILL.md
+++ b/plugins/dev/skills/engineering/ship/SKILL.md
@@ -1,74 +1,20 @@
 ---
 name: ship
-description: DEPRECATED (ADR 0081). Use `/dev:requeue #ISSUE --adopt-branch BRANCH --guidance 'reason'` to adopt a hand-done branch through the no-agent gate. This skill is a backwards-compat alias that redirects to requeue.
-argument-hint: "[--issue N] [--base BRANCH]"
+description: DEPRECATED (ADR 0081). Use `/dev:requeue #ISSUE --adopt-branch BRANCH --guidance 'reason'` to adopt a hand-done branch through the gate. Dead alias, not model-reachable.
+disable-model-invocation: true
 ---
 
-# /ship — DEPRECATED
+# /ship — DEPRECATED (ADR 0081)
 
-**`/ship` is retired (ADR 0081). Use `/dev:requeue` with `--adopt-branch` instead.**
+**`/ship` is retired. Use `/dev:requeue` instead.**
 
 ## What to use instead
 
-When you have done work by hand on an existing branch and want to run it through
-the gate and land it:
-
-```bash
-red-skills-dev requeue #ISSUE --adopt-branch BRANCH --guidance 'reason for adoption'
-```
-
-This routes the branch through the **no-agent landing lane** (ADR 0055 reconcile):
-gate-only validation (no agent re-run), then lands via the shared `doLanding` path.
-
-## Why /ship was retired
-
-`/ship` was an orphan command with a fuzzy trigger ("I never know when to call it").
-ADR 0081 dissolved it into requeue so the manual path and the AFK path share the
-same gate and landing logic — one code path, one authority.
+- **Adopt a hand-done branch through the gate** → `/dev:requeue #ISSUE --adopt-branch BRANCH --guidance 'reason'`.
+- **Dispatch an ad-hoc one-off demand** → `/dev:go "<demand>"`.
 
 ## Backwards-compat alias
 
-Running `dev ship` still works during rollout: it prints the deprecation notice,
-infers the issue number from the current branch, and delegates to
-`requeue #N --adopt-branch CURRENT_BRANCH --guidance '...'` automatically.
-Update your workflow to call requeue directly.
-
-## The ship pipeline (seven ordered stages)
-
-The validation the `/ship` concept always stood for now runs inside the shared
-gate that `/dev:requeue` and `/afk` both invoke. It is an **ordered pipeline** —
-each stage must pass before the next runs, and a failure at stage N stops the
-pipeline at N and reports the stage name and reason (no later stage runs):
-
-1. **Review** — scan the diff for obvious issues
-2. **Test** — run the full test suite
-3. **Docs** — verify public API or SKILL.md changes are documented
-4. **Lint** — run the linter / typecheck
-5. **Push** — push the branch to the remote
-6. **PR** — open or reuse the PR
-7. **CI** — wait for CI to pass
-
-The pipeline order is fixed in `SHIP_PIPELINE_STAGES` (`apps/dev/src/core/ship.ts`)
-and evaluated by `runShipPipeline`, which returns the first failing stage.
-
-## Mechanical vs intentional fix split
-
-Before applying any fix the pipeline proposes, it is **labelled** one of two
-classes (mapping to the existing INFRA/SEMANTIC distinction):
-
-- **Mechanical** — auto-applied silently. A fix is mechanical only when it cannot
-  change behaviour: formatting, import sort, unused variable, trailing
-  whitespace.
-- **Intentional** — escalated to the user (park `ready-for-human` or prompt
-  interactively) and **never** silently applied. A fix is intentional when it
-  changes a public symbol, contract, or observable behaviour.
-
-A fix that cannot be classified as mechanical **with confidence is treated as
-intentional** — the safe default. The classifier is `classifyFix` and the
-per-fix action is `decideFixApplication` (`apps/dev/src/core/ship.ts`).
-
-## See also
-
-- `/dev:requeue` — the replacement for manual branch adoption
-- `/dev:hitl` — when a human decision still needs to be extracted before requeueing
-- ADR 0081 — command topology decision (goal / go / afk; ship retired)
+Running `dev ship` still redirects to requeue during rollout — it prints this
+notice, infers the issue from the current branch, and delegates to
+`requeue #N --adopt-branch CURRENT_BRANCH`. Call `/dev:requeue` directly.


### PR DESCRIPTION
Automated AFK landing for #1136. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785815741&installation_id=129708444&pr_number=1152&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1152&signature=221fd16e739f956d2086d791b39ec59143270eb00626cf58a18f407c67873d54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->