### PR TITLE
merge: #1138 Reconcile branch-lock + git-guardrails with ADR 0083 semantics; prune both; flip user-only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## git-guardrails-claude-code (misc) — reconcile with ADR 0083, prune, user-only flip (issue #1138)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #1132 — this skill contradicted `branch-lock` on `dev.lock.primary-branch`: it presented the key as the guard's enabler and claimed "missing file/key means off", while ADR 0083 §2 makes the primary-branch guard fire unconditionally under `plugins.dev.enabled: true`. It also duplicated `branch-lock`'s docs and interleaved steps with reference.
+- **what changed**: Rewrote the primary-branch-guard section to the unconditional ADR 0083 semantics; removed the "missing key means off" claim; the legacy `dev.lock.primary-branch` key is now described as read-only history in one line. Shrank the branch-lock-awareness block to a one-line pointer at `branch-lock`. Collapsed the near-identical project/global JSON hook blocks to one block with the path delta described in a sentence. Added the house `<what-to-do>`/`<supporting-info>` split. Added `disable-model-invocation: true` (setup wizard, deliberately fired; the guard runs via hooks, not skill invocation). Prose-only — no hook/script behavior touched.
+
+## branch-lock (misc) — prune to `<what-to-do>` first, dedup block-vs-allow, user-only flip (issue #1138)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #1132 — heaviest skill in the misc bucket (206 lines) with a ~46-line reference preamble before `<what-to-do>` and block-vs-allow behaviour stated three times.
+- **what changed**: Moved the reference preamble (guard rationale, ADR 0083 background, work-loss family, enforcement notes) into `<supporting-info>` so no reference material precedes `<what-to-do>`. Collapsed block-vs-allow to a single authoritative section (removed the preamble enumeration and the later restatement). Compressed the deprecated-key YAML example to one line. Deleted the "Scope of this slice" / PRD-status block. Added `disable-model-invocation: true` (lock-management command, deliberately fired; the guard runs via hooks). Prose-only — no hook/script behavior touched.
+
 ## ship (engineering) — shrunk to a user-only redirect stub (issue #1136)
 
 - **status**: modified

--- a/plugins/dev/skills/misc/branch-lock/SKILL.md
+++ b/plugins/dev/skills/misc/branch-lock/SKILL.md
@@ -1,57 +1,12 @@
 ---
 name: branch-lock
 description: Lock the agent to a branch and block it from switching away. Sets up self-contained pre-tool hooks that block the agent's git checkout/switch to any other branch while a lock is active, and gives you a /branch-lock command to set, change, and clear the lock. Use when you want the agent pinned to one branch for a session.
+disable-model-invocation: true
 ---
 
 # Branch Lock
 
-Pins the agent to a single branch in the primary checkout and blocks it from
-switching away. The lock is a local fact — `./.red/tmp/branch-lock.yaml` whose
-content is the branch name — under the gitignored `.red/tmp/`, so every checkout
-and machine locks independently and nothing is committed. Absence of the file
-means unlocked: protection is strictly opt-in.
-
-The dev plugin also ships an **unconditional** primary-checkout branch guard
-(ADR 0083 §2, untouchable primary). Once the dev plugin is enabled
-(`plugins.dev.enabled: true`), the pre-tool hook blocks the agent from changing
-the primary checkout's branch (`git switch <branch>`, `git checkout <branch>`,
-`git switch -b <new>`) — always, with no lock file and no config toggle. The
-answer to "may an agent switch the primary checkout's branch" is not
-configurable: it is always **no**. `git commit`, `git worktree add`, read-only
-git, and `.red/tmp/work-*/` worktrees stay allowed.
-
-The historical `dev.lock.primary-branch` key stays **readable** for backward
-compatibility but can no longer enable or disable switching; the guard fires
-regardless of its value. `/doctor` may note it as redundant.
-
-```yaml
-# retained for backward compatibility only — no longer toggles the guard
-dev:
-  lock:
-    primary-branch: true
-```
-
-The same unconditional guard also blocks the work-destroying commands the
-standing maintainer rules forbid in the primary checkout, because parallel
-human WIP lives there and these have destroyed in-progress work before
-(issue #1024): `git reset` in **any** form (`--hard`/`--soft`/`--mixed`, with or
-without a pathspec), every `git stash` subcommand, and `git rebase --autostash`.
-The refusal points to the sanctioned alternative — do branch work in an isolated
-worktree under `.red/tmp/work-*/`, and if the local trunk diverged from origin,
-leave it alone and base on the fresh remote ref (ADR 0083). Inside isolated
-worktrees the reset/stash/autostash commands remain allowed — the guard is about
-the primary checkout only.
-
-Enforcement is **agent-only**, via runner pre-tool hooks — Claude Code
-`PreToolUse(Bash)` and Codex plugin `PreToolUse` — that intercept the agent's own
-tool calls, not the human's terminal (ADR 0006, unaffected). See
-[ADR 0006](../../../../../.red/adr/0006-branch-lock-agent-only-enforcement.md).
-The hook logic is self-contained: it depends on neither the
-`git-guardrails-claude-code` skill nor anything else, and the two stack
-harmlessly if both are installed.
-
-`/afk` and `/go` worktrees under `.red/tmp/` are always exempt — the lock protects
-the interactive primary checkout, never the autonomous loop.
+Pin the agent to one branch in the primary checkout and block it from switching away.
 
 <what-to-do>
 
@@ -120,6 +75,44 @@ lock; it never writes the lock itself.
 
 <supporting-info>
 
+## Why the lock exists
+
+The lock is a local fact — `./.red/tmp/branch-lock.yaml` whose content is the
+branch name — under the gitignored `.red/tmp/`, so every checkout and machine
+locks independently and nothing is committed. Absence of the file means unlocked:
+the branch-lock layer is strictly opt-in.
+
+Layered under it, the dev plugin ships an **unconditional** primary-checkout
+branch guard (ADR 0083 §2, untouchable primary). Once the dev plugin is enabled
+(`plugins.dev.enabled: true`), the pre-tool hook blocks the agent from changing
+the primary checkout's branch — always, with no lock file and no config toggle.
+The answer to "may an agent switch the primary checkout's branch" is not
+configurable: it is always **no**. The historical `dev.lock.primary-branch` key
+stays **readable** for backward compatibility but can no longer enable or disable
+switching; the guard fires regardless of its value, and `/doctor` may note it as
+redundant.
+
+```yaml
+dev: { lock: { primary-branch: true } }  # retained for backward compatibility only — no longer toggles the guard
+```
+
+The same unconditional guard also blocks the work-destroying commands the
+standing maintainer rules forbid in the primary checkout, because parallel human
+WIP lives there and these have destroyed in-progress work before (issue #1024).
+The refusal points to the sanctioned alternative — do branch work in an isolated
+worktree under `.red/tmp/work-*/`, and if the local trunk diverged from origin,
+leave it alone and base on the fresh remote ref (ADR 0083). Inside isolated
+worktrees these commands remain allowed — the guard is about the primary checkout
+only, and `/afk` and `/go` worktrees under `.red/tmp/` are always exempt.
+
+Enforcement is **agent-only**, via runner pre-tool hooks — Claude Code
+`PreToolUse(Bash)` and Codex plugin `PreToolUse` — that intercept the agent's own
+tool calls, not the human's terminal (ADR 0006, unaffected). See
+[ADR 0006](../../../../../.red/adr/0006-branch-lock-agent-only-enforcement.md).
+The hook logic is self-contained: it depends on neither the
+`git-guardrails-claude-code` skill nor anything else, and the two stack
+harmlessly if both are installed.
+
 ## Layout
 
 ```
@@ -172,12 +165,6 @@ It allows (exit 0, silent):
 - `git worktree add .red/tmp/...` — worktrees are how `/afk` and `/go` work
 - `git commit`, `git status` / read-only git, and any other command
 
-Even with no branch-lock file, the untouchable-primary guard still blocks every
-branch-changing command (`git switch <branch>`, `git checkout <branch>`,
-`git switch -b <new>`, `git checkout -b <new>`, `git switch -`) while allowing
-`git commit`, `git worktree add`, read-only git, targeted path checkout, and
-every `.red/tmp/work-*/` worktree.
-
 The dev command proxy has a stricter host-wide invariant when
 `plugins.dev.enabled: true`: any agent-created `git worktree add` destination
 must resolve under the repo's `.red/tmp/`. Branch-lock allows the command class;
@@ -193,14 +180,5 @@ for t in scripts/tests/*.test.sh; do bash "$t"; done
 ```
 
 Each prints `summary: N passed, 0 failed` and exits non-zero on any failure.
-
-## Scope of this slice
-
-Part of PRD #59. The lock-store, scope-resolver, classifier (branch-switch +
-work-loss family), Claude and Codex PreToolUse hooks, the SessionStart hook that
-offers to lock at session start, and the `/branch-lock` command are shipped. Not
-yet included
-(later slices): the PRD/issue branch pin read by `/afk`, and making
-`git-guardrails` lock-aware.
 
 </supporting-info>

--- a/plugins/dev/skills/misc/git-guardrails-claude-code/SKILL.md
+++ b/plugins/dev/skills/misc/git-guardrails-claude-code/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git-guardrails-claude-code
 description: Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.
+disable-model-invocation: true
 ---
 
 # Setup Git Guardrails
@@ -9,71 +10,24 @@ description: Set up Claude Code hooks to block dangerous git commands (push, res
 
 Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude executes them.
 
-## What Gets Blocked
+<what-to-do>
 
-- `git push` (all variants including `--force`)
-- `git reset --hard`
-- `git clean -f` / `git clean -fd`
-- `git branch -D`
-- `git checkout .` / `git restore .`
-
-When blocked, Claude sees a message telling it that it does not have authority to access these commands.
-
-## Primary branch guard
-
-If `.red/config.yaml` sets:
-
-```yaml
-dev:
-  lock:
-    primary-branch: true
-```
-
-this hook also blocks the agent from switching the primary checkout's branch
-(`git switch <branch>`, `git checkout <branch>`, `git switch -b <new>`), even
-without a branch-lock file. The key is read at runtime; missing file/key means
-off. `git commit`, `git worktree add`, read-only git, and `.red/tmp/work-*/`
-worktrees stay allowed. The human terminal is not intercepted.
-
-## Branch-lock awareness
-
-If a branch lock is active — an opt-in `./.red/tmp/branch-lock.yaml` whose content
-is the locked branch name — this hook **also** blocks the branch-leaving /
-work-loss family in the primary checkout: `git switch`/`git checkout` to another
-branch, `git switch -`, `git checkout -b <new>`, and bare `git stash`. Switching
-back to the locked branch, targeted file restore (`git checkout -- <path>`), and
-`git worktree add` stay allowed; `/afk` worktrees under `.red/tmp/work-*/` are
-exempt.
-
-This is **self-contained**: the hook reads the lock and classifies the command on
-its own and does **not** source or require the [`branch-lock`](../branch-lock/SKILL.md)
-skill. The two skills are independent — install either one and the lock is
-enforced. With both installed they reach the same verdict and stack idempotently
-(both deny, neither conflicts). Absence of the lock file means unlocked, so this
-layer is silent unless the user has opted in.
-
-## Steps
-
-### 1. Ask scope
+## 1. Ask scope
 
 Ask the user: install for **this project only** (`.claude/settings.json`) or **all projects** (`~/.claude/settings.json`)?
 
-### 2. Copy the hook script
+## 2. Copy the hook script
 
 The bundled script is at: [scripts/block-dangerous-git.sh](scripts/block-dangerous-git.sh)
 
-Copy it to the target location based on scope:
+Copy it to the target location based on scope, then make it executable with `chmod +x`:
 
 - **Project**: `.claude/hooks/block-dangerous-git.sh`
 - **Global**: `~/.claude/hooks/block-dangerous-git.sh`
 
-Make it executable with `chmod +x`.
+## 3. Add hook to settings
 
-### 3. Add hook to settings
-
-Add to the appropriate settings file:
-
-**Project** (`.claude/settings.json`):
+Add the `PreToolUse` hook to the appropriate settings file. The block is identical for both scopes — only the `command` path differs: **project** uses `"$CLAUDE_PROJECT_DIR"/.claude/hooks/block-dangerous-git.sh`, **global** uses `~/.claude/hooks/block-dangerous-git.sh`.
 
 ```json
 {
@@ -93,33 +47,13 @@ Add to the appropriate settings file:
 }
 ```
 
-**Global** (`~/.claude/settings.json`):
+If the settings file already exists, merge the hook into the existing `hooks.PreToolUse` array — don't overwrite other settings.
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/block-dangerous-git.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+## 4. Ask about customization
 
-If the settings file already exists, merge the hook into existing `hooks.PreToolUse` array — don't overwrite other settings.
+Ask if the user wants to add or remove any patterns from the blocked list. Edit the copied script accordingly.
 
-### 4. Ask about customization
-
-Ask if user wants to add or remove any patterns from the blocked list. Edit the copied script accordingly.
-
-### 5. Verify
+## 5. Verify
 
 Run a quick test:
 
@@ -129,7 +63,43 @@ echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
 
 Should exit with code 2 and print a BLOCKED message to stderr.
 
+</what-to-do>
+
+<supporting-info>
+
+## What gets blocked
+
+- `git push` (all variants including `--force`)
+- `git reset --hard`
+- `git clean -f` / `git clean -fd`
+- `git branch -D`
+- `git checkout .` / `git restore .`
+
+When blocked, Claude sees a message telling it that it does not have authority to access these commands.
+
+## Primary branch guard
+
+Once the dev plugin is enabled (`plugins.dev.enabled: true`), this hook blocks the
+agent from switching the primary checkout's branch (`git switch <branch>`,
+`git checkout <branch>`, `git switch -b <new>`) **unconditionally** — with no
+branch-lock file and no config toggle (ADR 0083 §2, untouchable primary). `git
+commit`, `git worktree add`, read-only git, and `.red/tmp/work-*/` worktrees stay
+allowed; the human terminal is not intercepted. The historical
+`dev.lock.primary-branch` key is retained as read-only legacy history only — it no
+longer enables or disables the guard.
+
+## Branch-lock awareness
+
+When an opt-in branch lock is active, this hook also blocks the branch-leaving /
+work-loss family in the primary checkout. That behaviour is documented in full at
+[`branch-lock`](../branch-lock/SKILL.md); this hook is self-contained and reaches
+the same verdict without sourcing it.
+
+## Tests
+
 The full behaviour (dangerous patterns + branch-lock awareness + worktree
 scope + the no-dependency contract) is pinned by
 [scripts/tests/block-dangerous-git.test.sh](scripts/tests/block-dangerous-git.test.sh),
 run directly with `bash`.
+
+</supporting-info>


### PR DESCRIPTION
Automated AFK landing for #1138. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1138

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785816236&installation_id=129708444&pr_number=1153&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1153&signature=c1fa65ed6463831f569ae242505bd0f9a08205623f0d10d7fc1c4afeff9a5e98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->