### PR TITLE
merge: #1139 memory init overhaul: remove build-step contradiction (ADR 0029), extract graph-branch reference, flip user-only

### DIFF
--- a/plugins/memory/skills/core/init/SKILL.md
+++ b/plugins/memory/skills/core/init/SKILL.md
@@ -1,30 +1,10 @@
 ---
 name: init
-description: One-time setup wizard for the memory plugin. Asks what storage to use and writes the per-project memory config. Two modes ship today — markdown-only (plain notes, no engine) and graph (governed operational memory over a per-project RedDB store). Hooks are optional in graph mode; MCP/read surfaces are available after build. Use when the user installs the memory plugin and wants to turn memory on, or says "memory init", "set up memory", "initialize memory".
+description: One-time setup wizard for the memory plugin. Asks what storage to use and writes the per-project memory config. Two modes ship today — markdown-only (plain notes, no engine) and graph (governed operational memory over a per-project RedDB store). Hooks are optional in graph mode; MCP/read surfaces come with graph mode. Use when the user installs the memory plugin and wants to turn memory on, or says "memory init", "set up memory", "initialize memory".
+disable-model-invocation: true
 ---
 
 # memory init
-
-Bootstraps the `memory` plugin for the current repo. Pick a storage mode:
-
-- **markdown-only** — searchable project notes with **zero engine dependency**:
-  notes are plain markdown under `.red/memory/notes/`, no hooks fire, no MCP
-  server runs, RedDB is not required.
-- **graph** — governed operational memory (nodes + edges) over a per-project
-  RedDB store at `.red/memory/graph.rdb`. `/memory:store` writes deduped facts;
-  `/memory:recall` returns zero-token governed context with graph expansion,
-  provenance/trust, and supersession handling. RedDB is required, but it runs
-  out-of-process from the bundled binary — no service to manage. Graph mode can
-  also opt into **auto-firing hooks** (SessionStart recall, PostToolUse re-index,
-  Stop extract, PreCompact flush where the host supports it); they default off.
-
-Hybrid mode is not a separate storage mode: use markdown-only for plain notes or
-graph for governed operational memory. markdown-only never gets hooks. MCP/read
-surfaces are available from the built CLI; hook activation still comes from the
-per-project config.
-
-The `memory` plugin requires the `dev` plugin (it builds on dev's processes —
-`/afk`, `/triage`, `/diagnose`). Install `dev` first.
 
 <what-to-do>
 
@@ -58,8 +38,10 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" init --mode graph --hooks
 markdown-only writes a `plugins.memory` block to `.red/config.yaml` (all hooks off, MCP off, RedDB
 not required) and creates `.red/memory/notes/`. graph writes the same config
 shape with `mode: "graph"`, `reddb: true`, a `storePath`, and provisions the
-RedDB store at `.red/memory/graph.rdb` (graph mode needs step 1's build to have
-run — the SDK and its bundled binary come from `node_modules/`).
+RedDB store at `.red/memory/graph.rdb`.
+
+If graph mode was chosen, read [graph-reference.md](graph-reference.md) for the
+written config shape and how graph writes are stored.
 
 Ask the user whether to turn the auto-firing hooks on. Pass `--hooks` only in
 graph mode and only if they say yes; the hooks are wired in the plugin manifest
@@ -80,8 +62,6 @@ context pack when needed.
 
 ## DOs / DON'Ts
 
-- ✅ Build the CLI before running it if `dist/` is absent (graph mode needs `@reddb-io/sdk` installed).
-- ✅ Keep hooks off in markdown-only mode — `--hooks` only applies to graph mode; the resolver forces them off otherwise.
 - ✅ Ask before passing `--hooks`; the config flag, not the manifest, is what makes a hook active vs dormant.
 - ❌ Don't require, install, or connect to RedDB in markdown-only mode.
 - ❌ Don't commit `.red/memory/graph.rdb*` — the store is per-project local state, like `node_modules/`.
@@ -91,49 +71,27 @@ context pack when needed.
 
 <supporting-info>
 
-## Config shape
+## Storage modes
 
-markdown-only:
+- **markdown-only** — searchable project notes with **zero engine dependency**:
+  notes are plain markdown under `.red/memory/notes/`, no hooks fire, no MCP
+  server runs, RedDB is not required.
+- **graph** — governed operational memory (nodes + edges) over a per-project
+  RedDB store at `.red/memory/graph.rdb`. `/memory:store` writes deduped facts;
+  `/memory:recall` returns zero-token governed context with graph expansion,
+  provenance/trust, and supersession handling. RedDB is required, but it runs
+  out-of-process from the bundled binary — no service to manage. Graph mode can
+  also opt into **auto-firing hooks** (SessionStart recall, PostToolUse re-index,
+  Stop extract, PreCompact flush where the host supports it); they default off.
 
-```json
-{
-  "version": 1,
-  "mode": "markdown-only",
-  "notesDir": ".red/memory/notes",
-  "hooks": { "sessionStart": false, "postToolUse": false, "stop": false, "preCompact": false },
-  "mcp": false,
-  "reddb": false
-}
-```
+Hybrid mode is not a separate storage mode: use markdown-only for plain notes or
+graph for governed operational memory. markdown-only never gets hooks. MCP/read
+surfaces are available from the fetched CLI; hook activation still comes from the
+per-project config.
 
-graph:
+## Plugin dependency
 
-```json
-{
-  "version": 1,
-  "mode": "graph",
-  "notesDir": ".red/memory/notes",
-  "storePath": ".red/memory/graph.rdb",
-  "hooks": { "sessionStart": false, "postToolUse": false, "stop": false, "preCompact": false },
-  "mcp": false,
-  "reddb": true
-}
-```
-
-## Graph storage internals
-
-Graph writes go through RedDB's multi-model DML (`INSERT … NODE/EDGE`), not
-table inserts, and dedupe lives in a KV index — see ADR 0007 for the engine
-constraints. The store is the embedded `file://` RedDB; the SDK spawns the
-bundled `red` binary out-of-process, so there is no service to run.
-
-## Scope of this slice
-
-Current graph mode includes the core `MemoryStore` over RedDB (node/edge write,
-dedupe, supersession, confidence/governance overlays), mode-routed
-`/memory:store` / `/memory:recall`, optional lifecycle hooks, MCP/HTTP read
-surfaces, context packs, claim checks, readiness, docs ingest, Skill telemetry,
-and Workbench diagnostics. The operational stance is evidence-first memory for
-RedSkills workflows, not a generic vector database.
+The `memory` plugin requires the `dev` plugin (it builds on dev's processes —
+`/afk`, `/triage`, `/diagnose`). Install `dev` first.
 
 </supporting-info>

--- a/plugins/memory/skills/core/init/graph-reference.md
+++ b/plugins/memory/skills/core/init/graph-reference.md
@@ -1,0 +1,40 @@
+# Graph-mode reference
+
+Read this only when graph mode was chosen — the config shape written for the
+`plugins.memory` block and how graph writes are stored.
+
+## Config shape
+
+markdown-only:
+
+```json
+{
+  "version": 1,
+  "mode": "markdown-only",
+  "notesDir": ".red/memory/notes",
+  "hooks": { "sessionStart": false, "postToolUse": false, "stop": false, "preCompact": false },
+  "mcp": false,
+  "reddb": false
+}
+```
+
+graph:
+
+```json
+{
+  "version": 1,
+  "mode": "graph",
+  "notesDir": ".red/memory/notes",
+  "storePath": ".red/memory/graph.rdb",
+  "hooks": { "sessionStart": false, "postToolUse": false, "stop": false, "preCompact": false },
+  "mcp": false,
+  "reddb": true
+}
+```
+
+## Graph storage internals
+
+Graph writes go through RedDB's multi-model DML (`INSERT … NODE/EDGE`), not
+table inserts, and dedupe lives in a KV index — see ADR 0007 for the engine
+constraints. The store is the embedded `file://` RedDB; the SDK spawns the
+bundled `red` binary out-of-process, so there is no service to run.


### PR DESCRIPTION
Automated AFK landing for #1139. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1139

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785816456&installation_id=129708444&pr_number=1154&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1154&signature=6b5b7fb35cbe196e4a5c8e8306222d575748fecce53122699ecda266408430e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->