### PR TITLE
merge: #1144 wiki: extract the single-branch C4 section behind pointers, adopt house tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## wiki (knowledge) — extract single-branch C4 section behind pointers, adopt house tags (issue #1144)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #1132 — at 263 lines `wiki` was the repo's second-largest skill, with its ~115-line C4 Diagram section (44% of the file) reachable from only two narrow paths, and it lacked the `<what-to-do>`/`<supporting-info>` house split the size makes acute.
+- **what changed**: Moved the entire C4 Diagram body into a bundled sibling `C4-reference.md` (following the existing `REFERENCES.md` pattern). Left exactly two one-line context pointers — the Ingest C4-awareness step and the Lint C4-staleness check — that own the *when* and link the reference for the *how*. Deduped inside the extracted content: the vocabulary-discipline rule now appears once, and the "When to create"/"When to update" trigger subsections were dropped (their conditions already live at the two pointer sites). Wrapped the verb procedures (Preconditions, Routing, Ingest, Query, Lint) in `<what-to-do>` and the Anti-patterns + References in `<supporting-info>`. SKILL.md dropped from 263 to ~154 lines; verb behavior, wiki schema contract, and `wiki-init` templates unchanged.
+
 ## daily-review (engineering) — merge weekly-review into one period-parameterized skill, shared wrapper, house tags, disable-model-invocation (issue #1142)
 
 - **status**: modified

--- a/plugins/dev/skills/knowledge/wiki/C4-reference.md
+++ b/plugins/dev/skills/knowledge/wiki/C4-reference.md
@@ -1,0 +1,101 @@
+# C4 Diagram — reference
+
+How to build and maintain the wiki's C4 model. The `wiki` skill decides *when* C4 work triggers (the Ingest C4-awareness step and the Lint C4-staleness check own those conditions); this file describes *how* to write it.
+
+Optional, complexity-gated. When the system has enough moving parts that one person can't keep the architecture in their head — typically **≥3 services / containers** or any non-trivial cross-system integration — maintain a [C4 model](https://c4model.com) at `.red/wiki/C4.md`. It is the single architectural map for the project; every other wiki page that touches structure references it. The wiki never auto-creates `C4.md` — when a trigger fires and the file is absent, propose creation; once it exists, keep it current.
+
+## Structure
+
+The Mermaid block stays minimal (it is just a rendering aid). The **prose around it carries the full C4 content** — actor/system/container/component names, responsibilities, technology choices, relationship semantics.
+
+````markdown
+# C4 — <system name>
+
+<one-line description, using the canonical system name from .red/CONTEXT.md>
+
+updated: <YYYY-MM-DD>
+context: ../CONTEXT.md   _(this file is bound to the glossary — every label below must match)_
+
+## Level 1 — Context
+
+```mermaid
+flowchart LR
+  user([User])
+  sys[System]
+  ext[(External service)]
+  user --> sys
+  sys -->|HTTPS| ext
+```
+
+**Actors**
+
+- **User** _(from CONTEXT.md)_ — <responsibility, what they want from the system>.
+
+**Systems**
+
+- **System** _(from CONTEXT.md)_ — <purpose, in one sentence>.
+- **External service** _(from CONTEXT.md)_ — <what it provides, why we depend on it>.
+
+**Relationships**
+
+- User → System: <how they interact, protocol, frequency>.
+- System → External service: <calls made, data exchanged, failure mode>.
+
+## Level 2 — Container
+
+```mermaid
+flowchart LR
+  user([User])
+  subgraph sys[System]
+    api[API]
+    db[(Postgres)]
+  end
+  user -->|HTTPS| api
+  api -->|SQL| db
+```
+
+**Containers (inside System)**
+
+- **API** _(from CONTEXT.md)_ — <responsibility>. Tech: <language, framework>. Owner: <team / module>.
+- **Postgres** _(from CONTEXT.md)_ — <what it stores>. Tech: <version, hosting>.
+
+**Relationships**
+
+- User → API: <protocol, auth, payload shape>.
+- API → Postgres: <connection style, transaction discipline>.
+
+## Level 3 — Component _(per container; only where complexity warrants)_
+
+### API _(from CONTEXT.md)_
+
+```mermaid
+flowchart LR
+  in([request]) --> handler --> service --> repo[(db)]
+```
+
+**Components**
+
+- **Handler** _(from CONTEXT.md)_ — <HTTP-facing layer, validation, auth>.
+- **Service** _(from CONTEXT.md)_ — <domain logic, orchestration>.
+- **Repo** _(from CONTEXT.md)_ — <persistence layer, queries owned>.
+
+**Relationships**
+
+- Handler → Service: <DTO shape, sync/async>.
+- Service → Repo: <which methods, transactional boundary>.
+
+## Notes
+
+- <decisions, assumptions, gaps, "to-be-decided" items — same vocabulary as above>
+- New terms surfaced during diagramming that need a CONTEXT.md entry: <list, or "none">.
+````
+
+The Mermaid syntax is intentionally simple — `flowchart` (universally rendered by every Mermaid viewer including GitHub), not `C4Context` / `C4Container` / `C4Component` (experimental, breaks in many renderers). Shape conventions: `[box]` for system/container/component, `([rounded])` for actor, `[(cylinder)]` for datastore, `subgraph` for "lives inside". The diagram is the index; the prose is the substance.
+
+Level 4 (Code) is intentionally omitted — derive it from the source on demand.
+
+## Vocabulary discipline
+
+Every name used in the diagram and the prose must match a term already defined in `.red/CONTEXT.md`. If you find yourself writing a name in `C4.md` that is not in the glossary, stop and update the glossary first, then reference it here. The C4 inherits its words from CONTEXT — never the other way around. A term invented inside `C4.md` without a glossary entry is a contradiction the next lint pass will flag.
+
+Bump the `updated:` frontmatter on every meaningful edit. The Lint staleness check uses that field to decide whether sources have outpaced the diagram.

--- a/plugins/dev/skills/knowledge/wiki/SKILL.md
+++ b/plugins/dev/skills/knowledge/wiki/SKILL.md
@@ -7,6 +7,8 @@ description: Operate the LLM Wiki — ingest a source (URL or file), query the w
 
 **Operate the LLM Wiki — ingest a source, query for answers, or lint for contradictions — reading `.red/agents/wiki.md` first (source of truth for this repo's conventions).**
 
+<what-to-do>
+
 ## Preconditions
 
 - `.red/wiki/` exists.
@@ -61,7 +63,7 @@ Append to `.red/wiki/log.md`:
 
 ### 6. C4 awareness (optional, complexity-gated)
 
-If `.red/wiki/C4.md` exists, check whether the new source introduces a service, integration, or dependency not yet on the diagram. If so, update C4.md and bump its `updated:` field. If the project doesn't yet have a C4 but the new source describes enough architectural surface to warrant one (≥3 services or non-trivial integration), propose creating it — see *C4 Diagram* below.
+If `.red/wiki/C4.md` exists, check whether the new source introduces a service, integration, or dependency not yet on the diagram. If so, update C4.md and bump its `updated:` field. If the project doesn't yet have a C4 but the new source describes enough architectural surface to warrant one (≥3 services or non-trivial integration), propose creating it. When C4 work triggers, read the [C4 reference](./C4-reference.md) for the model structure and conventions.
 
 ### 7. Verify gitignore
 
@@ -117,7 +119,7 @@ Runs checks against `.red/wiki/`. **Does not auto-fix** — reports and asks wha
 
 6. **Gaps** — questions in "Open questions" unresolved for `>60` days.
 
-7. **C4 staleness** — if `.red/wiki/C4.md` exists, flag when its `updated:` is older than the most recent `created:` of any source page whose `touches:` list names a container or component appearing in the diagram. Suggested action: regenerate the affected level.
+7. **C4 staleness** — if `.red/wiki/C4.md` exists, flag when its `updated:` is older than the most recent `created:` of any source page whose `touches:` list names a container or component appearing in the diagram. Suggested action: regenerate the affected level — when C4 work triggers, read the [C4 reference](./C4-reference.md).
 
 ### Output
 
@@ -129,122 +131,9 @@ Markdown report grouped by the checks above. For each item:
 
 Append to log: `## [date] lint — orphans: N, stale: N, contradictions: N, stubs: N, gaps: N`.
 
-## C4 Diagram
+</what-to-do>
 
-Optional, complexity-gated. When the system has enough moving parts that one person can't keep the architecture in their head — typically **≥3 services / containers** or any non-trivial cross-system integration — maintain a [C4 model](https://c4model.com) at `.red/wiki/C4.md`. It is the single architectural map for the project; every other wiki page that touches structure references it.
-
-### When to create
-
-The wiki does not auto-create `C4.md`. Trigger conditions:
-
-- During **ingest**, the new source describes architectural surface not yet captured.
-- During **query**, the user asks an architecture question and no C4 exists.
-- The user explicitly asks ("draw the C4", "diagram the system", "where does X fit").
-
-When any trigger fires and `C4.md` is absent, propose creation. Once it exists, keep it current.
-
-### Structure
-
-The Mermaid block stays minimal (it is just a rendering aid). The **prose around it carries the full C4 content** — actor/system/container/component names, responsibilities, technology choices, relationship semantics. Every name used in the diagram and the prose must match a term already defined in `.red/CONTEXT.md`; if a name is missing from the glossary, add it there first, then reference it here.
-
-````markdown
-# C4 — <system name>
-
-<one-line description, using the canonical system name from .red/CONTEXT.md>
-
-updated: <YYYY-MM-DD>
-context: ../CONTEXT.md   _(this file is bound to the glossary — every label below must match)_
-
-## Level 1 — Context
-
-```mermaid
-flowchart LR
-  user([User])
-  sys[System]
-  ext[(External service)]
-  user --> sys
-  sys -->|HTTPS| ext
-```
-
-**Actors**
-
-- **User** _(from CONTEXT.md)_ — <responsibility, what they want from the system>.
-
-**Systems**
-
-- **System** _(from CONTEXT.md)_ — <purpose, in one sentence>.
-- **External service** _(from CONTEXT.md)_ — <what it provides, why we depend on it>.
-
-**Relationships**
-
-- User → System: <how they interact, protocol, frequency>.
-- System → External service: <calls made, data exchanged, failure mode>.
-
-## Level 2 — Container
-
-```mermaid
-flowchart LR
-  user([User])
-  subgraph sys[System]
-    api[API]
-    db[(Postgres)]
-  end
-  user -->|HTTPS| api
-  api -->|SQL| db
-```
-
-**Containers (inside System)**
-
-- **API** _(from CONTEXT.md)_ — <responsibility>. Tech: <language, framework>. Owner: <team / module>.
-- **Postgres** _(from CONTEXT.md)_ — <what it stores>. Tech: <version, hosting>.
-
-**Relationships**
-
-- User → API: <protocol, auth, payload shape>.
-- API → Postgres: <connection style, transaction discipline>.
-
-## Level 3 — Component _(per container; only where complexity warrants)_
-
-### API _(from CONTEXT.md)_
-
-```mermaid
-flowchart LR
-  in([request]) --> handler --> service --> repo[(db)]
-```
-
-**Components**
-
-- **Handler** _(from CONTEXT.md)_ — <HTTP-facing layer, validation, auth>.
-- **Service** _(from CONTEXT.md)_ — <domain logic, orchestration>.
-- **Repo** _(from CONTEXT.md)_ — <persistence layer, queries owned>.
-
-**Relationships**
-
-- Handler → Service: <DTO shape, sync/async>.
-- Service → Repo: <which methods, transactional boundary>.
-
-## Notes
-
-- <decisions, assumptions, gaps, "to-be-decided" items — same vocabulary as above>
-- New terms surfaced during diagramming that need a CONTEXT.md entry: <list, or "none">.
-````
-
-The Mermaid syntax is intentionally simple — `flowchart` (universally rendered by every Mermaid viewer including GitHub), not `C4Context` / `C4Container` / `C4Component` (experimental, breaks in many renderers). Shape conventions: `[box]` for system/container/component, `([rounded])` for actor, `[(cylinder)]` for datastore, `subgraph` for "lives inside". The diagram is the index; the prose is the substance.
-
-Level 4 (Code) is intentionally omitted — derive it from the source on demand.
-
-**Vocabulary discipline.** If you find yourself writing a name in C4.md that is not in `.red/CONTEXT.md`, stop and update the glossary first. The C4 inherits its words from CONTEXT — never the other way around. A term invented inside C4.md without a glossary entry is a contradiction the next lint pass will flag.
-
-### When to update
-
-`C4.md` stays in sync **opportunistically**, not on every commit. Trigger an update when:
-
-1. An **ingest** step introduces a new service, dependency, or integration not yet shown.
-2. A **query** about architecture surfaces a contradiction between the answer and the diagram.
-3. **Lint** flags `C4 staleness` (Lint check #7 above).
-4. A code change visibly shifts the boundaries — new container, removed service, renamed component.
-
-Bump the `updated:` frontmatter on every meaningful edit. The Lint staleness check uses that field to decide whether sources have outpaced the diagram.
+<supporting-info>
 
 ## Anti-patterns
 
@@ -261,3 +150,5 @@ Bump the `updated:` frontmatter on every meaningful edit. The Lint staleness che
 - [Tolkien Gateway](./REFERENCES.md#tolkien-gateway) — example of incremental human wiki.
 - [qmd](./REFERENCES.md#qmd) — local search engine for md, optional.
 - [Obsidian Dataview](./REFERENCES.md#obsidian-dataview) — dynamic queries via frontmatter.
+
+</supporting-info>


### PR DESCRIPTION
Automated AFK landing for #1144. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1144

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785818138&installation_id=129708444&pr_number=1158&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1158&signature=eca25b06b7a343efacfc4f9a4fd205f97ea0277be3f6d46e7f65a0242965e07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->