### PR TITLE
merge: #1145 doctor + setup-statusline: move --fix table and per-host rationale behind branch-gated pointers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## doctor (engineering) — move `--fix` Apply table behind a branch-gated pointer, trim MCP-wiring archaeology (issue #1145)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #1132 — the ~18-row Apply table plus most of the Fix pass are used **only** when `--fix` is passed, yet the default read-only diagnose pass (the common path) paid for them inline; the MCP-wiring check also carried cancelled-migration history the current rule does not need.
+- **what changed**: Moved the whole Apply table (finding → `--fix` action + gate) into a bundled sibling `APPLY.md`, behind a one-line "running with `--fix` → read `APPLY.md`" pointer at the Fix pass (Pass 2). The findings→owner mapping now lives in exactly one home — the inline *Fix-home* table — while `APPLY.md` layers action+gate on top of it. Trimmed the MCP-wiring check's (check 8) reversed-amendment / archived-repo history to a single parenthetical sentence, keeping the current finding rule intact. The read-only diagnose pass now contains no `--fix` Apply detail.
+
+## setup-statusline (engineering) — move per-host rationale behind pointers, de-dup the bundle-resolution command (issue #1145)
+
+- **status**: modified
+- **upstream**: —
+- **why**: PRD #1132 — three host branches each carried deep rationale inline that only that branch needs, the long `sh -c` bundle-resolution command was duplicated verbatim across the install and verify steps, and the skill lacked the setup-wizard `disable-model-invocation: true` flag.
+- **what changed**: Moved the Claude-only "why this shape, not the plugin-root variable" + "why the cached bundle, not the runtime script" blocks and the Codex-only "surviving config resets" block into a bundled `HOST-NOTES.md`, behind per-branch one-line pointers. Factored the `sh -c` command so it appears exactly once (the verify step now references the install step's command instead of re-inlining it). Shrank the OpenCode nothing-to-install section to one line and added `disable-model-invocation: true` to the frontmatter. The installed statusLine command is byte-identical (verified) — prose moved, command untouched, still cached-bundle-first per ADR 0084.
+
 ## wiki (knowledge) — extract single-branch C4 section behind pointers, adopt house tags (issue #1144)
 
 - **status**: modified

--- a/plugins/dev/skills/engineering/doctor/APPLY.md
+++ b/plugins/dev/skills/engineering/doctor/APPLY.md
@@ -1,0 +1,27 @@
+# Apply — what `--fix` runs per finding
+
+Read this only on the `--fix` (Fix) pass. Each Pass-1 finding maps to a concrete
+action and a gate: **safe** fixes apply in a batch (idempotent, low-blast-radius);
+**confirm-each** fixes show the exact mutation and apply only on an explicit yes;
+**delegate** fixes trigger the single-writer tool that owns the change. The
+findings→owner mapping lives in the *Fix-home* table in `SKILL.md`; this table adds
+the action and gate on top of it.
+
+| Finding | `--fix` action | Gate |
+|---|---|---|
+| Missing canonical label | `gh label create <name> --color <c> --description "<d>"` | **safe** (batch) |
+| AGENTS≡CLAUDE Agent-skills / Development-workflow parity | run the development-workflow injector (`inject-development-workflow --root <repo>`) — upserts both blocks in place | **safe** (batch; idempotent) |
+| `dev.lock.primary-branch` unset | same injector (it sets the nested flag) | **safe** (batch) |
+| Statusline drift | rewrite the `.claude/settings.json` `statusLine` to the cached-bundle form (jq merge, preserve other keys) | **safe** (batch) |
+| `.red/.gitignore` self-ignore missing/incomplete | write `.red/.gitignore` (header + `tmp/` + `state/`) if absent, else append only the missing pattern(s) — never reorder or clobber existing lines; don't `git add` it; print a one-line receipt | **safe** (batch; idempotent) |
+| Label synonym / legacy / naming | `gh label rename <old> <new>` (or create canonical + migrate, then retire the old) | **confirm each** — re-tags every issue carrying the old label |
+| Legacy/top-level dev-plugin config (flat `lock-primary-branch`, top-level `dev.lock.*`, top-level `afk:`) | migrate the key(s) into the canonical `plugins.dev.*` namespace + delete the top-level orphan in `.red/config.yaml` (safe: the #697 fold reads both, the namespaced form wins) | **confirm each** |
+| `blocked:*` on a `ready-for-agent`/`running` issue | `gh issue edit <N> --remove-label blocked:<reason>` (rotate the stale reason) | **confirm each** |
+| MCP wiring | add/correct the expected servers in the repo's `.mcp.json` | **confirm each** |
+| Version coherence mismatch | **run** the single-writer version/release tool (ADR 0040); never patch a manifest | **delegate** |
+| Workflow naming-convention drift | `git mv` the file to the prefix its role requires (`reusable-*` / `rs-*` / `red-*`); filename only, body unchanged; then update any `uses:` + doc references to the old name | **confirm each** — renames a CI file |
+| AFK-lane auth gap (`rs-afk-attempt.yml`, no auth secret) | **do not set the secret** — print the per-provider `gh secret set … --repo` guidance + the public-repo org-secret note; delegate to `/setup-red-skills` | **delegate** |
+| AFK hook/backpressure static-validation `❌`/`⚠️` (check 12) | **`--fix` cannot auto-fix operator intent** — it cannot know whether the right repair is to rename the script, restore the file, or drop the command. Flag the finding and point at `/setup-red-skills` (re-seed a library hook) or a manual edit; never rewrite `.red/config.yaml` or `.red/hooks/` here, and never execute the command to "check" it. | **delegate** |
+| Per-plugin runtime distribution `❌`/`⚠️` (check 13) | **re-trigger the launcher fetch** for the plugin (`red-fetch.mjs <plugin> <version>` / rebuild locally) — the cache is launcher-owned, never hand-edited. `cache-corrupt` also removes the bad cached file first so the re-fetch re-downloads. A re-fetch hits the network and rewrites the cache, so it is never a safe batch. | **confirm each** — a network fetch that rewrites the cache |
+| `req:<PRD>` dependency edge (check 14) | **do not silently re-label** — a re-point needs the author to pick the right executable slice(s). Surface each offending edge and delegate to `/triage` (re-point) or `/to-issues` (author the missing slice); never edit the `req:*` label here. | **delegate** |
+| Context-stack gap (check 1) | run the relevant `memory`/context skill | **delegate** |

--- a/plugins/dev/skills/engineering/doctor/SKILL.md
+++ b/plugins/dev/skills/engineering/doctor/SKILL.md
@@ -42,7 +42,7 @@ Run the checks against the target repo (cwd by default; `--repo <path|owner/name
 
     During this read-only pass: never write `.red/config.yaml`.
 7. **Statusline drift** — the installed `.claude/settings.json` `statusLine` command resolves the **cached bundle** (`~/.cache/red-skills/bundles/dev-*.bundle.min.mjs`), not the OLD launcher form (`…/plugins/cache/red-skills/dev/*/…/afk.mjs`) which blanks on every plugin update.
-8. **MCP wiring** — does the repo wire the expected MCPs? The `dev` plugin should expose `code-nav`; the `memory` plugin should expose **`red-memory` (the local data MCP) + `red-ui` (the visualizer consumer)**. Per **ADR 0041 Amendment 1 (reversed, 2026-06-20)**, `red-memory` is a **local** server that execs the in-repo `bootstrap.mjs` (built from `apps/memory`, RedDB-backed via `@reddb-io/sdk`) — that local shape is the **intended** wiring, **not** drift. What *is* a finding: a server still named **`memory`** that was never renamed to `red-memory` (the rename is the one surviving piece of ADR 0041), or a `.mcp.json`/routing-guide that tries to **fetch `red-memory` from a GitHub release** (a leftover of the cancelled migration — there is no `red-memory` release and that repo is archived). Also check whether the repo wires `code-nav`/`red-memory` for its **own** dev (root `.mcp.json` or agent-doc reference).
+8. **MCP wiring** — does the repo wire the expected MCPs? The `dev` plugin should expose `code-nav`; the `memory` plugin should expose **`red-memory` (the local data MCP, a local server that execs the in-repo `bootstrap.mjs`, built from `apps/memory`, RedDB-backed via `@reddb-io/sdk`) + `red-ui` (the visualizer consumer)** — this local shape is the **intended** wiring, **not** drift (ADR 0041 Amendment 1 reversed the release-fetched migration). What *is* a finding: a server still named **`memory`** that was never renamed to `red-memory`, or a `.mcp.json`/routing-guide that tries to **fetch `red-memory` from a GitHub release** (there is no such release). Also check whether the repo wires `code-nav`/`red-memory` for its **own** dev (root `.mcp.json` or agent-doc reference).
 9. **Version coherence** — every plugin manifest pair is on the same version: for each `plugins/*/`, `.claude-plugin/plugin.json` `version` **==** `.codex-plugin/plugin.json` `version`. A mismatch is what `validate-install-metadata.sh` rejects and what fails `red-release` (e.g. a stale manifest landed manually). Fix-home = `→ release` (the single-writer version script, ADR 0040).
 10. **Workflow naming convention** — list `.github/workflows/*.yml` and classify each by **role**, decidable from its content: has `workflow_call:` → must be `reusable-*`; `uses:` a `reusable-*` → must be `rs-*` (a caller / instantiation); otherwise → must be `red-*` (a standalone workflow). Applies both in red-skills itself and in an adopter repo. Two findings, both tagged `→ /setup-red-skills`:
     - **Naming drift** — a file whose filename prefix doesn't match its role: a reusable caller named `red-*` (should be `rs-*`), a standalone named `rs-*`/`reusable-*` (should be `red-*`), a `workflow_call` workflow not named `reusable-*`, or a legacy `red-skills-*` (the retired caller prefix → now `rs-*`). Report the rename to the role-correct prefix. (A `reusable-*` referenced via `uses:` from another repo is exempt — it is *called*, never copied.)
@@ -61,11 +61,11 @@ Run the checks against the target repo (cwd by default; `--repo <path|owner/name
 
 ### Pass 2 — Fix (only with `--fix`; gated apply)
 
-For **every** non-green finding from Pass 1, apply its canonical fix from the *Apply* table in `<supporting-info>`. There is no finding the doctor reports but cannot heal: each row maps to a concrete action or a delegation to the single-writer tool that owns it.
+For **every** non-green finding from Pass 1, apply its canonical fix. Running with `--fix` → read [`APPLY.md`](APPLY.md) for the per-finding action and gate. There is no finding the doctor reports but cannot heal: each row maps to a concrete action or a delegation to the single-writer tool that owns it.
 
 The loop:
 
-1. **Group the findings** into **safe** (idempotent, low-blast-radius) and **hard-to-reverse** (per the *Apply* table's gate column).
+1. **Group the findings** into **safe** (idempotent, low-blast-radius) and **hard-to-reverse** (per the gate column in [`APPLY.md`](APPLY.md)).
 2. **Apply the safe batch** — run each safe fix, print a one-line receipt per action (`✅ created label needs-triage`, `✅ injected ## Development workflow into AGENTS.md`, …). Re-running is a no-op.
 3. **Confirm each hard-to-reverse fix individually** — show the exact mutation (the `gh label rename old new` that re-tags N issues, the config-key migration, the `blocked:*` removal on issue #N, the `.mcp.json` edit) and apply only on an explicit yes. A no leaves that finding open and recorded.
 4. **Delegate** what a single-writer tool owns — a version mismatch runs the version/release tool (never a manual manifest edit); context-stack gaps run the `memory`/context skills. `--fix` triggers the tool, then re-checks.
@@ -97,27 +97,6 @@ Canonical families live in the target repo's `.red/agents/triage-labels.md`: sta
 | `→ /triage` | `req:<PRD>` dependency edges (check 14) — re-point each offending edge at the target PRD's executable slices; `/triage` owns the authoring validation. |
 | `→ manual / maintainer` | label renames (`gh label edit`), retiring legacy labels — the operator decides. |
 | `→ release` | cross-manifest version mismatch — owned by the single-writer version script + `validate-install-metadata.sh` gate (ADR 0040); never hand-edit one manifest. |
-
-### Apply (what `--fix` runs per finding, and its gate)
-
-| Finding | `--fix` action | Gate |
-|---|---|---|
-| Missing canonical label | `gh label create <name> --color <c> --description "<d>"` | **safe** (batch) |
-| AGENTS≡CLAUDE Agent-skills / Development-workflow parity | run the development-workflow injector (`inject-development-workflow --root <repo>`) — upserts both blocks in place | **safe** (batch; idempotent) |
-| `dev.lock.primary-branch` unset | same injector (it sets the nested flag) | **safe** (batch) |
-| Statusline drift | rewrite the `.claude/settings.json` `statusLine` to the cached-bundle form (jq merge, preserve other keys) | **safe** (batch) |
-| `.red/.gitignore` self-ignore missing/incomplete | write `.red/.gitignore` (header + `tmp/` + `state/`) if absent, else append only the missing pattern(s) — never reorder or clobber existing lines; don't `git add` it; print a one-line receipt | **safe** (batch; idempotent) |
-| Label synonym / legacy / naming | `gh label rename <old> <new>` (or create canonical + migrate, then retire the old) | **confirm each** — re-tags every issue carrying the old label |
-| Legacy/top-level dev-plugin config (flat `lock-primary-branch`, top-level `dev.lock.*`, top-level `afk:`) | migrate the key(s) into the canonical `plugins.dev.*` namespace + delete the top-level orphan in `.red/config.yaml` (safe: the #697 fold reads both, the namespaced form wins) | **confirm each** |
-| `blocked:*` on a `ready-for-agent`/`running` issue | `gh issue edit <N> --remove-label blocked:<reason>` (rotate the stale reason) | **confirm each** |
-| MCP wiring | add/correct the expected servers in the repo's `.mcp.json` | **confirm each** |
-| Version coherence mismatch | **run** the single-writer version/release tool (ADR 0040); never patch a manifest | **delegate** |
-| Workflow naming-convention drift | `git mv` the file to the prefix its role requires (`reusable-*` / `rs-*` / `red-*`); filename only, body unchanged; then update any `uses:` + doc references to the old name | **confirm each** — renames a CI file |
-| AFK-lane auth gap (`rs-afk-attempt.yml`, no auth secret) | **do not set the secret** — print the per-provider `gh secret set … --repo` guidance + the public-repo org-secret note; delegate to `/setup-red-skills` | **delegate** |
-| AFK hook/backpressure static-validation `❌`/`⚠️` (check 12) | **`--fix` cannot auto-fix operator intent** — it cannot know whether the right repair is to rename the script, restore the file, or drop the command. Flag the finding and point at `/setup-red-skills` (re-seed a library hook) or a manual edit; never rewrite `.red/config.yaml` or `.red/hooks/` here, and never execute the command to "check" it. | **delegate** |
-| Per-plugin runtime distribution `❌`/`⚠️` (check 13) | **re-trigger the launcher fetch** for the plugin (`red-fetch.mjs <plugin> <version>` / rebuild locally) — the cache is launcher-owned, never hand-edited. `cache-corrupt` also removes the bad cached file first so the re-fetch re-downloads. A re-fetch hits the network and rewrites the cache, so it is never a safe batch. | **confirm each** — a network fetch that rewrites the cache |
-| `req:<PRD>` dependency edge (check 14) | **do not silently re-label** — a re-point needs the author to pick the right executable slice(s). Surface each offending edge and delegate to `/triage` (re-point) or `/to-issues` (author the missing slice); never edit the `req:*` label here. | **delegate** |
-| Context-stack gap (check 1) | run the relevant `memory`/context skill | **delegate** |
 
 ### Scope & boundaries
 

--- a/plugins/dev/skills/engineering/setup-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/setup-statusline/HOST-NOTES.md
@@ -1,0 +1,47 @@
+# Host notes — why each host branch is shaped the way it is
+
+Reference material for the three host branches in `SKILL.md`. Read the section for
+the branch you are wiring; each is rationale, not an extra step.
+
+## Claude Code — why the statusLine command is shaped this way
+
+**Why this shape, not `$CLAUDE_PLUGIN_ROOT`.** Claude Code does **not** export
+`CLAUDE_PLUGIN_ROOT` (nor `CLAUDE_PROJECT_DIR`) to a `statusLine` command — those
+are only set for plugin hooks and MCP/LSP subprocesses. A statusLine that
+references `$CLAUDE_PLUGIN_ROOT` expands it to an empty string and fails with
+`Cannot find module` — the statusline then silently renders blank.
+
+**Why the cached bundle, not `afk.mjs` directly.** Since ADR 0038, the installed
+`afk.mjs` is a tiny **launcher that fetches** the real runtime bundle from the
+GitHub release on first use (caching it at
+`~/.cache/red-skills/bundles/dev-<version>.bundle.min.mjs`). Pointing the
+statusLine straight at the launcher means **every plugin update** lands a new
+version whose bundle is not cached yet, so the launcher tries a **synchronous
+network download inside the statusline render** — which blows the render's tight
+timeout (blank statusline), or fails outright if that version's release asset is
+not published yet. The command instead runs the **highest-version
+already-fetched bundle** (`ls -1 …/.cache/red-skills/bundles/dev-*.bundle.min.mjs | sort -V | tail -1`
+— `sort -V` picks the highest semver, NOT `ls -t` which picks newest-by-mtime and
+can resolve an OLD version when an older dir was touched/re-extracted more recently) —
+no network in the hot path, so an update never blanks the line; it keeps showing
+the last good bundle until a normal `afk` run (or a SessionStart pre-fetch)
+caches the new one. It falls back to the launcher only when the cache is empty
+(first-ever install), to bootstrap. The project root is **not** passed as an
+argument: the AFK `statusline` subcommand reads it from `workspace.project_dir`
+in the JSON Claude Code pipes on stdin, which the `sh -c` wrapper forwards
+intact.
+
+This respects ADR 0084: the documented command stays cached-bundle-first and
+never fetches synchronously in a render path.
+
+## Codex — surviving config resets
+
+That global `tui.status_line` gets dropped whenever Codex rewrites
+`~/.codex/config.toml` (e.g. re-syncing plugin `[hooks.state]` on update),
+blanking the footer "every update". The dev plugin's Codex `SessionStart` hook
+re-asserts it: `hooks/ensure-codex-statusline.mjs` inserts `status_line` **only
+when absent** (never clobbers an operator's own value) via an **atomic** write
+(temp + rename — a race with Codex's writer can lose the update but never corrupt
+the file). So a reset self-heals on the next session start. The hook is additive
+and idempotent; disable it by removing the second `SessionStart` entry in
+`hooks/codex.hooks.json`.

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: setup-statusline
 description: Install or inspect the RedSkills statusline for the active host. RedSkills has one shared `statusline` producer in the dev bundle; Claude Code wires it through `.claude/settings.json` as a command-backed statusLine, while Codex configures the built-in `tui.status_line` footer and the dev plugin's SessionStart self-heal hook. Preserves existing config unless replacement is explicitly requested.
+disable-model-invocation: true
 ---
 
 # Statusline
@@ -37,40 +38,16 @@ This mirrors how Codex itself organizes customization: skills define reusable wo
 }
 ```
 
-**Why this shape, not `$CLAUDE_PLUGIN_ROOT`.** Claude Code does **not** export
-`CLAUDE_PLUGIN_ROOT` (nor `CLAUDE_PROJECT_DIR`) to a `statusLine` command — those
-are only set for plugin hooks and MCP/LSP subprocesses. A statusLine that
-references `$CLAUDE_PLUGIN_ROOT` expands it to an empty string and fails with
-`Cannot find module` — the statusline then silently renders blank.
-
-**Why the cached bundle, not `afk.mjs` directly.** Since ADR 0038, the installed
-`afk.mjs` is a tiny **launcher that fetches** the real runtime bundle from the
-GitHub release on first use (caching it at
-`~/.cache/red-skills/bundles/dev-<version>.bundle.min.mjs`). Pointing the
-statusLine straight at the launcher means **every plugin update** lands a new
-version whose bundle is not cached yet, so the launcher tries a **synchronous
-network download inside the statusline render** — which blows the render's tight
-timeout (blank statusline), or fails outright if that version's release asset is
-not published yet. The command above instead runs the **highest-version
-already-fetched bundle** (`ls -1 …/.cache/red-skills/bundles/dev-*.bundle.min.mjs | sort -V | tail -1`
-— `sort -V` picks the highest semver, NOT `ls -t` which picks newest-by-mtime and
-can resolve an OLD version when an older dir was touched/re-extracted more recently) —
-no network in the hot path, so an update never blanks the line; it keeps showing
-the last good bundle until a normal `afk` run (or a SessionStart pre-fetch)
-caches the new one. It falls back to the launcher only when the cache is empty
-(first-ever install), to bootstrap. The project root is **not** passed as an
-argument: the AFK `statusline` subcommand reads it from `workspace.project_dir`
-in the JSON Claude Code pipes on stdin, which the `sh -c` wrapper forwards
-intact.
+**Why this shape (cached-bundle-first, not `$CLAUDE_PLUGIN_ROOT`, not `afk.mjs` directly):** read [`HOST-NOTES.md`](HOST-NOTES.md) → *Claude Code*. The command above is cached-bundle-first by design (ADR 0084) — never alter it to fetch synchronously in the render path.
 
 Use `jq` to merge when `.claude/settings.json` already exists; create `.claude/`
 and a fresh file when it is missing. Keep unrelated settings intact.
 
-5. Verify: confirm `.claude/settings.json` is valid JSON and has `.statusLine.command`. Unlike the old `$CLAUDE_PLUGIN_ROOT` form, you **can** prove this one renders by piping a minimal session JSON to it:
+5. Verify: confirm `.claude/settings.json` is valid JSON and has `.statusLine.command`. Unlike the old `$CLAUDE_PLUGIN_ROOT` form, you **can** prove this one renders by piping a minimal session JSON into the **same `sh -c '…'` command from step 4** (no need to re-type it):
 
 ```bash
 printf '{"workspace":{"project_dir":"%s"},"model":{"display_name":"Opus"}}' "$PWD" \
-  | sh -c 'b=$(ls -1 "$HOME"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z "$b" ] && b=$(ls -1 "$HOME"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n "$b" ] && exec node "$b" statusline'
+  | <the step-4 statusLine command>
 ```
 
 It should print a line like `red-skills (main) · Opus`.
@@ -111,15 +88,7 @@ per-repo like the Claude path):
 status_line = ["project", "git-branch", "model-with-reasoning", "context-remaining", "task-progress"]
 ```
 
-**Surviving Codex config resets.** That global `tui.status_line` gets dropped
-whenever Codex rewrites `~/.codex/config.toml` (e.g. re-syncing plugin
-`[hooks.state]` on update), blanking the footer "every update". The dev plugin's
-Codex `SessionStart` hook re-asserts it: `hooks/ensure-codex-statusline.mjs`
-inserts `status_line` **only when absent** (never clobbers an operator's own
-value) via an **atomic** write (temp + rename — a race with Codex's writer can
-lose the update but never corrupt the file). So a reset self-heals on the next
-session start. The hook is additive and idempotent; disable it by removing the
-second `SessionStart` entry in `hooks/codex.hooks.json`.
+**Surviving Codex config resets.** A global `tui.status_line` gets dropped when Codex rewrites `~/.codex/config.toml`, but the dev plugin's Codex `SessionStart` hook re-asserts it so a reset self-heals on the next session start — why and how (the additive, atomic, absent-only re-write) is in [`HOST-NOTES.md`](HOST-NOTES.md) → *Codex*.
 
 This is intentionally host-global and plugin-gated. Codex stores footer
 preferences in `~/.codex/config.toml`, while RedSkills gates global hook side
@@ -138,12 +107,7 @@ AFK bundle so the line matches Claude Code's.
 
 ## OpenCode
 
-OpenCode is not a Codex/Claude-style host UI in RedSkills. It is the AFK
-API-auth runner lane selected explicitly with `--runner opencode` or
-`RED_AFK_RUNNER=opencode`; AFK observes it through the same GitHub envelopes,
-worker logs, `/afk monitor`, `/afk dashboard`, and Actions output as any other
-runner. There is no OpenCode footer/statusline adapter to install here because
-there is no interactive RedSkills-hosted OpenCode plugin surface.
+Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`), not an interactive host UI, so it has no footer/statusline adapter — observe it through `/afk monitor`, `/afk dashboard`, and Actions output like any other runner.
 
 ## Notes
 


### PR DESCRIPTION
Automated AFK landing for #1145. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1145

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785818597&installation_id=129708444&pr_number=1159&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1159&signature=295e741441d4324189fb3511d381c8e1cc83cd34a83b005a02a70a3cf0bb144a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->