### PR TITLE
refactor(memory+brain): shared preconditions and boundary references (#1146)

### DIFF
--- a/plugins/brain/skills/core/capture/SKILL.md
+++ b/plugins/brain/skills/core/capture/SKILL.md
@@ -36,12 +36,7 @@ When unsure, use `note`. Do not invent kinds outside the Brain vertex vocabulary
 
 ## 2. Check the Brain-vs-Memory boundary
 
-**Use Brain, not Memory, for Personal facts.** Before capturing, confirm the content belongs in Brain:
-
-- **Belongs in Brain**: biographical details, identity context, personal preferences, contact information, durable human decisions, knowledge about people and organizations, long-lived ideas, plans, and questions — anything the user wants to recall across sessions as human-facing knowledge.
-- **Belongs in Memory** (route to `/memory:store`): short operational facts from the current work session — a gotcha encountered, a why-note for a code decision, a validated approach, a scoped reminder for the agent.
-
-When the content is clearly about a person, relationship, or long-lived human preference, route to Brain even if a work session surfaced it. When the content is a code-level decision or engineering evidence, route to Memory.
+Confirm the content belongs in Brain before capturing — see [Brain-vs-Memory boundary](../../references/BRAIN_VS_MEMORY.md). If it is a short operational work fact (gotcha, why-note, code decision), route to `/memory:store` instead.
 
 ## 3. Capture
 
@@ -91,14 +86,7 @@ Report the artifact id and kind that was stored so the user can reference it lat
 
 ### Brain-vs-Memory boundary
 
-| Dimension | Brain | Memory |
-|---|---|---|
-| What is stored | Human and project knowledge artifacts | Operational work facts and evidence |
-| Who it serves | The human (recall, synthesis, decisions) | The agent (context packs, governed recall) |
-| Store | `.red/brain/brain.rdb` | `.red/memory/graph.rdb` (or notes) |
-| Skill to write | `brain capture` | `memory store` |
-| Skill to read | `brain search` / `brain think` | `memory recall` |
-| Examples | Person bio, open question, idea, past decision | Gotcha, why-note, validated approach |
+See [Brain-vs-Memory boundary](../../references/BRAIN_VS_MEMORY.md).
 
 ### Connection kinds
 

--- a/plugins/brain/skills/core/search/SKILL.md
+++ b/plugins/brain/skills/core/search/SKILL.md
@@ -86,12 +86,7 @@ Current ranking signals:
 
 ### Brain-vs-Memory boundary
 
-| Dimension | Brain | Memory |
-|---|---|---|
-| What is stored | Human and project knowledge artifacts | Operational work facts and evidence |
-| Read skill | `brain search` / `brain think` | `memory recall` |
-| Store | `.red/brain/brain.rdb` | `.red/memory/graph.rdb` (or notes) |
-| Examples | Person bio, decision, open question, idea | Gotcha, why-note, validated approach |
+See [Brain-vs-Memory boundary](../../references/BRAIN_VS_MEMORY.md).
 
 ### When to use `brain think` instead
 

--- a/plugins/brain/skills/core/think/SKILL.md
+++ b/plugins/brain/skills/core/think/SKILL.md
@@ -80,11 +80,6 @@ When `confidence` is `none` or `low`, or `missing_evidence` is non-empty:
 
 ### Brain-vs-Memory boundary
 
-| Dimension | Brain | Memory |
-|---|---|---|
-| What is stored | Human and project knowledge artifacts | Operational work facts and evidence |
-| Synthesis skill | `brain think` (cited, grounded answer) | `memory recall` (governed ranked hits, no synthesis) |
-| Store | `.red/brain/brain.rdb` | `.red/memory/graph.rdb` (or notes) |
-| Examples | Person bio, decision, open question, idea | Gotcha, why-note, validated approach |
+See [Brain-vs-Memory boundary](../../references/BRAIN_VS_MEMORY.md).
 
 </supporting-info>

--- a/plugins/brain/skills/references/BRAIN_VS_MEMORY.md
+++ b/plugins/brain/skills/references/BRAIN_VS_MEMORY.md
@@ -1,0 +1,16 @@
+# Brain-vs-Memory boundary
+
+Shared reference for brain and memory skills — the canonical routing table. Edit here instead of patching each skill individually.
+
+| Dimension | Brain | Memory |
+|---|---|---|
+| What is stored | Human and project knowledge artifacts | Operational work facts and evidence |
+| Who it serves | The human (recall, synthesis, decisions) | The agent (context packs, governed recall) |
+| Store | `.red/brain/brain.rdb` | `.red/memory/graph.rdb` (or notes) |
+| Skill to write | `brain capture` | `memory store` |
+| Skill to read | `brain search` / `brain think` | `memory recall` |
+| Examples | Person bio, open question, idea, past decision | Gotcha, why-note, validated approach |
+
+**Route to Brain** for: biographical details, identity context, personal preferences, contact information, durable human decisions, knowledge about people and organizations, long-lived ideas, plans, and open questions — anything the user wants to recall across sessions as human-facing knowledge.
+
+**Route to Memory** for: short operational facts from the current work session — gotchas, why-notes, code decisions, validated approaches, scoped reminders for the agent.

--- a/plugins/memory/skills/core/context-status/SKILL.md
+++ b/plugins/memory/skills/core/context-status/SKILL.md
@@ -28,7 +28,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" status context --json
 Read these sections together:
 
 - `committedContext` — whether `CLAUDE.md`/`AGENTS.md`, `.red/CONTEXT.md`, `.red/CONTEXT-MAP.md`, and `.red/adr/*.md` are present.
-- `memory` — whether Memory is uninitialized, markdown-only, or graph mode; whether graph store, graph freshness, hooks, and Skill telemetry are available.
+- `memory` — init-chain state (see [Memory preconditions](../../references/PRECONDITIONS.md#init-chain-state-taxonomy)), plus graph store, freshness, hooks, and Skill telemetry availability.
 - `wiki` — whether `.red/agents/wiki.md` and `.red/wiki/` are both present.
 - `score` — count of ready checks; this is a grounding signal, not a quality guarantee.
 - `recommendations` — setup actions that would improve context readiness.

--- a/plugins/memory/skills/core/doctor/SKILL.md
+++ b/plugins/memory/skills/core/doctor/SKILL.md
@@ -19,8 +19,7 @@ fresh; one that nobody reads goes cold and surfaces here.
 
 ## 1. Require graph mode
 
-`doctor` needs a `plugins.memory` block in `.red/config.yaml` with `mode: "graph"`. If memory is not
-initialized or is markdown-only, say so and stop — there is no graph to inspect.
+`doctor` needs graph mode — see [Memory preconditions](../../references/PRECONDITIONS.md). If memory is not initialized or is markdown-only, say so and stop — there is no graph to inspect.
 
 ## 2. Diagnose (read-only first)
 

--- a/plugins/memory/skills/core/export/SKILL.md
+++ b/plugins/memory/skills/core/export/SKILL.md
@@ -21,8 +21,7 @@ Dumps the whole graph (graph mode only) into a directory as three files:
 
 ## 1. Require graph mode
 
-`export` needs a `plugins.memory` block in `.red/config.yaml` with `mode: "graph"`. If memory is not
-initialized or is markdown-only, say so and stop.
+`export` needs graph mode — see [Memory preconditions](../../references/PRECONDITIONS.md). If memory is not initialized or is markdown-only, say so and stop.
 
 ## 2. Export
 

--- a/plugins/memory/skills/core/extract/SKILL.md
+++ b/plugins/memory/skills/core/extract/SKILL.md
@@ -13,16 +13,11 @@ Turns a transcript into `INFERRED` memory graph facts. This is the LLM-backed wr
 
 ## 1. Require graph mode and provider
 
-`extract` needs a `plugins.memory` block in `.red/config.yaml` with:
-
-- `mode: "graph"`
-- a configured `provider` block
-
-If either is missing, stop and explain the missing prerequisite. Do not silently fall back to markdown notes; extraction is graph-only.
+`extract` needs graph mode and a `provider` block — see [Memory preconditions](../../references/PRECONDITIONS.md). If either is missing, stop and explain; do not silently fall back to markdown notes.
 
 ## 2. Select the transcript deliberately
 
-Use a transcript/log that contains durable operational learning: decisions, root causes, gotchas, why-notes, or failed attempts that explain constraints. Do not extract secrets, raw credentials, private personal data, Odysseus-style Personal facts, biographical details, issue-only progress, PR numbers, commit SHAs, or stale task-completion logs. Long-lived human preferences and identity context belong in Brain, not Memory.
+Use a transcript/log that contains durable operational learning: decisions, root causes, gotchas, why-notes, or failed attempts that explain constraints. Do not extract secrets, raw credentials, private personal data, Odysseus-style Personal facts, biographical details, issue-only progress, PR numbers, commit SHAs, or stale task-completion logs. Long-lived human preferences and identity context belong in Brain — see [Brain-vs-Memory boundary](../../../../brain/skills/references/BRAIN_VS_MEMORY.md).
 
 ## 3. Run extraction
 

--- a/plugins/memory/skills/core/health/SKILL.md
+++ b/plugins/memory/skills/core/health/SKILL.md
@@ -21,16 +21,13 @@ Use `--root <dir>` when checking a repository other than the current working dir
 
 ## 2. Interpret the state
 
-- `missing` — Memory is not initialized. Recommend graph mode with Skill telemetry when self-improvement is desired.
-- `degraded` — Memory exists but graph mode, Skill telemetry, or graph freshness is not ready.
-- `attention` — Memory is operational and has pending/high-priority improvement work.
-- `ready` — Memory is operational and no immediate action is needed.
+Match the `state` field against the [init-chain state taxonomy](../../references/PRECONDITIONS.md#init-chain-state-taxonomy). `health` additionally reports `degraded` (a sub-component not ready), `attention` (pending improvement work), and `ready` (no action needed).
 
 ## 3. Use the operational counters
 
 Read these JSON fields before deciding the next action:
 
-- `initialized` — whether memory is configured (a `plugins.memory` block in `.red/config.yaml`, or the legacy `.red/memory/config.json`).
+- `initialized` — whether memory is configured (see [Memory preconditions](../../references/PRECONDITIONS.md)).
 - `graphMode` — whether graph mode is configured and the graph store exists.
 - `skillTelemetry` — `enabled` or `unavailable`.
 - `graphFreshness` — freshness of the graph store versus project files.

--- a/plugins/memory/skills/core/improve-skills/SKILL.md
+++ b/plugins/memory/skills/core/improve-skills/SKILL.md
@@ -53,9 +53,7 @@ The command writes proposals under:
 
 ## 2. Interpret states
 
-- `uninitialized` — Memory is not initialized; run `/memory:init` first if Skill self-improvement is desired.
-- `no-op` — Memory is initialized without graph mode; Skill telemetry cannot persist rollups here.
-- `unavailable` — graph mode exists but Skill telemetry is not enabled.
+See [init-chain state taxonomy](../../references/PRECONDITIONS.md#init-chain-state-taxonomy) — for `uninitialized`, run `/memory:init`; for `no-op`, re-run with `--mode graph`; for `unavailable`, add `--skill-telemetry`.
 - `no-candidates` — telemetry does not currently support a proposal.
 - `proposal-ready` — dry-run found proposal candidates but wrote no files. JSON summaries include `recentFailures`, `dominantErrorStage`, `dominantErrorClass`, `patchDrafted`, `score`, `priority`, and `scoreReasons` for machine-readable routing.
 - `proposal-written` — proposal files were written or refreshed for review, including recent failure evidence, a deterministic `Fingerprint`, and a draft structured patch block when the skill file has a safe unique insertion anchor.

--- a/plugins/memory/skills/core/ingest/SKILL.md
+++ b/plugins/memory/skills/core/ingest/SKILL.md
@@ -28,9 +28,7 @@ This is the `EXTRACTED` (deterministic) ingest path only. Conversation/git
 
 ## 1. Require graph mode
 
-Read the `plugins.memory` block of `.red/config.yaml` (or the legacy `.red/memory/config.json`). If neither is present, memory was never initialized —
-run `/memory:init`. If `mode` is not `graph`, ingest has nothing to write to;
-tell the user to re-run `memory init --mode graph`.
+See [Memory preconditions](../../references/PRECONDITIONS.md). If memory is not initialized, run `/memory:init`. If `mode` is not `graph`, ingest has nothing to write to; tell the user to re-run `memory init --mode graph`.
 
 ## 2. Ingest
 

--- a/plugins/memory/skills/core/recall/SKILL.md
+++ b/plugins/memory/skills/core/recall/SKILL.md
@@ -23,8 +23,7 @@ plugin README.
 
 ## 1. Require init
 
-If memory is not configured (no `plugins.memory` block in `.red/config.yaml`, nor a legacy `.red/memory/config.json`), memory was never initialized — there is
-nothing to recall. Suggest `/memory:init`.
+If memory is not configured — see [Memory preconditions](../../references/PRECONDITIONS.md) — there is nothing to recall; suggest `/memory:init`.
 
 ## 2. Recall
 

--- a/plugins/memory/skills/core/skills-status/SKILL.md
+++ b/plugins/memory/skills/core/skills-status/SKILL.md
@@ -21,10 +21,8 @@ Use `--all` to include bundled plugin/hub skills, and `--json` when another scri
 
 ## 2. Interpret the state
 
-- `uninitialized` — Memory is not initialized. Recommend `memory init --mode graph --skill-telemetry` if the user wants self-improvement telemetry.
-- `no-op` — Memory exists but is not graph mode. Skill telemetry needs graph mode.
-- `unavailable` — graph mode exists, but the explicit `skillTelemetry` opt-in is off.
-- `enabled` — read partitioned rollups and recent events. Rollups are stored per skill/event marker so telemetry can scale beyond the engine KV value cap.
+See the [init-chain state taxonomy](../../references/PRECONDITIONS.md#init-chain-state-taxonomy). For the `uninitialized` case, recommend `memory init --mode graph --skill-telemetry`; for `no-op`, graph mode is required; for `unavailable`, the explicit `skillTelemetry` opt-in is off.
+- `enabled` — read partitioned rollups and recent events; rollups are stored per skill/event marker so telemetry scales beyond the engine KV value cap.
 
 Do not treat non-enabled states as errors; this command is a diagnostic and exits cleanly.
 

--- a/plugins/memory/skills/core/store/SKILL.md
+++ b/plugins/memory/skills/core/store/SKILL.md
@@ -19,8 +19,7 @@ way the fact is recallable later with `/memory:recall`.
 
 ## 1. Require init
 
-If memory is not configured (no `plugins.memory` block in `.red/config.yaml`, nor a legacy `.red/memory/config.json`), memory was never initialized — run
-`/memory:init` (or tell the user to) before storing.
+If memory is not configured — see [Memory preconditions](../../references/PRECONDITIONS.md) — run `/memory:init` before storing.
 
 ## 2. Store the fact
 
@@ -41,7 +40,7 @@ Report the note path or graph node id so the user knows what was captured.
 
 - ✅ Store a single, self-contained fact per call (a decision, a gotcha, a why-note).
 - ✅ Capture the *why*, not just the *what*, when the user is explaining a decision.
-- ❌ Don't store Personal facts, biographical details, identity context, or long-lived human preferences in Memory; route them to Brain with `brain capture`.
+- ❌ Don't store Personal facts (biographical details, identity context, long-lived human preferences) in Memory — see [Brain-vs-Memory boundary](../../../../brain/skills/references/BRAIN_VS_MEMORY.md) and route to `brain capture` instead.
 - ❌ Don't store secrets — notes are plain text on disk and may be committed.
 - ❌ Don't hand-write files into `notesDir` — go through the CLI so ids and frontmatter stay consistent.
 

--- a/plugins/memory/skills/references/PRECONDITIONS.md
+++ b/plugins/memory/skills/references/PRECONDITIONS.md
@@ -1,0 +1,30 @@
+# Memory plugin preconditions
+
+Shared reference for all memory skills. Edit here instead of patching each skill individually.
+
+## Config requirements
+
+All memory skills require a `plugins.memory` block in `.red/config.yaml`. Legacy projects may instead have `.red/memory/config.json`; when neither is present, memory was never initialized — the calling skill stops and recommends `/memory:init`.
+
+Graph-mode skills additionally require `mode: "graph"` inside the `plugins.memory` block. The `extract` skill also requires a `provider` block inside that block.
+
+## Bootstrap invocation
+
+Every memory CLI call follows this form:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs" <verb> [args]
+```
+
+## Init-chain state taxonomy
+
+Every memory command checks the init chain before running. The states, in order:
+
+| State | Meaning | Recommended action |
+|---|---|---|
+| `uninitialized` / `missing` | No `plugins.memory` block and no legacy config | Run `/memory:init` |
+| `no-op` / `markdown-only` | Initialized, but `mode` is not `graph` | Run `memory init --mode graph` to enable graph features |
+| `unavailable` | Graph mode exists but a required feature opt-in is off | Enable the specific flag (e.g. `--skill-telemetry`) |
+| `enabled` / `ready` | Fully operational for this command | Proceed |
+| `degraded` | Operational but a sub-component (graph mode, freshness, telemetry) is not ready | Check `recommendedNextActions` |
+| `attention` | Operational with pending improvement work | Address pending proposals |


### PR DESCRIPTION
## Summary

- Creates `plugins/memory/skills/references/PRECONDITIONS.md` — single home for the `plugins.memory` config key, legacy fallback, bootstrap invocation form, and init-chain state taxonomy
- Creates `plugins/brain/skills/references/BRAIN_VS_MEMORY.md` — single home for the Brain-vs-Memory routing table
- Eight memory skills (store, recall, ingest, extract, doctor, export, health, context-status) replace their inline config-key precondition sentence with a one-line pointer
- Four state-taxonomy carriers (health, skills-status, context-status, improve-skills) replace the init-chain bullets with a pointer
- Brain skills capture/search/think replace their inline boundary tables with a pointer; capture's in-file duplication (step 2 prose + supporting-info table) collapses to a single pointer
- Memory skills store and extract replace their brain-routing echoes with a pointer to the shared reference

## Test plan

- [ ] Verify `plugins/memory/skills/references/PRECONDITIONS.md` exists and contains config keys, bootstrap form, and state taxonomy
- [ ] Verify `plugins/brain/skills/references/BRAIN_VS_MEMORY.md` exists and contains the routing table
- [ ] Confirm `grep "plugins.memory block" plugins/memory/skills/core/*/SKILL.md` returns 0 matches
- [ ] Confirm `brain/capture` has zero inline boundary table rows
- [ ] Confirm each of the 8 memory skills carries exactly one pointer to `PRECONDITIONS.md`
- [ ] Confirm capture/search/think each have exactly one `BRAIN_VS_MEMORY.md` pointer
- [ ] No behavioral change to any verb: commands, checks, and outputs are identical

Closes #1146

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785819285&installation_id=129708444&pr_number=1160&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1160&signature=c1ecabdd925e9d55e250b4a3e0b8b18b33d3a85f367020b817973ce81ee82661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->