### PR TITLE
test: heal stale doc-contract tests after PRD #1132 pruning (unblock CI)

### DIFF
--- a/apps/dev/tests/doctor-docs.test.ts
+++ b/apps/dev/tests/doctor-docs.test.ts
@@ -8,6 +8,13 @@ async function readDoctorSkill(): Promise<string> {
   return readFile(join(ROOT, "plugins/dev/skills/engineering/doctor/SKILL.md"), "utf8");
 }
 
+// The `--fix` Apply table lives in a bundled sibling `APPLY.md`, behind a
+// one-line pointer in SKILL.md (issue #1145). Assertions on Apply-row content
+// read APPLY.md; assertions on the read-only diagnose pass read SKILL.md.
+async function readDoctorApply(): Promise<string> {
+  return readFile(join(ROOT, "plugins/dev/skills/engineering/doctor/APPLY.md"), "utf8");
+}
+
 describe("doctor docs contract", () => {
   it("checks Development-workflow adoption read-only with setup-red-skills as the fix-home", async () => {
     const skill = await readDoctorSkill();
@@ -38,8 +45,9 @@ describe("doctor docs contract", () => {
     expect(skill).toContain("Namespacing conformance");
     expect(skill).toContain("dev-plugin settings belong under `plugins.dev.*`");
     expect(skill).toContain("hygiene, not breakage");
-    // The `--fix` Apply table has the migration row.
-    expect(skill).toContain("Legacy/top-level dev-plugin config");
+    // The `--fix` Apply table has the migration row (now in APPLY.md, #1145).
+    const apply = await readDoctorApply();
+    expect(apply).toContain("Legacy/top-level dev-plugin config");
   });
 
   it("audits per-plugin runtime distribution read-only, launcher fetch as the fix-home", async () => {
@@ -65,8 +73,10 @@ describe("doctor docs contract", () => {
     expect(skill).toContain("apps/dev/src/core/runtime-doctor.ts");
     // Fix-home is the launcher fetch, and the --fix re-fetch is gated.
     expect(skill).toContain("`→ launcher fetch`");
-    expect(skill).toContain("Per-plugin runtime distribution `❌`/`⚠️` (check 13)");
-    expect(skill).toContain("confirm each");
+    // The gated `--fix` Apply row moved to APPLY.md (#1145).
+    const apply = await readDoctorApply();
+    expect(apply).toContain("Per-plugin runtime distribution `❌`/`⚠️` (check 13)");
+    expect(apply).toContain("confirm each");
   });
 
   it("validates AFK hook/backpressure commands statically and never executes them", async () => {
@@ -80,8 +90,10 @@ describe("doctor docs contract", () => {
     expect(skill).toContain("cannot be statically resolved");
     // Unknown hook names are pre-caught read-only.
     expect(skill).toContain("Unknown hook names");
-    // --fix cannot auto-fix operator intent — it flags and points at the fix-home.
-    expect(skill).toContain("`--fix` cannot auto-fix operator intent");
+    // --fix cannot auto-fix operator intent — the Apply row (now in APPLY.md,
+    // #1145) flags and points at the fix-home.
+    const apply = await readDoctorApply();
+    expect(apply).toContain("`--fix` cannot auto-fix operator intent");
     expect(skill).toContain("`/setup-red-skills`");
   });
 });

--- a/apps/dev/tests/memory-brain-boundary-docs.test.ts
+++ b/apps/dev/tests/memory-brain-boundary-docs.test.ts
@@ -32,9 +32,9 @@ describe("Memory/Brain boundary docs", () => {
     expect(contextSkill).toContain("| Durable operational work fact | `/memory:store` |");
     expect(contextSkill).toContain("| Personal fact or human-facing context | `brain capture` / `/brain:capture` |");
     expect(memoryStore).toContain("Don't store Personal facts");
-    expect(memoryStore).toContain("route them to Brain with `brain capture`");
+    expect(memoryStore).toContain("route to `brain capture` instead");
     expect(memoryExtract).toContain("Do not extract");
     expect(memoryExtract).toContain("Odysseus-style Personal facts");
-    expect(brainCapture).toContain("Use Brain, not Memory, for Personal facts");
+    expect(brainCapture).toContain("Route personal facts, identity context, and human knowledge to Brain");
   });
 });


### PR DESCRIPTION
**`main` is red** — the `test` check fails on four doc-contract assertions. This blocks every AFK validation gate (any drained issue would park `blocked:validation`), so it is the highest-leverage flow unblock.

Root cause: the PRD #1132 skill-pruning wave relocated/reworded skill content but did not update the doc-contract tests that assert on it.

- **doctor-docs.test.ts** — issue #1145 moved the `--fix` Apply table out of `doctor/SKILL.md` into a bundled sibling `APPLY.md` (behind a one-line pointer). Three assertions still read SKILL.md for those rows. Added a `readDoctorApply()` helper and repointed them.
- **memory-brain-boundary-docs.test.ts** — two assertions checked verbatim phrases (`store` routing line, `brain/capture` boundary line) that were reworded when the skills collapsed restated boundary prose to pointers (commit `edddcd09`). Updated both to the current, semantically-identical wording.

**Test-only** — no skill content changed, so no `CHANGES.md` entry. Full `apps/dev` suite green locally (166 files / 3036 tests).

https://claude.ai/code/session_01S2NYYtLMFbqUePLC6mDL3n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785842196&installation_id=129708444&pr_number=1163&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1163&signature=57cdb0ae295400a16cb9352baea3cae99ae4672f6431cccd4b25397861d753a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->