### PR TITLE
merge: #1165 /go: Redesign the RedSkills dev statusline (apps/dev/src/core/statusline.ts, 

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -21,7 +21,7 @@ import { readBuildInfo } from "@reddb-io/build-info";
 import { type ClaudeInput, type ProjectInput } from "../core/statusline.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
-import { collectStatuslineAfk, collectStatuslineRepo } from "../runtime/wire.js";
+import { collectStatuslineAfk, collectStatuslineRepo, collectStatuslineWorkers } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
 
 /** Read the entire stdin stream as a UTF-8 string (empty when there is none). */
@@ -54,6 +54,13 @@ interface ClaudePayload {
   model?: { display_name?: string };
   effort?: { level?: string };
   context_window?: { total_input_tokens?: number; used_percentage?: number };
+  /** Pro/Max rolling usage windows — present only after the first API response of
+   * the session, absent entirely for non-Pro/Max accounts. Each window carries a
+   * `used_percentage` (and a `resets_at` the renderer does not surface yet). */
+  rate_limits?: {
+    five_hour?: { used_percentage?: number; resets_at?: string };
+    seven_day?: { used_percentage?: number; resets_at?: string };
+  };
 }
 
 function parsePayload(text: string): ClaudePayload {
@@ -124,12 +131,25 @@ function resolveClaude(payload: ClaudePayload): ClaudeInput | undefined {
   const effort = payload.effort?.level;
   const tokens = payload.context_window?.total_input_tokens;
   const pct = payload.context_window?.used_percentage;
-  if (model === undefined && tokens === undefined) return undefined;
+  // Rate-limit windows (Pro/Max only, after the first API response): pass through
+  // only when present so the renderer stays graceful for non-Pro/Max sessions.
+  const usage5h = payload.rate_limits?.five_hour?.used_percentage;
+  const usage7d = payload.rate_limits?.seven_day?.used_percentage;
+  if (
+    model === undefined &&
+    tokens === undefined &&
+    usage5h === undefined &&
+    usage7d === undefined
+  ) {
+    return undefined;
+  }
   return {
     model: model || undefined,
     effort: effort || undefined,
     contextTokens: tokens,
     contextPercent: pct,
+    usage5h,
+    usage7d,
   };
 }
 
@@ -159,20 +179,28 @@ export async function statuslineCommand(
   // header stats (line 1) render ALWAYS; the AFK block (line 2) only with live
   // workers, so both collectors run every render (each cheap + cached).
   const repoCtx = { root, repo: "", remote: "origin" };
-  const repo = await collectStatuslineRepo(repoCtx);
-  const afk = (await collectStatuslineAfk(repoCtx)) ?? undefined;
+  // The aggregate AFK block feeds the plain single-line form (NO_COLOR / Codex);
+  // the per-worker records feed the themed multi-line form (Claude Code). Both
+  // read the same worker states — cheap file reads — so the two forms stay in
+  // sync while each renders its own layout.
+  const [repo, afk, workers] = await Promise.all([
+    collectStatuslineRepo(repoCtx),
+    collectStatuslineAfk(repoCtx).then((a) => a ?? undefined),
+    collectStatuslineWorkers(repoCtx),
+  ]);
 
-  // Theme on by default (the two-line powerline wine layout with chipped KPI
-  // numbers); honour NO_COLOR for plain consumers, matching the de-facto colour
-  // opt-out. Claude Code exports $COLUMNS (v2.1.153+) so the AFK line fits its
-  // issue list to the terminal width; absent/unparseable → fixed-cap fallback.
+  // Theme on by default (the multi-line wine layout: a repo-global header line
+  // then one line per live worker); honour NO_COLOR for plain consumers (the
+  // single-line aggregate — the Codex-footer form), matching the de-facto colour
+  // opt-out. Claude Code exports $COLUMNS (v2.1.153+) as the width budget.
   const color = !process.env.NO_COLOR;
   const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
-  const line = renderStatuslineThemed(
-    { project, claude, repo, afk },
-    color,
-    Number.isFinite(columns) && columns > 0 ? columns : undefined,
-  );
+  const nowS = Math.floor(Date.now() / 1000);
+  const line = renderStatuslineThemed({ project, claude, repo, afk }, color, {
+    columns: Number.isFinite(columns) && columns > 0 ? columns : undefined,
+    workers,
+    now: nowS,
+  });
   stdout.write(`${line}\n`);
   return 0;
 }

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -1,40 +1,44 @@
 // core/statusline-style.ts — the ANSI styling slice for the /afk statusline.
 //
-// core/statusline.ts is deliberately PURE plain-text. This sibling adds the
-// theme: a TWO-LINE layout where only the leading IDENTITY ZONE (project +
-// model·effort) carries a wine-red BACKGROUND. Everything after it — the rest of
-// line 1 and ALL of line 2 — is background-transparent, so no red block ever
-// appears past the model. In the transparent zone each KPI is a `key=value`
-// pair: the KEY is a very-light, high-contrast red (≈ white), the VALUE is the
-// terminal's default foreground; every other glyph (runner, the `#` sigil, the
-// `·stage` suffix) uses a softer, lighter red. Abbreviations are always THREE
-// letters (wrk/rdy/hmn/blk/loc/wai/tok/usd; ctx/prs/iss); a diff is one
-// `loc=+A -R` pair, so the signed `+A -R` is the default-fg VALUE.
+// core/statusline.ts is deliberately PURE plain-text and SINGLE-LINE (the
+// NO_COLOR / Codex-footer render). This sibling adds the theme AND the MULTI-LINE
+// Claude Code layout (issue #1165): a repo-global HEADER line, always rendered,
+// then ONE line per live AFK worker.
 //
-//   line 1 (header, always): [wine » project (branch) v· model·effort] ctx=… prs=… iss=… loc=+A -R
-//   line 2 (AFK, workers>0):  runner wrk=… res=… loc=+A -R rdy=… hmn=… blk=… wai=… tok=… usd=… #issues
+//   line 1 (header, ALWAYS): [wine » project (branch) v· model·effort] ctx=… 5h=… 7d=… prs=… iss=… loc=+A -R
+//   line 2..N (one per live worker): the monitor's compact per-worker line
 //
-// The identity zone keeps the two wine shades (WINE2 project, WINE model) so a
-// faint block separator survives between them; the shift to transparent IS the
-// separator from the model onward. Width-aware: Claude Code exports $COLUMNS, so
-// line 2 fits its issue list to the budget and collapses the rest into `+N`.
-// Each line ends with a reset so the background never bleeds.
+// Only the leading IDENTITY ZONE of line 1 (project + model·effort) carries a
+// wine-red BACKGROUND; the rest of line 1 is background-transparent, each KPI a
+// `key=value` pair (light-red KEY, default-fg VALUE). The header's new tokens:
+// `5h=`/`7d=` are the Pro/Max rate-limit windows (rendered only when the payload
+// exposes them); `prs=`/`iss=` are repo-global GitHub counts; `loc=+A -R` is the
+// LOCAL branch diff vs origin/main.
+//
+// The per-worker lines REUSE the monitor's `renderWorkerCompactLine` verbatim
+// (core/monitor.ts) — the single source of truth shared with `/afk monitor
+// --once`, so the two surfaces never drift. Each line is tinted soft-red as a
+// whole (a colour wrapper, never a structural rewrite) and ends with a reset so
+// the background never bleeds. Zero live workers → only line 1 is emitted.
+//
+// CODEX keeps the single aggregate line: its `tui.status_line` footer is
+// single-line only (per-runner split, ADR 0003), so the NO_COLOR path returns the
+// plain single-line renderStatusline; the multi-line layout is Claude-Code-only.
 //
 // Everything here is PURE (inputs → string). The IO half
-// (commands/statusline.ts) decides colour (NO_COLOR → the plain renderer) and
-// passes the COLUMNS budget.
+// (commands/statusline.ts) decides colour (NO_COLOR → the plain renderer),
+// collects the live worker records, and passes `now`.
 
 import {
   formatCacheAge,
-  humanizeAlive,
   humanizeTokens,
   renderStatusline,
-  type AfkInput,
   type ClaudeInput,
   type ProjectInput,
   type RepoInput,
   type StatuslineInput,
 } from "./statusline.js";
+import { renderWorkerCompactLine, type CompactWorker } from "./monitor.js";
 
 /** Truecolor SGR helpers. */
 const WINE = "\x1b[48;2;114;47;55m"; // identity-zone bg (model block)
@@ -51,16 +55,6 @@ const NOBOLD = "\x1b[22m";
 const RESET = "\x1b[0m";
 
 const BRANCH_MAX = 28;
-/** Issue cap when no COLUMNS budget is available. */
-const ISSUE_CAP_NO_WIDTH = 3;
-/** Reserve columns for Claude Code's right-side notifications when budgeting. */
-const WIDTH_MARGIN = 6;
-/** Per-issue `·stage` suffixes only render at or below this worker count. */
-const STAGE_MAX_WORKERS = 2;
-
-/** Visible width of an ANSI string (escapes stripped). */
-// eslint-disable-next-line no-control-regex
-const vlen = (s: string): number => s.replace(/\x1b\[[0-9;]*m/g, "").length;
 
 /** A transparent-zone `key=value`: light-red KEY, default-fg VALUE, back to SOFT. */
 const kv = (key: string, value: string): string => `${KEY}${key}=${VAL}${value}${SOFT}`;
@@ -106,6 +100,16 @@ function ctxKv(claude: ClaudeInput | undefined): string | null {
   return kv("ctx", value);
 }
 
+/** `5h=<pct>% 7d=<pct>%` Pro/Max rate-limit windows, each only when the payload
+ * exposed it (absent for non-Pro/Max and on the first render). */
+function usageKvs(claude: ClaudeInput | undefined): string[] {
+  if (!claude) return [];
+  const parts: string[] = [];
+  if (claude.usage5h !== undefined) parts.push(kv("5h", `${Math.round(claude.usage5h)}%`));
+  if (claude.usage7d !== undefined) parts.push(kv("7d", `${Math.round(claude.usage7d)}%`));
+  return parts;
+}
+
 /** `prs=<n> iss=<n>` repo-global counts, each only when > 0. When the cache
  * was served TTL-stale and refresh failed, the first rendered count carries a
  * soft age suffix so day-old counts are never silently shown as current. */
@@ -143,111 +147,52 @@ export function renderHeaderLine(
   if (model !== null) s += `${WINE}${WHITE} ${model} `;
   // Drop the background: from here on the line is transparent.
   s += `${NOBG}${SOFT}`;
-  const tail = [ctxKv(claude), ...repoCountsKv(repo), ...localDiffKv(repo)].filter(
+  const tail = [ctxKv(claude), ...usageKvs(claude), ...repoCountsKv(repo), ...localDiffKv(repo)].filter(
     (x): x is string => x !== null,
   );
   if (tail.length) s += ` ${tail.join("  ")}`;
   return `${s}${RESET}`;
 }
 
-// ---------- line 2: AFK (fully transparent) ----------
+// ---------- line 2..N: one line per live worker ----------
 
-/** Compact model family name: `claude-opus-4-8` → `opus`, `claude-sonnet-5` → `sonnet`. */
-function compactModelName(model: string): string {
-  const m = model.match(/^claude-([a-z]+)-/);
-  return m ? m[1] : model;
-}
-
-/** Runner label with optional compact model+effort: `claude-opus max`, `codex`. */
-function formatRunnerLabel(
-  runner: string | undefined,
-  model: string | undefined,
-  effort: string | undefined,
-): string {
-  if (!runner) return "";
-  if (!model) return runner;
-  const compact = compactModelName(model);
-  return effort ? `${runner}-${compact} ${effort}` : `${runner} ${compact}`;
-}
-
-/** Line 2 — the AFK KPIs, transparent background, or null when no live workers. */
-export function renderAfkLine(afk: AfkInput | undefined, columns: number | undefined): string | null {
-  if (!afk || afk.workers <= 0) return null;
-
-  const groups: string[] = [];
-  const runnerLabel = formatRunnerLabel(afk.runner, afk.model, afk.effort);
-  if (runnerLabel) groups.push(`${SOFT}${runnerLabel}${VAL}`);
-
-  let workers = kv("wrk", String(afk.workers));
-  if (afk.resolved !== undefined && afk.resolved > 0) workers += ` ${kv("res", String(afk.resolved))}`;
-  groups.push(workers);
-
-  const diff = signedDiff(afk.added, afk.removed);
-  if (diff) groups.push(kv("loc", afk.locIsPeak ? `~${diff}` : diff));
-
-  const pipe: string[] = [];
-  // Age marker: parallel to the plain-render path in afkTokens(); same placement
-  // rule — rdy= gets the mark first, falls to hmn= when queue is 0.
-  const ageStr = afk.cacheAgeS !== undefined ? ` (${formatCacheAge(afk.cacheAgeS)})` : "";
-  if (afk.queue > 0) pipe.push(kv("rdy", String(afk.queue)) + ageStr);
-  if (afk.human > 0) {
-    const hmAge = ageStr && afk.queue === 0 ? ageStr : "";
-    pipe.push(kv("hmn", String(afk.human)) + hmAge);
-  }
-  if (afk.blocked > 0) pipe.push(kv("blk", String(afk.blocked)));
-  if (afk.waiting !== undefined && afk.waiting > 0) pipe.push(kv("wai", String(afk.waiting)));
-  if (afk.tokens !== undefined && afk.tokens > 0) pipe.push(kv("tok", humanizeTokens(afk.tokens)));
-  if (afk.costUsd !== undefined && afk.costUsd > 0) pipe.push(kv("usd", afk.costUsd.toFixed(2)));
-  if (pipe.length) groups.push(pipe.join(" "));
-
-  const fixed = `${NOBG}${SOFT} ${groups.join("  ")}`;
-  if (afk.issues.length === 0) return `${fixed} ${RESET}`;
-
-  const showStage = afk.workers <= STAGE_MAX_WORKERS;
-  const issueTok = (issue: number | string, i: number): string => {
-    const stage = showStage ? afk.stages?.[i] : undefined;
-    const alive = afk.aliveMs?.[i];
-    let suffix = stage ? `${SOFT}·${stage}` : "";
-    if (alive !== undefined && alive > 0) suffix += `${SOFT}·${humanizeAlive(alive)}`;
-    return `${SOFT}#${VAL}${issue}${suffix}`;
-  };
-
-  const budget = columns && columns > 0 ? columns - WIDTH_MARGIN : null;
-  const wrap = (inner: string, overflow: number): string => {
-    const over = overflow > 0 ? ` ${SOFT}+${overflow}` : "";
-    return `${fixed}  ${inner}${over} ${RESET}`;
-  };
-
-  const toks: string[] = [];
-  let shown = 0;
-  for (let i = 0; i < afk.issues.length; i++) {
-    if (budget === null && shown >= ISSUE_CAP_NO_WIDTH) break;
-    const next = [...toks, issueTok(afk.issues[i], i)].join(" ");
-    if (budget !== null && vlen(wrap(next, afk.issues.length - shown - 1)) > budget) break;
-    toks.push(issueTok(afk.issues[i], i));
-    shown += 1;
-  }
-  return wrap(toks.join(" "), afk.issues.length - shown);
+/** One worker line — the monitor's compact per-worker formatter
+ * ({@link renderWorkerCompactLine}), tinted soft-red as a whole and
+ * reset-terminated. The tint is a pure colour wrapper: it never rewrites the
+ * line's structure, so this and `/afk monitor --once` share ONE source of truth
+ * (the formatter) and can never drift. `now` is an epoch in seconds. */
+export function renderWorkerLine(worker: CompactWorker, now: number): string {
+  return `${NOBG}${SOFT}${renderWorkerCompactLine(worker, now)}${RESET}`;
 }
 
 // ---------- assembly ----------
 
-/** The full themed statusline: header line, plus the AFK line when workers are
- * live, joined by a newline (Claude Code renders each as a row). */
-export function styleStatusline(input: StatuslineInput, columns?: number): string {
+/** Options for the themed multi-line render: the terminal width budget (reserved
+ * for future per-line trimming), the live worker records, and `now` (epoch
+ * seconds) for their elapsed clocks. */
+export interface StyleOptions {
+  columns?: number;
+  workers?: ReadonlyArray<CompactWorker>;
+  now?: number;
+}
+
+/** The full themed statusline: the header line, plus one line per live worker
+ * (Claude Code renders each `\n`-separated segment as its own row). Zero workers
+ * → only the header line. */
+export function styleStatusline(input: StatuslineInput, opts: StyleOptions = {}): string {
   const lines = [renderHeaderLine(input.project, input.claude, input.repo)];
-  const afk = renderAfkLine(input.afk, columns);
-  if (afk !== null) lines.push(afk);
+  const now = opts.now ?? 0;
+  for (const worker of opts.workers ?? []) lines.push(renderWorkerLine(worker, now));
   return lines.join("\n");
 }
 
 /** Render the statusline, themed or plain. `color` is the switch: true → the
- * themed {@link styleStatusline}; false → the plain {@link renderStatusline}
- * (single line, no escapes) for NO_COLOR / non-terminal consumers. */
+ * themed multi-line {@link styleStatusline} (Claude Code); false → the plain,
+ * single-line {@link renderStatusline} (NO_COLOR / the Codex footer). */
 export function renderStatuslineThemed(
   input: StatuslineInput,
   color: boolean,
-  columns?: number,
+  opts: StyleOptions = {},
 ): string {
-  return color ? styleStatusline(input, columns) : renderStatusline(input);
+  return color ? styleStatusline(input, opts) : renderStatusline(input);
 }

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -1,9 +1,14 @@
 // Port of the RENDER path of statusline.sh — the /afk statusline aggregator for
 // Claude Code. statusline.sh reads the Claude Code stdin JSON payload (cwd,
-// model, effort, context window) and combines it with live /afk worker state
-// from <root>/.red/tmp/workers/*/* to emit ONE compact line like:
+// model, effort, context window, rate limits) and combines it with live /afk
+// worker state from <root>/.red/tmp/workers/*/* to emit ONE compact line like:
 //
-//   red-skills · Opus·high · 47k 24% · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17
+//   red-skills · Opus·high · 47k 24% · 5h=23% 7d=41% · prs=3 iss=24 loc=+142 -36 · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17
+//
+// This module is the SINGLE-LINE plain form — the NO_COLOR / Codex-footer render.
+// The themed Claude Code render is MULTI-LINE (issue #1165): a repo-global header
+// line plus one line per live AFK worker. That layout lives in the sibling style
+// module (core/statusline-style.ts); this file stays one aggregate line.
 //
 // The AFK KPIs use three-letter `key=value` mnemonics
 // (wrk/rdy/hmn/blk/loc/wai/tok/usd) instead of emojis; the optional ANSI
@@ -44,6 +49,15 @@ export interface ClaudeInput {
   contextTokens?: number;
   /** `.context_window.used_percentage`; rounded to an int and suffixed with `%`. */
   contextPercent?: number;
+  /** `.rate_limits.five_hour.used_percentage` — the rolling 5-hour usage window
+   * Claude Code exposes for Pro/Max accounts AFTER the first API response of the
+   * session (absent for non-Pro/Max and on the very first render). Rendered as a
+   * `5h=<pct>%` token, only when present, so its absence is graceful. */
+  usage5h?: number;
+  /** `.rate_limits.seven_day.used_percentage` — the rolling weekly usage window,
+   * same Pro/Max-only availability as {@link usage5h}. Rendered as `7d=<pct>%`,
+   * only when present. */
+  usage7d?: number;
 }
 
 /** The block-4 aggregated worker counts, already summed across live workers. */
@@ -284,6 +298,49 @@ export function afkTokens(afk: AfkInput | undefined): AfkToken[] {
 }
 
 /**
+ * Usage block: the Pro/Max rate-limit windows `5h=<pct>% 7d=<pct>%`, each token
+ * emitted only when its payload field is present (Claude Code exposes these only
+ * for Pro/Max, only after the first API response). Null when neither is present,
+ * so non-Pro/Max sessions render nothing here. Percents rounded like `%.0f`.
+ */
+export function renderUsageBlock(claude: ClaudeInput | undefined): string | null {
+  if (!claude) return null;
+  const parts: string[] = [];
+  if (claude.usage5h !== undefined) parts.push(`5h=${Math.round(claude.usage5h)}%`);
+  if (claude.usage7d !== undefined) parts.push(`7d=${Math.round(claude.usage7d)}%`);
+  return parts.length ? parts.join(" ") : null;
+}
+
+/**
+ * Repo-global block: `prs=<n> iss=<n> loc=+A -R`, each token emitted only when
+ * its count is > 0 (no zero-noise). The open-PR/open-issue counts are the
+ * repo-global GitHub-derived figures ({@link RepoInput.openPrs}/openIssues); the
+ * `loc=` diff is the LOCAL branch delta vs origin/main
+ * ({@link RepoInput.localAdded}/localRemoved). When the count cache was served
+ * TTL-stale and its refresh failed, the first rendered count carries a compact
+ * age suffix (`prs=3 (12m)`) so a day-old count is never silently shown as
+ * current — the same discipline as the AFK block's `rdy=`. Null when the whole
+ * block is empty. Wired into {@link renderStatusline} so the single-line (plain /
+ * Codex-footer) form carries the repo header stats too, not only the themed one.
+ */
+export function renderRepoBlock(repo: RepoInput | undefined): string | null {
+  if (!repo) return null;
+  const parts: string[] = [];
+  const ageSuffix = repo.cacheAgeS !== undefined ? ` (${formatCacheAge(repo.cacheAgeS)})` : "";
+  if (repo.openPrs && repo.openPrs > 0) parts.push(`prs=${repo.openPrs}${ageSuffix}`);
+  if (repo.openIssues && repo.openIssues > 0) {
+    // Age marker falls to iss= only when prs= didn't already carry it.
+    const issAge = ageSuffix && (!repo.openPrs || repo.openPrs === 0) ? ageSuffix : "";
+    parts.push(`iss=${repo.openIssues}${issAge}`);
+  }
+  const diff: string[] = [];
+  if (repo.localAdded && repo.localAdded > 0) diff.push(`+${repo.localAdded}`);
+  if (repo.localRemoved && repo.localRemoved > 0) diff.push(`-${repo.localRemoved}`);
+  if (diff.length) parts.push(`loc=${diff.join(" ")}`);
+  return parts.length ? parts.join(" ") : null;
+}
+
+/**
  * Block 4: the space-joined AFK token run in plain text. Null when there are no
  * live workers, matching the bash `(( total_workers > 0 ))` gate around the
  * block. The ANSI-painted variant lives in the style module and shares the
@@ -303,9 +360,14 @@ export function renderAfkBlock(afk: AfkInput | undefined): string | null {
  *
  * TOON note (PRD #928 / ADR 0081, issue #941): TOON becomes the default
  * agent-facing wire format for the multi-row read surfaces (monitor, dashboard,
- * daily-review). The statusline is deliberately exempt from the *tabular* form —
- * Claude Code's `statusLine` contract is a SINGLE line, so a multi-line TOON
- * table cannot be rendered here. The cheap AXI principles still apply, and
+ * daily-review). The statusline is deliberately exempt from the *tabular* form.
+ * Claude Code's `statusLine` DOES render multiple lines (issue #1165 — the themed
+ * variant now emits a repo-global header line plus one line per live AFK worker),
+ * but a TOON *table* — a schema-header row followed by bare CSV data rows — still
+ * does not fit: this single-line plain form (the NO_COLOR / Codex-footer render)
+ * is one aggregate line by contract, and even the themed multi-line form is a
+ * header + per-worker prose, not a column-aligned table. The cheap AXI principles
+ * still apply, and
  * already hold (story #27, "even where TOON does not help"):
  *   - minimal schema: each KPI token ({@link afkTokens}) is emitted only when its
  *     count is > 0 — no zero-noise;
@@ -321,6 +383,10 @@ export function renderStatusline(input: StatuslineInput): string {
   if (model !== null) sections.push(model);
   const context = renderContextBlock(input.claude);
   if (context !== null) sections.push(context);
+  const usage = renderUsageBlock(input.claude);
+  if (usage !== null) sections.push(usage);
+  const repo = renderRepoBlock(input.repo);
+  if (repo !== null) sections.push(repo);
   const afk = renderAfkBlock(input.afk);
   if (afk !== null) sections.push(afk);
   return sections.join(" · ");

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -855,6 +855,81 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
   };
 }
 
+/**
+ * Per-worker records for the themed Claude Code statusline's multi-line layout
+ * (issue #1165): one {@link CompactWorker} per LIVE worker, each rendered on its
+ * own line by the SAME `renderWorkerCompactLine` formatter `/afk monitor --once`
+ * uses (single source of truth — the two never drift). Mirrors the liveness
+ * filter of {@link collectStatuslineAfk} (only "stalled" workers are dropped) and
+ * its diff-fallback (a live `git diff --shortstat` when the state file's counts
+ * are both 0). Sorted by worker start for a deterministic line order. Returns []
+ * when no live workers, so the styled render emits the header line alone.
+ *
+ * The aggregate counts (queue/human + their gh cache) stay in
+ * collectStatuslineAfk — this collector is per-worker only; the command runs both
+ * (each a cheap handful of file reads) and feeds the aggregate to the plain form
+ * and the per-worker records to the themed form.
+ */
+export async function collectStatuslineWorkers(ctx: RepoContext): Promise<CompactWorker[]> {
+  const paths = afkPaths(ctx.root);
+  const nowMs = Date.now();
+  const records = await readAllWorkerStates(paths.tmpDir, { nowMs });
+  const workers: CompactWorker[] = [];
+  for (const { state, active, live: pidLive, liveness, livenessVerdict } of records) {
+    // Same rule as the aggregate collector: count everything the evaluator does
+    // not consider stalled (a long build/gate wait stays "alive"; "unknown"
+    // container workers count conservatively). Only "stalled" is excluded.
+    if (livenessVerdict.status === "stalled") continue;
+    let added = state.current.loc_added;
+    let removed = state.current.loc_removed;
+    if (added === 0 && removed === 0 && state.current.worktree) {
+      const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
+      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
+      added = stat.added;
+      removed = stat.removed;
+    }
+    workers.push({
+      state: {
+        worker_id: state.worker_id,
+        pid: state.pid,
+        runner: state.runner,
+        started_at: state.started_at,
+        origin: state.origin || undefined,
+        total: state.total,
+        done: state.done,
+        blocked: state.blocked,
+        failed: state.failed,
+        current: {
+          number: state.current.number,
+          title: state.current.title,
+          stage: state.current.stage,
+          started_at: state.current.started_at,
+          input_tokens: state.current.input_tokens,
+          output_tokens: state.current.output_tokens,
+          cost_usd: state.current.cost_usd,
+          tools_called_count: state.current.tools_called_count,
+          text_chunk_count: state.current.text_chunk_count,
+          reasoning_events: state.current.reasoning_events,
+          waiting_count: state.current.waiting_count,
+        },
+      },
+      liveness,
+      livenessVerdict,
+      live: active,
+      pidLive,
+      diffAdded: added,
+      diffRemoved: removed,
+    });
+  }
+  // Deterministic order: oldest worker first (by top-level start, then per-attempt).
+  workers.sort((a, b) => {
+    const ka = a.state.started_at || a.state.current.started_at || "";
+    const kb = b.state.started_at || b.state.current.started_at || "";
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+  return workers;
+}
+
 interface RepoStatsCache {
   openPrs: number;
   openIssues: number;

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -68,6 +68,18 @@ const PAYLOAD = JSON.stringify({
   context_window: { total_input_tokens: 47000, used_percentage: 24 },
 });
 
+/** Payload with the Pro/Max rate-limit windows Claude Code exposes after the
+ * first API response — only present for Pro/Max sessions. */
+const PAYLOAD_WITH_RATE_LIMITS = JSON.stringify({
+  model: { display_name: "Opus" },
+  effort: { level: "high" },
+  context_window: { total_input_tokens: 47000, used_percentage: 24 },
+  rate_limits: {
+    five_hour: { used_percentage: 23, resets_at: "2026-07-05T17:00:00Z" },
+    seven_day: { used_percentage: 41, resets_at: "2026-07-12T12:00:00Z" },
+  },
+});
+
 describe("statusline command — pure helpers", () => {
   it("resolveRoot prefers an existing first-arg directory", async () => {
     const dir = await mkdtemp(join(tmpdir(), "sl-root-"));
@@ -130,18 +142,21 @@ describe("statusline command — rendered line", () => {
     else process.env.NO_COLOR = oldNoColor;
   });
 
-  it("emits the full block run from a payload + live workers + cached counts", async () => {
-    // One live worker on #17 with ad12 rm3, blocked 2, runner claude, done 7;
-    // cached rq11 rh3; repo cache pr3 is24.
+  it("emits the multi-line themed layout: header row + one row per live worker", async () => {
+    // One live worker on #17 with ad12 rm3, blocked 2, runner claude, done 7,
+    // total 10; cached rq11 rh3; repo cache pr3 is24.
     await writeWorkerState(root, "wA", "17-a1", {
+      worker_id: "wA",
       runner: "claude",
       done: 7,
+      total: 10,
       blocked: 2,
       // A real worker stamps started_at; the statusline collector counts any
       // pid-live worker (#836) — freshness is not required, so a worker quiet on
-      // the agent lane during a long test/build still renders on line 2.
+      // the agent lane during a long test/build still renders on its own row.
       current: {
         number: 17,
+        stage: "impl",
         diff_added: 12,
         diff_removed: 3,
         started_at: new Date().toISOString(),
@@ -165,33 +180,82 @@ describe("statusline command — rendered line", () => {
       else process.env.NO_COLOR = oldNoColor;
     }
 
-    // Header and AFK KPI content may render on one or two rows depending on the
-    // host width, but the command contract is the field set.
     const text = stripAnsi(out.text());
-    expect(text).toContain("Opus·high");
-    expect(text).toContain("47k 24%");
-    expect(text).toContain("prs=3");
-    expect(text).toContain("iss=24");
-    expect(text).toContain("claude"); // runner
-    expect(text).toContain("wrk=1 res=7"); // workers + resolved
-    expect(text).toContain("loc=+12 -3"); // in-transit diff
-    expect(text).toContain("rdy=11 hmn=3 blk=2"); // pipeline
-    expect(text).toContain("#17");
+    const rows = text.trimEnd().split("\n");
+    expect(rows).toHaveLength(2); // header row + one worker row
+
+    // LINE 1 — repo-global header: model/ctx + repo counts.
+    expect(rows[0]).toContain("Opus·high");
+    expect(rows[0]).toContain("47k 24%");
+    expect(rows[0]).toContain("prs=3");
+    expect(rows[0]).toContain("iss=24");
+
+    // LINE 2 — the live worker, from the monitor's shared per-worker formatter.
+    expect(rows[1]).toContain("wA"); // worker id
+    expect(rows[1]).toContain("claude"); // runner
+    expect(rows[1]).toContain("issues 7/10"); // progress counter
+    expect(rows[1]).toContain("#17"); // issue
+    expect(rows[1]).toContain("stage:impl"); // stage
+    expect(rows[1]).toContain("+12 -3"); // per-worker diff
+
     // The raw output carries the wine-red background SGR (theme on by default).
     expect(out.text()).toContain("\x1b[48;2;114;47;55m");
   });
 
-  it("drops the AFK block when there are no live workers", async () => {
+  it("renders the 5h/7d rate-limit windows on the header when the payload exposes them", async () => {
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 0, 0);
     const out = sink();
-    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    const oldNoColor = process.env.NO_COLOR;
+    delete process.env.NO_COLOR;
+    try {
+      const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD_WITH_RATE_LIMITS));
+      expect(code).toBe(0);
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+    const text = stripAnsi(out.text());
+    expect(text).toContain("5h=23%");
+    expect(text).toContain("7d=41%");
+  });
+
+  it("omits the 5h/7d windows for a non-Pro/Max payload (no rate_limits)", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    const out = sink();
+    const oldNoColor = process.env.NO_COLOR;
+    delete process.env.NO_COLOR;
+    try {
+      await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+    const text = stripAnsi(out.text());
+    expect(text).not.toContain("5h=");
+    expect(text).not.toContain("7d=");
+  });
+
+  it("emits only the header row when there are no live workers", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    const out = sink();
+    const oldNoColor = process.env.NO_COLOR;
+    delete process.env.NO_COLOR;
+    let code: number;
+    try {
+      code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
     expect(code).toBe(0);
 
-    const line = stripAnsi(out.text().trim());
-    expect(line).toContain("Opus·high");
-    expect(line).toContain("47k 24%");
-    expect(line).not.toContain("wrk=");
+    const rows = stripAnsi(out.text()).trimEnd().split("\n");
+    expect(rows).toHaveLength(1); // 0 workers → header row alone
+    expect(rows[0]).toContain("Opus·high");
+    expect(rows[0]).toContain("47k 24%");
   });
 
   it("renders only the project block outside Claude Code (empty stdin)", async () => {
@@ -235,8 +299,10 @@ describe("statusline command — rendered line", () => {
 
     const out1 = sink();
     await statuslineCommand([root], root, out1.stream, fakeStdin(PAYLOAD));
-    expect(stripAnsi(out1.text())).toContain("loc=+12 -3");
-    expect(stripAnsi(out1.text())).not.toContain("loc=+99");
+    // The per-worker diff volume renders on the worker's own row (`+A -R`), read
+    // live from the state file — no cache involved.
+    expect(stripAnsi(out1.text())).toContain("+12 -3");
+    expect(stripAnsi(out1.text())).not.toContain("+99");
 
     // Mutate in-place: new diff +99 -5 — no process restart; next render reads fresh
     await writeWorkerState(root, "wA", "17-a1", {
@@ -254,8 +320,8 @@ describe("statusline command — rendered line", () => {
     const out2 = sink();
     await statuslineCommand([root], root, out2.stream, fakeStdin(PAYLOAD));
     // Live read: must reflect the mutation without any cache involvement
-    expect(stripAnsi(out2.text())).toContain("loc=+99 -5");
-    expect(stripAnsi(out2.text())).not.toContain("loc=+12");
+    expect(stripAnsi(out2.text())).toContain("+99 -5");
+    expect(stripAnsi(out2.text())).not.toContain("+12 -3");
   });
 
   it("idle fleet (workers=0) does not gate remote refresh behind workers>0 check", async () => {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
   renderStatusline,
-  type AfkInput,
+  type ClaudeInput,
   type RepoInput,
   type StatuslineInput,
 } from "../src/core/statusline.js";
+import type { CompactWorker } from "../src/core/monitor.js";
 import {
-  renderAfkLine,
   renderHeaderLine,
   renderStatuslineThemed,
+  renderWorkerLine,
   styleStatusline,
 } from "../src/core/statusline-style.js";
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
-const vlen = (s: string): number => stripAnsi(s).length;
 
 const WINE = "\x1b[48;2;114;47;55m";
 const WINE2 = "\x1b[48;2;88;36;42m";
@@ -22,18 +22,53 @@ const NOBG = "\x1b[49m";
 const SOFT = "\x1b[38;2;224;138;148m";
 const RESET = "\x1b[0m";
 
-const afk: AfkInput = { workers: 1, queue: 11, human: 3, blocked: 2, added: 12, removed: 3, issues: [17] };
+const NOW = 1_000_000; // fixed epoch seconds so worker elapsed clocks are deterministic
+
+/** A live worker fixture: on #17, 5 minutes elapsed, +12 -3 diff. */
+function worker(over: Partial<CompactWorker> = {}): CompactWorker {
+  return {
+    state: {
+      worker_id: "w1",
+      pid: 4242,
+      runner: "claude",
+      started_at: new Date((NOW - 300) * 1000).toISOString(),
+      total: 10,
+      done: 7,
+      blocked: 0,
+      failed: 0,
+      current: {
+        number: 17,
+        title: "redesign statusline",
+        stage: "impl",
+        started_at: new Date((NOW - 300) * 1000).toISOString(),
+      },
+    },
+    live: true,
+    pidLive: true,
+    diffAdded: 12,
+    diffRemoved: 3,
+    ...over,
+  };
+}
+
+const claude: ClaudeInput = {
+  model: "Opus",
+  effort: "high",
+  contextTokens: 47000,
+  contextPercent: 24,
+  usage5h: 23,
+  usage7d: 41,
+};
 const repo: RepoInput = { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 };
 const input: StatuslineInput = {
   project: { basename: "red-skills", branch: "main", version: "1.2.3" },
-  claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
+  claude,
   repo,
-  afk,
 };
 
 describe("statusline style — header line", () => {
-  it("powerlines » project, model·effort, ctx, pr/is, +local/-local — reset-terminated", () => {
-    const h = renderHeaderLine(input.project, input.claude, repo);
+  it("powerlines » project, model·effort, ctx, 5h/7d usage, prs/iss, +local/-local — reset-terminated", () => {
+    const h = renderHeaderLine(input.project, claude, repo);
     expect(h).not.toContain("\n");
     expect(h.endsWith(RESET)).toBe(true);
     expect(h).toContain(WINE2); // project block bg
@@ -41,183 +76,126 @@ describe("statusline style — header line", () => {
     expect(h).toContain(NOBG); // background drops to transparent after the model
     const t = stripAnsi(h);
     expect(t).toContain("» red-skills (main)");
-    expect(t).toContain("v1.2.3"); // fixed fixture version — proves the renderer echoes whatever version it is handed (not the live build version)
+    expect(t).toContain("v1.2.3");
     expect(t).toContain("Opus·high");
     expect(t).toContain("ctx=47k 24%");
+    expect(t).toContain("5h=23%");
+    expect(t).toContain("7d=41%");
     expect(t).toContain("prs=3");
     expect(t).toContain("iss=24");
     expect(t).toContain("loc=+142 -36");
   });
 
+  it("renders only the usage window that is present (graceful absence)", () => {
+    const t = stripAnsi(renderHeaderLine(input.project, { ...claude, usage7d: undefined }, repo));
+    expect(t).toContain("5h=23%");
+    expect(t).not.toContain("7d=");
+  });
+
+  it("drops the usage tokens entirely for a non-Pro/Max session", () => {
+    const t = stripAnsi(
+      renderHeaderLine(input.project, { ...claude, usage5h: undefined, usage7d: undefined }, repo),
+    );
+    expect(t).not.toContain("5h=");
+    expect(t).not.toContain("7d=");
+    expect(t).toContain("ctx=47k 24%"); // rest of the header intact
+  });
+
   it("prs= carries a compact age suffix when repo cacheAgeS is set (stale cache)", () => {
-    const t = stripAnsi(renderHeaderLine(input.project, input.claude, { ...repo, cacheAgeS: 720 }));
+    const t = stripAnsi(renderHeaderLine(input.project, claude, { ...repo, cacheAgeS: 720 }));
     expect(t).toContain("prs=3 (12m)");
-    expect(t).toContain("iss=24"); // iss= present but no duplicate age mark
-    expect(t.match(/\(12m\)/g)?.length ?? 0).toBe(1); // exactly one annotation
+    expect(t).toContain("iss=24");
+    expect(t.match(/\(12m\)/g)?.length ?? 0).toBe(1);
   });
 
   it("age suffix moves to iss= when openPrs is 0 and repo cache is stale", () => {
     const t = stripAnsi(
-      renderHeaderLine(input.project, input.claude, {
-        ...repo, openPrs: 0, cacheAgeS: 720,
-      }),
+      renderHeaderLine(input.project, claude, { ...repo, openPrs: 0, cacheAgeS: 720 }),
     );
     expect(t).not.toContain("prs=");
     expect(t).toContain("iss=24 (12m)");
   });
 
   it("drops the repo blocks when counts are zero / a clean branch", () => {
-    const h = renderHeaderLine(input.project, input.claude, {
-      openPrs: 0,
-      openIssues: 0,
-      localAdded: 0,
-      localRemoved: 0,
-    });
-    const t = stripAnsi(h);
+    const t = stripAnsi(
+      renderHeaderLine(input.project, claude, {
+        openPrs: 0,
+        openIssues: 0,
+        localAdded: 0,
+        localRemoved: 0,
+      }),
+    );
     expect(t).not.toContain("prs=");
     expect(t).not.toContain("iss=");
     expect(t).not.toContain("loc=");
   });
 
-  it("drops model/ctx/repo outside Claude Code with no repo stats", () => {
+  it("drops model/ctx/usage/repo outside Claude Code with no repo stats", () => {
     const h = renderHeaderLine({ basename: "c3" }, undefined, undefined);
     expect(stripAnsi(h)).toBe(" » c3 ");
     expect(h).not.toContain(WINE);
   });
 });
 
-describe("statusline style — AFK line", () => {
-  it("chips KPI numbers across the runner/workers/transit/pipeline blocks", () => {
-    const line = renderAfkLine({ ...afk, runner: "claude", resolved: 7 }, undefined);
-    expect(line).not.toBeNull();
-    expect(line!.endsWith(RESET)).toBe(true);
-    expect(line).toContain(NOBG); // line 2 is fully transparent — no red block
-    expect(line).toContain(SOFT); // softer red for the runner / sigils
-    expect(line).not.toContain(WINE); // never a wine background on line 2
-    const t = stripAnsi(line!);
-    expect(t).toContain("claude"); // runner
-    expect(t).toContain("wrk=1 res=7"); // workers + resolved
-    expect(t).toContain("loc=+12 -3"); // in-transit diff
-    expect(t).toContain("rdy=11 hmn=3 blk=2"); // pipeline
-    expect(t).toContain("#17");
+describe("statusline style — per-worker line", () => {
+  it("reuses the monitor's compact formatter, tinted and reset-terminated", () => {
+    const line = renderWorkerLine(worker(), NOW);
+    expect(line.endsWith(RESET)).toBe(true);
+    expect(line).toContain(NOBG); // fully transparent — no red block
+    expect(line).toContain(SOFT); // soft-red tint
+    expect(line).not.toContain(WINE); // never a wine background on a worker line
+    const t = stripAnsi(line);
+    expect(t).toContain("w1 [live] claude"); // wID + liveness badge + runner
+    expect(t).toContain("issues 7/10"); // progress counter
+    expect(t).toContain("#17 redesign statusline"); // issue + title
+    expect(t).toContain("stage:impl"); // stage
+    expect(t).toContain("00:05:00"); // elapsed
+    expect(t).toContain("+12 -3"); // diff volume
   });
 
-  it("omits runner and res when absent / zero", () => {
-    const t = stripAnsi(renderAfkLine(afk, undefined)!);
-    expect(t).not.toContain("res");
-    expect(t.startsWith(" wrk=1")).toBe(true); // first group is workers, no runner
-  });
-
-  it("renders compact model-effort alongside the runner label", () => {
-    const line = renderAfkLine(
-      { ...afk, runner: "claude", model: "claude-opus-4-8", effort: "max" },
-      undefined,
-    );
-    const t = stripAnsi(line!);
-    expect(t).toContain("claude-opus max");
-    expect(t).not.toContain("claude-opus-4-8"); // always compact
-  });
-
-  it("renders runner + compact model without effort when effort is absent", () => {
-    const t = stripAnsi(renderAfkLine({ ...afk, runner: "codex", model: "gpt-4o" }, undefined)!);
-    expect(t).toContain("codex gpt-4o"); // non-claude model: falls back to the full name
-  });
-
-  it("renders alive time suffix on issue tokens", () => {
-    const line = renderAfkLine(
-      { ...afk, issues: [17], stages: ["impl"], aliveMs: [5 * 60 * 1000] },
-      undefined,
-    );
-    expect(stripAnsi(line!)).toContain("#17·impl·5m");
-  });
-
-  it("renders loc= with a ~ prefix when locIsPeak is true", () => {
-    const t = stripAnsi(renderAfkLine({ ...afk, locIsPeak: true }, undefined)!);
-    expect(t).toContain("loc=~+12 -3");
-    expect(t).not.toContain("loc=+12 -3"); // ~ prefix replaces the plain form
-  });
-
-  it("is null when there are no live workers", () => {
-    expect(renderAfkLine(undefined, undefined)).toBeNull();
-    expect(renderAfkLine({ ...afk, workers: 0 }, undefined)).toBeNull();
-  });
-
-  it("fresh cache (no cacheAgeS) renders rdy= with no age annotation", () => {
-    const t = stripAnsi(renderAfkLine(afk, undefined)!);
-    expect(t).toContain("rdy=11");
-    expect(t).not.toContain("(");
-  });
-
-  it("rdy= carries a compact age suffix when cacheAgeS is set (stale cache)", () => {
-    // 720 s = 12 m stale → (12m) appears after the rdy= value
-    const t = stripAnsi(renderAfkLine({ ...afk, cacheAgeS: 720 }, undefined)!);
-    expect(t).toContain("rdy=11 (12m)");
-    expect(t).toContain("hmn=3"); // hmn= is present but carries no second age mark
-    expect(t.match(/\(12m\)/g)?.length ?? 0).toBe(1); // exactly one age annotation
-  });
-
-  it("age suffix moves to hmn= when queue is 0 but human is live", () => {
-    const t = stripAnsi(renderAfkLine({ ...afk, queue: 0, cacheAgeS: 720 }, undefined)!);
-    expect(t).not.toContain("rdy=");
-    expect(t).toContain("hmn=3 (12m)");
-  });
-
-  it("shows the ·stage suffix only at or below two workers", () => {
-    const few = renderAfkLine({ ...afk, workers: 2, issues: [17, 20], stages: ["impl", "tests"] }, undefined);
-    expect(stripAnsi(few!)).toContain("#17·impl");
-    expect(stripAnsi(few!)).toContain("#20·tests");
-
-    const many = renderAfkLine({ ...afk, workers: 5, issues: [17, 20], stages: ["impl", "tests"] }, undefined);
-    expect(stripAnsi(many!)).not.toContain("·impl");
-    expect(stripAnsi(many!)).toContain("#17");
-  });
-
-  it("caps the issue list at 3 with a +N overflow when no COLUMNS budget", () => {
-    const line = renderAfkLine({ ...afk, workers: 5, issues: [17, 20, 21, 22, 23] }, undefined);
-    const txt = stripAnsi(line!);
-    expect(txt).toContain("#17");
-    expect(txt).toContain("#21");
-    expect(txt).not.toContain("#22");
-    expect(txt).toContain("+2");
-  });
-
-  it("fits the issue list to the COLUMNS budget, collapsing the rest into +N", () => {
-    const wide = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 200);
-    expect(stripAnsi(wide!)).toContain("#6"); // all six issues fit in 200 cols (none collapsed)
-    // The verbose key=value KPI run is wider than the old 2-letter chips, so the
-    // fixed groups alone are ~40 cols for a busy fleet; the budget can only trim
-    // ISSUES. 56 is the realistic narrow floor where collapsing is exercised.
-    // (We assert collapse via a dropped #N, not a bare "+", since the loc=+A -R
-    // diff value also contains a "+".)
-    const narrow = renderAfkLine({ ...afk, workers: 6, issues: [1, 2, 3, 4, 5, 6] }, 56);
-    expect(vlen(narrow!)).toBeLessThanOrEqual(56);
-    expect(stripAnsi(narrow!)).not.toContain("#6"); // tail issues collapsed into +N
-    expect(stripAnsi(narrow!)).toMatch(/ \+\d/); // the +N overflow marker is present
+  it("shows per-worker token spend when the runner streamed usage", () => {
+    const w = worker({
+      state: {
+        ...worker().state,
+        current: { ...worker().state.current, input_tokens: 1200, output_tokens: 400 },
+      },
+    });
+    expect(stripAnsi(renderWorkerLine(w, NOW))).toContain("tok:1200/400");
   });
 });
 
 describe("statusline style — full themed assembly", () => {
-  it("emits two rows (header + AFK) when workers are live, each reset-terminated", () => {
-    const out = styleStatusline(input);
+  it("emits the header row plus one row per live worker, each reset-terminated", () => {
+    const out = styleStatusline(input, { workers: [worker(), worker({ state: { ...worker().state, worker_id: "w2", current: { ...worker().state.current, number: 20 } } })], now: NOW });
     const rows = out.split("\n");
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(3); // header + two workers
     expect(rows[0].endsWith(RESET)).toBe(true);
     expect(rows[1].endsWith(RESET)).toBe(true);
+    expect(rows[2].endsWith(RESET)).toBe(true);
     expect(stripAnsi(rows[0])).toContain("» red-skills");
     expect(stripAnsi(rows[0])).toContain("prs=3");
-    expect(stripAnsi(rows[1])).toContain("wrk=1");
+    expect(stripAnsi(rows[1])).toContain("w1 [live]");
+    expect(stripAnsi(rows[2])).toContain("#20");
   });
 
   it("emits only the header row when there are no live workers", () => {
-    const out = styleStatusline({ project: input.project, claude: input.claude, repo });
+    const out = styleStatusline(input, { workers: [], now: NOW });
     expect(out).not.toContain("\n");
     expect(stripAnsi(out)).toContain("Opus·high");
     expect(stripAnsi(out)).toContain("prs=3");
   });
 
-  it("renderStatuslineThemed switches between powerline and plain on the color flag", () => {
-    expect(renderStatuslineThemed(input, true)).toBe(styleStatusline(input));
-    expect(renderStatuslineThemed(input, false)).toBe(renderStatusline(input));
-    expect(renderStatuslineThemed(input, false)).not.toContain("\x1b");
+  it("defaults to the header row alone when no workers/now are supplied", () => {
+    const out = styleStatusline(input);
+    expect(out).not.toContain("\n");
+    expect(stripAnsi(out)).toContain("» red-skills");
+  });
+
+  it("renderStatuslineThemed switches between multi-line themed and plain on the color flag", () => {
+    const opts = { workers: [worker()], now: NOW };
+    expect(renderStatuslineThemed(input, true, opts)).toBe(styleStatusline(input, opts));
+    expect(renderStatuslineThemed(input, false, opts)).toBe(renderStatusline(input));
+    expect(renderStatuslineThemed(input, false, opts)).not.toContain("\x1b");
+    expect(renderStatuslineThemed(input, false, opts)).not.toContain("\n"); // plain form is single-line
   });
 });

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -7,7 +7,9 @@ import {
   renderContextBlock,
   renderModelBlock,
   renderProjectBlock,
+  renderRepoBlock,
   renderStatusline,
+  renderUsageBlock,
   type AfkInput,
   type StatuslineInput,
 } from "../src/core/statusline.js";
@@ -170,6 +172,61 @@ describe("statusline — context block", () => {
     expect(renderContextBlock({ contextTokens: 0 })).toBeNull();
     expect(renderContextBlock({})).toBeNull();
     expect(renderContextBlock(undefined)).toBeNull();
+  });
+});
+
+describe("statusline — usage block", () => {
+  it("renders both rate-limit windows as rounded percents", () => {
+    expect(renderUsageBlock({ usage5h: 23, usage7d: 41 })).toBe("5h=23% 7d=41%");
+  });
+
+  it("rounds each window like printf %.0f", () => {
+    expect(renderUsageBlock({ usage5h: 22.6, usage7d: 40.2 })).toBe("5h=23% 7d=40%");
+  });
+
+  it("renders only the window that is present (graceful absence)", () => {
+    expect(renderUsageBlock({ usage5h: 23 })).toBe("5h=23%");
+    expect(renderUsageBlock({ usage7d: 41 })).toBe("7d=41%");
+  });
+
+  it("renders a zero percent (0 is present, not absent)", () => {
+    expect(renderUsageBlock({ usage5h: 0, usage7d: 0 })).toBe("5h=0% 7d=0%");
+  });
+
+  it("drops the block entirely for a non-Pro/Max session (neither window)", () => {
+    expect(renderUsageBlock({})).toBeNull();
+    expect(renderUsageBlock(undefined)).toBeNull();
+    expect(renderUsageBlock({ model: "Opus", contextTokens: 47000 })).toBeNull();
+  });
+});
+
+describe("statusline — repo block", () => {
+  it("renders prs/iss counts and the local diff", () => {
+    expect(
+      renderRepoBlock({ openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 }),
+    ).toBe("prs=3 iss=24 loc=+142 -36");
+  });
+
+  it("drops each zero-valued count and a clean branch", () => {
+    expect(
+      renderRepoBlock({ openPrs: 0, openIssues: 0, localAdded: 0, localRemoved: 0 }),
+    ).toBeNull();
+    expect(renderRepoBlock(undefined)).toBeNull();
+  });
+
+  it("renders only the present sides of the local diff", () => {
+    expect(renderRepoBlock({ localAdded: 5 })).toBe("loc=+5");
+    expect(renderRepoBlock({ localRemoved: 2 })).toBe("loc=-2");
+  });
+
+  it("carries a compact age suffix on prs= when the cache is stale", () => {
+    expect(
+      renderRepoBlock({ openPrs: 3, openIssues: 24, cacheAgeS: 720 }),
+    ).toBe("prs=3 (12m) iss=24");
+  });
+
+  it("moves the age suffix to iss= when openPrs is 0", () => {
+    expect(renderRepoBlock({ openPrs: 0, openIssues: 24, cacheAgeS: 720 })).toBe("iss=24 (12m)");
   });
 });
 
@@ -337,6 +394,39 @@ describe("statusline — full assembly", () => {
     expect(renderStatusline(input)).toBe(
       "red-skills (main) · Opus·high · 47k 24% · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
     );
+  });
+
+  it("wires usage and repo blocks into the single aggregate line (Codex/plain form)", () => {
+    const input: StatuslineInput = {
+      project: { basename: "red-skills", branch: "main" },
+      claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24, usage5h: 23, usage7d: 41 },
+      repo: { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 },
+      afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
+    };
+    expect(renderStatusline(input)).toBe(
+      "red-skills (main) · Opus·high · 47k 24% · 5h=23% 7d=41% · prs=3 iss=24 loc=+142 -36 · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
+    );
+  });
+
+  it("keeps the pre-#1165 line byte-for-byte when repo and usage are absent", () => {
+    const input: StatuslineInput = {
+      project: { basename: "red-skills", branch: "main" },
+      claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24 },
+      afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
+    };
+    expect(renderStatusline(input)).toBe(
+      "red-skills (main) · Opus·high · 47k 24% · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
+    );
+  });
+
+  it("renders the header stats even with no live workers (repo line always shows)", () => {
+    const out = renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24, usage5h: 5 },
+      repo: { openPrs: 2, openIssues: 9 },
+    });
+    expect(out).toBe("red-skills (main) · Opus·high · 47k 24% · 5h=5% · prs=2 iss=9");
+    expect(out).not.toContain("wrk");
   });
 
   it("drops the model and context blocks outside Claude Code", () => {

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -8,7 +8,12 @@ disable-model-invocation: true
 
 **Wire the RedSkills statusline surface for the host the agent is running under — stop immediately if a gate condition is met.** RedSkills is client/CLI/coder/runner agnostic: the dev bundle owns one `statusline` producer, and each host gets the richest integration it actually supports. Claude Code can render the shared producer directly as a command-backed statusLine. Codex currently exposes only native footer widgets, so the skill configures those widgets and relies on the dev plugin's SessionStart hook to keep the footer present across Codex config rewrites.
 
-Install or inspect the RedSkills statusline for this repository. The shared producer renders the project name, branch, model/context data when the host provides it, repo counters, and the live AFK issue block: workers, ready queue count, ready-for-human count, diffstat, current issue numbers, and runner labels. The line is quiet when no AFK worker is active. Hosts that cannot run a command-backed statusline still get a useful native footer plus `/afk monitor` for live AFK visibility.
+Install or inspect the RedSkills statusline for this repository. The shared producer renders the project name, branch, model/context data when the host provides it, repo counters, and live AFK state. **The two hosts get two shapes (per-runner split, ADR 0003):**
+
+- **Claude Code — multi-line.** Claude Code's `statusLine` renders multiple rows, so the themed producer emits a repo-global **header line** — always shown, even with no live workers: project (branch) + version, model·effort + context, open PRs + open issues, local diff vs `origin/main`, and (Pro/Max only, when the payload exposes them) the 5-hour and weekly usage windows `5h=…% 7d=…%` — **then one line per live AFK worker**. Each worker line is the SAME compact row `/afk monitor --once` prints (single source of truth — worker id, stage, issue, elapsed, `+A -R`, tokens), so the two surfaces never drift. Zero live workers → only the header line.
+- **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
+
+The AFK rows are quiet when no worker is active. Hosts that cannot run a command-backed statusline still get a useful native footer plus `/afk monitor` for live AFK visibility.
 
 **Host capabilities differ; the product architecture should not.** Treat the RedSkills statusline as:
 
@@ -50,7 +55,7 @@ printf '{"workspace":{"project_dir":"%s"},"model":{"display_name":"Opus"}}' "$PW
   | <the step-4 statusLine command>
 ```
 
-It should print a line like `red-skills (main) · Opus`.
+It should print the themed **header line** (e.g. `» red-skills (main) v… Opus·high …`); when AFK workers are live it prints one additional row per worker below it. Under `NO_COLOR` the same command collapses to the single-line plain form `red-skills (main) · Opus·high · …`.
 
 ## Codex
 


### PR DESCRIPTION
Automated AFK landing for #1165. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1165

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785848074&installation_id=129708444&pr_number=1166&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1166&signature=20c096961146b04e8f062681764580ea6ed1eca154a0a44b6f1ad031800e3e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statusline now shows richer Claude usage details, including 5h and 7d rate-limit windows when available.
  * The themed statusline can now display one line per live worker, giving a clearer live activity view.
  * Repository summary stats now include PRs, issues, and local diff counts in the statusline.

* **Bug Fixes**
  * Improved statusline formatting and fallbacks so missing usage, repo, or worker data is handled cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->