### PR TITLE
merge: #1171 Sensitive-path parks are unclearable by requeue — every recovery loops, forcing a manual land

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -20,6 +20,8 @@ import { join } from "node:path";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { planRequeue, type RequeuePlan } from "../core/requeue.js";
+import { parseCurrentBlocker } from "../core/blocker-state.js";
+import { LABEL_SENSITIVE_PATH } from "../core/triage-labels.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
 import { makeFeedbackWorktree } from "../runtime/feedback-worktree.js";
 import { afkPaths, resolveRepoSlug } from "../runtime/wire.js";
@@ -44,6 +46,13 @@ export interface RequeueAdoptData {
   title: string;
   body: string;
   labels: readonly string[];
+  /**
+   * #1171: the park being adopted was `blocked:sensitive-path`, so the maintainer
+   * running `--adopt-branch` has reviewed the protected diff. Threaded into the
+   * ADR-0055 reconcile as `sensitivePathApproved`, which skips doLanding's
+   * sensitive-path guard for THIS human land only. Defaults false.
+   */
+  sensitivePathApproved?: boolean;
 }
 
 /**
@@ -115,6 +124,35 @@ function directiveComment(plan: RequeuePlan, guidance?: string): string {
     "</details>",
   ];
   return lines.join("\n");
+}
+
+/**
+ * #1171 audit comment for a `blocked:sensitive-path` adopt: a human explicitly
+ * approved a protected diff and is landing it through `--adopt-branch`, bypassing
+ * doLanding's sensitive-path guard. Records WHO (the gh authenticated login,
+ * best-effort) and WHEN (UTC), plus the recorded guidance, so the bypass is never
+ * silent.
+ */
+async function sensitivePathAdoptAudit(cwd: string, branch: string, guidance?: string): Promise<string> {
+  let who = "a maintainer";
+  try {
+    const r = await execTool("gh", ["api", "user", "-q", ".login"], { cwd });
+    if (r.code === 0 && r.stdout.trim()) who = `@${r.stdout.trim()}`;
+  } catch {
+    /* best-effort: the audit is still posted with the generic actor. */
+  }
+  const when = new Date().toISOString();
+  return [
+    "<details data-kind=\"sensitive-path-adopt\">",
+    "<summary>Sensitive-path adopt approved</summary>",
+    "",
+    `${who} approved the sensitive-path diff and landed \`${branch}\` via \`/requeue --adopt-branch\` at ${when}.`,
+    "The landing sensitive-path guard (#1102) was bypassed for this human-reviewed land only; every autonomous attempt keeps the guard armed (#1171).",
+    "",
+    "Human guidance:",
+    guidance?.trim() || "(none recorded)",
+    "</details>",
+  ].join("\n");
 }
 
 async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
@@ -246,6 +284,10 @@ async function runAdoptLanding(
       attempt: 0,
       attemptDir: join(paths.tmpDir, "adopt-landing", String(issue)),
       runner: "claude" as Runner,
+      // #1171: bypass doLanding's sensitive-path guard ONLY for a maintainer-
+      // reviewed adopt of a `blocked:sensitive-path` park. Defaults false — a
+      // normal adopt keeps the guard armed.
+      sensitivePathApproved: issueData.sensitivePathApproved === true,
     };
 
     const result = await reconcile(reconcileDeps, reconcileInput);
@@ -297,7 +339,19 @@ export async function requeueCommand(
     return 1;
   }
 
-  const plan = planRequeue({ body: issueState.body, labels: issueState.labels, guidance });
+  // #1171: an active `blocked:sensitive-path` park is requeueable ONLY when the
+  // maintainer is adopting a reviewed branch (`--adopt-branch`). Detect it from
+  // the PRE-transition state so the audit comment + guard bypass fire only here.
+  const wasSensitivePathPark =
+    issueState.labels.includes(LABEL_SENSITIVE_PATH) ||
+    parseCurrentBlocker(issueState.body)?.kind === "sensitive-path";
+
+  const plan = planRequeue({
+    body: issueState.body,
+    labels: issueState.labels,
+    guidance,
+    adoptBranch: adoptBranch !== undefined,
+  });
   if (!plan.requeueable) {
     if (plan.refuseForHitl) {
       process.stderr.write(`[afk] requeue #${issue}: refused — ${plan.reason}\n`);
@@ -342,7 +396,19 @@ export async function requeueCommand(
       ? [...issueState.labels.filter((l) => !plan.removeLabels.includes(l)), ...plan.addLabels]
       : [...issueState.labels];
     const postBody = plan.requeueable ? plan.body : issueState.body;
-    const adoptData: RequeueAdoptData = { title: "", body: postBody, labels: postLabels };
+    const adoptData: RequeueAdoptData = {
+      title: "",
+      body: postBody,
+      labels: postLabels,
+      sensitivePathApproved: wasSensitivePathPark,
+    };
+
+    // #1171 audit trail: a sensitive-path adopt is a human bypass of the landing
+    // guard — never silent. Record who approved + when, and the guidance, BEFORE
+    // the land so the approval is on the thread even if the land later parks.
+    if (wasSensitivePathPark) {
+      await gh.comment(issue, await sensitivePathAdoptAudit(cwd, adoptBranch, guidance));
+    }
 
     stdout.write(`Requeue #${issue}: adopting branch \`${adoptBranch}\` through the no-agent landing lane (ADR 0055)…\n`);
 

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -157,6 +157,19 @@ export interface LandingInput {
   issue: number;
   /** Issue title, for the merge/PR message + hook contexts. */
   title: string;
+  /**
+   * Sensitive-path guard bypass (issue #1171). Defaults false/undefined. When
+   * true, the step-0a sensitive-path guard scan is SKIPPED so a branch whose diff
+   * touches a protected path (CI workflow, lifecycle script, git hook, `.red/`
+   * config) can still land. This is set EXCLUSIVELY by the explicit
+   * `/requeue --adopt-branch` operator path (core/requeue + commands/requeue),
+   * after a maintainer has reviewed the diff — it is the human "already-reviewed"
+   * signal the ADR-0055 no-agent landing lane carries. HARD INVARIANT: it must be
+   * UNREACHABLE from any autonomous attempt (AFK/go inner-agent landing), so the
+   * guard keeps firing on every normal attempt. The default is false and only the
+   * operator adopt path ever passes true.
+   */
+  sensitivePathApproved?: boolean;
 }
 
 /** The pre_merge / post_merge hook context builders the caller owns (so the
@@ -307,7 +320,13 @@ export async function doLanding(
   // change (CI workflow, lifecycle script, git hook, .red/ config) that must
   // never auto-land — abort immediately and page a human. Opt-in: the guard is
   // skipped when getDiffPaths is absent (backwards-compatible default).
-  if (deps.getDiffPaths) {
+  //
+  // #1171 bypass: `input.sensitivePathApproved === true` means a maintainer has
+  // reviewed the protected diff and is landing it through the explicit
+  // `/requeue --adopt-branch` no-agent lane, so the guard is skipped ONLY here.
+  // The flag defaults false; no autonomous attempt path sets it, so the guard
+  // keeps firing on every normal AFK/go landing.
+  if (deps.getDiffPaths && input.sensitivePathApproved !== true) {
     const { changedFiles, packageJsonDiff } = await deps.getDiffPaths();
     const hits = checkSensitivePaths(changedFiles, packageJsonDiff);
     if (hits.length > 0) {

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -255,6 +255,15 @@ export interface ReconcileInput {
    * reconcile runs the scoped gate as its verdict, unchanged.
    */
   trustPriorValidation?: boolean;
+  /**
+   * Sensitive-path guard bypass (#1171). Threaded straight into {@link doLanding}
+   * as `sensitivePathApproved`. Set true EXCLUSIVELY by the `/requeue
+   * --adopt-branch` operator path, after a maintainer reviewed the protected diff,
+   * so a `blocked:sensitive-path` park can land through this no-agent lane without
+   * the landing guard re-parking it. Defaults false/undefined: the autonomous
+   * process-issue caller never sets it, so its landing guard keeps firing.
+   */
+  sensitivePathApproved?: boolean;
 }
 
 // ---------- result ----------
@@ -440,6 +449,10 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       trunk: input.trunk,
       issue,
       title: input.title,
+      // #1171: the operator adopt-branch path passes this true after reviewing a
+      // protected diff, so doLanding's sensitive-path guard is skipped ONLY here.
+      // Undefined for every autonomous caller → the guard fires as before.
+      sensitivePathApproved: input.sensitivePathApproved,
     },
     {
       preMerge: () => landingHookContext(input, branch, { mergeBase: input.base }),

--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -35,6 +35,14 @@ export const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-co
  */
 export const REQUEUE_SUPPORTED_KINDS = new Set(["validation", "spec"]);
 
+/**
+ * The `sensitive-path` blocker kind (`blocked:sensitive-path`, #1102). A bare
+ * requeue must STILL refuse it (→ /hitl); it becomes requeueable ONLY when the
+ * caller is adopting a human-reviewed branch (`--adopt-branch`, #1171). See
+ * {@link kindRequeueable}.
+ */
+const SENSITIVE_PATH_KIND = "sensitive-path";
+
 export interface RequeueInput {
   /** The current issue body markdown. */
   body: string;
@@ -42,6 +50,27 @@ export interface RequeueInput {
   labels: readonly string[];
   /** Human guidance recorded before requeueing; archived into `## Resolved blockers`. Required to apply the transition. */
   guidance?: string;
+  /**
+   * True when this requeue is paired with `--adopt-branch` (#1171): a maintainer
+   * has reviewed a hand-done branch and is landing it through the ADR-0055
+   * no-agent lane. Only then is a `blocked:sensitive-path` park clearable — the
+   * human review is what authorises bypassing the landing guard. A bare requeue
+   * (default false) STILL refuses `sensitive-path` → /hitl.
+   */
+  adoptBranch?: boolean;
+}
+
+/**
+ * Is `kind` requeueable given whether this is an `--adopt-branch` land (#1171)?
+ * The base supported set is `{validation, spec}` (#860). `sensitive-path` is the
+ * one kind gated on the adopt path: a landing-time guard (#1102) re-parks the
+ * same protected diff on every fresh attempt, so it can only be cleared by a
+ * human explicitly adopting the reviewed branch — never by a bare requeue.
+ */
+function kindRequeueable(kind: string, adoptBranch: boolean): boolean {
+  if (REQUEUE_SUPPORTED_KINDS.has(kind)) return true;
+  if (adoptBranch && kind === SENSITIVE_PATH_KIND) return true;
+  return false;
 }
 
 export interface RequeuePlan {
@@ -117,6 +146,7 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   const activeBlocker = parseCurrentBlocker(input.body);
   const blocked = blockedLabelsIn(input.labels);
   const hasHuman = input.labels.includes(LABEL_HUMAN);
+  const adoptBranch = input.adoptBranch === true;
 
   // "Parked" = something marks this issue as needing the human lane. Without an
   // active blocker, a blocked:* label, or ready-for-human there is nothing to
@@ -145,9 +175,13 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   const labelKind = blocked.length === 1 ? blocked[0].slice("blocked:".length) : null;
 
   // Unsupported label kind → /hitl handles other human-input blocker types.
-  if (labelKind !== null && !REQUEUE_SUPPORTED_KINDS.has(labelKind)) {
+  // `sensitive-path` is the exception: requeueable ONLY under `--adopt-branch`
+  // (#1171), so a bare requeue still lands here and is directed to /hitl.
+  if (labelKind !== null && !kindRequeueable(labelKind, adoptBranch)) {
     return refuse(
-      `blocked:${labelKind} is not in the supported set (validation, spec): use /hitl`,
+      labelKind === SENSITIVE_PATH_KIND
+        ? `blocked:${labelKind} is only clearable via /requeue --adopt-branch (human-reviewed land): use /hitl or re-run with --adopt-branch`
+        : `blocked:${labelKind} is not in the supported set (validation, spec): use /hitl`,
       true,
       activeBlocker,
       input.body,
@@ -158,10 +192,12 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
   if (
     activeBlocker !== null &&
     !MECHANICAL_BLOCKER_KINDS.has(activeBlocker.kind) &&
-    !REQUEUE_SUPPORTED_KINDS.has(activeBlocker.kind)
+    !kindRequeueable(activeBlocker.kind, adoptBranch)
   ) {
     return refuse(
-      `active blocker kind "${activeBlocker.kind}" is not in the supported set (validation, spec): use /hitl`,
+      activeBlocker.kind === SENSITIVE_PATH_KIND
+        ? `active blocker kind "${activeBlocker.kind}" is only clearable via /requeue --adopt-branch (human-reviewed land): use /hitl or re-run with --adopt-branch`
+        : `active blocker kind "${activeBlocker.kind}" is not in the supported set (validation, spec): use /hitl`,
       true,
       activeBlocker,
       input.body,

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -90,6 +90,12 @@ interface Opts {
    *   - "clean"→ getDiffPaths returns a diff with no sensitive paths
    */
   sensitivePaths?: "hit" | "clean";
+  /**
+   * Sensitive-path guard bypass (#1171). When true, `input.sensitivePathApproved`
+   * is set so the step-0a guard is skipped even on a "hit" diff. Models the
+   * `/requeue --adopt-branch` human land of a reviewed protected diff.
+   */
+  sensitivePathApproved?: boolean;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -230,6 +236,9 @@ function harness(opts: Opts = {}): Harness {
     trunk: "main",
     issue: 9,
     title: "Fix the thing",
+    // #1171: only set when the test opts in; default undefined keeps the guard
+    // armed for every existing landing assertion.
+    sensitivePathApproved: opts.sensitivePathApproved,
   };
 
   const hooks: LandingHookContexts = {
@@ -445,6 +454,27 @@ describe("doLanding — sensitive-path guard (issue #1102)", () => {
     const h = harness({ locked: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false });
+  });
+
+  it("sensitivePathApproved=true → guard bypassed, a hit diff lands normally (#1171 adopt path)", async () => {
+    // The `/requeue --adopt-branch` human land: getDiffPaths still HITS a
+    // protected path, but the maintainer-approved flag skips the guard so the
+    // reviewed branch lands.
+    const h = harness({ locked: false, sensitivePaths: "hit", sensitivePathApproved: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(h.pushedAttempt).toHaveLength(1);
+    expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+  });
+
+  it("sensitivePathApproved defaults undefined/false → a hit diff STILL parks (guard not weakened for the agent path)", async () => {
+    // The autonomous path never sets the flag, so the identical hit diff aborts.
+    const h = harness({ locked: false, sensitivePaths: "hit" });
+    expect(h.input.sensitivePathApproved).toBeUndefined();
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("sensitive-paths");
+    expect(h.pushedAttempt).toHaveLength(0);
   });
 });
 

--- a/apps/dev/tests/requeue-command.test.ts
+++ b/apps/dev/tests/requeue-command.test.ts
@@ -66,8 +66,16 @@ const specBlocker = {
   next: "Human must clarify before work proceeds.",
 };
 
+const sensitivePathBlocker = {
+  status: "blocked" as const,
+  kind: "sensitive-path",
+  summary: "Diff touches .github/workflows/ci.yml.",
+  next: "Human must review the protected diff before it can land.",
+};
+
 const parkedBody = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(validationBlocker)}\n`;
 const specBodyMismatch = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(specBlocker)}\n`;
+const sensitivePathBody = `## Summary\nDo it.\n\n## Current blocker\n\n${formatCurrentBlocker(sensitivePathBlocker)}\n`;
 
 describe("requeue command — happy path", () => {
   it("applies the full transition so a label flip alone is never the requeue", async () => {
@@ -318,6 +326,77 @@ describe("requeue command — adopt mode (--adopt-branch)", () => {
 
     expect(code).toBe(1);
     expect(adoptCalled).toBe(false);
+  });
+
+  it("bare requeue of a blocked:sensitive-path park still refuses → /hitl (exit 1, no adopt)", async () => {
+    const { gh, calls } = fakeGh({
+      state: "OPEN",
+      body: sensitivePathBody,
+      labels: ["ready-for-human", "blocked:sensitive-path"],
+    });
+    const { stream } = capture();
+    const err = captureStderr();
+
+    const code = await requeueCommand(["#42", "--guidance", "Reviewed the CI diff."], "/tmp", stream, gh);
+    err.restore();
+
+    expect(code).toBe(1);
+    expect(err.text()).toContain("refused");
+    expect(err.text()).toMatch(/adopt-branch/);
+    expect(calls.editBody + calls.editLabels + calls.comment).toBe(0);
+  });
+
+  it("--adopt-branch clears a blocked:sensitive-path park, flags the guard bypass, and lands", async () => {
+    const { gh, calls, state } = fakeGh({
+      state: "OPEN",
+      body: sensitivePathBody,
+      labels: ["ready-for-human", "blocked:sensitive-path"],
+    });
+    const { stream, text } = capture();
+    let adoptApproved: boolean | undefined;
+    const runner: RequeueAdoptRunner = async (_issue, _branch, issueData) => {
+      adoptApproved = issueData.sensitivePathApproved;
+      return "landed";
+    };
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Maintainer reviewed the workflow diff; land it.", "--adopt-branch", "afk/w/9-fix"],
+      "/tmp", stream, gh, runner,
+    );
+
+    expect(code).toBe(0);
+    // Transition applied: blocker cleared, sensitive-path label dropped.
+    expect(calls.editBody).toBe(1);
+    expect(calls.editLabels).toBe(1);
+    expect(state.labels).not.toContain("blocked:sensitive-path");
+    expect(state.labels).toContain("ready-for-agent");
+    // Guard bypass flag threaded to the adopt runner.
+    expect(adoptApproved).toBe(true);
+    // Audit comment posted in addition to the directive comment (never silent).
+    expect(calls.comment).toBeGreaterThanOrEqual(2);
+    expect(text()).toContain("validated and landed");
+  });
+
+  it("a NON-sensitive adopt does not set the guard-bypass flag (defaults false)", async () => {
+    const { gh } = fakeGh({
+      state: "OPEN",
+      body: parkedBody,
+      labels: ["ready-for-human", "blocked:validation"],
+    });
+    const { stream } = capture();
+    let adoptApproved: boolean | undefined = true;
+    const runner: RequeueAdoptRunner = async (_issue, _branch, issueData) => {
+      adoptApproved = issueData.sensitivePathApproved;
+      return "landed";
+    };
+
+    const code = await requeueCommand(
+      ["#42", "--guidance", "Gate flake fixed.", "--adopt-branch", "my-branch"],
+      "/tmp", stream, gh, runner,
+    );
+
+    expect(code).toBe(0);
+    expect(adoptApproved).toBe(false);
   });
 
   it("dry-run with --adopt-branch does not call adopt runner", async () => {

--- a/apps/dev/tests/requeue.test.ts
+++ b/apps/dev/tests/requeue.test.ts
@@ -35,6 +35,17 @@ const decisionBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${forma
   decisionBlocker,
 )}\n`;
 
+const sensitivePathBlocker = {
+  status: "blocked" as const,
+  kind: "sensitive-path",
+  summary: "Diff touches .github/workflows/ci.yml — protected path.",
+  next: "Human must review the protected diff before it can land.",
+};
+
+const sensitivePathBody = `## Summary\nDo the thing.\n\n## Current blocker\n\n${formatCurrentBlocker(
+  sensitivePathBlocker,
+)}\n`;
+
 describe("requeue — label flip invariant", () => {
   it("treats a label flip alone as an INCOMPLETE requeue while an active blocker remains", () => {
     // The exact no-op loop the issue describes: labels say ready-for-agent, but
@@ -163,6 +174,73 @@ describe("requeue — refusals that direct to /hitl", () => {
     expect(plan.requeueable).toBe(false);
     expect(plan.refuseForHitl).toBe(true);
     expect(plan.reason).toMatch(/label\/body kind mismatch/);
+  });
+});
+
+describe("requeue — sensitive-path is adopt-branch-only (#1171)", () => {
+  it("refuses a bare requeue of a blocked:sensitive-path park (→ /hitl)", () => {
+    const plan = planRequeue({
+      body: sensitivePathBody,
+      labels: ["ready-for-human", "blocked:sensitive-path"],
+      guidance: "Reviewed the CI diff.",
+      // adoptBranch omitted → bare requeue must still refuse.
+    });
+    expect(plan.requeueable).toBe(false);
+    expect(plan.refuseForHitl).toBe(true);
+    expect(plan.reason).toMatch(/adopt-branch/);
+    expect(plan.bodyChanged).toBe(false);
+    expect(plan.addLabels).toHaveLength(0);
+    expect(plan.removeLabels).toHaveLength(0);
+  });
+
+  it("clears a blocked:sensitive-path park when --adopt-branch is set", () => {
+    const plan = planRequeue({
+      body: sensitivePathBody,
+      labels: ["ready-for-human", "blocked:sensitive-path"],
+      guidance: "Maintainer reviewed the workflow diff; land it.",
+      adoptBranch: true,
+    });
+    expect(plan.requeueable).toBe(true);
+    expect(plan.refuseForHitl).toBe(false);
+    expect(plan.activeBlocker?.kind).toBe("sensitive-path");
+    expect(plan.bodyChanged).toBe(true);
+    expect(plan.body).toContain("## Resolved blockers");
+    expect(plan.removeLabels).toEqual(
+      expect.arrayContaining(["ready-for-human", "blocked:sensitive-path"]),
+    );
+    expect(plan.addLabels).toEqual(["ready-for-agent"]);
+  });
+
+  it("refuses a body-only sensitive-path blocker on a bare requeue but clears it under --adopt-branch", () => {
+    const bare = planRequeue({
+      body: sensitivePathBody,
+      labels: ["ready-for-human"],
+      guidance: "Reviewed.",
+    });
+    expect(bare.requeueable).toBe(false);
+    expect(bare.refuseForHitl).toBe(true);
+    expect(bare.reason).toMatch(/adopt-branch/);
+
+    const adopt = planRequeue({
+      body: sensitivePathBody,
+      labels: ["ready-for-human"],
+      guidance: "Reviewed.",
+      adoptBranch: true,
+    });
+    expect(adopt.requeueable).toBe(true);
+    expect(adopt.activeBlocker?.kind).toBe("sensitive-path");
+  });
+
+  it("does NOT widen other unsupported kinds — decision still refuses even under --adopt-branch", () => {
+    const plan = planRequeue({
+      body: decisionBody,
+      labels: ["ready-for-human", "blocked:decision"],
+      guidance: "Decision made.",
+      adoptBranch: true,
+    });
+    expect(plan.requeueable).toBe(false);
+    expect(plan.refuseForHitl).toBe(true);
+    expect(plan.reason).toMatch(/not in the supported set/);
   });
 });
 

--- a/plugins/dev/skills/engineering/hitl/SKILL.md
+++ b/plugins/dev/skills/engineering/hitl/SKILL.md
@@ -144,6 +144,8 @@ If non-delegable:
 
 Use `/hitl` when the pending human decision still has to be **extracted and answered** — it interviews you, decides delegability, then (when delegable) clears the active `## Current blocker` and requeues. When the decision is **already made** and you only need to put a parked `blocked:validation`/`blocked:spec` issue back in the queue, reach for [`/requeue`](../requeue/SKILL.md) instead — its **`/requeue` vs `/hitl` — the decision boundary** table is the authoritative split. Both end in the same safe state; never flip labels by hand, because AFK preflight re-reads the active blocker and re-parks the issue.
 
+**`blocked:sensitive-path` is NOT a manual-land dead-end (#1171).** A sensitive-path park (diff touches a protected path — CI workflow, lifecycle script, git hook, `.red/` config) is a landing gate that re-fires on every fresh attempt, so routing it back to `ready-for-agent` just spawns a new attempt that reproduces the same protected diff and re-parks — an infinite loop. Once you have **reviewed the protected diff**, clear it with [`/requeue`](../requeue/SKILL.md)` <issue> --adopt-branch <branch> --guidance "<review note>"`: it lands the already-reviewed branch through the ADR-0055 no-agent lane with the sensitive-path guard bypassed for that human land only (an audit comment records the approval). Do not hand-merge it — `--adopt-branch` is the supported path.
+
 ## Directive block template
 
 ```markdown

--- a/plugins/dev/skills/engineering/requeue/SKILL.md
+++ b/plugins/dev/skills/engineering/requeue/SKILL.md
@@ -44,7 +44,7 @@ The adopted branch and an AFK branch go through the same gate authority.
 3. Refuse without mutation (exit 1, direct to `/hitl`) when:
    - the issue carries **mixed `blocked:*` labels** (e.g., both `blocked:validation` and `blocked:spec`);
    - the `blocked:*` label kind does not match the active `## Current blocker` kind in the body (**label/body mismatch**);
-   - the blocked kind is not `validation` or `spec` (e.g., `blocked:decision`, `blocked:stalled`).
+   - the blocked kind is not `validation` or `spec` (e.g., `blocked:decision`, `blocked:stalled`). **Exception (#1171):** `blocked:sensitive-path` is refused on a **bare** requeue but is clearable with `--adopt-branch` (see below).
 4. If the issue is not parked AND `--adopt-branch` is NOT given: no-op exit 0.
 5. If the issue is parked and requeueable: apply the requeue transition atomically:
    - clear/archive the active `## Current blocker` into `## Resolved blockers`;
@@ -53,6 +53,18 @@ The adopted branch and an AFK branch go through the same gate authority.
 6. If `--adopt-branch` is given (whether or not the issue was parked):
    - adopt the branch through the no-agent landing lane (ADR 0055 reconcile);
    - exit 0 on `landed`, exit 1 on `parked` (gate failed), exit 0 on `skipped`.
+
+### Clearing a `blocked:sensitive-path` park (#1171)
+
+A `blocked:sensitive-path` park (its diff touches a protected path — CI workflow, lifecycle script, git hook, `.red/` config) is a **landing** gate that re-fires on every fresh attempt, so a bare requeue → `/hitl` → new attempt is an **infinite loop**: the new agent reproduces the same protected diff and re-parks.
+
+`--adopt-branch` breaks the loop. When a maintainer runs `/requeue <issue> --adopt-branch <branch> --guidance "<review note>"` on a `blocked:sensitive-path` park:
+
+- requeue clears the blocker, drops `ready-for-human` + `blocked:sensitive-path`, and adopts the reviewed branch through the no-agent lane **with the sensitive-path landing guard bypassed for that land only**;
+- an **audit comment** records who approved the diff and when — the bypass is never silent;
+- the guard is **never** weakened for the autonomous path: every normal AFK/go attempt still parks `blocked:sensitive-path`. The bypass is reachable **only** from this explicit `--adopt-branch` human command.
+
+A **bare** requeue of a `blocked:sensitive-path` issue still refuses → `/hitl` (the human must review the diff and land it via `--adopt-branch`).
 
 </what-to-do>
 
@@ -69,11 +81,12 @@ A validation or spec failure parks an issue with `ready-for-human`, a `blocked:*
 - The label kind and the active `## Current blocker` kind in the body agree.
 - You already have the retry guidance and do not need an interview to extract it.
 - OR: you have a hand-done branch to adopt (`--adopt-branch`).
+- OR: the issue is `blocked:sensitive-path` and you have **reviewed the protected diff** — clear it with `--adopt-branch <branch>` (a bare requeue still refuses).
 
 **Use `/hitl`** when:
 - The pending human decision still has to be **extracted and answered**.
 - The issue carries **mixed `blocked:*` labels** or a **label/body mismatch**.
-- The blocked kind is anything other than `validation` or `spec`.
+- The blocked kind is anything other than `validation` or `spec` — **except** `blocked:sensitive-path`, which `/requeue --adopt-branch` clears once you have reviewed the diff.
 
 Both commands end in the same safe state. `/requeue` is the focused shortcut; `/hitl` is the general path for everything else.
 


### PR DESCRIPTION
Automated AFK landing for #1171. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1171

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785893941&installation_id=129708444&pr_number=1172&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1172&signature=bd4270821d4be0150bcdb4344251b19f74f3dcd341ef39aff9b35ab10c7c2faf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for requeueing sensitive-path cases with `--adopt-branch`, including a clear approval trail and a bypass for the landing guard when explicitly approved.
  * Landing and reconcile flows now recognize an approved sensitive-path handoff so reviewed changes can proceed without re-triggering the guard.

* **Bug Fixes**
  * Requeue behavior now correctly distinguishes sensitive-path items from other blocked states.
  * Improved guidance and audit comments for cases that would otherwise loop back into blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->