### PR TITLE
fix(release): idempotent publish + multi-minute smoke budget (resumable release tail)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -489,6 +489,15 @@ jobs:
           fi
           cd packaging/npm
           npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+          # Publish must be idempotent so a re-run after a transient
+          # post-publish failure (for example registry-propagation lag in the
+          # smoke step) can resume the release tail instead of dying on a
+          # publish-over-published conflict. npm versions are immutable, so an
+          # already-served version IS the successful publish outcome.
+          if npm view "@reddb-io/red-skills@${version}" version >/dev/null 2>&1; then
+            echo "@reddb-io/red-skills@${version} already on the registry — publish already complete, resuming release tail"
+            exit 0
+          fi
           # Stable releases publish to npm's default `latest` tag. The opt-in
           # canary channel is moved later with scripts/afk-promote-channel.sh,
           # which points npm dist-tag `canary` at an already-published version.
@@ -505,7 +514,10 @@ jobs:
           trap 'rm -rf "$smoke"' EXIT
           export npm_config_cache="$smoke/npm-cache"
           export npm_config_prefix="$smoke/npm-prefix"
-          for attempt in 1 2 3 4 5; do
+          # Registry read replicas can lag the publish by several minutes
+          # (v2.0.1 took >2min to become resolvable, exhausting the previous
+          # ~105s budget). 10 attempts at attempt*15s ≈ 11min total budget.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
             if output="$(npx -y -p "@reddb-io/red-skills@${version}" red-skills-dev --version 2>&1)"; then
               printf '%s\n' "$output"
               if grep -qF "dev ${version} " <<<"$output"; then
@@ -516,11 +528,11 @@ jobs:
               exit 1
             fi
             printf '%s\n' "$output" >&2
-            if [ "$attempt" -eq 5 ]; then
+            if [ "$attempt" -eq 10 ]; then
               echo "::error::registry did not serve @reddb-io/red-skills@${version} after publish"
               exit 1
             fi
-            sleep $((attempt * 10))
+            sleep $((attempt * 15))
           done
 
       - name: Sync plugin manifest versions

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -75,6 +75,19 @@ else
   fail "registry smoke must fail when --version does not report the release version"
 fi
 
+if grep -qF 'already on the registry — publish already complete' "$WORKFLOW"; then
+  pass "publish is idempotent so a re-run can resume the release tail"
+else
+  fail "publish must no-op when the version is already on the registry (resumable release tail)"
+fi
+
+if grep -qF 'for attempt in 1 2 3 4 5 6 7 8 9 10' "$WORKFLOW" &&
+   grep -qF 'sleep $((attempt * 15))' "$WORKFLOW"; then
+  pass "registry smoke budget covers multi-minute registry propagation lag"
+else
+  fail "registry smoke must retry across a multi-minute propagation window (10 attempts, attempt*15s backoff)"
+fi
+
 if (( failures > 0 )); then
   printf '\n%d failure(s)\n' "$failures" >&2
   exit 1


### PR DESCRIPTION
## What

First live run of the #1204-hardened release pipeline (v2.0.1, run 28798276321): **publish succeeded, registry smoke failed on npm read-replica propagation lag** — 5 attempts over ~105s, all `ETARGET`, while the version became resolvable only minutes later. The load-bearing barrier worked exactly as designed (no stamp/tag/GH release for a version the registry wasn't serving), but the release was left incomplete: npm `latest` = 2.0.1 with manifests/tag still at 2.0.0.

Two fixes so this failure mode self-heals:

- **Idempotent publish** — the publish step no-ops (with an explicit resume log line) when the version is already on the registry. npm versions are immutable, so already-served IS the successful publish outcome; a re-run no longer dies on a publish-over-published conflict.
- **Smoke budget covers real propagation lag** — 10 attempts at `attempt*15s` (~11 min worst case) instead of 5 attempts over ~105s.

Both properties are locked in `scripts/test-red-release-npm-publish-contract.sh`.

## Self-completing tail

Merging this PR pushes to main → red-release recomputes `NEXT=v2.0.1` (tag doesn't exist yet; commits since v2.0.0 are fixes) → publish skips (already on registry) → smoke passes (version now resolvable) → **stamp + tag v2.0.1 + GH release complete the interrupted release**.

https://claude.ai/code/session_01JZvurMHV2aYMRWeZmVRUXw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785939740&installation_id=129708444&pr_number=1209&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1209&signature=19a046e86b48e9e0c2c01b68d1ef22feb1cb5bbfdab3a63c752e388e905c2984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->