### PR TITLE
merge: #1210 /go: Harden statusline data acquisition into a smart local cache so renders s

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -81,6 +81,7 @@ import { hostname } from "node:os";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
 import { initStateSync, readPidStartTime, updateState } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
+import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../core/loc-memo.js";
 import { createActivityMeter } from "../core/activity-meter.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
 import type { AgentStreamEvent, AttemptBudget } from "../core/execution.js";
@@ -1205,9 +1206,33 @@ export function buildProcessDeps(
         const baseRef = info.base
           ? `origin/${info.base}`
           : `origin/${getConfig(config, "dev.trunk") || "main"}`;
-        const { added, removed } = await gitx
-          .diffstatShortstat({ cwd: worktree }, baseRef)
-          .catch(() => ({ added: 0, removed: 0 }));
+        // Writer-side LOC ownership (#1210 Part B): the render paths no longer
+        // shell out to `git diff --shortstat`, so this heartbeat is the runner-
+        // agnostic owner that stamps loc_added/loc_removed for ALL runners (codex
+        // included). The diffstat is EXPENSIVE, so memoize it against the current
+        // HEAD sha in the attempt dir — computed at most once per commit; while
+        // HEAD is unchanged the memoized volume is served without spawning git.
+        const memoPath = locMemoPath(current.attemptDir, "/");
+        const { added, removed } = await resolveAttemptLoc({
+          headSha: head,
+          compute: () =>
+            gitx.diffstatShortstat({ cwd: worktree }, baseRef).catch(() => ({ added: 0, removed: 0 })),
+          readMemo: () => {
+            try {
+              const m = JSON.parse(readFileSync(memoPath, "utf8")) as Partial<LocMemo>;
+              return { sha: String(m.sha ?? ""), added: Number(m.added ?? 0), removed: Number(m.removed ?? 0) };
+            } catch {
+              return null;
+            }
+          },
+          writeMemo: (m) => {
+            try {
+              writeFileSync(memoPath, JSON.stringify(m), "utf8");
+            } catch {
+              // best-effort, like the surrounding heartbeat writes
+            }
+          },
+        });
         // Remember the volume for the on_heartbeat vitals provider (#832).
         lastHeartbeatDiff = { added, removed };
         // Update the per-attempt peak diff (only grows; never decreases).

--- a/apps/dev/src/core/loc-memo.ts
+++ b/apps/dev/src/core/loc-memo.ts
@@ -1,0 +1,67 @@
+// core/loc-memo.ts — commit-anchored LOC memo for /afk attempt worktrees.
+//
+// Issue #1210 (Part B): the statusline/monitor render paths must NEVER shell out
+// to `git diff --shortstat` — that ownership moves to the WRITERS (the per-attempt
+// heartbeat and/or post-commit hook), which stamp `loc_added`/`loc_removed` into
+// `afk.state.json` for ALL runners (codex included — the writer is runner-agnostic,
+// so the historical codex `0/0` gap that forced the render fallback disappears).
+//
+// The diffstat is EXPENSIVE (two git subprocesses via {@link diffstatShortstat}),
+// so this module memoizes it against the current HEAD sha in the attempt dir: the
+// diffstat is recomputed AT MOST ONCE PER COMMIT. While HEAD is unchanged the
+// memoized volume is served without spawning git; a new commit (HEAD moves)
+// invalidates the memo and triggers exactly one recompute. Pure and fully
+// injectable — the compute/read/write seams are passed in so the writer wires the
+// real git + fs closures and tests drive it hermetically.
+
+/** The persisted memo: the committed LOC volume anchored to the HEAD it was
+ * measured at. */
+export interface LocMemo {
+  /** Full HEAD sha the {@link added}/{@link removed} volume was measured against. */
+  sha: string;
+  added: number;
+  removed: number;
+}
+
+export interface ResolveAttemptLocInput {
+  /** Full HEAD sha of the attempt worktree. Empty when HEAD cannot be resolved
+   * (unborn branch / detached probe failure) — an empty sha never memoizes, so
+   * every call recomputes rather than caching a meaningless key. */
+  headSha: string;
+  /** Runs the actual `git diff --shortstat` (merge-base vs worktree). Invoked
+   * only on a memo miss — at most once per HEAD sha. */
+  compute: () => Promise<{ added: number; removed: number }>;
+  /** Reads the persisted memo, or null when absent/unreadable. */
+  readMemo: () => LocMemo | null;
+  /** Persists the memo after a recompute. Best-effort — a write failure must not
+   * fail the stamp. */
+  writeMemo: (memo: LocMemo) => void;
+}
+
+/**
+ * Resolve the attempt's committed LOC volume, computing the diffstat at most once
+ * per commit. When the persisted memo already matches {@link
+ * ResolveAttemptLocInput.headSha} the memoized volume is returned WITHOUT calling
+ * {@link ResolveAttemptLocInput.compute} (zero git subprocesses); otherwise the
+ * diffstat is computed once, persisted against the current sha, and returned. A
+ * falsy/empty sha always recomputes (it is never a stable memo key).
+ */
+export async function resolveAttemptLoc(
+  input: ResolveAttemptLocInput,
+): Promise<{ added: number; removed: number }> {
+  const { headSha, compute, readMemo, writeMemo } = input;
+  if (headSha) {
+    const memo = readMemo();
+    if (memo && memo.sha === headSha) {
+      return { added: memo.added, removed: memo.removed };
+    }
+  }
+  const { added, removed } = await compute();
+  if (headSha) writeMemo({ sha: headSha, added, removed });
+  return { added, removed };
+}
+
+/** Default on-disk location of an attempt's LOC memo, beside its state file. */
+export function locMemoPath(attemptDir: string, sep = "/"): string {
+  return `${attemptDir}${sep}.loc-memo.json`;
+}

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -538,31 +538,15 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
   const workers: CompactWorker[] = [];
   for (const { path, state, active, live: pidLive, liveness, livenessVerdict } of records) {
     // Diff volume: committed + uncommitted work for the attempt, measured from
-    // the branch's merge-base with origin/main. Prefer the state file's persisted
-    // counts; fall back to a live `git diff --shortstat` of the worktree when both
-    // are 0 (same logic as collectStatuslineAfk). Always populated — the dashboard
-    // renders the +A -R volume unconditionally (idle / zero included) and sums it
-    // into the fleet header, so it is never suppressed.
-    let added = state.current.loc_added;
-    let removed = state.current.loc_removed;
-    if (added === 0 && removed === 0) {
-      const attemptDir = dirname(path);
-      const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
-      // Resolve the real worktree path: the state file carries it after the first
-      // heartbeat tick. Before that (or for sandcastle where the initial seed is the
-      // legacy {attemptDir}/worktree path that never exists), fall back to
-      // worktreePathUnder which probes `git worktree list --porcelain` and resolves
-      // the sandcastle layout ({attemptDir}/.sandcastle/worktrees/{slug}) even before
-      // the heartbeat has had a chance to persist the resolved path.
-      const worktreePath =
-        state.current.worktree ||
-        (await gitx.worktreePathUnder({ cwd: attemptDir }, attemptDir).catch(() => undefined));
-      if (worktreePath) {
-        const stat = await gitx.diffstatShortstat({ cwd: worktreePath }, baseRef);
-        added = stat.added;
-        removed = stat.removed;
-      }
-    }
+    // the branch's merge-base with origin/main. #1210 Part B: read it from the
+    // state file's writer-stamped counts only — the monitor render performs NO
+    // git subprocess. The per-attempt heartbeat owns the diffstat for every
+    // runner (via the commit-anchored memo), so the old live `git diff
+    // --shortstat` fallback is gone. Always populated — the dashboard renders the
+    // +A -R volume unconditionally (idle / zero included) and sums it into the
+    // fleet header, so it is never suppressed.
+    const added = state.current.loc_added;
+    const removed = state.current.loc_removed;
 
     const logPath = state.log || join(dirname(path), "afk.log");
     const counts = logCounts.get(logPath);
@@ -776,13 +760,11 @@ export async function collectStatuslineAfk(ctx: RepoContext): Promise<AfkInput |
 
     let a = vitals.loc_added;
     let r = vitals.loc_removed;
-    if (a === 0 && r === 0 && state.current.worktree) {
-      // Fallback: compute the diffstat from the worktree like statusline.sh.
-      const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
-      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
-      a = stat.added;
-      r = stat.removed;
-    }
+    // #1210 Part B: the render NEVER shells out to git. LOC ownership moved to
+    // the writers (the per-attempt heartbeat stamps loc_added/loc_removed for
+    // ALL runners via the commit-anchored memo), so the old `git diff
+    // --shortstat` render fallback is gone. When the writer's live value is 0/0
+    // the sticky per-attempt peak below keeps `loc=` visible without git.
     // Sticky fallback: if the live diff is still 0 but a prior non-zero value
     // was seen this attempt, use the peak so `loc=` stays visible with a `~`
     // prefix instead of disappearing (which looks alarming even when intact).
@@ -899,14 +881,10 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
     // lane during the post-mortem window, so require its OWN pid to be alive (or
     // the isolation host pid) — a pid-0 sibling of a live successor is dropped.
     if (!pidIdentityLive && !hostPidLive) continue;
-    let added = state.current.loc_added;
-    let removed = state.current.loc_removed;
-    if (added === 0 && removed === 0 && state.current.worktree) {
-      const baseRef = state.current.base ? `origin/${state.current.base}` : "origin/main";
-      const stat = await gitx.diffstatShortstat({ cwd: state.current.worktree }, baseRef);
-      added = stat.added;
-      removed = stat.removed;
-    }
+    // #1210 Part B: no per-render git subprocess — read the writer-stamped LOC
+    // straight from the state file (the heartbeat owns it for every runner).
+    const added = state.current.loc_added;
+    const removed = state.current.loc_removed;
     workers.push({
       state: {
         worker_id: state.worker_id,

--- a/apps/dev/tests/loc-memo.test.ts
+++ b/apps/dev/tests/loc-memo.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../src/core/loc-memo.js";
+
+describe("resolveAttemptLoc — commit-anchored LOC memo (#1210)", () => {
+  it("computes once per commit: a memo hit on the same sha spawns no diffstat", async () => {
+    let computeCalls = 0;
+    let stored: LocMemo | null = null;
+    const deps = {
+      headSha: "deadbeefcafe",
+      compute: async () => {
+        computeCalls += 1;
+        return { added: 42, removed: 3 };
+      },
+      readMemo: () => stored,
+      writeMemo: (m: LocMemo) => {
+        stored = m;
+      },
+    };
+
+    // First call: memo miss → computes once and persists against the sha.
+    const first = await resolveAttemptLoc(deps);
+    expect(first).toEqual({ added: 42, removed: 3 });
+    expect(computeCalls).toBe(1);
+    expect(stored).toEqual({ sha: "deadbeefcafe", added: 42, removed: 3 });
+
+    // Second call, same HEAD: memo hit → served WITHOUT recomputing.
+    const second = await resolveAttemptLoc(deps);
+    expect(second).toEqual({ added: 42, removed: 3 });
+    expect(computeCalls).toBe(1); // still 1 — no extra git subprocess
+  });
+
+  it("recomputes when HEAD advances (a new commit invalidates the memo)", async () => {
+    let computeCalls = 0;
+    let stored: LocMemo | null = { sha: "old", added: 10, removed: 1 };
+    const result = await resolveAttemptLoc({
+      headSha: "new",
+      compute: async () => {
+        computeCalls += 1;
+        return { added: 88, removed: 9 }; // volume after the new commit
+      },
+      readMemo: () => stored,
+      writeMemo: (m) => {
+        stored = m;
+      },
+    });
+    expect(result).toEqual({ added: 88, removed: 9 });
+    expect(computeCalls).toBe(1);
+    expect(stored).toEqual({ sha: "new", added: 88, removed: 9 });
+  });
+
+  it("is runner-agnostic: a codex-runner attempt gets its non-zero LOC stamped", async () => {
+    // The memo never inspects the runner — the same path that serves claude serves
+    // codex, so the historical codex 0/0 gap that forced the render fallback is
+    // closed at the writer.
+    let stored: LocMemo | null = null;
+    const result = await resolveAttemptLoc({
+      headSha: "codexsha1",
+      compute: async () => ({ added: 123, removed: 7 }),
+      readMemo: () => stored,
+      writeMemo: (m) => {
+        stored = m;
+      },
+    });
+    expect(result).toEqual({ added: 123, removed: 7 });
+    expect(stored?.added).toBe(123);
+  });
+
+  it("an empty HEAD sha never memoizes: it always recomputes", async () => {
+    let computeCalls = 0;
+    let stored: LocMemo | null = null;
+    const deps = {
+      headSha: "",
+      compute: async () => {
+        computeCalls += 1;
+        return { added: 5, removed: 0 };
+      },
+      readMemo: () => stored,
+      writeMemo: (m: LocMemo) => {
+        stored = m;
+      },
+    };
+    await resolveAttemptLoc(deps);
+    await resolveAttemptLoc(deps);
+    expect(computeCalls).toBe(2); // no memo key → recompute each time
+    expect(stored).toBeNull(); // nothing persisted for an empty sha
+  });
+
+  it("locMemoPath sits beside the attempt state file", () => {
+    expect(locMemoPath("/tmp/attempt")).toBe("/tmp/attempt/.loc-memo.json");
+  });
+});

--- a/apps/dev/tests/loc-memo.test.ts
+++ b/apps/dev/tests/loc-memo.test.ts
@@ -52,17 +52,17 @@ describe("resolveAttemptLoc — commit-anchored LOC memo (#1210)", () => {
     // The memo never inspects the runner — the same path that serves claude serves
     // codex, so the historical codex 0/0 gap that forced the render fallback is
     // closed at the writer.
-    let stored: LocMemo | null = null;
+    const stored: LocMemo[] = [];
     const result = await resolveAttemptLoc({
       headSha: "codexsha1",
       compute: async () => ({ added: 123, removed: 7 }),
-      readMemo: () => stored,
+      readMemo: () => stored[0] ?? null,
       writeMemo: (m) => {
-        stored = m;
+        stored[0] = m;
       },
     });
     expect(result).toEqual({ added: 123, removed: 7 });
-    expect(stored?.added).toBe(123);
+    expect(stored[0]?.added).toBe(123);
   });
 
   it("an empty HEAD sha never memoizes: it always recomputes", async () => {

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -631,6 +631,52 @@ describe("collectStatuslineAfk — cache discipline", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("render performs NO git diffstat: 0/0 loc + a worktree falls to the sticky peak, never git (#1210)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      // Fresh gh cache → no gh subprocess either; this render must be fully
+      // subprocess-free.
+      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 0, human: 0, ts: nowS() }), "utf8");
+
+      // A live worker whose writer-stamped LOC is 0/0 but which points at a REAL
+      // git worktree (the project root) with a non-empty diff vs origin/main. The
+      // deleted fallback would have shelled `git diff --shortstat` and reported
+      // that volume; the render must instead serve the sticky peak and touch no
+      // git at all.
+      const dir = join(tmpDir, "workers", "wZ", "77-a1");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "afk.state.json"),
+        JSON.stringify({
+          pid: process.pid,
+          current: {
+            number: 77,
+            stage: "impl",
+            started_at: new Date().toISOString(),
+            loc_added: 0,
+            loc_removed: 0,
+            loc_peak_added: 84,
+            loc_peak_removed: 5,
+            worktree: root, // a real dir — the old fallback would diff it
+          },
+        }),
+        "utf8",
+      );
+
+      const result = await collectStatuslineAfk({ root, repo: "", remote: "origin" });
+      expect(result).not.toBeNull();
+      // The volume comes from the sticky peak (writer-owned), flagged as peak —
+      // proving the git fallback is gone.
+      expect(result!.added).toBe(84);
+      expect(result!.removed).toBe(5);
+      expect(result!.locIsPeak).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Automated AFK landing for #1210. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1210

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785942443&installation_id=129708444&pr_number=1214&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1214&signature=fd0dffccab780901658db9af542c2a4ed405c15e6600f6b1671ccbc80f4babef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->