### PR TITLE
merge: #1186 afk: legal-transition table for the issue lifecycle

### DIFF
--- a/apps/dev/src/core/hitl-resolution-plan.ts
+++ b/apps/dev/src/core/hitl-resolution-plan.ts
@@ -1,6 +1,7 @@
 import type { HitlDecisionExtraction } from "./hitl-decision-extraction.js";
 import { clearCurrentBlocker, parseCurrentBlocker, upsertCurrentBlocker } from "./blocker-state.js";
 import { upsertAgentBrief } from "./agent-brief.js";
+import { validateIssueLifecycleTransition } from "./issue-lifecycle.js";
 import { LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
 
 export interface HitlResolutionIssue {
@@ -74,6 +75,14 @@ ${input.disposition.kind}${next}
 
 export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPlan {
   if (input.disposition.kind === "delegable") {
+    const removeLabels = [LABEL_HUMAN, ...staleBlockerLabels(input.issue.labels)];
+    const addLabels = [LABEL_READY];
+    validateIssueLifecycleTransition({
+      edge: "human-delegable",
+      fromLabels: input.issue.labels ?? [LABEL_HUMAN],
+      removeLabels,
+      addLabels,
+    });
     const cleared = clearCurrentBlocker(input.issue.body, {
       summary:
         parseCurrentBlocker(input.issue.body)?.summary ??
@@ -83,11 +92,17 @@ export function planHitlResolution(input: HitlResolutionInput): HitlResolutionPl
     return {
       commentBody: directiveComment(input),
       bodyUpdate: upsertAgentBrief(cleared, input.disposition.agentBrief),
-      addLabels: [LABEL_READY],
-      removeLabels: [LABEL_HUMAN, ...staleBlockerLabels(input.issue.labels)],
+      addLabels,
+      removeLabels,
     };
   }
 
+  validateIssueLifecycleTransition({
+    edge: "human-blocked",
+    fromLabels: input.issue.labels ?? [],
+    removeLabels: [],
+    addLabels: [LABEL_HUMAN],
+  });
   return {
     commentBody: directiveComment(input),
     bodyUpdate: upsertCurrentBlocker(input.issue.body, {

--- a/apps/dev/src/core/issue-lifecycle.ts
+++ b/apps/dev/src/core/issue-lifecycle.ts
@@ -1,0 +1,180 @@
+import {
+  LABEL_CI,
+  LABEL_CRASHED,
+  LABEL_DEPENDENCY,
+  LABEL_HUMAN,
+  LABEL_INFRA,
+  LABEL_LANDING_MANUAL,
+  LABEL_MERGE_CONFLICT,
+  LABEL_POLICY,
+  LABEL_QUOTA,
+  LABEL_READY,
+  LABEL_RUNNING,
+  LABEL_RUNNER_TRANSIENT,
+  LABEL_SENSITIVE_PATH,
+  LABEL_SPEC,
+  LABEL_STALLED,
+  LABEL_TRUNK_DIVERGED,
+  LABEL_VALIDATION,
+  LABEL_VALIDATION_INFRA,
+} from "./triage-labels.js";
+
+export type IssueLifecycleState =
+  | "ready-for-agent"
+  | "claimed/active"
+  | "blocked:dependency"
+  | "blocked:validation"
+  | "ready-for-human"
+  | "landing:manual"
+  | "closed";
+
+export type IssueLifecycleEdge =
+  | "claim"
+  | "retry"
+  | "dependency-unblocked"
+  | "dependency-blocked"
+  | "preflight-blocked"
+  | "validation-blocked"
+  | "human-blocked"
+  | "human-delegable"
+  | "manual-landing"
+  | "close"
+  | "requeue"
+  | "requeue-mixed-blocked-refusal";
+
+export interface IssueLifecycleTransition {
+  edge: IssueLifecycleEdge;
+  from: IssueLifecycleState | "*";
+  to: IssueLifecycleState | "illegal";
+}
+
+export const BLOCKED_LABELS = [
+  LABEL_VALIDATION,
+  LABEL_VALIDATION_INFRA,
+  LABEL_STALLED,
+  LABEL_CRASHED,
+  LABEL_DEPENDENCY,
+  LABEL_SPEC,
+  LABEL_QUOTA,
+  LABEL_RUNNER_TRANSIENT,
+  LABEL_MERGE_CONFLICT,
+  LABEL_CI,
+  LABEL_POLICY,
+  LABEL_INFRA,
+  LABEL_TRUNK_DIVERGED,
+  LABEL_SENSITIVE_PATH,
+] as const;
+
+export const ISSUE_LIFECYCLE_TRANSITIONS: readonly IssueLifecycleTransition[] = [
+  { edge: "claim", from: "ready-for-agent", to: "claimed/active" },
+  { edge: "retry", from: "claimed/active", to: "ready-for-agent" },
+  { edge: "dependency-unblocked", from: "blocked:dependency", to: "ready-for-agent" },
+  { edge: "dependency-blocked", from: "ready-for-agent", to: "blocked:dependency" },
+  { edge: "preflight-blocked", from: "ready-for-agent", to: "ready-for-human" },
+  { edge: "validation-blocked", from: "claimed/active", to: "blocked:validation" },
+  { edge: "human-blocked", from: "*", to: "ready-for-human" },
+  { edge: "human-blocked", from: "*", to: "blocked:validation" },
+  { edge: "human-delegable", from: "ready-for-human", to: "ready-for-agent" },
+  { edge: "human-delegable", from: "blocked:validation", to: "ready-for-agent" },
+  { edge: "manual-landing", from: "claimed/active", to: "landing:manual" },
+  { edge: "close", from: "claimed/active", to: "closed" },
+  { edge: "close", from: "landing:manual", to: "closed" },
+  { edge: "requeue", from: "ready-for-human", to: "ready-for-agent" },
+  { edge: "requeue", from: "blocked:validation", to: "ready-for-agent" },
+  { edge: "requeue-mixed-blocked-refusal", from: "*", to: "illegal" },
+];
+
+export class IllegalIssueLifecycleTransitionError extends Error {
+  constructor(
+    readonly edge: IssueLifecycleEdge,
+    readonly from: IssueLifecycleState | "illegal",
+    readonly to: IssueLifecycleState | "illegal",
+    readonly reason: string,
+  ) {
+    super(`illegal issue lifecycle transition "${edge}": ${from} -> ${to}: ${reason}`);
+    this.name = "IllegalIssueLifecycleTransitionError";
+  }
+}
+
+export function blockedLabelsIn(labels: readonly string[]): string[] {
+  return labels.filter((label) => label.startsWith("blocked:"));
+}
+
+export function applyLabelMutation(
+  labels: readonly string[],
+  removeLabels: readonly string[],
+  addLabels: readonly string[],
+): string[] {
+  const next = new Set(labels);
+  for (const label of removeLabels) next.delete(label);
+  for (const label of addLabels) next.add(label);
+  return [...next];
+}
+
+export function classifyIssueLifecycleState(labels: readonly string[]): IssueLifecycleState | "illegal" {
+  const hasReady = labels.includes(LABEL_READY);
+  const hasRunning = labels.includes(LABEL_RUNNING);
+  const hasHuman = labels.includes(LABEL_HUMAN);
+  const hasManualLanding = labels.includes(LABEL_LANDING_MANUAL);
+  const blocked = blockedLabelsIn(labels);
+  const hasBlocked = blocked.length > 0;
+
+  if (blocked.length > 1) return "illegal";
+  if ((hasReady || hasRunning) && hasBlocked) return "illegal";
+  if (hasReady && hasRunning) return "illegal";
+  if (hasManualLanding && !hasHuman && !hasReady) return "illegal";
+
+  if (hasManualLanding && hasHuman) return "landing:manual";
+  if (hasRunning) return "claimed/active";
+  if (hasReady) return "ready-for-agent";
+  if (blocked[0] === LABEL_DEPENDENCY) return "blocked:dependency";
+  if (blocked[0] === LABEL_VALIDATION || blocked[0] === LABEL_VALIDATION_INFRA) return "blocked:validation";
+  if (hasHuman) return "ready-for-human";
+  if (hasBlocked) return "ready-for-human";
+  return "ready-for-human";
+}
+
+export function explainIllegalIssueLifecycleLabels(labels: readonly string[]): string | null {
+  const blocked = blockedLabelsIn(labels);
+  if (blocked.length > 1) return `mixed blocked:* labels [${blocked.join(", ")}]`;
+  if ((labels.includes(LABEL_READY) || labels.includes(LABEL_RUNNING)) && blocked.length > 0) {
+    return `queued/active issue cannot also carry blocked:* label ${blocked[0]}`;
+  }
+  if (labels.includes(LABEL_READY) && labels.includes(LABEL_RUNNING)) {
+    return `issue cannot carry both ${LABEL_READY} and ${LABEL_RUNNING}`;
+  }
+  if (labels.includes(LABEL_LANDING_MANUAL) && !labels.includes(LABEL_HUMAN) && !labels.includes(LABEL_READY)) {
+    return `${LABEL_LANDING_MANUAL} must ride a queued or human-parked issue`;
+  }
+  return null;
+}
+
+export function validateIssueLifecycleTransition(input: {
+  edge: IssueLifecycleEdge;
+  fromLabels: readonly string[];
+  removeLabels: readonly string[];
+  addLabels: readonly string[];
+}): string[] {
+  const from = classifyIssueLifecycleState(input.fromLabels);
+  const nextLabels = applyLabelMutation(input.fromLabels, input.removeLabels, input.addLabels);
+  const to = classifyIssueLifecycleState(nextLabels);
+  const illegalReason = explainIllegalIssueLifecycleLabels(nextLabels);
+  if (illegalReason !== null) {
+    throw new IllegalIssueLifecycleTransitionError(input.edge, from, "illegal", illegalReason);
+  }
+  const row = ISSUE_LIFECYCLE_TRANSITIONS.find(
+    (transition) =>
+      transition.edge === input.edge &&
+      (transition.from === "*" || transition.from === from) &&
+      transition.to === to,
+  );
+  if (!row) {
+    throw new IllegalIssueLifecycleTransitionError(
+      input.edge,
+      from,
+      to,
+      `no legal row for edge "${input.edge}" from ${from} to ${to}`,
+    );
+  }
+  return nextLabels;
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -699,7 +699,9 @@ import {
   LABEL_READY_FOR_REVIEW,
   LABEL_LANDING_MANUAL,
   LABEL_SENSITIVE_PATH,
+  LABEL_SPEC,
 } from "./triage-labels.js";
+import { validateIssueLifecycleTransition, type IssueLifecycleEdge } from "./issue-lifecycle.js";
 
 /**
  * The typed `blocked:*` labels present in a label set (#402). Promoting an issue
@@ -734,6 +736,18 @@ async function editLabelsTagged(
   if (typed === null) return deps.gh.editLabels(issue, remove, add);
   await deps.gh.ensureLabel(typed);
   return deps.gh.editLabels(issue, remove, [...add, typed]);
+}
+
+async function editIssueLifecycleLabels(
+  deps: ProcessIssueDeps,
+  issue: number,
+  fromLabels: readonly string[],
+  remove: string[],
+  add: string[],
+  edge: IssueLifecycleEdge,
+): Promise<boolean> {
+  validateIssueLifecycleTransition({ edge, fromLabels, removeLabels: remove, addLabels: add });
+  return deps.gh.editLabels(issue, remove, add);
 }
 
 /**
@@ -787,7 +801,7 @@ async function routeRecovery(
     // Build the escalate label set from the typed label (computed independent of
     // the composer's own decision) so a hook-FORCED escalate still pages cleanly.
     const addLabels = disp.typedLabel !== null ? [LABEL_HUMAN, disp.typedLabel] : [LABEL_HUMAN];
-    await deps.gh.editLabels(issue, [LABEL_RUNNING], addLabels);
+    await editIssueLifecycleLabels(deps, issue, [LABEL_RUNNING], [LABEL_RUNNING], addLabels, "human-blocked");
     // The budget-exhausted page comment only rides the composer's OWN escalate
     // (it tells a retry-budget story); a hook-forced escalate stays silent.
     if (decision === disp.decision && disp.escalationComment !== null) {
@@ -815,7 +829,7 @@ async function routeRecovery(
     }
   } else {
     // retry → CLEAN promotion: running → ready-for-agent, no blocked:* tag.
-    await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_READY]);
+    await editIssueLifecycleLabels(deps, issue, [LABEL_RUNNING], [LABEL_RUNNING], [LABEL_READY], "retry");
   }
   return decision;
 }
@@ -957,7 +971,7 @@ async function refuseNoSandboxForUntrustedAuthor(
   hooksFired: HookName[],
   reason: string,
 ): Promise<ProcessIssueResult> {
-  await deps.gh.editLabels(input.issue, [LABEL_READY], [LABEL_HUMAN]);
+  await editIssueLifecycleLabels(deps, input.issue, [LABEL_READY], [LABEL_READY], [LABEL_HUMAN], "preflight-blocked");
   await deps.gh.comment(
     input.issue,
     `🤖 /afk preflight stopped: ${reason}. Autonomous execution refused; maintainer intervention required.`,
@@ -1074,7 +1088,8 @@ export async function processIssue(
 
   const activeBlocker = parseCurrentBlocker(input.body);
   if (activeBlocker && !MECHANICAL_BLOCKER_KINDS.has(activeBlocker.kind)) {
-    await editLabelsTagged(deps, issue, [LABEL_READY], [LABEL_HUMAN], "blocked");
+    await deps.gh.ensureLabel(LABEL_SPEC);
+    await editIssueLifecycleLabels(deps, issue, labels, [LABEL_READY], [LABEL_HUMAN, LABEL_SPEC], "preflight-blocked");
     await deps.gh.comment(
       issue,
       `🤖 /afk preflight stopped: active Current blocker (${activeBlocker.kind}) still requires human input: ${activeBlocker.next}`,
@@ -1148,7 +1163,8 @@ export async function processIssue(
   // already won via the GitHub-native arbiter, so a failed label edit must not
   // abandon the attempt. Legacy callers (no `claimGh`) keep the old semantics
   // where the edit-to-running was the lock and its failure lost the claim.
-  const promoted = await deps.gh.editLabels(issue, [LABEL_READY, ...blockedLabelsIn(labels)], [LABEL_RUNNING]);
+  const claimRemoveLabels = [LABEL_READY, ...blockedLabelsIn(labels)];
+  const promoted = await editIssueLifecycleLabels(deps, issue, labels, claimRemoveLabels, [LABEL_RUNNING], "claim");
   if (!promoted && !deps.claimGh) {
     await deps.claimLock.release(issue);
     return claimLost(issue, hooksFired);
@@ -1160,7 +1176,7 @@ export async function processIssue(
   if (branch === null) {
     // A malformed ref refuses the iteration; restore the claim like the bash
     // "refusing malformed live branch ref" guard (return before running).
-    await deps.gh.editLabels(issue, [LABEL_RUNNING], [LABEL_READY]);
+    await editIssueLifecycleLabels(deps, issue, [LABEL_RUNNING], [LABEL_RUNNING], [LABEL_READY], "retry");
     await deps.claimLock.release(issue);
     return claimLost(issue, hooksFired);
   }

--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -18,6 +18,11 @@ import {
   parseCurrentBlocker,
   type CurrentBlocker,
 } from "./blocker-state.js";
+import {
+  IllegalIssueLifecycleTransitionError,
+  blockedLabelsIn,
+  validateIssueLifecycleTransition,
+} from "./issue-lifecycle.js";
 import { LABEL_HUMAN, LABEL_READY } from "./triage-labels.js";
 
 /**
@@ -95,10 +100,6 @@ export interface RequeuePlan {
   removeLabels: string[];
 }
 
-function blockedLabelsIn(labels: readonly string[]): string[] {
-  return labels.filter((l) => l.startsWith("blocked:"));
-}
-
 function refuse(
   reason: string,
   refuseForHitl: boolean,
@@ -161,10 +162,19 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     );
   }
 
-  // Mixed blocked:* labels → label state is ambiguous; /hitl must reconcile.
-  if (blocked.length > 1) {
+  try {
+    validateIssueLifecycleTransition({
+      edge: "requeue-mixed-blocked-refusal",
+      fromLabels: input.labels,
+      removeLabels: [],
+      addLabels: [],
+    });
+  } catch (error) {
+    if (!(error instanceof IllegalIssueLifecycleTransitionError) || !error.reason.startsWith("mixed blocked:*")) {
+      throw error;
+    }
     return refuse(
-      `mixed blocked:* labels [${blocked.join(", ")}]: label state is ambiguous — use /hitl to reconcile`,
+      `${error.reason}: label state is ambiguous — use /hitl to reconcile`,
       true,
       activeBlocker,
       input.body,
@@ -222,6 +232,13 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     : input.body;
 
   const removeLabels = [...(hasHuman ? [LABEL_HUMAN] : []), ...blocked];
+  const addLabels = [LABEL_READY];
+  validateIssueLifecycleTransition({
+    edge: "requeue",
+    fromLabels: input.labels,
+    removeLabels,
+    addLabels,
+  });
 
   return {
     requeueable: true,
@@ -232,7 +249,7 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     // `ready-for-agent` is always applied — a gh add of a label the issue
     // already carries is idempotent, so the transition is the same whether the
     // maintainer pre-flipped labels or not.
-    addLabels: [LABEL_READY],
+    addLabels,
     removeLabels,
   };
 }

--- a/apps/dev/tests/issue-lifecycle.test.ts
+++ b/apps/dev/tests/issue-lifecycle.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  ISSUE_LIFECYCLE_TRANSITIONS,
+  IllegalIssueLifecycleTransitionError,
+  classifyIssueLifecycleState,
+  validateIssueLifecycleTransition,
+  type IssueLifecycleEdge,
+} from "../src/core/issue-lifecycle.js";
+
+describe("issue lifecycle transition table", () => {
+  it("classifies lifecycle states from the triage label vocabulary", () => {
+    expect(classifyIssueLifecycleState(["ready-for-agent"])).toBe("ready-for-agent");
+    expect(classifyIssueLifecycleState(["running"])).toBe("claimed/active");
+    expect(classifyIssueLifecycleState(["blocked:dependency"])).toBe("blocked:dependency");
+    expect(classifyIssueLifecycleState(["ready-for-human", "blocked:validation"])).toBe("blocked:validation");
+    expect(classifyIssueLifecycleState(["ready-for-human"])).toBe("ready-for-human");
+    expect(classifyIssueLifecycleState(["ready-for-human", "landing:manual"])).toBe("landing:manual");
+  });
+
+  it("has table rows for every edge the runtime validates", () => {
+    const edges = new Set(ISSUE_LIFECYCLE_TRANSITIONS.map((row) => row.edge));
+    const expected: IssueLifecycleEdge[] = [
+      "claim",
+      "retry",
+      "dependency-unblocked",
+      "dependency-blocked",
+      "preflight-blocked",
+      "validation-blocked",
+      "human-blocked",
+      "human-delegable",
+      "manual-landing",
+      "close",
+      "requeue",
+      "requeue-mixed-blocked-refusal",
+    ];
+    expect([...edges].sort()).toEqual([...expected].sort());
+  });
+
+  it("accepts legal AFK runtime transitions", () => {
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "claim",
+        fromLabels: ["ready-for-agent"],
+        removeLabels: ["ready-for-agent"],
+        addLabels: ["running"],
+      }),
+    ).toEqual(["running"]);
+
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "validation-blocked",
+        fromLabels: ["running"],
+        removeLabels: ["running"],
+        addLabels: ["ready-for-human", "blocked:validation"],
+      }).sort(),
+    ).toEqual(["blocked:validation", "ready-for-human"]);
+
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "retry",
+        fromLabels: ["running"],
+        removeLabels: ["running"],
+        addLabels: ["ready-for-agent"],
+      }),
+    ).toEqual(["ready-for-agent"]);
+  });
+
+  it("accepts legal requeue and HITL transitions", () => {
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "requeue",
+        fromLabels: ["ready-for-human", "blocked:spec"],
+        removeLabels: ["ready-for-human", "blocked:spec"],
+        addLabels: ["ready-for-agent"],
+      }),
+    ).toEqual(["ready-for-agent"]);
+
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "human-delegable",
+        fromLabels: ["ready-for-human", "blocked:validation"],
+        removeLabels: ["ready-for-human", "blocked:validation"],
+        addLabels: ["ready-for-agent"],
+      }),
+    ).toEqual(["ready-for-agent"]);
+  });
+
+  it("rejects illegal mixed blocked states through a table edge", () => {
+    expect(() =>
+      validateIssueLifecycleTransition({
+        edge: "requeue-mixed-blocked-refusal",
+        fromLabels: ["ready-for-human", "blocked:validation", "blocked:spec"],
+        removeLabels: [],
+        addLabels: [],
+      }),
+    ).toThrow(/mixed blocked:\* labels \[blocked:validation, blocked:spec\]/);
+  });
+
+  it("rejects illegal transitions with an actionable edge name", () => {
+    let thrown: unknown;
+    try {
+      validateIssueLifecycleTransition({
+        edge: "claim",
+        fromLabels: ["ready-for-human"],
+        removeLabels: ["ready-for-human"],
+        addLabels: ["running"],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(IllegalIssueLifecycleTransitionError);
+    expect((thrown as Error).message).toContain('illegal issue lifecycle transition "claim"');
+    expect((thrown as Error).message).toContain("no legal row");
+  });
+
+  it("rejects impossible queued or active blocked label combinations", () => {
+    expect(() =>
+      validateIssueLifecycleTransition({
+        edge: "retry",
+        fromLabels: ["running"],
+        removeLabels: ["running"],
+        addLabels: ["ready-for-agent", "blocked:validation"],
+      }),
+    ).toThrow(/queued\/active issue cannot also carry blocked:\*/);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1186. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1186

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785951064&installation_id=129708444&pr_number=1221&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1221&signature=905fd7f47bf82b65b829f72a863f2b9b4d35de9c427ba8f7746b2bedad8e879f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle-aware validation for issue label transitions, helping keep triage states consistent.
  * Improved issue routing so blocked, retry, requeue, and human-handoff paths apply the correct labels automatically.

* **Bug Fixes**
  * Prevents invalid or conflicting label combinations from being applied.
  * Ensures label updates now remove outdated blocking labels when moving issues forward.

* **Tests**
  * Added coverage for valid lifecycle transitions and rejection of illegal label states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->