### PR TITLE
feat(afk): definitive worker rendering fix — liveness-gated render, ghost kill, org= token, dead-worker reclaim

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -79,7 +79,7 @@ import {
 import { join } from "node:path";
 import { hostname } from "node:os";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
-import { initStateSync, readPidStartTime, updateState } from "../core/state.js";
+import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../core/loc-memo.js";
 import { createActivityMeter } from "../core/activity-meter.js";
@@ -1860,6 +1860,18 @@ export async function runCommand(options: RunOptions): Promise<number> {
           // agent stream event; `validating`/`merging` by the orchestrator at the
           // gate/landing steps (deps.markPhase).
           "current.phase": "setup",
+        });
+        // Durable write-once identity sidecar (issue #1219): the immutable
+        // worker_id/runner/origin/number/started_at the isolation fallback in
+        // readWorkerState reads so a live isolation worker whose host-side
+        // afk.state.json is still zeroed renders its real identity instead of the
+        // `?  run=-  00:00:00` ghost. Never clobbered by vitals updateState writes.
+        writeIdentitySync(attemptDir, {
+          worker_id: c.workerId,
+          runner: c.runner,
+          origin: flags.origin ?? "",
+          number: candidate.number,
+          started_at: startedAt,
         });
       } catch {
         // Best-effort — a failed seed must never block the worker's actual work.

--- a/apps/dev/src/core/monitor.ts
+++ b/apps/dev/src/core/monitor.ts
@@ -253,6 +253,10 @@ export function compactWorkerTag(worker: CompactWorker): "live" | "quiet" | "sta
 export interface WorkerFields {
   workerId: string;
   runner: string;
+  /** Spawn-time provenance (`state.origin`, e.g. `afk` | `go`), or undefined when
+   * unstamped. Both per-worker surfaces render it as a 3-letter `org=` token,
+   * defaulting the DISPLAY to `afk` when absent (issue #1219). */
+  origin?: string;
   /** Model identifier the attempt ran with, or undefined (pre-schema state). */
   model?: string;
   /** Reasoning-effort level, or undefined when unavailable. */
@@ -281,6 +285,7 @@ export function workerFields(worker: CompactWorker, now: number): WorkerFields {
   return {
     workerId: state.worker_id || "?",
     runner: state.runner || "-",
+    origin: state.origin || undefined,
     model: state.current.model || undefined,
     effort: state.current.effort || undefined,
     done: state.done,
@@ -302,6 +307,9 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
   const workerId = state.worker_id || "?";
   const tag = compactWorkerTag(worker);
   const runner = state.runner || "-";
+  // Spawn-time provenance token (issue #1219) — for parity with the statusline's
+  // `org=` token. An unstamped worker is an afk-fleet worker, so default to afk.
+  const org = state.origin || "afk";
   const total = state.total;
   const done = state.done;
 
@@ -339,7 +347,7 @@ export function renderWorkerCompactLine(worker: CompactWorker, now: number): str
     cur = `  idle${diff}${logFrag}`;
   }
 
-  return `${workerId} [${tag}] ${runner}  issues ${done}/${total}${flags}${cur}`;
+  return `${workerId} [${tag}] ${runner} org=${org}  issues ${done}/${total}${flags}${cur}`;
 }
 
 /**
@@ -393,9 +401,12 @@ export function renderCompactDashboard(
 ): string {
   let added = 0;
   let removed = 0;
-  // Per-source counts: aggregate state.origin from all workers (not just live
-  // ones — liveness filtering happens at the collection layer). Only non-empty
-  // origins are counted; both surfaces read from the same state.origin field.
+  // Per-source counts: aggregate state.origin over the workers handed to the
+  // renderer. Liveness filtering now happens at the collection layer (issue
+  // #1219: collectMonitorInputs gates every record through `renderableLive`), so
+  // this counts only live workers — matching the statusline's per-source tally,
+  // which counts inside its own liveness gate. Only non-empty origins are
+  // counted; both surfaces read from the same state.origin field.
   const sourceMap = new Map<string, number>();
   for (const w of workers) {
     added += w.diffAdded ?? 0;

--- a/apps/dev/src/core/reclaim.ts
+++ b/apps/dev/src/core/reclaim.ts
@@ -164,6 +164,65 @@ export function planAttemptCap(
   return reaped;
 }
 
+// ---------- liveness-gated reclaim (issue #1219) ----------
+
+/** One dead-worker candidate for the read-time liveness reclaim. The caller has
+ * already resolved the OWNING worker's `worker.pid` liveness and the issue's
+ * preservation state. */
+export interface LivenessReclaimInput {
+  /** Absolute attempt dir path (`.../workers/{wid}/{N}-a{n}`). */
+  attemptDir: string;
+  /** Absolute path of the attempt's heavy `worktree/`. */
+  worktreePath: string;
+  /** Whether the OWNING worker's `worker.pid` still resolves to a live process.
+   * Keyed on the per-WORKER pid (shared across a worker's attempts), NOT the
+   * per-attempt `state.pid`: a worker live on a later attempt keeps ALL its
+   * attempt dirs. */
+  workerPidAlive: boolean;
+  /** Whether the issue is in a post-mortem preservation state (`blocked:*` /
+   * `ready-for-human`, existing #256/#257 policy) — its JSONL/handoff is kept. */
+  preserved: boolean;
+}
+
+/** The reclaim decision for one dead-worker attempt dir. */
+export interface LivenessReclaimAction {
+  attemptDir: string;
+  worktreePath: string;
+  /** Always true for an emitted action — the disposable `worktree/` of a dead
+   * worker is ALWAYS removed, even when the JSONL is preserved. */
+  removeWorktree: boolean;
+  /** Reclaim the WHOLE attempt dir. False when the issue is preserved (keep the
+   * JSONL/handoff for post-mortem; only the worktree goes). */
+  reclaimDir: boolean;
+}
+
+/**
+ * Plan the read-time liveness-gated reclaim (issue #1219). PURE — no I/O; the
+ * caller resolves `workerPidAlive` and `preserved`.
+ *   - A live worker's dir (workerPidAlive) is NEVER touched.
+ *   - A dead worker's `worktree/` is ALWAYS removed (disposable heavy dir).
+ *   - A dead worker's whole attempt dir is reclaimed UNLESS the issue is
+ *     preserved (blocked:* / ready-for-human), in which case the JSONL/handoff
+ *     stay and only the worktree is torn down.
+ * This runs immediately at read time, not gated on the boot orphan/attempt-cap
+ * TTLs, so a killed/crashed worker leaves no graveyard behind it.
+ */
+export function planLivenessReclaim(
+  inputs: readonly LivenessReclaimInput[],
+): LivenessReclaimAction[] {
+  const out: LivenessReclaimAction[] = [];
+  for (const i of inputs) {
+    if (i.workerPidAlive) continue;
+    out.push({
+      attemptDir: i.attemptDir,
+      worktreePath: i.worktreePath,
+      removeWorktree: true,
+      reclaimDir: !i.preserved,
+    });
+  }
+  return out;
+}
+
 // ---------- env resolvers (attempt_ttl_s / attempt_keep) ----------
 
 function resolvePositiveInt(

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -1,10 +1,76 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { AfkStateSchema, type AfkState } from "../types/state.js";
 
 export function defaultState(): AfkState {
   return AfkStateSchema.parse({});
+}
+
+/** The write-once identity sidecar filename in an attempt dir (issue #1219). */
+export const IDENTITY_FILENAME = "identity.json";
+
+/**
+ * The immutable spawn-time identity of one attempt (issue #1219). Written once by
+ * {@link writeIdentitySync} beside `afk.state.json` and NEVER clobbered by the
+ * vitals `updateState` read-modify-writes. It is the durable source the isolation
+ * fallback in {@link readWorkerState} reads to render a live worker's real
+ * `worker_id`/`runner`/`origin`/`started_at`/issue number when the host-side
+ * `afk.state.json` is still zeroed (pid 0, empty identity) pre-sync — so a live
+ * worker can never render as the `?  run=-  00:00:00` ghost.
+ */
+export interface WorkerIdentity {
+  worker_id: string;
+  runner: string;
+  origin: string;
+  number: number | string;
+  started_at: string;
+}
+
+/**
+ * Write the attempt's {@link WorkerIdentity} sidecar ONCE. Synchronous (same seam
+ * as {@link initStateSync}) and write-once: an existing `identity.json` is left
+ * untouched so a re-entered attempt keeps its original identity. Best-effort at
+ * the call site — a failed write must never block the worker's actual work.
+ */
+export function writeIdentitySync(attemptDir: string, identity: WorkerIdentity): void {
+  const path = join(attemptDir, IDENTITY_FILENAME);
+  if (existsSync(path)) return;
+  mkdirSync(attemptDir, { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}.sync`;
+  writeFileSync(tmp, `${JSON.stringify(identity)}\n`, "utf8");
+  renameSync(tmp, path);
+}
+
+/** Parse a {@link WorkerIdentity} from raw JSON text, or `null` when absent /
+ * malformed. Only string/number fields are honoured; anything else is dropped to
+ * the empty default so a partial file never throws. */
+export function parseIdentity(raw: string | null | undefined): WorkerIdentity | null {
+  if (!raw) return null;
+  try {
+    const p = JSON.parse(raw) as Partial<WorkerIdentity>;
+    if (typeof p !== "object" || p === null) return null;
+    return {
+      worker_id: typeof p.worker_id === "string" ? p.worker_id : "",
+      runner: typeof p.runner === "string" ? p.runner : "",
+      origin: typeof p.origin === "string" ? p.origin : "",
+      number:
+        typeof p.number === "number" || typeof p.number === "string" ? p.number : "",
+      started_at: typeof p.started_at === "string" ? p.started_at : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Synchronous read of the {@link WorkerIdentity} sidecar from an attempt dir, or
+ * `null` when the file is missing/unreadable/malformed. */
+export function readIdentitySync(attemptDir: string): WorkerIdentity | null {
+  try {
+    return parseIdentity(readFileSync(join(attemptDir, IDENTITY_FILENAME), "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -160,7 +160,7 @@ export function renderHeaderLine(
 
 /** The TERSE per-worker line for the Claude Code statusline (issue #1175, #1176):
  *
- *   <wID>  run=<runner> <model> <effort>  iss=<issue-number>  <stage>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
+ *   <wID>  run=<runner> <model> <effort>  org=<afk|go>  iss=<issue-number>  <stage>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
  *
  * A visual sibling of line 1: the `wID` is BOLD + red, and every k=v token
  * (`run=`/`iss=`/`loc=`/`tks=` and each vital `tls=`/`rsn=`/`txt=`) reuses the
@@ -185,6 +185,10 @@ export function renderWorkerLine(worker: CompactWorker, now: number): string {
   // wID — bold red, reusing BOLD + the SOFT red tone (no new ANSI).
   parts.push(`${BOLD}${f.workerId}${NOBOLD}`);
   parts.push(kv("run", runVal));
+  // org=<afk|go> — spawn-time provenance (issue #1219). 3-letter key (house
+  // rule), same kv colour convention. An unstamped worker is an afk-fleet
+  // worker, so default the display to afk.
+  parts.push(kv("org", f.origin || "afk"));
   // iss=<issue-number> from current.number (both /afk and /go lanes); the
   // <stage> follows bare and the legacy standalone #<n> token is dropped.
   if (f.issue !== null) {

--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -14,7 +14,7 @@
 import { readFileSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import type { AfkState } from "../types/state.js";
-import { parseState, isStateLive, type PidStartTimeProbe } from "./state.js";
+import { parseState, isStateLive, parseIdentity, readIdentitySync, type PidStartTimeProbe } from "./state.js";
 import { globWorkerStates } from "../runtime/fs.js";
 import { allWorkersRoots } from "./worker-paths.js";
 import {
@@ -74,6 +74,29 @@ export interface WorkerStateRecord {
    * local attempts (pid 0, no live host pid).
    */
   hostPidLive: boolean;
+  /**
+   * The SINGLE render-gate every observability surface shares (issue #1219):
+   * `livenessVerdict.status !== "stalled" && (pidIdentityLive || hostPidLive)`.
+   * Computed ONCE here so the statusline aggregate, the statusline per-worker
+   * lines, and the monitor dashboard all agree on who becomes a rendered row —
+   * no surface inlines its own copy of the gate. Also exported as the pure
+   * {@link isRenderableLive} helper for callers that hold a partial record.
+   */
+  renderableLive: boolean;
+}
+
+/**
+ * The ONE render-gate predicate (issue #1219): a record becomes a rendered
+ * worker row only when the evaluator does NOT call it stalled AND its own pid
+ * (or, for isolation workers, the host-side `worker.pid`) is genuinely alive.
+ * Every read surface routes through this so a finished/retained pid-0 attempt or
+ * a stalled worker never renders a phantom live line, and all three surfaces
+ * agree on liveness.
+ */
+export function isRenderableLive(
+  rec: Pick<WorkerStateRecord, "livenessVerdict" | "pidIdentityLive" | "hostPidLive">,
+): boolean {
+  return rec.livenessVerdict.status !== "stalled" && (rec.pidIdentityLive || rec.hostPidLive);
 }
 
 /** Display threshold: lane records this old → not "active". Matches the old
@@ -117,6 +140,15 @@ export interface WorkerStateReadOpts {
    * the host's `afk.state.json.pid` is never populated during the run.
    */
   workerPidContent?: string;
+  /**
+   * Raw text content of the per-attempt `identity.json` sidecar, for injection in
+   * tests. When omitted and the isolation fallback fires (state.pid 0 + a live
+   * host worker.pid), the reader reads `{dirname(path)}/identity.json` from disk.
+   * The durable write-once identity (issue #1219) that lets a live isolation
+   * worker render its real worker_id/runner/origin/started_at instead of the
+   * `?  run=-  00:00:00` ghost.
+   */
+  identityContent?: string;
 }
 
 /** Sync read of the newest liveness lane record timestamp (epoch-ms), or
@@ -227,8 +259,32 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
           crossCheckArmed: false,
           reason: `state.pid=0 but worker.pid=${hostPid} is alive (isolation worker)`,
         };
-        // Derive the issue number from the attempt-dir basename when the state
-        // carries no current.number (the state file is empty pre-sync).
+        // Durable identity fallback (issue #1219): a live isolation worker whose
+        // host-side afk.state.json is still zeroed (pid 0, empty worker_id/runner)
+        // must NOT render as the `?  run=-  00:00:00` ghost. Read the write-once
+        // identity.json sidecar and populate the zeroed identity fields from it —
+        // never overwriting a value the state file already carries.
+        const identity =
+          opts.identityContent !== undefined
+            ? parseIdentity(opts.identityContent)
+            : readIdentitySync(dirname(path));
+        if (identity) {
+          if (!state.worker_id && identity.worker_id) state.worker_id = identity.worker_id;
+          if (!state.runner && identity.runner) state.runner = identity.runner;
+          if (!state.origin && identity.origin) state.origin = identity.origin;
+          if (!state.started_at && identity.started_at) state.started_at = identity.started_at;
+          if (!state.current.started_at && identity.started_at) state.current.started_at = identity.started_at;
+          if (
+            (state.current.number === "" || state.current.number === undefined || state.current.number === null) &&
+            identity.number !== "" &&
+            identity.number !== undefined &&
+            identity.number !== null
+          ) {
+            state.current.number = identity.number;
+          }
+        }
+        // Derive the issue number from the attempt-dir basename when neither the
+        // state nor the identity sidecar carries a current.number (empty pre-sync).
         if (state.current.number === "" || state.current.number === undefined || state.current.number === null) {
           const attemptBasename = basename(dirname(path));
           const m = /^([1-9][0-9]*)-a[1-9][0-9]*$/.exec(attemptBasename);
@@ -255,6 +311,11 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
   // statusline worker-line filter needs (issue #1177).
   const pidIdentityLive = isStateLive(state, opts.kill, opts.pidStartTime);
 
+  // The ONE shared render-gate (issue #1219), computed once so all three
+  // surfaces route through the same predicate.
+  const renderableLive =
+    finalVerdict.status !== "stalled" && (pidIdentityLive || hostPidLive);
+
   return {
     path,
     state,
@@ -264,6 +325,7 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
     livenessVerdict: finalVerdict,
     pidIdentityLive,
     hostPidLive,
+    renderableLive,
   };
 }
 
@@ -293,6 +355,7 @@ export async function readWorkerStates(root: string, opts: WorkerStatesReadOpts 
       sandboxTag: opts.sandboxTag,
       psSnapshot: opts.psSnapshot,
       workerPidContent: opts.workerPidContent,
+      identityContent: opts.identityContent,
     });
     if (rec !== null) out.push(rec);
   }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -9,7 +9,7 @@
 // actually runs), so `monitor`, `reap`, and an empty `run` never pull the
 // provider subpaths.
 
-import { readFileSync, writeFileSync, renameSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import type { SandboxMode } from "../core/execution.js";
@@ -444,7 +444,8 @@ export function makeRunAgent(
 // ---------- monitor inputs ----------
 
 import type { CompactWorker, FleetState, SlotDetail } from "../core/monitor.js";
-import { readWorkerState, readAllWorkerStates } from "../core/worker-state-reader.js";
+import { readWorkerState, readAllWorkerStates, type WorkerStateRecord } from "../core/worker-state-reader.js";
+import { planLivenessReclaim, type LivenessReclaimInput } from "../core/reclaim.js";
 import type { WorkerVitals } from "../types/state.js";
 import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
 
@@ -521,10 +522,139 @@ export async function readFleetState(path: string): Promise<FleetState | null> {
   }
 }
 
+/** Injected seams for {@link reclaimDeadWorkers} (real defaults wire gh/git/fs). */
+export interface DeadWorkerSweepDeps {
+  /** Raw `worker.pid` text for a worker dir. Default reads `{workerDir}/worker.pid`. */
+  readWorkerPid?: (workerDir: string) => string | null;
+  /** `kill -0` liveness probe. Default `process.kill(pid, 0)`. */
+  killAlive?: (pid: number) => boolean;
+  /** Whether an issue is in a post-mortem preservation state (blocked:* /
+   * ready-for-human). Default `gh issue view --json labels`. Returns `true`
+   * (conservative — keep the JSONL) whenever it cannot resolve. */
+  isPreserved?: (issue: number) => Promise<boolean>;
+  /** `git worktree remove --force`. Default runtime git against `root`. */
+  removeWorktree?: (worktreePath: string) => Promise<void>;
+  /** `rm -rf`. Default `fsx.removeDir`. */
+  removeDir?: (dir: string) => Promise<void>;
+  /** Path existence probe. Default `existsSync`. */
+  exists?: (path: string) => boolean;
+}
+
+/**
+ * Read-time liveness-gated teardown (issue #1219): as workers finish/crash, take
+ * them out of context — remove the heavy local `worktree/` and reclaim the
+ * attempt dir immediately, without waiting for the boot TTLs (reclaim.ts). Runs
+ * across the SAME namespace union the reader uses (workers/go-workers/
+ * scout-workers) since it consumes {@link readAllWorkerStates} records.
+ *
+ * Safety rules (see {@link planLivenessReclaim}):
+ *   - NEVER touch a live worker's dir — keyed on the OWNING worker's `worker.pid`
+ *     (shared across a worker's attempts), so a worker live on a later attempt
+ *     keeps ALL its dirs.
+ *   - A dead worker's disposable `worktree/` is ALWAYS removed.
+ *   - The whole attempt dir is reclaimed UNLESS the issue is preserved
+ *     (blocked:* / ready-for-human), where the JSONL/handoff stay for post-mortem.
+ *
+ * Best-effort throughout: every fs/git/gh failure is swallowed so the sweep never
+ * breaks the read it rides on. Returns the reclaimed attempt-dir paths.
+ */
+export async function reclaimDeadWorkers(
+  root: string,
+  records: ReadonlyArray<WorkerStateRecord>,
+  repo = "",
+  deps: DeadWorkerSweepDeps = {},
+): Promise<string[]> {
+  const exists = deps.exists ?? ((p: string) => existsSync(p));
+  const readWorkerPid =
+    deps.readWorkerPid ??
+    ((workerDir: string): string | null => {
+      try {
+        return readFileSync(join(workerDir, "worker.pid"), "utf8");
+      } catch {
+        return null;
+      }
+    });
+  const killAlive =
+    deps.killAlive ??
+    ((pid: number): boolean => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+  const isPreserved =
+    deps.isPreserved ??
+    (async (issue: number): Promise<boolean> => {
+      try {
+        const labels = await ghx.viewLabels({ cwd: root, repo }, issue);
+        // Empty labels (gh failed) → conservative: keep the JSONL.
+        if (labels.length === 0) return true;
+        return labels.some((l) => l === LABEL_HUMAN || l.startsWith("blocked:"));
+      } catch {
+        return true;
+      }
+    });
+  const removeWorktree =
+    deps.removeWorktree ??
+    (async (worktreePath: string): Promise<void> => {
+      await gitx.worktreeRemove({ cwd: root }, worktreePath);
+    });
+  const removeDir = deps.removeDir ?? ((dir: string) => fsx.removeDir(dir));
+
+  // Per-worker `worker.pid` liveness, memoized so a worker's several attempt dirs
+  // resolve it once.
+  const workerAliveCache = new Map<string, boolean>();
+  const workerPidAlive = (workerDir: string): boolean => {
+    const cached = workerAliveCache.get(workerDir);
+    if (cached !== undefined) return cached;
+    const raw = readWorkerPid(workerDir);
+    const pid = raw ? parseInt(raw.trim(), 10) : NaN;
+    // Absent/unparseable worker.pid → treat as ALIVE (never reclaim a dir we
+    // cannot prove belongs to a dead worker).
+    const alive = Number.isFinite(pid) && pid > 0 ? killAlive(pid) : true;
+    workerAliveCache.set(workerDir, alive);
+    return alive;
+  };
+
+  // Build the pure planner inputs, resolving preservation only for dead workers.
+  const inputs: LivenessReclaimInput[] = [];
+  for (const rec of records) {
+    const attemptDir = dirname(rec.path);
+    const workerDir = dirname(attemptDir);
+    // A renderable-live record (or a worker still live on any attempt) is never
+    // a reclaim candidate.
+    const alive = rec.renderableLive || workerPidAlive(workerDir);
+    const num = rec.state.current.number;
+    const issue = typeof num === "number" ? num : Number.parseInt(String(num), 10);
+    const preserved =
+      Number.isFinite(issue) && issue > 0 ? await isPreserved(issue) : true;
+    inputs.push({
+      attemptDir,
+      worktreePath: join(attemptDir, "worktree"),
+      workerPidAlive: alive,
+      preserved,
+    });
+  }
+
+  const reclaimed: string[] = [];
+  for (const action of planLivenessReclaim(inputs)) {
+    if (action.removeWorktree && exists(action.worktreePath)) {
+      await removeWorktree(action.worktreePath).catch(() => undefined);
+    }
+    if (action.reclaimDir) {
+      await removeDir(action.attemptDir).catch(() => undefined);
+      reclaimed.push(action.attemptDir);
+    }
+  }
+  return reclaimed;
+}
+
 /** Read every worker state file + the history ledger into the pure renderer's
  * inputs, plus one `git diff --shortstat` per live worktree for the diff column
  * (small fleet → a handful of cheap git calls, like the statusline does). */
-export async function collectMonitorInputs(root = process.cwd()): Promise<MonitorInputs> {
+export async function collectMonitorInputs(root = process.cwd(), repo = ""): Promise<MonitorInputs> {
   const paths = afkPaths(root);
   // The ONE owner reads + normalizes + liveness-tags every worker state file
   // (core/worker-state-reader). The single source of liveness truth for all
@@ -534,10 +664,20 @@ export async function collectMonitorInputs(root = process.cwd()): Promise<Monito
   // tagged distinctly by state.origin. (Not the single-lane paths.workersRoot,
   // which would render only the `.red/tmp/workers` fleet lane.)
   const records = await readAllWorkerStates(paths.tmpDir);
+  // Read-time liveness-gated teardown (issue #1219): reclaim dead-worker
+  // worktrees/dirs immediately, not on the boot TTL. Best-effort — a failure
+  // here never blocks the render. Live-worker dirs and blocked/ready-for-human
+  // post-mortem artifacts are preserved (planLivenessReclaim).
+  await reclaimDeadWorkers(root, records, repo).catch(() => undefined);
   const logPaths = records.map(({ path, state }) => state.log || join(dirname(path), "afk.log"));
   const logCounts = await collectLogLineCounts(paths.monitorLogCursorPath, logPaths);
   const workers: CompactWorker[] = [];
-  for (const { path, state, active, live: pidLive, liveness, livenessVerdict } of records) {
+  for (const { path, state, active, live: pidLive, liveness, livenessVerdict, renderableLive } of records) {
+    // The ONE shared render-gate (issue #1219): the monitor used to render EVERY
+    // globbed dir (no gate) — the graveyard of stale rows. Route it through the
+    // same `renderableLive` predicate the statusline uses so the dashboard drops
+    // dead/stalled/finished-pid-0 workers and both surfaces agree on liveness.
+    if (!renderableLive) continue;
     // Diff volume: committed + uncommitted work for the attempt, measured from
     // the branch's merge-base with origin/main. #1210 Part B: read it from the
     // state file's writer-stamped counts only — the monitor render performs NO
@@ -743,22 +883,16 @@ export async function collectStatuslineAfk(
   const aliveMsList: number[] = [];
   const sourceMap = new Map<string, number>();
 
-  for (const { state, livenessVerdict, pidIdentityLive, hostPidLive } of records) {
-    // Statusline counts workers the evaluator does not consider stalled. A busy
-    // worker with live agent descendants shows as "alive" even when the liveness
-    // lane is silent (wedged-substrate guard in the evaluator), so a long
-    // build/gate wait no longer makes the AFK block vanish. "unknown" (container
-    // workers) is treated conservatively as live. Only "stalled" (stale lane AND
-    // no live descendants) is excluded.
-    if (livenessVerdict.status === "stalled") continue;
-    // But the statusline shows ONLY genuinely-live workers (issue #1177). A
-    // finished/retained attempt is stamped `pid: 0` and kept for post-mortem;
-    // its per-attempt lane can still read fresh during that window, so the
-    // "not stalled" gate alone would render it as a phantom live line beside the
-    // same worker's live successor attempt. Require the state's OWN pid to be
-    // alive (or, for isolation workers, the host-side worker.pid) so a pid-0
-    // sibling is always dropped.
-    if (!pidIdentityLive && !hostPidLive) continue;
+  for (const { state, renderableLive } of records) {
+    // The ONE shared render-gate (issue #1219): computed once in
+    // readAllWorkerStates as `livenessVerdict.status !== "stalled" &&
+    // (pidIdentityLive || hostPidLive)`. Drops stalled workers AND finished/
+    // retained pid-0 attempts (kept for post-mortem, whose per-attempt lane can
+    // still read fresh), while keeping busy workers with live descendants and
+    // live isolation workers (host-side worker.pid). The statusline aggregate,
+    // the per-worker lines, and the monitor dashboard all route through this
+    // same field so every surface agrees on who is live.
+    if (!renderableLive) continue;
 
     workers += 1;
     blocked += state.blocked;
@@ -896,16 +1030,12 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
   const nowMs = Date.now();
   const records = await readAllWorkerStates(paths.tmpDir, { nowMs });
   const workers: CompactWorker[] = [];
-  for (const { state, active, live: pidLive, liveness, livenessVerdict, pidIdentityLive, hostPidLive } of records) {
-    // Same rule as the aggregate collector: count everything the evaluator does
-    // not consider stalled (a long build/gate wait stays "alive"; "unknown"
-    // container workers count conservatively). Only "stalled" is excluded.
-    if (livenessVerdict.status === "stalled") continue;
-    // Statusline shows ONLY genuinely-live workers (issue #1177): a
-    // finished/retained attempt keeps its dir with `pid: 0` and a possibly-fresh
-    // lane during the post-mortem window, so require its OWN pid to be alive (or
-    // the isolation host pid) — a pid-0 sibling of a live successor is dropped.
-    if (!pidIdentityLive && !hostPidLive) continue;
+  for (const { state, active, live: pidLive, liveness, livenessVerdict, renderableLive } of records) {
+    // The ONE shared render-gate (issue #1219), identical to the aggregate
+    // collector and the monitor: drops stalled workers and finished/retained
+    // pid-0 attempts, keeps busy workers with live descendants and live
+    // isolation workers. See readAllWorkerStates / isRenderableLive.
+    if (!renderableLive) continue;
     // #1210 Part B: no per-render git subprocess — read the writer-stamped LOC
     // straight from the state file (the heartbeat owns it for every runner).
     const added = state.current.loc_added;

--- a/apps/dev/tests/companion-io.test.ts
+++ b/apps/dev/tests/companion-io.test.ts
@@ -29,6 +29,7 @@ function record(issue: number, attempt: number, current: Record<string, unknown>
     livenessVerdict: { status: live ? "alive" : "stalled", laneFresh: live, crossCheckArmed: false, reason: "" },
     pidIdentityLive: live,
     hostPidLive: false,
+    renderableLive: live,
   };
 }
 

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -65,8 +65,16 @@ describe("monitor — compact line", () => {
     // started 2026-05-30T11:00:00Z = 1780138800; now +1800s (30 min)
     const line = renderWorkerCompactLine(baseWorker(), 1780140600);
     expect(line).toBe(
-      "wAAAA [live] claude  issues 1/4  #42 do the thing  stage:impl  00:30:00  +10 -3",
+      "wAAAA [live] claude org=afk  issues 1/4  #42 do the thing  stage:impl  00:30:00  +10 -3",
     );
+  });
+
+  it("renders org=<afk|go> on the compact line (issue #1219), defaulting to afk when unstamped", () => {
+    // Unstamped → org=afk.
+    expect(renderWorkerCompactLine(baseWorker(), 1780140600)).toContain(" org=afk  ");
+    // A /go worker carries origin: "go".
+    const go = baseWorker({ state: { ...baseWorker().state, origin: "go" } });
+    expect(renderWorkerCompactLine(go, 1780140600)).toContain(" org=go  ");
   });
 
   it("appends per-worker token spend (and $cost when reported) when usage streamed", () => {

--- a/apps/dev/tests/reclaim.test.ts
+++ b/apps/dev/tests/reclaim.test.ts
@@ -6,9 +6,11 @@ import {
   ORPHAN_TTL_SHORT_S,
   decideOrphanFate,
   planAttemptCap,
+  planLivenessReclaim,
   resolveAttemptKeep,
   resolveAttemptTtlS,
   type AttemptDir,
+  type LivenessReclaimInput,
   type OrphanFate,
   type OrphanInput,
 } from "../src/core/reclaim.js";
@@ -230,5 +232,40 @@ describe("planAttemptCap", () => {
   it("returns nothing when every attempt is within both caps", () => {
     const attempts: AttemptDir[] = [attempt(1, 1 * DAY), attempt(2, 2 * DAY)];
     expect(planAttemptCap(attempts, { ttlS: 14 * DAY, keep: 5, nowS: NOW })).toEqual([]);
+  });
+});
+
+// issue #1219 PART 4: liveness-gated read-time reclaim planner.
+describe("planLivenessReclaim (issue #1219)", () => {
+  const input = (over: Partial<LivenessReclaimInput>): LivenessReclaimInput => ({
+    attemptDir: "/r/.red/tmp/workers/wA/5-a1",
+    worktreePath: "/r/.red/tmp/workers/wA/5-a1/worktree",
+    workerPidAlive: false,
+    preserved: false,
+    ...over,
+  });
+
+  it("never touches a live worker's dir", () => {
+    expect(planLivenessReclaim([input({ workerPidAlive: true })])).toEqual([]);
+  });
+
+  it("reclaims a dead, non-preserved worker's whole dir (worktree + dir)", () => {
+    const [action] = planLivenessReclaim([input({ workerPidAlive: false, preserved: false })]);
+    expect(action.removeWorktree).toBe(true);
+    expect(action.reclaimDir).toBe(true);
+  });
+
+  it("removes only the worktree of a dead but preserved worker (keeps JSONL/handoff)", () => {
+    const [action] = planLivenessReclaim([input({ workerPidAlive: false, preserved: true })]);
+    expect(action.removeWorktree).toBe(true);
+    expect(action.reclaimDir).toBe(false);
+  });
+
+  it("keeps a live worker's dir while reclaiming a sibling dead worker", () => {
+    const actions = planLivenessReclaim([
+      input({ attemptDir: "/r/.red/tmp/workers/wLIVE/5-a1", workerPidAlive: true }),
+      input({ attemptDir: "/r/.red/tmp/go-workers/wDEAD/6-a1", workerPidAlive: false, preserved: false }),
+    ]);
+    expect(actions.map((a) => a.attemptDir)).toEqual(["/r/.red/tmp/go-workers/wDEAD/6-a1"]);
   });
 });

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -187,6 +187,17 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(keys).toEqual(expect.arrayContaining(["run", "iss", "loc", "tks", "tls", "rsn", "txt"]));
   });
 
+  it("renders org=<afk|go> (issue #1219): the stamped origin, defaulting to afk when unstamped", () => {
+    // Unstamped worker → org=afk (an unstamped worker is an afk-fleet worker).
+    expect(stripAnsi(renderWorkerLine(worker(), NOW))).toContain("org=afk");
+    // A /go worker carries origin: "go".
+    const go = worker({ state: { ...worker().state, origin: "go" } });
+    expect(stripAnsi(renderWorkerLine(go, NOW))).toContain("org=go");
+    // An explicit afk origin still renders org=afk.
+    const afk = worker({ state: { ...worker().state, origin: "afk" } });
+    expect(stripAnsi(renderWorkerLine(afk, NOW))).toContain("org=afk");
+  });
+
   it("populates iss=<number> for a /go-shaped worker state (no queue — total 0/done 0)", () => {
     // A /go run has no queue, so done/total are 0/0 (the old counter was meaningless);
     // current.number still carries the single issue number, set on claim like /afk.

--- a/apps/dev/tests/wire-reclaim.test.ts
+++ b/apps/dev/tests/wire-reclaim.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { reclaimDeadWorkers, type DeadWorkerSweepDeps } from "../src/runtime/wire.js";
+import { parseState } from "../src/core/state.js";
+import type { WorkerStateRecord } from "../src/core/worker-state-reader.js";
+
+// issue #1219 PART 4: read-time liveness-gated teardown.
+//
+// A WorkerStateRecord fixture whose `path` encodes {worker}/{N}-a{n} so the
+// sweep can derive the attempt dir, worktree, and owning worker dir. Only the
+// fields reclaimDeadWorkers reads are populated.
+function record(
+  root: string,
+  worker: string,
+  issue: number,
+  renderableLive: boolean,
+): WorkerStateRecord {
+  return {
+    path: `${root}/.red/tmp/workers/${worker}/${issue}-a1/afk.state.json`,
+    state: parseState({ worker_id: worker, current: { number: issue } }),
+    live: renderableLive,
+    active: renderableLive,
+    liveness: renderableLive ? "active" : "dead",
+    livenessVerdict: {
+      status: renderableLive ? "alive" : "stalled",
+      laneFresh: renderableLive,
+      crossCheckArmed: false,
+      reason: "",
+    },
+    pidIdentityLive: renderableLive,
+    hostPidLive: false,
+    renderableLive,
+  };
+}
+
+/** A deps bundle capturing every fs/git/gh side effect for assertion. */
+function harness(over: Partial<DeadWorkerSweepDeps> = {}): {
+  deps: DeadWorkerSweepDeps;
+  removedWorktrees: string[];
+  removedDirs: string[];
+} {
+  const removedWorktrees: string[] = [];
+  const removedDirs: string[] = [];
+  const deps: DeadWorkerSweepDeps = {
+    // worker.pid text: default all dead unless overridden.
+    readWorkerPid: () => "9999",
+    killAlive: () => false,
+    isPreserved: async () => false,
+    exists: () => true,
+    removeWorktree: async (p) => {
+      removedWorktrees.push(p);
+    },
+    removeDir: async (d) => {
+      removedDirs.push(d);
+    },
+    ...over,
+  };
+  return { deps, removedWorktrees, removedDirs };
+}
+
+describe("reclaimDeadWorkers (issue #1219)", () => {
+  const ROOT = "/r";
+
+  it("reclaims a dead, non-preserved worker's worktree AND attempt dir", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness();
+    const reclaimed = await reclaimDeadWorkers(ROOT, [record(ROOT, "wDEAD", 5, false)], "", deps);
+    expect(removedWorktrees).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1/worktree"]);
+    expect(removedDirs).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1"]);
+    expect(reclaimed).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1"]);
+  });
+
+  it("NEVER touches a live worker's dir (worker.pid alive)", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({ killAlive: () => true });
+    const reclaimed = await reclaimDeadWorkers(ROOT, [record(ROOT, "wLIVE", 5, true)], "", deps);
+    expect(removedWorktrees).toEqual([]);
+    expect(removedDirs).toEqual([]);
+    expect(reclaimed).toEqual([]);
+  });
+
+  it("removes ONLY the worktree of a dead but preserved worker (keeps the JSONL)", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({ isPreserved: async () => true });
+    const reclaimed = await reclaimDeadWorkers(ROOT, [record(ROOT, "wBLOCKED", 6, false)], "", deps);
+    expect(removedWorktrees).toEqual(["/r/.red/tmp/workers/wBLOCKED/6-a1/worktree"]);
+    expect(removedDirs).toEqual([]);
+    expect(reclaimed).toEqual([]);
+  });
+
+  it("reclaims a dead worker while preserving a live sibling in the same sweep", async () => {
+    // wLIVE alive, wDEAD dead — keyed on the per-worker worker.pid.
+    const alive = new Set(["/r/.red/tmp/workers/wLIVE"]);
+    const { deps, removedDirs } = harness({
+      readWorkerPid: (workerDir) => (alive.has(workerDir) ? "111" : "222"),
+      killAlive: (pid) => pid === 111,
+    });
+    const reclaimed = await reclaimDeadWorkers(
+      ROOT,
+      [record(ROOT, "wLIVE", 5, true), record(ROOT, "wDEAD", 6, false)],
+      "",
+      deps,
+    );
+    expect(removedDirs).toEqual(["/r/.red/tmp/workers/wDEAD/6-a1"]);
+    expect(reclaimed).toEqual(["/r/.red/tmp/workers/wDEAD/6-a1"]);
+  });
+
+  it("skips the worktree removal when it does not exist, still reclaims the dir", async () => {
+    const { deps, removedWorktrees, removedDirs } = harness({ exists: () => false });
+    await reclaimDeadWorkers(ROOT, [record(ROOT, "wDEAD", 5, false)], "", deps);
+    expect(removedWorktrees).toEqual([]);
+    expect(removedDirs).toEqual(["/r/.red/tmp/workers/wDEAD/5-a1"]);
+  });
+});

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -324,9 +324,12 @@ describe("collectMonitorInputs", () => {
     try {
       const attemptDir = join(root, ".red", "tmp", "workers", "wAB12", "5-a1");
       mkdirSync(attemptDir, { recursive: true });
+      // pid process.pid → the worker is live, so it survives the monitor's
+      // renderableLive gate (#1219: the dashboard now drops dead/stale rows;
+      // dead-worker filtering is covered by worker-state-reader's isRenderableLive suite).
       writeFileSync(
         join(attemptDir, "afk.state.json"),
-        JSON.stringify({ worker_id: "wAB12", pid: 999999, runner: "claude", total: 3, done: 1 }),
+        JSON.stringify({ worker_id: "wAB12", pid: process.pid, runner: "claude", total: 3, done: 1 }),
       );
       writeFileSync(join(attemptDir, "afk.log"), "a\nb\n");
       const { workers } = await collectMonitorInputs(root);
@@ -335,7 +338,8 @@ describe("collectMonitorInputs", () => {
       expect(workers[0]!.state.done).toBe(1);
       expect(workers[0]!.logLines).toBe(2);
       expect(workers[0]!.logNewLines).toBe(2);
-      // pid 999999 is almost certainly dead → not live
+      // `.live` (= active) needs the full lane-fresh "alive" verdict, stricter than
+      // the renderableLive render-gate — a bare process.pid worker renders but is not active.
       expect(workers[0]!.live).toBe(false);
 
       writeFileSync(join(attemptDir, "afk.log"), "a\nb\nc\n");
@@ -849,11 +853,12 @@ describe("collectMonitorInputs — layout discovery (#1029)", () => {
     try {
       // Sandcastle layout: state file at the standard path; worktree field not yet
       // set (simulates the pre-heartbeat window where current.worktree = "").
+      // Live pid → survives the #1219 renderableLive gate so discovery is what's tested.
       const attemptDir = join(root, ".red", "tmp", "workers", "wSC", "42-a1");
       mkdirSync(attemptDir, { recursive: true });
       writeFileSync(
         join(attemptDir, "afk.state.json"),
-        JSON.stringify({ worker_id: "wSC", pid: 999999, runner: "claude", total: 5, done: 2 }),
+        JSON.stringify({ worker_id: "wSC", pid: process.pid, runner: "claude", total: 5, done: 2 }),
       );
       const { workers } = await collectMonitorInputs(root);
       // The worker must appear in the output — sandcastle layout does not hide the
@@ -876,8 +881,9 @@ describe("collectMonitorInputs — layout discovery (#1029)", () => {
       writeFileSync(
         join(attemptDir, "afk.state.json"),
         JSON.stringify({
+          // Live pid → survives the #1219 renderableLive gate; legacy-layout discovery is what's tested.
           worker_id: "wLG",
-          pid: 999999,
+          pid: process.pid,
           runner: "codex",
           total: 3,
           done: 0,

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { readWorkerState, readWorkerStates, readAllWorkerStates } from "../src/core/worker-state-reader.js";
+import { readWorkerState, readWorkerStates, readAllWorkerStates, isRenderableLive } from "../src/core/worker-state-reader.js";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 
 const NOW = Date.UTC(2026, 5, 22, 12, 0, 0);
@@ -228,6 +228,61 @@ describe("worker-state-reader", () => {
     expect(rec!.livenessVerdict.reason).toContain("worker.pid=9876 is alive");
   });
 
+  // issue #1219 PART 2: a live isolation worker whose host-side state is zeroed
+  // renders its real identity from the durable identity.json sidecar.
+  it("isolation: hostPidLive + zeroed state → real worker_id/runner/origin/started_at from identity.json", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-iso-identity-"));
+    const attemptDir = join(base, "wISO", "1181-a1");
+    // Fully zeroed host state (pre-sync isolation worker): pid 0, empty identity.
+    const path = await writeState(attemptDir, { pid: 0, current: {} });
+    const identity = JSON.stringify({
+      worker_id: "wREAL",
+      runner: "claude",
+      origin: "go",
+      number: 1181,
+      started_at: "2026-07-06T10:00:00Z",
+    });
+    const rec = readWorkerState(path, {
+      nowMs: NOW,
+      workerPidContent: "9876",
+      kill: () => true,
+      identityContent: identity,
+    });
+    expect(rec).not.toBeNull();
+    // Real identity, NOT the zeroed schema default (no `?  run=-  00:00:00` ghost).
+    expect(rec!.state.worker_id).toBe("wREAL");
+    expect(rec!.state.runner).toBe("claude");
+    expect(rec!.state.origin).toBe("go");
+    expect(rec!.state.started_at).toBe("2026-07-06T10:00:00Z");
+    expect(rec!.state.current.number).toBe(1181);
+    // A live isolation worker is renderable.
+    expect(rec!.renderableLive).toBe(true);
+    expect(rec!.hostPidLive).toBe(true);
+  });
+
+  // The identity sidecar never overwrites a value the state file already carries.
+  it("isolation: identity.json does not clobber a populated state field", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-iso-nonclobber-"));
+    const attemptDir = join(base, "wISO", "1181-a1");
+    const path = await writeState(attemptDir, { pid: 0, worker_id: "wKEEP", current: {} });
+    const identity = JSON.stringify({
+      worker_id: "wIDENTITY",
+      runner: "codex",
+      origin: "afk",
+      number: 1181,
+      started_at: "2026-07-06T10:00:00Z",
+    });
+    const rec = readWorkerState(path, {
+      nowMs: NOW,
+      workerPidContent: "9876",
+      kill: () => true,
+      identityContent: identity,
+    });
+    expect(rec!.state.worker_id).toBe("wKEEP");
+    // Empty fields still fall back to the identity.
+    expect(rec!.state.runner).toBe("codex");
+  });
+
   it("isolation: dead worker.pid + pid:0 state → dead", async () => {
     const base = await mkdtemp(join(tmpdir(), "wsr-iso-dead-"));
     const attemptDir = join(base, "wISO", "1085-a1");
@@ -260,5 +315,51 @@ describe("worker-state-reader", () => {
     expect(rec!.state.current.number).toBe(999);
     // The isolation fallback must NOT have fired (worker.pid check is skipped when state.pid > 0).
     expect(rec!.livenessVerdict.reason).not.toContain("worker.pid");
+  });
+
+  // issue #1219 PART 1: the ONE shared render-gate predicate.
+  describe("isRenderableLive predicate", () => {
+    const verdict = (status: "alive" | "stalled" | "unknown") =>
+      ({ status, laneFresh: false, crossCheckArmed: false, reason: "" }) as const;
+
+    it("drops a stalled worker even when pid identity is live", () => {
+      expect(
+        isRenderableLive({ livenessVerdict: verdict("stalled"), pidIdentityLive: true, hostPidLive: false }),
+      ).toBe(false);
+    });
+
+    it("drops a not-stalled record with neither pid signal (finished pid-0 sibling)", () => {
+      expect(
+        isRenderableLive({ livenessVerdict: verdict("alive"), pidIdentityLive: false, hostPidLive: false }),
+      ).toBe(false);
+    });
+
+    it("keeps a live worker (not stalled + pid identity live)", () => {
+      expect(
+        isRenderableLive({ livenessVerdict: verdict("alive"), pidIdentityLive: true, hostPidLive: false }),
+      ).toBe(true);
+    });
+
+    it("keeps a live isolation worker (not stalled + host pid live)", () => {
+      expect(
+        isRenderableLive({ livenessVerdict: verdict("alive"), pidIdentityLive: false, hostPidLive: true }),
+      ).toBe(true);
+    });
+
+    it("readWorkerState computes renderableLive consistently for stalled/live", async () => {
+      const base = await mkdtemp(join(tmpdir(), "wsr-renderable-"));
+      // Live: populated pid + fresh lane.
+      const livePath = await writeState(join(base, "wA", "5-a1"), {
+        worker_id: "wA", pid: 4242, current: { number: 5, last_event_at: fresh },
+      });
+      const live = readWorkerState(livePath, { nowMs: NOW, laneRecencyMs: LANE_FRESH_MS, kill: () => true });
+      expect(live!.renderableLive).toBe(true);
+      // Stalled: pid 0, stale lane, no host pid → dead.
+      const deadPath = await writeState(join(base, "wB", "6-a1"), {
+        worker_id: "wB", pid: 0, current: { number: 6 },
+      });
+      const dead = readWorkerState(deadPath, { nowMs: NOW, laneRecencyMs: LANE_STALE_MS, kill: () => false });
+      expect(dead!.renderableLive).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Definitive fix for AFK worker rendering on the statusline and the /afk monitor dashboard. Closes #1201.

Four parts, all in apps/dev/:
1. One shared `renderableLive` predicate computed once in `readWorkerState`, routed through all three surfaces (statusline aggregate, statusline per-worker, monitor — the last previously had NO gate). Kills the monitor graveyard of dead/stale rows.
2. Durable write-once `identity.json` sidecar so a live worker whose state is zeroed renders real worker_id/runner/stage/elapsed — the `? run=- 00:00:00` ghost can no longer appear for a live worker.
3. `org=<afk|go>` 3-letter token on both the statusline and monitor per-worker lines.
4. Liveness-gated read-time reclaim: a dead worker's worktree + attempt dir are torn down without waiting for the boot TTL, across workers/ and go-workers/, preserving live-worker dirs and blocked/ready-for-human post-mortem artifacts.

Verified in a clean env (no RED_AFK_WORKERS_NAMESPACE): 231 tests across the touched + adjacent suites green, typecheck clean. The full-suite red seen during the /go run was purely the #1215 namespace env-leak (worker-paths/supervisor-fs read RED_AFK_WORKERS_NAMESPACE=go-workers), not a defect — those suites pass in a clean env.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785952983&installation_id=129708444&pr_number=1223&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1223&signature=c733fe55232eb565090337e6c2f2da9c9ff5c9f6faf734d9c3315e81b5d61898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->