### PR TITLE
merge: #1189 afk: structured-first failure sniffer + per-issue-type outcome records

### DIFF
--- a/apps/dev/src/core/attempt-record.ts
+++ b/apps/dev/src/core/attempt-record.ts
@@ -14,6 +14,8 @@
 
 import type { ProcessOutcome } from "./process-issue.js";
 
+export type AttemptOutcomeRecord = "success" | "failure" | "escalated";
+
 /**
  * The AFK-side fields needed to build the Memory `ReasoningAttemptPayload`
  * (apps/memory/src/reasoning/attempt-writer.ts). Only the fields AFK
@@ -33,6 +35,12 @@ export interface AttemptRecordPayload {
   attemptNumber: number;
   /** Terminal AFK outcome (done / blocked / no-sentinel / merge-conflict / …). */
   status: ProcessOutcome | string;
+  /** Canonical issue type bucket from `type:*`, or `unknown` when absent. */
+  issueType: string;
+  /** AFK model tier used for this attempt, or `unknown` when not available. */
+  modelTier: string;
+  /** Coarse attempt result for routing policy queries. */
+  outcome: AttemptOutcomeRecord;
   /** Issue title at the time of recording. */
   issueTitle?: string;
   /** Issue URL at the time of recording. */
@@ -70,6 +78,12 @@ export interface AttemptContext {
   issue: number;
   attempt: number;
   outcome: ProcessOutcome | string;
+  /** Labels current when the attempt was recorded; `type:*` drives issueType. */
+  labels?: readonly string[];
+  /** Explicit issue-type override, when the caller already derived it. */
+  issueType?: string;
+  /** AFK model tier used for this attempt. */
+  modelTier?: string;
   title?: string;
   url?: string;
   body?: string;
@@ -92,6 +106,38 @@ function nonEmpty(s: string | undefined): string | undefined {
   return t.length > 0 ? s : undefined;
 }
 
+export function deriveIssueType(labels: readonly string[] | undefined): string {
+  for (const label of labels ?? []) {
+    const match = /^type:([a-z0-9][a-z0-9-]*)$/i.exec(label.trim());
+    if (match) return match[1]!.toLowerCase();
+  }
+  return "unknown";
+}
+
+export function deriveAttemptOutcomeRecord(outcome: ProcessOutcome | string): AttemptOutcomeRecord {
+  switch (outcome) {
+    case "done":
+      return "success";
+    case "review-requested":
+    case "manual-landing":
+      return "escalated";
+    default:
+      return "failure";
+  }
+}
+
+export function filterAttemptOutcomeRecords(
+  records: readonly AttemptRecordPayload[],
+  query: { issueType?: string; modelTier?: string; outcome?: AttemptOutcomeRecord },
+): AttemptRecordPayload[] {
+  return records.filter((record) => {
+    if (query.issueType !== undefined && record.issueType !== query.issueType) return false;
+    if (query.modelTier !== undefined && record.modelTier !== query.modelTier) return false;
+    if (query.outcome !== undefined && record.outcome !== query.outcome) return false;
+    return true;
+  });
+}
+
 /**
  * PURE mapping: AFK terminal context → {@link AttemptRecordPayload}. Maps the
  * outcome to the Memory status vocabulary (known outcomes pass through verbatim;
@@ -106,6 +152,9 @@ export function buildAttemptRecordPayload(ctx: AttemptContext): AttemptRecordPay
     issueNumber: ctx.issue,
     attemptNumber: ctx.attempt,
     status,
+    issueType: nonEmpty(ctx.issueType) ?? deriveIssueType(ctx.labels),
+    modelTier: nonEmpty(ctx.modelTier) ?? "unknown",
+    outcome: deriveAttemptOutcomeRecord(ctx.outcome),
   };
   const title = nonEmpty(ctx.title);
   if (title !== undefined) payload.issueTitle = title;

--- a/apps/dev/src/core/backpressure.ts
+++ b/apps/dev/src/core/backpressure.ts
@@ -126,7 +126,7 @@ export async function runBackpressure(
       result.code === KILLED_EXIT_CODE
         ? `command timed out after ${timeoutMs}ms`
         : outputSummary(status, `${result.stdout}${result.stderr}`);
-    const record = buildValidationRecord({ name, status, command, durationMs, summary });
+    const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
     checks.push({ name, command, status, record });
     sidecar.push(formatValidationLine(record));
   }

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -66,14 +66,15 @@ export type ValidationStatus = "passed" | "failed" | "skipped";
 
 /**
  * One `red.afk.validation.v1` sidecar record. Optional fields are omitted (not
- * null) when absent, exactly like the bash `jq` builder: `command` and
- * `durationMs` are present only for checks that ran, `summary` only when set.
+ * null) when absent, exactly like the bash `jq` builder: `command`, `exitCode`,
+ * and `durationMs` are present only for checks that ran, `summary` only when set.
  */
 export interface ValidationRecord {
   schema: typeof VALIDATION_SCHEMA;
   name: string;
   status: ValidationStatus;
   command?: string;
+  exitCode?: number;
   durationMs?: number;
   summary?: string;
 }
@@ -148,6 +149,7 @@ export function buildValidationRecord(input: {
   name: string;
   status: ValidationStatus;
   command?: string;
+  exitCode?: number;
   durationMs?: number;
   summary?: string;
 }): ValidationRecord {
@@ -157,6 +159,7 @@ export function buildValidationRecord(input: {
     status: input.status,
   };
   if (input.command !== undefined && input.command !== "") record.command = input.command;
+  if (input.exitCode !== undefined && Number.isFinite(input.exitCode)) record.exitCode = Math.trunc(input.exitCode);
   if (input.durationMs !== undefined) record.durationMs = input.durationMs;
   if (input.summary !== undefined && input.summary !== "") record.summary = input.summary;
   return record;
@@ -195,6 +198,9 @@ export function isInfraFeedbackFailure(feedback: RunFeedbackResult): boolean {
   if (feedback.ok) return false;
   for (const check of feedback.checks) {
     if (check.status !== "failed") continue;
+    const exitCode = check.record.exitCode;
+    if (exitCode === 0) continue;
+    if (exitCode === 137) return true;
     const summary = check.record.summary ?? "";
     if (
       summary.includes("feedback worktree setup failed") ||
@@ -478,7 +484,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
       if (status === "failed") failed = true;
       const summary = outputSummary(status, `${result.stdout}${result.stderr}`);
-      const record = buildValidationRecord({ name, status, command, durationMs, summary });
+      const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
       push({ name, script, label, scope, status, record });
     }
   }
@@ -503,7 +509,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
     if (status === "failed") failed = true;
     const summary = outputSummary(status, `${result.stdout}${result.stderr}`);
-    const record = buildValidationRecord({ name, status, command, durationMs, summary });
+    const record = buildValidationRecord({ name, status, command, exitCode: result.code, durationMs, summary });
     push({ name, script: "typecheck", label, scope, status, record });
   }
 

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -82,7 +82,7 @@ import {
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
-import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
+import { buildAttemptRecordPayload, deriveIssueType, type AttemptRecordPayload } from "./attempt-record.js";
 import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
 import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
 import {
@@ -1271,6 +1271,7 @@ export async function processIssue(
   // also why promptFile/handoffPath must stay absolute — sandcastle resolves
   // promptFile against process.cwd(), not against this cwd.
   let activeTaskClass: AfkModelTier = taskClass;
+  const issueType = deriveIssueType(labels);
   let escalatedSimpleFeedback = false;
   let workerBranch = branch;
   let current: ProcessIssueInput = { ...input, runner: activeRunner, attempt: attemptN };
@@ -1282,6 +1283,8 @@ export async function processIssue(
     slug,
     hooksFired,
     startedEpoch,
+    issueType,
+    modelTier: activeTaskClass,
   };
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
@@ -1520,6 +1523,8 @@ export async function processIssue(
       slug,
       hooksFired,
       startedEpoch,
+      issueType,
+      modelTier: activeTaskClass,
     } satisfies StageCommon;
 
     // ---- commit-leftovers salvage (codex DONE/partial-commit leftovers, ADR 0050) ----
@@ -2263,6 +2268,8 @@ async function recordAttemptBestEffort(
       issue: input.issue,
       attempt: input.attempt,
       outcome,
+      issueType: c.issueType,
+      modelTier: c.modelTier,
       title: input.title,
       body: input.body,
       workerId: input.workerId,
@@ -2291,6 +2298,8 @@ interface StageCommon {
   slug: string;
   hooksFired: HookName[];
   startedEpoch: number;
+  issueType: string;
+  modelTier: AfkModelTier;
 }
 
 /** Emit a failure-family envelope (blocked / no-sentinel / merge-conflict /

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -744,6 +744,7 @@ async function recordAttemptBestEffort(
         issue: input.issue,
         attempt: input.attempt,
         outcome,
+        labels: input.labels,
         title: input.title,
         body: input.body,
         workerId: input.workerId,

--- a/apps/dev/tests/attempt-record.test.ts
+++ b/apps/dev/tests/attempt-record.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAttemptRecordPayload,
+  deriveAttemptOutcomeRecord,
+  deriveIssueType,
+  filterAttemptOutcomeRecords,
   memoryConfiguredInYaml,
   toMemoryPayload,
   resolveMemoryCli,
@@ -52,6 +55,39 @@ describe("buildAttemptRecordPayload — identity + status mapping", () => {
   it("forwards an unknown outcome as its string status", () => {
     expect(buildAttemptRecordPayload({ ...base, outcome: "exhausted" }).status).toBe("exhausted");
   });
+
+  it("emits queryable issue type, model tier, and coarse outcome", () => {
+    const p = buildAttemptRecordPayload({
+      ...base,
+      labels: ["ready-for-agent", "type:bug"],
+      modelTier: "simple",
+    });
+    expect(p.issueType).toBe("bug");
+    expect(p.modelTier).toBe("simple");
+    expect(p.outcome).toBe("success");
+  });
+
+  it("derives issue type from canonical type labels with an unknown bucket", () => {
+    expect(deriveIssueType(["ready-for-agent", "type:prd"])).toBe("prd");
+    expect(deriveIssueType(["ready-for-agent"])).toBe("unknown");
+  });
+
+  it("maps terminal AFK statuses to success/failure/escalated", () => {
+    expect(deriveAttemptOutcomeRecord("done")).toBe("success");
+    expect(deriveAttemptOutcomeRecord("feedback-failed")).toBe("failure");
+    expect(deriveAttemptOutcomeRecord("review-requested")).toBe("escalated");
+  });
+
+  it("filters outcome records by issue type and model tier", () => {
+    const records = [
+      buildAttemptRecordPayload({ ...base, attempt: 1, labels: ["type:bug"], modelTier: "simple" }),
+      buildAttemptRecordPayload({ ...base, attempt: 2, labels: ["type:prd"], modelTier: "think" }),
+      buildAttemptRecordPayload({ ...base, attempt: 3, labels: ["type:bug"], modelTier: "complex" }),
+    ];
+
+    expect(filterAttemptOutcomeRecords(records, { issueType: "bug", modelTier: "simple" })).toEqual([records[0]]);
+    expect(filterAttemptOutcomeRecords(records, { issueType: "bug" }).map((r) => r.attemptNumber)).toEqual([1, 3]);
+  });
 });
 
 describe("buildAttemptRecordPayload — optional-field omission", () => {
@@ -62,6 +98,9 @@ describe("buildAttemptRecordPayload — optional-field omission", () => {
       issueNumber: 42,
       attemptNumber: 2,
       status: "done",
+      issueType: "unknown",
+      modelTier: "unknown",
+      outcome: "success",
     });
     expect("issueTitle" in p).toBe(false);
     expect("branch" in p).toBe(false);

--- a/apps/dev/tests/backpressure.test.ts
+++ b/apps/dev/tests/backpressure.test.ts
@@ -99,6 +99,7 @@ describe("runBackpressure", () => {
       name: "backpressure:npm run test",
       status: "passed",
       command: "npm run test",
+      exitCode: 0,
       durationMs: 1234,
       summary: "command exited 0",
     };

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -208,6 +208,7 @@ describe("runFeedback", () => {
       name: "test:plugins/memory",
       status: "passed",
       command: "pnpm -C /repo/plugins/memory test",
+      exitCode: 0,
       durationMs: 1234,
       summary: "command exited 0",
     };
@@ -364,6 +365,32 @@ describe("isInfraFeedbackFailure — INFRA root cause detection", () => {
       "test:apps/dev",
       "command output exceeded the capture ceiling (maxBuffer length exceeded); stdout maxBuffer length exceeded",
     );
+    expect(isInfraFeedbackFailure(result)).toBe(true);
+  });
+
+  it("trusts a clean structured exit over misleading infra-looking text", () => {
+    const record = buildValidationRecord({
+      name: "test:apps/dev",
+      status: "failed",
+      command: "pnpm -C apps/dev test",
+      exitCode: 0,
+      summary: "stderr mentioned feedback worktree install failed, but the runner reported a clean exit",
+    });
+    const result: RunFeedbackResult = {
+      ok: false,
+      checks: [
+        { name: "test:apps/dev", script: "test", label: "apps/dev", scope: "apps/dev", status: "failed", record },
+      ],
+      sidecar: [JSON.stringify(record)],
+      baselineDowngraded: [],
+      quarantined: [],
+    };
+
+    expect(isInfraFeedbackFailure(result)).toBe(false);
+  });
+
+  it("preserves keyword fallback when no structured exit evidence exists", () => {
+    const result = failedCheck("test:apps/dev", "feedback worktree install failed for afk/wX/123-slug (exit 1)");
     expect(isInfraFeedbackFailure(result)).toBe(true);
   });
 

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -2626,7 +2626,13 @@ describe("processIssue — validation.jsonl sidecar (SKILL.md §Validation Sidec
 
 describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)", () => {
   it("records the attempt AFTER the DONE envelope with the mapped payload", async () => {
-    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, recordAttempt: "ok" });
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "type:bug"],
+      classifyIssue: async () => "simple",
+      recordAttempt: "ok",
+    });
     const result = await processIssue(deps, input);
 
     expect(result.outcome).toBe("done");
@@ -2636,6 +2642,9 @@ describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)",
     expect(p.issueNumber).toBe(9);
     expect(p.attemptNumber).toBe(1);
     expect(p.status).toBe("done");
+    expect(p.issueType).toBe("bug");
+    expect(p.modelTier).toBe("simple");
+    expect(p.outcome).toBe("success");
     expect(p.issueTitle).toBe("Fix the thing");
     expect(p.branch).toBe("afk/wAAAA/9-fix-the-thing");
     expect(p.mergeCommit).toBe("abc1234");
@@ -2650,6 +2659,7 @@ describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)",
     expect(result.outcome).toBe("blocked");
     expect(trace.recordedAttempts).toHaveLength(1);
     expect(trace.recordedAttempts[0]!.status).toBe("blocked");
+    expect(trace.recordedAttempts[0]!.outcome).toBe("failure");
   });
 
   it("records the attempt on the merge-conflict path", async () => {

--- a/apps/memory/src/reasoning/attempt-writer.ts
+++ b/apps/memory/src/reasoning/attempt-writer.ts
@@ -82,6 +82,12 @@ export interface ReasoningAttemptPayload {
   attemptNumber: number;
   /** Terminal outcome reported by AFK. */
   status: ReasoningAttemptStatus | string;
+  /** Canonical issue type bucket, e.g. `bug`, `prd`, or `unknown`. */
+  issueType?: string;
+  /** AFK model tier used for the attempt, e.g. `validate`, `simple`, `complex`, or `think`. */
+  modelTier?: string;
+  /** Coarse routing outcome for later policy queries. */
+  outcome?: "success" | "failure" | "escalated";
   /** Issue title at the time of recording, if known. */
   issueTitle?: string;
   /** Issue URL at the time of recording, if known. */
@@ -243,6 +249,9 @@ export async function recordReasoningAttempt(
       worker_id: payload.workerId,
       ...(parentPrd != null ? { parent_prd: parentPrd } : {}),
       status: payload.status,
+      issue_type: payload.issueType,
+      model_tier: payload.modelTier,
+      outcome: payload.outcome,
       branch: payload.branch,
       duration_ms: payload.durationMs,
       diffstat: payload.diffstat,

--- a/apps/memory/tests/reasoning-attempt.test.ts
+++ b/apps/memory/tests/reasoning-attempt.test.ts
@@ -79,6 +79,9 @@ const samplePayload: ReasoningAttemptPayload = {
   issueNumber: 96,
   attemptNumber: 1,
   status: "done",
+  issueType: "bug",
+  modelTier: "simple",
+  outcome: "success",
   issueTitle: "Record a single Reasoning attempt into Memory Graph",
   issueUrl: "https://github.com/reddb-io/red-skills/issues/96",
   workerId: "claude",
@@ -175,6 +178,9 @@ describe("recordReasoningAttempt", () => {
       const props = (node?.properties ?? {}) as Record<string, unknown>;
 
       expect(props.status).toBe("done");
+      expect(props.issue_type).toBe(samplePayload.issueType);
+      expect(props.model_tier).toBe(samplePayload.modelTier);
+      expect(props.outcome).toBe(samplePayload.outcome);
       expect(props.branch).toBe(samplePayload.branch);
       expect(props.duration_ms).toBe(samplePayload.durationMs);
       expect(props.diffstat).toBe(samplePayload.diffstat);


### PR DESCRIPTION
Automated AFK landing for #1189. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1189

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785953881&installation_id=129708444&pr_number=1225&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1225&signature=ec3d5ad17154edf0d72c1d602c519d0c9ec6a11fc3faae27a5a6750d9c11c0b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->