### PR TITLE
fix(afk): LOC counts uncommitted work + self-healing submodule init + gate env-leak fix

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1209,14 +1209,23 @@ export function buildProcessDeps(
         // Writer-side LOC ownership (#1210 Part B): the render paths no longer
         // shell out to `git diff --shortstat`, so this heartbeat is the runner-
         // agnostic owner that stamps loc_added/loc_removed for ALL runners (codex
-        // included). The diffstat is EXPENSIVE, so memoize it against the current
-        // HEAD sha in the attempt dir — computed at most once per commit; while
-        // HEAD is unchanged the memoized volume is served without spawning git.
+        // included). The COMMITTED delta is EXPENSIVE but stable between commits,
+        // so memoize it against the current HEAD sha in the attempt dir — computed
+        // at most once per commit; while HEAD is unchanged the memoized volume is
+        // served without spawning git. The UNCOMMITTED working-tree delta is
+        // recomputed every tick and added on top (#1224 Part A): a codex worker
+        // never commits, so its HEAD sha is frozen and ONLY the working-tree diff
+        // reflects its work — memoizing the combined volume on HEAD sha would
+        // freeze the first tick's `+0 -0` for the whole attempt. The claude
+        // incremental path is unaffected: a new commit moves the delta into the
+        // sha-keyed committed memo. Render stays git-free either way.
         const memoPath = locMemoPath(current.attemptDir, "/");
         const { added, removed } = await resolveAttemptLoc({
           headSha: head,
           compute: () =>
-            gitx.diffstatShortstat({ cwd: worktree }, baseRef).catch(() => ({ added: 0, removed: 0 })),
+            gitx.diffstatCommitted({ cwd: worktree }, baseRef).catch(() => ({ added: 0, removed: 0 })),
+          computeUncommitted: () =>
+            gitx.diffstatUncommitted({ cwd: worktree }).catch(() => ({ added: 0, removed: 0 })),
           readMemo: () => {
             try {
               const m = JSON.parse(readFileSync(memoPath, "utf8")) as Partial<LocMemo>;

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -709,6 +709,37 @@ function shSingleQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+/**
+ * Build the `host.onWorktreeReady` command that GUARANTEES the `packages/red-castle`
+ * submodule is initialised in a fresh worker worktree before the inner agent runs
+ * (#1224 Part B — a belt-and-suspenders net for the ADR 0071 post-checkout hook).
+ *
+ * `git worktree add` does NOT populate submodules; the ADR 0071 tracked
+ * `post-checkout` hook is meant to run `git submodule update --init` on the new
+ * worktree, but it fires only when the hook is installed in the checkout's git
+ * dir — a missed install, or a host whose `core.hooksPath` was redirected before
+ * the hook ran, leaves `packages/red-castle` an empty gitlink (observed on worker
+ * wCNFH: the agent could not run vitest and implemented blind, while wU1TD — with
+ * the hook — was fine). sandcastle runs `host.onWorktreeReady` ON THE HOST with
+ * cwd = the new worktree, BEFORE the inner agent starts, so this re-asserts the
+ * submodule idempotently: if `packages/red-castle` has no checked-out content,
+ * run `git submodule update --init packages/red-castle`. `git submodule update`
+ * is a no-op on an already-initialised submodule (the common path when the hook
+ * DID fire), so this never does redundant work. Best-effort: a failure logs to
+ * stderr but the script always exits 0 — it can never abort the run.
+ */
+export function buildSubmoduleEnsureHook(): HostHookCommand {
+  const script = [
+    "# AFK submodule safety net (#1224 Part B): self-heal a missed post-checkout",
+    "# hook so a fresh worker worktree can always run local vitest.",
+    "if [ ! -e packages/red-castle/package.json ]; then",
+    '  git submodule update --init packages/red-castle >/dev/null 2>&1 || echo "[afk] warn: red-castle submodule init failed in worktree; local tests may be unavailable" >&2',
+    "fi",
+    "exit 0",
+  ].join("\n");
+  return { command: `sh -c ${shSingleQuote(script)}` };
+}
+
 /** Build the sandcastle `run` options for one issue iteration (pure). */
 export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): RunOptions {
   // Fork the worker branch off the resolved base (ADR 0031) via sandcastle's
@@ -721,15 +752,23 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
     branch: input.branch,
     ...(input.base ? { baseBranch: input.base } : {}),
   };
-  // Continuous-push guarantee (issue #191): when enabled, inject a single
-  // host.onWorktreeReady hook that runs ON THE HOST in the new worktree to push
-  // the branch up-front and install the post-commit push hook. sandcastle only
-  // runs this for host-visible worktrees (noSandbox / bind-mount worktree mode);
-  // for fully-isolated providers the agent works in a synced copy the hook can't
-  // see, so continuous push simply does not fire there (final sync only).
-  const hooks: RunOptions["hooks"] | undefined = input.continuousPush
-    ? { host: { onWorktreeReady: [buildContinuousPushHook(input.branch, input.remote ?? DEFAULT_REMOTE)] } }
-    : undefined;
+  // host.onWorktreeReady runs ON THE HOST in the freshly-created worktree BEFORE
+  // the inner agent starts (host-visible worktree modes only). Two host hooks ride
+  // here, in order:
+  //   1. Submodule safety net (#1224 Part B) — ALWAYS injected: re-assert the
+  //      packages/red-castle submodule so a missed ADR 0071 post-checkout hook can
+  //      never leave the worktree unable to run local vitest. Idempotent + best-
+  //      effort (it never aborts the run).
+  //   2. Continuous-push guarantee (issue #191) — injected only when enabled:
+  //      push the branch up-front and install the post-commit push hook.
+  // sandcastle only runs these for host-visible worktrees (noSandbox / bind-mount
+  // worktree mode); for fully-isolated providers the agent works in a synced copy
+  // the hooks can't see (final sync only).
+  const worktreeReady: HostHookCommand[] = [buildSubmoduleEnsureHook()];
+  if (input.continuousPush) {
+    worktreeReady.push(buildContinuousPushHook(input.branch, input.remote ?? DEFAULT_REMOTE));
+  }
+  const hooks: RunOptions["hooks"] = { host: { onWorktreeReady: worktreeReady } };
   // Observability lane (native-path liveness): point sandcastle's file-log at
   // the attempt dir's afk.log (the unified log, set by the caller) and, when a
   // sink is provided, forward each

--- a/apps/dev/src/core/loc-memo.ts
+++ b/apps/dev/src/core/loc-memo.ts
@@ -28,37 +28,65 @@ export interface ResolveAttemptLocInput {
    * (unborn branch / detached probe failure) — an empty sha never memoizes, so
    * every call recomputes rather than caching a meaningless key. */
   headSha: string;
-  /** Runs the actual `git diff --shortstat` (merge-base vs worktree). Invoked
-   * only on a memo miss — at most once per HEAD sha. */
+  /** Runs the actual `git diff --shortstat` for the COMMITTED delta
+   * (merge-base..HEAD). Invoked only on a memo miss — at most once per HEAD sha.
+   */
   compute: () => Promise<{ added: number; removed: number }>;
   /** Reads the persisted memo, or null when absent/unreadable. */
   readMemo: () => LocMemo | null;
   /** Persists the memo after a recompute. Best-effort — a write failure must not
    * fail the stamp. */
   writeMemo: (memo: LocMemo) => void;
+  /**
+   * Optional: runs the UNCOMMITTED working-tree delta (`git diff --shortstat
+   * HEAD`). Unlike {@link compute} this is NEVER memoized — it is recomputed on
+   * EVERY writer tick, because the working tree changes without HEAD moving.
+   *
+   * #1224 Part A: a codex worker does not commit incrementally, so its HEAD sha
+   * never advances during an attempt. Memoizing the combined committed+uncommitted
+   * diff on HEAD sha therefore froze the first tick's `+0 -0` for the whole run.
+   * Splitting the two — committed sha-memoized, uncommitted recomputed each tick —
+   * lets the per-worker LOC reflect total attempt work even with zero commits,
+   * without regressing the claude incremental-commit path (a new commit still
+   * moves the committed delta into the sha-keyed memo). When omitted, behaviour is
+   * exactly the legacy committed-only memo.
+   */
+  computeUncommitted?: () => Promise<{ added: number; removed: number }>;
 }
 
 /**
- * Resolve the attempt's committed LOC volume, computing the diffstat at most once
- * per commit. When the persisted memo already matches {@link
- * ResolveAttemptLocInput.headSha} the memoized volume is returned WITHOUT calling
- * {@link ResolveAttemptLocInput.compute} (zero git subprocesses); otherwise the
- * diffstat is computed once, persisted against the current sha, and returned. A
- * falsy/empty sha always recomputes (it is never a stable memo key).
+ * Resolve the attempt's LOC volume: the COMMITTED delta computed at most once per
+ * commit, PLUS (when {@link ResolveAttemptLocInput.computeUncommitted} is
+ * supplied) the UNCOMMITTED working-tree delta recomputed on every call. When the
+ * persisted memo already matches {@link ResolveAttemptLocInput.headSha} the
+ * committed volume is served WITHOUT calling {@link
+ * ResolveAttemptLocInput.compute} (zero git subprocesses for the committed part);
+ * otherwise it is computed once, persisted against the current sha, and returned.
+ * A falsy/empty sha always recomputes the committed part (it is never a stable
+ * memo key). The uncommitted part, being working-tree state, is always recomputed
+ * — that is what lets a non-committing (codex) attempt still surface its LOC.
  */
 export async function resolveAttemptLoc(
   input: ResolveAttemptLocInput,
 ): Promise<{ added: number; removed: number }> {
-  const { headSha, compute, readMemo, writeMemo } = input;
+  const { headSha, compute, readMemo, writeMemo, computeUncommitted } = input;
+  let committed: { added: number; removed: number } | null = null;
   if (headSha) {
     const memo = readMemo();
     if (memo && memo.sha === headSha) {
-      return { added: memo.added, removed: memo.removed };
+      committed = { added: memo.added, removed: memo.removed };
     }
   }
-  const { added, removed } = await compute();
-  if (headSha) writeMemo({ sha: headSha, added, removed });
-  return { added, removed };
+  if (committed === null) {
+    committed = await compute();
+    if (headSha) writeMemo({ sha: headSha, added: committed.added, removed: committed.removed });
+  }
+  if (!computeUncommitted) return committed;
+  const uncommitted = await computeUncommitted();
+  return {
+    added: committed.added + uncommitted.added,
+    removed: committed.removed + uncommitted.removed,
+  };
 }
 
 /** Default on-disk location of an attempt's LOC memo, beside its state file. */

--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -42,6 +42,27 @@ function slugForBranch(branch: string): string {
 }
 
 /**
+ * The environment for the feedback gate's `pnpm -C <scope> <script>` subprocess,
+ * with `RED_AFK_WORKERS_NAMESPACE` UNSET (#1224 Part C).
+ *
+ * A `/go` (or `scout`) worker runs the gate with `RED_AFK_WORKERS_NAMESPACE`
+ * pinned to its lane (`go-workers` / `scout-workers`) so its own worktree/state
+ * paths resolve into the lane. That env is inherited by every child process —
+ * INCLUDING the gate's test subprocess — where it poisons namespace-sensitive
+ * suites (worker-paths, supervisor-fs) that assert the DEFAULT lane. The result
+ * is a false full-suite red that churns/parks otherwise-green apps/dev work (this
+ * exact leak cost issue #1219 ~70 minutes). Strip the var for the gate's test
+ * subprocess ONLY — the worker's own namespace wiring (which owns the `/go` lane
+ * paths) is untouched, since this scrubs a fresh copy of `process.env` rather than
+ * mutating it.
+ */
+function gateSubprocessEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.RED_AFK_WORKERS_NAMESPACE;
+  return env;
+}
+
+/**
  * Split a feedback `-C` token into its worker branch and package scope.
  *
  * The feedback gate builds the token via `scopeDir(branch, scope)`: the branch
@@ -357,11 +378,11 @@ export function makeFeedbackWorktree(
       }
       const rewritten = scope === "." ? base : join(base, scope);
       const rest = args.filter((_, i) => i !== 0 && i !== cIdx && i !== cIdx + 1);
-      const r = await io.pnpm(["-C", rewritten, ...rest], { cwd: root });
+      const r = await io.pnpm(["-C", rewritten, ...rest], { cwd: root, env: gateSubprocessEnv() });
       return { code: r.code, stdout: r.stdout, stderr: r.stderr };
     }
     const head = args[0] === "pnpm" ? args.slice(1) : args;
-    const r = await io.pnpm(head, { cwd: root });
+    const r = await io.pnpm(head, { cwd: root, env: gateSubprocessEnv() });
     return { code: r.code, stdout: r.stdout, stderr: r.stderr };
   };
 

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -173,10 +173,45 @@ export async function diffstatShortstat(ctx: GitContext, base: string): Promise<
   const mb = await runGit(ctx, ["merge-base", base, "HEAD"]);
   if (mb.code === 0 && mb.stdout.trim() !== "") ref = mb.stdout.trim();
   const r = await runGit(ctx, ["diff", "--shortstat", ref]);
-  if (r.code !== 0) return { added: 0, removed: 0 };
-  const ins = /(\d+) insertion/.exec(r.stdout);
-  const del = /(\d+) deletion/.exec(r.stdout);
+  return parseShortstat(r.code === 0 ? r.stdout : "");
+}
+
+/** Extract the `N insertion` / `N deletion` integers from a `--shortstat` line,
+ * defaulting each to 0 when absent. Shared by the committed/uncommitted probes. */
+function parseShortstat(stdout: string): { added: number; removed: number } {
+  const ins = /(\d+) insertion/.exec(stdout);
+  const del = /(\d+) deletion/.exec(stdout);
   return { added: ins ? Number(ins[1]) : 0, removed: del ? Number(del[1]) : 0 };
+}
+
+/**
+ * Parsed diffstat of the attempt's **committed** work at `ctx.cwd` — the commits
+ * on the branch since it left `<base>`, EXCLUDING the working tree. Resolves
+ * `merge-base(<base>, HEAD)` and diffs that against HEAD (`git diff --shortstat
+ * <merge-base>..HEAD`), falling back to a plain `<base>..HEAD` when no merge-base
+ * resolves. This is the sha-memoizable half of the #1224 LOC counter: while HEAD
+ * is unchanged the committed volume is stable, so it is computed at most once per
+ * commit and the render path stays git-free.
+ */
+export async function diffstatCommitted(ctx: GitContext, base: string): Promise<{ added: number; removed: number }> {
+  let ref = base;
+  const mb = await runGit(ctx, ["merge-base", base, "HEAD"]);
+  if (mb.code === 0 && mb.stdout.trim() !== "") ref = mb.stdout.trim();
+  const r = await runGit(ctx, ["diff", "--shortstat", `${ref}..HEAD`]);
+  return parseShortstat(r.code === 0 ? r.stdout : "");
+}
+
+/**
+ * Parsed diffstat of the attempt's **uncommitted** working-tree edits at
+ * `ctx.cwd` — everything not yet committed (`git diff --shortstat HEAD`). This is
+ * the NON-memoizable half of the #1224 LOC counter: a codex worker never commits,
+ * so its HEAD sha is frozen and only this working-tree delta reflects its work.
+ * The writer recomputes it on every heartbeat tick and adds it to the memoized
+ * committed volume, so total attempt LOC surfaces even with zero commits.
+ */
+export async function diffstatUncommitted(ctx: GitContext): Promise<{ added: number; removed: number }> {
+  const r = await runGit(ctx, ["diff", "--shortstat", "HEAD"]);
+  return parseShortstat(r.code === 0 ? r.stdout : "");
 }
 
 /** `git log -n <count>` one-line block for a ref (the inner-prompt recent

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -273,19 +273,32 @@ describe("buildRunOptions", () => {
     expect(seen).toEqual([{ mode: "podman", mountPath: undefined }]);
   });
 
-  it("does NOT inject any hooks when continuous push is not requested (default)", () => {
+  it("injects ONLY the submodule-ensure host hook when continuous push is not requested (#1224 Part B)", () => {
+    // The submodule safety net is ALWAYS present so a fresh worker worktree can
+    // run local vitest even if the ADR 0071 post-checkout hook was missed. With
+    // continuous push off, it is the sole onWorktreeReady hook.
     const opts = buildRunOptions(makeDeps(async () => fakeResult()), baseInput);
-    expect(opts.hooks).toBeUndefined();
+    const hooks = opts.hooks?.host?.onWorktreeReady;
+    expect(hooks).toHaveLength(1);
+    const command = hooks?.[0]?.command ?? "";
+    expect(command.startsWith("sh -c ")).toBe(true);
+    // It self-heals the red-castle submodule idempotently (only when absent).
+    expect(command).toContain("packages/red-castle/package.json");
+    expect(command).toContain("git submodule update --init packages/red-castle");
+    // It must NOT carry the continuous-push behaviour when push is off.
+    expect(command).not.toContain("--force-with-lease");
   });
 
-  it("injects an onWorktreeReady host hook with the initial push + post-commit install when continuousPush is on", () => {
+  it("injects the submodule net + an onWorktreeReady host hook with the initial push + post-commit install when continuousPush is on", () => {
     const opts = buildRunOptions(
       makeDeps(async () => fakeResult()),
       { ...baseInput, continuousPush: true },
     );
     const hooks = opts.hooks?.host?.onWorktreeReady;
-    expect(hooks).toHaveLength(1);
-    const command = hooks?.[0]?.command ?? "";
+    // Two host hooks now: [0] submodule safety net, [1] continuous push (#1224).
+    expect(hooks).toHaveLength(2);
+    expect(hooks?.[0]?.command ?? "").toContain("git submodule update --init packages/red-castle");
+    const command = hooks?.[1]?.command ?? "";
     // It is a single portable `sh -c '...'` host command.
     expect(command.startsWith("sh -c ")).toBe(true);
     // (a) initial force-with-lease push of the worker branch up-front.
@@ -365,7 +378,9 @@ describe("buildRunOptions", () => {
       makeDeps(async () => fakeResult()),
       { ...baseInput, continuousPush: true, remote: "backup" },
     );
-    const command = opts.hooks?.host?.onWorktreeReady?.[0]?.command ?? "";
+    // Index [1]: the continuous-push hook rides behind the always-on submodule
+    // safety net at [0] (#1224 Part B).
+    const command = opts.hooks?.host?.onWorktreeReady?.[1]?.command ?? "";
     expect(command).toContain("git push backup -u");
     expect(command).toContain("git push backup HEAD --force-with-lease");
   });

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -487,3 +487,51 @@ describe("makeFeedbackWorktree — rebaseOnto (Pattern 2 drift mitigation)", () 
     expect(calls.filter((c) => c.op === "rebase")).toHaveLength(1);
   });
 });
+
+describe("gate test subprocess env (#1224 Part C)", () => {
+  // A /go (or scout) worker runs the feedback gate with RED_AFK_WORKERS_NAMESPACE
+  // pinned to its lane. That must NOT leak into the gate's `pnpm -C <scope> test`
+  // subprocess, or namespace-sensitive suites (worker-paths, supervisor-fs) see
+  // the /go lane instead of the default and fail — a false full-suite red that
+  // parks otherwise-green work (this leak cost issue #1219 ~70 minutes).
+  function captureEnvIO(): { io: FeedbackWorktreeIO; envFor: (script: string) => NodeJS.ProcessEnv | undefined } {
+    const seen: Array<{ script: string; env: NodeJS.ProcessEnv | undefined }> = [];
+    const io: FeedbackWorktreeIO = {
+      worktreeAdd: async () => true,
+      pnpm: async (args, opts) => {
+        // The gate rewrites the token to ["-C", <path>, <script>]; "install" is
+        // the materialise step, everything else is a gate check.
+        const script = args[0] === "install" ? "install" : (args[2] ?? args[1] ?? "");
+        seen.push({ script, env: opts.env });
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+      worktreeRemove: async () => {},
+      branchHead: async () => null,
+      worktreeHead: async () => null,
+      rebase: async () => ({ ok: true }),
+    };
+    return { io, envFor: (script) => seen.find((s) => s.script === script)?.env };
+  }
+
+  it("runs the gate's pnpm test subprocess with RED_AFK_WORKERS_NAMESPACE unset", async () => {
+    const prev = process.env.RED_AFK_WORKERS_NAMESPACE;
+    process.env.RED_AFK_WORKERS_NAMESPACE = "go-workers"; // the /go lane leak
+    try {
+      const { io, envFor } = captureEnvIO();
+      const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });
+
+      await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+
+      const env = envFor("test");
+      // The gate's test subprocess env exists and does NOT carry the namespace.
+      expect(env).toBeDefined();
+      expect(env && "RED_AFK_WORKERS_NAMESPACE" in env).toBe(false);
+      // The worker's own process env is untouched (we scrub a copy, not the real env).
+      expect(process.env.RED_AFK_WORKERS_NAMESPACE).toBe("go-workers");
+    } finally {
+      if (prev === undefined) delete process.env.RED_AFK_WORKERS_NAMESPACE;
+      else process.env.RED_AFK_WORKERS_NAMESPACE = prev;
+    }
+  });
+});

--- a/apps/dev/tests/loc-memo.test.ts
+++ b/apps/dev/tests/loc-memo.test.ts
@@ -88,4 +88,77 @@ describe("resolveAttemptLoc — commit-anchored LOC memo (#1210)", () => {
   it("locMemoPath sits beside the attempt state file", () => {
     expect(locMemoPath("/tmp/attempt")).toBe("/tmp/attempt/.loc-memo.json");
   });
+
+  // #1224 Part A: a codex worker never commits, so its HEAD sha is frozen for the
+  // whole attempt. The committed delta stays sha-memoized (0/0) while the
+  // uncommitted working-tree delta is recomputed EVERY tick and added on top — so
+  // the LOC counter reflects total work even with zero commits.
+  it("adds the uncommitted working-tree delta on top of the memoized committed delta", async () => {
+    let committedCalls = 0;
+    let uncommittedCalls = 0;
+    let uncommitted = { added: 0, removed: 0 };
+    let stored: LocMemo | null = null;
+    const deps = () => ({
+      headSha: "frozensha", // never advances — codex does not commit
+      compute: async () => {
+        committedCalls += 1;
+        return { added: 0, removed: 0 }; // no commits → committed delta is 0/0
+      },
+      computeUncommitted: async () => {
+        uncommittedCalls += 1;
+        return uncommitted;
+      },
+      readMemo: () => stored,
+      writeMemo: (m: LocMemo) => {
+        stored = m;
+      },
+    });
+
+    // First tick: worktree still empty.
+    const first = await resolveAttemptLoc(deps());
+    expect(first).toEqual({ added: 0, removed: 0 });
+
+    // Later tick: codex has written 120 uncommitted lines. HEAD sha unchanged, so
+    // the committed memo is a HIT (no recompute), but the uncommitted delta is
+    // recomputed and surfaces the work: +120, not the frozen +0.
+    uncommitted = { added: 120, removed: 4 };
+    const second = await resolveAttemptLoc(deps());
+    expect(second).toEqual({ added: 120, removed: 4 });
+
+    // Committed side computed at most once (memo hit on the frozen sha); the
+    // uncommitted side ran on every call.
+    expect(committedCalls).toBe(1);
+    expect(uncommittedCalls).toBe(2);
+  });
+
+  it("keeps the claude incremental-commit path correct: committed memo + uncommitted delta sum", async () => {
+    // A claude worker commits incrementally. After a commit the committed delta is
+    // sha-memoized; any not-yet-committed edits add on top of it.
+    let stored: LocMemo | null = { sha: "commitA", added: 50, removed: 2 };
+    const result = await resolveAttemptLoc({
+      headSha: "commitA", // memo hit — committed volume served without recompute
+      compute: async () => {
+        throw new Error("committed compute must not run on a memo hit");
+      },
+      computeUncommitted: async () => ({ added: 7, removed: 1 }), // uncommitted WIP
+      readMemo: () => stored,
+      writeMemo: (m) => {
+        stored = m;
+      },
+    });
+    expect(result).toEqual({ added: 57, removed: 3 });
+  });
+
+  it("omitting computeUncommitted preserves the legacy committed-only behaviour", async () => {
+    let stored: LocMemo | null = null;
+    const result = await resolveAttemptLoc({
+      headSha: "sha1",
+      compute: async () => ({ added: 9, removed: 0 }),
+      readMemo: () => stored,
+      writeMemo: (m) => {
+        stored = m;
+      },
+    });
+    expect(result).toEqual({ added: 9, removed: 0 });
+  });
 });


### PR DESCRIPTION
Three worker-infrastructure fixes surfaced by a monitor investigation. All in apps/dev/.

- **Part A — LOC counts uncommitted work.** The LOC memo now sums a sha-memoized committed delta with a per-tick uncommitted working-tree delta, so non-committing (codex) workers surface real +N LOC instead of a frozen +0 -0. Render path stays git-free; claude incremental path unchanged.
- **Part B — self-healing submodule init.** An always-on `onWorktreeReady` host hook idempotently inits `packages/red-castle` before the inner agent runs, so a missed ADR 0071 post-checkout hook can no longer leave a worktree unable to run vitest.
- **Part C — gate env-leak (#1215).** The feedback gate's `pnpm test` subprocess now runs with `RED_AFK_WORKERS_NAMESPACE` scrubbed from a copy of the env, so a /go (or scout) worker's namespace no longer poisons `worker-paths`/`supervisor-fs`. This is the leak that cost #1219 ~70 minutes of false-red churn.

Verified in a clean env (touched + adjacent suites: 193 tests green, typecheck clean). NOTE: origin/main is currently RED on lifecycle-table tests (requeue/hitl-resolution-plan — `no legal row for edge "requeue-mixed-blocked-refusal"`); that is a pre-existing main red from the #1171 requeue changes, orthogonal to this PR, and is being fixed separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785955085&installation_id=129708444&pr_number=1226&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1226&signature=555d592bb60599135de2660269511e26729b79f939bcb3f3b658f9c8af981334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live progress now reflects both committed and uncommitted file changes, so run status stays accurate even when no commits are created.
  * Worker environments now include a built-in safety check to help ensure required repository components are ready before execution.

* **Bug Fixes**
  * Fixed stale `+0/-0` change counts during long-running runs.
  * Prevented internal environment variables from leaking into subprocesses, improving run isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->