### PR TITLE
merge: #1188 afk: per-drain USD budget ladder with HARD_STOP

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -42,12 +42,20 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-function parseFleetArgs(args: readonly string[]): { stop: boolean; target: number; request?: string; runnerFlag?: string; passthrough: string[] } {
+function parsePositiveNumber(raw: string | undefined, flag: string): number {
+  if (raw === undefined) throw new Error(`${flag} requires a value`);
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) throw new Error(`${flag} requires a positive number`);
+  return n;
+}
+
+function parseFleetArgs(args: readonly string[]): { stop: boolean; target: number; request?: string; runnerFlag?: string; drainBudgetUsd?: number; passthrough: string[] } {
   const passthrough: string[] = [];
   let stop = false;
   let target: number | undefined;
   let request: string | undefined;
   let runnerFlag: string | undefined;
+  let drainBudgetUsd: number | undefined;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -73,13 +81,25 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; target: numbe
       runnerFlag = arg.slice("--runner=".length);
       continue;
     }
+    if (arg === "--budget-usd" || arg === "--drain-budget-usd") {
+      drainBudgetUsd = parsePositiveNumber(args[++i], arg);
+      continue;
+    }
+    if (arg.startsWith("--budget-usd=")) {
+      drainBudgetUsd = parsePositiveNumber(arg.slice("--budget-usd=".length), "--budget-usd");
+      continue;
+    }
+    if (arg.startsWith("--drain-budget-usd=")) {
+      drainBudgetUsd = parsePositiveNumber(arg.slice("--drain-budget-usd=".length), "--drain-budget-usd");
+      continue;
+    }
     if (/^[0-9]+$/.test(arg) && target === undefined) {
       target = Number(arg);
       continue;
     }
     passthrough.push(arg);
   }
-  return { stop, target: target ?? 2, request, runnerFlag, passthrough };
+  return { stop, target: target ?? 2, request, runnerFlag, drainBudgetUsd, passthrough };
 }
 
 export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetStopResult> {
@@ -169,6 +189,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     runner: detection.runner,
     passthrough: parsed.passthrough,
     request: parsed.request,
+    drainBudgetUsd: parsed.drainBudgetUsd,
   });
   if (!supervisorPid) {
     let tail = "";

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -14,6 +14,7 @@ import {
   initSupervisorState,
   resolveSupervisorConfig,
   runSupervisor,
+  type SpawnPolicy,
   type SupervisorDeps,
 } from "../core/supervisor.js";
 import { appendRecord } from "../core/jsonl-log.js";
@@ -31,6 +32,7 @@ import {
   workerLivenessFor,
   parkedSlotWorkFor,
   resolveIterDirInfo,
+  sumWorkerCostUsd,
   teardownIterDirNative,
 } from "../runtime/supervisor-fs.js";
 import * as ghx from "../runtime/gh.js";
@@ -42,6 +44,7 @@ import { buildStateChangeWake } from "../runtime/state-watch.js";
 import { resolveFleetHooks } from "../core/fleet-hook-config.js";
 import { dispatchFleetHook } from "../core/fleet-hook-dispatcher.js";
 import { makeHookExec, makeHookResolveOptions } from "../runtime/hooks.js";
+import { getConfig, loadConfig } from "../core/config.js";
 
 function isAlive(pid: number): boolean {
   try {
@@ -71,6 +74,16 @@ function fleetHeartbeatState(hb: FleetHeartbeat): string {
         parked: hb.slotsParked,
       },
       spawns_this_tick: hb.spawnsThisTick,
+      ...(hb.drainBudget
+        ? {
+            drain_budget: {
+              tier: hb.drainBudget.tier,
+              spent_usd: Number(hb.drainBudget.spentUsd.toFixed(4)),
+              limit_usd: Number(hb.drainBudget.limitUsd.toFixed(4)),
+              percent: Number((hb.drainBudget.percent * 100).toFixed(2)),
+            },
+          }
+        : {}),
     },
     null,
     2,
@@ -112,6 +125,7 @@ export const PASSTHROUGH_DENYLIST: readonly string[] = [
   "RED_AFK_WORKER_ID",
   "RED_AFK_EXIT_CODE",
   "RED_AFK_DURATION_S",
+  "RED_AFK_TASK_TIER_DOWNGRADE",
 ];
 
 /**
@@ -166,8 +180,12 @@ export function buildWorkerEnv(
 export function buildSlotEnv(
   workerEnv: Record<string, string>,
   slot: number,
+  policy: SpawnPolicy = {},
 ): Record<string, string> {
-  return { ...workerEnv, RED_AFK_SLOT: String(slot) };
+  const out: Record<string, string> = { ...workerEnv, RED_AFK_SLOT: String(slot) };
+  if (policy.taskTierDowngrade) out.RED_AFK_TASK_TIER_DOWNGRADE = "1";
+  else delete out.RED_AFK_TASK_TIER_DOWNGRADE;
+  return out;
 }
 
 /**
@@ -335,7 +353,7 @@ function buildSupervisorDeps(
 
   return {
     proc: {
-      spawnSlot: async (slot) => {
+      spawnSlot: async (slot, policy) => {
         // Forward the PRD/issue filter + runner-swap policy so a supervised
         // fleet honours the same filter a single `/afk run` would (gap 5).
         const runArgs = ["run", "--once", "--runner", runner, ...slotArgs];
@@ -346,7 +364,7 @@ function buildSupervisorDeps(
         const slotFd = openSync(slotLogFile, "a");
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
-          env: buildSlotEnv(workerEnv, slot),
+          env: buildSlotEnv(workerEnv, slot, policy),
           detached: true,
           stdio: ["ignore", slotFd, slotFd],
         });
@@ -409,6 +427,7 @@ function buildSupervisorDeps(
           // best-effort
         }
       },
+      fleetCostUsd: () => sumWorkerCostUsd(tmpDir),
     },
     gh: {
       comment: async (issue, body) => {
@@ -543,6 +562,14 @@ function buildSupervisorDeps(
               slots_total: String(hb.slotsTotal),
               slots_parked: String(hb.slotsParked),
               spawns_this_tick: String(hb.spawnsThisTick),
+              ...(hb.drainBudget
+                ? {
+                    drain_budget_tier: hb.drainBudget.tier,
+                    drain_budget_spent_usd: hb.drainBudget.spentUsd.toFixed(4),
+                    drain_budget_limit_usd: hb.drainBudget.limitUsd.toFixed(4),
+                    drain_budget_percent: (hb.drainBudget.percent * 100).toFixed(2),
+                  }
+                : {}),
             },
           },
         });
@@ -588,7 +615,8 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   if (existsSync(stopFile)) rmSync(stopFile, { force: true });
 
   const logFd = openSync(logFile, "a");
-  const config = resolveSupervisorConfig();
+  const values = loadConfig(paths.configPath, { warn: () => undefined });
+  const config = resolveSupervisorConfig(process.env, (key) => getConfig(values, key));
   const state = initSupervisorState(config.target);
   const repo = await resolveRepoSlug(root).catch(() => "");
   const ghCtx = { cwd: root, repo };

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -210,6 +210,15 @@ export type ConfigKey = keyof typeof CONFIG_DEFAULTS;
 export const AFK_MODEL_TIERS = ["validate", "simple", "complex", "think"] as const;
 export type AfkModelTier = (typeof AFK_MODEL_TIERS)[number];
 
+const AFK_MODEL_TIER_ORDER: readonly AfkModelTier[] = AFK_MODEL_TIERS;
+
+/** One-step downgrade in the model-tier-policy vocabulary. The cheapest tier is
+ * already the floor, so it stays `validate`. */
+export function downgradeAfkModelTier(tier: AfkModelTier): AfkModelTier {
+  const idx = AFK_MODEL_TIER_ORDER.indexOf(tier);
+  return idx <= 0 ? "validate" : AFK_MODEL_TIER_ORDER[idx - 1]!;
+}
+
 export interface ResolvedTier {
   model: string;
   effort: AgentEffort;
@@ -474,7 +483,10 @@ export function resolveTier(
   // ship a full table (CONFIG_DEFAULTS); any other runner (e.g. the runner-neutral
   // hermes) falls back to the claude table via the shared `toAgentRunner` seam.
   const tierRunner = toAgentRunner(runner as Runner);
-  const tier = (AFK_MODEL_TIERS as readonly string[]).includes(taskClass) ? taskClass : "think";
+  const requestedTier = (AFK_MODEL_TIERS as readonly string[]).includes(taskClass) ? taskClass : "think";
+  const tier = env.RED_AFK_TASK_TIER_DOWNGRADE === "1"
+    ? downgradeAfkModelTier(requestedTier)
+    : requestedTier;
   const modelKey = defaultTierKey(tierRunner, tier, "model")!;
   const effortKey = defaultTierKey(tierRunner, tier, "effort")!;
   const defaultModel = CONFIG_DEFAULTS[modelKey];

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -39,6 +39,7 @@ import {
 } from "./slot-circuit.js";
 import type { FleetHookContext, FleetHookDispatchResult } from "./fleet-hook-dispatcher.js";
 import type { FleetHookName } from "./fleet-hook-config.js";
+import { encodeToon } from "./toon.js";
 
 // ---------- tunables ----------
 
@@ -158,6 +159,12 @@ export interface SupervisorConfig {
    * falls back to the default.
    */
   supervisorRestartWindowS: number;
+  /**
+   * Per-drain USD budget. Undefined means today's behaviour: no budget ladder,
+   * no spawn downgrade, and no hard stop. Spend is read from the WorkerVitals
+   * lane (`current.cost_usd`) through SupervisorFs.fleetCostUsd.
+   */
+  drainBudgetUsd?: number;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -180,6 +187,38 @@ export const SUPERVISOR_DEFAULTS = {
   supervisorRestartWindowS: 300,
 } as const satisfies SupervisorConfig;
 
+export type DrainBudgetTier = "OK" | "WARNING" | "CRITICAL" | "HARD_STOP";
+
+export interface DrainBudgetStatus {
+  tier: DrainBudgetTier;
+  spentUsd: number;
+  limitUsd: number;
+  percent: number;
+}
+
+function parsePositiveNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+export type SupervisorConfigReader = (key: string) => string;
+
+export function evaluateDrainBudget(
+  spentUsd: number,
+  limitUsd: number | undefined,
+): DrainBudgetStatus | undefined {
+  if (limitUsd === undefined || limitUsd <= 0) return undefined;
+  const spent = Math.max(0, spentUsd);
+  const percent = spent / limitUsd;
+  const tier: DrainBudgetTier =
+    percent >= 1 ? "HARD_STOP" :
+    percent >= 0.9 ? "CRITICAL" :
+    percent >= 0.75 ? "WARNING" :
+    "OK";
+  return { tier, spentUsd: spent, limitUsd, percent };
+}
+
 /**
  * Resolve a SupervisorConfig from an env bag, mirroring the `${VAR:-default}`
  * ladder at the top of supervisor.sh. Non-numeric overrides fall back to the
@@ -188,6 +227,7 @@ export const SUPERVISOR_DEFAULTS = {
  */
 export function resolveSupervisorConfig(
   env: Record<string, string | undefined> = process.env,
+  getCfg: SupervisorConfigReader = () => "",
 ): SupervisorConfig {
   const num = (key: string, fallback: number): number => {
     const raw = env[key];
@@ -240,6 +280,9 @@ export function resolveSupervisorConfig(
     supervisorRestartWindowS:
       num("RED_AFK_SUPERVISOR_RESTART_WINDOW_S", SUPERVISOR_DEFAULTS.supervisorRestartWindowS) ||
       SUPERVISOR_DEFAULTS.supervisorRestartWindowS,
+    drainBudgetUsd:
+      parsePositiveNumber(env.RED_AFK_DRAIN_MAX_COST_USD) ??
+      parsePositiveNumber(getCfg("afk.drain.max_cost_usd")),
   };
 }
 
@@ -447,7 +490,7 @@ export interface ReconcileCandidate {
 export interface SupervisorProc {
   /** Spawn a worker for a slot; returns its pid and spawn epoch. Mirrors
    * spawn_slot's `nohup … &` + bookkeeping. */
-  spawnSlot(slot: number): Promise<{ pid: number; spawnEpoch: number }>;
+  spawnSlot(slot: number, policy?: SpawnPolicy): Promise<{ pid: number; spawnEpoch: number }>;
   /** True when the pid is alive (kill -0). Mirrors `kill -0 "$pid"`. */
   isAlive(pid: number): boolean;
   /** kill_tree the pid and its descendants: SIGTERM, grace, then SIGKILL, and
@@ -505,6 +548,16 @@ export interface SupervisorFs {
   parkedSlotWork(slot: number, lastPid: number | null): SweepWork;
   /** Remove a swept iter dir (rm -rf). Mirrors the per-pair `rm -rf "$dir"`. */
   removeDir(path: string): Promise<void>;
+  /**
+   * Cumulative fleet spend for this drain, derived from existing WorkerVitals
+   * state (`current.cost_usd`) rather than a parallel accounting channel.
+   */
+  fleetCostUsd?(): number;
+}
+
+export interface SpawnPolicy {
+  /** Set at CRITICAL so the spawned worker downgrades one model-policy tier. */
+  taskTierDowngrade?: boolean;
 }
 
 /** gh side effects. Best-effort: a failure is logged in bash but never blocks
@@ -587,6 +640,8 @@ export interface FleetHeartbeat {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  /** Optional per-drain budget status; absent when no budget is configured. */
+  drainBudget?: DrainBudgetStatus;
   /** Per-slot details for non-closed slots. Empty array when all slots are closed. */
   slotDetails: HeartbeatSlotDetail[];
 }
@@ -774,6 +829,10 @@ export interface SupervisorState {
    * the event lane delivered. Updated by runSupervisor after each iteration.
    */
   wakeStats: WakeStats;
+  /** Once HARD_STOP is reached, no new workers are spawned for this supervisor. */
+  drainBudgetHardStopped: boolean;
+  /** Last budget tier logged, to avoid repeating unchanged OK/WARNING/CRITICAL. */
+  lastDrainBudgetTier?: DrainBudgetTier;
 }
 
 /** Build the initial runtime for `target` slots. */
@@ -783,6 +842,7 @@ export function initSupervisorState(target: number): SupervisorState {
     lastProgressEpoch: 0,
     lastUnblockSweepEpoch: 0,
     wakeStats: freshWakeStats(),
+    drainBudgetHardStopped: false,
   };
 }
 
@@ -963,6 +1023,7 @@ export interface TickResult {
    * tick or when readyQueueDepth is unavailable). Used by emitFleetHeartbeat
    * so the queue is fetched exactly once per tick. */
   queueDepth: number;
+  drainBudget?: DrainBudgetStatus;
   /**
    * True when the tick was abandoned — guardedTick timed out or threw. An
    * abandoned tick does NOT advance lastProgressEpoch in the heartbeat; only
@@ -1033,6 +1094,7 @@ async function emitFleetHeartbeat(
     readyForAgent,
     ...fleetSlotCounts(state),
     spawnsThisTick: result.respawned.length,
+    ...(result.drainBudget ? { drainBudget: result.drainBudget } : {}),
     slotDetails: buildSlotDetails(state, config),
   };
   try {
@@ -1295,6 +1357,65 @@ export async function pollStallDetector(
   return reaped;
 }
 
+function readDrainBudget(state: SupervisorState, deps: SupervisorDeps, config: SupervisorConfig): DrainBudgetStatus | undefined {
+  if (config.drainBudgetUsd === undefined) return undefined;
+  let spent = 0;
+  try {
+    spent = deps.fs.fleetCostUsd?.() ?? 0;
+  } catch {
+    spent = 0;
+  }
+  const budget = evaluateDrainBudget(spent, config.drainBudgetUsd);
+  if (budget?.tier === "HARD_STOP") state.drainBudgetHardStopped = true;
+  return budget;
+}
+
+function logDrainBudgetTransition(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  budget: DrainBudgetStatus | undefined,
+  queueDepth: number,
+): void {
+  if (!budget || state.lastDrainBudgetTier === budget.tier) return;
+  state.lastDrainBudgetTier = budget.tier;
+  deps.log?.(
+    encodeToon({
+      schema_version: "red.afk.drain_budget.v1",
+      tier: budget.tier,
+      spent_usd: Number(budget.spentUsd.toFixed(4)),
+      limit_usd: Number(budget.limitUsd.toFixed(4)),
+      percent: Number((budget.percent * 100).toFixed(2)),
+      ready_for_agent: queueDepth,
+      action:
+        budget.tier === "HARD_STOP"
+          ? "hard_stop_no_new_spawns_inflight_finish"
+          : budget.tier === "CRITICAL"
+            ? "new_spawns_downgrade_one_model_tier"
+            : "observe",
+    }),
+  );
+}
+
+function spawnPolicyForBudget(
+  state: SupervisorState,
+  budget: DrainBudgetStatus | undefined,
+): SpawnPolicy | "hard-stop" | undefined {
+  if (state.drainBudgetHardStopped || budget?.tier === "HARD_STOP") return "hard-stop";
+  if (budget?.tier === "CRITICAL") return { taskTierDowngrade: true };
+  return undefined;
+}
+
+async function spawnSlotForBudget(
+  slot: number,
+  deps: SupervisorDeps,
+  state: SupervisorState,
+  budget: DrainBudgetStatus | undefined,
+): Promise<{ pid: number; spawnEpoch: number } | null> {
+  const policy = spawnPolicyForBudget(state, budget);
+  if (policy === "hard-stop") return null;
+  return policy ? deps.proc.spawnSlot(slot, policy) : deps.proc.spawnSlot(slot);
+}
+
 /**
  * handle_dead_slot (supervisor.sh ~994): a slot whose worker exited. Record the
  * death against the circuit breaker; on a trip park the slot and run the trip
@@ -1317,7 +1438,12 @@ export async function handleDeadSlot(
   deps: SupervisorDeps,
   config: SupervisorConfig,
   queueDepth = 0,
+  spawnPolicy?: SpawnPolicy | "hard-stop",
 ): Promise<{ parked: boolean }> {
+  const spawn = async (): Promise<{ pid: number; spawnEpoch: number } | null> => {
+    if (spawnPolicy === "hard-stop") return null;
+    return spawnPolicy ? deps.proc.spawnSlot(slot, spawnPolicy) : deps.proc.spawnSlot(slot);
+  };
   // Half-open probe death: resolve the circuit transition before the normal path.
   if (state.parked && state.halfOpen) {
     const now = deps.now();
@@ -1346,7 +1472,8 @@ export async function handleDeadSlot(
     // Respawn immediately so the closed slot has a live worker.
     state.spawning = true;
     try {
-      const spawned = await deps.proc.spawnSlot(slot);
+      const spawned = await spawn();
+      if (spawned === null) return { parked: true };
       state.pid = spawned.pid;
       state.spawnEpoch = spawned.spawnEpoch;
     } finally {
@@ -1384,7 +1511,11 @@ export async function handleDeadSlot(
     // Clean drain but queue has work → respawn immediately without feeding the breaker.
     state.spawning = true;
     try {
-      const spawned = await deps.proc.spawnSlot(slot);
+      const spawned = await spawn();
+      if (spawned === null) {
+        state.pid = null;
+        return { parked: true };
+      }
       state.pid = spawned.pid;
       state.spawnEpoch = spawned.spawnEpoch;
     } finally {
@@ -1429,7 +1560,11 @@ export async function handleDeadSlot(
 
   state.spawning = true;
   try {
-    const spawned = await deps.proc.spawnSlot(slot);
+    const spawned = await spawn();
+    if (spawned === null) {
+      state.pid = null;
+      return { parked: true };
+    }
     state.pid = spawned.pid;
     state.spawnEpoch = spawned.spawnEpoch;
   } finally {
@@ -1555,15 +1690,21 @@ export async function superviseTick(
     queueDepth = 0;
   }
   result.queueDepth = queueDepth;
+  const drainBudget = readDrainBudget(state, deps, config);
+  result.drainBudget = drainBudget;
+  logDrainBudgetTransition(state, deps, drainBudget, queueDepth);
+  const spawnPolicy = spawnPolicyForBudget(state, drainBudget);
 
   // Un-park idle-parked slots when the queue has work to do.
   for (let i = 0; i < state.slots.length; i += 1) {
     const slot = state.slots[i]!;
     if (!slot.idleParked || queueDepth === 0) continue;
+    if (spawnPolicy === "hard-stop") continue;
     slot.idleParked = false;
     slot.spawning = true;
     try {
-      const spawned = await deps.proc.spawnSlot(i);
+      const spawned = await spawnSlotForBudget(i, deps, state, drainBudget);
+      if (spawned === null) continue;
       slot.pid = spawned.pid;
       slot.spawnEpoch = spawned.spawnEpoch;
       slot.stalled = false;
@@ -1597,6 +1738,7 @@ export async function superviseTick(
     for (let i = 0; i < state.slots.length; i += 1) {
       const slot = state.slots[i]!;
       if (!slot.parked || slot.halfOpen || slot.spawning) continue;
+      if (spawnPolicy === "hard-stop") continue;
       if (!isHalfOpenDue(slot.tripEpoch, slot.backoffStep, now, config)) continue;
       deps.log?.(
         `circuit half-open: slot ${i} cooldown expired, spawning probe ` +
@@ -1605,7 +1747,8 @@ export async function superviseTick(
       slot.halfOpen = true;
       slot.spawning = true;
       try {
-        const spawned = await deps.proc.spawnSlot(i);
+        const spawned = await spawnSlotForBudget(i, deps, state, drainBudget);
+        if (spawned === null) continue;
         slot.pid = spawned.pid;
         slot.spawnEpoch = spawned.spawnEpoch;
         slot.stalled = false;
@@ -1659,7 +1802,20 @@ export async function superviseTick(
       // the stranded claim must be snapshotted here, while it still resolves.
       const deadInfo = deps.fs.resolveIterDir(i);
       result.deaths.push(i);
-      const { parked } = await handleDeadSlot(i, slot, deps, config, queueDepth);
+      if (spawnPolicy === "hard-stop") {
+        slot.pid = null;
+        slot.stalled = false;
+        slot.stallSinceEpoch = 0;
+        slot.reaped = false;
+        try {
+          const reconciled = await reconcileDeadWorkerClaim(deadInfo, deps);
+          if (reconciled !== null) result.crashReconciled.push(reconciled);
+        } catch {
+          // best-effort, same as the respawn path.
+        }
+        continue;
+      }
+      const { parked } = await handleDeadSlot(i, slot, deps, config, queueDepth, spawnPolicy);
       if (parked) {
         // A circuit-trip park already swept this slot's claimed issues
         // (sweepParkedSlot); an idle-park drained cleanly with no live claim.
@@ -1689,8 +1845,10 @@ export async function superviseTick(
 
   // Reconcile dispatch: use any free slot (e.g. just stall-reaped) for a parked
   // candidate. Best-effort; a failure or absent candidate is silently skipped.
-  const reconciledSlot = await dispatchReconcileIfPossible(state, deps);
-  if (reconciledSlot !== null) result.reconciledSlots.push(reconciledSlot);
+  if (spawnPolicy !== "hard-stop") {
+    const reconciledSlot = await dispatchReconcileIfPossible(state, deps);
+    if (reconciledSlot !== null) result.reconciledSlots.push(reconciledSlot);
+  }
 
   // Periodic dependency Unblock Sweep (#844). The boot-time sweep and the
   // event-driven close-cascade are both best-effort; when a cascade misses an
@@ -1795,9 +1953,12 @@ export async function runSupervisor(
   }
 
   // Spawn the initial fleet to target.
+  const initialBudget = readDrainBudget(state, deps, config);
+  logDrainBudgetTransition(state, deps, initialBudget, 0);
   for (let i = 0; i < state.slots.length; i += 1) {
     const slot = state.slots[i]!;
-    const spawned = await deps.proc.spawnSlot(i);
+    const spawned = await spawnSlotForBudget(i, deps, state, initialBudget);
+    if (spawned === null) continue;
     slot.pid = spawned.pid;
     slot.spawnEpoch = spawned.spawnEpoch;
     // Notify on_slot_spawn for each initial slot. Best-effort.

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -81,6 +81,36 @@ export function iterDirsForWorker(root: string, wid: string): string[] {
   return out;
 }
 
+/** Sum `current.cost_usd` from the current AFK worker state files. This is the
+ * supervisor's per-drain spend signal and deliberately reads the existing
+ * WorkerVitals field rather than maintaining a parallel ledger. */
+export function sumWorkerCostUsd(tmpDir: string): number {
+  const workersRoot = join(tmpDir, "workers");
+  let workerDirs: string[];
+  try {
+    workerDirs = readdirSync(workersRoot);
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const wid of workerDirs) {
+    const wdir = join(workersRoot, wid);
+    let attempts: string[];
+    try {
+      attempts = readdirSync(wdir);
+    } catch {
+      continue;
+    }
+    for (const attempt of attempts) {
+      const rec = readWorkerState(join(wdir, attempt, "afk.state.json"));
+      if (rec === null) continue;
+      const cost = rec.state.current.cost_usd;
+      if (Number.isFinite(cost) && cost > 0) total += cost;
+    }
+  }
+  return total;
+}
+
 /** `.current.number` from a dir's afk.state.json, or null. Mirrors
  * iter_dir_issue_number. Reads through the single owner
  * (core/worker-state-reader) so the schema + legacy-key shim apply — no private

--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -49,6 +49,8 @@ export interface SpawnSupervisorOptions {
   passthrough?: readonly string[];
   /** Optional fleet request, forwarded as RED_AFK_REQUEST + `--request`. */
   request?: string;
+  /** Optional per-drain USD budget, forwarded as RED_AFK_DRAIN_MAX_COST_USD. */
+  drainBudgetUsd?: number;
 }
 
 /**
@@ -71,6 +73,7 @@ export async function spawnSupervisor(opts: SpawnSupervisorOptions): Promise<num
     RED_AFK_RUNNER: opts.runner,
   };
   if (opts.request) env.RED_AFK_REQUEST = opts.request;
+  if (opts.drainBudgetUsd !== undefined) env.RED_AFK_DRAIN_MAX_COST_USD = String(opts.drainBudgetUsd);
 
   const out = openSync(logFile, "a");
   const child = spawn(process.execPath, [process.argv[1]!, "__supervise", ...childArgs], {

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -9,6 +9,7 @@ import {
   MalformedConfigError,
   parseConfigYaml,
   readBackpressure,
+  downgradeAfkModelTier,
   resolveTier,
   resolveCiTimeoutSeconds,
   DEFAULT_MERGE_CI_TIMEOUT_S,
@@ -419,6 +420,22 @@ describe("config — AFK model tier table (ADR 0049)", () => {
     expect(resolveTier(values, "opencode", "simple")).toEqual({
       model: "openrouter/anthropic/claude-sonnet-4",
       effort: "high",
+    });
+  });
+
+  it("downgrades one model-policy tier when RED_AFK_TASK_TIER_DOWNGRADE is set", () => {
+    const values = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });
+    expect(downgradeAfkModelTier("think")).toBe("complex");
+    expect(downgradeAfkModelTier("complex")).toBe("simple");
+    expect(downgradeAfkModelTier("simple")).toBe("validate");
+    expect(downgradeAfkModelTier("validate")).toBe("validate");
+    expect(resolveTier(values, "claude", "think", { RED_AFK_TASK_TIER_DOWNGRADE: "1" })).toEqual({
+      model: "claude-opus-4-8",
+      effort: "medium",
+    });
+    expect(resolveTier(values, "claude", "simple", { RED_AFK_TASK_TIER_DOWNGRADE: "1" })).toEqual({
+      model: "claude-haiku-4-5",
+      effort: "low",
     });
   });
 

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -93,6 +93,12 @@ describe("buildSlotEnv (per-slot RED_AFK_SLOT injection)", () => {
     expect(slotted.RED_AFK_SKIP_PERF).toBe("1");
     expect(slotted.RED_AFK_RUNNER).toBe("codex");
   });
+
+  it("marks only budget-critical spawns for a one-tier task downgrade", () => {
+    const base = buildWorkerEnv({ PATH: "/usr/bin" }, "claude");
+    expect(buildSlotEnv(base, 0).RED_AFK_TASK_TIER_DOWNGRADE).toBeUndefined();
+    expect(buildSlotEnv(base, 1, { taskTierDowngrade: true }).RED_AFK_TASK_TIER_DOWNGRADE).toBe("1");
+  });
 });
 
 describe("slotFilterArgs (gap 5: supervised fleet forwards the filter)", () => {

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -22,6 +22,7 @@ import {
   validateSupervisorStaleThreshold,
   validateSupervisorProgressThreshold,
   classifySupervisor,
+  evaluateDrainBudget,
   guardedTick,
   type IterDirInfo,
   type ReconcileCandidate,
@@ -116,6 +117,7 @@ interface FakeIo {
   crashedClaimState: ReturnType<typeof vi.fn>;
   emitFleetHeartbeat: ReturnType<typeof vi.fn>;
   unblockSweep: ReturnType<typeof vi.fn>;
+  fleetCostUsd: ReturnType<typeof vi.fn>;
   now: ReturnType<typeof vi.fn>;
 }
 
@@ -157,6 +159,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     crashedClaimState: vi.fn(async () => ({ ghOk: true, stillRunning: false, envelopePosted: false })),
     emitFleetHeartbeat: vi.fn(async () => {}),
     unblockSweep: vi.fn(async (): Promise<number[]> => []),
+    fleetCostUsd: vi.fn(() => 0),
     now: vi.fn(() => NOW),
     ...(over as Partial<FakeIo>),
   };
@@ -176,6 +179,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       teardownIterDir: io.teardownIterDir,
       parkedSlotWork: io.parkedSlotWork,
       removeDir: io.removeDir,
+      fleetCostUsd: io.fleetCostUsd,
     },
     gh: {
       comment: io.comment,
@@ -470,6 +474,32 @@ describe("resolveSupervisorConfig", () => {
   it("falls back to default for a garbage RED_AFK_SUPERVISOR_PROGRESS_STALE_S", () => {
     const c = resolveSupervisorConfig({ RED_AFK_SUPERVISOR_PROGRESS_STALE_S: "bad" });
     expect(c.progressStaleS).toBe(900);
+  });
+
+  it("resolves the drain USD budget from env or config and rejects typo values", () => {
+    expect(resolveSupervisorConfig({}).drainBudgetUsd).toBeUndefined();
+    expect(resolveSupervisorConfig({ RED_AFK_DRAIN_MAX_COST_USD: "12.50" }).drainBudgetUsd).toBe(12.5);
+    expect(resolveSupervisorConfig({}, (key) => (key === "afk.drain.max_cost_usd" ? "9.25" : ""))).toMatchObject({
+      drainBudgetUsd: 9.25,
+    });
+    expect(resolveSupervisorConfig({ RED_AFK_DRAIN_MAX_COST_USD: "0" }).drainBudgetUsd).toBeUndefined();
+    expect(resolveSupervisorConfig({}, () => "not-a-number").drainBudgetUsd).toBeUndefined();
+  });
+});
+
+describe("evaluateDrainBudget", () => {
+  it("is undefined when no budget is configured", () => {
+    expect(evaluateDrainBudget(10, undefined)).toBeUndefined();
+  });
+
+  it("classifies exact OK/WARNING/CRITICAL/HARD_STOP tier boundaries", () => {
+    expect(evaluateDrainBudget(7.49, 10)?.tier).toBe("OK");
+    expect(evaluateDrainBudget(7.5, 10)?.tier).toBe("WARNING");
+    expect(evaluateDrainBudget(8.99, 10)?.tier).toBe("WARNING");
+    expect(evaluateDrainBudget(9, 10)?.tier).toBe("CRITICAL");
+    expect(evaluateDrainBudget(9.99, 10)?.tier).toBe("CRITICAL");
+    expect(evaluateDrainBudget(10, 10)?.tier).toBe("HARD_STOP");
+    expect(evaluateDrainBudget(12, 10)?.tier).toBe("HARD_STOP");
   });
 });
 
@@ -1995,6 +2025,68 @@ describe("superviseTick — periodic dependency Unblock Sweep (#844)", () => {
 
     expect(result.unblocked).toEqual([]);
     expect(state.lastUnblockSweepEpoch).toBe(0); // never stamped
+  });
+});
+
+describe("superviseTick — drain USD budget ladder (#1188)", () => {
+  it("keeps unchanged spawn behavior with no configured budget", async () => {
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 123;
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => false),
+      readyQueueDepth: vi.fn(async () => 1),
+      fleetCostUsd: vi.fn(() => 999),
+    });
+
+    const result = await superviseTick(state, deps, config(), () => false);
+
+    expect(result.respawned).toEqual([0]);
+    expect(io.spawnSlot).toHaveBeenCalledWith(0);
+    expect(io.fleetCostUsd).not.toHaveBeenCalled();
+  });
+
+  it("marks CRITICAL and downgrades only newly spawned workers", async () => {
+    const state = initSupervisorState(2);
+    state.slots[0]!.pid = 111;
+    state.slots[1]!.pid = 222;
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn((pid: number) => pid === 222),
+      readyQueueDepth: vi.fn(async () => 2),
+      fleetCostUsd: vi.fn(() => 9),
+    });
+
+    const result = await superviseTick(state, deps, config({ target: 2, drainBudgetUsd: 10 }), () => false);
+
+    expect(result.drainBudget?.tier).toBe("CRITICAL");
+    expect(result.respawned).toEqual([0]);
+    expect(io.spawnSlot).toHaveBeenCalledOnce();
+    expect(io.spawnSlot).toHaveBeenCalledWith(0, { taskTierDowngrade: true });
+    expect(state.slots[1]!.pid).toBe(222);
+  });
+
+  it("HARD_STOP records queue state, stops new spawns, and lets in-flight workers finish", async () => {
+    const logs: string[] = [];
+    const state = initSupervisorState(2);
+    state.slots[0]!.pid = 111;
+    state.slots[1]!.pid = 222;
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn((pid: number) => pid === 222),
+      readyQueueDepth: vi.fn(async () => 3),
+      fleetCostUsd: vi.fn(() => 10),
+    });
+    deps.log = (line) => logs.push(line);
+
+    const result = await superviseTick(state, deps, config({ target: 2, drainBudgetUsd: 10 }), () => false);
+
+    expect(result.drainBudget?.tier).toBe("HARD_STOP");
+    expect(result.respawned).toEqual([]);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(io.killTree).not.toHaveBeenCalled();
+    expect(state.slots[0]!.pid).toBeNull();
+    expect(state.slots[1]!.pid).toBe(222);
+    expect(logs.join("\n")).toContain("schema_version: red.afk.drain_budget.v1");
+    expect(logs.join("\n")).toContain("tier: HARD_STOP");
+    expect(logs.join("\n")).toContain("ready_for_agent: 3");
   });
 });
 

--- a/plugins/dev/skills/engineering/afk/docs/CONFIG.md
+++ b/plugins/dev/skills/engineering/afk/docs/CONFIG.md
@@ -39,6 +39,7 @@ Scalar run settings live in `.red/config.yaml` under the `afk:` key (alongside t
 | `afk.companion.diff_drift_loc` | — | `4000` | Companion drift threshold: total churn (added + removed) at/above this is judged `scope-creep` (sprawling past the issue), the highest-priority signal. |
 | `afk.companion.min_progress_loc` | — | `5` | Companion progress floor: a worker that has added at least this many lines has produced real work and is never flagged for churn/stuck. |
 | `afk.companion.*` (cap) | `RED_AFK_RETRY_DRIFT` | `2` | Companion bounded re-enqueue budget. Each detected drift on an attempt injects **one** correction (write-only, idempotent via a fingerprint, rewriting `## Agent brief`); once the attempt count reaches this cap the companion **escalates** to `ready-for-human` (a `## Current blocker` of kind `drift`) instead of correcting again. Shares the bounded-recovery policy (`core/recovery.ts`); never kills a process — termination/respawn is the reaper + fleet's job. |
+| `afk.drain.max_cost_usd` | `RED_AFK_DRAIN_MAX_COST_USD` / `fleet --budget-usd` | _(unset)_ | Per-drain USD budget for the fleet supervisor. Spend is read from WorkerVitals (`current.cost_usd`) in worker state files, not a parallel ledger. Tiers are OK below 75%, WARNING at 75%, CRITICAL at 90%, and HARD_STOP at 100%. CRITICAL spawns new workers with one model-tier-policy downgrade; HARD_STOP stops all new spawns, lets in-flight workers finish, and records a TOON budget event in `.red/tmp/afk-supervisor.log`. |
 
 ```yaml
 afk:


### PR DESCRIPTION
Automated AFK landing for #1188. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1188

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785955121&installation_id=129708444&pr_number=1227&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1227&signature=b577b0e30205e34f76798ad9719fb9c97b6a62f142db6c22a4045c06027d1676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->