### PR TITLE
merge: #1190 afk: crash-safe worker state file + stop sentinel + exit-124 convention

### DIFF
--- a/apps/dev/src/commands/retake.ts
+++ b/apps/dev/src/commands/retake.ts
@@ -1,4 +1,6 @@
 import { execTool, type ExecFn, type ExecOutput } from "../runtime/exec.js";
+import { join, dirname } from "node:path";
+import { readAllWorkerStates } from "../core/worker-state-reader.js";
 import {
   branchMatchesIssue,
   normalizeBranchName,
@@ -13,6 +15,7 @@ import {
   type RetakeIssue,
   type RetakePullRequest,
   type RetakeWorktree,
+  type RetakeWorkerState,
 } from "../core/retake.js";
 
 interface RetakeFlags {
@@ -247,15 +250,39 @@ async function collectWorktrees(exec: ExecFn, cwd: string, issue: number): Promi
   return worktrees;
 }
 
+async function collectWorkerState(cwd: string, issue: number): Promise<RetakeWorkerState | undefined> {
+  const records = await readAllWorkerStates(join(cwd, ".red", "tmp")).catch(() => []);
+  const matches = records
+    .filter((record) => Number(record.state.current.number) === issue)
+    .sort((a, b) => String(b.state.current.last_event_at ?? "").localeCompare(String(a.state.current.last_event_at ?? "")));
+  const rec = matches[0];
+  if (rec === undefined) return undefined;
+  const current = rec.state.current;
+  const attemptMatch = /-a([0-9]+)$/.exec(dirname(rec.path));
+  const lastExitCode = Number((current as Record<string, unknown>).last_exit_code);
+  return {
+    path: rec.path,
+    attemptDir: dirname(rec.path),
+    issue,
+    attempt: attemptMatch?.[1] ? Number.parseInt(attemptMatch[1], 10) : undefined,
+    phase: typeof current.phase === "string" ? current.phase : undefined,
+    outcome: typeof (current as Record<string, unknown>).outcome === "string"
+      ? String((current as Record<string, unknown>).outcome)
+      : undefined,
+    lastExitCode: Number.isFinite(lastExitCode) ? lastExitCode : undefined,
+  };
+}
+
 async function collectRetakeFacts(exec: ExecFn, cwd: string, flags: RetakeFlags): Promise<RetakeFacts> {
   const repo = await resolveRepo(exec, cwd, flags.repo);
-  const [issue, pullRequests, branches, worktrees] = await Promise.all([
+  const [issue, pullRequests, branches, worktrees, workerState] = await Promise.all([
     collectIssue(exec, cwd, repo, flags.issue),
     collectPullRequests(exec, cwd, repo, flags.issue, flags.prLimit),
     collectBranches(exec, cwd, flags.issue),
     collectWorktrees(exec, cwd, flags.issue),
+    collectWorkerState(cwd, flags.issue),
   ]);
-  return { issue, pullRequests, branches, worktrees };
+  return { issue, pullRequests, branches, worktrees, workerState };
 }
 
 function renderRetakeReport(facts: RetakeFacts): string {
@@ -280,6 +307,16 @@ function renderRetakeReport(facts: RetakeFacts): string {
   if (facts.worktrees.length === 0) lines.push("  none found");
   for (const worktree of facts.worktrees) {
     lines.push(`  ${worktree.path} ${worktree.branch ?? "(detached)"} ${worktree.dirty ? "dirty" : "clean"}`);
+  }
+  lines.push("");
+  lines.push("worker state:");
+  if (facts.workerState === undefined) {
+    lines.push("  none found");
+  } else {
+    const s = facts.workerState;
+    lines.push(
+      `  ${s.attemptDir} phase=${s.phase ?? "unknown"} outcome=${s.outcome ?? "unknown"} exit=${s.lastExitCode ?? "unknown"}`,
+    );
   }
   lines.push("");
   lines.push(`next: ${recommendation.summary}`);

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1314,6 +1314,9 @@ export function buildProcessDeps(
         "current.phase": phase,
       }).catch(() => {});
     },
+    markState: (patch) => {
+      void updateState(join(current.attemptDir, "afk.state.json"), patch).catch(() => {});
+    },
     historyPath: paths.historyPath,
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },
     // BOUNDED auto-recovery reads its RED_AFK_RETRY_* caps from the process env.

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -496,6 +496,12 @@ export interface ProcessIssueDeps {
    */
   writeNotes?(path: string, content: string): void;
   /**
+   * Persist compact machine-readable attempt state beyond the coarse phase.
+   * The CLI binds this to afk.state.json updates; tests inject a recorder.
+   * Optional so older callers preserve their existing behaviour.
+   */
+  markState?(patch: Record<string, unknown>): void;
+  /**
    * Stamp the attempt's macro-lifecycle phase (issue #811) — the calm signal the
    * task-mirror title surfaces. processIssue calls it at the orchestrator-owned
    * lifecycle points the inner-agent stream cannot see: `validating` at the start
@@ -687,6 +693,38 @@ export interface ProcessIssueResult {
   preserved: boolean;
   /** True when the completion sweep ran (done only). */
   swept: boolean;
+}
+
+const CLEAN_EXIT_CODE = 0;
+const CRASH_EXIT_CODE = 1;
+const TIMEOUT_EXIT_CODE = 124;
+
+function stateExitPatch(outcome: ProcessOutcome): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    "current.phase": "terminal",
+    "current.outcome": outcome,
+  };
+  if (outcome === "done") return { ...base, "current.last_exit_code": CLEAN_EXIT_CODE };
+  if (outcome === "blocked") return { ...base, "current.last_exit_code": CLEAN_EXIT_CODE };
+  if (outcome === "stalled") {
+    return {
+      ...base,
+      "current.last_exit_code": TIMEOUT_EXIT_CODE,
+      "current.failure_kind": "timeout",
+    };
+  }
+  if (outcome === "no-sentinel") {
+    return {
+      ...base,
+      "current.last_exit_code": CRASH_EXIT_CODE,
+      "current.failure_kind": "crash",
+    };
+  }
+  return { ...base, "current.last_exit_code": CRASH_EXIT_CODE };
+}
+
+function markTerminalState(deps: ProcessIssueDeps, outcome: ProcessOutcome): void {
+  deps.markState?.(stateExitPatch(outcome));
 }
 
 // ---------- the orchestration ----------
@@ -2189,6 +2227,7 @@ export async function processIssue(
   await deps.git.deleteLocalBranch(workerBranch);
   await deps.fs.completionSweep(issue);
   await deps.claimLock.release(issue);
+  markTerminalState(deps, "done");
 
   // ---- 9. close cascade (event-driven auto-unblock) ----
   // Issue N just closed; re-evaluate every open issue carrying `req:N`. Any
@@ -2532,6 +2571,7 @@ async function terminalFailure(
   record: { notes?: string; validationSummary?: string } = {},
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
+  markTerminalState(deps, outcome);
   const decision = await routeRecovery(deps, input.issue, outcome, input.attempt);
   if (decision === "escalate") {
     await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, sections));

--- a/apps/dev/src/core/retake.ts
+++ b/apps/dev/src/core/retake.ts
@@ -32,10 +32,21 @@ export interface RetakeWorktree {
   dirty: boolean;
 }
 
+export interface RetakeWorkerState {
+  path: string;
+  attemptDir: string;
+  issue: number;
+  attempt?: number;
+  phase?: string;
+  outcome?: string;
+  lastExitCode?: number;
+}
+
 export type RetakeChecksState = "green" | "pending" | "failing" | "unknown";
 
 export type RetakeRecommendationKind =
   | "resolve-hitl"
+  | "continue-state"
   | "ship-pr"
   | "fix-pr"
   | "continue-worktree"
@@ -67,6 +78,7 @@ export interface RetakeFacts {
   pullRequests: readonly RetakePullRequest[];
   branches: readonly RetakeBranch[];
   worktrees: readonly RetakeWorktree[];
+  workerState?: RetakeWorkerState;
 }
 
 const FAILURE_CHECK_VALUES = new Set(["FAILURE", "FAILED", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"]);
@@ -164,6 +176,18 @@ export function recommendRetake(facts: RetakeFacts): RetakeRecommendation {
     };
   }
 
+  if (facts.workerState !== undefined && facts.workerState.issue === facts.issue.number) {
+    const suffix =
+      facts.workerState.outcome !== undefined
+        ? ` Last recorded outcome: ${facts.workerState.outcome}.`
+        : "";
+    return {
+      kind: "continue-state",
+      summary: `Worker state file anchors attempt ${facts.workerState.attempt ?? "?"}.${suffix}`,
+      command: `cd ${facts.workerState.attemptDir}`,
+    };
+  }
+
   const blockedPr = openPrs.find((pr) =>
     pr.reviewDecision?.toUpperCase() === "CHANGES_REQUESTED" ||
     pr.checksState === "failing" ||
@@ -227,6 +251,14 @@ export function planRetakeApply(facts: RetakeFacts): RetakeApplyPlan {
   const recommendation = recommendRetake(facts);
   const issue = facts.issue.number;
   const worktreePath = `.red/tmp/work-ship-${issue}`;
+
+  if (recommendation.kind === "continue-state") {
+    return {
+      summary: recommendation.summary,
+      operations: [],
+      nextCommand: recommendation.command,
+    };
+  }
 
   if (recommendation.kind === "create-branch") {
     const branch = `codex/${issue}-retake`;

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -49,6 +49,8 @@ interface Trace {
   classifierCalls: IssueClassificationMetadata[];
   /** Lines appended to the iteration log (deps.appendIterLog). */
   iterLogs: string[];
+  /** Compact state patches written to afk.state.json. */
+  statePatches: Array<Record<string, unknown>>;
   /** Branches for which cascadeRebase.rebaseAndPush was called (#1007). */
   cascadeRebaseAttempts: string[];
 }
@@ -209,6 +211,7 @@ function harness(opts: HarnessOptions = {}): {
     salvageCalls: [],
     classifierCalls: [],
     iterLogs: [],
+    statePatches: [],
     cascadeRebaseAttempts: [],
   };
 
@@ -515,6 +518,9 @@ function harness(opts: HarnessOptions = {}): {
     nowIso: () => "2026-05-30T00:00:00Z",
     appendIterLog: (line) => {
       trace.iterLogs.push(line);
+    },
+    markState: (patch) => {
+      trace.statePatches.push(patch);
     },
     recoveryEnv: opts.recoveryEnv ?? {},
     // ADR 0017 recording port: omitted by default (older-caller safety). "ok"
@@ -1119,6 +1125,12 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     expect(nsEdit.add).toContain("blocked:crashed");
     expect(trace.ensuredLabels).toContain("blocked:crashed");
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "no-sentinel" }]);
+    expect(trace.statePatches).toContainEqual({
+      "current.phase": "terminal",
+      "current.outcome": "no-sentinel",
+      "current.last_exit_code": 1,
+      "current.failure_kind": "crash",
+    });
     // on_attempt_error fires; post_attempt does NOT (ADR 0028).
     expect(result.hooksFired).toEqual(["pre_worktree", "pre_attempt", "on_attempt_error"]);
     // #568: the no-sentinel terminal also releases the per-issue claim.
@@ -2731,6 +2743,12 @@ describe("processIssue — timeout (attempt progress guard fired)", () => {
     expect(trace.ensuredLabels).toContain("blocked:stalled");
     // The failure envelope rides the generic `blocked` status bucket.
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.statePatches).toContainEqual({
+      "current.phase": "terminal",
+      "current.outcome": "stalled",
+      "current.last_exit_code": 124,
+      "current.failure_kind": "timeout",
+    });
     // on_attempt_timeout fires when the guard trips; on_reconcile reports the
     // ADR 0055 skip; then on_attempt_error escalates. post_attempt does NOT fire.
     expect(result.hooksFired).toEqual([

--- a/apps/dev/tests/retake.test.ts
+++ b/apps/dev/tests/retake.test.ts
@@ -72,6 +72,27 @@ describe("recommendRetake", () => {
     })).toMatchObject({ kind: "fix-pr", command: "cd /repo/.red/tmp/work-ship-123" });
   });
 
+  it("prefers a worker state file anchor over branch/worktree fallback", () => {
+    expect(recommendRetake({
+      issue,
+      pullRequests: [],
+      branches: [{ name: "origin/codex/123-retake", remote: true }],
+      worktrees: [],
+      workerState: {
+        path: "/repo/.red/tmp/workers/wAAAA/123-a2/afk.state.json",
+        attemptDir: "/repo/.red/tmp/workers/wAAAA/123-a2",
+        issue: 123,
+        attempt: 2,
+        phase: "terminal",
+        outcome: "stalled",
+        lastExitCode: 124,
+      },
+    })).toMatchObject({
+      kind: "continue-state",
+      command: "cd /repo/.red/tmp/workers/wAAAA/123-a2",
+    });
+  });
+
   it("recommends continuing a dirty matching worktree", () => {
     expect(recommendRetake({
       issue,
@@ -138,6 +159,27 @@ describe("recommendRetake", () => {
         { cmd: "git", args: ["worktree", "add", ".red/tmp/work-ship-123", "codex/123-retake"] },
       ],
       nextCommand: "cd .red/tmp/work-ship-123 && /ship --issue 123",
+    });
+  });
+
+  it("plans no git operations when worker state already anchors the attempt", () => {
+    expect(planRetakeApply({
+      issue,
+      pullRequests: [],
+      branches: [{ name: "origin/codex/123-retake", remote: true }],
+      worktrees: [],
+      workerState: {
+        path: "/repo/.red/tmp/workers/wAAAA/123-a2/afk.state.json",
+        attemptDir: "/repo/.red/tmp/workers/wAAAA/123-a2",
+        issue: 123,
+        attempt: 2,
+        phase: "terminal",
+        outcome: "stalled",
+        lastExitCode: 124,
+      },
+    })).toMatchObject({
+      operations: [],
+      nextCommand: "cd /repo/.red/tmp/workers/wAAAA/123-a2",
     });
   });
 


### PR DESCRIPTION
Automated AFK landing for #1190. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1190

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785955754&installation_id=129708444&pr_number=1228&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1228&signature=02ca0ed34ef4e2b6ae2c40981e4970847cdeea60aba961c47866cb0cb63d5b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->