### PR TITLE
fix(afk): complete the issue-lifecycle transition table — main was CI-red

### DIFF
--- a/apps/dev/src/core/issue-lifecycle.ts
+++ b/apps/dev/src/core/issue-lifecycle.ts
@@ -66,7 +66,13 @@ export const BLOCKED_LABELS = [
 ] as const;
 
 export const ISSUE_LIFECYCLE_TRANSITIONS: readonly IssueLifecycleTransition[] = [
-  { edge: "claim", from: "ready-for-agent", to: "claimed/active" },
+  // `claim` normalizes any pre-active state into claimed/active: it sheds the
+  // conflicting labels (blocked:*/ready-for-human) in the SAME edit as it adds
+  // `running`. It is legal from ready-for-agent (normal), ready-for-human (a
+  // lane:go issue claimed past preflight, #1045), and an illegal mixed-blocked
+  // set that the claim edit cleans up (#402). The `to` still has to be
+  // claimed/active — a claim that lands anywhere else finds no row and throws.
+  { edge: "claim", from: "*", to: "claimed/active" },
   { edge: "retry", from: "claimed/active", to: "ready-for-agent" },
   { edge: "dependency-unblocked", from: "blocked:dependency", to: "ready-for-agent" },
   { edge: "dependency-blocked", from: "ready-for-agent", to: "blocked:dependency" },
@@ -74,8 +80,11 @@ export const ISSUE_LIFECYCLE_TRANSITIONS: readonly IssueLifecycleTransition[] = 
   { edge: "validation-blocked", from: "claimed/active", to: "blocked:validation" },
   { edge: "human-blocked", from: "*", to: "ready-for-human" },
   { edge: "human-blocked", from: "*", to: "blocked:validation" },
-  { edge: "human-delegable", from: "ready-for-human", to: "ready-for-agent" },
-  { edge: "human-delegable", from: "blocked:validation", to: "ready-for-agent" },
+  // `human-delegable` (a HITL "delegable" disposition) clears a human park back
+  // to ready-for-agent. It is legal from ready-for-human and blocked:validation,
+  // and also from an illegal mixed-blocked set that the delegable resolution
+  // sheds on the way out (the "sheds stale blocked:* labels" case) — hence `*`.
+  { edge: "human-delegable", from: "*", to: "ready-for-agent" },
   { edge: "manual-landing", from: "claimed/active", to: "landing:manual" },
   { edge: "close", from: "claimed/active", to: "closed" },
   { edge: "close", from: "landing:manual", to: "closed" },
@@ -122,7 +131,10 @@ export function classifyIssueLifecycleState(labels: readonly string[]): IssueLif
   if (blocked.length > 1) return "illegal";
   if ((hasReady || hasRunning) && hasBlocked) return "illegal";
   if (hasReady && hasRunning) return "illegal";
-  if (hasManualLanding && !hasHuman && !hasReady) return "illegal";
+  // `landing:manual` is a MODE flag that must ride a real state: queued
+  // (ready-for-agent), active (running, #1049 works the issue before parking it),
+  // or human-parked. Alone it is illegal.
+  if (hasManualLanding && !hasHuman && !hasReady && !hasRunning) return "illegal";
 
   if (hasManualLanding && hasHuman) return "landing:manual";
   if (hasRunning) return "claimed/active";
@@ -143,8 +155,13 @@ export function explainIllegalIssueLifecycleLabels(labels: readonly string[]): s
   if (labels.includes(LABEL_READY) && labels.includes(LABEL_RUNNING)) {
     return `issue cannot carry both ${LABEL_READY} and ${LABEL_RUNNING}`;
   }
-  if (labels.includes(LABEL_LANDING_MANUAL) && !labels.includes(LABEL_HUMAN) && !labels.includes(LABEL_READY)) {
-    return `${LABEL_LANDING_MANUAL} must ride a queued or human-parked issue`;
+  if (
+    labels.includes(LABEL_LANDING_MANUAL) &&
+    !labels.includes(LABEL_HUMAN) &&
+    !labels.includes(LABEL_READY) &&
+    !labels.includes(LABEL_RUNNING)
+  ) {
+    return `${LABEL_LANDING_MANUAL} must ride a queued, active, or human-parked issue`;
   }
   return null;
 }

--- a/apps/dev/src/core/requeue.ts
+++ b/apps/dev/src/core/requeue.ts
@@ -19,7 +19,6 @@ import {
   type CurrentBlocker,
 } from "./blocker-state.js";
 import {
-  IllegalIssueLifecycleTransitionError,
   blockedLabelsIn,
   validateIssueLifecycleTransition,
 } from "./issue-lifecycle.js";
@@ -162,19 +161,16 @@ export function planRequeue(input: RequeueInput): RequeuePlan {
     );
   }
 
-  try {
-    validateIssueLifecycleTransition({
-      edge: "requeue-mixed-blocked-refusal",
-      fromLabels: input.labels,
-      removeLabels: [],
-      addLabels: [],
-    });
-  } catch (error) {
-    if (!(error instanceof IllegalIssueLifecycleTransitionError) || !error.reason.startsWith("mixed blocked:*")) {
-      throw error;
-    }
+  // Mixed blocked:* labels → label state is ambiguous; /hitl must reconcile.
+  // A no-op-mutation probe through validateIssueLifecycleTransition cannot
+  // express this: the `requeue-mixed-blocked-refusal` marker edge is
+  // `to: "illegal"`, so a legal (non-mixed) label set finds no matching row and
+  // throws "no legal row" instead of passing — the regression that turned every
+  // non-mixed requeue into an IllegalIssueLifecycleTransitionError. Detect the
+  // ambiguous state directly instead.
+  if (blocked.length > 1) {
     return refuse(
-      `${error.reason}: label state is ambiguous — use /hitl to reconcile`,
+      `mixed blocked:* labels [${blocked.join(", ")}]: label state is ambiguous — use /hitl to reconcile`,
       true,
       activeBlocker,
       input.body,

--- a/apps/dev/tests/issue-lifecycle.test.ts
+++ b/apps/dev/tests/issue-lifecycle.test.ts
@@ -99,11 +99,14 @@ describe("issue lifecycle transition table", () => {
   it("rejects illegal transitions with an actionable edge name", () => {
     let thrown: unknown;
     try {
+      // `claim` normalizes any pre-active state INTO claimed/active, so it is the
+      // destination that constrains it: a claim that lands somewhere other than
+      // claimed/active (here ready-for-human) has no legal row.
       validateIssueLifecycleTransition({
         edge: "claim",
-        fromLabels: ["ready-for-human"],
-        removeLabels: ["ready-for-human"],
-        addLabels: ["running"],
+        fromLabels: ["ready-for-agent"],
+        removeLabels: ["ready-for-agent"],
+        addLabels: ["ready-for-human"],
       });
     } catch (error) {
       thrown = error;


### PR DESCRIPTION
Strict `validateIssueLifecycleTransition` was enforced without completing the transition table, so real runtime transitions threw and `red-workspace-ci` went red on main. Five sites, one root class (details in the commit). Full apps/dev suite green locally (3157/3157). Closes #1229.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785956889&installation_id=129708444&pr_number=1230&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1230&signature=937775cd04f5bc9ecbadeede5406be72f1928a1df2d4bf40ec1d5be660385a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->