### PR TITLE
merge: #1192 memory: deterministic recall ranking pipeline (RRF, recency decay, MMR, session round-robin)

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -1368,6 +1368,7 @@ async function runRecall(args: ParsedArgs): Promise<void> {
         includeSuperseded: args.flags["include-superseded"] === true,
         scope: scopeFlags(args.flags),
         now: asOf ? 0 : undefined,
+        ranking: config.recallRanking,
       });
       const hits = layerFiltersOut ? [] : rawHits;
       if (hits.length === 0) {
@@ -3012,6 +3013,7 @@ async function runRegistryCliOperation(
       {
         store: graphContext.store,
         rootDir,
+        memoryConfig: graphContext.config,
         providerConfig: graphContext.config?.provider,
         transportSurface: "cli",
       },
@@ -3652,7 +3654,13 @@ async function runServe(args: ParsedArgs): Promise<void> {
   if (tokenEnv && !token) throw new Error(`--token-env ${tokenEnv} is not set`);
 
   const { store, config } = await openGraphStore(args);
-  const server = createMemoryHttpServer({ rootDir, store, token, providerConfig: config.provider });
+  const server = createMemoryHttpServer({
+    rootDir,
+    store,
+    token,
+    memoryConfig: config,
+    providerConfig: config.provider,
+  });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(port, host, () => {

--- a/apps/memory/src/config.ts
+++ b/apps/memory/src/config.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { AiProviderConfig } from "./extract-conversation.js";
+import type { RecallRankingConfig } from "./recall-ranking.js";
 import { mergeMemoryBlock, parsePluginsMemory } from "./shared-config.js";
 
 /** Storage backends the `memory init` wizard can configure. */
@@ -67,6 +68,12 @@ export interface MemoryConfig {
     /** Per-session byte budget for L2 events. Default {@link DEFAULT_L2_BYTE_BUDGET} (16 MiB). */
     byteBudget?: number;
   };
+  /**
+   * Deterministic governed-recall ranking pipeline overrides. Defaults are
+   * documented in `DEFAULT_RECALL_RANKING_CONFIG`; this block stays sparse so
+   * config only records operator changes.
+   */
+  recallRanking?: Partial<RecallRankingConfig>;
   /**
    * AI provider for LLM conversation extraction (the `INFERRED` path). Absent
    * until the user configures one; when absent, only the deterministic

--- a/apps/memory/src/graph-recall.ts
+++ b/apps/memory/src/graph-recall.ts
@@ -11,8 +11,14 @@ import {
 } from "./code-curation.js";
 import { normalizeEngineeringCode } from "./extraction-schema.js";
 import type { MemoryStore } from "./graph-store.js";
-import { hybridRecall, type Ranking } from "./hybrid-recall.js";
+import type { Ranking } from "./hybrid-recall.js";
 import { appendEngineOpEvent } from "./memory-events.js";
+import {
+  buildRecallQueryVariants,
+  rankRecallCandidates,
+  resolveRecallRankingConfig,
+  type RecallRankingConfig,
+} from "./recall-ranking.js";
 
 /** One Envelope user-hook execution surfaced on an attempt hit (issue #216). */
 export interface GraphRecallHookEntry {
@@ -62,7 +68,12 @@ export async function graphRecall(
   store: RecallStore,
   query: string,
   limit = 10,
-  opts: { includeSuperseded?: boolean; scope?: RecallScope; now?: number } = {},
+  opts: {
+    includeSuperseded?: boolean;
+    scope?: RecallScope;
+    now?: number;
+    ranking?: Partial<RecallRankingConfig>;
+  } = {},
 ): Promise<GraphRecallHit[]> {
   return (await graphRecallResult(store, query, limit, opts)).hits;
 }
@@ -75,15 +86,22 @@ export async function graphRecallResult(
   store: RecallStore,
   query: string,
   limit = 10,
-  opts: { includeSuperseded?: boolean; scope?: RecallScope; now?: number } = {},
+  opts: {
+    includeSuperseded?: boolean;
+    scope?: RecallScope;
+    now?: number;
+    ranking?: Partial<RecallRankingConfig>;
+  } = {},
 ): Promise<GraphRecallResult> {
+  const now = opts.now ?? Date.now();
+  const rankingConfig = resolveRecallRankingConfig(opts.ranking);
   const codeCanonicalize = await loadCodeCanonicalizer(store);
   const { nodes, diagnostics } = await recall(store, query, {
     k: limit,
     depth: 1,
     includeSuperseded: opts.includeSuperseded,
     scope: opts.scope,
-    now: opts.now,
+    now,
     codeCanonicalize,
   });
 
@@ -104,17 +122,31 @@ export async function graphRecallResult(
   const candidates = new Map<number, RecalledNode>();
   for (const node of nodes) candidates.set(node.rid, node);
 
-  const rankings: Ranking[] = [
-    { source: "keyword", rids: await keywordRanking(store, query, limit, candidates) },
-    { source: "vector", rids: await vectorRanking(store, query, limit, candidates) },
-    { source: "graph", rids: graphRanking(nodes) },
-  ];
+  const rankings: Ranking[] = [];
+  const variants = buildRecallQueryVariants(query, rankingConfig.queryVariantLimit);
+  for (const variant of variants) {
+    rankings.push({
+      source: `keyword:${variant}`,
+      rids: await keywordRanking(store, variant, limit, candidates),
+    });
+    rankings.push({
+      source: `vector:${variant}`,
+      rids: await vectorRanking(store, variant, limit, candidates),
+    });
+  }
+  rankings.push({ source: "graph", rids: graphRanking(nodes) });
 
-  const fused = hybridRecall(rankings);
+  const ranked = rankRecallCandidates({
+    query,
+    candidates: nodes,
+    rankings,
+    limit,
+    now,
+    config: rankingConfig,
+  });
   const hits: GraphRecallHit[] = [];
-  for (const entry of fused) {
-    const node = candidates.get(entry.rid);
-    if (!node) continue;
+  for (const entry of ranked) {
+    const node = entry.node;
     const hooks = extractHookEntries(node.properties.hooks);
     hits.push({
       id: String(node.rid),

--- a/apps/memory/src/http-server.ts
+++ b/apps/memory/src/http-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { MemoryStore } from "./graph-store.js";
+import type { MemoryConfig } from "./config.js";
 import type { AiProviderConfig } from "./extract-conversation.js";
 import { recall } from "./engine.js";
 import {
@@ -30,6 +31,7 @@ export interface MemoryHttpServerOptions {
   store: MemoryStore;
   token?: string;
   now?: number;
+  memoryConfig?: MemoryConfig;
   providerConfig?: AiProviderConfig;
 }
 
@@ -257,6 +259,7 @@ async function handleRegistryHttpOperation(
         store: opts.store,
         rootDir: opts.rootDir,
         now: opts.now,
+        memoryConfig: opts.memoryConfig,
         providerConfig: opts.providerConfig,
         transportSurface: "http",
       },

--- a/apps/memory/src/operations.ts
+++ b/apps/memory/src/operations.ts
@@ -116,7 +116,9 @@ import {
   type DocSearchViewerArtifact,
 } from "./doc-search-viewer.js";
 import { ask, type AskResult } from "./engine.js";
+import type { MemoryConfig } from "./config.js";
 import type { AiProviderConfig } from "./extract-conversation.js";
+import { graphRecallResult, type GraphRecallResult } from "./graph-recall.js";
 import {
   buildMemoryExtractionStatus,
   type MemoryExtractionStatus,
@@ -394,6 +396,7 @@ export interface MemoryOperationContext {
   store: MemoryStore;
   rootDir?: string;
   now?: number;
+  memoryConfig?: MemoryConfig;
   providerConfig?: AiProviderConfig;
   transportSurface?: string;
 }
@@ -545,6 +548,13 @@ const SmartSearchInputSchema = ScopeInputSchema.extend({
   include_superseded: z.boolean().default(false),
 });
 type SmartSearchInput = z.infer<typeof SmartSearchInputSchema>;
+
+const RecallRankingInputSchema = ScopeInputSchema.extend({
+  query: z.string().min(1),
+  limit: z.number().int().min(1).max(50).optional(),
+  include_superseded: z.boolean().default(false),
+});
+type RecallRankingInput = z.infer<typeof RecallRankingInputSchema>;
 
 const PrePrReviewInputSchema = z.object({
   changed_files: z.array(z.string().min(1)).optional(),
@@ -884,6 +894,7 @@ const DocRelatedOutputSchema = objectOutputSchema<DocRelatedReport>();
 const DocRelatedViewerOutputSchema = objectOutputSchema<DocRelatedViewerArtifact>();
 const DocSearchOutputSchema = objectOutputSchema<DocSearchReport>();
 const DocCoverageOutputSchema = objectOutputSchema<DocCoverageReport>();
+const RecallRankingOutputSchema = objectOutputSchema<GraphRecallResult>();
 const SmartSearchOutputSchema = objectOutputSchema<MemorySmartSearchReport>();
 const SmartSearchViewerOutputSchema =
   objectOutputSchema<MemorySmartSearchViewerArtifact>();
@@ -1277,6 +1288,15 @@ const MEMORY_OPERATION_FACETS: Record<string, MemoryOperationFacets> = {
     joinedPositionalInput("query", [
       flagField("limit", "number"),
       flagField("cache", "string"),
+    ]),
+    JSON_REPORT_OUTPUT,
+  ),
+  ...operationFacets(
+    ["memory.recall-ranking"],
+    joinedPositionalInput("query", [
+      flagField("limit", "number"),
+      flagField("include_superseded", "boolean"),
+      ...SCOPE_INPUT_FIELDS,
     ]),
     JSON_REPORT_OUTPUT,
   ),
@@ -2933,6 +2953,36 @@ const GLOBAL_SEARCH_OPERATION: MemoryOperationDefinition<
     }),
 };
 
+const RECALL_RANKING_OPERATION: MemoryOperationDefinition<
+  RecallRankingInput,
+  GraphRecallResult
+> = {
+  id: "memory.recall-ranking",
+  title: "Memory recall ranking",
+  description:
+    "Read-only governed recall through the deterministic ranking pipeline: candidate retrieval, query-variant RRF, recency decay, MMR diversity, and session round-robin interleaving.",
+  inputSchema: RecallRankingInputSchema,
+  outputSchema: RecallRankingOutputSchema,
+  safetyClass: "read-only",
+  sideEffectClass: "none",
+  capabilities: ["graph-store"],
+  renderer: {
+    cli: { command: "recall-ranked", supportsJson: true },
+    mcp: {
+      toolName: "memory_recall_ranked",
+      description:
+        "Read-only governed recall through the deterministic ranking pipeline. Returns ranked hits plus diagnostics; uses plugins.memory.recallRanking defaults and overrides when available.",
+    },
+  },
+  execute: (ctx, input) =>
+    graphRecallResult(ctx.store, input.query, input.limit ?? 10, {
+      includeSuperseded: input.include_superseded,
+      scope: scopeFromInput(input),
+      now: ctx.now,
+      ranking: ctx.memoryConfig?.recallRanking,
+    }),
+};
+
 const ONBOARDING_MAP_OPERATION: MemoryOperationDefinition<OnboardingMapInput, OnboardingMap> = {
   id: "memory.onboarding-map",
   title: "Memory onboarding map",
@@ -3516,6 +3566,7 @@ const READ_ONLY_OPERATIONS = createReadOnlyMemoryOperationRegistry([
   COMMUNITIES_VIEWER_OPERATION,
   COMMUNITY_DIGEST_OPERATION,
   GLOBAL_SEARCH_OPERATION,
+  RECALL_RANKING_OPERATION,
   REFERENCE_RADAR_OPERATION,
   CONTEXT_PACK_OPERATION,
   CONTEXT_PACK_VIEWER_OPERATION,

--- a/apps/memory/src/recall-ranking.ts
+++ b/apps/memory/src/recall-ranking.ts
@@ -1,0 +1,225 @@
+import { RRF_K, hybridRecall, type Ranking } from "./hybrid-recall.js";
+import type { RecalledNode } from "./engine.js";
+import { tokenize } from "./recall.js";
+
+export interface RecallRankingConfig {
+  /** RRF smoothing constant. Default: 60. */
+  rrfK: number;
+  /** Half-life for exponential recency decay. Default: 30 days. */
+  recencyHalfLifeDays: number;
+  /** Relevance-vs-diversity balance for MMR. Default: 0.72. */
+  mmrLambda: number;
+  /** Number of deterministic query variants to ask each retrieval channel for. Default: 4. */
+  queryVariantLimit: number;
+  /** Whether to interleave final hits by session id. Default: true. */
+  sessionRoundRobin: boolean;
+}
+
+export const DEFAULT_RECALL_RANKING_CONFIG: RecallRankingConfig = {
+  rrfK: RRF_K,
+  recencyHalfLifeDays: 30,
+  mmrLambda: 0.72,
+  queryVariantLimit: 4,
+  sessionRoundRobin: true,
+};
+
+export interface RecallRankingInput {
+  query: string;
+  candidates: readonly RecalledNode[];
+  rankings: readonly Ranking[];
+  limit: number;
+  now?: number;
+  config?: Partial<RecallRankingConfig>;
+}
+
+export interface RankedRecallCandidate {
+  node: RecalledNode;
+  score: number;
+  rrfScore: number;
+  recencyMultiplier: number;
+  mmrScore: number;
+}
+
+export function resolveRecallRankingConfig(
+  config: Partial<RecallRankingConfig> | null | undefined,
+): RecallRankingConfig {
+  const defaults = DEFAULT_RECALL_RANKING_CONFIG;
+  return {
+    rrfK: positive(config?.rrfK) ?? defaults.rrfK,
+    recencyHalfLifeDays: positive(config?.recencyHalfLifeDays) ?? defaults.recencyHalfLifeDays,
+    mmrLambda: unit(config?.mmrLambda) ?? defaults.mmrLambda,
+    queryVariantLimit: positiveInteger(config?.queryVariantLimit) ?? defaults.queryVariantLimit,
+    sessionRoundRobin:
+      typeof config?.sessionRoundRobin === "boolean"
+        ? config.sessionRoundRobin
+        : defaults.sessionRoundRobin,
+  };
+}
+
+export function buildRecallQueryVariants(
+  query: string,
+  limit = DEFAULT_RECALL_RANKING_CONFIG.queryVariantLimit,
+): string[] {
+  const normalized = query.trim().replace(/\s+/g, " ");
+  if (!normalized) return [];
+  const variants: string[] = [normalized];
+  const tokens = tokenize(normalized);
+  if (tokens.length > 1) variants.push(tokens.join(" "));
+  for (const token of tokens) {
+    if (token.length >= 4) variants.push(token);
+  }
+  return unique(variants).slice(0, Math.max(1, limit));
+}
+
+export function rankRecallCandidates(input: RecallRankingInput): RankedRecallCandidate[] {
+  const config = resolveRecallRankingConfig(input.config);
+  const now = input.now ?? Date.now();
+  const candidates = new Map<number, RecalledNode>();
+  for (const node of input.candidates) candidates.set(node.rid, node);
+  if (candidates.size === 0 || input.limit <= 0) return [];
+
+  const rankings = input.rankings.length > 0
+    ? input.rankings
+    : [{ source: "candidate", rids: input.candidates.map((node) => node.rid) }];
+  const fused = hybridRecall([...rankings], { k: config.rrfK });
+  const fusedRids = new Set(fused.map((hit) => hit.rid));
+  const baseOrder = input.candidates.map((node) => node.rid).filter((rid) => !fusedRids.has(rid));
+  const completeFused = baseOrder.length > 0
+    ? [
+        ...fused,
+        ...hybridRecall([{ source: "candidate", rids: baseOrder }], { k: config.rrfK }),
+      ]
+    : fused;
+
+  const scored: RankedRecallCandidate[] = [];
+  for (const hit of completeFused) {
+    const node = candidates.get(hit.rid);
+    if (!node) continue;
+    const recencyMultiplier = recencyDecay(node, now, config.recencyHalfLifeDays);
+    const score = hit.score * recencyMultiplier;
+    scored.push({ node, score, rrfScore: hit.score, recencyMultiplier, mmrScore: score });
+  }
+  scored.sort((a, b) => b.score - a.score || a.node.rid - b.node.rid);
+
+  const diversified = mmr(scored, config.mmrLambda, input.limit);
+  const finalOrder = config.sessionRoundRobin ? roundRobinBySession(diversified) : diversified;
+  return finalOrder.slice(0, input.limit);
+}
+
+function mmr(
+  candidates: readonly RankedRecallCandidate[],
+  lambda: number,
+  limit: number,
+): RankedRecallCandidate[] {
+  const remaining = [...candidates];
+  const selected: RankedRecallCandidate[] = [];
+  while (remaining.length > 0 && selected.length < limit) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+    for (let i = 0; i < remaining.length; i++) {
+      const candidate = remaining[i]!;
+      const maxSimilarity = selected.reduce(
+        (max, chosen) => Math.max(max, similarity(candidate.node, chosen.node)),
+        0,
+      );
+      const mmrScore = lambda * candidate.score - (1 - lambda) * maxSimilarity;
+      if (
+        mmrScore > bestScore ||
+        (mmrScore === bestScore && candidate.node.rid < remaining[bestIndex]!.node.rid)
+      ) {
+        bestIndex = i;
+        bestScore = mmrScore;
+      }
+    }
+    const [chosen] = remaining.splice(bestIndex, 1);
+    selected.push({ ...chosen!, mmrScore: bestScore });
+  }
+  return selected;
+}
+
+function roundRobinBySession(
+  candidates: readonly RankedRecallCandidate[],
+): RankedRecallCandidate[] {
+  const groups = new Map<string, RankedRecallCandidate[]>();
+  for (const candidate of candidates) {
+    const key = sessionKey(candidate.node);
+    groups.set(key, [...(groups.get(key) ?? []), candidate]);
+  }
+  const orderedKeys = [...groups.entries()]
+    .sort((a, b) => b[1]![0]!.mmrScore - a[1]![0]!.mmrScore || a[0].localeCompare(b[0]))
+    .map(([key]) => key);
+  const out: RankedRecallCandidate[] = [];
+  while (out.length < candidates.length) {
+    let progressed = false;
+    for (const key of orderedKeys) {
+      const next = groups.get(key)?.shift();
+      if (!next) continue;
+      out.push(next);
+      progressed = true;
+    }
+    if (!progressed) break;
+  }
+  return out;
+}
+
+function recencyDecay(node: RecalledNode, now: number, halfLifeDays: number): number {
+  const halfLifeMs = halfLifeDays * 86_400_000;
+  const ts = latestTimestamp(node);
+  const ageMs = Math.max(0, now - ts);
+  return 0.5 ** (ageMs / halfLifeMs);
+}
+
+function latestTimestamp(node: RecalledNode): number {
+  const p = node.properties;
+  return Math.max(p.accessed_at ?? 0, p.updated_at ?? 0, p.created_at ?? 0);
+}
+
+function similarity(a: RecalledNode, b: RecalledNode): number {
+  const left = textTokens(a);
+  const right = textTokens(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let intersection = 0;
+  for (const token of left) if (right.has(token)) intersection++;
+  return intersection / (left.size + right.size - intersection);
+}
+
+function textTokens(node: RecalledNode): Set<string> {
+  const p = node.properties;
+  const tags = Array.isArray(p.tags) ? p.tags.join(" ") : "";
+  return new Set(tokenize([node.label, p.title, p.summary, p.content, tags].filter(Boolean).join(" ")));
+}
+
+function sessionKey(node: RecalledNode): string {
+  const p = node.properties;
+  const explicit = p.session_id ?? p.sessionId ?? p.session;
+  if (typeof explicit === "string" && explicit) return explicit;
+  if (p.scope === "session" && typeof p.scope_id === "string" && p.scope_id) return p.scope_id;
+  const provenanceScope = p.provenance?.scope;
+  if (provenanceScope?.level === "session" && provenanceScope.id) return provenanceScope.id;
+  return `rid:${node.rid}`;
+}
+
+function positive(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function unit(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1
+    ? value
+    : undefined;
+}
+
+function unique(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}

--- a/apps/memory/src/shared-config.ts
+++ b/apps/memory/src/shared-config.ts
@@ -16,6 +16,7 @@
  */
 
 import type { AiProviderConfig } from "./extract-conversation.js";
+import { DEFAULT_RECALL_RANKING_CONFIG } from "./recall-ranking.js";
 import {
   CONFIG_VERSION,
   DEFAULT_MEMORY_EVENT_RETENTION_DAYS,
@@ -126,6 +127,23 @@ export function parsePluginsMemory(text: string): MemoryConfig | null {
   if (Number.isFinite(byteBudget) && byteBudget > 0) l2.byteBudget = byteBudget;
   if (l2.ttlMs !== undefined || l2.byteBudget !== undefined) config.l2 = l2;
 
+  const rankingRrfK = Number(flat[`${p}recallRanking.rrfK`]);
+  const rankingHalfLife = Number(flat[`${p}recallRanking.recencyHalfLifeDays`]);
+  const rankingMmrLambda = Number(flat[`${p}recallRanking.mmrLambda`]);
+  const rankingVariantLimit = Number(flat[`${p}recallRanking.queryVariantLimit`]);
+  const rankingRoundRobin = flat[`${p}recallRanking.sessionRoundRobin`];
+  const recallRanking: NonNullable<MemoryConfig["recallRanking"]> = {};
+  if (Number.isFinite(rankingRrfK) && rankingRrfK > 0) recallRanking.rrfK = rankingRrfK;
+  if (Number.isFinite(rankingHalfLife) && rankingHalfLife > 0)
+    recallRanking.recencyHalfLifeDays = rankingHalfLife;
+  if (Number.isFinite(rankingMmrLambda) && rankingMmrLambda >= 0 && rankingMmrLambda <= 1)
+    recallRanking.mmrLambda = rankingMmrLambda;
+  if (Number.isInteger(rankingVariantLimit) && rankingVariantLimit > 0)
+    recallRanking.queryVariantLimit = rankingVariantLimit;
+  if (rankingRoundRobin === "true" || rankingRoundRobin === "false")
+    recallRanking.sessionRoundRobin = rankingRoundRobin === "true";
+  if (Object.keys(recallRanking).length > 0) config.recallRanking = recallRanking;
+
   const provider: Record<string, string> = {};
   for (const [k, v] of Object.entries(flat)) {
     const m = k.startsWith(`${p}provider.`) ? k.slice(`${p}provider.`.length) : undefined;
@@ -180,6 +198,41 @@ export function emitMemoryBlockLines(config: MemoryConfig): string[] {
       sub.push(`      byteBudget: ${config.l2.byteBudget}`);
     if (sub.length > 0) {
       lines.push("    l2:");
+      lines.push(...sub);
+    }
+  }
+
+  if (config.recallRanking) {
+    const sub: string[] = [];
+    const defaults = DEFAULT_RECALL_RANKING_CONFIG;
+    if (config.recallRanking.rrfK !== undefined && config.recallRanking.rrfK !== defaults.rrfK)
+      sub.push(`      rrfK: ${config.recallRanking.rrfK}`);
+    if (
+      config.recallRanking.recencyHalfLifeDays !== undefined &&
+      config.recallRanking.recencyHalfLifeDays !== defaults.recencyHalfLifeDays
+    ) {
+      sub.push(`      recencyHalfLifeDays: ${config.recallRanking.recencyHalfLifeDays}`);
+    }
+    if (
+      config.recallRanking.mmrLambda !== undefined &&
+      config.recallRanking.mmrLambda !== defaults.mmrLambda
+    ) {
+      sub.push(`      mmrLambda: ${config.recallRanking.mmrLambda}`);
+    }
+    if (
+      config.recallRanking.queryVariantLimit !== undefined &&
+      config.recallRanking.queryVariantLimit !== defaults.queryVariantLimit
+    ) {
+      sub.push(`      queryVariantLimit: ${config.recallRanking.queryVariantLimit}`);
+    }
+    if (
+      config.recallRanking.sessionRoundRobin !== undefined &&
+      config.recallRanking.sessionRoundRobin !== defaults.sessionRoundRobin
+    ) {
+      sub.push(`      sessionRoundRobin: ${config.recallRanking.sessionRoundRobin}`);
+    }
+    if (sub.length > 0) {
+      lines.push("    recallRanking:");
       lines.push(...sub);
     }
   }

--- a/apps/memory/tests/recall-ranking.test.ts
+++ b/apps/memory/tests/recall-ranking.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "vitest";
+import type { RecalledNode } from "../src/engine.js";
+import type { StoredNode } from "../src/graph-store.js";
+import {
+  executeReadOnlyMemoryOperation,
+  getReadOnlyMemoryOperation,
+} from "../src/operations.js";
+import {
+  buildRecallQueryVariants,
+  rankRecallCandidates,
+} from "../src/recall-ranking.js";
+
+const NOW = Date.UTC(2026, 6, 6);
+const DAY = 86_400_000;
+
+function node(
+  rid: number,
+  label: string,
+  summary: string,
+  opts: {
+    daysOld?: number;
+    session?: string;
+    score?: number;
+  } = {},
+): RecalledNode {
+  return {
+    rid,
+    label,
+    node_type: "decision",
+    score: opts.score ?? 1,
+    depth: 0,
+    excerpt: summary,
+    properties: {
+      title: label,
+      summary,
+      content: summary,
+      created_at: NOW - (opts.daysOld ?? 0) * DAY,
+      updated_at: NOW - (opts.daysOld ?? 0) * DAY,
+      scope: opts.session ? "session" : "project",
+      ...(opts.session ? { scope_id: opts.session, session_id: opts.session } : {}),
+    },
+  };
+}
+
+describe("recall ranking pipeline", () => {
+  test("query variants are deterministic and bounded", () => {
+    expect(buildRecallQueryVariants("cache invalidation pipeline", 3)).toEqual([
+      "cache invalidation pipeline",
+      "cache",
+      "invalidation",
+    ]);
+  });
+
+  test("golden ordering shows RRF, recency decay, MMR, and session round-robin contributions", () => {
+    const freshFusion = node(
+      1,
+      "cache invalidation pipeline canonical",
+      "cache invalidation ranking pipeline keeps the current deterministic decision",
+      { session: "s1" },
+    );
+    const singleQueryLeader = node(
+      2,
+      "cache invalidation one channel",
+      "cache invalidation result that only the full query ranks first",
+      { session: "s1" },
+    );
+    const diverseSession = node(
+      3,
+      "ttl eviction session",
+      "ttl eviction policy documents a different session angle for recall ranking",
+      { session: "s2" },
+    );
+    const staleDuplicate = node(
+      4,
+      "cache invalidation pipeline stale duplicate",
+      "cache invalidation ranking pipeline keeps the current deterministic decision",
+      { daysOld: 120, session: "s1" },
+    );
+    const nearDuplicate = node(
+      5,
+      "cache invalidation pipeline near duplicate",
+      "cache invalidation ranking pipeline repeats the same current deterministic decision",
+      { session: "s1" },
+    );
+
+    const candidates = [
+      freshFusion,
+      singleQueryLeader,
+      diverseSession,
+      staleDuplicate,
+      nearDuplicate,
+    ];
+
+    const singleQueryOnly = rankRecallCandidates({
+      query: "cache invalidation pipeline",
+      candidates,
+      rankings: [{ source: "query:full", rids: [2, 1, 4, 5, 3] }],
+      limit: 5,
+      now: NOW,
+      config: { sessionRoundRobin: false },
+    });
+    expect(singleQueryOnly[0]!.node.rid).toBe(2);
+
+    const fused = rankRecallCandidates({
+      query: "cache invalidation pipeline",
+      candidates,
+      rankings: [
+        { source: "query:full", rids: [2, 1, 4, 5, 3] },
+        { source: "query:cache", rids: [1, 4, 5, 2, 3] },
+        { source: "query:pipeline", rids: [1, 5, 4, 2, 3] },
+      ],
+      limit: 5,
+      now: NOW,
+    });
+
+    expect(fused.map((hit) => hit.node.rid)).toEqual([1, 3, 2, 5, 4]);
+    expect(fused[0]!.rrfScore).toBeGreaterThan(singleQueryOnly[0]!.rrfScore);
+    expect(fused.find((hit) => hit.node.rid === 4)!.recencyMultiplier).toBeLessThan(0.07);
+
+    const noDiversity = rankRecallCandidates({
+      query: "cache invalidation pipeline",
+      candidates,
+      rankings: [
+        { source: "query:full", rids: [2, 1, 4, 5, 3] },
+        { source: "query:cache", rids: [1, 4, 5, 2, 3] },
+        { source: "query:pipeline", rids: [1, 5, 4, 2, 3] },
+      ],
+      limit: 5,
+      now: NOW,
+      config: { mmrLambda: 1, sessionRoundRobin: false },
+    });
+    expect(noDiversity.findIndex((hit) => hit.node.rid === 5)).toBeLessThan(
+      noDiversity.findIndex((hit) => hit.node.rid === 3),
+    );
+
+    const noRoundRobin = rankRecallCandidates({
+      query: "cache invalidation pipeline",
+      candidates,
+      rankings: [
+        { source: "query:full", rids: [2, 1, 4, 5, 3] },
+        { source: "query:cache", rids: [1, 4, 5, 2, 3] },
+        { source: "query:pipeline", rids: [1, 5, 4, 2, 3] },
+      ],
+      limit: 5,
+      now: NOW,
+      config: { sessionRoundRobin: false },
+    });
+    expect(noRoundRobin.findIndex((hit) => hit.node.rid === 3)).toBeLessThan(
+      noRoundRobin.findIndex((hit) => hit.node.rid === 5),
+    );
+
+    const roundRobinOnly = rankRecallCandidates({
+      query: "cache invalidation pipeline",
+      candidates,
+      rankings: [
+        { source: "query:full", rids: [2, 1, 4, 5, 3] },
+        { source: "query:cache", rids: [1, 4, 5, 2, 3] },
+        { source: "query:pipeline", rids: [1, 5, 4, 2, 3] },
+      ],
+      limit: 5,
+      now: NOW,
+      config: { mmrLambda: 1 },
+    });
+    expect(noDiversity.map((hit) => hit.node.rid).slice(0, 2)).toEqual([1, 2]);
+    expect(roundRobinOnly.map((hit) => hit.node.rid).slice(0, 3)).toEqual([1, 3, 2]);
+  });
+
+  test("recall ranking is registered as a MemoryOperation and runs through the registry seam", async () => {
+    const storeNodes: StoredNode[] = [
+      node(1, "cache pipeline canonical", "cache pipeline current", { session: "s1" }),
+      node(2, "cache single query", "cache only full query", { session: "s1" }),
+      node(3, "pipeline other session", "pipeline alternative session", { session: "s2" }),
+    ].map((candidate) => ({
+      rid: candidate.rid,
+      label: candidate.label,
+      node_type: candidate.node_type,
+      properties: { ...candidate.properties, scope: "project" },
+    }));
+    const searchRows = (query: string) => {
+      if (query === "cache pipeline") return [{ rid: 2, score: 1 }, { rid: 1, score: 0.9 }];
+      if (query === "cache") return [{ rid: 1, score: 1 }, { rid: 2, score: 0.9 }];
+      if (query === "pipeline") return [{ rid: 1, score: 1 }, { rid: 3, score: 0.9 }];
+      return [];
+    };
+    const fakeStore = {
+      listNodes: async () => storeNodes,
+      searchText: async (query: string) => searchRows(query),
+      searchVector: async () => [],
+      listEdges: async () => [],
+      neighborhood: async () => [],
+      supersededByMany: async () => new Map<number, number>(),
+    };
+
+    expect(getReadOnlyMemoryOperation("memory.recall-ranking").renderer.cli.command).toBe(
+      "recall-ranked",
+    );
+
+    const result = await executeReadOnlyMemoryOperation(
+      "memory.recall-ranking",
+      {
+        store: fakeStore as never,
+        now: NOW,
+        memoryConfig: { recallRanking: { sessionRoundRobin: false } } as never,
+      },
+      { query: "cache pipeline", limit: 3 },
+    );
+
+    expect((result as { hits: Array<{ rid: number }> }).hits.map((hit) => hit.rid)).toEqual([
+      1,
+      2,
+      3,
+    ]);
+  });
+});

--- a/apps/memory/tests/shared-config.test.ts
+++ b/apps/memory/tests/shared-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { CONFIG_VERSION, DEFAULT_NOTES_DIR } from "../src/config.js";
 import { graphConfig, markdownOnlyConfig } from "../src/init.js";
+import { DEFAULT_RECALL_RANKING_CONFIG } from "../src/recall-ranking.js";
 import {
   emitMemoryBlockLines,
   mergeMemoryBlock,
@@ -48,6 +49,28 @@ describe("parsePluginsMemory", () => {
     });
   });
 
+  test("reads deterministic recall-ranking overrides", () => {
+    const text = [
+      "plugins:",
+      "  memory:",
+      "    mode: graph",
+      "    recallRanking:",
+      "      rrfK: 42",
+      "      recencyHalfLifeDays: 14",
+      "      mmrLambda: 0.6",
+      "      queryVariantLimit: 3",
+      "      sessionRoundRobin: false",
+      "",
+    ].join("\n");
+    expect(parsePluginsMemory(text)?.recallRanking).toEqual({
+      rrfK: 42,
+      recencyHalfLifeDays: 14,
+      mmrLambda: 0.6,
+      queryVariantLimit: 3,
+      sessionRoundRobin: false,
+    });
+  });
+
   test("returns null when there is no plugins.memory block", () => {
     expect(parsePluginsMemory("")).toBeNull();
     expect(parsePluginsMemory("plugins:\n  dev:\n    afk:\n      default_runner: codex\n")).toBeNull();
@@ -77,6 +100,27 @@ describe("emitMemoryBlockLines (sparse)", () => {
     expect(lines.join("\n")).not.toContain("reddb:");
     expect(lines.join("\n")).not.toContain("version:");
     expect(lines.join("\n")).not.toContain("storePath:"); // default → omitted
+  });
+
+  test("recall-ranking defaults stay sparse and overrides emit", () => {
+    const defaults = emitMemoryBlockLines({
+      ...graphConfig(),
+      recallRanking: { ...DEFAULT_RECALL_RANKING_CONFIG },
+    }).join("\n");
+    expect(defaults).not.toContain("recallRanking:");
+
+    const lines = emitMemoryBlockLines({
+      ...graphConfig(),
+      recallRanking: {
+        recencyHalfLifeDays: 14,
+        mmrLambda: 0.6,
+        sessionRoundRobin: false,
+      },
+    });
+    expect(lines).toContain("    recallRanking:");
+    expect(lines).toContain("      recencyHalfLifeDays: 14");
+    expect(lines).toContain("      mmrLambda: 0.6");
+    expect(lines).toContain("      sessionRoundRobin: false");
   });
 });
 

--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -435,12 +435,15 @@ transcripts.
 - **graph** — governed operational memory over a per-project embedded RedDB store
   at `.red/memory/graph.rdb`. `/memory:store` upserts a deduped operational fact;
   `/memory:recall` runs the governed recall engine — deterministic text seeds
-  expanded through the graph neighborhood, then ranked by `importance × recency ×
-  graph-centrality × tier-weight` (durable decisions outrank reasoning traces
-  outrank ephemeral session noise), with the head of any `SUPERSEDED_BY` chain
-  returned in place of superseded nodes (`--include-superseded` returns the full
-  chain). Vector projections can contribute when explicitly ready, but they are
-  not the source of truth. RedDB runs out-of-process from the
+  expanded through the graph neighborhood, then passed through a deterministic
+  ranking pipeline: query-variant RRF, exponential recency decay, MMR diversity,
+  and session round-robin interleaving. Defaults are `rrfK: 60`,
+  `recencyHalfLifeDays: 30`, `mmrLambda: 0.72`, `queryVariantLimit: 4`, and
+  `sessionRoundRobin: true`; override them sparsely under
+  `plugins.memory.recallRanking` in `.red/config.yaml`. The head of any
+  `SUPERSEDED_BY` chain is returned in place of superseded nodes
+  (`--include-superseded` returns the full chain). Vector projections can
+  contribute when explicitly ready, but they are not the source of truth. RedDB runs out-of-process from the
   SDK's bundled binary — no service to manage. Graph writes use multi-model DML
   and KV-backed dedupe; see [ADR 0007](../../.red/adr/0007-reddb-graph-writes-via-multi-model-dml.md).
 


### PR DESCRIPTION
Automated AFK landing for #1192. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1192

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785958409&installation_id=129708444&pr_number=1232&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1232&signature=6c90646aae46a75587b5fc075cfe4af0c12eb6658608afdff51ddd2fbef4a2ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable recall ranking for memory search, with more deterministic and diverse result ordering.
  * Introduced a new read-only recall-ranking operation and exposed it through the CLI and HTTP server.
  * Added support for overriding recall-ranking settings in app configuration.

* **Bug Fixes**
  * Improved recall result ordering consistency and ensured configuration is applied across registry-backed and HTTP-triggered operations.

* **Documentation**
  * Updated the memory README with the new ranking behavior, defaults, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->