### PR TITLE
merge: #1193 memory: provenance promote-gate on extract (oracle vs proxy)

### DIFF
--- a/apps/memory/src/engine.ts
+++ b/apps/memory/src/engine.ts
@@ -21,6 +21,7 @@ import {
   type MemoryNodeProps,
   type MemoryScope,
   type NodeType,
+  type ProvenanceTier,
   type Tier,
 } from "./schema.js";
 
@@ -152,6 +153,11 @@ export const TRUST_WEIGHT: Record<Confidence, number> = {
   AMBIGUOUS: 0.65,
 };
 
+export const PROVENANCE_TIER_WEIGHT: Record<ProvenanceTier, number> = {
+  oracle: 1.15,
+  proxy: 1.0,
+};
+
 /** Recency half-life: a node's recency factor halves every 30 days of age. */
 export const RECENCY_HALF_LIFE_MS = 30 * 86_400_000;
 
@@ -170,6 +176,8 @@ export interface RankInputs {
   maxDegree: number;
   /** Provenance/confidence trust multiplier in (0, 1]. */
   trust?: number;
+  /** Authority tier multiplier. Missing legacy rows are scored as proxy. */
+  provenanceTier?: ProvenanceTier;
 }
 
 /**
@@ -182,7 +190,16 @@ export interface RankInputs {
 export function rankScore(i: RankInputs): number {
   const recency = 0.5 ** (Math.max(0, i.ageMs) / RECENCY_HALF_LIFE_MS);
   const centrality = (i.degree + 1) / (i.maxDegree + 1);
-  return i.relevance * i.importance * recency * centrality * TIER_WEIGHT[i.tier] * (i.trust ?? 1);
+  const provenanceTier = i.provenanceTier ?? "proxy";
+  return (
+    i.relevance *
+    i.importance *
+    recency *
+    centrality *
+    TIER_WEIGHT[i.tier] *
+    PROVENANCE_TIER_WEIGHT[provenanceTier] *
+    (i.trust ?? 1)
+  );
 }
 
 export interface AskResult {
@@ -707,6 +724,7 @@ export async function recall(
       degree: degree.get(rid) ?? 0,
       maxDegree,
       trust: trustWeight(node),
+      provenanceTier: node.properties.provenance_tier ?? "proxy",
     });
     const recalled = toRecalled(node, score, depthOf.get(rid));
     attachConfidence(recalled, node, confidenceCtx);

--- a/apps/memory/src/extract-conversation.ts
+++ b/apps/memory/src/extract-conversation.ts
@@ -416,6 +416,7 @@ export function factsToGraph(facts: ExtractedFact[], source = "conversation"): I
         tags: f.tags,
         source,
         confidence: "INFERRED" as const,
+        provenance_tier: "proxy" as const,
         structural_type: resolution.structuralType,
         engineering_code: resolution.engineeringCode ?? f.node_type,
         hash: contentHash(f.label, f.node_type, f.title, f.summary ?? ""),

--- a/apps/memory/src/graph-contract.ts
+++ b/apps/memory/src/graph-contract.ts
@@ -50,6 +50,8 @@ export interface ContractNode {
   source_location: string | null;
   /** Write provenance as stored by Memory; null when unavailable. */
   provenance: Record<string, unknown> | null;
+  /** Authority tier for ranking/governance; null when unavailable on legacy rows. */
+  provenance_tier: "oracle" | "proxy" | null;
   /** Freshness timestamps and retention horizon, in epoch ms when available. */
   freshness: ContractFreshness;
   /** Node salience signal for ranking/filtering; null when unavailable. */
@@ -81,6 +83,8 @@ export interface ContractEdge {
   source_location: string | null;
   /** Write provenance as stored by Memory; null when unavailable. */
   provenance: Record<string, unknown> | null;
+  /** Authority tier for ranking/governance; null when unavailable on legacy rows. */
+  provenance_tier: "oracle" | "proxy" | null;
   /** Freshness timestamps and retention horizon, in epoch ms when available. */
   freshness: ContractFreshness;
   /** Edges are directed; `source → target` is the semantic direction. */
@@ -143,6 +147,7 @@ const PROMOTED_NODE_PROPS = new Set([
   "source",
   "source_location",
   "provenance",
+  "provenance_tier",
   "created_at",
   "updated_at",
   "accessed_at",
@@ -156,6 +161,7 @@ const PROMOTED_EDGE_PROPS = new Set([
   "source",
   "source_location",
   "provenance",
+  "provenance_tier",
   "created_at",
   "updated_at",
   "expires_at",
@@ -206,6 +212,11 @@ function confidenceValue(props: Record<string, unknown>): string | null {
   return stringValue(props.confidence) ?? stringValue(provenance?.confidence);
 }
 
+function provenanceTierValue(props: Record<string, unknown>): "oracle" | "proxy" | null {
+  const value = props.provenance_tier;
+  return value === "oracle" || value === "proxy" ? value : null;
+}
+
 function sourceLocation(props: Record<string, unknown>): string | null {
   return stringValue(props.source_location) ?? stringValue(props.source);
 }
@@ -245,6 +256,7 @@ export function buildGraphContract({
       confidence: confidenceValue(props),
       source_location: sourceLocation(props),
       provenance: recordValue(props.provenance),
+      provenance_tier: provenanceTierValue(props),
       freshness: freshness(props),
       direction: "directed" as const,
       metadata: metadataWithout(props, PROMOTED_EDGE_PROPS),
@@ -266,6 +278,7 @@ export function buildGraphContract({
       confidence: confidenceValue(props),
       source_location: sourceLocation(props),
       provenance: recordValue(props.provenance),
+      provenance_tier: provenanceTierValue(props),
       freshness: freshness(props, true),
       salience: numberValue(props.salience),
       orphan: !inbound.has(node.rid),
@@ -313,6 +326,7 @@ const ContractNodeZ = z.object({
   confidence: z.string().nullable(),
   source_location: z.string().nullable(),
   provenance: z.record(z.unknown()).nullable(),
+  provenance_tier: z.enum(["oracle", "proxy"]).nullable(),
   freshness: z.object({
     created_at: z.number().nullable(),
     updated_at: z.number().nullable(),
@@ -335,6 +349,7 @@ const ContractEdgeZ = z.object({
   confidence: z.string().nullable(),
   source_location: z.string().nullable(),
   provenance: z.record(z.unknown()).nullable(),
+  provenance_tier: z.enum(["oracle", "proxy"]).nullable(),
   freshness: z.object({
     created_at: z.number().nullable(),
     updated_at: z.number().nullable(),
@@ -411,6 +426,7 @@ export function graphContractJsonSchema(): Record<string, any> {
             "confidence",
             "source_location",
             "provenance",
+            "provenance_tier",
             "freshness",
             "salience",
             "orphan",
@@ -428,6 +444,7 @@ export function graphContractJsonSchema(): Record<string, any> {
             confidence: { type: ["string", "null"] },
             source_location: { type: ["string", "null"] },
             provenance: { type: ["object", "null"] },
+            provenance_tier: { enum: ["oracle", "proxy", null] },
             freshness: {
               type: "object",
               required: ["created_at", "updated_at"],
@@ -460,6 +477,7 @@ export function graphContractJsonSchema(): Record<string, any> {
             "confidence",
             "source_location",
             "provenance",
+            "provenance_tier",
             "freshness",
             "direction",
             "metadata",
@@ -476,6 +494,7 @@ export function graphContractJsonSchema(): Record<string, any> {
             confidence: { type: ["string", "null"] },
             source_location: { type: ["string", "null"] },
             provenance: { type: ["object", "null"] },
+            provenance_tier: { enum: ["oracle", "proxy", null] },
             freshness: {
               type: "object",
               required: ["created_at", "updated_at"],

--- a/apps/memory/src/graph-store.ts
+++ b/apps/memory/src/graph-store.ts
@@ -17,6 +17,7 @@ import {
   type MemoryEdge,
   type MemoryNode,
   type MemoryProvenance,
+  type ProvenanceTier,
   type MemoryScope,
   type NodeType,
   defaultTier,
@@ -152,6 +153,7 @@ type PathAlgorithm = "bfs" | "dijkstra";
 const STRATEGIES: readonly TraverseStrategy[] = ["bfs", "dfs"];
 const DIRECTIONS: readonly GraphDirection[] = ["outgoing", "incoming", "both"];
 const ALGORITHMS: readonly PathAlgorithm[] = ["bfs", "dijkstra"];
+const CAUSAL_EDGE_LABELS = new Set<EdgeLabel>(["CAUSES", "PREVENTS", "BLOCKS", "ENABLES"]);
 
 /** Reject anything not in the allowlist — these tokens are interpolated raw
  *  into the graph DSL (they cannot be bound as `$1` params), so they must never
@@ -297,6 +299,7 @@ export class MemoryStore {
       ...(scopeId ? { scope_id: scopeId } : {}),
       importance: props.importance ?? DEFAULT_IMPORTANCE,
       tier,
+      provenance_tier: props.provenance_tier ?? defaultProvenanceTier(props),
       ...(layer != null ? { layer } : {}),
       created_at: createdAt,
       updated_at: now,
@@ -494,12 +497,15 @@ export class MemoryStore {
 
   /** Upsert an edge, deduped by (from, to, label) via KV. */
   async upsertEdge(edge: MemoryEdge): Promise<number> {
+    enforceEdgeProvenance(edge);
     const existing = await this.findEdge(edge.from_rid, edge.to_rid, edge.label);
     if (existing != null) return existing;
     const key = edgeKey(edge.from_rid, edge.to_rid, edge.label);
 
     const properties = {
       ...(edge.properties ?? {}),
+      provenance_tier:
+        edge.properties?.provenance_tier ?? defaultProvenanceTier(edge.properties ?? {}),
       created_at: edge.properties?.created_at ?? Date.now(),
     };
     // Same multi-model rule as nodes: the engine requires the `EDGE` keyword.
@@ -1550,6 +1556,36 @@ function conflictEdgeProps(conflict: DetectedConflict): {
     candidate_session: conflict.sessions.candidate,
     existing_session: conflict.sessions.existing,
   };
+}
+
+function defaultProvenanceTier(input: {
+  confidence?: unknown;
+  provenance?: { confidence?: unknown } | null;
+}): ProvenanceTier {
+  const confidence = input.confidence ?? input.provenance?.confidence;
+  return confidence === "EXTRACTED" ? "oracle" : "proxy";
+}
+
+function enforceEdgeProvenance(edge: MemoryEdge): void {
+  if (!CAUSAL_EDGE_LABELS.has(edge.label)) return;
+  if (!isCoOccurrenceEdge(edge.properties)) return;
+  throw new Error(`co-occurrence edge cannot use causal label ${edge.label}`);
+}
+
+function isCoOccurrenceEdge(props: MemoryEdge["properties"]): boolean {
+  if (!props) return false;
+  const candidates = [
+    props.relation_kind,
+    props.source_kind,
+    props.extraction_kind,
+    props.inference_kind,
+  ];
+  return candidates.some((value) => normalizeProvenanceMarker(value) === "co-occurrence");
+}
+
+function normalizeProvenanceMarker(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return value.toLowerCase().replace(/_/g, "-");
 }
 
 /**

--- a/apps/memory/src/schema.ts
+++ b/apps/memory/src/schema.ts
@@ -34,6 +34,17 @@ export type Confidence = "EXTRACTED" | "INFERRED" | "AMBIGUOUS";
 export type Tier = "ephemeral" | "durable" | "reasoning";
 
 /**
+ * Provenance authority tier for recall ranking (issue #1193).
+ *
+ * - `oracle` — execution-observed evidence such as command/test output or
+ *   deterministic extractor facts marked EXTRACTED.
+ * - `proxy` — AI-inferred, co-occurrence, manually migrated, or otherwise
+ *   indirect evidence. Legacy graph rows without this field are treated as
+ *   proxy by read paths.
+ */
+export type ProvenanceTier = "oracle" | "proxy";
+
+/**
  * Memory layer (PRD #174, issue #175). The *physical* storage layer a Memory
  * node currently lives in. Orthogonal to {@link Tier}: tier names the retention
  * class, layer names the physical location and may change on promotion or
@@ -152,6 +163,11 @@ export interface MemoryNodeProps {
   confidence?: Confidence;
   source?: string;
   provenance?: MemoryProvenance;
+  /**
+   * Authority tier for ranking. New writes always stamp this; legacy rows that
+   * predate #1193 omit it and are read as `proxy`.
+   */
+  provenance_tier?: ProvenanceTier;
   language?: string;
   project?: string;
   /** Scope classification for safe recall filtering; defaults to `project`. */
@@ -219,6 +235,11 @@ export interface MemoryEdgeProps {
   topological_weight?: number;
   reason?: string;
   provenance?: MemoryProvenance;
+  /**
+   * Authority tier for ranking/governance. New writes always stamp this;
+   * pre-existing edges without it are treated as `proxy`.
+   */
+  provenance_tier?: ProvenanceTier;
   extraction_backend?: string;
   source_location?: string;
   created_at?: number;

--- a/apps/memory/tests/engine-ranking.test.ts
+++ b/apps/memory/tests/engine-ranking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  PROVENANCE_TIER_WEIGHT,
   RECENCY_HALF_LIFE_MS,
   type RecallStore,
   TIER_WEIGHT,
@@ -7,7 +8,7 @@ import {
   recall,
 } from "../src/engine.js";
 import type { GraphRow, SearchRow, StoredNode } from "../src/graph-store.js";
-import type { MemoryScope, Tier } from "../src/schema.js";
+import type { MemoryScope, ProvenanceTier, Tier } from "../src/schema.js";
 
 /**
  * In-memory `RecallStore` for ranking unit tests — no RedDB, no `red` binary.
@@ -84,6 +85,16 @@ function node(
   };
 }
 
+function provenanceNode(
+  rid: number,
+  provenanceTier: ProvenanceTier | undefined,
+): StoredNode {
+  return node(rid, "durable", {
+    content: "alpha provenance parity",
+    ...(provenanceTier ? { provenance_tier: provenanceTier } : {}),
+  });
+}
+
 describe("rankScore (#72)", () => {
   const base = { relevance: 1, importance: 1, ageMs: 0, degree: 0, maxDegree: 0 } as const;
 
@@ -107,6 +118,13 @@ describe("rankScore (#72)", () => {
     const leaf = rankScore({ ...base, tier: "durable", degree: 0, maxDegree: 4 });
     expect(hub).toBeGreaterThan(leaf);
   });
+
+  test("provenance tier orders oracle above proxy", () => {
+    const oracle = rankScore({ ...base, tier: "durable", provenanceTier: "oracle" });
+    const proxy = rankScore({ ...base, tier: "durable", provenanceTier: "proxy" });
+    expect(oracle).toBeGreaterThan(proxy);
+    expect(proxy).toBe(PROVENANCE_TIER_WEIGHT.proxy);
+  });
 });
 
 describe("recall ranking with a mock store (#72)", () => {
@@ -119,6 +137,29 @@ describe("recall ranking with a mock store (#72)", () => {
     ]);
     const { nodes } = await recall(store, "alpha", { depth: 0, now: NOW });
     expect(nodes.map((n) => n.rid)).toEqual([2, 3, 1]);
+  });
+
+  test("ranks oracle facts above otherwise-equivalent proxy facts", async () => {
+    const store = new MockStore([
+      provenanceNode(1, "proxy"),
+      provenanceNode(2, "oracle"),
+    ]);
+
+    const { nodes } = await recall(store, "alpha", { depth: 0, now: NOW });
+
+    expect(nodes.map((n) => n.rid)).toEqual([2, 1]);
+  });
+
+  test("treats legacy facts without provenance_tier as proxy", async () => {
+    const store = new MockStore([
+      provenanceNode(1, undefined),
+      provenanceNode(2, "oracle"),
+    ]);
+
+    const { nodes } = await recall(store, "alpha", { depth: 0, now: NOW });
+
+    expect(nodes.map((n) => n.rid)).toEqual([2, 1]);
+    expect(nodes.find((n) => n.rid === 1)?.properties.provenance_tier).toBeUndefined();
   });
 
   test("returns the head of a SUPERSEDED_BY chain by default", async () => {

--- a/apps/memory/tests/extract-conversation.test.ts
+++ b/apps/memory/tests/extract-conversation.test.ts
@@ -321,6 +321,7 @@ describe("factsToGraph", () => {
     expect(nodes).toHaveLength(2);
     for (const n of nodes) {
       expect(n.properties.confidence).toBe("INFERRED");
+      expect(n.properties.provenance_tier).toBe("proxy");
       expect(n.properties.source).toBe("conversation");
       expect(n.properties.hash).toBeTruthy();
     }

--- a/apps/memory/tests/graph-store.test.ts
+++ b/apps/memory/tests/graph-store.test.ts
@@ -541,6 +541,58 @@ describe("MemoryStore over a file:// RedDB", () => {
   );
 
   test(
+    "co-occurrence edges cannot be written as causal labels",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const a = await store.upsertNode(factToNode("co occurrence node a", slugify));
+      const b = await store.upsertNode(factToNode("co occurrence node b", slugify));
+
+      await expect(
+        store.upsertEdge({
+          label: "CAUSES",
+          from_rid: a,
+          to_rid: b,
+          properties: { relation_kind: "co-occurrence" },
+        }),
+      ).rejects.toThrow(/co-occurrence edge cannot use causal label CAUSES/);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "new writes carry provenance_tier while legacy rows read without it",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const oracleRid = await store.upsertNode({
+        label: "oracle-validation",
+        node_type: "validation",
+        properties: {
+          title: "oracle validation",
+          content: "test command passed",
+          confidence: "EXTRACTED",
+        },
+      });
+      const proxyRid = await store.upsertNode(factToNode("manual legacy shaped fact", slugify));
+
+      await expect(store.getNode(oracleRid)).resolves.toMatchObject({
+        properties: { provenance_tier: "oracle" },
+      });
+      await expect(store.getNode(proxyRid)).resolves.toMatchObject({
+        properties: { provenance_tier: "proxy" },
+      });
+
+      const legacy = rowToNode({
+        rid: 999,
+        label: "legacy",
+        node_type: "concept",
+        PROPERTIES: { title: "legacy" },
+      });
+      expect(legacy.properties.provenance_tier).toBeUndefined();
+    },
+    TIMEOUT,
+  );
+
+  test(
     "listEdges reuses the edge snapshot until writes invalidate it",
     async () => {
       const store = await openStore(await tempRoot());

--- a/plugins/memory/docs/graph-contract.md
+++ b/plugins/memory/docs/graph-contract.md
@@ -47,6 +47,7 @@ The contract carries a `version` (currently `2.0.0`, exported as `GRAPH_CONTRACT
 | `confidence`      | string \| null   | Stored confidence (`EXTRACTED`, `INFERRED`, `AMBIGUOUS`, or future string); `null` when unavailable. |
 | `source_location` | string \| null   | Canonical source path/range/URN from `source_location` or `source`; `null` when unavailable. |
 | `provenance`      | object \| null   | Stored provenance object; `null` when unavailable.                                     |
+| `provenance_tier` | `"oracle"` \| `"proxy"` \| null | Stored authority tier; missing legacy values are treated as `proxy` by Memory recall. |
 | `freshness`       | object           | `created_at`, `updated_at`, optional `accessed_at` and `expires_at`, all epoch ms or `null`. |
 | `salience`        | number \| null   | Node salience for ranking/filtering; `null` when unavailable.                          |
 | `orphan`          | boolean          | `true` when **no edge targets this node** (no inbound edges), computed at export time. |
@@ -66,6 +67,7 @@ The contract carries a `version` (currently `2.0.0`, exported as `GRAPH_CONTRACT
 | `confidence`      | string \| null                            | Stored confidence (`EXTRACTED`, `INFERRED`, `AMBIGUOUS`, or future string); `null` when unavailable. |
 | `source_location` | string \| null                            | Canonical source path/range/URN from `source_location` or `source`; `null` when unavailable. |
 | `provenance`      | object \| null                            | Stored provenance object; `null` when unavailable.                       |
+| `provenance_tier` | `"oracle"` \| `"proxy"` \| null           | Stored authority tier; missing legacy values are treated as `proxy` by Memory recall. |
 | `freshness`       | object                                    | `created_at`, `updated_at`, optional `expires_at`, all epoch ms or `null`. |
 | `direction`       | `"directed"`                              | Edges are directed; `source → target` is the semantic direction.         |
 | `metadata`        | object                                    | Remaining edge properties, preserved losslessly.                         |


### PR DESCRIPTION
Automated AFK landing for #1193. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1193

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785960785&installation_id=129708444&pr_number=1239&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1239&signature=8534b10abf093582f1bcc4af43fcd1439172e8ecc16a99829d42572a7ef5c4ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->