### PR TITLE
merge: #1194 memory: bi-temporal supersession for conflicting facts

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -1385,6 +1385,17 @@ async function runRecall(args: ParsedArgs): Promise<void> {
           const parts = hit.hooks.map((h) => `${h.lifecycle}=${h.exit_code}`);
           console.log(`        hooks: ${parts.join(", ")}`);
         }
+        if (hit.superseded_by != null) {
+          const window = [
+            hit.valid_from != null ? `valid_from=${hit.valid_from}` : "",
+            hit.valid_until != null ? `valid_until=${hit.valid_until}` : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+          console.log(
+            `        lineage: superseded_by=memory_nodes:${hit.superseded_by}${window ? ` ${window}` : ""}`,
+          );
+        }
       }
     } finally {
       await store.close();

--- a/apps/memory/src/engine.ts
+++ b/apps/memory/src/engine.ts
@@ -1242,8 +1242,25 @@ function renderContext(
     // user hooks fired without re-reading the raw Envelope.
     const hooksLine = renderAttemptHooks(p.hooks);
     if (hooksLine) lines.push(`  ${hooksLine}`);
+    const lineageLine = renderSupersessionLine(p);
+    if (lineageLine) lines.push(`  ${lineageLine}`);
   }
   return `${lines.join("\n")}\n`;
+}
+
+function renderSupersessionLine(p: RecalledNode["properties"]): string | null {
+  const supersededBy = numericProp(p.superseded_by);
+  if (supersededBy == null) return null;
+  const parts = [`superseded_by=memory_nodes:${supersededBy}`];
+  const validFrom = numericProp(p.valid_from);
+  const validUntil = numericProp(p.valid_until);
+  if (validFrom != null) parts.push(`valid_from=${validFrom}`);
+  if (validUntil != null) parts.push(`valid_until=${validUntil}`);
+  return `_lineage: ${parts.join(" ")}_`;
+}
+
+function numericProp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function renderAttemptHooks(hooks: unknown): string | null {

--- a/apps/memory/src/graph-recall.ts
+++ b/apps/memory/src/graph-recall.ts
@@ -35,6 +35,10 @@ export interface GraphRecallHit {
   node_type: string;
   score: number;
   excerpt: string;
+  superseded_by?: number;
+  valid_from?: number;
+  valid_until?: number;
+  archived_at?: number;
   /**
    * User-hook executions from the Envelope `hooks` section (issue #216).
    * Only set when the underlying node carries a non-empty `hooks` property
@@ -155,12 +159,31 @@ export async function graphRecallResult(
       node_type: node.node_type,
       score: entry.score,
       excerpt: node.excerpt,
+      ...lineageFields(node.properties),
       ...(hooks ? { hooks } : {}),
     });
     if (hits.length >= limit) break;
   }
 
   return { hits, diagnostics };
+}
+
+function lineageFields(properties: RecalledNode["properties"]): Partial<GraphRecallHit> {
+  const supersededBy = numericProp(properties.superseded_by);
+  if (supersededBy == null) return {};
+  const validFrom = numericProp(properties.valid_from);
+  const validUntil = numericProp(properties.valid_until);
+  const archivedAt = numericProp(properties.archived_at);
+  return {
+    superseded_by: supersededBy,
+    ...(validFrom != null ? { valid_from: validFrom } : {}),
+    ...(validUntil != null ? { valid_until: validUntil } : {}),
+    ...(archivedAt != null ? { archived_at: archivedAt } : {}),
+  };
+}
+
+function numericProp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 async function loadCodeCanonicalizer(store: RecallStore): Promise<(code: string) => string> {

--- a/apps/memory/src/graph-store.ts
+++ b/apps/memory/src/graph-store.ts
@@ -396,6 +396,7 @@ export class MemoryStore {
           to_rid: conflict.rid,
           properties: conflictEdgeProps(conflict),
         });
+        await this.supersede(conflict.rid, rid, conflict.reason);
       }
     } catch {
       // best-effort — never block the underlying write
@@ -462,8 +463,11 @@ export class MemoryStore {
       const r = await this.db.query(`SELECT * FROM ${COLLECTIONS.nodes}`);
       this.nodeCache = r.rows.map(rowToNode);
     }
+    const archive = await this.readSupersessionArchiveMap();
     const evicted = await this.evictedRids();
-    return this.nodeCache.filter((n) => !isExpired(n, now) && !evicted.has(n.rid));
+    return this.nodeCache
+      .filter((n) => !isExpired(n, now) && !evicted.has(n.rid))
+      .map((node) => applySupersessionArchive(node, archive[node.rid]));
   }
 
   private invalidateNodeCache(): void {
@@ -610,15 +614,21 @@ export class MemoryStore {
    * recall instead.
    */
   async supersede(oldRid: number, newRid: number, reason?: string): Promise<number> {
+    const now = Date.now();
     const edgeRid = await this.upsertEdge({
       label: "SUPERSEDED_BY",
       from_rid: oldRid,
       to_rid: newRid,
-      properties: reason ? { reason } : undefined,
+      properties: {
+        ...(reason ? { reason } : {}),
+        valid_until: now,
+        archived_at: now,
+      },
     });
     const map = await this.readSupersededMap();
     map[oldRid] = newRid;
     await this.kv().put(SUPERSEDED_KEY, map);
+    await this.archiveSupersededNode(oldRid, newRid, now, reason);
     await this.emitEngineOp({
       op: "conflict-detected",
       outcome: "succeeded",
@@ -665,6 +675,36 @@ export class MemoryStore {
     const raw = await this.kv().get(SUPERSEDED_KEY);
     if (raw == null) return {};
     return (typeof raw === "string" ? JSON.parse(raw) : raw) as Record<string, number>;
+  }
+
+  private async archiveSupersededNode(
+    oldRid: number,
+    newRid: number,
+    now: number,
+    reason?: string,
+  ): Promise<void> {
+    const archive = await this.readSupersessionArchiveMap();
+    const existing = archive[oldRid];
+    const nodes = this.nodeCache ?? (await this.listNodes());
+    const node = nodes.find((candidate) => candidate.rid === oldRid);
+    archive[oldRid] = {
+      ...(existing ?? {}),
+      superseded_by: newRid,
+      valid_from:
+        existing?.valid_from ??
+        numberOrUndefined(node?.properties.valid_from) ??
+        numberOrUndefined(node?.properties.created_at),
+      valid_until: now,
+      archived_at: now,
+      ...(reason ? { reason } : {}),
+    };
+    await this.kv().put(SUPERSESSION_ARCHIVE_KEY, archive);
+  }
+
+  private async readSupersessionArchiveMap(): Promise<SupersessionArchiveMap> {
+    const raw = await this.kv().get(SUPERSESSION_ARCHIVE_KEY);
+    if (raw == null) return {};
+    return (typeof raw === "string" ? JSON.parse(raw) : raw) as SupersessionArchiveMap;
   }
 
   // -------------------------------------------------------------------
@@ -789,6 +829,11 @@ export class MemoryStore {
       if (sup[node.rid] != null) {
         delete sup[node.rid];
         await this.kv().put(SUPERSEDED_KEY, sup);
+      }
+      const archive = await this.readSupersessionArchiveMap();
+      if (archive[node.rid] != null) {
+        delete archive[node.rid];
+        await this.kv().put(SUPERSESSION_ARCHIVE_KEY, archive);
       }
       await this.kv().delete(nodeExpiryKey(node.rid));
     } finally {
@@ -1603,6 +1648,26 @@ export function rowToNode(row: Record<string, unknown>): StoredNode {
   };
 }
 
+function applySupersessionArchive(
+  node: StoredNode,
+  archive?: SupersessionArchiveRecord,
+): StoredNode {
+  if (!archive) return node;
+  return {
+    ...node,
+    properties: {
+      ...node.properties,
+      ...(archive.valid_from != null ? { valid_from: archive.valid_from } : {}),
+      valid_until: archive.valid_until,
+      valid_to: archive.valid_until,
+      archived_at: archive.archived_at,
+      superseded_by: archive.superseded_by,
+      superseded_by_rid: archive.superseded_by,
+      ...(archive.reason ? { supersession_reason: archive.reason } : {}),
+    },
+  };
+}
+
 /**
  * Turn a free-text fact (as `/memory:store` receives it) into a graph node:
  * a `concept` whose label is the slugified first line, full text in `content`.
@@ -1719,6 +1784,21 @@ function edgeTo(edge: Record<string, unknown>): number {
  *  graph, not one per node — see `supersede`. */
 const SUPERSEDED_KEY = "node:superseded:all";
 
+type SupersessionArchiveRecord = {
+  superseded_by: number;
+  valid_from?: number;
+  valid_until: number;
+  archived_at: number;
+  reason?: string;
+};
+
+type SupersessionArchiveMap = Record<string, SupersessionArchiveRecord>;
+
+/** Aggregate archive overlay: oldRid → validity/linkage stamp. The original
+ *  graph node row is preserved; read paths merge this stamp for audit recall.
+ */
+const SUPERSESSION_ARCHIVE_KEY = "node:supersession_archive:all";
+
 /** Aggregate logical edge-deletion map: edge rid → removed. */
 const REMOVED_EDGES_KEY = "edge:removed:all";
 
@@ -1735,6 +1815,10 @@ export function isExpired(node: StoredNode, now: number = Date.now()): boolean {
   if (node.properties.tier !== "ephemeral") return false;
   const expiresAt = node.properties.expires_at;
   return typeof expiresAt === "number" && now >= expiresAt;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 /** Aggregate access overlay: rid → {recall count, last-accessed time}. One KV

--- a/apps/memory/tests/graph-store.test.ts
+++ b/apps/memory/tests/graph-store.test.ts
@@ -664,6 +664,60 @@ describe("MemoryStore over a file:// RedDB", () => {
     TIMEOUT,
   );
 
+  test(
+    "conflicting fact write archives the old belief and audit recall shows lineage",
+    async () => {
+      const store = await openStore(await tempRoot());
+      const old = await store.upsertNode({
+        label: "release-window",
+        node_type: "decision",
+        properties: {
+          title: "release window",
+          content: "release window is friday afternoon",
+          created_at: 1_000,
+        },
+      });
+
+      const current = await store.upsertNode({
+        label: "release-window",
+        node_type: "decision",
+        properties: {
+          title: "release window",
+          content: "release window is tuesday morning",
+          created_at: 2_000,
+        },
+      });
+
+      expect(await store.supersededBy(old)).toBe(current);
+      const archived = await store.getNode(old);
+      expect(archived?.properties).toMatchObject({
+        superseded_by: current,
+        valid_until: expect.any(Number),
+        archived_at: expect.any(Number),
+      });
+
+      const defaultHits = await graphRecall(store, "release window friday tuesday", 10);
+      expect(defaultHits.map((hit) => hit.rid)).toContain(current);
+      expect(defaultHits.map((hit) => hit.rid)).not.toContain(old);
+
+      const auditHits = await graphRecall(
+        store,
+        "what did we believe before release window changed to tuesday",
+        10,
+        {
+          includeSuperseded: true,
+        },
+      );
+      const auditOld = auditHits.find((hit) => hit.rid === old);
+      expect(auditOld).toMatchObject({
+        superseded_by: current,
+        valid_until: expect.any(Number),
+      });
+      expect(auditOld?.excerpt).toContain("release window is friday afternoon");
+    },
+    TIMEOUT,
+  );
+
   test.each(SOFT_MERGE_LABELS)(
     "soft merge %s: recall hides the duplicate until the edge is removed",
     async (label) => {


### PR DESCRIPTION
Automated AFK landing for #1194. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1194

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785960852&installation_id=129708444&pr_number=1240&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1240&signature=fb229359e1c132773ead06597adc72d6e234cd1855b080710a911b0231f197f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->