### PR TITLE
merge: #1195 brain: outcome-event contract + append-only store + fire-and-forget AFK emission

### DIFF
--- a/apps/brain/package.json
+++ b/apps/brain/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "catalog:",
     "@reddb-io/build-info": "workspace:*",
+    "@reddb-io/shared": "workspace:*",
     "@reddb-io/sdk": "1.7.0",
     "zod": "catalog:"
   },

--- a/apps/brain/src/cli.ts
+++ b/apps/brain/src/cli.ts
@@ -11,6 +11,7 @@ import { buildBrainDashboard, buildBrainDashboardArtifact, serveBrainDashboardHt
 import { ARTIFACT_KINDS, CONNECTION_KINDS } from "./schema.js";
 import { loadIngestionState, saveIngestionState, scheduledIngest } from "./scheduled-ingestion.js";
 import type { KpiGroupBy, KpiInterval, KpiTimeField } from "./kpi-query.js";
+import { isOutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 
 async function main(): Promise<void> {
   const [command = "help", ...args] = process.argv.slice(2);
@@ -69,9 +70,24 @@ async function main(): Promise<void> {
     case "dashboard":
       await dashboard(args);
       return;
+    case "outcome-event":
+      await outcomeEvent(args);
+      return;
     default:
       throw new Error(`unknown brain command: ${command}`);
   }
+}
+
+async function outcomeEvent(args: string[]): Promise<void> {
+  const [subcommand, ...rest] = args;
+  if (subcommand !== "record") throw new Error("brain outcome-event requires subcommand: record");
+  const flags = parseFlags(rest);
+  const input = await readStdin();
+  const parsed = JSON.parse(input) as unknown;
+  if (!isOutcomeEvent(parsed)) throw new Error("invalid brain outcome event");
+  await withBrainRuntime(async ({ store }) => {
+    printJson(await store.appendOutcomeEvent(parsed));
+  }, stringFlag(flags, "root") ?? process.cwd());
 }
 
 async function capture(args: string[]): Promise<void> {
@@ -322,6 +338,14 @@ function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
 
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
 function printHelp(): void {
   console.log(`brain commands:
   init
@@ -337,6 +361,7 @@ function printHelp(): void {
   schedule-ingest [--session-key KEY] [--limit N] [--state PATH]
   kpi [--interval hour|day|week|month] [--group-by platform|event_type|target] [--time-field event|ingested] [--from T] [--to T] [--platform P] [--event-type T] [--target T]
   dashboard [--out PATH] [--json] [--serve] [--host 127.0.0.1] [--port 4738]
+  outcome-event record [--root PATH] < event.json
 `);
 }
 

--- a/apps/brain/src/schema.ts
+++ b/apps/brain/src/schema.ts
@@ -46,6 +46,7 @@ export type ConnectionKind = (typeof CONNECTION_KINDS)[number];
 export const COLLECTIONS = {
   artifacts: "brain_artifacts",
   connections: "brain_connections",
+  outcomeEvents: "brain_outcome_events",
   kv: "brain_kv",
 } as const;
 

--- a/apps/brain/src/store.ts
+++ b/apps/brain/src/store.ts
@@ -1,4 +1,5 @@
 import { type QueryParam, type RedDB, connect } from "@reddb-io/sdk";
+import { isOutcomeEvent, type OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import { contentHash, slugify } from "./hash.js";
 import { KpiQuery, type KpiQueryInput, type KpiResult } from "./kpi-query.js";
 import {
@@ -98,6 +99,7 @@ export class BrainStore {
   private db!: RedDB;
   private artifactCache: StoredBrainArtifact[] | null = null;
   private connectionCache: StoredBrainConnection[] | null = null;
+  private outcomeEventCache: OutcomeEvent[] | null = null;
 
   private constructor(private readonly opts: BrainStoreOptions) {}
 
@@ -119,6 +121,7 @@ export class BrainStore {
   async bootstrap(): Promise<void> {
     await this.db.execute(`CREATE GRAPH IF NOT EXISTS ${COLLECTIONS.artifacts}`);
     await this.db.execute(`CREATE GRAPH IF NOT EXISTS ${COLLECTIONS.connections}`);
+    await this.db.execute(`CREATE GRAPH IF NOT EXISTS ${COLLECTIONS.outcomeEvents}`);
   }
 
   private kv() {
@@ -295,6 +298,32 @@ export class BrainStore {
     return new KpiQuery(artifacts).events(input);
   }
 
+  async appendOutcomeEvent(event: OutcomeEvent): Promise<OutcomeEvent> {
+    if (!isOutcomeEvent(event)) throw new Error("invalid Brain outcome event");
+    const properties = { ...event };
+    const result = await this.db.query(
+      `INSERT INTO ${COLLECTIONS.outcomeEvents} NODE (label, node_type, properties) VALUES ($1, $2, $3) RETURNING *`,
+      event.id,
+      `outcome_event.v${event.schemaVersion}`,
+      properties as unknown as QueryParam,
+    );
+    if (!result.rows[0]) throw new Error("INSERT outcome event returned no row");
+    this.outcomeEventCache = null;
+    return event;
+  }
+
+  async replayOutcomeEvents(): Promise<OutcomeEvent[]> {
+    if (this.outcomeEventCache == null) {
+      const result = await this.db.query(`SELECT * FROM ${COLLECTIONS.outcomeEvents}`);
+      this.outcomeEventCache = result.rows
+        .map(rowToOutcomeEvent)
+        .filter(notNull)
+        .sort((a, b) => a.rid - b.rid)
+        .map(({ rid: _rid, event }) => event);
+    }
+    return [...this.outcomeEventCache];
+  }
+
   async think(query: string, limit = 8, options: ThinkOptions = {}): Promise<BrainThinkResult> {
     const hits = (await this.search(query, Math.max(limit * 2, limit + 5), options))
       .filter((hit) => !isDerivedArtifact(hit.artifact))
@@ -453,6 +482,13 @@ function rowToConnection(row: Record<string, unknown>): StoredBrainConnection | 
     weight: Number(row.weight ?? 1),
     properties: parseProperties(row.properties ?? row.PROPERTIES) as unknown as StoredBrainConnection["properties"],
   };
+}
+
+function rowToOutcomeEvent(row: Record<string, unknown>): { rid: number; event: OutcomeEvent } | null {
+  const rid = Number(row.red_entity_id ?? row.rid);
+  const properties = parseProperties(row.properties ?? row.PROPERTIES);
+  if (!Number.isFinite(rid) || !isOutcomeEvent(properties)) return null;
+  return { rid, event: properties };
 }
 
 function parseProperties(value: unknown): Record<string, unknown> {

--- a/apps/brain/tests/store.test.ts
+++ b/apps/brain/tests/store.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
+import { OUTCOME_EVENT_SCHEMA_VERSION, type OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import {
   createAfkHeadlessAutoLinkProvider,
   parseAutoLinkProviderResponse,
@@ -146,6 +147,49 @@ describe("BrainStore hybrid search", () => {
       ]);
       expect(result.answer).toContain('Brain has no cited evidence for "quantum roadmap".');
       expect(result.answer).toContain("Missing evidence:");
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("BrainStore outcome events", () => {
+  it("appends versioned outcome events and replays them in write order", async () => {
+    const root = await tempRoot();
+    const store = await BrainStore.open({ uri: `file://${join(root, "brain.rdb")}` });
+    const first: OutcomeEvent = {
+      schemaVersion: OUTCOME_EVENT_SCHEMA_VERSION,
+      id: "afk:o/r:9:1",
+      emitter: "afk",
+      occurredAt: "2026-07-06T20:14:16.000Z",
+      taskClass: "think",
+      chosenOption: { kind: "runner", runner: "claude", model: "claude-opus-4-8", effort: "high" },
+      outcome: "success",
+      cost: { signal: "unknown" },
+      context: {
+        repository: "o/r",
+        issueNumber: 9,
+        attemptNumber: 1,
+        issueType: "bug",
+        workerId: "wAAAA",
+        branch: "afk/wAAAA/9-fix-the-thing",
+        durationMs: 12_000,
+        status: "done",
+      },
+    };
+    const second: OutcomeEvent = {
+      ...first,
+      id: "afk:o/r:10:1",
+      occurredAt: "2026-07-06T20:15:16.000Z",
+      outcome: "failure",
+      context: { ...first.context, issueNumber: 10, status: "blocked" },
+    };
+
+    try {
+      await store.appendOutcomeEvent(first);
+      await store.appendOutcomeEvent(second);
+
+      expect(await store.replayOutcomeEvents()).toEqual([first, second]);
     } finally {
       await store.close();
     }

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -42,6 +42,8 @@ import {
 import type { LaneIdleStallConfig } from "../core/lane-idle-reaper.js";
 import { workerDir as workerDirPath, workerPidFile } from "../core/worker-paths.js";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { pluginEnabledInConfig } from "@reddb-io/shared/plugin-gate.js";
+import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import * as fsx from "../runtime/fs.js";
@@ -1329,6 +1331,7 @@ export function buildProcessDeps(
     // hop. ALL errors are swallowed (one warn line), so a memory failure can
     // NEVER fail the close.
     recordAttempt: makeRecordAttempt(ctx.root, current, exec),
+    recordOutcomeEvent: makeRecordOutcomeEvent(ctx.root, current, exec),
     // PRD cascade rebase (issue #1007): after a successful DONE landing, rebase
     // every open sibling branch (same prd:N, not held by a live worker) onto the
     // new base HEAD. Best-effort — failures log a warning, never fail the close.
@@ -1500,6 +1503,59 @@ function makeRecordAttempt(
       process.stderr.write(`[afk] memory attempt-record skipped (best-effort): ${String(err)}\n`);
     }
   };
+}
+
+function makeRecordOutcomeEvent(
+  gitRoot: string,
+  current: CurrentAttempt,
+  exec?: ExecFn,
+): (event: OutcomeEvent) => Promise<void> {
+  return async (event: OutcomeEvent): Promise<void> => {
+    try {
+      const configPath = join(gitRoot, ".red", "config.yaml");
+      const configText = readFileSync(configPath, "utf8");
+      if (!pluginEnabledInConfig(configText, "brain")) return;
+      const env = { ...process.env, BRAIN_REPO_ROOT: process.env.BRAIN_REPO_ROOT ?? gitRoot };
+      const brainCli = resolveBrainCli(gitRoot, env);
+      if (!brainCli) return;
+      const dir = current.attemptDir || gitRoot;
+      await fsx.ensureDir(dir);
+      const json = JSON.stringify(event);
+      await writeFile(join(dir, `brain-outcome-event-${event.context?.issueNumber ?? "unknown"}-a${event.context?.attemptNumber ?? "unknown"}.json`), json, "utf8");
+      const run = exec ?? (await import("../runtime/exec.js")).execTool;
+      const [cmd, ...head] = brainCli;
+      await run(cmd, [...head, "outcome-event", "record", "--root", gitRoot], {
+        cwd: gitRoot,
+        env,
+        input: json,
+      });
+    } catch (err) {
+      process.stderr.write(`[afk] brain outcome-event skipped (best-effort): ${String(err)}\n`);
+    }
+  };
+}
+
+function resolveBrainCli(gitRoot: string, env: NodeJS.ProcessEnv): string[] | undefined {
+  const override = env.RED_BRAIN_CLI;
+  if (override) return existsSync(override) ? ["node", override] : undefined;
+  const pathHit = findOnPath("brain", env.PATH);
+  if (pathHit) return ["brain"];
+  const pluginRoot = env.CLAUDE_PLUGIN_ROOT ?? env.CODEX_PLUGIN_ROOT;
+  if (pluginRoot) {
+    const sibling = join(pluginRoot, "..", "brain", "dist", "cli.js");
+    if (existsSync(sibling)) return ["node", sibling];
+  }
+  const inRepo = join(gitRoot, "plugins", "brain", "dist", "cli.js");
+  if (existsSync(inRepo)) return ["node", inRepo];
+  return undefined;
+}
+
+function findOnPath(bin: string, pathValue: string | undefined): string | undefined {
+  for (const dir of (pathValue ?? "").split(":").filter(Boolean)) {
+    const candidate = join(dir, bin);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
 }
 
 /** Per-issue mutable context the session-scoped process deps close over — the

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -83,6 +83,7 @@ import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookNa
 import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { buildAttemptRecordPayload, deriveIssueType, type AttemptRecordPayload } from "./attempt-record.js";
+import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
 import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
 import {
@@ -532,6 +533,13 @@ export interface ProcessIssueDeps {
    * Optional so tests/older callers omit it entirely (the call is `?.`-guarded).
    */
   recordAttempt?(payload: AttemptRecordPayload): Promise<void>;
+  /**
+   * AFK→Brain outcome-event recording. Called best-effort after attempt
+   * completion with the shared versioned outcome-event contract. Optional and
+   * fully swallowed: Brain absence/down must never fail or delay the attempt
+   * terminal path.
+   */
+  recordOutcomeEvent?(event: OutcomeEvent): Promise<void>;
   /**
    * Salvage uncommitted work the inner agent left in its worktree. The codex
    * runner sometimes edits, passes the gates, and emits `<promise>DONE</promise>`
@@ -1323,6 +1331,8 @@ export async function processIssue(
     startedEpoch,
     issueType,
     modelTier: activeTaskClass,
+    model: deps.model,
+    effort: deps.effort,
   };
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
@@ -1563,6 +1573,8 @@ export async function processIssue(
       startedEpoch,
       issueType,
       modelTier: activeTaskClass,
+      model: initialTier.model,
+      effort: initialTier.effort,
     } satisfies StageCommon;
 
     // ---- commit-leftovers salvage (codex DONE/partial-commit leftovers, ADR 0050) ----
@@ -2300,29 +2312,67 @@ async function recordAttemptBestEffort(
   fields: { durationS?: number; mergeSha?: string; notes?: string; validationSummary?: string } = {},
 ): Promise<void> {
   const { deps, input } = c;
-  if (!deps.recordAttempt) return;
+  const payload = buildAttemptRecordPayload({
+    repo: input.repo,
+    issue: input.issue,
+    attempt: input.attempt,
+    outcome,
+    issueType: c.issueType,
+    modelTier: c.modelTier,
+    title: input.title,
+    body: input.body,
+    workerId: input.workerId,
+    branch: c.branch,
+    durationS: fields.durationS,
+    diffstat: undefined,
+    mergeSha: fields.mergeSha,
+    notes: fields.notes,
+    validationSummary: fields.validationSummary,
+  });
+  if (deps.recordAttempt) {
+    try {
+      await deps.recordAttempt(payload);
+    } catch (err) {
+      deps.appendIterLog(
+        `🤖 /afk memory attempt-record for #${input.issue} failed (best-effort; ignored): ${String(err)}`,
+      );
+    }
+  }
+  if (!deps.recordOutcomeEvent) return;
   try {
-    const payload = buildAttemptRecordPayload({
-      repo: input.repo,
-      issue: input.issue,
-      attempt: input.attempt,
-      outcome,
-      issueType: c.issueType,
-      modelTier: c.modelTier,
-      title: input.title,
-      body: input.body,
-      workerId: input.workerId,
-      branch: c.branch,
-      durationS: fields.durationS,
-      diffstat: undefined,
-      mergeSha: fields.mergeSha,
-      notes: fields.notes,
-      validationSummary: fields.validationSummary,
+    const event: OutcomeEvent = {
+      schemaVersion: 1,
+      id: `afk:${input.repo}:${input.issue}:${input.attempt}`,
+      emitter: "afk",
+      occurredAt: deps.nowIso(),
+      taskClass: c.modelTier,
+      chosenOption: {
+        kind: "runner",
+        runner: input.runner,
+        model: c.model,
+        effort: c.effort,
+      },
+      outcome: payload.outcome,
+      cost: { signal: "unknown" },
+      context: {
+        repository: input.repo,
+        issueNumber: input.issue,
+        attemptNumber: input.attempt,
+        issueType: payload.issueType,
+        workerId: input.workerId,
+        branch: c.branch,
+        durationMs: payload.durationMs,
+        status: payload.status,
+      },
+    };
+    void deps.recordOutcomeEvent(event).catch((err) => {
+      deps.appendIterLog(
+        `🤖 /afk brain outcome-event for #${input.issue} failed (best-effort; ignored): ${String(err)}`,
+      );
     });
-    await deps.recordAttempt(payload);
   } catch (err) {
     deps.appendIterLog(
-      `🤖 /afk memory attempt-record for #${input.issue} failed (best-effort; ignored): ${String(err)}`,
+      `🤖 /afk brain outcome-event for #${input.issue} failed (best-effort; ignored): ${String(err)}`,
     );
   }
 }
@@ -2339,6 +2389,8 @@ interface StageCommon {
   startedEpoch: number;
   issueType: string;
   modelTier: AfkModelTier;
+  model?: string;
+  effort?: AgentEffort;
 }
 
 /** Emit a failure-family envelope (blocked / no-sentinel / merge-conflict /

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -9,6 +9,7 @@ import type { HookName } from "../src/core/hook-config.js";
 import type { ConfigValues } from "../src/core/config.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, SandboxMode } from "../src/core/execution.js";
 import type { AttemptRecordPayload } from "../src/core/attempt-record.js";
+import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import type { IssueClassificationMetadata } from "../src/core/issue-classifier.js";
 import type { TrustProvenance } from "../src/core/trust-gate.js";
 import { parseCurrentBlocker, upsertCurrentBlocker } from "../src/core/blocker-state.js";
@@ -41,6 +42,8 @@ interface Trace {
   sidecarWrites: Array<{ path: string; lines: string[] }>;
   /** Memory reasoning-attempt records fired after a terminal envelope. */
   recordedAttempts: AttemptRecordPayload[];
+  /** Brain outcome events fired after terminal attempt completion. */
+  outcomeEvents: OutcomeEvent[];
   /** Worker branches passed to the commit-leftovers salvage port. */
   salvageCalls: string[];
   /** Worker branches passed to the ADR 0083 §4 terminal exit barrier (#1021). */
@@ -139,6 +142,8 @@ interface HarnessOptions {
    * reject (proving a memory failure never fails the close); "ok" records the
    * payload; undefined omits the port entirely (older-caller safety). */
   recordAttempt?: "ok" | "throw";
+  /** When set, register the Brain outcome-event sink. "throw"/"hang" model Brain down/slow. */
+  recordOutcomeEvent?: "ok" | "throw" | "hang";
   /** When false, omit the optional fs.writeValidationSidecar port (older-caller
    * safety). Defaults to true (port present + recorded). */
   withSidecarPort?: boolean;
@@ -208,6 +213,7 @@ function harness(opts: HarnessOptions = {}): {
     ensuredLabels: [],
     sidecarWrites: [],
     recordedAttempts: [],
+    outcomeEvents: [],
     salvageCalls: [],
     classifierCalls: [],
     iterLogs: [],
@@ -530,6 +536,13 @@ function harness(opts: HarnessOptions = {}): {
       ? async (payload) => {
           if (opts.recordAttempt === "throw") throw new Error("memory exploded");
           trace.recordedAttempts.push(payload);
+        }
+      : undefined,
+    recordOutcomeEvent: opts.recordOutcomeEvent
+      ? async (event) => {
+          if (opts.recordOutcomeEvent === "throw") throw new Error("brain exploded");
+          if (opts.recordOutcomeEvent === "hang") return await new Promise<never>(() => {});
+          trace.outcomeEvents.push(event);
         }
       : undefined,
     // Commit-leftovers salvage port (codex DONE-without-commit). Omitted unless
@@ -2722,6 +2735,79 @@ describe("processIssue — AFK→Memory reasoning-attempt recording (ADR 0017)",
     expect(result.outcome).toBe("blocked");
     expect(result.envelopePosted).toBe(true);
     expect(result.preserved).toBe(true);
+  });
+});
+
+describe("processIssue — AFK→Brain outcome-event recording", () => {
+  it("emits one versioned outcome event for a completed DONE attempt", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      labels: ["ready-for-agent", "type:bug"],
+      classifyIssue: async () => "simple",
+      recordOutcomeEvent: "ok",
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.outcomeEvents).toHaveLength(1);
+    expect(trace.outcomeEvents[0]).toEqual({
+      schemaVersion: 1,
+      id: "afk:o/r:9:1",
+      emitter: "afk",
+      occurredAt: "2026-05-30T00:00:00Z",
+      taskClass: "simple",
+      chosenOption: {
+        kind: "runner",
+        runner: "claude",
+        model: "claude-opus-4-8",
+        effort: "high",
+      },
+      outcome: "success",
+      cost: { signal: "unknown" },
+      context: {
+        repository: "o/r",
+        issueNumber: 9,
+        attemptNumber: 1,
+        issueType: "bug",
+        workerId: "wAAAA",
+        branch: "afk/wAAAA/9-fix-the-thing",
+        durationMs: 0,
+        status: "done",
+      },
+    });
+  });
+
+  it("keeps the DONE close and timing path unchanged when Brain recording throws", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      recordOutcomeEvent: "throw",
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(result.envelopePosted).toBe(true);
+    expect(result.swept).toBe(true);
+    expect(trace.closed).toEqual([9]);
+    expect(trace.postedEnvelopes).toContainEqual({ issue: 9, status: "done" });
+    expect(trace.outcomeEvents).toEqual([]);
+  });
+
+  it("does not wait for a slow Brain recorder before completing DONE", async () => {
+    const { deps, input } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      recordOutcomeEvent: "hang",
+    });
+
+    const result = await Promise.race([
+      processIssue(deps, input),
+      new Promise<"timed-out">((resolve) => setTimeout(() => resolve("timed-out"), 100)),
+    ]);
+
+    expect(result).not.toBe("timed-out");
+    expect(result).toMatchObject({ outcome: "done", swept: true });
   });
 });
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -66,3 +66,4 @@ export {
   type EnsureBundleInput,
   type ResolveBundleInput,
 } from "./bundle-fetch.js";
+export * from "./outcome-event.js";

--- a/packages/shared/outcome-event.ts
+++ b/packages/shared/outcome-event.ts
@@ -1,0 +1,77 @@
+export const OUTCOME_EVENT_SCHEMA_VERSION = 1 as const;
+
+export type OutcomeEventOutcome = "success" | "failure" | "escalated";
+
+export type OutcomeEventCostSignal = "none" | "low" | "medium" | "high" | "unknown";
+
+export interface OutcomeEventChosenOption {
+  kind: string;
+  runner?: string;
+  model?: string;
+  effort?: string;
+}
+
+export interface OutcomeEventCost {
+  signal: OutcomeEventCostSignal;
+  totalUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface OutcomeEventContext {
+  repository?: string;
+  issueNumber?: number;
+  attemptNumber?: number;
+  issueType?: string;
+  workerId?: string;
+  branch?: string;
+  durationMs?: number;
+  status?: string;
+}
+
+export interface OutcomeEventV1 {
+  schemaVersion: typeof OUTCOME_EVENT_SCHEMA_VERSION;
+  id: string;
+  emitter: string;
+  occurredAt: string;
+  taskClass: string;
+  chosenOption: OutcomeEventChosenOption;
+  outcome: OutcomeEventOutcome;
+  cost: OutcomeEventCost;
+  context?: OutcomeEventContext;
+}
+
+export type OutcomeEvent = OutcomeEventV1;
+
+export function isOutcomeEvent(value: unknown): value is OutcomeEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.schemaVersion === OUTCOME_EVENT_SCHEMA_VERSION &&
+    typeof candidate.id === "string" &&
+    candidate.id.length > 0 &&
+    typeof candidate.emitter === "string" &&
+    candidate.emitter.length > 0 &&
+    typeof candidate.occurredAt === "string" &&
+    typeof candidate.taskClass === "string" &&
+    isChosenOption(candidate.chosenOption) &&
+    isOutcome(candidate.outcome) &&
+    isCost(candidate.cost)
+  );
+}
+
+function isChosenOption(value: unknown): value is OutcomeEventChosenOption {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.kind === "string" && candidate.kind.length > 0;
+}
+
+function isOutcome(value: unknown): value is OutcomeEventOutcome {
+  return value === "success" || value === "failure" || value === "escalated";
+}
+
+function isCost(value: unknown): value is OutcomeEventCost {
+  if (typeof value !== "object" || value === null) return false;
+  const signal = (value as Record<string, unknown>).signal;
+  return signal === "none" || signal === "low" || signal === "medium" || signal === "high" || signal === "unknown";
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,8 @@
     "./entrypoint-cli.js": "./entrypoint-cli.ts",
     "./self-update.js": "./self-update.ts",
     "./log.js": "./log.ts",
-    "./plugin-gate.js": "./plugin-gate.ts"
+    "./plugin-gate.js": "./plugin-gate.ts",
+    "./outcome-event.js": "./outcome-event.ts"
   },
   "dependencies": {
     "cli-args-parser": "^1.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@reddb-io/sdk':
         specifier: 1.7.0
         version: 1.7.0
+      '@reddb-io/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       zod:
         specifier: 'catalog:'
         version: 3.25.76


### PR DESCRIPTION
Automated AFK landing for #1195. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1195

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964191&installation_id=129708444&pr_number=1244&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1244&signature=e2ba093357e3083f3eac389e95cf33972549efb91222a30c68cbf4d2a9998c51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->