### PR TITLE
merge: #1238 /go: No bundle dev (apps/dev/src/**), multiplos writers do afk.state.json usa

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1848,7 +1848,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         return result;
       }
       const sp = join(pi.attemptDir, "afk.state.json");
-      if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }).catch(() => {});
+      if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
       return result;
     },
     processDeps: buildProcessDeps(

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -108,6 +108,21 @@ export async function readState(path: string): Promise<AfkState> {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mergeInto(target: Record<string, unknown>, patch: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(patch)) {
+    const existing = target[key];
+    if (isRecord(existing) && isRecord(value)) {
+      mergeInto(existing, value);
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
 function setDotted(target: Record<string, unknown>, key: string, value: unknown): void {
   const parts = key.split(".").filter(Boolean);
   if (parts.length === 0) throw new Error("empty state field");
@@ -117,7 +132,68 @@ function setDotted(target: Record<string, unknown>, key: string, value: unknown)
     if (!existing || typeof existing !== "object" || Array.isArray(existing)) cursor[part] = {};
     cursor = cursor[part] as Record<string, unknown>;
   }
-  cursor[parts[parts.length - 1]!] = value;
+  const leaf = parts[parts.length - 1]!;
+  const existing = cursor[leaf];
+  if (isRecord(existing) && isRecord(value)) {
+    mergeInto(existing, value);
+  } else {
+    cursor[leaf] = value;
+  }
+}
+
+function isStampedIdentityValue(value: unknown): boolean {
+  if (typeof value === "string") return value !== "";
+  if (typeof value === "number") return value !== 0;
+  return value !== undefined && value !== null;
+}
+
+function restoreStampedDotted(
+  target: Record<string, unknown>,
+  previous: Record<string, unknown>,
+  key: string,
+): void {
+  const parts = key.split(".").filter(Boolean);
+  let prev: unknown = previous;
+  for (const part of parts) {
+    if (!isRecord(prev)) return;
+    prev = prev[part];
+  }
+  if (!isStampedIdentityValue(prev)) return;
+  setDotted(target, key, prev);
+}
+
+const IMMUTABLE_STATE_FIELDS = [
+  "worker_id",
+  "pid_start_time",
+  "started_at",
+  "origin",
+  "runner",
+  "current.number",
+  "current.started_at",
+  "current.runner",
+  "current.model",
+  "current.effort",
+] as const;
+
+export interface UpdateStateOptions {
+  /** Only true at real attempt teardown, when the worker is no longer live. */
+  allowPidReset?: boolean;
+}
+
+const stateUpdateQueues = new Map<string, Promise<void>>();
+
+function preserveStampedIdentity(
+  next: Record<string, unknown>,
+  previous: AfkState,
+  options: UpdateStateOptions,
+): void {
+  const prev = previous as unknown as Record<string, unknown>;
+  for (const key of IMMUTABLE_STATE_FIELDS) restoreStampedDotted(next, prev, key);
+  if (previous.pid > 0 && !options.allowPidReset) {
+    next.pid = previous.pid;
+  } else if (previous.pid > 0 && next.pid !== 0) {
+    next.pid = previous.pid;
+  }
 }
 
 export async function writeStateAtomic(path: string, state: AfkState): Promise<void> {
@@ -162,12 +238,36 @@ export function initStateSync(path: string, updates: Record<string, unknown> = {
   return parsed;
 }
 
-export async function updateState(path: string, updates: Record<string, unknown>): Promise<AfkState> {
-  const state = (await readState(path)) as unknown as Record<string, unknown>;
+async function updateStateUnlocked(
+  path: string,
+  updates: Record<string, unknown>,
+  options: UpdateStateOptions = {},
+): Promise<AfkState> {
+  const previous = await readState(path);
+  const state = structuredClone(previous) as unknown as Record<string, unknown>;
   for (const [key, value] of Object.entries(updates)) setDotted(state, key, value);
+  preserveStampedIdentity(state, previous, options);
   const parsed = parseState(state);
   await writeStateAtomic(path, parsed);
   return parsed;
+}
+
+export async function updateState(
+  path: string,
+  updates: Record<string, unknown>,
+  options: UpdateStateOptions = {},
+): Promise<AfkState> {
+  const previous = stateUpdateQueues.get(path) ?? Promise.resolve();
+  const op = previous.catch(() => undefined).then(() => updateStateUnlocked(path, updates, options));
+  const tail = op.then(
+    () => undefined,
+    () => undefined,
+  );
+  stateUpdateQueues.set(path, tail);
+  tail.finally(() => {
+    if (stateUpdateQueues.get(path) === tail) stateUpdateQueues.delete(path);
+  });
+  return op;
 }
 
 export type PidStartTimeProbe = (pid: number) => string | null;

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -20,6 +20,7 @@ import {
 import { dirname, join } from "node:path";
 import type { FailureMarkers } from "../core/envelope-emit.js";
 import type { OrphanDir, StaleClaimDir } from "../core/boot.js";
+import { updateState } from "../core/state.js";
 
 export async function ensureDir(path: string): Promise<void> {
   await mkdir(path, { recursive: true });
@@ -201,24 +202,7 @@ export async function writeFailureMarkers(attemptDir: string, markers: FailureMa
 /** Persist the `envelope.posted` signal into the iteration state file. Best
  * effort: a malformed/absent state file degrades to writing a minimal object. */
 export async function writeEnvelopePosted(attemptDir: string, posted: boolean): Promise<void> {
-  const statePath = join(attemptDir, "afk.state.json");
-  let obj: Record<string, unknown> = {};
-  const text = await readText(statePath);
-  if (text !== null) {
-    try {
-      const parsed = JSON.parse(text);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) obj = parsed as Record<string, unknown>;
-    } catch {
-      obj = {};
-    }
-  }
-  const env = (obj.envelope && typeof obj.envelope === "object" ? obj.envelope : {}) as Record<string, unknown>;
-  env.posted = posted;
-  obj.envelope = env;
-  await mkdir(attemptDir, { recursive: true });
-  const tmp = `${statePath}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(obj)}\n`, "utf8");
-  await rename(tmp, statePath);
+  await updateState(join(attemptDir, "afk.state.json"), { "envelope.posted": posted });
 }
 
 /** Read the `envelope.posted` flag from an attempt state file (false when

--- a/apps/dev/tests/fs-envelope.test.ts
+++ b/apps/dev/tests/fs-envelope.test.ts
@@ -1,19 +1,45 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { readEnvelopePosted, writeEnvelopePosted } from "../src/runtime/fs.js";
 
 describe("envelope posted state persistence", () => {
-  it("preserves the original state when the atomic temp write fails", async () => {
+  it("preserves accumulated worker state while updating the envelope flag", async () => {
     const attemptDir = await mkdtemp(join(tmpdir(), "afk-envelope-"));
     const statePath = join(attemptDir, "afk.state.json");
-    const original = `${JSON.stringify({ pid: 123, envelope: { posted: false }, current: { stage: "impl" } })}\n`;
+    const original = `${JSON.stringify({
+      worker_id: "wENV",
+      pid: 123,
+      runner: "codex",
+      envelope: { posted: false },
+      current: {
+        number: 1238,
+        runner: "codex",
+        model: "gpt-5",
+        effort: "high",
+        stage: "impl",
+        loc_added: 12,
+        loc_removed: 4,
+      },
+    })}\n`;
     await writeFile(statePath, original, "utf8");
-    await mkdir(`${statePath}.tmp`);
 
-    await expect(writeEnvelopePosted(attemptDir, true)).rejects.toThrow();
-    expect(await readFile(statePath, "utf8")).toBe(original);
-    expect(await readEnvelopePosted(attemptDir)).toBe(false);
+    await writeEnvelopePosted(attemptDir, true);
+
+    const after = JSON.parse(await readFile(statePath, "utf8"));
+    expect(after.worker_id).toBe("wENV");
+    expect(after.pid).toBe(123);
+    expect(after.runner).toBe("codex");
+    expect(after.current).toMatchObject({
+      number: 1238,
+      runner: "codex",
+      model: "gpt-5",
+      effort: "high",
+      stage: "impl",
+      loc_added: 12,
+      loc_removed: 4,
+    });
+    expect(await readEnvelopePosted(attemptDir)).toBe(true);
   });
 });

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -62,6 +62,115 @@ describe("state", () => {
     expect(after.current.stage).toBe("tests");
   });
 
+  it("preserves stamped identity, vitals, and loc when a stage writer carries default identity fields", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+
+    initStateSync(path, {
+      worker_id: "w8UV2",
+      pid: 4242,
+      pid_start_time: "12345",
+      runner: "codex",
+      origin: "afk",
+      started_at: "2026-07-06T20:00:00.000Z",
+      "current.number": 1238,
+      "current.runner": "codex",
+      "current.model": "gpt-5",
+      "current.effort": "high",
+      "current.stage": "setup",
+      "current.phase": "setup",
+      "current.tools_called_count": 9,
+      "current.loc_added": 22,
+      "current.loc_removed": 3,
+      "current.last_event_at": "2026-07-06T20:01:00.000Z",
+    });
+
+    const after = await updateState(path, {
+      worker_id: "",
+      pid: 0,
+      pid_start_time: "",
+      runner: "",
+      origin: "",
+      started_at: "",
+      current: {
+        number: "",
+        runner: "",
+        model: "",
+        effort: "",
+        stage: "impl",
+      },
+    });
+
+    expect(after.worker_id).toBe("w8UV2");
+    expect(after.pid).toBe(4242);
+    expect(after.pid_start_time).toBe("12345");
+    expect(after.runner).toBe("codex");
+    expect(after.origin).toBe("afk");
+    expect(after.started_at).toBe("2026-07-06T20:00:00.000Z");
+    expect(after.current.number).toBe(1238);
+    expect(after.current.runner).toBe("codex");
+    expect(after.current.model).toBe("gpt-5");
+    expect(after.current.effort).toBe("high");
+    expect(after.current.stage).toBe("impl");
+    expect(after.current.tools_called_count).toBe(9);
+    expect(after.current.loc_added).toBe(22);
+    expect(after.current.loc_removed).toBe(3);
+    expect(after.current.last_event_at).toBe("2026-07-06T20:01:00.000Z");
+  });
+
+  it("preserves live pid and current identity when stamping the validating phase", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+
+    initStateSync(path, {
+      worker_id: "wSVD3",
+      pid: 263126,
+      runner: "codex",
+      "current.number": 1238,
+      "current.runner": "codex",
+      "current.model": "gpt-5",
+      "current.effort": "high",
+      "current.stage": "tests",
+      "current.phase": "coding",
+    });
+
+    const after = await updateState(path, {
+      worker_id: "",
+      pid: 0,
+      runner: "",
+      "current.number": "",
+      "current.runner": "",
+      "current.model": "",
+      "current.effort": "",
+      "current.phase": "validating",
+    });
+
+    expect(after.worker_id).toBe("wSVD3");
+    expect(after.pid).toBe(263126);
+    expect(after.runner).toBe("codex");
+    expect(after.current).toMatchObject({
+      number: 1238,
+      runner: "codex",
+      model: "gpt-5",
+      effort: "high",
+      stage: "tests",
+      phase: "validating",
+    });
+  });
+
+  it("only allows pid to reset to zero when the caller marks a real teardown", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+
+    initStateSync(path, { worker_id: "wLIVE", pid: 99, "current.number": 1238 });
+
+    const phase = await updateState(path, { pid: 0, "current.phase": "validating" });
+    expect(phase.pid).toBe(99);
+
+    const terminal = await updateState(path, { pid: 0 }, { allowPidReset: true });
+    expect(terminal.pid).toBe(0);
+  });
+
   it("checks liveness via the injected kill -0 predicate", () => {
     expect(isStateLive({ pid: 0 }, () => true)).toBe(false);
     expect(isStateLive({ pid: 123 }, (pid) => pid === 123)).toBe(true);


### PR DESCRIPTION
Automated AFK landing for #1238. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1238

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964285&installation_id=129708444&pr_number=1245&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1245&signature=f67f25a581d3f68d683017168719fa74da069e3ed744ee8329b8bf6a9867c9bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->