### PR TITLE
merge: #1197 afk: contest window after reap-requeue

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -532,6 +532,7 @@ function buildSupervisorDeps(
         return [];
       }
     },
+    attemptBranchHead: (branch) => gitx.branchHead({ cwd: root }, branch),
     // Fleet-scoped lifecycle hooks (#833). Commands are resolved from the same
     // .red/hooks/<point>/ + library layering as worker hooks. Best-effort:
     // a dispatch failure is returned to the caller; the caller catches and logs.

--- a/apps/dev/src/core/issue-lifecycle.ts
+++ b/apps/dev/src/core/issue-lifecycle.ts
@@ -1,5 +1,6 @@
 import {
   LABEL_CI,
+  LABEL_CONTESTED,
   LABEL_CRASHED,
   LABEL_DEPENDENCY,
   LABEL_HUMAN,
@@ -22,6 +23,7 @@ import {
 export type IssueLifecycleState =
   | "ready-for-agent"
   | "claimed/active"
+  | "contested"
   | "blocked:dependency"
   | "blocked:validation"
   | "ready-for-human"
@@ -30,6 +32,9 @@ export type IssueLifecycleState =
 
 export type IssueLifecycleEdge =
   | "claim"
+  | "contest"
+  | "contest-expired"
+  | "contest-reclaimed"
   | "retry"
   | "dependency-unblocked"
   | "dependency-blocked"
@@ -73,6 +78,9 @@ export const ISSUE_LIFECYCLE_TRANSITIONS: readonly IssueLifecycleTransition[] = 
   // set that the claim edit cleans up (#402). The `to` still has to be
   // claimed/active — a claim that lands anywhere else finds no row and throws.
   { edge: "claim", from: "*", to: "claimed/active" },
+  { edge: "contest", from: "claimed/active", to: "contested" },
+  { edge: "contest-reclaimed", from: "contested", to: "claimed/active" },
+  { edge: "contest-expired", from: "contested", to: "ready-for-agent" },
   { edge: "retry", from: "claimed/active", to: "ready-for-agent" },
   { edge: "dependency-unblocked", from: "blocked:dependency", to: "ready-for-agent" },
   { edge: "dependency-blocked", from: "ready-for-agent", to: "blocked:dependency" },
@@ -125,10 +133,12 @@ export function classifyIssueLifecycleState(labels: readonly string[]): IssueLif
   const hasRunning = labels.includes(LABEL_RUNNING);
   const hasHuman = labels.includes(LABEL_HUMAN);
   const hasManualLanding = labels.includes(LABEL_LANDING_MANUAL);
+  const hasContested = labels.includes(LABEL_CONTESTED);
   const blocked = blockedLabelsIn(labels);
   const hasBlocked = blocked.length > 0;
 
   if (blocked.length > 1) return "illegal";
+  if (hasContested && (!hasRunning || hasReady || hasHuman || hasBlocked || hasManualLanding)) return "illegal";
   if ((hasReady || hasRunning) && hasBlocked) return "illegal";
   if (hasReady && hasRunning) return "illegal";
   // `landing:manual` is a MODE flag that must ride a real state: queued
@@ -136,6 +146,7 @@ export function classifyIssueLifecycleState(labels: readonly string[]): IssueLif
   // or human-parked. Alone it is illegal.
   if (hasManualLanding && !hasHuman && !hasReady && !hasRunning) return "illegal";
 
+  if (hasContested) return "contested";
   if (hasManualLanding && hasHuman) return "landing:manual";
   if (hasRunning) return "claimed/active";
   if (hasReady) return "ready-for-agent";
@@ -149,6 +160,17 @@ export function classifyIssueLifecycleState(labels: readonly string[]): IssueLif
 export function explainIllegalIssueLifecycleLabels(labels: readonly string[]): string | null {
   const blocked = blockedLabelsIn(labels);
   if (blocked.length > 1) return `mixed blocked:* labels [${blocked.join(", ")}]`;
+  if (labels.includes(LABEL_CONTESTED)) {
+    if (!labels.includes(LABEL_RUNNING)) return `${LABEL_CONTESTED} must ride ${LABEL_RUNNING}`;
+    if (
+      labels.includes(LABEL_READY) ||
+      labels.includes(LABEL_HUMAN) ||
+      labels.includes(LABEL_LANDING_MANUAL) ||
+      blocked.length > 0
+    ) {
+      return `${LABEL_CONTESTED} cannot ride queued, human, manual-landing, or blocked state`;
+    }
+  }
   if ((labels.includes(LABEL_READY) || labels.includes(LABEL_RUNNING)) && blocked.length > 0) {
     return `queued/active issue cannot also carry blocked:* label ${blocked[0]}`;
   }

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -29,9 +29,11 @@ import { type RecoveryEnv } from "./recovery.js";
 import {
   LABEL_READY,
   LABEL_RUNNING,
+  LABEL_CONTESTED,
   LABEL_HUMAN,
   LABEL_RUNNER_ERROR,
 } from "./triage-labels.js";
+import { validateIssueLifecycleTransition } from "./issue-lifecycle.js";
 import {
   computeHalfOpenBackoff,
   isHalfOpenDue,
@@ -165,6 +167,10 @@ export interface SupervisorConfig {
    * lane (`current.cost_usd`) through SupervisorFs.fleetCostUsd.
    */
   drainBudgetUsd?: number;
+  /** RED_AFK_REAP_CONTEST_WINDOW_S — seconds a stall-reaped retry waits for the
+   * original attempt branch to advance before rotating the issue back to
+   * ready-for-agent. */
+  reapContestWindowS: number;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -185,6 +191,7 @@ export const SUPERVISOR_DEFAULTS = {
   unblockSweepIntervalS: 60,
   supervisorMaxRestarts: 5,
   supervisorRestartWindowS: 300,
+  reapContestWindowS: 30,
 } as const satisfies SupervisorConfig;
 
 export type DrainBudgetTier = "OK" | "WARNING" | "CRITICAL" | "HARD_STOP";
@@ -283,6 +290,7 @@ export function resolveSupervisorConfig(
     drainBudgetUsd:
       parsePositiveNumber(env.RED_AFK_DRAIN_MAX_COST_USD) ??
       parsePositiveNumber(getCfg("afk.drain.max_cost_usd")),
+    reapContestWindowS: num("RED_AFK_REAP_CONTEST_WINDOW_S", SUPERVISOR_DEFAULTS.reapContestWindowS),
   };
 }
 
@@ -653,6 +661,8 @@ export interface IterDirInfo {
   /** .current.number, or null when the worker died before claiming. */
   issue: number | null;
   workerId: string;
+  /** Live attempt branch (`afk/{worker}/{issue}-{slug}`), when recoverable. */
+  branch?: string;
   /** Tail of afk.log for the no-sentinel envelope's log section. */
   logTail: string;
   /** Extracted agent notes for the envelope's notes section, if any. */
@@ -749,9 +759,20 @@ export interface SupervisorDeps {
    * kill for that pass. Absent → no-op (backward-compatible). (#833)
    */
   dispatchFleetHook?(name: FleetHookName, context: FleetHookContext): Promise<FleetHookDispatchResult>;
+  /** Resolve the current local HEAD of an attempt branch. Best-effort: undefined
+   * means the contest window cannot observe advancement yet. */
+  attemptBranchHead?(branch: string): Promise<string | undefined>;
 }
 
 // ---------- per-slot runtime state ----------
+
+export interface ReapContestState {
+  issue: number;
+  branch: string;
+  headAtReap: string | undefined;
+  openedEpoch: number;
+  deadlineEpoch: number;
+}
 
 /** The supervisor's per-slot bookkeeping, mirroring the SLOT_* arrays. A fresh
  * slot is `freshSlot()`. The tick mutates these in place (the bash arrays are
@@ -785,6 +806,10 @@ export interface SlotState {
    * has been spawned. The probe's death resolves to either closed (success)
    * or re-parked-open (fast-death failure). */
   halfOpen: boolean;
+  /** Pending post-reap retry contest. While present, the issue carries
+   * `running` + `contested`; a late commit on `branch` reclaims the issue,
+   * otherwise the normal clean retry label flip runs when `deadlineEpoch` passes. */
+  contest: ReapContestState | null;
 }
 
 export function freshSlot(): SlotState {
@@ -802,6 +827,7 @@ export function freshSlot(): SlotState {
     idleParked: false,
     backoffStep: 0,
     halfOpen: false,
+    contest: null,
   };
 }
 
@@ -1192,6 +1218,7 @@ export async function reapStalledSlot(
   slot: number,
   state: SlotState,
   deps: SupervisorDeps,
+  config: Pick<SupervisorConfig, "reapContestWindowS"> = SUPERVISOR_DEFAULTS,
 ): Promise<void> {
   if (state.reaped) return;
   state.reaped = true;
@@ -1230,8 +1257,11 @@ export async function reapStalledSlot(
     // so the descriptor's (remove, add) sets are applied swapped.
     const disp = dispose("stalled", info.attempt, deps.recoveryEnv ?? {});
     if (disp.decision === "retry") {
-      // CLEAN re-queue: no blocked:* tag rides a re-queued issue.
-      await deps.gh.editLabels(info.issue, disp.addLabels, disp.removeLabels);
+      const opened = await openReapContest(slot, state, info, deps, config.reapContestWindowS);
+      if (!opened) {
+        // CLEAN re-queue: no blocked:* tag rides a re-queued issue.
+        await deps.gh.editLabels(info.issue, disp.addLabels, disp.removeLabels);
+      }
     } else {
       if (disp.typedLabel !== null) await deps.gh.ensureLabel(disp.typedLabel);
       // Escalation also sheds any stale ready-for-agent — the reaped slot was
@@ -1251,6 +1281,121 @@ export async function reapStalledSlot(
   if (info && confirmedDead) await deps.fs.teardownIterDir(info);
 }
 
+async function branchHeadForContest(deps: SupervisorDeps, branch: string): Promise<string | undefined> {
+  try {
+    return await deps.attemptBranchHead?.(branch);
+  } catch {
+    return undefined;
+  }
+}
+
+function logReapContest(
+  deps: SupervisorDeps,
+  event: "opened" | "reclaimed" | "expired",
+  details: Record<string, string | number | undefined>,
+): void {
+  deps.log?.(
+    encodeToon({
+      schema_version: "red.afk.reap_contest.v1",
+      event,
+      ...details,
+    }),
+  );
+}
+
+async function openReapContest(
+  slot: number,
+  state: SlotState,
+  info: IterDirInfo,
+  deps: SupervisorDeps,
+  windowS: number,
+): Promise<boolean> {
+  if (info.issue === null || !info.branch || windowS <= 0) return false;
+  const openedEpoch = deps.now();
+  const deadlineEpoch = openedEpoch + windowS;
+  const headAtReap = await branchHeadForContest(deps, info.branch);
+
+  validateIssueLifecycleTransition({
+    edge: "contest",
+    fromLabels: [LABEL_RUNNING],
+    removeLabels: [],
+    addLabels: [LABEL_CONTESTED],
+  });
+  await deps.gh.editLabels(info.issue, [LABEL_CONTESTED], []);
+  state.contest = {
+    issue: info.issue,
+    branch: info.branch,
+    headAtReap,
+    openedEpoch,
+    deadlineEpoch,
+  };
+  logReapContest(deps, "opened", {
+    slot,
+    issue: info.issue,
+    branch: info.branch,
+    head_at_reap: headAtReap,
+    deadline_epoch: deadlineEpoch,
+  });
+  return true;
+}
+
+export type ReapContestResolution = "pending" | "reclaimed" | "expired" | null;
+
+export async function resolveReapContest(
+  slot: number,
+  state: SlotState,
+  deps: SupervisorDeps,
+  _config: Pick<SupervisorConfig, "reapContestWindowS"> = SUPERVISOR_DEFAULTS,
+): Promise<ReapContestResolution> {
+  const contest = state.contest;
+  if (contest === null) return null;
+
+  const now = deps.now();
+  const currentHead = await branchHeadForContest(deps, contest.branch);
+  if (
+    now <= contest.deadlineEpoch &&
+    contest.headAtReap !== undefined &&
+    currentHead !== undefined &&
+    currentHead !== contest.headAtReap
+  ) {
+    validateIssueLifecycleTransition({
+      edge: "contest-reclaimed",
+      fromLabels: [LABEL_RUNNING, LABEL_CONTESTED],
+      removeLabels: [LABEL_CONTESTED],
+      addLabels: [],
+    });
+    await deps.gh.editLabels(contest.issue, [], [LABEL_CONTESTED]);
+    state.contest = null;
+    logReapContest(deps, "reclaimed", {
+      slot,
+      issue: contest.issue,
+      branch: contest.branch,
+      head_at_reap: contest.headAtReap,
+      head_at_resolution: currentHead,
+    });
+    return "reclaimed";
+  }
+
+  if (now < contest.deadlineEpoch) return "pending";
+
+  validateIssueLifecycleTransition({
+    edge: "contest-expired",
+    fromLabels: [LABEL_RUNNING, LABEL_CONTESTED],
+    removeLabels: [LABEL_RUNNING, LABEL_CONTESTED],
+    addLabels: [LABEL_READY],
+  });
+  await deps.gh.editLabels(contest.issue, [LABEL_READY], [LABEL_RUNNING, LABEL_CONTESTED]);
+  state.contest = null;
+  logReapContest(deps, "expired", {
+    slot,
+    issue: contest.issue,
+    branch: contest.branch,
+    head_at_reap: contest.headAtReap,
+    head_at_resolution: currentHead,
+  });
+  return "expired";
+}
+
 /**
  * pollStallDetector (supervisor.sh ~611): sample every non-parked slot. Flag /
  * clear the stall bit from the agent-lane mtime vs the stall threshold, then —
@@ -1263,7 +1408,7 @@ export async function reapStalledSlot(
 export async function pollStallDetector(
   state: SupervisorState,
   deps: SupervisorDeps,
-  config: Pick<SupervisorConfig, "stallThresholdS" | "stallKillThresholdS" | "runner">,
+  config: Pick<SupervisorConfig, "stallThresholdS" | "stallKillThresholdS" | "runner" | "reapContestWindowS">,
 ): Promise<number[]> {
   const now = deps.now();
   const reaped: number[] = [];
@@ -1343,7 +1488,7 @@ export async function pollStallDetector(
             }
           }
           if (!vetoed) {
-            await reapStalledSlot(i, slot, deps);
+            await reapStalledSlot(i, slot, deps, config);
             reaped.push(i);
           }
         }
@@ -1694,6 +1839,10 @@ export async function superviseTick(
   result.drainBudget = drainBudget;
   logDrainBudgetTransition(state, deps, drainBudget, queueDepth);
   const spawnPolicy = spawnPolicyForBudget(state, drainBudget);
+
+  for (let i = 0; i < state.slots.length; i += 1) {
+    await resolveReapContest(i, state.slots[i]!, deps, config);
+  }
 
   // Un-park idle-parked slots when the queue has work to do.
   for (let i = 0; i < state.slots.length; i += 1) {

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -10,6 +10,7 @@
 export const LABEL_READY = "ready-for-agent";
 export const LABEL_RUNNING = "running";
 export const LABEL_HUMAN = "ready-for-human";
+export const LABEL_CONTESTED = "contested";
 // PR-object entry label (PRD #745, issue #746): a maintainer applies this to a
 // PR to request the advisory cloud review. It is the only PR-specific label —
 // the review then transitions the PR through the shared lifecycle vocabulary

--- a/apps/dev/src/runtime/supervisor-fs.ts
+++ b/apps/dev/src/runtime/supervisor-fs.ts
@@ -16,6 +16,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { IterDirInfo, SweepWork, SweepWorker } from "../core/supervisor.js";
+import { buildRef } from "../core/remote-branch.js";
 import { parseWorkerAttemptPath, workerDir } from "../core/worker-paths.js";
 import { readWorkerState } from "../core/worker-state-reader.js";
 import {
@@ -261,6 +262,7 @@ export function resolveIterDirInfo(
   let issue: number | null = null;
   let workerId = "";
   let startedAt = "";
+  let branch: string | undefined;
   // Single owner (core/worker-state-reader): null when the dir has no/malformed
   // state, in which case issue/worker stay empty and teardown still proceeds.
   const rec = readWorkerState(join(dir, "afk.state.json"));
@@ -269,6 +271,9 @@ export function resolveIterDirInfo(
     if (typeof n === "number" && Number.isInteger(n)) issue = n;
     workerId = rec.state.worker_id;
     startedAt = rec.state.started_at;
+    if (issue !== null && workerId.length > 0) {
+      branch = buildRef("afk", workerId, issue, rec.state.current.title) ?? undefined;
+    }
   }
 
   let durationS = 0;
@@ -286,7 +291,7 @@ export function resolveIterDirInfo(
   // re-claim cap (#402). Degrades to attempt 1 when the path is non-canonical.
   const attempt = parseWorkerAttemptPath(dir)?.attempt ?? 1;
 
-  return { path: dir, issue, workerId, logTail, notes, durationS, attempt };
+  return { path: dir, issue, workerId, branch, logTail, notes, durationS, attempt };
 }
 
 /**

--- a/apps/dev/tests/fleet-hooks.test.ts
+++ b/apps/dev/tests/fleet-hooks.test.ts
@@ -53,6 +53,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     unblockSweepIntervalS: 60,
     supervisorMaxRestarts: 5,
     supervisorRestartWindowS: 300,
+    reapContestWindowS: 30,
     ...over,
   };
 }

--- a/apps/dev/tests/issue-lifecycle.test.ts
+++ b/apps/dev/tests/issue-lifecycle.test.ts
@@ -21,6 +21,9 @@ describe("issue lifecycle transition table", () => {
     const edges = new Set(ISSUE_LIFECYCLE_TRANSITIONS.map((row) => row.edge));
     const expected: IssueLifecycleEdge[] = [
       "claim",
+      "contest",
+      "contest-expired",
+      "contest-reclaimed",
       "retry",
       "dependency-unblocked",
       "dependency-blocked",
@@ -60,6 +63,33 @@ describe("issue lifecycle transition table", () => {
         edge: "retry",
         fromLabels: ["running"],
         removeLabels: ["running"],
+        addLabels: ["ready-for-agent"],
+      }),
+    ).toEqual(["ready-for-agent"]);
+
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "contest",
+        fromLabels: ["running"],
+        removeLabels: [],
+        addLabels: ["contested"],
+      }).sort(),
+    ).toEqual(["contested", "running"]);
+
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "contest-reclaimed",
+        fromLabels: ["running", "contested"],
+        removeLabels: ["contested"],
+        addLabels: [],
+      }),
+    ).toEqual(["running"]);
+
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "contest-expired",
+        fromLabels: ["running", "contested"],
+        removeLabels: ["running", "contested"],
         addLabels: ["ready-for-agent"],
       }),
     ).toEqual(["ready-for-agent"]);
@@ -126,5 +156,14 @@ describe("issue lifecycle transition table", () => {
         addLabels: ["ready-for-agent", "blocked:validation"],
       }),
     ).toThrow(/queued\/active issue cannot also carry blocked:\*/);
+
+    expect(() =>
+      validateIssueLifecycleTransition({
+        edge: "contest-expired",
+        fromLabels: ["running"],
+        removeLabels: ["running"],
+        addLabels: ["ready-for-agent"],
+      }),
+    ).toThrow(/no legal row/);
   });
 });

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -13,6 +13,7 @@ import {
   handleDeadSlot,
   initSupervisorState,
   pollStallDetector,
+  resolveReapContest,
   recordDeath,
   resolveSupervisorConfig,
   runSupervisor,
@@ -80,6 +81,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     unblockSweepIntervalS: 60,
     supervisorMaxRestarts: 5,
     supervisorRestartWindowS: 300,
+    reapContestWindowS: 30,
     ...over,
   };
 }
@@ -118,6 +120,8 @@ interface FakeIo {
   emitFleetHeartbeat: ReturnType<typeof vi.fn>;
   unblockSweep: ReturnType<typeof vi.fn>;
   fleetCostUsd: ReturnType<typeof vi.fn>;
+  attemptBranchHead: ReturnType<typeof vi.fn>;
+  logLines: string[];
   now: ReturnType<typeof vi.fn>;
 }
 
@@ -160,6 +164,8 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     emitFleetHeartbeat: vi.fn(async () => {}),
     unblockSweep: vi.fn(async (): Promise<number[]> => []),
     fleetCostUsd: vi.fn(() => 0),
+    attemptBranchHead: vi.fn(async () => undefined as string | undefined),
+    logLines: [],
     now: vi.fn(() => NOW),
     ...(over as Partial<FakeIo>),
   };
@@ -191,8 +197,12 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       crashedClaimState: io.crashedClaimState,
     },
     now: io.now,
+    log: (line) => {
+      io.logLines.push(line);
+    },
     emitFleetHeartbeat: io.emitFleetHeartbeat,
     unblockSweep: io.unblockSweep,
+    attemptBranchHead: io.attemptBranchHead,
   };
   return { deps, io };
 }
@@ -845,6 +855,7 @@ describe("pollStallDetector reaper gating", () => {
           path: "/w/wTEST/190-a1",
           issue: 190,
           workerId: "wTEST",
+          branch: "afk/wTEST/190-some-work",
           logTail: "[afk] inner: stalled tool call — never returns",
           notes: "mid-iteration progress note",
           durationS: 200,
@@ -852,6 +863,7 @@ describe("pollStallDetector reaper gating", () => {
           attempt: 1,
         }),
       ),
+      attemptBranchHead: vi.fn(async () => "aaa111"),
     });
     const state = stalledState();
 
@@ -864,11 +876,13 @@ describe("pollStallDetector reaper gating", () => {
     expect(issue).toBe(190);
     expect(body).toContain('data-attempt-status="no-sentinel"');
     expect(body).toContain("stalled tool call");
-    // #402: a re-queue UNDER the cap routes back to ready-for-agent CLEAN — no
-    // blocked:stalled rides along, so the adoption-doctor hygiene check stays at
-    // zero offenders. The typed label is NOT created on retry.
+    // #1197: the retry first opens a bounded contest window. The issue is not
+    // ready-for-agent yet, so a second worker cannot double-run it while the
+    // original branch may still report late commits.
     expect(io.ensureLabel).not.toHaveBeenCalled();
-    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent"], ["running"]);
+    expect(io.editLabels).toHaveBeenCalledWith(190, ["contested"], []);
+    expect(state.slots[0]!.contest?.issue).toBe(190);
+    expect(io.logLines.some((line) => line.includes("opened"))).toBe(true);
     expect(io.teardownIterDir).toHaveBeenCalledOnce();
     // Slot freed + idempotency guard set.
     const slot = state.slots[0]!;
@@ -882,6 +896,50 @@ describe("pollStallDetector reaper gating", () => {
     await pollStallDetector(state, deps, config());
     expect(io.killTree).not.toHaveBeenCalled();
     expect(io.comment).not.toHaveBeenCalled();
+  });
+
+  it("resolves a contest as reclaimed when the original branch advances inside the window", async () => {
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.contest = {
+      issue: 190,
+      branch: "afk/wTEST/190-some-work",
+      headAtReap: "aaa111",
+      openedEpoch: NOW - 5,
+      deadlineEpoch: NOW + 25,
+    };
+    const { deps, io } = makeDeps({
+      attemptBranchHead: vi.fn(async () => "bbb222"),
+    });
+
+    const result = await resolveReapContest(0, slot, deps, config());
+
+    expect(result).toBe("reclaimed");
+    expect(slot.contest).toBeNull();
+    expect(io.editLabels).toHaveBeenCalledWith(190, [], ["contested"]);
+    expect(io.logLines.some((line) => line.includes("reclaimed"))).toBe(true);
+  });
+
+  it("resolves a contest as expired and applies the normal clean requeue after the window", async () => {
+    const state = initSupervisorState(1);
+    const slot = state.slots[0]!;
+    slot.contest = {
+      issue: 190,
+      branch: "afk/wTEST/190-some-work",
+      headAtReap: "aaa111",
+      openedEpoch: NOW - 40,
+      deadlineEpoch: NOW - 10,
+    };
+    const { deps, io } = makeDeps({
+      attemptBranchHead: vi.fn(async () => "aaa111"),
+    });
+
+    const result = await resolveReapContest(0, slot, deps, config());
+
+    expect(result).toBe("expired");
+    expect(slot.contest).toBeNull();
+    expect(io.editLabels).toHaveBeenCalledWith(190, ["ready-for-agent"], ["running", "contested"]);
+    expect(io.logLines.some((line) => line.includes("expired"))).toBe(true);
   });
 
   it("does NOT tear down the worktree when the worker survives the kill (#580)", async () => {


### PR DESCRIPTION
Automated AFK landing for #1197. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1197

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964390&installation_id=129708444&pr_number=1246&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1246&signature=c7c23d61631a168c2bcd80e552e99aa2740d948e7d129449852a8aec14425abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->