### PR TITLE
merge: #1241 /go: Em apps/dev/src, o statusline e o /afk monitor renderizam UM ROW POR ATT

### DIFF
--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -11,7 +11,7 @@
 // inside sync closures and must not pay an await. `readWorkerStates(root)` is the
 // async fan-out the collectors use (glob → read each).
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import type { AfkState } from "../types/state.js";
 import { parseState, isStateLive, parseIdentity, readIdentitySync, type PidStartTimeProbe } from "./state.js";
@@ -97,6 +97,88 @@ export function isRenderableLive(
   rec: Pick<WorkerStateRecord, "livenessVerdict" | "pidIdentityLive" | "hostPidLive">,
 ): boolean {
   return rec.livenessVerdict.status !== "stalled" && (rec.pidIdentityLive || rec.hostPidLive);
+}
+
+function attemptName(path: string): string {
+  return basename(dirname(path));
+}
+
+function attemptNumberFromPath(path: string): number {
+  const m = /^[1-9][0-9]*-a([1-9][0-9]*)$/.exec(attemptName(path));
+  return m ? Number(m[1]) : 0;
+}
+
+function attemptMtimeMs(path: string): number {
+  try {
+    return statSync(dirname(path)).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function attemptStartedMs(rec: Pick<WorkerStateRecord, "path" | "state">): number {
+  const raw = rec.state.current.started_at || rec.state.started_at;
+  if (raw) {
+    const parsed = Date.parse(raw);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return attemptMtimeMs(rec.path);
+}
+
+function workerKey(rec: Pick<WorkerStateRecord, "path" | "state">): string {
+  return rec.state.worker_id || basename(dirname(dirname(rec.path)));
+}
+
+function compareWorkerAttempts(a: Pick<WorkerStateRecord, "path" | "state">, b: Pick<WorkerStateRecord, "path" | "state">): number {
+  const started = attemptStartedMs(a) - attemptStartedMs(b);
+  if (started !== 0) return started;
+  const attempt = attemptNumberFromPath(a.path) - attemptNumberFromPath(b.path);
+  if (attempt !== 0) return attempt;
+  return a.path.localeCompare(b.path);
+}
+
+/** Collapse a batch of read records to the single current renderable attempt per
+ * Worker. The current attempt is the newest started/mtime record for the worker,
+ * with the numeric `aN` suffix as a stable tie-breaker. */
+export function currentRenderableWorkerRecords(records: readonly WorkerStateRecord[]): WorkerStateRecord[] {
+  const byWorker = new Map<string, WorkerStateRecord>();
+  for (const rec of records) {
+    if (!rec.renderableLive) continue;
+    const key = workerKey(rec);
+    const prev = byWorker.get(key);
+    if (prev === undefined || compareWorkerAttempts(rec, prev) > 0) {
+      byWorker.set(key, rec);
+    }
+  }
+  return [...byWorker.values()];
+}
+
+function isNewestAttemptDirForWorker(path: string): boolean {
+  const attemptDir = dirname(path);
+  const workerDir = dirname(attemptDir);
+  let entries: string[];
+  try {
+    entries = readdirSync(workerDir);
+  } catch {
+    return true;
+  }
+  let newest: string | null = null;
+  let newestMtime = -1;
+  for (const entry of entries) {
+    const dir = join(workerDir, entry);
+    try {
+      const st = statSync(dir);
+      if (!st.isDirectory()) continue;
+      const mtime = st.mtimeMs;
+      if (mtime > newestMtime || (mtime === newestMtime && dir > (newest ?? ""))) {
+        newestMtime = mtime;
+        newest = dir;
+      }
+    } catch {
+      // Ignore raced-away entries.
+    }
+  }
+  return newest === null || newest === attemptDir;
 }
 
 /** Display threshold: lane records this old → not "active". Matches the old
@@ -226,7 +308,7 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
   // workers even before afk.state.json syncs back at run end.
   let finalVerdict = livenessVerdict;
   let hostPidLive = false;
-  if (livenessVerdict.status === "stalled" && state.pid === 0) {
+  if (livenessVerdict.status === "stalled" && state.pid === 0 && isNewestAttemptDirForWorker(path)) {
     // worker.pid lives one directory above the attempt dir:
     // {workersRoot}/{workerId}/{N}-a{n}/afk.state.json → {workersRoot}/{workerId}/worker.pid
     const workerPidPath = join(dirname(dirname(path)), "worker.pid");

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -444,7 +444,12 @@ export function makeRunAgent(
 // ---------- monitor inputs ----------
 
 import type { CompactWorker, FleetState, SlotDetail } from "../core/monitor.js";
-import { readWorkerState, readAllWorkerStates, type WorkerStateRecord } from "../core/worker-state-reader.js";
+import {
+  readWorkerState,
+  readAllWorkerStates,
+  currentRenderableWorkerRecords,
+  type WorkerStateRecord,
+} from "../core/worker-state-reader.js";
 import { planLivenessReclaim, type LivenessReclaimInput } from "../core/reclaim.js";
 import type { WorkerVitals } from "../types/state.js";
 import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
@@ -669,15 +674,13 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
   // here never blocks the render. Live-worker dirs and blocked/ready-for-human
   // post-mortem artifacts are preserved (planLivenessReclaim).
   await reclaimDeadWorkers(root, records, repo).catch(() => undefined);
-  const logPaths = records.map(({ path, state }) => state.log || join(dirname(path), "afk.log"));
+  const currentRecords = currentRenderableWorkerRecords(records);
+  const logPaths = currentRecords.map(({ path, state }) => state.log || join(dirname(path), "afk.log"));
   const logCounts = await collectLogLineCounts(paths.monitorLogCursorPath, logPaths);
   const workers: CompactWorker[] = [];
-  for (const { path, state, active, live: pidLive, liveness, livenessVerdict, renderableLive } of records) {
-    // The ONE shared render-gate (issue #1219): the monitor used to render EVERY
-    // globbed dir (no gate) — the graveyard of stale rows. Route it through the
-    // same `renderableLive` predicate the statusline uses so the dashboard drops
-    // dead/stalled/finished-pid-0 workers and both surfaces agree on liveness.
-    if (!renderableLive) continue;
+  for (const { path, state, active, live: pidLive, liveness, livenessVerdict } of currentRecords) {
+    // The shared current-worker selector applies the `renderableLive` gate and
+    // collapses retained sibling attempt dirs to one row per worker.
     // Diff volume: committed + uncommitted work for the attempt, measured from
     // the branch's merge-base with origin/main. #1210 Part B: read it from the
     // state file's writer-stamped counts only — the monitor render performs NO
@@ -860,7 +863,7 @@ export async function collectStatuslineAfk(
   // Namespace-blind union across the fleet, `/go`, and `--scout` lanes so the
   // statusline counts a live `/go`/`--scout` worker (rendered per-origin via
   // state.origin), not only the `.red/tmp/workers` fleet lane.
-  const records = await readAllWorkerStates(paths.tmpDir, { nowMs });
+  const records = currentRenderableWorkerRecords(await readAllWorkerStates(paths.tmpDir, { nowMs }));
   const gitCtx: gitx.GitContext = { cwd: ctx.root };
 
   let workers = 0;
@@ -883,17 +886,9 @@ export async function collectStatuslineAfk(
   const aliveMsList: number[] = [];
   const sourceMap = new Map<string, number>();
 
-  for (const { state, renderableLive } of records) {
-    // The ONE shared render-gate (issue #1219): computed once in
-    // readAllWorkerStates as `livenessVerdict.status !== "stalled" &&
-    // (pidIdentityLive || hostPidLive)`. Drops stalled workers AND finished/
-    // retained pid-0 attempts (kept for post-mortem, whose per-attempt lane can
-    // still read fresh), while keeping busy workers with live descendants and
-    // live isolation workers (host-side worker.pid). The statusline aggregate,
-    // the per-worker lines, and the monitor dashboard all route through this
-    // same field so every surface agrees on who is live.
-    if (!renderableLive) continue;
-
+  for (const { state } of records) {
+    // Shared with the monitor/per-worker statusline collectors: renderable rows
+    // are already gated and collapsed to one current attempt per worker.
     workers += 1;
     blocked += state.blocked;
     if (runner === "" && state.runner) runner = state.runner;
@@ -1028,14 +1023,11 @@ export async function collectStatuslineAfk(
 export async function collectStatuslineWorkers(ctx: RepoContext): Promise<CompactWorker[]> {
   const paths = afkPaths(ctx.root);
   const nowMs = Date.now();
-  const records = await readAllWorkerStates(paths.tmpDir, { nowMs });
+  const records = currentRenderableWorkerRecords(await readAllWorkerStates(paths.tmpDir, { nowMs }));
   const workers: CompactWorker[] = [];
-  for (const { state, active, live: pidLive, liveness, livenessVerdict, renderableLive } of records) {
-    // The ONE shared render-gate (issue #1219), identical to the aggregate
-    // collector and the monitor: drops stalled workers and finished/retained
-    // pid-0 attempts, keeps busy workers with live descendants and live
-    // isolation workers. See readAllWorkerStates / isRenderableLive.
-    if (!renderableLive) continue;
+  for (const { state, active, live: pidLive, liveness, livenessVerdict } of records) {
+    // The shared current-worker selector applies the `renderableLive` gate and
+    // collapses retained sibling attempt dirs to one row per worker.
     // #1210 Part B: no per-render git subprocess — read the writer-stamped LOC
     // straight from the state file (the heartbeat owns it for every runner).
     const added = state.current.loc_added;

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import {
   afkPaths,
   resolveRunSettings,
   collectMonitorInputs,
+  collectStatuslineWorkers,
   readFleetState,
   resolveAttemptGuardArming,
   resolveAttemptBudget,
@@ -20,6 +22,26 @@ import { runBoot } from "../src/core/boot.js";
 
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), "afk-wire-"));
+}
+
+function writeRenderableAttempt(root: string, worker: string, issue: number, startedAt: string): string {
+  const attemptDir = join(root, ".red", "tmp", "workers", worker, `${issue}-a1`);
+  mkdirSync(attemptDir, { recursive: true });
+  writeFileSync(
+    join(attemptDir, "afk.state.json"),
+    JSON.stringify({
+      worker_id: worker,
+      pid: process.pid,
+      runner: "codex",
+      started_at: startedAt,
+      current: { number: issue, title: `issue ${issue}`, started_at: startedAt },
+    }),
+  );
+  writeFileSync(
+    join(attemptDir, LIVENESS_LANE_FILENAME),
+    `${JSON.stringify({ at: Date.now() - 5_000, kind: "iteration-start" })}\n`,
+  );
+  return attemptDir;
 }
 
 describe("resolveAttemptGuardArming (issue #405)", () => {
@@ -346,6 +368,38 @@ describe("collectMonitorInputs", () => {
       const again = await collectMonitorInputs(root);
       expect(again.workers[0]!.logLines).toBe(3);
       expect(again.workers[0]!.logNewLines).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("collapses retained attempt dirs to one current worker row", async () => {
+    const root = scratch();
+    try {
+      writeRenderableAttempt(root, "wDED", 1775, "2026-07-06T10:00:00Z");
+      writeRenderableAttempt(root, "wDED", 1789, "2026-07-06T10:05:00Z");
+      writeRenderableAttempt(root, "wDED", 1802, "2026-07-06T10:10:00Z");
+      writeRenderableAttempt(root, "wDED", 1811, "2026-07-06T10:15:00Z");
+
+      const { workers } = await collectMonitorInputs(root);
+      expect(workers.map((w) => w.state.current.number)).toEqual([1811]);
+      expect(workers).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("statusline worker rows collapse retained attempt dirs to the current attempt", async () => {
+    const root = scratch();
+    try {
+      writeRenderableAttempt(root, "wDED", 1775, "2026-07-06T10:00:00Z");
+      writeRenderableAttempt(root, "wDED", 1789, "2026-07-06T10:05:00Z");
+      writeRenderableAttempt(root, "wDED", 1802, "2026-07-06T10:10:00Z");
+      writeRenderableAttempt(root, "wDED", 1811, "2026-07-06T10:15:00Z");
+
+      const workers = await collectStatuslineWorkers({ root, repo: "reddb-io/red-skills", remote: "origin" });
+      expect(workers.map((w) => w.state.current.number)).toEqual([1811]);
+      expect(workers).toHaveLength(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
@@ -296,6 +296,34 @@ describe("worker-state-reader", () => {
     expect(rec).not.toBeNull();
     expect(rec!.live).toBe(false);
     expect(rec!.liveness).toBe("dead");
+  });
+
+  it("isolation: hostPidLive does not readmit a retained sibling attempt", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-iso-sibling-"));
+    const workerDir = join(base, "wISO");
+    const retainedDir = join(workerDir, "1775-a1");
+    const currentDir = join(workerDir, "1811-a1");
+    const retainedPath = await writeState(retainedDir, {
+      worker_id: "wISO",
+      pid: 0,
+      current: { number: 1775 },
+    });
+    const currentPath = await writeState(currentDir, {
+      worker_id: "wISO",
+      pid: 0,
+      current: { number: 1811 },
+    });
+    await writeFile(join(workerDir, "worker.pid"), "9876", "utf8");
+    await utimes(retainedDir, new Date("2026-07-06T10:00:00Z"), new Date("2026-07-06T10:00:00Z"));
+    await utimes(currentDir, new Date("2026-07-06T10:10:00Z"), new Date("2026-07-06T10:10:00Z"));
+
+    const retained = readWorkerState(retainedPath, { nowMs: NOW, kill: () => true });
+    const current = readWorkerState(currentPath, { nowMs: NOW, kill: () => true });
+
+    expect(retained!.hostPidLive).toBe(false);
+    expect(retained!.renderableLive).toBe(false);
+    expect(current!.hostPidLive).toBe(true);
+    expect(current!.renderableLive).toBe(true);
   });
 
   it("regression: normal no-sandbox worker with populated pid + fresh lane renders as active", async () => {


### PR DESCRIPTION
Automated AFK landing for #1241. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1241

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964590&installation_id=129708444&pr_number=1247&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1247&signature=4c34166565abae10e87a60fbf9cc14b2b77bfcdf30c407f1d82d196fbab66bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->