### PR TITLE
merge: #1243 /go: Em apps/dev/src/core/statusline-style.ts, as linhas por-worker do status

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -57,6 +57,35 @@ const NOBOLD = "\x1b[22m";
 const RESET = "\x1b[0m";
 
 const BRANCH_MAX = 28;
+const WORKER_GUTTER = "  ";
+
+type WorkerColumn = "workerId" | "run" | "org" | "iss" | "stage" | "elapsed" | "loc" | "tks" | "tls" | "rsn" | "txt";
+const WORKER_COLUMNS: readonly WorkerColumn[] = [
+  "workerId",
+  "run",
+  "org",
+  "iss",
+  "stage",
+  "elapsed",
+  "loc",
+  "tks",
+  "tls",
+  "rsn",
+  "txt",
+];
+type WorkerCells = Record<WorkerColumn, string>;
+type WorkerWidths = Record<WorkerColumn, number>;
+
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+function visibleWidth(s: string): number {
+  return stripAnsi(s).length;
+}
+
+function padVisible(s: string, width: number): string {
+  return s + " ".repeat(Math.max(0, width - visibleWidth(s)));
+}
 
 /** A transparent-zone `key=value`: light-red KEY, default-fg VALUE, back to SOFT. */
 const kv = (key: string, value: string): string => `${KEY}${key}=${VAL}${value}${SOFT}`;
@@ -158,6 +187,52 @@ export function renderHeaderLine(
 
 // ---------- line 2..N: one line per live worker ----------
 
+function workerCells(worker: CompactWorker, now: number): WorkerCells {
+  const f = workerFields(worker, now);
+  const runVal = [f.runner, f.model ? shortModel(f.model) : undefined, f.effort]
+    .filter((x): x is string => Boolean(x))
+    .join(" ");
+  return {
+    workerId: f.workerId,
+    run: `run=${runVal}`,
+    org: `org=${f.origin || "afk"}`,
+    iss: f.issue === null ? "" : `iss=${String(f.issue)}`,
+    stage: f.issue === null ? "" : f.stage,
+    elapsed: f.elapsed,
+    loc: `loc=${formatDiff(f.added, f.removed)}`,
+    tks: `tks=${humanizeCount(f.tokens)}`,
+    tls: `tls=${String(f.tools)}`,
+    rsn: `rsn=${String(f.reasoning)}`,
+    txt: `txt=${String(f.text)}`,
+  };
+}
+
+function workerWidths(rows: readonly WorkerCells[]): WorkerWidths {
+  const widths = Object.fromEntries(WORKER_COLUMNS.map((column) => [column, 0])) as WorkerWidths;
+  for (const row of rows) {
+    for (const column of WORKER_COLUMNS) widths[column] = Math.max(widths[column], visibleWidth(row[column]));
+  }
+  return widths;
+}
+
+function colorWorkerCell(column: WorkerColumn, raw: string): string {
+  if (column === "workerId") return `${BOLD}${raw}${NOBOLD}`;
+  const eq = raw.indexOf("=");
+  if (eq > 0) return `${KEY}${raw.slice(0, eq + 1)}${VAL}${raw.slice(eq + 1)}${SOFT}`;
+  return raw;
+}
+
+function formatWorkerCells(row: WorkerCells, widths: WorkerWidths): string {
+  const parts = WORKER_COLUMNS.map((column) => colorWorkerCell(column, padVisible(row[column], widths[column])));
+  return `${NOBG}${SOFT}${parts.join(WORKER_GUTTER)}${RESET}`;
+}
+
+function renderWorkerLines(workers: ReadonlyArray<CompactWorker>, now: number): string[] {
+  const rows = workers.map((worker) => workerCells(worker, now));
+  const widths = workerWidths(rows);
+  return rows.map((row) => formatWorkerCells(row, widths));
+}
+
 /** The TERSE per-worker line for the Claude Code statusline (issue #1175, #1176):
  *
  *   <wID>  run=<runner> <model> <effort>  org=<afk|go>  iss=<issue-number>  <stage>  <elapsed>  loc=+A -R  tks=<h>  tls=<t> rsn=<r> txt=<x>
@@ -221,7 +296,7 @@ export interface StyleOptions {
 export function styleStatusline(input: StatuslineInput, opts: StyleOptions = {}): string {
   const lines = [renderHeaderLine(input.project, input.claude, input.repo)];
   const now = opts.now ?? 0;
-  for (const worker of opts.workers ?? []) lines.push(renderWorkerLine(worker, now));
+  lines.push(...renderWorkerLines(opts.workers ?? [], now));
   return lines.join("\n");
 }
 

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -279,6 +279,64 @@ describe("statusline style — full themed assembly", () => {
     expect(stripAnsi(out)).toContain("prs=3");
   });
 
+  it("aligns multi-worker rows by visible cell width while preserving ANSI color", () => {
+    const out = styleStatusline(input, {
+      now: NOW,
+      workers: [
+        worker({
+          state: {
+            ...worker().state,
+            worker_id: "wLONG",
+            runner: "codex",
+            current: {
+              ...worker().state.current,
+              number: 1243,
+              model: "gpt-5.5",
+              effort: "high",
+              stage: "validation",
+              input_tokens: 32000,
+              output_tokens: 2000,
+              tools_called_count: 38,
+            },
+          },
+          diffAdded: 248,
+          diffRemoved: 29,
+        }),
+        worker({
+          state: {
+            ...worker().state,
+            worker_id: "w2",
+            runner: "codex",
+            current: {
+              ...worker().state.current,
+              number: 9,
+              model: undefined,
+              effort: undefined,
+              stage: "impl",
+              tools_called_count: 8,
+            },
+          },
+          diffAdded: 83,
+          diffRemoved: 1,
+        }),
+      ],
+    });
+    const [header, firstRaw, secondRaw] = out.split("\n");
+    const rows = [stripAnsi(firstRaw), stripAnsi(secondRaw)];
+    for (const token of ["run=", "org=", "iss=", "00:05:00", "loc=", "tks=", "tls=", "rsn=", "txt="]) {
+      const starts = rows.map((row) => row.indexOf(token));
+      expect(starts[0]).toBeGreaterThanOrEqual(0);
+      expect(starts[1]).toBeGreaterThanOrEqual(0);
+      expect(starts[1]).toBe(starts[0]);
+    }
+    expect(rows[1].indexOf("impl")).toBe(rows[0].indexOf("validation"));
+    expect(header).toBe(renderHeaderLine(input.project, claude, repo));
+    expect(firstRaw).toContain(KEY);
+    expect(secondRaw).toContain(KEY);
+    expect(firstRaw).toContain(BOLD);
+    expect(secondRaw).toContain(BOLD);
+  });
+
   it("defaults to the header row alone when no workers/now are supplied", () => {
     const out = styleStatusline(input);
     expect(out).not.toContain("\n");


### PR DESCRIPTION
Automated AFK landing for #1243. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1243

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964680&installation_id=129708444&pr_number=1248&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1248&signature=6f978a684d01bcbf60ea7987e44f14806a7dcb3b24ea783ff9e4f85b71cfe62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->