### PR TITLE
merge: #1208 requeue --adopt-branch reconcile reports merge-conflict for a branch that fast-forwards origin/main

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -141,6 +141,13 @@ export interface LandingInput {
   remote: string;
   /** The worker branch sandcastle committed on (push + land source). */
   branch: string;
+  /**
+   * The already-validated worker tip SHA, when the caller resolved one before
+   * landing. Reconcile uses this to guarantee the commit being landed is the
+   * commit that passed validation, instead of re-reading a mutable local branch
+   * ref after the gate.
+   */
+  validatedBranchTip?: string;
   /** Resolved base branch (lock > pin > main). */
   base: string;
   /**
@@ -496,6 +503,13 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     });
     if (!integrated.ok) return { ok: false, reason: "integrate-failed", locked: input.locked };
 
+    const branchTip = input.validatedBranchTip ?? (await resolveRemoteBranchTip(deps.mergeExec, {
+      repo: landDir,
+      remote: input.remote,
+      branch: input.branch,
+    }));
+    if (!branchTip) return { ok: false, reason: "land-failed", locked: input.locked };
+
     // Zero-commit guard: `git merge --no-ff` succeeds on a branch with no new
     // commits (it creates a no-op merge commit), which would incorrectly close
     // the issue as done without delivering any work. The PR path rejects this
@@ -503,7 +517,7 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     // here: route a zero-commit direct landing to land-failed.
     const countRes = await deps.mergeExec([
       "git", "-C", landDir,
-      "rev-list", "--count", `origin/${input.base}..origin/${input.branch}`,
+      "rev-list", "--count", `origin/${input.base}..${branchTip}`,
     ]);
     const commitCount = parseInt(countRes.stdout.trim(), 10);
     if (countRes.code !== 0 || !Number.isInteger(commitCount) || commitCount === 0) {
@@ -513,10 +527,33 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     // Capture the integrated tip from the worktree as the rollback anchor.
     const preMergeSha = (await deps.mergeExec(["git", "-C", landDir, "rev-parse", "--short", "HEAD"])).stdout.trim();
 
+    const fastForwardable = await deps.mergeExec([
+      "git", "-C", landDir,
+      "merge-base", "--is-ancestor", `origin/${input.base}`, branchTip,
+    ]);
+    if (fastForwardable.code === 0) {
+      const ff = await deps.mergeExec(["git", "-C", landDir, "merge", "--ff-only", branchTip]);
+      if (ff.code !== 0) return { ok: false, reason: "land-failed", locked: input.locked };
+      const push = await deps.mergeExec([
+        "git",
+        "-C",
+        landDir,
+        "push",
+        input.remote,
+        `HEAD:refs/heads/${input.base}`,
+      ]);
+      if (push.code !== 0) {
+        await deps.mergeExec(["git", "-C", landDir, "reset", "--hard", preMergeSha]);
+        return { ok: false, reason: "land-failed", locked: input.locked };
+      }
+      const mergeSha = (await deps.mergeExec(["git", "-C", landDir, "rev-parse", "--short", "HEAD"])).stdout.trim();
+      return { ok: true, locked: input.locked, mergeSha: mergeSha || undefined };
+    }
+
     const merged = await landMerge(deps.mergeExec, {
       repo: landDir,
       remote: input.remote,
-      branch: input.branch,
+      branch: branchTip,
       target: input.base,
       n: input.issue,
       title: input.title,
@@ -564,4 +601,16 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
   } finally {
     await deps.removeLandingWorktree?.(landDir);
   }
+}
+
+async function resolveRemoteBranchTip(
+  exec: MergeExec,
+  input: { repo: string; remote: string; branch: string },
+): Promise<string | undefined> {
+  const r = await exec([
+    "git", "-C", input.repo,
+    "rev-parse", "--verify", "--quiet", `${input.remote}/${input.branch}`,
+  ]);
+  const tip = r.stdout.trim();
+  return r.code === 0 && tip !== "" ? tip : undefined;
 }

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -349,6 +349,21 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     return { outcome: "skipped", reason: "branch-absent" };
   }
 
+  const validatedBranchTip = await resolveFreshRemoteBranchTip(deps.mergeExec, {
+    repoDir: input.repoDir,
+    remote: input.remote,
+    branch,
+  });
+  if (!validatedBranchTip) {
+    deps.appendIterLog(
+      `🤖 /afk reconcile #${issue}: skipped (branch-absent) — \`${branch}\` did not resolve to a fetched \`${input.remote}/${branch}\` tip.`,
+    );
+    return { outcome: "skipped", reason: "branch-absent" };
+  }
+  deps.appendIterLog(
+    `🤖 /afk reconcile #${issue}: validating fetched \`${input.remote}/${branch}\` tip \`${validatedBranchTip.slice(0, 12)}\`.`,
+  );
+
   // ---- 3. commits gate: the branch must carry work ----
   // changedFiles() is a three-dot diff that returns [] for an EMPTY branch.
   // The fetch gate above guarantees the branch is local, so [] here means
@@ -445,6 +460,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       repoDir: input.repoDir,
       remote: input.remote,
       branch,
+      validatedBranchTip,
       base,
       trunk: input.trunk,
       issue,
@@ -480,9 +496,23 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   await deps.fs.completionSweep(issue);
   await runCloseCascade(deps, issue);
   deps.appendIterLog(
-    `🤖 /afk reconcile #${issue}: \`${branch}\` validated green and landed without re-running the agent (merge \`${mergeSha}\`).`,
+    `🤖 /afk reconcile #${issue}: \`${branch}\` tip \`${validatedBranchTip.slice(0, 12)}\` validated green and landed without re-running the agent (merge \`${mergeSha}\`).`,
   );
   return { outcome: "landed", mergeSha, locked, posted };
+}
+
+async function resolveFreshRemoteBranchTip(
+  exec: MergeExec,
+  input: { repoDir: string; remote: string; branch: string },
+): Promise<string | undefined> {
+  const fetched = await exec(["git", "-C", input.repoDir, "fetch", input.remote, input.branch, "--quiet"]);
+  if (fetched.code !== 0) return undefined;
+  const resolved = await exec([
+    "git", "-C", input.repoDir,
+    "rev-parse", "--verify", "--quiet", `${input.remote}/${input.branch}`,
+  ]);
+  const tip = resolved.stdout.trim();
+  return resolved.code === 0 && tip !== "" ? tip : undefined;
 }
 
 // ---------- guard ----------

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -23,6 +23,7 @@ const WT = "/wt";
 // (#1006). Distinct from WT so a test can assert the fetch/rebase/force-push
 // never `git -C`'d the primary checkout (`/repo`).
 const RWT = "/rwt";
+const DEFAULT_BRANCH_TIP = "feedfacecafebeef";
 
 interface Harness {
   deps: LandingDeps;
@@ -66,6 +67,8 @@ interface Opts {
   noWorktree?: boolean;
   /** Commits ahead of base returned by `git rev-list --count`. Default 3. */
   commitCount?: number;
+  /** Resolved origin/<branch> tip used by stale-local-ref regressions. */
+  branchTip?: string;
   /** Enable the PR-path pre-merge rebase provisioner (#1006). */
   rebaseWorktree?: boolean;
   /** The rebase provisioner returns null (could not provision → rebase skipped). */
@@ -111,6 +114,9 @@ function harness(opts: Opts = {}): Harness {
     mergeExec: async (argv): Promise<ExecResult> => {
       mergeCalls.push(argv);
       const j = argv.join(" ");
+      if (j.includes("merge-base --is-ancestor origin/")) {
+        return { code: opts.branchTip ? 0 : 1, stdout: "", stderr: "" };
+      }
       // ADR 0083 landing precondition (#1018), against the primary checkout.
       // `merge-base --is-ancestor local origin/<trunk>` — exit 1 = diverged.
       if (j.includes("merge-base --is-ancestor")) {
@@ -142,6 +148,9 @@ function harness(opts: Opts = {}): Harness {
       }
       if (j.includes("rev-list") && j.includes("--count")) {
         return { code: 0, stdout: `${opts.commitCount ?? 3}\n`, stderr: "" };
+      }
+      if (j.includes("rev-parse --verify --quiet origin/afk/wAAAA/9-fix-the-thing")) {
+        return { code: 0, stdout: `${opts.branchTip ?? DEFAULT_BRANCH_TIP}\n`, stderr: "" };
       }
       if (opts.integrateCode !== undefined && j.includes("merge --ff-only")) {
         return { code: opts.integrateCode, stdout: "", stderr: "" };
@@ -309,7 +318,7 @@ describe("doLanding — happy paths", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(j.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"))).toBe(true);
+    expect(j.some((c) => c.includes(`merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP}`))).toBe(true);
     expect(j.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
   });
@@ -327,7 +336,7 @@ describe("doLanding — happy paths", () => {
     expect(j.some((c) => c.includes("merge --ff-only origin/feature-locked"))).toBe(true);
     expect(j.some((c) => c.includes("merge --ff-only origin/main"))).toBe(false);
     // Attempt branch was merged (into current HEAD = lock-branch after the precheck fix).
-    expect(j.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"))).toBe(true);
+    expect(j.some((c) => c.includes(`merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP}`))).toBe(true);
     // Push targeted the lock branch (worktree HEAD → refs/heads/<base>), not main.
     expect(j.some((c) => c.includes("push origin HEAD:refs/heads/feature-locked"))).toBe(true);
     // The ADR 0083 precondition READS refs/heads/main (the trunk, read-only); the
@@ -644,7 +653,7 @@ describe("doLanding — the primary checkout is sacred (#572)", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     const j = joined(h.mergeCalls);
-    expect(j.some((c) => c.includes(`git -C ${WT} merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing`))).toBe(true);
+    expect(j.some((c) => c.includes(`git -C ${WT} merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP}`))).toBe(true);
     expect(j).toContain(`git -C ${WT} push origin HEAD:refs/heads/main`);
     assertPrimaryUntouched(h);
     expect(h.removedWorktrees).toEqual([WT]);
@@ -787,7 +796,7 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
   // the lock only resolves `base`. Four cells: {no lock, lock=X} × {true, false}.
   // `prMerged` = the admin-PR path ran; `directMerged` = the worktree merge ran.
   const prMerged = (j: string[]) => j.some((c) => c.includes("pr merge 42 --merge"));
-  const directMerged = (j: string[]) => j.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"));
+  const directMerged = (j: string[]) => j.some((c) => c.includes("merge --no-ff --no-verify"));
 
   it("no lock + true (default) → admin-merged PR into main (today's unlocked)", async () => {
     const h = harness({ locked: false, openPr: true });
@@ -812,6 +821,31 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
     expect(j.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
     // Merge ran in the isolated worktree, pushing main from its HEAD.
     expect(j).toContain(`git -C ${WT} push origin HEAD:refs/heads/main`);
+  });
+
+  it("no lock + false + stale local main → fast-forwards the freshly fetched origin/main to the validated branch tip", async () => {
+    const branchTip = "1234567890abcdef";
+    const h = harness({ locked: false, openPr: false, branchTip });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false, mergeSha: "abc1234" });
+
+    const j = joined(h.mergeCalls);
+    const fetchBaseIdx = j.findIndex((c) => c === "git -C /repo fetch origin main --quiet");
+    const integrateIdx = j.findIndex((c) => c === `git -C ${WT} merge --ff-only origin/main`);
+    const resolveTipIdx = j.findIndex(
+      (c) => c === `git -C ${WT} rev-parse --verify --quiet origin/afk/wAAAA/9-fix-the-thing`,
+    );
+    const ancestorIdx = j.findIndex((c) => c === `git -C ${WT} merge-base --is-ancestor origin/main ${branchTip}`);
+    const fastForwardIdx = j.findIndex((c) => c === `git -C ${WT} merge --ff-only ${branchTip}`);
+    const pushIdx = j.findIndex((c) => c === `git -C ${WT} push origin HEAD:refs/heads/main`);
+
+    expect(fetchBaseIdx).toBeGreaterThanOrEqual(0);
+    expect(integrateIdx).toBeGreaterThan(fetchBaseIdx);
+    expect(resolveTipIdx).toBeGreaterThan(integrateIdx);
+    expect(ancestorIdx).toBeGreaterThan(resolveTipIdx);
+    expect(fastForwardIdx).toBeGreaterThan(ancestorIdx);
+    expect(pushIdx).toBeGreaterThan(fastForwardIdx);
+    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(false);
   });
 
   it("lock=X + true (default) → admin-merged PR with base = the lock branch, not main (new)", async () => {

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -22,6 +22,8 @@ import type { AttemptProgressInfo } from "../src/core/execution.js";
 // injected `runAgent` port (ADR 0033): a fake returning a scripted
 // RunAgentResult, replacing the old fake runner-spawn + worktree-create deps.
 
+const DEFAULT_BRANCH_TIP = "feedfacecafebeef";
+
 interface Trace {
   labelEdits: Array<{ issue: number; remove: string[]; add: string[] }>;
   comments: Array<{ issue: number; body: string }>;
@@ -322,6 +324,18 @@ function harness(opts: HarnessOptions = {}): {
     },
     mergeExec: async (argv) => {
       const j = argv.join(" ");
+      if (j === "git -C /repo fetch origin afk/wAAAA/9-fix-the-thing --quiet") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (j === "git -C /repo rev-parse --verify --quiet origin/afk/wAAAA/9-fix-the-thing") {
+        return { code: 0, stdout: `${DEFAULT_BRANCH_TIP}\n`, stderr: "" };
+      }
+      if (j === "git -C /wt rev-parse --verify --quiet origin/afk/wAAAA/9-fix-the-thing") {
+        return { code: 0, stdout: `${DEFAULT_BRANCH_TIP}\n`, stderr: "" };
+      }
+      if (j.includes("merge-base --is-ancestor origin/")) {
+        return { code: 1, stdout: "", stderr: "" };
+      }
       // landPr reuses an open PR via `gh pr list`; reply with a number so it
       // resolves without a create round-trip.
       if (argv.includes("pr") && argv.includes("list")) {
@@ -905,9 +919,9 @@ describe("processIssue — landing mode decoupled from the lock (#842)", () => {
 
     expect(result.outcome).toBe("done");
     expect(result.locked).toBe(true);
-    // landMerge issues `git -C /repo merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing …`.
+    // landMerge issues `git -C <landing-worktree> merge --no-ff --no-verify <validated-tip> …`.
     const joined = calls.map((c) => c.join(" "));
-    expect(joined.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"))).toBe(true);
+    expect(joined.some((c) => c.includes(`merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP}`))).toBe(true);
     // No PR list/create/merge on the locked path.
     expect(joined.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
   });
@@ -977,8 +991,8 @@ describe("processIssue — landing mode decoupled from the lock (#842)", () => {
     expect(result.outcome).toBe("done");
     expect(result.locked).toBe(false);
     const joined = calls.map((c) => c.join(" "));
-    // Direct merge of the attempt branch; no PR list/merge anywhere.
-    expect(joined.some((c) => c.includes("merge --no-ff --no-verify afk/wAAAA/9-fix-the-thing"))).toBe(true);
+    // Direct merge of the validated attempt tip; no PR list/merge anywhere.
+    expect(joined.some((c) => c.includes(`merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP}`))).toBe(true);
     expect(joined.some((c) => c.includes("pr list") || c.includes("pr merge"))).toBe(false);
   });
 });

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -27,6 +27,8 @@ interface Trace {
   recordedOutcomes: string[];
   listByLabelCalls: string[];
   firedHooks: string[];
+  iterLogs: string[];
+  mergeCalls: string[][];
   pnpmCalls: number;
   /** Branches passed to the ADR 0083 §4 terminal exit barrier (#1021). */
   terminalBarrierCalls: string[];
@@ -72,6 +74,8 @@ function harness(opts: HarnessOptions = {}): {
     recordedOutcomes: [],
     listByLabelCalls: [],
     firedHooks: [],
+    iterLogs: [],
+    mergeCalls: [],
     pnpmCalls: 0,
     terminalBarrierCalls: [],
   };
@@ -131,7 +135,14 @@ function harness(opts: HarnessOptions = {}): {
       },
     },
     mergeExec: async (argv) => {
+      trace.mergeCalls.push(argv);
       const j = argv.join(" ");
+      if (j === "git -C /repo fetch origin afk/wAAAA/9-fix-the-thing --quiet") {
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (j === "git -C /repo rev-parse --verify --quiet origin/afk/wAAAA/9-fix-the-thing") {
+        return { code: 0, stdout: "feedfacecafebeef\n", stderr: "" };
+      }
       // landPr reuses an open PR via `gh pr list`; reply with a number.
       if (argv.includes("pr") && argv.includes("list")) {
         return { code: 0, stdout: "42\n", stderr: "" };
@@ -180,7 +191,9 @@ function harness(opts: HarnessOptions = {}): {
       return true;
     },
     nowEpoch: () => 1000,
-    appendIterLog: () => {},
+    appendIterLog: (line) => {
+      trace.iterLogs.push(line);
+    },
     recordAttempt: opts.recordAttempt
       ? async (payload) => {
           trace.recordedOutcomes.push(payload.status);
@@ -250,6 +263,8 @@ describe("reconcile — green → land", () => {
     expect(close.add).toEqual([]);
     // The landing fired the merge hooks via the injected fireHook.
     expect(trace.firedHooks).toEqual(["pre_merge", "post_merge"]);
+    expect(trace.iterLogs.some((line) => line.includes("validating fetched `origin/afk/wAAAA/9-fix-the-thing` tip `feedfacecafe`"))).toBe(true);
+    expect(trace.iterLogs.some((line) => line.includes("tip `feedfacecafe` validated green and landed"))).toBe(true);
   });
 
   it("trusts prior green (#1095): lands WITHOUT re-running the feedback gate", async () => {


### PR DESCRIPTION
Automated AFK landing for #1208. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1208

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785969896&installation_id=129708444&pr_number=1250&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1250&signature=efe57259eb504151eec8d913ace54b3935f805064d39e2a59881897b8208a26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->