### PR TITLE
merge: #1211 validation/scoping diffs read the stale LOCAL base — changedFiles/diffstat must use origin/<base>

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -255,6 +255,13 @@ export interface ProcessLookups {
   branchMerged?(branch: string, base: string): Promise<boolean>;
 }
 
+function remoteTrackingBaseRef(remote: string, base: string): string {
+  if (/^[0-9a-f]{7,40}$/i.test(base) || base.startsWith("refs/") || base.startsWith(`${remote}/`)) {
+    return base;
+  }
+  return `${remote}/${base}`;
+}
+
 /** The hook dispatch surface: the parsed config + the default resolver + the
  * injected command executor. resolveHooks runs once; dispatchHooks per point. */
 export interface ProcessHooks {
@@ -1304,7 +1311,7 @@ export async function processIssue(
   // remote-tracking ref to runAgent so sandcastle's baseBranch start point
   // uses the freshly-fetched ref, not the potentially-stale local branch.
   if (deps.git.fetchBase) await deps.git.fetchBase(base);
-  const baseRef = `${input.remote}/${base}`;
+  const baseRef = remoteTrackingBaseRef(input.remote, base);
   // Pin to a sandcastle-backed runner. claude/codex/opencode (ADR 0059) +
   // claude-minimax (PRD #788) each map to a first-class provider and pass
   // through; any other value (e.g. the runner-neutral hermes, which has no
@@ -1681,7 +1688,7 @@ export async function processIssue(
         // Scout runs read-only — the inner agent never commits, so there is
         // nothing to salvage. Always treat no-sentinel as a hard failure.
         input.runMode !== "scout" &&
-        (await deps.lookups.changedFiles(workerBranch, base)).length > 0 &&
+        (await deps.lookups.changedFiles(workerBranch, baseRef)).length > 0 &&
         (!deps.lookups.branchPresent || (await deps.lookups.branchPresent(workerBranch)));
       if (!branchHasWork) {
         await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "no-sentinel", current.attempt));
@@ -1907,7 +1914,7 @@ export async function processIssue(
     // happy path costs nothing.
     // Macro phase → `validating` (issue #811): the feedback gate is starting.
     deps.markPhase?.("validating");
-    const changedFiles = await deps.lookups.changedFiles(workerBranch, base);
+    const changedFiles = await deps.lookups.changedFiles(workerBranch, baseRef);
     // Compute the validation scope: when a workspace graph is injected, expand
     // to the full dependency cone (touched packages + transitive dependents);
     // otherwise fall back to the current directly-touched-packages behaviour.

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -129,6 +129,13 @@ export interface ReconcileLookups {
   isLocked(): Promise<boolean>;
 }
 
+function remoteTrackingBaseRef(remote: string, base: string): string {
+  if (/^[0-9a-f]{7,40}$/i.test(base) || base.startsWith("refs/") || base.startsWith(`${remote}/`)) {
+    return base;
+  }
+  return `${remote}/${base}`;
+}
+
 /**
  * All injected IO for one reconcile. Deliberately a structural SUBSET of
  * `ProcessIssueDeps` (same nested member shapes) so process-issue can pass its
@@ -297,6 +304,7 @@ export type ReconcileResult =
  */
 export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Promise<ReconcileResult> {
   const { issue, branch, base, labels, body } = input;
+  const baseRef = remoteTrackingBaseRef(input.remote, base);
 
   // ---- 1. guard: mechanical class only ----
   const disqualifier = mechanicalDisqualifier(labels, body);
@@ -368,7 +376,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   // changedFiles() is a three-dot diff that returns [] for an EMPTY branch.
   // The fetch gate above guarantees the branch is local, so [] here means
   // genuinely no commits — not a missing ref.
-  const changedFiles = await deps.lookups.changedFiles(branch, base);
+  const changedFiles = await deps.lookups.changedFiles(branch, baseRef);
   if (changedFiles.length === 0) {
     deps.appendIterLog(
       `🤖 /afk reconcile #${issue}: skipped (no-commits) — \`${branch}\` carries no work vs \`${base}\`.`,

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -58,6 +58,10 @@ interface Trace {
   statePatches: Array<Record<string, unknown>>;
   /** Branches for which cascadeRebase.rebaseAndPush was called (#1007). */
   cascadeRebaseAttempts: string[];
+  /** Arguments passed into feedback scope changed-file resolution. */
+  changedFileCalls: Array<{ branch: string; base: string }>;
+  /** Raw pnpm argv vectors emitted by the feedback/backpressure fakes. */
+  pnpmArgs: string[][];
 }
 
 interface HarnessOptions {
@@ -107,6 +111,8 @@ interface HarnessOptions {
    * context's `{env:{…}}` slice — proving it threads onto the runAgent input. */
   preWorktreeEnv?: Record<string, string>;
   changedFiles?: string[];
+  changedFilesByBase?: Record<string, string[]>;
+  packageScopes?: string[];
   /** FIX E: result of the worker-branch presence check. Defaults to true
    * (present). Set false to model "sandcastle commits never reached the host". */
   branchPresent?: boolean;
@@ -221,6 +227,8 @@ function harness(opts: HarnessOptions = {}): {
     iterLogs: [],
     statePatches: [],
     cascadeRebaseAttempts: [],
+    changedFileCalls: [],
+    pnpmArgs: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -381,6 +389,7 @@ function harness(opts: HarnessOptions = {}): {
       return { code: 0, stdout: "", stderr: "" };
     },
     pnpm: async (args) => {
+      trace.pnpmArgs.push([...args]);
       // AFK runner improvement: feedback now optionally probes the base branch
       // (the `baselineWorktree` passed to `runFeedback`) when the worker run
       // fails. The baseline probe re-runs ONLY the failing checks; every other
@@ -406,7 +415,7 @@ function harness(opts: HarnessOptions = {}): {
       return { code: ok ? 0 : 1, stdout: "", stderr: "" };
     },
     layout: {
-      hasPackage: (scope) => scope === ".",
+      hasPackage: (scope) => (opts.packageScopes ? opts.packageScopes.includes(scope) : scope === "."),
       hasScript: () => true,
     },
     // Backpressure gate (#430): a fake shell exec that fails when opted out. The
@@ -510,8 +519,9 @@ function harness(opts: HarnessOptions = {}): {
       async priorAttemptContext() {
         return undefined;
       },
-      async changedFiles() {
-        return opts.changedFiles ?? ["packages/x/src/a.ts"];
+      async changedFiles(branch, base) {
+        trace.changedFileCalls.push({ branch, base });
+        return opts.changedFilesByBase?.[base] ?? opts.changedFiles ?? ["packages/x/src/a.ts"];
       },
       async diffstat() {
         return "+1 -0 files=1";
@@ -2358,6 +2368,34 @@ describe("processIssue — base reaches sandcastle (ADR 0031)", () => {
     // runAgent receives the remote-tracking ref so sandcastle forks from the
     // freshly-fetched ref, not the potentially-stale local branch.
     expect(trace.runAgentCalls[0]?.base).toBe("origin/main");
+  });
+
+  it("resolves feedback scopes from the fetched origin base, not a stale local base", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      locked: true,
+      packageScopes: ["packages/stale", "packages/fresh"],
+      changedFilesByBase: {
+        main: ["packages/stale/src/old.ts"],
+        "origin/main": ["packages/fresh/src/new.ts"],
+      },
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.changedFileCalls).toContainEqual({
+      branch: "afk/wAAAA/9-fix-the-thing",
+      base: "origin/main",
+    });
+    const pnpmDirs = trace.pnpmArgs
+      .map((args) => {
+        const idx = args.indexOf("-C");
+        return idx >= 0 ? args[idx + 1] : undefined;
+      })
+      .filter(Boolean);
+    expect(pnpmDirs).toContain("afk/wAAAA/9-fix-the-thing/packages/fresh");
+    expect(pnpmDirs).not.toContain("afk/wAAAA/9-fix-the-thing/packages/stale");
   });
 
   it("resolves an unlocked, pinless issue to the configured Trunk and forks off origin/<trunk> (ADR 0083)", async () => {

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -30,6 +30,8 @@ interface Trace {
   iterLogs: string[];
   mergeCalls: string[][];
   pnpmCalls: number;
+  pnpmArgs: string[][];
+  changedFileCalls: Array<{ branch: string; base: string }>;
   /** Branches passed to the ADR 0083 §4 terminal exit barrier (#1021). */
   terminalBarrierCalls: string[];
 }
@@ -40,6 +42,8 @@ interface HarnessOptions {
   /** Aggregate feedback gate verdict. Defaults to passing (green). */
   feedbackOk?: boolean;
   changedFiles?: string[];
+  changedFilesByBase?: Record<string, string[]>;
+  packageScopes?: string[];
   branchPresent?: boolean;
   locked?: boolean;
   /** When true, the unlocked `gh pr merge` returns non-zero (land fails). */
@@ -77,6 +81,8 @@ function harness(opts: HarnessOptions = {}): {
     iterLogs: [],
     mergeCalls: [],
     pnpmCalls: 0,
+    pnpmArgs: [],
+    changedFileCalls: [],
     terminalBarrierCalls: [],
   };
 
@@ -124,8 +130,9 @@ function harness(opts: HarnessOptions = {}): {
             },
     },
     lookups: {
-      async changedFiles() {
-        return opts.changedFiles ?? ["packages/x/src/a.ts"];
+      async changedFiles(branch, base) {
+        trace.changedFileCalls.push({ branch, base });
+        return opts.changedFilesByBase?.[base] ?? opts.changedFiles ?? ["packages/x/src/a.ts"];
       },
       async branchPresent() {
         return opts.branchPresent ?? true;
@@ -160,6 +167,7 @@ function harness(opts: HarnessOptions = {}): {
     },
     pnpm: async (args) => {
       trace.pnpmCalls += 1;
+      trace.pnpmArgs.push([...args]);
       // AFK runner improvement: reconcile now passes the base as
       // `baselineWorktree` to `runFeedback`. The baseline probe always
       // returns success in this harness (it isn't modelling pre-existing
@@ -173,7 +181,7 @@ function harness(opts: HarnessOptions = {}): {
       return { code: opts.feedbackOk === false ? 1 : 0, stdout: "", stderr: "boom\n" };
     },
     layout: {
-      hasPackage: (scope) => scope === ".",
+      hasPackage: (scope) => (opts.packageScopes ? opts.packageScopes.includes(scope) : scope === "."),
       hasScript: () => true,
     },
     envelope: {
@@ -265,6 +273,31 @@ describe("reconcile — green → land", () => {
     expect(trace.firedHooks).toEqual(["pre_merge", "post_merge"]);
     expect(trace.iterLogs.some((line) => line.includes("validating fetched `origin/afk/wAAAA/9-fix-the-thing` tip `feedfacecafe`"))).toBe(true);
     expect(trace.iterLogs.some((line) => line.includes("tip `feedfacecafe` validated green and landed"))).toBe(true);
+  });
+
+  it("resolves feedback scopes from origin/<base>, not a stale local base", async () => {
+    const { deps, input, trace } = harness({
+      feedbackOk: true,
+      packageScopes: ["packages/stale", "packages/fresh"],
+      changedFilesByBase: {
+        main: ["packages/stale/src/old.ts"],
+        "origin/main": ["packages/fresh/src/new.ts"],
+      },
+    });
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("landed");
+    expect(trace.changedFileCalls).toEqual([
+      { branch: "afk/wAAAA/9-fix-the-thing", base: "origin/main" },
+    ]);
+    const pnpmDirs = trace.pnpmArgs
+      .map((args) => {
+        const idx = args.indexOf("-C");
+        return idx >= 0 ? args[idx + 1] : undefined;
+      })
+      .filter(Boolean);
+    expect(pnpmDirs).toContain("afk/wAAAA/9-fix-the-thing/packages/fresh");
+    expect(pnpmDirs).not.toContain("afk/wAAAA/9-fix-the-thing/packages/stale");
   });
 
   it("trusts prior green (#1095): lands WITHOUT re-running the feedback gate", async () => {


### PR DESCRIPTION
Automated AFK landing for #1211. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1211

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785971775&installation_id=129708444&pr_number=1252&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1252&signature=77afb3d699ec970f01d5522fbeef39a35af7e5c5842e369722e57f29a0cc4bc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed file detection now uses the fetched remote base when available, improving accuracy for feedback and reconciliation.
  * Fixed cases where validation and package scope checks could use a stale local base, leading to incorrect paths or scope selection.

* **Tests**
  * Added coverage for base-dependent behavior to ensure changed files are resolved from the correct remote-tracking ref.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->