### PR TITLE
merge: #1213 merge-conflict retry reuses the agent worktree without re-parenting onto fresh origin/<base>

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -844,6 +844,8 @@ export function buildProcessDeps(
       fetchBase: async (base) => {
         await gitx.gitExec(gitCtx)(["fetch", ctx.remote, base]);
       },
+      prepareFreshWorkerBranch: (input) =>
+        gitx.prepareFreshWorkerBranch(gitCtx, { ...input, remote: ctx.remote }),
     },
     mergeExec: gitx.mergeExec(gitCtx),
     remoteGit: gitx.gitExec(gitCtx),

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -214,6 +214,16 @@ export interface ProcessGit {
    * to sandcastle's HEAD default.
    */
   fetchBase?(base: string): Promise<void>;
+  /**
+   * Adapter-side guard for sandcastle's named-branch reuse path. After
+   * `fetchBase()` refreshes `origin/<base>`, remove stale local worker state
+   * before `runAgent()` so red-castle must recreate the worker branch from
+   * `baseRef` instead of reusing a branch whose merge-base predates the fresh
+   * base tip. `force` is true for a retry after a prior merge-conflict terminal;
+   * non-conflict retries still get a stale-merge-base check inside the runtime
+   * implementation, preserving same-run reuse when the branch is already current.
+   */
+  prepareFreshWorkerBranch?(input: { branch: string; baseRef: string; force: boolean }): Promise<boolean | void>;
 }
 
 /** Injected lookups the composed deciders need (issue body for the pin, the
@@ -260,6 +270,14 @@ function remoteTrackingBaseRef(remote: string, base: string): string {
     return base;
   }
   return `${remote}/${base}`;
+}
+
+function isMergeConflictRetry(priorAttemptContext: string | undefined): boolean {
+  if (!priorAttemptContext) return false;
+  const marker = "prev-failure-reason:";
+  const idx = priorAttemptContext.indexOf(marker);
+  const failureReason = idx === -1 ? priorAttemptContext : priorAttemptContext.slice(idx + marker.length);
+  return /\bmerge-conflict\b/.test(failureReason);
 }
 
 /** The hook dispatch surface: the parsed config + the default resolver + the
@@ -1312,6 +1330,11 @@ export async function processIssue(
   // uses the freshly-fetched ref, not the potentially-stale local branch.
   if (deps.git.fetchBase) await deps.git.fetchBase(base);
   const baseRef = remoteTrackingBaseRef(input.remote, base);
+  await deps.git.prepareFreshWorkerBranch?.({
+    branch,
+    baseRef,
+    force: isMergeConflictRetry(priorAttemptContext),
+  });
   // Pin to a sandcastle-backed runner. claude/codex/opencode (ADR 0059) +
   // claude-minimax (PRD #788) each map to a first-class provider and pass
   // through; any other value (e.g. the runner-neutral hermes, which has no

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -114,6 +114,61 @@ export async function fetchBranch(ctx: GitContext, branch: string): Promise<void
   await runGit(ctx, ["fetch", "origin", branch]);
 }
 
+export interface FreshWorkerBranchInput {
+  branch: string;
+  baseRef: string;
+  remote?: string;
+  force?: boolean;
+}
+
+/**
+ * Remove stale sandcastle worker-branch state before a retry enters `runAgent`.
+ *
+ * red-castle's named-branch collision path reuses an existing managed worktree
+ * and only fast-forwards it from `origin/<branch>`; it does not re-parent that
+ * branch onto a freshly-fetched `origin/<base>`. For a merge-conflict retry, or
+ * any branch whose merge-base with `baseRef` is not the current base tip, AFK
+ * must clear the local worktree + refs so red-castle's `baseBranch` creation path
+ * is used again. The prior diff is preserved by the attempt snapshot ref, not by
+ * the live retry branch.
+ */
+export async function prepareFreshWorkerBranch(
+  ctx: GitContext,
+  input: FreshWorkerBranchInput,
+): Promise<boolean> {
+  const branch = input.branch.trim();
+  const baseRef = input.baseRef.trim();
+  const remote = input.remote?.trim() || "origin";
+  if (!branch || !baseRef) return false;
+
+  const base = await runGit(ctx, ["rev-parse", "--verify", "--quiet", baseRef]);
+  const baseTip = base.code === 0 ? base.stdout.trim() : "";
+  if (!baseTip) return false;
+
+  const worktreePath = await worktreePathForBranch(ctx, branch);
+  const localBranchExists = await branchExists(ctx, branch);
+  const remoteTrackingRef = `refs/remotes/${remote}/${branch}`;
+  const remoteTracking = await runGit(ctx, ["rev-parse", "--verify", "--quiet", remoteTrackingRef]);
+  const remoteTrackingExists = remoteTracking.code === 0 && remoteTracking.stdout.trim() !== "";
+
+  const compareRef = localBranchExists ? branch : remoteTrackingExists ? `${remote}/${branch}` : undefined;
+  let stale = false;
+  if (compareRef) {
+    const mergeBase = await runGit(ctx, ["merge-base", compareRef, baseRef]);
+    stale = mergeBase.code !== 0 || mergeBase.stdout.trim() !== baseTip;
+  }
+
+  const hasReusableState = Boolean(worktreePath || localBranchExists || remoteTrackingExists);
+  const shouldClean = input.force ? hasReusableState : stale;
+  if (!shouldClean) return false;
+
+  if (worktreePath) await worktreeRemove(ctx, worktreePath);
+  if (localBranchExists) await deleteLocalBranch(ctx, branch);
+  if (remoteTrackingExists) await runGit(ctx, ["update-ref", "-d", remoteTrackingRef]);
+  await runGit(ctx, ["push", remote, "--delete", branch]);
+  return true;
+}
+
 /**
  * Has the worker branch ALREADY landed in `<base>`? — the own-merge signal for
  * the goal predicate (ADR 0057). When the attempt-guard poll observes the claimed

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -62,6 +62,10 @@ interface Trace {
   changedFileCalls: Array<{ branch: string; base: string }>;
   /** Raw pnpm argv vectors emitted by the feedback/backpressure fakes. */
   pnpmArgs: string[][];
+  /** Handoff bodies written before the sandcastle run. */
+  handoffs: Array<{ path: string; content: string }>;
+  /** Fresh-branch preparation calls before sandcastle can reuse a worktree. */
+  freshWorkerBranchCalls: Array<{ branch: string; baseRef: string; force: boolean }>;
 }
 
 interface HarnessOptions {
@@ -123,6 +127,8 @@ interface HarnessOptions {
   fallbackRunner?: boolean;
   /** Records each git fetch-base call (the ADR 0031 start-point fetch). */
   fetchedBases?: string[];
+  /** Restart-informed context block returned by the attempt ledger lookup. */
+  priorAttemptContext?: string;
   /** The configured Trunk (`plugins.dev.trunk`, ADR 0083) injected into base resolution. */
   configTrunk?: string;
   /** When set, the locked `git merge --no-ff` returns this rc (1 → conflict). */
@@ -229,6 +235,8 @@ function harness(opts: HarnessOptions = {}): {
     cascadeRebaseAttempts: [],
     changedFileCalls: [],
     pnpmArgs: [],
+    handoffs: [],
+    freshWorkerBranchCalls: [],
   };
 
   const outcome = opts.outcome ?? "done";
@@ -307,7 +315,9 @@ function harness(opts: HarnessOptions = {}): {
     },
     fs: {
       async ensureAttemptDir() {},
-      async writeHandoff() {},
+      async writeHandoff(path, content) {
+        trace.handoffs.push({ path, content });
+      },
       // Optional sidecar port: present unless the test opts it out (older-caller
       // safety). Records every (path, lines) write for assertion.
       writeValidationSidecar:
@@ -328,6 +338,10 @@ function harness(opts: HarnessOptions = {}): {
       async deleteLocalBranch() {},
       async fetchBase(base) {
         if (opts.fetchedBases) opts.fetchedBases.push(base);
+      },
+      async prepareFreshWorkerBranch(input) {
+        trace.freshWorkerBranchCalls.push(input);
+        return true;
       },
     },
     mergeExec: async (argv) => {
@@ -517,7 +531,7 @@ function harness(opts: HarnessOptions = {}): {
         return "https://github.com/o/r/issues/9";
       },
       async priorAttemptContext() {
-        return undefined;
+        return opts.priorAttemptContext;
       },
       async changedFiles(branch, base) {
         trace.changedFileCalls.push({ branch, base });
@@ -654,6 +668,65 @@ const labelTrace = (t: Trace): string[] =>
   t.labelEdits.map((e) => `-${e.remove.join("+")}|+${e.add.join("+")}`);
 
 describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", () => {
+  it("pre-cleans a merge-conflict retry branch before sandcastle can reuse a stale worktree", async () => {
+    const fetchedBases: string[] = [];
+    const priorAttemptContext = [
+      "prev-attempt: 1",
+      "prev-snapshot-branch: origin/afk-attempts/wOLD/9-fix-the-thing",
+      "prev-failure-reason:",
+      "merge-conflict",
+    ].join("\n");
+    const { deps, input, trace } = harness({
+      attempt: 2,
+      priorAttemptContext,
+      fetchedBases,
+      outcome: "done",
+      feedbackOk: true,
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(fetchedBases).toEqual(["main"]);
+    expect(trace.freshWorkerBranchCalls).toEqual([
+      {
+        branch: "afk/wAAAA/9-fix-the-thing",
+        baseRef: "origin/main",
+        force: true,
+      },
+    ]);
+    expect(trace.runAgentCalls[0]?.base).toBe("origin/main");
+    expect(trace.handoffs[0]?.content).toContain("prev-snapshot-branch: origin/afk-attempts/wOLD/9-fix-the-thing");
+    expect(trace.handoffs[0]?.content).toContain("prev-failure-reason:\nmerge-conflict");
+  });
+
+  it("keeps non-conflict same-run reuse eligible for the stale-base check only", async () => {
+    const priorAttemptContext = [
+      "prev-attempt: 1",
+      "prev-snapshot-branch: origin/afk-attempts/wOLD/9-fix-the-thing",
+      "prev-failure-reason:",
+      "validation failed",
+    ].join("\n");
+    const { deps, input, trace } = harness({
+      attempt: 2,
+      priorAttemptContext,
+      outcome: "done",
+      feedbackOk: true,
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.freshWorkerBranchCalls).toEqual([
+      {
+        branch: "afk/wAAAA/9-fix-the-thing",
+        baseRef: "origin/main",
+        force: false,
+      },
+    ]);
+    expect(trace.runAgentCalls).toHaveLength(1);
+  });
+
   it("runs claim → runAgent → push → feedback → land → close with the full transition + sweep", async () => {
     const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, locked: false });
     const result = await processIssue(deps, input);

--- a/apps/dev/tests/runtime-git-branch.test.ts
+++ b/apps/dev/tests/runtime-git-branch.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   branchExists,
   fetchBranch,
   changedFiles,
+  prepareFreshWorkerBranch,
   worktreePathForBranch,
   worktreePathUnder,
   salvageUncommitted,
@@ -28,6 +34,15 @@ function recordingExec(
 
 const ok = (stdout = ""): ExecOutput => ({ code: 0, stdout, stderr: "" });
 const fail = (code = 1): ExecOutput => ({ code, stdout: "", stderr: "" });
+const execFileP = promisify(execFile);
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileP("git", args, {
+    cwd,
+    env: { ...process.env, LC_ALL: "C" },
+  });
+  return stdout.trim();
+}
 
 describe("branchExists (FIX E)", () => {
   it("returns true when rev-parse --verify finds the local ref", async () => {
@@ -64,6 +79,82 @@ describe("fetchBranch (FIX E recovery)", () => {
     const ctx: GitContext = { cwd: "/repo", exec };
     await fetchBranch(ctx, "");
     expect(calls).toEqual([]);
+  });
+});
+
+describe("prepareFreshWorkerBranch (merge-conflict retry freshness)", () => {
+  it("removes stale local and tracking state so the retry branch is recreated from the moved base tip", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fresh-worker-"));
+    const origin = join(root, "origin.git");
+    const repo = join(root, "repo");
+    const staleWt = join(root, "stale-wt");
+    const retryWt = join(root, "retry-wt");
+    const branch = "afk/w1213/9-conflict";
+
+    try {
+      await git(root, ["init", "--bare", "--initial-branch=main", origin]);
+      await git(root, ["clone", origin, repo]);
+      await git(repo, ["config", "user.email", "agent@example.test"]);
+      await git(repo, ["config", "user.name", "Agent"]);
+
+      await writeFile(join(repo, "base.txt"), "base one\n");
+      await git(repo, ["add", "base.txt"]);
+      await git(repo, ["commit", "-m", "base one"]);
+      await git(repo, ["push", "-u", "origin", "main"]);
+
+      await git(repo, ["checkout", "-b", branch]);
+      await writeFile(join(repo, "attempt.txt"), "stale attempt\n");
+      await git(repo, ["add", "attempt.txt"]);
+      await git(repo, ["commit", "-m", "stale attempt"]);
+      await git(repo, ["push", "origin", `HEAD:refs/heads/${branch}`]);
+      await git(repo, ["checkout", "main"]);
+      await git(repo, ["worktree", "add", staleWt, branch]);
+
+      await writeFile(join(repo, "base.txt"), "base two\n");
+      await git(repo, ["add", "base.txt"]);
+      await git(repo, ["commit", "-m", "base two"]);
+      await git(repo, ["push", "origin", "main"]);
+      await git(repo, ["fetch", "origin", "main"]);
+      const movedBaseTip = await git(repo, ["rev-parse", "origin/main"]);
+
+      await expect(
+        prepareFreshWorkerBranch({ cwd: repo }, { branch, baseRef: "origin/main", remote: "origin", force: true }),
+      ).resolves.toBe(true);
+
+      await expect(git(repo, ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`])).rejects.toThrow();
+      await expect(
+        git(repo, ["rev-parse", "--verify", "--quiet", `refs/remotes/origin/${branch}`]),
+      ).rejects.toThrow();
+      await expect(git(repo, ["ls-remote", "--exit-code", "--heads", "origin", branch])).rejects.toThrow();
+
+      await git(repo, ["worktree", "add", "-b", branch, retryWt, "origin/main"]);
+      const retryMergeBase = await git(repo, ["merge-base", branch, "origin/main"]);
+      expect(retryMergeBase).toBe(movedBaseTip);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a current branch alone when its merge-base is already the base tip", async () => {
+    const { exec, calls } = recordingExec((_cmd, args) => {
+      const joined = args.join(" ");
+      if (joined === "rev-parse --verify --quiet origin/main") return ok("base-tip\n");
+      if (joined === "rev-parse --verify --quiet refs/heads/afk/w/1-current") return ok("branch-tip\n");
+      if (joined === "rev-parse --verify --quiet refs/remotes/origin/afk/w/1-current") return fail();
+      if (joined === "worktree list --porcelain") return ok("");
+      if (joined === "merge-base afk/w/1-current origin/main") return ok("base-tip\n");
+      return ok("");
+    });
+
+    await expect(
+      prepareFreshWorkerBranch(
+        { cwd: "/repo", exec },
+        { branch: "afk/w/1-current", baseRef: "origin/main", remote: "origin", force: false },
+      ),
+    ).resolves.toBe(false);
+
+    expect(calls.some((c) => c.includes("update-ref"))).toBe(false);
+    expect(calls.some((c) => c.includes("-D"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1213. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1213

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785976993&installation_id=129708444&pr_number=1254&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1254&signature=ebe407733625d57b40fe0718d4e72564d59c8244669f90f834b4a44afff154f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter worker-branch cleanup during retries so stale git state can be refreshed before a new run.
  * Retry handling now distinguishes merge-conflict cases from other restarts, helping reuse branches more safely.

* **Bug Fixes**
  * Prevents reusing worker branches whose merge base is out of date after a fresh fetch.
  * Removes stale local and remote branch state when a cleanup is needed.

* **Tests**
  * Added coverage for merge-conflict retries, stale-branch cleanup, and the no-op path when the branch is already up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->