### PR TITLE
merge: #1215 /go dispatch env (RED_AFK_WORKERS_NAMESPACE) leaks into the gate's baseline probe — apps/dev suite skipped as 'pre-existing failure on baseline'

### DIFF
--- a/apps/dev/src/runtime/feedback-worktree.ts
+++ b/apps/dev/src/runtime/feedback-worktree.ts
@@ -42,8 +42,8 @@ function slugForBranch(branch: string): string {
 }
 
 /**
- * The environment for the feedback gate's `pnpm -C <scope> <script>` subprocess,
- * with `RED_AFK_WORKERS_NAMESPACE` UNSET (#1224 Part C).
+ * The environment for the feedback gate's validation subprocesses, with AFK
+ * worker-dispatch path overrides UNSET (#1215 / #1224 Part C).
  *
  * A `/go` (or `scout`) worker runs the gate with `RED_AFK_WORKERS_NAMESPACE`
  * pinned to its lane (`go-workers` / `scout-workers`) so its own worktree/state
@@ -51,14 +51,18 @@ function slugForBranch(branch: string): string {
  * INCLUDING the gate's test subprocess — where it poisons namespace-sensitive
  * suites (worker-paths, supervisor-fs) that assert the DEFAULT lane. The result
  * is a false full-suite red that churns/parks otherwise-green apps/dev work (this
- * exact leak cost issue #1219 ~70 minutes). Strip the var for the gate's test
- * subprocess ONLY — the worker's own namespace wiring (which owns the `/go` lane
- * paths) is untouched, since this scrubs a fresh copy of `process.env` rather than
- * mutating it.
+ * exact leak cost issue #1219 ~70 minutes). Strip the path-routing dispatch
+ * vars for the gate subprocesses ONLY — the worker's own namespace wiring (which
+ * owns the `/go` lane paths) is untouched, since this scrubs a fresh copy of
+ * `process.env` rather than mutating it.
  */
 function gateSubprocessEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
-  delete env.RED_AFK_WORKERS_NAMESPACE;
+  for (const key of Object.keys(env)) {
+    if (key === "RED_AFK_WORKERS_NAMESPACE" || key.startsWith("RED_AFK_WORKER") || key.startsWith("RED_AFK_ITER")) {
+      delete env[key];
+    }
+  }
   return env;
 }
 

--- a/apps/dev/tests/feedback-worktree.test.ts
+++ b/apps/dev/tests/feedback-worktree.test.ts
@@ -488,13 +488,13 @@ describe("makeFeedbackWorktree — rebaseOnto (Pattern 2 drift mitigation)", () 
   });
 });
 
-describe("gate test subprocess env (#1224 Part C)", () => {
+describe("gate test subprocess env (#1215 / #1224 Part C)", () => {
   // A /go (or scout) worker runs the feedback gate with RED_AFK_WORKERS_NAMESPACE
   // pinned to its lane. That must NOT leak into the gate's `pnpm -C <scope> test`
   // subprocess, or namespace-sensitive suites (worker-paths, supervisor-fs) see
   // the /go lane instead of the default and fail — a false full-suite red that
   // parks otherwise-green work (this leak cost issue #1219 ~70 minutes).
-  function captureEnvIO(): { io: FeedbackWorktreeIO; envFor: (script: string) => NodeJS.ProcessEnv | undefined } {
+  function captureEnvIO(): { io: FeedbackWorktreeIO; envsFor: (script: string) => NodeJS.ProcessEnv[] } {
     const seen: Array<{ script: string; env: NodeJS.ProcessEnv | undefined }> = [];
     const io: FeedbackWorktreeIO = {
       worktreeAdd: async () => true,
@@ -511,27 +511,43 @@ describe("gate test subprocess env (#1224 Part C)", () => {
       worktreeHead: async () => null,
       rebase: async () => ({ ok: true }),
     };
-    return { io, envFor: (script) => seen.find((s) => s.script === script)?.env };
+    return { io, envsFor: (script) => seen.filter((s) => s.script === script).map((s) => s.env ?? {}) };
   }
 
-  it("runs the gate's pnpm test subprocess with RED_AFK_WORKERS_NAMESPACE unset", async () => {
-    const prev = process.env.RED_AFK_WORKERS_NAMESPACE;
+  it("runs gate pnpm subprocesses with AFK path-routing env unset", async () => {
+    const prevNamespace = process.env.RED_AFK_WORKERS_NAMESPACE;
+    const prevWorkerId = process.env.RED_AFK_WORKER_ID;
+    const prevIterDir = process.env.RED_AFK_ITER_DIR;
     process.env.RED_AFK_WORKERS_NAMESPACE = "go-workers"; // the /go lane leak
+    process.env.RED_AFK_WORKER_ID = "go-dispatch-worker";
+    process.env.RED_AFK_ITER_DIR = "/tmp/go-workers/go-dispatch-worker/1215-a1";
     try {
-      const { io, envFor } = captureEnvIO();
+      const { io, envsFor } = captureEnvIO();
       const fb = makeFeedbackWorktree("/root", "/root/.red/tmp/feedback", io, { cacheEnabled: false });
 
       await fb.pnpm(["pnpm", "-C", "afk/w1/42-fix", "test"]);
+      await fb.pnpm(["pnpm", "-C", "origin/main", "test"]);
 
-      const env = envFor("test");
-      // The gate's test subprocess env exists and does NOT carry the namespace.
-      expect(env).toBeDefined();
-      expect(env && "RED_AFK_WORKERS_NAMESPACE" in env).toBe(false);
+      const envs = envsFor("test");
+      // The gate's test subprocess env exists and does NOT carry AFK
+      // path-routing dispatch vars into worker-path-sensitive suites.
+      expect(envs).toHaveLength(2);
+      for (const env of envs) {
+        expect("RED_AFK_WORKERS_NAMESPACE" in env).toBe(false);
+        expect("RED_AFK_WORKER_ID" in env).toBe(false);
+        expect("RED_AFK_ITER_DIR" in env).toBe(false);
+      }
       // The worker's own process env is untouched (we scrub a copy, not the real env).
       expect(process.env.RED_AFK_WORKERS_NAMESPACE).toBe("go-workers");
+      expect(process.env.RED_AFK_WORKER_ID).toBe("go-dispatch-worker");
+      expect(process.env.RED_AFK_ITER_DIR).toBe("/tmp/go-workers/go-dispatch-worker/1215-a1");
     } finally {
-      if (prev === undefined) delete process.env.RED_AFK_WORKERS_NAMESPACE;
-      else process.env.RED_AFK_WORKERS_NAMESPACE = prev;
+      if (prevNamespace === undefined) delete process.env.RED_AFK_WORKERS_NAMESPACE;
+      else process.env.RED_AFK_WORKERS_NAMESPACE = prevNamespace;
+      if (prevWorkerId === undefined) delete process.env.RED_AFK_WORKER_ID;
+      else process.env.RED_AFK_WORKER_ID = prevWorkerId;
+      if (prevIterDir === undefined) delete process.env.RED_AFK_ITER_DIR;
+      else process.env.RED_AFK_ITER_DIR = prevIterDir;
     }
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1215. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1215

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785978232&installation_id=129708444&pr_number=1255&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1255&signature=2bbbd361f58dd583a5e937df9988bbc84ee9ef2d98f4f0cbe81129fb8b1fd6e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->