### PR TITLE
merge: #1216 statusline counts: stale-while-revalidate detached refresher + write-through on label mutations + single GraphQL count query

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -18,7 +18,7 @@ import { stopCommand } from "./commands/stop.js";
 import { respondCommand } from "./commands/respond.js";
 import { routeModelTierCommand } from "./commands/route-model-tier.js";
 import { shipCommand } from "./commands/ship.js";
-import { statuslineCommand } from "./commands/statusline.js";
+import { statuslineCommand, statuslineRefreshCountsCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { triageCommand } from "./commands/triage.js";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
@@ -46,6 +46,7 @@ export type CliCommand =
   | "codex-statusline"
   | "route-model-tier"
   | "statusline"
+  | "statusline-refresh-counts"
   | "inject-development-workflow"
   | "version"
   | "__supervise";
@@ -87,6 +88,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     "codex-statusline": {},
     "route-model-tier": {},
     statusline: {},
+    "statusline-refresh-counts": {},
     "inject-development-workflow": {},
     version: {},
     __supervise: {},
@@ -137,6 +139,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "codex-statusline") return codexStatuslineCommand(parsed.args);
   if (parsed.command === "route-model-tier") return routeModelTierCommand(parsed.args);
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);
+  if (parsed.command === "statusline-refresh-counts") return statuslineRefreshCountsCommand(parsed.args);
   if (parsed.command === "inject-development-workflow") return injectDevelopmentWorkflowCommand(parsed.args);
   if (parsed.command === "__supervise") return superviseCommand(parsed.args);
   return runCommand({ args: parsed.args });

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -24,7 +24,7 @@ import { parseCurrentBlocker } from "../core/blocker-state.js";
 import { LABEL_SENSITIVE_PATH } from "../core/triage-labels.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
 import { makeFeedbackWorktree } from "../runtime/feedback-worktree.js";
-import { afkPaths, resolveRepoSlug } from "../runtime/wire.js";
+import { afkPaths, editLabelsWithStatuslineCache, resolveRepoSlug, statuslineCountCachePath } from "../runtime/wire.js";
 import { branchLockPath, isLocked, readLockedBranch } from "../runtime/lock.js";
 import { resolveBase } from "../core/base-resolver.js";
 import { getConfig, loadConfig } from "../core/config.js";
@@ -82,6 +82,7 @@ function parseIssue(raw: string | undefined): number | undefined {
 
 function ghFor(cwd: string, repo: string): RequeueGh {
   const repoArgs = repo ? ["--repo", repo] : [];
+  const countCachePath = statuslineCountCachePath(cwd);
   const run = (args: readonly string[]): ReturnType<ExecFn> =>
     execTool("gh", args, { cwd, maxBuffer: 32 * 1024 * 1024 });
   return {
@@ -103,8 +104,17 @@ function ghFor(cwd: string, repo: string): RequeueGh {
       const args = ["issue", "edit", String(issue), ...repoArgs];
       for (const l of remove) args.push("--remove-label", l);
       for (const l of add) args.push("--add-label", l);
-      const out = await run(args);
-      if (out.code !== 0) throw new Error(`edit labels #${issue} failed: ${out.stderr.trim() || out.stdout.trim()}`);
+      const ok = await editLabelsWithStatuslineCache(
+        countCachePath,
+        async () => {
+          const out = await run(args);
+          if (out.code !== 0) throw new Error(`edit labels #${issue} failed: ${out.stderr.trim() || out.stdout.trim()}`);
+          return true;
+        },
+        remove,
+        add,
+      );
+      if (!ok) throw new Error(`edit labels #${issue} failed`);
     },
     async comment(issue, body) {
       await run(["issue", "comment", String(issue), ...repoArgs, "--body", body]);
@@ -176,6 +186,7 @@ async function runAdoptLanding(
   stdout: NodeJS.WritableStream,
 ): Promise<"landed" | "parked" | "skipped"> {
   const paths = afkPaths(cwd);
+  const countCachePath = statuslineCountCachePath(cwd);
   const ghCtx: GhContext = { cwd, repo };
   const gitCtx: GitContext = { cwd };
   const lockPath = branchLockPath(cwd);
@@ -206,8 +217,12 @@ async function runAdoptLanding(
     const reconcileDeps: ReconcileDeps = {
       gh: {
         editLabels: async (n, remove, add) => {
-          await ghx.editLabels(ghCtx, n, remove, add);
-          return true;
+          return editLabelsWithStatuslineCache(
+            countCachePath,
+            () => ghx.editLabels(ghCtx, n, remove, add),
+            remove,
+            add,
+          );
         },
         ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
         comment: (n, body) => ghx.comment(ghCtx, n, body),

--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -27,6 +27,8 @@ import {
   collectStatuslineAfk,
   collectStatuslineRepo,
   collectStatuslineWorkers,
+  inferGitHubRepoSlug,
+  refreshStatuslineCountCache,
   resolveStatuslineCacheTtl,
 } from "../runtime/wire.js";
 import * as gitx from "../runtime/git.js";
@@ -190,7 +192,7 @@ export async function statuslineCommand(
   // project root and let gh infer the repo from cwd (repo slug ""). The repo
   // header stats (line 1) render ALWAYS; the AFK block (line 2) only with live
   // workers, so both collectors run every render (each cheap + cached).
-  const repoCtx = { root, repo: "", remote: "origin" };
+  const repoCtx = { root, repo: inferGitHubRepoSlug(root), remote: "origin" };
   // Resolve the cache TTL ONCE here (env > afk.statusline_cache_ttl config > 180,
   // #1217) and thread it into both collectors — the hot render path never loads
   // config a second time per collector.
@@ -219,5 +221,21 @@ export async function statuslineCommand(
     now: nowS,
   });
   stdout.write(`${line}\n`);
+  return 0;
+}
+
+export async function statuslineRefreshCountsCommand(args: string[], cwd = process.cwd()): Promise<number> {
+  const root = args[0] ?? cwd;
+  let repo = "";
+  let lock = "";
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--repo") {
+      repo = args[++i] ?? "";
+    } else if (arg === "--lock") {
+      lock = args[++i] ?? "";
+    }
+  }
+  await refreshStatuslineCountCache(root, repo || inferGitHubRepoSlug(root), lock || undefined);
   return 0;
 }

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -724,6 +724,51 @@ async function countIssues(ctx: GhContext, args: string[]): Promise<number> {
   }
 }
 
+export interface StatuslineQueueCounts {
+  queue: number;
+  human: number;
+}
+
+function statuslineSearchQuery(repo: string, label: string): string {
+  return `repo:${repo} is:issue is:open label:"${label}"`;
+}
+
+/** Count both statusline queue buckets with one GraphQL search request. */
+export async function countStatuslineQueueCounts(ctx: GhContext): Promise<StatuslineQueueCounts> {
+  if (!ctx.repo) return { queue: 0, human: 0 };
+  const query = `
+    query($ready: String!, $human: String!) {
+      ready: search(type: ISSUE, query: $ready) { issueCount }
+      human: search(type: ISSUE, query: $human) { issueCount }
+    }
+  `;
+  const r = await runGh(ctx, [
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-F",
+    `ready=${statuslineSearchQuery(ctx.repo, LABEL_READY)}`,
+    "-F",
+    `human=${statuslineSearchQuery(ctx.repo, LABEL_HUMAN)}`,
+  ]);
+  if (r.code !== 0) return { queue: 0, human: 0 };
+  try {
+    const parsed = JSON.parse(r.stdout) as {
+      data?: {
+        ready?: { issueCount?: unknown };
+        human?: { issueCount?: unknown };
+      };
+    };
+    return {
+      queue: Number(parsed.data?.ready?.issueCount ?? 0),
+      human: Number(parsed.data?.human?.issueCount ?? 0),
+    };
+  } catch {
+    return { queue: 0, human: 0 };
+  }
+}
+
 /** Count issues that carry NO labels (the unlabeled straggler bucket). */
 export async function countUnlabeled(ctx: GhContext): Promise<number> {
   const r = await runGh(ctx, 

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -9,7 +9,9 @@
 // actually runs), so `monitor`, `reap`, and an empty `run` never pull the
 // provider subpaths.
 
-import { readFileSync, writeFileSync, renameSync, existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import type { SandboxMode } from "../core/execution.js";
@@ -765,7 +767,8 @@ import type { AfkInput, RepoInput } from "../core/statusline.js";
  * default) and threaded into both the writer (statusline command) and the
  * readers (monitor path + stale-marker threshold) so the network cost is paid at
  * most once per TTL, never per render (issue #1178, #1217). */
-export const STATUSLINE_CACHE_TTL_S = 180;
+export const STATUSLINE_CACHE_TTL_S = 900;
+export const STATUSLINE_REFRESH_LOCK_TTL_S = 60;
 
 /**
  * Resolve the effective statusline cache TTL (seconds) with precedence
@@ -815,6 +818,22 @@ interface StatuslineCache {
   ts: number;
 }
 
+type DetachedSpawn = (
+  command: string,
+  args: readonly string[],
+  options: { detached: true; stdio: "ignore"; env: NodeJS.ProcessEnv },
+) => Pick<ChildProcess, "unref">;
+
+export interface StatuslineRefreshSpawnOptions {
+  spawn?: DetachedSpawn;
+  nowS?: number;
+  argv1?: string;
+}
+
+export function statuslineCountCachePath(root: string): string {
+  return join(afkPaths(root).tmpDir, "statusline-cache.json");
+}
+
 function readStatuslineCache(path: string): StatuslineCache | null {
   try {
     const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<StatuslineCache>;
@@ -830,11 +849,159 @@ function readStatuslineCache(path: string): StatuslineCache | null {
 
 function writeStatuslineCacheAtomic(path: string, cache: StatuslineCache): void {
   try {
+    mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp`;
     writeFileSync(tmp, JSON.stringify(cache), "utf8");
     renameSync(tmp, path);
   } catch {
     // best-effort, like the bash `|| true`
+  }
+}
+
+export function parseGitHubRepoSlugFromRemoteUrl(url: string): string {
+  const trimmed = url.trim();
+  const ssh = /^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/.exec(trimmed);
+  if (ssh) return ssh[1] ?? "";
+  const https = /^https:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?\/?$/.exec(trimmed);
+  if (https) return https[1] ?? "";
+  return "";
+}
+
+function readGitFile(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export function inferGitHubRepoSlug(root: string): string {
+  const dotGit = join(root, ".git");
+  const gitMarker = readGitFile(dotGit);
+  const configCandidates = [join(dotGit, "config")];
+  const gitDir = /^gitdir:\s*(.+)$/m.exec(gitMarker)?.[1]?.trim();
+  if (gitDir) {
+    const absoluteGitDir = gitDir.startsWith("/") ? gitDir : join(root, gitDir);
+    configCandidates.push(join(absoluteGitDir, "config"));
+    configCandidates.push(join(absoluteGitDir, "..", "..", "config"));
+  }
+  for (const configPath of configCandidates) {
+    const config = readGitFile(configPath);
+    const origin = /\[remote "origin"\][\s\S]*?\n\s*url\s*=\s*(.+)\n/.exec(`${config}\n`)?.[1];
+    const slug = origin ? parseGitHubRepoSlugFromRemoteUrl(origin) : "";
+    if (slug) return slug;
+  }
+  return "";
+}
+
+function statuslineRefreshLockPath(cachePath: string): string {
+  return `${cachePath}.refresh.lock`;
+}
+
+function releaseStatuslineRefreshLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // best-effort
+  }
+}
+
+function acquireStatuslineRefreshLock(lockPath: string, nowS: number): boolean {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const payload = JSON.stringify({ pid: process.pid, ts: nowS });
+  try {
+    writeFileSync(lockPath, payload, { encoding: "utf8", flag: "wx" });
+    return true;
+  } catch {
+    const existing = readStatuslineCache(lockPath);
+    if (existing && nowS - existing.ts < STATUSLINE_REFRESH_LOCK_TTL_S) return false;
+    releaseStatuslineRefreshLock(lockPath);
+    try {
+      writeFileSync(lockPath, payload, { encoding: "utf8", flag: "wx" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export function applyStatuslineCountCacheLabelDelta(
+  cachePath: string,
+  remove: readonly string[],
+  add: readonly string[],
+  nowS: number = Math.floor(Date.now() / 1000),
+): boolean {
+  const cached = readStatuslineCache(cachePath);
+  if (!cached) return false;
+  const removed = new Set(remove);
+  const added = new Set(add);
+  const deltaFor = (label: string): number => (added.has(label) ? 1 : 0) - (removed.has(label) ? 1 : 0);
+  const queueDelta = deltaFor(LABEL_READY);
+  const humanDelta = deltaFor(LABEL_HUMAN);
+  if (queueDelta === 0 && humanDelta === 0) return false;
+  writeStatuslineCacheAtomic(cachePath, {
+    queue: Math.max(0, cached.queue + queueDelta),
+    human: Math.max(0, cached.human + humanDelta),
+    ts: nowS,
+  });
+  return true;
+}
+
+export async function editLabelsWithStatuslineCache(
+  cachePath: string,
+  edit: () => Promise<boolean>,
+  remove: readonly string[],
+  add: readonly string[],
+): Promise<boolean> {
+  const ok = await edit();
+  if (ok) applyStatuslineCountCacheLabelDelta(cachePath, remove, add);
+  return ok;
+}
+
+export async function refreshStatuslineCountCache(
+  root: string,
+  repo: string = inferGitHubRepoSlug(root),
+  lockPath?: string,
+): Promise<void> {
+  try {
+    const cachePath = statuslineCountCachePath(root);
+    const counts = await ghx.countStatuslineQueueCounts({ cwd: root, repo });
+    writeStatuslineCacheAtomic(cachePath, { ...counts, ts: Math.floor(Date.now() / 1000) });
+  } finally {
+    if (lockPath) releaseStatuslineRefreshLock(lockPath);
+  }
+}
+
+export function startDetachedStatuslineCountRefresh(
+  ctx: RepoContext,
+  options: StatuslineRefreshSpawnOptions = {},
+): boolean {
+  const cachePath = statuslineCountCachePath(ctx.root);
+  const nowS = options.nowS ?? Math.floor(Date.now() / 1000);
+  const lockPath = statuslineRefreshLockPath(cachePath);
+  const repo = ctx.repo || inferGitHubRepoSlug(ctx.root);
+  const argv1 = options.argv1 ?? process.argv[1];
+  if (!repo || !argv1) return false;
+  if (!acquireStatuslineRefreshLock(lockPath, nowS)) return false;
+  try {
+    const child = (options.spawn ?? spawn)(process.execPath, [
+      argv1,
+      "statusline-refresh-counts",
+      ctx.root,
+      "--repo",
+      repo,
+      "--lock",
+      lockPath,
+    ], {
+      detached: true,
+      stdio: "ignore",
+      env: { ...process.env, RED_AFK_STATUSLINE_REFRESH_CHILD: "1" },
+    });
+    child.unref();
+    return true;
+  } catch {
+    releaseStatuslineRefreshLock(lockPath);
+    return false;
   }
 }
 
@@ -856,6 +1023,7 @@ function writeStatuslineCacheAtomic(path: string, cache: StatuslineCache): void 
 export async function collectStatuslineAfk(
   ctx: RepoContext,
   cacheTtlS: number = STATUSLINE_CACHE_TTL_S,
+  refreshOptions: StatuslineRefreshSpawnOptions = {},
 ): Promise<AfkInput | null> {
   const paths = afkPaths(ctx.root);
   // Same single owner as the monitor (core/worker-state-reader).
@@ -946,23 +1114,20 @@ export async function collectStatuslineAfk(
   // GitHub-derived counts with a 180 s (3 min) cache (configurable, #1217) —
   // refreshed before the early-return so queue/human stay current even when the
   // fleet is idle (workers == 0).
-  const cachePath = join(paths.tmpDir, "statusline-cache.json");
+  const cachePath = statuslineCountCachePath(ctx.root);
   const nowS = Math.floor(Date.now() / 1000);
   const cached = readStatuslineCache(cachePath);
   let queue = cached?.queue ?? 0;
   let human = cached?.human ?? 0;
 
-  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
+  const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo || inferGitHubRepoSlug(ctx.root) };
   let refreshSucceeded = false;
   const refresh = async (): Promise<void> => {
-    const [q, h] = await Promise.all([
-      ghx.countReadyForAgent(ghCtx),
-      ghx.countReadyForHuman(ghCtx),
-    ]);
-    queue = q;
-    human = h;
+    const counts = await ghx.countStatuslineQueueCounts(ghCtx);
+    queue = counts.queue;
+    human = counts.human;
     refreshSucceeded = true;
-    writeStatuslineCacheAtomic(cachePath, { queue: q, human: h, ts: nowS });
+    writeStatuslineCacheAtomic(cachePath, { queue, human, ts: nowS });
   };
 
   let cacheAgeS: number | undefined;
@@ -972,12 +1137,12 @@ export async function collectStatuslineAfk(
     // or on any gh/auth/network error.
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
   } else if (nowS - cached.ts >= cacheTtlS) {
-    // Stale: await a bounded refresh so the cache is rewritten before the
-    // process exits. Shows the previous value on timeout (fail-open). When
-    // refresh fails, mark the age so the renderer can signal staleness.
     const staleAgeS = nowS - cached.ts;
-    await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
-    if (!refreshSucceeded) cacheAgeS = staleAgeS;
+    cacheAgeS = staleAgeS;
+    startDetachedStatuslineCountRefresh(
+      { ...ctx, repo: ghCtx.repo },
+      { ...refreshOptions, nowS },
+    );
   }
 
   if (workers <= 0) return null;
@@ -1244,7 +1409,7 @@ export async function collectReapInputs(ctx: RepoContext): Promise<ReapInputs> {
 import type { PrecheckFacts, BootOptions, BootDeps, BootstrapInput, OrphanDir } from "../core/boot.js";
 import type { AttemptDir } from "../core/reclaim.js";
 import type { IssueStateRow } from "./gh.js";
-import { LABEL_HUMAN, LABEL_RUNNING } from "../core/triage-labels.js";
+import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../core/triage-labels.js";
 import { parseWorkerAttemptPath } from "../core/worker-paths.js";
 import { parseClaimRecords } from "../core/claim.js";
 
@@ -1393,6 +1558,7 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: gitx.GitContext = { cwd: ctx.root };
   const cfg = loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined });
+  const countCachePath = statuslineCountCachePath(ctx.root);
   // ONE batched issue-state fetch backs every per-issue boot lookup below.
   const issueStates = await ghx.listIssueStates(ghCtx);
   const branchCache = await resolveBranchIssueCache(ghCtx, options, issueStates);
@@ -1412,7 +1578,12 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
     },
     gh: {
       editLabels: async (issue, remove, add) => {
-        await ghx.editLabels(ghCtx, issue, remove, add);
+        await editLabelsWithStatuslineCache(
+          countCachePath,
+          () => ghx.editLabels(ghCtx, issue, remove, add),
+          remove,
+          add,
+        );
       },
       comment: (issue, body) => ghx.comment(ghCtx, issue, body),
       viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),

--- a/apps/dev/tests/gh-statusline-counts.test.ts
+++ b/apps/dev/tests/gh-statusline-counts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { countStatuslineQueueCounts } from "../src/runtime/gh.js";
+import type { ExecFn } from "../src/runtime/exec.js";
+
+describe("gh statusline counts", () => {
+  it("fetches ready and human counts with one GraphQL request", async () => {
+    const calls: Array<{ tool: string; args: readonly string[] }> = [];
+    const exec: ExecFn = async (tool, args) => {
+      calls.push({ tool, args });
+      return {
+        code: 0,
+        stdout: JSON.stringify({ data: { ready: { issueCount: 7 }, human: { issueCount: 2 } } }),
+        stderr: "",
+      };
+    };
+
+    const counts = await countStatuslineQueueCounts({ cwd: "/repo", repo: "o/r", exec });
+
+    expect(counts).toEqual({ queue: 7, human: 2 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.tool).toBe("gh");
+    expect(calls[0]!.args.slice(0, 2)).toEqual(["api", "graphql"]);
+    expect(calls[0]!.args.join(" ")).toContain("ready: search");
+    expect(calls[0]!.args.join(" ")).toContain("human: search");
+    expect(calls[0]!.args).toContain('ready=repo:o/r is:issue is:open label:"ready-for-agent"');
+    expect(calls[0]!.args).toContain('human=repo:o/r is:issue is:open label:"ready-for-human"');
+  });
+});

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -16,6 +16,10 @@ import {
   collectStatuslineAfk,
   collectStatuslineRepo,
   STATUSLINE_CACHE_TTL_S,
+  applyStatuslineCountCacheLabelDelta,
+  editLabelsWithStatuslineCache,
+  parseGitHubRepoSlugFromRemoteUrl,
+  inferGitHubRepoSlug,
   resolveStatuslineCacheTtl,
 } from "../src/runtime/wire.js";
 import { runBoot } from "../src/core/boot.js";
@@ -554,6 +558,15 @@ function nowS(): number {
   return Math.floor(Date.now() / 1000);
 }
 
+function detachedSpawnRecorder() {
+  const calls: Array<{ command: string; args: readonly string[] }> = [];
+  const spawn = (command: string, args: readonly string[]) => {
+    calls.push({ command, args });
+    return { unref() { /* test double */ } };
+  };
+  return { calls, spawn };
+}
+
 // ---------------------------------------------------------------------------
 // collectStatuslineAfk — cache discipline (#818)
 // ---------------------------------------------------------------------------
@@ -578,7 +591,7 @@ describe("collectStatuslineAfk — cache discipline", () => {
     }
   });
 
-  it("stale cache: awaits gh + rewrites cache before returning", async () => {
+  it("stale cache: serves stale values immediately and starts one detached refresh", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
       const tmpDir = join(root, ".red", "tmp");
@@ -587,11 +600,53 @@ describe("collectStatuslineAfk — cache discipline", () => {
 
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
       writeFileSync(cachePath, JSON.stringify({ queue: 5, human: 3, ts: staleTs }), "utf8");
+      writeRenderableAttempt(root, "w1", 55, new Date().toISOString());
+      const rec = detachedSpawnRecorder();
 
-      await withFakeGh(() => collectStatuslineAfk({ root, repo: "", remote: "origin" }));
+      const result = await collectStatuslineAfk(
+        { root, repo: "o/r", remote: "origin" },
+        STATUSLINE_CACHE_TTL_S,
+        { spawn: rec.spawn, argv1: "/tmp/afk.mjs" },
+      );
 
       const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { queue: number; human: number; ts: number };
-      expect(cache.ts).toBeGreaterThan(staleTs); // ts advanced beyond the stale value
+      expect(result?.queue).toBe(5);
+      expect(result?.human).toBe(3);
+      expect(result?.cacheAgeS).toBeGreaterThanOrEqual(STATUSLINE_CACHE_TTL_S);
+      expect(cache.ts).toBe(staleTs);
+      expect(rec.calls).toHaveLength(1);
+      expect(rec.calls[0]!.args).toContain("statusline-refresh-counts");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stale cache: concurrent renders share one detached refresh lock", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const cachePath = join(tmpDir, "statusline-cache.json");
+      writeFileSync(
+        cachePath,
+        JSON.stringify({ queue: 8, human: 1, ts: nowS() - STATUSLINE_CACHE_TTL_S - 10 }),
+        "utf8",
+      );
+      writeRenderableAttempt(root, "w1", 55, new Date().toISOString());
+      const rec = detachedSpawnRecorder();
+
+      const renders = await Promise.all(
+        Array.from({ length: 8 }, () =>
+          collectStatuslineAfk(
+            { root, repo: "o/r", remote: "origin" },
+            STATUSLINE_CACHE_TTL_S,
+            { spawn: rec.spawn, argv1: "/tmp/afk.mjs" },
+          ),
+        ),
+      );
+
+      expect(renders.every((r) => r?.queue === 8 && r.human === 1 && r.cacheAgeS !== undefined)).toBe(true);
+      expect(rec.calls).toHaveLength(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -628,7 +683,7 @@ describe("collectStatuslineAfk — cache discipline", () => {
     }
   });
 
-  it("0 live workers: still refreshes stale cache before returning null", async () => {
+  it("0 live workers: still starts detached stale refresh before returning null", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
       const tmpDir = join(root, ".red", "tmp");
@@ -637,14 +692,18 @@ describe("collectStatuslineAfk — cache discipline", () => {
 
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
       writeFileSync(cachePath, JSON.stringify({ queue: 9, human: 1, ts: staleTs }), "utf8");
+      const rec = detachedSpawnRecorder();
 
-      const result = await withFakeGh(() =>
-        collectStatuslineAfk({ root, repo: "", remote: "origin" }),
+      const result = await collectStatuslineAfk(
+        { root, repo: "o/r", remote: "origin" },
+        STATUSLINE_CACHE_TTL_S,
+        { spawn: rec.spawn, argv1: "/tmp/afk.mjs" },
       );
 
       expect(result).toBeNull(); // 0 workers → null
       const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { ts: number };
-      expect(cache.ts).toBeGreaterThan(staleTs); // refreshed despite 0 workers
+      expect(cache.ts).toBe(staleTs);
+      expect(rec.calls).toHaveLength(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -732,6 +791,84 @@ describe("collectStatuslineAfk — cache discipline", () => {
       expect(result!.added).toBe(84);
       expect(result!.removed).toBe(5);
       expect(result!.locIsPeak).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("statusline count cache write-through", () => {
+  it("applies claim, park, requeue, and close label deltas without count reads", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-write-through-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const cachePath = join(tmpDir, "statusline-cache.json");
+      writeFileSync(cachePath, JSON.stringify({ queue: 4, human: 2, ts: 100 }), "utf8");
+
+      expect(applyStatuslineCountCacheLabelDelta(cachePath, ["ready-for-agent"], ["running"], 200)).toBe(true);
+      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 3, human: 2, ts: 200 });
+
+      expect(applyStatuslineCountCacheLabelDelta(cachePath, ["running"], ["ready-for-human", "blocked:validation"], 300)).toBe(true);
+      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 3, human: 3, ts: 300 });
+
+      expect(applyStatuslineCountCacheLabelDelta(cachePath, ["ready-for-human", "blocked:validation"], ["ready-for-agent"], 400)).toBe(true);
+      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 4, human: 2, ts: 400 });
+
+      expect(applyStatuslineCountCacheLabelDelta(cachePath, ["ready-for-human"], [], 500)).toBe(true);
+      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 4, human: 1, ts: 500 });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("wraps a successful mutation with write-through and does not add API calls", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-write-through-"));
+    try {
+      const cachePath = join(root, ".red", "tmp", "statusline-cache.json");
+      mkdirSync(join(root, ".red", "tmp"), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ queue: 1, human: 0, ts: 100 }), "utf8");
+      let edits = 0;
+
+      const ok = await editLabelsWithStatuslineCache(
+        cachePath,
+        async () => {
+          edits += 1;
+          return true;
+        },
+        ["ready-for-agent"],
+        ["running"],
+      );
+
+      const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { queue: number; human: number; ts: number };
+      expect(ok).toBe(true);
+      expect(edits).toBe(1);
+      expect(cache.queue).toBe(0);
+      expect(cache.human).toBe(0);
+      expect(cache.ts).toBeGreaterThan(100);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("statusline repo slug inference", () => {
+  it("parses GitHub ssh and https remotes", () => {
+    expect(parseGitHubRepoSlugFromRemoteUrl("git@github.com:reddb-io/red-skills.git")).toBe("reddb-io/red-skills");
+    expect(parseGitHubRepoSlugFromRemoteUrl("https://github.com/reddb-io/red-skills.git")).toBe("reddb-io/red-skills");
+    expect(parseGitHubRepoSlugFromRemoteUrl("ssh://example.com/reddb-io/red-skills.git")).toBe("");
+  });
+
+  it("infers the repo slug from local .git/config without gh", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
+    try {
+      mkdirSync(join(root, ".git"), { recursive: true });
+      writeFileSync(
+        join(root, ".git", "config"),
+        "[remote \"origin\"]\n\turl = git@github.com:reddb-io/red-skills.git\n",
+        "utf8",
+      );
+      expect(inferGitHubRepoSlug(root)).toBe("reddb-io/red-skills");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -843,24 +980,24 @@ describe("collectStatuslineRepo — cache discipline", () => {
 });
 
 // ---------------------------------------------------------------------------
-// STATUSLINE_CACHE_TTL_S — the default TTL constant (#1178, lowered #1217)
+// STATUSLINE_CACHE_TTL_S — the default TTL constant (#1178, lowered #1217, raised #1216)
 // ---------------------------------------------------------------------------
 
 describe("STATUSLINE_CACHE_TTL_S", () => {
-  it("defaults to 180 s (3 minutes): the network cost is paid at most once per 3 min", () => {
-    expect(STATUSLINE_CACHE_TTL_S).toBe(180);
+  it("defaults to 900 s (15 minutes): TTL is reconciliation-only for statusline counts", () => {
+    expect(STATUSLINE_CACHE_TTL_S).toBe(900);
   });
 });
 
 // ---------------------------------------------------------------------------
-// resolveStatuslineCacheTtl — env > config > 180, typo-safe fallback (#1217)
+// resolveStatuslineCacheTtl — env > config > 900, typo-safe fallback (#1217)
 // ---------------------------------------------------------------------------
 
 describe("resolveStatuslineCacheTtl (#1217)", () => {
   const noCfg = () => "";
 
-  it("defaults to 180 when neither env nor config is set", () => {
-    expect(resolveStatuslineCacheTtl({}, noCfg)).toBe(180);
+  it("defaults to 900 when neither env nor config is set", () => {
+    expect(resolveStatuslineCacheTtl({}, noCfg)).toBe(900);
     expect(resolveStatuslineCacheTtl({}, noCfg)).toBe(STATUSLINE_CACHE_TTL_S);
   });
 
@@ -881,15 +1018,15 @@ describe("resolveStatuslineCacheTtl (#1217)", () => {
     expect(resolveStatuslineCacheTtl({ RED_AFK_STATUSLINE_CACHE_TTL_S: "-5" }, getCfg)).toBe(240);
   });
 
-  it("falls back to 180 when BOTH env and config are garbage — never 0", () => {
+  it("falls back to 900 when BOTH env and config are garbage — never 0", () => {
     const bad = (v: string) => resolveStatuslineCacheTtl({ RED_AFK_STATUSLINE_CACHE_TTL_S: v }, () => v);
-    expect(bad("0")).toBe(180);
-    expect(bad("-1")).toBe(180);
-    expect(bad("abc")).toBe(180);
+    expect(bad("0")).toBe(900);
+    expect(bad("-1")).toBe(900);
+    expect(bad("abc")).toBe(900);
     // config-only garbage also falls through to the default
-    expect(resolveStatuslineCacheTtl({}, () => "0")).toBe(180);
-    expect(resolveStatuslineCacheTtl({}, () => "-9")).toBe(180);
-    expect(resolveStatuslineCacheTtl({}, () => "xyz")).toBe(180);
+    expect(resolveStatuslineCacheTtl({}, () => "0")).toBe(900);
+    expect(resolveStatuslineCacheTtl({}, () => "-9")).toBe(900);
+    expect(resolveStatuslineCacheTtl({}, () => "xyz")).toBe(900);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1216. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1216

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785979819&installation_id=129708444&pr_number=1256&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1256&signature=1969504c12f738535303ddaae7862d6860a7350b264746f976251f3e8c5c6f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->