### PR TITLE
merge: #1233 Auto-file a main-red repair issue from the baseline probe

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -780,6 +780,10 @@ export function buildProcessDeps(
         const { hitlCardCommand } = await import("./hitl-card.js");
         await hitlCardCommand(["render", `--issue=${issue}`, `--root=${ctx.root}`]);
       },
+      findMainRedRepairIssue: () => ghx.findMainRedRepairIssue(ghCtx),
+      createMainRedRepairIssue: (spec) => ghx.createMainRedRepairIssue(ghCtx, spec),
+      updateMainRedRepairIssue: (issue, spec) => ghx.updateMainRedRepairIssue(ghCtx, issue, spec),
+      closeMainRedRepairIssue: (issue, closeComment) => ghx.closeMainRedRepairIssue(ghCtx, issue, closeComment),
     },
     claimGh: {
       // ADR 0066: the atomic GitHub-native claim arbiter. Numeric comment ids

--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -312,6 +312,19 @@ export interface RunFeedbackResult {
    */
   baselineDowngraded: readonly string[];
   /**
+   * True when the baseline probe actually ran. This distinguishes "main is
+   * green for the failing worker checks" from "the happy path skipped the
+   * baseline probe entirely".
+   */
+  baselineProbeRan?: boolean;
+  /**
+   * The failed baseline check names observed by the probe. These are the
+   * pre-existing main failures a caller can surface in a repair issue. Equal to
+   * `baselineDowngraded` today, but kept as its own field because callers care
+   * about the baseline's state, not the worker reclassification mechanism.
+   */
+  baselineFailures?: readonly string[];
+  /**
    * Quarantine entries that were active for this gate run — the full validated
    * list from `RunFeedbackInput.quarantine`. Always empty when no quarantine
    * was configured. Surfaced for envelope builders that want to render the
@@ -544,7 +557,16 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       }
     }
     failed = checks.some((c) => c.status === "failed");
-    return { ok: !failed, checks, sidecar, baselineDowngraded: downgraded, quarantined: quarantine, validationScope };
+    return {
+      ok: !failed,
+      checks,
+      sidecar,
+      baselineDowngraded: downgraded,
+      baselineProbeRan: true,
+      baselineFailures: downgraded,
+      quarantined: quarantine,
+      validationScope,
+    };
   }
 
   return { ok: !failed, checks, sidecar, baselineDowngraded: [], quarantined: quarantine, validationScope };

--- a/apps/dev/src/core/main-red-repair.ts
+++ b/apps/dev/src/core/main-red-repair.ts
@@ -1,0 +1,69 @@
+import { LABEL_BUG, LABEL_READY, LABEL_URGENT } from "./triage-labels.js";
+
+export const MAIN_RED_REPAIR_TITLE = "main-red repair: baseline probe failures on main";
+export const MAIN_RED_REPAIR_MARKER = "<!-- red-skills:main-red-repair v1 -->";
+
+export interface MainRedRepairIssue {
+  number: number;
+  title?: string;
+  body?: string;
+  labels?: readonly string[];
+}
+
+export type MainRedRepairPlan =
+  | { action: "noop" }
+  | { action: "create"; title: string; body: string; labels: readonly string[] }
+  | { action: "update"; issue: number; title: string; body: string; labels: readonly string[] }
+  | { action: "close"; issue: number; comment: string };
+
+export function normalizeBaselineFailures(failures: readonly string[]): string[] {
+  return [...new Set(failures.map((f) => f.trim()).filter((f) => f.length > 0))].sort();
+}
+
+export function renderMainRedRepairBody(failures: readonly string[]): string {
+  const normalized = normalizeBaselineFailures(failures);
+  const list = normalized.map((failure) => `- ${failure}`).join("\n");
+  return [
+    MAIN_RED_REPAIR_MARKER,
+    "",
+    "## Summary",
+    "",
+    "The AFK feedback baseline probe found pre-existing failures on main. Repair main before relying on the feedback gate as a branch verdict.",
+    "",
+    "## Failing checks",
+    "",
+    list || "- (none)",
+    "",
+    "## Source",
+    "",
+    "Auto-filed by the AFK feedback baseline probe.",
+  ].join("\n");
+}
+
+export function planMainRedRepair(
+  baselineFailures: readonly string[],
+  currentOpenIssue: MainRedRepairIssue | null,
+): MainRedRepairPlan {
+  const failures = normalizeBaselineFailures(baselineFailures);
+  if (failures.length === 0) {
+    if (!currentOpenIssue) return { action: "noop" };
+    return {
+      action: "close",
+      issue: currentOpenIssue.number,
+      comment: "🤖 /afk baseline probe: main is green again; closing the auto-filed repair issue.",
+    };
+  }
+
+  const body = renderMainRedRepairBody(failures);
+  const labels = [LABEL_READY, LABEL_URGENT, LABEL_BUG];
+  if (!currentOpenIssue) {
+    return { action: "create", title: MAIN_RED_REPAIR_TITLE, body, labels };
+  }
+  return {
+    action: "update",
+    issue: currentOpenIssue.number,
+    title: MAIN_RED_REPAIR_TITLE,
+    body,
+    labels,
+  };
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -47,6 +47,10 @@ import {
   type RunFeedbackResult,
 } from "./feedback.js";
 import {
+  planMainRedRepair,
+  type MainRedRepairIssue,
+} from "./main-red-repair.js";
+import {
   computeValidationScope,
   formatValidationScope,
   scopesForValidationScope,
@@ -167,6 +171,18 @@ export interface ProcessGh {
    * behaviour preserved).
    */
   renderDecisionCard?(issue: number): Promise<void>;
+  /** Find the single open auto-filed main-red repair issue, if any. Optional so
+   * older callers degrade to the historical baseline-downgrade behaviour. */
+  findMainRedRepairIssue?(): Promise<MainRedRepairIssue | null>;
+  /** Create the auto-filed main-red repair issue. */
+  createMainRedRepairIssue?(spec: { title: string; body: string; labels: readonly string[] }): Promise<number>;
+  /** Refresh the auto-filed main-red repair issue's title/body/labels. */
+  updateMainRedRepairIssue?(
+    issue: number,
+    spec: { title: string; body: string; labels: readonly string[] },
+  ): Promise<void>;
+  /** Close the auto-filed main-red repair issue once the baseline probe is green. */
+  closeMainRedRepairIssue?(issue: number, comment: string): Promise<void>;
 }
 
 /** Claim-lock side effects (the local mkdir lock at .red/tmp/claims/{N}/). */
@@ -1062,6 +1078,55 @@ async function refuseNoSandboxForUntrustedAuthor(
     preserved: false,
     swept: false,
   };
+}
+
+async function syncMainRedRepairIssue(
+  deps: ProcessIssueDeps,
+  feedback: RunFeedbackResult,
+): Promise<void> {
+  if (!feedback.baselineProbeRan) return;
+  const {
+    findMainRedRepairIssue,
+    createMainRedRepairIssue,
+    updateMainRedRepairIssue,
+    closeMainRedRepairIssue,
+  } = deps.gh;
+  if (!findMainRedRepairIssue || !createMainRedRepairIssue || !updateMainRedRepairIssue || !closeMainRedRepairIssue) {
+    return;
+  }
+
+  try {
+    const current = await findMainRedRepairIssue();
+    const plan = planMainRedRepair(feedback.baselineFailures ?? [], current);
+    switch (plan.action) {
+      case "noop":
+        return;
+      case "create": {
+        const created = await createMainRedRepairIssue({
+          title: plan.title,
+          body: plan.body,
+          labels: plan.labels,
+        });
+        deps.appendIterLog(`🤖 /afk baseline probe: opened main-red repair issue #${created}.`);
+        return;
+      }
+      case "update":
+        await updateMainRedRepairIssue(plan.issue, {
+          title: plan.title,
+          body: plan.body,
+          labels: plan.labels,
+        });
+        deps.appendIterLog(`🤖 /afk baseline probe: updated main-red repair issue #${plan.issue}.`);
+        return;
+      case "close":
+        await closeMainRedRepairIssue(plan.issue, plan.comment);
+        deps.appendIterLog(`🤖 /afk baseline probe: closed main-red repair issue #${plan.issue}.`);
+        return;
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.appendIterLog(`warn: main-red repair issue sync failed: ${message}`);
+  }
 }
 
 /**
@@ -1985,6 +2050,7 @@ export async function processIssue(
         }),
       );
     }
+    await syncMainRedRepairIssue(deps, feedback);
     // post_feedback (#832): the scope-derived gate has produced its verdict.
     await fireHook(
       "post_feedback",

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -55,6 +55,7 @@ export const LABEL_TRIAGE_SUMMON = "triage:summon";
 export const LABEL_PRD = "type:prd";
 export const LABEL_URGENT = "priority:urgent";
 export const LABEL_HIGH = "priority:high";
+export const LABEL_BUG = "bug";
 
 // Blocked reason labels
 export const LABEL_VALIDATION = "blocked:validation";

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -24,6 +24,10 @@ import { classifySourceTrust, TRUSTED_ASSOCIATIONS, type SourceTrustLevel } from
 import type { ActorTrustVerdict, RepoVisibility } from "../core/trust-gate.js";
 import type { IssueOpenState } from "../core/reclaim.js";
 import type { UnblockCandidate, ReconcileSweepCandidate } from "../core/boot-sweep.js";
+import {
+  MAIN_RED_REPAIR_TITLE,
+  type MainRedRepairIssue,
+} from "../core/main-red-repair.js";
 
 export interface GhContext {
   /** owner/repo slug for `gh ... --repo`. */
@@ -376,6 +380,79 @@ export async function createIssue(
     throw new Error(`gh: failed to create issue (code ${r.code}): ${(r.stdout || r.stderr || "").trim()}`);
   }
   return num;
+}
+
+/** Find the single open auto-filed main-red repair issue by its stable title. */
+export async function findMainRedRepairIssue(ctx: GhContext): Promise<MainRedRepairIssue | null> {
+  const r = await runGh(ctx, [
+    "issue",
+    "list",
+    ...repoArgs(ctx),
+    "--state",
+    "open",
+    "--limit",
+    "50",
+    "--search",
+    `"${MAIN_RED_REPAIR_TITLE}" in:title`,
+    "--json",
+    "number,title,body,labels",
+  ]);
+  if (r.code !== 0) return null;
+  try {
+    const rows = JSON.parse(r.stdout || "[]") as Array<{
+      number?: number;
+      title?: string;
+      body?: string;
+      labels?: Array<{ name?: string }>;
+    }>;
+    if (!Array.isArray(rows)) return null;
+    const row = rows
+      .filter((item) => String(item.title ?? "") === MAIN_RED_REPAIR_TITLE)
+      .sort((a, b) => Number(a.number ?? 0) - Number(b.number ?? 0))[0];
+    if (!row || !Number(row.number)) return null;
+    return {
+      number: Number(row.number),
+      title: String(row.title ?? ""),
+      body: String(row.body ?? ""),
+      labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")) : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Create the auto-filed main-red repair issue. */
+export async function createMainRedRepairIssue(
+  ctx: GhContext,
+  spec: { title: string; body: string; labels: readonly string[] },
+): Promise<number> {
+  return createIssue(ctx, spec);
+}
+
+/** Refresh the auto-filed main-red repair issue. */
+export async function updateMainRedRepairIssue(
+  ctx: GhContext,
+  issue: number,
+  spec: { title: string; body: string; labels: readonly string[] },
+): Promise<void> {
+  const args = [
+    "issue",
+    "edit",
+    String(issue),
+    ...repoArgs(ctx),
+    "--title",
+    spec.title,
+    "--body",
+    spec.body,
+  ];
+  for (const label of spec.labels) args.push("--add-label", label);
+  await runGh(ctx, args);
+}
+
+/** Close the auto-filed main-red repair issue once main is green again. */
+export async function closeMainRedRepairIssue(ctx: GhContext, issue: number, closeComment: string): Promise<void> {
+  await comment(ctx, issue, closeComment);
+  await closeIssue(ctx, issue);
 }
 
 /** Idempotently create the `runner-error` label (best-effort). Mirrors

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -489,6 +489,8 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     // ZERO baseline probes (the gate was green, no reason to probe).
     const baselineCalls = Object.entries(counts).filter(([k]) => k.includes("main"));
     expect(baselineCalls).toEqual([]);
+    expect(result.baselineProbeRan).toBeUndefined();
+    expect(result.baselineFailures).toBeUndefined();
     expect(Object.values(counts).reduce((a, b) => a + b, 0)).toBe(5);
   });
 
@@ -515,6 +517,8 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     // test:apps/dev failed on worker AND on baseline → downgraded; gate passes.
     expect(result.ok).toBe(true);
     expect(result.baselineDowngraded).toEqual(["test:apps/dev"]);
+    expect(result.baselineProbeRan).toBe(true);
+    expect(result.baselineFailures).toEqual(["test:apps/dev"]);
     const testCheck = result.checks.find((c) => c.name === "test:apps/dev")!;
     expect(testCheck.status).toBe("skipped");
     expect(testCheck.record.summary).toBe("pre-existing failure on baseline");
@@ -537,6 +541,8 @@ describe("runFeedback — baseline probe downgrades pre-existing failures", () =
     });
     expect(result.ok).toBe(false);
     expect(result.baselineDowngraded).toEqual([]);
+    expect(result.baselineProbeRan).toBe(true);
+    expect(result.baselineFailures).toEqual([]);
     const testCheck = result.checks.find((c) => c.name === "test:apps/dev")!;
     expect(testCheck.status).toBe("failed");
   });

--- a/apps/dev/tests/main-red-repair.test.ts
+++ b/apps/dev/tests/main-red-repair.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAIN_RED_REPAIR_TITLE,
+  planMainRedRepair,
+  renderMainRedRepairBody,
+} from "../src/core/main-red-repair.js";
+import { LABEL_BUG, LABEL_READY, LABEL_URGENT } from "../src/core/triage-labels.js";
+
+describe("planMainRedRepair", () => {
+  it("creates one urgent tracked repair issue when baseline failures exist and none is open", () => {
+    const plan = planMainRedRepair(["test:apps/dev", "typecheck:workspace"], null);
+
+    expect(plan.action).toBe("create");
+    if (plan.action !== "create") throw new Error("unreachable");
+    expect(plan.title).toBe(MAIN_RED_REPAIR_TITLE);
+    expect(plan.labels).toEqual([LABEL_READY, LABEL_URGENT, LABEL_BUG]);
+    expect(plan.body).toContain("- test:apps/dev");
+    expect(plan.body).toContain("- typecheck:workspace");
+  });
+
+  it("updates the existing repair issue instead of creating a duplicate for same or overlapping failures", () => {
+    const plan = planMainRedRepair(["test:apps/dev", "test:apps/dev", "lint:apps/dev"], {
+      number: 123,
+      labels: [LABEL_URGENT],
+    });
+
+    expect(plan.action).toBe("update");
+    if (plan.action !== "update") throw new Error("unreachable");
+    expect(plan.issue).toBe(123);
+    expect(plan.body.match(/test:apps\/dev/g)).toHaveLength(1);
+    expect(plan.body).toContain("- lint:apps/dev");
+  });
+
+  it("closes the open repair issue when the next baseline probe is green", () => {
+    const plan = planMainRedRepair([], { number: 55 });
+
+    expect(plan).toEqual({
+      action: "close",
+      issue: 55,
+      comment: "🤖 /afk baseline probe: main is green again; closing the auto-filed repair issue.",
+    });
+  });
+
+  it("does nothing when main is green and no repair issue exists", () => {
+    expect(planMainRedRepair([], null)).toEqual({ action: "noop" });
+  });
+});
+
+describe("renderMainRedRepairBody", () => {
+  it("names each failing baseline check in a stable body", () => {
+    const body = renderMainRedRepairBody([" typecheck:workspace ", "test:apps/dev"]);
+
+    expect(body).toContain("## Failing checks");
+    expect(body).toContain("- test:apps/dev");
+    expect(body).toContain("- typecheck:workspace");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1233. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1233

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785979952&installation_id=129708444&pr_number=1257&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1257&signature=0e6ac01cb354ef20d5c78ea27a57cba88d1894be1196df9a4192e63467297c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->