### PR TITLE
merge: #1235 Run the whole suite (not just touched scope) for core-module changes

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -39,7 +39,6 @@ import {
   type SandboxMode,
 } from "./execution.js";
 import {
-  relevantScopes,
   runFeedback,
   isInfraFeedbackFailure,
   type Exec as PnpmExec,
@@ -2003,18 +2002,15 @@ export async function processIssue(
     // Macro phase → `validating` (issue #811): the feedback gate is starting.
     deps.markPhase?.("validating");
     const changedFiles = await deps.lookups.changedFiles(workerBranch, baseRef);
-    // Compute the validation scope: when a workspace graph is injected, expand
-    // to the full dependency cone (touched packages + transitive dependents);
-    // otherwise fall back to the current directly-touched-packages behaviour.
-    // Root-config changes (lockfile, tsconfig, .github/**) always escalate to
-    // whole-workspace regardless of which approach is used.
-    let validationScope: ValidationScope;
-    if (deps.graph) {
-      validationScope = computeValidationScope(changedFiles, deps.layout, deps.graph);
-    } else {
-      const scopes = relevantScopes(deps.layout, changedFiles);
-      validationScope = { type: "cone", packages: scopes, triggerPackages: scopes };
-    }
+    // Compute the validation scope: expand to the full dependency cone when a
+    // workspace graph is injected, otherwise keep the directly-touched package
+    // cone. Root-config and explicit core-module changes always escalate to
+    // whole-workspace before any package scoping.
+    const validationScope = computeValidationScope(
+      changedFiles,
+      deps.layout,
+      deps.graph ?? { packages: [] },
+    );
     const feedbackScopes = scopesForValidationScope(validationScope);
     // pre_feedback (#832): a pre_* gate around the scope-derived feedback run — a
     // non-zero exit VETOES validation and routes the attempt to the abort-after-

--- a/apps/dev/src/core/validation-scope.ts
+++ b/apps/dev/src/core/validation-scope.ts
@@ -79,8 +79,22 @@ const ROOT_TRIGGER_FILES = new Set([
   ".nvmrc",
 ]);
 
+/**
+ * Reviewable manifest of shared/core modules whose changes have cross-cutting
+ * blast radius beyond the package cone. Touching any path here escalates the
+ * AFK feedback gate to the whole workspace suite.
+ */
+export const CORE_MODULE_MANIFEST = [
+  "apps/dev/src/core",
+  "packages/shared",
+] as const;
+
 function stripDotSlash(file: string): string {
   return file.startsWith("./") ? file.slice(2) : file;
+}
+
+function isPathAtOrUnder(file: string, manifestPath: string): boolean {
+  return file === manifestPath || file.startsWith(`${manifestPath}/`);
 }
 
 /**
@@ -96,6 +110,24 @@ export function isRootTrigger(file: string): boolean {
   // Root-level files only (no directory separator = sits directly at repo root).
   if (!clean.includes("/")) return ROOT_TRIGGER_FILES.has(clean);
   return false;
+}
+
+function coreModuleTriggerFile(touchedFiles: readonly string[]): string | undefined {
+  for (const file of touchedFiles) {
+    const clean = stripDotSlash(file);
+    if (CORE_MODULE_MANIFEST.some((manifestPath) => isPathAtOrUnder(clean, manifestPath))) {
+      return clean;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Pure predicate for whether a changed-file set must run the whole workspace
+ * suite because it touches an explicit shared/core module manifest entry.
+ */
+export function scopeNeedsWholeSuite(touchedFiles: readonly string[]): boolean {
+  return coreModuleTriggerFile(touchedFiles) !== undefined;
 }
 
 /**
@@ -152,6 +184,11 @@ export function computeValidationScope(
     if (isRootTrigger(file)) {
       return { type: "whole-workspace", triggerFile: stripDotSlash(file) };
     }
+  }
+
+  const coreTrigger = coreModuleTriggerFile(changedFiles);
+  if (coreTrigger !== undefined) {
+    return { type: "whole-workspace", triggerFile: coreTrigger };
   }
 
   const touchedDirs = relevantScopes(layout, changedFiles);

--- a/apps/dev/tests/validation-scope.test.ts
+++ b/apps/dev/tests/validation-scope.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  CORE_MODULE_MANIFEST,
   computeValidationScope,
   formatValidationScope,
   isRootTrigger,
+  scopeNeedsWholeSuite,
   scopesForValidationScope,
   type ValidationScope,
   type WorkspaceGraph,
@@ -67,12 +69,25 @@ describe("isRootTrigger", () => {
 
   it("does NOT trigger on package-level tsconfig.json", () => {
     expect(isRootTrigger("apps/dev/tsconfig.json")).toBe(false);
-    expect(isRootTrigger("packages/shared/package.json")).toBe(false);
+    expect(isRootTrigger("packages/leaf/package.json")).toBe(false);
   });
 
   it("does NOT trigger on normal source files", () => {
     expect(isRootTrigger("apps/dev/src/index.ts")).toBe(false);
     expect(isRootTrigger("README.md")).toBe(false);
+  });
+});
+
+// ---- scopeNeedsWholeSuite ----
+
+describe("scopeNeedsWholeSuite", () => {
+  it("escalates core-module touches via the explicit manifest", () => {
+    expect(CORE_MODULE_MANIFEST).toContain("apps/dev/src/core");
+    expect(scopeNeedsWholeSuite(["apps/dev/src/core/process-issue.ts"])).toBe(true);
+  });
+
+  it("keeps leaf touches on the scoped package path", () => {
+    expect(scopeNeedsWholeSuite(["apps/dev/tests/feedback.test.ts"])).toBe(false);
   });
 });
 
@@ -117,70 +132,79 @@ describe("computeValidationScope — whole-workspace escalation", () => {
     expect(scope.type).toBe("whole-workspace");
     expect(scopesForValidationScope(scope)).toEqual(["."]);
   });
+
+  it("escalates to whole-workspace on a manifest core-module change", () => {
+    const scope = computeValidationScope(["apps/dev/src/core/process-issue.ts"], layout, g);
+    expect(scope.type).toBe("whole-workspace");
+    if (scope.type === "whole-workspace") {
+      expect(scope.triggerFile).toBe("apps/dev/src/core/process-issue.ts");
+    }
+    expect(scopesForValidationScope(scope)).toEqual(["."]);
+  });
 });
 
 // ---- computeValidationScope — cone expansion ----
 
 describe("computeValidationScope — cone expansion", () => {
   it("leaf-package change → exact cone (package only when no dependents)", () => {
-    // packages/shared has no dependents in this graph.
-    const layout = fakeLayout(["packages/shared"]);
-    const g = graph(["packages/shared"]);
-    const scope = computeValidationScope(["packages/shared/src/index.ts"], layout, g);
+    // packages/leaf has no dependents in this graph.
+    const layout = fakeLayout(["packages/leaf"]);
+    const g = graph(["packages/leaf"]);
+    const scope = computeValidationScope(["packages/leaf/src/index.ts"], layout, g);
 
     expect(scope.type).toBe("cone");
     if (scope.type === "cone") {
-      expect(scope.packages).toEqual(["packages/shared"]);
-      expect(scope.triggerPackages).toEqual(["packages/shared"]);
+      expect(scope.packages).toEqual(["packages/leaf"]);
+      expect(scope.triggerPackages).toEqual(["packages/leaf"]);
     }
   });
 
   it("leaf-package change → cone includes direct dependents", () => {
-    // apps/dev depends on packages/shared — changing shared must run apps/dev too.
-    const layout = fakeLayout(["apps/dev", "packages/shared"]);
-    const g = graph(["apps/dev", "packages/shared"], ["packages/shared"]);
-    // Note: first entry "apps/dev" has no dependsOn; second is packages/shared.
+    // apps/dev depends on packages/leaf — changing leaf must run apps/dev too.
+    const layout = fakeLayout(["apps/dev", "packages/leaf"]);
+    const g = graph(["apps/dev", "packages/leaf"], ["packages/leaf"]);
+    // Note: first entry "apps/dev" has no dependsOn; second is packages/leaf.
     // Rebuild to express the dependency properly:
     const g2 = fakeGraph([
-      { dir: "apps/dev", dependsOn: ["packages/shared"] },
-      { dir: "packages/shared", dependsOn: [] },
+      { dir: "apps/dev", dependsOn: ["packages/leaf"] },
+      { dir: "packages/leaf", dependsOn: [] },
     ]);
-    const scope = computeValidationScope(["packages/shared/src/utils.ts"], layout, g2);
+    const scope = computeValidationScope(["packages/leaf/src/utils.ts"], layout, g2);
 
     expect(scope.type).toBe("cone");
     if (scope.type === "cone") {
-      expect(scope.packages).toEqual(["apps/dev", "packages/shared"]);
-      expect(scope.triggerPackages).toEqual(["packages/shared"]);
+      expect(scope.packages).toEqual(["apps/dev", "packages/leaf"]);
+      expect(scope.triggerPackages).toEqual(["packages/leaf"]);
     }
   });
 
   it("leaf-package change → cone includes transitive dependents (BFS)", () => {
-    // apps/ui → apps/dev → packages/shared. Changing shared must reach apps/ui.
-    const layout = fakeLayout(["apps/dev", "apps/ui", "packages/shared"]);
+    // apps/ui → apps/dev → packages/leaf. Changing leaf must reach apps/ui.
+    const layout = fakeLayout(["apps/dev", "apps/ui", "packages/leaf"]);
     const g = fakeGraph([
-      { dir: "apps/dev", dependsOn: ["packages/shared"] },
+      { dir: "apps/dev", dependsOn: ["packages/leaf"] },
       { dir: "apps/ui", dependsOn: ["apps/dev"] },
-      { dir: "packages/shared", dependsOn: [] },
+      { dir: "packages/leaf", dependsOn: [] },
     ]);
-    const scope = computeValidationScope(["packages/shared/src/index.ts"], layout, g);
+    const scope = computeValidationScope(["packages/leaf/src/index.ts"], layout, g);
 
     expect(scope.type).toBe("cone");
     if (scope.type === "cone") {
-      expect(scope.packages).toEqual(["apps/dev", "apps/ui", "packages/shared"]);
-      expect(scope.triggerPackages).toEqual(["packages/shared"]);
+      expect(scope.packages).toEqual(["apps/dev", "apps/ui", "packages/leaf"]);
+      expect(scope.triggerPackages).toEqual(["packages/leaf"]);
     }
   });
 
   it("multi-package change → union of cones (sorted LC_ALL=C)", () => {
-    // apps/dev and packages/shared are both touched; apps/ui depends on apps/dev.
-    const layout = fakeLayout(["apps/dev", "apps/ui", "packages/shared"]);
+    // apps/dev and packages/leaf are both touched; apps/ui depends on apps/dev.
+    const layout = fakeLayout(["apps/dev", "apps/ui", "packages/leaf"]);
     const g = fakeGraph([
       { dir: "apps/dev", dependsOn: [] },
       { dir: "apps/ui", dependsOn: ["apps/dev"] },
-      { dir: "packages/shared", dependsOn: [] },
+      { dir: "packages/leaf", dependsOn: [] },
     ]);
     const scope = computeValidationScope(
-      ["apps/dev/src/x.ts", "packages/shared/src/y.ts"],
+      ["apps/dev/src/x.ts", "packages/leaf/src/y.ts"],
       layout,
       g,
     );
@@ -188,9 +212,9 @@ describe("computeValidationScope — cone expansion", () => {
     expect(scope.type).toBe("cone");
     if (scope.type === "cone") {
       // apps/dev is triggered directly AND via apps/ui's dependency on apps/dev;
-      // packages/shared is touched directly.
-      expect(scope.packages).toEqual(["apps/dev", "apps/ui", "packages/shared"]);
-      expect(scope.triggerPackages.sort()).toEqual(["apps/dev", "packages/shared"]);
+      // packages/leaf is touched directly.
+      expect(scope.packages).toEqual(["apps/dev", "apps/ui", "packages/leaf"]);
+      expect(scope.triggerPackages.sort()).toEqual(["apps/dev", "packages/leaf"]);
     }
   });
 
@@ -218,10 +242,10 @@ describe("scopesForValidationScope", () => {
   it("cone → the cone package dirs", () => {
     const scope: ValidationScope = {
       type: "cone",
-      packages: ["apps/dev", "packages/shared"],
-      triggerPackages: ["packages/shared"],
+      packages: ["apps/dev", "packages/leaf"],
+      triggerPackages: ["packages/leaf"],
     };
-    expect(scopesForValidationScope(scope)).toEqual(["apps/dev", "packages/shared"]);
+    expect(scopesForValidationScope(scope)).toEqual(["apps/dev", "packages/leaf"]);
   });
 
   it("empty cone → []", () => {
@@ -250,13 +274,13 @@ describe("formatValidationScope", () => {
   it("formats an expanded cone (trigger ≠ cone)", () => {
     const scope: ValidationScope = {
       type: "cone",
-      packages: ["apps/dev", "packages/shared"],
-      triggerPackages: ["packages/shared"],
+      packages: ["apps/dev", "packages/leaf"],
+      triggerPackages: ["packages/leaf"],
     };
     const result = formatValidationScope(scope);
-    expect(result).toContain("scope: cone [`apps/dev`, `packages/shared`]");
+    expect(result).toContain("scope: cone [`apps/dev`, `packages/leaf`]");
     expect(result).toContain("expanded from");
-    expect(result).toContain("`packages/shared`");
+    expect(result).toContain("`packages/leaf`");
   });
 
   it("formats an empty cone", () => {
@@ -282,13 +306,13 @@ describe("gate integration — runFeedback runs the cone", () => {
   }
 
   it("passes cone packages as pnpm -C targets", async () => {
-    // Changed file in packages/shared; apps/dev depends on it → cone = both.
-    const layout = fakeLayout(["apps/dev", "packages/shared"]);
+    // Changed file in packages/leaf; apps/dev depends on it → cone = both.
+    const layout = fakeLayout(["apps/dev", "packages/leaf"]);
     const g = fakeGraph([
-      { dir: "apps/dev", dependsOn: ["packages/shared"] },
-      { dir: "packages/shared", dependsOn: [] },
+      { dir: "apps/dev", dependsOn: ["packages/leaf"] },
+      { dir: "packages/leaf", dependsOn: [] },
     ]);
-    const changedFiles = ["packages/shared/src/index.ts"];
+    const changedFiles = ["packages/leaf/src/index.ts"];
     const scope = computeValidationScope(changedFiles, layout, g);
     const scopes = scopesForValidationScope(scope);
 
@@ -304,10 +328,10 @@ describe("gate integration — runFeedback runs the cone", () => {
     expect(result.ok).toBe(true);
     expect(result.validationScope).toBe(scope);
 
-    // Gate must have invoked pnpm for BOTH apps/dev and packages/shared.
+    // Gate must have invoked pnpm for BOTH apps/dev and packages/leaf.
     const dirs = new Set(pnpmCalls.map((a) => a[a.indexOf("-C") + 1] ?? ""));
     expect(dirs.has("/wt/apps/dev")).toBe(true);
-    expect(dirs.has("/wt/packages/shared")).toBe(true);
+    expect(dirs.has("/wt/packages/leaf")).toBe(true);
   });
 
   it("whole-workspace trigger passes ['.'] as the only scope", async () => {


### PR DESCRIPTION
Automated AFK landing for #1235. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1235

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785981676&installation_id=129708444&pr_number=1259&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1259&signature=4b15feee1b3a54dd746e33a498ec46166432c824d46f3b3f18941d06a13d924a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->