### PR TITLE
merge: #1236 Baseline-diff gating: block only on failures new vs main

### DIFF
--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -177,6 +177,47 @@ export interface ValidationRecord {
   summary?: string;
 }
 
+export interface BaselineDiffGateDecision {
+  /** True when at least one branch failure is green on the baseline. */
+  shouldBlock: boolean;
+  /** Failures present on the branch and absent from the baseline failing set. */
+  blockingFailures: readonly string[];
+  /** Failures present on both branch and baseline; callers must record these. */
+  preExistingFailures: readonly string[];
+}
+
+/**
+ * Pure baseline-diff gate predicate. A branch blocks only for failures that
+ * are new relative to the baseline failing set. Failures red in both places
+ * are pre-existing main-red failures and are returned separately so callers
+ * can route them to the main-red repair path instead of silently dropping them.
+ */
+export function decideBaselineDiffGate(
+  branchFailingSet: readonly string[],
+  baselineFailingSet: readonly string[],
+): BaselineDiffGateDecision {
+  const baselineFailures = new Set(baselineFailingSet);
+  const seen = new Set<string>();
+  const blockingFailures: string[] = [];
+  const preExistingFailures: string[] = [];
+
+  for (const failure of branchFailingSet) {
+    if (seen.has(failure)) continue;
+    seen.add(failure);
+    if (baselineFailures.has(failure)) {
+      preExistingFailures.push(failure);
+    } else {
+      blockingFailures.push(failure);
+    }
+  }
+
+  return {
+    shouldBlock: blockingFailures.length > 0,
+    blockingFailures,
+    preExistingFailures,
+  };
+}
+
 // ---------- pure scope resolution ----------
 
 /** Drop a leading `./`, matching the bash `${file#./}`. */
@@ -633,6 +674,14 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
       .filter((c) => c.status === "failed")
       .map((c) => ({ name: c.name, script: c.script, scope: c.scope }));
     const baselineResults = await runChecksForBaseline(exec, baselineWorktree, failing, layout, now, subprocessEnv);
+    const baselineFailing = [...baselineResults.entries()]
+      .filter(([, status]) => status === "failed")
+      .map(([name]) => name);
+    const gateDecision = decideBaselineDiffGate(
+      failing.map((check) => check.name),
+      baselineFailing,
+    );
+    const preExisting = new Set(gateDecision.preExistingFailures);
 
     // Re-classify any check that ALSO failed on the baseline as
     // `skipped (pre-existing failure on baseline)`. Rebuild the sidecar
@@ -643,8 +692,7 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
     for (let i = 0; i < checks.length; i += 1) {
       const check = checks[i]!;
       if (check.status !== "failed") continue;
-      const baselineStatus = baselineResults.get(check.name);
-      if (baselineStatus === "failed") {
+      if (preExisting.has(check.name)) {
         const newRecord = buildValidationRecord({
           name: check.name,
           status: "skipped",
@@ -656,14 +704,14 @@ export async function runFeedback(exec: Exec, input: RunFeedbackInput): Promise<
         downgraded.push(check.name);
       }
     }
-    failed = checks.some((c) => c.status === "failed");
+    failed = gateDecision.shouldBlock;
     return {
       ok: !failed,
       checks,
       sidecar,
       baselineDowngraded: downgraded,
       baselineProbeRan: true,
-      baselineFailures: downgraded,
+      baselineFailures: gateDecision.preExistingFailures,
       quarantined: quarantine,
       validationScope,
     };

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildValidationRecord,
+  decideBaselineDiffGate,
   isInfraFeedbackFailure,
   nearestPackageScope,
   outputSummary,
@@ -345,6 +346,37 @@ describe("pure shaping helpers", () => {
     expect(outputSummary("failed", "line a\nline b\n")).toBe("line a line b");
     const long = `${"x".repeat(2000)}\n`;
     expect(outputSummary("failed", long).length).toBe(1000);
+  });
+});
+
+describe("decideBaselineDiffGate", () => {
+  it("blocks branch-only failures and records no pre-existing failures", () => {
+    expect(decideBaselineDiffGate(["test:apps/dev"], [])).toEqual({
+      shouldBlock: true,
+      blockingFailures: ["test:apps/dev"],
+      preExistingFailures: [],
+    });
+  });
+
+  it("does not block pre-existing failures and records them for main-red repair", () => {
+    expect(decideBaselineDiffGate(["test:apps/dev"], ["test:apps/dev"])).toEqual({
+      shouldBlock: false,
+      blockingFailures: [],
+      preExistingFailures: ["test:apps/dev"],
+    });
+  });
+
+  it("blocks mixed branch-only failures while recording pre-existing failures", () => {
+    expect(
+      decideBaselineDiffGate(
+        ["test:apps/dev", "typecheck:apps/dev", "test:apps/dev"],
+        ["test:apps/dev", "lint:apps/dev"],
+      ),
+    ).toEqual({
+      shouldBlock: true,
+      blockingFailures: ["typecheck:apps/dev"],
+      preExistingFailures: ["test:apps/dev"],
+    });
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1236. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1236

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785982942&installation_id=129708444&pr_number=1260&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1260&signature=1ea693e9d218708eadfd4fe55018e079c3a8a581352cbaa73a3a14f637148a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->