### PR TITLE
merge: #1237 Admin-merge onto a red main requires an open main-red issue

### DIFF
--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -37,6 +37,7 @@ import {
   LABEL_BUDGET,
   LABEL_TRUNK_DIVERGED,
   LABEL_SENSITIVE_PATH,
+  LABEL_MAIN_RED_UNTRACKED,
 } from "./triage-labels.js";
 
 /**
@@ -101,6 +102,10 @@ export type AttemptOutcome =
   // auto-landing them would bypass auditability regardless of test/CI status.
   // Human-only (non-recoverable): a bounded retry does not change the diff.
   | "sensitive-path"
+  // Main-red tracking gate (#1237): admin-merge onto a red main is allowed only
+  // while the auto-filed main-red repair issue is open. If the repair issue is
+  // absent, landing refuses so the red baseline stays visible and tracked.
+  | "main-red-untracked"
   | "infra";
 
 /**
@@ -159,6 +164,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_TRUNK_DIVERGED;
     case "sensitive-path":
       return LABEL_SENSITIVE_PATH;
+    case "main-red-untracked":
+      return LABEL_MAIN_RED_UNTRACKED;
     case "infra":
       return LABEL_INFRA;
     case "done":
@@ -224,6 +231,10 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     // sensitive-path (#1102) folds into the generic `blocked` bucket — the diff
     // touched a sensitive path; a human must review it before landing.
     case "sensitive-path":
+    // main-red-untracked (#1237) folds into the generic `blocked` bucket — the
+    // branch passed its gate, but main is red without the auto-filed repair
+    // issue that keeps continued delivery visible and tracked.
+    case "main-red-untracked":
     case "infra":
     // review-requested is a handoff, not a failure: the per-issue lifecycle
     // emits no terminal failure envelope for it (it parks the issue + opens the
@@ -294,6 +305,10 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     // sensitive-path (#1102) is NON-recoverable: a retry runs the same diff and
     // hits the same guard. Only a human reviewing the sensitive change clears it.
     case "sensitive-path":
+    // main-red-untracked (#1237) is NON-recoverable until the missing auto-filed
+    // repair issue exists; rerunning the agent would re-hit the same visibility
+    // gate.
+    case "main-red-untracked":
     case "infra":
     case "done":
     case "claim-lost":

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -37,6 +37,7 @@ import {
   type Exec as MergeExec,
   type WaitForReviewInput,
 } from "./merge.js";
+import { decideMainRedAdminMerge, type MainRedRepairIssue } from "./main-red-repair.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { checkSensitivePaths, type SensitivePathHit } from "./shared-gate.js";
 
@@ -115,6 +116,8 @@ export interface LandingDeps {
    * immediately. Ignored on the locked path, which never opens a PR.
    */
   ciAwait?: CiAwaitInput;
+  /** Find the open auto-filed main-red repair issue for the #1237 admin-merge gate. */
+  findMainRedRepairIssue?(): Promise<MainRedRepairIssue | null>;
 }
 
 /** Static per-landing inputs the caller already resolved. */
@@ -177,6 +180,13 @@ export interface LandingInput {
    * operator adopt path ever passes true.
    */
   sensitivePathApproved?: boolean;
+  /**
+   * True when the feedback baseline probe found pre-existing failures on the
+   * trunk/main baseline. Used by the admin-PR path to enforce the tracked-red
+   * visibility gate (#1237). Defaults false/undefined so green-main landings are
+   * unaffected.
+   */
+  mainRed?: boolean;
 }
 
 /** The pre_merge / post_merge hook context builders the caller owns (so the
@@ -210,6 +220,7 @@ export type LandingResult =
         | "ci-pending"
         | "pr-conflict"
         | "pr-merge-failed"
+        | "main-red-untracked"
         // ADR 0083 landing precondition (#1018): the primary checkout's LOCAL
         // `<trunk>` ref has DIVERGED from `origin/<trunk>`. The landing aborted
         // BEFORE integrating the attempt branch and NEVER repaired the divergence
@@ -229,6 +240,8 @@ export type LandingResult =
       originTrunkSha?: string;
       /** Sensitive-path guard (`sensitive-paths`): the hits that triggered the guard. */
       sensitivePaths?: SensitivePathHit[];
+      /** Main-red tracking gate (`main-red-untracked`): actionable refusal text. */
+      message?: string;
     };
 
 /**
@@ -399,6 +412,14 @@ export async function doLanding(
  * fast-forward so the primary checkout is never written to (ADR 0083 §2, #1019).
  */
 async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<LandingResult> {
+  if (input.base === input.trunk && input.mainRed === true) {
+    const current = deps.findMainRedRepairIssue ? await deps.findMainRedRepairIssue() : null;
+    const decision = decideMainRedAdminMerge({ mainRed: true, openRepairIssue: current });
+    if (!decision.ok) {
+      return { ok: false, reason: "main-red-untracked", locked: input.locked, message: decision.message };
+    }
+  }
+
   // Pre-merge rebase (#1006): rebase the worker branch onto the fetched base tip
   // in an ISOLATED worktree and force-push it before opening/merging the PR, so
   // the admin-merge is never rejected as a stale non-fast-forward and then

--- a/apps/dev/src/core/main-red-repair.ts
+++ b/apps/dev/src/core/main-red-repair.ts
@@ -16,6 +16,8 @@ export type MainRedRepairPlan =
   | { action: "update"; issue: number; title: string; body: string; labels: readonly string[] }
   | { action: "close"; issue: number; comment: string };
 
+export type MainRedAdminMergeDecision = { ok: true } | { ok: false; message: string };
+
 export function normalizeBaselineFailures(failures: readonly string[]): string[] {
   return [...new Set(failures.map((f) => f.trim()).filter((f) => f.length > 0))].sort();
 }
@@ -65,5 +67,21 @@ export function planMainRedRepair(
     title: MAIN_RED_REPAIR_TITLE,
     body,
     labels,
+  };
+}
+
+export function decideMainRedAdminMerge(input: {
+  mainRed: boolean;
+  openRepairIssue: MainRedRepairIssue | null;
+}): MainRedAdminMergeDecision {
+  if (!input.mainRed) return { ok: true };
+  if (input.openRepairIssue) return { ok: true };
+
+  return {
+    ok: false,
+    message:
+      "Refusing admin-merge onto red main because no open main-red repair issue exists. " +
+      `Restore the tracked-red visibility gate by letting syncMainRedRepairIssue auto-file "${MAIN_RED_REPAIR_TITLE}" ` +
+      "from the AFK feedback baseline probe before landing.",
   };
 }

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1430,6 +1430,7 @@ export async function processIssue(
   };
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
+  let mainRed = false;
   let currentHandoff = handoff;
   let goVerifyRetriesUsed = 0;
   let salvagedUncommittedFiles = 0;
@@ -2046,6 +2047,7 @@ export async function processIssue(
         }),
       );
     }
+    mainRed = feedback.baselineProbeRan === true && (feedback.baselineFailures?.length ?? 0) > 0;
     await syncMainRedRepairIssue(deps, feedback);
     // post_feedback (#832): the scope-derived gate has produced its verdict.
     await fireHook(
@@ -2207,6 +2209,7 @@ export async function processIssue(
       conflictResolver: deps.conflictResolver,
       waitForReview: deps.waitForReview,
       ciAwait: deps.ciAwait,
+      findMainRedRepairIssue: deps.gh.findMainRedRepairIssue,
       makeLandingWorktree: deps.makeLandingWorktree,
       removeLandingWorktree: deps.removeLandingWorktree,
       makeRebaseWorktree: deps.makeRebaseWorktree,
@@ -2242,6 +2245,7 @@ export async function processIssue(
       trunk,
       issue,
       title: input.title,
+      mainRed,
     },
     {
       preMerge: () =>
@@ -2274,6 +2278,13 @@ export async function processIssue(
     // lifecycle script, git hook, or .red/ config — pages a human, never retries.
     if (landing.reason === "sensitive-paths") {
       return await sensitivePathGuarded(common, landing.sensitivePaths ?? [], landing.locked);
+    }
+    if (landing.reason === "main-red-untracked") {
+      return await mainRedUntrackedBlocked(
+        common,
+        landing.message ?? "Admin-merge refused: main is red without an open main-red repair issue.",
+        landing.locked,
+      );
     }
     // CI-aware landing failures (#812): a completed, MERGEABLE PR the admin-merge
     // could not land because the `enforce_admins` base's required checks failed /
@@ -2597,6 +2608,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         summary: oneLine(sections.log, "Diff touches a sensitive path (CI workflow, lifecycle script, git hook, or .red/ config)."),
         next: "Review the sensitive change, then requeue if it is safe to land.",
       };
+    case "main-red-untracked":
+      return {
+        status: "blocked",
+        kind: "main-red-untracked",
+        summary: oneLine(sections.log, "Admin-merge refused because main is red without an open main-red repair issue."),
+        next: "Restore or create the auto-filed main-red repair issue, then requeue.",
+      };
     case "manual-landing":
       return {
         status: "blocked",
@@ -2618,6 +2636,7 @@ const ACTIONABLE_BLOCKER_KINDS = new Set([
   "decision",
   "trunk-diverged",
   "sensitive-path",
+  "main-red-untracked",
 ]);
 
 function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {
@@ -2999,6 +3018,43 @@ async function sensitivePathGuarded(
   await deps.claimLock.release(input.issue);
   return {
     outcome: "sensitive-path",
+    issue: input.issue,
+    branch: c.branch,
+    base: c.base,
+    locked,
+    hooksFired: c.hooksFired,
+    envelopePosted: posted,
+    preserved: true,
+    swept: false,
+  };
+}
+
+/**
+ * Main-red tracking gate park (#1237). The feedback baseline probe says trunk is
+ * red, but the auto-filed main-red repair issue is not open, so admin-merge
+ * refuses before opening/merging a PR. This keeps red main visible as tracked
+ * work instead of allowing silent delivery onto an untracked broken baseline.
+ */
+async function mainRedUntrackedBlocked(
+  c: StageCommon,
+  message: string,
+  locked: boolean,
+): Promise<ProcessIssueResult> {
+  const { deps, input } = c;
+  const detail =
+    `${message} The attempt branch is intact and validated, but landing is held until the tracked-red ` +
+    `repair issue exists. Requeue after the auto-file path recreates it.`;
+  await routeRecovery(deps, input.issue, "main-red-untracked", input.attempt);
+  await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("main-red-untracked", { log: detail }));
+  const posted = await emitFailure(c, envelopeStatusFor("main-red-untracked"), "main-red-untracked", { log: detail });
+  await deps.gh.comment(input.issue, `🤖 /afk: ${detail}`);
+  await recordAttemptBestEffort(c, "main-red-untracked", {
+    durationS: deps.nowEpoch() - c.startedEpoch,
+    notes: detail,
+  });
+  await deps.claimLock.release(input.issue);
+  return {
+    outcome: "main-red-untracked",
     issue: input.issue,
     branch: c.branch,
     base: c.base,

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -97,6 +97,11 @@ export const LABEL_TRUNK_DIVERGED = "blocked:trunk-diverged";
 // configuration — an intent-class change that can never auto-land. A human
 // must review the change before it reaches the base branch.
 export const LABEL_SENSITIVE_PATH = "blocked:sensitive-path";
+// Main-red tracking gate (#1237): admin-merge may continue onto a red main only
+// while the auto-filed main-red repair issue is open. If main is red and that
+// visibility issue is absent, landing refuses with this human-only label instead
+// of silently delivering onto untracked red.
+export const LABEL_MAIN_RED_UNTRACKED = "blocked:main-red-untracked";
 // AFK runner improvement (#908): the per-attempt resource budget guard aborted
 // the attempt — it breached a token/cost/tool-call/waiting-window ceiling before
 // it could finish. Distinct from `blocked:stalled` (a stall is *no* progress;

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -34,6 +34,7 @@ interface Harness {
   firedHooks: string[];
   removedWorktrees: string[];
   removedRebaseWorktrees: string[];
+  mainRedRepairLookups: number;
   /** cwds the conflict resolver was dispatched in. */
   resolverCwds: string[];
 }
@@ -99,6 +100,10 @@ interface Opts {
    * `/requeue --adopt-branch` human land of a reviewed protected diff.
    */
   sensitivePathApproved?: boolean;
+  /** Main-red tracking gate (#1237): set input.mainRed. */
+  mainRed?: boolean;
+  /** Main-red tracking gate (#1237): whether the open repair issue finder returns an issue. */
+  mainRedRepairIssue?: boolean;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -107,6 +112,7 @@ function harness(opts: Opts = {}): Harness {
   const firedHooks: string[] = [];
   const removedWorktrees: string[] = [];
   const removedRebaseWorktrees: string[] = [];
+  let mainRedRepairLookups = 0;
   const resolverCwds: string[] = [];
   let mergeResolved = false;
 
@@ -226,6 +232,13 @@ function harness(opts: Opts = {}): Harness {
           packageJsonDiff: "",
         })
       : undefined,
+    findMainRedRepairIssue:
+      opts.mainRed === undefined
+        ? undefined
+        : async () => {
+            mainRedRepairLookups += 1;
+            return opts.mainRedRepairIssue ? { number: 123 } : null;
+          },
   };
 
   const input: LandingInput = {
@@ -248,6 +261,7 @@ function harness(opts: Opts = {}): Harness {
     // #1171: only set when the test opts in; default undefined keeps the guard
     // armed for every existing landing assertion.
     sensitivePathApproved: opts.sensitivePathApproved,
+    mainRed: opts.mainRed,
   };
 
   const hooks: LandingHookContexts = {
@@ -264,6 +278,9 @@ function harness(opts: Opts = {}): Harness {
     firedHooks,
     removedWorktrees,
     removedRebaseWorktrees,
+    get mainRedRepairLookups() {
+      return mainRedRepairLookups;
+    },
     resolverCwds,
   };
 }
@@ -302,6 +319,27 @@ describe("doLanding — happy paths", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: false });
     expect(joined(h.mergeCalls).some((c) => c.includes("pr checks"))).toBe(false);
+  });
+
+  it("unlocked + red main + open main-red repair issue → admin-merges", async () => {
+    const h = harness({ locked: false, mainRed: true, mainRedRepairIssue: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(h.mainRedRepairLookups).toBe(1);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+  });
+
+  it("unlocked + red main + no main-red repair issue → refuses before admin-merge", async () => {
+    const h = harness({ locked: false, mainRed: true, mainRedRepairIssue: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toBe("main-red-untracked");
+    expect(r.message).toContain("Refusing admin-merge onto red main");
+    expect(h.mainRedRepairLookups).toBe(1);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
   });
 
   it("default unlocked landing → merge runs without --admin (branch protection is honored, #1103)", async () => {

--- a/apps/dev/tests/main-red-repair.test.ts
+++ b/apps/dev/tests/main-red-repair.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  decideMainRedAdminMerge,
   MAIN_RED_REPAIR_TITLE,
   planMainRedRepair,
   renderMainRedRepairBody,
@@ -53,5 +54,25 @@ describe("renderMainRedRepairBody", () => {
     expect(body).toContain("## Failing checks");
     expect(body).toContain("- test:apps/dev");
     expect(body).toContain("- typecheck:workspace");
+  });
+});
+
+describe("decideMainRedAdminMerge", () => {
+  it("allows admin-merge onto a green main", () => {
+    expect(decideMainRedAdminMerge({ mainRed: false, openRepairIssue: null })).toEqual({ ok: true });
+  });
+
+  it("allows admin-merge onto a red main when a repair issue is open", () => {
+    expect(decideMainRedAdminMerge({ mainRed: true, openRepairIssue: { number: 123 } })).toEqual({ ok: true });
+  });
+
+  it("refuses admin-merge onto a red main with no open repair issue", () => {
+    const decision = decideMainRedAdminMerge({ mainRed: true, openRepairIssue: null });
+
+    expect(decision.ok).toBe(false);
+    if (decision.ok) throw new Error("unreachable");
+    expect(decision.message).toContain("Refusing admin-merge onto red main");
+    expect(decision.message).toContain("main-red repair issue");
+    expect(decision.message).toContain("syncMainRedRepairIssue");
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1237. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1237

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785983387&installation_id=129708444&pr_number=1261&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1261&signature=80d7f7ae725b52845b22a407275852f7aea168879b3ed13c018446c4a8a46a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->