### PR TITLE
merge: #1242 Auto-monitor-loop is statusline-defasado: skip/downgrade the /afk monitor cron when a rich multi-line statusline is present

### DIFF
--- a/apps/dev/src/commands/monitor.ts
+++ b/apps/dev/src/commands/monitor.ts
@@ -1,4 +1,11 @@
-import { renderCompactDashboard, renderCompactDashboardToon, type CompactWorker, type MonitorRemote } from "../core/monitor.js";
+import {
+  FLEET_STALE_AFTER_S,
+  renderCompactDashboard,
+  renderCompactDashboardToon,
+  type CompactWorker,
+  type FleetState,
+  type MonitorRemote,
+} from "../core/monitor.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { collectMonitorInputs, afkPaths, resolveRepoContext, resolveStatuslineCacheTtl } from "../runtime/wire.js";
 import { resolveSupervisorConfig } from "../core/supervisor.js";
@@ -144,6 +151,28 @@ export function runMirrorPlan(
   return `${callsOut}${JSON.stringify(noticeRecord)}\n`;
 }
 
+function reactiveWorkerAlert(worker: CompactWorker): string | null {
+  if (worker.livenessVerdict?.status !== "stalled") return null;
+  const issue = worker.state.current.number;
+  const issuePart = issue === "" || issue === null || issue === undefined ? "idle" : `#${issue}`;
+  const reason = worker.livenessVerdict.reason ? `: ${worker.livenessVerdict.reason}` : "";
+  return `actionable: worker ${worker.state.worker_id} ${issuePart} stalled${reason}`;
+}
+
+function reactiveFleetAlert(fleet: FleetState | undefined, now: number): string | null {
+  if (!fleet) return null;
+  const ageS = now - fleet.epoch;
+  if (ageS < FLEET_STALE_AFTER_S) return null;
+  return `actionable: fleet heartbeat stale ${ageS}s; inspect .red/tmp/afk-supervisor.log`;
+}
+
+function renderReactiveCheck(workers: readonly CompactWorker[], fleet: FleetState | undefined, now: number): string {
+  const alerts = workers.map(reactiveWorkerAlert).filter((line): line is string => line !== null);
+  const fleetAlert = reactiveFleetAlert(fleet, now);
+  if (fleetAlert) alerts.unshift(fleetAlert);
+  return alerts.join("\n");
+}
+
 /** Read all of stdin to a string (empty when nothing is piped / TTY). */
 async function readStdin(stdin: NodeJS.ReadableStream): Promise<string> {
   const chunks: Buffer[] = [];
@@ -190,6 +219,13 @@ export async function monitorCommand(
     const trackedJsonl = await readStdin(stdin);
     const out = runMirrorPlan(workers, trackedJsonl, { host });
     if (out !== "") stdout.write(out);
+    return 0;
+  }
+
+  if (args.includes("--reactive-check")) {
+    const { workers, fleet } = await collectMonitorInputs(cwd);
+    const out = renderReactiveCheck(workers, fleet ?? undefined, Math.floor(Date.now() / 1000));
+    if (out !== "") stdout.write(`${out}\n`);
     return 0;
   }
 

--- a/apps/dev/src/core/auto-monitor.ts
+++ b/apps/dev/src/core/auto-monitor.ts
@@ -1,0 +1,81 @@
+export type AutoMonitorCommand = "run" | "fleet" | "monitor" | "other";
+
+export type AutoMonitorDecision =
+  | { action: "schedule-full-render-cron"; cron: string; prompt: string; reason: "statusline-absent" }
+  | { action: "schedule-reactive-check"; cron: string; prompt: string; reason: "reactive-loop-requested" }
+  | {
+      action: "skip";
+      reason:
+        | "rich-statusline-present"
+        | "command-does-not-launch-worker"
+        | "single-supervised-run"
+        | "cron-unavailable"
+        | "non-claude-runner";
+    };
+
+export interface AutoMonitorDecisionInput {
+  runner: string;
+  command: AutoMonitorCommand;
+  cronAvailable: boolean;
+  richStatuslinePresent: boolean;
+  once?: boolean;
+  reactiveLoopRequested?: boolean;
+}
+
+export const AUTO_MONITOR_CRON = "*/10 * * * *";
+export const FULL_RENDER_MONITOR_PROMPT = "/dev:afk monitor";
+export const REACTIVE_MONITOR_PROMPT = "rtk env RED_AFK_REACTIVE_CHECK=1 red-skills-dev monitor --reactive-check";
+
+function normalized(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function decideAutoMonitorLoop(input: AutoMonitorDecisionInput): AutoMonitorDecision {
+  const commandLaunchesWorker = input.command === "run" || input.command === "fleet";
+  if (!commandLaunchesWorker) return { action: "skip", reason: "command-does-not-launch-worker" };
+  if (input.once) return { action: "skip", reason: "single-supervised-run" };
+  if (normalized(input.runner) !== "claude") return { action: "skip", reason: "non-claude-runner" };
+  if (!input.cronAvailable) return { action: "skip", reason: "cron-unavailable" };
+
+  if (input.richStatuslinePresent) {
+    if (input.reactiveLoopRequested) {
+      return {
+        action: "schedule-reactive-check",
+        cron: AUTO_MONITOR_CRON,
+        prompt: REACTIVE_MONITOR_PROMPT,
+        reason: "reactive-loop-requested",
+      };
+    }
+    return { action: "skip", reason: "rich-statusline-present" };
+  }
+
+  return {
+    action: "schedule-full-render-cron",
+    cron: AUTO_MONITOR_CRON,
+    prompt: FULL_RENDER_MONITOR_PROMPT,
+    reason: "statusline-absent",
+  };
+}
+
+export function hasRichClaudeStatusline(settingsJson: string | null | undefined): boolean {
+  if (!settingsJson) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(settingsJson);
+  } catch {
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object") return false;
+  const statusLine = (parsed as { statusLine?: unknown }).statusLine;
+  if (statusLine === null || typeof statusLine !== "object") return false;
+  const rec = statusLine as { type?: unknown; command?: unknown };
+  if (rec.type !== undefined && rec.type !== "command") return false;
+  if (typeof rec.command !== "string") return false;
+  return isRedSkillsStatuslineCommand(rec.command);
+}
+
+export function isRedSkillsStatuslineCommand(command: string): boolean {
+  const c = command.toLowerCase();
+  if (!/\bstatusline\b/.test(c)) return false;
+  return c.includes("red-skills") || c.includes("redskills") || c.includes("dev-");
+}

--- a/apps/dev/tests/auto-monitor.test.ts
+++ b/apps/dev/tests/auto-monitor.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideAutoMonitorLoop,
+  hasRichClaudeStatusline,
+} from "../src/core/auto-monitor.js";
+
+const REDSKILLS_STATUSLINE_SETTINGS = JSON.stringify({
+  statusLine: {
+    type: "command",
+    command: "sh -c 'exec node \"$HOME/.cache/red-skills/bundles/dev-2.3.0.bundle.min.mjs\" statusline'",
+    refreshInterval: 5,
+  },
+});
+
+describe("auto monitor loop decision", () => {
+  it("does not schedule the full-render cron when a rich RedSkills statusline is present", () => {
+    const decision = decideAutoMonitorLoop({
+      runner: "claude",
+      command: "run",
+      cronAvailable: true,
+      richStatuslinePresent: true,
+    });
+
+    expect(decision).toEqual({
+      action: "skip",
+      reason: "rich-statusline-present",
+    });
+  });
+
+  it("keeps the full-render cron fallback when the command-backed statusline is absent", () => {
+    const decision = decideAutoMonitorLoop({
+      runner: "claude",
+      command: "run",
+      cronAvailable: true,
+      richStatuslinePresent: false,
+    });
+
+    expect(decision.action).toBe("schedule-full-render-cron");
+    if (decision.action !== "schedule-full-render-cron") throw new Error("expected full-render cron");
+    expect(decision.prompt).toBe("/dev:afk monitor");
+    expect(decision.cron).toBe("*/10 * * * *");
+  });
+
+  it("can plan an optional lightweight reactive check without invoking the afk slash command", () => {
+    const decision = decideAutoMonitorLoop({
+      runner: "claude",
+      command: "fleet",
+      cronAvailable: true,
+      richStatuslinePresent: true,
+      reactiveLoopRequested: true,
+    });
+
+    expect(decision.action).toBe("schedule-reactive-check");
+    if (decision.action !== "schedule-reactive-check") throw new Error("expected reactive check");
+    expect(decision.prompt).toContain("red-skills-dev monitor --reactive-check");
+    expect(decision.prompt).not.toContain("/dev:afk monitor");
+  });
+});
+
+describe("rich Claude statusline detection", () => {
+  it("recognizes the RedSkills command-backed statusline", () => {
+    expect(hasRichClaudeStatusline(REDSKILLS_STATUSLINE_SETTINGS)).toBe(true);
+  });
+
+  it("does not treat an arbitrary Claude statusLine command as the AFK-rich statusline", () => {
+    expect(
+      hasRichClaudeStatusline(JSON.stringify({
+        statusLine: {
+          type: "command",
+          command: "echo ok",
+        },
+      })),
+    ).toBe(false);
+  });
+
+  it("treats missing or invalid settings as absent", () => {
+    expect(hasRichClaudeStatusline("{}")).toBe(false);
+    expect(hasRichClaudeStatusline("{")).toBe(false);
+  });
+});

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -363,14 +363,18 @@ Every terminal event posts exactly one structured `<details data-attempt-status=
 
 ## Auto-Monitor Loop (Claude Code only — binding)
 
-When `/afk` is invoked **to spawn a worker** (i.e., not the `monitor` subcommand), the agent additionally schedules a recurring `/dev:afk monitor` cron inside the current Claude Code session so the user sees progress without re-typing. Death of every worker auto-cancels the cron.
+When `/afk` is invoked **to spawn a worker** (i.e., not the `monitor` subcommand), the agent attaches the cheapest available Claude Code monitor surface. If the repo has the RedSkills command-backed multi-line `statusLine` wired in `.claude/settings.json`, the passive dashboard cron is **off by default** because the footer already renders the live worker header and one row per live worker continuously. Hosts without that rich statusline keep the historical recurring `/dev:afk monitor` dashboard cron. Death of every worker auto-cancels any monitor cron that was scheduled.
 
 **Setup (runs immediately after the `run` worker is launched in the background):**
 
-1. Fetch `CronCreate` and `CronList` via `ToolSearch` if not already loaded (they are deferred tools).
-2. `CronList` — if any existing job has `prompt == "/dev:afk monitor"`, **skip step 3** (don't double-schedule when the user runs a second parallel `/afk` in the same session).
-3. `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. The cron is session-only — it dies when the Claude Code session ends, so no risk of orphans across sessions. Auto-expires after 7 days regardless.
-4. Tell the user **one line**: `monitor loop scheduled (every 10 min) — auto-cancels when all workers exit.`
+1. Detect the rich statusline: `.claude/settings.json` has `statusLine.type == "command"` (or omitted type) and `statusLine.command` invokes the RedSkills `statusline` subcommand (the cached-bundle-first form from `/setup-statusline` is the canonical shape).
+2. Fetch `CronCreate` and `CronList` via `ToolSearch` if not already loaded (they are deferred tools).
+3. If the rich statusline is present, do **not** schedule the full-render `/dev:afk monitor` cron by default. Tell the user one line: `monitor loop skipped — RedSkills statusline already renders live AFK workers.`
+4. If the rich statusline is absent: `CronList` — if any existing job has `prompt == "/dev:afk monitor"`, **skip step 5** (don't double-schedule when the user runs a second parallel `/afk` in the same session).
+5. `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. The cron is session-only — it dies when the Claude Code session ends, so no risk of orphans across sessions. Auto-expires after 7 days regardless.
+6. Tell the user **one line**: `monitor loop scheduled (every 10 min) — auto-cancels when all workers exit.`
+
+**Optional reactive tick:** if the operator explicitly asks to keep a between-message wakeup while the rich statusline is present, schedule `CronCreate(cron="*/10 * * * *", prompt="rtk env RED_AFK_REACTIVE_CHECK=1 red-skills-dev monitor --reactive-check", recurring=true)` instead of `/dev:afk monitor`. This command runs the bundle directly, does not invoke the `/dev:afk` slash skill, emits nothing when there is no actionable condition, and only surfaces local actionable conditions such as a stale fleet heartbeat or a stalled worker.
 
 The monitor invocation handles its own teardown — see *Self-Cancel* in [`monitor.md`](./monitor.md).
 
@@ -378,6 +382,7 @@ The monitor invocation handles its own teardown — see *Self-Cancel* in [`monit
 
 - The invocation is `/afk monitor` (not a worker spawn).
 - The invocation is `/afk --once` (single supervised iteration; user is already watching).
+- The rich RedSkills command-backed statusline is present and no explicit reactive tick was requested.
 - `CronCreate` is unavailable (not running under Claude Code — e.g. Codex). Print one line `monitor loop unavailable in this runner; tail .red/tmp/workers/*/*/afk.log manually.` and continue.
 
 Under Codex the auto-loop is skipped in favour of a read-only sub-agent presentation layer: spawning a worker under Codex → read the *Codex Monitor Agent* section in [`monitor.md`](./monitor.md).

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -18,7 +18,7 @@ $ /dev:afk fleet 1   # every worker sees both vars
 
 Fleet mode is **runner-portable**: the supervisor is plain process orchestration, not a Claude Code primitive. Claude Code, Codex, and bare terminals may all launch and stop the supervisor when the normal AFK hard preconditions pass. Runner-specific observability degrades independently:
 
-- Claude Code: schedule the auto-monitor cron when `CronCreate`/`CronList` are available; if not, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
+- Claude Code: when `CronCreate`/`CronList` are available, attach the statusline-aware monitor surface from *Auto-Monitor Loop* in [`SKILL.md`](./SKILL.md): if the RedSkills command-backed multi-line statusline is present, skip the passive full-render cron by default; if absent, schedule the historical `/dev:afk monitor` cron. If cron tools are unavailable, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
 - Codex: launch fleet with `RED_AFK_RUNNER=codex`, skip cron, and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print the same manual-monitor guidance.
 - Bare terminal / unknown runner: launch fleet, skip cron/native monitor, and print the manual-monitor guidance.
 
@@ -39,7 +39,7 @@ Fleet mode is **runner-portable**: the supervisor is plain process orchestration
    ```
    The command performs the PID-file pre-check from step 2 itself (refusing if a live supervisor already runs), detaches the supervisor, and forwards the resolved runner and the `--request/-r` text to every worker it spawns. It waits up to 3 s for `.red/tmp/afk-supervisor.pid` to appear and contain a live PID, then prints the launched supervisor PID and target; on failure it reports the tail of `.red/tmp/afk-supervisor.log`. Capture the reported PID for the *Report back* step. The launched supervisor is the native `__supervise` entrypoint of the same bundle.
 4. **Attach the best available monitor surface.**
-   - Claude Code: same flow as *Auto-Monitor Loop* in [`SKILL.md`](./SKILL.md) — `CronList` first to deduplicate, then `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. If cron tools are unavailable, skip and use the manual-monitor line.
+   - Claude Code: same flow as *Auto-Monitor Loop* in [`SKILL.md`](./SKILL.md) — detect the RedSkills command-backed statusline first. With the rich statusline present, skip the passive full-render cron by default (or, only when explicitly requested, schedule `rtk env RED_AFK_REACTIVE_CHECK=1 red-skills-dev monitor --reactive-check`). With the rich statusline absent, `CronList` first to deduplicate, then `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)`. If cron tools are unavailable, skip and use the manual-monitor line.
    - Codex: fetch a sub-agent spawn primitive via `ToolSearch` (query: `spawn agent background monitor`). If available, emit the canonical prompt with `RED_AFK_RUNNER=codex red-skills-dev codex-monitor-agent --project-root "$PWD" --mode fleet` and spawn exactly one read-only Codex monitor agent for this newly-launched supervisor. Its task: from the project root, periodically run `/dev:afk monitor --once` (the bundle's `monitor --once`), report concise progress, and auto-close when `.red/tmp/afk-supervisor.pid` is missing/dead and no `[live]` workers remain. It must never edit files, claim issues, stop workers, or run merges. The user may close it manually; workers continue. If the primitive is unavailable, skip and use the manual-monitor line.
    - Bare/unknown: skip native monitor setup and use the manual-monitor line.
 5. **Report back.** Print:
@@ -52,6 +52,8 @@ Fleet mode is **runner-portable**: the supervisor is plain process orchestration
    Monitor status line choices:
    - Claude cron scheduled: `monitor loop scheduled (every 10 min) — auto-cancels when all workers exit.`
    - Claude cron already existed: `monitor loop already running (existing cron <id>).`
+   - Claude rich statusline present: `monitor loop skipped — RedSkills statusline already renders live AFK workers.`
+   - Claude reactive check scheduled: `reactive monitor check scheduled (every 10 min) — only reports actionable conditions.`
    - Codex monitor agent spawned: `Codex monitor agent spawned — auto-closes when fleet exits; manual monitor: /dev:afk monitor.`
    - Native monitor unavailable: `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
 
@@ -65,7 +67,7 @@ Steps, in order:
    - File present and PID alive → continue to step 2.
 2. **Touch the stop file.** `touch .red/tmp/afk-supervisor.stop`. The supervisor's health-check cycle (default `RED_AFK_POLL_S=15s`) picks it up and runs `cleanup`, which SIGTERMs every worker, removes the PID file, removes the stop file, and exits. Wait up to **30 s** for the PID file to disappear (poll every 1 s, deadline-bounded — never bare `while`). If it's gone, print `🛑 fleet stopped (supervisor pid=<pid> exited).`. If the deadline trips, print one warning line naming the PID and the log path, and continue to step 3 anyway — the stop file is still there and the supervisor will pick it up eventually.
 3. **Tear down runner-specific monitors.**
-   - Claude Code: `CronList` → find every job whose `prompt == "/dev:afk monitor"` (there will normally be one, possibly zero, occasionally more if the user manually `/loop`-ed). `CronDelete` each. Print one line: `auto-monitor cron cancelled (<count> entr{y,ies}).` (or `no auto-monitor cron to cancel.` when count is zero). If cron tools are unavailable, print `auto-monitor cron unavailable in this runner; skipped.`
+   - Claude Code: `CronList` → find every job whose `prompt == "/dev:afk monitor"` or whose prompt contains `red-skills-dev monitor --reactive-check` (there will normally be one, possibly zero, occasionally more if the user manually `/loop`-ed). `CronDelete` each. Print one line: `auto-monitor cron cancelled (<count> entr{y,ies}).` (or `no auto-monitor cron to cancel.` when count is zero). If cron tools are unavailable, print `auto-monitor cron unavailable in this runner; skipped.`
    - Codex: do not stop workers through the monitor agent. It auto-closes when it observes no supervisor/live workers, and the user may close it manually. Print `Codex monitor agent will self-close when it observes fleet stopped.`
    - Bare/unknown: print `no native monitor teardown for this runner.`
 4. **Idempotency.** Re-running `/dev:afk fleet stop` after a successful stop just hits the "file missing" branch in step 1 and the runner-specific teardown no-op in step 3. Exit 0 either way.

--- a/plugins/dev/skills/engineering/afk/monitor.md
+++ b/plugins/dev/skills/engineering/afk/monitor.md
@@ -68,18 +68,19 @@ The sparkline only counts `event == "done"`. Blockers and exhausted runs are rec
 
 ## Self-Cancel (binding when invoked under Claude Code)
 
-Every `/afk monitor` run — whether typed by the user or fired by the auto-monitor cron — is responsible for tearing down the cron once there's nothing left to watch.
+Every `/afk monitor` run — whether typed by the user or fired by the auto-monitor cron — is responsible for tearing down the cron once there's nothing left to watch. The historical full-render cron exists only when the rich RedSkills command-backed statusline is absent. When a rich statusline is present, the passive dashboard render is skipped by default; an explicitly armed reactive tick must run the bundle command `red-skills-dev monitor --reactive-check`, not the `/dev:afk monitor` slash command, so it does not re-inject this skill on every tick.
 
 After rendering the dashboard, the agent must:
 
 1. Count observable workers with status `[live]` or `[quiet]` in the rendered output (i.e., orchestrator pid identity alive, post-orphan-cleanup).
 2. If `observable_workers == 0`:
    - Fetch `CronList` and `CronDelete` via `ToolSearch` if not already loaded.
-   - `CronList` — find every job with `prompt == "/dev:afk monitor"`. There will normally be exactly one; multiples can appear if the user manually invoked `/loop 3m /dev:afk monitor` on top of the auto-loop.
+   - `CronList` — find every job with `prompt == "/dev:afk monitor"` or a prompt containing `red-skills-dev monitor --reactive-check`. There will normally be exactly one; multiples can appear if the user manually invoked `/loop 3m /dev:afk monitor` on top of the auto-loop.
    - `CronDelete` each match.
    - Append one line to the user-facing output: `🛑 no live workers — auto-cancelled monitor loop (cron <id>).`
 3. If `observable_workers >= 1` or `.red/tmp/afk-supervisor.pid` resolves to a live PID: arm the cron when unwatched (observe path — same dedup as the spawn path):
    - Fetch `CronCreate` and `CronList` via `ToolSearch` if not already loaded (deferred tools).
+   - If `.claude/settings.json` contains the RedSkills command-backed statusline, do not arm the full-render cron; the footer is the passive view.
    - `CronList` — if any existing job has `prompt == "/dev:afk monitor"`, **skip** (cron already present; it continues firing every 10 minutes).
    - Otherwise `CronCreate(cron="*/10 * * * *", prompt="/dev:afk monitor", recurring=true)` and tell the user one line: `monitor loop scheduled (every 10 min) — auto-cancels when all workers exit.`
    - If `CronCreate` is unavailable (non-Claude-Code host), skip silently.


### PR DESCRIPTION
Automated AFK landing for #1242. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1242

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785984279&installation_id=129708444&pr_number=1262&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1262&signature=9a77033cadaac2d5a0a218bb4e37ccc1161d668e73857328fbf4a3b00d1c7e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->