### PR TITLE
merge: #1212 pre-merge rebase is opt-in — landing can attempt admin-merge against a moved base and false-park blocked:merge-conflict

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -75,9 +75,10 @@ export interface LandingDeps {
    * PR path's pre-merge rebase (#1006), so the fetch / rebase / force-push run OFF
    * the primary checkout — the primary branch is sacred (#572). Returns the
    * worktree dir, or null when one could not be provisioned. Paired with
-   * {@link removeRebaseWorktree}. Absent → the pre-merge rebase is SKIPPED and the
-   * PR lands exactly as before (opt-in). Only the PR path uses it; the direct path
-   * already integrates origin inside its own detached landing worktree.
+   * {@link removeRebaseWorktree}. Absent → the PR landing is refused as infra
+   * before the admin-merge; fresh-base integration is a mandatory PR-path
+   * precondition (#1212). Only the PR path uses it; the direct path already
+   * integrates origin inside its own detached landing worktree.
    */
   makeRebaseWorktree?(branch: string): Promise<string | null>;
   /** Tear down a worktree returned by {@link makeRebaseWorktree} (best-effort). */
@@ -220,6 +221,7 @@ export type LandingResult =
         | "ci-pending"
         | "pr-conflict"
         | "pr-merge-failed"
+        | "infra"
         | "main-red-untracked"
         // ADR 0083 landing precondition (#1018): the primary checkout's LOCAL
         // `<trunk>` ref has DIVERGED from `origin/<trunk>`. The landing aborted
@@ -242,6 +244,8 @@ export type LandingResult =
       sensitivePaths?: SensitivePathHit[];
       /** Main-red tracking gate (`main-red-untracked`): actionable refusal text. */
       message?: string;
+      /** Infra failure (`infra`): actionable refusal text for the terminal note. */
+      infraReason?: string;
     };
 
 /**
@@ -425,8 +429,8 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
   // the admin-merge is never rejected as a stale non-fast-forward and then
   // false-flagged blocked:merge-conflict. A real rebase conflict — or a
   // --force-with-lease reject that survives the bounded retry — parks
-  // blocked:merge-conflict through the existing `pr-conflict` route. Opt-in:
-  // without the worktree provisioner the rebase is skipped (today's behaviour).
+  // blocked:merge-conflict through the existing `pr-conflict` route. Missing or
+  // failed provisioning is infra, never a silent skip (#1212).
   const rebaseFail = await preMergeRebaseInWorktree(deps, input);
   if (rebaseFail) return rebaseFail;
 
@@ -468,19 +472,32 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
  * on the worker branch and {@link preMergeRebase} it onto the fetched base,
  * force-pushing the result. Returns a failing {@link LandingResult} to abort the
  * landing (parked as blocked:merge-conflict via `pr-conflict`) on a real conflict
- * or an exhausted force-with-lease retry; returns `undefined` — "proceed to the
- * admin-merge" — on success, when no provisioner is wired (opt-in), or when a
- * worktree could not be provisioned (skip rather than risk the primary; the
- * CI-aware poll still catches a genuinely stale base). The worktree is always
- * torn down.
+ * or an exhausted force-with-lease retry; returns an infra failure when the
+ * rebase worktree provisioner is absent or cannot create a checkout; returns
+ * `undefined` — "proceed to the admin-merge" — only on completed integration.
+ * The worktree is always torn down.
  */
 async function preMergeRebaseInWorktree(
   deps: LandingDeps,
   input: LandingInput,
 ): Promise<LandingResult | undefined> {
-  if (!deps.makeRebaseWorktree) return undefined;
+  if (!deps.makeRebaseWorktree) {
+    return {
+      ok: false,
+      reason: "infra",
+      infraReason: "pre-merge rebase worktree could not be provisioned",
+      locked: input.locked,
+    };
+  }
   const dir = await deps.makeRebaseWorktree(input.branch);
-  if (!dir) return undefined;
+  if (!dir) {
+    return {
+      ok: false,
+      reason: "infra",
+      infraReason: "pre-merge rebase worktree could not be provisioned",
+      locked: input.locked,
+    };
+  }
   try {
     const rebased = await preMergeRebase(deps.mergeExec, {
       repo: dir,

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -129,7 +129,8 @@ export interface PreMergeRebaseResult {
  * false-flagged `blocked:merge-conflict`. The whole sequence runs on `repo` — a
  * throwaway worktree on the worker branch (#572) — so the primary checkout is
  * never touched. Sequence, mirroring the issue spec:
- *   1. `git fetch <remote> <base>` then `git rebase <remote>/<base>`;
+ *   1. `git fetch <remote> <base>`, then short-circuit if `<remote>/<base>` is
+ *      already an ancestor of `HEAD`; otherwise `git rebase <remote>/<base>`;
  *   2. on a rebase conflict → `git rebase --abort` → `{ ok:false, conflict }`;
  *   3. `git push <remote> HEAD:refs/heads/<branch> --force-with-lease`;
  *   4. on a push reject (a landing race), re-fetch + re-rebase the advanced base
@@ -143,9 +144,11 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
 
   // Fetch the base tip and rebase the worker branch onto it. Reused by the
   // push-retry loop so a racing base advance is re-integrated before each retry.
-  const rebaseOntoBase = async (): Promise<PreMergeRebaseResult> => {
+  const rebaseOntoBase = async (): Promise<PreMergeRebaseResult & { alreadyIntegrated?: boolean }> => {
     const fetch = await exec(["git", "-C", repo, "fetch", remote, base, "--quiet"]);
     if (fetch.code !== 0) return { ok: false, reason: "fetch-failed" };
+    const alreadyIntegrated = await exec(["git", "-C", repo, "merge-base", "--is-ancestor", baseRef, "HEAD"]);
+    if (alreadyIntegrated.code === 0) return { ok: true, alreadyIntegrated: true };
     const rebase = await exec(["git", "-C", repo, "rebase", baseRef]);
     if (rebase.code !== 0) {
       // #1095: give the opt-in mechanical resolver a chance to auto-resolve
@@ -162,6 +165,7 @@ export async function preMergeRebase(exec: Exec, input: PreMergeRebaseInput): Pr
 
   const first = await rebaseOntoBase();
   if (!first.ok) return first;
+  if (first.alreadyIntegrated) return { ok: true };
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     const push = await exec([

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -708,13 +708,11 @@ export interface ProcessIssueInput {
 // ---------- result ----------
 
 // The subset of `AttemptOutcome` that the per-issue lifecycle itself can return.
-// `infra` (boot setup) originates outside processIssue, so it is excluded here
-// while the shared owner (attempt-outcome) keeps the full union. `stalled` is
-// now ALSO a processIssue terminal: the attempt progress guard (execution.ts)
-// surfaces a `timeout` agent-outcome which processIssue maps to `stalled` (→
-// blocked:stalled, ready-for-human). Exclude<> ties this to the single owner so
-// the two can never drift.
-export type ProcessOutcome = Exclude<AttemptOutcome, "infra">;
+// `infra` now includes landing-infra preconditions (for example a missing
+// pre-merge rebase worktree, #1212) in addition to boot setup. `stalled` is also
+// a processIssue terminal: the attempt progress guard (execution.ts) surfaces a
+// `timeout` agent-outcome which processIssue maps to `stalled`.
+export type ProcessOutcome = AttemptOutcome;
 
 export interface ProcessIssueResult {
   outcome: ProcessOutcome;
@@ -2293,6 +2291,16 @@ export async function processIssue(
     if (landing.reason === "ci-failed" || landing.reason === "ci-pending") {
       return await ciBlocked(common, landing.reason, landing.prNumber);
     }
+    if (landing.reason === "infra") {
+      const reason = landing.infraReason ?? "landing infrastructure precondition failed";
+      return await terminalFailure(
+        common,
+        "infra",
+        "infra",
+        { log: reason },
+        { notes: reason },
+      );
+    }
     if (landing.reason === "pr-conflict") {
       return await prLandingBlocked(
         common,
@@ -2615,6 +2623,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         summary: oneLine(sections.log, "Admin-merge refused because main is red without an open main-red repair issue."),
         next: "Restore or create the auto-filed main-red repair issue, then requeue.",
       };
+    case "infra":
+      return {
+        status: "blocked",
+        kind: "infra",
+        summary: oneLine(sections.log, "Landing infrastructure precondition failed."),
+        next: "Fix the landing infrastructure failure, then requeue.",
+      };
     case "manual-landing":
       return {
         status: "blocked",
@@ -2637,6 +2652,7 @@ const ACTIONABLE_BLOCKER_KINDS = new Set([
   "trunk-diverged",
   "sensitive-path",
   "main-red-untracked",
+  "infra",
 ]);
 
 function shouldPreserveCurrentBlocker(existing: CurrentBlocker | null, next: CurrentBlocker): boolean {

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -286,7 +286,7 @@ export type ReconcileResult =
       // that the `validation-infra` recovery policy re-queues (or escalates
       // when the cap is exhausted). The original `feedback-failed` keeps its
       // semantic meaning (the worker's code really has a problem, page human).
-      reason: "feedback-failed" | "feedback-failed-infra" | "merge-conflict";
+      reason: "feedback-failed" | "feedback-failed-infra" | "merge-conflict" | "infra";
       posted: boolean;
     }
   | { outcome: "skipped"; reason: ReconcileSkipReason };
@@ -484,6 +484,14 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
     },
   );
   if (!landing.ok) {
+    if (landing.reason === "infra") {
+      return await parkInfraLanding(
+        deps,
+        input,
+        landing.infraReason ?? "landing infrastructure precondition failed",
+        startedEpoch,
+      );
+    }
     // The land path's own gates (drift-guard + integrate/rebase) rejected the
     // branch — park it as a merge conflict, exactly like the DONE path does.
     return await parkMergeConflict(deps, input, landing.reason, startedEpoch);
@@ -662,6 +670,32 @@ async function parkInfraRetry(
     `🤖 /afk reconcile #${issue}: \`${input.branch}\` failed re-validation for INFRA reason and the retry budget is exhausted (attempt ${input.attempt}/${cap}) — escalating.`,
   );
   return { outcome: "parked", reason: "feedback-failed-infra", posted };
+}
+
+/** Landing infrastructure failed before integration could safely run. This is
+ * not a merge conflict and must not consume the merge-conflict recovery budget. */
+async function parkInfraLanding(
+  deps: ReconcileDeps,
+  input: ReconcileInput,
+  reason: string,
+  startedEpoch: number,
+): Promise<ReconcileResult> {
+  const { issue, labels } = input;
+  const disp = dispose("infra", input.attempt, deps.recoveryEnv ?? {});
+  const typed = disp.typedLabel ?? LABEL_INFRA;
+  await deps.gh.ensureLabel(typed);
+  await deps.gh.editLabels(issue, parkDropLabels(labels), [LABEL_HUMAN, typed]);
+  const posted = await emitFailure(deps, input, disp.envelopeStatus, startedEpoch, {
+    log: `reconcile land infra failure: ${reason}`,
+  });
+  await recordAttemptBestEffort(deps, input, "infra", {
+    durationS: deps.nowEpoch() - startedEpoch,
+    notes: `Reconcile validated the branch green but landing infrastructure failed (${reason}).`,
+  });
+  deps.appendIterLog(
+    `🤖 /afk reconcile #${issue}: \`${input.branch}\` passed validation but landing infrastructure failed (${reason}) — escalating.`,
+  );
+  return { outcome: "parked", reason: "infra", posted };
 }
 
 /** The land path rejected the branch (integrate/rebase/drift) → park as a merge

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -70,7 +70,7 @@ interface Opts {
   commitCount?: number;
   /** Resolved origin/<branch> tip used by stale-local-ref regressions. */
   branchTip?: string;
-  /** Enable the PR-path pre-merge rebase provisioner (#1006). */
+  /** Enable the PR-path pre-merge rebase provisioner (#1006). Defaults true for PR landings (#1212). */
   rebaseWorktree?: boolean;
   /** The rebase provisioner returns null (could not provision → rebase skipped). */
   noRebaseWorktree?: boolean;
@@ -214,10 +214,11 @@ function harness(opts: Opts = {}): Harness {
     removeLandingWorktree: async (dir) => {
       removedWorktrees.push(dir);
     },
-    // #1006: only wired when the test opts in, so the existing PR-path suites keep
-    // skipping the rebase (opt-in — an absent provisioner is a no-op).
-    makeRebaseWorktree: opts.rebaseWorktree ? async () => (opts.noRebaseWorktree ? null : RWT) : undefined,
-    removeRebaseWorktree: opts.rebaseWorktree
+    // #1212: PR-path fresh-base integration is mandatory, so the harness wires a
+    // working rebase worktree by default. Tests that exercise infra provisioning
+    // failures opt out explicitly.
+    makeRebaseWorktree: opts.rebaseWorktree === false ? undefined : async () => (opts.noRebaseWorktree ? null : RWT),
+    removeRebaseWorktree: opts.rebaseWorktree !== false
       ? async (dir) => {
           removedRebaseWorktrees.push(dir);
         }
@@ -803,21 +804,30 @@ describe("doLanding — PR-path pre-merge rebase (#1006)", () => {
     expect(j.some((c) => c.includes("pr merge"))).toBe(false);
   });
 
-  it("no provisioner (opt-out) → rebase skipped, PR lands exactly as before", async () => {
-    const h = harness({ locked: false });
+  it("no provisioner → aborts as infra and never admin-merges", async () => {
+    const h = harness({ locked: false, rebaseWorktree: false });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
-    // No rebase touched the worker branch; the admin-merge still ran.
+    expect(r).toEqual({
+      ok: false,
+      reason: "infra",
+      infraReason: "pre-merge rebase worktree could not be provisioned",
+      locked: false,
+    });
     expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(false);
   });
 
-  it("worktree could not be provisioned → rebase skipped, PR still lands (never risks the primary)", async () => {
-    const h = harness({ locked: false, rebaseWorktree: true, noRebaseWorktree: true });
+  it("worktree could not be provisioned → aborts as infra and never admin-merges", async () => {
+    const h = harness({ locked: false, noRebaseWorktree: true });
     const r = await doLanding(h.deps, h.input, h.hooks);
-    expect(r).toEqual({ ok: true, locked: false });
+    expect(r).toEqual({
+      ok: false,
+      reason: "infra",
+      infraReason: "pre-merge rebase worktree could not be provisioned",
+      locked: false,
+    });
     expect(joined(h.mergeCalls).some((c) => c.includes("--force-with-lease"))).toBe(false);
-    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge"))).toBe(false);
   });
 
   it("the DIRECT (non-PR) path ignores the rebase provisioner (it integrates origin itself)", async () => {

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -775,9 +775,10 @@ describe("resolveMergeConflict (one-shot self-resolver)", () => {
 
 describe("preMergeRebase (#1006)", () => {
   const base = { repo: "/wt", remote: "origin", base: "main", branch: "afk/w/9-x" };
+  const needsRebase = { match: (a: string[]) => a.includes("merge-base"), result: { code: 1 } };
 
   it("clean rebase → fetches base, rebases, force-pushes the branch, ok", async () => {
-    const { exec, calls } = fakeExec();
+    const { exec, calls } = fakeExec([needsRebase]);
     const r = await preMergeRebase(exec, base);
     expect(r).toEqual({ ok: true });
     const j = joined(calls);
@@ -786,6 +787,17 @@ describe("preMergeRebase (#1006)", () => {
     expect(j).toContain("git -C /wt push origin HEAD:refs/heads/afk/w/9-x --force-with-lease");
     // A clean rebase never aborts.
     expect(j.some((c) => c.includes("rebase --abort"))).toBe(false);
+  });
+
+  it("freshly fetched base already ancestors HEAD → no rebase needed", async () => {
+    const { exec, calls } = fakeExec();
+    const r = await preMergeRebase(exec, base);
+    expect(r).toEqual({ ok: true });
+    const j = joined(calls);
+    expect(j).toContain("git -C /wt fetch origin main --quiet");
+    expect(j).toContain("git -C /wt merge-base --is-ancestor origin/main HEAD");
+    expect(j.some((c) => c.includes("rebase"))).toBe(false);
+    expect(j.some((c) => c.includes("push"))).toBe(false);
   });
 
   it("a fetch failure short-circuits before any rebase", async () => {
@@ -799,6 +811,7 @@ describe("preMergeRebase (#1006)", () => {
 
   it("a rebase conflict aborts the rebase and never pushes → conflict", async () => {
     const { exec, calls } = fakeExec([
+      needsRebase,
       { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
     ]);
     const r = await preMergeRebase(exec, base);
@@ -810,6 +823,7 @@ describe("preMergeRebase (#1006)", () => {
 
   it("#1095: an opt-in resolver that resolves the conflict → proceeds to push (no abort)", async () => {
     const { exec, calls } = fakeExec([
+      needsRebase,
       { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
     ]);
     let resolverRepo = "";
@@ -830,6 +844,7 @@ describe("preMergeRebase (#1006)", () => {
 
   it("#1095: a resolver that DECLINES → aborts exactly as before → conflict", async () => {
     const { exec, calls } = fakeExec([
+      needsRebase,
       { match: (a) => a.join(" ") === "git -C /wt rebase origin/main", result: { code: 1 } },
     ]);
     const r = await preMergeRebase(exec, { ...base, resolveMechanical: async () => false });
@@ -842,6 +857,7 @@ describe("preMergeRebase (#1006)", () => {
   it("a force-with-lease reject retries (re-fetch + re-rebase) then succeeds on the 2nd push", async () => {
     let pushes = 0;
     const { exec, calls } = fakeExec([
+      needsRebase,
       {
         match: (a) => a.includes("push"),
         result: { code: 1 },
@@ -870,6 +886,7 @@ describe("preMergeRebase (#1006)", () => {
         pushes++;
         return { code: 1, stdout: "", stderr: "rejected" };
       }
+      if (argv.includes("merge-base")) return { code: 1, stdout: "", stderr: "" };
       return { code: 0, stdout: "", stderr: "" };
     };
     const r = await preMergeRebase(exec, { ...base, maxPushRetries: 2 });
@@ -886,6 +903,7 @@ describe("preMergeRebase (#1006)", () => {
         // First rebase clean; the retry's re-rebase conflicts.
         return { code: rebases >= 2 ? 1 : 0, stdout: "", stderr: "" };
       }
+      if (argv.includes("merge-base")) return { code: 1, stdout: "", stderr: "" };
       if (argv.includes("push")) return { code: 1, stdout: "", stderr: "rejected" };
       return { code: 0, stdout: "", stderr: "" };
     };

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -491,6 +491,8 @@ function harness(opts: HarnessOptions = {}): {
     // the locked merge/push/rollback runs there instead of the primary checkout.
     makeLandingWorktree: async () => "/wt",
     removeLandingWorktree: async () => {},
+    makeRebaseWorktree: async () => "/rwt",
+    removeRebaseWorktree: async () => {},
     hooks: {
       config,
       resolveOptions: {

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -198,6 +198,8 @@ function harness(opts: HarnessOptions = {}): {
       trace.firedHooks.push(name);
       return true;
     },
+    makeRebaseWorktree: async () => "/rwt",
+    removeRebaseWorktree: async () => {},
     nowEpoch: () => 1000,
     appendIterLog: (line) => {
       trace.iterLogs.push(line);


### PR DESCRIPTION
Automated AFK landing for #1212. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1212

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785988237&installation_id=129708444&pr_number=1264&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1264&signature=af9cad4ab443dca1f186009846f186404b6f397553ac960a3f451970357a84d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR landings now surface infrastructure provisioning failures explicitly instead of silently continuing.

* **Bug Fixes**
  * Landing now stops earlier when required rebase worktree setup is unavailable.
  * Rebase steps are skipped when the branch is already up to date, avoiding unnecessary retries and pushes.
  * Infrastructure-related failures are now tracked and parked separately from merge conflicts.

* **Tests**
  * Updated coverage for PR landing, rebase, and reconciliation flows to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->