### PR TITLE
merge: #1199 brain: Thompson-sampling bandit advising model-tier-policy

### DIFF
--- a/apps/brain/src/model-tier-bandit.ts
+++ b/apps/brain/src/model-tier-bandit.ts
@@ -1,0 +1,290 @@
+import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
+
+export const MODEL_TIER_BANDIT_SCHEMA_VERSION = 1 as const;
+
+export const MODEL_TIER_BANDIT_TIERS = ["validate", "simple", "complex", "think"] as const;
+export type ModelTierBanditTier = (typeof MODEL_TIER_BANDIT_TIERS)[number];
+
+export interface ModelTierPosterior {
+  alpha: number;
+  beta: number;
+}
+
+export interface ModelTierBanditArmState {
+  posterior: ModelTierPosterior;
+  observations: number;
+  successes: number;
+  failures: number;
+  consecutiveFailures: number;
+}
+
+export interface ModelTierBanditBucketState {
+  arms: Record<ModelTierBanditTier, ModelTierBanditArmState>;
+}
+
+export interface ModelTierBanditDocument {
+  schemaVersion: typeof MODEL_TIER_BANDIT_SCHEMA_VERSION;
+  buckets: Record<string, ModelTierBanditBucketState>;
+}
+
+export interface ModelTierPosteriorStats extends ModelTierPosterior {
+  tier: ModelTierBanditTier;
+  mean: number;
+  observations: number;
+  successes: number;
+  failures: number;
+  consecutiveFailures: number;
+  sample: number;
+}
+
+export interface ModelTierEscalationBreaker {
+  fromTier: ModelTierBanditTier;
+  toTier: ModelTierBanditTier;
+  consecutiveFailures: number;
+}
+
+export interface ModelTierBanditAdvice {
+  source: "brain.model-tier-bandit";
+  taskClass: string;
+  recommendedTier: ModelTierBanditTier;
+  confidence: number;
+  posterior: ModelTierPosteriorStats[];
+  explanation: string;
+  breaker?: ModelTierEscalationBreaker;
+}
+
+export interface ReplayModelTierBanditOptions {
+  initial?: ModelTierBanditDocument;
+  tierForEvent?: (event: OutcomeEvent) => ModelTierBanditTier | undefined;
+}
+
+export interface RecommendModelTierOptions {
+  samplePosterior?: (stats: Omit<ModelTierPosteriorStats, "sample">) => number;
+  failureEscalationThreshold?: number;
+}
+
+const PRIOR_ALPHA = 1;
+const PRIOR_BETA = 1;
+const FAILURE_ESCALATION_THRESHOLD = 2;
+
+const SUCCESS_REWARD: Record<ModelTierBanditTier, number> = {
+  validate: 1,
+  simple: 0.85,
+  complex: 0.65,
+  think: 0.45,
+};
+
+export function createModelTierBanditDocument(): ModelTierBanditDocument {
+  return { schemaVersion: MODEL_TIER_BANDIT_SCHEMA_VERSION, buckets: {} };
+}
+
+export function replayModelTierBandit(
+  events: readonly OutcomeEvent[],
+  options: ReplayModelTierBanditOptions = {},
+): ModelTierBanditDocument {
+  const document = cloneDocument(options.initial ?? createModelTierBanditDocument());
+  for (const event of events) applyModelTierOutcome(document, event, options);
+  return document;
+}
+
+export function applyModelTierOutcome(
+  document: ModelTierBanditDocument,
+  event: OutcomeEvent,
+  options: ReplayModelTierBanditOptions = {},
+): ModelTierBanditDocument {
+  const tier = (options.tierForEvent ?? tierFromOutcomeEvent)(event);
+  if (!tier) return document;
+
+  const bucket = bucketFor(document, event.taskClass);
+  const arm = bucket.arms[tier];
+  const reward = rewardFor(event, tier);
+  arm.posterior.alpha = round(arm.posterior.alpha + reward);
+  arm.posterior.beta = round(arm.posterior.beta + (1 - reward));
+  arm.observations += 1;
+  if (event.outcome === "success") {
+    arm.successes += 1;
+    arm.consecutiveFailures = 0;
+  } else {
+    arm.failures += 1;
+    arm.consecutiveFailures += 1;
+  }
+  return document;
+}
+
+export function recommendModelTier(
+  document: ModelTierBanditDocument,
+  taskClass: string,
+  options: RecommendModelTierOptions = {},
+): ModelTierBanditAdvice {
+  const bucket = document.buckets[taskClass] ?? emptyBucket();
+  const samplePosterior =
+    options.samplePosterior ?? ((stats: Omit<ModelTierPosteriorStats, "sample">) => sampleBeta(stats.alpha, stats.beta));
+  const posterior = MODEL_TIER_BANDIT_TIERS.map((tier): ModelTierPosteriorStats => {
+    const arm = bucket.arms[tier];
+    const base = {
+      tier,
+      alpha: arm.posterior.alpha,
+      beta: arm.posterior.beta,
+      mean: posteriorMean(arm.posterior),
+      observations: arm.observations,
+      successes: arm.successes,
+      failures: arm.failures,
+      consecutiveFailures: arm.consecutiveFailures,
+    };
+    return { ...base, sample: round(samplePosterior(base)) };
+  }).sort((a, b) => b.sample - a.sample || b.mean - a.mean || tierRank(a.tier) - tierRank(b.tier));
+
+  const sampledWinner = posterior[0] ?? statsForEmptyTier("validate");
+  const breaker = escalationBreakerFor(sampledWinner, options.failureEscalationThreshold ?? FAILURE_ESCALATION_THRESHOLD);
+  const recommendedTier = breaker?.toTier ?? sampledWinner.tier;
+  const runnerUp = posterior.find((stats) => stats.tier !== sampledWinner.tier);
+  const confidence = round(Math.max(0, sampledWinner.mean - (runnerUp?.mean ?? 0)));
+
+  return {
+    source: "brain.model-tier-bandit",
+    taskClass,
+    recommendedTier,
+    confidence,
+    posterior,
+    explanation: renderExplanation(taskClass, sampledWinner, recommendedTier, confidence, breaker),
+    ...(breaker ? { breaker } : {}),
+  };
+}
+
+export function tierFromOutcomeEvent(event: OutcomeEvent): ModelTierBanditTier | undefined {
+  const kind = event.chosenOption.kind;
+  if (isModelTier(kind)) return kind;
+  const model = event.chosenOption.model?.toLowerCase() ?? "";
+  const effort = event.chosenOption.effort?.toLowerCase() ?? "";
+  if (model.includes("haiku")) return "validate";
+  if (model.includes("sonnet")) return "simple";
+  if (model.includes("opus") && effort === "high") return "think";
+  if (model.includes("opus")) return "complex";
+  return undefined;
+}
+
+function rewardFor(event: OutcomeEvent, tier: ModelTierBanditTier): number {
+  if (event.outcome !== "success") return 0;
+  return SUCCESS_REWARD[tier];
+}
+
+function escalationBreakerFor(
+  winner: ModelTierPosteriorStats,
+  threshold: number,
+): ModelTierEscalationBreaker | undefined {
+  if (winner.consecutiveFailures < threshold) return undefined;
+  const fromIdx = MODEL_TIER_BANDIT_TIERS.indexOf(winner.tier);
+  const toTier = MODEL_TIER_BANDIT_TIERS[Math.min(fromIdx + 1, MODEL_TIER_BANDIT_TIERS.length - 1)]!;
+  if (toTier === winner.tier) return undefined;
+  return { fromTier: winner.tier, toTier, consecutiveFailures: winner.consecutiveFailures };
+}
+
+function renderExplanation(
+  taskClass: string,
+  winner: ModelTierPosteriorStats,
+  recommendedTier: ModelTierBanditTier,
+  confidence: number,
+  breaker: ModelTierEscalationBreaker | undefined,
+): string {
+  const base =
+    `brain bandit advice for '${taskClass}': ${winner.tier} has posterior ` +
+    `alpha=${winner.alpha}, beta=${winner.beta}, mean=${winner.mean}`;
+  const suffix = `confidence=${confidence}`;
+  if (!breaker) return `${base}; recommended ${recommendedTier}; ${suffix}.`;
+  return (
+    `${base}, but ${winner.tier} has ${breaker.consecutiveFailures} consecutive failures; ` +
+    `escalation breaker recommends ${recommendedTier}; ${suffix}.`
+  );
+}
+
+function bucketFor(document: ModelTierBanditDocument, taskClass: string): ModelTierBanditBucketState {
+  const key = taskClass.trim() || "unknown";
+  document.buckets[key] ??= emptyBucket();
+  return document.buckets[key]!;
+}
+
+function emptyBucket(): ModelTierBanditBucketState {
+  return {
+    arms: {
+      validate: emptyArm(),
+      simple: emptyArm(),
+      complex: emptyArm(),
+      think: emptyArm(),
+    },
+  };
+}
+
+function emptyArm(): ModelTierBanditArmState {
+  return {
+    posterior: { alpha: PRIOR_ALPHA, beta: PRIOR_BETA },
+    observations: 0,
+    successes: 0,
+    failures: 0,
+    consecutiveFailures: 0,
+  };
+}
+
+function statsForEmptyTier(tier: ModelTierBanditTier): ModelTierPosteriorStats {
+  const arm = emptyArm();
+  return {
+    tier,
+    alpha: arm.posterior.alpha,
+    beta: arm.posterior.beta,
+    mean: posteriorMean(arm.posterior),
+    observations: 0,
+    successes: 0,
+    failures: 0,
+    consecutiveFailures: 0,
+    sample: 0.5,
+  };
+}
+
+function cloneDocument(document: ModelTierBanditDocument): ModelTierBanditDocument {
+  return JSON.parse(JSON.stringify(document)) as ModelTierBanditDocument;
+}
+
+function isModelTier(value: string): value is ModelTierBanditTier {
+  return (MODEL_TIER_BANDIT_TIERS as readonly string[]).includes(value);
+}
+
+function posteriorMean(posterior: ModelTierPosterior): number {
+  return round(posterior.alpha / (posterior.alpha + posterior.beta));
+}
+
+function tierRank(tier: ModelTierBanditTier): number {
+  return MODEL_TIER_BANDIT_TIERS.indexOf(tier);
+}
+
+function sampleBeta(alpha: number, beta: number, rng = Math.random): number {
+  const x = sampleGamma(alpha, rng);
+  const y = sampleGamma(beta, rng);
+  return x + y === 0 ? 0 : x / (x + y);
+}
+
+function sampleGamma(shape: number, rng: () => number): number {
+  if (shape <= 0) return 0;
+  if (shape < 1) {
+    return sampleGamma(shape + 1, rng) * Math.pow(Math.max(rng(), Number.MIN_VALUE), 1 / shape);
+  }
+
+  const d = shape - 1 / 3;
+  const c = 1 / Math.sqrt(9 * d);
+  for (;;) {
+    const x = normal(rng);
+    const v = Math.pow(1 + c * x, 3);
+    if (v <= 0) continue;
+    const u = rng();
+    if (u < 1 - 0.0331 * Math.pow(x, 4)) return d * v;
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v;
+  }
+}
+
+function normal(rng: () => number): number {
+  const u1 = Math.max(rng(), Number.MIN_VALUE);
+  const u2 = rng();
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}

--- a/apps/brain/src/store.ts
+++ b/apps/brain/src/store.ts
@@ -3,6 +3,11 @@ import { isOutcomeEvent, type OutcomeEvent } from "@reddb-io/shared/outcome-even
 import { contentHash, slugify } from "./hash.js";
 import { KpiQuery, type KpiQueryInput, type KpiResult } from "./kpi-query.js";
 import {
+  MODEL_TIER_BANDIT_SCHEMA_VERSION,
+  replayModelTierBandit,
+  type ModelTierBanditDocument,
+} from "./model-tier-bandit.js";
+import {
   AUTO_LINK_CONNECTION_KINDS,
   artifactToAutoLinkArtifact,
   autoLinkThinkQuery,
@@ -100,6 +105,7 @@ export class BrainStore {
   private artifactCache: StoredBrainArtifact[] | null = null;
   private connectionCache: StoredBrainConnection[] | null = null;
   private outcomeEventCache: OutcomeEvent[] | null = null;
+  private modelTierBanditCache: ModelTierBanditDocument | null = null;
 
   private constructor(private readonly opts: BrainStoreOptions) {}
 
@@ -322,6 +328,28 @@ export class BrainStore {
         .map(({ rid: _rid, event }) => event);
     }
     return [...this.outcomeEventCache];
+  }
+
+  async loadModelTierBanditDocument(): Promise<ModelTierBanditDocument | null> {
+    if (this.modelTierBanditCache != null) return this.modelTierBanditCache;
+    const stored = await this.kv().get(modelTierBanditKey());
+    if (stored == null) return null;
+    const parsed = typeof stored === "string" ? (JSON.parse(stored) as unknown) : stored;
+    if (!isModelTierBanditDocument(parsed)) return null;
+    this.modelTierBanditCache = parsed;
+    return parsed;
+  }
+
+  async saveModelTierBanditDocument(document: ModelTierBanditDocument): Promise<ModelTierBanditDocument> {
+    if (!isModelTierBanditDocument(document)) throw new Error("invalid Brain model-tier bandit document");
+    await this.kv().put(modelTierBanditKey(), JSON.stringify(document));
+    this.modelTierBanditCache = document;
+    return document;
+  }
+
+  async refreshModelTierBanditDocument(): Promise<ModelTierBanditDocument> {
+    const document = replayModelTierBandit(await this.replayOutcomeEvents());
+    return this.saveModelTierBanditDocument(document);
   }
 
   async think(query: string, limit = 8, options: ThinkOptions = {}): Promise<BrainThinkResult> {
@@ -746,6 +774,16 @@ function artifactHashKey(hash: string): string {
 
 function connectionKey(from: number, to: number, kind: ConnectionKind): string {
   return `connection.${from}.${kind}.${to}`;
+}
+
+function modelTierBanditKey(): string {
+  return `model-tier-bandit.v${MODEL_TIER_BANDIT_SCHEMA_VERSION}`;
+}
+
+function isModelTierBanditDocument(value: unknown): value is ModelTierBanditDocument {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return candidate.schemaVersion === MODEL_TIER_BANDIT_SCHEMA_VERSION && typeof candidate.buckets === "object";
 }
 
 function countBy(values: string[]): Record<string, number> {

--- a/apps/brain/tests/model-tier-bandit.test.ts
+++ b/apps/brain/tests/model-tier-bandit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { OUTCOME_EVENT_SCHEMA_VERSION, type OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
+import {
+  recommendModelTier,
+  replayModelTierBandit,
+  type ModelTierBanditDocument,
+  type ModelTierBanditTier,
+} from "../src/model-tier-bandit.js";
+
+const event = (
+  id: string,
+  taskClass: string,
+  tier: ModelTierBanditTier,
+  outcome: OutcomeEvent["outcome"],
+): OutcomeEvent => ({
+  schemaVersion: OUTCOME_EVENT_SCHEMA_VERSION,
+  id,
+  emitter: "afk-test",
+  occurredAt: `2026-07-07T00:00:${id.padStart(2, "0")}.000Z`,
+  taskClass,
+  chosenOption: { kind: tier },
+  outcome,
+  cost: { signal: "unknown" },
+});
+
+describe("model-tier Thompson bandit", () => {
+  it("replays outcome events into explainable posteriors and escalates after consecutive failures", () => {
+    const document = replayModelTierBandit([
+      event("1", "bugfix", "simple", "success"),
+      event("2", "bugfix", "simple", "success"),
+      event("3", "bugfix", "simple", "success"),
+      event("4", "bugfix", "simple", "success"),
+      event("5", "bugfix", "simple", "success"),
+      event("6", "bugfix", "complex", "success"),
+      event("7", "bugfix", "simple", "failure"),
+      event("8", "bugfix", "simple", "failure"),
+    ]);
+
+    expect(document.schemaVersion).toBe(1);
+    expect(document.buckets.bugfix?.arms.simple.posterior).toEqual({
+      alpha: 5.25,
+      beta: 3.75,
+    });
+    expect(document.buckets.bugfix?.arms.complex.posterior).toEqual({
+      alpha: 1.65,
+      beta: 1.35,
+    });
+
+    const advice = recommendModelTier(document, "bugfix", { samplePosterior: (stats) => stats.mean });
+
+    expect(advice.recommendedTier).toBe("complex");
+    expect(advice.confidence).toBeGreaterThan(0);
+    expect(advice.explanation).toContain("posterior");
+    expect(advice.breaker).toEqual({
+      fromTier: "simple",
+      toTier: "complex",
+      consecutiveFailures: 2,
+    });
+    expect(advice.posterior.find((arm) => arm.tier === "simple")).toMatchObject({
+      alpha: 5.25,
+      beta: 3.75,
+      observations: 7,
+      consecutiveFailures: 2,
+    });
+  });
+
+  it("round-trips as a small persisted document", () => {
+    const document: ModelTierBanditDocument = replayModelTierBandit([
+      event("1", "docs", "validate", "success"),
+    ]);
+
+    expect(JSON.stringify(document).length).toBeLessThan(1500);
+    expect(document.buckets.docs?.arms.validate.posterior.alpha).toBe(2);
+  });
+});

--- a/apps/brain/tests/store.test.ts
+++ b/apps/brain/tests/store.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { OUTCOME_EVENT_SCHEMA_VERSION, type OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
+import { recommendModelTier } from "../src/model-tier-bandit.js";
 import {
   createAfkHeadlessAutoLinkProvider,
   parseAutoLinkProviderResponse,
@@ -192,6 +193,44 @@ describe("BrainStore outcome events", () => {
       expect(await store.replayOutcomeEvents()).toEqual([first, second]);
     } finally {
       await store.close();
+    }
+  });
+
+  it("persists the model-tier bandit document derived from outcome events", async () => {
+    const root = await tempRoot();
+    const uri = `file://${join(root, "brain.rdb")}`;
+    const store = await BrainStore.open({ uri });
+    const first: OutcomeEvent = {
+      schemaVersion: OUTCOME_EVENT_SCHEMA_VERSION,
+      id: "afk:o/r:11:1",
+      emitter: "afk",
+      occurredAt: "2026-07-06T20:14:16.000Z",
+      taskClass: "feature",
+      chosenOption: { kind: "validate", runner: "claude", model: "claude-haiku-4-5", effort: "low" },
+      outcome: "success",
+      cost: { signal: "low" },
+    };
+
+    try {
+      await store.appendOutcomeEvent(first);
+      const document = await store.refreshModelTierBanditDocument();
+
+      expect(document.buckets.feature?.arms.validate.posterior.alpha).toBe(2);
+    } finally {
+      await store.close();
+    }
+
+    const reopened = await BrainStore.open({ uri });
+    try {
+      const document = await reopened.loadModelTierBanditDocument();
+      expect(document?.buckets.feature?.arms.validate.observations).toBe(1);
+      const advice = recommendModelTier(document!, "feature", { samplePosterior: (stats) => stats.mean });
+      expect(advice.posterior.find((arm) => arm.tier === "validate")).toMatchObject({
+        alpha: 2,
+        beta: 1,
+      });
+    } finally {
+      await reopened.close();
     }
   });
 });

--- a/apps/dev/src/core/model-tier-route.ts
+++ b/apps/dev/src/core/model-tier-route.ts
@@ -73,7 +73,7 @@ export interface PreToolUseInput {
  *                nudge and allow.
  */
 export type RouteAction =
-  | { kind: "noop" }
+  | { kind: "noop"; advice?: ModelTierPolicyAdvice }
   | {
       kind: "rewrite";
       tier: AfkModelTier;
@@ -81,12 +81,27 @@ export type RouteAction =
       effort: AgentEffort;
       updatedInput: Record<string, unknown>;
       reason: string;
+      advice?: ModelTierPolicyAdvice;
     }
-  | { kind: "block"; tier: AfkModelTier; model: string; reason: string }
-  | { kind: "audit"; tier: AfkModelTier; model: string; reason: string };
+  | { kind: "block"; tier: AfkModelTier; model: string; reason: string; advice?: ModelTierPolicyAdvice }
+  | { kind: "audit"; tier: AfkModelTier; model: string; reason: string; advice?: ModelTierPolicyAdvice };
 
 /** Which leg of the enforcement ladder the host can honour. */
 export type EnforcementCapability = "rewrite" | "block" | "audit";
+
+export interface ModelTierPolicyAdvice {
+  source: string;
+  taskClass: string;
+  recommendedTier: AfkModelTier;
+  confidence: number;
+  posterior: readonly unknown[];
+  explanation: string;
+}
+
+export interface RouteModelTierOptions {
+  advice?: ModelTierPolicyAdvice;
+  adoptAdvice?: boolean;
+}
 
 const SUBAGENT_TOOLS = new Set(["Task", "Agent"]);
 
@@ -121,15 +136,17 @@ export function routeModelTier(
   input: PreToolUseInput,
   config: ConfigValues,
   capability: EnforcementCapability = "rewrite",
+  options: RouteModelTierOptions = {},
 ): RouteAction {
   if (!input.tool_name || !SUBAGENT_TOOLS.has(input.tool_name)) return { kind: "noop" };
 
   const subagentType = readSubagentType(input);
   if (!subagentType) return { kind: "noop" };
 
-  const tier = TIER_AGENT_TIERS[subagentType];
-  if (!tier) return { kind: "noop" };
+  const declaredTier = TIER_AGENT_TIERS[subagentType];
+  if (!declaredTier) return adviceNoop(options.advice);
 
+  const tier = options.adoptAdvice && options.advice ? options.advice.recommendedTier : declaredTier;
   const resolved = resolveTier(config, "claude", tier);
   const expectedFamily = modelFamily(resolved.model);
   const dispatched = readModel(input);
@@ -137,7 +154,7 @@ export function routeModelTier(
 
   // Already correctly tiered: a model on the expected family. Nothing to do.
   if (dispatchedFamily !== undefined && dispatchedFamily === expectedFamily) {
-    return { kind: "noop" };
+    return adviceNoop(options.advice);
   }
 
   const reason =
@@ -147,13 +164,18 @@ export function routeModelTier(
     (dispatched
       ? `dispatch requested '${dispatched}'`
       : `dispatch left the model unset`) +
-    `.`;
+    `.` +
+    (options.adoptAdvice && options.advice
+      ? ` Adopted brain advice: ${options.advice.explanation}`
+      : options.advice
+        ? ` Brain advice available but not adopted: ${options.advice.explanation}`
+        : "");
 
   if (capability === "block") {
-    return { kind: "block", tier, model: resolved.model, reason };
+    return { kind: "block", tier, model: resolved.model, reason, ...(options.advice ? { advice: options.advice } : {}) };
   }
   if (capability === "audit") {
-    return { kind: "audit", tier, model: resolved.model, reason };
+    return { kind: "audit", tier, model: resolved.model, reason, ...(options.advice ? { advice: options.advice } : {}) };
   }
 
   // path (a): rewrite. Preserve the full original input, override model and effort.
@@ -166,5 +188,10 @@ export function routeModelTier(
     effort: resolved.effort,
     updatedInput,
     reason,
+    ...(options.advice ? { advice: options.advice } : {}),
   };
+}
+
+function adviceNoop(advice: ModelTierPolicyAdvice | undefined): RouteAction {
+  return advice ? { kind: "noop", advice } : { kind: "noop" };
 }

--- a/apps/dev/tests/model-tier-route.test.ts
+++ b/apps/dev/tests/model-tier-route.test.ts
@@ -6,6 +6,7 @@ import {
   TIER_AGENT_TIERS,
   type PreToolUseInput,
 } from "../src/core/model-tier-route.js";
+import type { ModelTierBanditAdvice } from "../../brain/src/model-tier-bandit.js";
 import { Readable } from "node:stream";
 import { renderClaudeDecision, routeModelTierCommand } from "../src/commands/route-model-tier.js";
 
@@ -33,6 +34,38 @@ const task = (tool_input: Record<string, unknown>): PreToolUseInput => ({
   tool_name: "Task",
   tool_input,
 });
+
+const banditAdvice = {
+  source: "brain.model-tier-bandit",
+  taskClass: "bugfix",
+  recommendedTier: "complex",
+  confidence: 0.2,
+  posterior: [
+    {
+      tier: "complex",
+      alpha: 3,
+      beta: 1,
+      mean: 0.75,
+      observations: 2,
+      successes: 2,
+      failures: 0,
+      consecutiveFailures: 0,
+      sample: 0.75,
+    },
+    {
+      tier: "validate",
+      alpha: 2,
+      beta: 2,
+      mean: 0.5,
+      observations: 2,
+      successes: 1,
+      failures: 1,
+      consecutiveFailures: 1,
+      sample: 0.5,
+    },
+  ],
+  explanation: "brain bandit advice for 'bugfix': complex posterior alpha=3, beta=1, mean=0.75.",
+} satisfies ModelTierBanditAdvice;
 
 describe("modelFamily", () => {
   it("extracts the family from full ids and aliases", () => {
@@ -143,6 +176,39 @@ describe("routeModelTier — capability degrade ladder", () => {
   it("audits (allow + nudge) when the host can neither rewrite nor block", () => {
     const action = routeModelTier(task({ subagent_type: "validate", model: "opus" }), defaults(), "audit");
     expect(action.kind).toBe("audit");
+  });
+});
+
+describe("routeModelTier — bandit advice", () => {
+  it("surfaces a brain bandit recommendation without changing a correctly-tiered route", () => {
+    const action = routeModelTier(
+      task({ subagent_type: "validate", model: "haiku" }),
+      defaults(),
+      "rewrite",
+      { advice: banditAdvice },
+    );
+
+    expect(action).toEqual({ kind: "noop", advice: banditAdvice });
+  });
+
+  it("adopts the brain bandit recommendation only when explicitly requested", () => {
+    const action = routeModelTier(
+      task({ subagent_type: "validate", model: "haiku", prompt: "p" }),
+      defaults(),
+      "rewrite",
+      { advice: banditAdvice, adoptAdvice: true },
+    );
+
+    expect(action.kind).toBe("rewrite");
+    if (action.kind !== "rewrite") return;
+    expect(action.tier).toBe("complex");
+    expect(action.model).toBe("claude-opus-4-8");
+    expect(action.advice).toBe(banditAdvice);
+    expect(action.updatedInput).toMatchObject({
+      subagent_type: "validate",
+      model: "claude-opus-4-8",
+      effort: "medium",
+    });
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1199. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1199

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785988399&installation_id=129708444&pr_number=1265&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1265&signature=4ee6a9412683806f99e8e4b22f84442c5c1677912acbc01d6b9b51c4e3b5d707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->