### PR TITLE
merge: #1263 afk claim lifecycle: parked/dead workers never concede comment-claims — ghost claims make requeued issues silently unclaimable

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { planRequeue, type RequeuePlan } from "../core/requeue.js";
+import { parseClaimRecords, renderClaimComment, type RawClaimComment } from "../core/claim.js";
 import { parseCurrentBlocker } from "../core/blocker-state.js";
 import { LABEL_SENSITIVE_PATH } from "../core/triage-labels.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
@@ -39,6 +40,8 @@ export interface RequeueGh {
   editBody(issue: number, body: string): Promise<void>;
   editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
   comment(issue: number, body: string): Promise<void>;
+  listClaims?(issue: number): Promise<RawClaimComment[]>;
+  postClaim?(issue: number, body: string): Promise<void>;
 }
 
 /** Metadata passed to the adopt runner after the requeue transition is applied. */
@@ -119,7 +122,45 @@ function ghFor(cwd: string, repo: string): RequeueGh {
     async comment(issue, body) {
       await run(["issue", "comment", String(issue), ...repoArgs, "--body", body]);
     },
+    listClaims: (issue) => ghx.listClaimComments({ cwd, repo }, issue),
+    postClaim: async (issue, body) => {
+      await ghx.postClaimComment({ cwd, repo }, issue, body);
+    },
   };
+}
+
+function activeClaimOwners(comments: readonly RawClaimComment[]): string[] {
+  interface Fold {
+    latestId: number;
+    latestKind: "claim" | "concede";
+  }
+  const folds = new Map<string, Fold>();
+  for (const r of parseClaimRecords(comments)) {
+    const f = folds.get(r.worker);
+    if (!f || r.commentId >= f.latestId) {
+      folds.set(r.worker, { latestId: r.commentId, latestKind: r.kind });
+    }
+  }
+  return [...folds.entries()]
+    .filter(([, f]) => f.latestKind === "claim")
+    .map(([worker]) => worker)
+    .sort();
+}
+
+async function sweepRequeueClaims(gh: RequeueGh, issue: number): Promise<string[]> {
+  if (!gh.listClaims || !gh.postClaim) return [];
+  const owners = activeClaimOwners(await gh.listClaims(issue));
+  for (const owner of owners) {
+    await gh.postClaim(issue, renderClaimComment({ worker: owner }, "concede"));
+  }
+  if (owners.length > 0) {
+    const who = owners.map((owner) => `\`${owner}\``).join(", ");
+    await gh.comment(
+      issue,
+      `🤖 /requeue claim sweep: conceded active AFK claim ${owners.length === 1 ? "marker" : "markers"} on behalf of ${who} before requeueing.`,
+    );
+  }
+  return owners;
 }
 
 function directiveComment(plan: RequeuePlan, guidance?: string): string {
@@ -390,6 +431,7 @@ export async function requeueCommand(
 
   // Apply the requeue transition when the issue is parked and requeueable.
   if (plan.requeueable) {
+    await sweepRequeueClaims(gh, issue);
     if (plan.bodyChanged) await gh.editBody(issue, plan.body);
     await gh.comment(issue, directiveComment(plan, guidance));
     await gh.editLabels(issue, plan.removeLabels, plan.addLabels);

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -43,6 +43,7 @@ import {
 } from "./boot-sweep.js";
 import {
   planStaleClaimSweep,
+  renderDeadClaimSweepAudit,
   renderStaleClaimSweepAudit,
   resolveClaimReaperConfig,
   type ClaimedIssue,
@@ -499,7 +500,12 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
       }
       const addLabels = currentLabels.includes(LABEL_HUMAN) ? [] : [LABEL_READY];
       await deps.gh.editLabels(p.issue, [LABEL_RUNNING], addLabels);
-      await deps.gh.comment(p.issue, renderStaleClaimSweepAudit(p.staleOwners));
+      const claimedIssue = claimed.find((c) => c.issue === p.issue);
+      const deadOwners = new Set(claimedIssue?.deadOwners ?? []);
+      const body = p.staleOwners.some((owner) => deadOwners.has(owner))
+        ? renderDeadClaimSweepAudit(p.staleOwners)
+        : renderStaleClaimSweepAudit(p.staleOwners);
+      await deps.gh.comment(p.issue, body);
       released.push(p.issue);
     } catch {
       // Best-effort: a failed release leaves the issue for the next boot's sweep.

--- a/apps/dev/src/core/claim-staleness.ts
+++ b/apps/dev/src/core/claim-staleness.ts
@@ -217,6 +217,8 @@ export interface ClaimedIssue {
   /** Most recent commit epoch across this issue's live attempt branches. When
    * recent enough, it proves active progress even if the claim marker is old. */
   attemptBranchCommitS?: number;
+  /** Claim owners proven dead on this host by their per-worker `worker.pid`. */
+  deadOwners?: readonly string[];
 }
 
 /** A planned release: the issue to return to the executable pool + the stale
@@ -238,6 +240,15 @@ export function renderStaleClaimSweepAudit(staleOwners: readonly string[]): stri
   );
 }
 
+/** Render the audit comment for an immediate same-host ghost-claim release. */
+export function renderDeadClaimSweepAudit(staleOwners: readonly string[]): string {
+  const who = staleOwners.map((w) => `\`${w}\``).join(", ");
+  return (
+    `🤖 AFK same-host ghost-claim sweep: released this issue back to \`ready-for-agent\` — ` +
+    `${staleOwners.length === 1 ? "the claim" : "the claims"} held by ${who} had a dead \`worker.pid\`.`
+  );
+}
+
 /**
  * Plan which claimed issues to release back to the executable pool (pure). An
  * issue is released ONLY when it has at least one stale claim AND no LIVE claim
@@ -254,9 +265,11 @@ export function planStaleClaimSweep(
   const isStale = makeStaleClaimPredicate(nowS, config);
   const releases: StaleClaimRelease[] = [];
   for (const c of claimed) {
-    const state = classifyIssueClaims(c.records, isStale);
+    const deadOwners = new Set(c.deadOwners ?? []);
+    const state = classifyIssueClaims(c.records, (record) => deadOwners.has(record.worker) || isStale(record));
     if (state.liveOwner === null && state.staleOwners.length > 0) {
-      if (isRecentAttemptCommit(c.attemptBranchCommitS, nowS, config.recentCommitProtectionS)) continue;
+      const hasDeadOwner = state.staleOwners.some((owner) => deadOwners.has(owner));
+      if (!hasDeadOwner && isRecentAttemptCommit(c.attemptBranchCommitS, nowS, config.recentCommitProtectionS)) continue;
       releases.push({ issue: c.issue, staleOwners: state.staleOwners });
     }
   }

--- a/apps/dev/src/core/claim.ts
+++ b/apps/dev/src/core/claim.ts
@@ -76,6 +76,10 @@ export interface ClaimDecision {
   winner: string | null;
   /** One-line rationale, for logs. */
   reason: string;
+  /** The winning claimant's earliest claim comment id, for operator diagnostics. */
+  winnerClaimId?: number;
+  /** The timestamp attached to the winning claimant's latest marker, when known. */
+  winnerCreatedAt?: string;
   /** Stale cross-host claimants this decision RECOVERED — workers whose latest
    * marker `isStale` rejected and who would otherwise have held an earlier claim
    * than the winner. Empty unless a stale claim was superseded. Drives the single
@@ -322,6 +326,8 @@ export function reconcileClaim(
     return {
       verdict: "won",
       winner: winner.worker,
+      winnerClaimId: winner.claimId,
+      winnerCreatedAt: folds.get(winner.worker)?.latestRecord.createdAt,
       reason:
         contenders.length === 1
           ? "solo claim"
@@ -332,6 +338,8 @@ export function reconcileClaim(
   return {
     verdict: "lost",
     winner: winner.worker,
+    winnerClaimId: winner.claimId,
+    winnerCreatedAt: folds.get(winner.worker)?.latestRecord.createdAt,
     reason: `worker ${winner.worker} holds earlier claim (id ${winner.claimId} < our ${self.commentId})`,
     recovered: [],
   };

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -87,7 +87,7 @@ import { formatStartedMarker } from "./heartbeat.js";
 import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { buildAttemptRecordPayload, deriveIssueType, type AttemptRecordPayload } from "./attempt-record.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
-import { acquireClaim, type ClaimGh, type ClaimReconcileOptions } from "./claim.js";
+import { acquireClaim, renderClaimComment, type ClaimGh, type ClaimReconcileOptions, type ClaimDecision } from "./claim.js";
 import { applyCurrentBlockerEdit, parseCurrentBlocker, type CurrentBlocker } from "./blocker-state.js";
 import {
   parseTrustPolicy,
@@ -1067,7 +1067,7 @@ async function refuseNoSandboxForUntrustedAuthor(
       // best-effort: card render failure is non-fatal.
     }
   }
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome: "blocked",
     issue: input.issue,
@@ -1141,6 +1141,15 @@ export async function processIssue(
   const hooksFired: HookName[] = [];
   const startedEpoch = deps.nowEpoch();
   const resolved: ResolvedHooks = resolveHooks(deps.hooks.config, deps.hooks.resolveOptions);
+  let ownsCommentClaim = false;
+  const releaseClaim = async () => {
+    if (ownsCommentClaim) {
+      ownsCommentClaim = false;
+      await releaseOwnedClaim(deps, input);
+      return;
+    }
+    await deps.claimLock.release(issue);
+  };
 
   // FIX J: the env slice the pre_worktree hook chain mutates (e.g. the cargo /
   // gradle defaults inject CARGO_TARGET_DIR=.../slot-N for per-slot build
@@ -1211,12 +1220,13 @@ export async function processIssue(
     if (decision.verdict === "lost") {
       // acquireClaim already conceded our marker; nothing to project, next issue.
       await deps.claimLock.release(issue);
-      return claimLost(issue, hooksFired);
+      return claimLost(issue, hooksFired, deps, decision);
     }
+    ownsCommentClaim = true;
   } else if (labels.includes(LABEL_RUNNING)) {
     // Legacy lock (no claimGh): `running` present means another worker holds it.
     await deps.claimLock.release(issue);
-    return claimLost(issue, hooksFired);
+    return claimLost(issue, hooksFired, deps, undefined, "running label already present");
   }
 
   const activeBlocker = parseCurrentBlocker(input.body);
@@ -1227,7 +1237,7 @@ export async function processIssue(
       issue,
       `🤖 /afk preflight stopped: active Current blocker (${activeBlocker.kind}) still requires human input: ${activeBlocker.next}`,
     );
-    await deps.claimLock.release(issue);
+    await releaseClaim();
     return {
       outcome: "blocked",
       issue,
@@ -1266,8 +1276,8 @@ export async function processIssue(
       deps.appendIterLog(
         `🤖 /afk trust gate refused #${issue} [${describeTrustPosture(trustPolicy)}]: ${verdict.reason} — not claimed; no worktree/handoff materialised.`,
       );
-      await deps.claimLock.release(issue);
-      return claimLost(issue, hooksFired);
+      await releaseClaim();
+      return claimLost(issue, hooksFired, deps, undefined, verdict.reason);
     }
   }
 
@@ -1299,7 +1309,7 @@ export async function processIssue(
   const claimRemoveLabels = [LABEL_READY, ...blockedLabelsIn(labels)];
   const promoted = await editIssueLifecycleLabels(deps, issue, labels, claimRemoveLabels, [LABEL_RUNNING], "claim");
   if (!promoted && !deps.claimGh) {
-    await deps.claimLock.release(issue);
+    await releaseClaim();
     return claimLost(issue, hooksFired);
   }
 
@@ -1310,7 +1320,7 @@ export async function processIssue(
     // A malformed ref refuses the iteration; restore the claim like the bash
     // "refusing malformed live branch ref" guard (return before running).
     await editIssueLifecycleLabels(deps, issue, [LABEL_RUNNING], [LABEL_RUNNING], [LABEL_READY], "retry");
-    await deps.claimLock.release(issue);
+    await releaseClaim();
     return claimLost(issue, hooksFired);
   }
   const base = await resolveBase(input.baseInput, deps.lookups.base);
@@ -1824,7 +1834,7 @@ export async function processIssue(
       } catch {
         // best-effort: a label failure on an already-closed issue is cosmetic.
       }
-      await deps.claimLock.release(issue);
+      await releaseClaim();
       return {
         outcome,
         issue,
@@ -1881,7 +1891,7 @@ export async function processIssue(
         // reconcile already closed the issue, dropped labels, deleted the remote
         // branch, swept the attempt dir + ran the close cascade — only the claim
         // lock (which AFK, not reconcile, owns) remains to release.
-        await deps.claimLock.release(issue);
+        await releaseClaim();
         return {
           outcome: "done",
           issue,
@@ -1896,7 +1906,7 @@ export async function processIssue(
         };
       }
       if (reconciled.outcome === "parked") {
-        await deps.claimLock.release(issue);
+        await releaseClaim();
         return {
           outcome: "feedback-failed",
           issue,
@@ -1941,7 +1951,7 @@ export async function processIssue(
         "_Scout completed without output. Check the attempt log for details._";
       await deps.gh.comment(issue, `## 🔍 Scout Report\n\n${report}`);
       await deps.gh.close(issue);
-      await deps.claimLock.release(issue);
+      await releaseClaim();
       return {
         outcome: "done",
         issue,
@@ -2779,7 +2789,7 @@ async function terminalFailure(
   // shared tail (no-sentinel / blocked / feedback-failed / stalled) did not, so
   // a retry-routed or human-requeued issue stayed un-claimable until the live
   // worker process exited and boot's stale-claim sweep reclaimed the dir (#568).
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return preservedTerminal(receipt, {
     outcome,
     issue: input.issue,
@@ -2845,7 +2855,7 @@ async function mergeFailed(c: StageCommon, _reason: string, locked = false): Pro
   // ADR 0083 §4 exit barrier (#1021): cross the barrier before reporting the
   // merge-conflict terminal so the preserved branch is salvaged + on origin.
   const receipt = await crossTerminalBarrier(deps, c.branch);
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return preservedTerminal(receipt, {
     outcome: "merge-conflict",
     issue: input.issue,
@@ -2897,7 +2907,7 @@ async function ciBlocked(
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: reason,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome,
     issue: input.issue,
@@ -2941,7 +2951,7 @@ async function prLandingBlocked(
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: `${prRef}: ${reason}`,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome,
     issue: input.issue,
@@ -2989,7 +2999,7 @@ async function trunkDivergedBlocked(
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: detail,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome: "trunk-diverged",
     issue: input.issue,
@@ -3031,7 +3041,7 @@ async function sensitivePathGuarded(
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: detail,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome: "sensitive-path",
     issue: input.issue,
@@ -3068,7 +3078,7 @@ async function mainRedUntrackedBlocked(
     durationS: deps.nowEpoch() - c.startedEpoch,
     notes: detail,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome: "main-red-untracked",
     issue: input.issue,
@@ -3131,7 +3141,7 @@ async function handoffForReview(
     validationSummary: validationSidecar.join("\n"),
     notes: `review-requested: PR #${opened.prNumber} labelled ${reviewLabel}`,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
 
   return {
     outcome: "review-requested",
@@ -3215,7 +3225,7 @@ async function handoffForManualLanding(
     validationSummary: validationSidecar.join("\n"),
     notes: `manual-landing: ${prRef} held for human merge`,
   });
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
 
   return {
     outcome: "manual-landing",
@@ -3363,8 +3373,35 @@ async function runCascadeRebase(
 
 // ---------- claim / hook-abort short-circuits ----------
 
-function claimLost(issue: number, hooksFired: HookName[]): ProcessIssueResult {
+function claimLost(
+  issue: number,
+  hooksFired: HookName[],
+  deps?: Pick<ProcessIssueDeps, "appendIterLog" | "nowEpoch">,
+  decision?: ClaimDecision,
+  fallbackReason?: string,
+): ProcessIssueResult {
+  if (deps) {
+    const parts = [`🤖 /afk claim-lost #${issue}`];
+    if (decision?.winner) parts.push(`holder=${decision.winner}`);
+    if (decision?.winnerClaimId !== undefined) parts.push(`claim_id=${decision.winnerClaimId}`);
+    if (decision?.winnerCreatedAt) {
+      const createdMs = Date.parse(decision.winnerCreatedAt);
+      if (!Number.isNaN(createdMs)) parts.push(`age_s=${Math.max(0, deps.nowEpoch() - Math.floor(createdMs / 1000))}`);
+    }
+    parts.push(`reason=${decision?.reason ?? fallbackReason ?? "issue no longer claimable"}`);
+    deps.appendIterLog(parts.join(" "));
+  }
   return { outcome: "claim-lost", issue, hooksFired, preserved: false, swept: false };
+}
+
+async function releaseOwnedClaim(deps: ProcessIssueDeps, input: ProcessIssueInput): Promise<void> {
+  if (deps.claimGh) {
+    await deps.claimGh.concede(
+      input.issue,
+      renderClaimComment({ worker: input.claimant ?? input.workerId, runner: input.runner }, "concede"),
+    );
+  }
+  await deps.claimLock.release(input.issue);
 }
 
 /** Abort after a successful claim (a pre_* hook aborted): restore
@@ -3394,7 +3431,7 @@ async function abortAfterClaim(
   // branch may not yet exist on origin (nothing committed); the receipt records
   // that truthfully (`pushed:false`) rather than throwing.
   const receipt = await crossTerminalBarrier(deps, branch);
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return preservedTerminal(receipt, {
     outcome: "hook-aborted",
     issue: input.issue,
@@ -3442,7 +3479,7 @@ async function exhausted(
       reason: both ? "both-runners" : runner,
     });
   }
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome: "exhausted",
     issue: input.issue,
@@ -3493,7 +3530,7 @@ async function runnerRecoverable(
       reason: both ? "both-runners" : runner,
     });
   }
-  await deps.claimLock.release(input.issue);
+  await releaseOwnedClaim(deps, input);
   return {
     outcome: "runner-transient",
     issue: input.issue,

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -13,6 +13,7 @@ import { spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { hostname } from "node:os";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import type { SandboxMode } from "../core/execution.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
@@ -37,6 +38,7 @@ import * as ghx from "./gh.js";
 import * as gitx from "./git.js";
 import * as fsx from "./fs.js";
 import { collectLogLineCounts } from "./log-cursor.js";
+import { isLivePid } from "./kill-tree.js";
 
 // ---------- repo resolution ----------
 
@@ -1557,7 +1559,8 @@ async function resolveBranchIssueCache(
 export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS: number): Promise<BootDeps> {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: gitx.GitContext = { cwd: ctx.root };
-  const cfg = loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined });
+  const paths = afkPaths(ctx.root);
+  const cfg = loadConfig(paths.configPath, { warn: () => undefined });
   const countCachePath = statuslineCountCachePath(ctx.root);
   // ONE batched issue-state fetch backs every per-issue boot lookup below.
   const issueStates = await ghx.listIssueStates(ghCtx);
@@ -1631,14 +1634,29 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
       // A per-issue read failure drops that issue from the sweep (best-effort).
       claimedIssues: async () => {
         const claimed = [];
+        const hostPrefix = `${hostname()}:`;
         for (const [issue, row] of issueStates) {
           if (row.state !== "OPEN") continue;
           if (!row.labels.includes(LABEL_RUNNING)) continue;
           try {
             const comments = await ghx.listClaimComments(ghCtx, issue);
+            const records = parseClaimRecords(comments);
+            const deadOwners = records
+              .map((r) => r.worker)
+              .filter((worker, idx, workers) => workers.indexOf(worker) === idx)
+              .filter((worker) => {
+                if (!worker.startsWith(hostPrefix)) return false;
+                const workerId = worker.slice(hostPrefix.length);
+                if (!workerId) return false;
+                const pidPath = join(paths.workersRoot, workerId, "worker.pid");
+                if (!existsSync(pidPath)) return true;
+                const pid = Number(readFileSync(pidPath, "utf8").trim());
+                return !Number.isInteger(pid) || !isLivePid(pid);
+              });
             claimed.push({
               issue,
-              records: parseClaimRecords(comments),
+              records,
+              deadOwners,
               attemptBranchCommitS: liveBranchCommitByIssue.get(issue),
             });
           } catch {

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -667,6 +667,20 @@ describe("runBoot cross-host stale-claim sweep (#627)", () => {
     expect(ghCalls.comment).toEqual([]);
   });
 
+  it("releases a fresh same-host ghost claim when worker.pid is dead", async () => {
+    const claimedIssues = async () => [
+      { issue: 42, records: [claim(10, "host1:wXY", 120)], deadOwners: ["host1:wXY"] },
+    ];
+    const { deps, ghCalls } = makeDeps({ claimedIssues });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [42] });
+    expect(ghCalls.editLabels).toEqual([
+      { issue: 42, remove: ["running"], add: ["ready-for-agent"] },
+    ]);
+    expect(ghCalls.comment[0].body).toContain("same-host ghost-claim sweep");
+    expect(ghCalls.comment[0].body).toContain("worker.pid");
+  });
+
   it("honours RED_AFK_CLAIM_REFRESH_S / tolerance from env", async () => {
     // 700s old: stale under the default 1200s window? no. Tighten the window to
     // 60×(1+0)=60s via env → 700s is now stale.

--- a/apps/dev/tests/claim.test.ts
+++ b/apps/dev/tests/claim.test.ts
@@ -93,10 +93,15 @@ describe("reconcileClaim interleavings", () => {
 
   it("late-arrival concede: a worker whose claim id is higher loses to the earlier claim", () => {
     // We post and GitHub gives us id 200, but an earlier active claim (id 50) exists.
-    const records = [rec(50, "other:host"), rec(200, "h:me")];
+    const records = [
+      { ...rec(50, "other:host"), createdAt: "2026-07-07T03:08:14Z" },
+      rec(200, "h:me"),
+    ];
     const d = reconcileClaim(records, self("h:me", 200));
     expect(d.verdict).toBe("lost");
     expect(d.winner).toBe("other:host");
+    expect(d.winnerClaimId).toBe(50);
+    expect(d.winnerCreatedAt).toBe("2026-07-07T03:08:14Z");
   });
 
   it("a flapping claimant cannot jump the queue by re-claiming", () => {

--- a/apps/dev/tests/requeue-command.test.ts
+++ b/apps/dev/tests/requeue-command.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Writable } from "node:stream";
 import { formatCurrentBlocker } from "../src/core/blocker-state.js";
+import { renderClaimComment } from "../src/core/claim.js";
 import { isRequeueComplete } from "../src/core/requeue.js";
 import { requeueCommand, type RequeueGh, type RequeueAdoptRunner } from "../src/commands/requeue.js";
 
@@ -28,9 +29,10 @@ function captureStderr(): { restore: () => void; text: () => string } {
 }
 
 function fakeGh(state: { state: string; body: string; labels: string[] }) {
-  const calls = { editBody: 0, editLabels: 0, comment: 0 };
+  const calls = { editBody: 0, editLabels: 0, comment: 0, postClaim: 0 };
   let lastRemove: string[] = [];
   let lastAdd: string[] = [];
+  const postedClaims: string[] = [];
   const gh: RequeueGh = {
     async view() {
       return state;
@@ -48,8 +50,15 @@ function fakeGh(state: { state: string; body: string; labels: string[] }) {
     async comment() {
       calls.comment += 1;
     },
+    async listClaims() {
+      return [];
+    },
+    async postClaim(_issue, body) {
+      calls.postClaim += 1;
+      postedClaims.push(body);
+    },
   };
-  return { gh, calls, get state() { return state; }, get lastRemove() { return lastRemove; }, get lastAdd() { return lastAdd; } };
+  return { gh, calls, postedClaims, get state() { return state; }, get lastRemove() { return lastRemove; }, get lastAdd() { return lastAdd; } };
 }
 
 const validationBlocker = {
@@ -94,6 +103,28 @@ describe("requeue command — happy path", () => {
     expect(calls.editLabels).toBe(1);
     expect(isRequeueComplete(state.body, ["ready-for-agent"])).toBe(true);
     expect(text()).toContain("Requeue #42");
+  });
+
+  it("concedes active claim markers before requeueing", async () => {
+    const { gh, calls, postedClaims } = fakeGh({
+      state: "OPEN",
+      body: parkedBody,
+      labels: ["ready-for-human", "blocked:validation"],
+    });
+    gh.listClaims = async () => [
+      { id: 10, body: renderClaimComment({ worker: "host:wOLD" }) },
+      { id: 20, body: renderClaimComment({ worker: "host:wDONE" }) },
+      { id: 30, body: renderClaimComment({ worker: "host:wDONE" }, "concede") },
+    ];
+    const { stream } = capture();
+
+    const code = await requeueCommand(["#42", "--guidance", "Retry is now safe."], "/tmp", stream, gh);
+
+    expect(code).toBe(0);
+    expect(calls.postClaim).toBe(1);
+    expect(postedClaims[0]).toContain("worker=host:wOLD");
+    expect(postedClaims[0]).toContain("kind=concede");
+    expect(calls.comment).toBe(2);
   });
 
   it("never mutates and reports a no-op when the issue is not parked", async () => {


### PR DESCRIPTION
Automated AFK landing for #1263. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1263

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785989193&installation_id=129708444&pr_number=1266&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1266&signature=e97484a712438afb98295bc84472e35db580d2b73e113b34f0c47a94810f148f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->