### PR TITLE
merge: #1267 landing: merge commits are not conventional-commit titled — releases silently never fire when worker commits lack feat:/fix: prefixes

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -168,6 +168,8 @@ export interface LandingInput {
   issue: number;
   /** Issue title, for the merge/PR message + hook contexts. */
   title: string;
+  /** Issue labels used to derive the landing-created conventional merge title. */
+  labels?: readonly string[];
   /**
    * Sensitive-path guard bypass (issue #1171). Defaults false/undefined. When
    * true, the step-0a sensitive-path guard scan is SKIPPED so a branch whose diff
@@ -188,6 +190,22 @@ export interface LandingInput {
    * unaffected.
    */
   mainRed?: boolean;
+}
+
+export function landingMergeTitle(input: { issue: number; title: string; labels?: readonly string[] }): string {
+  const labels = new Set((input.labels ?? []).map((label) => label.trim().toLowerCase()));
+  let prefix = "chore";
+  if (labels.has("type:bug") || labels.has("bug")) {
+    prefix = "fix";
+  } else if (
+    labels.has("type:feature") ||
+    labels.has("feature") ||
+    labels.has("type:enhancement") ||
+    labels.has("enhancement")
+  ) {
+    prefix = "feat";
+  }
+  return `${prefix}: #${input.issue} ${input.title}`;
 }
 
 /** The pre_merge / post_merge hook context builders the caller owns (so the
@@ -442,6 +460,7 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     target: input.base,
     n: input.issue,
     title: input.title,
+    mergeTitle: landingMergeTitle(input),
     waitForReview: deps.waitForReview,
     ciAwait: deps.ciAwait,
     // Untouchable primary (ADR 0083 §2, #1019): on a LOCKED landing landPr skips
@@ -595,6 +614,7 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
       target: input.base,
       n: input.issue,
       title: input.title,
+      mergeTitle: landingMergeTitle(input),
       preMergeSha,
     });
     let landed = merged.ok;

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -196,6 +196,8 @@ export interface LandMergeInput {
   n: number;
   /** Issue title, for the merge message. */
   title: string;
+  /** Full merge commit subject. Defaults to the historical `merge: #N <title>`. */
+  mergeTitle?: string;
   /** Integrated tip captured before the merge, for rollback on push reject. */
   preMergeSha: string;
 }
@@ -223,6 +225,7 @@ export interface LandMergeResult {
  */
 export async function landMerge(exec: Exec, input: LandMergeInput): Promise<LandMergeResult> {
   const { repo, remote, branch, target, n, title, preMergeSha } = input;
+  const mergeTitle = input.mergeTitle ?? `merge: #${n} ${title}`;
 
   const merge = await exec([
     "git",
@@ -237,7 +240,7 @@ export async function landMerge(exec: Exec, input: LandMergeInput): Promise<Land
     "--no-verify",
     branch,
     "-m",
-    `merge: #${n} ${title}`,
+    mergeTitle,
   ]);
   if (merge.code !== 0) return { ok: false, rolledBack: false };
 
@@ -511,6 +514,8 @@ export interface LandPrInput {
   n: number;
   /** Issue title, for the PR title. */
   title: string;
+  /** Full PR title / merge commit subject. Defaults to the historical `merge: #N <title>`. */
+  mergeTitle?: string;
   /** Worktree dir to force-push the attempt branch from; skipped when absent. */
   worktree?: string;
   /**
@@ -572,7 +577,7 @@ const PR_BODY_PREFIX = "Automated AFK landing for #";
  * Idempotent: a re-attempt reuses the open PR rather than creating a second.
  */
 export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResult> {
-  const { repo, gitRepo, remote, branch, target, n, title, worktree, waitForReview, ciAwait, locked } = input;
+  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, locked } = input;
 
   // 1. Make the attempt branch's origin state certain before opening the PR.
   if (worktree) {
@@ -589,7 +594,7 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   }
 
   // 2. Reuse an open PR for this head/base, else create one.
-  const prNumber = await ensurePr(exec, { repo, branch, target, n, title });
+  const prNumber = await ensurePr(exec, { repo, branch, target, n, title, mergeTitle });
   if (prNumber === undefined) return { ok: false, reason: "no-pr" };
 
   // 2b. Opt-in advisory-review wait (afk.merge.wait_for_review, ADR 0048). Hold
@@ -615,7 +620,9 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   }
 
   // 3. Merge: branch protection is honored rather than bypassed (#1103).
-  const merge = await exec(["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"]);
+  const mergeArgs = ["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"];
+  if (mergeTitle) mergeArgs.push("--subject", mergeTitle);
+  const merge = await exec(mergeArgs);
   if (merge.code !== 0) return { ok: false, prNumber, reason: "merge-failed" };
 
   // 4. Fast-forward local <target> to the merge commit (best-effort) — UNLOCKED
@@ -641,9 +648,10 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
  */
 async function ensurePr(
   exec: Exec,
-  input: { repo: string; branch: string; target: string; n: number; title: string },
+  input: { repo: string; branch: string; target: string; n: number; title: string; mergeTitle?: string },
 ): Promise<number | undefined> {
   const { repo, branch, target, n, title } = input;
+  const prTitle = input.mergeTitle ?? `merge: #${n} ${title}`;
   let prNumber = await listOpenPr(exec, repo, branch, target);
   if (prNumber === undefined) {
     const create = await exec([
@@ -657,7 +665,7 @@ async function ensurePr(
       "--head",
       branch,
       "--title",
-      `merge: #${n} ${title}`,
+      prTitle,
       "--body",
       `${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the \`afk-attempts/*\` snapshot branches.\n\nCloses #${n}`,
     ]);

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -2253,6 +2253,7 @@ export async function processIssue(
       trunk,
       issue,
       title: input.title,
+      labels,
       mainRed,
     },
     {

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -473,6 +473,7 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
       trunk: input.trunk,
       issue,
       title: input.title,
+      labels: input.labels,
       // #1171: the operator adopt-branch path passes this true after reviewing a
       // protected diff, so doLanding's sensitive-path guard is skipped ONLY here.
       // Undefined for every autonomous caller → the guard fires as before.

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -104,6 +104,10 @@ interface Opts {
   mainRed?: boolean;
   /** Main-red tracking gate (#1237): whether the open repair issue finder returns an issue. */
   mainRedRepairIssue?: boolean;
+  /** Issue labels used to derive the landing-created conventional merge title. */
+  labels?: string[];
+  /** Force the admin PR path to create a PR instead of reusing an open one. */
+  createPr?: boolean;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -115,6 +119,7 @@ function harness(opts: Opts = {}): Harness {
   let mainRedRepairLookups = 0;
   const resolverCwds: string[] = [];
   let mergeResolved = false;
+  let prCreated = false;
 
   const deps: LandingDeps = {
     mergeExec: async (argv): Promise<ExecResult> => {
@@ -146,7 +151,12 @@ function harness(opts: Opts = {}): Harness {
         return { code: opts.rebasePushCode ?? 0, stdout: "", stderr: "" };
       }
       if (argv.includes("pr") && argv.includes("list")) {
+        if (opts.createPr && !prCreated) return { code: 0, stdout: "", stderr: "" };
         return { code: 0, stdout: "42\n", stderr: "" };
+      }
+      if (argv.includes("pr") && argv.includes("create")) {
+        prCreated = true;
+        return { code: 0, stdout: "", stderr: "" };
       }
       // The rollback anchor + landed sha the locked worktree path reads.
       if (j.includes("rev-parse --short HEAD")) {
@@ -259,6 +269,7 @@ function harness(opts: Opts = {}): Harness {
     trunk: "main",
     issue: 9,
     title: "Fix the thing",
+    ...(opts.labels ? { labels: opts.labels } : {}),
     // #1171: only set when the test opts in; default undefined keeps the guard
     // armed for every existing landing assertion.
     sensitivePathApproved: opts.sensitivePathApproved,
@@ -382,6 +393,36 @@ describe("doLanding — happy paths", () => {
     // landing's WRITE ops (merge/push) must never target main.
     expect(j.some((c) => (c.includes("merge --") || c.includes("push ")) && c.includes("main"))).toBe(false);
     expect(h.firedHooks).toEqual(["pre_merge", "post_merge"]);
+  });
+});
+
+describe("doLanding — conventional landing titles (#1267)", () => {
+  it.each([
+    { labels: ["type:bug"], title: "fix: #9 Fix the thing" },
+    { labels: ["bug"], title: "fix: #9 Fix the thing" },
+    { labels: ["type:feature"], title: "feat: #9 Fix the thing" },
+    { labels: ["enhancement"], title: "feat: #9 Fix the thing" },
+    { labels: ["type:task"], title: "chore: #9 Fix the thing" },
+  ])("direct/no-agent landing maps $labels to $title", async ({ labels, title }) => {
+    const h = harness({ locked: true, labels });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r.ok).toBe(true);
+    expect(joined(h.mergeCalls)).toContain(
+      `git -C ${WT} merge --no-ff --no-verify ${DEFAULT_BRANCH_TIP} -m ${title}`,
+    );
+  });
+
+  it("admin PR landing uses the conventional title for the PR and merge commit subject", async () => {
+    const h = harness({ locked: false, createPr: true, labels: ["type:feature"] });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: true, locked: false });
+    const j = joined(h.mergeCalls);
+    expect(j).toContain(
+      "gh -R o/r pr create --base main --head afk/wAAAA/9-fix-the-thing --title feat: #9 Fix the thing --body Automated AFK landing for #9. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.\n\nCloses #9",
+    );
+    expect(j).toContain("gh -R o/r pr merge 42 --merge --subject feat: #9 Fix the thing");
   });
 });
 

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -277,6 +277,16 @@ describe("reconcile — green → land", () => {
     expect(trace.iterLogs.some((line) => line.includes("tip `feedfacecafe` validated green and landed"))).toBe(true);
   });
 
+  it("passes issue labels into the no-agent landing so the merge subject is releasable", async () => {
+    const { deps, input, trace } = harness({ feedbackOk: true, labels: ["running", "type:bug"] });
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("landed");
+    expect(trace.mergeCalls.map((c) => c.join(" "))).toContain(
+      "gh -R o/r pr merge 42 --merge --subject fix: #9 Fix the thing",
+    );
+  });
+
   it("resolves feedback scopes from origin/<base>, not a stale local base", async () => {
     const { deps, input, trace } = harness({
       feedbackOk: true,


### PR DESCRIPTION
Automated AFK landing for #1267. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1267

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785990214&installation_id=129708444&pr_number=1268&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1268&signature=2f074866a024927a6916607cd99658340a52b265bca2226c5c644ba8116c0c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->