### PR TITLE
fix: #1180 marketplace CI validator for both manifests

### DIFF
--- a/.github/workflows/red-marketplace-ci.yml
+++ b/.github/workflows/red-marketplace-ci.yml
@@ -1,0 +1,36 @@
+name: red-marketplace-ci
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/marketplace.json"
+      - ".agents/plugins/marketplace.json"
+      - "plugins/**"
+      - "scripts/validate-marketplace-manifests.sh"
+      - "scripts/test-validate-marketplace-manifests.sh"
+      - "scripts/fixtures/marketplace-manifests/**"
+  push:
+    branches: [main]
+    paths:
+      - ".claude-plugin/marketplace.json"
+      - ".agents/plugins/marketplace.json"
+      - "plugins/**"
+      - "scripts/validate-marketplace-manifests.sh"
+      - "scripts/test-validate-marketplace-manifests.sh"
+      - "scripts/fixtures/marketplace-manifests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-marketplace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate marketplace manifests
+        run: scripts/validate-marketplace-manifests.sh
+
+      - name: Test marketplace manifest validator
+        run: scripts/test-validate-marketplace-manifests.sh

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Test red-release npm publish contract
         run: scripts/test-red-release-npm-publish-contract.sh
 
+      - name: Test marketplace manifest validator
+        run: scripts/test-validate-marketplace-manifests.sh
+
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/fixtures/marketplace-manifests/valid/basic/.agents/plugins/marketplace.json
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "fixture-marketplace",
+  "plugins": [
+    {
+      "name": "alpha",
+      "source": {
+        "source": "local",
+        "path": "./plugins/alpha"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "beta",
+      "source": {
+        "source": "local",
+        "path": "./plugins/beta"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/scripts/fixtures/marketplace-manifests/valid/basic/.claude-plugin/marketplace.json
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "fixture-marketplace",
+  "plugins": [
+    {
+      "name": "alpha",
+      "source": "./plugins/alpha",
+      "description": "Alpha fixture plugin."
+    },
+    {
+      "name": "beta",
+      "source": "./plugins/beta",
+      "description": "Beta fixture plugin."
+    }
+  ]
+}

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/.claude-plugin/plugin.json
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "alpha",
+  "version": "0.1.0",
+  "description": "Alpha fixture plugin.",
+  "skills": [
+    "./skills/core/do-thing"
+  ]
+}

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/.codex-plugin/plugin.json
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "alpha",
+  "version": "0.1.0",
+  "description": "Alpha fixture plugin.",
+  "skills": "./skills/"
+}

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/skills/core/do-thing/SKILL.md
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/alpha/skills/core/do-thing/SKILL.md
@@ -1,0 +1,3 @@
+# Do Thing
+
+Fixture skill.

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/beta/.claude-plugin/plugin.json
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/beta/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "beta",
+  "version": "0.1.0",
+  "description": "Beta fixture plugin.",
+  "dependencies": [
+    "alpha"
+  ],
+  "skills": [
+    "./skills/core/remember"
+  ]
+}

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/beta/.codex-plugin/plugin.json
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/beta/.codex-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "beta",
+  "version": "0.1.0",
+  "description": "Beta fixture plugin.",
+  "dependencies": [
+    "alpha"
+  ],
+  "skills": "./skills/"
+}

--- a/scripts/fixtures/marketplace-manifests/valid/basic/plugins/beta/skills/core/remember/SKILL.md
+++ b/scripts/fixtures/marketplace-manifests/valid/basic/plugins/beta/skills/core/remember/SKILL.md
@@ -1,0 +1,3 @@
+# Remember
+
+Fixture skill.

--- a/scripts/test-validate-marketplace-manifests.sh
+++ b/scripts/test-validate-marketplace-manifests.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Fixture-based test for scripts/validate-marketplace-manifests.sh.
+#
+# Starts from one valid marketplace tree, mutates copies for each failure rule,
+# and asserts the expected pass/fail outcome.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+VALIDATOR="scripts/validate-marketplace-manifests.sh"
+FIX_ROOT="scripts/fixtures/marketplace-manifests/valid/basic"
+OUT=/tmp/.marketplace-manifests-out
+
+[ -x "$VALIDATOR" ] || {
+  printf 'error: %s is not executable\n' "$VALIDATOR" >&2
+  exit 1
+}
+
+command -v jq >/dev/null || {
+  printf 'error: jq is required\n' >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$OUT"' EXIT
+
+fail_count=0
+pass_count=0
+
+make_case() {
+  local label="$1"
+  local dest="$tmp/$label"
+  mkdir -p "$dest"
+  cp -R "$FIX_ROOT"/. "$dest"/
+  printf '%s\n' "$dest"
+}
+
+expect_pass() {
+  local label="$1"
+  local root
+  root="$(make_case "$label")"
+  if "$VALIDATOR" --root "$root" >"$OUT" 2>&1; then
+    printf 'PASS  valid/%s\n' "$label"
+    pass_count=$((pass_count + 1))
+  else
+    printf 'FAIL  valid/%s - expected pass, got fail:\n' "$label" >&2
+    sed 's/^/      /' "$OUT" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+expect_fail() {
+  local label="$1"
+  local needle="$2"
+  shift 2
+  local root
+  root="$(make_case "$label")"
+  "$@" "$root"
+  if "$VALIDATOR" --root "$root" >"$OUT" 2>&1; then
+    printf 'FAIL  invalid/%s - expected fail, got pass\n' "$label" >&2
+    fail_count=$((fail_count + 1))
+    return
+  fi
+  if ! grep -q "$needle" "$OUT"; then
+    printf 'FAIL  invalid/%s - failed but missing expected text %q\n' "$label" "$needle" >&2
+    sed 's/^/      /' "$OUT" >&2
+    fail_count=$((fail_count + 1))
+    return
+  fi
+  printf 'PASS  invalid/%s\n' "$label"
+  pass_count=$((pass_count + 1))
+}
+
+missing_plugin_dir() {
+  rm -rf "$1/plugins/beta"
+}
+
+missing_plugin_manifest() {
+  rm -f "$1/plugins/alpha/.claude-plugin/plugin.json"
+}
+
+malformed_plugin_manifest() {
+  printf '{\n' > "$1/plugins/alpha/.codex-plugin/plugin.json"
+}
+
+missing_manifest_field() {
+  jq 'del(.version)' "$1/plugins/alpha/.claude-plugin/plugin.json" > "$1/plugin.tmp"
+  mv "$1/plugin.tmp" "$1/plugins/alpha/.claude-plugin/plugin.json"
+}
+
+skill_without_skill_md() {
+  mkdir -p "$1/plugins/alpha/skills/core/missing-skill"
+}
+
+plugin_set_mismatch() {
+  jq 'del(.plugins[] | select(.name == "beta"))' "$1/.agents/plugins/marketplace.json" > "$1/marketplace.tmp"
+  mv "$1/marketplace.tmp" "$1/.agents/plugins/marketplace.json"
+}
+
+expect_pass basic
+expect_fail missing-plugin-dir       "plugin directory not found"       missing_plugin_dir
+expect_fail missing-plugin-manifest  "plugin manifest not found"        missing_plugin_manifest
+expect_fail malformed-manifest       "malformed plugin manifest"        malformed_plugin_manifest
+expect_fail missing-required-field   "missing required field"           missing_manifest_field
+expect_fail skill-without-skill-md   "skill directory missing SKILL.md" skill_without_skill_md
+expect_fail plugin-set-mismatch      "marketplace plugin set mismatch"  plugin_set_mismatch
+
+if [ "$fail_count" -ne 0 ]; then
+  printf '\n%d failed, %d passed\n' "$fail_count" "$pass_count" >&2
+  exit 1
+fi
+printf '\nall %d marketplace-manifest fixtures pass\n' "$pass_count"

--- a/scripts/validate-marketplace-manifests.sh
+++ b/scripts/validate-marketplace-manifests.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Validate Claude Code and Codex marketplace manifests against the plugin tree.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+usage: scripts/validate-marketplace-manifests.sh [--root PATH]
+
+Validates:
+  - Claude and Codex marketplace JSON is well-formed.
+  - Both marketplaces list the same plugin names.
+  - Every marketplace entry resolves to an existing plugin directory.
+  - Every listed plugin has well-formed Claude and Codex plugin manifests.
+  - Required plugin manifest fields are present.
+  - Every skills/<bucket>/<skill>/ directory contains SKILL.md.
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ "$#" -ge 2 ] || fail "--root requires a path"
+      ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+ROOT="$(cd "$ROOT" && pwd)"
+cd "$ROOT"
+
+command -v jq >/dev/null || fail "jq is required"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+CLAUDE_MARKETPLACE=".claude-plugin/marketplace.json"
+CODEX_MARKETPLACE=".agents/plugins/marketplace.json"
+
+validate_json_object() {
+  local label="$1"
+  local file="$2"
+
+  [ -f "$file" ] || fail "$label not found: $file"
+  jq -e 'type == "object"' "$file" >/dev/null 2>&1 \
+    || fail "malformed $label: $file"
+}
+
+marketplace_names() {
+  local file="$1"
+  jq -r '
+    if (.plugins | type) != "array" then
+      error("plugins must be an array")
+    else
+      .plugins[] | .name
+    end
+  ' "$file"
+}
+
+validate_json_object "Claude marketplace manifest" "$CLAUDE_MARKETPLACE"
+validate_json_object "Codex marketplace manifest" "$CODEX_MARKETPLACE"
+
+marketplace_names "$CLAUDE_MARKETPLACE" | sort -u > "$tmp/claude-names" \
+  || fail "malformed Claude marketplace manifest: $CLAUDE_MARKETPLACE"
+marketplace_names "$CODEX_MARKETPLACE" | sort -u > "$tmp/codex-names" \
+  || fail "malformed Codex marketplace manifest: $CODEX_MARKETPLACE"
+
+if ! diff -u "$tmp/claude-names" "$tmp/codex-names" > "$tmp/name-diff"; then
+  sed 's/^/  /' "$tmp/name-diff" >&2
+  fail "marketplace plugin set mismatch between Claude and Codex manifests"
+fi
+
+validate_plugin_manifest() {
+  local plugin="$1"
+  local host="$2"
+  local file="$3"
+
+  [ -f "$file" ] || fail "$plugin: $host plugin manifest not found: $file"
+  jq -e 'type == "object"' "$file" >/dev/null 2>&1 \
+    || fail "$plugin: malformed plugin manifest: $file"
+
+  local field
+  for field in name version description skills; do
+    jq -e --arg field "$field" '
+      has($field)
+      and (
+        if $field == "skills" then
+          ((.[$field] | type) == "string" and (.[$field] | length) > 0)
+          or ((.[$field] | type) == "array"
+              and (.[$field] | length) > 0
+              and ([.[$field][] | type == "string" and length > 0] | all))
+        else
+          (.[$field] | type) == "string" and (.[$field] | length) > 0
+        end
+      )
+    ' "$file" >/dev/null \
+      || fail "$plugin: $host plugin manifest missing required field '$field': $file"
+  done
+
+  jq -e --arg plugin "$plugin" '.name == $plugin' "$file" >/dev/null \
+    || fail "$plugin: $host plugin manifest name must match marketplace entry: $file"
+}
+
+validate_skill_dirs() {
+  local plugin="$1"
+  local dir="$2"
+  local skills_dir="$dir/skills"
+
+  [ -d "$skills_dir" ] || fail "$plugin: skills directory not found: $skills_dir"
+
+  while IFS= read -r -d '' skill_dir; do
+    [ -f "$skill_dir/SKILL.md" ] \
+      || fail "$plugin: skill directory missing SKILL.md: $skill_dir"
+  done < <(find "$skills_dir" -mindepth 2 -maxdepth 2 -type d \
+    -not -path '*/_*' \
+    -print0 | sort -z)
+}
+
+validate_marketplace_entry_paths() {
+  local host="$1"
+  local marketplace="$2"
+  local extractor="$3"
+
+  while IFS=$'\t' read -r plugin path; do
+    [ -n "$plugin" ] || fail "$host marketplace contains a plugin entry without a name"
+    [ -n "$path" ] || fail "$plugin: $host marketplace entry is missing a source path"
+    [ -d "$path" ] || fail "$plugin: plugin directory not found from $host marketplace: $path"
+  done < <(jq -r "$extractor" "$marketplace")
+}
+
+validate_marketplace_entry_paths \
+  "Claude" \
+  "$CLAUDE_MARKETPLACE" \
+  '.plugins[] | [.name, .source] | @tsv'
+validate_marketplace_entry_paths \
+  "Codex" \
+  "$CODEX_MARKETPLACE" \
+  '.plugins[] | [.name, .source.path] | @tsv'
+
+while IFS= read -r plugin; do
+  [ -n "$plugin" ] || continue
+  claude_path="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .source' "$CLAUDE_MARKETPLACE")"
+  codex_path="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .source.path' "$CODEX_MARKETPLACE")"
+
+  [ "$claude_path" = "$codex_path" ] \
+    || fail "$plugin: marketplace source path mismatch: Claude=$claude_path Codex=$codex_path"
+
+  validate_plugin_manifest "$plugin" "Claude" "$claude_path/.claude-plugin/plugin.json"
+  validate_plugin_manifest "$plugin" "Codex" "$codex_path/.codex-plugin/plugin.json"
+  validate_skill_dirs "$plugin" "$claude_path"
+done < "$tmp/claude-names"
+
+printf 'marketplace manifests ok\n'


### PR DESCRIPTION
Closes #1180

HITL-approved land of the validated attempt branch (tip a5b0d99f, feedback gate green).

The protected diff (new `red-marketplace-ci.yml` + validator test step in `red-workspace-ci.yml`) was maintainer-reviewed 2026-07-07: contents:read only, SHA-pinned actions, path-scoped triggers, repo-local scripts only.

Adopt-branch lane parked this as blocked:merge-conflict, but `git merge-tree` shows 0 conflict hunks — the park came from a stale divergent local ref (12/276 vs origin), since deleted. Landing via the PR surface under HITL authority.

https://claude.ai/code/session_01JZvurMHV2aYMRWeZmVRUXw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785993801&installation_id=129708444&pr_number=1269&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1269&signature=764ea52c3054159d9a8a741fa23bd6fd5ef538c71d7e7d8c36c4ec2548498fbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for marketplace manifests in CI, including checks on pull requests and pushes to `main`.
  * Added fixture marketplace content to support validation scenarios.
* **Bug Fixes**
  * Improved manifest checks to catch mismatched plugin lists, missing plugin files, invalid JSON, missing required fields, and missing skill documents.
* **Tests**
  * Added coverage for valid and invalid marketplace manifest cases, with CI now running the validator test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->