### PR TITLE
chore: #1181 marketplace: skill frontmatter audit (name==dir, description, no wildcard tool grants)

### DIFF
--- a/.github/workflows/red-lint-skill-first-line.yml
+++ b/.github/workflows/red-lint-skill-first-line.yml
@@ -8,6 +8,9 @@ name: red-lint-skill-first-line
 #      skills, <what-to-do> on bodies over ~100 lines, and orphaned bundled
 #      markdown files (cross-skill references allowed via a plugin-wide search).
 #      The test step exercises both fixture trees before the repo sweep runs.
+#   3. marketplace frontmatter audit: blocking check that name matches the skill
+#      directory, description is non-empty, and tool grants are not bare
+#      wildcards.
 
 on:
   pull_request:
@@ -32,3 +35,9 @@ jobs:
 
       - name: Report skill-body hygiene (description budget, house tags, orphans)
         run: bash scripts/lint-skill-body.sh
+
+      - name: Test marketplace skill frontmatter audit against fixtures
+        run: bash scripts/test-lint-skill-frontmatter.sh
+
+      - name: Audit marketplace skill frontmatter
+        run: bash scripts/lint-skill-frontmatter.sh

--- a/scripts/fixtures/skill-frontmatter/compliant/plugins/demo/skills/good/SKILL.md
+++ b/scripts/fixtures/skill-frontmatter/compliant/plugins/demo/skills/good/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: good
+description: Use when testing a valid skill frontmatter fixture.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Good
+
+**Use this fixture to prove the audit accepts valid skill frontmatter.**

--- a/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/bad-name/SKILL.md
+++ b/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/bad-name/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: wrong-name
+description: Use when testing the name and directory mismatch rule.
+---
+
+# Bad Name
+
+**Use this fixture to prove name drift fails.**

--- a/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/empty-description/SKILL.md
+++ b/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/empty-description/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: empty-description
+description:
+---
+
+# Empty Description
+
+**Use this fixture to prove empty descriptions fail.**

--- a/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/wildcard-tools/SKILL.md
+++ b/scripts/fixtures/skill-frontmatter/violating/plugins/demo/skills/wildcard-tools/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: wildcard-tools
+description: Use when testing wildcard tool grants.
+allowed-tools:
+  - "*"
+---
+
+# Wildcard Tools
+
+**Use this fixture to prove wildcard tool grants fail.**

--- a/scripts/lint-skill-frontmatter.sh
+++ b/scripts/lint-skill-frontmatter.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Blocking audit: shipped SKILL.md frontmatter must stay marketplace-safe.
+#
+# Rules:
+#   1. `name` must equal the skill directory name.
+#   2. `description` must be present and non-empty.
+#   3. Tool grant fields, when present, must not grant a bare wildcard (`*`).
+#
+# Usage:
+#   scripts/lint-skill-frontmatter.sh [--root DIR]
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      ROOT="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$ROOT"
+
+if [ ! -d plugins ]; then
+  echo "lint-skill-frontmatter: no plugins/ directory under $ROOT - nothing to check"
+  exit 0
+fi
+
+failures=0
+total=0
+
+frontmatter() {
+  awk 'NR==1 && $0!="---"{exit} /^---$/{c++; next} c==1{print} c>=2{exit}' "$1"
+}
+
+scalar_value() {
+  local key="$1"
+  sed -n "s/^${key}:[[:space:]]*//p" | head -1 | sed 's/[[:space:]]*#.*$//' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//; s/^'\''//; s/'\''$//'
+}
+
+has_non_empty_description() {
+  awk '
+    /^description:[[:space:]]*$/ { block=1; next }
+    /^description:[[:space:]]*[>|-]?/ { found=1; block=1; next }
+    /^description:/ {
+      value=$0
+      sub(/^description:[[:space:]]*/, "", value)
+      gsub(/[[:space:]]*#.*$/, "", value)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      if (value != "" && value != "\"\"" && value != "'\'''\''") found=1
+      next
+    }
+    block && /^[[:space:]]+/ {
+      value=$0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      if (value != "") found=1
+      next
+    }
+    block && /^[^[:space:]]/ { block=0 }
+    END { exit(found ? 0 : 1) }
+  '
+}
+
+wildcard_tool_grants() {
+  awk '
+    function clean(v) {
+      sub(/[[:space:]]*#.*/, "", v)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+      gsub(/^["'\''"]|["'\''"]$/, "", v)
+      return v
+    }
+    function isGrantKey(k) {
+      return k ~ /^(tools|allowed-tools|allowed_tools|tool-grants|tool_grants)$/
+    }
+    function isWildcard(v) {
+      v=clean(v)
+      return v == "*" || v == "[*]" || v == "[\"*\"]" || v == "['\''*'\'']"
+    }
+    /^[A-Za-z0-9_-]+:/ {
+      split($0, parts, ":")
+      key=parts[1]
+      in_grant=isGrantKey(key)
+      value=$0
+      sub(/^[^:]+:[[:space:]]*/, "", value)
+      if (in_grant && isWildcard(value)) print key
+      next
+    }
+    in_grant && /^[[:space:]]*-[[:space:]]*/ {
+      value=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", value)
+      if (isWildcard(value)) print key
+    }
+  '
+}
+
+while IFS= read -r file; do
+  total=$((total + 1))
+  skill_dir="$(basename "$(dirname "$file")")"
+  fm="$(frontmatter "$file")"
+
+  name="$(printf '%s\n' "$fm" | scalar_value name)"
+  if [ "$name" != "$skill_dir" ]; then
+    printf 'FAIL  %s\n      > name-matches-directory: frontmatter name "%s" must equal directory "%s"\n' "$file" "${name:-<missing>}" "$skill_dir"
+    failures=$((failures + 1))
+  fi
+
+  if ! printf '%s\n' "$fm" | has_non_empty_description; then
+    printf 'FAIL  %s\n      > description-non-empty: frontmatter description must be present and non-empty\n' "$file"
+    failures=$((failures + 1))
+  fi
+
+  while IFS= read -r grant_key; do
+    [ -z "$grant_key" ] && continue
+    printf 'FAIL  %s\n      > no-wildcard-tool-grant: %s must not grant bare wildcard "*"\n' "$file" "$grant_key"
+    failures=$((failures + 1))
+  done < <(printf '%s\n' "$fm" | wildcard_tool_grants)
+done < <(find plugins -name SKILL.md -not -path '*/in-progress/*' | sort)
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+  echo "lint-skill-frontmatter: all $total shipped skills passed marketplace frontmatter audit"
+else
+  echo "lint-skill-frontmatter: $failures finding(s) across $total shipped skills"
+fi
+
+exit "$([ "$failures" -eq 0 ] && echo 0 || echo 1)"

--- a/scripts/test-lint-skill-frontmatter.sh
+++ b/scripts/test-lint-skill-frontmatter.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fixture-based test for scripts/lint-skill-frontmatter.sh.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+LINT="scripts/lint-skill-frontmatter.sh"
+FIX_ROOT="scripts/fixtures/skill-frontmatter"
+
+[ -x "$LINT" ] || {
+  printf 'error: %s is not executable\n' "$LINT" >&2
+  exit 1
+}
+
+fail_count=0
+pass_count=0
+
+check() {
+  local label="$1"
+  local cond="$2"
+  if [ "$cond" = "1" ]; then
+    printf 'PASS  %s\n' "$label"
+    pass_count=$((pass_count + 1))
+  else
+    printf 'FAIL  %s\n' "$label" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+assert_grep() {
+  local label="$1" file="$2" pat="$3"
+  if grep -qF "$pat" "$file"; then check "$label" 1; else
+    check "$label" 0
+    printf '      expected to find: %s\n' "$pat" >&2
+  fi
+}
+
+assert_no_grep() {
+  local label="$1" file="$2" pat="$3"
+  if grep -qF "$pat" "$file"; then
+    check "$label" 0
+    printf '      expected NOT to find: %s\n' "$pat" >&2
+  else check "$label" 1; fi
+}
+
+"$LINT" --root "$FIX_ROOT/compliant" >/tmp/.skill-frontmatter-compliant 2>&1
+check "compliant/exit-0" "$([ "$?" -eq 0 ] && echo 1 || echo 0)"
+assert_grep "compliant/summary" /tmp/.skill-frontmatter-compliant "passed marketplace frontmatter audit"
+assert_no_grep "compliant/no-failures" /tmp/.skill-frontmatter-compliant "FAIL  "
+
+"$LINT" --root "$FIX_ROOT/violating" >/tmp/.skill-frontmatter-violating 2>&1
+check "violating/exit-1" "$([ "$?" -eq 1 ] && echo 1 || echo 0)"
+assert_grep "violating/name" /tmp/.skill-frontmatter-violating "bad-name/SKILL.md"
+assert_grep "violating/name-rule" /tmp/.skill-frontmatter-violating "name-matches-directory"
+assert_grep "violating/description" /tmp/.skill-frontmatter-violating "empty-description/SKILL.md"
+assert_grep "violating/description-rule" /tmp/.skill-frontmatter-violating "description-non-empty"
+assert_grep "violating/wildcard" /tmp/.skill-frontmatter-violating "wildcard-tools/SKILL.md"
+assert_grep "violating/wildcard-rule" /tmp/.skill-frontmatter-violating "no-wildcard-tool-grant"
+
+rm -f /tmp/.skill-frontmatter-compliant /tmp/.skill-frontmatter-violating
+
+if [ "$fail_count" -ne 0 ]; then
+  printf '\n%d failed, %d passed\n' "$fail_count" "$pass_count" >&2
+  exit 1
+fi
+printf '\nall %d skill-frontmatter lint assertions pass\n' "$pass_count"


### PR DESCRIPTION
Automated AFK landing for #1181. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1181

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994263&installation_id=129708444&pr_number=1270&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1270&signature=ce1cf02bab8d53481db1162326649b0c4c9dc8820497f3f874b9216e42f1c139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->