### PR TITLE
chore: #1182 marketplace: per-plugin structural smoke scripts + fleet runner workflow

### DIFF
--- a/.github/workflows/red-plugin-structural-smoke.yml
+++ b/.github/workflows/red-plugin-structural-smoke.yml
@@ -1,0 +1,26 @@
+name: red-plugin-structural-smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-structural-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Test broken structural smoke fixture
+        run: scripts/test-plugin-structural-smoke.sh
+
+      - name: Run plugin structural smoke fleet
+        run: scripts/run-plugin-structural-smokes.sh

--- a/plugins/brain/scripts/structural-smoke.sh
+++ b/plugins/brain/scripts/structural-smoke.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO"
+
+node scripts/plugin-structural-smoke.mjs plugins/brain

--- a/plugins/dev/scripts/structural-smoke.sh
+++ b/plugins/dev/scripts/structural-smoke.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO"
+
+node scripts/plugin-structural-smoke.mjs plugins/dev

--- a/plugins/memory/scripts/structural-smoke.sh
+++ b/plugins/memory/scripts/structural-smoke.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO"
+
+node scripts/plugin-structural-smoke.mjs plugins/memory

--- a/scripts/fixtures/plugin-structural-smoke/broken/README.md
+++ b/scripts/fixtures/plugin-structural-smoke/broken/README.md
@@ -1,0 +1,3 @@
+# Broken Plugin Fixture
+
+This fixture intentionally omits the plugin from the root shipping table.

--- a/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/.claude-plugin/plugin.json
+++ b/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "broken",
+  "version": "0.0.0",
+  "description": "Fixture plugin that intentionally violates structural smoke rules.",
+  "skills": [
+    "./skills/core/demo"
+  ]
+}

--- a/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/.codex-plugin/plugin.json
+++ b/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "broken",
+  "version": "0.0.0",
+  "description": "Fixture plugin that intentionally violates structural smoke rules.",
+  "skills": "./skills/"
+}

--- a/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/agents/bad.md
+++ b/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/agents/bad.md
@@ -1,0 +1,6 @@
+---
+description: Fixture agent with an intentionally unsafe wildcard grant.
+tools: "*"
+---
+
+# Bad Agent

--- a/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/skills/core/demo/SKILL.md
+++ b/scripts/fixtures/plugin-structural-smoke/broken/plugins/broken/skills/core/demo/SKILL.md
@@ -1,0 +1,3 @@
+# demo
+
+Fixture skill.

--- a/scripts/plugin-structural-smoke.mjs
+++ b/scripts/plugin-structural-smoke.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(scriptDir, "..");
+const pluginDir = process.argv[2] ? join(process.cwd(), process.argv[2]) : "";
+const rootDir = process.argv[3] ? join(process.cwd(), process.argv[3]) : repoRoot;
+const errors = [];
+
+if (!pluginDir) {
+  console.error("usage: node scripts/plugin-structural-smoke.mjs <plugin-dir> [repo-root]");
+  process.exit(2);
+}
+
+const plugin = basename(pluginDir);
+
+function fail(message) {
+  errors.push(`${plugin}: ${message}`);
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    fail(`${relative(rootDir, path)} is not valid JSON: ${error.message}`);
+    return {};
+  }
+}
+
+function walk(dir, predicate, out = []) {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const st = statSync(path);
+    if (st.isDirectory()) {
+      if (entry !== "node_modules") walk(path, predicate, out);
+    } else if (predicate(path)) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function normalizeSkillPath(path) {
+  return path.replace(/\/+$/, "");
+}
+
+function listedClaudeSkills(manifest) {
+  if (!Array.isArray(manifest.skills)) {
+    fail("Claude plugin manifest skills must be an array");
+    return [];
+  }
+  return manifest.skills.map(normalizeSkillPath).sort();
+}
+
+function publishedSkills() {
+  return walk(join(pluginDir, "skills"), (path) => basename(path) === "SKILL.md")
+    .filter((path) => !path.includes("/deprecated/") && !path.includes("/in-progress/"))
+    .map((path) => `./${relative(pluginDir, dirname(path))}`)
+    .map(normalizeSkillPath)
+    .sort();
+}
+
+function arraysEqual(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function validateRelativePath(manifest, key, owner) {
+  if (manifest[key] === undefined) return;
+  if (typeof manifest[key] !== "string" || !manifest[key].startsWith("./")) {
+    fail(`${owner} ${key} must be a relative ./ path`);
+    return;
+  }
+  const target = join(pluginDir, manifest[key].slice(2));
+  if (!existsSync(target)) fail(`${owner} ${key} target is missing: ${manifest[key]}`);
+}
+
+function validateCodexSkills(codex, skills) {
+  if (codex.skills === "./skills/") return;
+  if (!Array.isArray(codex.skills) || codex.skills.length === 0) {
+    fail("Codex plugin manifest skills must be ./skills/ or a non-empty array");
+    return;
+  }
+  const buckets = codex.skills.map((path) => path.replace(/\/+$/, "/"));
+  for (const bucket of buckets) {
+    if (!bucket.startsWith("./skills/") || !bucket.endsWith("/")) {
+      fail(`Codex skills bucket must be a ./skills/<bucket>/ path: ${bucket}`);
+      continue;
+    }
+    if (!existsSync(join(pluginDir, bucket.slice(2)))) {
+      fail(`Codex skills bucket is missing on disk: ${bucket}`);
+    }
+  }
+  for (const skill of skills) {
+    if (!buckets.some((bucket) => `${skill}/`.startsWith(bucket))) {
+      fail(`Codex skills buckets do not expose published skill ${skill}`);
+    }
+  }
+}
+
+function validateNoWildcardToolGrants() {
+  const files = [
+    join(pluginDir, ".claude-plugin", "plugin.json"),
+    join(pluginDir, ".codex-plugin", "plugin.json"),
+    ...walk(pluginDir, (path) => /\.(json|md|ya?ml)$/.test(path)),
+  ];
+  const seen = new Set();
+  for (const file of files) {
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const text = readFileSync(file, "utf8");
+    const rel = relative(rootDir, file);
+    if (/^\s*(tools|allowed-tools)\s*:\s*["']?\*["']?\s*$/m.test(text)) {
+      fail(`wildcard tool grant in ${rel}`);
+    }
+    if (/"(?:tools|allowed-tools)"\s*:\s*(?:"\*"|\[[^\]]*"[\w:-]*\*[\w:-]*")/s.test(text)) {
+      fail(`wildcard tool grant in ${rel}`);
+    }
+  }
+}
+
+const claudePath = join(pluginDir, ".claude-plugin", "plugin.json");
+const codexPath = join(pluginDir, ".codex-plugin", "plugin.json");
+if (!existsSync(claudePath)) fail("missing .claude-plugin/plugin.json");
+if (!existsSync(codexPath)) fail("missing .codex-plugin/plugin.json");
+
+const claude = existsSync(claudePath) ? readJson(claudePath) : {};
+const codex = existsSync(codexPath) ? readJson(codexPath) : {};
+
+if (claude.name !== plugin) fail(`Claude plugin name must be ${plugin}`);
+if (codex.name !== plugin) fail(`Codex plugin name must be ${plugin}`);
+if (!claude.version || claude.version !== codex.version) {
+  fail("Claude and Codex plugin versions must match and be non-empty");
+}
+
+for (const [manifest, owner] of [[claude, "Claude"], [codex, "Codex"]]) {
+  for (const key of ["mcpServers", "hooks"]) validateRelativePath(manifest, key, owner);
+}
+
+const skills = publishedSkills();
+if (!arraysEqual(skills, listedClaudeSkills(claude))) {
+  fail("Claude plugin skill list is out of sync with SKILL.md files on disk");
+}
+validateCodexSkills(codex, skills);
+
+const readmePath = join(rootDir, "README.md");
+if (!existsSync(readmePath)) {
+  fail("root README.md is missing");
+} else {
+  const readme = readFileSync(readmePath, "utf8");
+  if (!readme.includes(`./plugins/${plugin}/`)) {
+    fail("root README must list shipped plugin with a ./plugins/<plugin>/ link");
+  }
+}
+
+validateNoWildcardToolGrants();
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`error: ${error}`);
+  process.exit(1);
+}
+
+console.log(`${plugin} plugin structural smoke ok`);

--- a/scripts/run-plugin-structural-smokes.sh
+++ b/scripts/run-plugin-structural-smokes.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+mapfile -t smokes < <(find plugins -path '*/scripts/structural-smoke.sh' -type f | sort)
+
+if [[ "${#smokes[@]}" -eq 0 ]]; then
+  echo "error: no plugin structural smoke scripts found" >&2
+  exit 1
+fi
+
+for smoke in "${smokes[@]}"; do
+  bash "$smoke"
+done
+
+echo "plugin structural smoke fleet ok"

--- a/scripts/test-plugin-structural-smoke.sh
+++ b/scripts/test-plugin-structural-smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+if node scripts/plugin-structural-smoke.mjs \
+  scripts/fixtures/plugin-structural-smoke/broken/plugins/broken \
+  scripts/fixtures/plugin-structural-smoke/broken >"$out" 2>&1; then
+  cat "$out" >&2
+  fail "broken plugin fixture unexpectedly passed structural smoke"
+fi
+
+grep -Eq 'root README|wildcard tool grant' "$out" \
+  || fail "broken fixture failure did not report a structural smoke invariant"
+
+echo "plugin structural smoke fixture ok"


### PR DESCRIPTION
Automated AFK landing for #1182. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1182

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994380&installation_id=129708444&pr_number=1271&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1271&signature=267a7dc658c5c4fa6f5101fb20ac78ba8adb83d651b9a2b061d929f633ff2a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->