### PR TITLE
chore: #1183 internal plugin: bootstrap the maintainer-only plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -42,6 +42,19 @@
         "authentication": "ON_USE"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "internal",
+      "description": "Maintainer-only RedSkills repository operations plugin.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/internal"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,6 +22,11 @@
       "name": "brain",
       "source": "./plugins/brain",
       "description": "reddb.io brain plugin — project-local RedDB knowledge repository for freeform captures, typed artifacts, graph connections, and human-facing recall."
+    },
+    {
+      "name": "internal",
+      "source": "./plugins/internal",
+      "description": "reddb.io internal plugin — maintainer-only skills for operating the red-skills repository."
     }
   ]
 }

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -7,3 +7,5 @@ plugins:
     enabled: true                # opt this directory into the dev plugin (ADR 0067)
     lock:
       primary-branch: true       # primary-checkout branch-switch guard
+  internal:
+    enabled: true                # maintainer-only repo operations plugin (ADR 0067)

--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ Important states:
 | [`memory`](./plugins/memory/README.md) | Governed operational memory: decisions, validations, reasoning attempts, stale-claim checks, context packs, and skill telemetry evidence. | You want agents to stop repeating old mistakes after context resets. |
 | [`brain`](./plugins/brain/README.md) | Project-local knowledge: typed artifacts, personal/project facts, sources, graph connections, search, cited answers, and dashboards. | You want durable knowledge the human may ask about later. |
 
+Maintainer-only plugin:
+
+| Plugin | Job | Use it when |
+| --- | --- | --- |
+| [`internal`](./plugins/internal/README.md) | Maintainer-only skills for operating this repository. Installable through the normal marketplace flow, but active only when `plugins.internal.enabled: true` is present. | You maintain `red-skills` itself. |
+
 The short version:
 
 - **Dev moves work.**
@@ -482,6 +488,7 @@ Full guide: [AFK Actions lane](./plugins/dev/skills/engineering/afk/actions-lane
 | [`plugins/dev`](./plugins/dev) | Plugin definition, skills, hooks, scripts, MCP config, and docs for engineering workflow. |
 | [`plugins/memory`](./plugins/memory) | Plugin definition and skills for governed operational memory. Runtime source lives in `apps/memory`. |
 | [`plugins/brain`](./plugins/brain) | Plugin definition and skills for Brain. Runtime source lives in `apps/brain`. |
+| [`plugins/internal`](./plugins/internal) | Maintainer-only plugin definition and skills for operating this repository. |
 | [`apps/dev`](./apps/dev) | AFK, ship, dashboard, triage, runner, release/channel, and workflow runtime code. |
 | [`apps/memory`](./apps/memory) | Memory CLI, graph operations, Workbench, MCP/HTTP surfaces, evals, and diagnostics. |
 | [`apps/brain`](./apps/brain) | Brain CLI, store, MCP server, dashboard, channel bridge, and artifact logic. |

--- a/plugins/internal/.claude-plugin/plugin.json
+++ b/plugins/internal/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "internal",
+  "version": "2.1.0",
+  "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
+  "skills": [
+    "./skills/maintainer/bootstrap"
+  ]
+}

--- a/plugins/internal/.codex-plugin/plugin.json
+++ b/plugins/internal/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "internal",
+  "version": "2.1.0",
+  "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
+  "author": {
+    "name": "reddb.io",
+    "url": "https://github.com/reddb-io"
+  },
+  "homepage": "https://github.com/reddb-io/red-skills",
+  "repository": "https://github.com/reddb-io/red-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "claude-code",
+    "skills",
+    "agents",
+    "maintainer"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "RedSkills Internal",
+    "shortDescription": "Maintainer-only RedSkills repository operations.",
+    "longDescription": "RedSkills Internal is a maintainer-only plugin for operating the red-skills repository. It is installable through the normal marketplace flow, but repo activation is strictly gated by plugins.internal.enabled.",
+    "developerName": "reddb.io",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Shell"
+    ],
+    "websiteURL": "https://github.com/reddb-io/red-skills",
+    "defaultPrompt": [
+      "Run $bootstrap to confirm the internal plugin is enabled for this repo."
+    ],
+    "brandColor": "#7C3AED"
+  }
+}

--- a/plugins/internal/README.md
+++ b/plugins/internal/README.md
@@ -1,0 +1,20 @@
+# RedSkills Internal
+
+Maintainer-only plugin for skills that operate the `red-skills` repository
+itself. It is distributed through the normal RedSkills marketplace so maintainers
+can install it on other maintenance machines, but it stays inert unless a repo
+opts in with:
+
+```yaml
+plugins:
+  internal:
+    enabled: true
+```
+
+Per ADR 0067, installed plugins do not imply activation. This plugin must not
+create or edit `.red/`; `/setup-red-skills` remains the only RedSkills bootstrap
+path that creates project configuration.
+
+The initial `bootstrap` skill is intentionally a no-op placeholder so the
+marketplace install path is demoable end-to-end before real maintainer skills
+accumulate here.

--- a/plugins/internal/skills/maintainer/bootstrap/SKILL.md
+++ b/plugins/internal/skills/maintainer/bootstrap/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: bootstrap
+description: Placeholder maintainer-only internal skill. Use to confirm the internal plugin installed and that the current repo explicitly opted in with plugins.internal.enabled.
+disable-model-invocation: true
+---
+
+# internal bootstrap
+
+Confirms the maintainer-only `internal` plugin is installed and checks the ADR
+0067 activation gate. Read-only: do not create or edit `.red/`.
+
+<what-to-do>
+
+Run this check from the current working directory:
+
+```bash
+node -e '
+const { existsSync, readFileSync } = require("node:fs");
+const { dirname, join } = require("node:path");
+let dir = process.cwd();
+let config = null;
+for (let i = 0; i < 16; i++) {
+  const candidate = join(dir, ".red", "config.yaml");
+  if (existsSync(candidate)) {
+    config = candidate;
+    break;
+  }
+  const parent = dirname(dir);
+  if (parent === dir) break;
+  dir = parent;
+}
+if (!config) {
+  console.log("internal plugin installed; disabled (no .red/config.yaml)");
+  process.exit(0);
+}
+const text = readFileSync(config, "utf8");
+const lines = text.split(/\r?\n/);
+let inInternal = false;
+let enabled = false;
+for (const line of lines) {
+  if (/^  internal:\s*$/.test(line)) {
+    inInternal = true;
+    continue;
+  }
+  if (/^  \S[^:]*:/.test(line)) inInternal = false;
+  if (inInternal && /^    enabled: true(\s+#.*)?$/.test(line)) enabled = true;
+}
+console.log(enabled
+  ? `internal plugin installed and enabled by ${config}`
+  : `internal plugin installed; disabled by ${config}`);
+'
+```
+
+Report the printed line. If disabled, stop; do not create or edit `.red/`.
+
+</what-to-do>

--- a/scripts/validate-install-metadata.sh
+++ b/scripts/validate-install-metadata.sh
@@ -111,6 +111,23 @@ validate_plugin() {
 
 validate_plugin dev
 validate_plugin memory
+validate_plugin internal
+
+awk '
+  /^  internal:[[:space:]]*$/ { in_internal = 1; next }
+  /^  [^[:space:]][^:]*:/ { in_internal = 0 }
+  in_internal && /^    enabled: true([[:space:]]+#.*)?$/ { found = 1 }
+  END { exit found ? 0 : 1 }
+' .red/config.yaml \
+  || fail "internal: this repo must explicitly enable plugins.internal.enabled"
+
+jq -e '.plugins[] | select(.name == "internal" and (.description | test("maintainer-only"; "i")))' \
+  .agents/plugins/marketplace.json >/dev/null \
+  || fail "internal: Codex marketplace description must mark it maintainer-only"
+
+jq -e '.plugins[] | select(.name == "internal" and (.description | test("maintainer-only"; "i")))' \
+  .claude-plugin/marketplace.json >/dev/null \
+  || fail "internal: Claude marketplace description must mark it maintainer-only"
 
 validate_dev_fetch_hooks() {
   local root="$tmp/dev-plugin-root"


### PR DESCRIPTION
Automated AFK landing for #1183. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1183

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994495&installation_id=129708444&pr_number=1272&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1272&signature=4404dcd37a8f94772f88c954b6a9de47a97fad7eb9164a114364b9b8fdd06de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->