### PR TITLE
fix: #1191 afk cache-aware polling cadence review

### DIFF
--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -138,6 +138,10 @@ _Avoid_: afk clone, sandbox checkout
 The OS-process manager behind `/afk fleet`, maintaining a target number of independent AFK workers.
 _Avoid_: Claude fleet, task mirror, auto-monitor loop
 
+**AFK polling cadence rule**:
+The prompt-cache-aware rule for recurring AFK lane cadences: default recurring polls should be cache-warm at 270 seconds or less, or intentionally amortized at 20 minutes or more. Do not add defaults in the dead zone around 300 seconds. The current recurring-cadence inventory is: **Fleet supervisor** health tick `RED_AFK_POLL_S` 15s before/after; event-driven supervisor fallback `RED_AFK_WAKE_FALLBACK_S` 60s before/after; worker proof-of-life heartbeat `RED_AFK_HEARTBEAT_S` 60s before/after; periodic dependency Unblock Sweep `RED_AFK_UNBLOCK_SWEEP_INTERVAL_S` 60s before/after; statusline/monitor expensive-fact cache `RED_AFK_STATUSLINE_CACHE_TTL_S` 180s before/after; stale-claim refresh `RED_AFK_CLAIM_REFRESH_S` 300s before, 270s after. Supervisor watchdog values such as `RED_AFK_SUPERVISOR_STALE_S` and `RED_AFK_SUPERVISOR_RESTART_WINDOW_S` are recovery windows rather than polling cadences; keep them above their safety thresholds instead of treating them as recurring polls.
+_Avoid_: 300s default poll, prompt-cache dead-zone cadence
+
 **Auto-monitor loop**:
 An optional session-level observability loop that periodically renders AFK monitor state.
 _Avoid_: fleet supervisor, worker scheduler

--- a/apps/dev/src/core/claim-staleness.ts
+++ b/apps/dev/src/core/claim-staleness.ts
@@ -26,8 +26,9 @@ import type { ClaimRecord } from "./claim.js";
 
 /** Default seconds between a live worker's claim refreshes. Coarser than the
  * heartbeat (60s) so refresh re-posts do not flood the issue thread, yet far
- * tighter than any realistic attempt duration. */
-export const DEFAULT_CLAIM_REFRESH_S = 300;
+ * tighter than any realistic attempt duration. Kept at the cache-warm edge of
+ * the AFK polling cadence rule, not in the prompt-cache dead zone. */
+export const DEFAULT_CLAIM_REFRESH_S = 270;
 
 /** Default count of consecutive missed refreshes tolerated before a claim is
  * presumed stale. The window then spans `cadence × (tolerance + 1)` so a worker
@@ -290,7 +291,7 @@ function resolveNonNegativeInt(raw: string | undefined, fallback: number): numbe
 
 /**
  * Resolve the staleness policy from the environment. `RED_AFK_CLAIM_REFRESH_S`
- * (positive int, default 300) and `RED_AFK_CLAIM_STALE_TOLERANCE` (non-negative
+ * (positive int, default 270) and `RED_AFK_CLAIM_STALE_TOLERANCE` (non-negative
  * int, default 3). A missing / non-numeric / non-positive cadence falls back to
  * the default so an operator typo can never collapse the window to zero and rob
  * live claims; tolerance accepts 0 (window = exactly one cadence).

--- a/apps/dev/tests/claim-staleness.test.ts
+++ b/apps/dev/tests/claim-staleness.test.ts
@@ -36,24 +36,25 @@ const T0 = 1_700_000_000; // a fixed injected clock anchor (epoch seconds)
 
 describe("staleWindowS", () => {
   it("is cadence × (tolerance + 1) — comfortably exceeds the refresh cadence", () => {
-    const cfg: ClaimStalenessConfig = { refreshCadenceS: 300, tolerance: 3 };
-    expect(staleWindowS(cfg)).toBe(1200);
+    const cfg: ClaimStalenessConfig = { refreshCadenceS: 270, tolerance: 3 };
+    expect(staleWindowS(cfg)).toBe(1080);
     // The window strictly exceeds the cadence for any tolerance ≥ 0.
     expect(staleWindowS(cfg)).toBeGreaterThan(cfg.refreshCadenceS);
     expect(staleWindowS({ refreshCadenceS: 60, tolerance: 0 })).toBe(60);
   });
 
-  it("defaults to 300 × 4 = 1200s", () => {
+  it("defaults to 270 × 4 = 1080s", () => {
     expect(staleWindowS()).toBe(DEFAULT_CLAIM_REFRESH_S * (DEFAULT_CLAIM_STALE_TOLERANCE + 1));
-    expect(staleWindowS(DEFAULT_CLAIM_STALENESS)).toBe(1200);
+    expect(DEFAULT_CLAIM_REFRESH_S).toBe(270);
+    expect(staleWindowS(DEFAULT_CLAIM_STALENESS)).toBe(1080);
   });
 });
 
 describe("classifyClaim (pure, injected clock)", () => {
   const cfg: ClaimReaperConfig = {
-    refreshCadenceS: 300,
+    refreshCadenceS: 270,
     tolerance: 3,
-    claimGraceS: 300,
+    claimGraceS: 270,
     recentCommitProtectionS: 2700,
   };
 
@@ -62,16 +63,16 @@ describe("classifyClaim (pure, injected clock)", () => {
   });
 
   it("a claim within the window (missed a few refreshes) is still fresh — never robbed", () => {
-    // 900s old < 1200s window: missed 2 refreshes, tolerated.
+    // 900s old < 1080s window: missed 3 refreshes, tolerated.
     expect(classifyClaim(recAt(T0 - 900), T0, cfg)).toBe("fresh");
   });
 
   it("a claim exactly at the window boundary is fresh (inclusive)", () => {
-    expect(classifyClaim(recAt(T0 - 1200), T0, cfg)).toBe("fresh");
+    expect(classifyClaim(recAt(T0 - 1080), T0, cfg)).toBe("fresh");
   });
 
   it("a claim past the window is stale — owner presumed dead, recoverable", () => {
-    expect(classifyClaim(recAt(T0 - 1201), T0, cfg)).toBe("stale");
+    expect(classifyClaim(recAt(T0 - 1081), T0, cfg)).toBe("stale");
     expect(classifyClaim(recAt(T0 - 99999), T0, cfg)).toBe("stale");
   });
 
@@ -92,7 +93,7 @@ describe("classifyClaim (pure, injected clock)", () => {
 
 describe("makeStaleClaimPredicate", () => {
   it("returns true only for records past the window — the reconciler's isStale seam", () => {
-    const isStale = makeStaleClaimPredicate(T0, { refreshCadenceS: 300, tolerance: 3 });
+    const isStale = makeStaleClaimPredicate(T0, { refreshCadenceS: 270, tolerance: 3 });
     expect(isStale(recAt(T0 - 100))).toBe(false);
     expect(isStale(recAt(T0 - 5000))).toBe(true);
     expect(isStale({ commentId: 9, worker: "h:w", kind: "claim" })).toBe(false);
@@ -106,8 +107,8 @@ describe("resolveClaimStalenessConfig", () => {
 
   it("reads RED_AFK_CLAIM_REFRESH_S and RED_AFK_CLAIM_STALE_TOLERANCE", () => {
     expect(
-      resolveClaimStalenessConfig({ RED_AFK_CLAIM_REFRESH_S: "600", RED_AFK_CLAIM_STALE_TOLERANCE: "5" }),
-    ).toEqual({ refreshCadenceS: 600, tolerance: 5 });
+      resolveClaimStalenessConfig({ RED_AFK_CLAIM_REFRESH_S: "1200", RED_AFK_CLAIM_STALE_TOLERANCE: "5" }),
+    ).toEqual({ refreshCadenceS: 1200, tolerance: 5 });
   });
 
   it("tolerates a zero tolerance (window = exactly one cadence)", () => {
@@ -161,7 +162,7 @@ describe("resolveClaimReaperConfig", () => {
 });
 
 describe("classifyIssueClaims", () => {
-  const isStale = makeStaleClaimPredicate(T0, { refreshCadenceS: 300, tolerance: 3 });
+  const isStale = makeStaleClaimPredicate(T0, { refreshCadenceS: 270, tolerance: 3 });
 
   it("a single fresh claim is the live owner, no stale owners", () => {
     const st = classifyIssueClaims([claimAt(10, "live:host", 60)], isStale);
@@ -202,9 +203,9 @@ describe("classifyIssueClaims", () => {
 
 describe("planStaleClaimSweep", () => {
   const cfg: ClaimReaperConfig = {
-    refreshCadenceS: 300,
+    refreshCadenceS: 270,
     tolerance: 3,
-    claimGraceS: 300,
+    claimGraceS: 270,
     recentCommitProtectionS: 2700,
   };
 

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -1002,13 +1002,13 @@ describe("resolveStatuslineCacheTtl (#1217)", () => {
   });
 
   it("env RED_AFK_STATUSLINE_CACHE_TTL_S wins over config", () => {
-    const getCfg = (key: string) => (key === "afk.statusline_cache_ttl" ? "300" : "");
+    const getCfg = (key: string) => (key === "afk.statusline_cache_ttl" ? "240" : "");
     expect(resolveStatuslineCacheTtl({ RED_AFK_STATUSLINE_CACHE_TTL_S: "90" }, getCfg)).toBe(90);
   });
 
   it("uses the config value when env is absent", () => {
-    const getCfg = (key: string) => (key === "afk.statusline_cache_ttl" ? "300" : "");
-    expect(resolveStatuslineCacheTtl({}, getCfg)).toBe(300);
+    const getCfg = (key: string) => (key === "afk.statusline_cache_ttl" ? "240" : "");
+    expect(resolveStatuslineCacheTtl({}, getCfg)).toBe(240);
   });
 
   it("falls back to config when env is garbage (non-numeric / 0 / negative)", () => {


### PR DESCRIPTION
Closes #1191

HITL-approved land. Protected diff maintainer-reviewed: `.red/contexts/dev/CONTEXT.md` +4 (cadence-rule glossary entry only). Code change: `RED_AFK_CLAIM_REFRESH_S` 300s→270s out of the prompt-cache dead zone, tests updated.

https://claude.ai/code/session_01JZvurMHV2aYMRWeZmVRUXw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785994771&installation_id=129708444&pr_number=1274&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1274&signature=d7a53177057ee9eaf09e51d0cb26b6d2b647e642b9609b952d08ba30df1bd020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->