### PR TITLE
chore: #1196 internal plugin: /create-plugin scaffolder born-compliant with the marketplace contract

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## create-plugin (internal/maintainer)
+
+- **status**: added
+- **upstream**: none
+- **why**: issue #1196 - new repository plugins should be born compliant with the RedSkills marketplace contract instead of being retrofitted after creation.
+- **what changed**: added the internal `create-plugin` maintainer skill and scaffolder. Generated plugins include Claude and Codex manifests, a two-section seed SKILL.md, README, CHANGES stub, structural smoke script, root README entry, and entries in both marketplace manifests. Added an acceptance test that scaffolds a fixture plugin and runs marketplace validation, skill frontmatter audit, and the generated smoke script with zero manual edits.
+
 ## audit-skills (engineering)
 
 - **status**: added

--- a/plugins/internal/.claude-plugin/plugin.json
+++ b/plugins/internal/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
   "skills": [
-    "./skills/maintainer/bootstrap"
+    "./skills/maintainer/bootstrap",
+    "./skills/maintainer/create-plugin"
   ]
 }

--- a/plugins/internal/README.md
+++ b/plugins/internal/README.md
@@ -15,6 +15,16 @@ Per ADR 0067, installed plugins do not imply activation. This plugin must not
 create or edit `.red/`; `/setup-red-skills` remains the only RedSkills bootstrap
 path that creates project configuration.
 
-The initial `bootstrap` skill is intentionally a no-op placeholder so the
-marketplace install path is demoable end-to-end before real maintainer skills
-accumulate here.
+## Skills
+
+- `bootstrap` confirms the internal plugin is installed and enabled for the
+  current repository.
+- `create-plugin` scaffolds new repository plugins with both host manifests, a
+  seed skill, README, CHANGES stub, structural smoke script, and marketplace
+  entries.
+
+## Contract Changes
+
+Change `create-plugin` before changing the plugin marketplace contract. New
+plugins are born from that scaffold, so contract drift should appear first in
+the generator and its acceptance test.

--- a/plugins/internal/scripts/structural-smoke.sh
+++ b/plugins/internal/scripts/structural-smoke.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO"
+
+node scripts/plugin-structural-smoke.mjs plugins/internal

--- a/plugins/internal/skills/maintainer/create-plugin/SKILL.md
+++ b/plugins/internal/skills/maintainer/create-plugin/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-plugin
+description: Use when a RedSkills maintainer needs to scaffold a new repository plugin that is born compliant with the marketplace, skill, README, CHANGES, and structural-smoke contracts.
+disable-model-invocation: true
+---
+
+# create-plugin
+
+**Scaffold the plugin contract before changing the contract.** Any marketplace,
+skill-body, README, CHANGES, or smoke-script requirement change must update this
+scaffolder first, then the rest of the repo can follow from generated output.
+
+<what-to-do>
+
+Run the scaffolder from the RedSkills repository root:
+
+```bash
+bash plugins/internal/skills/maintainer/create-plugin/scripts/create-plugin.sh <plugin-name>
+```
+
+Use `--root <repo-root>` when operating on a copied fixture or another checkout:
+
+```bash
+bash plugins/internal/skills/maintainer/create-plugin/scripts/create-plugin.sh --root /tmp/red-skills-fixture acme-tools
+```
+
+The command creates:
+
+- `plugins/<plugin-name>/.claude-plugin/plugin.json`
+- `plugins/<plugin-name>/.codex-plugin/plugin.json`
+- `plugins/<plugin-name>/skills/core/<seed-skill>/SKILL.md`
+- `plugins/<plugin-name>/scripts/structural-smoke.sh`
+- `plugins/<plugin-name>/README.md`
+- `plugins/<plugin-name>/CHANGES.md`
+
+It also appends matching entries to `.claude-plugin/marketplace.json`,
+`.agents/plugins/marketplace.json`, and the root `README.md`.
+
+After scaffolding, run the printed validation commands. They are the contract for
+generated plugins: marketplace validation, frontmatter audit, and the generated
+plugin's own structural smoke script.
+
+</what-to-do>
+
+<supporting-info>
+
+The seed `SKILL.md` deliberately follows the two-section body convention:
+`<what-to-do>` carries executable steps and `<supporting-info>` carries context.
+Its first content sentence uses a bold imperative lead, and its frontmatter
+description includes a concrete `Use when` trigger so it passes both the
+frontmatter audit and the report-only body lint.
+
+The generated `CHANGES.md` starts with `status: added` and `upstream: none` so
+new plugins have a provenance stub before they accumulate inherited skills.
+
+</supporting-info>

--- a/plugins/internal/skills/maintainer/create-plugin/scripts/create-plugin.sh
+++ b/plugins/internal/skills/maintainer/create-plugin/scripts/create-plugin.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: create-plugin.sh [--root REPO_ROOT] <plugin-name>
+
+Scaffolds a RedSkills plugin and appends it to both marketplace manifests.
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ "$#" -ge 2 ] || fail "--root requires a path"
+      ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[ "$#" -eq 1 ] || {
+  usage >&2
+  exit 2
+}
+
+command -v jq >/dev/null || fail "jq is required"
+
+PLUGIN="$1"
+PLUGIN="$(printf '%s' "$PLUGIN" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+
+[ -n "$PLUGIN" ] || fail "plugin name normalizes to empty"
+[ "${#PLUGIN}" -le 64 ] || fail "plugin name must be 64 characters or fewer after normalization"
+
+ROOT="$(cd "$ROOT" && pwd)"
+PLUGIN_DIR="$ROOT/plugins/$PLUGIN"
+SKILL_NAME="${PLUGIN}-demo"
+SKILL_DIR="$PLUGIN_DIR/skills/core/$SKILL_NAME"
+
+[ ! -e "$PLUGIN_DIR" ] || fail "plugin already exists: plugins/$PLUGIN"
+[ -f "$ROOT/.claude-plugin/marketplace.json" ] || fail "missing .claude-plugin/marketplace.json"
+[ -f "$ROOT/.agents/plugins/marketplace.json" ] || fail "missing .agents/plugins/marketplace.json"
+
+mkdir -p \
+  "$PLUGIN_DIR/.claude-plugin" \
+  "$PLUGIN_DIR/.codex-plugin" \
+  "$SKILL_DIR" \
+  "$PLUGIN_DIR/scripts"
+
+cat > "$PLUGIN_DIR/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "$PLUGIN",
+  "version": "0.1.0",
+  "description": "reddb.io $PLUGIN plugin - repository-local RedSkills extension.",
+  "skills": [
+    "./skills/core/$SKILL_NAME"
+  ]
+}
+EOF
+
+cat > "$PLUGIN_DIR/.codex-plugin/plugin.json" <<EOF
+{
+  "name": "$PLUGIN",
+  "version": "0.1.0",
+  "description": "reddb.io $PLUGIN plugin - repository-local RedSkills extension.",
+  "author": {
+    "name": "reddb.io",
+    "url": "https://github.com/reddb-io"
+  },
+  "homepage": "https://github.com/reddb-io/red-skills",
+  "repository": "https://github.com/reddb-io/red-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "claude-code",
+    "skills",
+    "agents"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "$PLUGIN",
+    "shortDescription": "Repository-local RedSkills extension.",
+    "longDescription": "The $PLUGIN plugin is a repository-local RedSkills extension scaffolded with born-compliant marketplace metadata, skill structure, documentation, changelog, and structural smoke checks.",
+    "developerName": "reddb.io",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Shell"
+    ],
+    "websiteURL": "https://github.com/reddb-io/red-skills",
+    "defaultPrompt": [
+      "Run \$$SKILL_NAME to verify the $PLUGIN plugin is available."
+    ],
+    "brandColor": "#2563EB"
+  }
+}
+EOF
+
+cat > "$SKILL_DIR/SKILL.md" <<EOF
+---
+name: $SKILL_NAME
+description: Use when verifying that the scaffolded $PLUGIN plugin is installed, discoverable, and ready for repository-specific implementation.
+---
+
+# $SKILL_NAME
+
+**Verify the scaffold before adding domain behavior.** Keep this seed skill
+small until the plugin has a real maintainer workflow.
+
+<what-to-do>
+
+Run the plugin smoke script from the RedSkills repository root:
+
+\`\`\`bash
+bash plugins/$PLUGIN/scripts/structural-smoke.sh
+\`\`\`
+
+Report the printed result.
+
+</what-to-do>
+
+<supporting-info>
+
+This seed exists so new plugins ship with a valid skill tree on day one. Replace
+it only after the replacement skill keeps the same frontmatter discipline,
+two-section body structure, and marketplace-safe tool grants.
+
+</supporting-info>
+EOF
+
+cat > "$PLUGIN_DIR/scripts/structural-smoke.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO"
+
+node scripts/plugin-structural-smoke.mjs "plugins/$(basename "$(cd "$(dirname "$0")/.." && pwd)")"
+EOF
+chmod +x "$PLUGIN_DIR/scripts/structural-smoke.sh"
+
+cat > "$PLUGIN_DIR/README.md" <<EOF
+# $PLUGIN
+
+Repository-local RedSkills plugin scaffolded by the internal create-plugin
+maintainer skill.
+
+## Install
+
+Install through the RedSkills marketplace after this plugin has been committed
+to the repository and the marketplace manifests have been published.
+
+## Skills
+
+- \`$SKILL_NAME\` - verifies the scaffolded plugin structure before real
+  maintainer workflows are added.
+
+## Validation
+
+\`\`\`bash
+bash scripts/validate-marketplace-manifests.sh
+bash scripts/lint-skill-frontmatter.sh
+bash plugins/$PLUGIN/scripts/structural-smoke.sh
+\`\`\`
+
+## Maintenance
+
+Change the internal create-plugin scaffolder before changing this plugin
+contract. Generated plugins are the contract fixture for future plugin work.
+EOF
+
+cat > "$PLUGIN_DIR/CHANGES.md" <<EOF
+# CHANGES - $PLUGIN
+
+## $PLUGIN
+
+- **status**: added
+- **upstream**: none
+- **why**: new repository-local plugin scaffold.
+- **what changed**: created born-compliant plugin manifests, seed skill,
+  structural smoke script, README, and marketplace entries.
+EOF
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+jq --arg name "$PLUGIN" --arg source "./plugins/$PLUGIN" --arg description "reddb.io $PLUGIN plugin - repository-local RedSkills extension." '
+  if any(.plugins[]?; .name == $name) then
+    error("Claude marketplace already contains plugin " + $name)
+  else
+    .plugins += [{
+      "name": $name,
+      "source": $source,
+      "description": $description
+    }]
+  end
+' "$ROOT/.claude-plugin/marketplace.json" > "$tmp"
+mv "$tmp" "$ROOT/.claude-plugin/marketplace.json"
+
+jq --arg name "$PLUGIN" --arg path "./plugins/$PLUGIN" --arg description "Repository-local RedSkills extension." '
+  if any(.plugins[]?; .name == $name) then
+    error("Codex marketplace already contains plugin " + $name)
+  else
+    .plugins += [{
+      "name": $name,
+      "description": $description,
+      "source": {
+        "source": "local",
+        "path": $path
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Developer Tools"
+    }]
+  end
+' "$ROOT/.agents/plugins/marketplace.json" > "$tmp"
+mv "$tmp" "$ROOT/.agents/plugins/marketplace.json"
+
+if ! grep -Fq "./plugins/$PLUGIN/README.md" "$ROOT/README.md"; then
+  cat >> "$ROOT/README.md" <<EOF
+
+- [\`$PLUGIN\`](./plugins/$PLUGIN/README.md) - Repository-local RedSkills extension.
+EOF
+fi
+
+cat <<EOF
+created plugins/$PLUGIN
+
+validate with:
+  bash scripts/validate-marketplace-manifests.sh --root "$ROOT"
+  bash scripts/lint-skill-frontmatter.sh --root "$ROOT"
+  bash plugins/$PLUGIN/scripts/structural-smoke.sh
+EOF

--- a/scripts/test-internal-create-plugin.sh
+++ b/scripts/test-internal-create-plugin.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+SCAFFOLDER="plugins/internal/skills/maintainer/create-plugin/scripts/create-plugin.sh"
+PLUGIN="fixture-plugin"
+OUT=/tmp/.internal-create-plugin-out
+
+[ -f "$SCAFFOLDER" ] || {
+  printf 'error: missing scaffolder: %s\n' "$SCAFFOLDER" >&2
+  exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$OUT"' EXIT
+
+cp -R .claude-plugin .agents plugins scripts README.md "$tmp"/
+
+bash "$SCAFFOLDER" --root "$tmp" "$PLUGIN" >"$OUT" 2>&1
+
+grep -Fq "created plugins/$PLUGIN" "$OUT" \
+  || {
+    printf 'error: scaffolder output did not report created plugin\n' >&2
+    cat "$OUT" >&2
+    exit 1
+  }
+
+jq -e --arg plugin "$PLUGIN" '
+  any(.plugins[]; .name == $plugin and .source == ("./plugins/" + $plugin))
+' "$tmp/.claude-plugin/marketplace.json" >/dev/null \
+  || {
+    printf 'error: Claude marketplace entry missing or malformed\n' >&2
+    exit 1
+  }
+
+jq -e --arg plugin "$PLUGIN" '
+  any(.plugins[];
+    .name == $plugin
+    and .source.source == "local"
+    and .source.path == ("./plugins/" + $plugin)
+    and .policy.installation == "AVAILABLE"
+    and .policy.authentication == "ON_USE"
+    and .category == "Developer Tools"
+  )
+' "$tmp/.agents/plugins/marketplace.json" >/dev/null \
+  || {
+    printf 'error: Codex marketplace entry missing or malformed\n' >&2
+    exit 1
+  }
+
+grep -Fq "<what-to-do>" "$tmp/plugins/$PLUGIN/skills/core/$PLUGIN-demo/SKILL.md" \
+  || {
+    printf 'error: seed skill missing <what-to-do>\n' >&2
+    exit 1
+  }
+grep -Fq "<supporting-info>" "$tmp/plugins/$PLUGIN/skills/core/$PLUGIN-demo/SKILL.md" \
+  || {
+    printf 'error: seed skill missing <supporting-info>\n' >&2
+    exit 1
+  }
+grep -Fq "Use when" "$tmp/plugins/$PLUGIN/skills/core/$PLUGIN-demo/SKILL.md" \
+  || {
+    printf 'error: seed skill missing Use when trigger\n' >&2
+    exit 1
+  }
+
+grep -Fq "**status**: added" "$tmp/plugins/$PLUGIN/CHANGES.md" \
+  || {
+    printf 'error: generated CHANGES.md missing added status\n' >&2
+    exit 1
+  }
+grep -Fq "**upstream**: none" "$tmp/plugins/$PLUGIN/CHANGES.md" \
+  || {
+    printf 'error: generated CHANGES.md missing upstream none\n' >&2
+    exit 1
+  }
+
+bash scripts/validate-marketplace-manifests.sh --root "$tmp"
+bash scripts/lint-skill-frontmatter.sh --root "$tmp"
+bash "$tmp/plugins/$PLUGIN/scripts/structural-smoke.sh"
+
+echo "internal create-plugin scaffolder acceptance ok"


### PR DESCRIPTION
Automated AFK landing for #1196. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1196

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785995525&installation_id=129708444&pr_number=1276&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1276&signature=0e1497082acf931b0e8f8f1eb50e95d985ee5b3fc9ffbc3a731c7ae930ffcc9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->