### PR TITLE
fix: #1277 release: validate-install-metadata fails — internal plugin's Codex marketplace entry lost its maintainer-only description after manifest regeneration

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,6 +14,7 @@
         "installation": "INSTALLED_BY_DEFAULT",
         "authentication": "ON_USE"
       },
+      "description": "reddb.io dev plugin - engineering skills for code agents (autonomous /afk loop, triage, tdd, diagnose, graph-aware codebase understanding, wiki, ...)",
       "category": "Developer Tools"
     },
     {
@@ -29,6 +30,7 @@
       "dependencies": [
         "dev"
       ],
+      "description": "reddb.io memory plugin - governed operational memory for code agents on top of dev: markdown notes, RedDB graph memory, governed recall, context packs, claim checks, readiness, lifecycle hooks, MCP/HTTP surfaces, Workbench diagnostics, and Skill telemetry.",
       "category": "Developer Tools"
     },
     {
@@ -41,6 +43,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_USE"
       },
+      "description": "reddb.io brain plugin - project-local RedDB knowledge repository for freeform captures, typed artifacts, graph connections, and human-facing recall.",
       "category": "Developer Tools"
     },
     {
@@ -53,6 +56,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_USE"
       },
+      "description": "reddb.io internal plugin - maintainer-only skills for operating the red-skills repository.",
       "category": "Developer Tools"
     }
   ]

--- a/apps/dev/tests/codex-manifest-generator.test.ts
+++ b/apps/dev/tests/codex-manifest-generator.test.ts
@@ -20,6 +20,7 @@ describe("Codex manifest generator", () => {
     await mkdir(join(root, ".claude-plugin"), { recursive: true });
     await mkdir(join(root, "plugins/dev/.claude-plugin"), { recursive: true });
     await mkdir(join(root, "plugins/example/.claude-plugin"), { recursive: true });
+    await mkdir(join(root, "plugins/internal/.claude-plugin"), { recursive: true });
 
     await writeJson(join(root, ".claude-plugin/marketplace.json"), {
       name: "red-skills",
@@ -34,6 +35,11 @@ describe("Codex manifest generator", () => {
           source: "./plugins/example",
           description: "Example plugin — shows fixture generation.",
           dependencies: ["dev"],
+        },
+        {
+          name: "internal",
+          source: "./plugins/internal",
+          description: "Internal plugin — maintainer-only repository operations.",
         },
       ],
     });
@@ -55,6 +61,13 @@ describe("Codex manifest generator", () => {
       skills: ["./skills/core/init", "./skills/core/recall"],
     });
 
+    await writeJson(join(root, "plugins/internal/.claude-plugin/plugin.json"), {
+      name: "internal",
+      version: "9.9.9",
+      description: "Internal plugin — maintainer-only repository operations.",
+      skills: ["./skills/core/bootstrap"],
+    });
+
     await execFileAsync("node", [generator, "--root", root]);
 
     const marketplace = JSON.parse(await readFile(join(root, ".agents/plugins/marketplace.json"), "utf8"));
@@ -69,6 +82,20 @@ describe("Codex manifest generator", () => {
         authentication: "ON_USE",
       },
       dependencies: ["dev"],
+      description: "Example plugin - shows fixture generation.",
+      category: "Developer Tools",
+    });
+    expect(marketplace.plugins).toContainEqual({
+      name: "internal",
+      source: {
+        source: "local",
+        path: "./plugins/internal",
+      },
+      policy: {
+        installation: "AVAILABLE",
+        authentication: "ON_USE",
+      },
+      description: "Internal plugin - maintainer-only repository operations.",
       category: "Developer Tools",
     });
 

--- a/plugins/internal/.codex-plugin/plugin.json
+++ b/plugins/internal/.codex-plugin/plugin.json
@@ -33,7 +33,8 @@
     ],
     "websiteURL": "https://github.com/reddb-io/red-skills",
     "defaultPrompt": [
-      "Use $bootstrap when this workspace needs it."
+      "Use $bootstrap when this workspace needs it.",
+      "Use $create-plugin when this workspace needs it."
     ],
     "brandColor": "#D92D20"
   }

--- a/scripts/generate-codex-manifests.mjs
+++ b/scripts/generate-codex-manifests.mjs
@@ -140,6 +140,7 @@ export function buildCodexMarketplace(claudeMarketplace) {
         },
       };
       maybeSet(codexPlugin, "dependencies", plugin.dependencies);
+      maybeSet(codexPlugin, "description", codexText(plugin.description));
       codexPlugin.category = "Developer Tools";
       return codexPlugin;
     }),


### PR DESCRIPTION
Automated AFK landing for #1277. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1277

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786014330&installation_id=129708444&pr_number=1278&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1278&signature=fc759ce8077dac4004c971c4d06790404f29d53c4b331d4f2a40383e455c46ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer descriptions for several marketplace plugins, making it easier to understand what each one does.
  * Included an additional internal plugin in marketplace generation, with its details now shown consistently in generated output.
  * Improved plugin guidance so the workspace can surface the right creation-related helper when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->