### PR TITLE
chore: #1279 /go: Emit a non-blocking, aggregated GitHub PR review (event: COMMENT) that r

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -48,6 +48,7 @@ import * as ghx from "../runtime/gh.js";
 import * as gitx from "../runtime/git.js";
 import * as fsx from "../runtime/fs.js";
 import type { GhContext } from "../runtime/gh.js";
+import { buildReviewGh } from "../runtime/review-gh.js";
 import type { GitContext } from "../runtime/git.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { getConfig, loadConfig, readBackpressure, readPostAttemptFormat, resolveTier, resolveCiTimeoutSeconds } from "../core/config.js";
@@ -897,6 +898,13 @@ export function buildProcessDeps(
     // shell commands run against the same worker-branch checkout after feedback.
     backpressure: feedback.backpressure,
     backpressureCommands: mergedBackpressureCommands,
+    // Non-blocking backpressure evidence review (#1279): render the executed
+    // backpressure checks as ONE aggregated `event: COMMENT` review on the PR.
+    // Reuses ReviewGh.postReview (COMMENT-only, no APPROVE/REQUEST_CHANGES) with
+    // no inline comments — purely a top-level evidence ledger. Observability only;
+    // it never touches the merge/park decision.
+    postBackpressureReview: (pr, body) =>
+      buildReviewGh(ghCtx).postReview(pr, { summary: body, comments: [] }),
     goVerifyRetries,
     // Post-attempt-format step (#1015): operator-declared `afk.post_attempt_format`
     // commands run BEFORE the feedback gate and auto-commit any formatting delta.

--- a/apps/dev/src/core/backpressure.ts
+++ b/apps/dev/src/core/backpressure.ts
@@ -133,3 +133,36 @@ export async function runBackpressure(
 
   return { ok: !failed, checks, sidecar };
 }
+
+/**
+ * Header line for the aggregated backpressure evidence ledger (issue #1279). It
+ * states, in-band, that the review is purely additive observability so nobody
+ * reads a COMMENT review as a gate: the merge/park decision is owned entirely by
+ * {@link runBackpressure}'s `ok` flag and is byte-for-byte unchanged by this.
+ */
+export const BACKPRESSURE_REVIEW_HEADER =
+  "🤖 backpressure evidence ledger — operator-declared merge-gate checks " +
+  "(non-blocking, observability only; the merge/park decision is unchanged).";
+
+/**
+ * Render the aggregated, NON-BLOCKING backpressure evidence ledger for a PR
+ * review body (issue #1279). PURE — no IO, no clock. Maps every executed
+ * {@link BackpressureCheck} (both positive and negative) to one line:
+ *   - passed → `✅ backpressure:<cmd>`
+ *   - failed → `❌ backpressure:<cmd> → <summary>`
+ * (the check's `name` is already `backpressure:<cmd>`). Returns `null` for an
+ * empty check list so the caller posts NOTHING — an empty ledger is never a
+ * review. This renders an EVIDENCE view of what already ran; it never re-decides
+ * the merge, which stays owned by {@link RunBackpressureResult.ok}.
+ */
+export function renderBackpressureReviewBody(
+  checks: readonly BackpressureCheck[],
+): string | null {
+  if (checks.length === 0) return null;
+  const lines = checks.map((check) =>
+    check.status === "passed"
+      ? `✅ ${check.name}`
+      : `❌ ${check.name} → ${check.record.summary ?? "command failed"}`,
+  );
+  return [BACKPRESSURE_REVIEW_HEADER, "", ...lines].join("\n");
+}

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -119,6 +119,15 @@ export interface LandingDeps {
   ciAwait?: CiAwaitInput;
   /** Find the open auto-filed main-red repair issue for the #1237 admin-merge gate. */
   findMainRedRepairIssue?(): Promise<MainRedRepairIssue | null>;
+  /**
+   * Non-blocking observability hook (issue #1279): invoked by the PR landing path
+   * the moment the PR number is RESOLVED (open-or-reused, before the merge), so
+   * the caller can attach the aggregated backpressure evidence review to the PR.
+   * Best-effort and fully DECOUPLED — landPr swallows any rejection and the hook
+   * never affects whether/how the PR merges. Absent (the default) or on the
+   * direct path (no PR) → never called.
+   */
+  onPrResolved?: (prNumber: number) => Promise<void>;
 }
 
 /** Static per-landing inputs the caller already resolved. */
@@ -463,6 +472,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     mergeTitle: landingMergeTitle(input),
     waitForReview: deps.waitForReview,
     ciAwait: deps.ciAwait,
+    // Non-blocking backpressure evidence review (#1279): threaded through so
+    // landPr can attach the ledger the moment it resolves the PR number.
+    onPrResolved: deps.onPrResolved,
     // Untouchable primary (ADR 0083 §2, #1019): on a LOCKED landing landPr skips
     // its step-4 local fast-forward, so the integration reaches the maintainer
     // only via `origin/<locked-branch>` (they promote by pulling). The lock only

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -543,6 +543,14 @@ export interface LandPrInput {
    * immediately, fine on a base with no required status checks.
    */
   ciAwait?: CiAwaitInput;
+  /**
+   * Non-blocking observability hook (issue #1279): invoked once the PR number is
+   * RESOLVED (opened or reused), BEFORE any review/CI wait or the merge, so the
+   * caller can attach an aggregated evidence review to the open PR. Best-effort —
+   * a rejection is swallowed here so it can never fail or alter the landing.
+   * Absent (the default) → never called.
+   */
+  onPrResolved?: (prNumber: number) => Promise<void>;
 }
 
 /** Why an UNLOCKED landing did not admin-merge, so the caller can route the
@@ -577,7 +585,7 @@ const PR_BODY_PREFIX = "Automated AFK landing for #";
  * Idempotent: a re-attempt reuses the open PR rather than creating a second.
  */
 export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResult> {
-  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, locked } = input;
+  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, locked, onPrResolved } = input;
 
   // 1. Make the attempt branch's origin state certain before opening the PR.
   if (worktree) {
@@ -596,6 +604,17 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   // 2. Reuse an open PR for this head/base, else create one.
   const prNumber = await ensurePr(exec, { repo, branch, target, n, title, mergeTitle });
   if (prNumber === undefined) return { ok: false, reason: "no-pr" };
+
+  // Non-blocking evidence review (#1279): the PR number is now known — attach the
+  // aggregated backpressure ledger before any wait/merge. Best-effort and fully
+  // decoupled: a rejection is swallowed so it can never fail or alter the landing.
+  if (onPrResolved) {
+    try {
+      await onPrResolved(prNumber);
+    } catch {
+      // observability only — never let a failed review post block the merge.
+    }
+  }
 
   // 2b. Opt-in advisory-review wait (afk.merge.wait_for_review, ADR 0048). Hold
   // until the configured review check concludes, then fall through to merge

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -56,7 +56,12 @@ import {
   type ValidationScope,
   type WorkspaceGraph,
 } from "./validation-scope.js";
-import { runBackpressure, type BackpressureExec } from "./backpressure.js";
+import {
+  runBackpressure,
+  renderBackpressureReviewBody,
+  type BackpressureExec,
+  type BackpressureCheck,
+} from "./backpressure.js";
 import { runPostAttemptFormat, type PostAttemptFormatExec } from "./post-attempt-format.js";
 import {
   openReviewPr,
@@ -356,6 +361,17 @@ export interface ProcessIssueDeps {
    * scope-derived feedback gate; it does not replace it.
    */
   backpressureCommands?: readonly string[];
+  /**
+   * Non-blocking backpressure evidence review seam (issue #1279). When present,
+   * the engine posts ONE aggregated `event: COMMENT` PR review rendering the
+   * executed backpressure checks (positive AND negative) as a legible ledger on
+   * the AFK/go PR — purely additive observability. Optional → absent means no
+   * review is ever posted (today's behaviour) and the merge/park decision is
+   * unaffected either way. Bound in production to {@link ReviewGh.postReview}
+   * (event COMMENT), so it can never carry APPROVE/REQUEST_CHANGES gate
+   * semantics or trip GitHub's self-review restriction.
+   */
+  postBackpressureReview?: (pr: number, body: string) => Promise<void>;
   /**
    * `/go` only: bounded number of post-DONE machine-gate correction attempts.
    * The initial DONE validation is not counted; a value of 2 allows two
@@ -2148,6 +2164,11 @@ export async function processIssue(
         now: deps.nowEpoch,
       });
       backpressureSidecar = backpressure.sidecar;
+      // Capture the checks so the landing/handoff paths can render the
+      // non-blocking evidence ledger (#1279) once the PR number is known. This is
+      // observability only — the merge/park decision below stays owned by
+      // `backpressure.ok` and is unchanged by capturing the checks here.
+      common.backpressureChecks = backpressure.checks;
       if (!backpressure.ok) {
         // Persist BOTH gates' records (feedback passed, backpressure failed) for
         // Memory, but surface only the failing backpressure records in the envelope.
@@ -2222,6 +2243,11 @@ export async function processIssue(
       removeLandingWorktree: deps.removeLandingWorktree,
       makeRebaseWorktree: deps.makeRebaseWorktree,
       removeRebaseWorktree: deps.removeRebaseWorktree,
+      // Non-blocking backpressure evidence review (#1279): fired by the PR-landing
+      // path the moment the PR number is resolved (before the merge), so the
+      // aggregated COMMENT ledger lands on the open PR. Best-effort + fully
+      // decoupled — it never affects whether or how the PR merges.
+      onPrResolved: (pr) => emitBackpressureReview(common, pr),
       // Sensitive-path guard (issue #1102): diff the worker branch against the
       // resolved base before landing. Uses three-dot notation so the diff reflects
       // only what this branch changed, not the entire base history.
@@ -2513,6 +2539,35 @@ interface StageCommon {
   modelTier: AfkModelTier;
   model?: string;
   effort?: AgentEffort;
+  /**
+   * Backpressure checks that ran on the DONE path (issue #1279), captured so the
+   * downstream landing/handoff paths can render the non-blocking evidence ledger
+   * once the PR number is known. Absent/empty → nothing to post.
+   */
+  backpressureChecks?: readonly BackpressureCheck[];
+}
+
+/**
+ * Post the aggregated, NON-BLOCKING backpressure evidence review (issue #1279)
+ * on the PR once its number is known. Best-effort observability that is fully
+ * DECOUPLED from the merge/park decision: no seam / no PR / empty ledger → a
+ * no-op, and ANY posting failure is swallowed so it can never change or block a
+ * landing. Reuses the injected {@link ProcessIssueDeps.postBackpressureReview}
+ * seam (bound to the `event: COMMENT` review surface in production).
+ */
+async function emitBackpressureReview(
+  c: StageCommon,
+  prNumber: number | undefined,
+): Promise<void> {
+  const { deps } = c;
+  if (prNumber === undefined || !deps.postBackpressureReview) return;
+  const body = renderBackpressureReviewBody(c.backpressureChecks ?? []);
+  if (body === null) return;
+  try {
+    await deps.postBackpressureReview(prNumber, body);
+  } catch {
+    // Best-effort: the ledger is audit-only — never fail or alter the landing.
+  }
 }
 
 /** Emit a failure-family envelope (blocked / no-sentinel / merge-conflict /
@@ -3127,6 +3182,11 @@ async function handoffForReview(
     return await mergeFailed(c, "review-pr-open-failed");
   }
 
+  // Non-blocking backpressure evidence review (#1279): the review-gate handoff
+  // opened a PR that stays OPEN for the fresh-agent review — attach the ledger so
+  // the checks are visible before the human/agent merge. Best-effort, decoupled.
+  await emitBackpressureReview(c, opened.prNumber);
+
   // Park for the review→merge flow: drop running, add ready-for-human.
   // `review-requested` carries no typed `blocked:*` label (it is a handoff, not a
   // failure), so editLabelsTagged appends nothing extra to the routing labels.
@@ -3190,6 +3250,11 @@ async function handoffForManualLanding(
   if (!opened.ok) {
     return await mergeFailed(c, "manual-landing-pr-open-failed");
   }
+
+  // Non-blocking backpressure evidence review (#1279): manual landing leaves the
+  // PR OPEN for a human's final merge click — attach the ledger so the executed
+  // checks are visible on it. Best-effort, decoupled from the (held) merge.
+  await emitBackpressureReview(c, opened.prNumber);
 
   const prRef = opened.prNumber !== undefined ? `PR #${opened.prNumber}` : "the open PR";
   const prUrl = opened.prNumber !== undefined ? `https://github.com/${input.repo}/pull/${opened.prNumber}` : undefined;

--- a/apps/dev/tests/backpressure.test.ts
+++ b/apps/dev/tests/backpressure.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  BACKPRESSURE_REVIEW_HEADER,
   DEFAULT_BACKPRESSURE_TIMEOUT_MS,
+  renderBackpressureReviewBody,
   runBackpressure,
+  type BackpressureCheck,
   type BackpressureExec,
 } from "../src/core/backpressure.js";
 import { KILLED_EXIT_CODE } from "../src/runtime/exec.js";
@@ -183,5 +186,62 @@ describe("runBackpressure", () => {
     expect(hung?.record.summary).toBe("command timed out after 250ms");
     // The earlier command still passed — only the hung one blocks.
     expect(result.checks.find((c) => c.name === "backpressure:npm run test")?.status).toBe("passed");
+  });
+});
+
+describe("renderBackpressureReviewBody (#1279)", () => {
+  /** Build a minimal {@link BackpressureCheck} for the rendering tests. */
+  function check(command: string, status: "passed" | "failed", summary?: string): BackpressureCheck {
+    return {
+      name: `backpressure:${command}`,
+      command,
+      status,
+      record: { schema: "red.afk.validation.v1", name: `backpressure:${command}`, status, summary },
+    };
+  }
+
+  it("renders NOTHING (null) for an empty check list — an empty ledger is never a review", () => {
+    expect(renderBackpressureReviewBody([])).toBeNull();
+  });
+
+  it("aggregates mixed pass/fail into ONE body with the correct per-check lines", () => {
+    const body = renderBackpressureReviewBody([
+      check("npm run test", "passed"),
+      check("npm run lint", "failed", "lint broke here"),
+      check("npm run build", "passed"),
+    ]);
+
+    // Header states, in-band, that the ledger is non-blocking observability.
+    expect(body).not.toBeNull();
+    const lines = (body as string).split("\n");
+    expect(lines[0]).toBe(BACKPRESSURE_REVIEW_HEADER);
+    expect(BACKPRESSURE_REVIEW_HEADER).toContain("non-blocking");
+    expect(BACKPRESSURE_REVIEW_HEADER).toContain("unchanged");
+    // Both positive and negative checks are included, one line each, in order.
+    expect(lines).toContain("✅ backpressure:npm run test");
+    expect(lines).toContain("❌ backpressure:npm run lint → lint broke here");
+    expect(lines).toContain("✅ backpressure:npm run build");
+    // ONE aggregated body — a single COMMENT review, never one per check.
+    expect(lines.filter((l) => l.startsWith("✅") || l.startsWith("❌"))).toHaveLength(3);
+    // Never carries approve/request-changes gate semantics.
+    expect(body).not.toMatch(/APPROVE|REQUEST_CHANGES/);
+  });
+
+  it("falls back to a generic summary when a failed check carries none", () => {
+    const body = renderBackpressureReviewBody([check("flaky", "failed")]);
+    expect(body).toContain("❌ backpressure:flaky → command failed");
+  });
+
+  it("flows straight from runBackpressure output — passed-only ledger has no ❌ line", async () => {
+    const { exec } = fakeExec();
+    const result = await runBackpressure(exec, {
+      worktree: "/wt",
+      commands: ["npm run test", "npm run lint"],
+      now: fakeClock(),
+    });
+    const body = renderBackpressureReviewBody(result.checks);
+    expect(body).toContain("✅ backpressure:npm run test");
+    expect(body).toContain("✅ backpressure:npm run lint");
+    expect(body).not.toContain("❌");
   });
 });

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -42,6 +42,8 @@ interface Trace {
   ensuredLabels: string[];
   /** validation.jsonl writes: (path, lines) per write. */
   sidecarWrites: Array<{ path: string; lines: string[] }>;
+  /** Non-blocking backpressure evidence reviews posted via the #1279 seam. */
+  backpressureReviews: Array<{ pr: number; body: string }>;
   /** Memory reasoning-attempt records fired after a terminal envelope. */
   recordedAttempts: AttemptRecordPayload[];
   /** Brain outcome events fired after terminal attempt completion. */
@@ -226,6 +228,7 @@ function harness(opts: HarnessOptions = {}): {
     listByLabelCalls: [],
     ensuredLabels: [],
     sidecarWrites: [],
+    backpressureReviews: [],
     recordedAttempts: [],
     outcomeEvents: [],
     salvageCalls: [],
@@ -440,6 +443,11 @@ function harness(opts: HarnessOptions = {}): {
       stderr: "",
     }),
     backpressureCommands: opts.backpressureCommands,
+    // Non-blocking backpressure evidence review seam (#1279): record every
+    // aggregated COMMENT review the engine posts once the PR number is known.
+    postBackpressureReview: async (pr, body) => {
+      trace.backpressureReviews.push({ pr, body });
+    },
     goVerifyRetries: opts.goVerifyRetries,
     sandboxMode: opts.sandboxMode ?? "none",
     sandboxAvailable: async (mode) => (opts.availableSandboxes ?? ["docker", "podman"]).includes(mode),
@@ -1387,6 +1395,61 @@ describe("processIssue — no-sentinel (run ended without a <promise>)", () => {
     const { deps, input, trace } = harness({ outcome: "done" });
     await processIssue(deps, input);
     expect(trace.runAgentCalls[0]?.handoffContent ?? "").not.toContain("<merge-gate>");
+  });
+
+  it("posts ONE aggregated non-blocking backpressure review on the PR, the merge/close unchanged (#1279)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: true,
+      locked: false,
+    });
+    const result = await processIssue(deps, input);
+
+    // Merge/close decision is byte-for-byte the pre-#1279 behaviour.
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+
+    // Exactly ONE aggregated COMMENT review, on the landed PR (#42), all-green.
+    expect(trace.backpressureReviews).toHaveLength(1);
+    const review = trace.backpressureReviews[0]!;
+    expect(review.pr).toBe(42);
+    expect(review.body).toContain("✅ backpressure:npm run e2e");
+    // In-band statement that the ledger is non-blocking observability.
+    expect(review.body).toContain("non-blocking");
+    expect(review.body).not.toMatch(/APPROVE|REQUEST_CHANGES/);
+  });
+
+  it("posts NO review when no backpressure command is configured — an empty ledger is never a review (#1279)", async () => {
+    const { deps, input, trace } = harness({ outcome: "done", feedbackOk: true, locked: false });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    expect(trace.backpressureReviews).toEqual([]);
+  });
+
+  it("a FAILED backpressure command parks blocked:validation exactly as before, posting no review (no-new-blocking, #1279)", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      backpressureCommands: ["npm run e2e"],
+      backpressureOk: false,
+      locked: false,
+    });
+    const result = await processIssue(deps, input);
+
+    // The park is the pre-#1279 behaviour: blocked:validation, never merged.
+    expect(result.outcome).toBe("feedback-failed");
+    expect(labelTrace(trace)).toEqual([
+      "-ready-for-agent|+running",
+      "-running|+ready-for-human+blocked:validation",
+    ]);
+    expect(trace.pushedAttempt).toEqual([]);
+    // The failing gate blocks BEFORE any PR is opened → no surface to attach the
+    // ledger to; the review path fires nothing and cannot change the park.
+    expect(trace.backpressureReviews).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1279. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1279

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786034402&installation_id=129708444&pr_number=1280&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1280&signature=f813e2b5cd27ac6932d8fcdda066ca30c4c63855d0e8312187774ff3db3fe43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-blocking review summary for backpressure checks, so PRs can show a single consolidated status comment after checks run.
  * PR landing can now emit a best-effort update when the PR number is resolved, without affecting merge decisions.

* **Bug Fixes**
  * Improved handling of failed or missing backpressure details by showing a clear fallback message instead of leaving the review empty.
  * Ensured the new review comment is skipped when there’s nothing to report or when backpressure isn’t configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->