### PR TITLE
docs(readme): reflect v2 npm transport cutover + backpressure PR-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Attribution is preserved in [NOTICE](./NOTICE).
 Recommended for normal installs and upgrades:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash
 ```
 
 The installer resolves the latest GitHub Release, stores it under
@@ -58,22 +58,22 @@ Useful options:
 
 ```bash
 # inspect without writing
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --dry-run
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --dry-run
 
 # install only one host
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --only opencode
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --only opencode
 
 # pin a release
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --version v1.248.1
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --version v2.6.0
 
 # force plugin reinstall where the host supports removal
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --force
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --force
 
 # uninstall from every detected host
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --uninstall
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --uninstall
 
 # uninstall and remove the ~/.red-skills release cache
-curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v1/scripts/install.sh | bash -s -- --uninstall --purge
+curl -fsSL https://raw.githubusercontent.com/reddb-io/red-skills/v2/scripts/install.sh | bash -s -- --uninstall --purge
 ```
 
 After installing, restart any already-open CLI sessions so they reload plugin
@@ -471,17 +471,17 @@ for adopter repos that want cloud execution without a local fleet.
 | --- | --- | --- |
 | Trigger + policy | [`reusable-afk-attempt.yml`](./.github/workflows/reusable-afk-attempt.yml) | `workflow_call`, manual dispatch, and trust gate. |
 | Execution | [`.github/actions/afk-attempt`](./.github/actions/afk-attempt/action.yml) | Sets up Node, runner CLI, auth env, and invokes the AFK launcher. |
-| Runtime distribution | `afk.mjs` + GitHub Release assets | Fetches the versioned `dev` bundle matching the checked-out red-skills ref. |
+| Runtime distribution | `afk.mjs` + the `@reddb-io/red-skills` npm package | Resolves the versioned `dev` bundle matching the checked-out red-skills ref via npm (ADR 0091), cache-first. |
 
 Adoption paths:
 
 - **Turnkey caller:** install or copy an `rs-afk-attempt.yml` caller that wires
   issue/manual triggers to
-  `reddb-io/red-skills/.github/workflows/reusable-afk-attempt.yml@v1`.
+  `reddb-io/red-skills/.github/workflows/reusable-afk-attempt.yml@v2`.
 - **Composable action:** use
-  `reddb-io/red-skills/.github/actions/afk-attempt@v1` from your own workflow.
+  `reddb-io/red-skills/.github/actions/afk-attempt@v2` from your own workflow.
 
-Pin `@v1` to track the latest compatible v1 release. Pin a SHA when the caller
+Pin `@v2` to track the latest compatible v2 release. Pin a SHA when the caller
 needs a fully immutable action/runtime pair.
 
 Workflow naming convention:
@@ -513,12 +513,20 @@ Full guide: [AFK Actions lane](./plugins/dev/skills/engineering/afk/actions-lane
 | [`packages/cdp-driver`](./packages/cdp-driver) | CDP-based live-app driver for `red-browser`: connects to Chrome via DevTools Protocol, captures a11y-tree snapshots, and streams console/network events. |
 | [`packages/build-info`](./packages/build-info) | Shared runtime build metadata helpers consumed by bundled apps. |
 | [`packages/red-castle`](./packages/red-castle) | AFK execution substrate (vendored submodule, `@reddb-io/red-castle`): sandcastle fork that owns per-attempt worktree isolation, agent spawning, and signal detection. |
+| [`packaging/npm`](./packaging/npm) | The publishable `@reddb-io/red-skills` npm package (outside the pnpm workspace): built plugin bundles plus the three `red-skills-*` bin shims. The v2 client transport (ADR 0091). |
 | [`.red`](./.red) | RedSkills' own project configuration: context map, glossaries, ADRs, issue-tracker docs, and agent rules. |
 | [`.github/workflows`](./.github/workflows) | Release, CI, upstream watch, issue automation, PR review, and reusable AFK attempt workflows. |
 
 Installed plugin trees are definitions and launchers. Runtime bundles are built
-from `apps/*` and shipped as GitHub Release assets. Session-start hooks fetch the
-right bundle into the local RedSkills cache.
+from `apps/*` and shipped inside the [`@reddb-io/red-skills`](./packaging/npm)
+npm package (ADR 0091) — one tarball carrying the `dev`, `memory`, and `brain`
+JS bundles plus the `red-skills-dev` / `red-skills-memory` / `red-skills-brain`
+bin shims. Session-start launchers resolve the version-pinned package via npm
+(`npx -y @reddb-io/red-skills@<pin>` semantics), cache-first, and integrity is
+npm's own tarball shasum — no GitHub-release download and no client-side
+signature step. The Memory/Brain native `red` engine binary is the one
+per-platform artifact that cannot ride in the tarball; those plugins resolve it
+separately at runtime.
 
 ## Configuration
 
@@ -552,6 +560,24 @@ Model defaults and escalation rules are documented in
 [`model-tier-policy`](./plugins/dev/skills/engineering/model-tier-policy/SKILL.md).
 The runtime source of truth is `CONFIG_DEFAULTS` in
 [`apps/dev/src/core/config.ts`](./apps/dev/src/core/config.ts).
+
+Operator-declared pre-merge checks (backpressure):
+
+```yaml
+plugins:
+  dev:
+    afk:
+      backpressure:
+        - pnpm lint
+        - cargo fmt --check
+```
+
+`afk.backpressure` is an ordered list of shell commands run in the worker-branch
+worktree after the implicit feedback gate (test/typecheck/lint/build) passes on
+the DONE path. Any non-zero command blocks the merge and parks the issue exactly
+like a feedback failure. When the list is non-empty, every executed check — pass
+and fail alike — is also rendered as a single aggregated, non-blocking `COMMENT`
+PR review, so the PR carries a legible evidence ledger without adding a new gate.
 
 House rules:
 
@@ -604,10 +630,12 @@ the runtime apps and shared packages while excluding unrelated heavy packages
 where needed.
 
 Release is automated by [red-release.yml](./.github/workflows/red-release.yml):
-pushes to `main` with release-worthy commits bump versions, build bundles,
-publish release assets, update plugin metadata, and move the matching major tag
-such as `v1` to the same release commit so reusable workflows pinned to `@v1`
-keep advancing.
+pushes to `main` with release-worthy commits bump versions, build bundles, stage
+them into the `@reddb-io/red-skills` npm package, run the real packaged client
+against the packed tarball as a producer/consumer contract check, `npm publish`,
+smoke the published package from the registry, update plugin metadata, cut a git
+tag with a GitHub Release, and move the matching major tag such as `v2` to the
+same release commit so reusable workflows pinned to `@v2` keep advancing.
 
 The `release` job runs in the GitHub environment named `red-release`. Repository
 settings must keep that environment protected with required reviewers, because


### PR DESCRIPTION
## What

Refreshes the root README for the last 7 days of user-facing change. Two themes:

### 1. npm transport cutover (ADR 0091, v2 line)
The plugin-bundle runtime transport moved from GitHub-release assets + sigstore to the `@reddb-io/red-skills` npm package. README updated to match reality:
- **Runtime distribution** narrative rewritten: tarball-shipped `dev`/`memory`/`brain` bundles + `red-skills-{dev,memory,brain}` bin shims, `npx`-pinned cache-first resolution, npm-shasum integrity, no client signature step. Notes the native `red` engine binary is still resolved separately.
- All install/adopter pins repointed **v1 → v2**: `install.sh` curl URLs, `reusable-afk-attempt.yml@v2` / `afk-attempt@v2`, example `--version v2.6.0`, and the major-tag prose.
- `packaging/npm` added to the Repo Layout table.
- Release-workflow description updated to the npm publish + packed-tarball contract check + registry-smoke pipeline.

### 2. Operator-declared backpressure + PR-review evidence ledger
Documents `afk.backpressure` (ordered pre-merge command list) in Configuration, and the new **non-blocking aggregated `COMMENT` PR review** that renders every executed check — pass and fail — as a legible evidence ledger (PR #1280).

## Notes
- install.sh and the memory/brain engine binaries still legitimately use GitHub Release — that is distinct from the npm plugin-bundle transport and left intact.
- Scope confirmed with maintainer: broad survey + repoint everything to `@v2`.

Diff: +45 / −17, README-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786035529&installation_id=129708444&pr_number=1281&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1281&signature=9c845543c30721bb581dde367fff610e5b595b481f83cd6497f62007022bbde5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->