### PR TITLE
fix(afk): fast-forward the primary's local base after a successful landing

### DIFF
--- a/.red/adr/0083-afk-single-source-invariants.md
+++ b/.red/adr/0083-afk-single-source-invariants.md
@@ -74,6 +74,28 @@ local merge into the locked branch (ADR 0030/0031) is replaced by a push to
 its base/target semantics — only the write moves from the primary checkout to
 the remote.
 
+#### Amendment (2026-07-07): the guarded post-merge fast-forward
+
+The original "no primary write" rule left a repo running
+`lock.primary-branch: true` with a local base that **derives behind origin every
+session** — the maintainer was expected to "promote by pulling", and in practice
+never did (observed 415 commits behind, most of it fleet-landed work). Because
+AFK worker worktrees fork from the primary's **local** `<base>`, the next slice
+then branches from a stale base and silently fails validation on fixes that only
+landed on origin.
+
+So §2 is relaxed for exactly one operation: after a **successful** landing, the
+finalizer advances the primary's local `<base>` to the merged origin tip via
+`fastForwardLocalTarget` (`apps/dev/src/core/merge.ts`), for **both** lock
+states. The §2 **safety intent** — never eat primary WIP (the #1019 failure) — is
+preserved by making that promotion a guaranteed no-op on any primary it must not
+touch: it runs only when the primary is **on** `<base>`, its working tree is
+**clean**, and the local `<base>` is a **strict ancestor** of the remote tip; it
+uses `merge --ff-only` only — never `reset`, `rebase`, or a `--no-ff` merge
+commit. A destructive write to the primary remains a hard failure. Net: the
+letter ("no primary write") is narrowed, the intent ("no landing destroys the
+operator's WIP") is unchanged.
+
 ### 3. Liveness lane (owner: red-castle)
 
 Red-castle exposes the canonical "is this attempt alive" signal:

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -27,6 +27,7 @@
 // result (`mergeSha`) since the primary HEAD no longer advances.
 
 import {
+  fastForwardLocalTarget,
   integrateOrigin,
   landMerge,
   landPr,
@@ -616,6 +617,11 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
         return { ok: false, reason: "land-failed", locked: input.locked };
       }
       const mergeSha = (await deps.mergeExec(["git", "-C", landDir, "rev-parse", "--short", "HEAD"])).stdout.trim();
+      // Promote the primary's local <base> to the just-pushed origin tip — the
+      // direct path lands entirely in the worktree, so without this the primary
+      // never advances and its local base rots (ADR 0083 §2 amended). The helper
+      // is a guaranteed no-op on any primary it must not touch.
+      await fastForwardLocalTarget(deps.mergeExec, { gitRepo: input.repoDir, remote: input.remote, target: input.base });
       return { ok: true, locked: input.locked, mergeSha: mergeSha || undefined };
     }
 
@@ -667,6 +673,9 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     // The merge commit lives on the worktree's HEAD (and now origin/<base>); the
     // primary HEAD did not advance, so carry the landed sha back for the close.
     const mergeSha = (await deps.mergeExec(["git", "-C", landDir, "rev-parse", "--short", "HEAD"])).stdout.trim();
+    // Best-effort promote the primary's local <base> to the merged origin tip
+    // (ADR 0083 §2 amended) — guarded to never touch a dirty or diverged primary.
+    await fastForwardLocalTarget(deps.mergeExec, { gitRepo: input.repoDir, remote: input.remote, target: input.base });
     return { ok: true, locked: input.locked, mergeSha: mergeSha || undefined };
   } finally {
     await deps.removeLandingWorktree?.(landDir);

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -519,12 +519,12 @@ export interface LandPrInput {
   /** Worktree dir to force-push the attempt branch from; skipped when absent. */
   worktree?: string;
   /**
-   * Untouchable primary (ADR 0083 §2, #1019). When the landing is LOCKED, the
-   * primary checkout is read-only with NO exceptions — including the branch-lock
-   * landing — so the step-4 best-effort local fast-forward of `<target>` is
-   * SKIPPED: the integration lands on `origin/<target>` (the admin-merge is
-   * remote) and the maintainer promotes by pulling. Absent/false (the UNLOCKED
-   * default) keeps the local fast-forward unchanged (issue #1019 criterion 3).
+   * Session lock state, retained for caller compatibility and result
+   * observability. It no longer gates the step-4 local fast-forward (ADR 0083 §2
+   * amended): {@link fastForwardLocalTarget} now promotes the primary for both
+   * lock states, guarded so it is a guaranteed no-op on any primary it must not
+   * touch — the #1019 WIP-eating failure mode stays impossible without keeping a
+   * locked repo's local base permanently stale.
    */
   locked?: boolean;
   /**
@@ -574,6 +574,53 @@ export interface LandPrResult {
 const PR_BODY_PREFIX = "Automated AFK landing for #";
 
 /**
+ * Best-effort, non-destructive fast-forward of the primary checkout's local
+ * `<target>` to `<remote>/<target>` after a successful landing. This is the
+ * post-merge promotion the operator would otherwise do by hand: without it a
+ * repo running `lock.primary-branch: true` leaves local `main` deriving *behind*
+ * origin every session (observed 415 commits behind), and because AFK worker
+ * worktrees fork from the primary's LOCAL `main`, the next slice branches from
+ * that stale base and silently fails validation on fixes that only landed on
+ * origin. ADR 0083 §2's amendment (2026-07-07) documents the carve-out.
+ *
+ * Runs for BOTH lock states (ADR 0083 §2 amended). The §2 invariant existed to
+ * stop a landing from EATING primary WIP (#1019's pre-merge snapshot). That
+ * SAFETY intent is preserved here — this can never touch a dirty or diverged
+ * primary — while its literal "no primary write, no exceptions" is relaxed so
+ * locked repos stop rotting their local base:
+ *   1. no-op unless the primary is actually ON `<target>` (a locked primary is
+ *      pinned to main; if the human moved HEAD, leave it alone);
+ *   2. no-op if the working tree is DIRTY (uncommitted WIP is sacred, #1019);
+ *   3. no-op unless local `<target>` is a strict ancestor of the remote tip
+ *      (a 0-ahead pure fast-forward — an ahead/diverged local never gets a
+ *      merge commit or a reset);
+ *   4. `merge --ff-only` only — never `reset`, never `--no-ff`.
+ * Every git call is best-effort; any non-zero exit leaves the primary untouched.
+ */
+export async function fastForwardLocalTarget(
+  exec: Exec,
+  input: { gitRepo: string; remote: string; target: string },
+): Promise<void> {
+  const { gitRepo, remote, target } = input;
+  // 1. Only advance the branch the operator is actually on.
+  const head = await exec(["git", "-C", gitRepo, "symbolic-ref", "--short", "HEAD"]);
+  if (head.code !== 0 || head.stdout.trim() !== target) return;
+  // 2. A dirty primary keeps pending WIP — never write over it (#1019).
+  const status = await exec(["git", "-C", gitRepo, "status", "--porcelain"]);
+  if (status.code !== 0 || status.stdout.trim() !== "") return;
+  // Refresh the remote ref so the ancestry test and the FF see the merge.
+  await exec(["git", "-C", gitRepo, "fetch", remote, target, "--quiet"]);
+  // 3. Pure fast-forward only: local <target> must be an ancestor of the tip.
+  const ancestor = await exec([
+    "git", "-C", gitRepo,
+    "merge-base", "--is-ancestor", target, `${remote}/${target}`,
+  ]);
+  if (ancestor.code !== 0) return;
+  // 4. Advance the pointer. ff-only can only succeed as a pure fast-forward.
+  await exec(["git", "-C", gitRepo, "merge", "--ff-only", `${remote}/${target}`]);
+}
+
+/**
  * UNLOCKED landing (ADR 0030): land the attempt via a PR into `<target>`. Steps
  * mirror land_pr in afk.sh:
  *   1. force-push the attempt branch to `<remote>` (when a worktree is given);
@@ -585,7 +632,10 @@ const PR_BODY_PREFIX = "Automated AFK landing for #";
  * Idempotent: a re-attempt reuses the open PR rather than creating a second.
  */
 export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResult> {
-  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, locked, onPrResolved } = input;
+  // `locked` (LandPrInput) is no longer read here: step 4 promotes the primary
+  // for both lock states via the hardened fastForwardLocalTarget, which is a
+  // guaranteed no-op on any primary it must not touch.
+  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, onPrResolved } = input;
 
   // 1. Make the attempt branch's origin state certain before opening the PR.
   if (worktree) {
@@ -644,16 +694,12 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   const merge = await exec(mergeArgs);
   if (merge.code !== 0) return { ok: false, prNumber, reason: "merge-failed" };
 
-  // 4. Fast-forward local <target> to the merge commit (best-effort) — UNLOCKED
-  // ONLY. A LOCKED landing must never write to the primary checkout (ADR 0083 §2,
-  // untouchable primary, no exceptions — including the branch-lock landing): the
-  // integration already lives on `origin/<target>` after the remote merge,
-  // and the maintainer promotes by pulling, so the primary's local `<target>` is
-  // left untouched. The UNLOCKED path keeps its fast-forward (issue #1019 crit. 3).
-  if (!locked) {
-    await exec(["git", "-C", gitRepo, "fetch", remote, target, "--quiet"]);
-    await exec(["git", "-C", gitRepo, "merge", "--ff-only", `${remote}/${target}`]);
-  }
+  // 4. Promote the primary's local <target> to the freshly merged origin tip —
+  // for BOTH lock states now (ADR 0083 §2 amended). Hardened so it can never
+  // touch a dirty or diverged primary, so a locked repo no longer leaves local
+  // main deriving behind origin while its worker worktrees keep forking from
+  // that stale base (see fastForwardLocalTarget).
+  await fastForwardLocalTarget(exec, { gitRepo, remote, target });
 
   return { ok: true, prNumber };
 }

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -42,6 +42,13 @@ interface Harness {
 interface Opts {
   locked?: boolean;
   /**
+   * Make the primary checkout's working tree DIRTY (`git status --porcelain`
+   * returns a modified path). Drives the fastForwardLocalTarget WIP guard: a
+   * dirty primary must skip the post-merge promotion (ADR 0083 §2's #1019
+   * safety intent), even though §2's literal no-write rule is relaxed.
+   */
+  dirtyPrimary?: boolean;
+  /**
    * Landing MODE (#842), decoupled from the lock. Defaults to `!locked` so the
    * pre-#842 coupling is preserved for the existing path tests (locked → direct,
    * unlocked → PR); the (lock × flag) matrix suite below sets it explicitly to
@@ -125,6 +132,14 @@ function harness(opts: Opts = {}): Harness {
     mergeExec: async (argv): Promise<ExecResult> => {
       mergeCalls.push(argv);
       const j = argv.join(" ");
+      // fastForwardLocalTarget probes (ADR 0083 §2 amended): the primary sits on
+      // <base>, and its tree is clean unless the test opts into dirtyPrimary.
+      if (j.includes("symbolic-ref --short HEAD")) {
+        return { code: 0, stdout: `${input.base}\n`, stderr: "" };
+      }
+      if (j.includes("status --porcelain")) {
+        return { code: 0, stdout: opts.dirtyPrimary ? " M apps/dev/src/x.ts\n" : "", stderr: "" };
+      }
       if (j.includes("merge-base --is-ancestor origin/")) {
         return { code: opts.branchTip ? 0 : 1, stdout: "", stderr: "" };
       }
@@ -691,15 +706,19 @@ describe("doLanding — locked conflict self-resolve", () => {
 describe("doLanding — the primary checkout is sacred (#572)", () => {
   // Acceptance: a push-reject rollback never `git reset --hard`s the primary
   // working tree, and primary WIP survives a failed land. The locked merge/push/
-  // rollback all run in the isolated worktree (`/wt`); the ONLY `git -C /repo`
-  // touch is the non-destructive attempt-branch push (via remoteGit).
+  // rollback all run in the isolated worktree (`/wt`). The one allowed `git -C
+  // /repo` write is the guarded post-merge ff-only promotion (ADR 0083 §2
+  // amended); a DESTRUCTIVE op (reset, rebase, or a `--no-ff` merge commit) must
+  // never target the primary checkout.
   function assertPrimaryUntouched(h: Harness): void {
     const primaryOps = h.mergeCalls.filter((c) => c.includes("-C") && c.includes("/repo"));
-    // No destructive op ever targets the primary checkout.
     for (const op of primaryOps) {
       expect(op.includes("reset")).toBe(false);
-      expect(op.includes("merge")).toBe(false);
       expect(op.includes("rebase")).toBe(false);
+      // `merge` element (not `merge-base`) is allowed only as a pure ff.
+      if (op.includes("merge")) {
+        expect(op.includes("--ff-only")).toBe(true);
+      }
     }
   }
 
@@ -980,51 +999,69 @@ describe("doLanding — landing mode decoupled from the lock (lock × flag matri
   });
 });
 
-describe("doLanding — untouchable primary in the LOCKED landing (ADR 0083 §2, #1019)", () => {
-  // ADR 0083 §2: the primary checkout is READ-ONLY for agents, with NO exceptions
-  // — including the branch-lock landing. The integrated result reaches the
-  // maintainer only via `origin/<locked-branch>`; the maintainer promotes by
-  // pulling. So NO landing path may run a git WRITE verb against the primary
-  // (`git -C /repo`). The only legitimate `git -C /repo` touches are the
-  // read-only precondition probes (fetch a remote ref, rev-parse, merge-base).
-  const WRITE_VERBS = new Set(["merge", "reset", "rebase", "checkout", "switch", "commit", "cherry-pick"]);
-  /** Every `git -C /repo …` call carrying a mutating verb (`merge --ff-only`
-   * included; the read-only `merge-base` token is deliberately NOT `merge`). */
-  function primaryWrites(h: Harness): string[] {
+describe("doLanding — primary promotion is a guarded fast-forward only (ADR 0083 §2 amended, #1019)", () => {
+  // ADR 0083 §2 (amended): a landing may now advance the primary's local <base>
+  // to the freshly merged origin tip — for LOCKED landings too — via the
+  // hardened fastForwardLocalTarget, so a locked repo's local base stops rotting
+  // and the next worker forks a fresh base. The §2 SAFETY intent is preserved:
+  // the ONLY primary write any landing path may issue is `merge --ff-only`, and
+  // never on a dirty or diverged primary. A DESTRUCTIVE verb against `/repo`
+  // (`merge --no-ff`, reset, rebase, checkout, switch, commit, cherry-pick)
+  // remains categorically forbidden.
+  const DESTRUCTIVE_VERBS = new Set(["reset", "rebase", "checkout", "switch", "commit", "cherry-pick"]);
+  /** `git -C /repo …` calls that mutate primary content beyond a pure ff — the
+   * forbidden set. `merge --ff-only` is the one allowed primary write, so a
+   * `merge` token counts only when it is NOT `--ff-only`. */
+  function destructivePrimaryWrites(h: Harness): string[] {
     return h.mergeCalls
       .filter((argv) => {
         const i = argv.indexOf("/repo");
-        return i >= 1 && argv[i - 1] === "-C" && argv.some((tok) => WRITE_VERBS.has(tok));
+        if (i < 1 || argv[i - 1] !== "-C") return false;
+        const destructiveMerge = argv.includes("merge") && !argv.includes("--ff-only");
+        return destructiveMerge || argv.some((tok) => DESTRUCTIVE_VERBS.has(tok));
       })
       .map((argv) => argv.join(" "));
   }
 
-  it("locked + PR (default flag) → admin-merges remotely, NEVER fast-forwards the primary's local lock branch", async () => {
+  it("locked + PR (default flag) → admin-merges remotely AND guard-fast-forwards the primary's local lock branch", async () => {
     const h = harness({ locked: true, openPr: true });
     h.input.base = "feature-locked";
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: true });
     const j = joined(h.mergeCalls);
-    // The PR is admin-merged remotely — the integration lands on origin, not local.
+    // The PR is admin-merged remotely — the integration lands on origin.
     expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
-    // The step-4 best-effort local fast-forward of the primary's lock branch is GONE.
-    expect(j.some((c) => c.includes("git -C /repo merge --ff-only"))).toBe(false);
-    expect(j.some((c) => c.includes("git -C /repo fetch origin feature-locked"))).toBe(false);
-    // No landing path wrote to the primary checkout.
-    expect(primaryWrites(h)).toEqual([]);
+    // The guarded promotion now advances the primary's local lock branch too.
+    expect(j).toContain("git -C /repo merge --ff-only origin/feature-locked");
+    // …but no destructive write ever touches the primary.
+    expect(destructivePrimaryWrites(h)).toEqual([]);
   });
 
-  it("locked + direct → integrates/merges/pushes only in the isolated worktree, primary write-free", async () => {
+  it("locked + PR on a DIRTY primary → skips the promotion (WIP is sacred, #1019)", async () => {
+    const h = harness({ locked: true, openPr: true, dirtyPrimary: true });
+    h.input.base = "feature-locked";
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true });
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
+    // The dirty-tree guard makes the promotion a no-op — the primary is untouched.
+    expect(j.some((c) => c.includes("git -C /repo merge --ff-only"))).toBe(false);
+    expect(destructivePrimaryWrites(h)).toEqual([]);
+  });
+
+  it("locked + direct → merges/pushes in the worktree, then guard-fast-forwards the primary", async () => {
     const h = harness({ locked: true, openPr: false });
     h.input.base = "feature-locked";
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
     // The integrated result reaches the maintainer on origin/<lock-branch>.
     expect(joined(h.mergeCalls)).toContain(`git -C ${WT} push origin HEAD:refs/heads/feature-locked`);
-    expect(primaryWrites(h)).toEqual([]);
+    // The primary's local lock branch is promoted by the guarded ff, nothing more.
+    expect(joined(h.mergeCalls)).toContain("git -C /repo merge --ff-only origin/feature-locked");
+    expect(destructivePrimaryWrites(h)).toEqual([]);
   });
 
-  it("locked + direct conflict self-resolve stays in the worktree, primary write-free", async () => {
+  it("locked + direct conflict self-resolve stays in the worktree, primary destructive-write-free", async () => {
     const h = harness({ locked: true, openPr: false, mergeNoFfCode: 1, conflictResolve: "resolve" });
     h.input.base = "feature-locked";
     const r = await doLanding(h.deps, h.input, h.hooks);
@@ -1032,7 +1069,7 @@ describe("doLanding — untouchable primary in the LOCKED landing (ADR 0083 §2,
     // The resolver ran in the worktree, and the resolved lock branch pushed from it.
     expect(h.resolverCwds).toEqual([WT]);
     expect(joined(h.mergeCalls)).toContain(`git -C ${WT} push origin HEAD:refs/heads/feature-locked`);
-    expect(primaryWrites(h)).toEqual([]);
+    expect(destructivePrimaryWrites(h)).toEqual([]);
   });
 
   it("UNLOCKED PR landing is unchanged — still fast-forwards the primary's local main (criterion 3)", async () => {

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  fastForwardLocalTarget,
   integrateOrigin,
   landMerge,
   landPr,
@@ -187,6 +188,11 @@ describe("landPr (unlocked path)", () => {
       if (cmd.includes("pr list")) {
         return { code: 0, stdout: prMade ? "77\n" : "\n", stderr: "" };
       }
+      // fastForwardLocalTarget guards: on the target branch, clean tree (empty
+      // porcelain, the default), and a pure fast-forward (is-ancestor code 0).
+      if (cmd.includes("symbolic-ref --short HEAD")) {
+        return { code: 0, stdout: "main\n", stderr: "" };
+      }
       return { code: 0, stdout: "", stderr: "" };
     };
     const calls: string[][] = [];
@@ -271,12 +277,15 @@ describe("landPr (unlocked path)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("locked → admin-merges but NEVER fast-forwards the primary checkout (ADR 0083 §2, #1019)", async () => {
-    // Untouchable primary: a LOCKED landing integrates on origin/<target> only; the
-    // best-effort local ff of the primary's <target> is skipped so no write touches
-    // the primary checkout. The maintainer promotes by pulling.
+  it("locked → admin-merges AND now guard-fast-forwards the primary (ADR 0083 §2 amended)", async () => {
+    // The §2 invariant was about never EATING primary WIP (#1019). A locked
+    // landing on a clean primary sitting on <target> may safely advance the local
+    // base to the just-merged origin tip, so the next worker forks a fresh base.
     const { exec, calls } = fakeExec([
       { match: (a) => a.join(" ").includes("pr list"), result: { stdout: "42\n" } },
+      // Guards satisfied: on <target>, clean tree (empty porcelain default),
+      // pure fast-forward (is-ancestor code 0 default).
+      { match: (a) => a.join(" ").includes("symbolic-ref --short HEAD"), result: { stdout: "feature-locked\n" } },
     ]);
     const result = await landPr(exec, {
       repo: "reddb-io/red-skills",
@@ -290,11 +299,55 @@ describe("landPr (unlocked path)", () => {
     });
     expect(result.ok).toBe(true);
     const c = joined(calls);
-    // The admin-merge still ran (the integration lands remotely on origin).
     expect(c.some((x) => x.includes("pr merge 42 --merge"))).toBe(true);
-    // No local fast-forward, and no `git -C /repo` write op at all.
-    expect(c.some((x) => x.includes("git -C /repo merge --ff-only"))).toBe(false);
-    expect(c.some((x) => x.includes("git -C /repo fetch"))).toBe(false);
+    // The guarded promotion now runs for the locked path too.
+    expect(c).toContain("git -C /repo merge --ff-only origin/feature-locked");
+  });
+});
+
+describe("fastForwardLocalTarget (post-merge primary promotion, ADR 0083 §2 amended)", () => {
+  const base = { gitRepo: "/repo", remote: "origin", target: "main" } as const;
+  const onTarget = { match: (a: string[]) => a.join(" ").includes("symbolic-ref --short HEAD"), result: { stdout: "main\n" } };
+
+  it("fast-forwards a clean primary sitting on <target> with a pure-ff base", async () => {
+    const { exec, calls } = fakeExec([onTarget]);
+    await fastForwardLocalTarget(exec, base);
+    const c = joined(calls);
+    expect(c).toContain("git -C /repo fetch origin main --quiet");
+    expect(c).toContain("git -C /repo merge --ff-only origin/main");
+  });
+
+  it("no-ops when the primary is NOT on <target> (human moved HEAD)", async () => {
+    const { exec, calls } = fakeExec([
+      { match: (a) => a.join(" ").includes("symbolic-ref --short HEAD"), result: { stdout: "some-feature\n" } },
+    ]);
+    await fastForwardLocalTarget(exec, base);
+    const c = joined(calls);
+    // Bailed before touching the remote or the working tree.
+    expect(c.some((x) => x.includes("merge --ff-only"))).toBe(false);
+    expect(c.some((x) => x.includes("fetch"))).toBe(false);
+  });
+
+  it("no-ops on a DIRTY primary — pending WIP is sacred (#1019)", async () => {
+    const { exec, calls } = fakeExec([
+      onTarget,
+      { match: (a) => a.join(" ").includes("status --porcelain"), result: { stdout: " M apps/dev/src/x.ts\n" } },
+    ]);
+    await fastForwardLocalTarget(exec, base);
+    const c = joined(calls);
+    expect(c.some((x) => x.includes("merge --ff-only"))).toBe(false);
+    expect(c.some((x) => x.includes("fetch"))).toBe(false);
+  });
+
+  it("no-ops when local <target> is ahead/diverged (not a strict ancestor)", async () => {
+    const { exec, calls } = fakeExec([
+      onTarget,
+      { match: (a) => a.join(" ").includes("merge-base --is-ancestor"), result: { code: 1 } },
+    ]);
+    await fastForwardLocalTarget(exec, base);
+    const c = joined(calls);
+    // Fetch may run before the ancestry test, but no fast-forward is issued.
+    expect(c.some((x) => x.includes("merge --ff-only"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

The AFK/`/go` finalizer merges to **origin** and stops — it never advances the operator's local base. A repo running `lock.primary-branch: true` (this one) therefore leaves its local `main` deriving **behind** origin every session (observed **415 commits behind**, most of it fleet-landed work). Since AFK worker worktrees fork from the primary's **local** base, the next slice branches from a stale base and silently fails validation on fixes that only landed on origin — exactly the failure documented for stale-local-main.

Root cause: ADR 0083 §2 ("untouchable primary") said the primary is read-only **with no exceptions**, so the step-4 local fast-forward was skipped for every locked landing. The intent of §2 was narrower than its letter: it exists to stop a landing from **eating primary WIP** (#1019's pre-merge snapshot), not to keep the local base permanently stale.

## Fix

New hardened helper `fastForwardLocalTarget` (merge.ts), wired into **both** landing paths (`landPr` + `landDirectInWorktree`) for **both** lock states. It advances the primary's local `<base>` to the merged origin tip only when it is provably safe, and is otherwise a guaranteed no-op:

1. only when the primary is **on** `<base>` (HEAD check);
2. only when the working tree is **clean** (WIP is sacred, #1019);
3. only when local `<base>` is a **strict ancestor** of the remote tip (pure fast-forward — never a diverged/ahead local);
4. `merge --ff-only` only — never `reset`, `rebase`, or a `--no-ff` merge commit.

A destructive primary write remains a hard failure. **Net: §2's letter is narrowed, its safety intent is unchanged.**

## Changes
- `merge.ts` — export `fastForwardLocalTarget`; `landPr` calls it unconditionally (was UNLOCKED-only).
- `landing.ts` — `landDirectInWorktree` promotes the primary after both success paths.
- `.red/adr/0083` — amendment documenting the guarded carve-out.
- tests — helper guard-case unit tests; the §2 suites rewritten to assert the guarded ff is the ONLY allowed primary write and destructive verbs stay forbidden; a dirty-primary integration test proves the WIP guard holds.

## Verification
- `apps/dev` full suite: **3233 passed, 0 failed**; `tsc --noEmit` clean.

Maintainer directed a direct manual landing (no scout, no bug ticket).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786036858&installation_id=129708444&pr_number=1282&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1282&signature=e0f8650aa8190f173f63e1783beffc4c6802e4f76e4ab20ca6d6839b5935bc2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->