### PR TITLE
chore: #1285 Cascade gate in /to-prd and /to-issues: refuse to publish while referenced .red/ docs are unlanded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,20 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 - **why**: issue #1196 - new repository plugins should be born compliant with the RedSkills marketplace contract instead of being retrofitted after creation.
 - **what changed**: added the internal `create-plugin` maintainer skill and scaffolder. Generated plugins include Claude and Codex manifests, a two-section seed SKILL.md, README, CHANGES stub, structural smoke script, root README entry, and entries in both marketplace manifests. Added an acceptance test that scaffolds a fixture plugin and runs marketplace validation, skill frontmatter audit, and the generated smoke script with zero manual edits.
 
+## to-prd (engineering) — cascade gate before publish (issue #1285)
+
+- **status**: modified
+- **upstream**: `aaf2453` (upstream `to-prd`)
+- **why**: PRD #1283 — AFK workers branch from `origin/{base}` and cannot see primary-checkout working-tree edits; the cascade gate prevents publishing a PRD while the `.red/` docs it references are unlanded.
+- **what changed**: Added a new Step 3 "Cascade gate" before the publish step: `git fetch origin`, compare `.red/` docs between working tree and `origin/{base}` (origin-first comparison), run the `/start` end-of-session doc-landing procedure (ADR 0092) on mismatch, or abort loudly if landing is impossible. Old Step 3 (write + publish) renumbered to Step 4.
+
+## to-issues (engineering) — cascade gate before publish (issue #1285)
+
+- **status**: modified
+- **upstream**: `e74f006` (upstream `to-issues`)
+- **why**: PRD #1283 — same invariant as `/to-prd`: AFK workers cannot see unlanded docs; the gate must run before any issues enter `ready-for-agent`.
+- **what changed**: Added a new Step 5 "Cascade gate" between the quiz step and the publish step: identical origin-first comparison and doc-landing-procedure reference (ADR 0092), with loud abort when landing is impossible. Old Step 5 (publish) renumbered to Step 6. Added `cascade-gate-docs.test.ts` pinning the load-bearing gate phrases in both skills.
+
 ## start (engineering) — land grill-session docs before cascade (issue #1284)
 
 - **status**: modified

--- a/apps/dev/tests/cascade-gate-docs.test.ts
+++ b/apps/dev/tests/cascade-gate-docs.test.ts
@@ -1,0 +1,98 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+async function readSkill(relPath: string): Promise<string> {
+  return readFile(join(ROOT, relPath), "utf8");
+}
+
+describe("cascade gate docs contract — /to-prd", () => {
+  it("contains the cascade-gate directive with origin-first comparison", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-prd/SKILL.md"
+    );
+
+    expect(skill).toContain("Cascade gate");
+    expect(skill).toContain("git fetch origin");
+    expect(skill).toContain("origin/{base}");
+    expect(skill).toContain("origin-first comparison");
+    expect(skill).toContain("AFK workers");
+  });
+
+  it("references the doc-landing procedure and ADR 0092 instead of restating the git sequence", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-prd/SKILL.md"
+    );
+
+    expect(skill).toContain("doc-landing procedure");
+    expect(skill).toContain("ADR 0092");
+    expect(skill).toContain("/start");
+  });
+
+  it("aborts loudly when landing is impossible and never publishes while docs are unlanded", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-prd/SKILL.md"
+    );
+
+    expect(skill).toContain("abort");
+    expect(skill).toContain("never publish while docs are unlanded");
+  });
+
+  it("places the cascade gate before the publish step", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-prd/SKILL.md"
+    );
+
+    const gateIndex = skill.indexOf("Cascade gate");
+    // "Labels on publish:" is a phrase unique to the publish-step body
+    const publishIndex = skill.indexOf("Labels on publish:");
+    expect(gateIndex).toBeGreaterThan(0);
+    expect(publishIndex).toBeGreaterThan(gateIndex);
+  });
+});
+
+describe("cascade gate docs contract — /to-issues", () => {
+  it("contains the cascade-gate directive with origin-first comparison", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-issues/SKILL.md"
+    );
+
+    expect(skill).toContain("Cascade gate");
+    expect(skill).toContain("git fetch origin");
+    expect(skill).toContain("origin/{base}");
+    expect(skill).toContain("origin-first comparison");
+    expect(skill).toContain("AFK workers");
+  });
+
+  it("references the doc-landing procedure and ADR 0092 instead of restating the git sequence", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-issues/SKILL.md"
+    );
+
+    expect(skill).toContain("doc-landing procedure");
+    expect(skill).toContain("ADR 0092");
+    expect(skill).toContain("/start");
+  });
+
+  it("aborts loudly when landing is impossible and never publishes while docs are unlanded", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-issues/SKILL.md"
+    );
+
+    expect(skill).toContain("abort");
+    expect(skill).toContain("never publish while docs are unlanded");
+  });
+
+  it("places the cascade gate before the publish step", async () => {
+    const skill = await readSkill(
+      "plugins/dev/skills/engineering/to-issues/SKILL.md"
+    );
+
+    const gateIndex = skill.indexOf("Cascade gate");
+    const publishIndex = skill.indexOf("Publish in dependency order");
+    expect(gateIndex).toBeGreaterThan(0);
+    expect(publishIndex).toBeGreaterThan(gateIndex);
+  });
+});

--- a/plugins/dev/skills/engineering/to-issues/SKILL.md
+++ b/plugins/dev/skills/engineering/to-issues/SKILL.md
@@ -50,7 +50,15 @@ Then ask, **explicitly**:
 
 **Iterate until the user approves the breakdown.** Do not advance to Step 5 on silence or implicit approval.
 
-### Step 5 — Publish in dependency order
+### Step 5 — Cascade gate
+
+**Verify referenced `.red/` docs are landed on `origin/{base}` before publishing** — AFK workers branch from `origin/{base}` and cannot see the primary checkout's working-tree edits, so never publish while docs are unlanded.
+
+1. `git fetch origin`, then compare the `.red/` docs (`.red/CONTEXT.md`, `.red/CONTEXT-MAP.md`, `.red/contexts/**`, `.red/adr/**`) between the primary working tree and `origin/{base}` (base resolved lock > pin > main). "Landed" means reachable from `origin/{base}`, not merely present on disk — origin-first comparison, mirroring the `/review-adrs` convention.
+2. **On mismatch:** run the doc-landing procedure from the `/start` end-of-session finalizer (canonized by ADR 0092) first, then continue to Step 6.
+3. **If landing is impossible** (no network, no push access): abort — never publish while docs are unlanded. State clearly which files must be landed and stop.
+
+### Step 6 — Publish in dependency order
 
 For each approved slice, publish a new issue. Use the issue template in `<supporting-info>`.
 

--- a/plugins/dev/skills/engineering/to-prd/SKILL.md
+++ b/plugins/dev/skills/engineering/to-prd/SKILL.md
@@ -19,7 +19,13 @@ Check with the user that these seams match their expectations.
 
 **Capture every HITL call** made during the conversation that led to this PRD — testing seam choices, module shape choices, trade-offs the user took a side on, alternatives they rejected, constraints they imposed. These go into the `Human Decisions` section of the template. Do not silently fold them into `Implementation Decisions` — once `/to-issues` slices this PRD and `/afk` picks up the children, the human's calls become indistinguishable from agent inference unless they are flagged here.
 
-3. Write the PRD using the template below, then publish it to the project issue tracker.
+3. **Cascade gate — run before publishing.** AFK workers branch from `origin/{base}` and cannot see the primary checkout's working-tree edits, so never publish while docs are unlanded.
+
+   a. `git fetch origin`, then compare the `.red/` docs (`.red/CONTEXT.md`, `.red/CONTEXT-MAP.md`, `.red/contexts/**`, `.red/adr/**`) between the primary working tree and `origin/{base}` (base resolved lock > pin > main). "Landed" means reachable from `origin/{base}`, not merely present on disk — origin-first comparison, mirroring the `/review-adrs` convention.
+   b. **On mismatch:** run the doc-landing procedure from the `/start` end-of-session finalizer (canonized by ADR 0092) first, then continue to step 4.
+   c. **If landing is impossible** (no network, no push access): abort — never publish while docs are unlanded. State clearly which files must be landed and stop.
+
+4. Write the PRD using the template below, then publish it to the project issue tracker.
 
    **Labels on publish:** apply `type:prd` and `needs-slicing`. **Do not apply `ready-for-agent` to a PRD — a PRD is not an implementable unit; `/to-issues` must slice it first.** `/afk` hard-filters anything tagged `type:prd` so an accidental `ready-for-agent` will be ignored, but the right pre-condition is to not set it in the first place.
 


### PR DESCRIPTION
Automated AFK landing for #1285. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1285

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786129467&installation_id=129708444&pr_number=1304&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1304&signature=e1411b29df2777bdc303084180bc96c4f75a67a785318ca8425912bfe330fbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->