### PR TITLE
chore: #1288 /start: adopt grilling facts-vs-decisions distinction (upstream v1.1.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 - **why**: issue #1196 - new repository plugins should be born compliant with the RedSkills marketplace contract instead of being retrofitted after creation.
 - **what changed**: added the internal `create-plugin` maintainer skill and scaffolder. Generated plugins include Claude and Codex manifests, a two-section seed SKILL.md, README, CHANGES stub, structural smoke script, root README entry, and entries in both marketplace manifests. Added an acceptance test that scaffolds a fixture plugin and runs marketplace validation, skill frontmatter audit, and the generated smoke script with zero manual edits.
 
+## start (engineering) — facts-vs-decisions distinction in hard rules (issue #1288)
+
+- **status**: modified
+- **upstream**: `272f99b` (upstream `grilling`)
+- **why**: upstream v1.1.0 grilling fix — the old "explore instead of asking" rule could be read as license for the agent to answer decisions autonomously (self-grilling failure mode, especially with Fable). Facts can be looked up; decisions belong to the human.
+- **what changed**: replaced the blanket "explore when a question can be answered by reading code instead of asking" rule with three targeted rules: a ❌ prohibition on answering decisions yourself ("broken the interview"), a ✅ rule to look up facts in the codebase, and a ✅ rule to put every decision to the human and wait. Updated the docs-contract test to pin the three new load-bearing phrases.
+
 ## to-prd (engineering) — cascade gate before publish (issue #1285)
 
 - **status**: modified

--- a/apps/dev/tests/start-docs.test.ts
+++ b/apps/dev/tests/start-docs.test.ts
@@ -35,4 +35,15 @@ describe("start docs contract", () => {
     expect(skill).toContain("never stash");
     expect(skill).toContain("never reset");
   });
+
+  it("carries the facts-vs-decisions distinction in the hard rules", async () => {
+    const skill = await readStartSkill();
+
+    // answering decisions yourself is prohibited
+    expect(skill).toContain("broken the interview");
+    // positive: look facts up via codebase exploration
+    expect(skill).toContain("look up facts in the codebase");
+    // positive: put decisions to the human
+    expect(skill).toContain("decisions belong to the human");
+  });
 });

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -68,7 +68,9 @@ Paste the content, point to another path, or say "skip" and we'll grill on what 
 - ❌ Do **not** propose a final plan, design doc, or PRD. This skill ends in shared understanding, not artefacts.
 - ❌ Do **not** ask more than one question per turn.
 - ❌ Do **not** fetch URLs the user only **mentions** in passing. A ref becomes a fetch only when the user explicitly asks ("look at this", "ingest X") or the next question requires its content.
-- ✅ **Do** explore the codebase when a question can be answered by reading code instead of asking.
+- ❌ Do **not** answer a decision yourself — an agent that answers its own questions has broken the interview.
+- ✅ **Do** look up facts in the codebase (what the code does, what names exist, how something is wired) instead of asking the human for information that is already readable in the code.
+- ✅ **Do** put every decision to the human and wait for the answer. Facts can be looked up; decisions belong to the human.
 - ✅ **Do** challenge contradictions immediately — between user statements, between user and code, between user and `.red/CONTEXT.md`.
 - ✅ **Do** update `.red/CONTEXT.md` inline the moment a term is resolved (one term → one edit → next question). This is a side effect of the interview, not a separate phase.
 - ✅ **Do** offer an ADR only when the three-condition test in `<supporting-info>` passes.


### PR DESCRIPTION
Automated AFK landing for #1288. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1288

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786130021&installation_id=129708444&pr_number=1305&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1305&signature=afe668f1b40bd91926eb8ab34f00ddadac277bea2b9e69e114f067d0a1fbeaf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->