### PR TITLE
chore: #1292 Relabel sweep tool for the Spec/Ticket flip, with --dry-run (ADR 0093)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## relabel-sweep (internal/maintainer)
+
+- **status**: added
+- **upstream**: none
+- **why**: issue #1292 (Spec #1286, ADR 0093) — the big-bang Spec/Ticket vocabulary flip needs a one-shot sweep to migrate open Tickets' historical label families to the new vocabulary; closed Tickets keep their labels (history is not rewritten).
+- **what changed**: added the `dev relabel-sweep` runtime command (`apps/dev/src/commands/relabel-sweep.ts`) plus its pure planner (`apps/dev/src/core/relabel-sweep.ts`). It migrates OPEN Tickets' labels `type:prd → type:spec` and `prd:N → spec:N`, creating the missing target labels on demand, and leaves `req:*` and every other family untouched. `--dry-run` prints the complete per-Ticket plan and writes nothing; the real run applies exactly that plan and is idempotent (a replay finds no old-vocabulary labels and no-ops). The tool ships inert — executing the real sweep against the repo is a separate operator Ticket. Unit-tested planner + injected-gh command control flow; wired into the CLI router.
+
 ## create-plugin (internal/maintainer)
 
 - **status**: added

--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -11,6 +11,7 @@ import { injectDevelopmentWorkflowCommand } from "./commands/inject-development-
 import { monitorCommand } from "./commands/monitor.js";
 import { runCommand } from "./commands/run.js";
 import { reapCommand } from "./commands/reap.js";
+import { relabelSweepCommand } from "./commands/relabel-sweep.js";
 import { requeueCommand } from "./commands/requeue.js";
 import { retakeCommand } from "./commands/retake.js";
 import { reviewCommand } from "./commands/review.js";
@@ -35,6 +36,7 @@ export type CliCommand =
   | "daily-review"
   | "weekly-review"
   | "reap"
+  | "relabel-sweep"
   | "requeue"
   | "retake"
   | "review"
@@ -77,6 +79,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     "daily-review": {},
     "weekly-review": {},
     reap: {},
+    "relabel-sweep": {},
     requeue: {},
     retake: {},
     review: {},
@@ -128,6 +131,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "daily-review") return activityReviewCommand("daily", parsed.args);
   if (parsed.command === "weekly-review") return activityReviewCommand("weekly", parsed.args);
   if (parsed.command === "reap") return reapCommand(parsed.args);
+  if (parsed.command === "relabel-sweep") return relabelSweepCommand(parsed.args);
   if (parsed.command === "requeue") return requeueCommand(parsed.args);
   if (parsed.command === "retake") return retakeCommand(parsed.args);
   if (parsed.command === "review") return reviewCommand(parsed.args);

--- a/apps/dev/src/commands/relabel-sweep.ts
+++ b/apps/dev/src/commands/relabel-sweep.ts
@@ -1,0 +1,167 @@
+// commands/relabel-sweep.ts — the IO half of `dev relabel-sweep` (issue #1292).
+//
+// A one-shot operator sweep for the Spec/Ticket vocabulary flip (ADR 0093): it
+// migrates OPEN Tickets' labels `type:prd → type:spec` and `prd:N → spec:N`,
+// creating the target labels on demand. Closed Tickets are never listed, so
+// history is never rewritten; `req:*` and every other label family are left
+// untouched. The pure remove/add planner lives in `core/relabel-sweep.ts`.
+//
+// The tool ships INERT — wiring it into the CLI does not run it. `--dry-run`
+// prints the complete per-Ticket plan and writes nothing; the real run applies
+// exactly that plan and is idempotent (a replay finds no old-vocabulary labels
+// left and no-ops). Executing the real sweep against the repo is a separate
+// operator Ticket, run once with the fleet stopped.
+
+import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
+import { execTool, type ExecFn } from "../runtime/exec.js";
+import { resolveRepoSlug } from "../runtime/wire.js";
+import {
+  planRelabelSweep,
+  targetLabelsToEnsure,
+  type TicketLabelState,
+  type TicketRelabelPlan,
+} from "../core/relabel-sweep.js";
+
+/** The gh surface the sweep needs, injectable so the command's control flow is
+ * testable without touching the network. */
+export interface RelabelSweepGh {
+  /** Every OPEN Ticket with its number, title, and label-name list. */
+  listOpenTickets(): Promise<TicketLabelState[]>;
+  /** The set of label names that already exist in the repo. */
+  existingLabels(): Promise<Set<string>>;
+  /** Create a label (best-effort; a pre-existing label is a harmless no-op). */
+  createLabel(name: string): Promise<void>;
+  /** Apply the remove/add edit to one Ticket. */
+  editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
+}
+
+const FLAG_SCHEMA = {
+  repo: { kind: "value", aliases: ["R"], coerce: (raw: string): string => raw },
+  "dry-run": { kind: "boolean" },
+} satisfies FlagSchema;
+
+const NEW_LABEL_DESCRIPTION = "Spec/Ticket vocabulary (ADR 0093)";
+
+function ghFor(cwd: string, repo: string): RelabelSweepGh {
+  const repoArgs = repo ? ["--repo", repo] : [];
+  const run = (args: readonly string[]): ReturnType<ExecFn> =>
+    execTool("gh", args, { cwd, maxBuffer: 32 * 1024 * 1024 });
+  return {
+    async listOpenTickets() {
+      const out = await run([
+        "issue",
+        "list",
+        ...repoArgs,
+        "--state",
+        "open",
+        "--limit",
+        "1000",
+        "--json",
+        "number,title,labels",
+      ]);
+      if (out.code !== 0) {
+        throw new Error(`list open tickets failed: ${out.stderr.trim() || out.stdout.trim()}`);
+      }
+      const raw = JSON.parse(out.stdout || "[]") as Array<{
+        number?: number;
+        title?: string;
+        labels?: Array<{ name?: string }>;
+      }>;
+      return raw
+        .map((row) => ({
+          number: Number(row.number ?? 0),
+          title: typeof row.title === "string" ? row.title : undefined,
+          labels: Array.isArray(row.labels) ? row.labels.map((l) => String(l.name ?? "")).filter(Boolean) : [],
+        }))
+        .filter((t) => t.number > 0);
+    },
+    async existingLabels() {
+      const out = await run(["label", "list", ...repoArgs, "--limit", "1000", "--json", "name"]);
+      if (out.code !== 0) {
+        throw new Error(`list labels failed: ${out.stderr.trim() || out.stdout.trim()}`);
+      }
+      const raw = JSON.parse(out.stdout || "[]") as Array<{ name?: string }>;
+      return new Set(raw.map((l) => String(l.name ?? "")).filter(Boolean));
+    },
+    async createLabel(name) {
+      // Best-effort: a label that already exists exits non-zero and is ignored.
+      await run(["label", "create", name, ...repoArgs, "--description", NEW_LABEL_DESCRIPTION]);
+    },
+    async editLabels(issue, remove, add) {
+      const args = ["issue", "edit", String(issue), ...repoArgs];
+      for (const l of remove) args.push("--remove-label", l);
+      for (const l of add) args.push("--add-label", l);
+      const out = await run(args);
+      if (out.code !== 0) {
+        throw new Error(`edit labels #${issue} failed: ${out.stderr.trim() || out.stdout.trim()}`);
+      }
+    },
+  };
+}
+
+async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
+  if (explicit) return explicit;
+  return resolveRepoSlug(cwd);
+}
+
+function renderPlanLine(plan: TicketRelabelPlan): string {
+  const title = plan.title ? ` ${plan.title}` : "";
+  return `#${plan.number}${title}: remove=[${plan.remove.join(", ")}] add=[${plan.add.join(", ")}]`;
+}
+
+/**
+ * `relabel-sweep` — one-shot Spec/Ticket relabel (ADR 0093, issue #1292).
+ *
+ * Lists open Tickets, plans the `type:prd → type:spec` / `prd:N → spec:N`
+ * migration, then either prints the plan (`--dry-run`, writes nothing) or
+ * applies it: create the missing target labels, then edit each Ticket. Real
+ * runs are idempotent — a replay finds no old-vocabulary labels and no-ops.
+ */
+export async function relabelSweepCommand(
+  args: readonly string[],
+  cwd = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+  ghOverride?: RelabelSweepGh,
+): Promise<number> {
+  const { values } = parseFlags(args, FLAG_SCHEMA);
+  const dryRun = values["dry-run"] === true;
+
+  const repo = ghOverride ? "" : await resolveRepo(cwd, values.repo as string | undefined);
+  const gh = ghOverride ?? ghFor(cwd, repo);
+
+  const tickets = await gh.listOpenTickets();
+  const plans = planRelabelSweep(tickets);
+
+  if (plans.length === 0) {
+    stdout.write("relabel-sweep: no open Tickets carry type:prd or prd:N — nothing to migrate.\n");
+    return 0;
+  }
+
+  const mode = dryRun ? "dry-run" : "apply";
+  stdout.write(`relabel-sweep (${mode}): ${plans.length} open Ticket${plans.length === 1 ? "" : "s"} to migrate\n`);
+  for (const plan of plans) stdout.write(`  ${renderPlanLine(plan)}\n`);
+
+  const targets = targetLabelsToEnsure(plans);
+
+  if (dryRun) {
+    stdout.write(`relabel-sweep (dry-run): would ensure labels exist: [${targets.join(", ")}]\n`);
+    stdout.write("relabel-sweep (dry-run): no changes written.\n");
+    return 0;
+  }
+
+  // Create every target label the plans introduce that does not already exist.
+  const existing = await gh.existingLabels();
+  for (const label of targets) {
+    if (existing.has(label)) continue;
+    await gh.createLabel(label);
+    stdout.write(`relabel-sweep: created label ${label}\n`);
+  }
+
+  for (const plan of plans) {
+    await gh.editLabels(plan.number, plan.remove, plan.add);
+    stdout.write(`relabel-sweep: migrated #${plan.number}\n`);
+  }
+
+  stdout.write(`relabel-sweep: done — ${plans.length} Ticket${plans.length === 1 ? "" : "s"} migrated.\n`);
+  return 0;
+}

--- a/apps/dev/src/core/relabel-sweep.ts
+++ b/apps/dev/src/core/relabel-sweep.ts
@@ -1,0 +1,101 @@
+// core/relabel-sweep.ts — the pure planner for the Spec/Ticket vocabulary flip
+// relabel sweep (ADR 0093, issue #1292).
+//
+// ADR 0093 adopts upstream v1.1.0's rename at total vocabulary scope: the label
+// families `type:prd → type:spec` and `prd:N → spec:N`. The migration is a one
+// time big-bang sweep over OPEN Tickets only — closed Tickets keep their
+// historical labels (history is not rewritten). This module is the deterministic
+// heart of that sweep: given each open Ticket's label set it returns the exact
+// remove/add plan. The IO half (listing Tickets, creating missing target
+// labels, applying edits) lives in `commands/relabel-sweep.ts`.
+//
+// The planner is PURE and idempotent by construction: it only ever plans the
+// removal of an OLD-vocabulary label, and only adds a NEW-vocabulary label the
+// Ticket does not already carry. Re-running over an already-migrated Ticket
+// (no `type:prd`, no `prd:N`) yields no plan, so the real run no-ops on replay.
+
+/** The source (old-vocabulary) type label the sweep migrates away from. */
+export const OLD_TYPE_LABEL = "type:prd";
+/** The target (new-vocabulary) type label the sweep migrates to. */
+export const NEW_TYPE_LABEL = "type:spec";
+/** Matches an old-vocabulary parent-ref label `prd:<N>` (capturing N). */
+const OLD_REF_LABEL = /^prd:(\d+)$/;
+/** Build the new-vocabulary parent-ref label for a given Spec number. */
+export function newRefLabel(specNumber: string): string {
+  return `spec:${specNumber}`;
+}
+
+/** An open Ticket's label state, the sweep's input row. */
+export interface TicketLabelState {
+  number: number;
+  title?: string;
+  labels: readonly string[];
+}
+
+/** The exact label edit planned for one Ticket. `remove`/`add` are never both
+ * empty — a Ticket with nothing to migrate produces no plan at all. */
+export interface TicketRelabelPlan {
+  number: number;
+  title?: string;
+  remove: string[];
+  add: string[];
+}
+
+/**
+ * Plan the label migration for a single Ticket, or `null` when it carries no
+ * old-vocabulary label (nothing to do — the idempotent no-op case).
+ *
+ * `type:prd` → remove it and add `type:spec` (unless already present). Each
+ * `prd:N` → remove it and add `spec:N` (unless already present). Every other
+ * label family — `req:*`, `ready-for-agent`, `type:bug`, … — is left untouched.
+ */
+export function planTicketRelabel(ticket: TicketLabelState): TicketRelabelPlan | null {
+  const present = new Set(ticket.labels);
+  const remove: string[] = [];
+  const add: string[] = [];
+  const queueAdd = (label: string): void => {
+    // Never plan to add a label the Ticket already has, and never add the same
+    // target twice (defends the theoretical `prd:5`+`prd:5` duplicate).
+    if (!present.has(label) && !add.includes(label)) add.push(label);
+  };
+
+  for (const label of ticket.labels) {
+    if (label === OLD_TYPE_LABEL) {
+      remove.push(label);
+      queueAdd(NEW_TYPE_LABEL);
+      continue;
+    }
+    const ref = OLD_REF_LABEL.exec(label);
+    if (ref) {
+      remove.push(label);
+      queueAdd(newRefLabel(ref[1]));
+    }
+  }
+
+  if (remove.length === 0 && add.length === 0) return null;
+  return { number: ticket.number, title: ticket.title, remove, add };
+}
+
+/**
+ * Plan the sweep across every open Ticket, dropping the ones with nothing to
+ * migrate. Order is preserved from the input.
+ */
+export function planRelabelSweep(tickets: readonly TicketLabelState[]): TicketRelabelPlan[] {
+  const plans: TicketRelabelPlan[] = [];
+  for (const ticket of tickets) {
+    const plan = planTicketRelabel(ticket);
+    if (plan) plans.push(plan);
+  }
+  return plans;
+}
+
+/**
+ * The sorted, de-duplicated set of NEW-vocabulary labels the plans introduce —
+ * the labels the real run must create on demand before applying any edit (a
+ * `gh issue edit --add-label` for a non-existent label fails).
+ */
+export function targetLabelsToEnsure(plans: readonly TicketRelabelPlan[]): string[] {
+  const set = new Set<string>();
+  for (const plan of plans) for (const label of plan.add) set.add(label);
+  return [...set].sort();
+}

--- a/apps/dev/tests/cli-routing.test.ts
+++ b/apps/dev/tests/cli-routing.test.ts
@@ -8,6 +8,13 @@ describe("cli routing — native commands", () => {
     expect(parseCli(["__supervise", "3"])).toEqual({ command: "__supervise", args: ["3"] });
   });
 
+  it("routes relabel-sweep with its dry-run flag preserved", () => {
+    expect(parseCli(["relabel-sweep", "--dry-run"])).toEqual({
+      command: "relabel-sweep",
+      args: ["--dry-run"],
+    });
+  });
+
   it("routes ship as an interactive landing command", () => {
     expect(parseCli(["ship", "--issue", "395"])).toEqual({ command: "ship", args: ["--issue", "395"] });
   });

--- a/apps/dev/tests/relabel-sweep.test.ts
+++ b/apps/dev/tests/relabel-sweep.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+  planRelabelSweep,
+  planTicketRelabel,
+  targetLabelsToEnsure,
+} from "../src/core/relabel-sweep.js";
+import { relabelSweepCommand, type RelabelSweepGh } from "../src/commands/relabel-sweep.js";
+import type { TicketLabelState } from "../src/core/relabel-sweep.js";
+
+describe("relabel-sweep planner (core)", () => {
+  it("migrates type:prd → type:spec", () => {
+    expect(planTicketRelabel({ number: 1, labels: ["type:prd", "ready-for-agent"] })).toEqual({
+      number: 1,
+      title: undefined,
+      remove: ["type:prd"],
+      add: ["type:spec"],
+    });
+  });
+
+  it("migrates each prd:N → spec:N and leaves other families untouched", () => {
+    expect(
+      planTicketRelabel({ number: 2, title: "child", labels: ["prd:1013", "req:1010", "type:bug"] }),
+    ).toEqual({
+      number: 2,
+      title: "child",
+      remove: ["prd:1013"],
+      add: ["spec:1013"],
+    });
+  });
+
+  it("migrates both the type and ref families on one Ticket", () => {
+    const plan = planTicketRelabel({ number: 3, labels: ["type:prd", "prd:900"] });
+    expect(plan?.remove.sort()).toEqual(["prd:900", "type:prd"]);
+    expect(plan?.add.sort()).toEqual(["spec:900", "type:spec"]);
+  });
+
+  it("returns null for a Ticket with no old-vocabulary labels (idempotent no-op)", () => {
+    expect(planTicketRelabel({ number: 4, labels: ["type:spec", "spec:900", "req:1"] })).toBeNull();
+  });
+
+  it("removes the old label but does not re-add a target already present (idempotent convergence)", () => {
+    expect(planTicketRelabel({ number: 5, labels: ["type:prd", "type:spec"] })).toEqual({
+      number: 5,
+      title: undefined,
+      remove: ["type:prd"],
+      add: [],
+    });
+  });
+
+  it("does not match prd:N with a non-numeric suffix", () => {
+    expect(planTicketRelabel({ number: 6, labels: ["prd:foo", "prdish"] })).toBeNull();
+  });
+
+  it("planRelabelSweep keeps only Tickets with work and preserves order", () => {
+    const tickets: TicketLabelState[] = [
+      { number: 10, labels: ["type:prd"] },
+      { number: 11, labels: ["req:1"] },
+      { number: 12, labels: ["prd:5"] },
+    ];
+    expect(planRelabelSweep(tickets).map((p) => p.number)).toEqual([10, 12]);
+  });
+
+  it("targetLabelsToEnsure returns the sorted, de-duplicated add set", () => {
+    const plans = planRelabelSweep([
+      { number: 1, labels: ["type:prd", "prd:5"] },
+      { number: 2, labels: ["prd:5"] },
+      { number: 3, labels: ["prd:9"] },
+    ]);
+    expect(targetLabelsToEnsure(plans)).toEqual(["spec:5", "spec:9", "type:spec"]);
+  });
+});
+
+/** A recording fake gh surface for the command's control flow. */
+function fakeGh(tickets: TicketLabelState[], existing: string[] = []): RelabelSweepGh & {
+  created: string[];
+  edits: Array<{ issue: number; remove: string[]; add: string[] }>;
+} {
+  const created: string[] = [];
+  const edits: Array<{ issue: number; remove: string[]; add: string[] }> = [];
+  return {
+    created,
+    edits,
+    listOpenTickets: async () => tickets,
+    existingLabels: async () => new Set(existing),
+    createLabel: async (name) => {
+      created.push(name);
+    },
+    editLabels: async (issue, remove, add) => {
+      edits.push({ issue, remove, add });
+    },
+  };
+}
+
+function collect(): { stream: NodeJS.WritableStream; text: () => string } {
+  let buf = "";
+  const stream = { write: (s: string) => (buf += s, true) } as unknown as NodeJS.WritableStream;
+  return { stream, text: () => buf };
+}
+
+describe("relabel-sweep command (IO control flow)", () => {
+  it("--dry-run lists every affected Ticket and writes nothing", async () => {
+    const gh = fakeGh([
+      { number: 1, title: "spec doc", labels: ["type:prd"] },
+      { number: 2, title: "child", labels: ["prd:1", "req:9"] },
+      { number: 3, title: "unrelated", labels: ["type:bug"] },
+    ]);
+    const out = collect();
+    const code = await relabelSweepCommand(["--dry-run"], "/repo", out.stream, gh);
+    expect(code).toBe(0);
+    expect(out.text()).toContain("#1 spec doc: remove=[type:prd] add=[type:spec]");
+    expect(out.text()).toContain("#2 child: remove=[prd:1] add=[spec:1]");
+    expect(out.text()).not.toContain("#3");
+    expect(out.text()).toContain("no changes written");
+    // Nothing written.
+    expect(gh.created).toEqual([]);
+    expect(gh.edits).toEqual([]);
+  });
+
+  it("real run creates only missing labels and applies exactly the plan", async () => {
+    const gh = fakeGh(
+      [
+        { number: 1, labels: ["type:prd", "prd:5"] },
+        { number: 2, labels: ["prd:5"] },
+      ],
+      ["type:spec"], // already exists — must not be re-created
+    );
+    const out = collect();
+    const code = await relabelSweepCommand([], "/repo", out.stream, gh);
+    expect(code).toBe(0);
+    // type:spec pre-existed; only spec:5 created.
+    expect(gh.created).toEqual(["spec:5"]);
+    expect(gh.edits).toEqual([
+      { issue: 1, remove: ["type:prd", "prd:5"], add: ["type:spec", "spec:5"] },
+      { issue: 2, remove: ["prd:5"], add: ["spec:5"] },
+    ]);
+  });
+
+  it("is idempotent — a replay over already-migrated Tickets no-ops", async () => {
+    const gh = fakeGh([
+      { number: 1, labels: ["type:spec", "spec:5"] },
+      { number: 2, labels: ["req:9"] },
+    ]);
+    const out = collect();
+    const code = await relabelSweepCommand([], "/repo", out.stream, gh);
+    expect(code).toBe(0);
+    expect(out.text()).toContain("nothing to migrate");
+    expect(gh.created).toEqual([]);
+    expect(gh.edits).toEqual([]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1292. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1292

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786131036&installation_id=129708444&pr_number=1310&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1310&signature=4407733eefd12fbd95da6d0c21686f79b24c9a4045ba854cd13471be758fca7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->