### PR TITLE
chore: #1306 Requeue adopt-landing seeds an origin=requeue worker-presence state file (visibility, #1303 option a)

### DIFF
--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -16,7 +16,9 @@
 // re-run. The real adopt runner is built here; `RequeueAdoptRunner` is injectable
 // for tests (mirrors how `RequeueGh` is injected).
 
-import { join } from "node:path";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 import { planRequeue, type RequeuePlan } from "../core/requeue.js";
@@ -24,7 +26,14 @@ import { parseClaimRecords, renderClaimComment, type RawClaimComment } from "../
 import { parseCurrentBlocker } from "../core/blocker-state.js";
 import { LABEL_READY, LABEL_SENSITIVE_PATH } from "../core/triage-labels.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
+import {
+  REQUEUE_ORIGIN,
+  withAdoptPresence,
+  type AdoptPresenceIo,
+} from "../core/adopt-presence.js";
+import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../core/state.js";
 import { makeFeedbackWorktree } from "../runtime/feedback-worktree.js";
+import { pathExists, removeDir } from "../runtime/fs.js";
 import { afkPaths, editLabelsWithStatuslineCache, resolveRepoSlug, statuslineCountCachePath } from "../runtime/wire.js";
 import { branchLockPath, isLocked, readLockedBranch } from "../runtime/lock.js";
 import { resolveBase } from "../core/base-resolver.js";
@@ -212,6 +221,90 @@ async function resolveRepo(cwd: string, explicit?: string): Promise<string> {
   return r.code === 0 ? r.stdout.trim() : "";
 }
 
+/** Append one liveness-lane record so the (un-poisonable) liveness evaluator
+ * reads the adopt-landing presence row as fresh/`alive` for the idle window
+ * (#1306). Synchronous + best-effort — it mirrors the JSONL shape red-castle's
+ * `LivenessLane` writes, so `parseLivenessRecords` reads it back unchanged. */
+function appendAdoptLivenessRecord(attemptDir: string): void {
+  try {
+    mkdirSync(attemptDir, { recursive: true });
+    appendFileSync(
+      join(attemptDir, LIVENESS_LANE_FILENAME),
+      `${JSON.stringify({ at: Date.now(), kind: "iteration-start" })}\n`,
+    );
+  } catch {
+    // best-effort: the presence row still renders on pid liveness alone.
+  }
+}
+
+/**
+ * The real presence IO for the adopt-landing lane (#1306): seeds a live
+ * `origin="requeue"` worker-presence state file under the canonical workers
+ * root via the SAME `initStateSync`/`writeIdentitySync` helpers the AFK worker
+ * uses, advances its stage as reconcile progresses, and marks it not-live
+ * (`pid: 0`) + removes the attempt dir in the teardown. Every write is
+ * best-effort — presence must never block or fail the adopt landing.
+ */
+export function makeAdoptPresenceIo(runner: Runner): AdoptPresenceIo {
+  return {
+    seed(input) {
+      try {
+        const startedAt = new Date().toISOString();
+        initStateSync(input.statePath, {
+          worker_id: input.worker,
+          pid: process.pid,
+          pid_start_time: readPidStartTime(process.pid) ?? "",
+          runner,
+          // Spawn-time provenance (#1306): the origin-agnostic reader renders
+          // this as the row's per-source count, distinct from afk/go.
+          origin: REQUEUE_ORIGIN,
+          log: join(input.attemptDir, "afk.log"),
+          started_at: startedAt,
+          "current.number": input.issue,
+          "current.title": input.title,
+          "current.started_at": startedAt,
+          "current.runner": runner,
+          "current.stage": input.stage,
+          "current.phase": "validating",
+        });
+        writeIdentitySync(input.attemptDir, {
+          worker_id: input.worker,
+          runner,
+          origin: REQUEUE_ORIGIN,
+          number: input.issue,
+          started_at: startedAt,
+        });
+        appendAdoptLivenessRecord(input.attemptDir);
+      } catch {
+        // best-effort — a failed seed must never block the adopt landing.
+      }
+    },
+    async setStage(statePath, stage) {
+      try {
+        await updateState(statePath, {
+          "current.stage": stage,
+          "current.phase": stage === "landing" ? "merging" : "validating",
+        });
+        appendAdoptLivenessRecord(dirname(statePath));
+      } catch {
+        // best-effort — stage is cosmetic; never fail the reconcile on it.
+      }
+    },
+    async teardown(statePath, attemptDir) {
+      // Mark not-live first (so a mid-teardown reader never sees a live ghost),
+      // then remove the short-lived attempt dir so no residue is left behind.
+      try {
+        if (await pathExists(statePath)) {
+          await updateState(statePath, { pid: 0 }, { allowPidReset: true });
+        }
+      } catch {
+        // best-effort
+      }
+      await removeDir(attemptDir).catch(() => {});
+    },
+  };
+}
+
 /**
  * Build the real adopt runner: wires ReconcileDeps and calls reconcile() (ADR
  * 0055) for a hand-done branch. Mirrors makeBootReconcileRunner in commands/run.ts
@@ -233,6 +326,10 @@ async function runAdoptLanding(
   const lockPath = branchLockPath(cwd);
   const feedbackDir = join(paths.tmpDir, "adopt-landing", String(issue));
   const feedback = makeFeedbackWorktree(cwd, feedbackDir, undefined, {});
+
+  // Bound to the live worker-presence row's stage inside withAdoptPresence
+  // below; reconcile's `markStage` calls through it (#1306).
+  let presenceStage: ((stage: "validating" | "landing") => Promise<void>) | undefined;
 
   try {
     const base = await resolveBase(
@@ -319,6 +416,10 @@ async function runAdoptLanding(
       },
       nowEpoch: () => Math.floor(Date.now() / 1000),
       appendIterLog: (line) => { stdout.write(`${line}\n`); },
+      // Presence stage seam (#1306): wired to the live worker-presence row's
+      // stage inside the withAdoptPresence body below. Best-effort no-op until
+      // the presence handle is bound.
+      markStage: (stage) => (presenceStage ? presenceStage(stage) : Promise.resolve()),
       recoveryEnv: process.env,
     };
 
@@ -346,8 +447,18 @@ async function runAdoptLanding(
       sensitivePathApproved: issueData.sensitivePathApproved === true,
     };
 
-    const result = await reconcile(reconcileDeps, reconcileInput);
-    return result.outcome;
+    // Seed a short-lived `origin="requeue"` worker-presence row so the
+    // adopt-landing run is visible on the statusline / `/afk monitor` while its
+    // gate runs, marked not-live + torn down on EVERY exit path (#1306).
+    return await withAdoptPresence(
+      makeAdoptPresenceIo(reconcileInput.runner),
+      { tmpDir: paths.tmpDir, issue, title, runner: reconcileInput.runner },
+      async (handle) => {
+        presenceStage = handle.markStage;
+        const result = await reconcile(reconcileDeps, reconcileInput);
+        return result.outcome;
+      },
+    );
   } finally {
     await feedback.cleanup();
   }

--- a/apps/dev/src/core/adopt-presence.ts
+++ b/apps/dev/src/core/adopt-presence.ts
@@ -1,0 +1,126 @@
+// core/adopt-presence.ts — worker presence for the `/requeue --adopt-branch`
+// no-agent landing lane (ADR 0055, issue #1306).
+//
+// The adopt-landing lane validates and lands a hand-done branch WITHOUT running
+// an AFK worker, so while its gate ran the run was INVISIBLE on the live-worker
+// surfaces (statusline / `/afk monitor`) — a maintainer watching the fleet saw
+// nothing for the minute-plus the feedback gate takes. This seeds a SHORT-LIVED
+// worker-presence state file under the canonical workers root, stamped
+// `origin="requeue"`, so the (origin-agnostic) Worker state reader renders one
+// row for the run; the row advances through the validate → land stages and is
+// marked not-live + torn down in a `finally` on EVERY exit path (landed,
+// parked, or thrown).
+//
+// PURE orchestration over injected IO: the seam that seeds / advances / tears
+// down the state file is a port, so the whole lifecycle is unit-testable with
+// zero disk. No reader changes — the reader already unions every worker-lane
+// namespace and reads `origin` off the state (issue #1306).
+
+import { join } from "node:path";
+import { buildWorkerAttemptPath } from "./worker-paths.js";
+
+/** Spawn-time provenance stamped on an adopt-landing presence row, distinct from
+ * `afk` / `go` / `urgent` so the monitor/statusline render its per-source count
+ * as its own lane (issue #1306). */
+export const REQUEUE_ORIGIN = "requeue";
+
+/** Synthetic worker id for the adopt-landing presence row — a valid worker id
+ * (`[A-Za-z0-9_-]+`) so {@link buildWorkerAttemptPath} accepts it. */
+export const REQUEUE_ADOPT_WORKER = "requeue-adopt";
+
+/** The single adopt-landing presence attempt is always attempt 1 (there is only
+ * ever one presence row per adopt run). */
+export const REQUEUE_ADOPT_ATTEMPT = 1;
+
+/** The lifecycle stages an adopt-landing presence row advances through, in
+ * order: the feedback gate (`validating`) then the land (`landing`). */
+export type AdoptPresenceStage = "validating" | "landing";
+
+/** The immutable identity + issue fields a {@link AdoptPresenceIo.seed} writes
+ * onto the presence state file. */
+export interface AdoptPresenceSeed {
+  /** Absolute path of the presence `afk.state.json`. */
+  statePath: string;
+  /** The attempt dir the state file (and its liveness lane) live in. */
+  attemptDir: string;
+  /** Synthetic worker id ({@link REQUEUE_ADOPT_WORKER}). */
+  worker: string;
+  /** The issue whose branch is being adopted. */
+  issue: number;
+  /** Issue title, for the rendered row. */
+  title: string;
+  /** Runner label stamped on the row. */
+  runner: string;
+  /** The stage the row is seeded at ({@link AdoptPresenceStage}). */
+  stage: AdoptPresenceStage;
+}
+
+/**
+ * Injected IO for one adopt-landing presence lifecycle. Every effect is a port
+ * so {@link withAdoptPresence} is testable without touching disk.
+ */
+export interface AdoptPresenceIo {
+  /** Seed the presence state file LIVE (pid + `origin` + identity + a first
+   * liveness-lane record) so the reader renders the row immediately. */
+  seed(input: AdoptPresenceSeed): void;
+  /** Advance `current.stage` (and refresh liveness) as the run progresses.
+   * Best-effort: a failed update must never fail the adopt landing. */
+  setStage(statePath: string, stage: AdoptPresenceStage): Promise<void>;
+  /** Mark the presence row not-live (`pid: 0`) and remove its attempt dir — the
+   * `finally` teardown fired on every exit path. */
+  teardown(statePath: string, attemptDir: string): Promise<void>;
+}
+
+/** Static inputs for one adopt-landing presence lifecycle. */
+export interface AdoptPresenceParams {
+  /** The `.red/tmp` dir under which the canonical `workers/` root lives. */
+  tmpDir: string;
+  issue: number;
+  title: string;
+  runner: string;
+}
+
+/** Handle passed to the wrapped body so it can advance the presence stage as it
+ * crosses its own validate → land phases. */
+export interface AdoptPresenceHandle {
+  markStage(stage: AdoptPresenceStage): Promise<void>;
+}
+
+/**
+ * Run `body` with a live worker-presence row seeded around it. The row is
+ * created BEFORE `body` starts (stage `validating`), advanced through the
+ * handle, and marked not-live + torn down in a `finally` so it disappears on
+ * EVERY exit path — a landed run, a parked gate, or a thrown error alike.
+ * Returns whatever `body` returns (and re-throws whatever it throws, after the
+ * teardown has run).
+ */
+export async function withAdoptPresence<T>(
+  io: AdoptPresenceIo,
+  params: AdoptPresenceParams,
+  body: (handle: AdoptPresenceHandle) => Promise<T>,
+): Promise<T> {
+  const attemptDir = buildWorkerAttemptPath(
+    params.tmpDir,
+    REQUEUE_ADOPT_WORKER,
+    params.issue,
+    REQUEUE_ADOPT_ATTEMPT,
+  );
+  const statePath = join(attemptDir, "afk.state.json");
+  io.seed({
+    statePath,
+    attemptDir,
+    worker: REQUEUE_ADOPT_WORKER,
+    issue: params.issue,
+    title: params.title,
+    runner: params.runner,
+    stage: "validating",
+  });
+  const handle: AdoptPresenceHandle = {
+    markStage: (stage) => io.setStage(statePath, stage),
+  };
+  try {
+    return await body(handle);
+  } finally {
+    await io.teardown(statePath, attemptDir);
+  }
+}

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -202,6 +202,16 @@ export interface ReconcileDeps {
   /** Append one plain line to the iteration's afk.log. */
   appendIterLog(line: string): void;
   /**
+   * Advance the caller's worker-presence stage as reconcile crosses its
+   * validate → land phases (issue #1306). Optional — the autonomous AFK caller
+   * leaves it unset (its stage is driven by the agent-event sink); the
+   * `/requeue --adopt-branch` presence lane wires it to update its short-lived
+   * `origin="requeue"` presence state file so the live-worker surfaces show
+   * `validating` then `landing`. Best-effort at the call site — a failed update
+   * never fails the reconcile.
+   */
+  markStage?(stage: "validating" | "landing"): Promise<void>;
+  /**
    * ADR 0083 §4 exit barrier (every-terminal, #1021). The no-agent reconcile lane
    * obtains its branch-preservation write through the SAME barrier every other
    * terminal path uses: salvage-commit dirty paths + push the parked branch to
@@ -388,6 +398,8 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   // The merge-conflict reland route (#1095) trusts the prior green validation
   // and skips the gate; every other reland runs it exactly as the DONE path does.
   const startedEpoch = deps.nowEpoch();
+  // Presence stage (#1306): the adopt-landing lane's row now shows `validating`.
+  await deps.markStage?.("validating").catch(() => {});
   let feedback: RunFeedbackResult;
   if (input.trustPriorValidation) {
     // #1095 merge-conflict reland: the branch validated green before the
@@ -448,6 +460,8 @@ export async function reconcile(deps: ReconcileDeps, input: ReconcileInput): Pro
   // the lock which only resolved `base` (#842); `locked` is read for the echo.
   const locked = await deps.lookups.isLocked();
   const openPr = deps.worktreeLaunchesPr !== false;
+  // Presence stage (#1306): the adopt-landing lane's row now shows `landing`.
+  await deps.markStage?.("landing").catch(() => {});
   const landing = await doLanding(
     {
       mergeExec: deps.mergeExec,

--- a/apps/dev/tests/adopt-presence-io.test.ts
+++ b/apps/dev/tests/adopt-presence-io.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { makeAdoptPresenceIo } from "../src/commands/requeue.js";
+import { withAdoptPresence } from "../src/core/adopt-presence.js";
+import { readWorkerState } from "../src/core/worker-state-reader.js";
+
+// End-to-end proof that the REAL presence IO seeds a state file the UNCHANGED
+// Worker state reader renders as a live `origin="requeue"` row while the body
+// runs, and that the row is torn down (dir removed) on every exit path. No
+// reader code is touched — this reads through the shipped `readWorkerState`.
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "adopt-presence-io-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const attemptDir = (tmpDir: string, issue: number): string =>
+  join(tmpDir, "workers", "requeue-adopt", `${issue}-a1`);
+
+describe("makeAdoptPresenceIo — real state file, read through the shipped reader", () => {
+  it("renders a live requeue-origin row mid-run, advances stage, then tears down on the landed path", async () => {
+    const tmpDir = join(root, ".red", "tmp");
+    const io = makeAdoptPresenceIo("claude");
+    const dir = attemptDir(tmpDir, 42);
+    const statePath = join(dir, "afk.state.json");
+
+    const outcome = await withAdoptPresence(
+      io,
+      { tmpDir, issue: 42, title: "Fix the thing", runner: "claude" },
+      async (handle) => {
+        // Mid-run: the reader (unchanged) renders a live, requeue-origin row.
+        const seeded = readWorkerState(statePath);
+        expect(seeded).not.toBeNull();
+        expect(seeded!.state.origin).toBe("requeue");
+        expect(seeded!.state.current.number).toBe(42);
+        expect(seeded!.state.current.stage).toBe("validating");
+        expect(seeded!.renderableLive).toBe(true);
+
+        await handle.markStage("landing");
+        const landing = readWorkerState(statePath);
+        expect(landing!.state.current.stage).toBe("landing");
+        expect(landing!.renderableLive).toBe(true);
+
+        return "landed" as const;
+      },
+    );
+
+    expect(outcome).toBe("landed");
+    // Teardown removed the short-lived attempt dir — no residue.
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it("tears the row down on the failure path too (body throws)", async () => {
+    const tmpDir = join(root, ".red", "tmp");
+    const io = makeAdoptPresenceIo("claude");
+    const dir = attemptDir(tmpDir, 7);
+
+    await expect(
+      withAdoptPresence(io, { tmpDir, issue: 7, title: "Boom", runner: "claude" }, async () => {
+        // The row exists while the body runs.
+        expect(existsSync(join(dir, "afk.state.json"))).toBe(true);
+        throw new Error("gate exploded");
+      }),
+    ).rejects.toThrow("gate exploded");
+
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/apps/dev/tests/adopt-presence.test.ts
+++ b/apps/dev/tests/adopt-presence.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  REQUEUE_ADOPT_WORKER,
+  REQUEUE_ORIGIN,
+  withAdoptPresence,
+  type AdoptPresenceIo,
+  type AdoptPresenceSeed,
+  type AdoptPresenceStage,
+} from "../src/core/adopt-presence.js";
+
+interface Recorder {
+  io: AdoptPresenceIo;
+  seeds: AdoptPresenceSeed[];
+  stages: Array<{ statePath: string; stage: AdoptPresenceStage }>;
+  teardowns: Array<{ statePath: string; attemptDir: string }>;
+  events: string[];
+}
+
+function recorder(): Recorder {
+  const seeds: AdoptPresenceSeed[] = [];
+  const stages: Array<{ statePath: string; stage: AdoptPresenceStage }> = [];
+  const teardowns: Array<{ statePath: string; attemptDir: string }> = [];
+  const events: string[] = [];
+  const io: AdoptPresenceIo = {
+    seed(input) {
+      seeds.push(input);
+      events.push("seed");
+    },
+    async setStage(statePath, stage) {
+      stages.push({ statePath, stage });
+      events.push(`stage:${stage}`);
+    },
+    async teardown(statePath, attemptDir) {
+      teardowns.push({ statePath, attemptDir });
+      events.push("teardown");
+    },
+  };
+  return { io, seeds, stages, teardowns, events };
+}
+
+const params = { tmpDir: "/tmp/.red/tmp", issue: 42, title: "Fix the thing", runner: "claude" };
+
+describe("withAdoptPresence — seed", () => {
+  it("seeds one live presence row under the canonical workers root before the body runs", async () => {
+    const r = recorder();
+    let seenAtBodyStart = 0;
+
+    await withAdoptPresence(r.io, params, async () => {
+      seenAtBodyStart = r.seeds.length;
+      return "landed" as const;
+    });
+
+    // The row is seeded BEFORE the body executes.
+    expect(seenAtBodyStart).toBe(1);
+    const seed = r.seeds[0]!;
+    expect(seed.worker).toBe(REQUEUE_ADOPT_WORKER);
+    expect(seed.issue).toBe(42);
+    expect(seed.title).toBe("Fix the thing");
+    expect(seed.runner).toBe("claude");
+    expect(seed.stage).toBe("validating");
+    // Canonical `workers/` root (never go-workers/scout-workers) + a1 attempt.
+    expect(seed.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1");
+    expect(seed.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1/afk.state.json");
+  });
+
+  it("uses a distinct requeue provenance constant", () => {
+    // Guards the value the (origin-agnostic) reader renders as the source count.
+    expect(REQUEUE_ORIGIN).toBe("requeue");
+  });
+});
+
+describe("withAdoptPresence — teardown on every exit path", () => {
+  it("marks not-live + tears down after a LANDED body, and returns its value", async () => {
+    const r = recorder();
+
+    const outcome = await withAdoptPresence(r.io, params, async () => "landed" as const);
+
+    expect(outcome).toBe("landed");
+    expect(r.teardowns).toHaveLength(1);
+    expect(r.teardowns[0]!.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1");
+    // Seed happens before teardown.
+    expect(r.events).toEqual(["seed", "teardown"]);
+  });
+
+  it("marks not-live + tears down after a PARKED body too", async () => {
+    const r = recorder();
+
+    const outcome = await withAdoptPresence(r.io, params, async () => "parked" as const);
+
+    expect(outcome).toBe("parked");
+    expect(r.teardowns).toHaveLength(1);
+    expect(r.events[r.events.length - 1]).toBe("teardown");
+  });
+
+  it("tears down even when the body THROWS, and re-throws the error", async () => {
+    const r = recorder();
+
+    await expect(
+      withAdoptPresence(r.io, params, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // The presence row is still cleaned up — no residue on the failure path.
+    expect(r.teardowns).toHaveLength(1);
+    expect(r.events).toEqual(["seed", "teardown"]);
+  });
+});
+
+describe("withAdoptPresence — stage progression", () => {
+  it("advances the row through validate → land via the handle", async () => {
+    const r = recorder();
+
+    await withAdoptPresence(r.io, params, async (handle) => {
+      await handle.markStage("validating");
+      await handle.markStage("landing");
+      return "landed" as const;
+    });
+
+    expect(r.stages.map((s) => s.stage)).toEqual(["validating", "landing"]);
+    // Stage updates target the seeded presence state file.
+    for (const s of r.stages) {
+      expect(s.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1/afk.state.json");
+    }
+    // Order: seed → stages → teardown last.
+    expect(r.events).toEqual(["seed", "stage:validating", "stage:landing", "teardown"]);
+  });
+});

--- a/apps/dev/tests/reconcile.test.ts
+++ b/apps/dev/tests/reconcile.test.ts
@@ -28,6 +28,8 @@ interface Trace {
   listByLabelCalls: string[];
   firedHooks: string[];
   iterLogs: string[];
+  /** Presence stages reconcile advanced through via `markStage` (#1306). */
+  stageMarks: string[];
   mergeCalls: string[][];
   pnpmCalls: number;
   pnpmArgs: string[][];
@@ -79,6 +81,7 @@ function harness(opts: HarnessOptions = {}): {
     listByLabelCalls: [],
     firedHooks: [],
     iterLogs: [],
+    stageMarks: [],
     mergeCalls: [],
     pnpmCalls: 0,
     pnpmArgs: [],
@@ -203,6 +206,9 @@ function harness(opts: HarnessOptions = {}): {
     nowEpoch: () => 1000,
     appendIterLog: (line) => {
       trace.iterLogs.push(line);
+    },
+    markStage: async (stage) => {
+      trace.stageMarks.push(stage);
     },
     recordAttempt: opts.recordAttempt
       ? async (payload) => {
@@ -392,6 +398,32 @@ describe("reconcile — red → park", () => {
     expect(park.add).toContain("ready-for-human");
     expect(park.add).toContain("blocked:merge-conflict");
     expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "merge-conflict" }]);
+  });
+});
+
+describe("reconcile — presence stage progression (#1306)", () => {
+  it("advances the caller's stage validate → land on a green landed reconcile", async () => {
+    const { deps, input, trace } = harness({ feedbackOk: true });
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("landed");
+    expect(trace.stageMarks).toEqual(["validating", "landing"]);
+  });
+
+  it("stops at validating when the gate fails (never reaches landing)", async () => {
+    const { deps, input, trace } = harness({ feedbackOk: false });
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("parked");
+    expect(trace.stageMarks).toEqual(["validating"]);
+  });
+
+  it("marks no stage for a skipped (non-mechanical) reconcile — the gate never runs", async () => {
+    const { deps, input, trace } = harness({ labels: ["running", "blocked:spec"] });
+    const result = await reconcile(deps, input);
+
+    expect(result.outcome).toBe("skipped");
+    expect(trace.stageMarks).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1306. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1306

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786132560&installation_id=129708444&pr_number=1314&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1314&signature=4b4277ed959d4c584bcb0d1d452e995a659d6db5bf17abbc91652c79b33a79bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->