### PR TITLE
chore: #1290 write-a-skill: adopt Negation + Negative Space failure modes (upstream v1.1.0)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## write-a-skill (productivity) — adopt Negation + Negative Space steering failure modes (issue #1290)
+
+- **status**: modified
+- **upstream**: —
+- **why**: upstream v1.1.0 adoption — the skill taught nine sentence-level techniques and a review checklist but had no named failure modes for the Steering dimension; Negation and Negative Space are the two recurring patterns that survive the writing phase yet undermine the skill at inference time.
+- **what changed**: Added a new `## Steering failure modes` section between the writing-style techniques and the review checklist, with two named entries — **Negation** (prohibition amplifies the forbidden behaviour; cure: positive directive + paired alternative) and **Negative Space** (silence is delegated to priors; cure: deliberate fill-or-branch for every omission). Added two matching review-checklist items: `Negation check` and `Negative-space audit`.
+
+---
+
 ## afk (engineering) — remove auto-monitor loop (issue #1309)
 
 - **status**: modified

--- a/plugins/dev/skills/productivity/write-a-skill/SKILL.md
+++ b/plugins/dev/skills/productivity/write-a-skill/SKILL.md
@@ -197,6 +197,12 @@ writing any RedSkills SKILL.md. Each carries a one-line before → after.
    - Before: `Build a thin end-to-end path through every layer first, then flesh out.`
    - After: `Ship a **tracer bullet** first — and say "tracer bullet" every time you mean it.`
 
+## Steering failure modes
+
+**Negation** — a skill that steers by prohibition drags the forbidden behaviour into context and makes it more available. "Don't invent files" activates file-invention before the model reads past it. The cure: replace every prohibition with a positive directive. Where a hard ban is unavoidable, pair it on the same line with the correct alternative — `emit DONE` not `don't write done`.
+
+**Negative Space** — every case a skill leaves silent is delegated to the model's priors, not held neutral. Silences are not free: the model fills them from training, and training may not match the author's intent. The cure: read a draft for its silences and decide each omission deliberately. Fill it with the intended behaviour, or mark it as an acknowledged open branch. "Unaddressed" is not a valid final state.
+
 ## Review checklist (run after the draft compiles)
 
 - [ ] Description ends with the literal `"Use when …"` trigger.
@@ -211,3 +217,7 @@ writing any RedSkills SKILL.md. Each carries a one-line before → after.
 - [ ] **Trigger decision recorded** — the skill is explicitly user-only
   (`disable-model-invocation: true`) or model-invocable with a description that
   earns its context cost.
+- [ ] **Negation check** — each prohibition has a paired positive alternative on
+  the same line; rewrite standalone "don't X" entries as "do Y instead".
+- [ ] **Negative-space audit** — each silence is a deliberate open branch, not an
+  oversight; fill gaps or name them explicitly.


### PR DESCRIPTION
Automated AFK landing for #1290. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1290

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786133049&installation_id=129708444&pr_number=1315&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1315&signature=d8f6c6d3948fb75f0b4ae6ed5d2adef0faa914924e8319eba3a4b5ae2fbdbebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->