### PR TITLE
chore: #1295 Publishers write native sub-issue + blocked-by edges alongside req:N (ADR 0094)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Upstream base: `mattpocock/skills@272f99b22574f50e4266791c86b9302682970e23` (see
 
 ---
 
+## to-tickets and triage (engineering) — native dependency edges alongside req labels (issue #1295)
+
+- **status**: modified
+- **upstream**: `272f99b` (where applicable)
+- **why**: ADR 0094 adopts upstream v1.1.0's native dependency surface for humans while keeping RedSkills' proven `req:N` label runtime as the machine truth.
+- **what changed**: `/to-tickets` now directs publishers to create native sub-issue relationships for parent Spec children and native blocked-by relationships for dependencies while retaining `spec:N`, `blocked:dependency`, one `req:N` label per blocker, and the strict `## Blocked by` body fallback. `/triage` now carries the same both-surfaces directive when it creates or refreshes child/dependency metadata, with an explicit do-not-clean-up warning for the controlled redundancy.
+
 ## to-spec (engineering) — renamed from to-prd; vocabulary big bang (issue #1293)
 
 - **status**: renamed-from-to-prd

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -35,6 +35,30 @@ function shimEnv(home: string, extra: Record<string, string> = {}): NodeJS.Proce
 }
 
 describe("label vocabulary docs", () => {
+  it("teaches publishers to write native dependency edges and req labels together", async () => {
+    const toTickets = await readRepoFile("plugins/dev/skills/engineering/to-tickets/SKILL.md");
+    const triage = await readRepoFile("plugins/dev/skills/engineering/triage/SKILL.md");
+
+    for (const skill of [toTickets, triage]) {
+      expect(skill).toContain("native sub-issue relationship");
+      expect(skill).toContain("native blocked-by relationship");
+      expect(skill).toContain("req:N labels remain the machine truth");
+      expect(skill).toContain("human surface");
+      expect(skill).toContain("Do not clean up either side");
+    }
+  });
+
+  it("keeps the Blocked by body fallback beside native dependency edges", async () => {
+    const toTickets = await readRepoFile("plugins/dev/skills/engineering/to-tickets/SKILL.md");
+    const triage = await readRepoFile("plugins/dev/skills/engineering/triage/SKILL.md");
+
+    for (const skill of [toTickets, triage]) {
+      expect(skill).toContain("body fallback");
+      expect(skill).toContain("## Blocked by");
+      expect(skill).toContain("- [ ] #N");
+    }
+  });
+
   it("does not teach obsolete slice-routing labels", async () => {
     const docs = await Promise.all([
       readRepoFile("plugins/dev/skills/engineering/setup-red-skills/SKILL.md"),

--- a/plugins/dev/skills/engineering/to-tickets/SKILL.md
+++ b/plugins/dev/skills/engineering/to-tickets/SKILL.md
@@ -64,10 +64,10 @@ For each approved slice, publish a new issue. Use the issue template in `<suppor
 
 - Publish in **dependency order** (blockers first) so you can reference real issue identifiers in each "Blocked by" field
 - Tag only currently-unblocked AFK slices with the canonical `ready-for-agent` triage label (mapped string from `/setup-red-skills`).
-- If an AFK slice has open blockers, publish it as `blocked:dependency` + one `req:N` label **per blocker** (NOT `ready-for-human` — a dependency-blocked slice is healthy and must never page a human), keeping the strict `## Blocked by` task list in the body as the human-facing mirror. `req:N` labels are created on demand (`gh label create req:<n>` if missing). `/afk` auto-promotes the issue to `ready-for-agent` the moment its last dependency closes (event-driven close cascade, with the boot sweep as a safety net). See `/setup-red-skills` triage-labels *Dependency Edges*.
+- If an AFK slice has open blockers, publish it as `blocked:dependency` + one `req:N` label **per blocker** (NOT `ready-for-human` — a dependency-blocked slice is healthy and must never page a human). Also create the tracker-native blocked-by relationship for each blocker. The native blocked-by relationship is the human surface; req:N labels remain the machine truth for `/afk` close cascade, boot sweep, and gate census. Keep the strict `## Blocked by` task list in the body as the body fallback and human-facing mirror. `req:N` labels are created on demand (`gh label create req:<n>` if missing). `/afk` auto-promotes the issue to `ready-for-agent` the moment its last dependency closes (event-driven close cascade, with the boot sweep as a safety net). See `/setup-red-skills` triage-labels *Dependency Edges* and ADR 0094.
   - **`req:N` targets must be executable slices, never a Spec** (authoritative statement + rationale in Hard rules below). Before creating each `req:N` label, check the target with `gh issue view N --json labels`: if #N carries `type:spec`, **refuse the edge** and re-point it at the Spec's concrete executable slice(s) instead (the child issues carrying `spec:N`); when the Spec has no slices yet, first create the concrete slice the dependent actually waits on, then point `req:N` at that slice.
 - If a slice is HITL, publish it as `ready-for-human`. Do **not** include a literal `## Blocked by` section unless it should be auto-promoted to AFK after blockers close; use `## Current blocker` / `## Human decision needed` for gates, measurements, and decisions where closing a referenced issue is not enough to make the slice delegable.
-- If the parent is a Spec (carries `type:spec` + `needs-slicing`), tag every child with `spec:{N}` referencing the parent and, **after** all slices are published, remove `needs-slicing` from the parent Spec. Never remove `type:spec` — it is a permanent type marker. Never apply `ready-for-agent` to the parent Spec itself.
+- If the parent is a Spec (carries `type:spec` + `needs-slicing`), tag every child with `spec:{N}` referencing the parent and create the tracker-native sub-issue relationship from the parent Spec to the child Ticket. The native sub-issue relationship is the human surface; `spec:{N}` remains the label contract. After all slices are published, remove `needs-slicing` from the parent Spec. Never remove `type:spec` — it is a permanent type marker. Never apply `ready-for-agent` to the parent Spec itself.
 
 ### Hard rules — do not break these
 
@@ -76,6 +76,7 @@ For each approved slice, publish a new issue. Use the issue template in `<suppor
 - ❌ Do **not** create horizontal-slice issues ("the schema layer", "the API layer", "the UI layer")
 - ❌ Do **not** invent label strings — use the mapping from `/setup-red-skills`
 - ❌ Do **not** create a `req:N` edge whose target #N is a `type:spec` — dependency edges must point at executable slices. A Spec closes only after a manual bookkeeping step long after its substance ships (#907/#928: 46/46 children closed, Specs still open), so a `req:<Spec>` edge strands the dependent in `blocked:dependency` forever. Re-point at the Spec's `spec:N` children, or, when the Spec has no slices yet, first create the concrete slice the dependent waits on and point `req:N` at that.
+- ❌ Do **not** "clean up" controlled redundancy between native tracker edges and labels/body text. Do not clean up either side: native sub-issue relationship and native blocked-by relationship edges are for humans; req:N labels remain the machine truth; the `## Blocked by` body fallback stays for compatibility.
 - ❌ Do **not** inline file paths or code snippets in issue bodies — they go stale. The one exception is in `<supporting-info>` (decision-rich prototype output)
 - ✅ **Do** publish in dependency order so "Blocked by" fields point at real issue IDs
 - ✅ **Do** prefer many thin slices over few thick ones
@@ -119,6 +120,8 @@ Avoid specific file paths or code snippets — they go stale fast. **Exception**
 - [ ] #456
 
 Format: one GitHub task list entry per blocker, `- [ ] #N`. GitHub renders this as a native dependency widget ("Tracked by 0/N"), checkboxes auto-mark when the referenced issue closes. The `/afk` boot sweep parses this exact section to auto-promote issues whose blockers have all closed — keep the heading literal (`## Blocked by`, capitalised, no extra punctuation) and the format strict.
+
+This section is the body fallback required by ADR 0094. When the tracker supports native edges, publish the native blocked-by relationship too; keep this section anyway so older paths and audits retain the same source shape.
 
 Omit the section entirely (do not write "None") if the slice has no blockers.
 

--- a/plugins/dev/skills/engineering/triage/SKILL.md
+++ b/plugins/dev/skills/engineering/triage/SKILL.md
@@ -61,6 +61,7 @@ Show counts and one line per issue. Let the maintainer pick what to handle next.
 - ✅ **One category role + one state role per issue.** If state roles conflict on an existing issue, stop and ask the maintainer before doing anything else — proceeding with conflicting roles corrupts the triage state machine.
 - ❌ Do **not** invent label strings — use the mapping from `/setup-red-skills`; invented labels fragment the queue and break AFK claim queries. If a mapping is missing, ask the maintainer to run `/setup-red-skills` and stop.
 - ❌ Do **not** add a `req:N` dependency edge whose target #N carries `type:spec`. Before applying any `req:N` label, check the target with `gh issue view N --json labels`; if it is a Spec, refuse and re-point the edge at the Spec's concrete executable slice(s) (the `spec:N` children — or a named slice created for the dependent when the Spec has none yet). A Spec closes only after a manual bookkeeping step long after its substance ships (#907/#928: 46/46 children closed, Specs still open), so a `req:<Spec>` edge would strand the dependent in `blocked:dependency` forever. See `.red/agents/triage-labels.md` *Dependency Edges*.
+- ❌ Do **not** "clean up" controlled redundancy between native tracker edges and labels/body text. Do not clean up either side: when `/triage` creates or refreshes dependency metadata, create the native sub-issue relationship to the parent Spec when one exists, create the native blocked-by relationship for each blocker, and still keep `req:N` labels because req:N labels remain the machine truth for `/afk`; retain the `## Blocked by` body fallback with one `- [ ] #N` task-list entry per blocker.
 - ❌ Do **not** skip Step 3 (Reproduce) for bug-category issues — an unverified repro leaves the agent brief guessing at the code path.
 - ❌ Do **not** modify or close a parent issue while triaging children — parent state reflects aggregate child state and must be updated only when the child set settles.
 
@@ -120,6 +121,16 @@ An unlabeled issue normally goes to `needs-triage` first. From there:
 The maintainer can override at any time — flag transitions that look unusual and ask before proceeding.
 
 ## Outcome actions (from Flow B step 5)
+
+When the outcome publishes or refreshes a child Ticket under a parent Spec, write both relationship surfaces: add the `spec:N` label and create the native sub-issue relationship. When the outcome parks a Ticket behind open blockers, write all three dependency surfaces: `blocked:dependency` + one `req:N` label per blocker, the native blocked-by relationship for each blocker, and the body fallback section:
+
+```markdown
+## Blocked by
+
+- [ ] #N
+```
+
+ADR 0094 makes this deliberate redundancy. Native sub-issue relationship and native blocked-by relationship edges are the human surface; req:N labels remain the machine truth for `/afk` runtime dependency machinery. Do not clean up either side.
 
 | Final state | Action |
 |---|---|


### PR DESCRIPTION
Automated AFK landing for #1295. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1295

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786146541&installation_id=129708444&pr_number=1319&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1319&signature=80d9267f06765d50b222173b89d5ffdcf81fb212e021eddd07d7e40f6e9575da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->