### PR TITLE
Show gate step for no-agent requeue-adopt statusline rows (#1318)

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -75,6 +75,7 @@ const WORKER_COLUMNS: readonly WorkerColumn[] = [
 ];
 type WorkerCells = Record<WorkerColumn, string>;
 type WorkerWidths = Record<WorkerColumn, number>;
+const NO_AGENT_ORIGINS = new Set(["requeue"]);
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
@@ -192,6 +193,7 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
   const runVal = [f.runner, f.model ? shortModel(f.model) : undefined, f.effort]
     .filter((x): x is string => Boolean(x))
     .join(" ");
+  const noAgent = f.origin !== undefined && NO_AGENT_ORIGINS.has(f.origin);
   return {
     workerId: f.workerId,
     run: `run=${runVal}`,
@@ -199,11 +201,11 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
     iss: f.issue === null ? "" : `iss=${String(f.issue)}`,
     stage: f.issue === null ? "" : f.stage,
     elapsed: f.elapsed,
-    loc: `loc=${formatDiff(f.added, f.removed)}`,
-    tks: `tks=${humanizeCount(f.tokens)}`,
-    tls: `tls=${String(f.tools)}`,
-    rsn: `rsn=${String(f.reasoning)}`,
-    txt: `txt=${String(f.text)}`,
+    loc: noAgent ? "" : `loc=${formatDiff(f.added, f.removed)}`,
+    tks: noAgent ? "" : `tks=${humanizeCount(f.tokens)}`,
+    tls: noAgent ? "" : `tls=${String(f.tools)}`,
+    rsn: noAgent ? "" : `rsn=${String(f.reasoning)}`,
+    txt: noAgent ? "" : `txt=${String(f.text)}`,
   };
 }
 
@@ -271,6 +273,9 @@ export function renderWorkerLine(worker: CompactWorker, now: number): string {
     if (f.stage) parts.push(f.stage);
   }
   parts.push(f.elapsed);
+  if (f.origin !== undefined && NO_AGENT_ORIGINS.has(f.origin)) {
+    return `${NOBG}${SOFT}${parts.join("  ")}${RESET}`;
+  }
   parts.push(kv("loc", formatDiff(f.added, f.removed)));
   parts.push(kv("tks", humanizeCount(f.tokens)));
   // The vitals as INDIVIDUAL 3-letter k=v pairs (single-spaced group), same

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -325,6 +325,51 @@ describe("statusline command — rendered line", () => {
     expect(rows[1]).not.toContain("iss=2001");
   });
 
+  it("renders a requeue-origin no-agent row with gate stage and elapsed, not zero agent metrics", async () => {
+    await writeWorkerState(root, "requeue-adopt", "1293-a1", {
+      worker_id: "requeue-adopt",
+      runner: "claude",
+      origin: "requeue",
+      current: {
+        number: 1293,
+        stage: "typecheck",
+        diff_added: 0,
+        diff_removed: 0,
+        started_at: new Date().toISOString(),
+      },
+    });
+    await seedFreshCache(root, 0, 0);
+    await seedFreshRepoCache(root, 0, 0);
+
+    const out = sink();
+    const oldColumns = process.env.COLUMNS;
+    const oldNoColor = process.env.NO_COLOR;
+    process.env.COLUMNS = "200";
+    delete process.env.NO_COLOR;
+    try {
+      const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+      expect(code).toBe(0);
+    } finally {
+      if (oldColumns === undefined) delete process.env.COLUMNS;
+      else process.env.COLUMNS = oldColumns;
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+
+    const rows = stripAnsi(out.text()).trimEnd().split("\n");
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toContain("requeue-adopt");
+    expect(rows[1]).toContain("org=requeue");
+    expect(rows[1]).toContain("iss=1293");
+    expect(rows[1]).toContain("typecheck");
+    expect(rows[1]).toMatch(/\b\d{2}:\d{2}:\d{2}\b/);
+    expect(rows[1]).not.toContain("loc=+0 -0");
+    expect(rows[1]).not.toContain("tks=0");
+    expect(rows[1]).not.toContain("tls=0");
+    expect(rows[1]).not.toContain("rsn=0");
+    expect(rows[1]).not.toContain("txt=0");
+  });
+
   it("renders the 5h/7d rate-limit windows on the header when the payload exposes them", async () => {
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 0, 0);

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -254,6 +254,40 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(t).toContain("tls=11 rsn=13 txt=0");
     expect(t).not.toContain("stats=");
   });
+
+  it("renders requeue no-agent rows around gate stage and elapsed without zero activity metrics", () => {
+    const w = worker({
+      state: {
+        ...worker().state,
+        worker_id: "requeue-adopt",
+        origin: "requeue",
+        current: {
+          ...worker().state.current,
+          number: 1293,
+          stage: "typecheck",
+          input_tokens: 0,
+          output_tokens: 0,
+          tools_called_count: 0,
+          reasoning_events: 0,
+          text_chunk_count: 0,
+        },
+      },
+      diffAdded: 0,
+      diffRemoved: 0,
+    });
+    const t = stripAnsi(renderWorkerLine(w, NOW));
+    expect(t).toContain("requeue-adopt");
+    expect(t).toContain("run=claude opus high");
+    expect(t).toContain("org=requeue");
+    expect(t).toContain("iss=1293");
+    expect(t).toContain("typecheck");
+    expect(t).toContain("00:05:00");
+    expect(t).not.toContain("loc=+0 -0");
+    expect(t).not.toContain("tks=0");
+    expect(t).not.toContain("tls=0");
+    expect(t).not.toContain("rsn=0");
+    expect(t).not.toContain("txt=0");
+  });
 });
 
 describe("statusline style — full themed assembly", () => {
@@ -335,6 +369,45 @@ describe("statusline style — full themed assembly", () => {
     expect(secondRaw).toContain(KEY);
     expect(firstRaw).toContain(BOLD);
     expect(secondRaw).toContain(BOLD);
+  });
+
+  it("keeps agent metrics on agent rows while omitting them from requeue no-agent rows", () => {
+    const out = styleStatusline(input, {
+      now: NOW,
+      workers: [
+        worker({
+          state: {
+            ...worker().state,
+            worker_id: "requeue-adopt",
+            origin: "requeue",
+            current: { ...worker().state.current, number: 1293, stage: "lint" },
+          },
+          diffAdded: 0,
+          diffRemoved: 0,
+        }),
+        worker({
+          state: {
+            ...worker().state,
+            worker_id: "wA",
+            origin: "afk",
+            current: { ...worker().state.current, number: 17, stage: "impl", tools_called_count: 3 },
+          },
+          diffAdded: 12,
+          diffRemoved: 3,
+        }),
+      ],
+    });
+    const [, requeueRaw, agentRaw] = out.split("\n");
+    const requeue = stripAnsi(requeueRaw);
+    const agent = stripAnsi(agentRaw);
+    expect(requeue).toContain("org=requeue");
+    expect(requeue).toContain("lint");
+    expect(requeue).not.toContain("loc=");
+    expect(requeue).not.toContain("tks=");
+    expect(requeue).not.toContain("tls=");
+    expect(agent).toContain("org=afk");
+    expect(agent).toContain("loc=+12 -3");
+    expect(agent).toContain("tls=3");
   });
 
   it("defaults to the header row alone when no workers/now are supplied", () => {


### PR DESCRIPTION
Closes #1318. Salvaged from a codex AFK attempt (wRJ63) that produced the fix but was killed before committing. The requeue-adopt (no-agent) statusline row now surfaces the gate step + elapsed instead of zeroed agent metrics (tks/tls/rsn/txt/loc). Typecheck green locally; CI validates the suite. Branch is a clean fast-forward of main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786147434&installation_id=129708444&pr_number=1320&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1320&signature=fa7dd375e47a6f9c958918d15ec9ce8161e1560252ffe78ad7d4aaffcf9c5024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->