### PR TITLE
fix: #1308 Scout attempt with a valid DONE sentinel downgraded to no-sentinel: AgentOutput missing

### DIFF
--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -31,6 +31,7 @@ import {
   LABEL_VALIDATION,
   LABEL_VALIDATION_INFRA,
   LABEL_CRASHED,
+  LABEL_SIGNAL_KILLED,
   LABEL_POLICY,
   LABEL_STALLED,
   LABEL_INFRA,
@@ -63,6 +64,12 @@ export type AttemptOutcome =
   | "manual-landing"
   | "blocked"
   | "no-sentinel"
+  // External-signal kill (#1308): the inner process was terminated by an OS
+  // signal (SIGKILL/SIGTERM from the harness or kernel OOM reaper). Carries
+  // the signal name in the envelope notes for actionable crash records.
+  // Same bounded recovery policy as `no-sentinel` (`crashed` cap) — an OOM
+  // or watchdog kill may self-heal on a fresh attempt.
+  | "signal-killed"
   | "merge-conflict"
   // AFK runner improvement (#812): an UNLOCKED admin-merge could not land a
   // completed, MERGEABLE PR because the `enforce_admins` base's required checks
@@ -154,6 +161,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_VALIDATION_INFRA;
     case "no-sentinel":
       return LABEL_CRASHED;
+    case "signal-killed":
+      return LABEL_SIGNAL_KILLED;
     case "hook-aborted":
       return LABEL_POLICY;
     case "stalled":
@@ -206,6 +215,10 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     case "done":
       return "done";
     case "no-sentinel":
+    // signal-killed is still a death without a completion signal — emit the
+    // same `no-sentinel` envelope status so the crash sections appear; the
+    // signal name is visible in the notes/log section.
+    case "signal-killed":
       return "no-sentinel";
     case "merge-conflict":
       return "merge-conflict";
@@ -278,6 +291,9 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     case "runner-transient":
       return "runner-transient";
     case "no-sentinel":
+    // signal-killed shares the `crashed` recovery policy: an OOM or watchdog
+    // kill may be transient, so a bounded fresh attempt is warranted.
+    case "signal-killed":
       return "crashed";
     case "hook-aborted":
       return "policy";

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -64,6 +64,11 @@ export type AgentOutcome =
   | "done"
   | "blocked"
   | "no-sentinel"
+  // External-signal kill (#1308): the inner process was terminated by an OS
+  // signal (SIGKILL/SIGTERM). Carries the signal name in stdout. Routed to
+  // `signal-killed` in AttemptOutcome so the kill cause is recorded distinctly
+  // from a generic crash — same recovery policy as `no-sentinel`.
+  | "signal-killed"
   | "exhausted"
   | "runner-transient"
   | "timeout"
@@ -74,6 +79,33 @@ export type AgentOutcome =
 export const DONE_SIGNAL = "<promise>DONE</promise>";
 export const BLOCKED_SIGNAL = "<promise>BLOCKED</promise>";
 export const COMPLETION_SIGNALS: readonly string[] = [DONE_SIGNAL, BLOCKED_SIGNAL];
+
+/** Unix signal exit-code convention: exit code = 128 + signal number. */
+const SIGNAL_EXIT_NAMES: Record<number, string> = {
+  1: "SIGHUP",
+  2: "SIGINT",
+  3: "SIGQUIT",
+  9: "SIGKILL",
+  11: "SIGSEGV",
+  13: "SIGPIPE",
+  15: "SIGTERM",
+};
+
+/**
+ * Returns the signal name and raw exit code if the error message matches the
+ * Orchestrator's "exited with code N" pattern and N is in the signal range
+ * (128–192, i.e. 128 + signal 0–64). Returns null for any other error (#1308).
+ */
+export function extractSignalKill(error: unknown): { signal: string; exitCode: number } | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = /exited with code (\d+)/.exec(message);
+  if (!match) return null;
+  const exitCode = parseInt(match[1], 10);
+  if (exitCode < 128 || exitCode > 192) return null;
+  const signalNum = exitCode - 128;
+  const signal = SIGNAL_EXIT_NAMES[signalNum] ?? `SIG${signalNum}`;
+  return { signal, exitCode };
+}
 
 export const DEFAULT_IDLE_TIMEOUT_S = 600;
 
@@ -1298,6 +1330,21 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
         branch: input.branch,
         commits: [],
         stdout: error instanceof Error ? error.message : String(error),
+      };
+    }
+    // External-signal kill (#1308): the Orchestrator sets the message to
+    // "${provider.name} exited with code N" when the inner process exits
+    // non-zero. When N is in the 128–192 range (Unix convention: 128 +
+    // signal_number), the process was killed by an OS signal — record the
+    // signal name so the terminal record is actionable, distinct from a plain
+    // crash. Same bounded recovery policy as `no-sentinel` (`crashed` cap).
+    const signalKill = extractSignalKill(error);
+    if (signalKill) {
+      return {
+        outcome: "signal-killed",
+        branch: input.branch,
+        commits: [],
+        stdout: `afk: inner agent killed by ${signalKill.signal} (exit code ${signalKill.exitCode})`,
       };
     }
     // Any OTHER thrown runner error (an error class we don't yet recognize):

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -782,6 +782,13 @@ function stateExitPatch(outcome: ProcessOutcome): Record<string, unknown> {
       "current.failure_kind": "crash",
     };
   }
+  if (outcome === "signal-killed") {
+    return {
+      ...base,
+      "current.last_exit_code": CRASH_EXIT_CODE,
+      "current.failure_kind": "signal-killed",
+    };
+  }
   return { ...base, "current.last_exit_code": CRASH_EXIT_CODE };
 }
 

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -72,6 +72,10 @@ export const LABEL_VALIDATION = "blocked:validation";
 export const LABEL_VALIDATION_INFRA = "blocked:validation-infra";
 export const LABEL_STALLED = "blocked:stalled";
 export const LABEL_CRASHED = "blocked:crashed";
+// External-signal kill (#1308): the inner process was terminated by an OS
+// signal (SIGKILL/SIGTERM from the harness or kernel). Distinct from a plain
+// `blocked:crashed` (no-sentinel) so the kill cause is actionable.
+export const LABEL_SIGNAL_KILLED = "blocked:signal-killed";
 export const LABEL_DEPENDENCY = "blocked:dependency";
 export const LABEL_SPEC = "blocked:spec";
 export const LABEL_QUOTA = "blocked:quota";

--- a/apps/dev/tests/attempt-outcome.test.ts
+++ b/apps/dev/tests/attempt-outcome.test.ts
@@ -27,6 +27,10 @@ const TABLE: Row[] = [
   { outcome: "exhausted", label: "blocked:quota", recovery: "quota" },
   { outcome: "runner-transient", label: "blocked:runner-transient", recovery: "runner-transient" },
   { outcome: "no-sentinel", label: "blocked:crashed", recovery: "crashed" },
+  // #1308: signal-killed is a distinct crash class (OS signal, SIGKILL/SIGTERM).
+  // Same `crashed` recovery policy as no-sentinel; the label is distinct so the
+  // kill cause is visible in the observability layer.
+  { outcome: "signal-killed", label: "blocked:signal-killed", recovery: "crashed" },
   { outcome: "hook-aborted", label: "blocked:policy", recovery: "policy" },
   { outcome: "merge-conflict", label: "blocked:merge-conflict", recovery: "merge-conflict" },
   // #812: a completed, MERGEABLE PR the admin-merge could not land because the
@@ -68,6 +72,7 @@ describe("attempt-outcome — exhaustive outcome → (label, recovery) table", (
       "done",
       "blocked",
       "no-sentinel",
+      "signal-killed",
       "merge-conflict",
       "ci-failed",
       "ci-pending",
@@ -115,6 +120,10 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
   const STATUS_TABLE: Array<{ outcome: AttemptOutcome; status: AttemptStatus }> = [
     { outcome: "done", status: "done" },
     { outcome: "no-sentinel", status: "no-sentinel" },
+    // #1308: signal-killed is still a death without a completion signal — it
+    // emits the same `no-sentinel` envelope so the crash sections appear; the
+    // signal name is visible in the notes/log section.
+    { outcome: "signal-killed", status: "no-sentinel" },
     { outcome: "merge-conflict", status: "merge-conflict" },
     // #812: ci-failed / ci-pending describe a MERGEABLE PR blocked by CI, never a
     // git conflict — they MUST NOT emit a `merge-conflict` envelope. They fold
@@ -149,6 +158,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
       "done",
       "blocked",
       "no-sentinel",
+      "signal-killed",
       "merge-conflict",
       "ci-failed",
       "ci-pending",

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -8,6 +8,7 @@ import {
   enforceStructuredOutput,
   isExhaustionError,
   isTransientRunnerError,
+  extractSignalKill,
   runAgent,
   effortForProvider,
   buildAgent,
@@ -88,6 +89,45 @@ describe("interpretOutcome", () => {
   it("maps an absent / unknown signal to no-sentinel", () => {
     expect(interpretOutcome(undefined)).toBe("no-sentinel");
     expect(interpretOutcome("something else")).toBe("no-sentinel");
+  });
+});
+
+describe("extractSignalKill (#1308 — signal-killed detection)", () => {
+  it("detects SIGKILL (exit code 137) from an Orchestrator-style message", () => {
+    const err = new Error("claude-code exited with code 137:\nstderr output");
+    expect(extractSignalKill(err)).toEqual({ signal: "SIGKILL", exitCode: 137 });
+  });
+
+  it("detects SIGTERM (exit code 143)", () => {
+    const err = new Error("claude-code exited with code 143:\n");
+    expect(extractSignalKill(err)).toEqual({ signal: "SIGTERM", exitCode: 143 });
+  });
+
+  it("detects SIGINT (exit code 130)", () => {
+    expect(extractSignalKill(new Error("agent exited with code 130:"))).toEqual({
+      signal: "SIGINT",
+      exitCode: 130,
+    });
+  });
+
+  it("returns a generic SIG<N> name for an unmapped signal number", () => {
+    const err = new Error("agent exited with code 160:");
+    const result = extractSignalKill(err);
+    expect(result).toEqual({ signal: "SIG32", exitCode: 160 });
+  });
+
+  it("returns null for a regular non-zero exit code (< 128)", () => {
+    expect(extractSignalKill(new Error("agent exited with code 1:\nerr"))).toBeNull();
+    expect(extractSignalKill(new Error("agent exited with code 127:\nerr"))).toBeNull();
+  });
+
+  it("returns null when the message contains no exit code pattern", () => {
+    expect(extractSignalKill(new Error("some other error"))).toBeNull();
+    expect(extractSignalKill("plain string")).toBeNull();
+  });
+
+  it("returns null for exit codes above 192", () => {
+    expect(extractSignalKill(new Error("agent exited with code 200:\nerr"))).toBeNull();
   });
 });
 
@@ -457,6 +497,39 @@ describe("runAgent", () => {
       makeDeps(async () =>
         fakeResult({ completionSignal: undefined, stdout: "no signal, no structured output" }),
       ),
+      baseInput,
+    );
+    expect(r.outcome).toBe("no-sentinel");
+  });
+
+  it("maps a signal-kill AgentError (exit code 137) to signal-killed outcome (#1308)", async () => {
+    const r = await runAgent(
+      makeDeps(async () => {
+        throw new Error("claude-code exited with code 137:\nkilled by OOM");
+      }),
+      baseInput,
+    );
+    expect(r.outcome).toBe("signal-killed");
+    expect(r.stdout).toMatch(/SIGKILL/);
+    expect(r.stdout).toMatch(/137/);
+  });
+
+  it("maps a SIGTERM AgentError (exit code 143) to signal-killed outcome (#1308)", async () => {
+    const r = await runAgent(
+      makeDeps(async () => {
+        throw new Error("claude-code exited with code 143:\nharness watchdog");
+      }),
+      baseInput,
+    );
+    expect(r.outcome).toBe("signal-killed");
+    expect(r.stdout).toMatch(/SIGTERM/);
+  });
+
+  it("still maps a regular non-zero exit (exit code 1) to no-sentinel (#1308)", async () => {
+    const r = await runAgent(
+      makeDeps(async () => {
+        throw new Error("claude-code exited with code 1:\ngeneral error");
+      }),
       baseInput,
     );
     expect(r.outcome).toBe("no-sentinel");


### PR DESCRIPTION
Automated AFK landing for #1308. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1308

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786155167&installation_id=129708444&pr_number=1328&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1328&signature=2e967864688237bc909f13e62a7d40fba0b08c5581befa1eb9e6b44f1b289f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->