### PR TITLE
chore: #1327 /go: Replace the raw hostname in the AFK worker identity with a hashed finger

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -80,7 +80,7 @@ import {
   deathCauseForRecoveredWorker,
 } from "../core/process-safety.js";
 import { join } from "node:path";
-import { hostname } from "node:os";
+import { hostFingerprintPrefix, workerIdentity } from "../core/host-identity.js";
 import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
 import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
@@ -822,7 +822,7 @@ export function buildProcessDeps(
     // audit comment. The self identity only needs the host for the same-host
     // gate (a cross-host predecessor's log isn't on this filesystem).
     recoveredWorkerDeathCause: (recoveredWorker) =>
-      deathCauseForRecoveredWorker(paths.tmpDir, recoveredWorker, `${hostname()}:`),
+      deathCauseForRecoveredWorker(paths.tmpDir, recoveredWorker, hostFingerprintPrefix()),
     claimLock: {
       // Atomic POSIX mkdir lock (#434): a non-recursive mkdir that fails EEXIST,
       // so two simultaneous boots cannot both claim the same issue. The prior
@@ -1968,8 +1968,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
         runner: c.runner,
         workerId: c.workerId,
         // ADR 0066 claimant identity: `host:worker_id`, unique per worker process
-        // per host so the GitHub-native claim never collides across machines.
-        claimant: `${hostname()}:${c.workerId}`,
+        // per host so the GitHub-native claim never collides across machines. The
+        // host half is a fingerprint, never the raw name — it lands in public
+        // issue comments (#1327).
+        claimant: workerIdentity(c.workerId),
         tmpDir: c.issueTemplate.tmpDir,
         attempt,
         attemptDir,

--- a/apps/dev/src/core/host-identity.ts
+++ b/apps/dev/src/core/host-identity.ts
@@ -1,0 +1,44 @@
+// The AFK worker identity's host half (issue #1327).
+//
+// The claim substrate (ADR 0066) identifies a worker as `<host>:<worker_id>` and
+// that identity is emitted verbatim into PUBLIC issue comments and `afk:claim`
+// markers. Emitting the raw `hostname()` leaks the operator's machine name into
+// a public repo, so the host half is replaced by a fingerprint: the md5 of the
+// host name truncated to twelve hex chars.
+//
+// Obfuscation, NOT a security boundary — md5 and the truncation are chosen for
+// brevity and readability, not for preimage resistance. Requirements are only:
+// deterministic per host (so a worker still recognizes its own marker and the
+// same-host death-cause gate keeps working) and distinct across hosts in
+// practice (so two machines never collide on one claim identity).
+//
+// Every site that builds the host half routes through here. Legacy markers left
+// on live issues still carry a raw hostname; they parse unchanged and simply
+// read as a different (cross-host) claimant — degrade gracefully, no migration.
+
+import { createHash } from "node:crypto";
+import { hostname } from "node:os";
+
+/** Hex chars kept from the md5 digest. Twelve reads like a short device id and
+ * gives ~48 bits — far past collision range for a fleet of machines. */
+export const HOST_FINGERPRINT_LENGTH = 12;
+
+/** Fingerprint an arbitrary host name (pure — the testable core). */
+export function fingerprintHost(host: string): string {
+  return createHash("md5").update(host).digest("hex").slice(0, HOST_FINGERPRINT_LENGTH);
+}
+
+/** This host's fingerprint — the host half of every emitted worker identity. */
+export function hostFingerprint(): string {
+  return fingerprintHost(hostname());
+}
+
+/** `<fingerprint>:` — the prefix a same-host claim identity starts with. */
+export function hostFingerprintPrefix(): string {
+  return `${hostFingerprint()}:`;
+}
+
+/** The full claim identity for a worker on this host: `<fingerprint>:<worker_id>`. */
+export function workerIdentity(workerId: string): string {
+  return `${hostFingerprintPrefix()}${workerId}`;
+}

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -13,7 +13,7 @@ import { spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { hostname } from "node:os";
+import { hostFingerprintPrefix } from "../core/host-identity.js";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import type { SandboxMode } from "../core/execution.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
@@ -1640,7 +1640,7 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
       // A per-issue read failure drops that issue from the sweep (best-effort).
       claimedIssues: async () => {
         const claimed = [];
-        const hostPrefix = `${hostname()}:`;
+        const hostPrefix = hostFingerprintPrefix();
         for (const [issue, row] of issueStates) {
           if (row.state !== "OPEN") continue;
           if (!row.labels.includes(LABEL_RUNNING)) continue;

--- a/apps/dev/tests/host-identity.test.ts
+++ b/apps/dev/tests/host-identity.test.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto";
+import { hostname } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  HOST_FINGERPRINT_LENGTH,
+  fingerprintHost,
+  hostFingerprint,
+  hostFingerprintPrefix,
+  workerIdentity,
+} from "../src/core/host-identity.js";
+import { parseClaimRecords, renderClaimComment } from "../src/core/claim.js";
+import { splitClaimIdentity } from "../src/core/process-safety.js";
+
+describe("fingerprintHost", () => {
+  it("is the md5 of the host truncated to the fingerprint length", () => {
+    const expected = createHash("md5")
+      .update("cyber-XPS-13-9300")
+      .digest("hex")
+      .slice(0, HOST_FINGERPRINT_LENGTH);
+    expect(fingerprintHost("cyber-XPS-13-9300")).toBe(expected);
+    expect(fingerprintHost("cyber-XPS-13-9300")).toHaveLength(12);
+    expect(fingerprintHost("cyber-XPS-13-9300")).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("is deterministic per host, so a worker still recognizes its own marker", () => {
+    expect(fingerprintHost("mbp.local")).toBe(fingerprintHost("mbp.local"));
+  });
+
+  it("distinguishes different hosts", () => {
+    expect(fingerprintHost("mbp.local")).not.toBe(fingerprintHost("mbp2.local"));
+  });
+
+  it("never leaks the host name it hashed", () => {
+    expect(fingerprintHost("cyber-XPS-13-9300")).not.toContain("cyber");
+  });
+});
+
+describe("hostFingerprint", () => {
+  it("resolves this host's fingerprint through the one shared helper", () => {
+    expect(hostFingerprint()).toBe(fingerprintHost(hostname()));
+    expect(hostFingerprintPrefix()).toBe(`${hostFingerprint()}:`);
+  });
+});
+
+describe("workerIdentity", () => {
+  it("renders as <hashed-host>:<workerId> with the worker id unchanged", () => {
+    expect(workerIdentity("w2VPT")).toBe(`${hostFingerprint()}:w2VPT`);
+    expect(workerIdentity("w2VPT")).toMatch(/^[0-9a-f]{12}:w2VPT$/);
+    expect(splitClaimIdentity(workerIdentity("w2VPT"))).toEqual({
+      host: hostFingerprint(),
+      worker: "w2VPT",
+    });
+  });
+
+  it("keeps the raw host name out of the emitted claim and concede comments", () => {
+    const self = { worker: workerIdentity("w2VPT"), runner: "claude" };
+    const claim = renderClaimComment(self, "claim");
+    const concede = renderClaimComment(self, "concede");
+    for (const body of [claim, concede]) {
+      expect(body).not.toContain(hostname());
+      expect(body).toContain(`${hostFingerprint()}:w2VPT`);
+    }
+  });
+});
+
+describe("legacy raw-hostname markers", () => {
+  it("still parse without crashing (migration is out of scope)", () => {
+    const records = parseClaimRecords([
+      { id: 1, body: "<!-- afk:claim v1 worker=cyber-XPS-13-9300:w46N2 kind=claim runner=claude -->" },
+    ]);
+    expect(records).toEqual([
+      { commentId: 1, worker: "cyber-XPS-13-9300:w46N2", kind: "claim", runner: "claude", createdAt: undefined },
+    ]);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1327. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1327

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786156067&installation_id=129708444&pr_number=1330&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1330&signature=8df0a511832b15500ec421da075cf7c864149141b6888f1c3fd267c128471fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->