### PR TITLE
chore: #1335 AFK land step validates the post-merge tree, not the branch alone

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -129,6 +129,19 @@ export interface LandingDeps {
    * direct path (no PR) → never called.
    */
   onPrResolved?: (prNumber: number) => Promise<void>;
+  /**
+   * Opt-in post-merge-integration gate (#1335). When present, the landing re-runs
+   * the package-scoped feedback gate against the INTEGRATED tree (the worker branch
+   * merged with current origin/<base>) BEFORE pushing to the remote base. A failure
+   * aborts the landing and routes through the existing recovery instead of merging
+   * an unvalidated or stale-main-broken result. Absent (the default) → skipped,
+   * so existing callers that have not yet wired the dep are unchanged.
+   *
+   * Called with the path of the already-integrated worktree:
+   *   - direct path: the detached landing worktree after `integrateOrigin`
+   *   - PR path: the isolated rebase worktree after `preMergeRebase`
+   */
+  postMergeGate?: (mergedTreeDir: string) => Promise<{ ok: boolean }>;
 }
 
 /** Static per-landing inputs the caller already resolved. */
@@ -260,7 +273,13 @@ export type LandingResult =
         // Sensitive-path guard (issue #1102): the branch diff touches a CI
         // workflow file, a package.json lifecycle script, a git hook, or `.red/`
         // trust/gate configuration. Never auto-lands; pages a human.
-        | "sensitive-paths";
+        | "sensitive-paths"
+        // Post-merge-integration gate (#1335): the feedback gate failed on the
+        // integrated (worker branch merged with current origin/<base>) tree. The
+        // landing aborted BEFORE pushing anything to the remote base. The caller
+        // routes this through the existing merge-conflict/validation recovery so
+        // an unvalidated or stale-main-broken result is never merged.
+        | "post-merge-gate";
       locked: boolean;
       /** PR number left open for the CI-aware handoff (`ci-failed` / `ci-pending`). */
       prNumber?: number;
@@ -538,9 +557,19 @@ async function preMergeRebaseInWorktree(
       branch: input.branch,
       resolveMechanical: deps.resolveMechanicalConflict,
     });
-    if (rebased.ok) return undefined;
-    // Real conflict / exhausted force-with-lease retries → park merge-conflict.
-    return { ok: false, reason: "pr-conflict", locked: input.locked };
+    if (!rebased.ok) {
+      // Real conflict / exhausted force-with-lease retries → park merge-conflict.
+      return { ok: false, reason: "pr-conflict", locked: input.locked };
+    }
+    // Post-merge-integration gate (#1335): re-run the feedback gate on the
+    // rebased worktree (worker branch rebased onto current origin/<base>)
+    // before the admin-merge. A failure aborts here so a stale-main-broken
+    // result is never merged.
+    if (deps.postMergeGate) {
+      const gateResult = await deps.postMergeGate(dir);
+      if (!gateResult.ok) return { ok: false, reason: "post-merge-gate", locked: input.locked };
+    }
+    return undefined;
   } finally {
     await deps.removeRebaseWorktree?.(dir);
   }
@@ -572,6 +601,15 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
       inSync: false,
     });
     if (!integrated.ok) return { ok: false, reason: "integrate-failed", locked: input.locked };
+
+    // Post-merge-integration gate (#1335): re-run the feedback gate on the
+    // already-integrated worktree (worker branch merged with current
+    // origin/<base>) before pushing anything to the remote. A failure aborts
+    // here so a stale-main-broken result is never merged.
+    if (deps.postMergeGate) {
+      const gateResult = await deps.postMergeGate(landDir);
+      if (!gateResult.ok) return { ok: false, reason: "post-merge-gate", locked: input.locked };
+    }
 
     const branchTip = input.validatedBranchTip ?? (await resolveRemoteBranchTip(deps.mergeExec, {
       repo: landDir,

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -37,6 +37,8 @@ interface Harness {
   mainRedRepairLookups: number;
   /** cwds the conflict resolver was dispatched in. */
   resolverCwds: string[];
+  /** dirs the post-merge gate was invoked with (#1335). */
+  postMergeGateDirs: string[];
 }
 
 interface Opts {
@@ -115,6 +117,14 @@ interface Opts {
   labels?: string[];
   /** Force the admin PR path to create a PR instead of reusing an open one. */
   createPr?: boolean;
+  /**
+   * Post-merge-integration gate (#1335). When true, wire `deps.postMergeGate`
+   * so the test can assert which dirs the gate was called with. When false or
+   * absent, `postMergeGate` is absent → the gate is skipped (backwards-compat).
+   */
+  postMergeGate?: boolean;
+  /** When true AND `postMergeGate` is wired, the gate returns `{ ok: false }`. */
+  postMergeGateFails?: boolean;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -125,6 +135,7 @@ function harness(opts: Opts = {}): Harness {
   const removedRebaseWorktrees: string[] = [];
   let mainRedRepairLookups = 0;
   const resolverCwds: string[] = [];
+  const postMergeGateDirs: string[] = [];
   let mergeResolved = false;
   let prCreated = false;
 
@@ -265,6 +276,13 @@ function harness(opts: Opts = {}): Harness {
             mainRedRepairLookups += 1;
             return opts.mainRedRepairIssue ? { number: 123 } : null;
           },
+    // Post-merge-integration gate (#1335): only wired when the test opts in.
+    postMergeGate: opts.postMergeGate
+      ? async (dir) => {
+          postMergeGateDirs.push(dir);
+          return { ok: !opts.postMergeGateFails };
+        }
+      : undefined,
   };
 
   const input: LandingInput = {
@@ -309,6 +327,7 @@ function harness(opts: Opts = {}): Harness {
       return mainRedRepairLookups;
     },
     resolverCwds,
+    postMergeGateDirs,
   };
 }
 
@@ -1078,5 +1097,95 @@ describe("doLanding — primary promotion is a guarded fast-forward only (ADR 00
     expect(r).toEqual({ ok: true, locked: false });
     // The unlocked path keeps its best-effort local fast-forward of <target>=main.
     expect(joined(h.mergeCalls).some((c) => c.includes("git -C /repo merge --ff-only origin/main"))).toBe(true);
+  });
+});
+
+// --- post-merge-integration gate (#1335) ---
+// Validate the merged tree (origin/<base> integrated into the worker branch)
+// BEFORE pushing to the remote, so a stale-main-broken result is never merged.
+describe("doLanding — post-merge-integration gate (#1335)", () => {
+  it("direct path: gate absent → proceeds unchanged (backwards-compat)", async () => {
+    const h = harness({ locked: true, openPr: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
+    expect(h.postMergeGateDirs).toEqual([]);
+  });
+
+  it("PR path: gate absent → proceeds unchanged (backwards-compat)", async () => {
+    const h = harness({ locked: false, openPr: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(h.postMergeGateDirs).toEqual([]);
+  });
+
+  it("direct path: gate wired + passes → lands successfully, gate called with the landing worktree", async () => {
+    const h = harness({ locked: true, openPr: false, postMergeGate: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
+    // Gate was called exactly once with the landing worktree (WT), not the primary.
+    expect(h.postMergeGateDirs).toEqual([WT]);
+    // The merge still happened (gate passed, not a no-merge).
+    expect(joined(h.mergeCalls).some((c) => c.includes("merge"))).toBe(true);
+  });
+
+  it("PR path: gate wired + passes → lands successfully, gate called with the rebase worktree", async () => {
+    const h = harness({ locked: false, openPr: true, postMergeGate: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: false });
+    // Gate was called exactly once with the rebase worktree (RWT), not the primary.
+    expect(h.postMergeGateDirs).toEqual([RWT]);
+    // The admin-merge still happened.
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(true);
+  });
+
+  it("direct path: gate wired + fails → returns post-merge-gate, nothing pushed to remote", async () => {
+    const h = harness({ locked: true, openPr: false, postMergeGate: true, postMergeGateFails: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "post-merge-gate", locked: true });
+    // Gate was called with the landing worktree.
+    expect(h.postMergeGateDirs).toEqual([WT]);
+    // Nothing was pushed to the remote base (origin/<base>).
+    const j = joined(h.mergeCalls);
+    expect(j.some((c) => c.includes(`push origin HEAD:refs/heads/`))).toBe(false);
+    // No --no-ff landing merge was created (integrateOrigin's ff-only is allowed).
+    expect(j.some((c) => c.includes("merge --no-ff"))).toBe(false);
+  });
+
+  it("PR path: gate wired + fails → returns post-merge-gate, no admin-merge attempted", async () => {
+    const h = harness({ locked: false, openPr: true, postMergeGate: true, postMergeGateFails: true });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "post-merge-gate", locked: false });
+    // Gate was called with the rebase worktree.
+    expect(h.postMergeGateDirs).toEqual([RWT]);
+    // No admin-merge was attempted.
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(false);
+  });
+
+  it("direct path: gate failure aborts before the merge but worktree is still torn down", async () => {
+    const h = harness({ locked: true, openPr: false, postMergeGate: true, postMergeGateFails: true });
+    await doLanding(h.deps, h.input, h.hooks);
+    // The landing worktree is always cleaned up even on gate failure.
+    expect(h.removedWorktrees).toEqual([WT]);
+  });
+
+  it("PR path: gate failure aborts before admin-merge but rebase worktree is still torn down", async () => {
+    const h = harness({ locked: false, openPr: true, postMergeGate: true, postMergeGateFails: true });
+    await doLanding(h.deps, h.input, h.hooks);
+    // The rebase worktree is always cleaned up even on gate failure.
+    expect(h.removedRebaseWorktrees).toEqual([RWT]);
+  });
+
+  it("direct path: integrate-failed → gate is never called (gate only runs on success)", async () => {
+    const h = harness({ locked: true, openPr: false, postMergeGate: true, integrateCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "integrate-failed", locked: true });
+    expect(h.postMergeGateDirs).toEqual([]);
+  });
+
+  it("PR rebase conflict → gate is never called (gate only runs on successful rebase)", async () => {
+    const h = harness({ locked: false, openPr: true, postMergeGate: true, rebaseCode: 1 });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    expect(h.postMergeGateDirs).toEqual([]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1335. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1335

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786159837&installation_id=129708444&pr_number=1339&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1339&signature=17feb8b891146e19c63c6d038f3ead650d90e8d44cebb3d44e62c8cdec775798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->