### PR TITLE
chore: #1336 Slice for disjoint files + fleet-width-by-disjunction guidance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,24 @@ Upstream base: `mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3` (v1.
 
 ---
 
+## to-tickets (engineering) — file-disjunction rule: serialize overlapping slices (issue #1336)
+
+- **status**: modified
+- **upstream**: —
+- **why**: Spec #1333 root cause 1 — file-overlapping concurrent slices produce inherent merge conflicts at landing that no runtime can recover. The slicing skill lacked a rule directing the slicer to express file-level dependencies as `req:N` edges, leaving parallelism decisions to the slicer's judgment with no safety net.
+- **what changed**: Step 3 of `plugins/dev/skills/engineering/to-tickets/SKILL.md` now carries a "File disjunction check" paragraph directing the slicer to inspect parallel slices for file-set overlap and serialize entangled pairs with `req:N` edges. Added a matching Hard Rule (`❌ Do not mark two slices as parallelizable when they write to the same file(s)`). Extended the vertical-slice-rules in `<supporting-info>` with the parallel-implies-disjoint invariant.
+
+---
+
+## afk/fleet.md — fleet-width-by-disjunction guidance (issue #1336)
+
+- **status**: modified
+- **upstream**: —
+- **why**: Spec #1333 root cause 1 — operators had no documented guidance on choosing a safe fleet width. Running `fleet 2` on a fully entangled refactor serialized by `req:N` is wasteful at best and risks spurious conflicts if a dependency edge is missing.
+- **what changed**: added a "## Fleet Width by Disjunction" section to `plugins/dev/skills/engineering/afk/fleet.md` stating the rule: fleet width = degree of disjunction. Covers the disjoint-queue (full fleet safe), partially-entangled-queue (lower width to disjoint-group count), and fully-entangled-refactor (`fleet 1`) cases. Cross-references `/to-tickets` as the skill responsible for expressing file-level dependencies as `req:N` edges before queue publication.
+
+---
+
 ## afk (engineering) — validation-authority guard: the gate command is canonical (issue #1334)
 
 - **status**: modified

--- a/apps/dev/tests/disjoint-files-fleet-width-docs.test.ts
+++ b/apps/dev/tests/disjoint-files-fleet-width-docs.test.ts
@@ -1,0 +1,62 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const TO_TICKETS = "plugins/dev/skills/engineering/to-tickets/SKILL.md";
+const FLEET_MD = "plugins/dev/skills/engineering/afk/fleet.md";
+
+async function readToTickets(): Promise<string> {
+  return readFile(join(ROOT, TO_TICKETS), "utf8");
+}
+
+async function readFleetMd(): Promise<string> {
+  return readFile(join(ROOT, FLEET_MD), "utf8");
+}
+
+describe("disjoint-files + fleet-width-by-disjunction docs contract (#1336)", () => {
+  it("to-tickets Step 3 directs the slicer to serialize file-overlapping slices with req:N", async () => {
+    const skill = await readToTickets();
+
+    expect(skill).toContain("file-disjoint");
+    expect(skill).toContain("entangled");
+    expect(skill).toContain("serialize");
+  });
+
+  it("to-tickets hard rules forbid marking entangled slices as parallel", async () => {
+    const skill = await readToTickets();
+
+    expect(skill).toContain("file-entanglement merge conflict");
+    expect(skill).toContain("req:N` edges to serialize");
+  });
+
+  it("to-tickets vertical-slice-rules carry the parallel-implies-disjoint invariant", async () => {
+    const skill = await readToTickets();
+
+    expect(skill).toContain("Parallel slices must be file-disjoint");
+    expect(skill).toContain("file-overlapping slices get");
+    expect(skill).toContain("serialization edges");
+  });
+
+  it("fleet.md carries a Fleet Width by Disjunction section", async () => {
+    const fleet = await readFleetMd();
+
+    expect(fleet).toContain("## Fleet Width by Disjunction");
+    expect(fleet).toContain("degree of disjunction");
+  });
+
+  it("fleet.md names fleet 1 as the correct width for fully entangled refactors", async () => {
+    const fleet = await readFleetMd();
+
+    expect(fleet).toContain("fleet 1");
+    expect(fleet).toContain("entangled");
+    expect(fleet).toContain("fleet width = degree of disjunction");
+  });
+
+  it("fleet.md cross-references to-tickets as the responsible skill for req:N edges", async () => {
+    const fleet = await readFleetMd();
+
+    expect(fleet).toContain("/to-tickets");
+    expect(fleet).toContain("req:N` edges");
+  });
+});

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -82,6 +82,16 @@ The `runner-error` label is created idempotently by `/setup-red-skills` (see [tr
 
 Idempotency: `SLOT_SWEPT[slot]=1` blocks a second sweep within the same supervisor lifetime. Across restarts a new trip yields fresh worker IDs and fresh attempt dirs, so re-tripping never re-touches the previously swept issues. A trip that finds no claimed issues (all workers exited before claiming) parks the slot but posts no envelopes — the attempt-dir sweep is a no-op.
 
+## Fleet Width by Disjunction
+
+The safe fleet width for a given queue is the **degree of disjunction** — the maximum number of concurrently `ready-for-agent` slices that touch non-overlapping file sets.
+
+- **Disjoint queue** (each slice writes to files no other ready slice touches): run the full fleet. `fleet 4` is safe when the queue has four independent file cones.
+- **Partially entangled queue**: lower the fleet width to the number of disjoint groups. If two groups of two slices each are independent between groups but internally serialized via `req:N`, `fleet 2` drains both chains in parallel without risk.
+- **Fully entangled refactor** (every slice touches shared files, serialized via `req:N`): run `fleet 1` or bare `/afk`. Parallel workers share no ready-for-agent work at any moment — extra slots sit idle and raise the risk of a spurious merge conflict should a `req:N` edge be missing.
+
+**Rule: fleet width = degree of disjunction.** Raise it when the queue is disjoint; lower it to `fleet 1` when slices are entangled. The `/to-tickets` slicing skill is responsible for expressing file-level dependencies as `req:N` edges before the queue is published, so a correctly-sliced backlog never produces a file-overlap merge conflict from concurrent workers.
+
 ### Refs
 
 - The bundle's `fleet` / `fleet stop` commands — the entrypoints this section drives. Stop-file path, env contract, circuit breaker, and trip-sweep are part of the supervisor behaviour described above.

--- a/plugins/dev/skills/engineering/to-tickets/SKILL.md
+++ b/plugins/dev/skills/engineering/to-tickets/SKILL.md
@@ -32,6 +32,8 @@ Mark each slice with its routing class:
 
 Prefer AFK over HITL wherever possible.
 
+**File disjunction check — serialize entangled slices.** After assigning routing classes, inspect every pair of parallel slices (those with no `req:N` edge between them) for file-set overlap. Two slices are *entangled* when they both write to the same file(s). Entangled concurrent slices produce a merge conflict that no runtime resolves — the conflict is inherent, not recoverable. Serialize them: add a `req:N` dependency edge from the later slice to the earlier one so only one is `ready-for-agent` at a time. Parallel slots belong exclusively to *file-disjoint* slices that touch non-overlapping file sets. This is the canonical serialization mechanism; the AFK fleet width is calibrated from the resulting disjunction structure (see `/afk fleet` docs).
+
 ### Step 4 — Quiz the user (mandatory — do not skip)
 
 Present the proposed breakdown as a numbered list. For each slice show:
@@ -71,6 +73,7 @@ For each approved slice, publish a new issue. Use the issue template in `<suppor
 
 ### Hard rules — do not break these
 
+- ❌ Do **not** mark two slices as parallelizable when they write to the same file(s) — that is a file-entanglement merge conflict waiting to happen at landing. Add `req:N` edges to serialize them instead; file-disjoint slices run in parallel, entangled ones run serial.
 - ❌ Do **not** publish until the user explicitly approved the breakdown in Step 4
 - ❌ Do **not** modify or close any parent issue
 - ❌ Do **not** create horizontal-slice issues ("the schema layer", "the API layer", "the UI layer")
@@ -91,6 +94,7 @@ For each approved slice, publish a new issue. Use the issue template in `<suppor
 - Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
 - A completed slice is demoable or verifiable on its own
 - Prefer many thin slices over few thick ones
+- Parallel slices must be file-disjoint; file-overlapping slices get `req:N` serialization edges so they run serial, not concurrent
 </vertical-slice-rules>
 
 A horizontal slice ("build the schema for all tables") cannot be demoed and cannot be merged independently — it produces issues that block each other unnecessarily and tests imagined behaviour.


### PR DESCRIPTION
Automated AFK landing for #1336. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1336

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786160961&installation_id=129708444&pr_number=1340&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1340&signature=53fe6940097b91f9f791781c59cb5898b110621530e40035de683cf7720d025e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->