### PR TITLE
chore: #1337 AFK serializes lands (native merge queue or global land-lock)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -70,6 +70,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { isLivePid } from "../runtime/kill-tree.js";
 import { specialUserRequestBlock, claudeSpawnArgs, codexSpawnArgs } from "../core/runner-spawn.js";
 import { buildWorkerAttemptPath } from "../core/worker-paths.js";
+import { createLandLock } from "../runtime/land-lock.js";
 import { branchLockPath, readLockedBranch, isLocked } from "../runtime/lock.js";
 import { makeHookExec, makeHookResolveOptions, hookEnv } from "../runtime/hooks.js";
 import { makeFeedbackWorktree, type FeedbackWorktree } from "../runtime/feedback-worktree.js";
@@ -819,6 +820,22 @@ export function buildProcessDeps(
   // base (ADR 0031). Honours the namespaced + legacy fallback via loadConfig.
   const worktreeLaunchesPr = getConfig(config, "afk.worktree_launches_pull_request") !== "false";
 
+  // Serialized landing (#1337, Spec #1333 root cause 2). Two workers finishing in
+  // the same window used to both integrate-and-push into the base: the second push
+  // was rejected non-fast-forward, and re-integrating an overlapping diff conflicted.
+  //
+  //   afk.merge.native_queue: true → `<base>` has the forge's merge queue; the PR is
+  //     ENQUEUED and no local lock is taken (the queue rebases + revalidates each
+  //     entry onto the current tip itself).
+  //   otherwise → a global land-lock at `.red/tmp/afk-land.lock`, scoping mutual
+  //     exclusion to every AFK worker landing into this repo on this host. Default
+  //     ON; `afk.merge.land_lock: false` opts out into the pre-#1337 unserialized land.
+  const nativeMergeQueue = getConfig(config, "afk.merge.native_queue") === "true";
+  const landLock =
+    nativeMergeQueue || getConfig(config, "afk.merge.land_lock") === "false"
+      ? undefined
+      : createLandLock(paths.tmpDir, `pid-${process.pid}`);
+
   // Intra-attempt notes-loop (Track C, #924). Default OFF → exactly one agent
   // call. When enabled, processIssue wraps the inner invocation in a bounded
   // outer loop carrying an accumulated `notes.md` between iterations.
@@ -1018,6 +1035,8 @@ export function buildProcessDeps(
     waitForReview,
     ciAwait,
     worktreeLaunchesPr,
+    landLock,
+    nativeMergeQueue,
     reviewGate,
     reviewGateLabel: LABEL_READY_FOR_REVIEW,
     // One-shot merge-conflict resolver (merge_resolve_conflict): re-enter the

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -106,6 +106,18 @@ export const CONFIG_DEFAULTS = {
   // once it settles, routing a failed check (`blocked:ci`) / still-pending checks
   // distinctly. The wait budget is `RED_AFK_MERGE_CI_TIMEOUT_S` (default 1800s).
   "afk.merge.ci_aware": "false",
+  // Serialized landing (#1337). Two workers finishing in the same window used to
+  // both integrate-and-push into the base: the second push was rejected
+  // non-fast-forward, and re-integrating an overlapping diff conflicted. Set
+  // `afk.merge.native_queue: true` when `<base>` has the forge's merge queue — the
+  // PR is then ENQUEUED (`gh pr merge --auto`) and no local lock is taken, because
+  // the queue rebases + revalidates each entry onto the current tip itself.
+  "afk.merge.native_queue": "false",
+  // Otherwise every land takes a global land-lock at `.red/tmp/afk-land.lock`, so
+  // exactly one worker per host+repo is inside the integrate → revalidate → merge →
+  // push critical section. ON by default; set false only to restore the pre-#1337
+  // unserialized land (single-worker fleets, where nothing can race).
+  "afk.merge.land_lock": "true",
   // Landing-mode flag, decoupled from the branch-lock (ADR 0030 amended, #842).
   // The branch-lock now ONLY resolves the target base (lock > pin > main, ADR
   // 0031); this flag — independently — decides whether the attempt lands via an

--- a/apps/dev/src/core/land-lock.ts
+++ b/apps/dev/src/core/land-lock.ts
@@ -1,0 +1,176 @@
+// land-lock — the global mutual exclusion that SERIALIZES AFK landings (#1337).
+//
+// Root cause it closes (Spec #1333, root cause 2): two workers finish within the
+// same window and land into the same base. A pushes; B's push is rejected as a
+// non-fast-forward; B re-integrates and — if the two diffs overlap — conflicts.
+// Nothing about B's work was wrong; the two lands merely raced.
+//
+// TWO MECHANISMS, ONE PREFERENCE ORDER ({@link resolveLandSerialization}):
+//   1. `native-merge-queue` — the forge already serializes. When the base branch
+//      has a merge queue configured, AFK enqueues instead of merging directly and
+//      takes NO local lock: the queue rebases + revalidates each entry onto the
+//      current tip itself, which is exactly the guarantee we would otherwise build.
+//   2. `land-lock` — no native queue: only one worker at a time enters the local
+//      landing critical section (rebase/integrate → revalidate → merge → push), so
+//      every land observes a base tip no other worker can move underneath it.
+//   3. `unserialized` — neither is available. The pre-#1337 behaviour; the caller
+//      lands unguarded rather than refusing.
+//
+// PURE SEQUENCING over injected ports. The lock file, the clock, and holder
+// liveness are all injected; no real fs / process / timer is touched here.
+//
+// STALE TAKEOVER. A crashed worker must not deadlock the fleet forever, so a lock
+// is stolen when its record is older than `staleAfterMs`, when its holder process
+// is gone, or when the file is unparseable. Holder liveness is a same-host pid
+// probe — the lock file lives under the repo's local `.red/tmp/`, so every holder
+// shares this machine's process table.
+
+/** The holder record serialized into the lock file. */
+export interface LandLockRecord {
+  /** Worker id that owns the lock (observability + release ownership check). */
+  holder: string;
+  /** Holder's pid, probed by {@link LandLockDeps.isHolderAlive} for stale takeover. */
+  pid: number;
+  /** Wall-clock ms the lock was taken, compared against `staleAfterMs`. */
+  acquiredAtMs: number;
+}
+
+/** The three lock-file operations, injected so the lock is testable without fs. */
+export interface LandLockFs {
+  /**
+   * Create the lock file with O_EXCL semantics: `true` when THIS call created it,
+   * `false` when it already existed. The exclusivity of this one call is what makes
+   * the lock a lock — it must never overwrite an existing file.
+   */
+  createExclusive(path: string, contents: string): Promise<boolean>;
+  /** Read the lock file; `null` when it does not exist. */
+  read(path: string): Promise<string | null>;
+  /** Remove the lock file (best-effort; a missing file is not an error). */
+  remove(path: string): Promise<void>;
+}
+
+/** Injected time — `now` for the stale/timeout arithmetic, `sleep` between polls. */
+export interface LandLockClock {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+}
+
+export interface LandLockDeps {
+  fs: LandLockFs;
+  clock: LandLockClock;
+  /** Same-host pid liveness probe; `false` → the holder crashed → steal the lock. */
+  isHolderAlive(pid: number): boolean;
+}
+
+export interface LandLockOptions {
+  /** Absolute path of the lock file (one per repo, e.g. `.red/tmp/afk-land.lock`). */
+  path: string;
+  /** This worker's id, recorded so a release only removes a lock we still own. */
+  holder: string;
+  /** This worker's pid, recorded for the stale-takeover liveness probe. */
+  pid: number;
+  /** Total time a contended acquire waits before giving up. Default 15min. */
+  waitTimeoutMs?: number;
+  /** Delay between contention polls. Default 1s. */
+  pollMs?: number;
+  /** A lock older than this is considered abandoned and stolen. Default 30min. */
+  staleAfterMs?: number;
+}
+
+/** Release the lock. Idempotent, and a NO-OP once another worker owns the file. */
+export type LandLockRelease = () => Promise<void>;
+
+export interface LandLock {
+  /**
+   * Enter the landing critical section. Resolves with the release fn once the lock
+   * is held, or `null` when the wait timed out — the caller must then abort the
+   * landing rather than push unserialized.
+   */
+  acquire(): Promise<LandLockRelease | null>;
+}
+
+/** Which serialization mechanism a landing should use. Native queue wins: the forge
+ * serializes better than we can, and double-serializing would only add latency. */
+export type LandSerialization = "native-merge-queue" | "land-lock" | "unserialized";
+
+export function resolveLandSerialization(input: {
+  nativeMergeQueue?: boolean;
+  hasLandLock?: boolean;
+}): LandSerialization {
+  if (input.nativeMergeQueue === true) return "native-merge-queue";
+  return input.hasLandLock === true ? "land-lock" : "unserialized";
+}
+
+const DEFAULT_WAIT_TIMEOUT_MS = 15 * 60_000;
+const DEFAULT_POLL_MS = 1_000;
+const DEFAULT_STALE_AFTER_MS = 30 * 60_000;
+
+/** Parse a lock file's contents. `null` for absent, malformed, or wrong-shaped
+ * records — all of which are treated as an abandoned lock worth stealing, since a
+ * file we cannot read is a file whose holder we cannot wait for. */
+function parseRecord(raw: string | null): LandLockRecord | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const { holder, pid, acquiredAtMs } = parsed as Partial<LandLockRecord>;
+  if (typeof holder !== "string" || typeof pid !== "number" || typeof acquiredAtMs !== "number") return null;
+  return { holder, pid, acquiredAtMs };
+}
+
+function sameRecord(a: LandLockRecord, b: LandLockRecord): boolean {
+  return a.holder === b.holder && a.pid === b.pid && a.acquiredAtMs === b.acquiredAtMs;
+}
+
+export function createFileLandLock(deps: LandLockDeps, options: LandLockOptions): LandLock {
+  const { fs, clock, isHolderAlive } = deps;
+  const waitTimeoutMs = options.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+  const pollMs = options.pollMs ?? DEFAULT_POLL_MS;
+  const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+
+  /** Take the file, returning the release fn bound to the record we wrote — so a
+   * release after a stale takeover cannot delete the new owner's lock. */
+  async function tryTake(): Promise<LandLockRelease | null> {
+    const mine: LandLockRecord = { holder: options.holder, pid: options.pid, acquiredAtMs: clock.now() };
+    if (!(await fs.createExclusive(options.path, JSON.stringify(mine)))) return null;
+    return async () => {
+      const current = parseRecord(await fs.read(options.path));
+      if (current !== null && !sameRecord(current, mine)) return;
+      await fs.remove(options.path);
+    };
+  }
+
+  /** An abandoned lock: unreadable, older than `staleAfterMs`, or holder is gone. */
+  function abandoned(record: LandLockRecord | null): boolean {
+    if (record === null) return true;
+    if (clock.now() - record.acquiredAtMs >= staleAfterMs) return true;
+    return !isHolderAlive(record.pid);
+  }
+
+  return {
+    async acquire(): Promise<LandLockRelease | null> {
+      const deadline = clock.now() + waitTimeoutMs;
+      for (;;) {
+        const taken = await tryTake();
+        if (taken) return taken;
+
+        // Contended. Steal it only when the incumbent is provably abandoned — a
+        // LIVE holder is waited out, never evicted (that would resurrect the race).
+        if (abandoned(parseRecord(await fs.read(options.path)))) {
+          await fs.remove(options.path);
+          const stolen = await tryTake();
+          if (stolen) return stolen;
+        }
+
+        // Every iteration ends on the deadline check + a poll sleep, so a lock we
+        // can neither take nor steal times out instead of spinning.
+        if (clock.now() >= deadline) return null;
+        await clock.sleep(pollMs);
+      }
+    },
+  };
+}

--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -38,6 +38,7 @@ import {
   type Exec as MergeExec,
   type WaitForReviewInput,
 } from "./merge.js";
+import { resolveLandSerialization, type LandLock } from "./land-lock.js";
 import { decideMainRedAdminMerge, type MainRedRepairIssue } from "./main-red-repair.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { checkSensitivePaths, type SensitivePathHit } from "./shared-gate.js";
@@ -142,6 +143,17 @@ export interface LandingDeps {
    *   - PR path: the isolated rebase worktree after `preMergeRebase`
    */
   postMergeGate?: (mergedTreeDir: string) => Promise<{ ok: boolean }>;
+  /**
+   * Global AFK land-lock (#1337). Present → the landing critical section
+   * (integrate/rebase → revalidate → merge → push) runs under mutual exclusion, so
+   * only one worker at a time lands into `<base>` and each one rebases onto a tip
+   * no concurrent worker can move underneath it. A wait timeout aborts the landing
+   * as `infra` rather than pushing unserialized. Ignored when `<base>` has a native
+   * merge queue ({@link LandingInput.nativeMergeQueue}) — the forge serializes
+   * better than we can. Absent (the default) → lands unserialized, the pre-#1337
+   * behaviour, so callers that have not wired the dep are unchanged.
+   */
+  landLock?: LandLock;
 }
 
 /** Static per-landing inputs the caller already resolved. */
@@ -213,6 +225,14 @@ export interface LandingInput {
    * unaffected.
    */
   mainRed?: boolean;
+  /**
+   * `<base>` has the forge's native merge queue configured (#1337). True → the PR
+   * landing ENQUEUES (`gh pr merge --auto`) and takes NO local land-lock: the queue
+   * already serializes entries and rebases + revalidates each onto the current tip.
+   * Only meaningful on the PR path — a direct merge never opens a PR, so a queued
+   * base falls back to the land-lock there. Defaults false/undefined.
+   */
+  nativeMergeQueue?: boolean;
 }
 
 export function landingMergeTitle(input: { issue: number; title: string; labels?: readonly string[] }): string {
@@ -305,6 +325,10 @@ export type LandingResult =
  *   1. pushAttempt — make the worker branch's origin state certain so
  *      landMerge/landPr have a ref to merge.
  *   2. fireHook("pre_merge") — abort → { ok:false, reason:"pre_merge-abort" }.
+ *   3. SERIALIZE the land (#1337) — native merge queue when `<base>` has one, else
+ *      the global land-lock when wired, so no two workers integrate-and-push into
+ *      the same base concurrently. Everything after this point is the critical
+ *      section; the lock is always released, on success and on failure alike.
  *
  *   openPr=true → {@link landAdminPr}. The PR is admin-merged REMOTELY into
  *   `<base>`, so there is nothing to integrate locally first; the prior pre-merge
@@ -442,7 +466,44 @@ export async function doLanding(
     return { ok: false, reason: "pre_merge-abort", locked };
   }
 
-  const landed = input.openPr ? await landAdminPr(deps, input) : await landDirectInWorktree(deps, input);
+  // 3. Serialize the land (#1337). Everything below — integrate/rebase onto the
+  // fresh base, revalidate the integrated tree, merge, push — is the critical
+  // section two near-simultaneous workers used to race in: A pushes, B's push is
+  // rejected non-fast-forward, B re-integrates, and overlapping diffs conflict.
+  //
+  //   native-merge-queue → the forge serializes; take no local lock.
+  //   land-lock          → only one worker at a time enters, so each rebases onto
+  //                        a tip no concurrent land can move underneath it.
+  //   unserialized       → no lock wired (pre-#1337 default): land as before.
+  //
+  // A wait timeout ABORTS the landing as `infra` — pushing unserialized after
+  // failing to serialize would reintroduce exactly the race the lock exists for.
+  const serialization = resolveLandSerialization({
+    // The native queue is a PR-path mechanism: a direct merge never opens a PR, so
+    // a queued base still needs the local lock there.
+    nativeMergeQueue: input.openPr && input.nativeMergeQueue === true,
+    hasLandLock: deps.landLock !== undefined,
+  });
+
+  let release: (() => Promise<void>) | null = null;
+  if (serialization === "land-lock") {
+    release = (await deps.landLock?.acquire()) ?? null;
+    if (!release) {
+      return {
+        ok: false,
+        reason: "infra",
+        infraReason: "another worker held the AFK land-lock past the wait timeout",
+        locked,
+      };
+    }
+  }
+
+  let landed: LandingResult;
+  try {
+    landed = input.openPr ? await landAdminPr(deps, input) : await landDirectInWorktree(deps, input);
+  } finally {
+    await release?.();
+  }
   if (!landed.ok) return landed;
 
   // post_merge hook (best-effort; an abort here does not unwind the landing,
@@ -495,6 +556,9 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
     // Non-blocking backpressure evidence review (#1279): threaded through so
     // landPr can attach the ledger the moment it resolves the PR number.
     onPrResolved: deps.onPrResolved,
+    // Native merge queue (#1337): enqueue rather than merge on the spot, letting
+    // the forge serialize + rebase + revalidate every entry onto the current tip.
+    mergeQueue: input.nativeMergeQueue === true,
     // Untouchable primary (ADR 0083 §2, #1019): on a LOCKED landing landPr skips
     // its step-4 local fast-forward, so the integration reaches the maintainer
     // only via `origin/<locked-branch>` (they promote by pulling). The lock only

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -551,6 +551,17 @@ export interface LandPrInput {
    * Absent (the default) → never called.
    */
   onPrResolved?: (prNumber: number) => Promise<void>;
+  /**
+   * Native merge queue (#1337). True when `<target>` has the forge's merge queue
+   * configured, so the merge is ENQUEUED (`gh pr merge --auto`) instead of merged
+   * on the spot. The queue then serializes every entry, rebasing and revalidating
+   * each onto the current tip before it lands — the same guarantee the local
+   * land-lock provides, enforced by the forge and therefore preferred over it.
+   * The merge completes ASYNCHRONOUSLY once the queue drains; the PR body's
+   * `Closes #N` still closes the issue when it does. Absent (the default) → merge
+   * immediately, the pre-#1337 behaviour.
+   */
+  mergeQueue?: boolean;
 }
 
 /** Why an UNLOCKED landing did not admin-merge, so the caller can route the
@@ -635,7 +646,7 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
   // `locked` (LandPrInput) is no longer read here: step 4 promotes the primary
   // for both lock states via the hardened fastForwardLocalTarget, which is a
   // guaranteed no-op on any primary it must not touch.
-  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, onPrResolved } = input;
+  const { repo, gitRepo, remote, branch, target, n, title, mergeTitle, worktree, waitForReview, ciAwait, onPrResolved, mergeQueue } = input;
 
   // 1. Make the attempt branch's origin state certain before opening the PR.
   if (worktree) {
@@ -688,11 +699,20 @@ export async function landPr(exec: Exec, input: LandPrInput): Promise<LandPrResu
     if (ready === "pending") return { ok: false, prNumber, reason: "ci-pending" };
   }
 
-  // 3. Merge: branch protection is honored rather than bypassed (#1103).
+  // 3. Merge: branch protection is honored rather than bypassed (#1103). With a
+  // native merge queue on `<target>` (#1337), `--auto` ENQUEUES instead: the forge
+  // serializes the entries and rebases + revalidates each onto the current tip, so
+  // two workers landing at once can never race on a non-fast-forward push.
   const mergeArgs = ["gh", "-R", repo, "pr", "merge", String(prNumber), "--merge"];
+  if (mergeQueue) mergeArgs.push("--auto");
   if (mergeTitle) mergeArgs.push("--subject", mergeTitle);
   const merge = await exec(mergeArgs);
   if (merge.code !== 0) return { ok: false, prNumber, reason: "merge-failed" };
+
+  // An ENQUEUED PR has not merged yet — the queue lands it asynchronously once it
+  // drains, so there is no merge commit on `origin/<target>` to promote to. Skip
+  // the local fast-forward rather than pulling a tip that does not carry this work.
+  if (mergeQueue) return { ok: true, prNumber };
 
   // 4. Promote the primary's local <target> to the freshly merged origin tip —
   // for BOTH lock states now (ADR 0083 §2 amended). Hardened so it can never

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -71,6 +71,7 @@ import {
   type WaitForReviewInput,
   type CiAwaitInput,
 } from "./merge.js";
+import type { LandLock } from "./land-lock.js";
 import { doLanding } from "./landing.js";
 import { reconcile, type ReconcileInput } from "./reconcile.js";
 import { ExitBarrierError, type ExitReceipt, type TerminalReceipt } from "./exit-barrier.js";
@@ -450,6 +451,19 @@ export interface ProcessIssueDeps {
    * base now, not the mode. Undefined (tests) is treated as `true` (the default).
    */
   worktreeLaunchesPr?: boolean;
+  /**
+   * Global AFK land-lock (#1337). Threaded into {@link doLanding} so only one
+   * worker at a time enters the landing critical section (integrate/rebase →
+   * revalidate → merge → push) and no two near-simultaneous attempts race on a
+   * non-fast-forward push to the same base. Absent (tests) → unserialized.
+   */
+  landLock?: LandLock;
+  /**
+   * `<base>` has the forge's native merge queue configured (#1337). True → the PR
+   * landing enqueues and skips the local lock, because the queue already serializes
+   * entries and rebases + revalidates each onto the current tip. Default false.
+   */
+  nativeMergeQueue?: boolean;
   /**
    * Provision/tear down an isolated detached worktree at `<base>` for the DIRECT
    * (non-PR) landing (issue #572). The direct merge/push/rollback runs there so a
@@ -2250,6 +2264,9 @@ export async function processIssue(
       removeLandingWorktree: deps.removeLandingWorktree,
       makeRebaseWorktree: deps.makeRebaseWorktree,
       removeRebaseWorktree: deps.removeRebaseWorktree,
+      // Serialized landing (#1337): only one worker at a time integrates + pushes
+      // into the base, so concurrent lands queue instead of racing.
+      landLock: deps.landLock,
       // Non-blocking backpressure evidence review (#1279): fired by the PR-landing
       // path the moment the PR number is resolved (before the merge), so the
       // aggregated COMMENT ledger lands on the open PR. Best-effort + fully
@@ -2288,6 +2305,7 @@ export async function processIssue(
       title: input.title,
       labels,
       mainRed,
+      nativeMergeQueue: deps.nativeMergeQueue,
     },
     {
       preMerge: () =>

--- a/apps/dev/src/runtime/land-lock.ts
+++ b/apps/dev/src/runtime/land-lock.ts
@@ -1,0 +1,69 @@
+// runtime/land-lock.ts — the concrete host ports behind the global AFK land-lock
+// (#1337). core/land-lock.ts owns the acquire/steal/release SEQUENCING over these
+// injected closures; this file is the only place a real file, clock, or process
+// table is touched.
+//
+// The lock file lives at `<repo>/.red/tmp/afk-land.lock`, so its scope is exactly
+// "every AFK worker process on this host, landing into this repo" — which is the
+// set of workers that can race each other's push to the same base.
+
+import { open, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { createFileLandLock, type LandLock, type LandLockFs } from "../core/land-lock.js";
+
+/** Standard land-lock path for an AFK tmp dir (`.red/tmp/afk-land.lock`). */
+export function landLockPath(tmpDir: string): string {
+  return join(tmpDir, "afk-land.lock");
+}
+
+/** `node:fs` behind {@link LandLockFs}. `createExclusive` uses the `wx` flag, whose
+ * O_EXCL create is atomic — the whole lock rests on that one syscall. */
+const nodeLandLockFs: LandLockFs = {
+  async createExclusive(path, contents) {
+    let handle;
+    try {
+      handle = await open(path, "wx");
+    } catch {
+      // EEXIST (already held) or a missing parent dir — either way we did not take it.
+      return false;
+    }
+    try {
+      await handle.writeFile(contents);
+      return true;
+    } finally {
+      await handle.close();
+    }
+  },
+  async read(path) {
+    try {
+      return await readFile(path, "utf8");
+    } catch {
+      return null;
+    }
+  },
+  async remove(path) {
+    await rm(path, { force: true });
+  },
+};
+
+/** Same-host pid liveness: signal 0 probes the process table without delivering a
+ * signal. ESRCH → the holder crashed → its lock is stale and may be stolen. An
+ * EPERM (process exists, owned by another user) counts as ALIVE — refusing to
+ * steal is always the safe answer. */
+function isHolderAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/** Build the host-backed global land-lock for this worker process. */
+export function createLandLock(tmpDir: string, holder: string, pid: number = process.pid): LandLock {
+  return createFileLandLock(
+    { fs: nodeLandLockFs, clock: { now: () => Date.now(), sleep: (ms) => delay(ms) }, isHolderAlive },
+    { path: landLockPath(tmpDir), holder, pid },
+  );
+}

--- a/apps/dev/tests/land-lock.test.ts
+++ b/apps/dev/tests/land-lock.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+  createFileLandLock,
+  resolveLandSerialization,
+  type LandLockDeps,
+  type LandLockFs,
+} from "../src/core/land-lock.js";
+
+// The global AFK land-lock (#1337) serializes the landing critical section so two
+// near-simultaneous workers can never race on a non-fast-forward push to the same
+// base. Every side effect is injected: the lock file lives in a fake in-memory fs,
+// time only moves when the fake clock's `sleep` is awaited, and holder liveness is
+// a fake `isHolderAlive`. No real fs / process is touched here.
+
+/** In-memory `LandLockFs` with O_EXCL semantics — `createExclusive` fails when the
+ * path already exists, exactly like `fs.open(path, "wx")`. */
+function memFs(): LandLockFs & { files: Map<string, string> } {
+  const files = new Map<string, string>();
+  return {
+    files,
+    async createExclusive(path, contents) {
+      if (files.has(path)) return false;
+      files.set(path, contents);
+      return true;
+    },
+    async read(path) {
+      return files.get(path) ?? null;
+    },
+    async remove(path) {
+      files.delete(path);
+    },
+  };
+}
+
+interface Harness {
+  deps: LandLockDeps;
+  fs: ReturnType<typeof memFs>;
+  /** ms the fake clock has advanced (only `sleep` moves it). */
+  elapsed(): number;
+  /** every `sleep` duration awaited, in order. */
+  sleeps: number[];
+}
+
+interface Opts {
+  /** pids the fake `isHolderAlive` reports as running. Default: every pid is alive. */
+  alivePids?: number[];
+  /** Invoked before each fake `sleep` resolves — lets a test mutate the lock file mid-wait. */
+  onSleep?: (tick: number) => void;
+}
+
+function harness(opts: Opts = {}): Harness {
+  const fs = memFs();
+  const sleeps: number[] = [];
+  let clock = 0;
+  let tick = 0;
+  return {
+    fs,
+    sleeps,
+    elapsed: () => clock,
+    deps: {
+      fs,
+      clock: {
+        now: () => clock,
+        async sleep(ms) {
+          sleeps.push(ms);
+          clock += ms;
+          opts.onSleep?.(tick++);
+        },
+      },
+      isHolderAlive: (pid) => (opts.alivePids ? opts.alivePids.includes(pid) : true),
+    },
+  };
+}
+
+const LOCK = "/red/tmp/afk-land.lock";
+
+describe("resolveLandSerialization", () => {
+  it("prefers the forge's native merge queue over the local lock", () => {
+    expect(resolveLandSerialization({ nativeMergeQueue: true, hasLandLock: true })).toBe("native-merge-queue");
+    expect(resolveLandSerialization({ nativeMergeQueue: true, hasLandLock: false })).toBe("native-merge-queue");
+  });
+
+  it("falls back to the global land-lock when no native queue is configured", () => {
+    expect(resolveLandSerialization({ nativeMergeQueue: false, hasLandLock: true })).toBe("land-lock");
+  });
+
+  it("is unserialized only when neither mechanism is available", () => {
+    expect(resolveLandSerialization({ nativeMergeQueue: false, hasLandLock: false })).toBe("unserialized");
+    expect(resolveLandSerialization({})).toBe("unserialized");
+  });
+});
+
+describe("createFileLandLock", () => {
+  it("acquires an uncontended lock and writes the holder record", async () => {
+    const h = harness();
+    const lock = createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 });
+
+    const release = await lock.acquire();
+
+    expect(release).not.toBeNull();
+    expect(h.sleeps).toEqual([]);
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wAAAA", pid: 100 });
+  });
+
+  it("release removes the lock file so the next worker can acquire", async () => {
+    const h = harness();
+    const lock = createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 });
+
+    const release = await lock.acquire();
+    await release?.();
+
+    expect(h.fs.files.has(LOCK)).toBe(false);
+  });
+
+  it("a contended acquire waits, polling, until the holder releases", async () => {
+    const h = harness({
+      // The incumbent releases on the third poll — the waiter must not have
+      // acquired before that.
+      onSleep: (tick) => {
+        if (tick === 2) h.fs.files.delete(LOCK);
+      },
+    });
+    const incumbent = createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 });
+    expect(await incumbent.acquire()).not.toBeNull();
+
+    const waiter = createFileLandLock(h.deps, { path: LOCK, holder: "wBBBB", pid: 200, pollMs: 50 });
+    const release = await waiter.acquire();
+
+    expect(release).not.toBeNull();
+    expect(h.sleeps).toEqual([50, 50, 50]);
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wBBBB", pid: 200 });
+  });
+
+  it("gives up with null when the holder never releases within the wait timeout", async () => {
+    const h = harness();
+    const incumbent = createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 });
+    await incumbent.acquire();
+
+    const waiter = createFileLandLock(h.deps, {
+      path: LOCK,
+      holder: "wBBBB",
+      pid: 200,
+      pollMs: 100,
+      waitTimeoutMs: 250,
+    });
+
+    expect(await waiter.acquire()).toBeNull();
+    // Still the incumbent's record: a timed-out waiter never steals a live lock.
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wAAAA" });
+  });
+
+  it("steals a lock whose record is older than staleAfterMs", async () => {
+    const h = harness();
+    h.fs.files.set(LOCK, JSON.stringify({ holder: "wDEAD", pid: 100, acquiredAtMs: -60_000 }));
+
+    const lock = createFileLandLock(h.deps, { path: LOCK, holder: "wBBBB", pid: 200, staleAfterMs: 30_000 });
+    const release = await lock.acquire();
+
+    expect(release).not.toBeNull();
+    expect(h.sleeps).toEqual([]);
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wBBBB" });
+  });
+
+  it("steals a lock whose holder process is gone", async () => {
+    const h = harness({ alivePids: [200] });
+    h.fs.files.set(LOCK, JSON.stringify({ holder: "wDEAD", pid: 100, acquiredAtMs: 0 }));
+
+    const lock = createFileLandLock(h.deps, { path: LOCK, holder: "wBBBB", pid: 200 });
+
+    expect(await lock.acquire()).not.toBeNull();
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wBBBB" });
+  });
+
+  it("steals an unparseable lock file rather than deadlocking on it", async () => {
+    const h = harness();
+    h.fs.files.set(LOCK, "{ not json");
+
+    const lock = createFileLandLock(h.deps, { path: LOCK, holder: "wBBBB", pid: 200 });
+
+    expect(await lock.acquire()).not.toBeNull();
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wBBBB" });
+  });
+
+  it("release never removes a lock another worker now owns", async () => {
+    const h = harness();
+    const lock = createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100 });
+    const release = await lock.acquire();
+
+    // Our lock was stolen (stale takeover) and re-taken by another worker.
+    h.fs.files.set(LOCK, JSON.stringify({ holder: "wBBBB", pid: 200, acquiredAtMs: 5 }));
+    await release?.();
+
+    expect(JSON.parse(h.fs.files.get(LOCK) ?? "{}")).toMatchObject({ holder: "wBBBB" });
+  });
+
+  it("serializes two concurrent acquires — the second only enters after the first releases", async () => {
+    const h = harness();
+    const a = createFileLandLock(h.deps, { path: LOCK, holder: "wAAAA", pid: 100, pollMs: 10 });
+    const b = createFileLandLock(h.deps, { path: LOCK, holder: "wBBBB", pid: 200, pollMs: 10 });
+    const inside: string[] = [];
+
+    async function land(name: string, lock: { acquire: () => Promise<(() => Promise<void>) | null> }) {
+      const release = await lock.acquire();
+      expect(release).not.toBeNull();
+      inside.push(`enter:${name}`);
+      await h.deps.clock.sleep(10); // the critical section: rebase + revalidate + push
+      inside.push(`exit:${name}`);
+      await release?.();
+    }
+
+    await Promise.all([land("A", a), land("B", b)]);
+
+    // Never `enter:A, enter:B` — the second land waits out the first.
+    expect(inside).toEqual(["enter:A", "exit:A", "enter:B", "exit:B"]);
+  });
+});

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { doLanding, type LandingDeps, type LandingInput, type LandingHookContexts } from "../src/core/landing.js";
+import { createFileLandLock, type LandLock, type LandLockDeps, type LandLockFs } from "../src/core/land-lock.js";
 import type { ExecResult } from "../src/core/merge.js";
 
 // doLanding owns the flag-toggled landing (ADR 0030 amended by #842 / 0031):
@@ -125,6 +126,14 @@ interface Opts {
   postMergeGate?: boolean;
   /** When true AND `postMergeGate` is wired, the gate returns `{ ok: false }`. */
   postMergeGateFails?: boolean;
+  /**
+   * Global land-lock (#1337). Present → wire `deps.landLock` with this port, so a
+   * test can observe when the landing entered and left the critical section.
+   * Absent → the dep is unwired and the land runs unserialized (pre-#1337).
+   */
+  landLock?: LandLock;
+  /** Native merge queue (#1337): set `input.nativeMergeQueue`. */
+  nativeMergeQueue?: boolean;
 }
 
 function harness(opts: Opts = {}): Harness {
@@ -283,6 +292,8 @@ function harness(opts: Opts = {}): Harness {
           return { ok: !opts.postMergeGateFails };
         }
       : undefined,
+    // Global land-lock (#1337): only wired when the test opts in.
+    landLock: opts.landLock,
   };
 
   const input: LandingInput = {
@@ -307,6 +318,7 @@ function harness(opts: Opts = {}): Harness {
     // armed for every existing landing assertion.
     sensitivePathApproved: opts.sensitivePathApproved,
     mainRed: opts.mainRed,
+    nativeMergeQueue: opts.nativeMergeQueue,
   };
 
   const hooks: LandingHookContexts = {
@@ -1187,5 +1199,189 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
     expect(h.postMergeGateDirs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Serialized landing (#1337). Two near-simultaneous workers used to race on the
+// land: A pushes, B's push is rejected as a non-fast-forward, B re-integrates,
+// and overlapping diffs conflict. The land is now a critical section — entered
+// under the forge's native merge queue when `<base>` has one, else under the
+// global land-lock. These tests drive the REAL createFileLandLock over an
+// in-memory lock file, so what is asserted is the integration, not a mock.
+// ---------------------------------------------------------------------------
+
+/** In-memory `LandLockFs` with O_EXCL semantics, shared by both concurrent lands. */
+function memLockFs(): LandLockFs & { files: Map<string, string> } {
+  const files = new Map<string, string>();
+  return {
+    files,
+    async createExclusive(path, contents) {
+      if (files.has(path)) return false;
+      files.set(path, contents);
+      return true;
+    },
+    async read(path) {
+      return files.get(path) ?? null;
+    },
+    async remove(path) {
+      files.delete(path);
+    },
+  };
+}
+
+/** A land-lock that always times out — models an incumbent holding it past the wait. */
+const timedOutLock: LandLock = { acquire: async () => null };
+
+/** A land-lock that records every enter/exit into a shared trace. */
+function tracingLock(trace: string[], name: string, inner: LandLock): LandLock {
+  return {
+    async acquire() {
+      const release = await inner.acquire();
+      if (!release) return null;
+      trace.push(`enter:${name}`);
+      return async () => {
+        trace.push(`exit:${name}`);
+        await release();
+      };
+    },
+  };
+}
+
+/** Wrap a harness's mergeExec so every push to the remote base lands in `trace`. */
+function traceBasePushes(h: Harness, trace: string[], name: string): void {
+  const inner = h.deps.mergeExec;
+  h.deps.mergeExec = async (args: string[]) => {
+    if (args.join(" ").includes("push origin HEAD:refs/heads/main")) trace.push(`push:${name}`);
+    return inner(args);
+  };
+}
+
+describe("doLanding — serialized landing (#1337)", () => {
+  it("two concurrent direct lands serialize: the second never pushes before the first releases", async () => {
+    const fs = memLockFs();
+    const clock = { t: 0 };
+    const deps: LandLockDeps = {
+      fs,
+      clock: {
+        now: () => clock.t,
+        // Advance the fake clock, but yield the microtask queue so the OTHER land
+        // actually makes progress while this one polls — real concurrency, not a stub.
+        sleep: async (ms) => {
+          clock.t += ms;
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        },
+      },
+      isHolderAlive: () => true,
+    };
+    const trace: string[] = [];
+    const lockFor = (name: string, pid: number) =>
+      tracingLock(trace, name, createFileLandLock(deps, { path: "/afk-land.lock", holder: name, pid, pollMs: 5 }));
+
+    const a = harness({ locked: true, openPr: false, landLock: lockFor("A", 100) });
+    const b = harness({ locked: true, openPr: false, landLock: lockFor("B", 200) });
+    traceBasePushes(a, trace, "A");
+    traceBasePushes(b, trace, "B");
+
+    const [ra, rb] = await Promise.all([doLanding(a.deps, a.input, a.hooks), doLanding(b.deps, b.input, b.hooks)]);
+
+    expect(ra.ok).toBe(true);
+    expect(rb.ok).toBe(true);
+    // The whole point: no `push:B` between `enter:A` and `exit:A`.
+    expect(trace).toEqual(["enter:A", "push:A", "exit:A", "enter:B", "push:B", "exit:B"]);
+    // …and B got that order by WAITING on a contended lock, not by luck of
+    // scheduling: an uncontended acquire never polls, so the clock never advances.
+    expect(clock.t).toBeGreaterThan(0);
+    // The lock file is left clean for the next worker.
+    expect(fs.files.size).toBe(0);
+  });
+
+  it("land-lock wait timeout → infra failure, nothing pushed to the remote base", async () => {
+    const h = harness({ locked: true, openPr: false, landLock: timedOutLock });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({
+      ok: false,
+      reason: "infra",
+      infraReason: "another worker held the AFK land-lock past the wait timeout",
+      locked: true,
+    });
+    // Refusing to serialize means refusing to land — never an unserialized push.
+    expect(joined(h.mergeCalls).some((c) => c.includes("push origin HEAD:refs/heads/main"))).toBe(false);
+    // No landing worktree was even provisioned.
+    expect(h.removedWorktrees).toEqual([]);
+  });
+
+  it("releases the land-lock when the landing fails inside the critical section", async () => {
+    const fs = memLockFs();
+    const deps: LandLockDeps = {
+      fs,
+      clock: { now: () => 0, sleep: async () => {} },
+      isHolderAlive: () => true,
+    };
+    const lock = createFileLandLock(deps, { path: "/afk-land.lock", holder: "A", pid: 100 });
+    const h = harness({ locked: true, openPr: false, landLock: lock, integrateCode: 1 });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: false, reason: "integrate-failed", locked: true });
+    // A failed land must not leave the lock held — the next worker would deadlock.
+    expect(fs.files.size).toBe(0);
+  });
+
+  it("native merge queue → no land-lock is taken and the PR is enqueued with --auto", async () => {
+    let acquires = 0;
+    const countingLock: LandLock = {
+      acquire: async () => {
+        acquires += 1;
+        return async () => {};
+      },
+    };
+    const h = harness({ locked: false, openPr: true, nativeMergeQueue: true, landLock: countingLock });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: true, locked: false });
+    // The forge serializes; double-serializing would only add latency.
+    expect(acquires).toBe(0);
+    expect(joined(h.mergeCalls).some((c) => c.includes("pr merge 42 --merge --auto"))).toBe(true);
+  });
+
+  it("native merge queue on the DIRECT path still takes the land-lock (no PR to enqueue)", async () => {
+    let acquires = 0;
+    const countingLock: LandLock = {
+      acquire: async () => {
+        acquires += 1;
+        return async () => {};
+      },
+    };
+    const h = harness({ locked: true, openPr: false, nativeMergeQueue: true, landLock: countingLock });
+
+    expect((await doLanding(h.deps, h.input, h.hooks)).ok).toBe(true);
+    expect(acquires).toBe(1);
+  });
+
+  it("no land-lock wired → lands unserialized, exactly as before #1337", async () => {
+    const h = harness({ locked: true, openPr: false });
+    const r = await doLanding(h.deps, h.input, h.hooks);
+    expect(r).toEqual({ ok: true, locked: true, mergeSha: "abc1234" });
+    expect(joined(h.mergeCalls).some((c) => c.includes("push origin HEAD:refs/heads/main"))).toBe(true);
+  });
+
+  it("PR path without a native queue is serialized by the land-lock", async () => {
+    let acquires = 0;
+    const countingLock: LandLock = {
+      acquire: async () => {
+        acquires += 1;
+        return async () => {};
+      },
+    };
+    const h = harness({ locked: false, openPr: true, landLock: countingLock });
+
+    expect((await doLanding(h.deps, h.input, h.hooks)).ok).toBe(true);
+    expect(acquires).toBe(1);
+    // Plain admin-merge, never enqueued.
+    expect(joined(h.mergeCalls).some((c) => c.includes("--auto"))).toBe(false);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1337. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1337

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786162771&installation_id=129708444&pr_number=1341&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1341&signature=45233dd1222822e81818973de285e60ee1fa4c846232af4e86047ff7f8c62b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->