### PR TITLE
chore: #1342 /wayfinder fidelity gaps vs upstream: restore Decisions-so-far + Notes, refer-by-name, one-ticket-per-session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,21 @@ Upstream base: `mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3` (v1.
 
 ---
 
+## wayfinder (engineering) — fidelity restoration: Decisions so far, Notes, refer-by-name, one-ticket-per-session, zoom-as-needed (issue #1342)
+
+- **status**: modified
+- **upstream**: `d574778` (v1.1.0)
+- **why**: Side-by-side audit found four gaps between our adopted /wayfinder and the upstream v1.1.0 design: missing map sections (`## Decisions so far`, `## Notes`), no refer-by-name rule, no one-ticket-per-session discipline for HITL children, and no zoom-as-needed loading directive.
+- **what changed**:
+  - Map body template (step 2 and Map Ticket template) now carries all five sections: Destination, Decisions so far, Not yet specified, Out of scope, Notes — with descriptions for each.
+  - Step 5 explicitly records gists into `## Decisions so far` (was: generic "add a short gist").
+  - "Refer by name" directive added to step 2: titles with embedded links, never bare `#N`.
+  - "One-ticket-per-session discipline" added to step 4 HITL section: one HITL child per session; charting is one session's work.
+  - "Zoom-as-needed loading" directive added to step 1: load map at low resolution, fetch child bodies on demand.
+  - Docs-contract test (`label-vocabulary-docs.test.ts`) extended with a second `it` block pinning all four restored directives.
+
+---
+
 ## to-tickets (engineering) — file-disjunction rule: serialize overlapping slices (issue #1336)
 
 - **status**: modified

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -204,8 +204,10 @@ describe("wayfinder docs", () => {
     const labels = await readRepoFile("plugins/dev/skills/engineering/setup-red-skills/triage-labels.md");
 
     expect(skill).toContain("## Destination");
+    expect(skill).toContain("## Decisions so far");
     expect(skill).toContain("## Not yet specified");
     expect(skill).toContain("## Out of scope");
+    expect(skill).toContain("## Notes");
     expect(skill).toContain("wayfinder:map");
     expect(skill).toContain("wayfinder:research");
     expect(skill).toContain("wayfinder:grilling");
@@ -228,5 +230,31 @@ describe("wayfinder docs", () => {
     ]) {
       expect(labels).toContain(label);
     }
+  });
+
+  it("pins the fidelity-restoration directives from upstream v1.1.0", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/engineering/wayfinder/SKILL.md");
+
+    // Decisions so far is load-bearing: step 5 records gists there
+    expect(skill).toContain("## Decisions so far");
+    expect(skill).toContain("into `## Decisions so far`");
+
+    // Notes carries standing preferences and skills to consult
+    expect(skill).toContain("## Notes");
+    expect(skill).toContain("Standing preferences");
+
+    // Refer-by-name rule: title with embedded link, never bare #N
+    expect(skill).toContain("Refer by name");
+    expect(skill).toContain("never a bare `#N`");
+
+    // One-ticket-per-session discipline for HITL children and charting
+    expect(skill).toContain("One-ticket-per-session discipline");
+    expect(skill).toContain("resolves exactly one HITL child and stops");
+    expect(skill).toContain("Charting the map is itself one session");
+
+    // Zoom-as-needed loading
+    expect(skill).toContain("Zoom-as-needed loading");
+    expect(skill).toContain("low resolution");
+    expect(skill).toContain("fetch the full body of a specific child only when");
   });
 });

--- a/plugins/dev/skills/engineering/wayfinder/SKILL.md
+++ b/plugins/dev/skills/engineering/wayfinder/SKILL.md
@@ -14,6 +14,8 @@ argument-hint: "[destination or issue/URL/path to map]"
 
 Start breadth-first. Read the current conversation and any referenced issue, URL, or path. Ask or answer only the first few scope questions needed to decide whether the work has unresolved in-scope fog.
 
+**Zoom-as-needed loading.** Load the map at low resolution — read only the map's section headings first; fetch the full body of a specific child only when the session's work touches it.
+
 Use the **no-fog early exit**: if the opening breadth-first grilling surfaces no fog, stop and ask the user to continue with `/start`, `/to-spec`, `/to-tickets`, `/go`, or `/afk` instead of creating a map nobody needs. A map is warranted only when there is named destination plus multiple unknowns that cannot be cleared in one session.
 
 ## 2. Create The Map Ticket
@@ -27,6 +29,10 @@ The map body must carry these headings:
 
 The named end state. Keep this concrete enough that later child Tickets can decide whether new fog is in scope.
 
+## Decisions so far
+
+One line per closed child: a short gist of the decision or result followed by a link to the child Ticket. Built up by step 5 as children resolve.
+
 ## Not yet specified
 
 In-scope fog. Each entry is a frontier question or unresolved branch that can graduate into a child Ticket.
@@ -34,9 +40,15 @@ In-scope fog. Each entry is a frontier question or unresolved branch that can gr
 ## Out of scope
 
 Ruled beyond the destination. These entries never graduate into child Tickets unless the destination is explicitly renamed.
+
+## Notes
+
+Standing preferences for this effort and which skills every session should consult.
 ```
 
-The map is an **index, not a store**. Keep durable decisions, evidence, prototypes, and implementation notes in the child Tickets that produced them; the map only gists and links to those Tickets.
+The map is an **index, not a store**. Keep durable decisions, evidence, prototypes, and implementation notes in the child Tickets that produced them; the map only gists and links to those Tickets via `## Decisions so far`.
+
+**Refer by name.** Every reference to a map or child Ticket uses its *title* with the link embedded in the name — never a bare `#N`. Bare-number narration is illegible to anyone reading the trail.
 
 ## 3. Publish Child Tickets
 
@@ -69,6 +81,8 @@ HITL-typed children (`wayfinder:grilling`, `wayfinder:prototype`) route to human
 - Assign the human or role expected to run the `/start` or `/prototype` session.
 - Use `## Current blocker` / `## Human decision needed` for the pending decision or prototype question, not `## Blocked by`, unless closing concrete dependency Tickets is enough to make the child delegable.
 
+**One-ticket-per-session discipline.** A grilling or prototype session resolves exactly one HITL child and stops. Charting the map is itself one session's work. Do not collapse multiple HITL children into a single session.
+
 When a HITL child becomes delegable, `/hitl` or `/requeue` moves it into `ready-for-agent`; do not create a parallel queue.
 
 ## 5. Advance The Frontier
@@ -76,7 +90,7 @@ When a HITL child becomes delegable, `/hitl` or `/requeue` moves it into `ready-
 After a child resolves, update the map only as an index:
 
 - Link the child under the relevant `## Not yet specified` entry or remove the fog entry if the child answered it.
-- Add a short gist of the decision or result with a link to the child Ticket.
+- Add a short gist of the decision or result with a link to the child Ticket into `## Decisions so far`.
 - Move newly discovered in-scope fog into `## Not yet specified`.
 - Move rejected branches into `## Out of scope`.
 
@@ -95,6 +109,10 @@ Never copy full decisions, research logs, prototype output, or implementation no
 
 <named end state>
 
+## Decisions so far
+
+<!-- populated by step 5 as children resolve — one line per closed child -->
+
 ## Not yet specified
 
 - <in-scope fog item>
@@ -102,6 +120,10 @@ Never copy full decisions, research logs, prototype output, or implementation no
 ## Out of scope
 
 - <ruled-out branch>
+
+## Notes
+
+- <standing preference or skill every session should consult>
 ```
 
 Labels: `wayfinder:map`.


### PR DESCRIPTION
Automated AFK landing for #1342. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1342

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786165947&installation_id=129708444&pr_number=1346&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1346&signature=6e6dbe0337e6aa22483bc323b455c736ea527f7df064fe809cd4b28332b9679d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->