### PR TITLE
chore: #1344 /go: Make fleet boot (and fleet stop/status) reap stale supervisor state: whe

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -8,6 +8,7 @@ import { teardownWedgedSupervisor } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
 import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
+import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 
 export interface FleetLaunchResult {
   status: "launched";
@@ -22,16 +23,6 @@ export interface FleetStopResult {
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-async function readPid(path: string): Promise<number | null> {
-  try {
-    const raw = (await readFile(path, "utf8")).trim();
-    if (!/^\d+$/.test(raw)) return null;
-    return Number(raw);
-  } catch {
-    return null;
-  }
-}
 
 async function fileExists(path: string): Promise<boolean> {
   try {
@@ -106,15 +97,15 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
   const tmp = join(root, ".red", "tmp");
   const pidFile = join(tmp, "afk-supervisor.pid");
   const stopFile = join(tmp, "afk-supervisor.stop");
-  const pid = await readPid(pidFile);
+  const supervisor = await reapStaleSupervisorState(tmp, isLivePid);
+  if (supervisor.status === "stale") {
+    stdout.write(`no fleet running (stale supervisor files under .red/tmp — cleaned).\n`);
+    return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
+  }
+  const pid = supervisor.pid;
   if (!pid) {
     stdout.write("no fleet running.\n");
     return { status: "none" };
-  }
-  if (!isLivePid(pid)) {
-    await rm(pidFile, { force: true });
-    stdout.write(`no fleet running (stale pid file at .red/tmp/afk-supervisor.pid — cleaning).\n`);
-    return { status: "stale", pid };
   }
   await writeFile(stopFile, "", "utf8");
   const deadline = Date.now() + 30_000;
@@ -154,8 +145,12 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   await mkdir(tmp, { recursive: true });
   const pidFile = join(tmp, "afk-supervisor.pid");
   const logFile = join(tmp, "afk-supervisor.log");
-  const existing = await readPid(pidFile);
-  if (existing && isLivePid(existing)) {
+  const supervisor = await reapStaleSupervisorState(tmp, isLivePid);
+  if (supervisor.status === "stale") {
+    stdout.write(`cleaned stale supervisor files under .red/tmp before fleet launch.\n`);
+  }
+  const existing = supervisor.status === "live" ? supervisor.pid : null;
+  if (existing) {
     // A live PID is not necessarily a healthy fleet (#407): a supervisor whose
     // #406 heartbeat has gone stale past RED_AFK_SUPERVISOR_STALE_S is hard-hung
     // (drain loop wedged) and cannot re-arm itself. This launch is an

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -45,6 +45,7 @@ import { resolveFleetHooks } from "../core/fleet-hook-config.js";
 import { dispatchFleetHook } from "../core/fleet-hook-dispatcher.js";
 import { makeHookExec, makeHookResolveOptions } from "../runtime/hooks.js";
 import { getConfig, loadConfig } from "../core/config.js";
+import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 
 function isAlive(pid: number): boolean {
   try {
@@ -599,6 +600,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   // Ensure the workers root exists so the event-driven wake's fs.watch (#934) can
   // attach from boot rather than waiting for the first worker to create it.
   await import("../runtime/fs.js").then((m) => m.ensureDir(join(tmp, "workers")));
+  await reapStaleSupervisorState(tmp, isAlive);
   // single-supervisor lock
   if (existsSync(pidFile)) {
     try {

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -1,0 +1,74 @@
+import { constants } from "node:fs";
+import { access, readdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { isLivePid as defaultIsLivePid } from "./kill-tree.js";
+
+export interface SupervisorStateReapResult {
+  status: "absent" | "live" | "stale";
+  pid?: number;
+  removed: string[];
+}
+
+export async function readSupervisorPid(pidFile: string): Promise<number | null> {
+  try {
+    const raw = (await readFile(pidFile, "utf8")).trim();
+    if (!/^\d+$/.test(raw)) return null;
+    const pid = Number(raw);
+    return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function supervisorArtifactPaths(tmpDir: string): Promise<string[]> {
+  const out = [
+    join(tmpDir, "afk-supervisor.pid"),
+    join(tmpDir, "afk-supervisor.state.json"),
+    join(tmpDir, "afk-supervisor.state.json.tmp"),
+    join(tmpDir, "afk-supervisor.stop"),
+  ];
+  try {
+    for (const entry of await readdir(tmpDir)) {
+      if (entry.startsWith("afk-supervisor.log")) out.push(join(tmpDir, entry));
+    }
+  } catch {
+    // Missing/unreadable tmp dir means there are no removable artifacts we can see.
+  }
+  return [...new Set(out)];
+}
+
+export async function reapStaleSupervisorState(
+  tmpDir: string,
+  isLivePid: (pid: number) => boolean = defaultIsLivePid,
+): Promise<SupervisorStateReapResult> {
+  const pidFile = join(tmpDir, "afk-supervisor.pid");
+  const pid = await readSupervisorPid(pidFile);
+  if (pid !== null && isLivePid(pid)) return { status: "live", pid, removed: [] };
+
+  const artifacts = await supervisorArtifactPaths(tmpDir);
+  const present: string[] = [];
+  for (const path of artifacts) {
+    if (await exists(path)) present.push(path);
+  }
+  if (present.length === 0) return { status: "absent", removed: [] };
+
+  const removed: string[] = [];
+  for (const path of present) {
+    try {
+      await rm(path, { force: true });
+      removed.push(path);
+    } catch {
+      // Best-effort cleanup: leave failures for the caller's normal path.
+    }
+  }
+  return { status: "stale", ...(pid !== null ? { pid } : {}), removed };
+}

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const killTreeMocks = vi.hoisted(() => ({
+  isLivePid: vi.fn((_pid: number) => false),
+  killTreeAndWait: vi.fn(async () => false),
+}));
+
+vi.mock("../src/runtime/kill-tree.js", () => ({
+  isLivePid: killTreeMocks.isLivePid,
+  killTreeAndWait: killTreeMocks.killTreeAndWait,
+}));
+
+vi.mock("../src/runtime/supervisor-spawn.js", () => ({
+  spawnSupervisor: vi.fn(async () => 43210),
+}));
+
+import { launchFleet, stopFleet } from "../src/commands/fleet.js";
+import { isLivePid } from "../src/runtime/kill-tree.js";
+import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
+
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), "afk-fleet-command-"));
+}
+
+function writeSupervisorArtifacts(root: string, pid: number | string): Record<string, string> {
+  const tmp = join(root, ".red", "tmp");
+  mkdirSync(tmp, { recursive: true });
+  const paths = {
+    pid: join(tmp, "afk-supervisor.pid"),
+    state: join(tmp, "afk-supervisor.state.json"),
+    log: join(tmp, "afk-supervisor.log"),
+    firehose: join(tmp, "afk-supervisor.log.jsonl"),
+  };
+  writeFileSync(paths.pid, String(pid), "utf8");
+  writeFileSync(paths.state, "{not json", "utf8");
+  writeFileSync(paths.log, "old supervisor log\n", "utf8");
+  writeFileSync(paths.firehose, "old firehose\n", "utf8");
+  return paths;
+}
+
+function stream(): NodeJS.WritableStream {
+  return { write: vi.fn(() => true) } as unknown as NodeJS.WritableStream;
+}
+
+describe("fleet command stale supervisor state", () => {
+  beforeEach(() => {
+    vi.mocked(isLivePid).mockReset();
+    vi.mocked(isLivePid).mockReturnValue(false);
+    killTreeMocks.killTreeAndWait.mockReset();
+    killTreeMocks.killTreeAndWait.mockResolvedValue(false);
+    vi.mocked(spawnSupervisor).mockClear();
+    vi.mocked(spawnSupervisor).mockResolvedValue(43210);
+  });
+
+  it("launchFleet removes dead supervisor pid/state/log files before spawning", async () => {
+    const root = scratch();
+    try {
+      const paths = writeSupervisorArtifacts(root, 999_999_999);
+
+      await launchFleet(["1"], root, stream());
+
+      expect(spawnSupervisor).toHaveBeenCalledTimes(1);
+      expect(existsSync(paths.pid)).toBe(false);
+      expect(existsSync(paths.state)).toBe(false);
+      expect(existsSync(paths.log)).toBe(false);
+      expect(existsSync(paths.firehose)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stopFleet removes dead supervisor pid/state/log files", async () => {
+    const root = scratch();
+    try {
+      const paths = writeSupervisorArtifacts(root, 999_999_999);
+
+      const result = await stopFleet(root, stream());
+
+      expect(result).toMatchObject({ status: "stale", pid: 999_999_999 });
+      expect(existsSync(paths.pid)).toBe(false);
+      expect(existsSync(paths.state)).toBe(false);
+      expect(existsSync(paths.log)).toBe(false);
+      expect(existsSync(paths.firehose)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stopFleet leaves live supervisor files untouched", async () => {
+    const root = scratch();
+    try {
+      const paths = writeSupervisorArtifacts(root, 12345);
+      vi.mocked(isLivePid).mockReturnValueOnce(true).mockReturnValue(false);
+
+      const result = await stopFleet(root, stream());
+
+      expect(result.status).toBe("stopped");
+      expect(existsSync(paths.pid)).toBe(true);
+      expect(existsSync(paths.state)).toBe(true);
+      expect(existsSync(paths.log)).toBe(true);
+      expect(existsSync(paths.firehose)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1344. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1344

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786166479&installation_id=129708444&pr_number=1347&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1347&signature=99f7eaa6cb42e41cc6c1c3b45920cd5e64a4e10d3089e5a7a52554a59ff5a288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->