### PR TITLE
chore: #1345 /go: Apply the upstream Wayfinder 'Refer by name' rule to the AFK runtime's H

### DIFF
--- a/apps/dev/src/commands/hitl-card.ts
+++ b/apps/dev/src/commands/hitl-card.ts
@@ -31,6 +31,7 @@ import {
   type PrStatus,
   type CardCommand,
 } from "../core/hitl-card.js";
+import { enrichIssueReferences as enrichTicketRefs } from "../core/issue-reference.js";
 
 const FLAG_SCHEMA = {
   issue: { kind: "value", coerce: (raw: string): number => Number(raw) },
@@ -61,6 +62,7 @@ function repoArgs(repo: string): string[] {
 interface IssueData {
   number: number;
   title: string;
+  url: string;
   body: string;
   labels: string[];
   comments: Array<{ id: number; body: string; databaseId?: number }>;
@@ -70,12 +72,13 @@ async function fetchIssue(exec: Exec, repo: string, issue: number): Promise<Issu
   const r = await exec([
     "gh", "issue", "view", String(issue),
     ...repoArgs(repo),
-    "--json", "number,title,body,labels,comments",
+    "--json", "number,title,url,body,labels,comments",
   ]);
   if (r.code !== 0) throw new Error(`fetch issue #${issue} failed: ${r.stderr.trim()}`);
   const raw = JSON.parse(r.stdout) as {
     number?: number;
     title?: string;
+    url?: string;
     body?: string;
     labels?: Array<{ name?: string }>;
     comments?: Array<{ id?: number; body?: string; databaseId?: number }>;
@@ -83,6 +86,7 @@ async function fetchIssue(exec: Exec, repo: string, issue: number): Promise<Issu
   return {
     number: Number(raw.number ?? issue),
     title: String(raw.title ?? ""),
+    url: String(raw.url ?? ""),
     body: String(raw.body ?? ""),
     labels: (raw.labels ?? []).map((l) => String(l.name ?? "")).filter(Boolean),
     comments: (raw.comments ?? []).map((c) => ({
@@ -91,6 +95,21 @@ async function fetchIssue(exec: Exec, repo: string, issue: number): Promise<Issu
       body: String(c.body ?? ""),
     })),
   };
+}
+
+async function fetchIssueReference(exec: Exec, repo: string, issue: number): Promise<{ number: number; title?: string; url?: string } | undefined> {
+  const r = await exec([
+    "gh", "issue", "view", String(issue),
+    ...repoArgs(repo),
+    "--json", "number,title,url",
+  ]);
+  if (r.code !== 0) return undefined;
+  try {
+    const raw = JSON.parse(r.stdout) as { number?: number; title?: string; url?: string };
+    return { number: Number(raw.number ?? issue), title: String(raw.title ?? ""), url: String(raw.url ?? "") };
+  } catch {
+    return undefined;
+  }
 }
 
 async function fetchPrStatus(exec: Exec, repo: string, prNumber: number): Promise<PrStatus> {
@@ -173,7 +192,8 @@ async function cmdRender(
 ): Promise<number> {
   const issue = await fetchIssue(exec, repo, issueNumber);
   const blocker = parseCurrentBlocker(issue.body);
-  const pendingDecision = blocker?.next ?? blocker?.summary ?? "Human guidance required.";
+  const pendingDecisionRaw = blocker?.next ?? blocker?.summary ?? "Human guidance required.";
+  const pendingDecision = await enrichTicketRefs(pendingDecisionRaw, (n) => fetchIssueReference(exec, repo, n));
 
   const prNumber = await findLinkedPr(exec, repo, issueNumber, blocker?.ref);
   const prStatus: PrStatus = prNumber
@@ -181,7 +201,7 @@ async function cmdRender(
     : { ci: "none", ciPassed: 0, ciTotal: 0, mergeability: "UNKNOWN" };
 
   const updatedAt = nowUtc();
-  const card = renderCard({ issueNumber, pendingDecision, prStatus, updatedAt });
+  const card = renderCard({ issueNumber, issueTitle: issue.title, issueUrl: issue.url, pendingDecision, prStatus, updatedAt });
   const existing = findCardComment(issue.comments);
   await upsertCardComment(exec, repo, issueNumber, card, existing);
 

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -430,6 +430,7 @@ function makeBootReconcileRunner(
         close: (issue) => ghx.closeIssue(ghCtx, issue),
         listByLabel: (label) => ghx.listByLabel(ghCtx, label),
         issueClosed: (n) => ghx.issueClosed(ghCtx, n),
+        issueReference: (n) => ghx.issueReference(ghCtx, n),
       },
       git: {
         headShortSha: () => gitx.headShortSha(gitCtx),
@@ -488,6 +489,7 @@ function makeBootReconcileRunner(
         // observability hooks that are silently skipped in this context.
         writeMarkers: async () => {},
         writePosted: async () => {},
+        issueReference: (issue) => ghx.issueReference(ghCtx, issue),
       },
       nowEpoch: () => Math.floor(Date.now() / 1000),
       appendIterLog: () => {},
@@ -863,6 +865,7 @@ export function buildProcessDeps(
       close: (issue) => ghx.closeIssue(ghCtx, issue),
       listByLabel: (label) => ghx.listByLabel(ghCtx, label),
       issueClosed: (n) => ghx.issueClosed(ghCtx, n),
+      issueReference: (n) => ghx.issueReference(ghCtx, n),
       // Trust-gate provenance (#621): author + ready-for-agent label actor, read
       // from the issue timeline. Consulted at claim time only when an allowlist
       // is configured (plugins.dev.afk.trust-gate.allowlist) or the repo fails
@@ -1141,6 +1144,7 @@ export function buildProcessDeps(
       // buildProcessInput before each processIssue call.
       writeMarkers: (markers) => fsx.writeFailureMarkers(current.attemptDir, markers),
       writePosted: (posted) => fsx.writeEnvelopePosted(current.attemptDir, posted),
+      issueReference: (issue) => ghx.issueReference(ghCtx, issue),
     },
     nowEpoch: () => Math.floor(Date.now() / 1000),
     nowIso: () => new Date().toISOString(),

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -527,6 +527,7 @@ function buildSupervisorDeps(
             comment: async (issue, body) => {
               await ghx.comment(ghCtx, issue, body);
             },
+            issueReference: (issue) => ghx.issueReference(ghCtx, issue),
           },
         );
       } catch {

--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -27,6 +27,11 @@
 /** The literal `## Blocked by` heading line, allowing only trailing whitespace.
  * Mirrors awk `/^## Blocked by[[:space:]]*$/`. */
 import { LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT, LABEL_DEPENDENCY, LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
+import {
+  renderIssueReferenceList,
+  resolveIssueReferences,
+  type IssueReferenceLookup,
+} from "./issue-reference.js";
 
 const BLOCKED_BY_HEADING_RE = /^## Blocked by[ \t]*$/;
 /** Any `## ` heading — the awk `/^## /` that closes the Blocked-by section. */
@@ -120,6 +125,14 @@ export function auditComment(refs: readonly string[]): string {
  * e.g. `🤖 /afk unblocked: all dependencies closed (#101, #102).` */
 export function cascadeAuditComment(reqs: readonly number[]): string {
   return `🤖 /afk unblocked: all dependencies closed (${reqs.map((n) => `#${n}`).join(", ")}).`;
+}
+
+export async function cascadeAuditCommentFor(
+  reqs: readonly number[],
+  lookup?: IssueReferenceLookup,
+): Promise<string> {
+  const refs = await resolveIssueReferences(reqs, lookup);
+  return `🤖 /afk unblocked: all dependencies closed (${renderIssueReferenceList(reqs.map((n) => refs.get(n) ?? { number: n }))}).`;
 }
 
 /** A dependent issue (carrying `req:*` labels) re-evaluated by the close
@@ -259,6 +272,8 @@ export interface UnblockSweepGh {
   /** Rotate labels — REMOVE first, ADD second (BootDeps.gh order). */
   editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
   comment(issue: number, body: string): Promise<void>;
+  /** Optional human-facing metadata lookup for rendered dependency refs. */
+  issueReference?(issue: number): Promise<{ number: number; title?: string; url?: string } | undefined>;
 }
 
 /**
@@ -289,7 +304,11 @@ export async function executeUnblockSweep(
     const held = labelsByIssue.get(p.number) ?? [];
     const remove = held.includes(LABEL_DEPENDENCY) ? LABEL_DEPENDENCY : LABEL_HUMAN;
     await gh.editLabels(p.number, [remove, ...p.reqLabels], [LABEL_READY]);
-    await gh.comment(p.number, p.comment);
+    const reqs = p.refs.map(refToNumber).filter((n): n is number => n !== null);
+    const comment = p.reqLabels.length > 0 && reqs.length > 0
+      ? await cascadeAuditCommentFor(reqs, gh.issueReference)
+      : p.comment;
+    await gh.comment(p.number, comment);
     promoted.push(p.number);
   }
   return promoted;

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -153,6 +153,8 @@ export interface BootGh {
   comment(issue: number, body: string): Promise<void>;
   /** gh issue view --json labels → flat name list. */
   viewLabels(issue: number): Promise<string[]>;
+  /** Optional human-facing metadata lookup for rendered issue refs. */
+  issueReference?(issue: number): Promise<{ number: number; title?: string; url?: string } | undefined>;
 }
 
 /** git side effects: delete a remote or local branch ref. Best-effort. The

--- a/apps/dev/src/core/envelope-emit.ts
+++ b/apps/dev/src/core/envelope-emit.ts
@@ -23,6 +23,7 @@
 import { buildEnvelope, type AttemptStatus, type EnvelopeSection } from "./envelope.js";
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { historyAppend, type HistoryAppendFields, type HistoryClock, type HistoryEvent, type HistoryIO } from "./history.js";
+import { enrichIssueReferences, type IssueReferenceLookup } from "./issue-reference.js";
 
 /** Render N seconds as `<m>m<s>s`. Mirrors envelope_fmt_duration. */
 export function fmtDuration(seconds: number): string {
@@ -182,6 +183,8 @@ export interface EmitEnvelopeDeps {
   historyAppend?: typeof historyAppend;
   /** Injected history IO (filesystem swap for tests). */
   historyIO?: HistoryIO;
+  /** Optional human-facing metadata lookup for refs in envelope notes. */
+  issueReference?: IssueReferenceLookup;
 }
 
 export interface EmitEnvelopeInput {
@@ -291,9 +294,13 @@ export async function emitEnvelope(
   }
 
   // --- compose body (steps 3) ---
+  const sections = { ...(input.sections ?? {}) };
+  if (sections.notes !== undefined) {
+    sections.notes = await enrichIssueReferences(sections.notes, deps.issueReference);
+  }
   const sectionList = buildSections(
     input.status,
-    input.sections ?? {},
+    sections,
     {
       repo: input.repo ?? "",
       worktreeRel: input.worktreeRel ?? "",

--- a/apps/dev/src/core/hitl-card.ts
+++ b/apps/dev/src/core/hitl-card.ts
@@ -8,6 +8,8 @@
 // comment body. The issue body and PR diff are NEVER parsed for commands — they
 // appear in the card render only as display data, not as instruction input.
 
+import { renderIssueReference } from "./issue-reference.js";
+
 export const CARD_OPEN = "<!-- red:hitl-card v1 -->";
 export const CARD_CLOSE = "<!-- /red:hitl-card -->";
 export const CARD_STATUS_OPEN = "<!-- red:hitl-card:status -->";
@@ -40,6 +42,8 @@ export interface PrStatus {
 /** Options for rendering the full decision card. */
 export interface RenderCardOpts {
   issueNumber: number;
+  issueTitle?: string;
+  issueUrl?: string;
   pendingDecision: string;
   prStatus: PrStatus;
   /** ISO-8601 or human-readable refresh timestamp shown in the status section. */
@@ -80,10 +84,11 @@ function renderStatusSection(prStatus: PrStatus, updatedAt: string): string {
 
 /** Render the full decision card markdown for posting as an issue comment. */
 export function renderCard(opts: RenderCardOpts): string {
-  const { issueNumber, pendingDecision, prStatus, updatedAt } = opts;
+  const { issueNumber, issueTitle, issueUrl, pendingDecision, prStatus, updatedAt } = opts;
+  const issueRef = renderIssueReference({ number: issueNumber, title: issueTitle, url: issueUrl });
   return [
     CARD_OPEN,
-    `## Decision card — #${issueNumber}`,
+    `## Decision card — ${issueRef}`,
     "",
     `> **Pending decision:** ${pendingDecision}`,
     "",

--- a/apps/dev/src/core/issue-reference.ts
+++ b/apps/dev/src/core/issue-reference.ts
@@ -1,0 +1,59 @@
+export interface IssueReference {
+  number: number;
+  title?: string;
+  url?: string;
+}
+
+export type IssueReferenceLookup = (issue: number) => Promise<IssueReference | undefined>;
+
+function escapeMarkdownLinkText(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\]/g, "\\]");
+}
+
+function escapeMarkdownUrl(value: string): string {
+  return value.replace(/\)/g, "%29");
+}
+
+export function renderIssueReference(ref: IssueReference): string {
+  const title = ref.title?.trim();
+  const url = ref.url?.trim();
+  if (!title || !url) return `#${ref.number}`;
+  return `[${escapeMarkdownLinkText(title)} (#${ref.number})](${escapeMarkdownUrl(url)})`;
+}
+
+export function renderIssueReferenceList(refs: readonly IssueReference[]): string {
+  return refs.map(renderIssueReference).join(", ");
+}
+
+export async function resolveIssueReferences(
+  issues: readonly number[],
+  lookup?: IssueReferenceLookup,
+): Promise<Map<number, IssueReference>> {
+  const out = new Map<number, IssueReference>();
+  for (const issue of issues) out.set(issue, { number: issue });
+  if (!lookup) return out;
+
+  await Promise.all(
+    [...new Set(issues)].map(async (issue) => {
+      try {
+        const resolved = await lookup(issue);
+        if (resolved?.title?.trim() && resolved.url?.trim()) {
+          out.set(issue, { number: issue, title: resolved.title, url: resolved.url });
+        }
+      } catch {
+        // Human-facing enrichment must never block the machine transition.
+      }
+    }),
+  );
+  return out;
+}
+
+export async function enrichIssueReferences(
+  text: string,
+  lookup?: IssueReferenceLookup,
+): Promise<string> {
+  const ids = [...new Set([...text.matchAll(/#([0-9]+)/g)].map((m) => Number(m[1])))];
+  if (ids.length === 0) return text;
+  const refs = await resolveIssueReferences(ids, lookup);
+  return text.replace(/#([0-9]+)/g, (raw, idRaw: string) => renderIssueReference(refs.get(Number(idRaw)) ?? { number: Number(idRaw) || 0 }) || raw);
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -90,7 +90,7 @@ import {
 } from "./attempt-outcome.js";
 import { resolveHooks, type ResolveHooksOptions, type ResolvedHooks, type HookName } from "./hook-config.js";
 import { formatStartedMarker } from "./heartbeat.js";
-import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
+import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { buildAttemptRecordPayload, deriveIssueType, type AttemptRecordPayload } from "./attempt-record.js";
 import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
 import { acquireClaim, renderClaimComment, type ClaimGh, type ClaimReconcileOptions, type ClaimDecision } from "./claim.js";
@@ -146,6 +146,8 @@ export interface ProcessGh {
   /** Resolve whether issue `n` is CLOSED. Resolves the cascade's per-dependency
    * `req:*` closed-states. A 404 / transient failure resolves to false. */
   issueClosed(n: number): Promise<boolean>;
+  /** Optional human-facing metadata lookup for rendered dependency refs. */
+  issueReference?(issue: number): Promise<{ number: number; title?: string; url?: string } | undefined>;
   /**
    * Trust-gate provenance (#621, ADR 0085): the issue author + the actor who
    * applied `ready-for-agent`, read from the issue TIMELINE — never inferred from
@@ -3374,7 +3376,8 @@ async function runCloseCascade(deps: ProcessIssueDeps, closedIssue: number): Pro
     const plans = planCloseCascade(closedIssue, dependents);
     for (const p of plans) {
       await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [LABEL_READY]);
-      await deps.gh.comment(p.number, p.comment);
+      const reqs = p.refs.map((ref) => Number(ref.slice(1))).filter((n) => Number.isFinite(n));
+      await deps.gh.comment(p.number, await cascadeAuditCommentFor(reqs, deps.gh.issueReference));
     }
   } catch (err) {
     deps.appendIterLog(

--- a/apps/dev/src/core/reconcile.ts
+++ b/apps/dev/src/core/reconcile.ts
@@ -45,7 +45,7 @@ import {
 } from "./remote-branch.js";
 import { emitEnvelope, type EmitEnvelopeDeps } from "./envelope-emit.js";
 import { parseCurrentBlocker } from "./blocker-state.js";
-import { parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
+import { cascadeAuditCommentFor, parseReqLabels, planCloseCascade, type DependentIssue } from "./boot-sweep.js";
 import { buildAttemptRecordPayload, type AttemptRecordPayload } from "./attempt-record.js";
 import type { TerminalReceipt } from "./exit-barrier.js";
 import { type RecoveryEnv } from "./recovery.js";
@@ -100,6 +100,8 @@ export interface ReconcileGh {
   listByLabel(label: string): Promise<{ number: number; labels: string[] }[]>;
   /** Resolve whether issue `n` is CLOSED (a transient failure resolves to false). */
   issueClosed(n: number): Promise<boolean>;
+  /** Optional human-facing metadata lookup for rendered dependency refs. */
+  issueReference?(issue: number): Promise<{ number: number; title?: string; url?: string } | undefined>;
 }
 
 /** git reads/cleanup reconcile needs beyond the merge/remote primitives. */
@@ -894,7 +896,8 @@ async function runCloseCascade(deps: ReconcileDeps, closedIssue: number): Promis
 
     for (const p of planCloseCascade(closedIssue, dependents)) {
       await deps.gh.editLabels(p.number, [LABEL_DEPENDENCY, ...p.reqLabels], [LABEL_READY]);
-      await deps.gh.comment(p.number, p.comment);
+      const reqs = p.refs.map((ref) => Number(ref.slice(1))).filter((n) => Number.isFinite(n));
+      await deps.gh.comment(p.number, await cascadeAuditCommentFor(reqs, deps.gh.issueReference));
     }
   } catch (err) {
     deps.appendIterLog(

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -551,6 +551,25 @@ export async function issueUrl(ctx: GhContext, issue: number): Promise<string> {
   }
 }
 
+/** `gh issue view --json number,title,url` for human-facing issue references. */
+export async function issueReference(
+  ctx: GhContext,
+  issue: number,
+): Promise<{ number: number; title?: string; url?: string } | undefined> {
+  const r = await runGh(ctx, ["issue", "view", String(issue), ...repoArgs(ctx), "--json", "number,title,url"]);
+  if (r.code !== 0) return undefined;
+  try {
+    const parsed = JSON.parse(r.stdout) as { number?: number; title?: string; url?: string };
+    return {
+      number: Number(parsed.number ?? issue),
+      title: String(parsed.title ?? ""),
+      url: String(parsed.url ?? ""),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /** A `resolveActorTrust`-bound lookup the projection consults for an author whose
  * association alone does not confer trust (issue #1100). Injected so gh.ts stays
  * the only IO seam and the source-trust decision stays pure. */

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1596,6 +1596,7 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
       },
       comment: (issue, body) => ghx.comment(ghCtx, issue, body),
       viewLabels: (issue) => ghx.viewLabels(ghCtx, issue),
+      issueReference: (issue) => ghx.issueReference(ghCtx, issue),
     },
     git: {
       deleteRemoteBranch: (branch) => gitx.deleteRemoteBranch(gitCtx, branch),

--- a/apps/dev/tests/boot-sweep.test.ts
+++ b/apps/dev/tests/boot-sweep.test.ts
@@ -317,7 +317,7 @@ describe("executeUnblockSweep", () => {
 
   // Records the gh mutations the sweep applies, so a test can assert the exact
   // label rotation + audit comment per promoted issue.
-  function recordingGh() {
+  function recordingGh(issueReference?: (issue: number) => Promise<{ number: number; title?: string; url?: string } | undefined>) {
     const edits: Array<{ issue: number; remove: string[]; add: string[] }> = [];
     const comments: Array<{ issue: number; body: string }> = [];
     return {
@@ -330,6 +330,7 @@ describe("executeUnblockSweep", () => {
         comment: async (issue: number, body: string) => {
           comments.push({ issue, body });
         },
+        issueReference,
       },
     };
   }
@@ -347,6 +348,25 @@ describe("executeUnblockSweep", () => {
     ]);
     expect(rec.comments).toEqual([
       { issue: 7, body: "🤖 /afk unblocked: all dependencies closed (#101, #102)." },
+    ]);
+  });
+
+  it("renders dependency refs as title+number links when metadata resolves", async () => {
+    const candidates: UnblockCandidate[] = [
+      { number: 7, labels: ["blocked:dependency", "req:101", "req:102"], body: "" },
+    ];
+    const rec = recordingGh(async (issue) =>
+      issue === 101
+        ? { number: 101, title: "Wayfinder fidelity restoration", url: "https://github.com/reddb-io/red-skills/issues/101" }
+        : undefined,
+    );
+    await executeUnblockSweep(candidates, lookupFor({ 101: "CLOSED", 102: "CLOSED" }), rec.gh);
+
+    expect(rec.comments).toEqual([
+      {
+        issue: 7,
+        body: "🤖 /afk unblocked: all dependencies closed ([Wayfinder fidelity restoration (#101)](https://github.com/reddb-io/red-skills/issues/101), #102).",
+      },
     ]);
   });
 

--- a/apps/dev/tests/envelope-emit.test.ts
+++ b/apps/dev/tests/envelope-emit.test.ts
@@ -245,6 +245,33 @@ describe("emitEnvelope — per-status summary + sections", () => {
     expect(res.body.indexOf('data-section="validation"')).toBeLessThan(res.body.indexOf('data-section="diff"'));
   });
 
+  it("enriches issue refs in notes while leaving log text literal", async () => {
+    const { deps } = makeDeps();
+    deps.issueReference = async (issue) =>
+      issue === 42
+        ? { number: 42, title: "Wayfinder fidelity restoration", url: "https://github.com/reddb-io/red-skills/issues/42" }
+        : undefined;
+    const res = await emitEnvelope(deps, {
+      status: "no-sentinel",
+      issue: 12,
+      worker: "wTEST",
+      durationS: 30,
+      branch: "afk/wTEST/12-foo",
+      attempt: 1,
+      diff: "+0 -0",
+      remoteName: "afk-attempts/wTEST/12-foo",
+      repo: "reddb-io/red-skills",
+      repoDir: "/tmp/x",
+      worktreeRel: ".w",
+      diffstat: "+0 -0 files=0",
+      sections: { notes: "blocked behind #42 and #404", log: "grep saw #42" },
+    });
+
+    expect(res.body).toContain("[Wayfinder fidelity restoration (#42)](https://github.com/reddb-io/red-skills/issues/42)");
+    expect(res.body).toContain("#404");
+    expect(res.body).toContain("grep saw #42");
+  });
+
   it("no-sentinel: notes < diff < log, log fenced", async () => {
     const { deps } = makeDeps();
     const res = await emitEnvelope(deps, {

--- a/apps/dev/tests/hitl-card.test.ts
+++ b/apps/dev/tests/hitl-card.test.ts
@@ -30,6 +30,25 @@ describe("renderCard", () => {
     expect(card).toContain("Approve merge of PR #42");
   });
 
+  it("renders the card issue as title+number link when metadata is present", () => {
+    const card = renderCard({
+      issueNumber: 10,
+      issueTitle: "Wayfinder fidelity restoration",
+      issueUrl: "https://github.com/reddb-io/red-skills/issues/10",
+      pendingDecision: "test",
+      prStatus: GREEN_PR,
+      updatedAt: "2026-01-01 12:00 UTC",
+    });
+    expect(card).toContain(
+      "## Decision card — [Wayfinder fidelity restoration (#10)](https://github.com/reddb-io/red-skills/issues/10)",
+    );
+  });
+
+  it("falls back to the bare issue number when card metadata is missing", () => {
+    const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
+    expect(card).toContain("## Decision card — #10");
+  });
+
   it("includes status section markers", () => {
     const card = renderCard({ issueNumber: 10, pendingDecision: "test", prStatus: GREEN_PR, updatedAt: "2026-01-01 12:00 UTC" });
     expect(card).toContain(CARD_STATUS_OPEN);

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -147,6 +147,8 @@ interface HarnessOptions {
   /** Close-cascade fixture: issues resolved as CLOSED by gh.issueClosed. The
    * just-closed issue is treated as closed without consulting this set. */
   closedIssues?: number[];
+  /** Close-cascade fixture: metadata for human-facing dependency references. */
+  issueRefs?: Record<number, { title: string; url: string }>;
   /** Attempt number (1-based) the issue runs under — drives the BOUNDED
    * auto-recovery cap (recovery.ts). Defaults to 1. */
   attempt?: number;
@@ -277,6 +279,10 @@ function harness(opts: HarnessOptions = {}): {
       },
       async issueClosed(n) {
         return (opts.closedIssues ?? []).includes(n);
+      },
+      async issueReference(n) {
+        const ref = opts.issueRefs?.[n];
+        return ref ? { number: n, ...ref } : undefined;
       },
       // Trust-gate provenance port (#621): registered only when the test opts in,
       // so legacy-shaped tests omit it and the gate never fires (permissive).
@@ -2779,6 +2785,27 @@ describe("close cascade (event-driven auto-unblock)", () => {
       issue: 30,
       remove: ["blocked:dependency", "req:8", "req:9"],
       add: ["ready-for-agent"],
+    });
+  });
+
+  it("renders close-cascade dependency refs as title+number links when metadata resolves", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: true,
+      dependentsByLabel: {
+        "req:9": [{ number: 20, labels: ["blocked:dependency", "req:9"] }],
+      },
+      issueRefs: {
+        9: {
+          title: "Wayfinder fidelity restoration",
+          url: "https://github.com/reddb-io/red-skills/issues/9",
+        },
+      },
+    });
+    await processIssue(deps, input);
+    expect(trace.comments).toContainEqual({
+      issue: 20,
+      body: "🤖 /afk unblocked: all dependencies closed ([Wayfinder fidelity restoration (#9)](https://github.com/reddb-io/red-skills/issues/9)).",
     });
   });
 


### PR DESCRIPTION
Automated AFK landing for #1345. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1345

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786166733&installation_id=129708444&pr_number=1349&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1349&signature=ba6bf650aa919d0230691c59aeadd15fdff26db3d7e289173a2d2e258eecbf7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->