### PR TITLE
chore: #1350 /go: Writing-quality pass over two skill docs, guided by upstream mattpocock/

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,24 @@ Upstream base: `mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3` (v1.
 
 ---
 
+## wayfinder (engineering) - upstream voice pass: fog, frontier, and route language (issue #1350)
+
+- **status**: modified
+- **upstream**: `d574778` (v1.1.0)
+- **why**: RedSkills had restored the upstream /wayfinder mechanics but its prose had flattened the upstream leading-word vocabulary around fog of war, frontier, charting, and the route becoming clear.
+- **what changed**: Rewrote `plugins/dev/skills/engineering/wayfinder/SKILL.md` to carry the upstream wayfinding voice while preserving the RedSkills AFK/HITL routing contract, map sections, no-fog early exit, refer-by-name rule, one-ticket-per-session discipline, zoom-as-needed loading, and `index, not a store` invariant.
+
+---
+
+## write-a-skill (productivity) - Steering glossary import: leading word, completion criterion, premature completion (issue #1350)
+
+- **status**: modified
+- **upstream**: `d574778` (v1.1.0)
+- **why**: The RedSkills writing-style framework had adopted sentence-level techniques but had not yet woven in the remaining upstream Steering glossary concepts that explain how those techniques steer runtime behavior.
+- **what changed**: Integrated Leading Word, Completion Criterion, and Premature Completion into the existing ninth writing-style technique in `plugins/dev/skills/productivity/write-a-skill/SKILL.md`, keeping the guidance as part of the nine-technique framework instead of appending a loose glossary dump. Added a docs-contract assertion pinning the imported terms.
+
+---
+
 ## afk (engineering) - upstream Steering taxonomy pass (issue #1343)
 
 - **status**: modified

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -258,3 +258,13 @@ describe("wayfinder docs", () => {
     expect(skill).toContain("fetch the full body of a specific child only when");
   });
 });
+
+describe("write-a-skill docs", () => {
+  it("incorporates the upstream Steering glossary concepts into the writing-style framework", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/productivity/write-a-skill/SKILL.md");
+
+    expect(skill).toContain("Leading Word");
+    expect(skill).toContain("Premature Completion");
+    expect(skill).toContain("Completion Criterion");
+  });
+});

--- a/plugins/dev/skills/engineering/wayfinder/SKILL.md
+++ b/plugins/dev/skills/engineering/wayfinder/SKILL.md
@@ -6,28 +6,28 @@ argument-hint: "[destination or issue/URL/path to map]"
 
 # Wayfinder
 
-**Chart one shared map for work too large for one agent session, then route each frontier child through the normal RedSkills queues.** The map fixes destination and fog; child Tickets do the work.
+**Chart one shared map for work too large for one agent session, then route each frontier child through the normal RedSkills queues.** The destination names where the expedition is headed; the map marks the fog of war; child Tickets advance the frontier until the route is clear.
 
 <what-to-do>
 
 ## 1. Check For Real Fog
 
-Start breadth-first. Read the current conversation and any referenced issue, URL, or path. Ask or answer only the first few scope questions needed to decide whether the work has unresolved in-scope fog.
+Start breadth-first. Read the current conversation and any referenced issue, URL, or path. Do not charge down the first trail; fan out just far enough to see whether unresolved in-scope fog still hides the way.
 
 **Zoom-as-needed loading.** Load the map at low resolution — read only the map's section headings first; fetch the full body of a specific child only when the session's work touches it.
 
-Use the **no-fog early exit**: if the opening breadth-first grilling surfaces no fog, stop and ask the user to continue with `/start`, `/to-spec`, `/to-tickets`, `/go`, or `/afk` instead of creating a map nobody needs. A map is warranted only when there is named destination plus multiple unknowns that cannot be cleared in one session.
+Use the **no-fog early exit**: if the opening breadth-first grilling surfaces no fog, stop and ask the user to continue with `/start`, `/to-spec`, `/to-tickets`, `/go`, or `/afk` instead of creating a map nobody needs. A map is warranted only when there is a named destination plus multiple unknowns that cannot be cleared in one session.
 
 ## 2. Create The Map Ticket
 
-Create exactly one map Ticket and label it `wayfinder:map`. Name the destination first; it fixes scope.
+Create exactly one map Ticket and label it `wayfinder:map`. Name the destination first; it fixes the horizon, the scope, and which fog belongs on this map.
 
 The map body must carry these headings:
 
 ```markdown
 ## Destination
 
-The named end state. Keep this concrete enough that later child Tickets can decide whether new fog is in scope.
+The named end state. Keep this concrete enough that later child Tickets can decide whether new fog is on the route or beyond it.
 
 ## Decisions so far
 
@@ -35,11 +35,11 @@ One line per closed child: a short gist of the decision or result followed by a 
 
 ## Not yet specified
 
-In-scope fog. Each entry is a frontier question or unresolved branch that can graduate into a child Ticket.
+In-scope fog. Each entry is a frontier question or unresolved branch that can graduate into a child Ticket once the way ahead sharpens.
 
 ## Out of scope
 
-Ruled beyond the destination. These entries never graduate into child Tickets unless the destination is explicitly renamed.
+Ruled beyond the destination. These entries sit past the edge of this map and never graduate into child Tickets unless the destination is explicitly renamed.
 
 ## Notes
 
@@ -48,7 +48,7 @@ Standing preferences for this effort and which skills every session should consu
 
 The map is an **index, not a store**. Keep durable decisions, evidence, prototypes, and implementation notes in the child Tickets that produced them; the map only gists and links to those Tickets via `## Decisions so far`.
 
-**Refer by name.** Every reference to a map or child Ticket uses its *title* with the link embedded in the name — never a bare `#N`. Bare-number narration is illegible to anyone reading the trail.
+**Refer by name.** Every reference to a map or child Ticket uses its *title* with the link embedded in the name — never a bare `#N`. Bare-number narration turns the trail into coordinates without landmarks; names keep the route readable.
 
 ## 3. Publish Child Tickets
 
@@ -59,7 +59,7 @@ Children are native sub-issues of the `wayfinder:map` Ticket. Give each child ex
 - `wayfinder:prototype` - HITL-typed. Use for design/logic uncertainty that must route to a `/prototype` session and be claimed by assignment.
 - `wayfinder:task` - AFK-typed. Use for implementation or docs work that is already scoped to one agent session.
 
-Each child must be scoped to one session. If a child still contains multiple frontier questions, split it before publishing.
+Each child must be scoped to one session. If a child still contains multiple frontier questions, split it before publishing; a child Ticket should take one clear step across the frontier.
 
 Use native tracker edges plus RedSkills labels:
 
@@ -81,7 +81,7 @@ HITL-typed children (`wayfinder:grilling`, `wayfinder:prototype`) route to human
 - Assign the human or role expected to run the `/start` or `/prototype` session.
 - Use `## Current blocker` / `## Human decision needed` for the pending decision or prototype question, not `## Blocked by`, unless closing concrete dependency Tickets is enough to make the child delegable.
 
-**One-ticket-per-session discipline.** A grilling or prototype session resolves exactly one HITL child and stops. Charting the map is itself one session's work. Do not collapse multiple HITL children into a single session.
+**One-ticket-per-session discipline.** A grilling or prototype session resolves exactly one HITL child and stops. Charting the map is itself one session's work. Do not collapse multiple HITL children into a single session; the route becomes clear by advancing one frontier edge at a time.
 
 When a HITL child becomes delegable, `/hitl` or `/requeue` moves it into `ready-for-agent`; do not create a parallel queue.
 
@@ -94,7 +94,7 @@ After a child resolves, update the map only as an index:
 - Move newly discovered in-scope fog into `## Not yet specified`.
 - Move rejected branches into `## Out of scope`.
 
-Never copy full decisions, research logs, prototype output, or implementation notes into the map. Those live in the child Tickets.
+Never copy full decisions, research logs, prototype output, or implementation notes into the map. Those live in the child Tickets; the map stays the shared chart, not the expedition journal.
 
 </what-to-do>
 

--- a/plugins/dev/skills/productivity/write-a-skill/SKILL.md
+++ b/plugins/dev/skills/productivity/write-a-skill/SKILL.md
@@ -191,11 +191,17 @@ writing any RedSkills SKILL.md. Each carries a one-line before → after.
    - Before: `## Review` followed by `(Only do this after the draft is complete.)`
    - After: `## Review (after the draft compiles and runs)`
 
-9. **Leading words (prior-triggering domain terms)** — compress the core behavior
-   into one consistent term, repeat that exact term throughout the skill, and
-   confirm it took by watching for it in the agent's reasoning traces.
+9. **Leading Word + Completion Criterion** — compress the core behavior into one
+   pretrained domain term, then bind each step to a checkable completion bar.
+   The Leading Word recruits the right prior every time it appears; the
+   Completion Criterion tells the agent when that unit is actually done.
    - Before: `Build a thin end-to-end path through every layer first, then flesh out.`
-   - After: `Ship a **tracer bullet** first — and say "tracer bullet" every time you mean it.`
+   - After: `Ship a **tracer bullet** first — done only when one request crosses every layer and returns a visible result.`
+
+Use the nine techniques to resist **Premature Completion**: if a step is vague,
+the agent will feel the pull of the later steps and leave early. Sharpen the
+Completion Criterion first; split the phase only when the criterion is
+irreducibly fuzzy and the visible later work keeps causing the rush.
 
 ## Steering failure modes
 


### PR DESCRIPTION
Automated AFK landing for #1350. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786188425&installation_id=129708444&pr_number=1351&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1351&signature=ba64cbefe785ae8f4dba339f9dc4612a956f0ccba5a040770ab2a9d096d687d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->