### PR TITLE
chore: #1355 /go: Add a namespace-aware reaper for dead empty AFK worker shells, closing t

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -143,6 +143,8 @@ export interface BootFs {
   writeWorkerPid(pidFile: string, pid: number): Promise<void>;
   /** rm -rf an orphaned attempt dir. */
   removeDir(path: string): Promise<void>;
+  /** Best-effort cleanup of dead empty worker.pid shells after orphan cleanup. */
+  reapDeadEmptyWorkerShells?(tmpDir: string): Promise<unknown>;
 }
 
 /** gh side effects: label edits and audit/recovery comments. Best-effort. */
@@ -608,6 +610,8 @@ async function runOrphanCleanup(
     await deps.fs.removeDir(claim.path);
     claimsReleased.push(claim.path);
   }
+
+  await deps.fs.reapDeadEmptyWorkerShells?.(options.bootstrap.tmpDir).catch(() => undefined);
 
   return { removed, restored, kept, legacyWiped, claimsReleased };
 }

--- a/apps/dev/src/core/worker-paths.ts
+++ b/apps/dev/src/core/worker-paths.ts
@@ -76,9 +76,9 @@ export function buildWorkerAttemptPath(
 export function parseWorkerAttemptPath(path: string): WorkerAttemptIdentity | null {
   if (!path) return null;
   const normalized = path.replace(/\/$/, "");
-  // Accept both the fleet (`workers`) and `/go` (`go-workers`) segments so a
-  // parked-attempt path reverses regardless of which lane minted it.
-  const match = normalized.match(/(?:^|\/)(?:go-)?workers\/([^/]+)\/([1-9][0-9]*)-a([1-9][0-9]*)$/);
+  // Accept every worker-lane segment so a parked-attempt path reverses
+  // regardless of which lane minted it.
+  const match = normalized.match(/(?:^|\/)(?:workers|go-workers|scout-workers)\/([^/]+)\/([1-9][0-9]*)-a([1-9][0-9]*)$/);
   if (!match) return null;
   const [, worker, issue, attempt] = match;
   if (!isValidWorkerId(worker)) return null;

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -14,6 +14,7 @@ import {
   readFile,
   rename,
   rm,
+  rmdir,
   stat,
   writeFile,
 } from "node:fs/promises";
@@ -21,6 +22,7 @@ import { dirname, join } from "node:path";
 import type { FailureMarkers } from "../core/envelope-emit.js";
 import type { OrphanDir, StaleClaimDir } from "../core/boot.js";
 import { updateState } from "../core/state.js";
+import { allWorkersRoots } from "../core/worker-paths.js";
 
 export async function ensureDir(path: string): Promise<void> {
   await mkdir(path, { recursive: true });
@@ -265,6 +267,133 @@ export async function listOrphanDirs(workersRoot: string, nowS: number): Promise
     }
   }
   return out;
+}
+
+export interface DeadEmptyWorkerShellReapResult {
+  workerDirs: string[];
+  workerPidFiles: string[];
+  emptyAttemptDirs: string[];
+}
+
+/** Remove dead worker shells under every worker namespace. A shell is removable
+ * only when its worker.pid is absent/corrupt/dead and the worker dir contains
+ * no non-empty attempt evidence. */
+export async function reapDeadEmptyWorkerShells(tmpDir: string): Promise<DeadEmptyWorkerShellReapResult> {
+  const result: DeadEmptyWorkerShellReapResult = {
+    workerDirs: [],
+    workerPidFiles: [],
+    emptyAttemptDirs: [],
+  };
+
+  for (const workersRoot of allWorkersRoots(tmpDir)) {
+    const partial = await reapDeadEmptyWorkerShellsInRoot(workersRoot);
+    result.workerDirs.push(...partial.workerDirs);
+    result.workerPidFiles.push(...partial.workerPidFiles);
+    result.emptyAttemptDirs.push(...partial.emptyAttemptDirs);
+  }
+
+  return result;
+}
+
+async function reapDeadEmptyWorkerShellsInRoot(workersRoot: string): Promise<DeadEmptyWorkerShellReapResult> {
+  const result: DeadEmptyWorkerShellReapResult = {
+    workerDirs: [],
+    workerPidFiles: [],
+    emptyAttemptDirs: [],
+  };
+  let workers: string[];
+  try {
+    workers = await readdir(workersRoot);
+  } catch {
+    return result;
+  }
+
+  for (const worker of workers) {
+    const workerPath = join(workersRoot, worker);
+    try {
+      const st = await stat(workerPath);
+      if (!st.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const pidPath = join(workerPath, "worker.pid");
+    if (pidAlive(await readText(pidPath))) continue;
+
+    let entries: string[];
+    try {
+      entries = await readdir(workerPath);
+    } catch {
+      continue;
+    }
+
+    const emptyAttemptDirs: string[] = [];
+    let removable = true;
+    for (const entry of entries) {
+      const path = join(workerPath, entry);
+      if (entry === "worker.pid") {
+        try {
+          const st = await stat(path);
+          if (!st.isFile()) removable = false;
+        } catch {
+          // Raced away or missing: still an empty shell candidate.
+        }
+        if (!removable) break;
+        continue;
+      }
+
+      if (!/^[1-9][0-9]*-a[1-9][0-9]*$/.test(entry)) {
+        removable = false;
+        break;
+      }
+
+      try {
+        const st = await stat(path);
+        if (!st.isDirectory()) {
+          removable = false;
+          break;
+        }
+        if ((await readdir(path)).length > 0) {
+          removable = false;
+          break;
+        }
+      } catch {
+        removable = false;
+        break;
+      }
+      emptyAttemptDirs.push(path);
+    }
+    if (!removable) continue;
+
+    const removedEmptyAttemptDirs: string[] = [];
+    for (const dir of emptyAttemptDirs) {
+      try {
+        await rmdir(dir);
+        removedEmptyAttemptDirs.push(dir);
+      } catch {
+        removable = false;
+        break;
+      }
+    }
+    if (!removable) continue;
+
+    let removedPidFile = false;
+    try {
+      if (await pathExists(pidPath)) {
+        await rm(pidPath, { force: true });
+        removedPidFile = true;
+      }
+      await rmdir(workerPath);
+    } catch {
+      continue;
+    }
+
+    result.workerDirs.push(workerPath);
+    if (removedPidFile) result.workerPidFiles.push(pidPath);
+    result.emptyAttemptDirs.push(...removedEmptyAttemptDirs);
+  }
+
+  return result;
 }
 
 /** Liveness probe (kill -0) for a recorded pid string. A blank/non-numeric pid

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -678,6 +678,7 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
   // here never blocks the render. Live-worker dirs and blocked/ready-for-human
   // post-mortem artifacts are preserved (planLivenessReclaim).
   await reclaimDeadWorkers(root, records, repo).catch(() => undefined);
+  await fsx.reapDeadEmptyWorkerShells(paths.tmpDir).catch(() => undefined);
   const currentRecords = currentRenderableWorkerRecords(records);
   const logPaths = currentRecords.map(({ path, state }) => state.log || join(dirname(path), "afk.log"));
   const logCounts = await collectLogLineCounts(paths.monitorLogCursorPath, logPaths);
@@ -1418,13 +1419,13 @@ import type { PrecheckFacts, BootOptions, BootDeps, BootstrapInput, OrphanDir } 
 import type { AttemptDir } from "../core/reclaim.js";
 import type { IssueStateRow } from "./gh.js";
 import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../core/triage-labels.js";
-import { parseWorkerAttemptPath } from "../core/worker-paths.js";
+import { allWorkersRoots, parseWorkerAttemptPath } from "../core/worker-paths.js";
 import { parseClaimRecords } from "../core/claim.js";
 
 /**
  * Discover every per-step input boot's sweeps consume, replacing the empty
  * placeholders the native cutover shipped with:
- *   - orphans: every attempt dir under the workers root with its age + issue.
+ *   - orphans: every attempt dir under every worker namespace with its age + issue.
  *   - attemptCap: those same dirs grouped by issue, each stat'd for mtime +
  *     liveness (live attempts are excluded from the cap).
  *   - branches: the three afk/* / afk-attempts/* ref namespaces (snapshot
@@ -1444,7 +1445,7 @@ export async function collectBootOptions(
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
 
   // Orphan dirs + the same dirs grouped by issue for the cap pass.
-  const orphans = await fsx.listOrphanDirs(paths.workersRoot, nowS);
+  const orphans = (await Promise.all(allWorkersRoots(paths.tmpDir).map((root) => fsx.listOrphanDirs(root, nowS)))).flat();
   const byIssue = new Map<number, AttemptDir[]>();
   for (const o of orphans) {
     const parsed = parseWorkerAttemptPath(o.path);
@@ -1584,6 +1585,7 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
       ensureGitignoreLine: fsx.ensureGitignoreLine,
       writeWorkerPid: fsx.writeWorkerPid,
       removeDir: fsx.removeDir,
+      reapDeadEmptyWorkerShells: fsx.reapDeadEmptyWorkerShells,
     },
     gh: {
       editLabels: async (issue, remove, add) => {

--- a/apps/dev/tests/fs-sweep.test.ts
+++ b/apps/dev/tests/fs-sweep.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
@@ -8,6 +8,7 @@ import {
   listLegacyWorkDirs,
   tryAcquireClaimDir,
   listOrphanDirs,
+  reapDeadEmptyWorkerShells,
 } from "../src/runtime/fs.js";
 
 function scratch(): string {
@@ -298,6 +299,75 @@ describe("listOrphanDirs (#444 — skip live siblings)", () => {
       writeFileSync(join(root, "wDEAD", "worker.pid"), DEAD_PID);
       const orphans = await listOrphanDirs(root, Math.floor(Date.now() / 1000));
       expect(orphans.map((o) => o.path)).toEqual([dead]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("reapDeadEmptyWorkerShells (#1355)", () => {
+  it("removes dead empty worker shells across every worker namespace", async () => {
+    const root = scratch();
+    try {
+      for (const ns of ["workers", "go-workers", "scout-workers"]) {
+        const worker = join(root, ns, `w-${ns}`);
+        mkdirSync(worker, { recursive: true });
+        writeFileSync(join(worker, "worker.pid"), DEAD_PID);
+      }
+
+      const result = await reapDeadEmptyWorkerShells(root);
+
+      expect(result.workerDirs.sort()).toEqual([
+        join(root, "go-workers", "w-go-workers"),
+        join(root, "scout-workers", "w-scout-workers"),
+        join(root, "workers", "w-workers"),
+      ].sort());
+      expect(existsSync(join(root, "workers", "w-workers"))).toBe(false);
+      expect(existsSync(join(root, "go-workers", "w-go-workers"))).toBe(false);
+      expect(existsSync(join(root, "scout-workers", "w-scout-workers"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("spares a live worker shell", async () => {
+    const root = scratch();
+    try {
+      const worker = join(root, "workers", "wLIVE");
+      mkdirSync(worker, { recursive: true });
+      writeFileSync(join(worker, "worker.pid"), ALIVE_PID);
+
+      expect(await reapDeadEmptyWorkerShells(root)).toEqual({
+        workerDirs: [],
+        workerPidFiles: [],
+        emptyAttemptDirs: [],
+      });
+      expect(readFileSync(join(worker, "worker.pid"), "utf8")).toBe(ALIVE_PID);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes only empty attempt dirs and preserves non-empty attempt evidence", async () => {
+    const root = scratch();
+    try {
+      const emptyWorker = join(root, "go-workers", "wEMPTYATT");
+      mkdirSync(join(emptyWorker, "12-a1"), { recursive: true });
+      writeFileSync(join(emptyWorker, "worker.pid"), "corrupt");
+
+      const preservedWorker = join(root, "scout-workers", "wPRESERVE");
+      const preservedAttempt = join(preservedWorker, "13-a1");
+      mkdirSync(preservedAttempt, { recursive: true });
+      writeFileSync(join(preservedAttempt, "agent.log.jsonl"), "blocked evidence");
+      writeFileSync(join(preservedWorker, "worker.pid"), DEAD_PID);
+
+      const result = await reapDeadEmptyWorkerShells(root);
+
+      expect(result.workerDirs).toEqual([emptyWorker]);
+      expect(result.emptyAttemptDirs).toEqual([join(emptyWorker, "12-a1")]);
+      expect(existsSync(emptyWorker)).toBe(false);
+      expect(readdirSync(preservedAttempt)).toEqual(["agent.log.jsonl"]);
+      expect(readFileSync(join(preservedWorker, "worker.pid"), "utf8")).toBe(DEAD_PID);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/worker-paths.test.ts
+++ b/apps/dev/tests/worker-paths.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   allWorkersRoots,
   buildWorkerAttemptPath,
@@ -13,6 +13,14 @@ import {
 } from "../src/core/worker-paths.js";
 
 describe("worker paths", () => {
+  beforeEach(() => {
+    delete process.env.RED_AFK_WORKERS_NAMESPACE;
+  });
+
+  afterEach(() => {
+    delete process.env.RED_AFK_WORKERS_NAMESPACE;
+  });
+
   it("round-trips the nested worker/issue/attempt layout", () => {
     const path = buildWorkerAttemptPath(".red/tmp/", "wZ2R4", 142, 3);
     expect(path).toBe(".red/tmp/workers/wZ2R4/142-a3");
@@ -35,6 +43,10 @@ describe("worker paths", () => {
 });
 
 describe("worker paths — /go namespace", () => {
+  beforeEach(() => {
+    delete process.env.RED_AFK_WORKERS_NAMESPACE;
+  });
+
   afterEach(() => {
     delete process.env.RED_AFK_WORKERS_NAMESPACE;
   });
@@ -67,6 +79,11 @@ describe("worker paths — /go namespace", () => {
       "/repo/.red/tmp/go-workers",
       "/repo/.red/tmp/scout-workers",
     ]);
+    expect(parseWorkerAttemptPath("/repo/.red/tmp/scout-workers/wSCOUT/15-a2")).toEqual({
+      worker: "wSCOUT",
+      issue: 15,
+      attempt: 2,
+    });
   });
 
   it("allWorkersRoots is namespace-blind (ignores RED_AFK_WORKERS_NAMESPACE)", () => {

--- a/plugins/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
+++ b/plugins/dev/skills/engineering/afk/docs/BOOT-SWEEPS.md
@@ -6,7 +6,7 @@
 
 ## Orphan Cleanup (boot-time)
 
-Right after bootstrap and before *Straggler Check*, `/afk` runs two passes. First it **drain-wipes** any leftover **legacy flat** `.red/tmp/work-*/` dirs — these are never created under the nested scheme (the drain-first cutover, issue #252), so any survivor is a pre-cutover relic and is removed unconditionally. Then it sweeps the nested attempt dirs `.red/tmp/workers/*/*/` whose parent worker's `worker.pid` is dead, and afterwards removes the dead `worker.pid` files and the now-empty worker dirs. For each orphaned attempt dir:
+Right after bootstrap and before *Straggler Check*, `/afk` runs two passes. First it **drain-wipes** any leftover **legacy flat** `.red/tmp/work-*/` dirs — these are never created under the nested scheme (the drain-first cutover, issue #252), so any survivor is a pre-cutover relic and is removed unconditionally. Then it sweeps the nested attempt dirs in every worker namespace (`.red/tmp/workers/*/*/`, `.red/tmp/go-workers/*/*/`, and `.red/tmp/scout-workers/*/*/`) whose parent worker's `worker.pid` is dead, and afterwards removes dead empty worker shells across those namespaces: dead/corrupt/missing `worker.pid` files plus the worker dir when it contains no attempt dirs or only empty attempt dirs. Live `worker.pid` dirs and non-empty preserved attempt dirs are left untouched. For each orphaned attempt dir:
 
 1. **(Slice D — heartbeat sub-shell retired.)** No zombie reap step is needed; older state files may still carry a `heartbeat_pid` but it's vestigial and ignored.
 2. **Decide fate from issue state.** `gh issue view N --json labels,state`:
@@ -56,4 +56,3 @@ The sweeps above (*Orphan Cleanup*, *Attempt Cap*, *Snapshot Branch Grace Cleanu
 So in **fleet mode** the **supervisor** runs the full sweep suite **exactly once, before it spawns any worker**, and logs the result to `.red/tmp/afk-supervisor.log` (`boot sweeps complete: orphans … | attempt-cap … | branches … | unblocked … | stragglers …`). Every worker the supervisor spawns carries a `RED_AFK_SWEEPS_DONE=1` marker; a marked worker's boot is **bootstrap + claim only** — it ensures its dirs/gitignore/`worker.pid` and goes straight to claiming an issue, skipping every shared sweep. This makes respawns cheap and keeps workers from racing each other over boot state. The supervisor runs the sweeps a single time per lifetime: a worker that exits and is respawned does **not** re-trigger them.
 
 A **solo** `/afk run` (no supervisor, no marker) is unchanged — it runs the full sweep suite itself, exactly as described above. `/afk run --boot-only` reports which path it took: `sweeps ran` for a solo boot, `sweeps skipped (supervisor-owned)` for a marked worker.
-


### PR DESCRIPTION
Automated AFK landing for #1355. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1355

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786190350&installation_id=129708444&pr_number=1357&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1357&signature=f1b9bcdd1ed870752ed86f532ca11700112bddf8358f4d60a806b2ab51aa7574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->