### PR TITLE
chore: #1358 /go: Split plugins/dev/skills/productivity/write-a-skill/SKILL.md per the pro

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@ Upstream base: `mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3` (v1.
 
 ---
 
+## write-a-skill (productivity) - progressive-disclosure split and structural-tag lint hardening (issue #1358)
+
+- **status**: modified
+- **upstream**: `d574778` (v1.1.0)
+- **why**: `write-a-skill/SKILL.md` carried the full sentence-level technique catalog and Steering failure-mode material in the hot path, and the body-tag linters accepted `<what-to-do>` inside fenced examples as if it were a real structural split.
+- **what changed**: Moved the nine writing-style techniques plus Negation and Negative Space Steering failure modes into `plugins/dev/skills/productivity/write-a-skill/WRITING-STYLE.md` behind a hot-path pointer, added real structural tags to `SKILL.md`, retargeted the CLAUDE.md style pointer, hardened the shell and TypeScript linters to count only standalone tags outside fenced code blocks, widened orphan-reference checks to sibling markdown reference docs, and linked AFK's fallback `runner-hermes.md` from the AFK runner reference list so the widened sweep has no runner-doc orphan.
+
+---
+
 ## afk (engineering) - post-extraction relative-link repair and link guard (issue #1354)
 
 - **status**: modified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Never reorder priorities so that documentation/side-effect work in `<supporting-
 
 ### SKILL.md writing style (sentence-level)
 
-The body convention above is **section-level** — it decides *where* a sentence goes. Underneath it sits the **sentence-level** writing convention: nine techniques (bold lead-in + gloss; maxim/slogan compression; prohibition + reason inline; literal phrasing in quotes; vocabulary hygiene; numbered taxonomy; self-demonstrating voice; precondition-carrying headers; leading words) that decide *how each sentence reads*. It is **additive — it complements the `<what-to-do>`/`<supporting-info>` split, it does not replace it.** When writing or editing any RedSkills SKILL.md, apply both. The full list with before → after examples lives in the `write-a-skill` skill's "SKILL.md writing style" section.
+The body convention above is **section-level** — it decides *where* a sentence goes. Underneath it sits the **sentence-level** writing convention: nine techniques (bold lead-in + gloss; maxim/slogan compression; prohibition + reason inline; literal phrasing in quotes; vocabulary hygiene; numbered taxonomy; self-demonstrating voice; precondition-carrying headers; leading words) that decide *how each sentence reads*. It is **additive — it complements the `<what-to-do>`/`<supporting-info>` split, it does not replace it.** When writing or editing any RedSkills SKILL.md, apply both. The full list with before → after examples lives in `plugins/dev/skills/productivity/write-a-skill/WRITING-STYLE.md`.
 
 ## Agent skills
 

--- a/apps/dev/src/commands/audit-skills.ts
+++ b/apps/dev/src/commands/audit-skills.ts
@@ -93,8 +93,9 @@ function pluginRoot(rel: string): string {
 /**
  * Enumerate shipped skills + compute per-skill orphaned bundled files. Mirrors
  * the lint glob (find plugins -name SKILL.md, excluding any in-progress/ path),
- * minus the self-exempt meta-skill. Orphan detection widens the reference search to
- * every SKILL.md in the same plugin (as the lint does).
+ * minus the self-exempt meta-skill. Orphan detection widens the reference
+ * search to every shipped markdown file in the same plugin (as the lint does),
+ * so extracted sibling reference docs can own links too.
  */
 export async function enumerateSkills(
   root: string,
@@ -117,9 +118,14 @@ export async function enumerateSkills(
     bundled,
   );
 
-  // Cache each SKILL.md's content once (used for both audit + reference search).
+  // Cache each SKILL.md's content once for audit.
   const contents = new Map<string, string>();
   for (const p of skillPaths) contents.set(p, await readFile(path.join(root, p), "utf8"));
+
+  // Cache every shipped plugin markdown file once for reference search.
+  const referencePaths = [...new Set([...skillPaths, ...bundled])].sort();
+  const referenceContents = new Map<string, string>();
+  for (const p of referencePaths) referenceContents.set(p, await readFile(path.join(root, p), "utf8"));
 
   const result: Array<{ doc: SkillDoc; orphanedFiles: string[] }> = [];
   for (const p of skillPaths) {
@@ -131,9 +137,9 @@ export async function enumerateSkills(
       .filter((b) => path.posix.dirname(b) === skillDir)
       .filter((b) => {
         const base = path.posix.basename(b);
-        // Referenced if any SKILL.md in the plugin mentions the basename.
-        for (const [sp, content] of contents) {
-          if (sp.startsWith(`${proot}/`) && content.includes(base)) return false;
+        // Referenced if any other shipped markdown file in the plugin mentions the basename.
+        for (const [rp, content] of referenceContents) {
+          if (rp !== b && rp.startsWith(`${proot}/`) && content.includes(base)) return false;
         }
         return true;
       })

--- a/apps/dev/src/core/skill-audit.ts
+++ b/apps/dev/src/core/skill-audit.ts
@@ -9,8 +9,9 @@
 //   1. MECHANICAL — objective, pure facts ported from the report-only lint
 //      (scripts/lint-skill-body.sh + lint-skill-first-line.sh): description
 //      budget, the 1024-char hard cap, literal "Use when", <what-to-do> on long
-//      bodies, bold-imperative first line, name: frontmatter, English-only,
-//      orphaned bundled files. Each is a pass/warn/fail FACT, never a gate.
+//      bodies (standalone and outside fenced code), bold-imperative first line,
+//      name: frontmatter, English-only, orphaned bundled files. Each is a
+//      pass/warn/fail FACT, never a gate.
 //   2. SEMANTIC — the LLM judge scores the nine sentence-level techniques from
 //      write-a-skill plus trigger clarity, deletion-test bloat, and
 //      <what-to-do>/<supporting-info> placement. Its shape + validator live
@@ -168,6 +169,20 @@ const NON_ENGLISH_MARKERS = [
   "não é",
 ];
 
+/** True when `tag` appears as a standalone structural line outside code fences. */
+export function hasStructuralTag(body: string, tag: string): boolean {
+  let fenced = false;
+  for (const line of body.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) continue;
+    if (line.trim() === tag) return true;
+  }
+  return false;
+}
+
 export interface MechanicalContext {
   /** Bundled non-README markdown files under this skill folder not referenced
    * by any SKILL.md in the plugin (computed by the fs enumeration layer). */
@@ -228,8 +243,9 @@ export function runMechanicalChecks(doc: SkillDoc, ctx: MechanicalContext = {}):
     }
   }
 
-  // 3. House tags: bodies over the threshold need <what-to-do>.
-  if (parsed.bodyLineCount > BODY_LINE_THRESHOLD && !parsed.body.includes("<what-to-do>")) {
+  // 3. House tags: bodies over the threshold need a structural <what-to-do>.
+  const hasWhatToDo = hasStructuralTag(parsed.body, "<what-to-do>");
+  if (parsed.bodyLineCount > BODY_LINE_THRESHOLD && !hasWhatToDo) {
     checks.push({
       id: "what-to-do-tag",
       status: "fail",

--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -260,11 +260,13 @@ describe("wayfinder docs", () => {
 });
 
 describe("write-a-skill docs", () => {
-  it("incorporates the upstream Steering glossary concepts into the writing-style framework", async () => {
+  it("keeps Steering glossary concepts in the extracted writing-style reference", async () => {
     const skill = await readRepoFile("plugins/dev/skills/productivity/write-a-skill/SKILL.md");
+    const style = await readRepoFile("plugins/dev/skills/productivity/write-a-skill/WRITING-STYLE.md");
 
-    expect(skill).toContain("Leading Word");
-    expect(skill).toContain("Premature Completion");
-    expect(skill).toContain("Completion Criterion");
+    expect(skill).toContain("[WRITING-STYLE.md](WRITING-STYLE.md)");
+    expect(style).toContain("Leading Word");
+    expect(style).toContain("Premature Completion");
+    expect(style).toContain("Completion Criterion");
   });
 });

--- a/apps/dev/tests/skill-audit.test.ts
+++ b/apps/dev/tests/skill-audit.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   parseSkill,
   firstContentLine,
@@ -17,7 +20,7 @@ import {
   type MechanicalCheck,
 } from "../src/core/skill-audit.js";
 import { buildSkillAuditPrompt, makeExtractSkillAudit } from "../src/core/skill-audit-extract.js";
-import { runAudit, type AuditDeps } from "../src/commands/audit-skills.js";
+import { enumerateSkills, runAudit, type AuditDeps } from "../src/commands/audit-skills.js";
 
 // --- fixtures ---------------------------------------------------------------
 
@@ -105,6 +108,20 @@ describe("runMechanicalChecks", () => {
     expect(findCheck(checks, "what-to-do-tag").status).toBe("fail");
   });
 
+  it("ignores <what-to-do> inside fenced code blocks", () => {
+    const longBody = [
+      "**b**",
+      "```md",
+      "<what-to-do>",
+      "template text",
+      "</what-to-do>",
+      "```",
+      ...Array.from({ length: 120 }, (_, i) => `line ${i}`),
+    ].join("\n");
+    const checks = runMechanicalChecks({ path: "p/SKILL.md", content: skill("name: a\ndescription: d. Use when e.", longBody) });
+    expect(findCheck(checks, "what-to-do-tag").status).toBe("fail");
+  });
+
   it("warns when the first content line is not bold", () => {
     const checks = runMechanicalChecks({ path: "p/SKILL.md", content: skill("name: a\ndescription: d. Use when e.", "not bold at all") });
     expect(findCheck(checks, "bold-first-line").status).toBe("warn");
@@ -119,6 +136,28 @@ describe("runMechanicalChecks", () => {
     const checks = runMechanicalChecks({ path: "p/SKILL.md", content: GOOD }, { orphanedFiles: ["template.md"] });
     expect(findCheck(checks, "orphaned-files").status).toBe("fail");
     expect(mechanicalScore(checks)).toBeLessThan(100);
+  });
+});
+
+describe("enumerateSkills", () => {
+  it("counts sibling reference docs when checking orphaned bundled files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "red-skill-audit-"));
+    try {
+      const skillDir = join(root, "plugins/dev/skills/engineering/producer");
+      const consumerDir = join(root, "plugins/dev/skills/engineering/consumer");
+      await mkdir(skillDir, { recursive: true });
+      await mkdir(consumerDir, { recursive: true });
+      await writeFile(join(skillDir, "SKILL.md"), skill("name: producer\ndescription: d. Use when e.", "See [REFERENCE.md](REFERENCE.md).\n"));
+      await writeFile(join(skillDir, "REFERENCE.md"), "Uses sibling [runner-opencode.md](../consumer/runner-opencode.md).\n");
+      await writeFile(join(consumerDir, "SKILL.md"), skill("name: consumer\ndescription: d. Use when e.", "**Run** — no direct reference here.\n"));
+      await writeFile(join(consumerDir, "runner-opencode.md"), "Runner notes.\n");
+
+      const docs = await enumerateSkills(root);
+      const consumer = docs.find((d) => d.doc.path.endsWith("/consumer/SKILL.md"));
+      expect(consumer?.orphanedFiles).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -74,6 +74,10 @@ Read the focused reference before touching that concern:
 - Handoff wrappers and inner-agent prompt materialisation:
   [`docs/HANDOFF.md`](./docs/HANDOFF.md) and
   [`AGENT-PROMPT.md`](./AGENT-PROMPT.md).
+- Runner-specific behavior: [`runner-claude.md`](./runner-claude.md),
+  [`runner-codex.md`](./runner-codex.md),
+  [`runner-opencode.md`](./runner-opencode.md), and fallback
+  [`runner-hermes.md`](./runner-hermes.md).
 - Liveness, stall protection, and lane-idle rules:
   [`docs/LIVENESS.md`](./docs/LIVENESS.md).
 - Config, env overrides, lifecycle hooks, sandbox/runner/model settings, and

--- a/plugins/dev/skills/productivity/write-a-skill/SKILL.md
+++ b/plugins/dev/skills/productivity/write-a-skill/SKILL.md
@@ -5,6 +5,8 @@ description: Create new agent skills with proper structure, progressive disclosu
 
 # Writing Skills
 
+<what-to-do>
+
 ## Process
 
 1. **Gather requirements** — ask the user, before drafting anything:
@@ -21,6 +23,10 @@ description: Create new agent skills with proper structure, progressive disclosu
 3. **Review with the user** — present the draft and ask whether it covers the
    use cases, what is missing or unclear, and which section needs more or less
    detail. Do not ship before this loop closes.
+
+</what-to-do>
+
+<supporting-info>
 
 ## Skill structure
 
@@ -149,65 +155,9 @@ pull toward shipping; and `writing-fragments` is separate from `writing-shape` /
 ## SKILL.md writing style
 
 Section structure (`<what-to-do>` / `<supporting-info>`) decides *where* a
-sentence goes; this section decides *how the sentence reads*. Apply these nine
-sentence-level techniques — borrowed from `anthropics/launch-your-agent` — when
-writing any RedSkills SKILL.md. Each carries a one-line before → after.
-
-1. **Bold lead-in + gloss** — open a step with the imperative in bold, then
-   explain it.
-   - Before: `You should gather the requirements from the user first.`
-   - After: `**Gather requirements** — ask the user what task the skill covers.`
-
-2. **Maxim/slogan compression** — fold a rule into one memorable line.
-   - Before: `The description matters because it is what the agent uses to decide whether to load the skill.`
-   - After: `The description is the only thing the agent sees before loading — write it for the picker, not the reader.`
-
-3. **Prohibition + reason inline (em-dash consequence)** — state the ban and its
-   cost on one line.
-   - Before: `Do not exceed 100 lines. Long skills are hard to read.`
-   - After: `Never exceed ~100 lines — past that the agent skims and drops steps.`
-
-4. **Literal phrasing in quotes** — quote the exact words the agent must emit or
-   match.
-   - Before: `End the description with a phrase about when to use it.`
-   - After: `End the description with "Use when …" so the trigger is matchable verbatim.`
-
-5. **Vocabulary hygiene (real term, ban synonym)** — name a thing once, forbid
-   its synonyms.
-   - Before: `Put your docs / guidance / instructions in the file.`
-   - After: `Call it the SKILL.md — never "the doc", "the manifest", or "the guide".`
-
-6. **Numbered taxonomy when concepts blur** — number a set whose members are
-   easily conflated.
-   - Before: `Add scripts for deterministic work and split files for big skills.`
-   - After: `Two distinct moves: (1) add a script for deterministic work; (2) split a file once SKILL.md passes ~100 lines.`
-
-7. **Self-demonstrating voice** — write the instruction in the style it teaches.
-   - Before: `Instructions should be concise and imperative.`
-   - After: `Write every step imperative and bold-led — like this one.`
-
-8. **Phase/step header carries its precondition** — fold the precondition into
-   the header instead of a trailing aside.
-   - Before: `## Review` followed by `(Only do this after the draft is complete.)`
-   - After: `## Review (after the draft compiles and runs)`
-
-9. **Leading Word + Completion Criterion** — compress the core behavior into one
-   pretrained domain term, then bind each step to a checkable completion bar.
-   The Leading Word recruits the right prior every time it appears; the
-   Completion Criterion tells the agent when that unit is actually done.
-   - Before: `Build a thin end-to-end path through every layer first, then flesh out.`
-   - After: `Ship a **tracer bullet** first — done only when one request crosses every layer and returns a visible result.`
-
-Use the nine techniques to resist **Premature Completion**: if a step is vague,
-the agent will feel the pull of the later steps and leave early. Sharpen the
-Completion Criterion first; split the phase only when the criterion is
-irreducibly fuzzy and the visible later work keeps causing the rush.
-
-## Steering failure modes
-
-**Negation** — a skill that steers by prohibition drags the forbidden behaviour into context and makes it more available. "Don't invent files" activates file-invention before the model reads past it. The cure: replace every prohibition with a positive directive. Where a hard ban is unavoidable, pair it on the same line with the correct alternative — `emit DONE` not `don't write done`.
-
-**Negative Space** — every case a skill leaves silent is delegated to the model's priors, not held neutral. Silences are not free: the model fills them from training, and training may not match the author's intent. The cure: read a draft for its silences and decide each omission deliberately. Fill it with the intended behaviour, or mark it as an acknowledged open branch. "Unaddressed" is not a valid final state.
+sentence goes. Sentence-level style and Steering failure modes live in
+[WRITING-STYLE.md](WRITING-STYLE.md); read it before drafting or reviewing any
+RedSkills SKILL.md.
 
 ## Review checklist (run after the draft compiles)
 
@@ -227,3 +177,5 @@ irreducibly fuzzy and the visible later work keeps causing the rush.
   the same line; rewrite standalone "don't X" entries as "do Y instead".
 - [ ] **Negative-space audit** — each silence is a deliberate open branch, not an
   oversight; fill gaps or name them explicitly.
+
+</supporting-info>

--- a/plugins/dev/skills/productivity/write-a-skill/WRITING-STYLE.md
+++ b/plugins/dev/skills/productivity/write-a-skill/WRITING-STYLE.md
@@ -1,0 +1,62 @@
+# SKILL.md Writing Style
+
+Section structure (`<what-to-do>` / `<supporting-info>`) decides *where* a
+sentence goes; this section decides *how the sentence reads*. Apply these nine
+sentence-level techniques — borrowed from `anthropics/launch-your-agent` — when
+writing any RedSkills SKILL.md. Each carries a one-line before → after.
+
+1. **Bold lead-in + gloss** — open a step with the imperative in bold, then
+   explain it.
+   - Before: `You should gather the requirements from the user first.`
+   - After: `**Gather requirements** — ask the user what task the skill covers.`
+
+2. **Maxim/slogan compression** — fold a rule into one memorable line.
+   - Before: `The description matters because it is what the agent uses to decide whether to load the skill.`
+   - After: `The description is the only thing the agent sees before loading — write it for the picker, not the reader.`
+
+3. **Prohibition + reason inline (em-dash consequence)** — state the ban and its
+   cost on one line.
+   - Before: `Do not exceed 100 lines. Long skills are hard to read.`
+   - After: `Never exceed ~100 lines — past that the agent skims and drops steps.`
+
+4. **Literal phrasing in quotes** — quote the exact words the agent must emit or
+   match.
+   - Before: `End the description with a phrase about when to use it.`
+   - After: `End the description with "Use when …" so the trigger is matchable verbatim.`
+
+5. **Vocabulary hygiene (real term, ban synonym)** — name a thing once, forbid
+   its synonyms.
+   - Before: `Put your docs / guidance / instructions in the file.`
+   - After: `Call it the SKILL.md — never "the doc", "the manifest", or "the guide".`
+
+6. **Numbered taxonomy when concepts blur** — number a set whose members are
+   easily conflated.
+   - Before: `Add scripts for deterministic work and split files for big skills.`
+   - After: `Two distinct moves: (1) add a script for deterministic work; (2) split a file once SKILL.md passes ~100 lines.`
+
+7. **Self-demonstrating voice** — write the instruction in the style it teaches.
+   - Before: `Instructions should be concise and imperative.`
+   - After: `Write every step imperative and bold-led — like this one.`
+
+8. **Phase/step header carries its precondition** — fold the precondition into
+   the header instead of a trailing aside.
+   - Before: `## Review` followed by `(Only do this after the draft is complete.)`
+   - After: `## Review (after the draft compiles and runs)`
+
+9. **Leading Word + Completion Criterion** — compress the core behavior into one
+   pretrained domain term, then bind each step to a checkable completion bar.
+   The Leading Word recruits the right prior every time it appears; the
+   Completion Criterion tells the agent when that unit is actually done.
+   - Before: `Build a thin end-to-end path through every layer first, then flesh out.`
+   - After: `Ship a **tracer bullet** first — done only when one request crosses every layer and returns a visible result.`
+
+Use the nine techniques to resist **Premature Completion**: if a step is vague,
+the agent will feel the pull of the later steps and leave early. Sharpen the
+Completion Criterion first; split the phase only when the criterion is
+irreducibly fuzzy and the visible later work keeps causing the rush.
+
+## Steering Failure Modes
+
+**Negation** — a skill that steers by prohibition drags the forbidden behaviour into context and makes it more available. "Don't invent files" activates file-invention before the model reads past it. The cure: replace every prohibition with a positive directive. Where a hard ban is unavoidable, pair it on the same line with the correct alternative — `emit DONE` not `don't write done`.
+
+**Negative Space** — every case a skill leaves silent is delegated to the model's priors, not held neutral. Silences are not free: the model fills them from training, and training may not match the author's intent. The cure: read a draft for its silences and decide each omission deliberately. Fill it with the intended behaviour, or mark it as an acknowledged open branch. "Unaddressed" is not a valid final state.

--- a/scripts/fixtures/skill-body/compliant/plugins/dev/skills/engineering/consumer/SKILL.md
+++ b/scripts/fixtures/skill-body/compliant/plugins/dev/skills/engineering/consumer/SKILL.md
@@ -5,6 +5,6 @@ description: A sibling skill that owns a shared template. Use when checking that
 
 # consumer
 
-This skill folder bundles a template file that is referenced by the sibling
-`good` skill rather than here — its own SKILL.md deliberately never names the
-file. The plugin-wide reference search keeps it out of the orphaned-file report.
+This skill folder bundles a template file consumed by an extracted sibling
+reference doc rather than by any SKILL.md. The plugin-wide reference search
+must include bundled reference docs to keep it out of the orphaned-file report.

--- a/scripts/fixtures/skill-body/compliant/plugins/dev/skills/engineering/good/SKILL.md
+++ b/scripts/fixtures/skill-body/compliant/plugins/dev/skills/engineering/good/SKILL.md
@@ -7,6 +7,6 @@ description: A tidy model-invocable skill. Use when you want a compliant sample 
 
 Short body, well under the 100-line threshold, so it needs no `<what-to-do>`
 tag. It references its bundled companion [notes.md](./notes.md) so the file is
-not orphaned. It also consumes a sibling skill's template,
-[shared-template.md](../consumer/shared-template.md), exercising the
-cross-skill escape.
+not orphaned. It also links [extracted-reference.md](./extracted-reference.md),
+which consumes a sibling skill's template and exercises the extracted-reference
+escape.

--- a/scripts/fixtures/skill-body/compliant/plugins/dev/skills/engineering/good/extracted-reference.md
+++ b/scripts/fixtures/skill-body/compliant/plugins/dev/skills/engineering/good/extracted-reference.md
@@ -1,0 +1,3 @@
+The sibling consumer template [shared-template.md](../consumer/shared-template.md)
+is deliberately referenced from this extracted reference doc, not from a
+SKILL.md.

--- a/scripts/fixtures/skill-body/violating/plugins/dev/skills/engineering/bad/SKILL.md
+++ b/scripts/fixtures/skill-body/violating/plugins/dev/skills/engineering/bad/SKILL.md
@@ -9,6 +9,12 @@ This body deliberately exceeds one hundred lines and never declares the
 house directive tag, so it trips the house-tag check. It also bundles an
 unreferenced companion file it deliberately never names.
 
+```md
+<what-to-do>
+This template tag is fenced example text, not the skill's structural split.
+</what-to-do>
+```
+
 Filler line 1 to push the body past the threshold.
 Filler line 2 to push the body past the threshold.
 Filler line 3 to push the body past the threshold.

--- a/scripts/lint-skill-body.sh
+++ b/scripts/lint-skill-body.sh
@@ -16,17 +16,17 @@
 #
 #   2. House tags. A SKILL.md whose body (everything after the frontmatter)
 #      exceeds SKILL_BODY_LINE_THRESHOLD lines (default 100) must carry a
-#      `<what-to-do>` tag. Short skills may omit the tags — the threshold
-#      encodes that allowance.
+#      standalone structural `<what-to-do>` tag outside fenced code blocks.
+#      Short skills may omit the tags — the threshold encodes that allowance.
 #
 #   3. Orphaned bundled files. Every non-README markdown file inside a skill
-#      folder should be referenced (by basename) from a SKILL.md. Cross-skill
-#      consumers are legitimate (e.g. one skill's bundled templates consumed
-#      by a sibling skill), so the reference search is WIDENED to every
-#      SKILL.md in the same plugin (the `plugins/<name>/` ancestor). A file
-#      referenced by any SKILL.md in its plugin is not flagged. This is the
-#      chosen escape mechanism (plugin-wide search rather than an explicit
-#      allowlist): it needs no per-file annotation and keeps the wiki
+#      folder should be referenced (by basename) from shipped markdown in the
+#      same plugin. Cross-skill consumers and extracted sibling reference docs
+#      are legitimate, so the reference search is WIDENED to every shipped
+#      markdown file in the same plugin (the `plugins/<name>/` ancestor). A
+#      file referenced by any other markdown file in its plugin is not flagged.
+#      This is the chosen escape mechanism (plugin-wide search rather than an
+#      explicit allowlist): it needs no per-file annotation and keeps the wiki
 #      templates — consumed by the wiki/wiki-init skills — out of the report.
 #
 # Config (environment variables):
@@ -77,6 +77,31 @@ plugin_root() {
       printf ''
       ;;
   esac
+}
+
+# has_structural_tag FILE TAG — true when TAG appears as a standalone markdown
+# structural line outside fenced code blocks.
+has_structural_tag() {
+  local file="$1" tag="$2"
+  awk -v tag="$tag" '
+    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
+    fence { next }
+    $0 ~ "^[[:space:]]*" tag "[[:space:]]*$" { found = 1 }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+}
+
+# referenced_in_plugin_markdown FILE PROOT BASENAME — true when BASENAME appears
+# in any shipped markdown file in PROOT other than FILE itself.
+referenced_in_plugin_markdown() {
+  local file="$1" proot="$2" base="$3"
+  while IFS= read -r ref; do
+    [ "$ref" = "$file" ] && continue
+    if grep -qF "$base" "$ref"; then
+      return 0
+    fi
+  done < <(find "$proot" -name '*.md' -not -path '*/in-progress/*' | sort)
+  return 1
 }
 
 desc_findings=0
@@ -135,7 +160,7 @@ while IFS= read -r file; do
   ' "$file")"
 
   if [ "$body_lines" -gt "$BODY_LINE_THRESHOLD" ]; then
-    if ! grep -q '<what-to-do>' "$file"; then
+    if ! has_structural_tag "$file" '<what-to-do>'; then
       printf 'FAIL  %s\n      > %s-line body has no <what-to-do> tag\n' "$file" "$body_lines"
       tag_findings=$((tag_findings + 1))
     fi
@@ -144,18 +169,18 @@ done < <(find plugins -name SKILL.md -not -path '*/in-progress/*' | sort)
 
 echo ""
 echo "== Check 3: orphaned bundled markdown files =="
-echo "   (reference search widened to every SKILL.md in the same plugin)"
+echo "   (reference search widened to every shipped markdown file in the same plugin)"
 while IFS= read -r file; do
   base="$(basename "$file")"
   proot="$(plugin_root "$file")"
   [ -z "$proot" ] && continue
 
-  # Referenced if any SKILL.md in the plugin mentions the basename.
-  if grep -rqF "$base" --include=SKILL.md "$proot"; then
+  # Referenced if any other shipped markdown file in the plugin mentions the basename.
+  if referenced_in_plugin_markdown "$file" "$proot" "$base"; then
     continue
   fi
 
-  printf 'FAIL  %s\n      > not referenced by any SKILL.md in %s\n' "$file" "$proot"
+  printf 'FAIL  %s\n      > not referenced by any shipped markdown file in %s\n' "$file" "$proot"
   orphan_findings=$((orphan_findings + 1))
 done < <(find plugins -path '*/skills/*' -name '*.md' -not -name SKILL.md -not -name 'README.md' -not -path '*/in-progress/*' | sort)
 

--- a/scripts/test-lint-skill-body.sh
+++ b/scripts/test-lint-skill-body.sh
@@ -71,7 +71,7 @@ check "violating/exit-0" "$([ "$?" -eq 0 ] && echo 1 || echo 0)"
 assert_grep "violating/desc-usewhen"   /tmp/.skill-body-violating 'missing "Use when"'
 assert_grep "violating/desc-overbudget" /tmp/.skill-body-violating "over budget (548 > 500)"
 assert_grep "violating/house-tag"      /tmp/.skill-body-violating "has no <what-to-do> tag"
-assert_grep "violating/orphan"         /tmp/.skill-body-violating "not referenced by any SKILL.md"
+assert_grep "violating/orphan"         /tmp/.skill-body-violating "not referenced by any shipped markdown file"
 assert_grep "violating/desc-count"     /tmp/.skill-body-violating "description discipline: 1 finding(s)"
 assert_grep "violating/tags-count"     /tmp/.skill-body-violating "house tags:             1 finding(s)"
 assert_grep "violating/orphan-count"   /tmp/.skill-body-violating "orphaned bundled files: 1 finding(s)"


### PR DESCRIPTION
Automated AFK landing for #1358. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1358

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786192697&installation_id=129708444&pr_number=1359&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1359&signature=0b3845fb84cef95e3452b313532c8881280a839c5544131608a711789809a836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->