### PR TITLE
chore: #1362 /go: Lean plugins/dev/skills/engineering/setup-statusline/SKILL.md and finish

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,24 @@ Upstream base: `mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3` (v1.
 
 ---
 
+## setup-statusline (engineering) - progressive-disclosure host recipe extraction (issue #1362)
+
+- **status**: modified
+- **upstream**: —
+- **why**: `setup-statusline/SKILL.md` carried shared statusline architecture and full per-host adapter recipes in the hot path instead of keeping the host-routing loop lean.
+- **what changed**: Leaned `plugins/dev/skills/engineering/setup-statusline/SKILL.md` into a host-selection and action procedure with `<what-to-do>` / `<supporting-info>` tags, moved the shared architecture, Claude Code command-backed adapter, Codex footer adapter, OpenCode no-install note, and host rationale into `HOST-NOTES.md` behind resolving links, and re-checked `ask-red` coverage. No router change was needed because this was not a skill add, rename, removal, or flow change.
+
+---
+
+## wiki-init (knowledge) - progressive-disclosure template reference extraction (issue #1362)
+
+- **status**: modified
+- **upstream**: —
+- **why**: `wiki-init/SKILL.md` mixed the bootstrap interview/write loop with reference-only bundled template inventory.
+- **what changed**: Added `<what-to-do>` / `<supporting-info>` tags, kept the wiki initialization loop and required seed-template instructions hot, moved the bundled template/example inventory into `TEMPLATE-REFERENCE.md`, and verified the external `../wiki/REFERENCES.md` link remains the resolving LLM Wiki reference.
+
+---
+
 ## setup-red-skills (engineering) - progressive-disclosure split (issue #1360)
 
 - **status**: modified

--- a/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
+++ b/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "../../..");
+
+function readRepoFile(path: string) {
+  return readFile(join(ROOT, path), "utf8");
+}
+
+describe("skill progressive-disclosure docs", () => {
+  it("keeps setup-statusline routing hot while preserving host recipes in HOST-NOTES", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/engineering/setup-statusline/SKILL.md");
+    const hostNotes = await readRepoFile("plugins/dev/skills/engineering/setup-statusline/HOST-NOTES.md");
+
+    expect(skill).toContain("<what-to-do>");
+    expect(skill).toContain("<supporting-info>");
+    expect(skill).toContain("[HOST-NOTES.md](HOST-NOTES.md)");
+    expect(skill).not.toContain("Claude Code's `statusLine` renders multiple rows");
+    expect(skill).not.toContain("red-skills-dev codex-statusline --fix");
+
+    expect(hostNotes).toContain("Claude Code's `statusLine` renders multiple rows");
+    expect(hostNotes).toContain("red-skills-dev codex-statusline --fix");
+    expect(hostNotes).toContain("Every `k=v` key on this line is **exactly 3 letters**");
+    expect(hostNotes).toContain("OpenCode is an AFK API-auth runner lane");
+  });
+
+  it("keeps wiki-init init loop hot while moving the bundled template inventory behind a link", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/knowledge/wiki-init/SKILL.md");
+    const templates = await readRepoFile("plugins/dev/skills/knowledge/wiki-init/TEMPLATE-REFERENCE.md");
+
+    expect(skill).toContain("<what-to-do>");
+    expect(skill).toContain("<supporting-info>");
+    expect(skill).toContain("[TEMPLATE-REFERENCE.md](./TEMPLATE-REFERENCE.md)");
+    expect(skill).toContain("[LLM Wiki](../wiki/REFERENCES.md)");
+    expect(skill).not.toContain("## Bundled templates");
+
+    for (const template of [
+      "schema-template.md",
+      "index-template.md",
+      "page-template-entity.md",
+      "page-template-concept.md",
+      "page-template-source.md",
+      "page-template-synthesis.md",
+      "examples/research.md",
+      "examples/book-reading.md",
+    ]) {
+      expect(templates).toContain(template);
+    }
+    expect(templates).toContain("[REFERENCES.md](../wiki/REFERENCES.md)");
+  });
+});

--- a/plugins/dev/skills/engineering/setup-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/setup-statusline/HOST-NOTES.md
@@ -1,9 +1,71 @@
-# Host notes — why each host branch is shaped the way it is
+# Host Notes
 
-Reference material for the three host branches in `SKILL.md`. Read the section for
-the branch you are wiring; each is rationale, not an extra step.
+Reference material for the host branches in `SKILL.md`. Read only the section for
+the branch you are wiring; these notes preserve the recipes, line-shape rules,
+and rationale outside the hot path.
 
-## Claude Code — why the statusLine command is shaped this way
+## Shared Architecture And Line Shapes
+
+Install or inspect the RedSkills statusline for this repository. The shared producer renders the project name, branch, model/context data when the host provides it, repo counters, and live AFK state. **The two hosts get two shapes (per-runner split, ADR 0003):**
+
+- **Claude Code — multi-line.** Claude Code's `statusLine` renders multiple rows, so the themed producer emits a repo-global **header line** — always shown, even with no live workers: project (branch) + version, model·effort + context, open PRs + open issues, local diff vs `origin/main`, and (Pro/Max only, when the payload exposes them) the 5-hour and weekly usage windows `5h=…% 7d=…%` — **then one line per live AFK worker**. The worker line is a **terse, colored `k=v` form** that reads as a visual sibling of the header — every token follows the header's `key=value` colour convention:
+
+  ```
+  w82UX  run=claude opus high  iss=1173  tests  00:04:41  loc=+10 -11  tks=34k  tls=11 rsn=13 txt=0
+  ```
+
+  Every `k=v` key on this line is **exactly 3 letters** (house rule). The `wID` is **bold + red**; then `run=<runner> <model> <effort>` (model shortened, e.g. `claude-opus-4-8` → `opus`; the effort word is omitted when unavailable), `iss=<issue-number>` (the bare ISSUE NUMBER from the worker's `current.number`, populated for BOTH `/afk` and `/go` lanes — not a `done/total` counter), the bare `<stage>` word (no `stage:` prefix, no standalone `#<n>` token), the required `HH:MM:SS` elapsed, `loc=+A -R`, `tks=<humanized>` (SI k/M/B token total), and the vitals as INDIVIDUAL 3-letter `k=v` pairs `tls=<t> rsn=<r> txt=<x>` (never a nested `stats=…:…` blob). The `/afk monitor` dashboard uses the same vitals vocabulary (`tls`/`rsn`/`txt`) while keeping its fuller row shape. The truncated issue TITLE, the `[live]`/`[quiet]` badge, `wait`, and `log` are **dropped** here — that verbosity stays on the fuller `/afk monitor` line. The two surfaces share only the per-worker FIELD DATA (`workerFields`), never a renderer, so the terse statusline form never bleeds into the monitor. Zero live workers → only the header line.
+
+  The **`/afk monitor` dashboard keeps its fuller per-worker row** (title, `[live]`/`[quiet]`, `wait`, `log`) — it is a full dashboard, not a compact statusline — but its vitals tokens are the same `tls`/`rsn`/`txt` vocabulary as the statusline.
+
+  For an on-demand decode table, run `red-skills-dev statusline --legend` or `red-skills-dev monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
+- **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
+
+The AFK rows are quiet when no worker is active. Hosts that cannot run a command-backed statusline still get a useful native footer plus `/afk monitor` for live AFK visibility.
+
+**Host capabilities differ; the product architecture should not.** Treat the RedSkills statusline as:
+
+1. A shared producer: the dev bundle's `statusline` subcommand.
+2. Host adapters: Claude Code's command-backed `statusLine`; Codex's global `tui.status_line` list and plugin `SessionStart` hook.
+3. Fallback visibility: `/afk monitor`, which works when a host has no command-backed footer.
+
+This mirrors how Codex itself organizes customization: skills define reusable workflows, plugins distribute skills plus hooks/MCP/apps, `config.toml` stores host settings, and hooks attach lifecycle behavior next to the active plugin/config layer. Keep RedSkills logic in the bundle and keep host-specific wiring in the host sections below.
+
+## Claude Code Adapter Recipe
+
+1. Inspect the repo: `.red/config.yaml`, `.claude/settings.json`, and whether `jq` is available.
+
+2. **Early exit — opt-out:** if `.red/config.yaml` has top-level `statusline: false` or nested `afk.statusline: false`, stop and tell the user it is disabled. Do not proceed.
+
+3. **Early exit — already configured:** if `.claude/settings.json` already has `statusLine`, do not overwrite it unless the user explicitly asked to replace it (then replace only `statusLine`, preserving all other keys).
+
+4. Write the RedSkills statusline:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh -c 'b=$(ls -1 \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z \"$b\" ] && b=$(ls -1 \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
+    "refreshInterval": 5
+  }
+}
+```
+
+**Why this shape (cached-bundle-first, not `$CLAUDE_PLUGIN_ROOT`, not `afk.mjs` directly):** the command above is cached-bundle-first by design (ADR 0084) — never alter it to fetch synchronously in the render path.
+
+Use `jq` to merge when `.claude/settings.json` already exists; create `.claude/`
+and a fresh file when it is missing. Keep unrelated settings intact.
+
+5. Verify: confirm `.claude/settings.json` is valid JSON and has `.statusLine.command`. Unlike the old `$CLAUDE_PLUGIN_ROOT` form, you **can** prove this one renders by piping a minimal session JSON into the **same `sh -c '…'` command from step 4** (no need to re-type it):
+
+```bash
+printf '{"workspace":{"project_dir":"%s"},"model":{"display_name":"Opus"}}' "$PWD" \
+  | <the step-4 statusLine command>
+```
+
+It should print the themed **header line** (e.g. `» red-skills (main) v… Opus·high …`); when AFK workers are live it prints one additional row per worker below it. Under `NO_COLOR` the same command collapses to the single-line plain form `red-skills (main) · Opus·high · …`.
+
+## Claude Code Rationale
 
 **Why this shape, not `$CLAUDE_PLUGIN_ROOT`.** Claude Code does **not** export
 `CLAUDE_PLUGIN_ROOT` (nor `CLAUDE_PROJECT_DIR`) to a `statusLine` command — those
@@ -34,7 +96,60 @@ intact.
 This respects ADR 0084: the documented command stays cached-bundle-first and
 never fetches synchronously in a render path.
 
-## Codex — surviving config resets
+## Codex Adapter Recipe
+
+Codex configures its footer through the `tui.status_line` key in `config.toml`
+— an ordered list of **built-in** item identifiers (`project`, `git-branch`,
+`model-with-reasoning`, `context-remaining`, `task-progress`, `current-dir`,
+…). When unset, Codex currently uses `["model-with-reasoning",
+"context-remaining", "current-dir"]`; set it to `[]` to hide the footer.
+This skill offers the **global** `~/.codex/config.toml` path because the footer
+is a personal host preference, not repo state. There is no command hook, so the
+shared RedSkills `statusline` producer cannot be injected into the footer yet.
+
+Codex has a native `/statusline` command for picking and reordering these
+footer items and persisting them to `config.toml`. The dev bundle also exposes
+an explicit inspector/fixer:
+
+```bash
+red-skills-dev codex-statusline
+red-skills-dev codex-statusline --fix
+```
+
+The inspector reports the active `tui.status_line`, flags a missing
+`task-progress` widget, prints the recommended order, and reminds the operator
+that rich AFK worker state still lives in `/afk monitor`. `--fix` is explicit:
+it appends `task-progress` to an existing visible footer or installs the
+recommended footer when `status_line` is absent. If the user already has a
+custom `tui.status_line`, preserve it unless they explicitly ask for `--fix`;
+that custom value is the operator's host preference, not repo state.
+
+Offer to set a useful footer (note: this is **global** Codex config, not
+per-repo like the Claude path):
+
+```toml
+[tui]
+status_line = ["project", "git-branch", "model-with-reasoning", "context-remaining", "task-progress"]
+```
+
+**Surviving Codex config resets.** A global `tui.status_line` gets dropped when Codex rewrites `~/.codex/config.toml`, but the dev plugin's Codex `SessionStart` hook re-asserts it so a reset self-heals on the next session start — why and how (the additive, atomic, absent-only re-write) is described below.
+
+This is intentionally host-global and plugin-gated. Codex stores footer
+preferences in `~/.codex/config.toml`, while RedSkills gates global hook side
+effects on the repo's `.red/config.yaml` `plugins.dev.enabled: true` flag. That
+keeps the installed plugin available everywhere but inert outside opted-in
+repos, matching the rest of the RedSkills hook model.
+
+For live AFK visibility under Codex, `/afk monitor` remains the canonical
+dashboard. Normal `/afk run` launches and `/afk fleet` launches also try to
+attach one read-only Codex monitor agent when the host exposes a sub-agent
+primitive; the prompt comes from `afk codex-monitor-agent --mode run|fleet`.
+When the primitive is unavailable, Codex falls back to the monitor dashboard.
+When Codex ships a command-backed statusline (openai/codex#17827 / #20244), this
+skill can add a `{ type = "command", command = … }` entry pointing at the same
+AFK bundle so the line matches Claude Code's.
+
+## Codex Rationale
 
 That global `tui.status_line` gets dropped whenever Codex rewrites
 `~/.codex/config.toml` (e.g. re-syncing plugin `[hooks.state]` on update),
@@ -45,3 +160,7 @@ when absent** (never clobbers an operator's own value) via an **atomic** write
 the file). So a reset self-heals on the next session start. The hook is additive
 and idempotent; disable it by removing the second `SessionStart` entry in
 `hooks/codex.hooks.json`.
+
+## OpenCode Adapter
+
+Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`), not an interactive host UI, so it has no footer/statusline adapter — observe it through `/afk monitor`, `/afk dashboard`, and Actions output like any other runner.

--- a/plugins/dev/skills/engineering/setup-statusline/SKILL.md
+++ b/plugins/dev/skills/engineering/setup-statusline/SKILL.md
@@ -6,125 +6,53 @@ disable-model-invocation: true
 
 # Statusline
 
-**Wire the RedSkills statusline surface for the host the agent is running under — stop immediately if a gate condition is met.** RedSkills is client/CLI/coder/runner agnostic: the dev bundle owns one `statusline` producer, and each host gets the richest integration it actually supports. Claude Code can render the shared producer directly as a command-backed statusLine. Codex currently exposes only native footer widgets, so the skill configures those widgets and relies on the dev plugin's SessionStart hook to keep the footer present across Codex config rewrites.
+**Wire the RedSkills statusline surface for the current host — stop as soon as a gate condition is met.** Keep the host branch hot here; read [HOST-NOTES.md](HOST-NOTES.md) only for the exact adapter recipe, shared line shape, or rationale needed by the selected host.
 
-Install or inspect the RedSkills statusline for this repository. The shared producer renders the project name, branch, model/context data when the host provides it, repo counters, and live AFK state. **The two hosts get two shapes (per-runner split, ADR 0003):**
+<what-to-do>
 
-- **Claude Code — multi-line.** Claude Code's `statusLine` renders multiple rows, so the themed producer emits a repo-global **header line** — always shown, even with no live workers: project (branch) + version, model·effort + context, open PRs + open issues, local diff vs `origin/main`, and (Pro/Max only, when the payload exposes them) the 5-hour and weekly usage windows `5h=…% 7d=…%` — **then one line per live AFK worker**. The worker line is a **terse, colored `k=v` form** that reads as a visual sibling of the header — every token follows the header's `key=value` colour convention:
+## 1. Identify The Host
 
-  ```
-  w82UX  run=claude opus high  iss=1173  tests  00:04:41  loc=+10 -11  tks=34k  tls=11 rsn=13 txt=0
-  ```
+**Pick one branch.** Use Claude Code when `.claude/` or Claude plugin state is the active surface, Codex when the active client is Codex CLI, and OpenCode only when the user asks about the OpenCode runner lane.
 
-  Every `k=v` key on this line is **exactly 3 letters** (house rule). The `wID` is **bold + red**; then `run=<runner> <model> <effort>` (model shortened, e.g. `claude-opus-4-8` → `opus`; the effort word is omitted when unavailable), `iss=<issue-number>` (the bare ISSUE NUMBER from the worker's `current.number`, populated for BOTH `/afk` and `/go` lanes — not a `done/total` counter), the bare `<stage>` word (no `stage:` prefix, no standalone `#<n>` token), the required `HH:MM:SS` elapsed, `loc=+A -R`, `tks=<humanized>` (SI k/M/B token total), and the vitals as INDIVIDUAL 3-letter `k=v` pairs `tls=<t> rsn=<r> txt=<x>` (never a nested `stats=…:…` blob). The `/afk monitor` dashboard uses the same vitals vocabulary (`tls`/`rsn`/`txt`) while keeping its fuller row shape. The truncated issue TITLE, the `[live]`/`[quiet]` badge, `wait`, and `log` are **dropped** here — that verbosity stays on the fuller `/afk monitor` line. The two surfaces share only the per-worker FIELD DATA (`workerFields`), never a renderer, so the terse statusline form never bleeds into the monitor. Zero live workers → only the header line.
+**Respect explicit intent.** Install only when the user asks to install, fix, replace, or configure. Otherwise inspect and report the current state.
 
-  The **`/afk monitor` dashboard keeps its fuller per-worker row** (title, `[live]`/`[quiet]`, `wait`, `log`) — it is a full dashboard, not a compact statusline — but its vitals tokens are the same `tls`/`rsn`/`txt` vocabulary as the statusline.
+## 2. Claude Code
 
-  For an on-demand decode table, run `red-skills-dev statusline --legend` or `red-skills-dev monitor --legend`. The legend prints `token / name / gloss` rows and exits without rendering the live statusline or monitor surface.
-- **Codex — single line.** The `tui.status_line` footer is single-line only, so the plain producer stays ONE aggregate line (project · model · context · usage · repo counts · the AFK block). The multi-line layout is Claude-Code-only.
+1. Inspect `.red/config.yaml`, `.claude/settings.json`, and whether `jq` is available.
+2. **Opt-out gate** — if `.red/config.yaml` has top-level `statusline: false` or nested `afk.statusline: false`, stop and tell the user it is disabled.
+3. **Existing-config gate** — if `.claude/settings.json` already has `statusLine`, preserve it unless the user explicitly asked to replace it. Replacement touches only `statusLine`; keep every other key.
+4. **Apply the adapter recipe** — read [HOST-NOTES.md](HOST-NOTES.md#claude-code-adapter-recipe), then write or merge the cached-bundle-first `statusLine` block exactly as documented there.
+5. **Verify the write** — confirm `.claude/settings.json` is valid JSON, contains `.statusLine.command`, and renders by piping minimal session JSON into the same command from the recipe.
 
-The AFK rows are quiet when no worker is active. Hosts that cannot run a command-backed statusline still get a useful native footer plus `/afk monitor` for live AFK visibility.
+## 3. Codex
 
-**Host capabilities differ; the product architecture should not.** Treat the RedSkills statusline as:
+1. Inspect the active `~/.codex/config.toml` footer preference with `red-skills-dev codex-statusline`.
+2. **Preserve host preference** — if `tui.status_line` is already custom, leave it alone unless the user explicitly asks to fix or replace it.
+3. **Apply the adapter recipe only on request** — read [HOST-NOTES.md](HOST-NOTES.md#codex-adapter-recipe), then run the explicit fixer or write the recommended global footer. Treat this as host-global config, not repo state.
+4. **Report AFK visibility honestly** — Codex gets native footer widgets plus `/afk monitor`; it cannot inject the shared command-backed producer into the footer yet.
 
-1. A shared producer: the dev bundle's `statusline` subcommand.
-2. Host adapters: Claude Code's command-backed `statusLine`; Codex's global `tui.status_line` list and plugin `SessionStart` hook.
-3. Fallback visibility: `/afk monitor`, which works when a host has no command-backed footer.
+## 4. OpenCode
 
-This mirrors how Codex itself organizes customization: skills define reusable workflows, plugins distribute skills plus hooks/MCP/apps, `config.toml` stores host settings, and hooks attach lifecycle behavior next to the active plugin/config layer. Keep RedSkills logic in the bundle and keep host-specific wiring in the host sections below.
+**Install nothing.** OpenCode is a runner lane, not an interactive host UI with a footer adapter. Point the user to `/afk monitor`, `/afk dashboard`, and Actions output. The full note is in [HOST-NOTES.md](HOST-NOTES.md#opencode-adapter).
 
-## Claude Code
+## 5. Finish
 
-1. Inspect the repo: `.red/config.yaml`, `.claude/settings.json`, and whether `jq` is available.
+Tell the user which host branch you used, what changed or why nothing changed, and how to observe live AFK state.
 
-2. **Early exit — opt-out:** if `.red/config.yaml` has top-level `statusline: false` or nested `afk.statusline: false`, stop and tell the user it is disabled. Do not proceed.
+</what-to-do>
 
-3. **Early exit — already configured:** if `.claude/settings.json` already has `statusLine`, do not overwrite it unless the user explicitly asked to replace it (then replace only `statusLine`, preserving all other keys).
+<supporting-info>
 
-4. Write the RedSkills statusline:
+## Reference Map
 
-```json
-{
-  "statusLine": {
-    "type": "command",
-    "command": "sh -c 'b=$(ls -1 \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z \"$b\" ] && b=$(ls -1 \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
-    "refreshInterval": 5
-  }
-}
-```
+- **Shared architecture and line shapes:** [HOST-NOTES.md](HOST-NOTES.md#shared-architecture-and-line-shapes).
+- **Claude Code command-backed adapter:** [HOST-NOTES.md](HOST-NOTES.md#claude-code-adapter-recipe).
+- **Codex native footer adapter:** [HOST-NOTES.md](HOST-NOTES.md#codex-adapter-recipe).
+- **OpenCode no-install note:** [HOST-NOTES.md](HOST-NOTES.md#opencode-adapter).
 
-**Why this shape (cached-bundle-first, not `$CLAUDE_PLUGIN_ROOT`, not `afk.mjs` directly):** read [`HOST-NOTES.md`](HOST-NOTES.md) → *Claude Code*. The command above is cached-bundle-first by design (ADR 0084) — never alter it to fetch synchronously in the render path.
-
-Use `jq` to merge when `.claude/settings.json` already exists; create `.claude/`
-and a fresh file when it is missing. Keep unrelated settings intact.
-
-5. Verify: confirm `.claude/settings.json` is valid JSON and has `.statusLine.command`. Unlike the old `$CLAUDE_PLUGIN_ROOT` form, you **can** prove this one renders by piping a minimal session JSON into the **same `sh -c '…'` command from step 4** (no need to re-type it):
-
-```bash
-printf '{"workspace":{"project_dir":"%s"},"model":{"display_name":"Opus"}}' "$PWD" \
-  | <the step-4 statusLine command>
-```
-
-It should print the themed **header line** (e.g. `» red-skills (main) v… Opus·high …`); when AFK workers are live it prints one additional row per worker below it. Under `NO_COLOR` the same command collapses to the single-line plain form `red-skills (main) · Opus·high · …`.
-
-## Codex
-
-Codex configures its footer through the `tui.status_line` key in `config.toml`
-— an ordered list of **built-in** item identifiers (`project`, `git-branch`,
-`model-with-reasoning`, `context-remaining`, `task-progress`, `current-dir`,
-…). When unset, Codex currently uses `["model-with-reasoning",
-"context-remaining", "current-dir"]`; set it to `[]` to hide the footer.
-This skill offers the **global** `~/.codex/config.toml` path because the footer
-is a personal host preference, not repo state. There is no command hook, so the
-shared RedSkills `statusline` producer cannot be injected into the footer yet.
-
-Codex has a native `/statusline` command for picking and reordering these
-footer items and persisting them to `config.toml`. The dev bundle also exposes
-an explicit inspector/fixer:
-
-```bash
-red-skills-dev codex-statusline
-red-skills-dev codex-statusline --fix
-```
-
-The inspector reports the active `tui.status_line`, flags a missing
-`task-progress` widget, prints the recommended order, and reminds the operator
-that rich AFK worker state still lives in `/afk monitor`. `--fix` is explicit:
-it appends `task-progress` to an existing visible footer or installs the
-recommended footer when `status_line` is absent. If the user already has a
-custom `tui.status_line`, preserve it unless they explicitly ask for `--fix`;
-that custom value is the operator's host preference, not repo state.
-
-Offer to set a useful footer (note: this is **global** Codex config, not
-per-repo like the Claude path):
-
-```toml
-[tui]
-status_line = ["project", "git-branch", "model-with-reasoning", "context-remaining", "task-progress"]
-```
-
-**Surviving Codex config resets.** A global `tui.status_line` gets dropped when Codex rewrites `~/.codex/config.toml`, but the dev plugin's Codex `SessionStart` hook re-asserts it so a reset self-heals on the next session start — why and how (the additive, atomic, absent-only re-write) is in [`HOST-NOTES.md`](HOST-NOTES.md) → *Codex*.
-
-This is intentionally host-global and plugin-gated. Codex stores footer
-preferences in `~/.codex/config.toml`, while RedSkills gates global hook side
-effects on the repo's `.red/config.yaml` `plugins.dev.enabled: true` flag. That
-keeps the installed plugin available everywhere but inert outside opted-in
-repos, matching the rest of the RedSkills hook model.
-
-For live AFK visibility under Codex, `/afk monitor` remains the canonical
-dashboard. Normal `/afk run` launches and `/afk fleet` launches also try to
-attach one read-only Codex monitor agent when the host exposes a sub-agent
-primitive; the prompt comes from `afk codex-monitor-agent --mode run|fleet`.
-When the primitive is unavailable, Codex falls back to the monitor dashboard.
-When Codex ships a command-backed statusline (openai/codex#17827 / #20244), this
-skill can add a `{ type = "command", command = … }` entry pointing at the same
-AFK bundle so the line matches Claude Code's.
-
-## OpenCode
-
-Nothing to install: OpenCode is an AFK API-auth runner lane (`--runner opencode`), not an interactive host UI, so it has no footer/statusline adapter — observe it through `/afk monitor`, `/afk dashboard`, and Actions output like any other runner.
-
-## Notes
+## Invocation Notes
 
 - Invoke as `/setup-statusline` (Claude Code) or `$setup-statusline` (Codex). Wire the host you are running under; do not imply the statusline feature belongs to only one client.
 - `/setup-red-skills` may offer the Claude Code command-backed adapter during project bootstrap. Under Codex, use this skill to inspect or configure the native footer path.
+
+</supporting-info>

--- a/plugins/dev/skills/knowledge/wiki-init/SKILL.md
+++ b/plugins/dev/skills/knowledge/wiki-init/SKILL.md
@@ -10,6 +10,8 @@ disable-model-invocation: true
 
 Sets up the [LLM Wiki](../wiki/REFERENCES.md) pattern. After this runs, the agent has a persistent, incrementally-maintained knowledge base inside `.red/wiki/` and a schema in `.red/agents/wiki.md` that teaches future sessions how to ingest sources, query, and lint.
 
+<what-to-do>
+
 ## Process
 
 Light grilling — three questions, then preview, then write. Don't dump all three at once; ask one, get the answer, move on.
@@ -77,6 +79,7 @@ Use the seed templates bundled with this skill:
 - [schema-template.md](./schema-template.md) → `.red/agents/wiki.md` (substituting placeholders `{{domain}}`, `{{source-types}}`, `{{voice}}`)
 - [index-template.md](./index-template.md) → `.red/wiki/index.md`
 - `log.md` starts with the heading `# Log` and nothing else.
+- For the full bundled template inventory, see [TEMPLATE-REFERENCE.md](./TEMPLATE-REFERENCE.md).
 
 **Append to `.gitignore`:**
 
@@ -112,15 +115,13 @@ Tell the user:
 - Next step: run `/wiki ingest <first source>`.
 - That the schema is living — they can edit `.red/agents/wiki.md` directly, or ask the agent to update it as conventions emerge.
 
-## Bundled templates
+</what-to-do>
 
-- [schema-template.md](./schema-template.md)
-- [index-template.md](./index-template.md)
-- [page-template-entity.md](./page-template-entity.md)
-- [page-template-concept.md](./page-template-concept.md)
-- [page-template-source.md](./page-template-source.md)
-- [page-template-synthesis.md](./page-template-synthesis.md)
-- [examples/research.md](./examples/research.md)
-- [examples/book-reading.md](./examples/book-reading.md)
+<supporting-info>
 
-External references: see [REFERENCES.md](../wiki/REFERENCES.md) in the `wiki` skill.
+## References
+
+- Bundled templates and examples: [TEMPLATE-REFERENCE.md](./TEMPLATE-REFERENCE.md).
+- External LLM Wiki pattern reference: [REFERENCES.md](../wiki/REFERENCES.md) in the `wiki` skill.
+
+</supporting-info>

--- a/plugins/dev/skills/knowledge/wiki-init/TEMPLATE-REFERENCE.md
+++ b/plugins/dev/skills/knowledge/wiki-init/TEMPLATE-REFERENCE.md
@@ -1,0 +1,17 @@
+# Template Reference
+
+Reference-only inventory for `wiki-init/SKILL.md`. Load this when checking the
+bundled template set or following the external LLM Wiki pattern.
+
+## Bundled Templates
+
+- [schema-template.md](./schema-template.md)
+- [index-template.md](./index-template.md)
+- [page-template-entity.md](./page-template-entity.md)
+- [page-template-concept.md](./page-template-concept.md)
+- [page-template-source.md](./page-template-source.md)
+- [page-template-synthesis.md](./page-template-synthesis.md)
+- [examples/research.md](./examples/research.md)
+- [examples/book-reading.md](./examples/book-reading.md)
+
+External references: see [REFERENCES.md](../wiki/REFERENCES.md) in the `wiki` skill.


### PR DESCRIPTION
Automated AFK landing for #1362. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1362

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786194347&installation_id=129708444&pr_number=1363&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1363&signature=40fbea5dc7e165d40f04fa64dcefa2c886c1cc227a5bea77ba1577fe63ae51d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->