### PR TITLE
chore: #1367 /go: Build a remediation sweep command for ALREADY-public leaked comments, pe

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -11,6 +11,7 @@ import { injectDevelopmentWorkflowCommand } from "./commands/inject-development-
 import { monitorCommand } from "./commands/monitor.js";
 import { runCommand } from "./commands/run.js";
 import { reapCommand } from "./commands/reap.js";
+import { redactSweepCommand } from "./commands/redact-sweep.js";
 import { relabelSweepCommand } from "./commands/relabel-sweep.js";
 import { requeueCommand } from "./commands/requeue.js";
 import { retakeCommand } from "./commands/retake.js";
@@ -36,6 +37,7 @@ export type CliCommand =
   | "daily-review"
   | "weekly-review"
   | "reap"
+  | "redact-sweep"
   | "relabel-sweep"
   | "requeue"
   | "retake"
@@ -79,6 +81,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     "daily-review": {},
     "weekly-review": {},
     reap: {},
+    "redact-sweep": {},
     "relabel-sweep": {},
     requeue: {},
     retake: {},
@@ -131,6 +134,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "daily-review") return activityReviewCommand("daily", parsed.args);
   if (parsed.command === "weekly-review") return activityReviewCommand("weekly", parsed.args);
   if (parsed.command === "reap") return reapCommand(parsed.args);
+  if (parsed.command === "redact-sweep") return redactSweepCommand(parsed.args);
   if (parsed.command === "relabel-sweep") return relabelSweepCommand(parsed.args);
   if (parsed.command === "requeue") return requeueCommand(parsed.args);
   if (parsed.command === "retake") return retakeCommand(parsed.args);

--- a/apps/dev/src/commands/redact-sweep.ts
+++ b/apps/dev/src/commands/redact-sweep.ts
@@ -1,0 +1,239 @@
+import { hostname } from "node:os";
+import { setTimeout as delay } from "node:timers/promises";
+import { execTool } from "../runtime/exec.js";
+import {
+  scanRedactTargets,
+  type RedactPlan,
+  type RedactSweepConfig,
+  type RedactTarget,
+  type SkippedRedactTarget,
+} from "../core/redact-sweep.js";
+
+export interface RedactSweepGitHub {
+  viewerLogin(): Promise<string>;
+  listTargets(repo: string): Promise<RedactTarget[]>;
+  updateTarget(target: RedactTarget, body: string): Promise<void>;
+}
+
+interface RedactSweepOptions {
+  repos: string[];
+  apply: boolean;
+  json: boolean;
+  hostPatterns: string[];
+}
+
+interface RepoReport {
+  repo: string;
+  mode: "dry-run" | "apply";
+  editable: RedactPlan[];
+  skipped: SkippedRedactTarget[];
+  edited: string[];
+}
+
+const LEGACY_HOST_PATTERN = "cyber-XPS";
+
+function parseOptions(args: readonly string[]): RedactSweepOptions {
+  const repos: string[] = [];
+  const hostPatterns: string[] = [hostname(), LEGACY_HOST_PATTERN].filter(Boolean);
+  let apply = false;
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    const takeValue = (name: string): string => {
+      const value = args[i + 1];
+      if (value === undefined) throw new Error(`${name} requires a value`);
+      i += 1;
+      return value;
+    };
+    if (arg === "--repo" || arg === "-R") {
+      repos.push(takeValue(arg));
+    } else if (arg.startsWith("--repo=")) {
+      repos.push(arg.slice("--repo=".length));
+    } else if (arg === "--host-pattern" || arg === "--hostname-pattern") {
+      hostPatterns.push(takeValue(arg));
+    } else if (arg.startsWith("--host-pattern=")) {
+      hostPatterns.push(arg.slice("--host-pattern=".length));
+    } else if (arg.startsWith("--hostname-pattern=")) {
+      hostPatterns.push(arg.slice("--hostname-pattern=".length));
+    } else if (arg === "--apply") {
+      apply = true;
+    } else if (arg === "--dry-run") {
+      apply = false;
+    } else if (arg === "--json") {
+      json = true;
+    } else {
+      throw new Error(`unknown redact-sweep argument: ${arg}`);
+    }
+  }
+
+  if (repos.length === 0) throw new Error("redact-sweep requires at least one --repo <owner/name>");
+  return { repos, apply, json, hostPatterns };
+}
+
+async function tokenFromEnvironmentOrGh(cwd: string): Promise<string> {
+  const envToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (envToken) return envToken;
+  const out = await execTool("gh", ["auth", "token"], { cwd });
+  if (out.code !== 0 || !out.stdout.trim()) {
+    throw new Error(`GitHub token unavailable: ${out.stderr.trim() || out.stdout.trim() || "gh auth token failed"}`);
+  }
+  return out.stdout.trim();
+}
+
+function parseNextLink(link: string | null): boolean {
+  return link?.split(",").some((part) => part.includes('rel="next"')) ?? false;
+}
+
+class RestRedactSweepGitHub implements RedactSweepGitHub {
+  constructor(private readonly token: string) {}
+
+  async viewerLogin(): Promise<string> {
+    const user = await this.requestJson<{ login?: string }>("/user");
+    if (!user.login) throw new Error("GitHub API did not return an authenticated login");
+    return user.login;
+  }
+
+  async listTargets(repo: string): Promise<RedactTarget[]> {
+    const [issues, comments, reviewComments] = await Promise.all([
+      this.paginate<IssueRow>(`/repos/${repo}/issues?state=all&per_page=100`),
+      this.paginate<CommentRow>(`/repos/${repo}/issues/comments?per_page=100`),
+      this.paginate<CommentRow>(`/repos/${repo}/pulls/comments?per_page=100`),
+    ]);
+
+    return [
+      ...issues.flatMap((issue) => this.issueBodyTarget(repo, issue)),
+      ...comments.flatMap((comment) => this.commentTarget(repo, "issue-comment", comment)),
+      ...reviewComments.flatMap((comment) => this.commentTarget(repo, "review-comment", comment)),
+    ];
+  }
+
+  async updateTarget(target: RedactTarget, body: string): Promise<void> {
+    if (target.kind === "issue-body") {
+      await this.requestJson(`/repos/${target.repo}/issues/${target.id}`, { method: "PATCH", body: { body } });
+      return;
+    }
+    const family = target.kind === "issue-comment" ? "issues/comments" : "pulls/comments";
+    await this.requestJson(`/repos/${target.repo}/${family}/${target.id}`, { method: "PATCH", body: { body } });
+  }
+
+  private issueBodyTarget(repo: string, issue: IssueRow): RedactTarget[] {
+    if (typeof issue.number !== "number" || typeof issue.body !== "string" || !issue.body) return [];
+    const author = issue.user?.login;
+    if (!author || !issue.html_url) return [];
+    return [{ kind: "issue-body", repo, id: issue.number, url: issue.html_url, author, body: issue.body }];
+  }
+
+  private commentTarget(repo: string, kind: "issue-comment" | "review-comment", comment: CommentRow): RedactTarget[] {
+    if (typeof comment.id !== "number" || typeof comment.body !== "string" || !comment.body) return [];
+    const author = comment.user?.login;
+    if (!author || !comment.html_url) return [];
+    return [{ kind, repo, id: comment.id, url: comment.html_url, author, body: comment.body }];
+  }
+
+  private async paginate<T>(path: string): Promise<T[]> {
+    const rows: T[] = [];
+    let page = 1;
+    for (;;) {
+      const separator = path.includes("?") ? "&" : "?";
+      const response = await this.request(`${path}${separator}page=${page}`);
+      const json = await response.json() as T[];
+      rows.push(...json);
+      if (!parseNextLink(response.headers.get("link"))) break;
+      page += 1;
+    }
+    return rows;
+  }
+
+  private async requestJson<T = unknown>(
+    path: string,
+    options: { method?: string; body?: unknown } = {},
+  ): Promise<T> {
+    const response = await this.request(path, options);
+    return await response.json() as T;
+  }
+
+  private async request(path: string, options: { method?: string; body?: unknown } = {}): Promise<Response> {
+    const url = path.startsWith("http") ? path : `https://api.github.com${path}`;
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const response = await fetch(url, {
+        method: options.method ?? "GET",
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+          "x-github-api-version": "2022-11-28",
+        },
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      });
+      if (response.status !== 403 || attempt === 5) {
+        if (!response.ok) throw new Error(`GitHub API ${options.method ?? "GET"} ${path} failed: ${response.status} ${await response.text()}`);
+        return response;
+      }
+      const retryAfter = Number(response.headers.get("retry-after") ?? "0");
+      await delay(retryAfter > 0 ? retryAfter * 1000 : 1000 * 2 ** attempt);
+    }
+    throw new Error(`GitHub API ${options.method ?? "GET"} ${path} failed after retries`);
+  }
+}
+
+interface IssueRow {
+  number?: number;
+  html_url?: string;
+  body?: string | null;
+  user?: { login?: string };
+}
+
+interface CommentRow {
+  id?: number;
+  html_url?: string;
+  body?: string | null;
+  user?: { login?: string };
+}
+
+function renderHumanReport(report: RepoReport, stdout: NodeJS.WritableStream): void {
+  stdout.write(`redact-sweep (${report.mode}) ${report.repo}: ${report.editable.length} editable hit(s), ${report.skipped.length} skipped\n`);
+  for (const plan of report.editable) {
+    stdout.write(`  ${plan.target.url}\n`);
+    stdout.write(`    classes=[${plan.classes.join(", ")}]\n`);
+    stdout.write(`    preview=${plan.preview}\n`);
+  }
+  for (const skipped of report.skipped) {
+    stdout.write(`  skipped ${skipped.target.url}\n`);
+    stdout.write(`    author=${skipped.target.author} reason=${skipped.reason} classes=[${skipped.classes.join(", ")}]\n`);
+  }
+  if (report.mode === "dry-run") stdout.write("redact-sweep (dry-run): no changes written.\n");
+}
+
+export async function redactSweepCommand(
+  args: readonly string[],
+  cwd = process.cwd(),
+  stdout: NodeJS.WritableStream = process.stdout,
+  ghOverride?: RedactSweepGitHub,
+): Promise<number> {
+  const options = parseOptions(args);
+  const gh = ghOverride ?? new RestRedactSweepGitHub(await tokenFromEnvironmentOrGh(cwd));
+  const authenticatedLogin = await gh.viewerLogin();
+  const config: RedactSweepConfig = { hostPatterns: options.hostPatterns };
+  const reports: RepoReport[] = [];
+
+  for (const repo of options.repos) {
+    const targets = await gh.listTargets(repo);
+    const scan = scanRedactTargets(targets, authenticatedLogin, config);
+    const edited: string[] = [];
+    if (options.apply) {
+      for (const plan of scan.editable) {
+        await gh.updateTarget(plan.target, plan.redactedBody);
+        edited.push(plan.target.url);
+      }
+    }
+    reports.push({ repo, mode: options.apply ? "apply" : "dry-run", editable: scan.editable, skipped: scan.skipped, edited });
+  }
+
+  if (options.json) {
+    stdout.write(`${JSON.stringify({ authenticatedLogin, reports }, null, 2)}\n`);
+    return 0;
+  }
+  for (const report of reports) renderHumanReport(report, stdout);
+  return 0;
+}

--- a/apps/dev/src/core/redact-sweep.ts
+++ b/apps/dev/src/core/redact-sweep.ts
@@ -1,0 +1,122 @@
+export type RedactionClass = "claude-session" | "host" | "home-path";
+
+export interface RedactSweepConfig {
+  hostPatterns: readonly string[];
+}
+
+export interface RedactionHit {
+  class: RedactionClass;
+  value: string;
+}
+
+export interface RedactTarget {
+  kind: "issue-body" | "issue-comment" | "review-comment";
+  repo: string;
+  id: number;
+  url: string;
+  author: string;
+  body: string;
+}
+
+export interface RedactPlan {
+  target: RedactTarget;
+  classes: RedactionClass[];
+  redactedBody: string;
+  preview: string;
+}
+
+export interface SkippedRedactTarget {
+  target: RedactTarget;
+  classes: RedactionClass[];
+  reason: "other-author";
+}
+
+const CLAUDE_SESSION_RE = /https?:\/\/claude\.ai\/code\/session_[^\s<>"')\]}]+/g;
+const HOME_PATH_RE = /\/home\/([A-Za-z0-9._-]+)(?=\/|\b)/g;
+
+function unique<T>(items: readonly T[]): T[] {
+  return [...new Set(items)];
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hostRegexes(patterns: readonly string[]): RegExp[] {
+  return unique(patterns.map((pattern) => pattern.trim()).filter(Boolean))
+    .map((pattern) => new RegExp(`${escapeRegExp(pattern)}[A-Za-z0-9._-]*`, "g"));
+}
+
+export function findRedactionHits(text: string, config: RedactSweepConfig): RedactionHit[] {
+  const hits: RedactionHit[] = [];
+  for (const match of text.matchAll(CLAUDE_SESSION_RE)) {
+    if (match[0]) hits.push({ class: "claude-session", value: match[0] });
+  }
+  for (const re of hostRegexes(config.hostPatterns)) {
+    for (const match of text.matchAll(re)) {
+      if (match[0] && !match[0].startsWith("[REDACTED_")) hits.push({ class: "host", value: match[0] });
+    }
+  }
+  for (const match of text.matchAll(HOME_PATH_RE)) {
+    if (match[1] !== "[REDACTED_USER]") hits.push({ class: "home-path", value: match[0] });
+  }
+  return hits;
+}
+
+export function redactText(text: string, config: RedactSweepConfig): { text: string; hits: RedactionHit[] } {
+  const hits = findRedactionHits(text, config);
+  let redacted = text.replace(CLAUDE_SESSION_RE, "[REDACTED_CLAUDE_SESSION]");
+  for (const re of hostRegexes(config.hostPatterns)) {
+    redacted = redacted.replace(re, "[REDACTED_HOST]");
+  }
+  redacted = redacted.replace(HOME_PATH_RE, "/home/[REDACTED_USER]");
+  return { text: redacted, hits };
+}
+
+export function canEditRedactTarget(target: RedactTarget, authenticatedLogin: string): boolean {
+  return target.author === authenticatedLogin;
+}
+
+export function redactedPreview(text: string, maxLength = 240): string {
+  const singleLine = text.replace(/\s+/g, " ").trim();
+  if (singleLine.length <= maxLength) return singleLine;
+  return `${singleLine.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+export function planRedactTarget(
+  target: RedactTarget,
+  config: RedactSweepConfig,
+): { classes: RedactionClass[]; redactedBody: string; preview: string } | null {
+  const redacted = redactText(target.body, config);
+  if (redacted.hits.length === 0) return null;
+  return {
+    classes: unique(redacted.hits.map((hit) => hit.class)),
+    redactedBody: redacted.text,
+    preview: redactedPreview(redacted.text),
+  };
+}
+
+export function scanRedactTargets(
+  targets: readonly RedactTarget[],
+  authenticatedLogin: string,
+  config: RedactSweepConfig,
+): { editable: RedactPlan[]; skipped: SkippedRedactTarget[]; clean: RedactTarget[] } {
+  const editable: RedactPlan[] = [];
+  const skipped: SkippedRedactTarget[] = [];
+  const clean: RedactTarget[] = [];
+
+  for (const target of targets) {
+    const plan = planRedactTarget(target, config);
+    if (!plan) {
+      clean.push(target);
+      continue;
+    }
+    if (!canEditRedactTarget(target, authenticatedLogin)) {
+      skipped.push({ target, classes: plan.classes, reason: "other-author" });
+      continue;
+    }
+    editable.push({ target, ...plan });
+  }
+
+  return { editable, skipped, clean };
+}

--- a/apps/dev/tests/redact-sweep.test.ts
+++ b/apps/dev/tests/redact-sweep.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  canEditRedactTarget,
+  findRedactionHits,
+  redactText,
+  scanRedactTargets,
+  type RedactTarget,
+} from "../src/core/redact-sweep.js";
+import { redactSweepCommand, type RedactSweepGitHub } from "../src/commands/redact-sweep.js";
+import { parseCli } from "../src/cli.js";
+
+const CONFIG = {
+  hostPatterns: ["cyber-XPS", "build-host"],
+};
+
+function target(body: string, author = "alice"): RedactTarget {
+  return {
+    kind: "issue-comment",
+    repo: "reddb-io/red-skills",
+    id: 10,
+    url: "https://github.com/reddb-io/red-skills/issues/1#issuecomment-10",
+    author,
+    body,
+  };
+}
+
+function collect(): { stream: NodeJS.WritableStream; text: () => string } {
+  let buf = "";
+  const stream = { write: (s: string) => (buf += s, true) } as unknown as NodeJS.WritableStream;
+  return { stream, text: () => buf };
+}
+
+function fakeGh(targets: RedactTarget[]): RedactSweepGitHub & {
+  updates: Array<{ url: string; body: string }>;
+} {
+  const updates: Array<{ url: string; body: string }> = [];
+  return {
+    updates,
+    viewerLogin: async () => "alice",
+    listTargets: async () => targets,
+    updateTarget: async (item, body) => {
+      updates.push({ url: item.url, body });
+      item.body = body;
+    },
+  };
+}
+
+describe("redact-sweep detection and redaction", () => {
+  it("detects claude session links, configured host patterns, and /home paths", () => {
+    const text = [
+      "session https://claude.ai/code/session_01ABCxyz",
+      "host cyber-XPS-9560 and build-host",
+      "path /home/cyber/Work/reddb.io/red-skills/file.ts",
+    ].join("\n");
+
+    expect(findRedactionHits(text, CONFIG).map((hit) => hit.class)).toEqual([
+      "claude-session",
+      "host",
+      "host",
+      "home-path",
+    ]);
+  });
+
+  it("redacts each leak class with stable placeholders", () => {
+    const text = "https://claude.ai/code/session_secret on cyber-XPS-13 in /home/cyber/project";
+    expect(redactText(text, CONFIG).text).toBe(
+      "[REDACTED_CLAUDE_SESSION] on [REDACTED_HOST] in /home/[REDACTED_USER]/project",
+    );
+  });
+
+  it("is idempotent after redaction", () => {
+    const first = redactText("https://claude.ai/code/session_secret /home/cyber/project cyber-XPS-13", CONFIG);
+    expect(findRedactionHits(first.text, CONFIG)).toEqual([]);
+    expect(redactText(first.text, CONFIG).text).toBe(first.text);
+  });
+
+  it("skips targets not authored by the authenticated actor", () => {
+    expect(canEditRedactTarget(target("leak", "alice"), "alice")).toBe(true);
+    expect(canEditRedactTarget(target("leak", "bob"), "alice")).toBe(false);
+  });
+
+  it("plans editable hits and reports other authors as skipped", () => {
+    const result = scanRedactTargets(
+      [
+        target("https://claude.ai/code/session_secret", "alice"),
+        target("/home/bob/project", "bob"),
+        target("ordinary text", "alice"),
+      ],
+      "alice",
+      CONFIG,
+    );
+
+    expect(result.editable.map((item) => item.target.id)).toEqual([10]);
+    expect(result.skipped.map((item) => item.target.author)).toEqual(["bob"]);
+    expect(result.clean.map((item) => item.id)).toEqual([10]);
+  });
+
+  it("routes the dev CLI redact-sweep command", () => {
+    expect(parseCli(["redact-sweep", "--repo", "reddb-io/red-skills", "--json"])).toEqual({
+      command: "redact-sweep",
+      args: ["--repo", "reddb-io/red-skills", "--json"],
+    });
+  });
+
+  it("defaults to dry-run and writes nothing", async () => {
+    const gh = fakeGh([target("https://claude.ai/code/session_secret from /home/cyber/project")]);
+    const out = collect();
+    const code = await redactSweepCommand(["--repo", "reddb-io/red-skills"], "/repo", out.stream, gh);
+
+    expect(code).toBe(0);
+    expect(out.text()).toContain("redact-sweep (dry-run) reddb-io/red-skills: 1 editable hit(s), 0 skipped");
+    expect(out.text()).toContain("[REDACTED_CLAUDE_SESSION] from /home/[REDACTED_USER]/project");
+    expect(gh.updates).toEqual([]);
+  });
+
+  it("--apply edits only authenticated-user targets and is replay-idempotent", async () => {
+    const gh = fakeGh([
+      target("https://claude.ai/code/session_secret from /home/cyber/project"),
+      target("cyber-XPS-13 from /home/bob/project", "bob"),
+    ]);
+    const first = collect();
+    expect(await redactSweepCommand(["--repo", "reddb-io/red-skills", "--apply"], "/repo", first.stream, gh)).toBe(0);
+
+    expect(gh.updates).toEqual([
+      {
+        url: "https://github.com/reddb-io/red-skills/issues/1#issuecomment-10",
+        body: "[REDACTED_CLAUDE_SESSION] from /home/[REDACTED_USER]/project",
+      },
+    ]);
+    expect(first.text()).toContain("1 editable hit(s), 1 skipped");
+
+    gh.updates.length = 0;
+    const second = collect();
+    expect(await redactSweepCommand(["--repo", "reddb-io/red-skills", "--apply"], "/repo", second.stream, gh)).toBe(0);
+    expect(gh.updates).toEqual([]);
+    expect(second.text()).toContain("0 editable hit(s), 1 skipped");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1367. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1367

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786196242&installation_id=129708444&pr_number=1369&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1369&signature=229f3e1a86b307e06289e4f1f81d94dd91843e16b89bc359bd80cae7d56de505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->