### PR TITLE
chore: #1365 /go: Add a single outbound-redaction seam scrubOutbound() in apps/dev and app

### DIFF
--- a/apps/dev/src/commands/hitl-card.ts
+++ b/apps/dev/src/commands/hitl-card.ts
@@ -14,6 +14,7 @@
 
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
+import { scrubOutbound } from "../runtime/outbound-redaction.js";
 import { parseTrustPolicy, resolveActorTrust } from "../core/trust-gate.js";
 import { actorTrustSignals, type GhContext } from "../runtime/gh.js";
 import { loadConfig } from "../core/config.js";
@@ -170,11 +171,11 @@ async function upsertCardComment(exec: Exec, repo: string, issueNumber: number, 
       "gh", "api",
       `repos/{owner}/{repo}/issues/comments/${existing.databaseId}`,
       "--method", "PATCH",
-      "--field", `body=${card}`,
+      "--field", `body=${scrubOutbound(card)}`,
       ...repoArgs(repo),
     ]);
   } else {
-    await exec(["gh", "issue", "comment", String(issueNumber), ...repoArgs(repo), "--body", card]);
+    await exec(["gh", "issue", "comment", String(issueNumber), ...repoArgs(repo), "--body", scrubOutbound(card)]);
   }
 }
 
@@ -294,7 +295,7 @@ async function executeReject(exec: Exec, repo: string, issue: IssueData, prNumbe
   const closeResult = await exec([
     "gh", "pr", "close", String(prNumber),
     ...repoArgs(repo),
-    "--comment", reason ? `Rejected: ${reason}` : "Rejected by maintainer.",
+    "--comment", scrubOutbound(reason ? `Rejected: ${reason}` : "Rejected by maintainer."),
   ]);
   if (closeResult.code !== 0) {
     return `PR close failed: ${closeResult.stderr.trim()}`;
@@ -317,7 +318,7 @@ async function executeRequeue(exec: Exec, repo: string, issue: IssueData, guidan
 
   // Apply the requeue transition.
   if (plan.bodyChanged) {
-    await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--body", plan.body]);
+    await exec(["gh", "issue", "edit", String(issue.number), ...repoArgs(repo), "--body", scrubOutbound(plan.body)]);
   }
   const editArgs = ["gh", "issue", "edit", String(issue.number), ...repoArgs(repo)];
   for (const l of plan.removeLabels) editArgs.push("--remove-label", l);
@@ -345,7 +346,7 @@ async function cmdAct(
     await exec([
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
-      "--body", `⛔ Action denied: ${trust.reason ?? "you are not a trusted maintainer"}.`,
+      "--body", scrubOutbound(`⛔ Action denied: ${trust.reason ?? "you are not a trusted maintainer"}.`),
     ]);
     process.stderr.write(`[afk] hitl-card act #${issueNumber}: trust refused — ${trust.reason}\n`);
     return 1;
@@ -359,7 +360,7 @@ async function cmdAct(
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
       "--body",
-      "🤖 I couldn't identify your intent. Use `/approve`, `/approve-ci`, `/reject [reason]`, or `/requeue <guidance>`.",
+      scrubOutbound("🤖 I couldn't identify your intent. Use `/approve`, `/approve-ci`, `/reject [reason]`, or `/requeue <guidance>`."),
     ]);
     stdout.write(`hitl-card act #${issueNumber}: unrecognised command (NL classification returned nothing).\n`);
     return 0;
@@ -375,7 +376,7 @@ async function cmdAct(
       "gh", "issue", "comment", String(issueNumber),
       ...repoArgs(repo),
       "--body",
-      `⚠️ Could not find a linked PR for #${issueNumber}. Post the PR number explicitly or use \`/requeue\` to send back to the agent.`,
+      scrubOutbound(`⚠️ Could not find a linked PR for #${issueNumber}. Post the PR number explicitly or use \`/requeue\` to send back to the agent.`),
     ]);
     return 1;
   }
@@ -396,12 +397,12 @@ async function cmdAct(
   await exec([
     "gh", "issue", "comment", String(issueNumber),
     ...repoArgs(repo),
-    "--body", directiveComment(command),
+    "--body", scrubOutbound(directiveComment(command)),
   ]);
   await exec([
     "gh", "issue", "comment", String(issueNumber),
     ...repoArgs(repo),
-    "--body", `🤖 **${command.action}**: ${resultMessage}`,
+    "--body", scrubOutbound(`🤖 **${command.action}**: ${resultMessage}`),
   ]);
 
   stdout.write(`hitl-card act #${issueNumber}: executed /${command.action} — ${resultMessage}\n`);

--- a/apps/dev/src/commands/requeue.ts
+++ b/apps/dev/src/commands/requeue.ts
@@ -21,6 +21,7 @@ import { dirname, join } from "node:path";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
+import { scrubOutbound } from "../runtime/outbound-redaction.js";
 import { planRequeue, type RequeuePlan } from "../core/requeue.js";
 import { parseClaimRecords, renderClaimComment, type RawClaimComment } from "../core/claim.js";
 import { parseCurrentBlocker } from "../core/blocker-state.js";
@@ -109,7 +110,7 @@ function ghFor(cwd: string, repo: string): RequeueGh {
       };
     },
     async editBody(issue, body) {
-      const out = await run(["issue", "edit", String(issue), ...repoArgs, "--body", body]);
+      const out = await run(["issue", "edit", String(issue), ...repoArgs, "--body", scrubOutbound(body)]);
       if (out.code !== 0) throw new Error(`edit body #${issue} failed: ${out.stderr.trim() || out.stdout.trim()}`);
     },
     async editLabels(issue, remove, add) {
@@ -129,7 +130,7 @@ function ghFor(cwd: string, repo: string): RequeueGh {
       if (!ok) throw new Error(`edit labels #${issue} failed`);
     },
     async comment(issue, body) {
-      await run(["issue", "comment", String(issue), ...repoArgs, "--body", body]);
+      await run(["issue", "comment", String(issue), ...repoArgs, "--body", scrubOutbound(body)]);
     },
     listClaims: (issue) => ghx.listClaimComments({ cwd, repo }, issue),
     postClaim: async (issue, body) => {

--- a/apps/dev/src/commands/respond.ts
+++ b/apps/dev/src/commands/respond.ts
@@ -12,6 +12,7 @@
 import { parseFlags, type FlagSchema } from "@reddb-io/shared/args.js";
 import { Output } from "@reddb-io/red-castle";
 import { execTool } from "../runtime/exec.js";
+import { scrubOutbound } from "../runtime/outbound-redaction.js";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import { resolveConfigPath } from "./route-model-tier.js";
 import { defaultSandcastleDeps, type AgentRunner } from "../core/execution.js";
@@ -91,7 +92,7 @@ export async function respondCommand(
     async reply(target, replyBody) {
       const flag = isPr ? "pr" : "issue";
       const repoArgs = repo ? ["--repo", repo] : [];
-      await execTool("gh", [flag, "comment", String(target), ...repoArgs, "--body", replyBody], { cwd: root });
+      await execTool("gh", [flag, "comment", String(target), ...repoArgs, "--body", scrubOutbound(replyBody)], { cwd: root });
     },
   };
 

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -15,6 +15,8 @@
 //                branch, open or reuse the PR, `gh pr merge --merge`), then
 //                fast-forward local <target> to the merge commit.
 
+import { scrubOutbound } from "../runtime/outbound-redaction.js";
+
 /** Result of a single executed command. Mirrors a child-process completion. */
 export interface ExecResult {
   code: number;
@@ -750,9 +752,9 @@ async function ensurePr(
       "--head",
       branch,
       "--title",
-      prTitle,
+      scrubOutbound(prTitle),
       "--body",
-      `${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the \`afk-attempts/*\` snapshot branches.\n\nCloses #${n}`,
+      scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the \`afk-attempts/*\` snapshot branches.\n\nCloses #${n}`),
     ]);
     if (create.code !== 0) return undefined;
     prNumber = await listOpenPr(exec, repo, branch, target);

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -28,6 +28,7 @@ import {
   MAIN_RED_REPAIR_TITLE,
   type MainRedRepairIssue,
 } from "../core/main-red-repair.js";
+import { scrubOutbound } from "./outbound-redaction.js";
 
 export interface GhContext {
   /** owner/repo slug for `gh ... --repo`. */
@@ -282,7 +283,7 @@ export async function editLabels(
 
 /** `gh issue comment --body …` (best-effort). */
 export async function comment(ctx: GhContext, issue: number, body: string): Promise<void> {
-  await runGh(ctx, ["issue", "comment", String(issue), ...repoArgs(ctx), "--body", body]);
+  await runGh(ctx, ["issue", "comment", String(issue), ...repoArgs(ctx), "--body", scrubOutbound(body)]);
 }
 
 // ---------- atomic GitHub-native claim (ADR 0066) ----------
@@ -306,7 +307,7 @@ export async function postClaimComment(ctx: GhContext, issue: number, body: stri
     "POST",
     apiPath(ctx, `issues/${issue}/comments`),
     "-f",
-    `body=${body}`,
+    `body=${scrubOutbound(body)}`,
     "--jq",
     ".id",
   ]);
@@ -350,7 +351,7 @@ export async function listClaimComments(
 
 /** `gh issue edit --body …`. */
 export async function editBody(ctx: GhContext, issue: number, body: string): Promise<boolean> {
-  const r = await runGh(ctx, ["issue", "edit", String(issue), ...repoArgs(ctx), "--body", body]);
+  const r = await runGh(ctx, ["issue", "edit", String(issue), ...repoArgs(ctx), "--body", scrubOutbound(body)]);
   return r.code === 0;
 }
 
@@ -369,9 +370,9 @@ export async function createIssue(
     "create",
     ...repoArgs(ctx),
     "--title",
-    spec.title,
+    scrubOutbound(spec.title),
     "--body",
-    spec.body,
+    scrubOutbound(spec.body),
     ...labelArgs,
   ]);
   const match = (r.stdout ?? "").match(/\/issues\/(\d+)\b/);
@@ -441,9 +442,9 @@ export async function updateMainRedRepairIssue(
     String(issue),
     ...repoArgs(ctx),
     "--title",
-    spec.title,
+    scrubOutbound(spec.title),
     "--body",
-    spec.body,
+    scrubOutbound(spec.body),
   ];
   for (const label of spec.labels) args.push("--add-label", label);
   await runGh(ctx, args);

--- a/apps/dev/src/runtime/outbound-redaction.ts
+++ b/apps/dev/src/runtime/outbound-redaction.ts
@@ -1,0 +1,101 @@
+import { homedir, hostname as osHostname, userInfo } from "node:os";
+import { hostFingerprint } from "../core/host-identity.js";
+
+const CLAUDE_SESSION_RE = /https:\/\/claude\.ai\/code\/session_[A-Za-z0-9_-]+/g;
+const SECRET_KEY_RE = /(?:TOKEN|SECRET|KEY|PASSWORD|PASS|AUTH|BEARER|COOKIE|SESSION|ANTHROPIC|OPENAI|MINIMAX|OPENROUTER|AWS_|GOOGLE_|SLACK_|NPM_|GH_|GITHUB_)/i;
+const FALSEY_SECRET_VALUES = new Set(["true", "false", "null", "0", "1"]);
+
+export interface ScrubOutboundOptions {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  hostname?: string;
+  username?: string;
+  hostReplacement?: string;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceLiteral(input: string, needle: string, replacement: string): string {
+  if (!needle || needle === replacement || !input.includes(needle)) return input;
+  return input.split(needle).join(replacement);
+}
+
+function validSecretValue(value: string | undefined): value is string {
+  if (!value || value.length < 8) return false;
+  return !FALSEY_SECRET_VALUES.has(value.trim().toLowerCase());
+}
+
+function envSecretValues(env: NodeJS.ProcessEnv): string[] {
+  const values = new Set<string>();
+  for (const [key, value] of Object.entries(env)) {
+    if (!SECRET_KEY_RE.test(key)) continue;
+    if (validSecretValue(value)) values.add(value);
+  }
+  return [...values].sort((a, b) => b.length - a.length);
+}
+
+function replaceTokenBoundary(input: string, token: string, replacement: string): string {
+  if (token.length < 3 || token === replacement) return input;
+  const re = new RegExp(`(?<![A-Za-z0-9_-])${escapeRegex(token)}(?![A-Za-z0-9_-])`, "g");
+  return input.replace(re, replacement);
+}
+
+function defaultHostReplacement(): string {
+  try {
+    return hostFingerprint();
+  } catch {
+    return "[REDACTED_HOST]";
+  }
+}
+
+function scrubKeyValueSecrets(input: string): string {
+  const key = String.raw`[A-Za-z0-9_.-]*(?:TOKEN|SECRET|KEY|PASSWORD|PASS|AUTH|BEARER|COOKIE|SESSION|ANTHROPIC|OPENAI|MINIMAX|OPENROUTER|AWS_|GOOGLE_|SLACK_|NPM_|GH_|GITHUB_)[A-Za-z0-9_.-]*`;
+  const assignment = new RegExp(`\\b(${key})(\\s*=\\s*)([^\\s"'\\\`]+)`, "gi");
+  const jsonish = new RegExp(`(["']?${key}["']?\\s*:\\s*["'])([^"'\\n\\r]{8,})(["'])`, "gi");
+  return input
+    .replace(assignment, (_m, name: string, sep: string, value: string) =>
+      value === "[REDACTED_SECRET]" ? `${name}${sep}${value}` : `${name}${sep}[REDACTED_SECRET]`,
+    )
+    .replace(jsonish, (_m, prefix: string, value: string, suffix: string) =>
+      value === "[REDACTED_SECRET]" ? `${prefix}${value}${suffix}` : `${prefix}[REDACTED_SECRET]${suffix}`,
+    );
+}
+
+function scrubHomeIdentity(input: string, options: ScrubOutboundOptions): string {
+  let out = input;
+  const home = options.homeDir || homedir();
+  out = replaceLiteral(out, "/home/cyber", "[REDACTED_HOME]");
+  if (home) out = replaceLiteral(out, home, "[REDACTED_HOME]");
+  out = out.replace(/\/home\/([A-Za-z0-9._-]+)\//g, "/home/[REDACTED_USER]/");
+  out = out.replace(/\/Users\/([A-Za-z0-9._-]+)\//g, "/Users/[REDACTED_USER]/");
+  return out;
+}
+
+export function scrubOutbound(value: unknown, options: ScrubOutboundOptions = {}): string {
+  try {
+    let out = typeof value === "string" ? value : String(value ?? "");
+    out = out.replace(CLAUDE_SESSION_RE, "[REDACTED_CLAUDE_SESSION]");
+    for (const secret of envSecretValues(options.env ?? process.env)) {
+      out = replaceLiteral(out, secret, "[REDACTED_SECRET]");
+    }
+    out = scrubKeyValueSecrets(out);
+    out = scrubHomeIdentity(out, options);
+
+    const host = options.hostname ?? osHostname();
+    out = replaceTokenBoundary(out, host, options.hostReplacement ?? defaultHostReplacement());
+    let username = options.username;
+    if (username === undefined) {
+      try {
+        username = userInfo().username;
+      } catch {
+        username = undefined;
+      }
+    }
+    if (username) out = replaceTokenBoundary(out, username, "[REDACTED_USER]");
+    return out;
+  } catch {
+    return typeof value === "string" ? value : String(value ?? "");
+  }
+}

--- a/apps/dev/src/runtime/review-gh.ts
+++ b/apps/dev/src/runtime/review-gh.ts
@@ -15,6 +15,7 @@ import type { GhContext } from "./gh.js";
 import type { InlineComment, PrContext, ReviewGh } from "../core/review.js";
 import { classifySourceTrust, TRUSTED_ASSOCIATIONS } from "../core/source-trust.js";
 import type { ActorTrustVerdict } from "../core/trust-gate.js";
+import { scrubOutbound } from "./outbound-redaction.js";
 
 function runGh(ctx: GhContext, args: readonly string[]): Promise<ExecOutput> {
   const opts: ExecOptions = { cwd: ctx.cwd };
@@ -78,12 +79,12 @@ export function buildReviewGh(ctx: GhContext, resolveTrust?: PrTrustResolver): R
       // goes through a temp JSON file consumed by `gh api --input`.
       const reviewBody = {
         event: "COMMENT" as const,
-        body: payload.summary,
+        body: scrubOutbound(payload.summary),
         comments: payload.comments.map((c: InlineComment) => ({
           path: c.path,
           line: c.line,
           side: "RIGHT" as const,
-          body: c.body,
+          body: scrubOutbound(c.body),
         })),
       };
       const dir = mkdtempSync(join(tmpdir(), "red-review-"));
@@ -98,7 +99,7 @@ export function buildReviewGh(ctx: GhContext, resolveTrust?: PrTrustResolver): R
     },
 
     async comment(pr, body) {
-      await runGh(ctx, ["pr", "comment", String(pr), ...repoArgs(ctx), "--body", body]);
+      await runGh(ctx, ["pr", "comment", String(pr), ...repoArgs(ctx), "--body", scrubOutbound(body)]);
     },
 
     async ensureLabel(name) {

--- a/apps/dev/tests/outbound-redaction.test.ts
+++ b/apps/dev/tests/outbound-redaction.test.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { comment, createIssue, editBody, postClaimComment, updateMainRedRepairIssue, type GhContext } from "../src/runtime/gh.js";
+import { buildReviewGh } from "../src/runtime/review-gh.js";
+import { scrubOutbound } from "../src/runtime/outbound-redaction.js";
+import { landPr, type Exec } from "../src/core/merge.js";
+import type { ExecFn, ExecOutput } from "../src/runtime/exec.js";
+
+const LEAK_ENV_KEY = "RED_SKILLS_TEST_TOKEN";
+const LEAK_ENV_VALUE = "red-skills-test-token-123456";
+const LEAK_TEXT = [
+  "session https://claude.ai/code/session_abc123_X-y",
+  `literal ${LEAK_ENV_VALUE}`,
+  "OPENAI_API_KEY=sk-test-123456789",
+  '{"github_token":"ghp_1234567890abcdef"}',
+  "/home/cyber/.config/red-skills",
+].join("\n");
+
+function withSyntheticEnv(): void {
+  process.env[LEAK_ENV_KEY] = LEAK_ENV_VALUE;
+}
+
+afterEach(() => {
+  delete process.env[LEAK_ENV_KEY];
+});
+
+function expectScrubbed(value: string): void {
+  expect(value).not.toContain("claude.ai/code/session_");
+  expect(value).not.toContain(LEAK_ENV_VALUE);
+  expect(value).not.toContain("sk-test-123456789");
+  expect(value).not.toContain("ghp_1234567890abcdef");
+  expect(value).not.toContain("/home/cyber");
+  expect(value).toContain("[REDACTED_CLAUDE_SESSION]");
+  expect(value).toContain("[REDACTED_SECRET]");
+  expect(value).toContain("[REDACTED_HOME]");
+}
+
+describe("scrubOutbound", () => {
+  it("redacts session links, env values, key-value secrets, home paths, host and user identity", () => {
+    const input = [
+      LEAK_TEXT,
+      "TOKEN=another-secret-value",
+      '{"secret":"json-secret-value"}',
+      "/home/alice/project /Users/bob/project host-a alice",
+      "<!-- afk:claim v1 worker=host-a:w123 kind=claim runner=codex -->",
+    ].join("\n");
+
+    const out = scrubOutbound(input, {
+      env: { [LEAK_ENV_KEY]: LEAK_ENV_VALUE },
+      homeDir: "/home/alice",
+      hostname: "host-a",
+      username: "alice",
+      hostReplacement: "hostfingerprint",
+    });
+
+    expectScrubbed(out);
+    expect(out).toContain("TOKEN=[REDACTED_SECRET]");
+    expect(out).toContain('"secret":"[REDACTED_SECRET]"');
+    expect(out).toContain("[REDACTED_HOME]/project");
+    expect(out).toContain("/Users/[REDACTED_USER]/project");
+    expect(out).toContain("hostfingerprint [REDACTED_USER]");
+  });
+
+  it("is idempotent and preserves non-leaking machine markers byte-identical", () => {
+    const marker = [
+      "<!-- afk:claim v1 worker=8cb3eafdcbd2:w95PS kind=claim runner=codex -->",
+      "<!-- red:hitl-card v1 -->",
+      "<!-- red:blocker-state v1 -->",
+      "Refs #1365",
+    ].join("\n");
+
+    const once = scrubOutbound(marker);
+    expect(once).toBe(marker);
+    expect(scrubOutbound(once)).toBe(once);
+  });
+
+  it("never throws on non-string and binary-ish input", () => {
+    expect(typeof scrubOutbound(Buffer.from([0, 1, 2, 255]))).toBe("string");
+    expect(scrubOutbound(null)).toBe("");
+  });
+});
+
+describe("GitHub outbound write seams", () => {
+  it("scrubs issue comments, claim comments, issue body edits, issue creation, and main-red repair updates", async () => {
+    withSyntheticEnv();
+    const calls: { cmd: string; args: string[] }[] = [];
+    const exec: ExecFn = async (cmd, args): Promise<ExecOutput> => {
+      calls.push({ cmd, args: [...args] });
+      if (args.includes("--jq")) return { code: 0, stdout: "123\n", stderr: "" };
+      if (args[0] === "issue" && args[1] === "create") {
+        return { code: 0, stdout: "https://github.com/acme/widgets/issues/77\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const ctx: GhContext = { cwd: "/repo", repo: "acme/widgets", exec };
+
+    await comment(ctx, 1, LEAK_TEXT);
+    await postClaimComment(ctx, 1, `<!-- afk:claim v1 worker=w kind=claim runner=codex -->\n${LEAK_TEXT}`);
+    await editBody(ctx, 1, LEAK_TEXT);
+    await createIssue(ctx, { title: `Issue ${LEAK_ENV_VALUE}`, body: LEAK_TEXT, labels: ["ready-for-agent"] });
+    await updateMainRedRepairIssue(ctx, 1, { title: `Repair ${LEAK_ENV_VALUE}`, body: LEAK_TEXT, labels: ["ready-for-human"] });
+
+    const joined = calls.flatMap((c) => c.args).join("\n");
+    expectScrubbed(joined);
+    expect(joined).toContain("<!-- afk:claim v1 worker=w kind=claim runner=codex -->");
+  });
+
+  it("scrubs PR review summaries, inline comments, and fallback PR comments", async () => {
+    withSyntheticEnv();
+    const postedBodies: string[] = [];
+    const calls: string[][] = [];
+    const exec: ExecFn = async (_cmd, args): Promise<ExecOutput> => {
+      calls.push([...args]);
+      const inputIndex = args.indexOf("--input");
+      if (inputIndex >= 0) {
+        const raw = readFileSync(String(args[inputIndex + 1]), "utf8");
+        postedBodies.push(raw);
+      }
+      const bodyIndex = args.indexOf("--body");
+      if (bodyIndex >= 0) postedBodies.push(String(args[bodyIndex + 1]));
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    const gh = buildReviewGh({ cwd: "/repo", repo: "acme/widgets", exec });
+
+    await gh.postReview(9, {
+      summary: LEAK_TEXT,
+      comments: [{ path: "src/a.ts", line: 1, body: LEAK_TEXT }],
+    });
+    await gh.comment(9, LEAK_TEXT);
+
+    expectScrubbed(postedBodies.join("\n"));
+    expect(calls.some((args) => args.includes("repos/acme/widgets/pulls/9/reviews"))).toBe(true);
+  });
+
+  it("scrubs PR create title and body in the merge seam", async () => {
+    withSyntheticEnv();
+    const calls: string[][] = [];
+    const exec: Exec = async (args) => {
+      calls.push([...args]);
+      if (args.includes("list")) {
+        const previousCreates = calls.filter((call) => call.includes("create")).length;
+        return { code: 0, stdout: previousCreates > 0 ? "88\n" : "", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    };
+
+    await landPr(exec, {
+      repo: "acme/widgets",
+      gitRepo: "/repo",
+      remote: "origin",
+      branch: "afk/test",
+      target: "main",
+      n: 1365,
+      title: LEAK_TEXT,
+      mergeQueue: true,
+    });
+
+    const create = calls.find((args) => args.includes("create"));
+    expect(create).toBeTruthy();
+    expectScrubbed(create!.join("\n"));
+    expect(create!.join("\n")).toContain("Closes #1365");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1365. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1365

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786196424&installation_id=129708444&pr_number=1371&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1371&signature=71dd706431b531a9927ce05aa0bdae67628dfe88546c1de10ad556847dbba475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->