### PR TITLE
fix(afk): protect plugin hooks/scripts and CI composite actions in the sensitive-path gate

### DIFF
--- a/apps/dev/src/commands/redact-sweep.ts
+++ b/apps/dev/src/commands/redact-sweep.ts
@@ -30,11 +30,11 @@ interface RepoReport {
   edited: string[];
 }
 
-const LEGACY_HOST_PATTERN = "cyber-XPS";
-
 function parseOptions(args: readonly string[]): RedactSweepOptions {
   const repos: string[] = [];
-  const hostPatterns: string[] = [hostname(), LEGACY_HOST_PATTERN].filter(Boolean);
+  // Current hostname by default; historical/legacy host prefixes come in via
+  // --host-pattern so no machine identity is ever hardcoded in public source.
+  const hostPatterns: string[] = [hostname()].filter(Boolean);
   let apply = false;
   let json = false;
 

--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -187,10 +187,13 @@ export async function runSharedGate(
  */
 export const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
   /^\.github\/workflows\//,     // CI workflow files
+  /^\.github\/actions\//,       // composite actions executed by CI workflows
   /(?:^|\/)\.git\/hooks\//,    // git hooks directory
   /^\.husky\//,                // Husky hooks
   /^\.githooks\//,             // alternative git hooks directory
   /^\.red\//,                  // .red/ trust/gate config and gate's own config
+  /^plugins\/[^/]+\/hooks\//,  // agent plugin hooks — execute on every agent action
+  /^plugins\/[^/]+\/scripts\//, // agent plugin launcher scripts invoked by hooks
 ];
 
 /**
@@ -272,9 +275,12 @@ export function checkSensitivePaths(
 
 function sensitivePathReason(filePath: string): string {
   if (/^\.github\/workflows\//.test(filePath)) return "CI workflow file";
+  if (/^\.github\/actions\//.test(filePath)) return "CI composite action";
   if (/(?:^|\/)\.git\/hooks\//.test(filePath) || /^\.husky\//.test(filePath) || /^\.githooks\//.test(filePath))
     return "git hook";
   if (/^\.red\//.test(filePath)) return "trust/gate configuration";
+  if (/^plugins\/[^/]+\/hooks\//.test(filePath)) return "agent plugin hook";
+  if (/^plugins\/[^/]+\/scripts\//.test(filePath)) return "agent plugin launcher script";
   return "sensitive path";
 }
 

--- a/apps/dev/src/runtime/outbound-redaction.ts
+++ b/apps/dev/src/runtime/outbound-redaction.ts
@@ -5,6 +5,22 @@ const CLAUDE_SESSION_RE = /https:\/\/claude\.ai\/code\/session_[A-Za-z0-9_-]+/g;
 const SECRET_KEY_RE = /(?:TOKEN|SECRET|KEY|PASSWORD|PASS|AUTH|BEARER|COOKIE|SESSION|ANTHROPIC|OPENAI|MINIMAX|OPENROUTER|AWS_|GOOGLE_|SLACK_|NPM_|GH_|GITHUB_)/i;
 const FALSEY_SECRET_VALUES = new Set(["true", "false", "null", "0", "1"]);
 
+/**
+ * OS usernames that are also ordinary prose/protocol words. Bare token-boundary
+ * masking of these would mangle unrelated text — `runner=codex` in a claim
+ * marker becomes `[REDACTED_USER]=codex` when the process runs as the GitHub
+ * Actions `runner` user. Path-context masking (`/home/<user>/`) still applies.
+ */
+const COMMON_USERNAMES = new Set([
+  "runner", "root", "user", "admin", "ubuntu", "debian", "node",
+  "dev", "ci", "build", "agent", "worker", "actions", "git",
+]);
+
+function maskableUsername(username: string | undefined): username is string {
+  if (!username || username.length < 4) return false;
+  return !COMMON_USERNAMES.has(username.toLowerCase());
+}
+
 export interface ScrubOutboundOptions {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
@@ -66,10 +82,9 @@ function scrubKeyValueSecrets(input: string): string {
 function scrubHomeIdentity(input: string, options: ScrubOutboundOptions): string {
   let out = input;
   const home = options.homeDir || homedir();
-  out = replaceLiteral(out, "/home/cyber", "[REDACTED_HOME]");
   if (home) out = replaceLiteral(out, home, "[REDACTED_HOME]");
-  out = out.replace(/\/home\/([A-Za-z0-9._-]+)\//g, "/home/[REDACTED_USER]/");
-  out = out.replace(/\/Users\/([A-Za-z0-9._-]+)\//g, "/Users/[REDACTED_USER]/");
+  out = out.replace(/\/home\/([A-Za-z0-9._-]+)(?![A-Za-z0-9._-])/g, "/home/[REDACTED_USER]");
+  out = out.replace(/\/Users\/([A-Za-z0-9._-]+)(?![A-Za-z0-9._-])/g, "/Users/[REDACTED_USER]");
   return out;
 }
 
@@ -93,7 +108,7 @@ export function scrubOutbound(value: unknown, options: ScrubOutboundOptions = {}
         username = undefined;
       }
     }
-    if (username) out = replaceTokenBoundary(out, username, "[REDACTED_USER]");
+    if (maskableUsername(username)) out = replaceTokenBoundary(out, username, "[REDACTED_USER]");
     return out;
   } catch {
     return typeof value === "string" ? value : String(value ?? "");

--- a/apps/dev/tests/outbound-redaction.test.ts
+++ b/apps/dev/tests/outbound-redaction.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { comment, createIssue, editBody, postClaimComment, updateMainRedRepairIssue, type GhContext } from "../src/runtime/gh.js";
 import { buildReviewGh } from "../src/runtime/review-gh.js";
@@ -13,7 +14,10 @@ const LEAK_TEXT = [
   `literal ${LEAK_ENV_VALUE}`,
   "OPENAI_API_KEY=sk-test-123456789",
   '{"github_token":"ghp_1234567890abcdef"}',
-  "/home/cyber/.config/red-skills",
+  // The REAL current home so [REDACTED_HOME] asserts hold on any machine/CI,
+  // plus a foreign home for the generic /home/<user> rule.
+  `${homedir()}/.config/red-skills`,
+  "/home/leakuser/data",
 ].join("\n");
 
 function withSyntheticEnv(): void {
@@ -29,10 +33,12 @@ function expectScrubbed(value: string): void {
   expect(value).not.toContain(LEAK_ENV_VALUE);
   expect(value).not.toContain("sk-test-123456789");
   expect(value).not.toContain("ghp_1234567890abcdef");
-  expect(value).not.toContain("/home/cyber");
+  expect(value).not.toContain(homedir());
+  expect(value).not.toContain("/home/leakuser");
   expect(value).toContain("[REDACTED_CLAUDE_SESSION]");
   expect(value).toContain("[REDACTED_SECRET]");
   expect(value).toContain("[REDACTED_HOME]");
+  expect(value).toContain("/home/[REDACTED_USER]/data");
 }
 
 describe("scrubOutbound", () => {
@@ -77,6 +83,20 @@ describe("scrubOutbound", () => {
   it("never throws on non-string and binary-ish input", () => {
     expect(typeof scrubOutbound(Buffer.from([0, 1, 2, 255]))).toBe("string");
     expect(scrubOutbound(null)).toBe("");
+  });
+
+  it("does NOT bare-mask common-word usernames (GitHub Actions runs as `runner`)", () => {
+    const marker = "<!-- afk:claim v1 worker=w kind=claim runner=codex -->";
+    // `runner` as OS username must not mangle `runner=codex` in machine markers.
+    expect(scrubOutbound(marker, { username: "runner", hostname: "host-x" })).toBe(marker);
+    // Path-context masking still protects a common-word user's home path.
+    expect(
+      scrubOutbound("/home/runner/work/x", { username: "runner", hostname: "host-x", homeDir: "/root/none" }),
+    ).toBe("/home/[REDACTED_USER]/work/x");
+    // Distinctive usernames are still bare-masked at token boundaries.
+    expect(scrubOutbound("built by alicezilla today", { username: "alicezilla", hostname: "host-x" })).toBe(
+      "built by [REDACTED_USER] today",
+    );
   });
 });
 

--- a/apps/dev/tests/redact-sweep.test.ts
+++ b/apps/dev/tests/redact-sweep.test.ts
@@ -10,7 +10,7 @@ import { redactSweepCommand, type RedactSweepGitHub } from "../src/commands/reda
 import { parseCli } from "../src/cli.js";
 
 const CONFIG = {
-  hostPatterns: ["cyber-XPS", "build-host"],
+  hostPatterns: ["leakhost-XPS", "build-host"],
 };
 
 function target(body: string, author = "alice"): RedactTarget {
@@ -49,8 +49,8 @@ describe("redact-sweep detection and redaction", () => {
   it("detects claude session links, configured host patterns, and /home paths", () => {
     const text = [
       "session https://claude.ai/code/session_01ABCxyz",
-      "host cyber-XPS-9560 and build-host",
-      "path /home/cyber/Work/reddb.io/red-skills/file.ts",
+      "host leakhost-XPS-9560 and build-host",
+      "path /home/leakuser/Work/reddb.io/red-skills/file.ts",
     ].join("\n");
 
     expect(findRedactionHits(text, CONFIG).map((hit) => hit.class)).toEqual([
@@ -62,14 +62,14 @@ describe("redact-sweep detection and redaction", () => {
   });
 
   it("redacts each leak class with stable placeholders", () => {
-    const text = "https://claude.ai/code/session_secret on cyber-XPS-13 in /home/cyber/project";
+    const text = "https://claude.ai/code/session_secret on leakhost-XPS-13 in /home/leakuser/project";
     expect(redactText(text, CONFIG).text).toBe(
       "[REDACTED_CLAUDE_SESSION] on [REDACTED_HOST] in /home/[REDACTED_USER]/project",
     );
   });
 
   it("is idempotent after redaction", () => {
-    const first = redactText("https://claude.ai/code/session_secret /home/cyber/project cyber-XPS-13", CONFIG);
+    const first = redactText("https://claude.ai/code/session_secret /home/leakuser/project leakhost-XPS-13", CONFIG);
     expect(findRedactionHits(first.text, CONFIG)).toEqual([]);
     expect(redactText(first.text, CONFIG).text).toBe(first.text);
   });
@@ -103,7 +103,7 @@ describe("redact-sweep detection and redaction", () => {
   });
 
   it("defaults to dry-run and writes nothing", async () => {
-    const gh = fakeGh([target("https://claude.ai/code/session_secret from /home/cyber/project")]);
+    const gh = fakeGh([target("https://claude.ai/code/session_secret from /home/leakuser/project")]);
     const out = collect();
     const code = await redactSweepCommand(["--repo", "reddb-io/red-skills"], "/repo", out.stream, gh);
 
@@ -115,8 +115,8 @@ describe("redact-sweep detection and redaction", () => {
 
   it("--apply edits only authenticated-user targets and is replay-idempotent", async () => {
     const gh = fakeGh([
-      target("https://claude.ai/code/session_secret from /home/cyber/project"),
-      target("cyber-XPS-13 from /home/bob/project", "bob"),
+      target("https://claude.ai/code/session_secret from /home/leakuser/project"),
+      target("leakhost-XPS-13 from /home/bob/project", "bob"),
     ]);
     const first = collect();
     expect(await redactSweepCommand(["--repo", "reddb-io/red-skills", "--apply"], "/repo", first.stream, gh)).toBe(0);

--- a/apps/dev/tests/shared-gate.test.ts
+++ b/apps/dev/tests/shared-gate.test.ts
@@ -336,6 +336,27 @@ describe("isSensitivePath — path pattern matching", () => {
     expect(isSensitivePath(".red/adr/0001-init.md")).toBe(true);
   });
 
+  it("flags .github/actions/* composite actions as sensitive", () => {
+    expect(isSensitivePath(".github/actions/afk-attempt/action.yml")).toBe(true);
+    expect(isSensitivePath(".github/actions/install-red-binary/action.yml")).toBe(true);
+  });
+
+  it("flags agent plugin hooks as sensitive (any plugin)", () => {
+    expect(isSensitivePath("plugins/dev/hooks/command-guard.sh")).toBe(true);
+    expect(isSensitivePath("plugins/dev/hooks/claude.hooks.json")).toBe(true);
+    expect(isSensitivePath("plugins/memory/hooks/precompact.sh")).toBe(true);
+  });
+
+  it("flags agent plugin launcher scripts as sensitive (any plugin)", () => {
+    expect(isSensitivePath("plugins/dev/scripts/memory-bridge.sh")).toBe(true);
+    expect(isSensitivePath("plugins/brain/scripts/bootstrap.mjs")).toBe(true);
+  });
+
+  it("does NOT flag plugin skills or docs as sensitive", () => {
+    expect(isSensitivePath("plugins/dev/skills/engineering/afk/SKILL.md")).toBe(false);
+    expect(isSensitivePath("plugins/dev/.claude-plugin/plugin.json")).toBe(false);
+  });
+
   it("does NOT flag ordinary source files", () => {
     expect(isSensitivePath("src/index.ts")).toBe(false);
     expect(isSensitivePath("apps/dev/src/core/landing.ts")).toBe(false);


### PR DESCRIPTION
Closes the guard gap observed when ticket #1366 (PR #1370) modified `plugins/dev/hooks/command-guard.sh` and auto-landed without the `blocked:sensitive-path` park.

Extends the closed `SENSITIVE_PATH_PATTERNS` set (issue #1102) with:
- `plugins/*/hooks/` — agent plugin hooks, executed on every agent action
- `plugins/*/scripts/` — the launcher/bootstrap scripts those hooks invoke
- `.github/actions/` — composite actions executed by CI workflows

Plugin skills/docs/manifests stay unprotected (negative tests included). Also the first `fix:`-typed commit since v2.21.0, so the deferred release (carrying the #1364 no-leak wave: scrubOutbound #1371, contract+guard #1370, redact-sweep #1369) ships.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786197509&installation_id=129708444&pr_number=1372&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1372&signature=4e89a34ed271c6ff3da2c443ceca531a15310d296d2011991b4140f8d6d0a9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->