### PR TITLE
chore: #1373 /go and AFK landings type every PR commit as chore:, silently deferring semantic releases

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -205,6 +205,8 @@ export interface LandingInput {
   title: string;
   /** Issue labels used to derive the landing-created conventional merge title. */
   labels?: readonly string[];
+  /** Changed files in the worker branch, used to classify fallback landing titles. */
+  changedFiles?: readonly string[];
   /**
    * Sensitive-path guard bypass (issue #1171). Defaults false/undefined. When
    * true, the step-0a sensitive-path guard scan is SKIPPED so a branch whose diff
@@ -235,10 +237,46 @@ export interface LandingInput {
   nativeMergeQueue?: boolean;
 }
 
-export function landingMergeTitle(input: { issue: number; title: string; labels?: readonly string[] }): string {
+function isDocsOnlyPath(path: string): boolean {
+  const normalized = path.trim().toLowerCase();
+  return normalized !== "" && (
+    normalized.startsWith("docs/") ||
+    normalized.startsWith(".github/issue_template/") ||
+    normalized.endsWith(".md") ||
+    normalized.endsWith(".mdx") ||
+    normalized.endsWith(".txt") ||
+    normalized.endsWith(".adoc") ||
+    normalized.endsWith(".rst")
+  );
+}
+
+function isRuntimePath(path: string): boolean {
+  const normalized = path.trim().toLowerCase();
+  if (normalized === "" || isDocsOnlyPath(normalized)) return false;
+  if (normalized.startsWith("apps/") || normalized.startsWith("packages/") || normalized.startsWith("plugins/")) {
+    return /\.(cjs|cts|js|jsx|mjs|mts|sh|ts|tsx)$/.test(normalized);
+  }
+  if (normalized.startsWith("src/")) {
+    return /\.(cjs|cts|js|jsx|mjs|mts|sh|ts|tsx)$/.test(normalized);
+  }
+  if (normalized.startsWith("scripts/") && !normalized.startsWith("scripts/test-")) {
+    return /\.(cjs|cts|js|jsx|mjs|mts|sh|ts|tsx)$/.test(normalized);
+  }
+  return false;
+}
+
+export function landingMergeTitle(input: {
+  issue: number;
+  title: string;
+  labels?: readonly string[];
+  changedFiles?: readonly string[];
+}): string {
   const labels = new Set((input.labels ?? []).map((label) => label.trim().toLowerCase()));
   let prefix = "chore";
-  if (labels.has("type:bug") || labels.has("bug")) {
+  const changedFiles = input.changedFiles ?? [];
+  if (changedFiles.length > 0 && changedFiles.every(isDocsOnlyPath)) {
+    prefix = "docs";
+  } else if (labels.has("type:bug") || labels.has("bug") || labels.has("type:fix") || labels.has("fix")) {
     prefix = "fix";
   } else if (
     labels.has("type:feature") ||
@@ -247,6 +285,8 @@ export function landingMergeTitle(input: { issue: number; title: string; labels?
     labels.has("enhancement")
   ) {
     prefix = "feat";
+  } else if (changedFiles.some(isRuntimePath)) {
+    prefix = "fix";
   }
   return `${prefix}: #${input.issue} ${input.title}`;
 }
@@ -421,8 +461,11 @@ export async function doLanding(
   // `/requeue --adopt-branch` no-agent lane, so the guard is skipped ONLY here.
   // The flag defaults false; no autonomous attempt path sets it, so the guard
   // keeps firing on every normal AFK/go landing.
-  if (deps.getDiffPaths && input.sensitivePathApproved !== true) {
-    const { changedFiles, packageJsonDiff } = await deps.getDiffPaths();
+  const diffPaths = deps.getDiffPaths ? await deps.getDiffPaths() : undefined;
+  const landingInput = diffPaths ? { ...input, changedFiles: diffPaths.changedFiles } : input;
+
+  if (diffPaths && input.sensitivePathApproved !== true) {
+    const { changedFiles, packageJsonDiff } = diffPaths;
     const hits = checkSensitivePaths(changedFiles, packageJsonDiff);
     if (hits.length > 0) {
       return { ok: false, reason: "sensitive-paths", locked, sensitivePaths: hits };
@@ -500,7 +543,7 @@ export async function doLanding(
 
   let landed: LandingResult;
   try {
-    landed = input.openPr ? await landAdminPr(deps, input) : await landDirectInWorktree(deps, input);
+    landed = landingInput.openPr ? await landAdminPr(deps, landingInput) : await landDirectInWorktree(deps, landingInput);
   } finally {
     await release?.();
   }

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -116,6 +116,8 @@ interface Opts {
   mainRedRepairIssue?: boolean;
   /** Issue labels used to derive the landing-created conventional merge title. */
   labels?: string[];
+  /** Changed files used for fallback conventional-title classification (#1373). */
+  changedFiles?: string[];
   /** Force the admin PR path to create a PR instead of reusing an open one. */
   createPr?: boolean;
   /**
@@ -268,13 +270,14 @@ function harness(opts: Opts = {}): Harness {
           removedRebaseWorktrees.push(dir);
         }
       : undefined,
-    // #1102: only wired when the test opts in (opt-in — absent → guard skipped).
-    getDiffPaths: opts.sensitivePaths
+    // #1102/#1373: only wired when the test opts in (opt-in — absent → guard skipped).
+    getDiffPaths: opts.sensitivePaths || opts.changedFiles
       ? async () => ({
           changedFiles:
-            opts.sensitivePaths === "hit"
+            opts.changedFiles ??
+            (opts.sensitivePaths === "hit"
               ? [".github/workflows/ci.yml", "src/index.ts"]
-              : ["src/index.ts", "apps/dev/src/core/landing.ts"],
+              : ["src/index.ts", "apps/dev/src/core/landing.ts"]),
           packageJsonDiff: "",
         })
       : undefined,
@@ -449,8 +452,11 @@ describe("doLanding — conventional landing titles (#1267)", () => {
     { labels: ["type:feature"], title: "feat: #9 Fix the thing" },
     { labels: ["enhancement"], title: "feat: #9 Fix the thing" },
     { labels: ["type:task"], title: "chore: #9 Fix the thing" },
-  ])("direct/no-agent landing maps $labels to $title", async ({ labels, title }) => {
-    const h = harness({ locked: true, labels });
+    { labels: ["lane:go"], changedFiles: ["apps/dev/src/core/go.ts"], title: "fix: #9 Fix the thing" },
+    { labels: ["lane:go"], changedFiles: ["docs/OPERATIONS.md"], title: "docs: #9 Fix the thing" },
+    { labels: ["lane:go"], changedFiles: ["scripts/test-red-release-bump-kind.sh"], title: "chore: #9 Fix the thing" },
+  ])("direct/no-agent landing maps $labels to $title", async ({ labels, changedFiles, title }) => {
+    const h = harness({ locked: true, labels, changedFiles });
     const r = await doLanding(h.deps, h.input, h.hooks);
 
     expect(r.ok).toBe(true);

--- a/scripts/decide-release-bump-kind.mjs
+++ b/scripts/decide-release-bump-kind.mjs
@@ -110,7 +110,13 @@ function decideBumpKind(commits, allowMajor) {
     return { kind: "patch", consumeMajorOptIn: false, warning: "" };
   }
 
-  return { kind: "none", consumeMajorOptIn: false, warning: "" };
+  return {
+    kind: "none",
+    consumeMajorOptIn: false,
+    warning: commits.length > 0
+      ? `::warning::red-release skipped ${commits.length} non-releasable commit(s) with no feat/fix conventional type: ${commits.map(commitLabel).join("; ")}`
+      : "",
+  };
 }
 
 function writeOutput(name, value) {

--- a/scripts/test-red-release-bump-kind.sh
+++ b/scripts/test-red-release-bump-kind.sh
@@ -21,6 +21,7 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 commits="$tmpdir/commits.json"
+non_releasable_commits="$tmpdir/non-releasable-commits.json"
 workflow=".github/workflows/red-release.yml"
 cat > "$commits" <<'JSON'
 [
@@ -36,10 +37,32 @@ cat > "$commits" <<'JSON'
   }
 ]
 JSON
+cat > "$non_releasable_commits" <<'JSON'
+[
+  {
+    "hash": "cccccccccccccccccccccccccccccccccccccccc",
+    "subject": "docs: refresh AFK guide",
+    "body": ""
+  },
+  {
+    "hash": "dddddddddddddddddddddddddddddddddddddddd",
+    "subject": "chore: #1364 preserve security cleanup",
+    "body": ""
+  }
+]
+JSON
 
 run_decider() {
   local allow_major="$1" stdout_file="$2" output_file="$3"
   RED_RELEASE_COMMIT_FIXTURE="$commits" \
+    RED_RELEASE_ALLOW_MAJOR="$allow_major" \
+    GITHUB_OUTPUT="$output_file" \
+    node scripts/decide-release-bump-kind.mjs > "$stdout_file"
+}
+
+run_decider_with_fixture() {
+  local fixture="$1" allow_major="$2" stdout_file="$3" output_file="$4"
+  RED_RELEASE_COMMIT_FIXTURE="$fixture" \
     RED_RELEASE_ALLOW_MAJOR="$allow_major" \
     GITHUB_OUTPUT="$output_file" \
     node scripts/decide-release-bump-kind.mjs > "$stdout_file"
@@ -87,6 +110,26 @@ if run_decider "true" "$stdout" "$outputs"; then
   fi
 else
   fail "decider failed with opt-in"
+fi
+
+stdout="$tmpdir/non-releasable.stdout"
+outputs="$tmpdir/non-releasable.outputs"
+if run_decider_with_fixture "$non_releasable_commits" "" "$stdout" "$outputs"; then
+  if grep -q '^kind=none$' "$outputs"; then
+    pass "non-releasable commits still skip the version bump"
+  else
+    fail "non-releasable commits must output kind=none"
+  fi
+
+  if grep -q '^::warning::red-release skipped 2 non-releasable commit(s)' "$stdout" &&
+     grep -q 'cccccccc docs: refresh AFK guide' "$stdout" &&
+     grep -q 'dddddddd chore: #1364 preserve security cleanup' "$stdout"; then
+    pass "skip warning names commits with non-releasable types"
+  else
+    fail "kind=none must emit a visible warning naming skipped commits"
+  fi
+else
+  fail "decider failed for non-releasable commits"
 fi
 
 if grep -qF 'run: scripts/test-red-release-bump-kind.sh' "$workflow"; then


### PR DESCRIPTION
Automated AFK landing for #1373. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1373

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786201771&installation_id=129708444&pr_number=1376&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1376&signature=d649b77fd387c9f2169a26518df30dbd58429d4fed3a589736fe0e6af828d1a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->