### PR TITLE
fix: #1378 Progress guard gives a non-committing edit-loop worker 90min of runway; stale-base test-spin runaways block the pipeline

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -434,6 +434,7 @@ export interface RunAgentResult {
   branch: string;
   commits: readonly { sha: string }[];
   completionSignal?: string;
+  timeoutReason?: AttemptTimeoutReason;
   /**
    * The validated structured completion (ADR 0082) when the agent emitted a
    * well-formed `<agent-output>` block. Carries `summary`, `key_changes_made`,
@@ -1043,6 +1044,9 @@ export interface AttemptBudgetUsage {
   waiting: number;
 }
 
+export type AttemptTimeoutReason = "stalled" | "edit-loop-stall" | "hard-cap";
+type AttemptGuardAbortReason = AttemptTimeoutReason | "goal-moot" | "budget";
+
 /**
  * Pure budget predicate: is any configured ceiling reached? Returns the breached
  * ceiling's name (for the abort message / observability) or `undefined`. Unset
@@ -1067,11 +1071,11 @@ export function startAttemptGuard(opts: {
   headProbe: () => Promise<string | undefined>;
   now: () => number;
   schedule: (fn: () => void, ms: number) => () => void;
-  /** `reason` distinguishes the soft commit/edit deadline ("stalled") from the
-   * commit-anchored hard cap ("hard-cap", issue #637) and the goal predicate
-   * ("goal-moot", ADR 0057 — the claimed issue is already CLOSED). Callbacks that
-   * ignore the argument keep the prior behaviour. */
-  abort: (reason: "stalled" | "hard-cap" | "goal-moot" | "budget") => void;
+  /** `reason` distinguishes the soft commit/edit deadline ("stalled"), edit-loop
+   * churn without diff growth ("edit-loop-stall"), the commit-anchored hard cap
+   * ("hard-cap", issue #637), and the non-timeout guards. Callbacks that ignore
+   * the argument keep the prior behaviour. */
+  abort: (reason: AttemptGuardAbortReason) => void;
   /**
    * Per-attempt resource budget (#908). When both `budget` and `budgetUsage` are
    * supplied, the guard reads the cumulative usage each poll and aborts with
@@ -1109,6 +1113,8 @@ export function startAttemptGuard(opts: {
   let lastCommit = opts.now();
   let lastHead: string | undefined;
   let lastVolume: number | undefined;
+  let diffHighWater: number | undefined;
+  let sawNonGrowingEditSinceProgress = false;
   let fired = false;
   let goalMoot = false;
   let budgetFired = false;
@@ -1161,8 +1167,10 @@ export function startAttemptGuard(opts: {
         headOk = false;
       }
       if (fired) return;
-      // Edit signal (optional). A new commit OR a change in the worktree's
-      // line-volume since the last poll is real progress → reset the deadline.
+      // Edit signal (optional). Only NEW diff high-water growth is real progress.
+      // Plain motion (shrinking/oscillating volume) proves the agent is active,
+      // but it does not advance the branch diff vs base and must not keep the
+      // soft deadline open until the hard cap.
       let volume: number | undefined;
       if (opts.progressProbe) {
         try {
@@ -1173,24 +1181,33 @@ export function startAttemptGuard(opts: {
       }
       if (fired) return;
       const committed = headOk && head !== undefined && head !== lastHead;
-      const edited = volume !== undefined && lastVolume !== undefined && volume !== lastVolume;
+      const volumeChanged = volume !== undefined && lastVolume !== undefined && volume !== lastVolume;
+      const grewDiff = volume !== undefined && diffHighWater !== undefined && volume > diffHighWater;
+      const nonGrowingEdit = volumeChanged && !grewDiff;
       if (committed) {
         lastProgress = opts.now();
         lastCommit = opts.now();
-      } else if (edited) {
+        sawNonGrowingEditSinceProgress = false;
+      } else if (grewDiff) {
         lastProgress = opts.now();
+        sawNonGrowingEditSinceProgress = false;
+      } else if (nonGrowingEdit) {
+        sawNonGrowingEditSinceProgress = true;
       }
-      // The soft deadline resets on commit OR edit; the hard cap resets on
+      // The soft deadline resets on commit OR diff growth; the hard cap resets on
       // commit ONLY, so periodic edits cannot keep an uncommitting agent alive
       // past it (issue #637 — the 5h+ re-validation loop).
-      const softExpired = !committed && !edited && opts.now() - lastProgress >= opts.capMs;
+      const softExpired = !committed && !grewDiff && opts.now() - lastProgress >= opts.capMs;
       const hardExpired = !committed && opts.hardCapMs !== undefined && opts.now() - lastCommit >= opts.hardCapMs;
       if (softExpired || hardExpired) {
         fired = true;
-        opts.abort(hardExpired && !softExpired ? "hard-cap" : "stalled");
+        opts.abort(hardExpired && !softExpired ? "hard-cap" : sawNonGrowingEditSinceProgress ? "edit-loop-stall" : "stalled");
       }
       if (headOk && head !== undefined) lastHead = head;
-      if (volume !== undefined) lastVolume = volume;
+      if (volume !== undefined) {
+        lastVolume = volume;
+        diffHighWater = diffHighWater === undefined ? volume : Math.max(diffHighWater, volume);
+      }
       opts.onTick?.({ head: head ?? lastHead, lastProgressMs: lastProgress, nowMs: opts.now() });
     })();
   }, opts.intervalMs);
@@ -1252,6 +1269,7 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
   let guard:
     | { stop: () => void; firedTimeout: () => boolean; firedGoalMoot: () => boolean; firedBudget: () => boolean }
     | undefined;
+  let timeoutReason: AttemptTimeoutReason | undefined;
   let laneReaper: { stop: () => void; firedReap: () => boolean } | undefined;
   let controller: AbortController | undefined;
   if (input.attemptTimeoutSeconds && input.attemptTimeoutSeconds > 0 && input.headProbe) {
@@ -1269,7 +1287,8 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
       schedule,
       ...(input.goalProbe ? { goalProbe: input.goalProbe } : {}),
       ...(input.budget && input.budgetUsage ? { budget: input.budget, budgetUsage: input.budgetUsage } : {}),
-      abort: (reason) =>
+      abort: (reason) => {
+        if (reason === "stalled" || reason === "edit-loop-stall" || reason === "hard-cap") timeoutReason = reason;
         controller?.abort(
           new Error(
             reason === "goal-moot"
@@ -1278,9 +1297,12 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
                 ? "afk: attempt aborted — per-attempt resource budget exceeded (#908)"
                 : reason === "hard-cap"
                   ? `afk: attempt aborted — no new commit within ${hardCap}s despite worktree edits (hard cap, stalled)`
-                  : `afk: attempt aborted — no new commit within ${cap}s (stalled)`,
+                  : reason === "edit-loop-stall"
+                    ? `afk: attempt aborted — worktree diff kept changing without new high-water progress within ${cap}s (edit-loop-stall)`
+                    : `afk: attempt aborted — no new commit within ${cap}s (stalled)`,
           ),
-        ),
+        );
+      },
       // Externalized proof-of-life (PR-B): each poll fires the caller's opaque
       // heartbeat sink (firehose record + state.last_progress_at + on_heartbeat
       // hook). execution.ts stays ignorant of what it does.
@@ -1375,7 +1397,13 @@ export async function runAgent(deps: SandcastleDeps, input: RunAgentInput): Prom
         outcome: "timeout",
         branch: input.branch,
         commits: [],
-        stdout: `afk: attempt aborted — no new commit within ${input.attemptTimeoutSeconds}s (stalled)`,
+        timeoutReason: timeoutReason ?? "stalled",
+        stdout:
+          timeoutReason === "edit-loop-stall"
+            ? `afk: attempt aborted — worktree diff kept changing without new high-water progress within ${input.attemptTimeoutSeconds}s (edit-loop-stall)`
+            : timeoutReason === "hard-cap"
+              ? `afk: attempt aborted — no new commit within ${input.attemptHardCapSeconds}s despite worktree edits (hard cap, stalled)`
+              : `afk: attempt aborted — no new commit within ${input.attemptTimeoutSeconds}s (stalled)`,
       };
     }
     if (isExhaustionError(error)) {

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -808,6 +808,21 @@ function stateExitPatch(outcome: ProcessOutcome): Record<string, unknown> {
   return { ...base, "current.last_exit_code": CRASH_EXIT_CODE };
 }
 
+function timeoutReasonForEnvelope(reason: RunAgentResult["timeoutReason"] | undefined): string {
+  return reason ?? "stalled";
+}
+
+function timeoutNotes(reason: RunAgentResult["timeoutReason"] | undefined): string {
+  const typedReason = timeoutReasonForEnvelope(reason);
+  if (typedReason === "edit-loop-stall") {
+    return "_(attempt aborted by attempt guard: edit-loop-stall — worktree diff volume changed without reaching a new high-water mark)_";
+  }
+  if (typedReason === "hard-cap") {
+    return "_(attempt aborted by attempt guard: hard-cap — worktree edits continued without a fresh commit)_";
+  }
+  return "_(attempt aborted by attempt guard: stalled — no new commit or diff growth within the wall-clock guard)_";
+}
+
 function markTerminalState(deps: ProcessIssueDeps, outcome: ProcessOutcome): void {
   deps.markState?.(stateExitPatch(outcome));
 }
@@ -1896,7 +1911,7 @@ export async function processIssue(
           workspace: branch,
           runner: activeRunner,
           attempt_n: attemptN,
-          reason: "timeout",
+          reason: timeoutReasonForEnvelope(run.timeoutReason),
         }),
       );
       // Before escalating, try the ADR 0055 NO-AGENT reconcile: a stalled attempt
@@ -1963,7 +1978,7 @@ export async function processIssue(
       // ("stalled") = null → always escalate).
       await fireHook("on_attempt_error", onErrorContext(current, workerBranch, "stalled", current.attempt));
       return await terminalFailure(common, "stalled", "stalled", {
-        notes: "_(no Notes appended; attempt aborted — inner agent made no progress within the wall-clock guard)_",
+        notes: timeoutNotes(run.timeoutReason),
         log: run.stdout || "(attempt progress guard fired)",
       });
     } else {

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -1704,7 +1704,7 @@ describe("startAttemptGuard — diff-anchored progress (ADR 0051, codex false-st
     expect(g.firedTimeout()).toBe(true);
   });
 
-  it("treats a volume change in EITHER direction as progress (edits then a partial revert)", async () => {
+  it("does not reset the deadline for shrinking diff volume, but stays alive while still within the cap", async () => {
     let clock = 0;
     let volume = 100;
     const sched = manualScheduler();
@@ -1722,11 +1722,45 @@ describe("startAttemptGuard — diff-anchored progress (ADR 0051, codex false-st
     });
     await sched.tick(); // anchor (100)
     clock = 80;
-    volume = 60; // a revert is still activity
+    volume = 60; // shrink is activity, but not diff growth
     await sched.tick();
-    clock = 160;
-    await sched.tick(); // only 80ms since the last change → alive
+    clock = 90;
+    await sched.tick(); // only 90ms since anchor → alive even though shrink did not reset
     expect(aborted).toBe(false);
+  });
+
+  it("aborts an edit-loop whose diff volume oscillates without a new high-water mark", async () => {
+    let clock = 0;
+    let volume = 10;
+    const sched = manualScheduler();
+    let reason: string | undefined;
+    const g = startAttemptGuard({
+      capMs: 100,
+      intervalMs: 50,
+      hardCapMs: 1000,
+      headProbe: async () => "sha-static",
+      progressProbe: async () => volume,
+      now: () => clock,
+      schedule: sched.schedule,
+      abort: (r) => {
+        reason = r;
+      },
+    });
+    await sched.tick(); // anchor at volume=10
+    clock = 50;
+    volume = 20;
+    await sched.tick(); // new high-water mark → real progress
+    expect(reason).toBeUndefined();
+    clock = 100;
+    volume = 10;
+    await sched.tick(); // shrink: activity, no progress reset
+    expect(reason).toBeUndefined();
+    clock = 150;
+    volume = 20;
+    await sched.tick(); // oscillates back to the old high-water mark → abort before hard cap
+    expect(reason).toBe("edit-loop-stall");
+    expect(g.firedTimeout()).toBe(true);
+    g.stop();
   });
 
   it("degrades to commit-anchored when progressProbe rejects (never the cause of a false reset)", async () => {
@@ -1845,7 +1879,7 @@ describe("startAttemptGuard — commit-anchored hard cap (issue #637, busy-but-u
     expect(reason).toBe("stalled");
   });
 
-  it("without hardCapMs, continuous edits extend indefinitely (ADR 0051 behaviour unchanged)", async () => {
+  it("without hardCapMs, continuous diff growth extends indefinitely (ADR 0051 behaviour unchanged)", async () => {
     let clock = 0;
     let volume = 10;
     const sched = manualScheduler();
@@ -1877,6 +1911,45 @@ describe("startAttemptGuard — commit-anchored hard cap (issue #637, busy-but-u
 });
 
 describe("runAgent — hard cap wiring (issue #637)", () => {
+  it("returns timeout with edit-loop-stall when oscillating edits do not grow the diff", async () => {
+    let clock = 0;
+    let volume = 10;
+    const sched = manualScheduler();
+    const controller = new AbortController();
+    const deps: SandcastleDeps = {
+      ...makeDeps(
+        (o) =>
+          new Promise<RunResult>((_resolve, reject) => {
+            o.signal?.addEventListener("abort", () => reject(o.signal?.reason ?? new Error("aborted")));
+          }),
+      ),
+      now: () => clock,
+      schedule: sched.schedule,
+      makeAbortController: () => controller,
+    };
+    const p = runAgent(deps, {
+      ...baseInput,
+      attemptTimeoutSeconds: 1,
+      attemptHardCapSeconds: 90,
+      headProbe: async () => "static",
+      progressProbe: async () => volume,
+    });
+    await sched.tick(); // anchor
+    clock = 500;
+    volume = 20;
+    await sched.tick(); // growth → alive
+    clock = 1000;
+    volume = 10;
+    await sched.tick(); // shrink → no reset
+    clock = 1500;
+    volume = 20;
+    await sched.tick(); // no new high-water mark → soft abort, well before 90s hard cap
+    const res = await p;
+    expect(res.outcome).toBe("timeout");
+    expect(res.timeoutReason).toBe("edit-loop-stall");
+    expect(String((controller.signal.reason as Error).message)).toContain("edit-loop-stall");
+  });
+
   it("returns the 'timeout' outcome when the hard cap aborts an editing-but-never-committing run", async () => {
     let clock = 0;
     let volume = 0;

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -78,6 +78,7 @@ interface HarnessOptions {
    * the verdict for the test (self worker is "h:w"). */
   claim?: { winner: "self" | "other" };
   outcome?: RunAgentResult["outcome"];
+  timeoutReason?: RunAgentResult["timeoutReason"];
   /** Scripted per-call outcomes (overrides `outcome`); one entry per runAgent call. */
   outcomes?: RunAgentResult["outcome"][];
   feedbackOk?: boolean;
@@ -476,6 +477,7 @@ function harness(opts: HarnessOptions = {}): {
             : thisOutcome === "blocked"
               ? "<promise>BLOCKED</promise>"
               : undefined,
+        timeoutReason: thisOutcome === "timeout" ? opts.timeoutReason : undefined,
         stdout: thisOutcome === "no-sentinel" ? "Edit src/x.ts\nlast line, no sentinel" : "",
       };
     },
@@ -3061,6 +3063,20 @@ describe("processIssue — timeout (attempt progress guard fired)", () => {
       "on_reconcile",
       "on_attempt_error",
     ]);
+  });
+
+  it("records edit-loop-stall distinctly in the blocked envelope when oscillating edits trip the guard", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "timeout",
+      timeoutReason: "edit-loop-stall",
+      changedFiles: [],
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("stalled");
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.envelopeBodies.at(-1)).toContain("edit-loop-stall");
+    expect(result.hooksFired).toContain("on_attempt_timeout");
   });
 
   it("reconcile lands the stalled-but-green branch WITHOUT re-running the agent (no escalation)", async () => {


### PR DESCRIPTION
Automated AFK landing for #1378. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1378

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786204820&installation_id=129708444&pr_number=1381&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1381&signature=2fef58c763b0f488eef3b84dd71db4bf391f594488340ef7b7b7bbec5e807f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->