### PR TITLE
fix: #1380 Worker base resolution can branch from a deeply stale local base — resolve the fetched origin tip or park typed

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -947,8 +947,10 @@ export function buildProcessDeps(
       headShortSha: () => gitx.headShortSha(gitCtx),
       deleteLocalBranch: (branch) => gitx.deleteLocalBranch(gitCtx, branch),
       // Make the resolved base ref current before sandcastle forks off it
-      // (ADR 0031). Best-effort: a fetch failure leaves sandcastle on the
-      // stale/HEAD default rather than aborting the iteration.
+      // (ADR 0031/#1380). Online workers fork from freshly-fetched
+      // origin/<base>; offline workers may use the local base only when it is not
+      // behind the last-known origin tip.
+      resolveFreshBase: (input) => gitx.resolveFreshBase(gitCtx, input),
       fetchBase: async (base) => {
         await gitx.gitExec(gitCtx)(["fetch", ctx.remote, base]);
       },

--- a/apps/dev/src/core/attempt-outcome.ts
+++ b/apps/dev/src/core/attempt-outcome.ts
@@ -39,6 +39,7 @@ import {
   LABEL_TRUNK_DIVERGED,
   LABEL_SENSITIVE_PATH,
   LABEL_MAIN_RED_UNTRACKED,
+  LABEL_BASE_STALE,
 } from "./triage-labels.js";
 
 /**
@@ -113,6 +114,10 @@ export type AttemptOutcome =
   // while the auto-filed main-red repair issue is open. If the repair issue is
   // absent, landing refuses so the red baseline stays visible and tracked.
   | "main-red-untracked"
+  // Base freshness guard (#1380): remote fetch failed and the local base branch is
+  // behind the last-known remote-tracking tip. The worker never starts from that
+  // rotten local base; the issue parks for a human/network recovery.
+  | "base-stale"
   | "infra";
 
 /**
@@ -175,6 +180,8 @@ export function blockedLabelFor(o: AttemptOutcome): string | null {
       return LABEL_SENSITIVE_PATH;
     case "main-red-untracked":
       return LABEL_MAIN_RED_UNTRACKED;
+    case "base-stale":
+      return LABEL_BASE_STALE;
     case "infra":
       return LABEL_INFRA;
     case "done":
@@ -248,6 +255,9 @@ export function envelopeStatusFor(o: AttemptOutcome): AttemptStatus {
     // branch passed its gate, but main is red without the auto-filed repair
     // issue that keeps continued delivery visible and tracked.
     case "main-red-untracked":
+    // base-stale (#1380) folds into the generic `blocked` bucket — no worker ran;
+    // the local base is too stale to trust while the remote is unreachable.
+    case "base-stale":
     case "infra":
     // review-requested is a handoff, not a failure: the per-issue lifecycle
     // emits no terminal failure envelope for it (it parks the issue + opens the
@@ -325,6 +335,9 @@ export function recoveryReasonFor(o: AttemptOutcome): RecoveryReason | null {
     // repair issue exists; rerunning the agent would re-hit the same visibility
     // gate.
     case "main-red-untracked":
+    // base-stale (#1380) is NON-recoverable in-process: a bounded agent retry
+    // cannot make the remote reachable or refresh the local base safely.
+    case "base-stale":
     case "infra":
     case "done":
     case "claim-lost":

--- a/apps/dev/src/core/envelope-emit.ts
+++ b/apps/dev/src/core/envelope-emit.ts
@@ -103,6 +103,8 @@ export interface SectionBodies {
   log?: string;
   /** Package-aware feedback report (done). */
   validation?: string;
+  /** Resolved worker base ref/sha evidence (issue #1380). */
+  base?: string;
   /** One `<lifecycle> <command> exit=<rc>` line per user-declared hook that ran
    * (issue #215). Empty/undefined skips the section. Excluded on `discarded`. */
   hooks?: string;
@@ -140,17 +142,21 @@ export function buildSections(
 
   if (status === "done") {
     if (sections.validation !== undefined) out.push({ name: "validation", body: sections.validation });
+    if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   } else if (status === "blocked") {
     out.push({ name: "notes", body: sections.notes ?? "" });
     if (sections.validation !== undefined) out.push({ name: "validation", body: sections.validation });
     out.push({ name: "diff", body: diffBody() });
+    if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   } else if (status === "no-sentinel") {
     out.push({ name: "notes", body: sections.notes ?? "" });
     out.push({ name: "diff", body: diffBody() });
     out.push({ name: "log", body: sections.log ?? "", fenced: true });
+    if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   } else if (status === "merge-conflict") {
     out.push({ name: "diff", body: diffBody() });
     out.push({ name: "log", body: sections.log ?? "", fenced: true });
+    if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   }
 
   // Hooks block sits last across every status except discarded; skipped when

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -238,6 +238,13 @@ export interface ProcessGit {
    */
   fetchBase?(base: string): Promise<void>;
   /**
+   * Resolve the exact base commit a new worker branch should fork from. Preferred
+   * over `fetchBase`: online it fetches and returns `origin/<base>`; offline it
+   * permits the local branch only when it is not behind the last-known origin tip,
+   * else returns `ok:false, reason:"base-stale"` so the attempt parks typed.
+   */
+  resolveFreshBase?(input: { base: string; remote: string }): Promise<WorkerBaseResolution>;
+  /**
    * Adapter-side guard for sandcastle's named-branch reuse path. After
    * `fetchBase()` refreshes `origin/<base>`, remove stale local worker state
    * before `runAgent()` so red-castle must recreate the worker branch from
@@ -247,6 +254,20 @@ export interface ProcessGit {
    * implementation, preserving same-run reuse when the branch is already current.
    */
   prepareFreshWorkerBranch?(input: { branch: string; baseRef: string; force: boolean }): Promise<boolean | void>;
+}
+
+export interface WorkerBaseResolution {
+  ok: boolean;
+  base: string;
+  baseRef: string;
+  sha: string;
+  source: "remote" | "local";
+  remoteReachable: boolean;
+  localSha?: string;
+  localAhead?: number;
+  localBehind?: number;
+  reason?: "base-stale";
+  message?: string;
 }
 
 /** Injected lookups the composed deciders need (issue body for the pin, the
@@ -293,6 +314,34 @@ function remoteTrackingBaseRef(remote: string, base: string): string {
     return base;
   }
   return `${remote}/${base}`;
+}
+
+function baseResolutionStatePatch(resolution: WorkerBaseResolution): Record<string, unknown> {
+  return {
+    "current.base": resolution.base,
+    "current.base_ref": resolution.baseRef,
+    "current.base_sha": resolution.sha,
+    "current.base_source": resolution.source,
+    "current.base_remote_reachable": resolution.remoteReachable,
+    ...(resolution.localSha ? { "current.base_local_sha": resolution.localSha } : {}),
+    ...(resolution.localAhead !== undefined ? { "current.base_local_ahead": resolution.localAhead } : {}),
+    ...(resolution.localBehind !== undefined ? { "current.base_local_behind": resolution.localBehind } : {}),
+  };
+}
+
+function formatBaseResolution(resolution: WorkerBaseResolution): string {
+  return [
+    `base: ${resolution.base}`,
+    `ref: ${resolution.baseRef}`,
+    `sha: ${resolution.sha || "(unresolved)"}`,
+    `source: ${resolution.source}`,
+    `remote_reachable: ${String(resolution.remoteReachable)}`,
+    resolution.localSha ? `local_sha: ${resolution.localSha}` : undefined,
+    resolution.localAhead !== undefined ? `local_ahead: ${resolution.localAhead}` : undefined,
+    resolution.localBehind !== undefined ? `local_behind: ${resolution.localBehind}` : undefined,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
 }
 
 function isMergeConflictRetry(priorAttemptContext: string | undefined): boolean {
@@ -1450,12 +1499,47 @@ export async function processIssue(
   // prompt, detects the DONE/BLOCKED completion signal, and commits on `branch`.
   // Make the resolved base ref current so sandcastle forks the worker branch off
   // it (ADR 0031): the pinned/locked base becomes the branch's parent, not HEAD.
-  // fetchBase runs `git fetch origin <base>` which updates the remote-tracking
-  // ref (origin/main) but NOT the local branch. We therefore pass the
-  // remote-tracking ref to runAgent so sandcastle's baseBranch start point
-  // uses the freshly-fetched ref, not the potentially-stale local branch.
-  if (deps.git.fetchBase) await deps.git.fetchBase(base);
-  const baseRef = remoteTrackingBaseRef(input.remote, base);
+  // The preferred resolver fetches `origin/<base>` and returns that concrete tip;
+  // if the remote is unreachable it permits the local branch only when it is not
+  // behind the last-known origin tip. A stale local base parks typed instead of
+  // silently forking a branch that can revert already-landed sibling work (#1380).
+  let baseResolution: WorkerBaseResolution;
+  if (deps.git.resolveFreshBase) {
+    baseResolution = await deps.git.resolveFreshBase({ base, remote: input.remote });
+  } else {
+    if (deps.git.fetchBase) await deps.git.fetchBase(base);
+    baseResolution = {
+      ok: true,
+      base,
+      baseRef: remoteTrackingBaseRef(input.remote, base),
+      sha: "",
+      source: "remote",
+      remoteReachable: true,
+    };
+  }
+  deps.markState?.(baseResolutionStatePatch(baseResolution));
+  if (!baseResolution.ok) {
+    const staleCommon: StageCommon = {
+      deps,
+      input,
+      branch,
+      base,
+      slug,
+      hooksFired,
+      startedEpoch,
+      issueType: deriveIssueType(labels),
+      modelTier: taskClass,
+      model: deps.model,
+      effort: deps.effort,
+      resolvedBase: baseResolution,
+    };
+    const message = baseResolution.message ?? "Base is stale; remote is unreachable and local ref is behind.";
+    return await terminalFailure(staleCommon, "base-stale", "base-stale", {
+      notes: message,
+      log: message,
+    });
+  }
+  const baseRef = baseResolution.baseRef;
   await deps.git.prepareFreshWorkerBranch?.({
     branch,
     baseRef,
@@ -1489,6 +1573,7 @@ export async function processIssue(
     modelTier: activeTaskClass,
     model: deps.model,
     effort: deps.effort,
+    resolvedBase: baseResolution,
   };
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
@@ -2581,6 +2666,8 @@ interface StageCommon {
   modelTier: AfkModelTier;
   model?: string;
   effort?: AgentEffort;
+  /** Resolved base commit/ref evidence for state and envelope observability. */
+  resolvedBase?: WorkerBaseResolution;
   /**
    * Backpressure checks that ran on the DONE path (issue #1279), captured so the
    * downstream landing/handoff paths can render the non-blocking evidence ledger
@@ -2636,7 +2723,7 @@ async function emitFailure(
     repoDir: input.repoDir,
     worktreeRel: input.attemptDir,
     diffstat: "",
-    sections,
+    sections: { ...sections, ...(c.resolvedBase ? { base: formatBaseResolution(c.resolvedBase) } : {}) },
     historyPath: deps.historyPath,
     historyClock: deps.historyClock,
     historyFields: { runner: input.runner },
@@ -2730,6 +2817,13 @@ function blockerForFailure(outcome: ProcessOutcome, sections: SectionBodies): Cu
         kind: "main-red-untracked",
         summary: oneLine(sections.log, "Admin-merge refused because main is red without an open main-red repair issue."),
         next: "Restore or create the auto-filed main-red repair issue, then requeue.",
+      };
+    case "base-stale":
+      return {
+        status: "blocked",
+        kind: "base-stale",
+        summary: oneLine(sections.log, "Remote base was unreachable and the local base is stale."),
+        next: "Refresh the local base from origin, or restore remote access, then requeue.",
       };
     case "infra":
       return {
@@ -2921,7 +3015,10 @@ async function emitDone(
     attempt: input.attempt,
     mergeSha,
     diff: "merged",
-    sections: { validation: `${scopeHeader}${validationSidecar.join("\n")}` },
+    sections: {
+      validation: `${scopeHeader}${validationSidecar.join("\n")}`,
+      ...(c.resolvedBase ? { base: formatBaseResolution(c.resolvedBase) } : {}),
+    },
     historyPath: deps.historyPath,
     historyClock: deps.historyClock,
     historyFields: { runner: input.runner, merge_sha: mergeSha },

--- a/apps/dev/src/core/triage-labels.ts
+++ b/apps/dev/src/core/triage-labels.ts
@@ -109,6 +109,11 @@ export const LABEL_SENSITIVE_PATH = "blocked:sensitive-path";
 // visibility issue is absent, landing refuses with this human-only label instead
 // of silently delivering onto untracked red.
 export const LABEL_MAIN_RED_UNTRACKED = "blocked:main-red-untracked";
+// Attempt base resolution guard (#1380): the remote base could not be fetched and
+// the local base branch is behind the last-known remote-tracking tip. A worker
+// must never branch from that stale local base because it can revert already
+// landed sibling work.
+export const LABEL_BASE_STALE = "blocked:base-stale";
 // AFK runner improvement (#908): the per-attempt resource budget guard aborted
 // the attempt — it breached a token/cost/tool-call/waiting-window ceiling before
 // it could finish. Distinct from `blocked:stalled` (a stall is *no* progress;

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -114,6 +114,120 @@ export async function fetchBranch(ctx: GitContext, branch: string): Promise<void
   await runGit(ctx, ["fetch", "origin", branch]);
 }
 
+export interface ResolveFreshBaseInput {
+  base: string;
+  remote?: string;
+}
+
+export interface FreshBaseResolution {
+  ok: boolean;
+  base: string;
+  baseRef: string;
+  sha: string;
+  source: "remote" | "local";
+  remoteReachable: boolean;
+  localSha?: string;
+  localAhead?: number;
+  localBehind?: number;
+  reason?: "base-stale";
+  message?: string;
+}
+
+async function revParse(ctx: GitContext, ref: string): Promise<string | undefined> {
+  const r = await runGit(ctx, ["rev-parse", "--verify", "--quiet", ref]);
+  const sha = r.stdout.trim();
+  return r.code === 0 && sha !== "" ? sha : undefined;
+}
+
+async function localAheadBehind(
+  ctx: GitContext,
+  localRef: string,
+  remoteRef: string,
+): Promise<{ ahead: number; behind: number } | undefined> {
+  const r = await runGit(ctx, ["rev-list", "--left-right", "--count", `${localRef}...${remoteRef}`]);
+  if (r.code !== 0) return undefined;
+  const [aheadRaw, behindRaw] = r.stdout.trim().split(/\s+/);
+  const ahead = Number(aheadRaw);
+  const behind = Number(behindRaw);
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) return undefined;
+  return { ahead, behind };
+}
+
+/**
+ * Resolve the concrete commit a new AFK worker should branch from.
+ *
+ * Online: fetch `<remote> <base>` and use the freshly-fetched
+ * `<remote>/<base>` ref, never the local branch. Offline: fall back to the local
+ * branch only when it is not behind the last-known remote-tracking tip; a stale
+ * local branch returns a typed `base-stale` park decision instead of silently
+ * forking from rotten history.
+ */
+export async function resolveFreshBase(
+  ctx: GitContext,
+  input: ResolveFreshBaseInput,
+): Promise<FreshBaseResolution> {
+  const base = input.base.trim();
+  const remote = input.remote?.trim() || "origin";
+  const remoteRef = `${remote}/${base}`;
+  const localRef = `refs/heads/${base}`;
+  const fetch = base ? await runGit(ctx, ["fetch", remote, base]) : failOutput("empty base");
+  const remoteSha = base ? await revParse(ctx, remoteRef) : undefined;
+  const localSha = base ? await revParse(ctx, localRef) : undefined;
+  const counts =
+    localSha && remoteSha ? await localAheadBehind(ctx, localRef, remoteRef) : undefined;
+  const localAhead = counts?.ahead;
+  const localBehind = counts?.behind;
+
+  if (fetch.code === 0 && remoteSha) {
+    return {
+      ok: true,
+      base,
+      baseRef: remoteRef,
+      sha: remoteSha,
+      source: "remote",
+      remoteReachable: true,
+      localSha,
+      localAhead,
+      localBehind,
+    };
+  }
+
+  if (localSha && (localBehind ?? 0) === 0) {
+    return {
+      ok: true,
+      base,
+      baseRef: base,
+      sha: localSha,
+      source: "local",
+      remoteReachable: false,
+      localSha,
+      localAhead,
+      localBehind,
+    };
+  }
+
+  return {
+    ok: false,
+    base,
+    baseRef: remoteRef,
+    sha: remoteSha ?? localSha ?? "",
+    source: "local",
+    remoteReachable: false,
+    localSha,
+    localAhead,
+    localBehind,
+    reason: "base-stale",
+    message:
+      localSha && remoteSha
+        ? `local ${base} is ${localBehind ?? "unknown"} commit(s) behind last-known ${remoteRef}`
+        : `could not resolve a fresh or non-stale local base for ${base}`,
+  };
+}
+
+function failOutput(stderr: string): ExecOutput {
+  return { code: 1, stdout: "", stderr };
+}
+
 export interface FreshWorkerBranchInput {
   branch: string;
   baseRef: string;

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -54,6 +54,17 @@ export const AfkCurrentSchema = z.object({
    * first heartbeat so the monitor/statusline fallback diffstat uses the correct
    * ref instead of hardcoding origin/main. */
   base: z.string().default(""),
+  /** Concrete resolved base ref/tip evidence for this attempt (#1380). The
+   * attempt-start path writes these before the inner agent runs so monitor and
+   * envelopes can distinguish a freshly fetched `origin/<base>` worker from an
+   * offline local-base fallback or a typed stale-base park. */
+  base_ref: z.string().default(""),
+  base_sha: z.string().default(""),
+  base_source: z.string().default(""),
+  base_remote_reachable: z.boolean().default(false),
+  base_local_sha: z.string().default(""),
+  base_local_ahead: z.number().default(0),
+  base_local_behind: z.number().default(0),
   /** Per-attempt stream-activity counters (the WorkerVitals activity + progress
    * groups, ADR 0065), mirrored from the proof-of-life heartbeat's `statePatch`
    * (core/heartbeat.ts → buildProgressHeartbeat) each ~60s poll. These MUST be

--- a/apps/dev/tests/attempt-outcome.test.ts
+++ b/apps/dev/tests/attempt-outcome.test.ts
@@ -51,6 +51,7 @@ const TABLE: Row[] = [
   // #908: a budget abort carries the typed `blocked:budget` label and is NOT
   // auto-recoverable (escalate — a runaway is not a transient flake).
   { outcome: "budget-exceeded", label: "blocked:budget", recovery: null },
+  { outcome: "base-stale", label: "blocked:base-stale", recovery: null },
   { outcome: "infra", label: "blocked:infra", recovery: null },
   // no typed label, no recovery (success / abandoned)
   { outcome: "done", label: null, recovery: null },
@@ -84,6 +85,7 @@ describe("attempt-outcome — exhaustive outcome → (label, recovery) table", (
       "runner-transient",
       "stalled",
       "budget-exceeded",
+      "base-stale",
       "infra",
     ];
     const covered = TABLE.map((r) => r.outcome).sort();
@@ -144,6 +146,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
     { outcome: "claim-lost", status: "blocked" },
     { outcome: "stalled", status: "blocked" },
     { outcome: "budget-exceeded", status: "blocked" },
+    { outcome: "base-stale", status: "blocked" },
     { outcome: "infra", status: "blocked" },
   ];
 
@@ -170,6 +173,7 @@ describe("attempt-outcome — exhaustive outcome → envelope status table", () 
       "runner-transient",
       "stalled",
       "budget-exceeded",
+      "base-stale",
       "infra",
     ];
     const covered = STATUS_TABLE.map((r) => r.outcome).sort();

--- a/apps/dev/tests/runtime-git-branch.test.ts
+++ b/apps/dev/tests/runtime-git-branch.test.ts
@@ -9,6 +9,7 @@ import {
   fetchBranch,
   changedFiles,
   prepareFreshWorkerBranch,
+  resolveFreshBase,
   worktreePathForBranch,
   worktreePathUnder,
   salvageUncommitted,
@@ -79,6 +80,73 @@ describe("fetchBranch (FIX E recovery)", () => {
     const ctx: GitContext = { cwd: "/repo", exec };
     await fetchBranch(ctx, "");
     expect(calls).toEqual([]);
+  });
+});
+
+describe("resolveFreshBase (worker base freshness)", () => {
+  it("fetches the base and uses the remote-tracking tip when local is behind", async () => {
+    const { exec, calls } = recordingExec((_cmd, args) => {
+      const joined = args.join(" ");
+      if (joined === "fetch origin main") return ok("");
+      if (joined === "rev-parse --verify --quiet origin/main") return ok("remote-tip\n");
+      if (joined === "rev-parse --verify --quiet refs/heads/main") return ok("local-tip\n");
+      if (joined === "rev-list --left-right --count refs/heads/main...origin/main") return ok("0\t3\n");
+      return fail();
+    });
+
+    await expect(resolveFreshBase({ cwd: "/repo", exec }, { base: "main", remote: "origin" })).resolves.toMatchObject({
+      ok: true,
+      baseRef: "origin/main",
+      sha: "remote-tip",
+      source: "remote",
+      remoteReachable: true,
+      localSha: "local-tip",
+      localAhead: 0,
+      localBehind: 3,
+    });
+    expect(calls[0]).toEqual(["git", "fetch", "origin", "main"]);
+  });
+
+  it("allows offline local fallback when local is not behind the last-known origin tip", async () => {
+    const { exec } = recordingExec((_cmd, args) => {
+      const joined = args.join(" ");
+      if (joined === "fetch origin main") return fail();
+      if (joined === "rev-parse --verify --quiet origin/main") return ok("same-tip\n");
+      if (joined === "rev-parse --verify --quiet refs/heads/main") return ok("same-tip\n");
+      if (joined === "rev-list --left-right --count refs/heads/main...origin/main") return ok("0\t0\n");
+      return fail();
+    });
+
+    await expect(resolveFreshBase({ cwd: "/repo", exec }, { base: "main", remote: "origin" })).resolves.toMatchObject({
+      ok: true,
+      baseRef: "main",
+      sha: "same-tip",
+      source: "local",
+      remoteReachable: false,
+      localBehind: 0,
+    });
+  });
+
+  it("parks typed when offline local fallback is behind the last-known origin tip", async () => {
+    const { exec } = recordingExec((_cmd, args) => {
+      const joined = args.join(" ");
+      if (joined === "fetch origin main") return fail();
+      if (joined === "rev-parse --verify --quiet origin/main") return ok("remote-tip\n");
+      if (joined === "rev-parse --verify --quiet refs/heads/main") return ok("local-tip\n");
+      if (joined === "rev-list --left-right --count refs/heads/main...origin/main") return ok("0\t4\n");
+      return fail();
+    });
+
+    await expect(resolveFreshBase({ cwd: "/repo", exec }, { base: "main", remote: "origin" })).resolves.toMatchObject({
+      ok: false,
+      reason: "base-stale",
+      baseRef: "origin/main",
+      sha: "remote-tip",
+      source: "local",
+      remoteReachable: false,
+      localSha: "local-tip",
+      localBehind: 4,
+    });
   });
 });
 

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -35,6 +35,35 @@ describe("state", () => {
     expect(await readFile(path, "utf8")).toContain('"version":1');
   });
 
+  it("round-trips resolved base provenance fields through state updates", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+    await initState(path, { worker_id: "wAAAA", pid: 123, "current.stage": "setup" });
+
+    await updateState(path, {
+      "current.base": "main",
+      "current.base_ref": "origin/main",
+      "current.base_sha": "feedface",
+      "current.base_source": "remote",
+      "current.base_remote_reachable": true,
+      "current.base_local_sha": "badc0de",
+      "current.base_local_ahead": 0,
+      "current.base_local_behind": 4,
+    });
+
+    const state = await readState(path);
+    expect(state.current).toMatchObject({
+      base: "main",
+      base_ref: "origin/main",
+      base_sha: "feedface",
+      base_source: "remote",
+      base_remote_reachable: true,
+      base_local_sha: "badc0de",
+      base_local_ahead: 0,
+      base_local_behind: 4,
+    });
+  });
+
   it("initStateSync seeds identity synchronously so a later updateState preserves it", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
     const path = join(dir, "afk.state.json");


### PR DESCRIPTION
Automated AFK landing for #1380. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1380

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786205138&installation_id=129708444&pr_number=1382&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1382&signature=271cf90e4e5b8f6ccd9295d52b00e5bbeb3c6e3d11c6d8eb1f3d8d0edfbfca0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->