### PR TITLE
feat(afk): host-env allowlist + capture-time stream redaction (#1368)

### DIFF
--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -14,6 +14,8 @@
 
 import type { AgentStreamEvent, RunOptions, RunResult, LivenessVerdict } from "@reddb-io/red-castle";
 import { extractAgentOutput } from "@reddb-io/red-castle";
+import { buildLineRedactor } from "../runtime/outbound-redaction.js";
+import { resolveHostEnvAllowlist } from "./host-env-allowlist.js";
 import { isRunnerExhausted } from "./runner-spawn.js";
 import { startLaneIdleReaper, DEFAULT_STALL_POLL_S } from "./lane-idle-reaper.js";
 import { RUNNER_SPECS, runnerSupportsStructuredOutput } from "./runner-spec.js";
@@ -870,6 +872,13 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
     ? {
         type: "file",
         path: input.logPath,
+        // Capture-time leak masking (issue #1368): every textual stream event
+        // (raw line, text/reasoning message, result, tool-call args) passes
+        // through the precomputed line redactor BEFORE the event sink and the
+        // verbose file sink, so secrets/session links/host identity never
+        // reach the firehose, heartbeat vitals, or log tails that envelopes
+        // later relay. Defense-in-depth under the outbound scrubOutbound seam.
+        redactLine: buildLineRedactor(),
         ...(input.onAgentEvent ? { onAgentStreamEvent: input.onAgentEvent } : {}),
       }
     : undefined;
@@ -1517,7 +1526,15 @@ export async function defaultSandcastleDeps(): Promise<SandcastleDeps> {
     const mounts = opts?.mountPath ? [{ hostPath: opts.mountPath, sandboxPath: opts.mountPath }] : undefined;
     if (mode === "docker") return dockerMod.docker(mounts ? { mounts } : undefined);
     if (mode === "podman") return podmanMod.podman(mounts ? { mounts } : undefined);
-    return noSandboxMod.noSandbox();
+    // Host-env minimization (issue #1368): the agent process inherits only the
+    // allowlisted host env (shell basics, ssh/git/gh, agent auth, RED_*, the
+    // language toolchains) — never the full process.env with unrelated host
+    // secrets. RED_AFK_HOST_ENV_ALLOW extends the list; the literal `*`
+    // disables minimization (pre-#1368 behavior). Per-attempt env delivered by
+    // mutating process.env (the FIX J lane) stays visible because those keys
+    // (CARGO*, RED_*) are allowlisted.
+    const hostEnvAllowlist = resolveHostEnvAllowlist(process.env);
+    return noSandboxMod.noSandbox(hostEnvAllowlist ? { hostEnvAllowlist } : undefined);
   };
   return { run: core.run as SandcastleDeps["run"], agentFor, sandboxFor, warn };
 }

--- a/apps/dev/src/core/host-env-allowlist.ts
+++ b/apps/dev/src/core/host-env-allowlist.ts
@@ -1,0 +1,67 @@
+/**
+ * Host-env allowlist for the no-sandbox agent process (issue #1368).
+ *
+ * Under the default `noSandbox` mode the inner agent used to inherit the
+ * ENTIRE host `process.env` — including cloud credentials and arbitrary shell
+ * exports the agent has no business seeing. red-castle's
+ * `noSandbox({ hostEnvAllowlist })` now filters the base env; this module owns
+ * WHAT the AFK runtime admits.
+ *
+ * Policy: default-deny with a generous toolchain allowlist. Everything an
+ * agent legitimately needs — shell basics, ssh/git/gh auth, the agent CLIs'
+ * own auth and state, our RED_* controls, and the language toolchains the
+ * reddb ecosystem builds with — passes; unrelated host secrets (AWS_*,
+ * GOOGLE_*, SLACK_*, DOCKER_*, random exports) do not.
+ *
+ * Entries are exact names or `*`-suffixed prefix globs (red-castle
+ * `pickAllowedEnv` semantics). Go vars are enumerated individually because a
+ * `GO*` glob would admit `GOOGLE_*`.
+ */
+export const AFK_HOST_ENV_ALLOWLIST: readonly string[] = [
+  // shell / locale / terminal basics
+  "PATH", "HOME", "SHELL", "USER", "LOGNAME", "PWD",
+  "TMPDIR", "TMP", "TEMP", "TERM", "COLORTERM",
+  "LANG", "LANGUAGE", "LC_*", "TZ", "EDITOR", "PAGER", "CI",
+  "XDG_*",
+  // ssh + git + GitHub CLI (worker pushes over SSH; gh needs its token)
+  "SSH_*", "GIT_*", "GH_*", "GITHUB_*",
+  // agent CLIs: auth, state, harness signals
+  "CLAUDE*", "ANTHROPIC*", "CODEX*", "OPENAI*", "OPENCODE*",
+  "MINIMAX*", "OPENROUTER*",
+  // our own controls (afk knobs, heartbeat, namespaces)
+  "RED_*", "RTK_*",
+  // JS/TS toolchain
+  "NODE*", "NVM_*", "ASDF*", "NPM*", "PNPM*", "COREPACK*",
+  "BUN*", "YARN*", "TURBO*", "VITEST*",
+  // Rust
+  "CARGO*", "RUSTUP*", "RUST*",
+  // Go (enumerated — a GO* glob would admit GOOGLE_*)
+  "GOPATH", "GOROOT", "GOBIN", "GOCACHE", "GOMODCACHE",
+  "GOFLAGS", "GOPROXY", "GOPRIVATE", "GONOSUMDB", "GOTOOLCHAIN",
+  // Python
+  "PYTHON*", "PIP*", "UV_*", "VIRTUAL_ENV", "PYENV*",
+  // JVM
+  "JAVA*", "GRADLE*", "MAVEN*", "M2_*", "SDKMAN*", "KOTLIN*",
+  // PHP / .NET / Dart / Zig
+  "PHP*", "COMPOSER*", "DOTNET*", "NUGET*", "DART*", "PUB_*", "FLUTTER*", "ZIG*",
+  // native build basics
+  "CC", "CXX", "MAKEFLAGS", "PKG_CONFIG*", "LD_*",
+];
+
+/**
+ * Resolve the effective allowlist. `RED_AFK_HOST_ENV_ALLOW` extends the
+ * default with comma-separated extra entries; the single literal `*` is the
+ * escape hatch that disables minimization entirely (returns undefined →
+ * red-castle inherits the full host env, the pre-#1368 behavior).
+ */
+export function resolveHostEnvAllowlist(
+  env: NodeJS.ProcessEnv = process.env,
+): readonly string[] | undefined {
+  const raw = env.RED_AFK_HOST_ENV_ALLOW ?? "";
+  const extra = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (extra.includes("*")) return undefined;
+  return extra.length > 0 ? [...AFK_HOST_ENV_ALLOWLIST, ...extra] : AFK_HOST_ENV_ALLOWLIST;
+}

--- a/apps/dev/src/runtime/outbound-redaction.ts
+++ b/apps/dev/src/runtime/outbound-redaction.ts
@@ -114,3 +114,43 @@ export function scrubOutbound(value: unknown, options: ScrubOutboundOptions = {}
     return typeof value === "string" ? value : String(value ?? "");
   }
 }
+
+/**
+ * Build a fast per-line redactor for hot paths (the red-castle stream
+ * `redactLine` hook runs on EVERY agent output line). Unlike
+ * {@link scrubOutbound}, the expensive inputs — env secret values, home dir,
+ * hostname, its fingerprint replacement — are resolved ONCE at build time and
+ * captured in the closure; each call is then pure string work. Same redaction
+ * classes as scrubOutbound minus bare-username masking (see the common-word
+ * username lesson on the COMMON_USERNAMES doc).
+ */
+export function buildLineRedactor(options: ScrubOutboundOptions = {}): (text: string) => string {
+  let secrets: string[] = [];
+  let home = "";
+  let host = "";
+  let hostReplacement = "[REDACTED_HOST]";
+  try {
+    secrets = envSecretValues(options.env ?? process.env);
+    home = options.homeDir || homedir();
+    host = options.hostname ?? osHostname();
+    hostReplacement = options.hostReplacement ?? defaultHostReplacement();
+  } catch {
+    // Partial initialization is fine — each captured input degrades independently.
+  }
+  return (text: string): string => {
+    try {
+      let out = text.replace(CLAUDE_SESSION_RE, "[REDACTED_CLAUDE_SESSION]");
+      for (const secret of secrets) {
+        out = replaceLiteral(out, secret, "[REDACTED_SECRET]");
+      }
+      out = scrubKeyValueSecrets(out);
+      if (home) out = replaceLiteral(out, home, "[REDACTED_HOME]");
+      out = out.replace(/\/home\/([A-Za-z0-9._-]+)(?![A-Za-z0-9._-])/g, "/home/[REDACTED_USER]");
+      out = out.replace(/\/Users\/([A-Za-z0-9._-]+)(?![A-Za-z0-9._-])/g, "/Users/[REDACTED_USER]");
+      if (host) out = replaceTokenBoundary(out, host, hostReplacement);
+      return out;
+    } catch {
+      return text;
+    }
+  };
+}

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -397,7 +397,22 @@ describe("buildRunOptions", () => {
       makeDeps(async () => fakeResult()),
       { ...baseInput, logPath: "/abs/attempt/dir/sandcastle.log" },
     );
-    expect(opts.logging).toEqual({ type: "file", path: "/abs/attempt/dir/sandcastle.log" });
+    expect(opts.logging).toMatchObject({ type: "file", path: "/abs/attempt/dir/sandcastle.log" });
+  });
+
+  it("wires a capture-time redactLine into file logging (#1368 leak masking)", () => {
+    const opts = buildRunOptions(
+      makeDeps(async () => fakeResult()),
+      { ...baseInput, logPath: "/abs/attempt/dir/sandcastle.log" },
+    );
+    const redact = (opts.logging as { redactLine?: (t: string) => string }).redactLine;
+    expect(redact).toBeTypeOf("function");
+    expect(redact!("see https://claude.ai/code/session_abc123 now")).toBe(
+      "see [REDACTED_CLAUDE_SESSION] now",
+    );
+    // Non-leaking machine markers pass through byte-identical.
+    const marker = "<!-- afk:claim v1 worker=w kind=claim runner=codex -->";
+    expect(redact!(marker)).toBe(marker);
   });
 
   it("wires onAgentEvent into logging.onAgentStreamEvent for native-path liveness", () => {

--- a/apps/dev/tests/host-env-allowlist.test.ts
+++ b/apps/dev/tests/host-env-allowlist.test.ts
@@ -1,0 +1,90 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { pickAllowedEnv } from "@reddb-io/red-castle/sandboxes/no-sandbox";
+import { AFK_HOST_ENV_ALLOWLIST, resolveHostEnvAllowlist } from "../src/core/host-env-allowlist.js";
+import { buildLineRedactor } from "../src/runtime/outbound-redaction.js";
+
+describe("AFK_HOST_ENV_ALLOWLIST", () => {
+  const pick = (env: Record<string, string>) => pickAllowedEnv(env, AFK_HOST_ENV_ALLOWLIST);
+
+  it("admits shell basics, ssh/git/gh auth, agent auth, RED_* and toolchains", () => {
+    const admitted = pick({
+      PATH: "/bin",
+      HOME: "/home/x",
+      SSH_AUTH_SOCK: "/tmp/agent.sock",
+      GH_TOKEN: "t",
+      GITHUB_TOKEN: "t",
+      ANTHROPIC_API_KEY: "k",
+      CLAUDE_CODE_ENTRYPOINT: "cli",
+      CODEX_HOME: "/home/x/.codex",
+      RED_AFK_RUNNER: "codex",
+      CARGO_TARGET_DIR: "/tmp/slot-1",
+      PNPM_HOME: "/home/x/.pnpm",
+      GOPATH: "/home/x/go",
+      JAVA_HOME: "/usr/lib/jvm",
+      LC_ALL: "C.UTF-8",
+      XDG_CONFIG_HOME: "/home/x/.config",
+    });
+    expect(Object.keys(admitted)).toHaveLength(15);
+  });
+
+  it("denies unrelated host secrets (default-deny)", () => {
+    const denied = pick({
+      AWS_SECRET_ACCESS_KEY: "leak",
+      AWS_ACCESS_KEY_ID: "leak",
+      GOOGLE_APPLICATION_CREDENTIALS: "/leak.json",
+      SLACK_BOT_TOKEN: "leak",
+      DOCKER_PASSWORD: "leak",
+      MY_RANDOM_EXPORT: "leak",
+      DATABASE_URL: "leak",
+    });
+    expect(denied).toEqual({});
+  });
+
+  it("the Go entries are enumerated so GOOGLE_* is never admitted by a glob", () => {
+    const out = pick({ GOPATH: "x", GOOGLE_API_KEY: "leak" });
+    expect(out).toEqual({ GOPATH: "x" });
+  });
+});
+
+describe("resolveHostEnvAllowlist", () => {
+  it("returns the default list when the override is unset", () => {
+    expect(resolveHostEnvAllowlist({})).toBe(AFK_HOST_ENV_ALLOWLIST);
+  });
+
+  it("extends the default with comma-separated extra entries", () => {
+    const out = resolveHostEnvAllowlist({ RED_AFK_HOST_ENV_ALLOW: "FOO, BAR_*" });
+    expect(out).toContain("FOO");
+    expect(out).toContain("BAR_*");
+    expect(out).toContain("PATH");
+  });
+
+  it("the literal * escape hatch disables minimization entirely", () => {
+    expect(resolveHostEnvAllowlist({ RED_AFK_HOST_ENV_ALLOW: "*" })).toBeUndefined();
+    expect(resolveHostEnvAllowlist({ RED_AFK_HOST_ENV_ALLOW: "FOO,*" })).toBeUndefined();
+  });
+});
+
+describe("buildLineRedactor", () => {
+  it("precomputes inputs once and masks session links, env secrets, and home paths per line", () => {
+    const redact = buildLineRedactor({
+      env: { MY_TEST_TOKEN: "tok-abcdef-123456" },
+      homeDir: "/home/alice",
+      hostname: "host-a",
+      hostReplacement: "hostfp",
+    });
+    expect(redact("x https://claude.ai/code/session_zz9 y")).toBe("x [REDACTED_CLAUDE_SESSION] y");
+    expect(redact("value tok-abcdef-123456 end")).toBe("value [REDACTED_SECRET] end");
+    expect(redact("/home/alice/w and /home/bob/w on host-a")).toBe(
+      "[REDACTED_HOME]/w and /home/[REDACTED_USER]/w on hostfp",
+    );
+  });
+
+  it("is idempotent and preserves machine markers", () => {
+    const redact = buildLineRedactor({ env: {}, homeDir: homedir(), hostname: "host-a" });
+    const marker = "<!-- afk:claim v1 worker=abc:w1 kind=claim runner=codex -->";
+    expect(redact(marker)).toBe(marker);
+    const once = redact("s https://claude.ai/code/session_a1");
+    expect(redact(once)).toBe(once);
+  });
+});


### PR DESCRIPTION
Second half of the #1364 no-leak program: the red-castle substrate side (submodule pin → `6d40437` on the consumed `afk/1022-liveness-lane-substrate` lineage) plus the apps/dev wiring.

- Agent processes no longer inherit the full host env: default-deny allowlist (shell basics, ssh/git/gh auth, agent CLI auth/state, `RED_*`, language toolchains). `RED_AFK_HOST_ENV_ALLOW` extends it; literal `*` is the escape hatch.
- Every textual agent-stream event is masked at capture time (`redactLine` → precomputed `buildLineRedactor()`): session links, env-secret values, home paths, hostname → fingerprint. Defense-in-depth under the `scrubOutbound` posting seam.
- red-castle side validated with its own suite on the lineage (1529 green); workspace gate 9/9 + typecheck clean on the bump.

Note: red-castle `origin/main` has DIVERGED from the consumed lineage (it lacks the liveness lane + AgentOutput exports). This PR pins the lineage branch tip; the divergence is filed separately.

Closes #1368

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786206104&installation_id=129708444&pr_number=1383&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1383&signature=a27c771b648718e268af4819732f8c704e0a1a69d9e47e6bcd9f64f0d78e9210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->