### PR TITLE
fix: #1379 Issue selection: --issues N errors on a priority:urgent ticket (urgent prefix removes it from the filterable remainder)

### DIFF
--- a/apps/dev/src/core/session.ts
+++ b/apps/dev/src/core/session.ts
@@ -120,14 +120,17 @@ export class IssueSelectionError extends Error {
  *   1. Spec exclusion (hard): drop every `type:spec` candidate before any filter.
  *   2. Urgent prepend (hard, ahead of filters): split out `priority:urgent`;
  *      they jump the head sorted by number ascending (oldest fires first).
- *   3. Filter the non-urgent remainder:
+ *   3. Filter the queue:
  *        - issues: keep the requested numbers in ARGUMENT order; throw an
  *          IssueSelectionError if any requested number is missing from the pool
  *          or (present but) not labelled ready-for-agent. type:spec numbers were
  *          already dropped in step 1, so an explicit Spec reads as "missing".
+ *          Lookup uses the full post-spec pool so urgent issues are explicitly
+ *          addressable, then final queue assembly keeps urgents first.
  *        - spec: keep candidates with a spec:#N body ref / spec:N label.
  *        - all: keep the whole remainder.
- *      The filtered remainder is sorted priority:high→rest, then number asc.
+ *      The spec/all filtered remainder is sorted priority:high→rest, then
+ *      number asc.
  *   4. Concat `[urgent…] + [filtered…]`, deduped by number keeping the urgent
  *      slot at the front.
  */
@@ -139,11 +142,11 @@ export function selectIssues(candidates: readonly IssueCandidate[], filter: Sele
   const urgent = pool.filter((c) => hasLabel(c, LABEL_URGENT)).sort((a, b) => a.number - b.number);
   const rest = pool.filter((c) => !hasLabel(c, LABEL_URGENT));
 
-  // 3. Filter the non-urgent remainder.
+  // 3. Filter the queue.
   let filtered: IssueCandidate[];
   switch (filter.kind) {
     case "issues": {
-      const byNumber = new Map(rest.map((c) => [c.number, c] as const));
+      const byNumber = new Map(pool.map((c) => [c.number, c] as const));
       // A requested number is "unselectable" when it is absent from the
       // ready-for-agent pool entirely. (The pool is the ready-for-agent list,
       // so absence covers both missing and not-labelled-ready-for-agent.)

--- a/apps/dev/tests/session.test.ts
+++ b/apps/dev/tests/session.test.ts
@@ -63,6 +63,24 @@ describe("selectIssues", () => {
     expect(out.map((c) => c.number)).toEqual([30, 10, 20]);
   });
 
+  it("--issues can explicitly select an urgent ready-for-agent issue", () => {
+    const list = [
+      cand(1378, ["ready-for-agent", "priority:urgent"]),
+      cand(20, ["ready-for-agent"]),
+    ];
+    const out = selectIssues(list, { kind: "issues", numbers: [1378] });
+    expect(out.map((c) => c.number)).toEqual([1378]);
+  });
+
+  it("--issues preserves urgent-first ordering when an urgent issue is requested after a normal issue", () => {
+    const list = [
+      cand(1378, ["ready-for-agent", "priority:urgent"]),
+      cand(20, ["ready-for-agent"]),
+    ];
+    const out = selectIssues(list, { kind: "issues", numbers: [20, 1378] });
+    expect(out.map((c) => c.number)).toEqual([1378, 20]);
+  });
+
   it("--issues throws when a requested number is missing from the ready-for-agent pool", () => {
     const list = [cand(10), cand(20)];
     try {

--- a/plugins/dev/skills/engineering/afk/docs/OPERATIONS.md
+++ b/plugins/dev/skills/engineering/afk/docs/OPERATIONS.md
@@ -196,10 +196,10 @@ The systemic fix is the `red-issues-needs-triage.yml` workflow installed by `/se
 
 Pull: `gh issue list --label ready-for-agent --state open --json number,title,labels,body --limit 100`. Drop every `type:spec` issue before any filter (log `/to-tickets N` warning for each). Prepend `priority:urgent` issues before any filter, oldest first.
 
-Filters for the **non-urgent remainder**:
-1. `--issues N…`: keep those numbers in argument order; error if missing or not `ready-for-agent`; Specs rejected.
-2. `--spec N`: keep issues with `spec: #N` in body, parent link, or `spec:N` label; Spec itself excluded.
-3. Default: all remaining `ready-for-agent`, `priority:high` first, then ascending by number.
+Filters:
+1. `--issues N…`: match requested numbers against the full post-Spec `ready-for-agent` set, urgent included; keep those numbers in argument order; error if missing or not `ready-for-agent`; Specs rejected.
+2. `--spec N`: keep non-urgent issues with `spec: #N` in body, parent link, or `spec:N` label; Spec itself excluded.
+3. Default: all remaining non-urgent `ready-for-agent`, `priority:high` first, then ascending by number.
 
 Final queue: `[urgent…] + [filtered…]`, deduped. Empty → `<promise>NO MORE TASKS</promise>`, exit 0.
 


### PR DESCRIPTION
Automated AFK landing for #1379. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1379

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786211133&installation_id=129708444&pr_number=1386&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1386&signature=2142ccd0eb5208284924f279b427dbeb37b95305daa836fd178ec65927c03afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->