### PR TITLE
fix(vitals): reasoning events no longer overwrite concrete stage

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -615,16 +615,17 @@ async function runReconcileWorker(
  */
 /**
  * Map a sandcastle agent stream event to an AFK pipeline stage, or `undefined`
- * when the event carries no stage signal (a text chunk, or an unrecognised
- * tool). Mirrors the shell *Stage Detection* table against tool calls and the
- * reasoning stream: reasoning → `plan`, Edit/Write → `impl`,
- * Read/Grep/`git ls-files`/`find` → `explore`, runner commands → their matching
- * command stage. Used by `recordAgentEvent` to advance `current.stage` in
- * afk.state.json so the monitor reflects progress; keyed off tool calls plus
- * the reasoning case to bound the state-write rate.
+ * when the event carries no stage signal (a text chunk, reasoning event, or an
+ * unrecognised tool). Mirrors the shell *Stage Detection* table against tool
+ * calls: Edit/Write → `impl`, Read/Grep/`git ls-files`/`find` → `explore`,
+ * runner commands → their matching command stage. Reasoning events return
+ * `undefined` — they interleave every tool call on thinking-heavy runners
+ * (Opus effort=high) and carry no exclusive stage signal; returning `undefined`
+ * prevents them from clobbering a concrete stage already set by the preceding
+ * tool call. Used by `recordAgentEvent` to advance `current.stage` in
+ * afk.state.json so the monitor reflects progress.
  */
 type DerivedStage =
-  | "plan"
   | "explore"
   | "impl"
   | "tests"
@@ -704,7 +705,6 @@ const COMMAND_STAGE_PATTERNS: readonly StagePattern[] = [
 ];
 
 export function deriveStage(event: AgentStreamEvent): string | undefined {
-  if (event.type === "reasoning") return "plan";
   if (event.type !== "toolCall") return undefined;
   const name = event.name.toLowerCase();
   const args = event.formattedArgs.toLowerCase();

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -22,8 +22,18 @@ describe("deriveStage (native-path monitor stage detection)", () => {
     expect(deriveStage({ type: "text", message: "thinking…", iteration: 1, timestamp: new Date(0) })).toBeUndefined();
   });
 
-  it("maps reasoning without a tool call to plan", () => {
-    expect(deriveStage(reasoning())).toBe("plan");
+  it("returns undefined for reasoning events (never overwrites a concrete stage)", () => {
+    expect(deriveStage(reasoning())).toBeUndefined();
+  });
+
+  it("reasoning after a concrete tool call does not clobber the concrete stage (#1389)", () => {
+    // Simulate: reasoning → toolCall(Edit) → reasoning
+    // The derived stage after the sequence must end at "impl", not "plan".
+    const stages = [reasoning(), tool("Edit", "src/foo.ts"), reasoning()].map(deriveStage);
+    expect(stages).toEqual([undefined, "impl", undefined]);
+    // The last non-undefined stage in the stream is "impl", not "plan".
+    const lastConcrete = stages.filter(Boolean).at(-1);
+    expect(lastConcrete).toBe("impl");
   });
 
   it("maps Edit/Write tools to impl", () => {


### PR DESCRIPTION
Recovers work from AFK worker `wDH3Z`, which completed the fix and pushed both commits before its host process was killed (no PR was opened).

## Fix

`deriveStage()` returned `plan` for every reasoning event. On thinking-heavy runners (Opus at `effort=high`) a reasoning event precedes nearly every tool call, so each concrete stage (`impl`, `tests`, `lint`) was immediately clobbered back to `plan` — making the statusline show a permanently "planning" worker that was in fact editing, committing, and running tests.

Reasoning events now return `undefined`: they interleave everything and carry no exclusive stage signal, so they no longer overwrite the stage set by the preceding tool call. `plan` is dropped from the `DerivedStage` union.

## Validation

The worker was killed before it reached the gate, so this branch is CI-validated only. A regression test over a synthetic `reasoning → toolCall(Edit) → reasoning` stream asserts the derived stage ends at `impl`.

Closes #1389

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786219361&installation_id=129708444&pr_number=1393&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1393&signature=bdc5a44cafdb6c54ad0ce89754bfb683fa8386b805d4c57a2668e990da1ae6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->