### PR TITLE
Fix code-nav npm bundle packaging

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -466,6 +466,16 @@ jobs:
           pnpm pack --pack-destination .
           tarball="$(ls reddb-io-red-skills-*.tgz | head -n1)"
           echo "packed $tarball"
+          for expected in \
+            package/dist/dev.bundle.min.mjs \
+            package/dist/code-nav.bundle.min.mjs \
+            package/dist/memory.bundle.min.mjs \
+            package/dist/brain.bundle.min.mjs; do
+            if ! tar -tzf "$tarball" | grep -qx "$expected"; then
+              echo "::error::npm tarball missing $expected"
+              exit 1
+            fi
+          done
           # Contract check: install the packed tarball into a throwaway prefix and
           # run the REAL packaged client (the bin the launcher execs) — proves the
           # tarball resolves and runs before we publish it.

--- a/packages/shared/bundle-fetch.test.ts
+++ b/packages/shared/bundle-fetch.test.ts
@@ -114,6 +114,8 @@ describe("npm spec + registry URL builders", () => {
   it("names the packaged bundle path inside the tarball", () => {
     expect(packagedBundleName("memory")).toBe("memory.bundle.min.mjs");
     expect(packagedBundleRelPath("memory")).toBe("dist/memory.bundle.min.mjs");
+    expect(packagedBundleName("code-nav")).toBe("code-nav.bundle.min.mjs");
+    expect(packagedBundleRelPath("code-nav")).toBe("dist/code-nav.bundle.min.mjs");
   });
 });
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,14 +1,15 @@
 # @reddb-io/red-skills
 
-The RedSkills plugin runtime bundles (`dev`, `memory`, `brain`), distributed over
+The RedSkills plugin runtime bundles (`dev`, `code-nav`, `memory`, `brain`), distributed over
 **npm** — the v2 client transport (ADR 0091), replacing the broken GitHub-release
 + hand-rolled sigstore channel.
 
 The tarball carries the platform-independent JS bundles under `dist/` plus three
 bin shims (`red-skills-dev`, `red-skills-memory`, `red-skills-brain`) that exec
-the corresponding packaged bundle. **No postinstall download** — the bundles ship
-in the tarball, so integrity is npm's own shasum/provenance and delivery is
-atomic.
+the corresponding packaged bundle. `code-nav` has no bin shim; the dev plugin's
+MCP launcher resolves `dist/code-nav.bundle.min.mjs` through the shared bundle
+fetcher. **No postinstall download** — the bundles ship in the tarball, so
+integrity is npm's own shasum/provenance and delivery is atomic.
 
 ## Client resolution
 

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@reddb-io/red-skills",
   "version": "0.0.0",
-  "description": "RedSkills plugin runtime bundles (dev, memory, brain) distributed over npm \u2014 the v2 client transport (ADR 0091). Carries the platform-independent JS bundles inside the tarball plus thin bin shims; no postinstall download.",
+  "description": "RedSkills plugin runtime bundles (dev, code-nav, memory, brain) distributed over npm \u2014 the v2 client transport (ADR 0091). Carries the platform-independent JS bundles inside the tarball plus thin bin shims; no postinstall download.",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -19,7 +19,12 @@ const repoRoot = join(pkgRoot, "..", "..");
 const srcDist = join(repoRoot, "dist");
 const destDist = join(pkgRoot, "dist");
 
-const BUNDLES = ["dev.bundle.min.mjs", "memory.bundle.min.mjs", "brain.bundle.min.mjs"];
+const BUNDLES = [
+  "dev.bundle.min.mjs",
+  "code-nav.bundle.min.mjs",
+  "memory.bundle.min.mjs",
+  "brain.bundle.min.mjs",
+];
 
 mkdirSync(destDist, { recursive: true });
 let staged = 0;

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -68,6 +68,13 @@ else
   fail "registry smoke must run the real client via npx from the npm registry"
 fi
 
+if grep -qF 'package/dist/code-nav.bundle.min.mjs' "$WORKFLOW" &&
+   grep -qF 'npm tarball missing $expected' "$WORKFLOW"; then
+  pass "pack contract checks the code-nav bundle is in the npm tarball"
+else
+  fail "pack contract must fail when code-nav is missing from the npm tarball"
+fi
+
 if grep -qF 'registry smoke returned' "$WORKFLOW" &&
    grep -qF 'dev ${version} ' "$WORKFLOW"; then
   pass "registry smoke verifies the reported release version"


### PR DESCRIPTION
## Summary
- stage code-nav.bundle.min.mjs into the @reddb-io/red-skills npm package
- make the release pack contract fail if required runtime bundles are missing from the tarball
- document code-nav as a package-carried runtime bundle and pin its packaged path in bundle-fetch tests

## Verification
- node_modules/.pnpm/node_modules/.bin/vitest run packages/shared/bundle-fetch.test.ts packages/shared/entrypoint-cli.test.ts
- bash scripts/test-red-release-npm-publish-contract.sh
- local prepare + pnpm pack fixture confirmed package/dist/code-nav.bundle.min.mjs is present
- hotfixed local cache from v2.22.1 release asset and verified code-nav MCP initialize handshake

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786220533&installation_id=129708444&pr_number=1394&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1394&signature=416fe60555ac5e0eff6eeae6b094be4595b7abc2ee4fba51d231c2e7b2425d5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->