### PR TITLE
fix: #1391 AFK vitals: token counters stay 0 for the claude runner (`tks=0`)

### DIFF
--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -100,6 +100,10 @@ function signedDiff(added: number | undefined, removed: number | undefined): str
   return parts.length ? parts.join(" ") : null;
 }
 
+function tokenDisplay(f: ReturnType<typeof workerFields>): string {
+  return f.runner === "claude" && f.tokens === 0 ? "—" : humanizeCount(f.tokens);
+}
+
 // ---------- identity zone (wine background) ----------
 
 /** `» bold-project dim-(branch) dim-vX`. Branch truncated like the plain renderer. */
@@ -211,7 +215,7 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
     stage: f.issue === null ? "" : f.stage,
     elapsed: f.elapsed,
     loc: noAgent ? "" : `loc=${formatDiff(f.added, f.removed)}`,
-    tks: noAgent ? "" : `tks=${humanizeCount(f.tokens)}`,
+    tks: noAgent ? "" : `tks=${tokenDisplay(f)}`,
     tls: noAgent ? "" : `tls=${String(f.tools)}`,
     rsn: noAgent ? "" : `rsn=${String(f.reasoning)}`,
     txt: noAgent ? "" : `txt=${String(f.text)}`,
@@ -286,7 +290,7 @@ export function renderWorkerLine(worker: CompactWorker, now: number): string {
     return `${NOBG}${SOFT}${parts.join("  ")}${RESET}`;
   }
   parts.push(kv("loc", formatDiff(f.added, f.removed)));
-  parts.push(kv("tks", humanizeCount(f.tokens)));
+  parts.push(kv("tks", tokenDisplay(f)));
   // The vitals as INDIVIDUAL 3-letter k=v pairs (single-spaced group), same
   // convention and vocabulary as the monitor dashboard.
   parts.push(`${kv("tls", String(f.tools))} ${kv("rsn", String(f.reasoning))} ${kv("txt", String(f.text))}`);

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -160,7 +160,7 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(t).toContain("impl"); // bare stage (no stage: prefix, no #<n>)
     expect(t).toContain("00:05:00"); // elapsed REQUIRED
     expect(t).toContain("loc=+12 -3"); // diff as loc= k=v
-    expect(t).toContain("tks=0"); // humanized tokens (none yet)
+    expect(t).toContain("tks=—"); // claude has no live usage stream yet
     expect(t).toContain("tls=0 rsn=0 txt=0"); // vitals as individual 3-letter k=v pairs
     // The DROPPED verbosity must be gone.
     expect(t).not.toContain("iss=7/10"); // the old done/total counter is gone
@@ -236,6 +236,24 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
       },
     });
     expect(stripAnsi(renderWorkerLine(w, NOW))).toContain("tks=34k");
+  });
+
+  it("keeps genuine zero-token codex/opencode workers numeric on the tks= token", () => {
+    const codex = worker({
+      state: {
+        ...worker().state,
+        runner: "codex",
+      },
+    });
+    const opencode = worker({
+      state: {
+        ...worker().state,
+        runner: "opencode",
+      },
+    });
+
+    expect(stripAnsi(renderWorkerLine(codex, NOW))).toContain("tks=0");
+    expect(stripAnsi(renderWorkerLine(opencode, NOW))).toContain("tks=0");
   });
 
   it("carries the individual vitals as k=v pairs, never a stats= blob", () => {


### PR DESCRIPTION
Automated AFK landing for #1391. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786220692&installation_id=129708444&pr_number=1395&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1395&signature=89f8591b9ebf4a06137a08631c4ab64c4b57e26b707df5b4ba5b7f39f3f8d2dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->