### PR TITLE
Fix code-nav MCP launcher to use npm shim

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -491,6 +491,10 @@ jobs:
           npm install "./$tarball" --prefix "$smoke" --no-audit --no-fund --ignore-scripts --loglevel=error
           pkg="$smoke/node_modules/@reddb-io/red-skills"
           node "$pkg/bin/red-skills-dev.mjs" --version
+          # code-nav launches via an npm-shim bin (#1396) that resolves the packaged
+          # code-nav bundle; smoke both the shim and the bundle it resolves.
+          test -x "$smoke/node_modules/.bin/red-skills-code-nav"
+          test -f "$smoke/node_modules/@reddb-io/red-skills/dist/code-nav.bundle.min.mjs"
           # rsp needs a provisioned RedDB store (the `red` binary is not present under
           # --ignore-scripts), so it cannot reach exit 0 here. What we DO smoke is that
           # the packaged rsp bin resolves its bundle: a bin-without-bundle makes the

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -4,12 +4,11 @@ The RedSkills plugin runtime bundles (`dev`, `code-nav`, `memory`, `brain`), dis
 **npm** — the v2 client transport (ADR 0091), replacing the broken GitHub-release
 + hand-rolled sigstore channel.
 
-The tarball carries the platform-independent JS bundles under `dist/` plus three
-bin shims (`red-skills-dev`, `red-skills-memory`, `red-skills-brain`) that exec
-the corresponding packaged bundle. `code-nav` has no bin shim; the dev plugin's
-MCP launcher resolves `dist/code-nav.bundle.min.mjs` through the shared bundle
-fetcher. **No postinstall download** — the bundles ship in the tarball, so
-integrity is npm's own shasum/provenance and delivery is atomic.
+The tarball carries the platform-independent JS bundles under `dist/` plus bin
+shims (`red-skills-dev`, `red-skills-code-nav`, `red-skills-memory`,
+`red-skills-brain`) that exec the corresponding packaged bundle. **No
+postinstall download** — the bundles ship in the tarball, so integrity is npm's
+own shasum/provenance and delivery is atomic.
 
 ## Client resolution
 

--- a/packaging/npm/bin/red-skills-code-nav.mjs
+++ b/packaging/npm/bin/red-skills-code-nav.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * red-skills-code-nav — thin shim that execs the `code-nav` MCP runtime bundle
+ * packaged inside this npm tarball (`dist/code-nav.bundle.min.mjs`).
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundle = join(here, "..", "dist", "code-nav.bundle.min.mjs");
+if (!existsSync(bundle)) {
+  process.stderr.write(`red-skills-code-nav: packaged bundle missing at ${bundle}\n`);
+  process.exit(1);
+}
+const res = spawnSync(process.execPath, [bundle, ...process.argv.slice(2)], { stdio: "inherit" });
+if (res.signal) process.kill(process.pid, res.signal);
+process.exit(res.status ?? 1);

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -14,6 +14,7 @@
   },
   "bin": {
     "red-skills-dev": "bin/red-skills-dev.mjs",
+    "red-skills-code-nav": "bin/red-skills-code-nav.mjs",
     "red-skills-memory": "bin/red-skills-memory.mjs",
     "red-skills-brain": "bin/red-skills-brain.mjs",
     "rsp": "bin/rsp.mjs"

--- a/plugins/dev/hooks/code-nav-mcp.sh
+++ b/plugins/dev/hooks/code-nav-mcp.sh
@@ -34,27 +34,15 @@ if [ -n "$plugin_json" ]; then
   ver="$(node -e "process.stdout.write(require(process.argv[1]).version)" "$plugin_json" 2>/dev/null || true)"
 fi
 
-cache="${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}"
 bundle=""
 
-if [ -n "$ver" ] && [ -f "$cache/code-nav-$ver.bundle.min.mjs" ]; then
-  bundle="$cache/code-nav-$ver.bundle.min.mjs"
-fi
-
-if [ -z "$bundle" ] && [ -n "$root" ] && [ -n "$ver" ]; then
-  for fetcher in \
-    "$root/hooks/red-fetch.mjs" \
-    "$root/dist/red-fetch.mjs" \
-    "$root/../../dist/red-fetch.mjs"; do
-    if [ -f "$fetcher" ]; then
-      node "$fetcher" code-nav "$ver" >/dev/null 2>&1 || true
-      break
-    fi
-  done
-
-  if [ -f "$cache/code-nav-$ver.bundle.min.mjs" ]; then
-    bundle="$cache/code-nav-$ver.bundle.min.mjs"
+if [ -n "$ver" ]; then
+  npx -y -p "@reddb-io/red-skills@$ver" red-skills-code-nav
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
   fi
+  printf 'code-nav: npm package launcher failed for %s (exit %s); trying local dist fallback\n' "$ver" "$status" >&2
 fi
 
 if [ -z "$bundle" ]; then
@@ -68,7 +56,7 @@ fi
 
 if [ -z "$bundle" ]; then
   expected="${ver:-<unknown>}"
-  printf 'code-nav: could not locate code-nav-mcp bundle for %s (looked in cache %s and repo-root dist; red-fetch on-demand also failed)\\n' "$expected" "$cache" >&2
+  printf 'code-nav: could not launch red-skills-code-nav for %s and could not locate repo-root dist fallback\n' "$expected" >&2
   exit 0
 fi
 

--- a/scripts/test-red-release-npm-publish-contract.sh
+++ b/scripts/test-red-release-npm-publish-contract.sh
@@ -75,6 +75,13 @@ else
   fail "pack contract must fail when code-nav is missing from the npm tarball"
 fi
 
+if grep -qF 'test -x "$smoke/node_modules/.bin/red-skills-code-nav"' "$WORKFLOW" &&
+   grep -qF 'test -f "$smoke/node_modules/@reddb-io/red-skills/dist/code-nav.bundle.min.mjs"' "$WORKFLOW"; then
+  pass "pack contract checks the code-nav npm bin and packaged bundle"
+else
+  fail "pack contract must verify the code-nav npm bin and packaged bundle"
+fi
+
 if grep -qF 'registry smoke returned' "$WORKFLOW" &&
    grep -qF 'dev ${version} ' "$WORKFLOW"; then
   pass "registry smoke verifies the reported release version"


### PR DESCRIPTION
## Summary
- add a packaged red-skills-code-nav bin shim for the code-nav MCP runtime
- launch code-nav MCP through npx -y -p @reddb-io/red-skills@<version> red-skills-code-nav instead of red-fetch/cache bundle resolution
- extend release packaging checks to verify the code-nav bin and packaged bundle

## Verification
- sh -n plugins/dev/hooks/code-nav-mcp.sh
- node --check packaging/npm/bin/red-skills-code-nav.mjs
- bash scripts/test-red-release-npm-publish-contract.sh
- local npm pack fixture + npm install verified .bin/red-skills-code-nav and dist/code-nav.bundle.min.mjs
- npx -y -p <local tarball> red-skills-code-nav

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786221422&installation_id=129708444&pr_number=1396&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1396&signature=b74892e835ca8ef3ca89068730004a6bf79074248204fd0c1a55383d30182cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->