### PR TITLE
fix: #1390 AFK vitals: loc-memo never invalidates when HEAD moves — committed LoC never counted

### DIFF
--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -68,6 +68,13 @@ export async function headShortSha(ctx: GitContext): Promise<string> {
   return r.code === 0 ? r.stdout.trim() : "";
 }
 
+/** `git -C cwd rev-parse --verify --quiet HEAD`, full sha. */
+export async function headSha(ctx: GitContext): Promise<string | undefined> {
+  const r = await runGit(ctx, ["rev-parse", "--verify", "--quiet", "HEAD"]);
+  const sha = r.stdout.trim();
+  return r.code === 0 && sha !== "" ? sha : undefined;
+}
+
 /** Delete a local branch (git branch -D). Best-effort. */
 export async function deleteLocalBranch(ctx: GitContext, branch: string): Promise<void> {
   if (!branch) return;

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -326,6 +326,15 @@ export function resolveAttemptGuardArming(opts: {
   return { guardArmed, laneArmed };
 }
 
+export async function resolveAttemptHead(ctx: gitx.GitContext, branch: string): Promise<string | undefined> {
+  const worktree = await gitx.worktreePathForBranch(ctx, branch);
+  if (worktree) {
+    const head = await gitx.headSha({ ...ctx, cwd: worktree });
+    if (head) return head;
+  }
+  return gitx.branchHead(ctx, branch);
+}
+
 // ---------- lazy sandcastle runAgent binding ----------
 
 /**
@@ -408,7 +417,7 @@ export function makeRunAgent(
         ? {
             attemptTimeoutSeconds: attemptTimeout,
             attemptHardCapSeconds: attemptHardCap,
-            headProbe: () => gitx.branchHead({ cwd: input.cwd ?? process.cwd() }, input.branch),
+            headProbe: () => resolveAttemptHead({ cwd: input.cwd ?? process.cwd() }, input.branch),
             // Edit signal (ADR 0051): the changed-line volume of the agent's real
             // worktree (committed + uncommitted). A change between polls resets
             // the deadline, so a runner that edits without committing (codex) is

--- a/apps/dev/tests/loc-memo.test.ts
+++ b/apps/dev/tests/loc-memo.test.ts
@@ -131,6 +131,46 @@ describe("resolveAttemptLoc — commit-anchored LOC memo (#1210)", () => {
     expect(uncommittedCalls).toBe(2);
   });
 
+  it("recomputes committed LOC exactly once per distinct HEAD while uncommitted stays per tick", async () => {
+    let headSha = "boot-base";
+    let stored: LocMemo | null = null;
+    let uncommitted = { added: 3, removed: 0 };
+    const committedCalls: string[] = [];
+    let uncommittedCalls = 0;
+    const committedByHead = new Map([
+      ["boot-base", { added: 0, removed: 0 }],
+      ["moved-head", { added: 1222, removed: 48 }],
+    ]);
+    const deps = () => ({
+      headSha,
+      compute: async () => {
+        committedCalls.push(headSha);
+        return committedByHead.get(headSha) ?? { added: 0, removed: 0 };
+      },
+      computeUncommitted: async () => {
+        uncommittedCalls += 1;
+        return uncommitted;
+      },
+      readMemo: () => stored,
+      writeMemo: (m: LocMemo) => {
+        stored = m;
+      },
+    });
+
+    await expect(resolveAttemptLoc(deps())).resolves.toEqual({ added: 3, removed: 0 });
+    uncommitted = { added: 5, removed: 1 };
+    await expect(resolveAttemptLoc(deps())).resolves.toEqual({ added: 5, removed: 1 });
+
+    headSha = "moved-head";
+    uncommitted = { added: 0, removed: 0 };
+    await expect(resolveAttemptLoc(deps())).resolves.toEqual({ added: 1222, removed: 48 });
+    await expect(resolveAttemptLoc(deps())).resolves.toEqual({ added: 1222, removed: 48 });
+
+    expect(committedCalls).toEqual(["boot-base", "moved-head"]);
+    expect(uncommittedCalls).toBe(4);
+    expect(stored).toEqual({ sha: "moved-head", added: 1222, removed: 48 });
+  });
+
   it("keeps the claude incremental-commit path correct: committed memo + uncommitted delta sum", async () => {
     // A claude worker commits incrementally. After a commit the committed delta is
     // sha-memoized; any not-yet-committed edits add on top of it.

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -21,8 +21,10 @@ import {
   parseGitHubRepoSlugFromRemoteUrl,
   inferGitHubRepoSlug,
   resolveStatuslineCacheTtl,
+  resolveAttemptHead,
 } from "../src/runtime/wire.js";
 import { runBoot } from "../src/core/boot.js";
+import type { ExecOutput } from "../src/runtime/exec.js";
 
 function scratch(): string {
   return mkdtempSync(join(tmpdir(), "afk-wire-"));
@@ -86,6 +88,57 @@ describe("resolveAttemptGuardArming (issue #405)", () => {
       guardArmed: true,
       laneArmed: false,
     });
+  });
+});
+
+describe("resolveAttemptHead (#1390)", () => {
+  const ok = (stdout = ""): ExecOutput => ({ code: 0, stdout, stderr: "" });
+  const fail = (code = 1): ExecOutput => ({ code, stdout: "", stderr: "" });
+
+  it("prefers the live worker worktree HEAD over a stale branch ref", async () => {
+    const calls: string[][] = [];
+    const exec = async (cmd: string, args: readonly string[]): Promise<ExecOutput> => {
+      calls.push([cmd, ...args]);
+      const joined = args.join(" ");
+      if (joined === "worktree list --porcelain") {
+        return ok(
+          [
+            "worktree /repo",
+            "HEAD base",
+            "branch refs/heads/main",
+            "",
+            "worktree /repo/.red/tmp/workers/w1/1390-a1/.sandcastle/worktrees/afk-w1-1390",
+            "HEAD moved-head",
+            "branch refs/heads/afk/w1/1390-loc",
+            "",
+          ].join("\n"),
+        );
+      }
+      if (joined === "rev-parse --verify --quiet HEAD") return ok("moved-head\n");
+      if (joined === "rev-parse --verify --quiet refs/heads/afk/w1/1390-loc") return ok("boot-base\n");
+      return fail();
+    };
+
+    await expect(
+      resolveAttemptHead(
+        { cwd: "/repo/.red/tmp/workers/w1/1390-a1", exec },
+        "afk/w1/1390-loc",
+      ),
+    ).resolves.toBe("moved-head");
+    expect(calls).toContainEqual(["git", "rev-parse", "--verify", "--quiet", "HEAD"]);
+  });
+
+  it("falls back to the branch ref when no registered worker worktree exists yet", async () => {
+    const exec = async (_cmd: string, args: readonly string[]): Promise<ExecOutput> => {
+      const joined = args.join(" ");
+      if (joined === "worktree list --porcelain") return ok("worktree /repo\nbranch refs/heads/main\n");
+      if (joined === "rev-parse --verify --quiet refs/heads/afk/w1/1390-loc") return ok("branch-head\n");
+      return fail();
+    };
+
+    await expect(resolveAttemptHead({ cwd: "/repo/.red/tmp/workers/w1/1390-a1", exec }, "afk/w1/1390-loc")).resolves.toBe(
+      "branch-head",
+    );
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1390. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1390

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786224510&installation_id=129708444&pr_number=1398&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1398&signature=e540b1d76fa80dfd0161b6ca00a8a972eea32f435c81b227ac554abcccc27984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->