### PR TITLE
chore: #1399 /go: Build the AFK-in-a-box: a self-sufficient Docker image that drains ready

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -96,3 +96,6 @@ jobs:
 
       - name: Test apps/opencode-host
         run: pnpm -C apps/opencode-host test
+
+      - name: Test apps/afk-container
+        run: pnpm -C apps/afk-container test

--- a/apps/afk-container/.dockerignore
+++ b/apps/afk-container/.dockerignore
@@ -1,0 +1,6 @@
+# The image ships only src/ — the engine itself comes from npm.
+node_modules
+tests
+vitest.config.mjs
+package.json
+README.md

--- a/apps/afk-container/Dockerfile
+++ b/apps/afk-container/Dockerfile
@@ -1,0 +1,75 @@
+# AFK-in-a-box — a self-sufficient image that drains `ready-for-agent` issues from
+# GitHub repos through the existing AFK engine, one ephemeral run at a time.
+#
+# The image carries no repo source: it installs the published `@reddb-io/red-skills`
+# npm package (ADR 0091) and calls its `red-skills-dev` bin, so the claim protocol,
+# heartbeat, validation gate and pull request all come from the same engine the
+# local fleet and the Actions lane use. Pin the engine with
+# `--build-arg RED_SKILLS_VERSION=<semver>`; `latest` is a convenience, not a contract.
+#
+#   docker build -t afk-in-a-box --build-arg RED_SKILLS_VERSION=2.23.1 apps/afk-container
+#
+# Stateless by construction: no VOLUME, no daemon, no cache to preserve. Every run
+# clones into a temp dir and deletes it. See README.md for the env/secret table.
+
+ARG NODE_VERSION=22
+
+FROM node:${NODE_VERSION}-bookworm-slim
+
+# Renovate/dependabot-friendly pins. `latest` keeps a first-run cheap; production
+# deployments should pass exact versions for every one of these.
+ARG RED_SKILLS_VERSION=latest
+ARG CLAUDE_CODE_VERSION=latest
+ARG CODEX_VERSION=latest
+ARG OPENCODE_VERSION=latest
+ARG PNPM_VERSION=11.5.0
+
+LABEL org.opencontainers.image.title="afk-in-a-box" \
+      org.opencontainers.image.description="Self-sufficient AFK worker: drains ready-for-agent issues via the red-skills engine." \
+      org.opencontainers.image.source="https://github.com/reddb-io/red-skills" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# git + gh drive the repo and the issue tracker; jq/ripgrep/curl are what agent
+# runners reach for constantly. ca-certificates is required for every HTTPS call.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl git gnupg jq less openssh-client procps ripgrep \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Target repos run their own validation gate; most of ours are pnpm workspaces.
+RUN corepack enable && corepack prepare "pnpm@${PNPM_VERSION}" --activate
+
+# The three runners the cadence rotates through, plus the engine itself.
+# claude-minimax reuses the claude-code CLI, so it needs no extra install.
+RUN npm install -g --no-fund --no-audit \
+      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+      "@openai/codex@${CODEX_VERSION}" \
+      "opencode-ai@${OPENCODE_VERSION}" \
+      "@reddb-io/red-skills@${RED_SKILLS_VERSION}" \
+ && npm cache clean --force
+
+# The claude CLI refuses `--dangerously-skip-permissions` as root, and the engine
+# always passes it on this lane — so the run must not be root.
+RUN useradd --create-home --shell /bin/bash afk
+
+COPY --chown=afk:afk src/ /opt/afk/src/
+
+USER afk
+WORKDIR /home/afk
+
+# Ephemeral clones land here. Nothing survives the container; no VOLUME on purpose.
+ENV RED_AFK_WORK_ROOT=/home/afk/work
+RUN mkdir -p /home/afk/work
+
+ENTRYPOINT ["node", "/opt/afk/src/entrypoint.mjs"]

--- a/apps/afk-container/README.md
+++ b/apps/afk-container/README.md
@@ -1,0 +1,142 @@
+# afk-container — AFK-in-a-box
+
+A self-sufficient Docker image that drains `ready-for-agent` issues from GitHub
+repositories, one ephemeral run at a time, through the **existing AFK engine**.
+
+The container reimplements nothing. It picks a runner, picks the queue head, clones
+the target repo into a temp directory, and hands the issue to
+`red-skills-dev run --issues <N> --runner <R> --once` — the same engine path the
+local fleet and the Actions lane drive. Claim comment, heartbeat, validation gate
+and pull request all come from that engine.
+
+## Stateless by construction
+
+No volume, no daemon, no cache to preserve. All durable state is on GitHub:
+
+- the issue — its labels and its claim / heartbeat / park comments;
+- the run branch the engine pushes, and the pull request it opens.
+
+The clone lives in a temp directory and is deleted when the run ends, on any path.
+**Kill the container at any moment** — mid-clone, mid-agent, mid-gate — and the issue
+stays reclaimable: the claim comment goes stale and the engine's existing stale-claim
+reconciliation hands it back to the queue. There is nothing to clean up by hand.
+
+## Build
+
+```bash
+docker build -t afk-in-a-box \
+  --build-arg RED_SKILLS_VERSION=2.23.1 \
+  apps/afk-container
+```
+
+Build args (all default to `latest`, which is a convenience, not a contract — pin
+them for anything you run repeatedly):
+
+| Build arg              | Pins                             |
+| ---------------------- | -------------------------------- |
+| `RED_SKILLS_VERSION`   | `@reddb-io/red-skills` (the engine) |
+| `CLAUDE_CODE_VERSION`  | `@anthropic-ai/claude-code`       |
+| `CODEX_VERSION`        | `@openai/codex`                   |
+| `OPENCODE_VERSION`     | `opencode-ai`                     |
+| `NODE_VERSION`         | the `node:<v>-bookworm-slim` base |
+| `PNPM_VERSION`         | the corepack-activated pnpm       |
+
+## Run
+
+One issue, then exit:
+
+```bash
+docker run --rm \
+  -e GH_TOKEN \
+  -e ANTHROPIC_API_KEY \
+  -e RED_AFK_TARGET_REPOS=reddb-io/red-skills \
+  afk-in-a-box
+```
+
+Keep draining, sleeping when the queue empties:
+
+```bash
+docker run --rm \
+  -e GH_TOKEN -e ANTHROPIC_API_KEY -e OPENAI_API_KEY -e OPENROUTER_API_KEY \
+  -e RED_AFK_TARGET_REPOS=owner/one,owner/two \
+  -e RED_AFK_RUNNER_CADENCE=claude,codex,opencode \
+  -e RED_AFK_LOOP=true \
+  afk-in-a-box
+```
+
+Exit codes: `0` when a run finishes or the queue is empty; the engine's own exit code
+when a run fails; `2` on a bad configuration or when no cadence runner is credentialed.
+
+## Environment
+
+| Variable                     | Required | Default                  | Meaning                                                                   |
+| ---------------------------- | -------- | ------------------------ | ------------------------------------------------------------------------- |
+| `GH_TOKEN` / `GITHUB_TOKEN`  | yes      | —                        | Reads the queue, posts the claim trail, pushes the branch, opens the PR.   |
+| `RED_AFK_TARGET_REPOS`       | yes      | —                        | One `owner/name` slug, or a comma-separated list. Rotated per run.         |
+| `RED_AFK_RUNNER_CADENCE`     | no       | `claude,codex,opencode`  | Round-robin order, one step per run. See the cadence section below.        |
+| `RED_AFK_LOOP`               | no       | `false`                  | `true` repeats forever; an empty queue sleeps instead of exiting.          |
+| `RED_AFK_LOOP_IDLE_SECONDS`  | no       | `60`                     | First idle sleep; doubles per consecutive empty queue.                     |
+| `RED_AFK_LOOP_MAX_IDLE_SECONDS` | no    | `900`                    | Ceiling for that backoff.                                                  |
+| `RED_AFK_QUEUE_LABEL`        | no       | `ready-for-agent`        | The queue label to drain.                                                  |
+| `RED_AFK_MODEL`              | no       | repo config              | Model override for every tier. Passed straight through to the engine.      |
+| `RED_AFK_EFFORT`             | no       | repo config              | Reasoning-effort override (still provider-gated).                          |
+| `RED_AFK_WORK_ROOT`          | no       | `/home/afk/work`         | Where the ephemeral clone is made.                                         |
+| `GIT_AUTHOR_NAME`            | no       | `afk-container[bot]`     | Committer identity for the run branch.                                     |
+| `GIT_AUTHOR_EMAIL`           | no       | `afk-container@users.noreply.github.com` | Committer email.                                           |
+
+`RED_AFK_SANDBOX` is forced to `none` — the container *is* the sandbox, so a target
+repo configured for docker/podman never nests another one. `RED_AFK_LANE=container`
+tags the run for observability.
+
+### Runner credentials
+
+A runner without a credential is skipped, and the cadence falls through to the next
+one. Any single non-blank value credentials the runner:
+
+| Runner           | Credential env (engine precedence)                       |
+| ---------------- | -------------------------------------------------------- |
+| `claude`         | `ANTHROPIC_API_KEY`, or `CLAUDE_CODE_OAUTH_TOKEN`        |
+| `codex`          | `OPENAI_API_KEY`                                          |
+| `opencode`       | `OPENAI_API_KEY` > `MINIMAX_API_KEY` > `OPENROUTER_API_KEY` |
+| `claude-minimax` | `MINIMAX_API_KEY`                                         |
+
+If no cadence entry is credentialed, the container exits `2` without touching the
+queue — it never claims an issue it cannot work.
+
+## Cadence
+
+The cadence rotates by one per run: run 0 uses the first entry, run 1 the second, and
+so on. When the selected runner has no credential, selection walks forward through the
+cadence (wrapping once) to the first one that does. Fallback stays **inside** the
+cadence, so a runner you never listed can never be reached.
+
+### The claude-minimax evaluation lane
+
+`claude-minimax` is never in the default cadence. MiniMax-M3 does not reliably emit the
+DONE sentinel, so it is an evaluation lane, entered only when you name it explicitly:
+
+```bash
+docker run --rm \
+  -e GH_TOKEN -e MINIMAX_API_KEY \
+  -e RED_AFK_TARGET_REPOS=owner/name \
+  -e RED_AFK_RUNNER_CADENCE=claude-minimax \
+  -e RED_AFK_MODEL=MiniMax-M3 \
+  afk-in-a-box
+```
+
+`RED_AFK_MODEL` is passed through untouched — the same contract as the Actions lane's
+`model:` input. Leave it unset and the target repo's `.red/config.yaml` stays in charge.
+
+## Target repo requirements
+
+The target repo needs whatever its own AFK validation gate needs (for a pnpm workspace:
+a lockfile the image's pnpm can install). Submodules are cloned recursively, and SSH
+submodule URLs are rewritten to token-authenticated HTTPS, because the image carries no
+SSH key.
+
+## Not in scope
+
+No Kubernetes or Helm, no org-level listening, no stateful internal daemon, and no
+changes to the Actions lane (`rs-afk-attempt.yml`) — that lane keeps working exactly as
+before. This image is the third way to run one AFK attempt, next to the local fleet and
+GitHub Actions.

--- a/apps/afk-container/package.json
+++ b/apps/afk-container/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@reddb-io/afk-container",
+  "version": "2.23.1",
+  "private": true,
+  "description": "AFK-in-a-box — a self-sufficient Docker image that drains ready-for-agent issues from GitHub repos through the existing AFK engine (red-skills-dev), one ephemeral run at a time. Stateless by construction: the issue and the run branch are the only state.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "entrypoint": "node src/entrypoint.mjs"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
+  }
+}

--- a/apps/afk-container/src/attempt.mjs
+++ b/apps/afk-container/src/attempt.mjs
@@ -1,0 +1,68 @@
+/**
+ * One AFK run, start to finish: choose a runner, find a queue head, clone it
+ * ephemerally, hand the issue to the engine, delete the clone.
+ *
+ * The engine (`red-skills-dev run --issues N --runner R --once`) owns the claim
+ * comment, the heartbeat, the validation gate and the pull request. Nothing here
+ * reimplements any of it, and nothing here persists: kill the container at any
+ * point and the only residue is the claim comment on the issue, which the
+ * engine's own stale-claim reconciliation reclaims.
+ */
+
+import { buildRunEnv } from "./config.mjs";
+import { listReadyIssues, pickIssue, rotate } from "./queue.mjs";
+import { selectRunner } from "./runners.mjs";
+
+/**
+ * @param {object} params
+ * @param {object} params.config resolved container config
+ * @param {number} params.cycle  0-based run counter, driving both round-robins
+ * @param {object} params.env    process environment (credentials live here)
+ * @param {object} params.io     side-effect seam: listIssues/makeWorkdir/clone/runEngine/cleanup
+ * @param {(message: string) => void} params.log
+ * @returns {Promise<{status: "worked"|"failed"|"empty"|"no-runner", repo?: string, issue?: number, runner?: string, exitCode?: number, skipped?: string[]}>}
+ */
+export async function runCycle({ config, cycle, env, io, log }) {
+  const { runner, skipped } = selectRunner(config.cadence, cycle, env);
+  if (skipped.length > 0) {
+    log(`runner ${skipped.join(", ")} skipped — no credential in this environment`);
+  }
+  if (!runner) {
+    log(`no cadence runner is credentialed (cadence: ${config.cadence.join(", ")})`);
+    return { status: "no-runner", skipped };
+  }
+
+  for (const repo of rotate(config.repos, cycle)) {
+    const issues = await io.listIssues({ repo, label: config.label });
+    const issue = pickIssue(issues);
+    if (!issue) {
+      log(`${repo}: no actionable "${config.label}" issue`);
+      continue;
+    }
+
+    log(`${repo}#${issue.number}: attempting with runner ${runner}`);
+    const dir = await io.makeWorkdir({ repo, issue: issue.number });
+    try {
+      await io.clone({ repo, dir });
+      const exitCode = await io.runEngine({
+        dir,
+        issue: issue.number,
+        runner,
+        env: buildRunEnv(env, { token: config.token, model: config.model, effort: config.effort }),
+      });
+      return {
+        status: exitCode === 0 ? "worked" : "failed",
+        repo,
+        issue: issue.number,
+        runner,
+        exitCode,
+        skipped,
+      };
+    } finally {
+      // Ephemeral by construction — the clone dies with the run, success or not.
+      await io.cleanup(dir);
+    }
+  }
+
+  return { status: "empty" };
+}

--- a/apps/afk-container/src/config.mjs
+++ b/apps/afk-container/src/config.mjs
@@ -1,0 +1,96 @@
+/**
+ * Environment contract for the AFK container lane.
+ *
+ * Every knob is an env var — the image carries no config file and no state, so
+ * `docker run -e …` is the whole interface. The engine keeps its own precedence
+ * rules; this module only decides what reaches it.
+ */
+
+import { parseCadence } from "./runners.mjs";
+
+const REPO_SLUG = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+const DEFAULT_LABEL = "ready-for-agent";
+const DEFAULT_IDLE_SECONDS = 60;
+const DEFAULT_MAX_IDLE_SECONDS = 900;
+
+function trimmed(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function positiveInt(raw, fallback) {
+  const parsed = Number.parseInt(trimmed(raw), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isTrue(raw) {
+  return trimmed(raw).toLowerCase() === "true";
+}
+
+/** Parse `RED_AFK_TARGET_REPOS` — one `owner/name` slug, or a comma-separated list of them. */
+export function parseTargetRepos(raw) {
+  const repos = trimmed(raw)
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (repos.length === 0) {
+    throw new Error("RED_AFK_TARGET_REPOS is required (one `owner/name` slug, or a comma-separated list)");
+  }
+  const malformed = repos.filter((repo) => !REPO_SLUG.test(repo));
+  if (malformed.length > 0) {
+    throw new Error(`RED_AFK_TARGET_REPOS holds malformed repo slug(s): ${malformed.join(", ")} (want "owner/name")`);
+  }
+  return repos;
+}
+
+/** Resolve the whole runtime configuration from the process environment. Throws on a missing requirement. */
+export function resolveConfig(env) {
+  const token = trimmed(env.GH_TOKEN) || trimmed(env.GITHUB_TOKEN);
+  if (!token) throw new Error("GH_TOKEN (or GITHUB_TOKEN) is required to read the queue and open pull requests");
+
+  const idleSeconds = positiveInt(env.RED_AFK_LOOP_IDLE_SECONDS, DEFAULT_IDLE_SECONDS);
+  const maxIdleSeconds = Math.max(idleSeconds, positiveInt(env.RED_AFK_LOOP_MAX_IDLE_SECONDS, DEFAULT_MAX_IDLE_SECONDS));
+
+  return {
+    token,
+    repos: parseTargetRepos(env.RED_AFK_TARGET_REPOS),
+    cadence: parseCadence(env.RED_AFK_RUNNER_CADENCE),
+    label: trimmed(env.RED_AFK_QUEUE_LABEL) || DEFAULT_LABEL,
+    loop: isTrue(env.RED_AFK_LOOP),
+    idleSeconds,
+    maxIdleSeconds,
+    model: trimmed(env.RED_AFK_MODEL),
+    effort: trimmed(env.RED_AFK_EFFORT),
+    workRoot: trimmed(env.RED_AFK_WORK_ROOT),
+    gitUserName: trimmed(env.GIT_AUTHOR_NAME) || "afk-container[bot]",
+    gitUserEmail: trimmed(env.GIT_AUTHOR_EMAIL) || "afk-container@users.noreply.github.com",
+  };
+}
+
+/**
+ * The environment the engine child inherits.
+ *
+ * `RED_AFK_SANDBOX=none` unconditionally: the container IS the sandbox, so a
+ * target repo configured for docker/podman must not nest another one. An empty
+ * model/effort override is deleted rather than passed as `""`, leaving the target
+ * repo's `.red/config.yaml` in charge — the same contract as the Actions lane.
+ */
+export function buildRunEnv(env, overrides = {}) {
+  const runEnv = { ...env, RED_AFK_SANDBOX: "none", RED_AFK_LANE: "container" };
+
+  if (overrides.token) runEnv.GH_TOKEN = overrides.token;
+
+  const model = trimmed(overrides.model);
+  const effort = trimmed(overrides.effort);
+  if (model) runEnv.RED_AFK_MODEL = model;
+  else delete runEnv.RED_AFK_MODEL;
+  if (effort) runEnv.RED_AFK_EFFORT = effort;
+  else delete runEnv.RED_AFK_EFFORT;
+
+  return runEnv;
+}
+
+/** Exponential idle backoff for loop mode, capped at `ceiling`. */
+export function nextBackoffSeconds(current, ceiling) {
+  return Math.min(ceiling, current * 2);
+}

--- a/apps/afk-container/src/entrypoint.mjs
+++ b/apps/afk-container/src/entrypoint.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * AFK-in-a-box entrypoint.
+ *
+ * Reads the target repos from the environment, drains one `ready-for-agent` issue
+ * per run through the existing AFK engine, and exits 0. `RED_AFK_LOOP=true` repeats
+ * with an exponential idle backoff instead of exiting on an empty queue.
+ *
+ * State lives on GitHub — the issue's labels and its claim/heartbeat/park comments,
+ * plus the run branch. The container mounts no volume and writes nothing it keeps.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runCycle } from "./attempt.mjs";
+import { buildRunEnv, nextBackoffSeconds, resolveConfig } from "./config.mjs";
+import { listReadyIssues } from "./queue.mjs";
+
+const ENGINE_BIN = "red-skills-dev";
+
+/** Live clone directories, so a SIGTERM mid-run still leaves the filesystem clean. */
+const liveWorkdirs = new Set();
+let child = null;
+let aborting = false;
+
+function log(message) {
+  process.stdout.write(`[afk-container] ${message}\n`);
+}
+
+/** Run a command to completion, capturing its output (used for `gh` queries). */
+function capture(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { ...options, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (chunk) => (stdout += chunk));
+    proc.stderr.on("data", (chunk) => (stderr += chunk));
+    proc.on("error", reject);
+    proc.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+/** Run a command with inherited stdio, resolving to its exit code. */
+function inherit(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { ...options, stdio: "inherit" });
+    child = proc;
+    proc.on("error", reject);
+    proc.on("close", (code) => {
+      child = null;
+      resolve(code ?? 1);
+    });
+  });
+}
+
+async function mustSucceed(command, args, options = {}) {
+  const code = await inherit(command, args, options);
+  if (code !== 0) throw new Error(`${command} ${args.join(" ")} failed with exit ${code}`);
+}
+
+/**
+ * Give git a committer identity, a token-backed credential helper, and an HTTPS
+ * rewrite for SSH submodule URLs (a repo vendoring `git@github.com:` submodules
+ * cannot resolve them here — the container carries no SSH key).
+ */
+async function prepareGit(config, env) {
+  await mustSucceed("git", ["config", "--global", "user.name", config.gitUserName], { env });
+  await mustSucceed("git", ["config", "--global", "user.email", config.gitUserEmail], { env });
+  await mustSucceed("git", ["config", "--global", "url.https://github.com/.insteadOf", "git@github.com:"], { env });
+  await mustSucceed("gh", ["auth", "setup-git"], { env });
+}
+
+function makeIo(env) {
+  return {
+    listIssues: ({ repo, label }) => listReadyIssues({ repo, label, exec: (cmd, args) => capture(cmd, args, { env }) }),
+
+    async makeWorkdir({ repo }) {
+      const root = env.RED_AFK_WORK_ROOT || tmpdir();
+      const dir = await mkdtemp(join(root, `afk-${repo.replace("/", "-")}-`));
+      liveWorkdirs.add(dir);
+      return dir;
+    },
+
+    // A full clone, not a shallow one: the engine diffs the run branch against the
+    // merge base and the validation gate needs real history.
+    clone: ({ repo, dir }) =>
+      mustSucceed("git", ["clone", "--recurse-submodules", `https://github.com/${repo}.git`, dir], { env }),
+
+    // The SAME engine path every other AFK lane uses. It claims, heartbeats,
+    // validates, and opens the pull request.
+    runEngine: ({ dir, issue, runner, env: runEnv }) =>
+      inherit(ENGINE_BIN, ["run", "--issues", String(issue), "--runner", runner, "--once"], { cwd: dir, env: runEnv }),
+
+    async cleanup(dir) {
+      await rm(dir, { recursive: true, force: true });
+      liveWorkdirs.delete(dir);
+    },
+  };
+}
+
+function sleep(seconds) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, seconds * 1000);
+    timer.unref?.();
+    // A shutdown signal must not wait out the backoff.
+    const poll = setInterval(() => {
+      if (aborting) {
+        clearTimeout(timer);
+        clearInterval(poll);
+        resolve();
+      }
+    }, 250);
+    poll.unref?.();
+  });
+}
+
+/**
+ * Kill the engine, drop the ephemeral clones, and leave. The issue keeps its claim
+ * comment; the engine's stale-claim reconciliation hands it back to the queue.
+ */
+function installSignalHandlers() {
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => {
+      if (aborting) return;
+      aborting = true;
+      log(`${signal} received — abandoning the run; the issue stays reclaimable by stale-claim reconciliation`);
+      child?.kill(signal);
+      for (const dir of liveWorkdirs) {
+        try {
+          rm(dir, { recursive: true, force: true });
+        } catch {
+          // best effort — the container is going away anyway
+        }
+      }
+      process.exitCode = signal === "SIGINT" ? 130 : 143;
+      setTimeout(() => process.exit(process.exitCode), 5_000).unref?.();
+    });
+  }
+}
+
+export async function main(env = process.env) {
+  let config;
+  try {
+    config = resolveConfig(env);
+  } catch (error) {
+    process.stderr.write(`[afk-container] ${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
+
+  installSignalHandlers();
+  await prepareGit(config, buildRunEnv(env, { token: config.token }));
+
+  log(`repos=${config.repos.join(",")} cadence=${config.cadence.join(",")} loop=${config.loop}`);
+
+  let cycle = 0;
+  let backoff = config.idleSeconds;
+
+  for (;;) {
+    if (aborting) return process.exitCode ?? 143;
+
+    const outcome = await runCycle({ config, cycle, env, io: makeIo(env), log });
+    cycle += 1;
+
+    if (outcome.status === "no-runner") return 2;
+
+    if (outcome.status === "empty") {
+      if (!config.loop) {
+        log("queue empty — nothing to do");
+        return 0;
+      }
+      log(`queue empty — sleeping ${backoff}s`);
+      await sleep(backoff);
+      backoff = nextBackoffSeconds(backoff, config.maxIdleSeconds);
+      continue;
+    }
+
+    log(`${outcome.repo}#${outcome.issue}: engine exited ${outcome.exitCode} (runner ${outcome.runner})`);
+    backoff = config.idleSeconds;
+    // One-shot mode surfaces the engine's own verdict; loop mode keeps draining.
+    if (!config.loop) return outcome.status === "worked" ? 0 : (outcome.exitCode ?? 1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      process.stderr.write(`[afk-container] ${error instanceof Error ? error.stack || error.message : String(error)}\n`);
+      process.exit(1);
+    });
+}

--- a/apps/afk-container/src/queue.mjs
+++ b/apps/afk-container/src/queue.mjs
@@ -1,0 +1,71 @@
+/**
+ * Queue reading for the AFK container lane.
+ *
+ * Selection only — the engine still owns the claim. This mirrors the Actions
+ * lane's auto-pick predicate (reusable-afk-attempt.yml): the oldest open issue
+ * carrying the queue label, skipping anything parked, because the engine's own
+ * preflight would refuse a parked issue and the run would burn for nothing.
+ */
+
+const PARKED_LABEL = "ready-for-human";
+const PARKED_PREFIX = "blocked:";
+
+function labelNames(issue) {
+  return (issue.labels ?? []).map((label) => (typeof label === "string" ? label : (label?.name ?? "")));
+}
+
+/** True when a label parks the issue out of agent reach (`ready-for-human` / `blocked:*`). */
+export function isParked(issue) {
+  return labelNames(issue).some((name) => name === PARKED_LABEL || name.startsWith(PARKED_PREFIX));
+}
+
+/**
+ * The queue head: oldest actionable issue, ties broken by issue number so the
+ * pick is deterministic across containers reading the same queue.
+ *
+ * @returns the issue, or `null` when nothing is actionable.
+ */
+export function pickIssue(issues) {
+  const actionable = (issues ?? []).filter((issue) => !isParked(issue));
+  if (actionable.length === 0) return null;
+  return [...actionable].sort((a, b) => {
+    const byAge = String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? ""));
+    return byAge !== 0 ? byAge : a.number - b.number;
+  })[0];
+}
+
+/**
+ * List the open issues carrying `label` in `repo`. `gh issue list` already
+ * excludes pull requests, so the caller never sees one.
+ *
+ * @param {{ repo: string, label: string, exec: (cmd: string, args: string[]) => Promise<{code:number,stdout:string,stderr:string}> }} params
+ */
+export async function listReadyIssues({ repo, label, exec }) {
+  const result = await exec("gh", [
+    "issue",
+    "list",
+    "--repo",
+    repo,
+    "--label",
+    label,
+    "--state",
+    "open",
+    "--limit",
+    "100",
+    "--json",
+    "number,createdAt,labels",
+  ]);
+  if (result.code !== 0) {
+    throw new Error(`gh issue list failed for ${repo} (exit ${result.code}): ${result.stderr.trim()}`);
+  }
+  const parsed = JSON.parse(result.stdout || "[]");
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+/** Rotate a list so run number `cycle` starts at a different element — fair sharing across repos. */
+export function rotate(items, cycle) {
+  if (items.length === 0) return [];
+  const size = items.length;
+  const start = ((cycle % size) + size) % size;
+  return [...items.slice(start), ...items.slice(0, start)];
+}

--- a/apps/afk-container/src/runners.mjs
+++ b/apps/afk-container/src/runners.mjs
@@ -1,0 +1,92 @@
+/**
+ * Runner cadence + credential policy for the AFK container lane.
+ *
+ * The container drives the SAME engine runners as every other AFK lane
+ * (`red-skills-dev run --runner <id>`). This module owns only two decisions:
+ * which runner a given run uses (round-robin over the cadence) and whether that
+ * runner has a credential to use at all (fallback when it does not).
+ *
+ * `claude-minimax` is deliberately absent from `DEFAULT_CADENCE`: MiniMax-M3 does
+ * not reliably emit the DONE sentinel, so it is the evaluation lane, entered only
+ * when an operator names it in `RED_AFK_RUNNER_CADENCE`.
+ */
+
+/** Every runner id the engine's `--runner` flag accepts on this lane. */
+export const KNOWN_RUNNERS = Object.freeze(["claude", "codex", "opencode", "claude-minimax"]);
+
+/** The cadence used when `RED_AFK_RUNNER_CADENCE` is unset. Never includes claude-minimax. */
+export const DEFAULT_CADENCE = Object.freeze(["claude", "codex", "opencode"]);
+
+/**
+ * Credential env vars per runner, in the engine's own precedence order. A runner
+ * is credentialed when ANY of its vars carries a non-blank value: opencode reads
+ * the first set key of OPENAI_API_KEY > MINIMAX_API_KEY > OPENROUTER_API_KEY
+ * (opencode-env.ts), and the claude CLI accepts either an API key or an OAuth token.
+ */
+export const RUNNER_CREDENTIAL_ENVS = Object.freeze({
+  claude: Object.freeze(["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]),
+  codex: Object.freeze(["OPENAI_API_KEY"]),
+  opencode: Object.freeze(["OPENAI_API_KEY", "MINIMAX_API_KEY", "OPENROUTER_API_KEY"]),
+  "claude-minimax": Object.freeze(["MINIMAX_API_KEY"]),
+});
+
+/**
+ * Parse `RED_AFK_RUNNER_CADENCE` into an ordered, de-duplicated runner list.
+ * Blank/unset yields `DEFAULT_CADENCE`. An unknown id throws rather than being
+ * dropped — a typo'd cadence must not silently degrade to a different runner.
+ */
+export function parseCadence(raw) {
+  const listed = String(raw ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  if (listed.length === 0) return [...DEFAULT_CADENCE];
+
+  const unknown = listed.filter((runner) => !KNOWN_RUNNERS.includes(runner));
+  if (unknown.length > 0) {
+    throw new Error(
+      `unknown runner(s) in RED_AFK_RUNNER_CADENCE: ${unknown.join(", ")} (known: ${KNOWN_RUNNERS.join(", ")})`,
+    );
+  }
+  return [...new Set(listed)];
+}
+
+function isSet(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/** The credential env vars a runner would need but does not have in `env`. */
+export function missingCredentialEnvs(runner, env) {
+  const candidates = RUNNER_CREDENTIAL_ENVS[runner] ?? [];
+  return candidates.filter((name) => !isSet(env[name]));
+}
+
+/** True when at least one of the runner's credential env vars carries a value. */
+export function hasCredential(runner, env) {
+  const candidates = RUNNER_CREDENTIAL_ENVS[runner] ?? [];
+  return candidates.some((name) => isSet(env[name]));
+}
+
+/**
+ * Pick the runner for run number `cycle`: start at `cycle % cadence.length` and
+ * walk forward (wrapping once) to the first credentialed entry. Fallback stays
+ * inside the cadence, so a runner an operator never listed — claude-minimax in
+ * particular — can never be reached by a missing-credential fallback.
+ *
+ * @returns {{ runner: string|null, skipped: string[] }} `runner: null` when no
+ * cadence entry is credentialed; `skipped` names the entries passed over.
+ */
+export function selectRunner(cadence, cycle, env) {
+  if (!Array.isArray(cadence) || cadence.length === 0) {
+    throw new Error("selectRunner: cadence must be a non-empty runner list");
+  }
+  const size = cadence.length;
+  const start = ((cycle % size) + size) % size;
+  const skipped = [];
+  for (let step = 0; step < size; step += 1) {
+    const runner = cadence[(start + step) % size];
+    if (hasCredential(runner, env)) return { runner, skipped };
+    skipped.push(runner);
+  }
+  return { runner: null, skipped };
+}

--- a/apps/afk-container/tests/attempt.test.mjs
+++ b/apps/afk-container/tests/attempt.test.mjs
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runCycle } from "../src/attempt.mjs";
+
+const config = {
+  token: "gh-token",
+  repos: ["owner/one"],
+  cadence: ["claude", "codex", "opencode"],
+  label: "ready-for-agent",
+  model: "",
+  effort: "",
+};
+
+const issueList = (numbers) => numbers.map((number) => ({ number, createdAt: `2026-01-0${number}`, labels: [] }));
+
+function fakeIo(overrides = {}) {
+  return {
+    listIssues: vi.fn().mockResolvedValue(issueList([7])),
+    makeWorkdir: vi.fn().mockResolvedValue("/tmp/afk-run"),
+    clone: vi.fn().mockResolvedValue(undefined),
+    runEngine: vi.fn().mockResolvedValue(0),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const env = { ANTHROPIC_API_KEY: "a", OPENAI_API_KEY: "o" };
+const log = () => {};
+
+describe("runCycle", () => {
+  it("claims the queue head through the engine in an ephemeral clone", async () => {
+    const io = fakeIo();
+    const outcome = await runCycle({ config, cycle: 0, env, io, log });
+
+    expect(outcome).toMatchObject({ status: "worked", repo: "owner/one", issue: 7, runner: "claude", exitCode: 0 });
+    expect(io.clone).toHaveBeenCalledWith({ repo: "owner/one", dir: "/tmp/afk-run" });
+    expect(io.runEngine).toHaveBeenCalledWith(
+      expect.objectContaining({ dir: "/tmp/afk-run", issue: 7, runner: "claude" }),
+    );
+  });
+
+  it("removes the ephemeral clone after the run", async () => {
+    const io = fakeIo();
+    await runCycle({ config, cycle: 0, env, io, log });
+    expect(io.cleanup).toHaveBeenCalledWith("/tmp/afk-run");
+  });
+
+  it("removes the ephemeral clone even when the engine throws", async () => {
+    const io = fakeIo({ runEngine: vi.fn().mockRejectedValue(new Error("engine exploded")) });
+    await expect(runCycle({ config, cycle: 0, env, io, log })).rejects.toThrow(/engine exploded/);
+    expect(io.cleanup).toHaveBeenCalledWith("/tmp/afk-run");
+  });
+
+  it("reports a non-zero engine exit without throwing", async () => {
+    const io = fakeIo({ runEngine: vi.fn().mockResolvedValue(3) });
+    const outcome = await runCycle({ config, cycle: 0, env, io, log });
+    expect(outcome).toMatchObject({ status: "failed", exitCode: 3 });
+    expect(io.cleanup).toHaveBeenCalled();
+  });
+
+  it("moves to the next target repo when the first queue is empty", async () => {
+    const io = fakeIo({
+      listIssues: vi.fn(async ({ repo }) => (repo === "owner/two" ? issueList([4]) : [])),
+    });
+    const outcome = await runCycle({ config: { ...config, repos: ["owner/one", "owner/two"] }, cycle: 0, env, io, log });
+
+    expect(outcome).toMatchObject({ status: "worked", repo: "owner/two", issue: 4 });
+  });
+
+  it("rotates the repo list so no repo starves", async () => {
+    const io = fakeIo();
+    const outcome = await runCycle({ config: { ...config, repos: ["owner/one", "owner/two"] }, cycle: 1, env, io, log });
+    expect(outcome.repo).toBe("owner/two");
+  });
+
+  it("exits clean on an empty queue without cloning anything", async () => {
+    const io = fakeIo({ listIssues: vi.fn().mockResolvedValue([]) });
+    const outcome = await runCycle({ config, cycle: 0, env, io, log });
+
+    expect(outcome).toEqual({ status: "empty" });
+    expect(io.clone).not.toHaveBeenCalled();
+    expect(io.makeWorkdir).not.toHaveBeenCalled();
+  });
+
+  it("skips a runner whose credential is missing and uses the next in cadence", async () => {
+    const io = fakeIo();
+    const outcome = await runCycle({ config, cycle: 0, env: { OPENAI_API_KEY: "o" }, io, log });
+    expect(outcome.runner).toBe("codex");
+  });
+
+  it("advances the runner one step per cycle", async () => {
+    const io = fakeIo();
+    const second = await runCycle({ config, cycle: 1, env, io, log });
+    expect(second.runner).toBe("codex");
+  });
+
+  it("stops before touching the queue when no cadence runner is credentialed", async () => {
+    const io = fakeIo();
+    const outcome = await runCycle({ config, cycle: 0, env: {}, io, log });
+
+    expect(outcome).toMatchObject({ status: "no-runner" });
+    expect(io.listIssues).not.toHaveBeenCalled();
+  });
+
+  it("passes the model override through to the engine for the claude-minimax lane", async () => {
+    const io = fakeIo();
+    const minimax = { ...config, cadence: ["claude-minimax"], model: "MiniMax-M3", effort: "low" };
+    const outcome = await runCycle({ config: minimax, cycle: 0, env: { MINIMAX_API_KEY: "m" }, io, log });
+
+    expect(outcome.runner).toBe("claude-minimax");
+    const runEnv = io.runEngine.mock.calls[0][0].env;
+    expect(runEnv.RED_AFK_MODEL).toBe("MiniMax-M3");
+    expect(runEnv.RED_AFK_EFFORT).toBe("low");
+    expect(runEnv.RED_AFK_SANDBOX).toBe("none");
+  });
+
+  it("never reaches claude-minimax through a missing-credential fallback", async () => {
+    const io = fakeIo();
+    const outcome = await runCycle({ config, cycle: 0, env: { MINIMAX_API_KEY: "m" }, io, log });
+    expect(outcome.runner).toBe("opencode");
+  });
+});

--- a/apps/afk-container/tests/config.test.mjs
+++ b/apps/afk-container/tests/config.test.mjs
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRunEnv, nextBackoffSeconds, resolveConfig } from "../src/config.mjs";
+
+const base = { GH_TOKEN: "gh-token", RED_AFK_TARGET_REPOS: "owner/name", ANTHROPIC_API_KEY: "a" };
+
+describe("resolveConfig", () => {
+  it("reads a single target repo", () => {
+    expect(resolveConfig(base).repos).toEqual(["owner/name"]);
+  });
+
+  it("reads a comma-separated repo list, trimming blanks", () => {
+    const config = resolveConfig({ ...base, RED_AFK_TARGET_REPOS: " a/one , b/two ,, " });
+    expect(config.repos).toEqual(["a/one", "b/two"]);
+  });
+
+  it("accepts GITHUB_TOKEN as an alias for GH_TOKEN", () => {
+    const config = resolveConfig({ RED_AFK_TARGET_REPOS: "o/n", GITHUB_TOKEN: "t" });
+    expect(config.token).toBe("t");
+  });
+
+  it("requires a token", () => {
+    expect(() => resolveConfig({ RED_AFK_TARGET_REPOS: "o/n" })).toThrow(/GH_TOKEN/);
+  });
+
+  it("requires at least one target repo", () => {
+    expect(() => resolveConfig({ GH_TOKEN: "t" })).toThrow(/RED_AFK_TARGET_REPOS/);
+  });
+
+  it("rejects a malformed repo slug", () => {
+    expect(() => resolveConfig({ ...base, RED_AFK_TARGET_REPOS: "not-a-slug" })).toThrow(/not-a-slug/);
+    expect(() => resolveConfig({ ...base, RED_AFK_TARGET_REPOS: "https://github.com/o/n" })).toThrow(/slug/);
+  });
+
+  it("defaults the cadence, queue label and loop mode", () => {
+    const config = resolveConfig(base);
+    expect(config.cadence).toEqual(["claude", "codex", "opencode"]);
+    expect(config.label).toBe("ready-for-agent");
+    expect(config.loop).toBe(false);
+  });
+
+  it("honours an explicit cadence and loop mode", () => {
+    const config = resolveConfig({
+      ...base,
+      RED_AFK_RUNNER_CADENCE: "opencode,claude-minimax",
+      RED_AFK_LOOP: "TRUE",
+      RED_AFK_QUEUE_LABEL: "agent-ready",
+    });
+    expect(config.cadence).toEqual(["opencode", "claude-minimax"]);
+    expect(config.loop).toBe(true);
+    expect(config.label).toBe("agent-ready");
+  });
+
+  it("carries the model/effort overrides through unchanged", () => {
+    const config = resolveConfig({ ...base, RED_AFK_MODEL: "MiniMax-M3", RED_AFK_EFFORT: "low" });
+    expect(config.model).toBe("MiniMax-M3");
+    expect(config.effort).toBe("low");
+  });
+
+  it("clamps the idle backoff bounds to sane numbers", () => {
+    const config = resolveConfig({ ...base, RED_AFK_LOOP_IDLE_SECONDS: "5", RED_AFK_LOOP_MAX_IDLE_SECONDS: "0" });
+    expect(config.idleSeconds).toBe(5);
+    expect(config.maxIdleSeconds).toBeGreaterThanOrEqual(config.idleSeconds);
+  });
+
+  it("ignores a non-numeric backoff and uses the default", () => {
+    expect(resolveConfig({ ...base, RED_AFK_LOOP_IDLE_SECONDS: "soon" }).idleSeconds).toBe(60);
+  });
+});
+
+describe("buildRunEnv", () => {
+  it("forces the no-sandbox lane and tags the container lane", () => {
+    const env = buildRunEnv({ ...base, RED_AFK_SANDBOX: "docker" }, {});
+    expect(env.RED_AFK_SANDBOX).toBe("none");
+    expect(env.RED_AFK_LANE).toBe("container");
+  });
+
+  it("passes RED_AFK_MODEL and RED_AFK_EFFORT through when set", () => {
+    const env = buildRunEnv(base, { model: "MiniMax-M3", effort: "low" });
+    expect(env.RED_AFK_MODEL).toBe("MiniMax-M3");
+    expect(env.RED_AFK_EFFORT).toBe("low");
+  });
+
+  it("omits an empty model/effort so the target repo config stays in charge", () => {
+    const env = buildRunEnv({ ...base, RED_AFK_MODEL: "inherited" }, { model: "", effort: undefined });
+    expect(env.RED_AFK_MODEL).toBeUndefined();
+    expect(env.RED_AFK_EFFORT).toBeUndefined();
+  });
+
+  it("keeps the credential env vars the runner CLIs read", () => {
+    const env = buildRunEnv({ ...base, MINIMAX_API_KEY: "m" }, {});
+    expect(env.ANTHROPIC_API_KEY).toBe("a");
+    expect(env.MINIMAX_API_KEY).toBe("m");
+    expect(env.GH_TOKEN).toBe("gh-token");
+  });
+});
+
+describe("nextBackoffSeconds", () => {
+  it("doubles up to the ceiling", () => {
+    expect(nextBackoffSeconds(60, 900)).toBe(120);
+    expect(nextBackoffSeconds(600, 900)).toBe(900);
+    expect(nextBackoffSeconds(900, 900)).toBe(900);
+  });
+});

--- a/apps/afk-container/tests/queue.test.mjs
+++ b/apps/afk-container/tests/queue.test.mjs
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isParked, listReadyIssues, pickIssue, rotate } from "../src/queue.mjs";
+
+const issue = (number, createdAt, labels = ["ready-for-agent"]) => ({
+  number,
+  createdAt,
+  labels: labels.map((name) => ({ name })),
+});
+
+describe("isParked", () => {
+  it("parks ready-for-human and every blocked:* label", () => {
+    expect(isParked(issue(1, "2026-01-01", ["ready-for-agent", "ready-for-human"]))).toBe(true);
+    expect(isParked(issue(1, "2026-01-01", ["blocked:dependency"]))).toBe(true);
+    expect(isParked(issue(1, "2026-01-01", ["blocked:validation"]))).toBe(true);
+  });
+
+  it("does not park an ordinary queued issue", () => {
+    expect(isParked(issue(1, "2026-01-01", ["ready-for-agent", "type:bug"]))).toBe(false);
+  });
+
+  it("accepts bare string labels", () => {
+    expect(isParked({ number: 1, labels: ["blocked:dependency"] })).toBe(true);
+  });
+});
+
+describe("pickIssue", () => {
+  it("takes the oldest actionable issue", () => {
+    const picked = pickIssue([issue(9, "2026-02-01"), issue(4, "2026-01-01"), issue(7, "2026-03-01")]);
+    expect(picked.number).toBe(4);
+  });
+
+  it("skips parked issues even when they are older", () => {
+    const picked = pickIssue([
+      issue(2, "2026-01-01", ["ready-for-agent", "blocked:dependency"]),
+      issue(5, "2026-02-01"),
+    ]);
+    expect(picked.number).toBe(5);
+  });
+
+  it("breaks createdAt ties by issue number", () => {
+    expect(pickIssue([issue(8, "2026-01-01"), issue(3, "2026-01-01")]).number).toBe(3);
+  });
+
+  it("returns null when nothing is actionable", () => {
+    expect(pickIssue([])).toBeNull();
+    expect(pickIssue([issue(1, "2026-01-01", ["ready-for-human"])])).toBeNull();
+  });
+});
+
+describe("listReadyIssues", () => {
+  it("asks gh for open labelled issues and parses the JSON payload", async () => {
+    const exec = vi.fn().mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify([{ number: 3, createdAt: "2026-01-01", labels: [{ name: "ready-for-agent" }] }]),
+      stderr: "",
+    });
+    const issues = await listReadyIssues({ repo: "owner/name", label: "ready-for-agent", exec });
+
+    expect(issues).toHaveLength(1);
+    expect(exec).toHaveBeenCalledWith("gh", [
+      "issue",
+      "list",
+      "--repo",
+      "owner/name",
+      "--label",
+      "ready-for-agent",
+      "--state",
+      "open",
+      "--limit",
+      "100",
+      "--json",
+      "number,createdAt,labels",
+    ]);
+  });
+
+  it("throws with gh's stderr when the query fails", async () => {
+    const exec = vi.fn().mockResolvedValue({ code: 1, stdout: "", stderr: "HTTP 401" });
+    await expect(listReadyIssues({ repo: "owner/name", label: "ready-for-agent", exec })).rejects.toThrow(/HTTP 401/);
+  });
+
+  it("returns an empty list for an empty queue", async () => {
+    const exec = vi.fn().mockResolvedValue({ code: 0, stdout: "[]\n", stderr: "" });
+    await expect(listReadyIssues({ repo: "owner/name", label: "ready-for-agent", exec })).resolves.toEqual([]);
+  });
+});
+
+describe("rotate", () => {
+  it("starts the list at the cycle offset, wrapping", () => {
+    expect(rotate(["a", "b", "c"], 0)).toEqual(["a", "b", "c"]);
+    expect(rotate(["a", "b", "c"], 1)).toEqual(["b", "c", "a"]);
+    expect(rotate(["a", "b", "c"], 4)).toEqual(["b", "c", "a"]);
+  });
+
+  it("handles an empty list", () => {
+    expect(rotate([], 3)).toEqual([]);
+  });
+});

--- a/apps/afk-container/tests/runners.test.mjs
+++ b/apps/afk-container/tests/runners.test.mjs
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_CADENCE,
+  RUNNER_CREDENTIAL_ENVS,
+  hasCredential,
+  missingCredentialEnvs,
+  parseCadence,
+  selectRunner,
+} from "../src/runners.mjs";
+
+describe("parseCadence", () => {
+  it("falls back to the default cadence when unset or blank", () => {
+    expect(parseCadence(undefined)).toEqual(["claude", "codex", "opencode"]);
+    expect(parseCadence("")).toEqual([...DEFAULT_CADENCE]);
+    expect(parseCadence("  , ,")).toEqual([...DEFAULT_CADENCE]);
+  });
+
+  it("never puts claude-minimax in the default cadence", () => {
+    expect(DEFAULT_CADENCE).not.toContain("claude-minimax");
+    expect(parseCadence(undefined)).not.toContain("claude-minimax");
+  });
+
+  it("admits claude-minimax only when explicitly listed", () => {
+    expect(parseCadence("claude-minimax")).toEqual(["claude-minimax"]);
+    expect(parseCadence("claude, claude-minimax")).toEqual(["claude", "claude-minimax"]);
+  });
+
+  it("trims, lowercases and de-duplicates while preserving order", () => {
+    expect(parseCadence(" Codex , claude ,codex ")).toEqual(["codex", "claude"]);
+  });
+
+  it("rejects an unknown runner instead of silently dropping it", () => {
+    expect(() => parseCadence("claude,hal9000")).toThrow(/hal9000/);
+  });
+});
+
+describe("hasCredential", () => {
+  it("maps each runner to its credential env vars", () => {
+    expect(RUNNER_CREDENTIAL_ENVS.claude).toContain("ANTHROPIC_API_KEY");
+    expect(RUNNER_CREDENTIAL_ENVS.codex).toContain("OPENAI_API_KEY");
+    expect(RUNNER_CREDENTIAL_ENVS["claude-minimax"]).toEqual(["MINIMAX_API_KEY"]);
+  });
+
+  it("accepts any one of a runner's alternative credentials", () => {
+    expect(hasCredential("claude", { CLAUDE_CODE_OAUTH_TOKEN: "tok" })).toBe(true);
+    expect(hasCredential("opencode", { OPENROUTER_API_KEY: "k" })).toBe(true);
+    expect(hasCredential("opencode", {})).toBe(false);
+  });
+
+  it("treats a blank value as missing", () => {
+    expect(hasCredential("codex", { OPENAI_API_KEY: "   " })).toBe(false);
+    expect(missingCredentialEnvs("codex", {})).toEqual(["OPENAI_API_KEY"]);
+  });
+});
+
+describe("selectRunner", () => {
+  const all = { ANTHROPIC_API_KEY: "a", OPENAI_API_KEY: "o", OPENROUTER_API_KEY: "r" };
+
+  it("round-robins across the cadence, one step per run", () => {
+    const cadence = ["claude", "codex", "opencode"];
+    const picks = [0, 1, 2, 3].map((cycle) => selectRunner(cadence, cycle, all).runner);
+    expect(picks).toEqual(["claude", "codex", "opencode", "claude"]);
+  });
+
+  it("falls back to the next credentialed runner when a credential is missing", () => {
+    const cadence = ["claude", "codex", "opencode"];
+    const onlyOpenRouter = { OPENROUTER_API_KEY: "r" };
+    const selection = selectRunner(cadence, 0, onlyOpenRouter);
+    expect(selection.runner).toBe("opencode");
+    expect(selection.skipped).toEqual(["claude", "codex"]);
+  });
+
+  it("wraps around the cadence when the fallback passes the end", () => {
+    const cadence = ["claude", "codex", "opencode"];
+    const onlyAnthropic = { ANTHROPIC_API_KEY: "a" };
+    const selection = selectRunner(cadence, 2, onlyAnthropic);
+    expect(selection.runner).toBe("claude");
+    expect(selection.skipped).toEqual(["opencode"]);
+  });
+
+  it("never falls back onto claude-minimax when it is not in the cadence", () => {
+    const cadence = ["claude", "codex", "opencode"];
+    const onlyMiniMax = { MINIMAX_API_KEY: "m" };
+    // MINIMAX_API_KEY does credential opencode, so opencode — not claude-minimax — wins.
+    expect(selectRunner(cadence, 0, onlyMiniMax).runner).toBe("opencode");
+  });
+
+  it("selects claude-minimax when it is listed and credentialed", () => {
+    const selection = selectRunner(["claude-minimax"], 0, { MINIMAX_API_KEY: "m" });
+    expect(selection.runner).toBe("claude-minimax");
+  });
+
+  it("returns no runner when every cadence entry lacks a credential", () => {
+    const selection = selectRunner(["claude", "codex"], 0, {});
+    expect(selection.runner).toBeNull();
+    expect(selection.skipped).toEqual(["claude", "codex"]);
+  });
+
+  it("rejects an empty cadence", () => {
+    expect(() => selectRunner([], 0, all)).toThrow(/cadence/);
+  });
+});

--- a/apps/afk-container/vitest.config.mjs
+++ b/apps/afk-container/vitest.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.mjs"],
+    environment: "node",
+    pool: "forks",
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
         specifier: ^5.6.0
         version: 5.9.3
 
+  apps/afk-container:
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@25.9.1)
+
   apps/benchmark-code-understanding:
     dependencies:
       '@reddb-io/build-info':
@@ -5148,6 +5154,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.19)
 
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.9.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.9.1)
+
   '@vitest/mocker@3.2.6(vite@5.4.21(@types/node@25.9.1))':
     dependencies:
       '@vitest/spy': 3.2.6
@@ -6674,6 +6688,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@25.9.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.9.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@25.9.1):
     dependencies:
       cac: 6.7.14
@@ -6734,6 +6766,41 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@25.9.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.9.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.9.1)
+      vite-node: 2.1.9(@types/node@25.9.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
Automated AFK landing for #1399. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1399

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226907&installation_id=129708444&pr_number=1400&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1400&signature=0b17c8354e1fda5c3a3a3a0d1d5284a44be80627a0ae173faa5be218a91f3137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->