### PR TITLE
fix: #1405 packages/toon: shared TOON spec-v3.2 encode+decode package

### DIFF
--- a/packages/toon/index.test.ts
+++ b/packages/toon/index.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { appendSummaryField, decode, encode, projectFields } from "./index.js";
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}
+
+const quoteForcingStrings = [
+  "",
+  "007",
+  "true",
+  "false",
+  "null",
+  "has: colon",
+  'quote " mark',
+  "slash \\ mark",
+  "array[0]",
+  "object{key}",
+  "a,b",
+  "-dash",
+  "line\nbreak",
+  "tab\tbreak",
+  "unicode caf\u00e9",
+  "control\u0001char",
+];
+
+function generatedJson(rng: () => number, depth = 0): JsonValue {
+  if (depth > 3) return generatedScalar(rng);
+  const kind = Math.floor(rng() * 6);
+  if (kind <= 2) return generatedScalar(rng);
+  if (kind === 3) {
+    const length = Math.floor(rng() * 4);
+    return Array.from({ length }, () => generatedJson(rng, depth + 1));
+  }
+  const fields = ["id", "name", "active", "note"].slice(0, 1 + Math.floor(rng() * 4));
+  const rowCount = Math.floor(rng() * 4);
+  if (kind === 4) {
+    return Array.from({ length: rowCount }, (_, index) =>
+      Object.fromEntries(fields.map((field) => [field, field === "id" ? index + 1 : generatedScalar(rng)])),
+    );
+  }
+  return Object.fromEntries(fields.map((field) => [field, generatedJson(rng, depth + 1)]));
+}
+
+function generatedScalar(rng: () => number): JsonPrimitive {
+  const kind = Math.floor(rng() * 5);
+  if (kind === 0) return null;
+  if (kind === 1) return rng() > 0.5;
+  if (kind === 2) return Math.floor(rng() * 10_000) - 5_000;
+  if (kind === 3) return quoteForcingStrings[Math.floor(rng() * quoteForcingStrings.length)] ?? "";
+  return `text-${Math.floor(rng() * 1000)}`;
+}
+
+describe("shared TOON package", () => {
+  it("round-trips generated JSON-shaped values through the public encoder and decoder", () => {
+    const rng = makeRng(0x5eed);
+    const cases = [
+      null,
+      "",
+      "unicode caf\u00e9",
+      "has: colon",
+      { empty: "", nil: null, nested: { active: true } },
+      { rows: [{ id: 1, value: "a,b" }, { id: 2, value: "-dash" }] },
+      ...Array.from({ length: 80 }, () => generatedJson(rng)),
+    ];
+
+    for (const value of cases) {
+      expect(decode(encode(value))).toEqual(value);
+    }
+  });
+
+  it("emits exact spec-v3.2 fixture bytes for RedSkills-supported forms", () => {
+    expect(encode({ users: [{ id: 1, name: "Alice", active: true }, { id: 2, name: "Bob", active: false }] })).toBe(
+      ["users[2]{id,name,active}:", "  1,Alice,true", "  2,Bob,false"].join("\n"),
+    );
+    expect(encode({ project: { id: "p1", meta: { owner: "ops", ok: true } } })).toBe(
+      ["project:", "  id: p1", "  meta:", "    owner: ops", "    ok: true"].join("\n"),
+    );
+    expect(encode("hello")).toBe("hello");
+    expect(encode({ obj: {}, arr: [] })).toBe(["obj:", "arr: []"].join("\n"));
+    expect(encode({ rows: [{ value: "a,b" }, { value: "-dash" }, { value: "true" }, { value: "null" }] })).toBe(
+      ['rows[4]{value}:', '  "a,b"', '  "-dash"', '  "true"', '  "null"'].join("\n"),
+    );
+    expect(encode({ text: 'backslash \\ quote " newline\ncarriage\r tab\t nul\u0001' })).toBe(
+      'text: "backslash \\\\ quote \\" newline\\ncarriage\\r tab\\t nul\\u0001"',
+    );
+    expect(encode({ rows: [{ value: "a|b" }, { value: "a,b" }] }, { delimiter: "|" })).toBe(
+      ['rows[2|]{value}:', '  "a|b"', "  a,b"].join("\n"),
+    );
+  });
+
+  it("enforces strict [N] length agreement while decoding", () => {
+    expect(() => decode(["rows[2]{id}:", "  1"].join("\n"))).toThrow(/Expected 2 tabular rows, but got 1/);
+  });
+
+  it("appends a pre-computed rollup as a trailing summary field in the same document", () => {
+    const output = appendSummaryField({ rows: [{ id: 1, status: "ok" }] }, "1 row ok");
+
+    expect(output).toBe(["rows[1]{id,status}:", "  1,ok", "summary: 1 row ok"].join("\n"));
+    expect(decode(output)).toEqual({ rows: [{ id: 1, status: "ok" }], summary: "1 row ok" });
+  });
+
+  it("projects object arrays onto an explicit field allowlist in allowlist order", () => {
+    expect(projectFields([{ id: 1, name: "Alice", secret: "drop", status: "active" }], ["status", "id"])).toEqual([
+      { status: "active", id: 1 },
+    ]);
+  });
+});

--- a/packages/toon/index.ts
+++ b/packages/toon/index.ts
@@ -1,0 +1,65 @@
+import { encode } from "@toon-format/toon";
+import type { EncodeOptions, JsonObject, JsonValue } from "@toon-format/toon";
+
+export {
+  DEFAULT_DELIMITER,
+  DELIMITERS,
+  ToonDecodeError,
+  decode,
+  decodeFromLines,
+  decodeStream,
+  decodeStreamSync,
+  encode,
+  encodeLines,
+} from "@toon-format/toon";
+export type {
+  DecodeOptions,
+  DecodeStreamOptions,
+  Delimiter,
+  DelimiterKey,
+  EncodeOptions,
+  EncodeReplacer,
+  JsonArray,
+  JsonObject,
+  JsonPrimitive,
+  JsonStreamEvent,
+  JsonValue,
+  ResolvedDecodeOptions,
+  ResolvedEncodeOptions,
+} from "@toon-format/toon";
+
+type JsonRecord = Record<string, JsonValue>;
+
+function entriesWithoutSummary(value: JsonObject): [string, JsonValue][] {
+  return Object.entries(value).filter(([key]) => key !== "summary") as [string, JsonValue][];
+}
+
+/**
+ * Encodes an object with a trailing spec-legal `summary:` field.
+ *
+ * This retires the old bare summary-line dialect: the returned bytes are one
+ * conforming TOON document, so `decode(output)` parses the rollup with the rest
+ * of the payload.
+ */
+export function appendSummaryField(value: JsonObject, summary: JsonValue, options?: EncodeOptions): string {
+  return encode(Object.fromEntries([...entriesWithoutSummary(value), ["summary", summary]]) as JsonRecord, options);
+}
+
+/**
+ * Projects object rows onto an explicit minimal schema, preserving allowlist
+ * order and dropping all non-allowlisted fields.
+ */
+export function projectFields<T extends Readonly<Record<string, JsonValue>>, const Field extends readonly string[]>(
+  rows: readonly T[],
+  fields: Field,
+): Array<Partial<Record<Field[number], JsonValue>>> {
+  return rows.map((row) => {
+    const projected: Partial<Record<Field[number], JsonValue>> = {};
+    for (const field of fields) {
+      if (Object.prototype.hasOwnProperty.call(row, field)) {
+        projected[field as Field[number]] = row[field] as JsonValue;
+      }
+    }
+    return projected;
+  });
+}

--- a/packages/toon/package.json
+++ b/packages/toon/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@reddb-io/toon",
+  "version": "2.23.1",
+  "private": true,
+  "type": "module",
+  "description": "Shared TOON spec-v3.2 encode/decode authority for RedSkills packages.",
+  "license": "Apache-2.0",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@toon-format/toon": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/toon/tsconfig.json
+++ b/packages/toon/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "resolveJsonModule": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/toon/vitest.config.ts
+++ b/packages/toon/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@modelcontextprotocol/sdk':
       specifier: ^1.0.0
       version: 1.29.0
+    '@toon-format/toon':
+      specifier: ^2.3.0
+      version: 2.3.0
     '@types/node':
       specifier: ^22.0.0
       version: 22.19.19
@@ -385,6 +388,22 @@ importers:
       cli-args-parser:
         specifier: ^1.0.6
         version: 1.0.6
+
+  packages/toon:
+    dependencies:
+      '@toon-format/toon':
+        specifier: 'catalog:'
+        version: 2.3.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.19)
 
 packages:
 
@@ -1856,6 +1875,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@toon-format/toon@2.3.0':
+    resolution: {integrity: sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w==}
 
   '@turbo/darwin-64@2.9.16':
     resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
@@ -5041,6 +5063,8 @@ snapshots:
       tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@toon-format/toon@2.3.0': {}
 
   '@turbo/darwin-64@2.9.16':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   "@types/node": ^22.0.0
   zod: ^3.23.8
   "@modelcontextprotocol/sdk": ^1.0.0
+  "@toon-format/toon": ^2.3.0
 
 onlyBuiltDependencies:
   - "@reddb-io/sdk"


### PR DESCRIPTION
Automated AFK landing for #1405. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1405

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786273675&installation_id=129708444&pr_number=1421&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1421&signature=addd107b792602319508bcc0558e71fa597cc78fdd604de1feeca1ef8d9459f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->