### PR TITLE
fix: #1406 rsp scaffold: neutral package, single binary, elision store with handle retrieval (rsp show)

### DIFF
--- a/apps/rsp/README.md
+++ b/apps/rsp/README.md
@@ -1,0 +1,19 @@
+# @reddb-io/rsp
+
+`rsp` is the neutral RedSkills binary for reversible command-output elision.
+This package currently carries the elision store and retrieval command from ADR
+0095; wrappers and hook interception land in later slices.
+
+Elision handles are stable short content-addressed ids rendered as `el:<id>`,
+where `<id>` is 12 lowercase hexadecimal characters. The only write API is
+`RspElisionStore.mint(original, meta)`, which stores the original bytes and
+returns the handle, preserving the handle/elision invariant.
+
+The store uses the namespaced `rsp_elisions_v1` KV collection in the repo RedDB
+store. Retention defaults are `ttlDays: 7` and `byteBudget: 67108864`; top-level
+`.red/config.yaml` keys `rsp.ttlDays` and `rsp.byteBudget` override them.
+
+`rsp show el:<id>` writes the original bytes verbatim to stdout. Expired or
+evicted handles write `expired <ISO date> — re-run: <original command>` to stdout
+and exit 1. Calling `rsp` with no arguments prints live store stats as scalar
+TOON fields instead of help text.

--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@reddb-io/rsp",
+  "version": "2.23.1",
+  "private": true,
+  "description": "RedSkills neutral rsp binary: reversible elision store and retrieval over the repo RedDB store.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "rsp": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.build.json && pnpm bundle",
+    "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/rsp.bundle.min.mjs --asset rsp.bundle.min.mjs --minify --reddb-from-package",
+    "test": "vitest run",
+    "dev": "node --import tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@reddb-io/build-info": "workspace:*",
+    "@reddb-io/sdk": "1.7.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@reddb-io/sdk"
+    ]
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "esbuild": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { RspElisionStore } from "./elision-store.js";
+import { resolveRspConfig } from "./config.js";
+
+interface ParsedArgs {
+  command?: string;
+  handle?: string;
+  storeUri?: string;
+}
+
+async function main(argv = process.argv.slice(2)): Promise<number> {
+  const args = parseArgs(argv);
+  const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
+  const store = await RspElisionStore.open({
+    uri: config.storeUri,
+    ttlDays: config.ttlDays,
+    byteBudget: config.byteBudget,
+  });
+
+  try {
+    if (!args.command) {
+      const stats = await store.stats();
+      process.stdout.write(renderStats(stats));
+      return 0;
+    }
+
+    if (args.command === "show" && args.handle) {
+      const record = await store.get(args.handle);
+      if (record && "original" in record && record.original) {
+        process.stdout.write(record.original);
+        return 0;
+      }
+      if (record?.status === "expired") {
+        process.stdout.write(`expired ${record.expired_at} — re-run: ${record.command}\n`);
+        return 1;
+      }
+      process.stdout.write(`expired unknown — re-run: ${args.handle}\n`);
+      return 1;
+    }
+
+    process.stdout.write("error: usage rsp show el:<id>\n");
+    return 2;
+  } finally {
+    await store.close();
+  }
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--store-uri") out.storeUri = argv[++i];
+    else positional.push(arg);
+  }
+  out.command = positional[0];
+  out.handle = positional[1];
+  return out;
+}
+
+function renderStats(stats: { records: number; bytes: number; oldest: string | null; budget: number }): string {
+  return [
+    `records: ${stats.records}`,
+    `bytes: ${stats.bytes}`,
+    `oldest: ${stats.oldest ?? "none"}`,
+    `budget: ${stats.budget}`,
+    "",
+  ].join("\n");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((code) => process.exit(code), (err) => {
+    process.stdout.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}
+
+export { main, renderStats };

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -1,0 +1,75 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "./elision-store.js";
+
+export interface RspRuntimeConfig {
+  storeUri: string;
+  ttlDays: number;
+  byteBudget: number;
+}
+
+export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitStoreUri?: string): RspRuntimeConfig {
+  const configPath = findUp(cwd, join(".red", "config.yaml"));
+  const root = configPath ? dirname(dirname(configPath)) : cwd;
+  const yaml = configPath ? readFileSync(configPath, "utf8") : "";
+  const ttlDays = positiveNumber(readNumericYamlPath(yaml, "rsp.ttlDays"), DEFAULT_RSP_TTL_DAYS);
+  const byteBudget = positiveNumber(readNumericYamlPath(yaml, "rsp.byteBudget"), DEFAULT_RSP_BYTE_BUDGET);
+  const storeUri = explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${join(resolve(root), ".red", "red.rdb")}`;
+
+  ensureFileUriParent(storeUri);
+  return { storeUri, ttlDays, byteBudget };
+}
+
+function ensureFileUriParent(uri: string): void {
+  if (!uri.startsWith("file://")) return;
+  mkdirSync(dirname(fileURLToPath(uri)), { recursive: true });
+}
+
+function findUp(start: string, relativePath: string): string | null {
+  let dir = resolve(start);
+  for (let i = 0; i < 32; i++) {
+    const candidate = join(dir, relativePath);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+function readNumericYamlPath(yaml: string, dottedPath: string): number | undefined {
+  const value = readYamlPath(yaml, dottedPath);
+  if (value == null) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function readYamlPath(yaml: string, dottedPath: string): string | undefined {
+  const target = dottedPath.split(".");
+  const stack: Array<{ indent: number; key: string }> = [];
+  for (const rawLine of yaml.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const indent = line.length - line.trimStart().length;
+    const key = line.slice(0, colon).trim();
+    if (!key) continue;
+    const value = stripInlineComment(line.slice(colon + 1));
+    while (stack.length > 0 && stack[stack.length - 1]!.indent >= indent) stack.pop();
+    stack.push({ indent, key });
+    if (value !== "" && stack.map((entry) => entry.key).join(".") === target.join(".")) return value;
+  }
+  return undefined;
+}
+
+function stripInlineComment(value: string): string {
+  const hash = value.indexOf(" #");
+  return (hash >= 0 ? value.slice(0, hash) : value).trim();
+}
+
+function positiveNumber(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,0 +1,325 @@
+import { createHash } from "node:crypto";
+import { connect, type RedDB } from "@reddb-io/sdk";
+
+export const RSP_ELISION_COLLECTION = "rsp_elisions_v1";
+const INDEX_KEY = "__rsp_elision_index_v1";
+
+export const DEFAULT_RSP_TTL_DAYS = 7;
+export const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
+
+export type RspLossLevel = "lossless" | "brief" | "terse" | (string & {});
+
+export interface RspLossMeta {
+  level: RspLossLevel;
+  bytes_elided: number;
+}
+
+export interface RspMintMeta {
+  command: string;
+  loss: RspLossMeta;
+}
+
+export interface RspElisionRecord {
+  collection: typeof RSP_ELISION_COLLECTION;
+  handle: `el:${string}`;
+  original: Buffer;
+  command: string;
+  created_at: string;
+  loss: RspLossMeta;
+}
+
+export interface RspExpiredHandle {
+  status: "expired";
+  expired_at: string;
+  command: string;
+  original?: undefined;
+}
+
+export interface RspStoreStats {
+  records: number;
+  bytes: number;
+  oldest: string | null;
+  budget: number;
+}
+
+export interface RspElisionStoreOptions {
+  uri: string;
+  ttlDays?: number;
+  byteBudget?: number;
+  now?: () => Date;
+}
+
+interface StoredRecord {
+  collection: typeof RSP_ELISION_COLLECTION;
+  handle: `el:${string}`;
+  original: string;
+  original_encoding: "base64";
+  original_bytes: number;
+  command: string;
+  created_at: string;
+  expires_at: string;
+  loss: RspLossMeta;
+}
+
+interface IndexEntry {
+  handle: `el:${string}`;
+  key: string;
+  bytes: number;
+  command: string;
+  created_at: string;
+  expires_at: string;
+}
+
+interface IndexDocument {
+  version: 1;
+  records: IndexEntry[];
+}
+
+export class RspElisionStore {
+  private db!: RedDB;
+
+  private constructor(private readonly opts: Required<Omit<RspElisionStoreOptions, "ttlDays" | "byteBudget">> & {
+    ttlDays: number;
+    byteBudget: number;
+  }) {}
+
+  static async open(opts: RspElisionStoreOptions): Promise<RspElisionStore> {
+    const store = new RspElisionStore({
+      uri: opts.uri,
+      ttlDays: positiveNumber(opts.ttlDays, DEFAULT_RSP_TTL_DAYS),
+      byteBudget: positiveNumber(opts.byteBudget, DEFAULT_RSP_BYTE_BUDGET),
+      now: opts.now ?? (() => new Date()),
+    });
+    store.db = await connect(store.opts.uri);
+    return store;
+  }
+
+  async close(): Promise<void> {
+    await this.db.close();
+  }
+
+  async mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
+    const bytes = Buffer.from(original);
+    const now = this.opts.now();
+    const createdAt = now.toISOString();
+    const expiresAt = new Date(now.getTime() + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
+    const handle = contentHandle(bytes, meta);
+    const key = recordKey(handle);
+
+    const record: StoredRecord = {
+      collection: RSP_ELISION_COLLECTION,
+      handle,
+      original: bytes.toString("base64"),
+      original_encoding: "base64",
+      original_bytes: bytes.length,
+      command: meta.command,
+      created_at: createdAt,
+      expires_at: expiresAt,
+      loss: meta.loss,
+    };
+
+    await this.kv().put(key, record);
+    await this.removeTombstone(handle);
+    await this.upsertIndex({
+      handle,
+      key,
+      bytes: bytes.length,
+      command: meta.command,
+      created_at: createdAt,
+      expires_at: expiresAt,
+    });
+    await this.prune();
+    return handle;
+  }
+
+  async get(handle: string): Promise<RspElisionRecord | RspExpiredHandle | null> {
+    if (!isHandle(handle)) return null;
+    const tombstone = await this.tombstone(handle);
+    if (tombstone) return tombstone;
+
+    const raw = parseStoredValue(await this.kv().get(recordKey(handle)));
+    if (!isStoredRecord(raw)) return null;
+
+    if (Date.parse(raw.expires_at) <= this.opts.now().getTime()) {
+      const expired = { status: "expired" as const, expired_at: raw.expires_at, command: raw.command };
+      await this.expireEntry({
+        handle: raw.handle,
+        key: recordKey(raw.handle),
+        bytes: raw.original_bytes,
+        command: raw.command,
+        created_at: raw.created_at,
+        expires_at: raw.expires_at,
+      }, raw.expires_at);
+      return expired;
+    }
+
+    return {
+      collection: RSP_ELISION_COLLECTION,
+      handle: raw.handle,
+      original: Buffer.from(raw.original, "base64"),
+      command: raw.command,
+      created_at: raw.created_at,
+      loss: raw.loss,
+    };
+  }
+
+  async stats(): Promise<RspStoreStats> {
+    await this.prune();
+    const index = await this.readIndex();
+    const records = index.records;
+    return {
+      records: records.length,
+      bytes: records.reduce((sum, entry) => sum + entry.bytes, 0),
+      oldest: records.reduce<string | null>((oldest, entry) => {
+        if (oldest == null) return entry.created_at;
+        return entry.created_at < oldest ? entry.created_at : oldest;
+      }, null),
+      budget: this.opts.byteBudget,
+    };
+  }
+
+  private kv() {
+    return this.db.kv(RSP_ELISION_COLLECTION);
+  }
+
+  private async readIndex(): Promise<IndexDocument> {
+    const raw = parseStoredValue(await this.kv().get(INDEX_KEY));
+    if (!isIndexDocument(raw)) return { version: 1, records: [] };
+    return raw;
+  }
+
+  private async writeIndex(index: IndexDocument): Promise<void> {
+    await this.kv().put(INDEX_KEY, index);
+  }
+
+  private async upsertIndex(entry: IndexEntry): Promise<void> {
+    const index = await this.readIndex();
+    const withoutExisting = index.records.filter((record) => record.handle !== entry.handle);
+    withoutExisting.push(entry);
+    await this.writeIndex({ version: 1, records: withoutExisting });
+  }
+
+  private async prune(): Promise<void> {
+    const nowMs = this.opts.now().getTime();
+    const nowIso = new Date(nowMs).toISOString();
+    const index = await this.readIndex();
+    const live: IndexEntry[] = [];
+
+    for (const entry of index.records) {
+      if (Date.parse(entry.expires_at) <= nowMs) {
+        await this.expireEntry(entry, entry.expires_at);
+      } else {
+        live.push(entry);
+      }
+    }
+
+    let bytes = live.reduce((sum, entry) => sum + entry.bytes, 0);
+    live.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    while (bytes > this.opts.byteBudget && live.length > 0) {
+      const evicted = live.shift()!;
+      bytes -= evicted.bytes;
+      await this.expireEntry(evicted, nowIso);
+    }
+
+    await this.writeIndex({ version: 1, records: live });
+  }
+
+  private async expireEntry(entry: IndexEntry, expiredAt: string): Promise<void> {
+    await this.kv().delete(entry.key);
+    await this.kv().put(tombstoneKey(entry.handle), {
+      status: "expired",
+      expired_at: expiredAt,
+      command: entry.command,
+    });
+  }
+
+  private async tombstone(handle: `el:${string}`): Promise<RspExpiredHandle | null> {
+    const raw = parseStoredValue(await this.kv().get(tombstoneKey(handle)));
+    return isExpiredHandle(raw) ? raw : null;
+  }
+
+  private async removeTombstone(handle: `el:${string}`): Promise<void> {
+    await this.kv().delete(tombstoneKey(handle));
+  }
+}
+
+function contentHandle(original: Buffer, meta: RspMintMeta): `el:${string}` {
+  const hash = createHash("sha256")
+    .update("rsp-elision-v1\0")
+    .update(original)
+    .update("\0")
+    .update(JSON.stringify({ command: meta.command, loss: meta.loss }))
+    .digest("hex")
+    .slice(0, 12);
+  return `el:${hash}`;
+}
+
+function recordKey(handle: `el:${string}`): string {
+  return `record:${handle.slice(3)}`;
+}
+
+function tombstoneKey(handle: `el:${string}`): string {
+  return `expired:${handle.slice(3)}`;
+}
+
+function isHandle(value: string): value is `el:${string}` {
+  return /^el:[a-f0-9]{12}$/.test(value);
+}
+
+function positiveNumber(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function isStoredRecord(value: unknown): value is StoredRecord {
+  if (!isRecord(value)) return false;
+  return value.collection === RSP_ELISION_COLLECTION &&
+    typeof value.handle === "string" &&
+    isHandle(value.handle) &&
+    typeof value.original === "string" &&
+    value.original_encoding === "base64" &&
+    typeof value.original_bytes === "number" &&
+    typeof value.command === "string" &&
+    typeof value.created_at === "string" &&
+    typeof value.expires_at === "string" &&
+    isLossMeta(value.loss);
+}
+
+function isIndexDocument(value: unknown): value is IndexDocument {
+  if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.records)) return false;
+  return value.records.every((entry) =>
+    isRecord(entry) &&
+    typeof entry.handle === "string" &&
+    isHandle(entry.handle) &&
+    typeof entry.key === "string" &&
+    typeof entry.bytes === "number" &&
+    typeof entry.command === "string" &&
+    typeof entry.created_at === "string" &&
+    typeof entry.expires_at === "string"
+  );
+}
+
+function isExpiredHandle(value: unknown): value is RspExpiredHandle {
+  return isRecord(value) &&
+    value.status === "expired" &&
+    typeof value.expired_at === "string" &&
+    typeof value.command === "string";
+}
+
+function isLossMeta(value: unknown): value is RspLossMeta {
+  return isRecord(value) &&
+    typeof value.level === "string" &&
+    typeof value.bytes_elided === "number";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStoredValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { RspElisionStore } from "../src/elision-store.js";
+
+const roots: string[] = [];
+const cli = join(import.meta.dirname, "..", "src", "cli.ts");
+const packageRoot = join(import.meta.dirname, "..");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-cli-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function runRsp(root: string, args: string[], env: Record<string, string>) {
+  return spawnSync(process.execPath, ["--import", "tsx", cli, ...args], {
+    cwd: packageRoot,
+    env: { ...process.env, ...env },
+    encoding: "buffer",
+  });
+}
+
+describe("rsp cli", () => {
+  it("prints store stats instead of help when called without arguments", async () => {
+    const root = await tempRoot();
+    const storeUri = `file://${join(root, "red.rdb")}`;
+    const store = await RspElisionStore.open({
+      uri: storeUri,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    try {
+      await store.mint(Buffer.from("abc"), {
+        command: "cmd",
+        loss: { level: "terse", bytes_elided: 3 },
+      });
+    } finally {
+      await store.close();
+    }
+
+    const res = runRsp(root, [], { RSP_STORE_URI: storeUri });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(Buffer.from("records: 1\nbytes: 3\noldest: 2026-07-10T12:00:00.000Z\nbudget: 67108864\n"));
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
+  it("rsp show prints original bytes verbatim on hit", async () => {
+    const root = await tempRoot();
+    const storeUri = `file://${join(root, "red.rdb")}`;
+    const original = Buffer.from([0x1b, 0x5b, 0x33, 0x32, 0x6d, 0x00, 0x62, 0xff]);
+    const store = await RspElisionStore.open({ uri: storeUri });
+    let handle = "";
+    try {
+      handle = await store.mint(original, {
+        command: "printf bytes",
+        loss: { level: "terse", bytes_elided: original.length },
+      });
+    } finally {
+      await store.close();
+    }
+
+    const res = runRsp(root, ["show", handle], { RSP_STORE_URI: storeUri });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(original);
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
+  it("rsp show prints structured expiry with the original command and exits 1", async () => {
+    const root = await tempRoot();
+    const storeUri = `file://${join(root, "red.rdb")}`;
+    let now = new Date("2026-07-10T12:00:00.000Z");
+    const store = await RspElisionStore.open({ uri: storeUri, ttlDays: 1, now: () => now });
+    let handle = "";
+    try {
+      handle = await store.mint(Buffer.from("old"), {
+        command: "rerun me",
+        loss: { level: "terse", bytes_elided: 3 },
+      });
+      now = new Date("2026-07-12T12:00:00.000Z");
+      await store.mint(Buffer.from("new"), {
+        command: "new",
+        loss: { level: "terse", bytes_elided: 3 },
+      });
+    } finally {
+      await store.close();
+    }
+
+    const res = runRsp(root, ["show", handle], { RSP_STORE_URI: storeUri });
+
+    expect(res.status).toBe(1);
+    expect(res.stdout).toEqual(Buffer.from("expired 2026-07-11T12:00:00.000Z — re-run: rerun me\n"));
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+});

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -1,0 +1,31 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveRspConfig } from "../src/config.js";
+
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-config-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("resolveRspConfig", () => {
+  it("reads retention knobs from the top-level rsp block", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  ttlDays: 3\n  byteBudget: 42\n", "utf8");
+
+    expect(resolveRspConfig(join(root, "nested"), {}, undefined)).toEqual({
+      storeUri: `file://${join(root, ".red", "red.rdb")}`,
+      ttlDays: 3,
+      byteBudget: 42,
+    });
+  });
+});

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_RSP_BYTE_BUDGET,
+  DEFAULT_RSP_TTL_DAYS,
+  RSP_ELISION_COLLECTION,
+  RspElisionStore,
+} from "../src/elision-store.js";
+
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-store-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("RspElisionStore", () => {
+  it("mints elision handles and round-trips original bytes exactly", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({
+      uri: `file://${join(root, "red.rdb")}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    try {
+      const original = Buffer.from([0x1b, 0x5b, 0x33, 0x31, 0x6d, 0x00, 0x41, 0xff, 0x0a]);
+      const handle = await store.mint(original, {
+        command: "printf ansi-and-nul",
+        loss: { level: "terse", bytes_elided: original.length },
+      });
+
+      expect(handle).toMatch(/^el:[a-f0-9]{12}$/);
+      const record = await store.get(handle);
+
+      expect(record).toEqual(expect.objectContaining({ collection: RSP_ELISION_COLLECTION }));
+      if (!record || "status" in record) throw new Error("expected live elision record");
+      expect(record?.collection).toBe(RSP_ELISION_COLLECTION);
+      expect(record?.original).toEqual(original);
+      expect(record?.command).toBe("printf ansi-and-nul");
+      expect(record?.loss).toEqual({ level: "terse", bytes_elided: original.length });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("expires records by TTL on amortized write and reports the original command", async () => {
+    let now = new Date("2026-07-10T12:00:00.000Z");
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({
+      uri: `file://${join(root, "red.rdb")}`,
+      ttlDays: 1,
+      now: () => now,
+    });
+    try {
+      const handle = await store.mint(Buffer.from("old output"), {
+        command: "old command",
+        loss: { level: "terse", bytes_elided: 10 },
+      });
+
+      now = new Date("2026-07-12T12:00:00.000Z");
+      await store.mint(Buffer.from("new output"), {
+        command: "new command",
+        loss: { level: "terse", bytes_elided: 10 },
+      });
+
+      expect(await store.get(handle)).toEqual({
+        status: "expired",
+        expired_at: "2026-07-11T12:00:00.000Z",
+        command: "old command",
+      });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("evicts oldest records when the byte budget is exceeded on write", async () => {
+    let tick = 0;
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({
+      uri: `file://${join(root, "red.rdb")}`,
+      byteBudget: 10,
+      now: () => new Date(Date.UTC(2026, 6, 10, 12, 0, tick++)),
+    });
+    try {
+      const first = await store.mint(Buffer.from("123456"), {
+        command: "first",
+        loss: { level: "terse", bytes_elided: 6 },
+      });
+      const second = await store.mint(Buffer.from("abcdef"), {
+        command: "second",
+        loss: { level: "terse", bytes_elided: 6 },
+      });
+
+      expect(await store.get(first)).toEqual({
+        status: "expired",
+        expired_at: "2026-07-10T12:00:03.000Z",
+        command: "first",
+      });
+      expect((await store.get(second))?.original).toEqual(Buffer.from("abcdef"));
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("reports live store stats as scalar values", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({
+      uri: `file://${join(root, "red.rdb")}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    try {
+      await store.mint(Buffer.from("abc"), {
+        command: "cmd",
+        loss: { level: "terse", bytes_elided: 3 },
+      });
+
+      expect(await store.stats()).toEqual({
+        records: 1,
+        bytes: 3,
+        oldest: "2026-07-10T12:00:00.000Z",
+        budget: DEFAULT_RSP_BYTE_BUDGET,
+      });
+      expect(DEFAULT_RSP_TTL_DAYS).toBe(7);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/apps/rsp/tsconfig.build.json
+++ b/apps/rsp/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/apps/rsp/tsconfig.json
+++ b/apps/rsp/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests"]
+}

--- a/apps/rsp/vitest.config.ts
+++ b/apps/rsp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packaging/npm/bin/rsp.mjs
+++ b/packaging/npm/bin/rsp.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * rsp — thin shim that execs the neutral rsp runtime bundle packaged inside
+ * this npm tarball (`dist/rsp.bundle.min.mjs`).
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundle = join(here, "..", "dist", "rsp.bundle.min.mjs");
+if (!existsSync(bundle)) {
+  process.stderr.write(`rsp: packaged bundle missing at ${bundle}\n`);
+  process.exit(1);
+}
+const res = spawnSync(process.execPath, [bundle, ...process.argv.slice(2)], { stdio: "inherit" });
+if (res.signal) process.kill(process.pid, res.signal);
+process.exit(res.status ?? 1);

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -15,7 +15,8 @@
   "bin": {
     "red-skills-dev": "bin/red-skills-dev.mjs",
     "red-skills-memory": "bin/red-skills-memory.mjs",
-    "red-skills-brain": "bin/red-skills-brain.mjs"
+    "red-skills-brain": "bin/red-skills-brain.mjs",
+    "rsp": "bin/rsp.mjs"
   },
   "files": [
     "bin/",

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -24,6 +24,7 @@ const BUNDLES = [
   "code-nav.bundle.min.mjs",
   "memory.bundle.min.mjs",
   "brain.bundle.min.mjs",
+  "rsp.bundle.min.mjs",
 ];
 
 mkdirSync(destDist, { recursive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,31 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.19)
 
+  apps/rsp:
+    dependencies:
+      '@reddb-io/build-info':
+        specifier: workspace:*
+        version: link:../../packages/build-info
+      '@reddb-io/sdk':
+        specifier: 1.7.0
+        version: 1.7.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.24.2
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.19)
+
   packages/browser-bridge:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
Automated AFK landing for #1406. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1406

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786274624&installation_id=129708444&pr_number=1422&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1422&signature=e120e04af8c18ddae0edec526037209ecb9b49b49c107736aeb5d2838ecd7176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->