### PR TITLE
fix: #1408 Memory CLI recall goes TOON-first (--json byte-identical, measured token delta)

### DIFF
--- a/apps/memory/package.json
+++ b/apps/memory/package.json
@@ -28,6 +28,7 @@
     "@reddb-io/build-info": "workspace:*",
     "@reddb-io/sdk": "1.7.0",
     "@reddb-io/shared": "workspace:*",
+    "@reddb-io/toon": "workspace:*",
     "fast-glob": "^3.3.2",
     "gray-matter": "^4.0.3",
     "js-tiktoken": "^1.0.21",

--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -113,7 +113,11 @@ import {
   type EvidenceCitation,
   type EvidenceProposalApplyState,
 } from "./evidence-card.js";
-import { graphRecallResult, renderSignalProvenance } from "./graph-recall.js";
+import {
+  graphRecallResult,
+  renderSignalProvenance,
+  type GraphRecallHit,
+} from "./graph-recall.js";
 import {
   buildMemoryGovernanceReport,
   type MemoryGovernanceReport,
@@ -304,6 +308,7 @@ import type { Confidence, MemoryLayer, MemoryProvenance, MemoryScope } from "./s
 import { slugify, storeNote } from "./store.js";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { parseLooseArgs, type LooseParsedArgs } from "@reddb-io/shared/args.js";
+import { renderToonOutput } from "./toon-output.js";
 
 const USAGE = `memory — governed operational memory for code agents
 
@@ -1371,35 +1376,32 @@ async function runRecall(args: ParsedArgs): Promise<void> {
         ranking: config.recallRanking,
       });
       const hits = layerFiltersOut ? [] : rawHits;
-      if (hits.length === 0) {
-        console.log(`memory: no matches for "${query}"`);
-        console.log(`  ${formatVectorRecallDiagnostic(diagnostics.vector)}`);
+      if (args.flags.json === true) {
+        printLegacyGraphRecall(query, hits, diagnostics);
         return;
       }
-      console.log(`memory: ${hits.length} match(es) for "${query}"`);
-      console.log(`  ${formatVectorRecallDiagnostic(diagnostics.vector)}`);
-      for (const hit of hits) {
-        console.log(`  [${hit.score}] ${hit.id} (${hit.node_type}) ${hit.label}`);
-        console.log(`        ${hit.excerpt}`);
-        for (const line of renderSignalProvenance(hit.signal_provenance)) {
-          console.log(`        ${line}`);
-        }
-        if (hit.hooks && hit.hooks.length > 0) {
-          const parts = hit.hooks.map((h) => `${h.lifecycle}=${h.exit_code}`);
-          console.log(`        hooks: ${parts.join(", ")}`);
-        }
-        if (hit.superseded_by != null) {
-          const window = [
-            hit.valid_from != null ? `valid_from=${hit.valid_from}` : "",
-            hit.valid_until != null ? `valid_until=${hit.valid_until}` : "",
-          ]
-            .filter(Boolean)
-            .join(" ");
-          console.log(
-            `        lineage: superseded_by=memory_nodes:${hit.superseded_by}${window ? ` ${window}` : ""}`,
-          );
-        }
+      if (hits.length === 0) {
+        printRecallToon({
+          items: [],
+          query,
+          store: "graph",
+          ranking: "hybrid-rrf",
+          vector: diagnostics.vector,
+        });
+        return;
       }
+      printRecallToon({
+        items: hits.map((hit) => ({
+          id: hit.id,
+          score: hit.score,
+          kind: hit.node_type,
+          content: `${hit.label} ${hit.excerpt}`.trim(),
+        })),
+        query,
+        store: "graph",
+        ranking: "hybrid-rrf",
+        vector: diagnostics.vector,
+      });
     } finally {
       await store.close();
     }
@@ -1409,6 +1411,75 @@ async function runRecall(args: ParsedArgs): Promise<void> {
   const hits = layerFiltersOut
     ? []
     : await recall(resolveNotesDir(rootDir, config), query, limit);
+  if (args.flags.json === true) {
+    printLegacyMarkdownRecall(query, hits);
+    return;
+  }
+  if (hits.length === 0) {
+    printRecallToon({
+      items: [],
+      query,
+      store: "markdown",
+      ranking: "term-count",
+    });
+    return;
+  }
+  printRecallToon({
+    items: hits.map((hit) => ({
+      id: hit.id,
+      score: hit.score,
+      kind: "note",
+      content: hit.excerpt,
+    })),
+    query,
+    store: "markdown",
+    ranking: "term-count",
+  });
+}
+
+type RecallToonItem = {
+  id: string;
+  score: number;
+  kind: string;
+  content: string;
+};
+
+function printRecallToon(opts: {
+  items: RecallToonItem[];
+  query: string;
+  store: "markdown" | "graph";
+  ranking: string;
+  vector?: {
+    status: "unavailable" | "available" | "contributed";
+    candidates: number;
+    contributed: number;
+    reason?: string;
+  };
+}): void {
+  const zero = opts.items.length === 0;
+  console.log(
+    renderToonOutput({
+      rowsKey: "items",
+      rows: opts.items,
+      fields: ["id", "score", "kind", "content"],
+      summary: {
+        status: zero ? "0 results" : `${opts.items.length} results`,
+        results: opts.items.length,
+        query: opts.query,
+        store: opts.store,
+        ranking: opts.ranking,
+        ...(opts.vector ? { vector: opts.vector } : {}),
+      },
+      extra: zero
+        ? {
+            next: 'try `memory store "..."` to add governed context, then rerun recall',
+          }
+        : {},
+    }),
+  );
+}
+
+function printLegacyMarkdownRecall(query: string, hits: Array<{ id: string; score: number; excerpt: string }>): void {
   if (hits.length === 0) {
     console.log(`memory: no matches for "${query}"`);
     return;
@@ -1417,6 +1488,42 @@ async function runRecall(args: ParsedArgs): Promise<void> {
   for (const hit of hits) {
     console.log(`  [${hit.score}] ${hit.id}`);
     console.log(`        ${hit.excerpt}`);
+  }
+}
+
+function printLegacyGraphRecall(
+  query: string,
+  hits: GraphRecallHit[],
+  diagnostics: { vector: Parameters<typeof formatVectorRecallDiagnostic>[0] },
+): void {
+  if (hits.length === 0) {
+    console.log(`memory: no matches for "${query}"`);
+    console.log(`  ${formatVectorRecallDiagnostic(diagnostics.vector)}`);
+    return;
+  }
+  console.log(`memory: ${hits.length} match(es) for "${query}"`);
+  console.log(`  ${formatVectorRecallDiagnostic(diagnostics.vector)}`);
+  for (const hit of hits) {
+    console.log(`  [${hit.score}] ${hit.id} (${hit.node_type}) ${hit.label}`);
+    console.log(`        ${hit.excerpt}`);
+    for (const line of renderSignalProvenance(hit.signal_provenance)) {
+      console.log(`        ${line}`);
+    }
+    if (hit.hooks && hit.hooks.length > 0) {
+      const parts = hit.hooks.map((h) => `${h.lifecycle}=${h.exit_code}`);
+      console.log(`        hooks: ${parts.join(", ")}`);
+    }
+    if (hit.superseded_by != null) {
+      const window = [
+        hit.valid_from != null ? `valid_from=${hit.valid_from}` : "",
+        hit.valid_until != null ? `valid_until=${hit.valid_until}` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      console.log(
+        `        lineage: superseded_by=memory_nodes:${hit.superseded_by}${window ? ` ${window}` : ""}`,
+      );
+    }
   }
 }
 

--- a/apps/memory/src/toon-output.ts
+++ b/apps/memory/src/toon-output.ts
@@ -1,0 +1,36 @@
+import {
+  appendSummaryField,
+  projectFields,
+  type JsonObject,
+  type JsonValue,
+} from "@reddb-io/toon";
+
+type JsonRecord = Record<string, JsonValue>;
+
+export interface ToonOutputOptions<Row extends JsonRecord> {
+  rowsKey: string;
+  rows: readonly Row[];
+  fields: readonly (keyof Row & string)[];
+  summary: JsonValue;
+  extra?: JsonRecord;
+}
+
+/**
+ * Shared AXI/TOON renderer for agent-facing structured CLI output.
+ *
+ * Callers choose the row key, fields, and summary. The helper only enforces
+ * the common TOON shape: projected tabular rows plus a trailing summary field.
+ */
+export function renderToonOutput<Row extends JsonRecord>({
+  rowsKey,
+  rows,
+  fields,
+  summary,
+  extra = {},
+}: ToonOutputOptions<Row>): string {
+  const value = {
+    [rowsKey]: projectFields(rows, fields),
+    ...extra,
+  } as JsonObject;
+  return appendSummaryField(value, summary);
+}

--- a/apps/memory/tests/fixtures/recall-toon-corpus.json
+++ b/apps/memory/tests/fixtures/recall-toon-corpus.json
@@ -1,0 +1,46 @@
+{
+  "items": [
+    {
+      "id": "decision-auth-refresh",
+      "score": 0.92,
+      "kind": "decision",
+      "content": "Auth refresh retries are capped at three attempts before surfacing operator action."
+    },
+    {
+      "id": "root-cause-cache-stampede",
+      "score": 0.87,
+      "kind": "root_cause",
+      "content": "The cache stampede came from a missing singleflight guard around token refresh."
+    },
+    {
+      "id": "validation-refresh-regression",
+      "score": 0.81,
+      "kind": "validation",
+      "content": "Regression coverage runs the refresh worker twice and asserts the second pass is idempotent."
+    },
+    {
+      "id": "fix-refresh-lock",
+      "score": 0.78,
+      "kind": "fix",
+      "content": "Use a per-account lock and persist the lease owner in the retry metadata."
+    },
+    {
+      "id": "doc-refresh-runbook",
+      "score": 0.64,
+      "kind": "doc",
+      "content": "The runbook points operators at memory recall before touching refresh-worker state."
+    }
+  ],
+  "summary": {
+    "status": "5 results",
+    "results": 5,
+    "query": "auth refresh retry",
+    "store": "graph",
+    "ranking": "hybrid-rrf",
+    "vector": {
+      "status": "contributed",
+      "candidates": 9,
+      "contributed": 3
+    }
+  }
+}

--- a/apps/memory/tests/recall-cli-toon.test.ts
+++ b/apps/memory/tests/recall-cli-toon.test.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { encodingForModel } from "js-tiktoken";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+import { decode } from "@reddb-io/toon";
+import recallCorpus from "./fixtures/recall-toon-corpus.json" with { type: "json" };
+import { resolveNotesDir } from "../src/config.js";
+import { initMarkdownOnly } from "../src/init.js";
+import { storeNote } from "../src/store.js";
+import { renderToonOutput } from "../src/toon-output.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, "..");
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "memory-recall-toon-"));
+  roots.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: PLUGIN_ROOT,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+}
+
+async function rootWithRecallFacts(): Promise<string> {
+  const root = await tempRoot();
+  const { config } = await initMarkdownOnly(root);
+  await storeNote(
+    resolveNotesDir(root, config),
+    "redis cache redis eviction policy is allkeys-lru",
+    new Date("2026-01-02T03:04:05.006Z"),
+  );
+  return root;
+}
+
+const LEGACY_RECALL_BYTES = [
+  "memory: 1 match(es) for \"redis\"",
+  "  [2] 2026-01-02T03-04-05-006Z-redis-cache-redis-eviction-policy-is-allkeys-lru",
+  "        redis cache redis eviction policy is allkeys-lru",
+  "",
+].join("\n");
+
+describe("memory recall TOON output", () => {
+  test("defaults to spec-decodable TOON with minimal item rows and a summary field", async () => {
+    const root = await rootWithRecallFacts();
+
+    const result = runMemory(["recall", "--root", root, "redis"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const decoded = decode(result.stdout) as {
+      items: Array<Record<string, unknown>>;
+      summary: Record<string, unknown>;
+    };
+    expect(decoded.items).toEqual([
+      {
+        id: "2026-01-02T03-04-05-006Z-redis-cache-redis-eviction-policy-is-allkeys-lru",
+        score: 2,
+        kind: "note",
+        content: "redis cache redis eviction policy is allkeys-lru",
+      },
+    ]);
+    expect(decoded.summary).toMatchObject({
+      results: 1,
+      store: "markdown",
+      ranking: "term-count",
+    });
+  });
+
+  test("--json preserves the pre-slice recall bytes exactly", async () => {
+    const root = await rootWithRecallFacts();
+
+    const result = runMemory(["recall", "--root", root, "redis", "--json"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(LEGACY_RECALL_BYTES);
+  });
+
+  test("empty recall output is explicit and tells the agent what to try next", async () => {
+    const root = await tempRoot();
+    await initMarkdownOnly(root);
+
+    const result = runMemory(["recall", "--root", root, "kafka"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const decoded = decode(result.stdout) as { summary: Record<string, unknown>; next: string };
+    expect(decoded.summary).toMatchObject({ status: "0 results", results: 0 });
+    expect(decoded.next).toBe('try `memory store "..."` to add governed context, then rerun recall');
+  });
+
+  test("reports a measured token delta for representative recall payloads", () => {
+    const payload = recallCorpus;
+    const json = JSON.stringify(payload, null, 2);
+    const toon = renderToonOutput({
+      rowsKey: "items",
+      rows: payload.items,
+      fields: ["id", "score", "kind", "content"],
+      summary: payload.summary,
+    });
+    const tokenizer = encodingForModel("gpt-4o");
+    const jsonTokens = tokenizer.encode(json).length;
+    const toonTokens = tokenizer.encode(toon).length;
+    const reduction = ((jsonTokens - toonTokens) / jsonTokens) * 100;
+    console.info(
+      `memory recall token delta: json=${jsonTokens} toon=${toonTokens} reduction=${reduction.toFixed(1)}%`,
+    );
+
+    expect(Number.isFinite(reduction)).toBe(true);
+    expect(decode(toon)).toEqual(payload);
+  });
+});

--- a/apps/memory/tests/store-recall-roundtrip.test.ts
+++ b/apps/memory/tests/store-recall-roundtrip.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
+import { decode } from "@reddb-io/toon";
 import { initMarkdownOnly } from "../src/init.js";
 import { resolveNotesDir } from "../src/config.js";
 import { recall } from "../src/recall.js";
@@ -99,7 +100,10 @@ describe("memory recall --layer (issue #175)", () => {
     for (const layer of ["L1", "L2"]) {
       const run = runMemory(["recall", "--root", root, "--layer", layer, "database password rotation"]);
       expect(run.status).toBe(0);
-      expect(run.stdout).toContain("no matches");
+      expect(decode(run.stdout)).toMatchObject({
+        items: [],
+        summary: { status: "0 results", results: 0 },
+      });
     }
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@reddb-io/toon':
+        specifier: workspace:*
+        version: link:../../packages/toon
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.3


### PR DESCRIPTION
Automated AFK landing for #1408. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1408

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786280679&installation_id=129708444&pr_number=1424&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1424&signature=867d7356106ac5e62ff9766fbc1149a7bc7123cc7d0a8c5928eb8feabd7740de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->