### PR TITLE
fix: #1409 Memory CLI batch 2: context-pack, timeline, dashboard go TOON-first

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -33,7 +33,7 @@ import type { CommunityAnalyticsReport } from "./communities.js";
 import { buildCommunitiesViewerArtifact } from "./communities-viewer.js";
 import type { CommunityDigestReport } from "./community-digest.js";
 import type { MemoryGlobalSearchReport } from "./global-search.js";
-import { buildContextPack } from "./context-pack.js";
+import { buildContextPack, type ContextPack } from "./context-pack.js";
 import { buildContextPackViewerArtifact } from "./context-pack-viewer.js";
 import { claimCheck, type ClaimCheckResult } from "./claim-check.js";
 import { buildDocBundle } from "./doc-bundle.js";
@@ -185,6 +185,7 @@ import { buildMemoryMapFreshnessReport } from "./map-freshness.js";
 import {
   buildMemoryOperationalDashboard,
   buildMemoryOperationalDashboardArtifact,
+  type MemoryOperationalDashboard,
 } from "./operational-dashboard.js";
 import { buildConfidenceReport, renderConfidenceMarkdown } from "./confidence.js";
 import { buildPathExplainReport } from "./path-explain.js";
@@ -1820,10 +1821,77 @@ async function runContextPack(args: ParsedArgs): Promise<void> {
       console.log(JSON.stringify(pack, null, 2));
       return;
     }
-    process.stdout.write(pack.markdown);
+    printContextPackToon(pack);
   } finally {
     await store.close();
   }
+}
+
+type ContextPackToonEntry = {
+  section: string;
+  title: string;
+  nodeType: string;
+  importance: number;
+  confidence: string;
+  trust: number;
+  citation: string;
+  reason: string;
+  excerpt: string;
+  expandHandle: string;
+};
+
+function printContextPackToon(pack: ContextPack): void {
+  const rows: ContextPackToonEntry[] = pack.entries.map((entry) => ({
+    section: entry.section,
+    title: entry.title,
+    nodeType: entry.nodeType,
+    importance: entry.importance,
+    confidence: entry.confidence,
+    trust: entry.trust,
+    citation: entry.citation.urn,
+    reason: entry.reason,
+    excerpt: entry.excerpt,
+    expandHandle: entry.expandHandle,
+  }));
+  console.log(
+    renderToonOutput({
+      rowsKey: "entries",
+      rows,
+      fields: [
+        "section",
+        "title",
+        "nodeType",
+        "importance",
+        "confidence",
+        "trust",
+        "citation",
+        "reason",
+        "excerpt",
+        "expandHandle",
+      ],
+      summary: {
+        status: pack.status,
+        goal: pack.goal,
+        entries: pack.entries.length,
+        coreContext: pack.coreContext.length,
+        warnings: pack.warnings.length,
+        omittedEntries: pack.omittedEntries,
+        budgetChars: pack.budgetChars,
+        usedChars: pack.usedChars,
+      },
+      extra: {
+        warnings: pack.warnings.map((warning) => ({
+          kind: warning.kind,
+          message: warning.message,
+        })),
+        ...(pack.entries.length === 0
+          ? {
+              next: 'run `memory store "..." --root <root>` or `memory ingest . --root <root>`, then rerun context-pack',
+            }
+          : {}),
+      },
+    }),
+  );
 }
 
 async function runCapsule(args: ParsedArgs): Promise<void> {
@@ -2002,18 +2070,110 @@ async function runDashboard(args: ParsedArgs): Promise<void> {
       console.log(JSON.stringify(dashboard, null, 2));
       return;
     }
-    const outPath = resolve(
-      stringFlag(args.flags, "out") ?? join(rootDir, ".red/memory/dashboard.html"),
-    );
-    const artifact = buildMemoryOperationalDashboardArtifact(dashboard);
-    await mkdir(dirname(outPath), { recursive: true });
-    await writeFile(outPath, artifact.html, "utf8");
-    console.log(`memory: operational dashboard written ${outPath}`);
-    console.log(`  state: ${dashboard.state}`);
-    console.log(`  contract: ${artifact.contract.consumes}`);
+    const outFlag = stringFlag(args.flags, "out");
+    if (outFlag !== undefined) {
+      const outPath = resolve(outFlag);
+      const artifact = buildMemoryOperationalDashboardArtifact(dashboard);
+      await mkdir(dirname(outPath), { recursive: true });
+      await writeFile(outPath, artifact.html, "utf8");
+      console.log(`memory: operational dashboard written ${outPath}`);
+      console.log(`  state: ${dashboard.state}`);
+      console.log(`  contract: ${artifact.contract.consumes}`);
+      return;
+    }
+    printDashboardToon(dashboard);
   } finally {
     await store.close();
   }
+}
+
+type DashboardToonSection = {
+  area: string;
+  status: string;
+  metric: string;
+  value: number;
+  detail: string;
+};
+
+function printDashboardToon(dashboard: MemoryOperationalDashboard): void {
+  const sections: DashboardToonSection[] = [
+    {
+      area: "stats",
+      status: dashboard.state,
+      metric: "nodes",
+      value: dashboard.stats.nodes,
+      detail: `${dashboard.stats.docs} docs; ${dashboard.stats.edges} edges`,
+    },
+    {
+      area: "vector",
+      status: dashboard.vector.overall,
+      metric: "ready",
+      value: dashboard.vector.ready,
+      detail: `${dashboard.vector.total} total; ${dashboard.vector.unavailable} unavailable; ${dashboard.vector.failed} failed`,
+    },
+    {
+      area: "docs",
+      status: dashboard.docs.ungrounded > 0 ? "attention" : "ready",
+      metric: "grounded",
+      value: dashboard.docs.grounded,
+      detail: `${dashboard.docs.total} total; ${dashboard.docs.warnings} warning(s)`,
+    },
+    {
+      area: "hooks",
+      status: dashboard.hooks.actionable_gaps > 0 ? "attention" : "ready",
+      metric: "wired_events",
+      value: dashboard.hooks.wired_events,
+      detail: `${dashboard.hooks.enabled_events} enabled; ${dashboard.hooks.actionable_gaps} actionable gap(s)`,
+    },
+    {
+      area: "extraction",
+      status: dashboard.extraction.inferred_available ? "ready" : "unavailable",
+      metric: "inferred_facts",
+      value: dashboard.extraction.inferred_facts,
+      detail: dashboard.extraction.egress ?? "no inferred extraction egress",
+    },
+    {
+      area: "stale",
+      status: dashboard.stale.stale_nodes > 0 ? "attention" : "ready",
+      metric: "stale_nodes",
+      value: dashboard.stale.stale_nodes,
+      detail: `${dashboard.stale.total_nodes} total; ${dashboard.stale.stale_days} day policy`,
+    },
+    {
+      area: "decay",
+      status: dashboard.decay.status,
+      metric: "review",
+      value: dashboard.decay.review,
+      detail: `${dashboard.decay.keep} keep; ${dashboard.decay.deprecate} deprecate; ${dashboard.decay.expire} expire`,
+    },
+  ];
+  const empty = dashboard.stats.nodes === 0 && dashboard.stats.docs === 0;
+  console.log(
+    renderToonOutput({
+      rowsKey: "sections",
+      rows: sections,
+      fields: ["area", "status", "metric", "value", "detail"],
+      summary: {
+        status: empty ? "empty" : dashboard.state,
+        state: dashboard.state,
+        nodes: dashboard.stats.nodes,
+        edges: dashboard.stats.edges,
+        docs: dashboard.stats.docs,
+        warnings: dashboard.warnings.length,
+        actions: dashboard.recommended_next_actions.length + (empty ? 1 : 0),
+        schema: dashboard.schema_version,
+      },
+      extra: {
+        warnings: dashboard.warnings.map((message) => ({ message })),
+        next: [
+          ...dashboard.recommended_next_actions.map((action) => ({ action })),
+          ...(empty
+            ? [{ action: "run `memory ingest . --root <root>` to populate dashboard evidence" }]
+            : []),
+        ],
+      },
+    }),
+  );
 }
 
 async function runWorkbench(args: ParsedArgs): Promise<void> {
@@ -6917,7 +7077,7 @@ async function runTimeline(args: ParsedArgs): Promise<void> {
       console.log(JSON.stringify(timeline, null, 2));
       return;
     }
-    printTimeline(timeline, { includeAudit: args.flags["include-audit"] === true });
+    printTimelineToon(timeline, { includeAudit: args.flags["include-audit"] === true });
   } finally {
     await store.close();
   }
@@ -7057,6 +7217,61 @@ function printTimeline(timeline: TopicTimeline, opts: { includeAudit: boolean })
       console.log(`    ${edge.label} ${edge.fromRid} -> ${edge.toRid}${reason}`);
     }
   }
+}
+
+type TimelineToonEntry = {
+  rid: number;
+  status: string;
+  activeRid: number;
+  nodeType: string;
+  label: string;
+  title: string;
+  content: string;
+};
+
+function printTimelineToon(timeline: TopicTimeline, opts: { includeAudit: boolean }): void {
+  const rows: TimelineToonEntry[] = timeline.entries.map((entry) => ({
+    rid: entry.rid,
+    status: entry.status,
+    activeRid: entry.activeRid,
+    nodeType: entry.nodeType,
+    label: entry.label,
+    title: entry.title,
+    content: entry.content,
+  }));
+  const zero = rows.length === 0;
+  console.log(
+    renderToonOutput({
+      rowsKey: "entries",
+      rows,
+      fields: ["rid", "status", "activeRid", "nodeType", "label", "title", "content"],
+      summary: {
+        status: zero ? "0 entries" : `${rows.length} entries`,
+        topic: timeline.topic,
+        entries: rows.length,
+        active: rows.filter((entry) => entry.status === "active").length,
+        superseded: rows.filter((entry) => entry.status === "superseded").length,
+        auditLinks: timeline.auditLinks.length,
+      },
+      extra: {
+        ...(opts.includeAudit
+          ? {
+              auditLinks: timeline.auditLinks.map((edge) => ({
+                label: edge.label,
+                fromRid: edge.fromRid,
+                toRid: edge.toRid,
+                reason: edge.reason,
+              })),
+            }
+          : {}),
+        ...(zero
+          ? {
+              next: "store or ingest topic evidence, then rerun `memory timeline <topic>`",
+            }
+          : {}),
+      },
+    }),
+  );
 }
 
 async function runStructuralImpact(args: ParsedArgs): Promise<void> {
@@ -8035,6 +8250,7 @@ async function main(): Promise<void> {
   if (
     registryOperation &&
     registryOperation.outputKind.kind === "viewer" &&
+    (registryOperation.id !== "memory.dashboard" || stringFlag(args.flags, "out") !== undefined) &&
     args.flags.json !== true
   ) {
     return runRegistryCliOperation(registryOperation, args);

--- a/apps/memory/tests/fixtures/context-pack-toon-corpus.json
+++ b/apps/memory/tests/fixtures/context-pack-toon-corpus.json
@@ -1,0 +1,27 @@
+{
+  "entries": [
+    {
+      "section": "hard_constraints",
+      "title": "JWT docs update required",
+      "nodeType": "decision",
+      "importance": 0.9,
+      "confidence": "high",
+      "trust": 1,
+      "citation": "urn: memory_nodes:1",
+      "reason": "matched the goal term jwt",
+      "excerpt": "JWT token work must update docs/security.md and use signed fixtures.",
+      "expandHandle": "memory:recall 1"
+    }
+  ],
+  "warnings": [],
+  "summary": {
+    "status": "ok",
+    "goal": "jwt token work",
+    "entries": 1,
+    "coreContext": 1,
+    "warnings": 0,
+    "omittedEntries": 0,
+    "budgetChars": 1200,
+    "usedChars": 362
+  }
+}

--- a/apps/memory/tests/fixtures/dashboard-toon-corpus.json
+++ b/apps/memory/tests/fixtures/dashboard-toon-corpus.json
@@ -1,0 +1,44 @@
+{
+  "sections": [
+    {
+      "area": "stats",
+      "status": "ready",
+      "metric": "docs",
+      "value": 4,
+      "detail": "4 documents indexed"
+    },
+    {
+      "area": "hooks",
+      "status": "ready",
+      "metric": "wired_events",
+      "value": 7,
+      "detail": "7 hook events wired"
+    },
+    {
+      "area": "decay",
+      "status": "attention",
+      "metric": "review",
+      "value": 2,
+      "detail": "2 nodes need review"
+    }
+  ],
+  "warnings": [
+    {
+      "message": "decay: 2 review, 0 deprecate, 0 expire"
+    }
+  ],
+  "next": [
+    {
+      "action": "review stale Memory nodes with `memory doctor`"
+    }
+  ],
+  "summary": {
+    "state": "attention",
+    "nodes": 12,
+    "edges": 8,
+    "docs": 4,
+    "warnings": 1,
+    "actions": 1,
+    "schema": "memory.operational_dashboard.v1"
+  }
+}

--- a/apps/memory/tests/fixtures/timeline-toon-corpus.json
+++ b/apps/memory/tests/fixtures/timeline-toon-corpus.json
@@ -1,0 +1,37 @@
+{
+  "entries": [
+    {
+      "rid": 1,
+      "status": "superseded",
+      "activeRid": 2,
+      "nodeType": "decision",
+      "label": "deploy-friday",
+      "title": "deploy-friday",
+      "content": "deploy policy friday"
+    },
+    {
+      "rid": 2,
+      "status": "active",
+      "activeRid": 2,
+      "nodeType": "decision",
+      "label": "deploy-tuesday",
+      "title": "deploy-tuesday",
+      "content": "deploy policy tuesday"
+    }
+  ],
+  "auditLinks": [
+    {
+      "label": "SUPERSEDED_BY",
+      "fromRid": 1,
+      "toRid": 2,
+      "reason": "policy changed"
+    }
+  ],
+  "summary": {
+    "topic": "friday",
+    "entries": 2,
+    "active": 1,
+    "superseded": 1,
+    "auditLinks": 1
+  }
+}

--- a/apps/memory/tests/memory-cli-batch2-toon.test.ts
+++ b/apps/memory/tests/memory-cli-batch2-toon.test.ts
@@ -1,0 +1,244 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { encodingForModel } from "js-tiktoken";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { decode } from "@reddb-io/toon";
+import contextPackCorpus from "./fixtures/context-pack-toon-corpus.json" with { type: "json" };
+import dashboardCorpus from "./fixtures/dashboard-toon-corpus.json" with { type: "json" };
+import timelineCorpus from "./fixtures/timeline-toon-corpus.json" with { type: "json" };
+import { MemoryStore } from "../src/graph-store.js";
+import { initGraph } from "../src/init.js";
+import { renderToonOutput } from "../src/toon-output.js";
+
+const TIMEOUT = 40_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+async function graphRoot(prefix = "memory-batch2-toon-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  const init = runMemory(["init", "--mode", "graph", "--root", root, "--yes"]);
+  expect(init.status, init.stderr).toBe(0);
+  return root;
+}
+
+async function seedContextPackRoot(): Promise<string> {
+  const root = await graphRoot("memory-context-pack-toon-");
+  const stored = runMemory([
+    "store",
+    "Decision: JWT token work must update docs/security.md and use signed fixtures.",
+    "--root",
+    root,
+  ]);
+  expect(stored.status, stored.stderr).toBe(0);
+  return root;
+}
+
+async function seedTimelineRoot(): Promise<string> {
+  const root = await graphRoot("memory-timeline-toon-");
+  const store = await MemoryStore.open({ uri: `file://${join(root, ".red/memory/graph.rdb")}` });
+  try {
+    const oldRid = await store.upsertNode({
+      label: "deploy-friday",
+      node_type: "decision",
+      properties: {
+        title: "deploy-friday",
+        content: "deploy policy friday",
+        created_at: 1,
+        updated_at: 1,
+      },
+    });
+    const newRid = await store.upsertNode({
+      label: "deploy-tuesday",
+      node_type: "decision",
+      properties: {
+        title: "deploy-tuesday",
+        content: "deploy policy tuesday",
+        created_at: 2,
+        updated_at: 2,
+      },
+    });
+    await store.supersede(oldRid, newRid, "policy changed");
+  } finally {
+    await store.close();
+  }
+  return root;
+}
+
+function tokenReduction(jsonPayload: unknown, toon: string): number {
+  const tokenizer = encodingForModel("gpt-4o");
+  const jsonTokens = tokenizer.encode(JSON.stringify(jsonPayload, null, 2)).length;
+  const toonTokens = tokenizer.encode(toon).length;
+  return ((jsonTokens - toonTokens) / jsonTokens) * 100;
+}
+
+describe("memory CLI batch 2 TOON output", () => {
+  test("context-pack defaults to decodable TOON and keeps legacy JSON bytes under --json", async () => {
+    const root = await seedContextPackRoot();
+
+    const json = runMemory(["context-pack", "jwt token work", "--root", root, "--budget", "1200", "--json"]);
+    expect(json.status, json.stderr).toBe(0);
+
+    const toon = runMemory(["context-pack", "jwt token work", "--root", root, "--budget", "1200"]);
+    expect(toon.status, toon.stderr).toBe(0);
+    const decoded = decode(toon.stdout) as {
+      entries: Array<Record<string, unknown>>;
+      summary: Record<string, unknown>;
+    };
+    const legacy = JSON.parse(json.stdout) as {
+      status: string;
+      entries: Array<{ citation: { urn: string }; reason: string }>;
+    };
+
+    expect(decoded.summary).toMatchObject({
+      status: legacy.status,
+      goal: "jwt token work",
+      entries: legacy.entries.length,
+    });
+    expect(decoded.entries[0]).toMatchObject({
+      citation: legacy.entries[0].citation.urn,
+      reason: legacy.entries[0].reason,
+    });
+  });
+
+  test("context-pack empty state is definitive and suggests a next step", async () => {
+    const root = await graphRoot("memory-context-pack-empty-toon-");
+
+    const result = runMemory(["context-pack", "missing topic", "--root", root]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const decoded = decode(result.stdout) as { summary: Record<string, unknown>; next: string };
+    expect(decoded.summary).toMatchObject({ status: "insufficient-context", entries: 0 });
+    expect(decoded.next).toBe("run `memory store \"...\" --root <root>` or `memory ingest . --root <root>`, then rerun context-pack");
+  });
+
+  test("timeline defaults to decodable TOON and keeps legacy JSON bytes under --json", async () => {
+    const root = await seedTimelineRoot();
+
+    const json = runMemory(["timeline", "friday", "--root", root, "--json"]);
+    expect(json.status, json.stderr).toBe(0);
+
+    const toon = runMemory(["timeline", "friday", "--root", root]);
+    expect(toon.status, toon.stderr).toBe(0);
+    const decoded = decode(toon.stdout) as {
+      entries: Array<Record<string, unknown>>;
+      summary: Record<string, unknown>;
+    };
+    const legacy = JSON.parse(json.stdout) as { entries: Array<{ rid: number; status: string }> };
+
+    expect(decoded.entries.map((entry) => entry.rid)).toEqual(legacy.entries.map((entry) => entry.rid));
+    expect(decoded.summary).toMatchObject({
+      topic: "friday",
+      entries: legacy.entries.length,
+      active: 1,
+      superseded: 1,
+    });
+  });
+
+  test("timeline empty state is definitive and suggests a next step", async () => {
+    const root = await graphRoot("memory-timeline-empty-toon-");
+
+    const result = runMemory(["timeline", "missing topic", "--root", root]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const decoded = decode(result.stdout) as { summary: Record<string, unknown>; next: string };
+    expect(decoded.summary).toMatchObject({ status: "0 entries", entries: 0, topic: "missing topic" });
+    expect(decoded.next).toBe("store or ingest topic evidence, then rerun `memory timeline <topic>`");
+  });
+
+  test("dashboard defaults to decodable TOON and keeps legacy JSON bytes under --json", async () => {
+    const root = await graphRoot("memory-dashboard-toon-");
+
+    const json = runMemory(["dashboard", "--root", root, "--json"]);
+    expect(json.status, json.stderr).toBe(0);
+
+    const toon = runMemory(["dashboard", "--root", root]);
+    expect(toon.status, toon.stderr).toBe(0);
+    const decoded = decode(toon.stdout) as {
+      sections: Array<Record<string, unknown>>;
+      summary: Record<string, unknown>;
+    };
+    const legacy = JSON.parse(json.stdout) as {
+      schema_version: string;
+      state: string;
+      stats: { nodes: number; edges: number; docs: number };
+    };
+
+    expect(decoded.summary).toMatchObject({
+      schema: legacy.schema_version,
+      state: legacy.state,
+      nodes: legacy.stats.nodes,
+      edges: legacy.stats.edges,
+      docs: legacy.stats.docs,
+    });
+    expect(decoded.sections.map((section) => section.area)).toEqual([
+      "stats",
+      "vector",
+      "docs",
+      "hooks",
+      "extraction",
+      "stale",
+      "decay",
+    ]);
+  });
+
+  test("dashboard empty state is definitive and suggests a next step", async () => {
+    const root = await graphRoot("memory-dashboard-empty-toon-");
+
+    const result = runMemory(["dashboard", "--root", root]);
+
+    expect(result.status, result.stderr).toBe(0);
+    const decoded = decode(result.stdout) as { summary: Record<string, unknown>; next: Array<Record<string, unknown>> };
+    expect(decoded.summary).toMatchObject({ status: "empty", nodes: 0, docs: 0 });
+    expect(decoded.next.some((item) => item.action === "run `memory ingest . --root <root>` to populate dashboard evidence")).toBe(true);
+  });
+
+  test("token-delta fixtures report measured percentages for all three surfaces", () => {
+    const contextPackToon = renderToonOutput({
+      rowsKey: "entries",
+      rows: contextPackCorpus.entries,
+      fields: ["section", "title", "nodeType", "importance", "confidence", "trust", "citation", "reason", "excerpt", "expandHandle"],
+      summary: contextPackCorpus.summary,
+      extra: { warnings: contextPackCorpus.warnings },
+    });
+    const timelineToon = renderToonOutput({
+      rowsKey: "entries",
+      rows: timelineCorpus.entries,
+      fields: ["rid", "status", "activeRid", "nodeType", "label", "title", "content"],
+      summary: timelineCorpus.summary,
+      extra: { auditLinks: timelineCorpus.auditLinks },
+    });
+    const dashboardToon = renderToonOutput({
+      rowsKey: "sections",
+      rows: dashboardCorpus.sections,
+      fields: ["area", "status", "metric", "value", "detail"],
+      summary: dashboardCorpus.summary,
+      extra: { warnings: dashboardCorpus.warnings, next: dashboardCorpus.next },
+    });
+
+    for (const [name, payload, toon] of [
+      ["context-pack", contextPackCorpus, contextPackToon],
+      ["timeline", timelineCorpus, timelineToon],
+      ["dashboard", dashboardCorpus, dashboardToon],
+    ] as const) {
+      const reduction = tokenReduction(payload, toon);
+      console.info(`memory ${name} token delta: reduction=${reduction.toFixed(1)}%`);
+      expect(Number.isFinite(reduction)).toBe(true);
+      expect(decode(toon)).toEqual(payload);
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1409. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1409

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786281787&installation_id=129708444&pr_number=1425&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1425&signature=7762c19c4fa35e0dd0418468e02201e4a5e6541a1cc2b4c86072824318bc8cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->