### PR TITLE
fix: #1412 rsp git wrapper via porcelain contracts + the fidelity/admission harness

### DIFF
--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -20,8 +20,10 @@
     "dev": "node --import tsx src/cli.ts"
   },
   "dependencies": {
+    "@reddb-io/toon": "workspace:*",
     "@reddb-io/build-info": "workspace:*",
-    "@reddb-io/sdk": "1.7.0"
+    "@reddb-io/sdk": "1.7.0",
+    "js-tiktoken": "^1.0.21"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/apps/rsp/src/admission.ts
+++ b/apps/rsp/src/admission.ts
@@ -1,0 +1,103 @@
+import { encode, type JsonObject } from "@reddb-io/toon";
+import { encodingForModel } from "js-tiktoken";
+import { renderFixture, type FidelityFixture, type FidelityRunOptions } from "./fidelity.js";
+
+export interface AdmissionOptions {
+  thresholdPct: number;
+}
+
+export interface AdmissionFilterReport {
+  filter: string;
+  median_delta_pct: number;
+  active: boolean;
+  mode: "active" | "passthrough";
+}
+
+export interface AdmissionReport {
+  filters: AdmissionFilterReport[];
+  summary: string;
+}
+
+export interface AdmittedRunResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  mode: "active" | "passthrough";
+}
+
+const tokenizer = encodingForModel("gpt-4o");
+
+export function evaluateAdmission(fixtures: readonly FidelityFixture[], options: AdmissionOptions): AdmissionReport {
+  const byFilter = new Map<string, number[]>();
+  for (const fixture of fixtures) {
+    if (fixture.recorded.status !== 0) continue;
+    const filter = filterName(fixture);
+    const rendered = renderedFixtureText(fixture);
+    const delta = tokenDelta(fixture.recorded.stdout, rendered);
+    byFilter.set(filter, [...(byFilter.get(filter) ?? []), delta]);
+  }
+
+  const filters = [...byFilter.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([filter, deltas]) => {
+    const median = medianOf(deltas);
+    const active = median >= options.thresholdPct;
+    return {
+      filter,
+      median_delta_pct: Number(median.toFixed(1)),
+      active,
+      mode: active ? "active" as const : "passthrough" as const,
+    };
+  });
+
+  return {
+    filters,
+    summary: `${filters.filter((row) => row.active).length}/${filters.length} filters active at threshold ${options.thresholdPct}%`,
+  };
+}
+
+export async function runAdmittedFixture(
+  fixture: FidelityFixture,
+  options: AdmissionOptions & FidelityRunOptions,
+): Promise<AdmittedRunResult> {
+  const report = evaluateAdmission([fixture], options);
+  const row = report.filters.find((candidate) => candidate.filter === filterName(fixture));
+  if (!row?.active) {
+    return {
+      stdout: Buffer.from(fixture.recorded.stdout),
+      stderr: Buffer.from(fixture.recorded.stderr),
+      status: fixture.recorded.status,
+      signal: fixture.recorded.signal,
+      mode: "passthrough",
+    };
+  }
+  const result = await renderFixture(fixture, options);
+  return { ...result, mode: "active" };
+}
+
+export function renderAdmissionReportToon(report: AdmissionReport): string {
+  return encode(report as unknown as JsonObject);
+}
+
+function renderedFixtureText(fixture: FidelityFixture): string {
+  if (fixture.expected === "git empty\n") return fixture.expected;
+  if (typeof fixture.expected === "string") return fixture.expected;
+  return encode(fixture.expected as JsonObject);
+}
+
+function filterName(fixture: FidelityFixture): string {
+  return fixture.command.slice(0, 2).join(":");
+}
+
+function tokenDelta(original: string, filtered: string): number {
+  const before = tokenizer.encode(original).length;
+  const after = tokenizer.encode(filtered).length;
+  if (before === 0) return 0;
+  return ((before - after) / before) * 100;
+}
+
+function medianOf(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+  return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 import { RspElisionStore } from "./elision-store.js";
 import { resolveRspConfig } from "./config.js";
+import { runGitWrapper } from "./git-wrapper.js";
 
 interface ParsedArgs {
   command?: string;
   handle?: string;
   storeUri?: string;
+  level: "lossless" | "brief" | "terse";
+  positional: string[];
 }
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
@@ -22,6 +25,17 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       const stats = await store.stats();
       process.stdout.write(renderStats(stats));
       return 0;
+    }
+
+    if (args.command === "git") {
+      const result = await runGitWrapper(args.positional, { level: args.level, store });
+      process.stdout.write(result.stdout);
+      process.stderr.write(result.stderr);
+      if (result.signal) {
+        process.kill(process.pid, result.signal);
+        return 128;
+      }
+      return result.status ?? 0;
     }
 
     if (args.command === "show" && args.handle) {
@@ -46,15 +60,18 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
-  const out: ParsedArgs = {};
+  const out: ParsedArgs = { level: "lossless", positional: [] };
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--store-uri") out.storeUri = argv[++i];
+    else if (arg === "--brief") out.level = "brief";
+    else if (arg === "--terse") out.level = "terse";
     else positional.push(arg);
   }
   out.command = positional[0];
   out.handle = positional[1];
+  out.positional = positional;
   return out;
 }
 

--- a/apps/rsp/src/fidelity.ts
+++ b/apps/rsp/src/fidelity.ts
@@ -1,0 +1,149 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { decode } from "@reddb-io/toon";
+import { encodingForModel } from "js-tiktoken";
+import { renderGitContract, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
+import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+
+export interface FidelityAssertion {
+  question: string;
+  path: string;
+  expected: unknown;
+}
+
+export interface FidelityFixture {
+  name: string;
+  command: string[];
+  recorded: RecordedGitContract;
+  expected: unknown;
+  assertions: FidelityAssertion[];
+}
+
+export interface AssertionFailure {
+  question: string;
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface FidelityRunOptions {
+  level: RspLossLevel;
+  store: RspElisionStore;
+}
+
+export interface FidelityRunResult extends GitRenderResult {
+  assertionFailures: AssertionFailure[];
+  tokenDelta: number;
+}
+
+const tokenizer = encodingForModel("gpt-4o");
+
+export async function discoverFidelityFixtures(root: string): Promise<FidelityFixture[]> {
+  const files = await discoverJsonFiles(root);
+  const fixtures = await Promise.all(files.map(async (file) => parseFixture(await readFile(file, "utf8"), file)));
+  return fixtures.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function runFidelityFixture(
+  fixture: FidelityFixture,
+  options: FidelityRunOptions,
+): Promise<FidelityRunResult> {
+  const result = await renderFixture(fixture, options);
+  const assertionFailures = result.status === 0 && result.stdout.length > 0
+    ? evaluateAssertions(readDecodedToon(result.stdout), fixture.assertions)
+    : [];
+  return {
+    ...result,
+    assertionFailures,
+    tokenDelta: tokenDelta(fixture.recorded.stdout, result.stdout.toString("utf8")),
+  };
+}
+
+export async function renderFixture(
+  fixture: FidelityFixture,
+  options: FidelityRunOptions,
+): Promise<GitRenderResult> {
+  if (fixture.command[0] !== "git") throw new Error(`unsupported fixture command: ${fixture.command.join(" ")}`);
+  return await renderGitContract(fixture.command, fixture.recorded, options);
+}
+
+function readDecodedToon(stdout: Buffer): unknown {
+  const text = stdout.toString("utf8");
+  if (text === "git empty\n") return "git empty\n";
+  const toon = text.split("\n").filter((line) => !line.startsWith("… elided ")).join("\n");
+  return decode(toon);
+}
+
+function evaluateAssertions(decoded: unknown, assertions: readonly FidelityAssertion[]): AssertionFailure[] {
+  const failures: AssertionFailure[] = [];
+  for (const assertion of assertions) {
+    const actual = getPath(decoded, assertion.path);
+    if (!Object.is(actual, assertion.expected)) {
+      failures.push({ question: assertion.question, expected: assertion.expected, actual });
+    }
+  }
+  return failures;
+}
+
+function getPath(value: unknown, path: string): unknown {
+  let cursor = value;
+  for (const segment of path.split(".")) {
+    if (segment === "length" && Array.isArray(cursor)) {
+      cursor = cursor.length;
+    } else if (/^\d+$/.test(segment) && Array.isArray(cursor)) {
+      cursor = cursor[Number(segment)];
+    } else if (isRecord(cursor)) {
+      cursor = cursor[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return cursor;
+}
+
+function tokenDelta(original: string, filtered: string): number {
+  const before = tokenizer.encode(original).length;
+  const after = tokenizer.encode(filtered).length;
+  if (before === 0) return 0;
+  return ((before - after) / before) * 100;
+}
+
+async function discoverJsonFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) out.push(...await discoverJsonFiles(path));
+    else if (entry.isFile() && entry.name.endsWith(".json")) out.push(path);
+  }
+  return out;
+}
+
+function parseFixture(raw: string, file: string): FidelityFixture {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isFixture(parsed)) throw new Error(`invalid fidelity fixture: ${file}`);
+  return parsed;
+}
+
+function isFixture(value: unknown): value is FidelityFixture {
+  return isRecord(value) &&
+    typeof value.name === "string" &&
+    Array.isArray(value.command) &&
+    value.command.every((part) => typeof part === "string") &&
+    isRecord(value.recorded) &&
+    typeof value.recorded.stdout === "string" &&
+    typeof value.recorded.stderr === "string" &&
+    (typeof value.recorded.status === "number" || value.recorded.status === null) &&
+    (typeof value.recorded.signal === "string" || value.recorded.signal === null) &&
+    Array.isArray(value.assertions) &&
+    value.assertions.every(isAssertion);
+}
+
+function isAssertion(value: unknown): value is FidelityAssertion {
+  return isRecord(value) &&
+    typeof value.question === "string" &&
+    typeof value.path === "string" &&
+    Object.prototype.hasOwnProperty.call(value, "expected");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -1,0 +1,294 @@
+import { spawn } from "node:child_process";
+import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+
+export type GitSubcommand = "status" | "log" | "diff" | "commit" | "push";
+
+export interface RecordedGitContract {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+export interface GitRenderOptions {
+  level: RspLossLevel;
+  store?: RspElisionStore;
+}
+
+export interface GitRenderResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  payload?: JsonObject;
+  mintedHandle?: `el:${string}`;
+  bytesElided?: number;
+  rowsElided?: number;
+}
+
+export async function runGitWrapper(argv: readonly string[], options: GitRenderOptions): Promise<GitRenderResult> {
+  const subcommand = parseGitSubcommand(argv);
+  const contract = await collectGitContract(subcommand, argv.slice(1));
+  return renderGitContract(argv, contract, options);
+}
+
+export async function renderGitContract(
+  command: readonly string[],
+  contract: RecordedGitContract,
+  options: GitRenderOptions,
+): Promise<GitRenderResult> {
+  if ((contract.status ?? 0) !== 0 || contract.signal) {
+    return {
+      stdout: Buffer.from(contract.stdout),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+    };
+  }
+
+  const subcommand = parseGitSubcommand(command);
+  const payload = parseGitPayload(subcommand, command, contract.stdout);
+  if (payload === "git empty\n") {
+    return {
+      stdout: Buffer.from(payload),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+    };
+  }
+
+  const fullToon = encode(payload);
+  if (options.level !== "terse") {
+    return {
+      stdout: Buffer.from(fullToon),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+      payload,
+    };
+  }
+
+  const terse = tersePayload(payload);
+  if (!terse) {
+    return {
+      stdout: Buffer.from(fullToon),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+      payload,
+    };
+  }
+
+  const bytesElided = Buffer.byteLength(fullToon);
+  const handle = await options.store?.mint(Buffer.from(fullToon), {
+    command: command.join(" "),
+    loss: { level: "terse", bytes_elided: bytesElided },
+  });
+  if (!handle) throw new Error("terse git output requires an elision store");
+
+  const marker = `… elided ${terse.rowsElided} rows (+${bytesElided}) — rsp show ${handle}\n`;
+  return {
+    stdout: Buffer.from(`${encode(terse.payload)}\n${marker}`),
+    stderr: Buffer.from(contract.stderr),
+    status: contract.status,
+    signal: contract.signal,
+    payload: terse.payload,
+    mintedHandle: handle,
+    bytesElided,
+    rowsElided: terse.rowsElided,
+  };
+}
+
+function parseGitSubcommand(argv: readonly string[]): GitSubcommand {
+  if (argv[0] !== "git") throw new Error("expected rsp git <subcommand>");
+  const subcommand = argv[1];
+  if (subcommand === "status" || subcommand === "log" || subcommand === "diff" || subcommand === "commit" || subcommand === "push") {
+    return subcommand;
+  }
+  throw new Error(`unsupported git subcommand: ${subcommand ?? ""}`);
+}
+
+function machineArgs(subcommand: GitSubcommand, rest: readonly string[]): string[] {
+  const passthrough = rest.slice(1);
+  switch (subcommand) {
+    case "status":
+      return ["status", "--porcelain=v2", "-z", "-b", ...passthrough];
+    case "log":
+      return ["log", "--format=%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s", "-z", ...passthrough];
+    case "diff":
+      return ["diff", "--numstat", "-z", ...passthrough];
+    case "commit":
+      return ["commit", ...passthrough];
+    case "push":
+      return ["push", "--porcelain", ...passthrough];
+  }
+}
+
+async function collectGitContract(subcommand: GitSubcommand, rest: readonly string[]): Promise<RecordedGitContract> {
+  const child = spawn("git", machineArgs(subcommand, [subcommand, ...rest]), { stdio: ["ignore", "pipe", "pipe"] });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+  return await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        status,
+        signal,
+      });
+    });
+  });
+}
+
+function parseGitPayload(subcommand: GitSubcommand, command: readonly string[], stdout: string): JsonObject | "git empty\n" {
+  switch (subcommand) {
+    case "status":
+      return parseStatus(command, stdout);
+    case "log":
+      return parseLog(command, stdout);
+    case "diff":
+      return parseDiff(command, stdout);
+    case "commit":
+      return parseCommit(command, stdout);
+    case "push":
+      return parsePush(command, stdout);
+  }
+}
+
+function parseStatus(command: readonly string[], stdout: string): JsonObject | "git empty\n" {
+  let branch = "";
+  const rows: JsonObject[] = [];
+  for (const raw of stdout.split("\0")) {
+    if (!raw) continue;
+    if (raw.startsWith("# branch.head ")) {
+      branch = raw.slice("# branch.head ".length);
+      continue;
+    }
+    if (!raw.startsWith("1 ")) continue;
+    const parts = raw.split(" ");
+    const xy = parts[1] ?? "..";
+    const path = parts.slice(8).join(" ");
+    rows.push({
+      path,
+      index: xy[0] ?? ".",
+      worktree: xy[1] ?? ".",
+      state: statusState(xy),
+    });
+  }
+  if (rows.length === 0) return "git empty\n";
+  const counts = countBy(rows, "state");
+  return {
+    command: command.join(" "),
+    branch,
+    rows,
+    summary: `${rows.length} changes: ${counts.added ?? 0} added, ${counts.modified ?? 0} modified, ${counts.deleted ?? 0} deleted`,
+  };
+}
+
+function parseLog(command: readonly string[], stdout: string): JsonObject {
+  const commits = stdout.split("\0").filter(Boolean).map((record) => {
+    const fields = record.replace(/^\x1e/, "").split("\x1f");
+    return {
+      hash: fields[0] ?? "",
+      short: fields[1] ?? "",
+      author: fields[2] ?? "",
+      date: fields[3] ?? "",
+      subject: fields[4] ?? "",
+    };
+  });
+  return { command: command.join(" "), commits, summary: `${commits.length} commits` };
+}
+
+function parseDiff(command: readonly string[], stdout: string): JsonObject {
+  const fields = stdout.split("\0").filter(Boolean);
+  const files = fields.map((entry) => {
+    const [added, deleted, path] = entry.split("\t");
+    return {
+      path: path ?? "",
+      added: added === "-" ? null : Number(added ?? 0),
+      deleted: deleted === "-" ? null : Number(deleted ?? 0),
+    };
+  });
+  const totals = files.reduce((acc, file) => {
+    acc.added += typeof file.added === "number" ? file.added : 0;
+    acc.deleted += typeof file.deleted === "number" ? file.deleted : 0;
+    return acc;
+  }, { added: 0, deleted: 0 });
+  return { command: command.join(" "), files, summary: `${files.length} files, +${totals.added} -${totals.deleted}` };
+}
+
+function parseCommit(command: readonly string[], stdout: string): JsonObject {
+  const first = stdout.split("\n")[0] ?? "";
+  const match = /^\[([^ ]+) ([0-9a-f]+)\] (.+)$/.exec(first);
+  const changed = /(\d+) files? changed/.exec(stdout);
+  const insertions = /(\d+) insertions?\(\+\)/.exec(stdout);
+  const deletions = /(\d+) deletions?\(-\)/.exec(stdout);
+  const branch = match?.[1] ?? "";
+  const commit = match?.[2] ?? "";
+  const filesChanged = Number(changed?.[1] ?? 0);
+  const added = Number(insertions?.[1] ?? 0);
+  const deleted = Number(deletions?.[1] ?? 0);
+  return {
+    command: command.join(" "),
+    branch,
+    commit,
+    subject: match?.[3] ?? "",
+    files_changed: filesChanged,
+    insertions: added,
+    deletions: deleted,
+    summary: `commit ${commit} on ${branch}: ${filesChanged} files, +${added} -${deleted}`,
+  };
+}
+
+function parsePush(command: readonly string[], stdout: string): JsonObject {
+  const lines = stdout.split("\n").filter(Boolean);
+  const remote = lines.find((line) => line.startsWith("To "))?.slice(3) ?? "";
+  const refs = lines.filter((line) => line.includes("\t")).map((line) => {
+    const [flag, refspec, summary = ""] = line.split("\t");
+    const [from, to] = (refspec ?? "").split(":");
+    return { flag: flag ?? "", from: from ?? "", to: to ?? "", summary };
+  });
+  const pushed = refs.find((ref) => ref.flag !== "=") ?? refs[0];
+  const branch = pushed?.to.startsWith("refs/heads/") ? pushed.to.slice("refs/heads/".length) : (pushed?.to ?? "");
+  const commitCount = pushed?.summary.includes("..") ? 1 : 0;
+  return {
+    command: command.join(" "),
+    remote,
+    refs,
+    summary: `pushed ${branch} -> ${remote} +${commitCount} commits`,
+  };
+}
+
+function statusState(xy: string): string {
+  if (xy.includes("A")) return "added";
+  if (xy.includes("D")) return "deleted";
+  if (xy.includes("R")) return "renamed";
+  if (xy.includes("M")) return "modified";
+  return "changed";
+}
+
+function countBy(rows: readonly JsonObject[], field: string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows) {
+    const key = String(row[field] ?? "");
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+}
+
+function tersePayload(payload: JsonObject): { payload: JsonObject; rowsElided: number } | null {
+  for (const key of ["rows", "commits", "files", "refs"] as const) {
+    const value = payload[key];
+    if (Array.isArray(value) && value.length > 1) {
+      return {
+        payload: { ...payload, [key]: value.slice(0, 1) as JsonValue },
+        rowsElided: value.length - 1,
+      };
+    }
+  }
+  return null;
+}

--- a/apps/rsp/tests/fixtures/fidelity-red/push-wrong-assertion.json
+++ b/apps/rsp/tests/fixtures/fidelity-red/push-wrong-assertion.json
@@ -1,0 +1,21 @@
+{
+  "name": "push-wrong-assertion",
+  "command": ["git", "push"],
+  "recorded": {
+    "stdout": "To github.com:reddb-io/red-skills.git\nremote: counting objects: 100% (40/40), done.\nremote: compressing objects: 100% (25/25), done.\nremote: total 25 (delta 12), reused 0 (delta 0), pack-reused 0\nremote: resolving deltas: 100% (12/12), completed with 12 local objects.\nremote: this verbose machine-side transcript is retained in the recorded contract so the fixture has a positive token delta.\n \trefs/heads/feature/rsp:refs/heads/feature/rsp\t1111111..2222222\nDone\n",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git push",
+    "remote": "github.com:reddb-io/red-skills.git",
+    "refs": [
+      { "flag": " ", "from": "refs/heads/feature/rsp", "to": "refs/heads/feature/rsp", "summary": "1111111..2222222" }
+    ],
+    "summary": "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits"
+  },
+  "assertions": [
+    { "question": "which branch was pushed?", "path": "refs.0.to", "expected": "main" }
+  ]
+}

--- a/apps/rsp/tests/fixtures/git/commit/created.json
+++ b/apps/rsp/tests/fixtures/git/commit/created.json
@@ -1,0 +1,23 @@
+{
+  "name": "commit-created",
+  "command": ["git", "commit"],
+  "recorded": {
+    "stdout": "[feature/rsp 1234567] Refs #1412 add wrapper\n 2 files changed, 40 insertions(+), 1 deletion(-)\n",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git commit",
+    "branch": "feature/rsp",
+    "commit": "1234567",
+    "subject": "Refs #1412 add wrapper",
+    "files_changed": 2,
+    "insertions": 40,
+    "deletions": 1,
+    "summary": "commit 1234567 on feature/rsp: 2 files, +40 -1"
+  },
+  "assertions": [
+    { "question": "which commit was created?", "path": "commit", "expected": "1234567" }
+  ]
+}

--- a/apps/rsp/tests/fixtures/git/diff/numstat.json
+++ b/apps/rsp/tests/fixtures/git/diff/numstat.json
@@ -1,0 +1,22 @@
+{
+  "name": "diff-numstat",
+  "command": ["git", "diff"],
+  "recorded": {
+    "stdout": "3\t1\tapps/rsp/src/cli.ts\u00000\t12\told.txt\u0000-\t-\tassets/logo.bin\u0000",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git diff",
+    "files": [
+      { "path": "apps/rsp/src/cli.ts", "added": 3, "deleted": 1 },
+      { "path": "old.txt", "added": 0, "deleted": 12 },
+      { "path": "assets/logo.bin", "added": null, "deleted": null }
+    ],
+    "summary": "3 files, +3 -13"
+  },
+  "assertions": [
+    { "question": "how many lines were added?", "path": "files.0.added", "expected": 3 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/git/log/basic.json
+++ b/apps/rsp/tests/fixtures/git/log/basic.json
@@ -1,0 +1,21 @@
+{
+  "name": "log-contract",
+  "command": ["git", "log"],
+  "recorded": {
+    "stdout": "\u001e1111111111111111111111111111111111111111\u001f1111111\u001fAda\u001f2026-07-10T10:00:00+00:00\u001fAdd rsp wrapper\u0000\u001e2222222222222222222222222222222222222222\u001f2222222\u001fBen\u001f2026-07-09T10:00:00+00:00\u001fScaffold elision store\u0000",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git log",
+    "commits": [
+      { "hash": "1111111111111111111111111111111111111111", "short": "1111111", "author": "Ada", "date": "2026-07-10T10:00:00+00:00", "subject": "Add rsp wrapper" },
+      { "hash": "2222222222222222222222222222222222222222", "short": "2222222", "author": "Ben", "date": "2026-07-09T10:00:00+00:00", "subject": "Scaffold elision store" }
+    ],
+    "summary": "2 commits"
+  },
+  "assertions": [
+    { "question": "what is the newest short hash?", "path": "commits.0.short", "expected": "1111111" }
+  ]
+}

--- a/apps/rsp/tests/fixtures/git/push/porcelain.json
+++ b/apps/rsp/tests/fixtures/git/push/porcelain.json
@@ -1,0 +1,22 @@
+{
+  "name": "push-porcelain",
+  "command": ["git", "push"],
+  "recorded": {
+    "stdout": "To github.com:reddb-io/red-skills.git\n=\trefs/heads/main:refs/heads/main\t[up to date]\n \trefs/heads/feature/rsp:refs/heads/feature/rsp\t1111111..2222222\nDone\n",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git push",
+    "remote": "github.com:reddb-io/red-skills.git",
+    "refs": [
+      { "flag": "=", "from": "refs/heads/main", "to": "refs/heads/main", "summary": "[up to date]" },
+      { "flag": " ", "from": "refs/heads/feature/rsp", "to": "refs/heads/feature/rsp", "summary": "1111111..2222222" }
+    ],
+    "summary": "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits"
+  },
+  "assertions": [
+    { "question": "which branch was pushed?", "path": "refs.1.to", "expected": "refs/heads/feature/rsp" }
+  ]
+}

--- a/apps/rsp/tests/fixtures/git/push/rejected.json
+++ b/apps/rsp/tests/fixtures/git/push/rejected.json
@@ -1,0 +1,12 @@
+{
+  "name": "push-rejected",
+  "command": ["git", "push"],
+  "recorded": {
+    "stdout": "",
+    "stderr": "fatal: unable to access 'https://example.invalid/repo.git/': denied\n",
+    "status": 1,
+    "signal": null
+  },
+  "expected": "",
+  "assertions": []
+}

--- a/apps/rsp/tests/fixtures/git/status/clean.json
+++ b/apps/rsp/tests/fixtures/git/status/clean.json
@@ -1,0 +1,12 @@
+{
+  "name": "status-clean",
+  "command": ["git", "status"],
+  "recorded": {
+    "stdout": "# branch.oid abc123\u0000# branch.head main\u0000",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": "git empty\n",
+  "assertions": []
+}

--- a/apps/rsp/tests/fixtures/git/status/working-tree.json
+++ b/apps/rsp/tests/fixtures/git/status/working-tree.json
@@ -1,0 +1,24 @@
+{
+  "name": "status-working-tree",
+  "command": ["git", "status"],
+  "recorded": {
+    "stdout": "# branch.oid abc123\u0000# branch.head feature/rsp\u00001 .M N... 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa apps/rsp/src/cli.ts\u00001 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb apps/rsp/src/git-wrapper.ts\u00001 D. N... 100644 000000 000000 cccccccccccccccccccccccccccccccccccccccc 0000000000000000000000000000000000000000 old.txt\u0000",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git status",
+    "branch": "feature/rsp",
+    "rows": [
+      { "path": "apps/rsp/src/cli.ts", "index": ".", "worktree": "M", "state": "modified" },
+      { "path": "apps/rsp/src/git-wrapper.ts", "index": "A", "worktree": ".", "state": "added" },
+      { "path": "old.txt", "index": "D", "worktree": ".", "state": "deleted" }
+    ],
+    "summary": "3 changes: 1 added, 1 modified, 1 deleted"
+  },
+  "assertions": [
+    { "question": "which branch is checked out?", "path": "branch", "expected": "feature/rsp" },
+    { "question": "how many files changed?", "path": "rows.length", "expected": 3 }
+  ]
+}

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -1,0 +1,171 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { decode } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
+import { runFidelityFixture, discoverFidelityFixtures } from "../src/fidelity.js";
+import { RspElisionStore } from "../src/elision-store.js";
+
+const roots: string[] = [];
+const fixtureRoot = join(import.meta.dirname, "fixtures", "git");
+const redFixtureRoot = join(import.meta.dirname, "fixtures", "fidelity-red");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-git-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp git fidelity fixtures", () => {
+  it("auto-discovers git wrapper fixtures by directory convention", async () => {
+    const fixtureNames = (await discoverFidelityFixtures(fixtureRoot)).map((fixture) => fixture.name).sort();
+
+    expect(fixtureNames).toEqual([
+      "commit-created",
+      "diff-numstat",
+      "log-contract",
+      "push-porcelain",
+      "push-rejected",
+      "status-clean",
+      "status-working-tree",
+    ]);
+  });
+
+  it("renders five git subcommands from recorded machine contracts as decodable TOON", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      for (const fixture of await discoverFidelityFixtures(fixtureRoot)) {
+        if (fixture.name === "status-clean" || fixture.name === "push-rejected") continue;
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+        expect(result.status).toBe(fixture.recorded.status);
+        expect(result.stderr).toEqual(Buffer.from(fixture.recorded.stderr, "utf8"));
+        expect(result.assertionFailures).toEqual([]);
+        expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("returns the definitive clean-tree empty state without minting a handle", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "status-clean")!;
+      const result = await runFidelityFixture(fixture, { level: "brief", store });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toEqual(Buffer.from("git empty\n"));
+      expect(result.mintedHandle).toBeUndefined();
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("mints a terse elision handle with the exact marker line and show can retrieve the original", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "status-working-tree")!;
+      const result = await runFidelityFixture(fixture, { level: "terse", store });
+      const stdout = result.stdout.toString("utf8");
+      const marker = stdout.split("\n").at(-2)!;
+
+      expect(marker).toMatch(/^… elided 2 rows \(\+\d+\) — rsp show el:[a-f0-9]{12}$/);
+      expect(marker).toBe(`… elided 2 rows (+${result.bytesElided}) — rsp show ${result.mintedHandle}`);
+      expect(result.mintedHandle).toBeDefined();
+
+      const record = await store.get(result.mintedHandle!);
+      if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+      expect(decode(record.original.toString("utf8"))).toEqual(fixture.expected);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("forwards non-zero git status and stderr byte-intact from fault fixtures", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "push-rejected")!;
+      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toEqual(Buffer.from("fatal: unable to access 'https://example.invalid/repo.git/': denied\n"));
+      expect(result.stdout).toEqual(Buffer.from(""));
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("fails the suite when a fixture assertion is false even with positive token delta", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const [fixture] = await discoverFidelityFixtures(redFixtureRoot);
+      const result = await runFidelityFixture(fixture!, { level: "lossless", store });
+
+      expect(result.tokenDelta).toBeGreaterThan(0);
+      expect(result.assertionFailures).toEqual([
+        {
+          question: "which branch was pushed?",
+          expected: "main",
+          actual: "refs/heads/feature/rsp",
+        },
+      ]);
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("rsp git admission harness", () => {
+  it("reports per-filter median token delta with a real tokenizer and enforces passthrough below threshold", async () => {
+    const fixtures = await discoverFidelityFixtures(fixtureRoot);
+    const report = evaluateAdmission(fixtures, { thresholdPct: 60 });
+    const pushRow = report.filters.find((row) => row.filter === "git:push")!;
+
+    expect(report.summary).toBe("1/5 filters active at threshold 60%");
+    expect(pushRow).toMatchObject({ median_delta_pct: expect.any(Number), active: false, mode: "passthrough" });
+
+    const tmp = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(tmp, "red.rdb")}` });
+    try {
+      const fixture = fixtures.find((candidate) => candidate.name === "push-porcelain")!;
+      const result = await runAdmittedFixture(fixture, { thresholdPct: 60, level: "lossless", store });
+
+      expect(result.mode).toBe("passthrough");
+      expect(result.stdout).toEqual(Buffer.from(fixture.recorded.stdout, "utf8"));
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("fixture convention guard", () => {
+  it("does not need a central registry file", async () => {
+    const entries = await readdir(fixtureRoot);
+    expect(entries).not.toContain("registry.json");
+  });
+
+  it("discovers nested fixture files", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, "git", "status"), { recursive: true });
+    await writeFile(join(root, "git", "status", "clean.json"), JSON.stringify({
+      name: "nested-clean",
+      command: ["git", "status"],
+      recorded: { stdout: "# branch.oid abc\0# branch.head main\0", stderr: "", status: 0, signal: null },
+      expected: "git empty\n",
+      assertions: [],
+    }));
+
+    await expect(discoverFidelityFixtures(join(root, "git"))).resolves.toHaveLength(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,12 @@ importers:
       '@reddb-io/sdk':
         specifier: 1.7.0
         version: 1.7.0
+      '@reddb-io/toon':
+        specifier: workspace:*
+        version: link:../../packages/toon
+      js-tiktoken:
+        specifier: ^1.0.21
+        version: 1.0.21
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Automated AFK landing for #1412. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1412

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786285901&installation_id=129708444&pr_number=1429&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1429&signature=e700d068066f703f510d8678f6e76d7678878b7df5a702258142322ea06ee206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->