### PR TITLE
fix: #1413 rsp test wrapper family: vitest and cargo via JSON reporters, failures-only + rollup

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { RspElisionStore } from "./elision-store.js";
 import { resolveRspConfig } from "./config.js";
 import { runGitWrapper } from "./git-wrapper.js";
+import { runTestWrapper } from "./test-wrapper.js";
 
 interface ParsedArgs {
   command?: string;
@@ -35,6 +36,17 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
 
     if (args.command === "git") {
       const result = await runGitWrapper(args.positional, { level: args.level, store });
+      process.stdout.write(result.stdout);
+      process.stderr.write(result.stderr);
+      if (result.signal) {
+        process.kill(process.pid, result.signal);
+        return 128;
+      }
+      return result.status ?? 0;
+    }
+
+    if (args.command === "vitest" || args.command === "cargo") {
+      const result = await runTestWrapper(args.positional, { level: args.level, store });
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
       if (result.signal) {

--- a/apps/rsp/src/fidelity.ts
+++ b/apps/rsp/src/fidelity.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { decode } from "@reddb-io/toon";
 import { encodingForModel } from "js-tiktoken";
 import { renderGitContract, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
+import { renderTestContract } from "./test-wrapper.js";
 import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
 
 export interface FidelityAssertion {
@@ -62,6 +63,9 @@ export async function renderFixture(
   fixture: FidelityFixture,
   options: FidelityRunOptions,
 ): Promise<GitRenderResult> {
+  if (fixture.command[0] === "vitest" || fixture.command[0] === "cargo") {
+    return await renderTestContract(fixture.command, fixture.recorded, options);
+  }
   if (fixture.command[0] !== "git") throw new Error(`unsupported fixture command: ${fixture.command.join(" ")}`);
   return await renderGitContract(fixture.command, fixture.recorded, options);
 }

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -1,0 +1,280 @@
+import { spawn } from "node:child_process";
+import { encode, type JsonObject } from "@reddb-io/toon";
+import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+import type { GitRenderResult, RecordedGitContract } from "./git-wrapper.js";
+
+export interface TestRenderOptions {
+  level: RspLossLevel;
+  store?: RspElisionStore;
+}
+
+interface TestFailure extends JsonObject {
+  suite: string;
+  name: string;
+  excerpt: string;
+}
+
+interface TestPayload {
+  exit_code: number | null;
+  summary: string;
+  failures?: TestFailure[];
+}
+
+interface ParsedTestRun {
+  failed: number;
+  total: number;
+  suites: number;
+  durationSeconds: number;
+  failures: TestFailureSource[];
+}
+
+interface TestFailureSource {
+  suite: string;
+  name: string;
+  excerpt: string;
+}
+
+const EXCERPT_LIMIT_BYTES = 320;
+
+export async function runTestWrapper(argv: readonly string[], options: TestRenderOptions): Promise<GitRenderResult> {
+  const contract = await collectTestContract(argv);
+  return await renderTestContract(argv, contract, options);
+}
+
+export async function renderTestContract(
+  command: readonly string[],
+  contract: RecordedGitContract,
+  options: TestRenderOptions,
+): Promise<GitRenderResult> {
+  const runner = parseTestRunner(command);
+  const parsed = runner === "vitest" ? parseVitest(contract.stdout) : parseCargoTest(contract.stdout);
+  const status = contract.status;
+
+  if (!parsed || ((status ?? 0) !== 0 && parsed.failed === 0)) {
+    return {
+      stdout: Buffer.from(contract.stdout),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+    };
+  }
+
+  const failures: TestFailure[] = [];
+  let mintedHandle: `el:${string}` | undefined;
+  let bytesElided = 0;
+
+  for (const failure of parsed.failures) {
+    const excerpt = await renderExcerpt(failure.excerpt, command.join(" "), options.store);
+    failures.push({ suite: failure.suite, name: failure.name, excerpt: excerpt.text });
+    mintedHandle ??= excerpt.handle;
+    bytesElided += excerpt.bytesElided;
+  }
+
+  const payload: TestPayload = {
+    exit_code: status,
+    summary: `${parsed.failed}/${parsed.total} failed · ${parsed.suites} suites · ${formatDuration(parsed.durationSeconds)}`,
+  };
+  if (failures.length > 0) payload.failures = failures;
+
+  return {
+    stdout: Buffer.from(encode(payload as unknown as JsonObject)),
+    stderr: Buffer.from(contract.stderr),
+    status: contract.status,
+    signal: contract.signal,
+    payload: payload as unknown as JsonObject,
+    mintedHandle,
+    bytesElided: bytesElided > 0 ? bytesElided : undefined,
+    rowsElided: failures.length > 0 ? Math.max(0, parsed.total - failures.length) : undefined,
+  };
+}
+
+function parseTestRunner(command: readonly string[]): "vitest" | "cargo" {
+  if (command[0] === "vitest") return "vitest";
+  if (command[0] === "cargo" && command[1] === "test") return "cargo";
+  throw new Error(`unsupported test command: ${command.join(" ")}`);
+}
+
+function machineArgs(command: readonly string[]): { executable: string; args: string[] } {
+  const runner = parseTestRunner(command);
+  if (runner === "vitest") {
+    const args = command.slice(1);
+    const hasReporter = args.some((arg) => arg === "--reporter=json" || arg === "--reporter" || arg.startsWith("--reporter="));
+    return { executable: "vitest", args: hasReporter ? args : ["run", "--reporter=json", ...args] };
+  }
+
+  const args = command.slice(1);
+  const hasMessageFormat = args.some((arg) => arg === "--message-format=json" || arg.startsWith("--message-format="));
+  return { executable: "cargo", args: hasMessageFormat ? args : ["test", "--message-format=json", ...args.slice(1)] };
+}
+
+async function collectTestContract(command: readonly string[]): Promise<RecordedGitContract> {
+  const machine = machineArgs(command);
+  const child = spawn(machine.executable, machine.args, { stdio: ["ignore", "pipe", "pipe"] });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+  return await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        status,
+        signal,
+      });
+    });
+  });
+}
+
+function parseVitest(stdout: string): ParsedTestRun | null {
+  const parsed = parseJson(stdout);
+  if (!isRecord(parsed)) return null;
+
+  const testResults = Array.isArray(parsed.testResults) ? parsed.testResults : [];
+  const failures: TestFailureSource[] = [];
+  let total = numberField(parsed.numTotalTests);
+  let failed = numberField(parsed.numFailedTests);
+  let durationSeconds = durationFromMs(numberField(parsed.startTime), numberField(parsed.endTime));
+
+  for (const suite of testResults) {
+    if (!isRecord(suite)) continue;
+    const suiteName = stringField(suite.name) || stringField(suite.file) || "";
+    const assertions = Array.isArray(suite.assertionResults) ? suite.assertionResults : [];
+    for (const assertion of assertions) {
+      if (!isRecord(assertion)) continue;
+      if (assertion.status !== "failed") continue;
+      failures.push({
+        suite: suiteName,
+        name: stringField(assertion.fullName) || stringField(assertion.title) || stringField(assertion.name),
+        excerpt: failureMessage(assertion.failureMessages) || stringField(assertion.failureMessage),
+      });
+    }
+  }
+
+  total ||= testResults.reduce((sum, suite) => {
+    if (!isRecord(suite) || !Array.isArray(suite.assertionResults)) return sum;
+    return sum + suite.assertionResults.length;
+  }, 0);
+  failed ||= failures.length;
+  durationSeconds ||= testResults.reduce((sum, suite) => {
+    if (!isRecord(suite)) return sum;
+    return sum + numberField(suite.perfStats && isRecord(suite.perfStats) ? suite.perfStats.runtime : suite.duration) / 1000;
+  }, 0);
+
+  return {
+    failed,
+    total,
+    suites: testResults.length || 1,
+    durationSeconds,
+    failures,
+  };
+}
+
+function parseCargoTest(stdout: string): ParsedTestRun | null {
+  const messages = stdout.split("\n").filter(Boolean).map((line) => parseJson(line)).filter(isRecord);
+  if (messages.length === 0) return null;
+
+  const failures: TestFailureSource[] = [];
+  let total = 0;
+  let failed = 0;
+  let suites = 0;
+  let durationSeconds = 0;
+  const compileErrors: string[] = [];
+
+  for (const message of messages) {
+    if (message.type === "suite") {
+      if (message.event === "started") {
+        suites += 1;
+        total += numberField(message.test_count);
+      }
+      if (message.event === "failed" || message.event === "ok") {
+        failed += numberField(message.failed);
+        durationSeconds += numberField(message.exec_time);
+      }
+      continue;
+    }
+
+    if (message.type === "test" && message.event === "failed") {
+      failures.push({
+        suite: stringField(message.name).split("::").slice(0, -1).join("::"),
+        name: stringField(message.name),
+        excerpt: stringField(message.stdout),
+      });
+      continue;
+    }
+
+    if (message.reason === "compiler-message" && isRecord(message.message)) {
+      const rendered = stringField(message.message.rendered);
+      if (rendered) compileErrors.push(rendered);
+    }
+  }
+
+  if (failures.length === 0 && compileErrors.length > 0) {
+    failures.push({ suite: "cargo check", name: "compile-error", excerpt: compileErrors.join("\n") });
+    suites ||= 1;
+    total ||= 1;
+    failed ||= 1;
+  }
+
+  failed ||= failures.length;
+  suites ||= 1;
+  total ||= Math.max(failed, failures.length);
+
+  return { failed, total, suites, durationSeconds, failures };
+}
+
+async function renderExcerpt(
+  excerpt: string,
+  command: string,
+  store?: RspElisionStore,
+): Promise<{ text: string; handle?: `el:${string}`; bytesElided: number }> {
+  const bytes = Buffer.from(excerpt);
+  if (bytes.length <= EXCERPT_LIMIT_BYTES) return { text: excerpt, bytesElided: 0 };
+  if (!store) throw new Error("over-limit test failure excerpt requires an elision store");
+
+  const handle = await store.mint(bytes, {
+    command,
+    loss: { level: "brief", bytes_elided: bytes.length },
+  });
+  const head = bytes.subarray(0, EXCERPT_LIMIT_BYTES).toString("utf8").replace(/\uFFFD$/, "");
+  const omitted = bytes.length - Buffer.byteLength(head);
+  return {
+    text: `${head}\n… elided ${omitted} bytes (+${bytes.length}) — rsp show ${handle}`,
+    handle,
+    bytesElided: bytes.length,
+  };
+}
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function failureMessage(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return value.map((item) => String(item)).filter(Boolean).join("\n");
+}
+
+function formatDuration(seconds: number): string {
+  return `${Number(seconds.toFixed(1))}s`;
+}
+
+function durationFromMs(start: number, end: number): number {
+  return start > 0 && end > start ? (end - start) / 1000 : 0;
+}
+
+function numberField(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/tests/fixtures/test-runners/cargo/compile-error.json
+++ b/apps/rsp/tests/fixtures/test-runners/cargo/compile-error.json
@@ -1,0 +1,26 @@
+{
+  "name": "cargo-compile-error",
+  "command": ["cargo", "test"],
+  "recorded": {
+    "stdout": "{\"reason\":\"compiler-message\",\"package_id\":\"red-skills 0.1.0\",\"target\":{\"name\":\"red_skills\"},\"message\":{\"rendered\":\"error[E0425]: cannot find value `missing_symbol` in this scope\\n --> src/lib.rs:9:5\\n  |\\n9 |     missing_symbol\\n  |     ^^^^^^^^^^^^^^ not found in this scope\\n\"}}\n{\"reason\":\"build-finished\",\"success\":false}\n",
+    "stderr": "",
+    "status": 101,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 101,
+    "summary": "1/1 failed · 1 suites · 0s",
+    "failures": [
+      {
+        "suite": "cargo check",
+        "name": "compile-error",
+        "excerpt": "error[E0425]: cannot find value `missing_symbol` in this scope\n --> src/lib.rs:9:5\n  |\n9 |     missing_symbol\n  |     ^^^^^^^^^^^^^^ not found in this scope\n"
+      }
+    ]
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "1/1 failed · 1 suites · 0s" },
+    { "question": "which test names failed?", "path": "failures.0.name", "expected": "compile-error" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 101 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/test-runners/cargo/green.json
+++ b/apps/rsp/tests/fixtures/test-runners/cargo/green.json
@@ -1,0 +1,18 @@
+{
+  "name": "cargo-green",
+  "command": ["cargo", "test"],
+  "recorded": {
+    "stdout": "{\"type\":\"suite\",\"event\":\"started\",\"test_count\":2}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"parser::accepts_basic_query\"}\n{\"type\":\"test\",\"event\":\"ok\",\"name\":\"parser::accepts_basic_query\",\"exec_time\":0.01,\"stdout\":\"\"}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"planner::keeps_join_order\"}\n{\"type\":\"test\",\"event\":\"ok\",\"name\":\"planner::keeps_join_order\",\"exec_time\":0.02,\"stdout\":\"\"}\n{\"type\":\"suite\",\"event\":\"ok\",\"passed\":2,\"failed\":0,\"ignored\":0,\"measured\":0,\"filtered_out\":0,\"exec_time\":0.33}\n",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 0,
+    "summary": "0/2 failed · 1 suites · 0.3s"
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "0/2 failed · 1 suites · 0.3s" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 0 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/test-runners/cargo/red.json
+++ b/apps/rsp/tests/fixtures/test-runners/cargo/red.json
@@ -1,0 +1,26 @@
+{
+  "name": "cargo-red",
+  "command": ["cargo", "test"],
+  "recorded": {
+    "stdout": "{\"type\":\"suite\",\"event\":\"started\",\"test_count\":3}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"parser::accepts_basic_query\"}\n{\"type\":\"test\",\"event\":\"ok\",\"name\":\"parser::accepts_basic_query\",\"exec_time\":0.01,\"stdout\":\"\"}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"replication::rejects_stale_ack\"}\n{\"type\":\"test\",\"event\":\"failed\",\"name\":\"replication::rejects_stale_ack\",\"exec_time\":0.05,\"stdout\":\"thread 'replication::rejects_stale_ack' panicked at src/replication.rs:42:9:\\nassertion failed: left == right\\n  left: 7\\n right: 8\"}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"planner::keeps_join_order\"}\n{\"type\":\"test\",\"event\":\"ok\",\"name\":\"planner::keeps_join_order\",\"exec_time\":0.02,\"stdout\":\"\"}\n{\"type\":\"suite\",\"event\":\"failed\",\"passed\":2,\"failed\":1,\"ignored\":0,\"measured\":0,\"filtered_out\":0,\"exec_time\":1.75}\n",
+    "stderr": "",
+    "status": 101,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 101,
+    "summary": "1/3 failed · 1 suites · 1.8s",
+    "failures": [
+      {
+        "suite": "replication",
+        "name": "replication::rejects_stale_ack",
+        "excerpt": "thread 'replication::rejects_stale_ack' panicked at src/replication.rs:42:9:\nassertion failed: left == right\n  left: 7\n right: 8"
+      }
+    ]
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "1/3 failed · 1 suites · 1.8s" },
+    { "question": "which test names failed?", "path": "failures.0.name", "expected": "replication::rejects_stale_ack" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 101 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/test-runners/vitest/fault-green-nonzero.json
+++ b/apps/rsp/tests/fixtures/test-runners/vitest/fault-green-nonzero.json
@@ -1,0 +1,15 @@
+{
+  "name": "vitest-fault-green-nonzero",
+  "command": ["vitest", "run"],
+  "recorded": {
+    "stdout": "{\"numTotalTests\":2,\"numPassedTests\":2,\"numFailedTests\":0,\"startTime\":1783695600000,\"endTime\":1783695600100,\"testResults\":[{\"name\":\"apps/rsp/tests/fault.test.ts\",\"assertionResults\":[{\"fullName\":\"fault looks green\",\"title\":\"looks green\",\"status\":\"passed\"},{\"fullName\":\"fault also green\",\"title\":\"also green\",\"status\":\"passed\"}]}]}",
+    "stderr": "worker crashed after reporting JSON\n",
+    "status": 1,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 1,
+    "summary": "fault passthrough"
+  },
+  "assertions": []
+}

--- a/apps/rsp/tests/fixtures/test-runners/vitest/green.json
+++ b/apps/rsp/tests/fixtures/test-runners/vitest/green.json
@@ -1,0 +1,18 @@
+{
+  "name": "vitest-green",
+  "command": ["vitest", "run"],
+  "recorded": {
+    "stdout": "{\"numTotalTests\":2,\"numPassedTests\":2,\"numFailedTests\":0,\"startTime\":1783695600000,\"endTime\":1783695601200,\"testResults\":[{\"name\":\"apps/rsp/tests/math.test.ts\",\"status\":\"passed\",\"message\":\"\",\"assertionResults\":[{\"fullName\":\"math adds numbers\",\"title\":\"adds numbers\",\"status\":\"passed\",\"duration\":5},{\"fullName\":\"math multiplies numbers\",\"title\":\"multiplies numbers\",\"status\":\"passed\",\"duration\":6}],\"perfStats\":{\"runtime\":1200},\"coverage\":{\"statements\":{\"total\":200,\"covered\":200,\"skipped\":0,\"pct\":100}},\"verboseNoise\":\"This recorded reporter payload intentionally keeps verbose pass metadata so the admission benchmark measures the delta instead of inheriting it. Passing tests should not be itemized by rsp.\"}]}",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 0,
+    "summary": "0/2 failed · 1 suites · 1.2s"
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "0/2 failed · 1 suites · 1.2s" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 0 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/test-runners/vitest/long-failure.json
+++ b/apps/rsp/tests/fixtures/test-runners/vitest/long-failure.json
@@ -1,0 +1,26 @@
+{
+  "name": "vitest-long-failure",
+  "command": ["vitest", "run"],
+  "recorded": {
+    "stdout": "{\"numTotalTests\":1,\"numPassedTests\":0,\"numFailedTests\":1,\"startTime\":1783695600000,\"endTime\":1783695604100,\"testResults\":[{\"name\":\"apps/rsp/tests/snapshot.test.ts\",\"assertionResults\":[{\"fullName\":\"snapshot matches large diff\",\"title\":\"matches large diff\",\"status\":\"failed\",\"failureMessages\":[\"Snapshot mismatch\\nreceived: \\\"line-001\\\"\\nreceived: \\\"line-002\\\"\\nreceived: \\\"line-003\\\"\\nreceived: \\\"line-004\\\"\\nreceived: \\\"line-005\\\"\\nreceived: \\\"line-006\\\"\\nreceived: \\\"line-007\\\"\\nreceived: \\\"line-008\\\"\\nreceived: \\\"line-009\\\"\\nreceived: \\\"line-010\\\"\\nreceived: \\\"line-011\\\"\\nreceived: \\\"line-012\\\"\\nreceived: \\\"line-013\\\"\\nreceived: \\\"line-014\\\"\\nreceived: \\\"line-015\\\"\\nreceived: \\\"line-016\\\"\\nreceived: \\\"line-017\\\"\\nreceived: \\\"line-018\\\"\\nreceived: \\\"line-019\\\"\\nreceived: \\\"line-020\\\"\\nreceived: \\\"line-021\\\"\\nreceived: \\\"line-022\\\"\\nreceived: \\\"line-023\\\"\\nreceived: \\\"line-024\\\"\\nreceived: \\\"line-025\\\"\\nreceived: \\\"line-026\\\"\\nreceived: \\\"line-027\\\"\\nreceived: \\\"line-028\\\"\\nreceived: \\\"line-029\\\"\\nreceived: \\\"line-030\\\"\\nreceived: \\\"line-031\\\"\\nreceived: \\\"line-032\\\"\\nreceived: \\\"line-033\\\"\\nreceived: \\\"line-034\\\"\\nreceived: \\\"line-035\\\"\\nreceived: \\\"line-036\\\"\\nreceived: \\\"line-037\\\"\\nreceived: \\\"line-038\\\"\\nreceived: \\\"line-039\\\"\\nreceived: \\\"line-040\\\"\"]}]}]}",
+    "stderr": "",
+    "status": 1,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 1,
+    "summary": "1/1 failed · 1 suites · 4.1s",
+    "failures": [
+      {
+        "suite": "apps/rsp/tests/snapshot.test.ts",
+        "name": "snapshot matches large diff",
+        "excerpt": "truncated"
+      }
+    ]
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "1/1 failed · 1 suites · 4.1s" },
+    { "question": "which test names failed?", "path": "failures.0.name", "expected": "snapshot matches large diff" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 1 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/test-runners/vitest/mixed.json
+++ b/apps/rsp/tests/fixtures/test-runners/vitest/mixed.json
@@ -1,0 +1,26 @@
+{
+  "name": "vitest-mixed",
+  "command": ["vitest", "run"],
+  "recorded": {
+    "stdout": "{\"numTotalTests\":4,\"numPassedTests\":3,\"numFailedTests\":1,\"startTime\":1783695600000,\"endTime\":1783695602500,\"testResults\":[{\"name\":\"apps/rsp/tests/math.test.ts\",\"assertionResults\":[{\"fullName\":\"math adds numbers\",\"title\":\"adds numbers\",\"status\":\"passed\",\"duration\":5},{\"fullName\":\"math divides by zero\",\"title\":\"divides by zero\",\"status\":\"failed\",\"failureMessages\":[\"AssertionError: expected Infinity to equal 0\\n- Expected: 0\\n+ Received: Infinity\\n    at math.test.ts:14:12\"],\"duration\":7}]},{\"name\":\"apps/rsp/tests/strings.test.ts\",\"assertionResults\":[{\"fullName\":\"strings trims\",\"title\":\"trims\",\"status\":\"passed\",\"duration\":4},{\"fullName\":\"strings uppercases\",\"title\":\"uppercases\",\"status\":\"passed\",\"duration\":3}]}],\"verboseNoise\":\"All passing assertions and internal timing details remain here in the reporter output, but rsp should emit only the failing row plus the rollup.\"}",
+    "stderr": "",
+    "status": 1,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 1,
+    "summary": "1/4 failed · 2 suites · 2.5s",
+    "failures": [
+      {
+        "suite": "apps/rsp/tests/math.test.ts",
+        "name": "math divides by zero",
+        "excerpt": "AssertionError: expected Infinity to equal 0\n- Expected: 0\n+ Received: Infinity\n    at math.test.ts:14:12"
+      }
+    ]
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "1/4 failed · 2 suites · 2.5s" },
+    { "question": "which test names failed?", "path": "failures.0.name", "expected": "math divides by zero" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 1 }
+  ]
+}

--- a/apps/rsp/tests/test-wrapper.test.ts
+++ b/apps/rsp/tests/test-wrapper.test.ts
@@ -1,0 +1,130 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { decode } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
+import { discoverFidelityFixtures, runFidelityFixture } from "../src/fidelity.js";
+import { RspElisionStore } from "../src/elision-store.js";
+
+const roots: string[] = [];
+const fixtureRoot = join(import.meta.dirname, "fixtures", "test-runners");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-test-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp test runner fidelity fixtures", () => {
+  it("auto-discovers vitest and cargo fixtures by directory convention", async () => {
+    const fixtureNames = (await discoverFidelityFixtures(fixtureRoot)).map((fixture) => fixture.name).sort();
+
+    expect(fixtureNames).toEqual([
+      "cargo-compile-error",
+      "cargo-green",
+      "cargo-red",
+      "vitest-fault-green-nonzero",
+      "vitest-green",
+      "vitest-long-failure",
+      "vitest-mixed",
+    ]);
+  });
+
+  it("emits summary-only TOON for green vitest and cargo suites", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      for (const fixture of (await discoverFidelityFixtures(fixtureRoot)).filter((candidate) => candidate.name.endsWith("-green"))) {
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+        expect(result.status).toBe(0);
+        expect(result.assertionFailures).toEqual([]);
+        expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+        expect(result.stdout.toString("utf8")).not.toContain("failures:");
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("emits failures-only rows plus summary for red and compile-error suites", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      for (const fixture of (await discoverFidelityFixtures(fixtureRoot)).filter((candidate) => ["vitest-mixed", "cargo-red", "cargo-compile-error"].includes(candidate.name))) {
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+        const decoded = decode(result.stdout.toString("utf8"));
+
+        expect(result.status).toBe(fixture.recorded.status);
+        expect(result.assertionFailures).toEqual([]);
+        expect(decoded).toEqual(fixture.expected);
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("does not render a green summary when the recorded exit code is non-zero", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-fault-green-nonzero")!;
+      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toEqual(Buffer.from(fixture.recorded.stdout, "utf8"));
+      expect(result.stdout.toString("utf8")).not.toContain("0/2 failed");
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("mints an elision handle for over-limit failure excerpts and show can retrieve the full excerpt", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-long-failure")!;
+      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+      const stdout = result.stdout.toString("utf8");
+
+      expect(result.assertionFailures).toEqual([]);
+      expect(stdout).toMatch(/… elided \d+ bytes \(\+\d+\) — rsp show el:[a-f0-9]{12}/);
+      expect(result.mintedHandle).toBeDefined();
+
+      const record = await store.get(result.mintedHandle!);
+      if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+      expect(record.original.toString("utf8")).toContain("received: \"line-001\"");
+      expect(record.original.toString("utf8")).toContain("received: \"line-040\"");
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("rsp test runner admission fixtures", () => {
+  it("measures vitest and cargo deltas with the existing admission harness", async () => {
+    const fixtures = await discoverFidelityFixtures(fixtureRoot);
+    const report = evaluateAdmission(fixtures, { thresholdPct: 60 });
+
+    expect(report.filters.find((row) => row.filter === "vitest:run")).toMatchObject({ active: true, mode: "active" });
+    expect(report.filters.find((row) => row.filter === "cargo:test")).toMatchObject({ active: true, mode: "active" });
+
+    const root = await tempRoot();
+    await mkdir(root, { recursive: true });
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = fixtures.find((candidate) => candidate.name === "vitest-green")!;
+      const result = await runAdmittedFixture(fixture, { thresholdPct: 60, level: "lossless", store });
+
+      expect(result.mode).toBe("active");
+      expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+    } finally {
+      await store.close();
+    }
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1413. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1413

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786289797&installation_id=129708444&pr_number=1443&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1443&signature=474a999f7d1474caf64b2301d2bcc85fa5e75a8021120913c9f182c4b9d623d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->