### PR TITLE
fix: #1414 rsp gh wrapper: PR/issue/run surfaces via gh --json contracts, catalog schemas as prior art

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { RspElisionStore } from "./elision-store.js";
 import { resolveRspConfig } from "./config.js";
 import { runGitWrapper } from "./git-wrapper.js";
+import { runGhWrapper } from "./gh-wrapper.js";
 import { runTestWrapper } from "./test-wrapper.js";
 
 interface ParsedArgs {
@@ -36,6 +37,17 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
 
     if (args.command === "git") {
       const result = await runGitWrapper(args.positional, { level: args.level, store });
+      process.stdout.write(result.stdout);
+      process.stderr.write(result.stderr);
+      if (result.signal) {
+        process.kill(process.pid, result.signal);
+        return 128;
+      }
+      return result.status ?? 0;
+    }
+
+    if (args.command === "gh") {
+      const result = await runGhWrapper(args.positional, { level: args.level, store });
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
       if (result.signal) {

--- a/apps/rsp/src/fidelity.ts
+++ b/apps/rsp/src/fidelity.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { decode } from "@reddb-io/toon";
 import { encodingForModel } from "js-tiktoken";
 import { renderGitContract, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
+import { renderGhContract } from "./gh-wrapper.js";
 import { renderTestContract } from "./test-wrapper.js";
 import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
 
@@ -66,6 +67,7 @@ export async function renderFixture(
   if (fixture.command[0] === "vitest" || fixture.command[0] === "cargo") {
     return await renderTestContract(fixture.command, fixture.recorded, options);
   }
+  if (fixture.command[0] === "gh") return await renderGhContract(fixture.command, fixture.recorded, options);
   if (fixture.command[0] !== "git") throw new Error(`unsupported fixture command: ${fixture.command.join(" ")}`);
   return await renderGitContract(fixture.command, fixture.recorded, options);
 }
@@ -73,6 +75,7 @@ export async function renderFixture(
 function readDecodedToon(stdout: Buffer): unknown {
   const text = stdout.toString("utf8");
   if (text === "git empty\n") return "git empty\n";
+  if (text.startsWith("0 ")) return text;
   const toon = text.split("\n").filter((line) => !line.startsWith("… elided ")).join("\n");
   return decode(toon);
 }
@@ -93,6 +96,8 @@ function getPath(value: unknown, path: string): unknown {
   for (const segment of path.split(".")) {
     if (segment === "length" && Array.isArray(cursor)) {
       cursor = cursor.length;
+    } else if (segment === "length" && isRecord(cursor)) {
+      cursor = Object.keys(cursor).length;
     } else if (/^\d+$/.test(segment) && Array.isArray(cursor)) {
       cursor = cursor[Number(segment)];
     } else if (isRecord(cursor)) {

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -1,0 +1,383 @@
+import { spawn } from "node:child_process";
+import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+import type { RecordedGitContract } from "./git-wrapper.js";
+
+export type GhKind = "pr" | "issue" | "run";
+export type GhAction = "list" | "view";
+
+export interface GhRenderOptions {
+  level: RspLossLevel;
+  store?: RspElisionStore;
+}
+
+export interface GhRenderResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  payload?: JsonObject;
+  mintedHandle?: `el:${string}`;
+  bytesElided?: number;
+  rowsElided?: number;
+}
+
+interface GhCommand {
+  kind: GhKind;
+  action: GhAction;
+  full: boolean;
+  wide: boolean;
+  passthrough: string[];
+}
+
+const DEFAULT_FIELDS: Record<`${GhKind}:${GhAction}`, string[]> = {
+  "pr:list": ["number", "title", "state", "isDraft"],
+  "pr:view": ["number", "title", "state", "body"],
+  "issue:list": ["number", "title", "state", "labels"],
+  "issue:view": ["number", "title", "state", "body"],
+  "run:list": ["databaseId", "name", "status", "conclusion"],
+  "run:view": ["databaseId", "name", "status", "conclusion", "jobs"],
+};
+
+const WIDE_FIELDS: Record<`${GhKind}:${GhAction}`, string[]> = {
+  "pr:list": ["number", "title", "state", "isDraft", "author", "labels", "url", "updatedAt"],
+  "pr:view": ["number", "title", "state", "body", "author", "labels", "url", "baseRefName", "headRefName"],
+  "issue:list": ["number", "title", "state", "labels", "author", "url", "updatedAt"],
+  "issue:view": ["number", "title", "state", "body", "author", "labels", "url", "updatedAt"],
+  "run:list": ["databaseId", "name", "status", "conclusion", "event", "headBranch", "workflowName", "createdAt"],
+  "run:view": ["databaseId", "name", "status", "conclusion", "event", "headBranch", "workflowName", "createdAt", "jobs", "url"],
+};
+
+const BODY_LIMIT = 160;
+const LOG_LIMIT = 160;
+
+export async function runGhWrapper(argv: readonly string[], options: GhRenderOptions): Promise<GhRenderResult> {
+  const command = parseGhCommand(argv);
+  const contract = await collectGhContract(command);
+  return renderGhContract(argv, contract, options);
+}
+
+export async function renderGhContract(
+  commandArgv: readonly string[],
+  contract: RecordedGitContract,
+  options: GhRenderOptions,
+): Promise<GhRenderResult> {
+  if ((contract.status ?? 0) !== 0 || contract.signal) {
+    return {
+      stdout: Buffer.from(contract.stdout),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+    };
+  }
+
+  const command = parseGhCommand(commandArgv);
+  const parsed = parseJson(contract.stdout);
+  const payload = renderGhPayload(command, commandArgv, parsed);
+  if (typeof payload === "string") {
+    return {
+      stdout: Buffer.from(payload),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+    };
+  }
+
+  const handleRequest = findHandleRequest(payload);
+  if (handleRequest) {
+    if (!options.store) throw new Error("truncated gh output requires an elision store");
+    const handle = await options.store.mint(Buffer.from(handleRequest.original), {
+      command: commandArgv.join(" "),
+      loss: { level: command.full ? "brief" : options.level, bytes_elided: handleRequest.bytes },
+    });
+    handleRequest.target.truncated.handle = handle;
+  }
+
+  const mintedTextHandle = handleRequest?.target.truncated.handle || undefined;
+  const fullToon = encode(payload);
+  if (options.level !== "terse") {
+    return {
+      stdout: Buffer.from(fullToon),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+      payload,
+      mintedHandle: mintedTextHandle,
+      bytesElided: handleRequest?.bytes,
+    };
+  }
+
+  const terse = tersePayload(payload);
+  if (!terse) {
+    return {
+      stdout: Buffer.from(fullToon),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+      payload,
+      mintedHandle: mintedTextHandle,
+      bytesElided: handleRequest?.bytes,
+    };
+  }
+
+  const bytesElided = Buffer.byteLength(fullToon);
+  const handle = await options.store?.mint(Buffer.from(fullToon), {
+    command: commandArgv.join(" "),
+    loss: { level: "terse", bytes_elided: bytesElided },
+  });
+  if (!handle) throw new Error("terse gh output requires an elision store");
+
+  const marker = `… elided ${terse.rowsElided} rows (+${bytesElided}) — rsp show ${handle}\n`;
+  return {
+    stdout: Buffer.from(`${encode(terse.payload)}\n${marker}`),
+    stderr: Buffer.from(contract.stderr),
+    status: contract.status,
+    signal: contract.signal,
+    payload: terse.payload,
+    mintedHandle: handle,
+    bytesElided,
+    rowsElided: terse.rowsElided,
+  };
+}
+
+function parseGhCommand(argv: readonly string[]): GhCommand {
+  if (argv[0] !== "gh") throw new Error("expected rsp gh <surface> <subcommand>");
+  const kind = argv[1];
+  const action = argv[2];
+  if (!(kind === "pr" || kind === "issue" || kind === "run")) throw new Error(`unsupported gh surface: ${kind ?? ""}`);
+  if (!(action === "list" || action === "view")) throw new Error(`unsupported gh subcommand: ${action ?? ""}`);
+
+  const passthrough: string[] = [];
+  let full = false;
+  let wide = false;
+  for (const arg of argv.slice(3)) {
+    if (arg === "--full") full = true;
+    else if (arg === "--wide") wide = true;
+    else passthrough.push(arg);
+  }
+  return { kind, action, full, wide, passthrough };
+}
+
+function machineArgs(command: GhCommand): string[] {
+  const key = `${command.kind}:${command.action}` as const;
+  const fields = command.wide ? WIDE_FIELDS[key] : DEFAULT_FIELDS[key];
+  return [command.kind, command.action, ...command.passthrough, "--json", fields.join(",")];
+}
+
+async function collectGhContract(command: GhCommand): Promise<RecordedGitContract> {
+  const child = spawn("gh", machineArgs(command), { stdio: ["ignore", "pipe", "pipe"] });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+  return await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        status,
+        signal,
+      });
+    });
+  });
+}
+
+function renderGhPayload(command: GhCommand, commandArgv: readonly string[], parsed: unknown): JsonObject | string {
+  if (command.action === "list" && Array.isArray(parsed) && parsed.length === 0) {
+    return emptyState(command.kind);
+  }
+
+  const base = { command: commandArgv.join(" ") };
+  switch (`${command.kind}:${command.action}`) {
+    case "pr:list": {
+      const rows = arrayOfRecords(parsed).map((row) => projectPr(row, command.wide));
+      return { ...base, prs: rows, summary: `${rows.length} ${stateWord(rows, "open")} PRs` };
+    }
+    case "pr:view":
+      return { ...base, pr: projectPrView(recordOf(parsed), command), summary: `PR #${numberField(recordOf(parsed), "number")}` };
+    case "issue:list": {
+      const rows = arrayOfRecords(parsed).map((row) => projectIssue(row, command.wide));
+      return { ...base, issues: rows, summary: `${rows.length} ${stateWord(rows, "open")} issues` };
+    }
+    case "issue:view":
+      return { ...base, issue: projectIssueView(recordOf(parsed), command), summary: `issue #${numberField(recordOf(parsed), "number")}` };
+    case "run:list": {
+      const rows = arrayOfRecords(parsed).map((row) => projectRun(row, command.wide));
+      return { ...base, runs: rows, summary: `${rows.length} runs` };
+    }
+    case "run:view":
+      return { ...base, run: projectRunView(recordOf(parsed), command), summary: `run ${numberField(recordOf(parsed), "databaseId")}` };
+  }
+  throw new Error(`unsupported gh command: ${command.kind} ${command.action}`);
+}
+
+function emptyState(kind: GhKind): string {
+  if (kind === "pr") return "0 open PRs — try: rsp gh issue list\n";
+  if (kind === "issue") return "0 open issues — try: rsp gh issue list --state all\n";
+  return "0 runs — try: rsp gh run list --limit 20\n";
+}
+
+function projectPr(row: Record<string, unknown>, wide: boolean): JsonObject {
+  const out: JsonObject = {
+    number: numberField(row, "number"),
+    title: stringField(row, "title"),
+    state: stateClass(row),
+    draft: Boolean(row.isDraft),
+  };
+  if (wide) Object.assign(out, wideCommon(row));
+  return out;
+}
+
+function projectPrView(row: Record<string, unknown>, command: GhCommand): JsonObject {
+  const out: JsonObject = projectPr(row, command.wide);
+  out.body = textField(row, "body", BODY_LIMIT, command.full);
+  if (command.wide) {
+    out.base = stringField(row, "baseRefName");
+    out.head = stringField(row, "headRefName");
+  }
+  return out;
+}
+
+function projectIssue(row: Record<string, unknown>, wide: boolean): JsonObject {
+  const out: JsonObject = {
+    number: numberField(row, "number"),
+    title: stringField(row, "title"),
+    state: stateClass(row),
+    labels: labels(row.labels),
+  };
+  if (wide) Object.assign(out, wideCommon(row));
+  return out;
+}
+
+function projectIssueView(row: Record<string, unknown>, command: GhCommand): JsonObject {
+  const out: JsonObject = projectIssue(row, command.wide);
+  out.body = textField(row, "body", BODY_LIMIT, command.full);
+  return out;
+}
+
+function projectRun(row: Record<string, unknown>, wide: boolean): JsonObject {
+  const out: JsonObject = {
+    id: numberField(row, "databaseId"),
+    name: stringField(row, "name"),
+    status: stateClass(row),
+    conclusion: stringField(row, "conclusion"),
+  };
+  if (wide) {
+    out.event = stringField(row, "event");
+    out.branch = stringField(row, "headBranch");
+    out.workflow = stringField(row, "workflowName");
+    out.created = stringField(row, "createdAt");
+  }
+  return out;
+}
+
+function projectRunView(row: Record<string, unknown>, command: GhCommand): JsonObject {
+  const out: JsonObject = projectRun(row, command.wide);
+  const jobs = arrayOfRecords(row.jobs).map((job) => ({
+    name: stringField(job, "name"),
+    status: stateClass(job),
+    conclusion: stringField(job, "conclusion"),
+    log: textField(job, "log", LOG_LIMIT, command.full),
+  }));
+  out.jobs = jobs as JsonValue;
+  return out;
+}
+
+function textField(row: Record<string, unknown>, field: string, limit: number, full: boolean): JsonValue {
+  const value = stringField(row, field);
+  if (full || Buffer.byteLength(value) <= limit) return value;
+  const shown = value.slice(0, limit);
+  const out = {
+    preview: shown,
+    truncated: {
+      bytes: Buffer.byteLength(value),
+      shown_bytes: Buffer.byteLength(shown),
+      hint: "--full",
+      handle: "",
+    },
+  };
+  Object.defineProperty(out, "__rsp_original", { value, enumerable: false });
+  return out;
+}
+
+function findHandleRequest(payload: JsonObject): { target: { truncated: { handle: `el:${string}` | "" } }; original: string; bytes: number } | null {
+  const stack: unknown[] = [payload];
+  while (stack.length > 0) {
+    const value = stack.pop();
+    if (Array.isArray(value)) {
+      stack.push(...value);
+    } else if (isRecord(value)) {
+      if (isRecord(value.truncated) && value.truncated.handle === "" && typeof value.preview === "string") {
+        const original = typeof value.__rsp_original === "string" ? value.__rsp_original : value.preview;
+        return { target: value as { truncated: { handle: "" } }, original, bytes: Number(value.truncated.bytes ?? 0) };
+      }
+      stack.push(...Object.values(value));
+    }
+  }
+  return null;
+}
+
+function tersePayload(payload: JsonObject): { payload: JsonObject; rowsElided: number } | null {
+  for (const key of ["prs", "issues", "runs", "jobs"] as const) {
+    const value = payload[key];
+    if (Array.isArray(value) && value.length > 1) {
+      return { payload: { ...payload, [key]: value.slice(0, 1) as JsonValue }, rowsElided: value.length - 1 };
+    }
+  }
+  return null;
+}
+
+function stateWord(rows: readonly JsonObject[], preferred: string): string {
+  if (rows.every((row) => row.state === preferred)) return preferred;
+  return "returned";
+}
+
+function stateClass(row: Record<string, unknown>): string {
+  const state = stringField(row, "state") || stringField(row, "status");
+  return state.toLowerCase();
+}
+
+function wideCommon(row: Record<string, unknown>): JsonObject {
+  return {
+    author: authorLogin(row.author),
+    labels: labels(row.labels),
+    url: stringField(row, "url"),
+    updated: stringField(row, "updatedAt"),
+  };
+}
+
+function labels(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => isRecord(item) ? stringField(item, "name") : String(item)).filter(Boolean);
+}
+
+function authorLogin(value: unknown): string {
+  return isRecord(value) ? stringField(value, "login") : "";
+}
+
+function parseJson(raw: string): unknown {
+  return raw.trim() ? JSON.parse(raw) : null;
+}
+
+function arrayOfRecords(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function recordOf(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function stringField(row: Record<string, unknown>, field: string): string {
+  const value = row[field];
+  return typeof value === "string" ? value : "";
+}
+
+function numberField(row: Record<string, unknown>, field: string): number {
+  const value = row[field];
+  return typeof value === "number" ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/tests/fixtures/gh/issue/auth-failure.json
+++ b/apps/rsp/tests/fixtures/gh/issue/auth-failure.json
@@ -1,0 +1,13 @@
+{
+  "name": "issue-list-auth-failure",
+  "command": ["gh", "issue", "list"],
+  "catalog_prior_art": "official catalog GitHub wrapper leaves gh authentication failures untouched.",
+  "recorded": {
+    "stdout": "",
+    "stderr": "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.\n",
+    "status": 4,
+    "signal": null
+  },
+  "expected": "",
+  "assertions": []
+}

--- a/apps/rsp/tests/fixtures/gh/issue/list.json
+++ b/apps/rsp/tests/fixtures/gh/issue/list.json
@@ -1,0 +1,23 @@
+{
+  "name": "issue-list-default",
+  "command": ["gh", "issue", "list"],
+  "catalog_prior_art": "official catalog GitHub wrapper field choice mined for issue list: number,title,state,labels.",
+  "recorded": {
+    "stdout": "[{\"number\":1414,\"title\":\"rsp gh wrapper\",\"state\":\"OPEN\",\"labels\":[{\"name\":\"ready-for-agent\"}]},{\"number\":1412,\"title\":\"rsp git wrapper\",\"state\":\"CLOSED\",\"labels\":[{\"name\":\"type:ticket\"}]}]",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "gh issue list",
+    "issues": [
+      { "number": 1414, "title": "rsp gh wrapper", "state": "open", "labels": ["ready-for-agent"] },
+      { "number": 1412, "title": "rsp git wrapper", "state": "closed", "labels": ["type:ticket"] }
+    ],
+    "summary": "2 returned issues"
+  },
+  "assertions": [
+    { "question": "how many fields are in a default issue row?", "path": "issues.0.length", "expected": 4 },
+    { "question": "which issue is first?", "path": "issues.0.number", "expected": 1414 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/gh/issue/view.json
+++ b/apps/rsp/tests/fixtures/gh/issue/view.json
@@ -1,0 +1,16 @@
+{
+  "name": "issue-view-body",
+  "command": ["gh", "issue", "view", "1414"],
+  "catalog_prior_art": "official catalog GitHub wrapper field choice mined for issue view: number,title,state,body, with body elided unless --full.",
+  "recorded": {
+    "stdout": "{\"number\":1414,\"title\":\"rsp gh wrapper\",\"state\":\"OPEN\",\"labels\":[{\"name\":\"ready-for-agent\"}],\"body\":\"Issue body text starts with the concrete request and continues with acceptance criteria, blocked-by metadata, fixture donor notes, passthrough requirements, and enough extra detail to force truncation in the fixture.\"}",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {},
+  "assertions": [
+    { "question": "which issue was viewed?", "path": "issue.number", "expected": 1414 },
+    { "question": "what escape hatch is advertised?", "path": "issue.body.truncated.hint", "expected": "--full" }
+  ]
+}

--- a/apps/rsp/tests/fixtures/gh/pr/empty.json
+++ b/apps/rsp/tests/fixtures/gh/pr/empty.json
@@ -1,0 +1,13 @@
+{
+  "name": "pr-list-empty",
+  "command": ["gh", "pr", "list"],
+  "catalog_prior_art": "official catalog GitHub wrapper returns definitive empty states instead of an empty JSON array.",
+  "recorded": {
+    "stdout": "[]",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": "0 open PRs — try: rsp gh issue list\n",
+  "assertions": []
+}

--- a/apps/rsp/tests/fixtures/gh/pr/list.json
+++ b/apps/rsp/tests/fixtures/gh/pr/list.json
@@ -1,0 +1,23 @@
+{
+  "name": "pr-list-default",
+  "command": ["gh", "pr", "list"],
+  "catalog_prior_art": "official catalog GitHub wrapper field choice mined for PR list: number,title,state,isDraft; wider metadata stays opt-in.",
+  "recorded": {
+    "stdout": "[{\"number\":42,\"title\":\"Add rsp gh wrapper\",\"state\":\"OPEN\",\"isDraft\":false},{\"number\":41,\"title\":\"Draft docs\",\"state\":\"OPEN\",\"isDraft\":true}]",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "gh pr list",
+    "prs": [
+      { "number": 42, "title": "Add rsp gh wrapper", "state": "open", "draft": false },
+      { "number": 41, "title": "Draft docs", "state": "open", "draft": true }
+    ],
+    "summary": "2 open PRs"
+  },
+  "assertions": [
+    { "question": "how many fields are in a default PR row?", "path": "prs.0.length", "expected": 4 },
+    { "question": "which PR is first?", "path": "prs.0.number", "expected": 42 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/gh/pr/view.json
+++ b/apps/rsp/tests/fixtures/gh/pr/view.json
@@ -1,0 +1,16 @@
+{
+  "name": "pr-view-body",
+  "command": ["gh", "pr", "view", "42"],
+  "catalog_prior_art": "official catalog GitHub wrapper field choice mined for PR view: number,title,state,body, with body elided unless --full.",
+  "recorded": {
+    "stdout": "{\"number\":42,\"title\":\"Add rsp gh wrapper\",\"state\":\"OPEN\",\"isDraft\":false,\"body\":\"This pull request adds the GitHub wrapper surface. It includes recorded gh json fixtures, default schemas, wider opt-in output, fidelity checks, admission checks, and enough detail to force truncation in the fixture body.\"}",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {},
+  "assertions": [
+    { "question": "which PR was viewed?", "path": "pr.number", "expected": 42 },
+    { "question": "what escape hatch is advertised?", "path": "pr.body.truncated.hint", "expected": "--full" }
+  ]
+}

--- a/apps/rsp/tests/fixtures/gh/run/list.json
+++ b/apps/rsp/tests/fixtures/gh/run/list.json
@@ -1,0 +1,23 @@
+{
+  "name": "run-list-default",
+  "command": ["gh", "run", "list"],
+  "catalog_prior_art": "official catalog GitHub wrapper field choice mined for run list: databaseId,name,status,conclusion.",
+  "recorded": {
+    "stdout": "[{\"databaseId\":9001,\"name\":\"CI\",\"status\":\"completed\",\"conclusion\":\"success\"},{\"databaseId\":9002,\"name\":\"Release\",\"status\":\"in_progress\",\"conclusion\":\"\"}]",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "gh run list",
+    "runs": [
+      { "id": 9001, "name": "CI", "status": "completed", "conclusion": "success" },
+      { "id": 9002, "name": "Release", "status": "in_progress", "conclusion": "" }
+    ],
+    "summary": "2 runs"
+  },
+  "assertions": [
+    { "question": "how many fields are in a default run row?", "path": "runs.0.length", "expected": 4 },
+    { "question": "which run is first?", "path": "runs.0.id", "expected": 9001 }
+  ]
+}

--- a/apps/rsp/tests/fixtures/gh/run/rate-limit.json
+++ b/apps/rsp/tests/fixtures/gh/run/rate-limit.json
@@ -1,0 +1,13 @@
+{
+  "name": "run-list-rate-limit",
+  "command": ["gh", "run", "list"],
+  "catalog_prior_art": "official catalog GitHub wrapper leaves gh rate-limit errors untouched.",
+  "recorded": {
+    "stdout": "",
+    "stderr": "API rate limit exceeded for installation ID 12345.\n",
+    "status": 1,
+    "signal": null
+  },
+  "expected": "",
+  "assertions": []
+}

--- a/apps/rsp/tests/fixtures/gh/run/view.json
+++ b/apps/rsp/tests/fixtures/gh/run/view.json
@@ -1,0 +1,16 @@
+{
+  "name": "run-view-log",
+  "command": ["gh", "run", "view", "9001"],
+  "catalog_prior_art": "official catalog GitHub wrapper field choice mined for run view: databaseId,name,status,conclusion,jobs; job log text is elided unless --full.",
+  "recorded": {
+    "stdout": "{\"databaseId\":9001,\"name\":\"CI\",\"status\":\"completed\",\"conclusion\":\"failure\",\"jobs\":[{\"name\":\"test\",\"status\":\"completed\",\"conclusion\":\"failure\",\"log\":\"vitest failed in apps/rsp/tests/gh-wrapper.test.ts after rendering a long assertion message, stack trace, expected payload, received payload, fixture path, retry hint, and final process summary.\"}]}",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {},
+  "assertions": [
+    { "question": "which run was viewed?", "path": "run.id", "expected": 9001 },
+    { "question": "what escape hatch is advertised?", "path": "run.jobs.0.log.truncated.hint", "expected": "--full" }
+  ]
+}

--- a/apps/rsp/tests/gh-wrapper.test.ts
+++ b/apps/rsp/tests/gh-wrapper.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { decode } from "@reddb-io/toon";
+import { afterEach, describe, expect, it } from "vitest";
+import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
+import { discoverFidelityFixtures, runFidelityFixture } from "../src/fidelity.js";
+import { RspElisionStore } from "../src/elision-store.js";
+
+const roots: string[] = [];
+const fixtureRoot = join(import.meta.dirname, "fixtures", "gh");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-gh-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp gh fidelity fixtures", () => {
+  it("auto-discovers gh wrapper fixtures by directory convention", async () => {
+    const fixtureNames = (await discoverFidelityFixtures(fixtureRoot)).map((fixture) => fixture.name).sort();
+
+    expect(fixtureNames).toEqual([
+      "issue-list-auth-failure",
+      "issue-list-default",
+      "issue-view-body",
+      "pr-list-default",
+      "pr-list-empty",
+      "pr-view-body",
+      "run-list-default",
+      "run-list-rate-limit",
+      "run-view-log",
+    ]);
+  });
+
+  it("renders six gh subcommand surfaces from recorded --json contracts", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      for (const fixture of await discoverFidelityFixtures(fixtureRoot)) {
+        if (fixture.expected === "" || fixture.expected === "0 open PRs — try: rsp gh issue list\n" || fixture.name.endsWith("-body") || fixture.name.endsWith("-log")) {
+          continue;
+        }
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+        expect(result.status).toBe(fixture.recorded.status);
+        expect(result.stderr).toEqual(Buffer.from(fixture.recorded.stderr, "utf8"));
+        expect(result.assertionFailures).toEqual([]);
+        expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("returns a definitive empty PR state without minting a handle", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "pr-list-empty")!;
+      const result = await runFidelityFixture(fixture, { level: "brief", store });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toEqual(Buffer.from("0 open PRs — try: rsp gh issue list\n"));
+      expect(result.mintedHandle).toBeUndefined();
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("truncates PR and issue bodies with size hints, --full escape, and an elision handle", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixtures = await discoverFidelityFixtures(fixtureRoot);
+      for (const name of ["pr-view-body", "issue-view-body"]) {
+        const fixture = fixtures.find((candidate) => candidate.name === name)!;
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+        const decoded = decode(result.stdout.toString("utf8")) as { pr?: { body: TruncatedText }; issue?: { body: TruncatedText } };
+        const body = decoded.pr?.body ?? decoded.issue?.body;
+
+        expect(body?.truncated).toMatchObject({ hint: "--full", bytes: expect.any(Number), shown_bytes: expect.any(Number) });
+        expect(body?.truncated.handle).toMatch(/^el:[a-f0-9]{12}$/);
+        expect(result.assertionFailures).toEqual([]);
+
+        const record = await store.get(body!.truncated.handle);
+        if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+        expect(record.original.toString("utf8")).toContain("force truncation");
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("--full keeps large gh body/log fields lossless and skips handle minting", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = {
+        ...(await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "run-view-log")!,
+        command: ["gh", "run", "view", "9001", "--full"],
+      };
+      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+      const decoded = decode(result.stdout.toString("utf8")) as { run: { jobs: Array<{ log: string }> } };
+
+      expect(decoded.run.jobs[0]!.log).toContain("final process summary");
+      expect(result.mintedHandle).toBeUndefined();
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("forwards gh auth failures and rate limits byte-intact", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixtures = await discoverFidelityFixtures(fixtureRoot);
+      const auth = fixtures.find((candidate) => candidate.name === "issue-list-auth-failure")!;
+      const rate = fixtures.find((candidate) => candidate.name === "run-list-rate-limit")!;
+
+      await expect(runFidelityFixture(auth, { level: "lossless", store })).resolves.toMatchObject({
+        status: 4,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from("gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.\n"),
+      });
+      await expect(runFidelityFixture(rate, { level: "lossless", store })).resolves.toMatchObject({
+        status: 1,
+        stdout: Buffer.from(""),
+        stderr: Buffer.from("API rate limit exceeded for installation ID 12345.\n"),
+      });
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+describe("rsp gh admission harness", () => {
+  it("reports gh filters from fixture discovery and can pass through below threshold", async () => {
+    const fixtures = await discoverFidelityFixtures(fixtureRoot);
+    const report = evaluateAdmission(fixtures, { thresholdPct: 95 });
+    const prRow = report.filters.find((row) => row.filter === "gh:pr")!;
+
+    expect(report.filters.map((row) => row.filter)).toEqual(["gh:issue", "gh:pr", "gh:run"]);
+    expect(prRow).toMatchObject({ median_delta_pct: expect.any(Number), active: false, mode: "passthrough" });
+
+    const tmp = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(tmp, "red.rdb")}` });
+    try {
+      const fixture = fixtures.find((candidate) => candidate.name === "pr-list-default")!;
+      const result = await runAdmittedFixture(fixture, { thresholdPct: 95, level: "lossless", store });
+
+      expect(result.mode).toBe("passthrough");
+      expect(result.stdout).toEqual(Buffer.from(fixture.recorded.stdout, "utf8"));
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+interface TruncatedText {
+  preview: string;
+  truncated: {
+    bytes: number;
+    shown_bytes: number;
+    hint: "--full";
+    handle: `el:${string}`;
+  };
+}


### PR DESCRIPTION
Automated AFK landing for #1414. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1414

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786290517&installation_id=129708444&pr_number=1444&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1444&signature=427e95b23785eac3dcef8736cf0dff497577c86c5d75b4872a6c3ada6a009a32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->