### PR TITLE
fix: #1426 Statusline fleet segment: render supervisor presence, slot occupancy and runner from the supervisor snapshot

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -25,6 +25,7 @@ import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
 import {
   collectStatuslineAfk,
+  collectStatuslineFleet,
   collectStatuslineRepo,
   collectStatuslineWorkers,
   inferGitHubRepoSlug,
@@ -202,9 +203,10 @@ export async function statuslineCommand(
   // the per-worker records feed the themed multi-line form (Claude Code). Both
   // read the same worker states — cheap file reads — so the two forms stay in
   // sync while each renders its own layout.
-  const [repo, afk, workers] = await Promise.all([
+  const [repo, afk, fleet, workers] = await Promise.all([
     collectStatuslineRepo(repoCtx, cacheTtlS),
     collectStatuslineAfk(repoCtx, cacheTtlS).then((a) => a ?? undefined),
+    collectStatuslineFleet(repoCtx),
     collectStatuslineWorkers(repoCtx),
   ]);
 
@@ -215,7 +217,7 @@ export async function statuslineCommand(
   const color = !process.env.NO_COLOR;
   const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
   const nowS = Math.floor(Date.now() / 1000);
-  const line = renderStatuslineThemed({ project, claude, repo, afk }, color, {
+  const line = renderStatuslineThemed({ project, claude, repo, fleet, afk }, color, {
     columns: Number.isFinite(columns) && columns > 0 ? columns : undefined,
     workers,
     now: nowS,

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -34,8 +34,10 @@ import {
   humanizeCount,
   humanizeTokens,
   renderStatusline,
+  renderFleetBlock,
   shortModel,
   type ClaudeInput,
+  type FleetInput,
   type ProjectInput,
   type RepoInput,
   type StatuslineInput,
@@ -181,20 +183,30 @@ function localDiffKv(repo: RepoInput | undefined): string[] {
   return value ? [kv("loc", value)] : [];
 }
 
+function fleetKv(fleet: FleetInput | undefined): string[] {
+  const block = renderFleetBlock(fleet);
+  return block ? [block] : [];
+}
+
 /** Line 1 — wine identity zone (project + model) then a transparent KPI tail. */
 export function renderHeaderLine(
   project: ProjectInput,
   claude: ClaudeInput | undefined,
   repo: RepoInput | undefined,
+  fleet?: FleetInput,
 ): string {
   let s = `${WINE2}${WHITE} ${projectContent(project)} `;
   const model = modelContent(claude);
   if (model !== null) s += `${WINE}${WHITE} ${model} `;
   // Drop the background: from here on the line is transparent.
   s += `${NOBG}${SOFT}`;
-  const tail = [ctxKv(claude), ...usageKvs(claude), ...repoCountsKv(repo), ...localDiffKv(repo)].filter(
-    (x): x is string => x !== null,
-  );
+  const tail = [
+    ctxKv(claude),
+    ...usageKvs(claude),
+    ...repoCountsKv(repo),
+    ...localDiffKv(repo),
+    ...fleetKv(fleet),
+  ].filter((x): x is string => x !== null);
   if (tail.length) s += ` ${tail.join("  ")}`;
   return `${s}${RESET}`;
 }
@@ -329,7 +341,7 @@ export interface StyleOptions {
  * (Claude Code renders each `\n`-separated segment as its own row). Zero workers
  * → only the header line. */
 export function styleStatusline(input: StatuslineInput, opts: StyleOptions = {}): string {
-  const lines = [renderHeaderLine(input.project, input.claude, input.repo)];
+  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet)];
   const now = opts.now ?? 0;
   lines.push(...renderWorkerLines(opts.workers ?? [], now));
   return lines.join("\n");

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -149,11 +149,26 @@ export interface RepoInput {
   cacheAgeS?: number;
 }
 
+/** Repo-global fleet-supervisor segment, independent of live worker rows. */
+export interface FleetInput {
+  /** Supervisor runner (`codex`, `claude`, `opencode`, ...). */
+  runner: string;
+  /** Busy slots from the supervisor snapshot. */
+  busy: number;
+  /** Total slots from the supervisor snapshot. */
+  total: number;
+  /** Ready-for-agent queue depth from the supervisor snapshot. */
+  queue: number;
+  /** Parked slots from the supervisor snapshot. */
+  parked?: number;
+}
+
 /** All the resolved inputs for one statusline render. */
 export interface StatuslineInput {
   project: ProjectInput;
   claude?: ClaudeInput;
   repo?: RepoInput;
+  fleet?: FleetInput;
   afk?: AfkInput;
 }
 
@@ -387,6 +402,20 @@ export function renderRepoBlock(repo: RepoInput | undefined): string | null {
   return parts.length ? parts.join(" ") : null;
 }
 
+/** Supervisor fleet cell: rendered only after IO proves pid-live and fresh. */
+export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
+  if (!fleet) return null;
+  const runner = fleet.runner || "?";
+  const busy = Math.max(0, Math.floor(fleet.busy));
+  const total = Math.max(0, Math.floor(fleet.total));
+  const queue = Math.max(0, Math.floor(fleet.queue));
+  const parts = [`flt=${runner} ${busy}/${total} busy`, `q=${queue}`];
+  if (fleet.parked !== undefined && fleet.parked > 0) {
+    parts.push(`park=${Math.floor(fleet.parked)}`);
+  }
+  return parts.join(" · ");
+}
+
 /**
  * Block 4: the space-joined AFK token run in plain text. Null when there are no
  * live workers, matching the bash `(( total_workers > 0 ))` gate around the
@@ -434,6 +463,8 @@ export function renderStatusline(input: StatuslineInput): string {
   if (usage !== null) sections.push(usage);
   const repo = renderRepoBlock(input.repo);
   if (repo !== null) sections.push(repo);
+  const fleet = renderFleetBlock(input.fleet);
+  if (fleet !== null) sections.push(fleet);
   const afk = renderAfkBlock(input.afk);
   if (afk !== null) sections.push(afk);
   return sections.join(" · ");

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -769,7 +769,7 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
 
 // ---------- statusline inputs ----------
 
-import type { AfkInput, RepoInput } from "../core/statusline.js";
+import type { AfkInput, FleetInput, RepoInput } from "../core/statusline.js";
 
 /** The DEFAULT TTL (seconds) of every EXPENSIVE FETCHED statusline number — the
  * GitHub-derived queue/human and open-PR/open-issue counts AND the repo-global
@@ -1180,6 +1180,44 @@ export async function collectStatuslineAfk(
     effort: effort || undefined,
     sourceCounts,
     cacheAgeS,
+  };
+}
+
+const STATUSLINE_FLEET_MAX_AGE_S = 120;
+
+function readSupervisorPid(path: string): number | null {
+  try {
+    const pid = Number.parseInt(readFileSync(path, "utf8").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Repo-summary fleet segment input. It is intentionally independent of live
+ * worker rows: the supervisor can be landing, validating, merging, or idle
+ * between worker loops while zero worker records are renderable.
+ */
+export async function collectStatuslineFleet(
+  ctx: RepoContext,
+  maxAgeS: number = STATUSLINE_FLEET_MAX_AGE_S,
+  nowS: number = Math.floor(Date.now() / 1000),
+): Promise<FleetInput | undefined> {
+  const paths = afkPaths(ctx.root);
+  const pid = readSupervisorPid(join(paths.tmpDir, "afk-supervisor.pid"));
+  if (pid === null || !isLivePid(pid)) return undefined;
+
+  const state = await readFleetState(paths.fleetStatePath);
+  if (!state) return undefined;
+  if (nowS - state.epoch > maxAgeS) return undefined;
+
+  return {
+    runner: state.runner,
+    busy: state.slotsBusy,
+    total: state.slotsTotal,
+    queue: state.readyForAgent,
+    parked: state.slotsParked,
   };
 }
 

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -91,6 +91,28 @@ async function seedFreshRepoCache(
   );
 }
 
+async function writeFleetSnapshot(
+  root: string,
+  over: Record<string, unknown> = {},
+): Promise<void> {
+  const dir = join(root, ".red", "tmp");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "afk-supervisor.pid"), `${process.pid}\n`, "utf8");
+  await writeFile(
+    join(dir, "afk-supervisor.state.json"),
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      epoch: Math.floor(Date.now() / 1000),
+      runner: "codex",
+      ready_for_agent: 2,
+      slots: { busy: 1, free: 0, total: 1, parked: 0 },
+      spawns_this_tick: 0,
+      ...over,
+    }),
+    "utf8",
+  );
+}
+
 const PAYLOAD = JSON.stringify({
   model: { display_name: "Opus" },
   effort: { level: "high" },
@@ -433,6 +455,66 @@ describe("statusline command — rendered line", () => {
     expect(rows).toHaveLength(1); // 0 workers → header row alone
     expect(rows[0]).toContain("Opus·high");
     expect(rows[0]).toContain("47k 24%");
+  });
+
+  it("renders a fresh live supervisor fleet segment even when zero worker rows render", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 2, 0);
+    await writeFleetSnapshot(root);
+
+    const out = sink();
+    const oldNoColor = process.env.NO_COLOR;
+    delete process.env.NO_COLOR;
+    try {
+      const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+      expect(code).toBe(0);
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+
+    const rows = stripAnsi(out.text()).trimEnd().split("\n");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain("flt=codex 1/1 busy");
+    expect(rows[0]).toContain("q=2");
+    expect(rows[0]).not.toContain("wrk=");
+  });
+
+  it("suppresses the fleet segment when the supervisor pid is dead", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 2, 0);
+    await writeFleetSnapshot(root);
+    await writeFile(join(root, ".red", "tmp", "afk-supervisor.pid"), "999999999\n", "utf8");
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).not.toContain("flt=");
+  });
+
+  it("suppresses the fleet segment when the supervisor snapshot is stale", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 2, 0);
+    await writeFleetSnapshot(root, { epoch: Math.floor(Date.now() / 1000) - 3600 });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).not.toContain("flt=");
+  });
+
+  it("surfaces parked slots in the fleet segment", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 4, 0);
+    await writeFleetSnapshot(root, {
+      ready_for_agent: 4,
+      slots: { busy: 1, free: 0, total: 2, parked: 1 },
+    });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("park=1");
   });
 
   it("renders only the project block outside Claude Code (empty stdin)", async () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -7,6 +7,7 @@ import {
   shortModel,
   renderAfkBlock,
   renderContextBlock,
+  renderFleetBlock,
   renderModelBlock,
   renderProjectBlock,
   renderRepoBlock,
@@ -294,6 +295,14 @@ describe("statusline — repo block", () => {
 
   it("moves the age suffix to iss= when openPrs is 0 and todayPrs is 0", () => {
     expect(renderRepoBlock({ openPrs: 0, openIssues: 24, cacheAgeS: 720 })).toBe("iss=24 (12m)");
+  });
+});
+
+describe("statusline — fleet block", () => {
+  it("renders runner, busy/total occupancy, queue depth, and parked slots", () => {
+    expect(renderFleetBlock({ runner: "codex", busy: 1, total: 2, queue: 7, parked: 1 })).toBe(
+      "flt=codex 1/2 busy · q=7 · park=1",
+    );
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1426. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1426

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786296854&installation_id=129708444&pr_number=1446&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1446&signature=cc82be642d3680e193192d247f16ce129e366808d24e0ca1a569306c6ffa4cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->