### PR TITLE
fix: #1427 Statusline landing visibility: slot renders gate/merge/cascade phase after the agent loop ends

### DIFF
--- a/apps/dev/src/core/landing.ts
+++ b/apps/dev/src/core/landing.ts
@@ -154,6 +154,14 @@ export interface LandingDeps {
    * behaviour, so callers that have not wired the dep are unchanged.
    */
   landLock?: LandLock;
+  /**
+   * Best-effort landing visibility sink (#1427). The caller wires this to the
+   * attempt's worker-shaped state (`current.phase` + `current.started_at`) so
+   * statusline/monitor readers see the post-agent landing lane after the inner
+   * agent has exited. Uses the normal WorkerVitals `phase` field, not a parallel
+   * state vocabulary.
+   */
+  landingPhase?(phase: "gate" | "push-pr" | "merge" | "cascade"): void | Promise<void>;
 }
 
 /** Static per-landing inputs the caller already resolved. */
@@ -499,6 +507,7 @@ export async function doLanding(
   // attempt produces a false "zero-diff" land-failed (the true cause is a push
   // failure, not a merge conflict). Fail early with the real reason so no work
   // is silently lost and the issue is not mis-labelled blocked:merge-conflict.
+  await deps.landingPhase?.("gate");
   const pushed = await pushAttempt(deps.remoteGit, input.repoDir, input.branch, input.branch);
   if (!pushed.ok) {
     return { ok: false, reason: "land-failed", locked };
@@ -551,6 +560,7 @@ export async function doLanding(
 
   // post_merge hook (best-effort; an abort here does not unwind the landing,
   // matching the prior behaviour which never branched on its result).
+  await deps.landingPhase?.("cascade");
   await deps.fireHook("post_merge", hooks.postMerge(landed.mergeSha));
   return landed;
 }
@@ -585,6 +595,7 @@ async function landAdminPr(deps: LandingDeps, input: LandingInput): Promise<Land
   const rebaseFail = await preMergeRebaseInWorktree(deps, input);
   if (rebaseFail) return rebaseFail;
 
+  await deps.landingPhase?.("push-pr");
   const r = await landPr(deps.mergeExec, {
     repo: input.repo,
     gitRepo: input.repoDir,
@@ -673,6 +684,7 @@ async function preMergeRebaseInWorktree(
     // before the admin-merge. A failure aborts here so a stale-main-broken
     // result is never merged.
     if (deps.postMergeGate) {
+      await deps.landingPhase?.("gate");
       const gateResult = await deps.postMergeGate(dir);
       if (!gateResult.ok) return { ok: false, reason: "post-merge-gate", locked: input.locked };
     }
@@ -714,6 +726,7 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
     // origin/<base>) before pushing anything to the remote. A failure aborts
     // here so a stale-main-broken result is never merged.
     if (deps.postMergeGate) {
+      await deps.landingPhase?.("gate");
       const gateResult = await deps.postMergeGate(landDir);
       if (!gateResult.ok) return { ok: false, reason: "post-merge-gate", locked: input.locked };
     }
@@ -747,6 +760,7 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
       "merge-base", "--is-ancestor", `origin/${input.base}`, branchTip,
     ]);
     if (fastForwardable.code === 0) {
+      await deps.landingPhase?.("merge");
       const ff = await deps.mergeExec(["git", "-C", landDir, "merge", "--ff-only", branchTip]);
       if (ff.code !== 0) return { ok: false, reason: "land-failed", locked: input.locked };
       const push = await deps.mergeExec([
@@ -770,6 +784,7 @@ async function landDirectInWorktree(deps: LandingDeps, input: LandingInput): Pro
       return { ok: true, locked: input.locked, mergeSha: mergeSha || undefined };
     }
 
+    await deps.landingPhase?.("merge");
     const merged = await landMerge(deps.mergeExec, {
       repo: landDir,
       remote: input.remote,

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -2351,8 +2351,19 @@ export async function processIssue(
     return await handoffForReview(common, activeTaskClass, validationSidecar);
   }
 
-  // Macro phase → `merging` (issue #811): the lock-toggled landing is starting.
-  deps.markPhase?.("merging");
+  const markLandingPhase = (phase: "gate" | "push-pr" | "merge" | "cascade"): void => {
+    const startedAt = deps.nowIso();
+    deps.markState?.({
+      "current.activity": "landing",
+      "current.phase": phase,
+      "current.started_at": startedAt,
+    });
+    deps.markPhase?.(phase);
+  };
+
+  // Macro phase → landing gate (issue #1427): the agent loop is done, but the
+  // slot is still busy validating, opening/merging, and cascading dependent work.
+  markLandingPhase("gate");
   const landing = await doLanding(
     {
       mergeExec: deps.mergeExec,
@@ -2393,6 +2404,7 @@ export async function processIssue(
         ]);
         return { changedFiles, packageJsonDiff: diffRes.stdout };
       },
+      landingPhase: markLandingPhase,
     },
     {
       openPr,
@@ -2490,6 +2502,7 @@ export async function processIssue(
   // to the primary HEAD for the unlocked path (which best-effort fast-forwards it).
   const mergeSha = landing.mergeSha ?? (await deps.git.headShortSha());
   const durationS = deps.nowEpoch() - startedEpoch;
+  markLandingPhase("cascade");
   // Write the machine-readable validation sidecar ($ITER_DIR/validation.jsonl,
   // SKILL.md) the Memory bridge consumes. Best-effort: never fails the close.
   await writeValidationSidecar(deps, input.attemptDir, validationSidecar);

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -78,6 +78,7 @@ const WORKER_COLUMNS: readonly WorkerColumn[] = [
 type WorkerCells = Record<WorkerColumn, string>;
 type WorkerWidths = Record<WorkerColumn, number>;
 const NO_AGENT_ORIGINS = new Set(["requeue"]);
+const LANDING_PHASES = new Set(["gate", "push-pr", "merge", "cascade"]);
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
@@ -233,11 +234,12 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
   const runVal = [f.runner, f.model ? shortModel(f.model) : undefined, f.effort]
     .filter((x): x is string => Boolean(x))
     .join(" ");
-  const noAgent = f.origin !== undefined && NO_AGENT_ORIGINS.has(f.origin);
+  const landing = LANDING_PHASES.has(f.phase);
+  const noAgent = landing || (f.origin !== undefined && NO_AGENT_ORIGINS.has(f.origin));
   return {
     workerId: f.workerId,
     run: `run=${runVal}`,
-    org: `org=${f.origin || "afk"}`,
+    org: `org=${landing ? "landing" : f.origin || "afk"}`,
     iss: f.issue === null ? "" : `iss=${String(f.issue)}`,
     phase: f.issue === null ? "" : progressCell(f.phase, f.activity),
     elapsed: f.elapsed,
@@ -305,7 +307,8 @@ export function renderWorkerLine(worker: CompactWorker, now: number): string {
   // org=<afk|go> — spawn-time provenance (issue #1219). 3-letter key (house
   // rule), same kv colour convention. An unstamped worker is an afk-fleet
   // worker, so default the display to afk.
-  parts.push(kv("org", f.origin || "afk"));
+  const landing = LANDING_PHASES.has(f.phase);
+  parts.push(kv("org", landing ? "landing" : f.origin || "afk"));
   // iss=<issue-number> from current.number (both /afk and /go lanes); the
   // <phase·activity> cell follows bare and the legacy standalone #<n> token is
   // dropped.
@@ -315,7 +318,7 @@ export function renderWorkerLine(worker: CompactWorker, now: number): string {
     if (progress) parts.push(progress);
   }
   parts.push(f.elapsed);
-  if (f.origin !== undefined && NO_AGENT_ORIGINS.has(f.origin)) {
+  if (landing || (f.origin !== undefined && NO_AGENT_ORIGINS.has(f.origin))) {
     return `${NOBG}${SOFT}${parts.join("  ")}${RESET}`;
   }
   parts.push(kv("loc", formatDiff(f.added, f.removed)));

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -40,6 +40,8 @@ interface Harness {
   resolverCwds: string[];
   /** dirs the post-merge gate was invoked with (#1335). */
   postMergeGateDirs: string[];
+  /** landing visibility phase transitions published for statusline (#1427). */
+  landingPhases: string[];
 }
 
 interface Opts {
@@ -147,6 +149,7 @@ function harness(opts: Opts = {}): Harness {
   let mainRedRepairLookups = 0;
   const resolverCwds: string[] = [];
   const postMergeGateDirs: string[] = [];
+  const landingPhases: string[] = [];
   let mergeResolved = false;
   let prCreated = false;
 
@@ -297,6 +300,9 @@ function harness(opts: Opts = {}): Harness {
       : undefined,
     // Global land-lock (#1337): only wired when the test opts in.
     landLock: opts.landLock,
+    landingPhase: async (phase) => {
+      landingPhases.push(phase);
+    },
   };
 
   const input: LandingInput = {
@@ -343,6 +349,7 @@ function harness(opts: Opts = {}): Harness {
     },
     resolverCwds,
     postMergeGateDirs,
+    landingPhases,
   };
 }
 
@@ -362,6 +369,7 @@ describe("doLanding — happy paths", () => {
     expect(j.some((c) => c.includes("pr merge 42 --merge"))).toBe(true);
     // unlocked never merges the attempt branch locally.
     expect(j.some((c) => c.includes("merge --no-ff afk/"))).toBe(false);
+    expect(h.landingPhases).toEqual(["gate", "push-pr", "cascade"]);
   });
 
   it("unlocked + wait_for_review → polls the review check before the admin-merge", async () => {
@@ -1144,6 +1152,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     expect(h.postMergeGateDirs).toEqual([WT]);
     // The merge still happened (gate passed, not a no-merge).
     expect(joined(h.mergeCalls).some((c) => c.includes("merge"))).toBe(true);
+    expect(h.landingPhases).toEqual(["gate", "gate", "merge", "cascade"]);
   });
 
   it("PR path: gate wired + passes → lands successfully, gate called with the rebase worktree", async () => {
@@ -1154,6 +1163,7 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     expect(h.postMergeGateDirs).toEqual([RWT]);
     // The admin-merge still happened.
     expect(joined(h.mergeCalls).some((c) => c.includes("pr merge"))).toBe(true);
+    expect(h.landingPhases).toEqual(["gate", "gate", "push-pr", "cascade"]);
   });
 
   it("direct path: gate wired + fails → returns post-merge-gate, nothing pushed to remote", async () => {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -198,6 +198,44 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     expect(stripAnsi(renderWorkerLine(afk, NOW))).toContain("org=afk");
   });
 
+  it.each(["gate", "push-pr", "merge", "cascade"])(
+    "renders landing phase %s as a distinct non-agent row (#1427)",
+    (phase) => {
+      const w = worker({
+        state: {
+          ...worker().state,
+          worker_id: "wLAND",
+          current: {
+            ...worker().state.current,
+            number: 1408,
+            activity: "landing",
+            phase,
+            started_at: new Date((NOW - 432) * 1000).toISOString(),
+          },
+        },
+      });
+      const t = stripAnsi(renderWorkerLine(w, NOW));
+      expect(t).toContain("wLAND");
+      expect(t).toContain("org=landing");
+      expect(t).toContain("iss=1408");
+      expect(t).toContain(phase);
+      expect(t).toContain("00:07:12");
+      expect(t).not.toContain("loc=");
+      expect(t).not.toContain("tks=");
+      expect(t).not.toContain("tls=");
+      expect(t).not.toContain("rsn=");
+      expect(t).not.toContain("txt=");
+    },
+  );
+
+  it("clears the landing row once the slot has no live worker record (#1427)", () => {
+    const out = styleStatusline(input, { workers: [], now: NOW });
+    const rows = out.split("\n");
+    expect(rows).toHaveLength(1);
+    expect(stripAnsi(out)).not.toContain("org=landing");
+    expect(stripAnsi(out)).not.toContain("iss=1408");
+  });
+
   it("populates iss=<number> for a /go-shaped worker state (no queue — total 0/done 0)", () => {
     // A /go run has no queue, so done/total are 0/0 (the old counter was meaningless);
     // current.number still carries the single issue number, set on claim like /afk.


### PR DESCRIPTION
Automated AFK landing for #1427. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1427

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786299089&installation_id=129708444&pr_number=1447&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1447&signature=f8aecbc1b411552307141387a2002b9fbf8a5895e0e6250bbdc0d0ddbe7c3e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->