### PR TITLE
fix: #1428 bench-latency p99 invariant flakes under machine load, parking unrelated memory slices in blocked:validation

### DIFF
--- a/apps/memory/package.json
+++ b/apps/memory/package.json
@@ -20,6 +20,7 @@
     "bundle:cli": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/memory.bundle.min.mjs --asset memory.bundle.min.mjs --minify --reddb-from-package",
     "bundle:mcp": "node ../../scripts/bundle-app.mjs --entry src/mcp-server.ts --outfile ../../dist/memory-mcp.bundle.min.mjs --asset memory-mcp.bundle.min.mjs --minify --reddb-from-package",
     "test": "vitest run",
+    "test:bench-latency": "RED_MEMORY_ASSERT_LATENCY_INVARIANT=1 vitest run tests/bench-latency.test.ts",
     "test:integration": "RED_MEMORY_RECALL_P50_TARGET_MS=250 vitest run --config vitest.integration.config.ts",
     "dev": "node --import tsx src/cli.ts"
   },

--- a/apps/memory/src/bench-latency.ts
+++ b/apps/memory/src/bench-latency.ts
@@ -463,7 +463,7 @@ export function formatLatencyReport(report: LatencyReport): string {
   lines.push("## Reproducibility");
   lines.push("");
   lines.push(
-    "The workload (session/key access sequence) is byte-deterministic across runs (seeded mulberry32, fixed warmup + iteration counts). Measured wall-clock percentiles vary with host noise; the test suite asserts the architectural invariant (`p99(ams) >= p99(ours)`) rather than absolute numbers. Typical run-to-run drift on a quiet developer laptop is within ±20% at p50 and ±50% at p99.9 — re-run several times when comparing reports.",
+    "The workload (session/key access sequence) is byte-deterministic across runs (seeded mulberry32, fixed warmup + iteration counts). Measured wall-clock percentiles vary with host noise; the default test suite keeps a smoke assertion for the latency code path, while the opt-in bench-latency target asserts the architectural invariant (`p99(ams) >= p99(ours)`). Typical run-to-run drift on a quiet developer laptop is within ±20% at p50 and ±50% at p99.9 — re-run several times when comparing reports.",
   );
   lines.push("");
   return lines.join("\n");

--- a/apps/memory/tests/bench-latency.test.ts
+++ b/apps/memory/tests/bench-latency.test.ts
@@ -15,11 +15,13 @@ const FIXED_NOW = new Date("2026-05-26T00:00:00.000Z");
 // iteration count above ~200.
 const SMALL = { iterations: 400, warmup: 100 };
 
-// The p99 "architectural invariant" compares two paths at microsecond scale,
-// so host scheduling noise can transiently flip it. AFK feedback gates set
-// RED_AFK_SKIP_PERF=1 to keep this off the merge gate; dev / CI perf runs
-// without the var still assert it.
-const skipPerf = process.env.RED_AFK_SKIP_PERF === "1";
+// The default test target keeps this file as a smoke test for the latency
+// measurement code path: both strategies run, produce finite distributions, and
+// stay inside generous sanity bounds. The p99 architectural invariant compares
+// two live microsecond-scale measurements, so unrelated machine load can
+// transiently pause the in-process path and flip the comparison. That invariant
+// is therefore an opt-in bench assertion, not a hard merge-gate assertion.
+const assertLatencyInvariant = process.env.RED_MEMORY_ASSERT_LATENCY_INVARIANT === "1";
 
 describe("memory bench latency — percentile arithmetic", () => {
   test("percentile picks the expected slot on a sorted array", () => {
@@ -65,22 +67,28 @@ describe("memory bench latency — runner", () => {
         expect(stats.p99_us).toBeLessThanOrEqual(stats.p999_us);
         expect(stats.min_us).toBeLessThanOrEqual(stats.p50_us);
         expect(stats.p999_us).toBeLessThanOrEqual(stats.max_us);
+        expect(Number.isFinite(stats.mean_us)).toBe(true);
+        expect(stats.count).toBeGreaterThan(0);
+        expect(stats.max_us).toBeLessThan(10_000_000);
       }
     }
   });
 
-  test.skipIf(skipPerf)("ams-on-redis path is never faster than the in-process path at p99 (architectural invariant)", async () => {
-    const report = await runBenchLatency({
-      workload: { ...SMALL },
-      now: () => FIXED_NOW,
-    });
-    for (const r of report.results) {
-      // The wire-serialised path does strictly more CPU work than the Map
-      // lookup path; if this invariant ever flips, either the bench or the
-      // hot-read path has regressed.
-      expect(r.ams_reference.p99_us).toBeGreaterThanOrEqual(r.ours.p99_us);
-    }
-  });
+  test.skipIf(!assertLatencyInvariant)(
+    "ams-on-redis path is never faster than the in-process path at p99 (architectural invariant)",
+    async () => {
+      const report = await runBenchLatency({
+        workload: { ...SMALL },
+        now: () => FIXED_NOW,
+      });
+      for (const r of report.results) {
+        // The wire-serialised path does strictly more CPU work than the Map
+        // lookup path; if this invariant ever flips, either the bench or the
+        // hot-read path has regressed.
+        expect(r.ams_reference.p99_us).toBeGreaterThanOrEqual(r.ours.p99_us);
+      }
+    },
+  );
 
   test("--ops filter narrows the op set", async () => {
     const ops: OpClass[] = ["working-get"];


### PR DESCRIPTION
Automated AFK landing for #1428. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1428

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786303505&installation_id=129708444&pr_number=1449&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1449&signature=07a92dc290a49c3b71f0c0ac22fa12163c6549f350eb62adbbed4b7935c732c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->