### PR TITLE
fix: #1430 Semantic extraction pass at corpus ingest: provider-routed INFERRED lane with confidence bands and per-run token cost

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -140,7 +140,12 @@ import {
   recallObservationFromContextPack,
   renderRecallTelemetryReport,
 } from "./recall-telemetry.js";
-import { collectCandidates, ingestProject, refreshFiles } from "./ingest.js";
+import {
+  collectCandidates,
+  ingestProject,
+  refreshFiles,
+  renderIngestReportToon,
+} from "./ingest.js";
 import {
   defaultIgnorePatterns,
   formatScopeReport,
@@ -425,7 +430,7 @@ Usage:
   memory provenance <rid|label>     [--root <dir>] [--json]
   memory governance                 [--root <dir>] [--stale-progress-days N] [--json]
   memory governance-viewer          [--root <dir>] [--stale-progress-days N] [--out <file>]
-  memory ingest <path>              [--root <dir>] [--max-files N]
+  memory ingest <path>              [--root <dir>] [--max-files N] [--structural-only]
   memory refresh [<path...>]         [--root <dir>] [--stdin] [--changed|--staged] [--json]
   memory extract [<transcript-file>] [--root <dir>] [--local]   (reads stdin if no file)
   memory extraction status           [--root <dir>] [--json]
@@ -4068,6 +4073,7 @@ async function runIngest(args: ParsedArgs): Promise<void> {
     typeof args.flags["max-files"] === "string"
       ? Number(args.flags["max-files"])
       : undefined;
+  const structuralOnly = args.flags["structural-only"] === true;
 
   // Pre-ingest scope wizard (#235): pick a preset, report the candidate count
   // before processing, and optionally generate the committed `.memoryignore`.
@@ -4084,12 +4090,24 @@ async function runIngest(args: ParsedArgs): Promise<void> {
   const memoryIgnore = await readMemoryIgnore(cwd);
   console.log(formatScopeReport(planScope(candidateFiles, preset.name, memoryIgnore)));
 
+  const semanticProvider = !structuralOnly && config.provider ? resolveProvider(config.provider) : null;
+  if (semanticProvider && config.provider) applyProviderEnv(semanticProvider, config.provider.apiKeyEnv);
+
   const store = await MemoryStore.open({ uri: resolveStoreUri(rootDir, config) });
   try {
-    const report = await ingestProject(store, { cwd, maxFiles, ignore: preset.ignore });
-    console.log(`memory: ingested ${cwd}`);
+    const report = await ingestProject(store, {
+      cwd,
+      maxFiles,
+      ignore: preset.ignore,
+      semantic: {
+        enabled: Boolean(semanticProvider),
+        client: semanticProvider && config.provider ? redDbProviderClient(store, config.provider) : undefined,
+      },
+    });
     console.log(
-      `  ${report.files} file(s) → ${report.nodes} node(s), ${report.edges} edge(s), ${report.docs} doc(s) in ${report.durationMs}ms`,
+      renderIngestReportToon(report, {
+        includeSemanticCost: Boolean(semanticProvider),
+      }),
     );
     // Audit-marker contract (.red/agents/memory.md): commit-trailer surface.
     // Emit guidance for the commit that lands this ingest rather than writing

--- a/apps/memory/src/extract-conversation.ts
+++ b/apps/memory/src/extract-conversation.ts
@@ -1,7 +1,14 @@
 import { z } from "zod";
 import { EXTRACTION_PROFILES, STRUCTURAL_TYPES } from "./extraction-schema.js";
 import { contentHash } from "./hash.js";
-import { EDGE_LABELS, NODE_TYPES, type EdgeLabel, type MemoryNode, type NodeType } from "./schema.js";
+import {
+  EDGE_LABELS,
+  NODE_TYPES,
+  type EdgeLabel,
+  type MemoryEdgeProps,
+  type MemoryNode,
+  type NodeType,
+} from "./schema.js";
 
 /**
  * LLM conversation extraction — the `INFERRED` path.
@@ -107,6 +114,7 @@ export interface ExtractedFact {
   node_type: string;
   title: string;
   summary?: string;
+  confidence_band?: "low" | "medium" | "high";
   tags?: string[];
   relations: Array<{ label: EdgeLabel; target: string }>;
 }
@@ -220,6 +228,7 @@ const FactSchema = z.object({
   node_type: z.string().min(1),
   title: z.string().min(1),
   summary: z.string().optional(),
+  confidence_band: z.enum(["low", "medium", "high"]).optional(),
   tags: z.array(z.string()).optional(),
   relations: z.array(RelationSchema).optional(),
 });
@@ -265,6 +274,7 @@ export function parseExtraction(raw: string): ExtractedFact[] {
       summary: f.summary,
       tags: f.tags,
       relations: f.relations ?? [],
+      ...(f.confidence_band ? { confidence_band: f.confidence_band } : {}),
     });
   }
   // Drop relations whose target is not itself an extracted fact.
@@ -385,7 +395,12 @@ const KNOWN_NODE_TYPES: ReadonlySet<string> = new Set<string>([
 /** A graph fragment ready for the ingest indexer: nodes + label-keyed edges. */
 export interface InferredExtraction {
   nodes: MemoryNode[];
-  edges: Array<{ fromLabel: string; toLabel: string; label: EdgeLabel }>;
+  edges: Array<{
+    fromLabel: string;
+    toLabel: string;
+    label: EdgeLabel;
+    properties?: MemoryEdgeProps;
+  }>;
 }
 
 /**
@@ -416,6 +431,7 @@ export function factsToGraph(facts: ExtractedFact[], source = "conversation"): I
         tags: f.tags,
         source,
         confidence: "INFERRED" as const,
+        confidence_band: f.confidence_band ?? "medium",
         provenance_tier: "proxy" as const,
         structural_type: resolution.structuralType,
         engineering_code: resolution.engineeringCode ?? f.node_type,
@@ -427,7 +443,16 @@ export function factsToGraph(facts: ExtractedFact[], source = "conversation"): I
   const edges: InferredExtraction["edges"] = [];
   for (const f of facts) {
     for (const rel of f.relations) {
-      edges.push({ fromLabel: f.label, toLabel: rel.target, label: rel.label });
+      edges.push({
+        fromLabel: f.label,
+        toLabel: rel.target,
+        label: rel.label,
+        properties: {
+          confidence: "INFERRED",
+          confidence_band: "medium",
+          source,
+        },
+      });
     }
   }
   return { nodes, edges };

--- a/apps/memory/src/ingest.ts
+++ b/apps/memory/src/ingest.ts
@@ -1,15 +1,36 @@
 import { readFile } from "node:fs/promises";
-import { extname, isAbsolute, resolve } from "node:path";
+import { extname, isAbsolute, relative, resolve } from "node:path";
 import fg from "fast-glob";
+import { getEncoding } from "js-tiktoken";
 import { extractAsset, isAssetFile } from "./extract-asset.js";
 import { extractCode } from "./extract-code.js";
+import {
+  buildExtractionPrompt,
+  factsToGraph,
+  parseExtraction,
+  type ProviderClient,
+  type ProviderRequest,
+} from "./extract-conversation.js";
 import { extractDevArtifact, isDevArtifact } from "./extract-dev-artifact.js";
 import { extractMarkdown } from "./extract-markdown.js";
 import { extractSql } from "./extract-sql.js";
 import { contentHash } from "./hash.js";
 import { readMemoryIgnore } from "./scope.js";
+import { renderToonOutput } from "./toon-output.js";
 import type { MemoryStore } from "./graph-store.js";
 import type { EdgeLabel, MemoryDoc, MemoryEdgeProps, MemoryNode } from "./schema.js";
+
+type IngestToonRow = {
+  files: number;
+  nodes: number;
+  edges: number;
+  docs: number;
+  semantic_nodes: number;
+  semantic_edges: number;
+  semantic_token_input?: number;
+  semantic_token_output?: number;
+  duration_ms: number;
+};
 
 export interface IngestOptions {
   /** Root directory to walk. */
@@ -18,6 +39,7 @@ export interface IngestOptions {
   ignore?: string[];
   /** Hard cap on files indexed in one pass. Protects against huge monorepos. */
   maxFiles?: number;
+  semantic?: SemanticIngestOptions;
 }
 
 export interface IngestReport {
@@ -29,7 +51,26 @@ export interface IngestReport {
   updated: number;
   skipped: number;
   stale: number;
+  semantic: SemanticIngestReport;
   durationMs: number;
+}
+
+export interface SemanticIngestOptions {
+  enabled: boolean;
+  client?: ProviderClient;
+  source?: string;
+}
+
+export interface SemanticTokenCost {
+  input: number;
+  output: number;
+}
+
+export interface SemanticIngestReport {
+  enabled: boolean;
+  nodes: number;
+  edges: number;
+  token_cost: SemanticTokenCost;
 }
 
 const DEFAULT_PATTERNS = [
@@ -83,6 +124,7 @@ export async function ingestProject(
     totals.edges += r.edges;
     totals.docs += r.docs;
   }
+  const semantic = await runSemanticIngest(store, slice, opts);
 
   return {
     files: slice.length,
@@ -91,6 +133,7 @@ export async function ingestProject(
     updated: 0,
     skipped: 0,
     stale: 0,
+    semantic,
     durationMs: Date.now() - start,
   };
 }
@@ -146,6 +189,120 @@ interface FileExtraction {
 export async function indexFile(store: MemoryStore, path: string): Promise<FileIndexReport> {
   const extraction = await extractFile(path);
   return writeExtraction(store, extraction);
+}
+
+async function runSemanticIngest(
+  store: MemoryStore,
+  files: string[],
+  opts: IngestOptions,
+): Promise<SemanticIngestReport> {
+  if (!opts.semantic?.enabled || !opts.semantic.client) return emptySemanticReport(false);
+  const corpus = await buildSemanticCorpus(opts.cwd, files);
+  if (!corpus.trim()) return emptySemanticReport(true);
+  const req = buildExtractionPrompt(corpus);
+  let raw: string;
+  try {
+    raw = await opts.semantic.client.complete(req);
+  } catch {
+    return {
+      ...emptySemanticReport(true),
+      token_cost: { input: countProviderRequestTokens(req), output: 0 },
+    };
+  }
+  const extraction = factsToGraph(parseExtraction(raw), opts.semantic.source ?? "corpus-ingest");
+  const report = await writeExtraction(store, {
+    nodes: extraction.nodes,
+    edges: extraction.edges,
+    elements: graphElements(opts.semantic.source ?? "corpus-ingest", extraction.nodes, false),
+  });
+  return {
+    enabled: true,
+    nodes: report.nodes,
+    edges: report.edges,
+    token_cost: {
+      input: countProviderRequestTokens(req),
+      output: countTokens(raw),
+    },
+  };
+}
+
+async function buildSemanticCorpus(cwd: string, files: string[]): Promise<string> {
+  const chunks: string[] = [];
+  for (const file of files) {
+    if (isAssetFile(file)) continue;
+    try {
+      const body = await readFile(file, "utf8");
+      chunks.push(`File: ${relative(cwd, file)}\n\n${body}`);
+    } catch {
+      /* Binary or unreadable text-like file: structural indexing already handled it. */
+    }
+  }
+  return chunks.join("\n\n---\n\n");
+}
+
+function emptySemanticReport(enabled: boolean): SemanticIngestReport {
+  return { enabled, nodes: 0, edges: 0, token_cost: { input: 0, output: 0 } };
+}
+
+let tokenizer: ReturnType<typeof getEncoding> | null = null;
+
+function countProviderRequestTokens(req: ProviderRequest): number {
+  return countTokens(`${req.system}\n\n${req.user}`);
+}
+
+function countTokens(text: string): number {
+  if (!text) return 0;
+  tokenizer ??= getEncoding("cl100k_base");
+  return tokenizer.encode(text).length;
+}
+
+export function renderIngestReportToon(
+  report: IngestReport,
+  opts: { includeSemanticCost: boolean },
+): string {
+  const semanticCostFields: readonly (keyof IngestToonRow & string)[] = opts.includeSemanticCost
+    ? ["semantic_token_input", "semantic_token_output"]
+    : [];
+  const fields: readonly (keyof IngestToonRow & string)[] = [
+    "files",
+    "nodes",
+    "edges",
+    "docs",
+    "semantic_nodes",
+    "semantic_edges",
+    ...semanticCostFields,
+    "duration_ms",
+  ];
+  const row: IngestToonRow = {
+    files: report.files,
+    nodes: report.nodes,
+    edges: report.edges,
+    docs: report.docs,
+    semantic_nodes: report.semantic.nodes,
+    semantic_edges: report.semantic.edges,
+    ...(opts.includeSemanticCost
+      ? {
+          semantic_token_input: report.semantic.token_cost.input,
+          semantic_token_output: report.semantic.token_cost.output,
+        }
+      : {}),
+    duration_ms: report.durationMs,
+  };
+  return renderToonOutput({
+    rowsKey: "ingest",
+    rows: [row],
+    fields,
+    summary: {
+      files: report.files,
+      semantic_enabled: report.semantic.enabled,
+      ...(opts.includeSemanticCost
+        ? {
+            semantic_token_input: report.semantic.token_cost.input,
+            semantic_token_output: report.semantic.token_cost.output,
+          }
+        : {}),
+    },
+  });
 }
 
 async function extractFile(path: string): Promise<FileExtraction> {
@@ -350,7 +507,7 @@ export async function refreshFiles(
     await writeFileManifestEntry(store, path, { hash, elements: report.elements });
   }
 
-  return { ...totals, durationMs: Date.now() - start };
+  return { ...totals, semantic: emptySemanticReport(false), durationMs: Date.now() - start };
 }
 
 /**

--- a/apps/memory/tests/extract-conversation.test.ts
+++ b/apps/memory/tests/extract-conversation.test.ts
@@ -330,7 +330,16 @@ describe("factsToGraph", () => {
   test("relations become label-keyed edges for the indexer to resolve", () => {
     const { edges } = factsToGraph(GOLDEN);
     expect(edges).toEqual([
-      { fromLabel: "warm-pool-in-boot", toLabel: "cold-start-deploy-failure", label: "FIXES" },
+      {
+        fromLabel: "warm-pool-in-boot",
+        toLabel: "cold-start-deploy-failure",
+        label: "FIXES",
+        properties: {
+          confidence: "INFERRED",
+          confidence_band: "medium",
+          source: "conversation",
+        },
+      },
     ]);
   });
 

--- a/apps/memory/tests/ingest.test.ts
+++ b/apps/memory/tests/ingest.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import { graphRecall } from "../src/graph-recall.js";
 import { MemoryStore } from "../src/graph-store.js";
-import { ingestProject, refreshFiles } from "../src/ingest.js";
+import { ingestProject, refreshFiles, renderIngestReportToon } from "../src/ingest.js";
 
 // RedDB connects by spawning the bundled `red` binary; give each test room.
 const TIMEOUT = 30_000;
@@ -54,6 +54,119 @@ describe("ingestProject over a TS+MD fixture repo", () => {
 
       const { nodes } = await store.stats();
       expect(nodes).toBe(report.nodes);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "semantic pass writes INFERRED graph facts with confidence bands and token cost",
+    async () => {
+      const store = await openStore();
+      const calls: string[] = [];
+      const report = await ingestProject(store, {
+        cwd: FIXTURE_REPO,
+        semantic: {
+          enabled: true,
+          client: {
+            async complete(req) {
+              calls.push(`${req.system}\n${req.user}`);
+              return JSON.stringify({
+                facts: [
+                  {
+                    label: "fixture-token-rotation",
+                    node_type: "decision",
+                    title: "Fixture token rotation",
+                    summary: "The fixture documents JWT token rotation behavior.",
+                    confidence_band: "high",
+                    relations: [{ label: "REFERENCES", target: "fixture-token-verifier" }],
+                  },
+                  {
+                    label: "fixture-token-verifier",
+                    node_type: "symbol",
+                    title: "Fixture token verifier",
+                    summary: "The code fixture verifies issued tokens.",
+                    confidence_band: "medium",
+                  },
+                ],
+              });
+            },
+          },
+        },
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toContain("src/auth.ts");
+      expect(calls[0]).toContain("docs/guide.md");
+      expect(report.semantic).toMatchObject({
+        enabled: true,
+        nodes: 2,
+        edges: 1,
+      });
+      expect(report.semantic.token_cost.input).toBeGreaterThan(0);
+      expect(report.semantic.token_cost.output).toBeGreaterThan(0);
+
+      const nodes = await store.listNodes();
+      const inferred = nodes.find((node) => node.label === "fixture-token-rotation");
+      expect(inferred).toMatchObject({
+        node_type: "decision",
+        properties: {
+          confidence: "INFERRED",
+          confidence_band: "high",
+          source: "corpus-ingest",
+        },
+      });
+      const target = nodes.find((node) => node.label === "fixture-token-verifier");
+      expect(target?.properties.confidence_band).toBe("medium");
+      const edges = await store.listEdges();
+      const inferredEdge = edges.find(
+        (edge) =>
+          edge.from_rid === inferred?.rid &&
+          edge.to_rid === target?.rid &&
+          edge.label === "REFERENCES",
+      );
+      expect(inferredEdge?.properties ?? inferredEdge?.PROPERTIES).toEqual(
+        expect.objectContaining({
+          confidence: "INFERRED",
+          confidence_band: "medium",
+        }),
+      );
+
+      const toon = renderIngestReportToon(report, { includeSemanticCost: true });
+      expect(toon).toContain("ingest[1]{files,nodes,edges,docs");
+      expect(toon).toContain("semantic_token_input");
+      expect(toon).toContain("semantic_token_output");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "structural-only semantic setting skips provider entirely and omits cost from TOON",
+    async () => {
+      const store = await openStore();
+      let calls = 0;
+      const report = await ingestProject(store, {
+        cwd: FIXTURE_REPO,
+        semantic: {
+          enabled: false,
+          client: {
+            async complete() {
+              calls += 1;
+              throw new Error("provider must not be called");
+            },
+          },
+        },
+      });
+
+      expect(calls).toBe(0);
+      expect(report.semantic).toEqual({
+        enabled: false,
+        nodes: 0,
+        edges: 0,
+        token_cost: { input: 0, output: 0 },
+      });
+      expect(renderIngestReportToon(report, { includeSemanticCost: false })).not.toContain(
+        "semantic_token",
+      );
     },
     TIMEOUT,
   );

--- a/apps/memory/tests/vcs-refresh.test.ts
+++ b/apps/memory/tests/vcs-refresh.test.ts
@@ -16,6 +16,7 @@ function emptyReport(): IngestReport {
     updated: 0,
     skipped: 0,
     stale: 0,
+    semantic: { enabled: false, nodes: 0, edges: 0, token_cost: { input: 0, output: 0 } },
     durationMs: 1,
   };
 }


### PR DESCRIPTION
Automated AFK landing for #1430. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1430

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786305935&installation_id=129708444&pr_number=1450&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1450&signature=7cf75ff4ad8446611afc7e3d0da73935205a696d48b88fe101e8720a73005770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->