### PR TITLE
fix: #1433 Hub report: high-degree concept surface over the stored graph

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -32,6 +32,7 @@ import { buildMemoryReferenceRadar } from "./references-radar.js";
 import type { CommunityAnalyticsReport } from "./communities.js";
 import { buildCommunitiesViewerArtifact } from "./communities-viewer.js";
 import type { CommunityDigestReport } from "./community-digest.js";
+import type { HubReport, HubRankBy, HubReportRow } from "./hub-report.js";
 import type { MemoryGlobalSearchReport } from "./global-search.js";
 import { buildContextPack, type ContextPack } from "./context-pack.js";
 import { buildContextPackViewerArtifact } from "./context-pack-viewer.js";
@@ -7192,6 +7193,75 @@ async function runCommunityDigest(args: ParsedArgs): Promise<void> {
   }
 }
 
+async function runHubReport(args: ParsedArgs): Promise<void> {
+  const { store } = await openGraphStore(args);
+  try {
+    const rankBy = parseHubRankBy(stringFlag(args.flags, "rank-by") ?? stringFlag(args.flags, "rank_by"));
+    const report = (await executeReadOnlyMemoryOperation("memory.hub-report", { store }, {
+      limit: intFlag(args.flags, "limit"),
+      rank_by: rankBy,
+    })) as HubReport;
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log(renderHubReportToon(report, { wide: args.flags.wide === true }));
+  } finally {
+    await store.close();
+  }
+}
+
+function parseHubRankBy(value: string | undefined): HubRankBy {
+  if (value == null) return "total";
+  if (value === "total" || value === "in" || value === "out") return value;
+  throw new Error('--rank-by must be "total", "in", or "out"');
+}
+
+function renderHubReportToon(report: HubReport, opts: { wide: boolean }): string {
+  const fields: readonly (keyof HubReportRow & string)[] = opts.wide
+    ? [
+        "rid",
+        "label",
+        "title",
+        "node_type",
+        "community_id",
+        "total_degree",
+        "in_degree",
+        "out_degree",
+        "seal_mix",
+        "seal_count",
+        "seals",
+      ]
+    : ["label", "title", "community_id", "total_degree", "in_degree", "out_degree", "seal_mix"];
+  const rows = report.hubs.map((hub) => ({ ...hub }));
+  return renderToonOutput({
+    rowsKey: "hubs",
+    rows,
+    fields,
+    summary: report.summary.empty
+      ? {
+          state: "empty_graph",
+          message: "No graph nodes found.",
+          nodes: report.summary.nodes,
+          edges: report.summary.edges,
+          next: report.next,
+        }
+      : {
+          rank_by: report.rank_by,
+          reported: report.summary.reported,
+          nodes: report.summary.nodes,
+          edges: report.summary.edges,
+          max_total_degree: report.summary.max_total_degree,
+          communities: report.summary.communities,
+          next: report.next,
+        },
+    extra: {
+      schema_version: report.schema_version,
+      graph_hash: report.graph_hash,
+    },
+  });
+}
+
 function parseRid(value: string, name: string): number {
   const rid = Number(value);
   if (!Number.isInteger(rid) || rid <= 0) throw new Error(`${name} must be a positive integer`);
@@ -8452,6 +8522,8 @@ async function main(): Promise<void> {
       return runCommunitiesViewer(args);
     case "community-digest":
       return runCommunityDigest(args);
+    case "hub-report":
+      return runHubReport(args);
     case "global-search":
       return runGlobalSearch(args);
     case "structural-impact":

--- a/apps/memory/src/hub-report.ts
+++ b/apps/memory/src/hub-report.ts
@@ -1,0 +1,194 @@
+import { graphStateHash } from "./communities.js";
+import type { MemoryStore, StoredNode } from "./graph-store.js";
+
+export type HubRankBy = "total" | "in" | "out";
+
+export interface HubReportOptions {
+  limit?: number;
+  rankBy?: HubRankBy;
+}
+
+export interface HubReportRow {
+  rid: number;
+  label: string;
+  title: string;
+  node_type: string;
+  community_id: string | null;
+  total_degree: number;
+  in_degree: number;
+  out_degree: number;
+  seal_mix: string;
+  seal_count: number;
+  seals: string[];
+}
+
+export interface HubReport {
+  schema_version: "memory.hub-report.v1";
+  read_only: true;
+  graph_hash: string;
+  generated_at: string;
+  rank_by: HubRankBy;
+  limit: number;
+  summary: {
+    nodes: number;
+    edges: number;
+    reported: number;
+    max_total_degree: number;
+    max_in_degree: number;
+    max_out_degree: number;
+    communities: number;
+    empty: boolean;
+  };
+  next: string[];
+  hubs: HubReportRow[];
+}
+
+interface DegreeStats {
+  total: number;
+  in: number;
+  out: number;
+  seals: Set<string>;
+}
+
+const DEFAULT_LIMIT = 10;
+const NEXT_STEPS = [
+  "memory communities --json",
+  "memory export --communities",
+];
+
+export async function buildHubReport(
+  store: MemoryStore,
+  opts: HubReportOptions = {},
+): Promise<HubReport> {
+  const limit = clampLimit(opts.limit);
+  const rankBy = opts.rankBy ?? "total";
+  const [nodes, edges, communities] = await Promise.all([
+    store.listNodes(),
+    store.listEdges(),
+    store.communities(),
+  ]);
+  const graphHash = graphStateHash(nodes, edges);
+  const degreeByRid = new Map<number, DegreeStats>();
+  for (const node of nodes) {
+    degreeByRid.set(node.rid, { total: 0, in: 0, out: 0, seals: new Set() });
+  }
+
+  for (const edge of edges) {
+    const from = edgeEndpoint(edge, "from");
+    const to = edgeEndpoint(edge, "to");
+    const fromStats = degreeByRid.get(from);
+    const toStats = degreeByRid.get(to);
+    if (!fromStats || !toStats) continue;
+    const seal = edgeSeal(edge);
+    fromStats.out += 1;
+    fromStats.total += 1;
+    fromStats.seals.add(seal);
+    toStats.in += 1;
+    toStats.total += 1;
+    toStats.seals.add(seal);
+  }
+
+  const rows = nodes
+    .map((node) => hubRow(node, degreeByRid.get(node.rid), communities.get(node.rid) ?? null))
+    .sort((a, b) => compareHubRows(a, b, rankBy))
+    .slice(0, limit);
+
+  return {
+    schema_version: "memory.hub-report.v1",
+    read_only: true,
+    graph_hash: graphHash,
+    generated_at: new Date().toISOString(),
+    rank_by: rankBy,
+    limit,
+    summary: {
+      nodes: nodes.length,
+      edges: edges.length,
+      reported: rows.length,
+      max_total_degree: max(rows.map((row) => row.total_degree)),
+      max_in_degree: max(rows.map((row) => row.in_degree)),
+      max_out_degree: max(rows.map((row) => row.out_degree)),
+      communities: new Set([...communities.values()]).size,
+      empty: nodes.length === 0,
+    },
+    next: NEXT_STEPS,
+    hubs: rows,
+  };
+}
+
+function hubRow(
+  node: StoredNode,
+  stats: DegreeStats | undefined,
+  communityId: string | null,
+): HubReportRow {
+  const seals = [...(stats?.seals ?? [])].sort();
+  return {
+    rid: node.rid,
+    label: node.label,
+    title: node.properties.title ?? node.label,
+    node_type: String(node.node_type),
+    community_id: communityId,
+    total_degree: stats?.total ?? 0,
+    in_degree: stats?.in ?? 0,
+    out_degree: stats?.out ?? 0,
+    seal_mix: seals.length === 0 ? "none" : seals.join("+"),
+    seal_count: seals.length,
+    seals,
+  };
+}
+
+function compareHubRows(a: HubReportRow, b: HubReportRow, rankBy: HubRankBy): number {
+  const primary =
+    rankBy === "in"
+      ? b.in_degree - a.in_degree
+      : rankBy === "out"
+        ? b.out_degree - a.out_degree
+        : b.total_degree - a.total_degree;
+  return (
+    primary ||
+    b.total_degree - a.total_degree ||
+    b.in_degree - a.in_degree ||
+    b.out_degree - a.out_degree ||
+    a.label.localeCompare(b.label) ||
+    a.rid - b.rid
+  );
+}
+
+function edgeEndpoint(edge: Record<string, unknown>, side: "from" | "to"): number {
+  const value =
+    side === "from"
+      ? edge.from ?? edge.from_id ?? edge.from_rid ?? edge.source ?? edge.FROM
+      : edge.to ?? edge.to_id ?? edge.to_rid ?? edge.target ?? edge.TO;
+  return Number(value ?? 0);
+}
+
+function edgeSeal(edge: Record<string, unknown>): string {
+  const properties = isRecord(edge.properties)
+    ? edge.properties
+    : isRecord(edge.PROPERTIES)
+      ? edge.PROPERTIES
+      : {};
+  const value =
+    edge.seal ??
+    edge.audit_seal ??
+    edge.confidence ??
+    properties.seal ??
+    properties.audit_seal ??
+    properties.confidence ??
+    edge.label ??
+    edge.LABEL;
+  return String(value ?? "unsealed");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit == null) return DEFAULT_LIMIT;
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(100, Math.trunc(limit)));
+}
+
+function max(values: number[]): number {
+  return values.length === 0 ? 0 : Math.max(...values);
+}

--- a/apps/memory/src/operations.ts
+++ b/apps/memory/src/operations.ts
@@ -44,6 +44,11 @@ import {
   type CommunityDigestReport,
 } from "./community-digest.js";
 import {
+  buildHubReport,
+  type HubRankBy,
+  type HubReport,
+} from "./hub-report.js";
+import {
   buildMemoryGlobalSearch,
   type MemoryGlobalSearchReport,
 } from "./global-search.js";
@@ -485,6 +490,12 @@ const MapContractInputSchema = z.object({
 });
 type MapContractInput = z.infer<typeof MapContractInputSchema>;
 
+const HubReportInputSchema = z.object({
+  limit: z.number().int().min(1).max(100).optional(),
+  rank_by: z.enum(["total", "in", "out"]).default("total"),
+});
+type HubReportInput = z.infer<typeof HubReportInputSchema>;
+
 const DocSearchInputSchema = z.object({
   query: z.string().min(1),
   limit: z.number().int().min(1).max(50).optional(),
@@ -800,6 +811,40 @@ const CommunitiesOutputSchema = z.object({
   inter_community_edges: z.array(InterCommunityEdgeSchema),
 }) satisfies z.ZodType<CommunityAnalyticsReport>;
 const CommunitiesViewerOutputSchema = objectOutputSchema<CommunitiesViewerArtifact>();
+
+const HubReportRowSchema = z.object({
+  rid: z.number(),
+  label: z.string(),
+  title: z.string(),
+  node_type: z.string(),
+  community_id: z.string().nullable(),
+  total_degree: z.number(),
+  in_degree: z.number(),
+  out_degree: z.number(),
+  seal_mix: z.string(),
+  seal_count: z.number(),
+  seals: z.array(z.string()),
+});
+const HubReportOutputSchema = z.object({
+  schema_version: z.literal("memory.hub-report.v1"),
+  read_only: z.literal(true),
+  graph_hash: z.string(),
+  generated_at: z.string(),
+  rank_by: z.enum(["total", "in", "out"]),
+  limit: z.number(),
+  summary: z.object({
+    nodes: z.number(),
+    edges: z.number(),
+    reported: z.number(),
+    max_total_degree: z.number(),
+    max_in_degree: z.number(),
+    max_out_degree: z.number(),
+    communities: z.number(),
+    empty: z.boolean(),
+  }),
+  next: z.array(z.string()),
+  hubs: z.array(HubReportRowSchema),
+}) satisfies z.ZodType<HubReport>;
 
 const CommunityDigestCountSchema = z.object({
   value: z.string(),
@@ -1282,6 +1327,14 @@ const MEMORY_OPERATION_FACETS: Record<string, MemoryOperationFacets> = {
       "memory.communities-viewer": VIEWER_OUTPUT,
       "memory.community-digest": JSON_REPORT_OUTPUT,
     },
+  ),
+  ...operationFacets(
+    ["memory.hub-report"],
+    inputBinding([
+      flagField("limit", "number"),
+      flagField("rank_by", "string"),
+    ]),
+    JSON_REPORT_OUTPUT,
   ),
   ...operationFacets(
     ["memory.global-search"],
@@ -2924,6 +2977,28 @@ const COMMUNITY_DIGEST_OPERATION: MemoryOperationDefinition<
     buildCommunityDigest(ctx.store, { cache: input.cache, providerConfig: ctx.providerConfig }),
 };
 
+const HUB_REPORT_OPERATION: MemoryOperationDefinition<HubReportInput, HubReport> = {
+  id: "memory.hub-report",
+  title: "Memory hub report",
+  description:
+    "Read-only high-degree concept report over the stored graph, with community membership and seal mix.",
+  inputSchema: HubReportInputSchema,
+  outputSchema: HubReportOutputSchema,
+  safetyClass: "read-only",
+  sideEffectClass: "none",
+  capabilities: ["graph-store"],
+  renderer: {
+    cli: { command: "hub-report", supportsJson: true },
+    mcp: {
+      toolName: "memory_hub_report",
+      description:
+        "Read-only Memory graph hub report: ranks stored graph nodes by total, inbound, or outbound degree and returns each hub's community id plus edge seal mix. Computes directly from graph nodes/edges without writing analysis state.",
+    },
+  },
+  execute: (ctx, input) =>
+    buildHubReport(ctx.store, { limit: input.limit, rankBy: input.rank_by as HubRankBy }),
+};
+
 const GLOBAL_SEARCH_OPERATION: MemoryOperationDefinition<
   GlobalSearchInput,
   MemoryGlobalSearchReport
@@ -3565,6 +3640,7 @@ const READ_ONLY_OPERATIONS = createReadOnlyMemoryOperationRegistry([
   COMMUNITIES_OPERATION,
   COMMUNITIES_VIEWER_OPERATION,
   COMMUNITY_DIGEST_OPERATION,
+  HUB_REPORT_OPERATION,
   GLOBAL_SEARCH_OPERATION,
   RECALL_RANKING_OPERATION,
   REFERENCE_RADAR_OPERATION,

--- a/apps/memory/tests/hub-report-cli.test.ts
+++ b/apps/memory/tests/hub-report-cli.test.ts
@@ -1,0 +1,184 @@
+import { decode } from "@reddb-io/toon";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { MemoryStore } from "../src/graph-store.js";
+import { initGraph } from "../src/init.js";
+import { getReadOnlyMemoryOperation } from "../src/operations.js";
+
+const TIMEOUT = 40_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+const stores: MemoryStore[] = [];
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+async function initRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "memory-hub-report-cli-"));
+  roots.push(root);
+  await initGraph(root);
+  return root;
+}
+
+async function openStore(root: string): Promise<MemoryStore> {
+  const store = await MemoryStore.open({
+    uri: `file://${join(root, ".red/memory/graph.rdb")}`,
+    project: "test",
+  });
+  stores.push(store);
+  return store;
+}
+
+async function seedHubTopology(root: string): Promise<void> {
+  const store = await openStore(root);
+  const mk = (label: string, title: string) =>
+    store.upsertNode({
+      label,
+      node_type: "concept",
+      properties: { title, content: title },
+    });
+  const [hub, inboundA, inboundB, outboundA, satellite] = await Promise.all([
+    mk("auth-hub", "auth hub"),
+    mk("token-rotation", "token rotation"),
+    mk("session-policy", "session policy"),
+    mk("audit-log", "audit log"),
+    mk("cache-ttl", "cache ttl"),
+  ]);
+  await store.upsertEdge({
+    label: "REFERENCES",
+    from_rid: inboundA,
+    to_rid: hub,
+    properties: { seal: "EXTRACTED" },
+  });
+  await store.upsertEdge({
+    label: "REFERENCES",
+    from_rid: inboundB,
+    to_rid: hub,
+    properties: { seal: "INFERRED" },
+  });
+  await store.upsertEdge({
+    label: "REFERENCES",
+    from_rid: hub,
+    to_rid: outboundA,
+    properties: { seal: "EXTRACTED" },
+  });
+  await store.upsertEdge({
+    label: "REFERENCES",
+    from_rid: satellite,
+    to_rid: outboundA,
+    properties: { seal: "AMBIGUOUS" },
+  });
+  await store.close();
+}
+
+describe("memory hub-report CLI", () => {
+  test(
+    "ranks top-N graph hubs with community membership and seal mix in TOON and JSON",
+    async () => {
+      const root = await initRoot();
+      await seedHubTopology(root);
+      expect(getReadOnlyMemoryOperation("memory.hub-report").renderer.cli).toMatchObject({
+        command: "hub-report",
+        supportsJson: true,
+      });
+
+      const toonResult = runMemory(["hub-report", "--root", root, "--limit", "3"]);
+      expect(toonResult.status).toBe(0);
+      const toon = decode(toonResult.stdout) as {
+        schema_version: string;
+        hubs: Array<{
+          label: string;
+          title: string;
+          community_id: string | null;
+          total_degree: number;
+          in_degree: number;
+          out_degree: number;
+          seal_mix: string;
+          rid?: number;
+          seals?: string[];
+        }>;
+        summary: { reported: number; max_total_degree: number; next: string[] };
+      };
+
+      expect(toon.schema_version).toBe("memory.hub-report.v1");
+      expect(toon.hubs).toHaveLength(3);
+      expect(toon.hubs[0]).toMatchObject({
+        label: "auth-hub",
+        title: "auth hub",
+        total_degree: 3,
+        in_degree: 2,
+        out_degree: 1,
+        seal_mix: "EXTRACTED+INFERRED",
+      });
+      expect(toon.hubs[0].community_id).toEqual(expect.any(String));
+      expect(toon.hubs[0]).not.toHaveProperty("rid");
+      expect(toon.hubs[0]).not.toHaveProperty("seals");
+      expect(toon.summary).toMatchObject({
+        reported: 3,
+        max_total_degree: 3,
+      });
+      expect(toon.summary.next).toContain("memory communities --json");
+
+      const wideResult = runMemory(["hub-report", "--root", root, "--limit", "1", "--wide"]);
+      expect(wideResult.status).toBe(0);
+      const wide = decode(wideResult.stdout) as {
+        hubs: Array<{ rid: number; node_type: string; seal_count: number; seals: string[] }>;
+      };
+      expect(wide.hubs[0]).toMatchObject({
+        node_type: "concept",
+        seal_count: 2,
+        seals: ["EXTRACTED", "INFERRED"],
+      });
+      expect(wide.hubs[0].rid).toEqual(expect.any(Number));
+
+      const jsonResult = runMemory(["hub-report", "--root", root, "--rank-by", "in", "--json"]);
+      expect(jsonResult.status).toBe(0);
+      const json = JSON.parse(jsonResult.stdout) as {
+        schema_version: string;
+        rank_by: string;
+        hubs: Array<{ label: string; in_degree: number; total_degree: number }>;
+      };
+      expect(json.schema_version).toBe("memory.hub-report.v1");
+      expect(json.rank_by).toBe("in");
+      expect(json.hubs[0]).toMatchObject({ label: "auth-hub", in_degree: 2, total_degree: 3 });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "emits a definitive empty state with a next-step suggestion",
+    async () => {
+      const root = await initRoot();
+
+      const result = runMemory(["hub-report", "--root", root]);
+      expect(result.status).toBe(0);
+      const body = decode(result.stdout) as {
+        hubs: unknown[];
+        summary: { state: string; message: string; nodes: number; edges: number; next: string[] };
+      };
+
+      expect(body.hubs).toEqual([]);
+      expect(body.summary).toMatchObject({
+        state: "empty_graph",
+        message: "No graph nodes found.",
+        nodes: 0,
+        edges: 0,
+      });
+      expect(body.summary.next).toContain("memory export --communities");
+    },
+    TIMEOUT,
+  );
+});

--- a/apps/memory/tests/operations-registry.test.ts
+++ b/apps/memory/tests/operations-registry.test.ts
@@ -42,6 +42,36 @@ describe("read-only Memory operations registry", () => {
     expect(listReadOnlyMemoryOperations().map((op) => op.id)).toContain("memory.communities");
   });
 
+  test("declares contract metadata for the hub report operation", () => {
+    const operation = getReadOnlyMemoryOperation("memory.hub-report");
+
+    expect(operation).toMatchObject({
+      id: "memory.hub-report",
+      safetyClass: "read-only",
+      sideEffectClass: "none",
+      capabilities: ["graph-store"],
+      renderer: {
+        cli: { command: "hub-report", supportsJson: true },
+        mcp: { toolName: "memory_hub_report" },
+      },
+      inputBinding: {
+        fields: [
+          {
+            field: "limit",
+            sources: ["flag", "query"],
+            type: "number",
+          },
+          {
+            field: "rank_by",
+            sources: ["flag", "query"],
+            type: "string",
+          },
+        ],
+      },
+      outputKind: { kind: "report", format: "json" },
+    });
+  });
+
   test("declares read-only contracts for agent-native readiness and trust operations", () => {
     const operations = listReadOnlyMemoryOperations();
 
@@ -94,6 +124,7 @@ describe("read-only Memory operations registry", () => {
         "memory.work-frontier-viewer",
         "memory.hook-coverage",
         "memory.hook-coverage-viewer",
+        "memory.hub-report",
         "memory.learning-debt",
         "memory.learning-debt-viewer",
         "memory.layers",
@@ -181,6 +212,7 @@ describe("read-only Memory operations registry", () => {
         "memory_work_frontier_viewer",
         "memory_hook_coverage",
         "memory_hook_coverage_viewer",
+        "memory_hub_report",
         "memory_learning_debt",
         "memory_learning_debt_viewer",
         "memory_layers",


### PR DESCRIPTION
Automated AFK landing for #1433. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1433

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786316099&installation_id=129708444&pr_number=1453&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1453&signature=f4b0a09da3e4904aa285d1ad59607dc275b4ece0cbae042c38808b90a46d501a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->