### PR TITLE
fix: #1434 Bridge detection and per-community cohesion exposure

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -7112,28 +7112,61 @@ async function runCommunities(args: ParsedArgs): Promise<void> {
       console.log(JSON.stringify(report, null, 2));
       return;
     }
-    console.log(
-      `memory: ${report.communities.length} community(ies), ${report.assignments.length} assigned node(s)`,
-    );
-    console.log(
-      `  navigation: ${report.node_analytics.length} ranked node(s), ${report.inter_community_edges.length} inter-community edge(s)`,
-    );
-    console.log(`  graph hash: ${report.graph_hash}`);
-    console.log(`  cache: ${report.cached ? "hit" : "miss"}`);
-    for (const community of report.communities) {
-      console.log(
-        `  ${community.id}: ${community.count} node(s), degree ${community.total_degree}, centrality ${community.avg_centrality}`,
-      );
-      if (community.titles.length > 0) {
-        console.log(`        top titles: ${community.titles.join(", ")}`);
-      }
-      if (community.labels.length > 0) {
-        console.log(`        labels: ${community.labels.join(", ")}`);
-      }
-    }
+    console.log(renderCommunitiesToon(report));
   } finally {
     await store.close();
   }
+}
+
+function renderCommunitiesToon(report: CommunityAnalyticsReport): string {
+  return renderToonOutput({
+    rowsKey: "communities",
+    rows: report.communities.map((community) => ({
+      id: community.id,
+      count: community.count,
+      cohesion_score: community.cohesion_score,
+      internal_edge_weight: community.internal_edge_weight,
+      external_edge_weight: community.external_edge_weight,
+      labels: community.labels.join(","),
+    })),
+    fields: [
+      "id",
+      "count",
+      "cohesion_score",
+      "internal_edge_weight",
+      "external_edge_weight",
+      "labels",
+    ],
+    extra: {
+      bridge_nodes: report.bridge_nodes.slice(0, 20).map((node) => ({
+        rid: node.rid,
+        label: node.label,
+        community_id: node.community_id,
+        connected_community_count: node.connected_community_count,
+        connected_community_ids: node.connected_community_ids.join(","),
+        cross_community_edge_count: node.cross_community_edge_count,
+        cross_community_weight: node.cross_community_weight,
+      })),
+      bridge_edges: report.bridge_edges.slice(0, 20).map((edge) => ({
+        from_label: edge.from_label,
+        to_label: edge.to_label,
+        from_community_id: edge.from_community_id,
+        to_community_id: edge.to_community_id,
+        weight: edge.weight,
+      })),
+      graph: {
+        hash: report.graph_hash,
+        cache: report.cached ? "hit" : "miss",
+        assignments: report.assignments.length,
+        ranked_nodes: report.node_analytics.length,
+        inter_community_edges: report.inter_community_edges.length,
+      },
+    },
+    summary: {
+      status: report.summary.status,
+      next: report.summary.next,
+    },
+  });
 }
 
 async function runCommunitiesViewer(args: ParsedArgs): Promise<void> {

--- a/apps/memory/src/communities-viewer.ts
+++ b/apps/memory/src/communities-viewer.ts
@@ -3,7 +3,6 @@ import type {
   CommunityAnalyticsReport,
   CommunityAssignment,
   CommunitySummary,
-  InterCommunityEdge,
 } from "./communities.js";
 
 export interface CommunitiesViewerArtifact {
@@ -138,23 +137,28 @@ function renderCommunitiesViewer(report: CommunityAnalyticsReport): string {
       ${metric("Communities", report.communities.length)}
       ${metric("Assigned Nodes", report.assignments.length)}
       ${metric("Inter-community Edges", report.inter_community_edges.length)}
-      ${metric("Largest", report.communities[0]?.count ?? 0)}
+      ${metric("Bridge Nodes", report.bridge_nodes.length)}
     </div>
     <div class="layout">
       <div class="stack">
         <section>
           <h2>Communities</h2>
-          ${report.communities.length === 0 ? `<p class="empty">No community assignments available.</p>` : `<ul>${report.communities.map((community) => communityItem(community, assignmentsByCommunity.get(community.id) ?? [])).join("")}</ul>`}
+          ${report.communities.length === 0 ? `<p class="empty">No community assignments available. Ingest graph evidence, then refresh communities.</p>` : `<ul>${report.communities.map((community) => communityItem(community, assignmentsByCommunity.get(community.id) ?? [])).join("")}</ul>`}
         </section>
         <section>
-          <h2>Community Links</h2>
-          ${report.inter_community_edges.length === 0 ? `<p class="empty">No inter-community relationships.</p>` : `<ul>${report.inter_community_edges.slice(0, 40).map(interCommunityEdgeItem).join("")}</ul>`}
+          <h2>Bridge Nodes</h2>
+          ${report.bridge_nodes.length === 0 ? `<p class="empty">No cross-community bridge nodes detected.</p>` : `<ul>${report.bridge_nodes.slice(0, 40).map(bridgeNodeItem).join("")}</ul>`}
         </section>
       </div>
       <div class="stack">
         <section>
+          <h2>Bridge Edges</h2>
+          ${report.bridge_edges.length === 0 ? `<p class="empty">No cross-community bridge edges detected.</p>` : `<ul>${report.bridge_edges.slice(0, 40).map(bridgeEdgeItem).join("")}</ul>`}
+        </section>
+        <section>
           <h2>Cache</h2>
           <p class="meta"><code>${escapeHtml(report.cache_key)}</code></p>
+          <p class="meta">${escapeHtml(report.summary.next)}</p>
           <p class="meta">Communities are analytics over graph shape; they are not written back as durable Memory evidence.</p>
         </section>
         <section>
@@ -179,9 +183,31 @@ function communityItem(
       <h3>${escapeHtml(community.id)}</h3>
       <p class="meta">${escapeHtml(community.titles.join(", ") || "No titles")}</p>
       <p class="meta">${escapeHtml(nodeTypes.join(", ") || "unknown node types")}</p>
-      <p class="meta">degree ${community.total_degree} - centrality ${community.avg_centrality} - external weight ${community.external_edge_weight}</p>
+      <p class="meta">cohesion ${community.cohesion_score} - internal weight ${community.internal_edge_weight} - external weight ${community.external_edge_weight}</p>
+      <p class="meta">degree ${community.total_degree} - centrality ${community.avg_centrality}</p>
     </div>
     <span class="pill">${community.count} node(s)</span>
+  </li>`;
+}
+
+function bridgeNodeItem(node: CommunityAnalyticsReport["bridge_nodes"][number]): string {
+  return `<li>
+    <div>
+      <h3>${escapeHtml(node.title)}</h3>
+      <p class="meta"><code>memory_nodes:${node.rid}</code> - ${escapeHtml(node.label)} - ${escapeHtml(node.node_type)}</p>
+      <p class="meta">communities ${escapeHtml(node.connected_community_ids.join(", "))} - ${node.cross_community_edge_count} edge(s), weight ${node.cross_community_weight}</p>
+    </div>
+    <span class="pill">${node.connected_community_count} communities</span>
+  </li>`;
+}
+
+function bridgeEdgeItem(edge: CommunityAnalyticsReport["bridge_edges"][number]): string {
+  return `<li>
+    <div>
+      <h3>${escapeHtml(edge.from_label)} -> ${escapeHtml(edge.to_label)}</h3>
+      <p class="meta">${escapeHtml(edge.from_community_id)} -> ${escapeHtml(edge.to_community_id)} - ${escapeHtml(edge.label || "edge")}</p>
+    </div>
+    <span class="pill">${edge.weight}</span>
   </li>`;
 }
 
@@ -192,15 +218,5 @@ function assignmentItem(assignment: CommunityAssignment): string {
       <p class="meta"><code>memory_nodes:${assignment.rid}</code> - ${escapeHtml(assignment.label)} - ${escapeHtml(assignment.node_type)}</p>
     </div>
     <span class="pill">${escapeHtml(assignment.community_id)}</span>
-  </li>`;
-}
-
-function interCommunityEdgeItem(edge: InterCommunityEdge): string {
-  return `<li>
-    <div>
-      <h3>${escapeHtml(edge.from_community_id)} -> ${escapeHtml(edge.to_community_id)}</h3>
-      <p class="meta">${edge.edge_count} edge(s), weight ${edge.weight}</p>
-    </div>
-    <span class="pill">${edge.weight}</span>
   </li>`;
 }

--- a/apps/memory/src/communities.ts
+++ b/apps/memory/src/communities.ts
@@ -16,7 +16,9 @@ export interface CommunitySummary {
   count: number;
   total_degree: number;
   avg_centrality: number;
+  internal_edge_weight: number;
   external_edge_weight: number;
+  cohesion_score: number;
   labels: string[];
   titles: string[];
 }
@@ -38,6 +40,34 @@ export interface InterCommunityEdge {
   edge_count: number;
 }
 
+export interface BridgeNode {
+  rid: number;
+  label: string;
+  title: string;
+  node_type: string;
+  community_id: string;
+  connected_community_count: number;
+  connected_community_ids: string[];
+  cross_community_edge_count: number;
+  cross_community_weight: number;
+}
+
+export interface BridgeEdge {
+  from_rid: number;
+  to_rid: number;
+  from_label: string;
+  to_label: string;
+  from_community_id: string;
+  to_community_id: string;
+  label: string;
+  weight: number;
+}
+
+export interface CommunityAnalyticsSummary {
+  status: "empty" | "ready";
+  next: string;
+}
+
 export interface CommunityAnalyticsReport {
   schema_version: "memory.communities.v1";
   read_only: true;
@@ -49,15 +79,27 @@ export interface CommunityAnalyticsReport {
   assignments: CommunityAssignment[];
   node_analytics: CommunityNodeAnalytics[];
   inter_community_edges: InterCommunityEdge[];
+  bridge_nodes: BridgeNode[];
+  bridge_edges: BridgeEdge[];
+  summary: CommunityAnalyticsSummary;
 }
 
 interface CachedCommunityAnalytics {
-  schema_version: "memory.communities.cache.v2";
+  schema_version: "memory.communities.cache.v3";
   graph_hash: string;
   assignments: Array<{ rid: number; community_id: string }>;
   node_analytics: CommunityNodeAnalytics[];
   inter_community_edges: InterCommunityEdge[];
+  bridge_nodes: BridgeNode[];
+  bridge_edges: BridgeEdge[];
+  community_edge_weights: CommunityEdgeWeights[];
   generated_at: string;
+}
+
+interface CommunityEdgeWeights {
+  community_id: string;
+  internal_edge_weight: number;
+  external_edge_weight: number;
 }
 
 interface BuildCommunityAnalyticsOptions {
@@ -72,7 +114,7 @@ export async function buildCommunityAnalytics(
   const cacheMode = opts.cache ?? "read-write";
   const [nodes, edges] = await Promise.all([store.listNodes(), store.listEdges()]);
   const graphHash = graphStateHash(nodes, edges);
-  const cacheKey = `cache:communities:v2:${graphHash}`;
+  const cacheKey = `cache:communities:v3:${graphHash}`;
   const cached =
     cacheMode === "off"
       ? null
@@ -81,15 +123,18 @@ export async function buildCommunityAnalytics(
   const cacheHit = cached?.graph_hash === graphHash;
   const communityPairs = cacheHit ? cached.assignments : mapToPairs(await store.communities());
   const analytics = cacheHit
-    ? {
-        node_analytics: cached.node_analytics,
-        inter_community_edges: cached.inter_community_edges,
-      }
-    : buildNavigationAnalytics(communityPairs, edges);
+      ? {
+          node_analytics: cached.node_analytics,
+          inter_community_edges: cached.inter_community_edges,
+          bridge_nodes: cached.bridge_nodes,
+          bridge_edges: cached.bridge_edges,
+          community_edge_weights: cached.community_edge_weights,
+        }
+      : buildNavigationAnalytics(communityPairs, nodes, edges);
 
   if (cacheMode === "read-write" && !cacheHit) {
     await store.kvPut(cacheKey, {
-      schema_version: "memory.communities.cache.v2",
+      schema_version: "memory.communities.cache.v3",
       graph_hash: graphHash,
       assignments: communityPairs,
       ...analytics,
@@ -98,6 +143,12 @@ export async function buildCommunityAnalytics(
   }
 
   const assignments = decorateAssignments(nodes, communityPairs);
+  const communities = summarizeCommunities(
+    assignments,
+    analytics.node_analytics,
+    analytics.inter_community_edges,
+    analytics.community_edge_weights,
+  );
   return {
     schema_version: "memory.communities.v1",
     read_only: true,
@@ -105,10 +156,13 @@ export async function buildCommunityAnalytics(
     cache_key: cacheKey,
     cached: cacheHit,
     generated_at: cacheHit ? cached.generated_at : generatedAt,
-    communities: summarizeCommunities(assignments, analytics.node_analytics, analytics.inter_community_edges),
+    communities,
     assignments,
     node_analytics: analytics.node_analytics,
     inter_community_edges: analytics.inter_community_edges,
+    bridge_nodes: analytics.bridge_nodes,
+    bridge_edges: analytics.bridge_edges,
+    summary: summarizeReport(communities, analytics.bridge_nodes, analytics.bridge_edges),
   };
 }
 
@@ -127,11 +181,14 @@ function isCachedCommunityAnalytics(value: unknown): value is CachedCommunityAna
   if (!value || typeof value !== "object") return false;
   const item = value as Partial<CachedCommunityAnalytics>;
   return (
-    item.schema_version === "memory.communities.cache.v2" &&
+    item.schema_version === "memory.communities.cache.v3" &&
     typeof item.graph_hash === "string" &&
     Array.isArray(item.assignments) &&
     Array.isArray(item.node_analytics) &&
     Array.isArray(item.inter_community_edges) &&
+    Array.isArray(item.bridge_nodes) &&
+    Array.isArray(item.bridge_edges) &&
+    Array.isArray(item.community_edge_weights) &&
     typeof item.generated_at === "string"
   );
 }
@@ -167,6 +224,7 @@ function summarizeCommunities(
   assignments: CommunityAssignment[],
   nodeAnalytics: CommunityNodeAnalytics[],
   interCommunityEdges: InterCommunityEdge[],
+  communityEdgeWeights: CommunityEdgeWeights[],
 ): CommunitySummary[] {
   const groups = new Map<string, CommunityAssignment[]>();
   for (const assignment of assignments) {
@@ -181,6 +239,7 @@ function summarizeCommunities(
     analyticsByCommunity.set(item.community_id, group);
   }
   const externalWeight = new Map<string, number>();
+  const weightsByCommunity = new Map(communityEdgeWeights.map((item) => [item.community_id, item]));
   for (const edge of interCommunityEdges) {
     externalWeight.set(
       edge.from_community_id,
@@ -205,7 +264,9 @@ function summarizeCommunities(
         count: group.length,
         total_degree: totalDegree,
         avg_centrality: avgCentrality,
+        internal_edge_weight: round6(weightsByCommunity.get(id)?.internal_edge_weight ?? 0),
         external_edge_weight: round6(externalWeight.get(id) ?? 0),
+        cohesion_score: cohesionScore(weightsByCommunity.get(id)),
         labels: sorted.slice(0, 5).map((item) => item.label),
         titles: sorted.slice(0, 5).map((item) => item.title),
       };
@@ -215,24 +276,40 @@ function summarizeCommunities(
 
 function buildNavigationAnalytics(
   assignments: Array<{ rid: number; community_id: string }>,
+  nodes: StoredNode[],
   edges: Record<string, unknown>[],
 ): {
   node_analytics: CommunityNodeAnalytics[];
   inter_community_edges: InterCommunityEdge[];
+  bridge_nodes: BridgeNode[];
+  bridge_edges: BridgeEdge[];
+  community_edge_weights: CommunityEdgeWeights[];
 } {
   const communityByRid = new Map(assignments.map((assignment) => [assignment.rid, assignment.community_id]));
+  const nodeByRid = new Map(nodes.map((node) => [node.rid, node]));
   const degree = new Map<number, number>();
   const inDegree = new Map<number, number>();
   const outDegree = new Map<number, number>();
   const weightedDegree = new Map<number, number>();
+  const internalWeight = new Map<string, number>();
+  const externalByCommunity = new Map<string, number>();
+  const bridgeCommunities = new Map<number, Set<string>>();
+  const bridgeEdgeCount = new Map<number, number>();
+  const bridgeWeight = new Map<number, number>();
   for (const rid of communityByRid.keys()) {
     degree.set(rid, 0);
     inDegree.set(rid, 0);
     outDegree.set(rid, 0);
     weightedDegree.set(rid, 0);
+    const communityId = communityByRid.get(rid);
+    if (communityId) {
+      internalWeight.set(communityId, internalWeight.get(communityId) ?? 0);
+      externalByCommunity.set(communityId, externalByCommunity.get(communityId) ?? 0);
+    }
   }
 
   const interCommunity = new Map<string, InterCommunityEdge>();
+  const bridgeEdges: BridgeEdge[] = [];
   for (const edge of edges) {
     const from = edgeEndpoint(edge, "from");
     const to = edgeEndpoint(edge, "to");
@@ -247,7 +324,31 @@ function buildNavigationAnalytics(
 
     const fromCommunity = communityByRid.get(from);
     const toCommunity = communityByRid.get(to);
-    if (!fromCommunity || !toCommunity || fromCommunity === toCommunity) continue;
+    if (!fromCommunity || !toCommunity) continue;
+    if (fromCommunity === toCommunity) {
+      internalWeight.set(fromCommunity, round6((internalWeight.get(fromCommunity) ?? 0) + weight));
+      continue;
+    }
+    externalByCommunity.set(fromCommunity, round6((externalByCommunity.get(fromCommunity) ?? 0) + weight));
+    externalByCommunity.set(toCommunity, round6((externalByCommunity.get(toCommunity) ?? 0) + weight));
+    addBridgeCommunity(bridgeCommunities, from, fromCommunity, toCommunity);
+    addBridgeCommunity(bridgeCommunities, to, toCommunity, fromCommunity);
+    bridgeEdgeCount.set(from, (bridgeEdgeCount.get(from) ?? 0) + 1);
+    bridgeEdgeCount.set(to, (bridgeEdgeCount.get(to) ?? 0) + 1);
+    bridgeWeight.set(from, round6((bridgeWeight.get(from) ?? 0) + weight));
+    bridgeWeight.set(to, round6((bridgeWeight.get(to) ?? 0) + weight));
+    const fromNode = nodeByRid.get(from);
+    const toNode = nodeByRid.get(to);
+    bridgeEdges.push({
+      from_rid: from,
+      to_rid: to,
+      from_label: fromNode?.label ?? String(from),
+      to_label: toNode?.label ?? String(to),
+      from_community_id: fromCommunity,
+      to_community_id: toCommunity,
+      label: String(edge.label ?? edge.LABEL ?? ""),
+      weight,
+    });
     const key = `${fromCommunity}\u0000${toCommunity}`;
     const current = interCommunity.get(key) ?? {
       from_community_id: fromCommunity,
@@ -261,6 +362,29 @@ function buildNavigationAnalytics(
   }
 
   const maxDegree = Math.max(1, ...degree.values());
+  const bridgeNodes = [...bridgeCommunities.entries()]
+    .map(([rid, communities]) => {
+      const node = nodeByRid.get(rid);
+      const connected = [...communities].sort();
+      return {
+        rid,
+        label: node?.label ?? String(rid),
+        title: node?.properties.title ?? node?.label ?? String(rid),
+        node_type: String(node?.node_type ?? ""),
+        community_id: communityByRid.get(rid) ?? "",
+        connected_community_count: connected.length,
+        connected_community_ids: connected,
+        cross_community_edge_count: bridgeEdgeCount.get(rid) ?? 0,
+        cross_community_weight: round6(bridgeWeight.get(rid) ?? 0),
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.connected_community_count - a.connected_community_count ||
+        b.cross_community_weight - a.cross_community_weight ||
+        b.cross_community_edge_count - a.cross_community_edge_count ||
+        a.label.localeCompare(b.label),
+    );
   return {
     node_analytics: [...communityByRid.entries()]
       .map(([rid, community_id]) => ({
@@ -280,7 +404,35 @@ function buildNavigationAnalytics(
         a.from_community_id.localeCompare(b.from_community_id) ||
         a.to_community_id.localeCompare(b.to_community_id),
     ),
+    bridge_nodes: bridgeNodes,
+    bridge_edges: bridgeEdges.sort(
+      (a, b) =>
+        b.weight - a.weight ||
+        a.from_community_id.localeCompare(b.from_community_id) ||
+        a.to_community_id.localeCompare(b.to_community_id) ||
+        a.from_label.localeCompare(b.from_label) ||
+        a.to_label.localeCompare(b.to_label),
+    ),
+    community_edge_weights: [...new Set([...internalWeight.keys(), ...externalByCommunity.keys()])]
+      .map((community_id) => ({
+        community_id,
+        internal_edge_weight: round6(internalWeight.get(community_id) ?? 0),
+        external_edge_weight: round6(externalByCommunity.get(community_id) ?? 0),
+      }))
+      .sort((a, b) => a.community_id.localeCompare(b.community_id)),
   };
+}
+
+function addBridgeCommunity(
+  bridgeCommunities: Map<number, Set<string>>,
+  rid: number,
+  ownCommunity: string,
+  otherCommunity: string,
+): void {
+  const set = bridgeCommunities.get(rid) ?? new Set<string>();
+  set.add(ownCommunity);
+  set.add(otherCommunity);
+  bridgeCommunities.set(rid, set);
 }
 
 function edgeEndpoint(edge: Record<string, unknown>, side: "from" | "to"): number {
@@ -298,6 +450,36 @@ function edgeWeight(edge: Record<string, unknown>): number {
 
 function round6(value: number): number {
   return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function cohesionScore(weights: CommunityEdgeWeights | undefined): number {
+  const internal = weights?.internal_edge_weight ?? 0;
+  const external = weights?.external_edge_weight ?? 0;
+  const total = internal + external;
+  return total === 0 ? 0 : round6(internal / total);
+}
+
+function summarizeReport(
+  communities: CommunitySummary[],
+  bridgeNodes: BridgeNode[],
+  bridgeEdges: BridgeEdge[],
+): CommunityAnalyticsSummary {
+  if (communities.length === 0) {
+    return {
+      status: "empty",
+      next: "ingest graph evidence, then run memory communities again",
+    };
+  }
+  if (bridgeNodes.length === 0 && bridgeEdges.length === 0) {
+    return {
+      status: "ready",
+      next: "no cross-community bridges found; inspect low-cohesion communities if cohesion_score is below 0.5",
+    };
+  }
+  return {
+    status: "ready",
+    next: "inspect bridge_nodes and low-cohesion communities before treating clusters as independent",
+  };
 }
 
 export function graphStateHash(nodes: StoredNode[], edges: Record<string, unknown>[]): string {

--- a/apps/memory/src/operations.ts
+++ b/apps/memory/src/operations.ts
@@ -768,7 +768,9 @@ const CommunitySummarySchema = z.object({
   count: z.number(),
   total_degree: z.number(),
   avg_centrality: z.number(),
+  internal_edge_weight: z.number(),
   external_edge_weight: z.number(),
+  cohesion_score: z.number(),
   labels: z.array(z.string()),
   titles: z.array(z.string()),
 });
@@ -798,6 +800,29 @@ const InterCommunityEdgeSchema = z.object({
   edge_count: z.number(),
 });
 
+const BridgeNodeSchema = z.object({
+  rid: z.number(),
+  label: z.string(),
+  title: z.string(),
+  node_type: z.string(),
+  community_id: z.string(),
+  connected_community_count: z.number(),
+  connected_community_ids: z.array(z.string()),
+  cross_community_edge_count: z.number(),
+  cross_community_weight: z.number(),
+});
+
+const BridgeEdgeSchema = z.object({
+  from_rid: z.number(),
+  to_rid: z.number(),
+  from_label: z.string(),
+  to_label: z.string(),
+  from_community_id: z.string(),
+  to_community_id: z.string(),
+  label: z.string(),
+  weight: z.number(),
+});
+
 const CommunitiesOutputSchema = z.object({
   schema_version: z.literal("memory.communities.v1"),
   read_only: z.literal(true),
@@ -809,6 +834,12 @@ const CommunitiesOutputSchema = z.object({
   assignments: z.array(CommunityAssignmentSchema),
   node_analytics: z.array(CommunityNodeAnalyticsSchema),
   inter_community_edges: z.array(InterCommunityEdgeSchema),
+  bridge_nodes: z.array(BridgeNodeSchema),
+  bridge_edges: z.array(BridgeEdgeSchema),
+  summary: z.object({
+    status: z.enum(["empty", "ready"]),
+    next: z.string(),
+  }),
 }) satisfies z.ZodType<CommunityAnalyticsReport>;
 const CommunitiesViewerOutputSchema = objectOutputSchema<CommunitiesViewerArtifact>();
 
@@ -2920,7 +2951,7 @@ const COMMUNITIES_OPERATION: MemoryOperationDefinition<CommunitiesInput, Communi
     mcp: {
       toolName: "memory_communities",
       description:
-        "Read-only Memory graph community analytics: native Louvain assignments, node degree/centrality ranking metadata, weighted inter-community edges, community counts, top labels/titles, and graph-hash cache metadata. Does not write derived clusters into Memory graph evidence.",
+        "Read-only Memory graph community analytics: native Louvain assignments, node degree/centrality ranking metadata, weighted inter-community edges, bridge node/edge rankings, per-community cohesion scores, top labels/titles, and graph-hash cache metadata. Does not write derived clusters into Memory graph evidence.",
     },
   },
   execute: (ctx, input) => buildCommunityAnalytics(ctx.store, { cache: input.cache }),

--- a/apps/memory/src/readiness.ts
+++ b/apps/memory/src/readiness.ts
@@ -344,6 +344,12 @@ async function communitySummary(
       assignments: [],
       node_analytics: [],
       inter_community_edges: [],
+      bridge_nodes: [],
+      bridge_edges: [],
+      summary: {
+        status: "empty",
+        next: "ingest graph evidence, then run memory communities again",
+      },
       error: err instanceof Error ? err.message : String(err),
     };
   }

--- a/apps/memory/tests/communities-cli.test.ts
+++ b/apps/memory/tests/communities-cli.test.ts
@@ -66,10 +66,52 @@ async function seedTwoCommunities(root: string): Promise<void> {
   await e(y, z);
   await e(z, x);
   await e(c, x);
+  await e(c, y);
+  await e(c, z);
+  await e(b, x);
+  await e(b, y);
   await store.close();
 }
 
 describe("memory communities CLI", () => {
+  test(
+    "reports definitive empty states",
+    async () => {
+      const root = await initRoot();
+
+      const json = runMemory(["communities", "--root", root, "--json"]);
+      expect(json.status).toBe(0);
+      const body = JSON.parse(json.stdout) as {
+        communities: unknown[];
+        bridge_nodes: unknown[];
+        bridge_edges: unknown[];
+        summary: { status: string; next: string };
+      };
+      expect(body.communities).toEqual([]);
+      expect(body.bridge_nodes).toEqual([]);
+      expect(body.bridge_edges).toEqual([]);
+      expect(body.summary).toEqual({
+        status: "empty",
+        next: "ingest graph evidence, then run memory communities again",
+      });
+
+      const toon = runMemory(["communities", "--root", root]);
+      expect(toon.status).toBe(0);
+      expect(toon.stdout).toContain("communities: []");
+      expect(toon.stdout).toContain("status: empty");
+      expect(toon.stdout).toContain("ingest graph evidence");
+
+      const out = join(root, "empty-communities.html");
+      const viewer = runMemory(["communities-viewer", "--root", root, "--out", out]);
+      expect(viewer.status).toBe(0);
+      const html = await readFile(out, "utf8");
+      expect(html).toContain("No community assignments available. Ingest graph evidence, then refresh communities.");
+      expect(html).toContain("No cross-community bridge nodes detected.");
+      expect(html).toContain("No cross-community bridge edges detected.");
+    },
+    TIMEOUT,
+  );
+
   test(
     "reports assignments, counts, readable labels, cache hits, and does not mutate graph evidence",
     async () => {
@@ -101,7 +143,9 @@ describe("memory communities CLI", () => {
           count: number;
           total_degree: number;
           avg_centrality: number;
+          internal_edge_weight: number;
           external_edge_weight: number;
+          cohesion_score: number;
           labels: string[];
           titles: string[];
         }>;
@@ -121,26 +165,56 @@ describe("memory communities CLI", () => {
           weight: number;
           edge_count: number;
         }>;
+        bridge_nodes: Array<{
+          rid: number;
+          label: string;
+          title: string;
+          community_id: string;
+          connected_community_count: number;
+          connected_community_ids: string[];
+          cross_community_edge_count: number;
+          cross_community_weight: number;
+        }>;
+        bridge_edges: Array<{
+          from_label: string;
+          to_label: string;
+          from_community_id: string;
+          to_community_id: string;
+          weight: number;
+        }>;
+        summary: { status: string; next: string };
       };
 
       expect(firstBody.schema_version).toBe("memory.communities.v1");
       expect(firstBody.read_only).toBe(true);
       expect(firstBody.cached).toBe(false);
       expect(firstBody.graph_hash).toMatch(/^[a-f0-9]{64}$/);
-      expect(firstBody.cache_key).toContain("cache:communities:v2:");
+      expect(firstBody.cache_key).toContain("cache:communities:v3:");
       expect(firstBody.communities).toHaveLength(2);
       expect(firstBody.assignments).toHaveLength(6);
       expect(firstBody.node_analytics).toHaveLength(6);
       expect(firstBody.inter_community_edges).toHaveLength(1);
-      expect(firstBody.inter_community_edges[0]).toMatchObject({ weight: 1, edge_count: 1 });
+      expect(firstBody.inter_community_edges[0]).toMatchObject({ weight: 5, edge_count: 5 });
+      expect(firstBody.bridge_edges).toHaveLength(5);
+      expect(firstBody.bridge_nodes[0]).toMatchObject({
+        label: "auth-session",
+        connected_community_count: 2,
+        cross_community_edge_count: 3,
+        cross_community_weight: 3,
+      });
+      expect(firstBody.bridge_nodes[0].connected_community_ids).toHaveLength(2);
       expect(firstBody.node_analytics[0].centrality).toBeGreaterThan(0);
       expect(firstBody.node_analytics[0].degree).toBeGreaterThan(0);
       expect(firstBody.communities.map((c) => c.count).sort()).toEqual([3, 3]);
       expect(firstBody.communities.every((c) => c.total_degree > 0)).toBe(true);
       expect(firstBody.communities.every((c) => c.avg_centrality > 0)).toBe(true);
-      expect(firstBody.communities.every((c) => c.external_edge_weight === 1)).toBe(true);
+      expect(firstBody.communities.every((c) => c.internal_edge_weight === 3)).toBe(true);
+      expect(firstBody.communities.every((c) => c.external_edge_weight === 5)).toBe(true);
+      expect(firstBody.communities.every((c) => c.cohesion_score === 0.375)).toBe(true);
       expect(firstBody.communities.some((c) => c.labels.includes("auth-login"))).toBe(true);
       expect(firstBody.communities.some((c) => c.titles.includes("cache ttl"))).toBe(true);
+      expect(firstBody.summary).toMatchObject({ status: "ready" });
+      expect(firstBody.summary.next).toContain("bridge_nodes");
 
       const second = runMemory(["communities", "--root", root, "--json"]);
       expect(second.status).toBe(0);
@@ -150,6 +224,14 @@ describe("memory communities CLI", () => {
       expect(secondBody.assignments).toEqual(firstBody.assignments);
       expect(secondBody.node_analytics).toEqual(firstBody.node_analytics);
       expect(secondBody.inter_community_edges).toEqual(firstBody.inter_community_edges);
+      expect(secondBody.bridge_nodes).toEqual(firstBody.bridge_nodes);
+      expect(secondBody.bridge_edges).toEqual(firstBody.bridge_edges);
+
+      const toon = runMemory(["communities", "--root", root, "--no-cache"]);
+      expect(toon.status).toBe(0);
+      expect(toon.stdout).toContain("communities[2]{id,count,cohesion_score");
+      expect(toon.stdout).toContain("bridge_nodes[5]{rid,label");
+      expect(toon.stdout).toContain("summary:");
 
       const out = join(root, "communities.html");
       const viewer = runMemory(["communities-viewer", "--root", root, "--out", out]);
@@ -159,6 +241,8 @@ describe("memory communities CLI", () => {
       const html = await readFile(out, "utf8");
       expect(html).toContain("Graph Communities");
       expect(html).toContain("auth login flow");
+      expect(html).toContain("cohesion 0.375");
+      expect(html).toContain("Bridge Nodes");
       expect(html).toContain('id="communities-data"');
       expect(html).not.toContain("<script src=");
 


### PR DESCRIPTION
Automated AFK landing for #1434. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1434

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786317114&installation_id=129708444&pr_number=1454&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1454&signature=c23829e52b675bc518e772dc6fd8be4985d057e42595bd048dd2ac4bfa9048cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->