### PR TITLE
fix: #1435 Community labeling: short human-readable names via the provider abstraction

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -7123,6 +7123,7 @@ function renderCommunitiesToon(report: CommunityAnalyticsReport): string {
     rowsKey: "communities",
     rows: report.communities.map((community) => ({
       id: community.id,
+      label: community.short_label ?? community.id,
       count: community.count,
       cohesion_score: community.cohesion_score,
       internal_edge_weight: community.internal_edge_weight,
@@ -7131,6 +7132,7 @@ function renderCommunitiesToon(report: CommunityAnalyticsReport): string {
     })),
     fields: [
       "id",
+      "label",
       "count",
       "cohesion_score",
       "internal_edge_weight",
@@ -7211,7 +7213,8 @@ async function runCommunityDigest(args: ParsedArgs): Promise<void> {
       }`,
     );
     for (const digest of report.digests) {
-      console.log(`  ${digest.community_id}: ${digest.size} node(s)`);
+      console.log(`  ${digest.short_label ?? digest.community_id}: ${digest.size} node(s)`);
+      console.log(`        community: ${digest.community_id}`);
       console.log(`        top label: ${digest.top_label}`);
       console.log(`        top type: ${digest.top_node_type}`);
       if (digest.top_engineering_code) {
@@ -7221,6 +7224,9 @@ async function runCommunityDigest(args: ParsedArgs): Promise<void> {
         console.log(`        summary: ${digest.narrative_summary}`);
       }
     }
+    console.log(
+      `  labeling: generated ${report.summary.labeling.generated}, reused ${report.summary.labeling.reused}, estimated tokens ${report.summary.labeling.token_cost.total_tokens}`,
+    );
   } finally {
     await store.close();
   }

--- a/apps/memory/src/communities-viewer.ts
+++ b/apps/memory/src/communities-viewer.ts
@@ -180,7 +180,8 @@ function communityItem(
   const nodeTypes = [...new Set(assignments.map((assignment) => assignment.node_type))].sort();
   return `<li>
     <div>
-      <h3>${escapeHtml(community.id)}</h3>
+      <h3>${escapeHtml(community.short_label ?? community.id)}</h3>
+      ${community.short_label ? `<p class="meta"><code>${escapeHtml(community.id)}</code></p>` : ""}
       <p class="meta">${escapeHtml(community.titles.join(", ") || "No titles")}</p>
       <p class="meta">${escapeHtml(nodeTypes.join(", ") || "unknown node types")}</p>
       <p class="meta">cohesion ${community.cohesion_score} - internal weight ${community.internal_edge_weight} - external weight ${community.external_edge_weight}</p>

--- a/apps/memory/src/communities.ts
+++ b/apps/memory/src/communities.ts
@@ -13,6 +13,8 @@ export interface CommunityAssignment {
 
 export interface CommunitySummary {
   id: string;
+  short_label: string | null;
+  label_provenance: CommunityLabelProvenance | null;
   count: number;
   total_degree: number;
   avg_centrality: number;
@@ -21,6 +23,16 @@ export interface CommunitySummary {
   cohesion_score: number;
   labels: string[];
   titles: string[];
+}
+
+export interface CommunityLabelProvenance {
+  source: "provider" | "deterministic" | "cached";
+  provider: {
+    mode: string | null;
+    model: string | null;
+  };
+  membership_hash: string;
+  generated_at: string;
 }
 
 export interface CommunityNodeAnalytics {
@@ -143,11 +155,16 @@ export async function buildCommunityAnalytics(
   }
 
   const assignments = decorateAssignments(nodes, communityPairs);
-  const communities = summarizeCommunities(
+  const communities = await attachStoredLabels(
+    store,
+    summarizeCommunities(
     assignments,
     analytics.node_analytics,
     analytics.inter_community_edges,
     analytics.community_edge_weights,
+    ),
+    assignments,
+    nodes,
   );
   return {
     schema_version: "memory.communities.v1",
@@ -261,6 +278,8 @@ function summarizeCommunities(
           : round6(analytics.reduce((sum, item) => sum + item.centrality, 0) / analytics.length);
       return {
         id,
+        short_label: null,
+        label_provenance: null,
         count: group.length,
         total_degree: totalDegree,
         avg_centrality: avgCentrality,
@@ -272,6 +291,94 @@ function summarizeCommunities(
       };
     })
     .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id));
+}
+
+async function attachStoredLabels(
+  store: MemoryStore,
+  communities: CommunitySummary[],
+  assignments: CommunityAssignment[],
+  nodes: StoredNode[],
+): Promise<CommunitySummary[]> {
+  const membersByCommunity = new Map<string, CommunityAssignment[]>();
+  for (const assignment of assignments) {
+    const group = membersByCommunity.get(assignment.community_id) ?? [];
+    group.push(assignment);
+    membersByCommunity.set(assignment.community_id, group);
+  }
+  const nodesByRid = new Map(nodes.map((node) => [node.rid, node]));
+  return Promise.all(
+    communities.map(async (community) => {
+      const membership_hash = membershipHash(
+        (membersByCommunity.get(community.id) ?? [])
+          .map((assignment) => nodesByRid.get(assignment.rid))
+          .filter((node): node is StoredNode => node != null),
+      );
+      const label = parseStoredCommunityLabel(
+        await store.kvGet<StoredCommunityLabel | string>(communityLabelKey(membership_hash)),
+      );
+      if (!label || label.provenance.membership_hash !== membership_hash) return community;
+      return {
+        ...community,
+        short_label: label.short_label,
+        label_provenance: label.provenance,
+      };
+    }),
+  );
+}
+
+interface StoredCommunityLabel {
+  schema_version: "memory.community-label.v1";
+  community_id: string;
+  short_label: string;
+  provenance: CommunityLabelProvenance;
+}
+
+function parseStoredCommunityLabel(raw: StoredCommunityLabel | string | null): StoredCommunityLabel | null {
+  if (raw == null) return null;
+  const parsed = typeof raw === "string" ? parseJson(raw) : raw;
+  if (!parsed || typeof parsed !== "object") return null;
+  const item = parsed as Partial<StoredCommunityLabel>;
+  if (
+    item.schema_version !== "memory.community-label.v1" ||
+    typeof item.community_id !== "string" ||
+    typeof item.short_label !== "string" ||
+    !item.provenance ||
+    typeof item.provenance.membership_hash !== "string"
+  ) {
+    return null;
+  }
+  return item as StoredCommunityLabel;
+}
+
+function membershipHash(members: StoredNode[]): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify(
+        members
+          .slice()
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .map((node) => ({
+            rid: node.rid,
+            label: node.label,
+            node_type: node.node_type,
+            title: node.properties.title,
+            hash: node.properties.hash,
+          })),
+      ),
+    )
+    .digest("hex");
+}
+
+function communityLabelKey(membershipHash: string): string {
+  return `cache:community-label:v1:${membershipHash}`;
+}
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
 }
 
 function buildNavigationAnalytics(

--- a/apps/memory/src/community-digest.ts
+++ b/apps/memory/src/community-digest.ts
@@ -35,6 +35,27 @@ export interface CommunityDigestProviderStatus {
   error?: string;
 }
 
+export interface CommunityLabelProvenance {
+  source: "provider" | "deterministic" | "cached";
+  provider: {
+    mode: ProviderMode | null;
+    model: string | null;
+  };
+  membership_hash: string;
+  generated_at: string;
+}
+
+export interface CommunityLabelingSummary {
+  generated: number;
+  reused: number;
+  token_cost: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    estimated: true;
+  };
+}
+
 /**
  * The per-community digest entry: a deterministic top-label baseline summary
  * over the RedDB-native community assignment, optionally enriched by a provider
@@ -45,6 +66,10 @@ export interface CommunityDigestProviderStatus {
 export interface CommunityDigest {
   community_id: string;
   size: number;
+  /** Short provider-readable theme label for listings and downstream reports. */
+  short_label: string | null;
+  /** Provenance for the persisted short label, including the membership hash. */
+  label_provenance: CommunityLabelProvenance | null;
   /** Representative label: most frequent node label, ties broken alphabetically. */
   top_label: string;
   /** Dominant node_type: most frequent node_type, ties broken alphabetically. */
@@ -71,6 +96,9 @@ export interface CommunityDigestReport {
   provider: CommunityDigestProviderStatus;
   community_count: number;
   digests: CommunityDigest[];
+  summary: {
+    labeling: CommunityLabelingSummary;
+  };
 }
 
 interface CachedDigest {
@@ -79,6 +107,9 @@ interface CachedDigest {
   generated_at: string;
   community_count: number;
   digests: CommunityDigest[];
+  summary?: {
+    labeling?: CommunityLabelingSummary;
+  };
 }
 
 interface BuildCommunityDigestOptions {
@@ -130,11 +161,28 @@ export async function buildCommunityDigest(
       provider: cached.provider,
       community_count: cached.community_count,
       digests: cached.digests,
+      summary: {
+        labeling: cached.summary?.labeling ?? emptyLabelingSummary(),
+      },
     };
   }
 
   const assignments = await store.communities();
   let digests = computeDigests(nodes, assignments, curation);
+  const labelRun = await labelCommunities({
+    store,
+    digests,
+    nodes,
+    assignments,
+    provider,
+    providerConfig,
+    client:
+      provider.status === "available" && providerConfig
+        ? opts.providerClient ?? redDbProviderClient(store, providerConfig)
+        : undefined,
+    now: opts.now ?? new Date(),
+  });
+  digests = labelRun.digests;
   let finalProvider = provider;
   if (provider.status === "available" && providerConfig) {
     const enriched = await enrichDigestsWithNarratives({
@@ -157,6 +205,9 @@ export async function buildCommunityDigest(
       generated_at: generatedAt,
       community_count: digests.length,
       digests,
+      summary: {
+        labeling: labelRun.summary,
+      },
     } satisfies CachedDigest);
   }
 
@@ -170,6 +221,9 @@ export async function buildCommunityDigest(
     provider: finalProvider,
     community_count: digests.length,
     digests,
+    summary: {
+      labeling: labelRun.summary,
+    },
   };
 }
 
@@ -210,6 +264,8 @@ function computeDigests(
       return {
         community_id: communityId,
         size: members.length,
+        short_label: null,
+        label_provenance: null,
         top_label: labels[0]?.value ?? "",
         top_node_type: nodeTypes[0]?.value ?? "",
         top_engineering_code: engineeringCodes[0]?.value ?? null,
@@ -220,6 +276,269 @@ function computeDigests(
       };
     })
     .sort((a, b) => b.size - a.size || a.community_id.localeCompare(b.community_id));
+}
+
+interface CommunityMembersForPrompt {
+  community_id: string;
+  digest: CommunityDigest;
+  members: StoredNode[];
+  membership_hash: string;
+}
+
+interface StoredCommunityLabel {
+  schema_version: "memory.community-label.v1";
+  community_id: string;
+  short_label: string;
+  provenance: CommunityLabelProvenance;
+}
+
+async function labelCommunities(opts: {
+  store: MemoryStore;
+  digests: CommunityDigest[];
+  nodes: StoredNode[];
+  assignments: Map<number, string>;
+  provider: CommunityDigestProviderStatus;
+  providerConfig?: AiProviderConfig;
+  client?: ProviderClient;
+  now: Date;
+}): Promise<{ digests: CommunityDigest[]; summary: CommunityLabelingSummary }> {
+  if (opts.digests.length === 0) {
+    return { digests: opts.digests, summary: emptyLabelingSummary() };
+  }
+  const contexts = communityMemberContexts(opts.digests, opts.nodes, opts.assignments);
+  const labelByCommunity = new Map<string, StoredCommunityLabel>();
+  const needsProvider: CommunityMembersForPrompt[] = [];
+  let reused = 0;
+  for (const context of contexts) {
+    const cached = parseStoredCommunityLabel(
+      await opts.store.kvGet<StoredCommunityLabel | string>(
+        communityLabelKey(context.membership_hash),
+      ),
+    );
+    if (cached?.provenance.membership_hash === context.membership_hash && cached.short_label) {
+      reused += 1;
+      labelByCommunity.set(context.community_id, cached);
+    } else {
+      needsProvider.push(context);
+    }
+  }
+
+  let generated = 0;
+  let promptTokens = 0;
+  let completionTokens = 0;
+  if (needsProvider.length > 0) {
+    let generatedLabels = new Map<string, string>();
+    if (opts.provider.status === "available" && opts.providerConfig && opts.client) {
+      const request = buildLabelPrompt(needsProvider);
+      promptTokens += estimateTokens(request.system) + estimateTokens(request.user);
+      try {
+        const raw = await opts.client.complete(request);
+        completionTokens += estimateTokens(raw);
+        generatedLabels = parseCommunityLabels(raw);
+      } catch {
+        generatedLabels = new Map();
+      }
+    }
+    const generatedAt = opts.now.toISOString();
+    for (const context of needsProvider) {
+      const shortLabel =
+        sanitizeShortLabel(generatedLabels.get(context.community_id)) ??
+        deterministicShortLabel(context.digest);
+      const source = generatedLabels.has(context.community_id) ? "provider" : "deterministic";
+      const record: StoredCommunityLabel = {
+        schema_version: "memory.community-label.v1",
+        community_id: context.community_id,
+        short_label: shortLabel,
+        provenance: {
+          source,
+          provider: {
+            mode: opts.provider.mode,
+            model: opts.provider.model,
+          },
+          membership_hash: context.membership_hash,
+          generated_at: generatedAt,
+        },
+      };
+      await opts.store.kvPut(communityLabelKey(context.membership_hash), record);
+      labelByCommunity.set(context.community_id, record);
+      generated += 1;
+    }
+  }
+
+  return {
+    digests: opts.digests.map((digest) => {
+      const record = labelByCommunity.get(digest.community_id);
+      return {
+        ...digest,
+        short_label: record?.short_label ?? null,
+        label_provenance: record?.provenance ?? null,
+      };
+    }),
+    summary: {
+      generated,
+      reused,
+      token_cost: {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: promptTokens + completionTokens,
+        estimated: true,
+      },
+    },
+  };
+}
+
+function communityMemberContexts(
+  digests: CommunityDigest[],
+  nodes: StoredNode[],
+  assignments: Map<number, string>,
+): CommunityMembersForPrompt[] {
+  const byRid = new Map(nodes.map((node) => [node.rid, node]));
+  const byCommunity = new Map<string, StoredNode[]>();
+  for (const [rid, communityId] of assignments) {
+    const node = byRid.get(rid);
+    if (!node) continue;
+    const group = byCommunity.get(communityId) ?? [];
+    group.push(node);
+    byCommunity.set(communityId, group);
+  }
+  return digests.map((digest) => {
+    const members = (byCommunity.get(digest.community_id) ?? [])
+      .slice()
+      .sort((a, b) => a.label.localeCompare(b.label));
+    return {
+      community_id: digest.community_id,
+      digest,
+      members,
+      membership_hash: membershipHash(members),
+    };
+  });
+}
+
+function buildLabelPrompt(contexts: CommunityMembersForPrompt[]) {
+  return {
+    system: [
+      "You label Memory graph communities for an engineering agent.",
+      "Return ONLY JSON of the form:",
+      '{ "labels": [ { "community_id": string, "label": string } ] }',
+      "Write a short human-readable theme name, two to four words.",
+      "Use the member hubs, labels, titles, content snippets, and cohesion context. Do not invent facts.",
+    ].join("\n"),
+    user: JSON.stringify({
+      task: "community-labels",
+      communities: contexts.map((context) => ({
+        community_id: context.community_id,
+        size: context.digest.size,
+        top_label: context.digest.top_label,
+        top_node_type: context.digest.top_node_type,
+        top_engineering_code: context.digest.top_engineering_code,
+        cohesion: {
+          labels: context.digest.labels.slice(0, 10),
+          node_types: context.digest.node_types,
+          engineering_codes: context.digest.engineering_codes,
+        },
+        members: context.members.slice(0, 12).map((node) => ({
+          label: node.label,
+          node_type: String(node.node_type),
+          title: typeof node.properties.title === "string" ? node.properties.title : undefined,
+          content:
+            typeof node.properties.content === "string"
+              ? node.properties.content.slice(0, 240)
+              : undefined,
+        })),
+      })),
+    }),
+  };
+}
+
+function parseStoredCommunityLabel(raw: StoredCommunityLabel | string | null): StoredCommunityLabel | null {
+  if (raw == null) return null;
+  const parsed = typeof raw === "string" ? parseJson(raw) : raw;
+  if (!parsed || typeof parsed !== "object") return null;
+  const item = parsed as Partial<StoredCommunityLabel>;
+  if (
+    item.schema_version !== "memory.community-label.v1" ||
+    typeof item.community_id !== "string" ||
+    typeof item.short_label !== "string" ||
+    !item.provenance ||
+    typeof item.provenance.membership_hash !== "string"
+  ) {
+    return null;
+  }
+  return item as StoredCommunityLabel;
+}
+
+function parseCommunityLabels(raw: string): Map<string, string> {
+  const parsed = parseJson(unfence(raw));
+  if (!parsed || typeof parsed !== "object") return new Map();
+  const labels = Array.isArray((parsed as { labels?: unknown }).labels)
+    ? (parsed as { labels: unknown[] }).labels
+    : [];
+  const out = new Map<string, string>();
+  for (const item of labels) {
+    if (!item || typeof item !== "object") continue;
+    const communityId = (item as { community_id?: unknown }).community_id;
+    const label = sanitizeShortLabel((item as { label?: unknown }).label);
+    if (typeof communityId === "string" && label) out.set(communityId, label);
+  }
+  return out;
+}
+
+function sanitizeShortLabel(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const cleaned = raw.replace(/\s+/g, " ").trim().replace(/^["']|["']$/g, "");
+  if (!cleaned) return null;
+  return cleaned.split(" ").slice(0, 4).join(" ");
+}
+
+function deterministicShortLabel(digest: CommunityDigest): string {
+  return titleCase(digest.top_engineering_code ?? digest.top_label.replace(/^.*[#:/]/, ""));
+}
+
+function titleCase(value: string): string {
+  const words = value
+    .replace(/[-_./:]+/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 4);
+  if (words.length === 0) return "Community";
+  return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(" ");
+}
+
+function membershipHash(members: StoredNode[]): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify(
+        members.map((node) => ({
+          rid: node.rid,
+          label: node.label,
+          node_type: node.node_type,
+          title: node.properties.title,
+          hash: node.properties.hash,
+        })),
+      ),
+    )
+    .digest("hex");
+}
+
+function communityLabelKey(membershipHash: string): string {
+  return `cache:community-label:v1:${membershipHash}`;
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function emptyLabelingSummary(): CommunityLabelingSummary {
+  return {
+    generated: 0,
+    reused: 0,
+    token_cost: {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+      estimated: true,
+    },
+  };
 }
 
 function canonicalEngineeringCode(

--- a/apps/memory/src/global-search.ts
+++ b/apps/memory/src/global-search.ts
@@ -15,6 +15,7 @@ export interface GlobalSearchDigestEvidence {
   score: number;
   matched_terms: string[];
   size: number;
+  short_label: string | null;
   top_label: string;
   top_node_type: string;
   top_engineering_code: string | null;
@@ -147,6 +148,7 @@ function scoreDigest(
     score,
     matched_terms: [...matched].sort(),
     size: digest.size,
+    short_label: digest.short_label,
     top_label: digest.top_label,
     top_node_type: digest.top_node_type,
     top_engineering_code: digest.top_engineering_code,

--- a/apps/memory/src/operations.ts
+++ b/apps/memory/src/operations.ts
@@ -765,6 +765,18 @@ type FederationInput = z.infer<typeof FederationInputSchema>;
 
 const CommunitySummarySchema = z.object({
   id: z.string(),
+  short_label: z.string().nullable(),
+  label_provenance: z
+    .object({
+      source: z.enum(["provider", "deterministic", "cached"]),
+      provider: z.object({
+        mode: z.string().nullable(),
+        model: z.string().nullable(),
+      }),
+      membership_hash: z.string(),
+      generated_at: z.string(),
+    })
+    .nullable(),
   count: z.number(),
   total_degree: z.number(),
   avg_centrality: z.number(),
@@ -884,6 +896,24 @@ const CommunityDigestCountSchema = z.object({
 const CommunityDigestEntrySchema = z.object({
   community_id: z.string(),
   size: z.number(),
+  short_label: z.string().nullable(),
+  label_provenance: z
+    .object({
+      source: z.enum(["provider", "deterministic", "cached"]),
+      provider: z.object({
+        mode: z.union([
+          z.literal("openai-compat"),
+          z.literal("openai-native"),
+          z.literal("anthropic-native"),
+          z.literal("bedrock"),
+          z.null(),
+        ]),
+        model: z.string().nullable(),
+      }),
+      membership_hash: z.string(),
+      generated_at: z.string(),
+    })
+    .nullable(),
   top_label: z.string(),
   top_node_type: z.string(),
   top_engineering_code: z.string().nullable(),
@@ -915,6 +945,18 @@ const CommunityDigestOutputSchema = z.object({
   provider: CommunityDigestProviderSchema,
   community_count: z.number(),
   digests: z.array(CommunityDigestEntrySchema),
+  summary: z.object({
+    labeling: z.object({
+      generated: z.number(),
+      reused: z.number(),
+      token_cost: z.object({
+        prompt_tokens: z.number(),
+        completion_tokens: z.number(),
+        total_tokens: z.number(),
+        estimated: z.literal(true),
+      }),
+    }),
+  }),
 }) satisfies z.ZodType<CommunityDigestReport>;
 const GlobalSearchEvidenceSchema = z.object({
   source: z.literal("community-digest"),
@@ -922,6 +964,7 @@ const GlobalSearchEvidenceSchema = z.object({
   score: z.number(),
   matched_terms: z.array(z.string()),
   size: z.number(),
+  short_label: z.string().nullable(),
   top_label: z.string(),
   top_node_type: z.string(),
   top_engineering_code: z.string().nullable(),

--- a/apps/memory/tests/communities-cli.test.ts
+++ b/apps/memory/tests/communities-cli.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import { MemoryStore } from "../src/graph-store.js";
 import { initGraph } from "../src/init.js";
 import { getReadOnlyMemoryOperation } from "../src/operations.js";
+import { buildCommunityDigest } from "../src/community-digest.js";
 
 const TIMEOUT = 40_000;
 const pkgRoot = resolve(__dirname, "..");
@@ -128,6 +129,36 @@ describe("memory communities CLI", () => {
 
       const before = await openStore(root);
       const beforeStats = await before.stats();
+      await buildCommunityDigest(before, {
+        cache: "off",
+        providerConfig: {
+          mode: "openai-compat",
+          model: "llama3.1",
+          baseUrl: "http://localhost:11434/v1",
+        },
+        providerClient: {
+          async complete(req) {
+            const body = JSON.parse(req.user) as {
+              task?: string;
+              communities: Array<{ community_id: string; top_label: string }>;
+            };
+            if (body.task === "community-labels") {
+              return JSON.stringify({
+                labels: body.communities.map((community) => ({
+                  community_id: community.community_id,
+                  label: community.top_label.startsWith("auth") ? "Auth Flow" : "Cache Ops",
+                })),
+              });
+            }
+            return JSON.stringify({
+              summaries: body.communities.map((community) => ({
+                community_id: community.community_id,
+                summary: `Narrative for ${community.top_label}`,
+              })),
+            });
+          },
+        },
+      });
       await before.close();
 
       const first = runMemory(["communities", "--root", root, "--json"]);
@@ -140,6 +171,7 @@ describe("memory communities CLI", () => {
         cache_key: string;
         communities: Array<{
           id: string;
+          short_label: string | null;
           count: number;
           total_degree: number;
           avg_centrality: number;
@@ -191,6 +223,10 @@ describe("memory communities CLI", () => {
       expect(firstBody.graph_hash).toMatch(/^[a-f0-9]{64}$/);
       expect(firstBody.cache_key).toContain("cache:communities:v3:");
       expect(firstBody.communities).toHaveLength(2);
+      expect(firstBody.communities.map((c) => c.short_label).sort()).toEqual([
+        "Auth Flow",
+        "Cache Ops",
+      ]);
       expect(firstBody.assignments).toHaveLength(6);
       expect(firstBody.node_analytics).toHaveLength(6);
       expect(firstBody.inter_community_edges).toHaveLength(1);
@@ -229,7 +265,8 @@ describe("memory communities CLI", () => {
 
       const toon = runMemory(["communities", "--root", root, "--no-cache"]);
       expect(toon.status).toBe(0);
-      expect(toon.stdout).toContain("communities[2]{id,count,cohesion_score");
+      expect(toon.stdout).toContain("communities[2]{id,label,count,cohesion_score");
+      expect(toon.stdout).toContain("Auth Flow");
       expect(toon.stdout).toContain("bridge_nodes[5]{rid,label");
       expect(toon.stdout).toContain("summary:");
 
@@ -240,6 +277,7 @@ describe("memory communities CLI", () => {
       expect(viewer.stdout).toContain("contract: memory.communities.v1");
       const html = await readFile(out, "utf8");
       expect(html).toContain("Graph Communities");
+      expect(html).toContain("Auth Flow");
       expect(html).toContain("auth login flow");
       expect(html).toContain("cohesion 0.375");
       expect(html).toContain("Bridge Nodes");

--- a/apps/memory/tests/community-digest-cli.test.ts
+++ b/apps/memory/tests/community-digest-cli.test.ts
@@ -90,9 +90,19 @@ interface DigestBody {
     error?: string;
   };
   community_count: number;
-  digests: Array<{
+    digests: Array<{
     community_id: string;
     size: number;
+    short_label: string | null;
+    label_provenance: {
+      source: "provider" | "deterministic" | "cached";
+      provider: {
+        mode: string | null;
+        model: string | null;
+      };
+      membership_hash: string;
+      generated_at: string;
+    } | null;
     top_label: string;
     top_node_type: string;
     top_engineering_code: string | null;
@@ -101,6 +111,18 @@ interface DigestBody {
     engineering_codes: Array<{ value: string; count: number }>;
     narrative_summary: string | null;
   }>;
+  summary: {
+    labeling: {
+      generated: number;
+      reused: number;
+      token_cost: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+        estimated: boolean;
+      };
+    };
+  };
 }
 
 describe("memory community-digest CLI", () => {
@@ -287,7 +309,8 @@ describe("memory community-digest CLI", () => {
           `^cache:community-digest:${first.graph_hash}:codes:[a-f0-9]{12}:provider:openai-compat:llama3\\.1$`,
         ),
       );
-      expect(calls).toHaveLength(1);
+      expect(calls.filter((call) => JSON.parse(call.user).task === "community-labels")).toHaveLength(1);
+      expect(calls.filter((call) => JSON.parse(call.user).task !== "community-labels")).toHaveLength(1);
       expect(first.digests).toHaveLength(2);
       expect(first.digests.every((digest) => digest.narrative_summary)).toBe(true);
 
@@ -301,7 +324,105 @@ describe("memory community-digest CLI", () => {
       expect(second.graph_hash).toBe(first.graph_hash);
       expect(second.generated_at).toBe(first.generated_at);
       expect(second.digests).toEqual(first.digests);
-      expect(calls).toHaveLength(1);
+      expect(calls).toHaveLength(2);
+      await store.close();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "provider labeling persists short labels, reuses unchanged memberships, and regenerates changed communities",
+    async () => {
+      const root = await initRoot();
+      await seedTwoCommunities(root);
+      const calls: ProviderRequest[] = [];
+      const providerClient = {
+        async complete(req: ProviderRequest): Promise<string> {
+          calls.push(req);
+          const body = JSON.parse(req.user) as {
+            task: string;
+            communities: Array<{ community_id: string; top_label: string; members: Array<{ label: string }> }>;
+          };
+          if (body.task === "community-labels") {
+            return JSON.stringify({
+              labels: body.communities.map((community) => ({
+                community_id: community.community_id,
+                label: community.members.some((member) => member.label === "auth-metrics")
+                  ? "Auth Metrics"
+                  : community.top_label.startsWith("auth")
+                    ? "Auth Flow"
+                    : "Cache Ops",
+              })),
+            });
+          }
+          return JSON.stringify({
+            summaries: body.communities.map((community) => ({
+              community_id: community.community_id,
+              summary: `Narrative for ${community.top_label}`,
+            })),
+          });
+        },
+      };
+      const providerConfig = {
+        mode: "openai-compat" as const,
+        model: "llama3.1",
+        baseUrl: "http://localhost:11434/v1",
+      };
+      const store = await openStore(root);
+      const first = await buildCommunityDigest(store, {
+        cache: "off",
+        providerConfig,
+        providerClient,
+        now: new Date("2026-01-01T00:00:00.000Z"),
+      });
+      expect(first.digests.map((digest) => digest.short_label).sort()).toEqual([
+        "Auth Flow",
+        "Cache Ops",
+      ]);
+      expect(first.digests.every((digest) => digest.label_provenance?.source === "provider")).toBe(true);
+      expect(first.summary.labeling).toMatchObject({
+        generated: 2,
+        reused: 0,
+        token_cost: { estimated: true },
+      });
+      expect(first.summary.labeling.token_cost.total_tokens).toBeGreaterThan(0);
+      expect(calls.filter((call) => JSON.parse(call.user).task === "community-labels")).toHaveLength(1);
+
+      const second = await buildCommunityDigest(store, {
+        cache: "off",
+        providerConfig,
+        providerClient,
+        now: new Date("2026-02-02T00:00:00.000Z"),
+      });
+      expect(second.digests.map((digest) => digest.short_label).sort()).toEqual([
+        "Auth Flow",
+        "Cache Ops",
+      ]);
+      expect(second.summary.labeling).toMatchObject({
+        generated: 0,
+        reused: 2,
+      });
+      expect(calls.filter((call) => JSON.parse(call.user).task === "community-labels")).toHaveLength(1);
+
+      const target = (await store.listNodes()).find((node) => node.label === "auth-login");
+      expect(target).toBeDefined();
+      const newRid = await store.upsertNode({
+        label: "auth-metrics",
+        node_type: "concept",
+        properties: { title: "auth metrics", content: "auth metrics" },
+      });
+      await store.upsertEdge({ label: "REFERENCES", from_rid: newRid, to_rid: target!.rid });
+
+      const third = await buildCommunityDigest(store, {
+        cache: "off",
+        providerConfig,
+        providerClient,
+        now: new Date("2026-03-03T00:00:00.000Z"),
+      });
+      expect(third.digests.some((digest) => digest.short_label === "Auth Metrics")).toBe(true);
+      expect(third.summary.labeling.generated).toBeGreaterThanOrEqual(1);
+      expect(third.summary.labeling.reused).toBeGreaterThanOrEqual(1);
+      expect(calls.filter((call) => JSON.parse(call.user).task === "community-labels")).toHaveLength(2);
       await store.close();
     },
     TIMEOUT,


### PR DESCRIPTION
Automated AFK landing for #1435. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1435

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786318073&installation_id=129708444&pr_number=1455&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1455&signature=4d50fee66b7bc35d4ee40bd0dcb1dd2139bda406082dd21645e792694453c9ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->