### PR TITLE
fix: #1436 Suggested questions generated from graph structure

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -33,6 +33,7 @@ import type { CommunityAnalyticsReport } from "./communities.js";
 import { buildCommunitiesViewerArtifact } from "./communities-viewer.js";
 import type { CommunityDigestReport } from "./community-digest.js";
 import type { HubReport, HubRankBy, HubReportRow } from "./hub-report.js";
+import type { SuggestedQuestionsReport } from "./suggested-questions.js";
 import type { MemoryGlobalSearchReport } from "./global-search.js";
 import { buildContextPack, type ContextPack } from "./context-pack.js";
 import { buildContextPackViewerArtifact } from "./context-pack-viewer.js";
@@ -476,6 +477,7 @@ Usage:
   memory communities                [--root <dir>] [--no-cache] [--json]
   memory communities-viewer         [--root <dir>] [--no-cache] [--out <file>]
   memory community-digest           [--root <dir>] [--no-cache] [--json]
+  memory suggested-questions        [--root <dir>] [--limit N] [--json]
   memory global-search <query...>   [--root <dir>] [--limit N] [--no-cache] [--json]
   memory structural-impact          [--root <dir>] [--file <path>] [--symbol <name>]
   memory structural-impact-viewer   [--root <dir>] [--file <path>] [--symbol <name>] [--out <file>]
@@ -7250,6 +7252,26 @@ async function runHubReport(args: ParsedArgs): Promise<void> {
   }
 }
 
+async function runSuggestedQuestions(args: ParsedArgs): Promise<void> {
+  const { store, config } = await openGraphStore(args);
+  try {
+    const report = (await executeReadOnlyMemoryOperation(
+      "memory.suggested-questions",
+      { store, providerConfig: config.provider },
+      {
+        limit: intFlag(args.flags, "limit"),
+      },
+    )) as SuggestedQuestionsReport;
+    if (args.flags.json === true) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log(renderSuggestedQuestionsToon(report));
+  } finally {
+    await store.close();
+  }
+}
+
 function parseHubRankBy(value: string | undefined): HubRankBy {
   if (value == null) return "total";
   if (value === "total" || value === "in" || value === "out") return value;
@@ -7298,6 +7320,48 @@ function renderHubReportToon(report: HubReport, opts: { wide: boolean }): string
       schema_version: report.schema_version,
       graph_hash: report.graph_hash,
     },
+  });
+}
+
+function renderSuggestedQuestionsToon(report: SuggestedQuestionsReport): string {
+  const rows: Array<Record<string, any>> = report.questions.map((question) => ({
+    id: question.id,
+    signal_type: question.signal_type,
+    question: question.question,
+    rationale: question.rationale,
+    references: question.references.map((ref) => ({ ...ref })),
+  }));
+  return renderToonOutput({
+    rowsKey: "questions",
+    rows,
+    fields: [
+      "id",
+      "signal_type",
+      "question",
+      "rationale",
+      "references",
+    ],
+    summary: {
+      status: report.summary.status,
+      nodes: report.summary.nodes,
+      edges: report.summary.edges,
+      signals: report.summary.signals,
+      questions: report.summary.questions,
+      provider_status: report.provider.status,
+      provider_error: report.provider.error ?? null,
+      next: report.summary.next,
+    },
+    extra: {
+      schema_version: report.schema_version,
+      graph_hash: report.graph_hash,
+      signals: report.signals.map((signal) => ({
+        signal_id: signal.signal_id,
+        signal_type: signal.signal_type,
+        title: signal.title,
+        score: signal.score,
+        references: signal.references.map((ref) => ({ ...ref })),
+      })),
+    } as Record<string, any>,
   });
 }
 
@@ -8563,6 +8627,8 @@ async function main(): Promise<void> {
       return runCommunityDigest(args);
     case "hub-report":
       return runHubReport(args);
+    case "suggested-questions":
+      return runSuggestedQuestions(args);
     case "global-search":
       return runGlobalSearch(args);
     case "structural-impact":

--- a/apps/memory/src/operations.ts
+++ b/apps/memory/src/operations.ts
@@ -49,6 +49,12 @@ import {
   type HubReport,
 } from "./hub-report.js";
 import {
+  buildSuggestedQuestions,
+  type SuggestedQuestionReference,
+  type SuggestedQuestionSignalType,
+  type SuggestedQuestionsReport,
+} from "./suggested-questions.js";
+import {
   buildMemoryGlobalSearch,
   type MemoryGlobalSearchReport,
 } from "./global-search.js";
@@ -496,6 +502,11 @@ const HubReportInputSchema = z.object({
 });
 type HubReportInput = z.infer<typeof HubReportInputSchema>;
 
+const SuggestedQuestionsInputSchema = z.object({
+  limit: z.number().int().min(1).max(50).optional(),
+});
+type SuggestedQuestionsInput = z.infer<typeof SuggestedQuestionsInputSchema>;
+
 const DocSearchInputSchema = z.object({
   query: z.string().min(1),
   limit: z.number().int().min(1).max(50).optional(),
@@ -888,6 +899,68 @@ const HubReportOutputSchema = z.object({
   next: z.array(z.string()),
   hubs: z.array(HubReportRowSchema),
 }) satisfies z.ZodType<HubReport>;
+
+const SuggestedQuestionReferenceSchema = z.object({
+  kind: z.enum(["node", "edge", "community"]),
+  rid: z.number().optional(),
+  label: z.string().optional(),
+  title: z.string().optional(),
+  from_rid: z.number().optional(),
+  to_rid: z.number().optional(),
+  community_id: z.string().optional(),
+}) satisfies z.ZodType<SuggestedQuestionReference>;
+const SuggestedQuestionSignalTypeSchema = z.enum([
+  "hub",
+  "bridge",
+  "weak_community",
+  "inferred_edge",
+]) satisfies z.ZodType<SuggestedQuestionSignalType>;
+const SuggestedQuestionSignalSchema = z.object({
+  signal_id: z.string(),
+  signal_type: SuggestedQuestionSignalTypeSchema,
+  title: z.string(),
+  rationale: z.string(),
+  score: z.number(),
+  references: z.array(SuggestedQuestionReferenceSchema),
+});
+const SuggestedQuestionSchema = z.object({
+  id: z.string(),
+  signal_id: z.string(),
+  signal_type: SuggestedQuestionSignalTypeSchema,
+  question: z.string(),
+  rationale: z.string(),
+  references: z.array(SuggestedQuestionReferenceSchema),
+});
+const SuggestedQuestionsOutputSchema = z.object({
+  schema_version: z.literal("memory.suggested-questions.v1"),
+  read_only: z.literal(true),
+  graph_hash: z.string(),
+  generated_at: z.string(),
+  provider: z.object({
+    status: z.enum(["available", "unavailable"]),
+    mode: z
+      .union([
+        z.literal("openai-compat"),
+        z.literal("openai-native"),
+        z.literal("anthropic-native"),
+        z.literal("bedrock"),
+        z.null(),
+      ]),
+    model: z.string().nullable(),
+    egress: z.union([z.literal("local"), z.literal("external"), z.null()]),
+    error: z.string().optional(),
+  }),
+  summary: z.object({
+    status: z.enum(["empty_graph", "no_notable_signals", "provider_unavailable", "ready"]),
+    nodes: z.number(),
+    edges: z.number(),
+    signals: z.number(),
+    questions: z.number(),
+    next: z.array(z.string()),
+  }),
+  signals: z.array(SuggestedQuestionSignalSchema),
+  questions: z.array(SuggestedQuestionSchema),
+}) satisfies z.ZodType<SuggestedQuestionsReport>;
 
 const CommunityDigestCountSchema = z.object({
   value: z.string(),
@@ -1408,6 +1481,11 @@ const MEMORY_OPERATION_FACETS: Record<string, MemoryOperationFacets> = {
       flagField("limit", "number"),
       flagField("rank_by", "string"),
     ]),
+    JSON_REPORT_OUTPUT,
+  ),
+  ...operationFacets(
+    ["memory.suggested-questions"],
+    inputBinding([flagField("limit", "number")]),
     JSON_REPORT_OUTPUT,
   ),
   ...operationFacets(
@@ -3073,6 +3151,35 @@ const HUB_REPORT_OPERATION: MemoryOperationDefinition<HubReportInput, HubReport>
     buildHubReport(ctx.store, { limit: input.limit, rankBy: input.rank_by as HubRankBy }),
 };
 
+const SUGGESTED_QUESTIONS_OPERATION: MemoryOperationDefinition<
+  SuggestedQuestionsInput,
+  SuggestedQuestionsReport
+> = {
+  id: "memory.suggested-questions",
+  title: "Memory suggested questions",
+  description:
+    "Read-only graph-structure question suggestions grounded in hubs, bridges, weak communities, and inferred edges.",
+  inputSchema: SuggestedQuestionsInputSchema,
+  outputSchema: SuggestedQuestionsOutputSchema,
+  safetyClass: "read-only",
+  sideEffectClass: "none",
+  capabilities: ["graph-store"],
+  renderer: {
+    cli: { command: "suggested-questions", supportsJson: true },
+    mcp: {
+      toolName: "memory_suggested_questions",
+      description:
+        "Read-only Memory graph suggested-question report: deterministic structural signal selection over hubs, cross-community bridges, weak-cohesion communities, and high-confidence INFERRED edges; provider phrasing produces questions that retain graph references.",
+    },
+  },
+  execute: (ctx, input) =>
+    buildSuggestedQuestions(ctx.store, {
+      limit: input.limit,
+      providerConfig: ctx.providerConfig,
+      now: ctx.now ? new Date(ctx.now) : undefined,
+    }),
+};
+
 const GLOBAL_SEARCH_OPERATION: MemoryOperationDefinition<
   GlobalSearchInput,
   MemoryGlobalSearchReport
@@ -3715,6 +3822,7 @@ const READ_ONLY_OPERATIONS = createReadOnlyMemoryOperationRegistry([
   COMMUNITIES_VIEWER_OPERATION,
   COMMUNITY_DIGEST_OPERATION,
   HUB_REPORT_OPERATION,
+  SUGGESTED_QUESTIONS_OPERATION,
   GLOBAL_SEARCH_OPERATION,
   RECALL_RANKING_OPERATION,
   REFERENCE_RADAR_OPERATION,

--- a/apps/memory/src/suggested-questions.ts
+++ b/apps/memory/src/suggested-questions.ts
@@ -1,0 +1,578 @@
+import { graphStateHash } from "./communities.js";
+import {
+  type AiProviderConfig,
+  type Egress,
+  type ProviderClient,
+  type ProviderMode,
+  resolveProvider,
+} from "./extract-conversation.js";
+import type { MemoryStore, StoredNode } from "./graph-store.js";
+import { redDbProviderClient } from "./provider-client.js";
+
+export type SuggestedQuestionSignalType =
+  | "hub"
+  | "bridge"
+  | "weak_community"
+  | "inferred_edge";
+
+export interface SuggestedQuestionReference {
+  kind: "node" | "edge" | "community";
+  rid?: number;
+  label?: string;
+  title?: string;
+  from_rid?: number;
+  to_rid?: number;
+  community_id?: string;
+}
+
+export interface SuggestedQuestionSignal {
+  signal_id: string;
+  signal_type: SuggestedQuestionSignalType;
+  title: string;
+  rationale: string;
+  score: number;
+  references: SuggestedQuestionReference[];
+}
+
+export interface SuggestedQuestion {
+  id: string;
+  signal_id: string;
+  signal_type: SuggestedQuestionSignalType;
+  question: string;
+  rationale: string;
+  references: SuggestedQuestionReference[];
+}
+
+export interface SuggestedQuestionsProviderStatus {
+  status: "available" | "unavailable";
+  mode: ProviderMode | null;
+  model: string | null;
+  egress: Egress | null;
+  error?: string;
+}
+
+export interface SuggestedQuestionsReport {
+  schema_version: "memory.suggested-questions.v1";
+  read_only: true;
+  graph_hash: string;
+  generated_at: string;
+  provider: SuggestedQuestionsProviderStatus;
+  summary: {
+    status: "empty_graph" | "no_notable_signals" | "provider_unavailable" | "ready";
+    nodes: number;
+    edges: number;
+    signals: number;
+    questions: number;
+    next: string[];
+  };
+  signals: SuggestedQuestionSignal[];
+  questions: SuggestedQuestion[];
+}
+
+export interface SuggestedQuestionsOptions {
+  limit?: number;
+  now?: Date;
+  providerConfig?: AiProviderConfig;
+  providerClient?: ProviderClient;
+}
+
+interface NormalizedEdge {
+  from: number;
+  to: number;
+  label: string;
+  seal: string;
+  weight: number;
+  confidence: number | null;
+}
+
+interface DegreeStats {
+  total: number;
+  in: number;
+  out: number;
+}
+
+interface CommunityStats {
+  community_id: string;
+  members: StoredNode[];
+  internal_weight: number;
+  external_weight: number;
+  cohesion: number;
+}
+
+const DEFAULT_LIMIT = 12;
+const NEXT_STEPS = [
+  "memory hub-report --json",
+  "memory communities --json",
+  "memory path-explain <from> <to>",
+];
+
+export async function buildSuggestedQuestions(
+  store: MemoryStore,
+  opts: SuggestedQuestionsOptions = {},
+): Promise<SuggestedQuestionsReport> {
+  const limit = clampLimit(opts.limit);
+  const provider = resolveProviderStatus(opts.providerConfig);
+  const [nodes, rawEdges, assignments] = await Promise.all([
+    store.listNodes(),
+    store.listEdges(),
+    store.communities(),
+  ]);
+  const edges = rawEdges.map(normalizeEdge).filter((edge): edge is NormalizedEdge => edge != null);
+  const graphHash = graphStateHash(nodes, rawEdges);
+  const signals = selectSignals(nodes, edges, assignments).slice(0, limit);
+  let finalProvider = provider;
+  let questions: SuggestedQuestion[] = [];
+
+  if (signals.length > 0 && provider.status === "available" && opts.providerConfig) {
+    const client = opts.providerClient ?? redDbProviderClient(store, opts.providerConfig);
+    const phrased = await phraseQuestions(client, signals);
+    if (phrased.error) {
+      finalProvider = { ...provider, status: "unavailable", error: phrased.error };
+    } else {
+      questions = phrased.questions.slice(0, limit);
+    }
+  }
+
+  return {
+    schema_version: "memory.suggested-questions.v1",
+    read_only: true,
+    graph_hash: graphHash,
+    generated_at: (opts.now ?? new Date()).toISOString(),
+    provider: finalProvider,
+    summary: {
+      status: summaryStatus(nodes.length, signals.length, finalProvider, questions.length),
+      nodes: nodes.length,
+      edges: rawEdges.length,
+      signals: signals.length,
+      questions: questions.length,
+      next: NEXT_STEPS,
+    },
+    signals,
+    questions,
+  };
+}
+
+function selectSignals(
+  nodes: StoredNode[],
+  edges: NormalizedEdge[],
+  assignments: Map<number, string>,
+): SuggestedQuestionSignal[] {
+  const nodeByRid = new Map(nodes.map((node) => [node.rid, node]));
+  const degreeByRid = degreeStats(nodes, edges);
+  const signals: SuggestedQuestionSignal[] = [
+    ...hubSignals(nodes, degreeByRid, assignments),
+    ...bridgeSignals(edges, nodeByRid, assignments),
+    ...weakCommunitySignals(nodes, edges, assignments),
+    ...inferredEdgeSignals(edges, nodeByRid, assignments),
+  ];
+  return signals.sort(compareSignals);
+}
+
+function hubSignals(
+  nodes: StoredNode[],
+  degreeByRid: Map<number, DegreeStats>,
+  assignments: Map<number, string>,
+): SuggestedQuestionSignal[] {
+  return nodes
+    .map((node) => ({ node, stats: degreeByRid.get(node.rid) ?? { total: 0, in: 0, out: 0 } }))
+    .filter(({ stats }) => stats.total >= 3)
+    .map(({ node, stats }) => ({
+      signal_id: `hub:${node.rid}`,
+      signal_type: "hub" as const,
+      title: nodeTitle(node),
+      rationale: `${node.label} is connected to ${stats.total} graph edge(s).`,
+      score: stats.total,
+      references: [
+        nodeRef(node),
+        ...(assignments.has(node.rid)
+          ? [{ kind: "community" as const, community_id: assignments.get(node.rid) }]
+          : []),
+      ],
+    }));
+}
+
+function bridgeSignals(
+  edges: NormalizedEdge[],
+  nodeByRid: Map<number, StoredNode>,
+  assignments: Map<number, string>,
+): SuggestedQuestionSignal[] {
+  return edges
+    .map<SuggestedQuestionSignal | null>((edge) => {
+      const fromCommunity = assignments.get(edge.from);
+      const toCommunity = assignments.get(edge.to);
+      if (!fromCommunity || !toCommunity || fromCommunity === toCommunity) return null;
+      const from = nodeByRid.get(edge.from);
+      const to = nodeByRid.get(edge.to);
+      if (!from || !to) return null;
+      return {
+        signal_id: `bridge:${edge.from}->${edge.to}:${edge.label}`,
+        signal_type: "bridge" as const,
+        title: `${from.label} -> ${to.label}`,
+        rationale: `${edge.label} links community ${fromCommunity} to ${toCommunity}.`,
+        score: edge.weight,
+        references: [
+          edgeRef(edge),
+          nodeRef(from),
+          nodeRef(to),
+          { kind: "community" as const, community_id: fromCommunity },
+          { kind: "community" as const, community_id: toCommunity },
+        ],
+      };
+    })
+    .filter((signal): signal is SuggestedQuestionSignal => signal != null);
+}
+
+function weakCommunitySignals(
+  nodes: StoredNode[],
+  edges: NormalizedEdge[],
+  assignments: Map<number, string>,
+): SuggestedQuestionSignal[] {
+  return communityStats(nodes, edges, assignments)
+    .filter((community) => {
+      const total = community.internal_weight + community.external_weight;
+      return community.members.length >= 2 && total > 0 && community.cohesion < 0.5;
+    })
+    .map((community) => ({
+      signal_id: `weak-community:${community.community_id}`,
+      signal_type: "weak_community" as const,
+      title: community.community_id,
+      rationale: `Community ${community.community_id} has cohesion ${round3(community.cohesion)} with ${community.external_weight} external edge weight.`,
+      score: 1 - community.cohesion,
+      references: [
+        { kind: "community" as const, community_id: community.community_id },
+        ...community.members.slice(0, 5).map(nodeRef),
+      ],
+    }));
+}
+
+function inferredEdgeSignals(
+  edges: NormalizedEdge[],
+  nodeByRid: Map<number, StoredNode>,
+  assignments: Map<number, string>,
+): SuggestedQuestionSignal[] {
+  return edges
+    .filter((edge) => edge.seal === "INFERRED" && (edge.confidence == null || edge.confidence >= 0.75))
+    .map<SuggestedQuestionSignal | null>((edge) => {
+      const from = nodeByRid.get(edge.from);
+      const to = nodeByRid.get(edge.to);
+      if (!from || !to) return null;
+      return {
+        signal_id: `inferred-edge:${edge.from}->${edge.to}:${edge.label}`,
+        signal_type: "inferred_edge" as const,
+        title: `${from.label} -> ${to.label}`,
+        rationale: `${edge.label} is marked INFERRED${edge.confidence == null ? "" : ` with confidence ${edge.confidence}`}.`,
+        score: edge.confidence ?? 0.75,
+        references: [
+          edgeRef(edge),
+          nodeRef(from),
+          nodeRef(to),
+          ...(assignments.has(edge.from)
+            ? [{ kind: "community" as const, community_id: assignments.get(edge.from) }]
+            : []),
+          ...(assignments.has(edge.to)
+            ? [{ kind: "community" as const, community_id: assignments.get(edge.to) }]
+            : []),
+        ],
+      };
+    })
+    .filter((signal): signal is SuggestedQuestionSignal => signal != null);
+}
+
+async function phraseQuestions(
+  client: ProviderClient,
+  signals: SuggestedQuestionSignal[],
+): Promise<{ questions: SuggestedQuestion[]; error?: undefined } | { questions: []; error: string }> {
+  try {
+    const raw = await client.complete({
+      system: [
+        "You write concise questions for an engineering agent exploring a Memory graph.",
+        "Return ONLY JSON of the form:",
+        '{ "questions": [ { "signal_id": string, "question": string } ] }',
+        "Use the supplied graph references. Do not invent new evidence.",
+      ].join("\n"),
+      user: JSON.stringify({
+        task: "suggested-questions",
+        signals: signals.map((signal) => ({
+          signal_id: signal.signal_id,
+          signal_type: signal.signal_type,
+          title: signal.title,
+          rationale: signal.rationale,
+          references: signal.references,
+        })),
+      }),
+    });
+    return { questions: applyProviderQuestions(raw, signals) };
+  } catch (err) {
+    return { questions: [], error: `question phrasing failed: ${errorMessage(err)}` };
+  }
+}
+
+function applyProviderQuestions(raw: string, signals: SuggestedQuestionSignal[]): SuggestedQuestion[] {
+  const parsed = parseJson(raw);
+  if (!parsed || !Array.isArray(parsed.questions)) return [];
+  const signalById = new Map(signals.map((signal) => [signal.signal_id, signal]));
+  const seen = new Set<string>();
+  const questions: SuggestedQuestion[] = [];
+  for (const item of parsed.questions) {
+    if (!item || typeof item !== "object") continue;
+    const signalId = stringValue((item as Record<string, unknown>).signal_id);
+    const question = sanitizeQuestion(stringValue((item as Record<string, unknown>).question));
+    const signal = signalId ? signalById.get(signalId) : undefined;
+    if (!signal || !question || seen.has(signal.signal_id)) continue;
+    seen.add(signal.signal_id);
+    questions.push({
+      id: `question:${signal.signal_id}`,
+      signal_id: signal.signal_id,
+      signal_type: signal.signal_type,
+      question,
+      rationale: signal.rationale,
+      references: signal.references,
+    });
+  }
+  return questions;
+}
+
+function degreeStats(nodes: StoredNode[], edges: NormalizedEdge[]): Map<number, DegreeStats> {
+  const map = new Map<number, DegreeStats>();
+  for (const node of nodes) {
+    map.set(node.rid, { total: 0, in: 0, out: 0 });
+  }
+  for (const edge of edges) {
+    const from = map.get(edge.from);
+    const to = map.get(edge.to);
+    if (!from || !to) continue;
+    from.total += 1;
+    from.out += 1;
+    to.total += 1;
+    to.in += 1;
+  }
+  return map;
+}
+
+function communityStats(
+  nodes: StoredNode[],
+  edges: NormalizedEdge[],
+  assignments: Map<number, string>,
+): CommunityStats[] {
+  const groups = new Map<string, StoredNode[]>();
+  for (const node of nodes) {
+    const communityId = assignments.get(node.rid);
+    if (!communityId) continue;
+    const group = groups.get(communityId) ?? [];
+    group.push(node);
+    groups.set(communityId, group);
+  }
+  const weights = new Map<string, { internal: number; external: number }>();
+  for (const communityId of groups.keys()) {
+    weights.set(communityId, { internal: 0, external: 0 });
+  }
+  for (const edge of edges) {
+    const fromCommunity = assignments.get(edge.from);
+    const toCommunity = assignments.get(edge.to);
+    if (!fromCommunity || !toCommunity) continue;
+    if (fromCommunity === toCommunity) {
+      const current = weights.get(fromCommunity);
+      if (current) current.internal += edge.weight;
+    } else {
+      const from = weights.get(fromCommunity);
+      const to = weights.get(toCommunity);
+      if (from) from.external += edge.weight;
+      if (to) to.external += edge.weight;
+    }
+  }
+  return [...groups.entries()]
+    .map(([community_id, members]) => {
+      const weight = weights.get(community_id) ?? { internal: 0, external: 0 };
+      const total = weight.internal + weight.external;
+      return {
+        community_id,
+        members: members.slice().sort((a, b) => a.label.localeCompare(b.label)),
+        internal_weight: round3(weight.internal),
+        external_weight: round3(weight.external),
+        cohesion: total === 0 ? 0 : round3(weight.internal / total),
+      };
+    })
+    .sort(
+      (a, b) =>
+        a.cohesion - b.cohesion ||
+        b.external_weight - a.external_weight ||
+        a.community_id.localeCompare(b.community_id),
+    );
+}
+
+function normalizeEdge(edge: Record<string, unknown>): NormalizedEdge | null {
+  const from = edgeEndpoint(edge, "from");
+  const to = edgeEndpoint(edge, "to");
+  if (!Number.isFinite(from) || !Number.isFinite(to) || from <= 0 || to <= 0) return null;
+  return {
+    from,
+    to,
+    label: String(edge.label ?? edge.LABEL ?? ""),
+    seal: edgeSeal(edge),
+    weight: edgeWeight(edge),
+    confidence: numberValue(propertyValue(edge, "confidence_score") ?? propertyValue(edge, "score")),
+  };
+}
+
+function edgeEndpoint(edge: Record<string, unknown>, side: "from" | "to"): number {
+  const value =
+    side === "from"
+      ? edge.from ?? edge.from_id ?? edge.from_rid ?? edge.source ?? edge.FROM
+      : edge.to ?? edge.to_id ?? edge.to_rid ?? edge.target ?? edge.TO;
+  return Number(value ?? 0);
+}
+
+function edgeWeight(edge: Record<string, unknown>): number {
+  const weight = Number(edge.weight ?? edge.WEIGHT ?? propertyValue(edge, "weight") ?? 1);
+  return Number.isFinite(weight) && weight > 0 ? weight : 1;
+}
+
+function edgeSeal(edge: Record<string, unknown>): string {
+  const value =
+    edge.seal ??
+    edge.audit_seal ??
+    edge.confidence ??
+    propertyValue(edge, "seal") ??
+    propertyValue(edge, "audit_seal") ??
+    propertyValue(edge, "confidence") ??
+    edge.label ??
+    edge.LABEL;
+  return String(value ?? "unsealed").toUpperCase();
+}
+
+function propertyValue(edge: Record<string, unknown>, key: string): unknown {
+  const properties = isRecord(edge.properties)
+    ? edge.properties
+    : isRecord(edge.PROPERTIES)
+      ? edge.PROPERTIES
+      : {};
+  return properties[key];
+}
+
+function nodeRef(node: StoredNode): SuggestedQuestionReference {
+  return {
+    kind: "node",
+    rid: node.rid,
+    label: node.label,
+    title: nodeTitle(node),
+  };
+}
+
+function edgeRef(edge: NormalizedEdge): SuggestedQuestionReference {
+  return {
+    kind: "edge",
+    label: edge.label,
+    from_rid: edge.from,
+    to_rid: edge.to,
+  };
+}
+
+function nodeTitle(node: StoredNode): string {
+  return node.properties.title ?? node.label;
+}
+
+function compareSignals(a: SuggestedQuestionSignal, b: SuggestedQuestionSignal): number {
+  return (
+    signalRank(a.signal_type) - signalRank(b.signal_type) ||
+    b.score - a.score ||
+    a.title.localeCompare(b.title) ||
+    a.signal_id.localeCompare(b.signal_id)
+  );
+}
+
+function signalRank(type: SuggestedQuestionSignalType): number {
+  switch (type) {
+    case "hub":
+      return 0;
+    case "bridge":
+      return 1;
+    case "weak_community":
+      return 2;
+    case "inferred_edge":
+      return 3;
+  }
+}
+
+function resolveProviderStatus(config: AiProviderConfig | undefined): SuggestedQuestionsProviderStatus {
+  if (!config) {
+    return {
+      status: "unavailable",
+      mode: null,
+      model: null,
+      egress: null,
+      error: "no AI provider configured for suggested questions",
+    };
+  }
+  try {
+    const provider = resolveProvider(config);
+    return {
+      status: "available",
+      mode: provider.mode,
+      model: provider.model,
+      egress: provider.egress,
+    };
+  } catch (err) {
+    return {
+      status: "unavailable",
+      mode: null,
+      model: null,
+      egress: null,
+      error: errorMessage(err),
+    };
+  }
+}
+
+function summaryStatus(
+  nodeCount: number,
+  signalCount: number,
+  provider: SuggestedQuestionsProviderStatus,
+  questionCount: number,
+): SuggestedQuestionsReport["summary"]["status"] {
+  if (nodeCount === 0) return "empty_graph";
+  if (signalCount === 0) return "no_notable_signals";
+  if (provider.status !== "available" || questionCount === 0) return "provider_unavailable";
+  return "ready";
+}
+
+function sanitizeQuestion(value: string | null): string | null {
+  if (!value) return null;
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (!trimmed) return null;
+  return trimmed.endsWith("?") ? trimmed : `${trimmed}?`;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function parseJson(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit == null) return DEFAULT_LIMIT;
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(50, Math.trunc(limit)));
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1_000) / 1_000;
+}

--- a/apps/memory/tests/operations-registry.test.ts
+++ b/apps/memory/tests/operations-registry.test.ts
@@ -72,6 +72,31 @@ describe("read-only Memory operations registry", () => {
     });
   });
 
+  test("declares contract metadata for the suggested questions operation", () => {
+    const operation = getReadOnlyMemoryOperation("memory.suggested-questions");
+
+    expect(operation).toMatchObject({
+      id: "memory.suggested-questions",
+      safetyClass: "read-only",
+      sideEffectClass: "none",
+      capabilities: ["graph-store"],
+      renderer: {
+        cli: { command: "suggested-questions", supportsJson: true },
+        mcp: { toolName: "memory_suggested_questions" },
+      },
+      inputBinding: {
+        fields: [
+          {
+            field: "limit",
+            sources: ["flag", "query"],
+            type: "number",
+          },
+        ],
+      },
+      outputKind: { kind: "report", format: "json" },
+    });
+  });
+
   test("declares read-only contracts for agent-native readiness and trust operations", () => {
     const operations = listReadOnlyMemoryOperations();
 
@@ -157,6 +182,7 @@ describe("read-only Memory operations registry", () => {
         "memory.smart-search-viewer",
         "memory.structural-impact",
         "memory.structural-impact-viewer",
+        "memory.suggested-questions",
         "memory.vector-search",
         "memory.vector-status",
         "memory.vector-status-viewer",
@@ -245,6 +271,7 @@ describe("read-only Memory operations registry", () => {
         "memory_smart_search_viewer",
         "memory_structural_impact",
         "memory_structural_impact_viewer",
+        "memory_suggested_questions",
         "memory_vector_search",
         "memory_vector_status",
         "memory_vector_status_viewer",

--- a/apps/memory/tests/suggested-questions-cli.test.ts
+++ b/apps/memory/tests/suggested-questions-cli.test.ts
@@ -1,0 +1,199 @@
+import { decode } from "@reddb-io/toon";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { MemoryStore } from "../src/graph-store.js";
+import { initGraph } from "../src/init.js";
+import { getReadOnlyMemoryOperation } from "../src/operations.js";
+import { buildSuggestedQuestions } from "../src/suggested-questions.js";
+
+const TIMEOUT = 40_000;
+const pkgRoot = resolve(__dirname, "..");
+const roots: string[] = [];
+const stores: MemoryStore[] = [];
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((s) => s.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+function runMemory(args: string[]) {
+  return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    cwd: pkgRoot,
+    encoding: "utf8",
+    timeout: TIMEOUT,
+  });
+}
+
+async function initRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "memory-suggested-questions-cli-"));
+  roots.push(root);
+  await initGraph(root);
+  return root;
+}
+
+async function openStore(root: string): Promise<MemoryStore> {
+  const store = await MemoryStore.open({
+    uri: `file://${join(root, ".red/memory/graph.rdb")}`,
+    project: "test",
+  });
+  stores.push(store);
+  return store;
+}
+
+async function seedQuestionTopology(root: string): Promise<MemoryStore> {
+  const store = await openStore(root);
+  const mk = (label: string, title: string) =>
+    store.upsertNode({
+      label,
+      node_type: "concept",
+      properties: { title, content: title },
+    });
+  const [
+    authHub,
+    login,
+    token,
+    session,
+    billingHub,
+    invoice,
+    payment,
+    rollout,
+  ] = await Promise.all([
+    mk("auth-hub", "auth hub"),
+    mk("login-flow", "login flow"),
+    mk("token-rotation", "token rotation"),
+    mk("session-policy", "session policy"),
+    mk("billing-hub", "billing hub"),
+    mk("invoice-sync", "invoice sync"),
+    mk("payment-state", "payment state"),
+    mk("rollout-plan", "rollout plan"),
+  ]);
+  const edge = (
+    from_rid: number,
+    to_rid: number,
+    seal: "EXTRACTED" | "INFERRED" = "EXTRACTED",
+    confidence_score?: number,
+  ) =>
+    store.upsertEdge({
+      label: "REFERENCES",
+      from_rid,
+      to_rid,
+      properties: { seal, ...(confidence_score == null ? {} : { confidence_score }) },
+    });
+  await edge(login, authHub);
+  await edge(token, authHub, "INFERRED", 0.91);
+  await edge(authHub, session);
+  await edge(session, login);
+  await edge(invoice, billingHub);
+  await edge(payment, billingHub);
+  await edge(billingHub, invoice);
+  await edge(payment, invoice);
+  await edge(authHub, billingHub);
+  await edge(session, billingHub);
+  await edge(rollout, authHub);
+  await edge(rollout, billingHub);
+  return store;
+}
+
+describe("memory suggested-questions", () => {
+  test(
+    "phrases deterministic graph signals through the provider and keeps graph references",
+    async () => {
+      const root = await initRoot();
+      const store = await seedQuestionTopology(root);
+      const calls: Array<{ task?: string; signals: Array<{ signal_id: string; signal_type: string }> }> = [];
+      const providerClient = {
+        async complete(req: { user: string }) {
+          const body = JSON.parse(req.user) as {
+            task?: string;
+            signals: Array<{ signal_id: string; signal_type: string; title: string }>;
+          };
+          calls.push(body);
+          return JSON.stringify({
+            questions: body.signals.map((signal) => ({
+              signal_id: signal.signal_id,
+              question: `Fake ${signal.signal_type} question for ${signal.title}?`,
+            })),
+          });
+        },
+      };
+
+      const first = await buildSuggestedQuestions(store, {
+        now: new Date("2026-07-10T00:00:00.000Z"),
+        providerConfig: {
+          mode: "openai-compat",
+          model: "llama3.1",
+          baseUrl: "http://localhost:11434/v1",
+        },
+        providerClient,
+      });
+      const second = await buildSuggestedQuestions(store, {
+        now: new Date("2026-07-10T00:00:00.000Z"),
+        providerConfig: {
+          mode: "openai-compat",
+          model: "llama3.1",
+          baseUrl: "http://localhost:11434/v1",
+        },
+        providerClient,
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0].task).toBe("suggested-questions");
+      expect(calls[0].signals.map((signal) => signal.signal_id)).toEqual(
+        calls[1].signals.map((signal) => signal.signal_id),
+      );
+      expect(new Set(first.signals.map((signal) => signal.signal_type))).toEqual(
+        new Set(["hub", "bridge", "weak_community", "inferred_edge"]),
+      );
+      expect(first.questions.map((question) => question.signal_id)).toEqual(
+        second.questions.map((question) => question.signal_id),
+      );
+      expect(first.questions.length).toBe(first.signals.length);
+      expect(first.questions.every((question) => question.question.startsWith("Fake "))).toBe(true);
+      expect(first.questions.every((question) => question.references.length > 0)).toBe(true);
+      expect(first.questions.some((question) => question.references.some((ref) => ref.kind === "edge"))).toBe(true);
+      expect(first.summary.status).toBe("ready");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "registers the CLI surface and emits a definitive TOON empty state",
+    async () => {
+      const root = await initRoot();
+      expect(getReadOnlyMemoryOperation("memory.suggested-questions").renderer.cli).toMatchObject({
+        command: "suggested-questions",
+        supportsJson: true,
+      });
+
+      const result = runMemory(["suggested-questions", "--root", root]);
+      expect(result.status).toBe(0);
+      const body = decode(result.stdout) as {
+        schema_version: string;
+        questions: unknown[];
+        summary: {
+          status: string;
+          nodes: number;
+          edges: number;
+          signals: number;
+          questions: number;
+          next: string[];
+        };
+      };
+
+      expect(body.schema_version).toBe("memory.suggested-questions.v1");
+      expect(body.questions).toEqual([]);
+      expect(body.summary).toMatchObject({
+        status: "empty_graph",
+        nodes: 0,
+        edges: 0,
+        signals: 0,
+        questions: 0,
+      });
+      expect(body.summary.next).toContain("memory hub-report --json");
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
Automated AFK landing for #1436. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1436

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786319092&installation_id=129708444&pr_number=1456&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1456&signature=a00a1dccfb2ed2a3af1663ed97295c1f7604b925a25587b8f658f761cc8091f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->