### PR TITLE
fix: #1437 Answer-becomes-a-node: answered graph queries feed back as governed memories

### DIFF
--- a/apps/memory/src/governed-write.ts
+++ b/apps/memory/src/governed-write.ts
@@ -1,5 +1,5 @@
 import type { MemoryStore } from "./graph-store.js";
-import type { Confidence, MemoryProvenance } from "./schema.js";
+import type { Confidence, MemoryNode, MemoryProvenance } from "./schema.js";
 import { slugify } from "./store.js";
 import { createEvidenceCard, writeEvidenceCard } from "./evidence-card.js";
 
@@ -20,6 +20,24 @@ export interface MemoryStoreEvidenceInput {
   proposalPath?: string;
 }
 
+export interface AnsweredQuerySourceElement {
+  kind: "node" | "edge" | "community";
+  rid?: number;
+  label?: string;
+  title?: string;
+  from_rid?: number;
+  to_rid?: number;
+  community_id?: string;
+}
+
+export interface MemoryStoreAnsweredQueryInput {
+  question?: string;
+  answer?: string;
+  sourceElements?: AnsweredQuerySourceElement[];
+  observer?: string;
+  confidence?: Confidence;
+}
+
 export interface MemoryStoreEvidenceOptions {
   rootDir?: string;
   now?: Date;
@@ -27,7 +45,7 @@ export interface MemoryStoreEvidenceOptions {
 
 export interface GovernedWriteResult {
   schema_version: "memory.governed_write.v1";
-  operation: "memory_store_evidence";
+  operation: "memory_store_evidence" | "memory_store_answered_query";
   outcome: GovernedWriteOutcome;
   reason: string;
   policy: {
@@ -175,12 +193,101 @@ export async function memoryStoreEvidence(
   );
 }
 
+export async function memoryStoreAnsweredQuery(
+  store: MemoryStore,
+  input: MemoryStoreAnsweredQueryInput,
+): Promise<GovernedWriteResult> {
+  const normalized = normalizeAnsweredQueryInput(input);
+  const missing = [
+    ...(!normalized.question ? ["question"] : []),
+    ...(!normalized.answer ? ["answer"] : []),
+    ...(normalized.sourceElements.length === 0 ? ["sourceElements"] : []),
+    ...(!normalized.observer ? ["observer"] : []),
+  ];
+  const resultInput = answeredQueryResultInput(normalized);
+  if (missing.length > 0) {
+    return governedWriteResult(
+      "rejected",
+      `missing_required_fields:${missing.join(",")}`,
+      resultInput,
+      null,
+      { operation: "memory_store_answered_query", sourceKind: "derived" },
+    );
+  }
+
+  const existingRid = await store.findNodeByLabel(normalized.label, "answer");
+  if (existingRid != null) {
+    const existing = await store.getNode(existingRid);
+    if (existing) {
+      await removeOutgoingReferences(store, existingRid);
+      await store.deleteNode(existing);
+    }
+  }
+
+  const node: MemoryNode = {
+    label: normalized.label,
+    node_type: "answer",
+    properties: {
+      title: normalized.question,
+      summary: normalized.answer,
+      content: normalized.answer,
+      question: normalized.question,
+      answer: normalized.answer,
+      confidence: normalized.confidence,
+      seal: normalized.confidence,
+      source: normalized.sourceRef,
+      source_elements: normalized.sourceElements,
+      tags: ["answered-query", "graph-feedback"],
+      tier: "durable",
+      layer: "L3",
+      provenance_tier: "proxy",
+      provenance: {
+        source_kind: "derived",
+        writer: normalized.observer,
+        command: "memory store-answered-query",
+        confidence: normalized.confidence,
+        evidence: normalized.evidence,
+      },
+    },
+  };
+  const rid = await store.upsertNode(node);
+  for (const sourceRid of sourceNodeRids(normalized.sourceElements)) {
+    await store.upsertEdge({
+      label: "REFERENCES",
+      from_rid: rid,
+      to_rid: sourceRid,
+      properties: {
+        confidence: normalized.confidence,
+        source: normalized.sourceRef,
+        provenance_tier: "proxy",
+        provenance: {
+          source_kind: "derived",
+          writer: normalized.observer,
+          command: "memory store-answered-query",
+          confidence: normalized.confidence,
+          evidence: normalized.evidence,
+        },
+      },
+    });
+  }
+
+  return governedWriteResult(
+    "stored",
+    existingRid == null ? "answered_query_stored" : "answered_query_updated",
+    resultInput,
+    rid,
+    { operation: "memory_store_answered_query", sourceKind: "derived" },
+  );
+}
+
 function governedWriteResult(
   outcome: GovernedWriteOutcome,
   reason: string,
   input: MemoryStoreEvidenceInput,
   rid: number | null,
   extra: {
+    operation?: GovernedWriteResult["operation"];
+    sourceKind?: MemoryProvenance["source_kind"];
     risk?: GovernedWriteRisk;
     reviewArtifact?: GovernedWriteResult["review_artifact"];
   } = {},
@@ -189,7 +296,7 @@ function governedWriteResult(
   const risk = extra.risk ?? (outcome === "stored" ? "low" : "unknown");
   return {
     schema_version: "memory.governed_write.v1",
-    operation: "memory_store_evidence",
+    operation: extra.operation ?? "memory_store_evidence",
     outcome,
     reason,
     policy: {
@@ -198,7 +305,7 @@ function governedWriteResult(
       mode_required: outcome === "proposed" ? "evidence_review" : "graph",
     },
     provenance: {
-      source_kind: "manual",
+      source_kind: extra.sourceKind ?? "manual",
       writer: normalized.observer || null,
       evidence:
         normalized.sourceRef && normalized.citationExcerpt
@@ -213,6 +320,121 @@ function governedWriteResult(
     },
     review_artifact: extra.reviewArtifact ?? null,
   };
+}
+
+function normalizeAnsweredQueryInput(input: MemoryStoreAnsweredQueryInput): {
+  question: string;
+  answer: string;
+  sourceElements: AnsweredQuerySourceElement[];
+  observer: string;
+  confidence: Exclude<Confidence, "EXTRACTED">;
+  label: string;
+  sourceRef: string;
+  evidence: string[];
+} {
+  const question = input.question?.replace(/\s+/g, " ").trim() ?? "";
+  const answer = input.answer?.replace(/\s+/g, " ").trim() ?? "";
+  const observer = input.observer?.trim() ?? "";
+  const confidence = input.confidence === "AMBIGUOUS" ? "AMBIGUOUS" : "INFERRED";
+  const label = `answered-query:${slugify(question, 80)}`;
+  const sourceRef = label;
+  const sourceElements = (input.sourceElements ?? []).map(normalizeSourceElement).filter((item) => item != null);
+  return {
+    question,
+    answer,
+    sourceElements,
+    observer,
+    confidence,
+    label,
+    sourceRef,
+    evidence: [`question: ${question}`, ...sourceElements.map(sourceElementEvidence)],
+  };
+}
+
+function normalizeSourceElement(
+  element: AnsweredQuerySourceElement,
+): AnsweredQuerySourceElement | null {
+  if (element.kind === "node") {
+    const rid = finitePositive(element.rid);
+    if (rid == null && !element.label) return null;
+    return {
+      kind: "node",
+      ...(rid == null ? {} : { rid }),
+      ...(element.label ? { label: element.label.trim() } : {}),
+      ...(element.title ? { title: element.title.trim() } : {}),
+    };
+  }
+  if (element.kind === "edge") {
+    const from = finitePositive(element.from_rid);
+    const to = finitePositive(element.to_rid);
+    if (from == null && to == null && !element.label) return null;
+    return {
+      kind: "edge",
+      ...(element.label ? { label: element.label.trim() } : {}),
+      ...(from == null ? {} : { from_rid: from }),
+      ...(to == null ? {} : { to_rid: to }),
+    };
+  }
+  if (element.kind === "community") {
+    const communityId = element.community_id?.trim();
+    return communityId ? { kind: "community", community_id: communityId } : null;
+  }
+  return null;
+}
+
+function sourceElementEvidence(element: AnsweredQuerySourceElement): string {
+  if (element.kind === "node") {
+    return `node:${element.rid ?? "unknown"}:${element.label ?? element.title ?? "unknown"}`;
+  }
+  if (element.kind === "edge") {
+    return `edge:${element.from_rid ?? "unknown"}->${element.to_rid ?? "unknown"}:${element.label ?? "unknown"}`;
+  }
+  return `community:${element.community_id ?? "unknown"}`;
+}
+
+function sourceNodeRids(elements: AnsweredQuerySourceElement[]): number[] {
+  const rids = new Set<number>();
+  for (const element of elements) {
+    if (element.kind === "node" && element.rid != null) rids.add(element.rid);
+    if (element.kind === "edge") {
+      if (element.from_rid != null) rids.add(element.from_rid);
+      if (element.to_rid != null) rids.add(element.to_rid);
+    }
+  }
+  return [...rids];
+}
+
+async function removeOutgoingReferences(store: MemoryStore, fromRid: number): Promise<void> {
+  for (const edge of await store.listEdges()) {
+    if (String(edge.label ?? edge.LABEL ?? "") !== "REFERENCES") continue;
+    const from = Number(edge.from ?? edge.from_id ?? edge.from_rid ?? edge.FROM);
+    const to = Number(edge.to ?? edge.to_id ?? edge.to_rid ?? edge.TO);
+    if (from === fromRid && Number.isFinite(to)) {
+      await store.removeEdge(fromRid, to, "REFERENCES");
+    }
+  }
+}
+
+function answeredQueryResultInput(input: {
+  question: string;
+  sourceRef: string;
+  observer: string;
+  evidence: string[];
+  confidence: Confidence;
+}): MemoryStoreEvidenceInput {
+  return {
+    claim: input.question,
+    sourceRef: input.sourceRef,
+    citationExcerpt: input.question,
+    intent: "answered-query-feedback",
+    observer: input.observer,
+    confidence: input.confidence,
+  };
+}
+
+function finitePositive(value: unknown): number | undefined {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? num : undefined;
 }
 
 function normalizeInput(input: MemoryStoreEvidenceInput): Required<MemoryStoreEvidenceInput> {

--- a/apps/memory/src/handoff.ts
+++ b/apps/memory/src/handoff.ts
@@ -114,6 +114,7 @@ function scoreNode(node: StoredNode, terms: string[], now: number): number {
     why_note: 6,
     workflow: 5,
     concept: 4,
+    answer: 5,
     file: 3,
     solution: 5,
     fix: 5,

--- a/apps/memory/src/schema.ts
+++ b/apps/memory/src/schema.ts
@@ -88,6 +88,7 @@ export const NODE_TYPES = [
   "session",
   "task",
   "goal",
+  "answer",
   // Engineering semantic graph (PRD #95): AFK execution history.
   "attempt",
   "issue",

--- a/apps/memory/tests/governed-write-cli.test.ts
+++ b/apps/memory/tests/governed-write-cli.test.ts
@@ -7,7 +7,8 @@ import { afterEach, describe, expect, test } from "vitest";
 import { MemoryStore } from "../src/graph-store.js";
 import { graphRecall } from "../src/graph-recall.js";
 import { initGraph, initMarkdownOnly } from "../src/init.js";
-import { memoryStoreEvidence } from "../src/governed-write.js";
+import { memoryStoreAnsweredQuery, memoryStoreEvidence } from "../src/governed-write.js";
+import { buildSuggestedQuestions } from "../src/suggested-questions.js";
 import { evidenceInboxRoot, parseEvidenceCardYaml } from "../src/evidence-card.js";
 
 const TIMEOUT = 40_000;
@@ -362,6 +363,155 @@ describe("memory_store_evidence governed write", () => {
         reason: "graph_mode_required",
         memory: { id: null },
       });
+    },
+    TIMEOUT,
+  );
+});
+
+describe("memory_store_answered_query governed write", () => {
+  test(
+    "persists an explicitly confirmed graph answer as a sealed node with provenance and source links",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+      const store = await MemoryStore.open({ uri: storeUri, project: "test" });
+      stores.push(store);
+      const authRid = await store.upsertNode({
+        label: "auth-hub",
+        node_type: "concept",
+        properties: { title: "Auth hub", content: "Auth hub" },
+      });
+      const tokenRid = await store.upsertNode({
+        label: "token-rotation",
+        node_type: "concept",
+        properties: { title: "Token rotation", content: "Token rotation" },
+      });
+
+      const result = await memoryStoreAnsweredQuery(store, {
+        question: "How does token rotation connect to auth?",
+        answer: "Token rotation is governed by the auth hub.",
+        sourceElements: [
+          { kind: "node", rid: authRid, label: "auth-hub" },
+          { kind: "node", rid: tokenRid, label: "token-rotation" },
+        ],
+        observer: "unit-test",
+        confidence: "INFERRED",
+      });
+
+      expect(result).toMatchObject({
+        operation: "memory_store_answered_query",
+        outcome: "stored",
+        reason: "answered_query_stored",
+        provenance: {
+          writer: "unit-test",
+          source_ref: "answered-query:how-does-token-rotation-connect-to-auth",
+          citation_excerpt: "How does token rotation connect to auth?",
+        },
+      });
+      expect(result.memory.id).toEqual(expect.any(Number));
+      const node = await store.getNode(result.memory.id!);
+      expect(node).toMatchObject({
+        label: "answered-query:how-does-token-rotation-connect-to-auth",
+        node_type: "answer",
+        properties: {
+          title: "How does token rotation connect to auth?",
+          content: "Token rotation is governed by the auth hub.",
+          confidence: "INFERRED",
+          seal: "INFERRED",
+          question: "How does token rotation connect to auth?",
+          answer: "Token rotation is governed by the auth hub.",
+          source_elements: [
+            { kind: "node", rid: authRid, label: "auth-hub" },
+            { kind: "node", rid: tokenRid, label: "token-rotation" },
+          ],
+          provenance: {
+            source_kind: "derived",
+            writer: "unit-test",
+            command: "memory store-answered-query",
+            confidence: "INFERRED",
+            evidence: [
+              "question: How does token rotation connect to auth?",
+              `node:${authRid}:auth-hub`,
+              `node:${tokenRid}:token-rotation`,
+            ],
+          },
+        },
+      });
+      const edges = await store.listEdges();
+      expect(edges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: "REFERENCES", from_rid: result.memory.id, to_rid: authRid }),
+          expect.objectContaining({ label: "REFERENCES", from_rid: result.memory.id, to_rid: tokenRid }),
+        ]),
+      );
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "re-answering the same question replaces the answer node instead of duplicating it",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+      const store = await MemoryStore.open({ uri: storeUri, project: "test" });
+      stores.push(store);
+
+      await memoryStoreAnsweredQuery(store, {
+        question: "Which store path writes answered graph queries?",
+        answer: "The first answer is incomplete.",
+        sourceElements: [{ kind: "community", community_id: "community-1" }],
+        observer: "unit-test",
+        confidence: "INFERRED",
+      });
+      const second = await memoryStoreAnsweredQuery(store, {
+        question: "Which store path writes answered graph queries?",
+        answer: "Answered graph queries write through the governed store path.",
+        sourceElements: [{ kind: "community", community_id: "community-1" }],
+        observer: "unit-test",
+        confidence: "AMBIGUOUS",
+      });
+
+      const answers = (await store.listNodes()).filter(
+        (node) => node.label === "answered-query:which-store-path-writes-answered-graph-queries",
+      );
+      expect(answers).toHaveLength(1);
+      expect(answers[0]).toMatchObject({
+        rid: second.memory.id,
+        node_type: "answer",
+        properties: {
+          answer: "Answered graph queries write through the governed store path.",
+          confidence: "AMBIGUOUS",
+          seal: "AMBIGUOUS",
+          provenance: {
+            confidence: "AMBIGUOUS",
+            evidence: [
+              "question: Which store path writes answered graph queries?",
+              "community:community-1",
+            ],
+          },
+        },
+      });
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "plain suggested-question queries leave the temp store untouched",
+    async () => {
+      const root = await tempRoot();
+      const { storeUri } = await initGraph(root);
+      const store = await MemoryStore.open({ uri: storeUri, project: "test" });
+      stores.push(store);
+      await store.upsertNode({
+        label: "auth-hub",
+        node_type: "concept",
+        properties: { title: "Auth hub", content: "Auth hub" },
+      });
+      const before = await store.listNodes();
+
+      await buildSuggestedQuestions(store, { now: new Date("2026-07-10T00:00:00.000Z") });
+
+      expect(await store.listNodes()).toEqual(before);
     },
     TIMEOUT,
   );


### PR DESCRIPTION
Automated AFK landing for #1437. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1437

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786319988&installation_id=129708444&pr_number=1457&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1457&signature=bcf9f337940c62b11661a07dbd08a9e1bbb6bbb757d4db162d79792a908b7c35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->