### PR TITLE
fix: #1448 statusline: loc diff hardcodes origin/main — must resolve the locked/configured base branch (lock > pin > trunk)

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -19,10 +19,12 @@
 import { existsSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
+import { resolveBase } from "../core/base-resolver.js";
 import { type ClaudeInput, type ProjectInput } from "../core/statusline.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
+import { branchLockPath, readLockedBranch } from "../runtime/lock.js";
 import {
   collectStatuslineAfk,
   collectStatuslineFleet,
@@ -199,12 +201,22 @@ export async function statuslineCommand(
   // config a second time per collector.
   const cfg = loadConfig(join(root, ".red", "config.yaml"), { warn: () => undefined });
   const cacheTtlS = resolveStatuslineCacheTtl(process.env, (key) => getConfig(cfg, key));
+  const base = await resolveBase(
+    { issueBody: "" },
+    {
+      readLockedBranch: () => readLockedBranch(branchLockPath(root)),
+      configLockedBranch: getConfig(cfg, "dev.lock.branch"),
+      configTrunk: getConfig(cfg, "dev.trunk"),
+      fetchIssueBody: async () => undefined,
+    },
+  );
+  const repoLocBaseRef = `origin/${base}`;
   // The aggregate AFK block feeds the plain single-line form (NO_COLOR / Codex);
   // the per-worker records feed the themed multi-line form (Claude Code). Both
   // read the same worker states — cheap file reads — so the two forms stay in
   // sync while each renders its own layout.
   const [repo, afk, fleet, workers] = await Promise.all([
-    collectStatuslineRepo(repoCtx, cacheTtlS),
+    collectStatuslineRepo(repoCtx, cacheTtlS, repoLocBaseRef),
     collectStatuslineAfk(repoCtx, cacheTtlS).then((a) => a ?? undefined),
     collectStatuslineFleet(repoCtx),
     collectStatuslineWorkers(repoCtx),

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1294,6 +1294,7 @@ export async function collectStatuslineWorkers(ctx: RepoContext): Promise<Compac
 }
 
 interface RepoStatsCache {
+  baseRef: string;
   openPrs: number;
   todayPrs: number;
   openIssues: number;
@@ -1306,6 +1307,7 @@ function readRepoStatsCache(path: string): RepoStatsCache | null {
   try {
     const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<RepoStatsCache>;
     return {
+      baseRef: typeof parsed.baseRef === "string" && parsed.baseRef.trim() ? parsed.baseRef.trim() : "origin/main",
       openPrs: Number(parsed.openPrs ?? 0),
       todayPrs: Number(parsed.todayPrs ?? 0),
       openIssues: Number(parsed.openIssues ?? 0),
@@ -1331,7 +1333,8 @@ function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
 /**
  * Repo-global statusline header inputs (line 1, ALWAYS rendered — unlike the
  * AFK block these show with no live workers): open-PR / open-issue counts from
- * GitHub PLUS the LOCAL branch diffstat (committed + uncommitted vs origin/main)
+ * GitHub PLUS the LOCAL branch diffstat (committed + uncommitted vs the
+ * resolved base ref)
  * measured at the project root. All three are EXPENSIVE FETCHED numbers (gh/git
  * subprocesses), so all three are cached together for {@link
  * STATUSLINE_CACHE_TTL_S} seconds in `.red/tmp/statusline-repo-cache.json`: a
@@ -1342,30 +1345,32 @@ function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
 export async function collectStatuslineRepo(
   ctx: RepoContext,
   cacheTtlS: number = STATUSLINE_CACHE_TTL_S,
+  baseRef = "origin/main",
 ): Promise<RepoInput> {
   const paths = afkPaths(ctx.root);
   const cachePath = join(paths.tmpDir, "statusline-repo-cache.json");
   const nowS = Math.floor(Date.now() / 1000);
   const cached = readRepoStatsCache(cachePath);
+  const cacheMatchesBase = cached?.baseRef === baseRef;
   let openPrs = cached?.openPrs ?? 0;
   let todayPrs = cached?.todayPrs ?? 0;
   let openIssues = cached?.openIssues ?? 0;
-  let localAdded = cached?.localAdded ?? 0;
-  let localRemoved = cached?.localRemoved ?? 0;
+  let localAdded = cacheMatchesBase ? (cached?.localAdded ?? 0) : 0;
+  let localRemoved = cacheMatchesBase ? (cached?.localRemoved ?? 0) : 0;
 
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   let repoRefreshSucceeded = false;
   const refresh = async (): Promise<void> => {
-    // The local branch diff (committed + uncommitted) vs origin/main is folded
-    // into the same refresh as the gh counts — diffstatShortstat resolves the
-    // merge-base, so this counts every commit on the branch plus the dirty
-    // worktree. It is a git subprocess and therefore cacheable: no per-render
-    // git diff.
+    // The local branch diff (committed + uncommitted) vs the resolved base ref
+    // is folded into the same refresh as the gh counts — diffstatShortstat
+    // resolves the merge-base, so this counts every commit on the branch plus
+    // the dirty worktree. It is a git subprocess and therefore cacheable: no
+    // per-render git diff.
     const [p, t, i, diff] = await Promise.all([
       ghx.countOpenPrs(ghCtx),
       ghx.countPrsCreatedToday(ghCtx),
       ghx.countOpenIssues(ghCtx),
-      gitx.diffstatShortstat({ cwd: ctx.root }, "origin/main"),
+      gitx.diffstatShortstat({ cwd: ctx.root }, baseRef),
     ]);
     openPrs = p;
     todayPrs = t;
@@ -1374,6 +1379,7 @@ export async function collectStatuslineRepo(
     localRemoved = diff.removed;
     repoRefreshSucceeded = true;
     writeRepoStatsCacheAtomic(cachePath, {
+      baseRef,
       openPrs: p,
       todayPrs: t,
       openIssues: i,
@@ -1383,7 +1389,7 @@ export async function collectStatuslineRepo(
     });
   };
   let repoCacheAgeS: number | undefined;
-  if (!cached) {
+  if (!cached || !cacheMatchesBase) {
     await withTimeout(refresh(), STATUSLINE_GH_COLD_TIMEOUT_MS, undefined).catch(() => undefined);
   } else if (nowS - cached.ts >= cacheTtlS) {
     // Stale: await a bounded refresh so the cache is rewritten before the

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Readable } from "node:stream";
@@ -130,6 +131,45 @@ const PAYLOAD_WITH_RATE_LIMITS = JSON.stringify({
     seven_day: { used_percentage: 41, resets_at: "2026-07-12T12:00:00Z" },
   },
 });
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+async function initRepoWithDevelopTrunk(root: string): Promise<void> {
+  git(root, ["init"]);
+  git(root, ["config", "user.email", "agent@example.test"]);
+  git(root, ["config", "user.name", "Agent"]);
+  git(root, ["checkout", "-b", "main"]);
+  await writeFile(join(root, "base.txt"), "base\n", "utf8");
+  git(root, ["add", "base.txt"]);
+  git(root, ["commit", "-m", "base"]);
+  git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+
+  git(root, ["checkout", "-b", "develop"]);
+  await writeFile(join(root, "backlog.txt"), "backlog\n", "utf8");
+  git(root, ["add", "backlog.txt"]);
+  git(root, ["commit", "-m", "develop backlog"]);
+  git(root, ["update-ref", "refs/remotes/origin/develop", "HEAD"]);
+
+  git(root, ["checkout", "-b", "feature/statusline"]);
+  await writeFile(join(root, "work.txt"), "work\n", "utf8");
+  git(root, ["add", "work.txt"]);
+  git(root, ["commit", "-m", "feature work"]);
+}
+
+async function withFakeGh<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "fake-gh-"));
+  const orig = process.env.PATH;
+  try {
+    await writeFile(join(dir, "gh"), "#!/bin/sh\necho '[]'\n", { mode: 0o755 });
+    process.env.PATH = `${dir}:${orig ?? ""}`;
+    return await fn();
+  } finally {
+    process.env.PATH = orig;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
 
 describe("statusline command — pure helpers", () => {
   it("resolveRoot prefers an existing first-arg directory", async () => {
@@ -455,6 +495,34 @@ describe("statusline command — rendered line", () => {
     expect(rows).toHaveLength(1); // 0 workers → header row alone
     expect(rows[0]).toContain("Opus·high");
     expect(rows[0]).toContain("47k 24%");
+  });
+
+  it("uses the configured trunk as the repo-wide loc= diff base", async () => {
+    await initRepoWithDevelopTrunk(root);
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    trunk: develop\n", "utf8");
+    await seedFreshCache(root, 0, 0);
+
+    const out = sink();
+    const oldNoColor = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const code = await withFakeGh(() => statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD)));
+      expect(code).toBe(0);
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+
+    const text = stripAnsi(out.text());
+    expect(text).toContain("loc=+1");
+    expect(text).not.toContain("loc=+2");
+    const cache = JSON.parse(await readFile(join(root, ".red", "tmp", "statusline-repo-cache.json"), "utf8")) as {
+      baseRef: string;
+      localAdded: number;
+    };
+    expect(cache.baseRef).toBe("origin/develop");
+    expect(cache.localAdded).toBe(1);
   });
 
   it("renders a fresh live supervisor fleet segment even when zero worker rows render", async () => {


### PR DESCRIPTION
Automated AFK landing for #1448. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1448

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786330064&installation_id=129708444&pr_number=1459&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1459&signature=4d3f59fa321cd8d64add126446fc6697d7eb0579feeeb1d02ccc58c50be81d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->