### PR TITLE
fix(red-release): unbreak npm pack gate (SIGPIPE presence check, rsp bundle staging, red-castle build cascade)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -466,22 +466,43 @@ jobs:
           pnpm pack --pack-destination .
           tarball="$(ls reddb-io-red-skills-*.tgz | head -n1)"
           echo "packed $tarball"
+          # Materialize the tar listing ONCE. Never pipe `tar -tzf` straight into
+          # `grep -q`: grep closes the pipe on its first match, tar then dies with
+          # SIGPIPE (exit 141), and `pipefail` propagates that failure — so once the
+          # tarball grew past the pipe buffer the check misreported a present bundle
+          # as missing. Matching each expected entry against the captured listing with
+          # a here-string (no pipe) lets tar always read to completion.
+          listing="$(tar -tzf "$tarball")"
           for expected in \
             package/dist/dev.bundle.min.mjs \
             package/dist/code-nav.bundle.min.mjs \
             package/dist/memory.bundle.min.mjs \
-            package/dist/brain.bundle.min.mjs; do
-            if ! tar -tzf "$tarball" | grep -qx "$expected"; then
+            package/dist/brain.bundle.min.mjs \
+            package/dist/rsp.bundle.min.mjs; do
+            if ! grep -qxF "$expected" <<<"$listing"; then
               echo "::error::npm tarball missing $expected"
               exit 1
             fi
           done
           # Contract check: install the packed tarball into a throwaway prefix and
-          # run the REAL packaged client (the bin the launcher execs) — proves the
+          # run the REAL packaged clients (the bins the launcher execs) — proves the
           # tarball resolves and runs before we publish it.
           smoke="$(mktemp -d)"
           npm install "./$tarball" --prefix "$smoke" --no-audit --no-fund --ignore-scripts --loglevel=error
-          node "$smoke/node_modules/@reddb-io/red-skills/bin/red-skills-dev.mjs" --version
+          pkg="$smoke/node_modules/@reddb-io/red-skills"
+          node "$pkg/bin/red-skills-dev.mjs" --version
+          # rsp needs a provisioned RedDB store (the `red` binary is not present under
+          # --ignore-scripts), so it cannot reach exit 0 here. What we DO smoke is that
+          # the packaged rsp bin resolves its bundle: a bin-without-bundle makes the
+          # shim print "packaged bundle missing" and exit before ever loading the
+          # runtime. Fail iff that guard fires — that is the exact "dangling bin" defect.
+          rsp_out="$(node "$pkg/bin/rsp.mjs" --store-uri "file://$smoke/rsp-store" 2>&1 || true)"
+          if grep -qF 'packaged bundle missing' <<<"$rsp_out"; then
+            echo "::error::packaged rsp bin shipped without its dist/rsp.bundle.min.mjs bundle"
+            printf '%s\n' "$rsp_out"
+            exit 1
+          fi
+          echo "packaged rsp bin resolved its bundle"
           rm -rf "$smoke"
 
       - name: Publish to npm

--- a/packaging/npm/scripts/prepare.mjs
+++ b/packaging/npm/scripts/prepare.mjs
@@ -19,25 +19,32 @@ const repoRoot = join(pkgRoot, "..", "..");
 const srcDist = join(repoRoot, "dist");
 const destDist = join(pkgRoot, "dist");
 
+// Each entry stages one bundle into this package's dist/. `dest` is the packaged
+// filename the bin shims / launchers resolve; the first existing `sources` entry
+// is copied to it. Most bundles are named identically by `pnpm bundle`, but
+// code-nav's turbo outfile is `code-nav-mcp.bundle.min.mjs` while the packaged /
+// release-asset name is `code-nav.bundle.min.mjs` — so it lists both: CI's
+// dedicated code-nav step pre-copies the asset name, and the plain `pnpm bundle`
+// path falls back to the turbo outfile. No bundle silently skips as "not built".
 const BUNDLES = [
-  "dev.bundle.min.mjs",
-  "code-nav.bundle.min.mjs",
-  "memory.bundle.min.mjs",
-  "brain.bundle.min.mjs",
-  "rsp.bundle.min.mjs",
+  { dest: "dev.bundle.min.mjs", sources: ["dev.bundle.min.mjs"] },
+  { dest: "code-nav.bundle.min.mjs", sources: ["code-nav.bundle.min.mjs", "code-nav-mcp.bundle.min.mjs"] },
+  { dest: "memory.bundle.min.mjs", sources: ["memory.bundle.min.mjs"] },
+  { dest: "brain.bundle.min.mjs", sources: ["brain.bundle.min.mjs"] },
+  { dest: "rsp.bundle.min.mjs", sources: ["rsp.bundle.min.mjs"] },
 ];
 
 mkdirSync(destDist, { recursive: true });
 let staged = 0;
-for (const name of BUNDLES) {
-  const src = join(srcDist, name);
-  if (!existsSync(src)) {
-    process.stderr.write(`prepare: ${name} not built at ${src}; skipping\n`);
+for (const { dest, sources } of BUNDLES) {
+  const src = sources.map((name) => join(srcDist, name)).find((path) => existsSync(path));
+  if (!src) {
+    process.stderr.write(`prepare: ${dest} not built (looked for ${sources.join(", ")}); skipping\n`);
     continue;
   }
-  copyFileSync(src, join(destDist, name));
+  copyFileSync(src, join(destDist, dest));
   staged += 1;
-  process.stdout.write(`prepare: staged ${name}\n`);
+  process.stdout.write(`prepare: staged ${dest}\n`);
 }
 if (staged === 0) {
   process.stderr.write("prepare: no bundles staged — run `pnpm bundle` first\n");

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,14 @@
       "dependsOn": ["^build"],
       "outputs": ["../../dist/**"]
     },
+    "@reddb-io/dev#bundle": {
+      "dependsOn": [
+        "@reddb-io/build-info#build",
+        "@reddb-io/shared#build",
+        "@reddb-io/toon#build"
+      ],
+      "outputs": ["../../dist/**"]
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "../../dist/**"]


### PR DESCRIPTION
Closes #1461

The `red-release` "Pack npm package + producer/consumer contract check" step was failing (`Error: npm tarball missing package/dist/dev.bundle.min.mjs`), blocking the 2.24.x publish. Three coupled defects, all fixed here (release/build/CI wiring only — no rsp source, no RTK, no version bumps):

- **A — SIGPIPE false negative** (`aee0b8ae`): the presence loop piped `tar -tzf | grep -qx` under `pipefail`; `grep -qx` closed the pipe early, `tar` took SIGPIPE (`tar: stdout: write error`), and pipefail misreported a *present* bundle as missing. Now the tar listing is materialized once and grepped, so tar always reads to completion.
- **B — rsp/code-nav bundle staging** (`cd3c2b71`): `bin/rsp.mjs` shipped without `dist/rsp.bundle.min.mjs`. prepare.mjs now stages the bundle from its turbo outfile; red-release enumerates rsp in the presence check and smokes the packaged `rsp` bin.
- **C — red-castle build cascade** (`8fa354f1`): `pnpm bundle` (`turbo run bundle --filter=!red-castle`) still pulled `red-castle#build` via apps/dev's `^build` topological cascade; red-castle declares `packageManager: npm`, so turbo's pnpm invocation was refused and killed the gate. Added a `@reddb-io/dev#bundle` override depending only on the JS packages the bundle needs (build-info, shared, toon) — red-castle is consumed from source, so bundles never need its dist.

**Verified locally**: the exact merge-gate command passes with all five bundles (dev, code-nav, memory, brain, rsp) present; a reproduction of the CI rsp-bin smoke confirms the packaged `bin/rsp.mjs` resolves its bundle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786333544&installation_id=129708444&pr_number=1468&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1468&signature=5b13b17533a43bd9d1afbaaf0440899f5427166293ac59adbb2c1d2c08e79299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->