### PR TITLE
fix: #1464 rsp vitest wrapper: terse excerpt budget + top-K failures with elision

### DIFF
--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -1,16 +1,16 @@
-rsp two-axis benchmark: 17 fixtures across 7 filters
+rsp two-axis benchmark: 18 fixtures across 7 filters
 
 Production mode uses admission threshold 60%; passthrough filters count as 0% token delta because rsp returns the original command output.
 
 | Filter | Mode | Fixtures | brief median/p90 token delta | brief fidelity | terse median/p90 token delta | terse fidelity | RTK median/p90 token delta | RTK fidelity |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| cargo:test | active | 3 | 61.9/84.2% | 100% | 61.9/84.2% | 100% | 67.8/82.4% | 100% |
+| cargo:test | active | 3 | 61.9/84.2% | 100% | 57.7/84.2% | 100% | 67.8/82.4% | 100% |
 | git:commit | passthrough | 1 | 0/0% | 100% | 0/0% | 100% | -78.8/-78.8% | 100% |
 | git:diff | passthrough | 2 | 0/0% | 100% | 0/0% | 100% | 38.3/99.6% | 100% |
 | git:log | passthrough | 2 | 0/0% | 100% | 0/0% | 100% | 79.4/99.7% | 100% |
 | git:push | passthrough | 2 | 0/0% | 100% | 0/0% | 100% | 13.8/27.6% | 100% |
 | git:status | active | 2 | 60.5/75% | 100% | 60.5/75% | 50% | 23.7/72.3% | 100% |
-| vitest:run | active | 5 | 64.1/100% | 100% | 64.1/100% | 100% | 87.4/100% | 100% |
+| vitest:run | active | 6 | 58.8/100% | 100% | 70/100% | 100% | 86.3/100% | 100% |
 
 Large-output filters: git:diff, git:log, vitest:run.
 

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -1,6 +1,6 @@
 benchmark: rsp-two-axis
 corpus:
-  fixture_count: 17
+  fixture_count: 18
   filters[7]: "cargo:test","git:commit","git:diff","git:log","git:push","git:status","vitest:run"
   large_output_filters[3]: "git:diff","git:log","vitest:run"
 method:
@@ -28,7 +28,7 @@ filters[7]:
       fidelity_pass_rate_pct: 100
       source: measured
     terse:
-      median_delta_pct: 61.9
+      median_delta_pct: 57.7
       p90_delta_pct: 84.2
       fidelity_pass_rate_pct: 100
       source: measured
@@ -154,28 +154,28 @@ filters[7]:
       source: recorded
   - filter: "vitest:run"
     mode: active
-    fixture_count: 5
+    fixture_count: 6
     raw:
       median_delta_pct: 0
       p90_delta_pct: 0
       fidelity_pass_rate_pct: 100
       source: recorded
     brief:
-      median_delta_pct: 64.1
+      median_delta_pct: 58.8
       p90_delta_pct: 100
       fidelity_pass_rate_pct: 100
       source: measured
     terse:
-      median_delta_pct: 64.1
+      median_delta_pct: 70
       p90_delta_pct: 100
       fidelity_pass_rate_pct: 100
       source: measured
     rtk:
-      median_delta_pct: 87.4
+      median_delta_pct: 86.3
       p90_delta_pct: 100
       fidelity_pass_rate_pct: 100
       source: recorded
 parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
   cargo-test,"cargo:test",61.9,67.8,100,100,fail
   git-commit,"git:commit",0,-78.8,100,100,pass
-summary: "17 fixtures, 7 filters; shipped modes apply admission threshold 60%"
+summary: "18 fixtures, 7 filters; shipped modes apply admission threshold 60%"

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -35,6 +35,10 @@ interface TestFailureSource {
 }
 
 const EXCERPT_LIMIT_BYTES = 320;
+// Under `terse` the excerpt budget tightens to first + last line, capped at half the
+// lossless budget, and only the top-K failures stay inline — the rest collapse to a handle.
+const TERSE_EXCERPT_LIMIT_BYTES = 160;
+const TERSE_TOP_K_FAILURES = 3;
 
 export async function runTestWrapper(argv: readonly string[], options: TestRenderOptions): Promise<GitRenderResult> {
   const contract = await collectTestContract(argv);
@@ -59,6 +63,12 @@ export async function renderTestContract(
     };
   }
 
+  const summary = `${parsed.failed}/${parsed.total} failed · ${parsed.suites} suites · ${formatDuration(parsed.durationSeconds)}`;
+
+  if (options.level === "terse") {
+    return await renderTerse(command, contract, parsed, status, summary, options);
+  }
+
   const failures: TestFailure[] = [];
   let mintedHandle: `el:${string}` | undefined;
   let bytesElided = 0;
@@ -70,10 +80,7 @@ export async function renderTestContract(
     bytesElided += excerpt.bytesElided;
   }
 
-  const payload: TestPayload = {
-    exit_code: status,
-    summary: `${parsed.failed}/${parsed.total} failed · ${parsed.suites} suites · ${formatDuration(parsed.durationSeconds)}`,
-  };
+  const payload: TestPayload = { exit_code: status, summary };
   if (failures.length > 0) payload.failures = failures;
 
   return {
@@ -86,6 +93,77 @@ export async function renderTestContract(
     bytesElided: bytesElided > 0 ? bytesElided : undefined,
     rowsElided: failures.length > 0 ? Math.max(0, parsed.total - failures.length) : undefined,
   };
+}
+
+async function renderTerse(
+  command: readonly string[],
+  contract: RecordedGitContract,
+  parsed: ParsedTestRun,
+  status: number | null,
+  summary: string,
+  options: TestRenderOptions,
+): Promise<GitRenderResult> {
+  const inline: TestFailure[] = parsed.failures.slice(0, TERSE_TOP_K_FAILURES).map((failure) => ({
+    suite: failure.suite,
+    name: failure.name,
+    excerpt: terseExcerpt(failure.excerpt),
+  }));
+
+  const tersePayload: TestPayload = { exit_code: status, summary };
+  if (inline.length > 0) tersePayload.failures = inline;
+  const terseToon = encode(tersePayload as unknown as JsonObject);
+
+  const elidedFailures = Math.max(0, parsed.failures.length - inline.length);
+  const excerptTrimmed = inline.some((row, index) => row.excerpt !== parsed.failures[index].excerpt);
+
+  // Nothing was lost — the tighter view is byte-identical to the full one, so emit it as-is.
+  if (elidedFailures === 0 && !excerptTrimmed) {
+    return {
+      stdout: Buffer.from(terseToon),
+      stderr: Buffer.from(contract.stderr),
+      status: contract.status,
+      signal: contract.signal,
+      payload: tersePayload as unknown as JsonObject,
+    };
+  }
+
+  const fullPayload: TestPayload = { exit_code: status, summary };
+  if (parsed.failures.length > 0) {
+    fullPayload.failures = parsed.failures.map((failure) => ({
+      suite: failure.suite,
+      name: failure.name,
+      excerpt: failure.excerpt,
+    }));
+  }
+  const fullToon = encode(fullPayload as unknown as JsonObject);
+  const bytesElided = Buffer.byteLength(fullToon);
+
+  const handle = await options.store?.mint(Buffer.from(fullToon), {
+    command: command.join(" "),
+    loss: { level: "terse", bytes_elided: bytesElided },
+  });
+  if (!handle) throw new Error("terse test output requires an elision store");
+
+  const label = elidedFailures > 0 ? `${elidedFailures} failures` : "full detail";
+  const marker = `… elided ${label} (+${bytesElided}) — rsp show ${handle}`;
+  return {
+    stdout: Buffer.from(`${terseToon}\n${marker}`),
+    stderr: Buffer.from(contract.stderr),
+    status: contract.status,
+    signal: contract.signal,
+    payload: tersePayload as unknown as JsonObject,
+    mintedHandle: handle,
+    bytesElided,
+    rowsElided: elidedFailures,
+  };
+}
+
+function terseExcerpt(excerpt: string): string {
+  const lines = excerpt.split("\n");
+  const compact = lines.length <= 2 ? excerpt : `${lines[0]}\n…\n${lines[lines.length - 1]}`;
+  const bytes = Buffer.from(compact);
+  if (bytes.length <= TERSE_EXCERPT_LIMIT_BYTES) return compact;
+  return bytes.subarray(0, TERSE_EXCERPT_LIMIT_BYTES).toString("utf8").replace(/�$/, "");
 }
 
 function parseTestRunner(command: readonly string[]): "vitest" | "cargo" {

--- a/apps/rsp/tests/fixtures/rtk/baselines.json
+++ b/apps/rsp/tests/fixtures/rtk/baselines.json
@@ -86,6 +86,11 @@
       "name": "vitest-mixed",
       "stdout": "rtk vitest run --reporter=json\n4 tests: 3 passed, 1 failed\nmath divides by zero: expected Infinity to equal 0\n",
       "fidelity_assertions_passed": true
+    },
+    {
+      "name": "vitest-many-failures",
+      "stdout": "rtk vitest run --reporter=json\n8 tests: 3 passed, 5 failed\nalpha case one: expected 1 got 2\nalpha case two: expected 3 got 4\nalpha case three: expected 5 got 6\nbeta case four: expected 7 got 8\nbeta case five: expected 9 got 10\n",
+      "fidelity_assertions_passed": true
     }
   ]
 }

--- a/apps/rsp/tests/fixtures/test-runners/vitest/many-failures.json
+++ b/apps/rsp/tests/fixtures/test-runners/vitest/many-failures.json
@@ -1,0 +1,45 @@
+{
+  "name": "vitest-many-failures",
+  "command": ["vitest", "run"],
+  "recorded": {
+    "stdout": "{\"numTotalTests\":8,\"numPassedTests\":3,\"numFailedTests\":5,\"startTime\":1783695600000,\"endTime\":1783695603200,\"testResults\":[{\"name\":\"apps/rsp/tests/alpha.test.ts\",\"assertionResults\":[{\"fullName\":\"alpha passes\",\"title\":\"passes\",\"status\":\"passed\",\"duration\":2},{\"fullName\":\"alpha case one\",\"title\":\"case one\",\"status\":\"failed\",\"failureMessages\":[\"AssertionError: case one failed\\n- Expected: 1\\n+ Received: 2\\n    at alpha.test.ts:11:5\"],\"duration\":3},{\"fullName\":\"alpha case two\",\"title\":\"case two\",\"status\":\"failed\",\"failureMessages\":[\"AssertionError: case two failed\\n- Expected: 3\\n+ Received: 4\\n    at alpha.test.ts:19:5\"],\"duration\":3},{\"fullName\":\"alpha case three\",\"title\":\"case three\",\"status\":\"failed\",\"failureMessages\":[\"AssertionError: case three failed\\n- Expected: 5\\n+ Received: 6\\n    at alpha.test.ts:27:5\"],\"duration\":3}]},{\"name\":\"apps/rsp/tests/beta.test.ts\",\"assertionResults\":[{\"fullName\":\"beta passes twice\",\"title\":\"passes twice\",\"status\":\"passed\",\"duration\":2},{\"fullName\":\"beta stays green\",\"title\":\"stays green\",\"status\":\"passed\",\"duration\":2},{\"fullName\":\"beta case four\",\"title\":\"case four\",\"status\":\"failed\",\"failureMessages\":[\"AssertionError: case four failed\\n- Expected: 7\\n+ Received: 8\\n    at beta.test.ts:14:5\"],\"duration\":3},{\"fullName\":\"beta case five\",\"title\":\"case five\",\"status\":\"failed\",\"failureMessages\":[\"AssertionError: case five failed\\n- Expected: 9\\n+ Received: 10\\n    at beta.test.ts:22:5\"],\"duration\":3}]}]}",
+    "stderr": "",
+    "status": 1,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 1,
+    "summary": "5/8 failed · 2 suites · 3.2s",
+    "failures": [
+      {
+        "suite": "apps/rsp/tests/alpha.test.ts",
+        "name": "alpha case one",
+        "excerpt": "AssertionError: case one failed\n- Expected: 1\n+ Received: 2\n    at alpha.test.ts:11:5"
+      },
+      {
+        "suite": "apps/rsp/tests/alpha.test.ts",
+        "name": "alpha case two",
+        "excerpt": "AssertionError: case two failed\n- Expected: 3\n+ Received: 4\n    at alpha.test.ts:19:5"
+      },
+      {
+        "suite": "apps/rsp/tests/alpha.test.ts",
+        "name": "alpha case three",
+        "excerpt": "AssertionError: case three failed\n- Expected: 5\n+ Received: 6\n    at alpha.test.ts:27:5"
+      },
+      {
+        "suite": "apps/rsp/tests/beta.test.ts",
+        "name": "beta case four",
+        "excerpt": "AssertionError: case four failed\n- Expected: 7\n+ Received: 8\n    at beta.test.ts:14:5"
+      },
+      {
+        "suite": "apps/rsp/tests/beta.test.ts",
+        "name": "beta case five",
+        "excerpt": "AssertionError: case five failed\n- Expected: 9\n+ Received: 10\n    at beta.test.ts:22:5"
+      }
+    ]
+  },
+  "assertions": [
+    { "question": "how many failed?", "path": "summary", "expected": "5/8 failed · 2 suites · 3.2s" },
+    { "question": "what was the exit code?", "path": "exit_code", "expected": 1 }
+  ]
+}

--- a/apps/rsp/tests/test-wrapper.test.ts
+++ b/apps/rsp/tests/test-wrapper.test.ts
@@ -32,6 +32,7 @@ describe("rsp test runner fidelity fixtures", () => {
       "vitest-green",
       "vitest-large-green",
       "vitest-long-failure",
+      "vitest-many-failures",
       "vitest-mixed",
     ]);
   });
@@ -101,6 +102,84 @@ describe("rsp test runner fidelity fixtures", () => {
       if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
       expect(record.original.toString("utf8")).toContain("received: \"line-001\"");
       expect(record.original.toString("utf8")).toContain("received: \"line-040\"");
+    } finally {
+      await store.close();
+    }
+  });
+});
+
+function decodeTerse(stdout: string): unknown {
+  return decode(stdout.split("\n").filter((line) => !line.startsWith("… elided ")).join("\n"));
+}
+
+describe("rsp vitest terse failure budget", () => {
+  it("caps inline failures to top-K and elides the remainder behind a retrievable handle", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-many-failures")!;
+      const result = await runFidelityFixture(fixture, { level: "terse", store });
+      const stdout = result.stdout.toString("utf8");
+      const decoded = decodeTerse(stdout) as { summary: string; failures: unknown[] };
+
+      // Rollup preserved; only the top-3 failures stay inline.
+      expect(decoded.summary).toBe("5/8 failed · 2 suites · 3.2s");
+      expect(decoded.failures).toHaveLength(3);
+      expect(result.rowsElided).toBe(2);
+
+      // A single handle behind an elision marker collapses the remaining failures.
+      expect(stdout).toMatch(/… elided 2 failures \(\+\d+\) — rsp show el:[a-f0-9]{12}/);
+      expect(result.mintedHandle).toBeDefined();
+
+      // Full detail — all five failures — remains retrievable via `rsp show`.
+      const record = await store.get(result.mintedHandle!);
+      if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+      const full = decode(record.original.toString("utf8")) as { failures: unknown[] };
+      expect(full.failures).toHaveLength(5);
+      expect(record.original.toString("utf8")).toContain("beta case five");
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("shortens each inline excerpt to first + last line under terse", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-long-failure")!;
+      const result = await runFidelityFixture(fixture, { level: "terse", store });
+      const decoded = decodeTerse(result.stdout.toString("utf8")) as { failures: { excerpt: string }[] };
+      const excerpt = decoded.failures[0].excerpt;
+
+      // First and last line survive; the middle is dropped.
+      expect(excerpt).toContain("Snapshot mismatch");
+      expect(excerpt).toContain('received: "line-040"');
+      expect(excerpt).not.toContain('received: "line-020"');
+      expect(excerpt).toContain("…");
+
+      // Full excerpt stays retrievable even when no failures were dropped.
+      expect(result.rowsElided).toBe(0);
+      expect(result.mintedHandle).toBeDefined();
+      const record = await store.get(result.mintedHandle!);
+      if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+      const full = decode(record.original.toString("utf8")) as { failures: { excerpt: string }[] };
+      expect(full.failures[0].excerpt).toContain('received: "line-020"');
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("keeps the green-suite summary line unchanged under terse", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-green")!;
+      const result = await runFidelityFixture(fixture, { level: "terse", store });
+
+      expect(result.status).toBe(0);
+      expect(result.mintedHandle).toBeUndefined();
+      expect(result.stdout.toString("utf8")).not.toContain("… elided");
+      expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
     } finally {
       await store.close();
     }


### PR DESCRIPTION
Automated AFK landing for #1464. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1464

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786336625&installation_id=129708444&pr_number=1469&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1469&signature=4b80b6c2f71e087f12d155f4e9d0986e1fcaeb1295a2686e543516d014320490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->