### PR TITLE
fix: #1471 AFK precheck hardcodes main — resolve the configured trunk (lock > pin > trunk > main)

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -79,10 +79,16 @@ export interface PrecheckFacts {
   /**
    * The currently locked branch from `.red/tmp/branch-lock.yaml`, or
    * `undefined` when the session is unlocked. When set, the precheck gates on
-   * `currentBranch === lockedBranch` rather than `currentBranch === "main"`,
-   * so a locked checkout is on the lock branch, not main.
+   * `currentBranch === lockedBranch` rather than the configured trunk, so a
+   * locked checkout is on the lock branch, not the trunk.
    */
   lockedBranch?: string;
+  /**
+   * The configured AFK boot branch resolved by the caller from repo config
+   * (config lock/trunk, falling back to main). Kept injected so precheck stays
+   * a pure rule over facts.
+   */
+  configuredTrunk?: string;
   pnpmInstalled: boolean;
   /**
    * Relax the SSH-only remote rule. "Reject https remote" is a LOCAL-dev safety
@@ -96,9 +102,10 @@ export interface PrecheckFacts {
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and
- * `detail` carries the offending value (e.g. the https URL, the wrong branch).
- * pnpm-missing is a WARNING in afk.sh (`log "warn: …"`), not a `die`; it is
- * surfaced via `warnings` while the verdict still passes. */
+ * `detail` carries the offending value (e.g. the https URL) or, for a branch
+ * mismatch, the branch the checkout was expected to be on. pnpm-missing is a
+ * WARNING in afk.sh (`log "warn: …"`), not a `die`; it is surfaced via
+ * `warnings` while the verdict still passes. */
 export type PrecheckResult =
   | { ok: true; warnings: string[] }
   | { ok: false; failed: Precondition; detail?: string };
@@ -119,9 +126,9 @@ export function precheck(facts: PrecheckFacts): PrecheckResult {
     }
   }
   if (!facts.hasMainBranch) return { ok: false, failed: "no-main-branch" };
-  const expectedBranch = facts.lockedBranch ?? "main";
+  const expectedBranch = facts.lockedBranch ?? facts.configuredTrunk ?? "main";
   if (facts.currentBranch !== expectedBranch) {
-    return { ok: false, failed: "not-on-main", detail: facts.currentBranch };
+    return { ok: false, failed: "not-on-main", detail: expectedBranch };
   }
   const warnings: string[] = [];
   if (!facts.pnpmInstalled) {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -15,6 +15,7 @@ import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, unlinkS
 import { dirname, join } from "node:path";
 import { hostFingerprintPrefix } from "../core/host-identity.js";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
+import { resolveBase } from "../core/base-resolver.js";
 import type { SandboxMode } from "../core/execution.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
 // Value import (pure, no sandcastle pull — the providers load lazily via
@@ -1550,6 +1551,9 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const { branchLockPath, readLockedBranch } = await import("./lock.js");
   const lockPath = branchLockPath(ctx.root);
+  const config = loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined });
+  const configLockedBranch = getConfig(config, "dev.lock.branch") || undefined;
+  const configTrunk = getConfig(config, "dev.trunk") || undefined;
   const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch, pnpmProbe, lockedBranch] =
     await Promise.all([
       ghx.ghInstalled(ghCtx),
@@ -1561,6 +1565,15 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
       import("./exec.js").then((m) => m.pnpm(["--version"], { cwd: ctx.root })),
       readLockedBranch(lockPath),
     ]);
+  const configuredTrunk = await resolveBase(
+    { issueBody: "" },
+    {
+      readLockedBranch: async () => lockedBranch,
+      configLockedBranch,
+      configTrunk,
+      fetchIssueBody: async () => undefined,
+    },
+  );
   const pnpmInstalled = pnpmProbe.code !== 127;
   return {
     ghInstalled,
@@ -1570,6 +1583,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     hasMainBranch: hasMain,
     currentBranch,
     lockedBranch,
+    configuredTrunk,
     pnpmInstalled,
     // CI lanes (the GHA Actions lane) check out an https remote token-authed by
     // GITHUB_TOKEN — the intended setup — so the SSH-only rule must not fire there.

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -86,11 +86,26 @@ describe("precheck", () => {
     });
   });
 
-  it("fails not-on-main, naming the current branch", () => {
+  it("fails not-on-main, naming the expected default branch", () => {
     expect(precheck(facts({ currentBranch: "feature/x" }))).toEqual({
       ok: false,
       failed: "not-on-main",
-      detail: "feature/x",
+      detail: "main",
+    });
+  });
+
+  it("passes when the current branch matches the configured trunk", () => {
+    expect(precheck(facts({ currentBranch: "develop", configuredTrunk: "develop" }))).toEqual({
+      ok: true,
+      warnings: [],
+    });
+  });
+
+  it("fails not-on-main, naming the configured trunk when the checkout is on main", () => {
+    expect(precheck(facts({ currentBranch: "main", configuredTrunk: "develop" }))).toEqual({
+      ok: false,
+      failed: "not-on-main",
+      detail: "develop",
     });
   });
 
@@ -101,11 +116,26 @@ describe("precheck", () => {
     });
   });
 
+  it("locked: overrides the configured trunk", () => {
+    expect(
+      precheck(
+        facts({
+          currentBranch: "feature-locked",
+          lockedBranch: "feature-locked",
+          configuredTrunk: "develop",
+        }),
+      ),
+    ).toEqual({
+      ok: true,
+      warnings: [],
+    });
+  });
+
   it("locked: fails not-on-main when currentBranch is main instead of the lock value", () => {
     expect(precheck(facts({ currentBranch: "main", lockedBranch: "feature-locked" }))).toEqual({
       ok: false,
       failed: "not-on-main",
-      detail: "main",
+      detail: "feature-locked",
     });
   });
 
@@ -113,7 +143,7 @@ describe("precheck", () => {
     expect(precheck(facts({ currentBranch: "other-branch", lockedBranch: "feature-locked" }))).toEqual({
       ok: false,
       failed: "not-on-main",
-      detail: "other-branch",
+      detail: "feature-locked",
     });
   });
 


### PR DESCRIPTION
Automated AFK landing for #1471. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1471

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786360894&installation_id=129708444&pr_number=1472&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1472&signature=930bdba97a3975f546d9a4f64438ef18b791f2f72716da3ecdbf2da5187c580a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->