### PR TITLE
fix(red-release): add Build rsp runtime bundle step (unblocks 2.24.x publish)

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -443,6 +443,23 @@ jobs:
           console.log('benchmark-code-understanding bundle manifest:', JSON.stringify(manifest));
           EOF
 
+      # The rsp CLI ships its single bundle (dist/rsp.bundle.min.mjs) INSIDE the
+      # npm package (bin/rsp.mjs resolves it), not as a release-fetched runtime,
+      # so it needs no checksum manifest. Every other runtime app has its own
+      # per-app bundle step; rsp had a bin + prepare/verify entry but no build
+      # step, so the pack contract check failed on a genuinely-missing bundle.
+      # Build it from its own app dir so pnpm bundle emits ../../dist/rsp.bundle.min.mjs.
+      - name: Build rsp runtime bundle
+        if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
+        working-directory: apps/rsp
+        env:
+          RED_BUILD_VERSION: ${{ steps.version.outputs.next }}
+          RED_BUILD_GIT_SHA: ${{ github.sha }}
+          RED_BUILD_TIME: ${{ github.event.head_commit.timestamp }}
+        run: |
+          set -euo pipefail
+          pnpm bundle
+
       # ADR 0091: npm is the ONLY client transport. Stage the built bundles into
       # the packaging/npm package, pnpm pack it, then run the REAL client resolver
       # (the packaged bin) against the packed tarball as a producer/consumer


### PR DESCRIPTION
The red-release pack step fails with `npm tarball missing package/dist/rsp.bundle.min.mjs`, blocking the 2.24.x publish.

**Root cause:** the workflow builds each runtime bundle in its own per-app step (`Build dev/memory/brain/code-nav/... runtime bundle`), and rsp was given a packaged bin (`bin/rsp.mjs`), a `prepare.mjs` staging entry, and a pack-verify entry — but **no build step**. The root `pnpm bundle` (turbo full) is never invoked in this workflow, so the #1474 `@reddb-io/rsp#bundle` turbo override never fired in CI. rsp bundled fine locally (turbo) but was never built on the runner.

**Fix:** add a `Build rsp runtime bundle` step (`working-directory: apps/rsp`, `pnpm bundle`) before the pack step, mirroring the other apps. No runtime manifest — rsp ships inside the npm package, not as a release-fetched asset.

Verified locally: `cd apps/rsp && pnpm bundle` emits `dist/rsp.bundle.min.mjs` (58kb); YAML valid. Completes the rsp packaging started in #1468 (SIGPIPE + prepare/verify) and #1474 (turbo override).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786368991&installation_id=129708444&pr_number=1476&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1476&signature=5b25c51a3b3bba3d83369f49cc181d16afa9fca5409c8e80f13e943824706d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->