### PR TITLE
fix: #1473 AFK main-red-untracked strands the issue instead of parking to ready-for-human (silent chain freeze)

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1183,8 +1183,8 @@ async function refuseNoSandboxForUntrustedAuthor(
 async function syncMainRedRepairIssue(
   deps: ProcessIssueDeps,
   feedback: RunFeedbackResult,
-): Promise<void> {
-  if (!feedback.baselineProbeRan) return;
+): Promise<string | null> {
+  if (!feedback.baselineProbeRan) return null;
   const {
     findMainRedRepairIssue,
     createMainRedRepairIssue,
@@ -1192,7 +1192,7 @@ async function syncMainRedRepairIssue(
     closeMainRedRepairIssue,
   } = deps.gh;
   if (!findMainRedRepairIssue || !createMainRedRepairIssue || !updateMainRedRepairIssue || !closeMainRedRepairIssue) {
-    return;
+    return null;
   }
 
   try {
@@ -1200,7 +1200,7 @@ async function syncMainRedRepairIssue(
     const plan = planMainRedRepair(feedback.baselineFailures ?? [], current);
     switch (plan.action) {
       case "noop":
-        return;
+        return null;
       case "create": {
         const created = await createMainRedRepairIssue({
           title: plan.title,
@@ -1208,7 +1208,7 @@ async function syncMainRedRepairIssue(
           labels: plan.labels,
         });
         deps.appendIterLog(`🤖 /afk baseline probe: opened main-red repair issue #${created}.`);
-        return;
+        return null;
       }
       case "update":
         await updateMainRedRepairIssue(plan.issue, {
@@ -1217,15 +1217,16 @@ async function syncMainRedRepairIssue(
           labels: plan.labels,
         });
         deps.appendIterLog(`🤖 /afk baseline probe: updated main-red repair issue #${plan.issue}.`);
-        return;
+        return null;
       case "close":
         await closeMainRedRepairIssue(plan.issue, plan.comment);
         deps.appendIterLog(`🤖 /afk baseline probe: closed main-red repair issue #${plan.issue}.`);
-        return;
+        return null;
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     deps.appendIterLog(`warn: main-red repair issue sync failed: ${message}`);
+    return message;
   }
 }
 
@@ -1578,6 +1579,7 @@ export async function processIssue(
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
   let mainRed = false;
+  let mainRedRepairSyncFailure: string | null = null;
   let currentHandoff = handoff;
   let goVerifyRetriesUsed = 0;
   let salvagedUncommittedFiles = 0;
@@ -2195,7 +2197,7 @@ export async function processIssue(
       );
     }
     mainRed = feedback.baselineProbeRan === true && (feedback.baselineFailures?.length ?? 0) > 0;
-    await syncMainRedRepairIssue(deps, feedback);
+    mainRedRepairSyncFailure = await syncMainRedRepairIssue(deps, feedback);
     // post_feedback (#832): the scope-derived gate has produced its verdict.
     await fireHook(
       "post_feedback",
@@ -2458,6 +2460,7 @@ export async function processIssue(
         common,
         landing.message ?? "Admin-merge refused: main is red without an open main-red repair issue.",
         landing.locked,
+        mainRedRepairSyncFailure,
       );
     }
     // CI-aware landing failures (#812): a completed, MERGEABLE PR the admin-merge
@@ -3273,11 +3276,15 @@ async function mainRedUntrackedBlocked(
   c: StageCommon,
   message: string,
   locked: boolean,
+  repairSyncFailure: string | null = null,
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
+  const syncFailureDetail = repairSyncFailure
+    ? ` The auto-file attempt for the main-red repair issue failed and must be inspected: ${repairSyncFailure}.`
+    : "";
   const detail =
-    `${message} The attempt branch is intact and validated, but landing is held until the tracked-red ` +
-    `repair issue exists. Requeue after the auto-file path recreates it.`;
+    `${message} The attempt branch \`${c.branch}\` is intact and validated, but landing is held until the tracked-red ` +
+    `repair issue exists.${syncFailureDetail} Requeue after the auto-file path recreates it.`;
   await routeRecovery(deps, input.issue, "main-red-untracked", input.attempt);
   await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("main-red-untracked", { log: detail }));
   const posted = await emitFailure(c, envelopeStatusFor("main-red-untracked"), "main-red-untracked", { log: detail });

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -56,6 +56,8 @@ interface Trace {
   classifierCalls: IssueClassificationMetadata[];
   /** Lines appended to the iteration log (deps.appendIterLog). */
   iterLogs: string[];
+  /** Main-red repair issue create attempts from the baseline probe sync path. */
+  mainRedRepairCreates: Array<{ title: string; body: string; labels: readonly string[] }>;
   /** Compact state patches written to afk.state.json. */
   statePatches: Array<Record<string, unknown>>;
   /** Branches for which cascadeRebase.rebaseAndPush was called (#1007). */
@@ -82,6 +84,12 @@ interface HarnessOptions {
   /** Scripted per-call outcomes (overrides `outcome`); one entry per runAgent call. */
   outcomes?: RunAgentResult["outcome"][];
   feedbackOk?: boolean;
+  /** When true, the feedback baseline probe fails the same check as the worker. */
+  baselineFails?: boolean;
+  /** Existing main-red repair issue returned by the finder. false/null means missing. */
+  mainRedRepairIssue?: boolean;
+  /** When set, creating the main-red repair issue throws this message. */
+  mainRedRepairCreateError?: string;
   /** Scripted per-feedback-gate outcomes. Each feedback run executes the four
    * standard scripts; this controls the aggregate pass/fail for each run. */
   feedbackResults?: boolean[];
@@ -237,6 +245,7 @@ function harness(opts: HarnessOptions = {}): {
     salvageCalls: [],
     classifierCalls: [],
     iterLogs: [],
+    mainRedRepairCreates: [],
     statePatches: [],
     cascadeRebaseAttempts: [],
     changedFileCalls: [],
@@ -251,6 +260,8 @@ function harness(opts: HarnessOptions = {}): {
   // verification reads above key off it to model "the agent resolved the merge".
   let mergeResolved = false;
   let pnpmCalls = 0;
+  let currentMainRedRepairIssue: { number: number; title?: string; body?: string; labels?: readonly string[] } | null =
+    opts.mainRedRepairIssue ? { number: 123 } : null;
 
   const deps: ProcessIssueDeps = {
     gh: {
@@ -297,6 +308,31 @@ function harness(opts: HarnessOptions = {}): {
             inCodeowners: false,
           })
         : undefined,
+      findMainRedRepairIssue:
+        opts.baselineFails || opts.mainRedRepairIssue !== undefined || opts.mainRedRepairCreateError
+          ? async () => currentMainRedRepairIssue
+          : undefined,
+      createMainRedRepairIssue:
+        opts.baselineFails || opts.mainRedRepairIssue !== undefined || opts.mainRedRepairCreateError
+          ? async (spec) => {
+              trace.mainRedRepairCreates.push(spec);
+              if (opts.mainRedRepairCreateError) throw new Error(opts.mainRedRepairCreateError);
+              currentMainRedRepairIssue = { number: 124 };
+              return 124;
+            }
+          : undefined,
+      updateMainRedRepairIssue:
+        opts.baselineFails || opts.mainRedRepairIssue !== undefined || opts.mainRedRepairCreateError
+          ? async (issue, spec) => {
+              currentMainRedRepairIssue = { number: issue, ...spec };
+            }
+          : undefined,
+      closeMainRedRepairIssue:
+        opts.baselineFails || opts.mainRedRepairIssue !== undefined || opts.mainRedRepairCreateError
+          ? async () => {
+              currentMainRedRepairIssue = null;
+            }
+          : undefined,
     },
     claimGh: opts.claim
       ? {
@@ -429,7 +465,7 @@ function harness(opts: HarnessOptions = {}): {
       const cIdx = Array.isArray(args) ? args.indexOf("-C") : -1;
       const dir = cIdx >= 0 ? (args[cIdx + 1] ?? "") : "";
       if (dir === "main" || dir.startsWith("main/")) {
-        return { code: 0, stdout: "", stderr: "" };
+        return { code: opts.baselineFails ? 1 : 0, stdout: "", stderr: "" };
       }
       const feedbackRun = Math.floor(pnpmCalls / 4);
       pnpmCalls += 1;
@@ -901,6 +937,46 @@ describe("processIssue — CI-aware unlocked landing (#812)", () => {
     expect(trace.closed).toEqual([]);
     expect(trace.deletedRemote).toEqual([]);
     expect(trace.runAgentCalls.length).toBe(1);
+    expect(trace.released).toEqual([9]);
+  });
+});
+
+describe("processIssue — main-red-untracked landing park (#1473)", () => {
+  it("red main + missing repair issue parks ready-for-human, preserves the branch, and surfaces auto-file failure", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      feedbackOk: false,
+      baselineFails: true,
+      locked: false,
+      mainRedRepairIssue: false,
+      mainRedRepairCreateError: "gh issue create failed",
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("main-red-untracked");
+    expect(result.preserved).toBe(true);
+    expect(result.branch).toBe("afk/wAAAA/9-fix-the-thing");
+    expect(trace.mainRedRepairCreates).toHaveLength(1);
+    expect(trace.iterLogs).toContain("warn: main-red repair issue sync failed: gh issue create failed");
+    expect(trace.ensuredLabels).toContain("blocked:main-red-untracked");
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-human") && e.add.includes("blocked:main-red-untracked"))).toBe(
+      true,
+    );
+    expect(trace.labelEdits.some((e) => e.add.includes("ready-for-agent"))).toBe(false);
+    expect(trace.closed).toEqual([]);
+    expect(trace.deletedRemote).toEqual([]);
+    expect(trace.pushedAttempt.length).toBe(1);
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+
+    const blocker = parseCurrentBlocker(trace.bodyEdits.at(-1)?.body ?? "");
+    expect(blocker?.status).toBe("blocked");
+    expect(blocker?.kind).toBe("main-red-untracked");
+    expect(blocker?.summary).toContain("red main");
+    expect(blocker?.summary).toContain("gh issue create failed");
+    expect(blocker?.summary).toContain("afk/wAAAA/9-fix-the-thing");
+    expect(trace.comments.at(-1)?.body).toContain("afk/wAAAA/9-fix-the-thing");
+    expect(trace.comments.at(-1)?.body).toContain("gh issue create failed");
     expect(trace.released).toEqual([9]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1473. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1473

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786374468&installation_id=129708444&pr_number=1478&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1478&signature=31a9d516188e386eff41e5555d5b75accbc0068098bcedeb46b44f46e2c22cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->