### PR TITLE
fix: #1465 rsp: adopt AXI token levers (--query, combined ops, help[] disclosure)

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -11,6 +11,7 @@ interface ParsedArgs {
   command?: string;
   handle?: string;
   storeUri?: string;
+  query?: string;
   level: "lossless" | "brief" | "terse";
   positional: string[];
 }
@@ -97,7 +98,12 @@ function parseArgs(argv: string[]): ParsedArgs {
     if (arg === "--store-uri") out.storeUri = argv[++i];
     else if (arg === "--brief") out.level = "brief";
     else if (arg === "--terse") out.level = "terse";
+    else if (arg === "--query") out.query = argv[++i];
+    else if (arg.startsWith("--query=")) out.query = arg.slice("--query=".length);
     else positional.push(arg);
+  }
+  if (out.query && positional[0] !== "show" && !positional.some((arg) => arg === "--query" || arg.startsWith("--query="))) {
+    positional.push("--query", out.query);
   }
   out.command = positional[0];
   out.handle = positional[1];

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -2,9 +2,10 @@ import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
 import type { RecordedGitContract } from "./git-wrapper.js";
+import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
 export type GhKind = "pr" | "issue" | "run";
-export type GhAction = "list" | "view";
+export type GhAction = "list" | "view" | "combined";
 
 export interface GhRenderOptions {
   level: RspLossLevel;
@@ -25,12 +26,16 @@ export interface GhRenderResult {
 interface GhCommand {
   kind: GhKind;
   action: GhAction;
+  target?: string;
   full: boolean;
   wide: boolean;
   passthrough: string[];
+  query?: string;
 }
 
-const DEFAULT_FIELDS: Record<`${GhKind}:${GhAction}`, string[]> = {
+type MachineGhAction = Exclude<GhAction, "combined">;
+
+const DEFAULT_FIELDS: Record<`${GhKind}:${MachineGhAction}`, string[]> = {
   "pr:list": ["number", "title", "state", "isDraft"],
   "pr:view": ["number", "title", "state", "body"],
   "issue:list": ["number", "title", "state", "labels"],
@@ -39,7 +44,7 @@ const DEFAULT_FIELDS: Record<`${GhKind}:${GhAction}`, string[]> = {
   "run:view": ["databaseId", "name", "status", "conclusion", "jobs"],
 };
 
-const WIDE_FIELDS: Record<`${GhKind}:${GhAction}`, string[]> = {
+const WIDE_FIELDS: Record<`${GhKind}:${MachineGhAction}`, string[]> = {
   "pr:list": ["number", "title", "state", "isDraft", "author", "labels", "url", "updatedAt"],
   "pr:view": ["number", "title", "state", "body", "author", "labels", "url", "baseRefName", "headRefName"],
   "issue:list": ["number", "title", "state", "labels", "author", "url", "updatedAt"],
@@ -62,9 +67,10 @@ export async function renderGhContract(
   contract: RecordedGitContract,
   options: GhRenderOptions,
 ): Promise<GhRenderResult> {
+  const parsedCommand = extractQueryArg(commandArgv);
   if ((contract.status ?? 0) !== 0 || contract.signal) {
     return {
-      stdout: Buffer.from(contract.stdout),
+      stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
       stderr: Buffer.from(contract.stderr),
       status: contract.status,
       signal: contract.signal,
@@ -141,31 +147,74 @@ export async function renderGhContract(
 }
 
 function parseGhCommand(argv: readonly string[]): GhCommand {
-  if (argv[0] !== "gh") throw new Error("expected rsp gh <surface> <subcommand>");
-  const kind = argv[1];
-  const action = argv[2];
+  const parsed = extractQueryArg(argv);
+  if (parsed.argv[0] !== "gh") throw new Error("expected rsp gh <surface> <subcommand>");
+  const kind = parsed.argv[1];
+  const action = parsed.argv[2];
   if (!(kind === "pr" || kind === "issue" || kind === "run")) throw new Error(`unsupported gh surface: ${kind ?? ""}`);
-  if (!(action === "list" || action === "view")) throw new Error(`unsupported gh subcommand: ${action ?? ""}`);
+  const combined = kind === "pr" && action && action !== "list" && action !== "view";
+  if (!(action === "list" || action === "view" || combined)) throw new Error(`unsupported gh subcommand: ${action ?? ""}`);
 
   const passthrough: string[] = [];
   let full = false;
   let wide = false;
-  for (const arg of argv.slice(3)) {
+  for (const arg of parsed.argv.slice(3)) {
     if (arg === "--full") full = true;
     else if (arg === "--wide") wide = true;
     else passthrough.push(arg);
   }
-  return { kind, action, full, wide, passthrough };
+  const parsedAction: GhAction = combined ? "combined" : action === "list" ? "list" : "view";
+  return { kind, action: parsedAction, target: combined ? action : undefined, full, wide, passthrough, query: parsed.query };
 }
 
 function machineArgs(command: GhCommand): string[] {
+  if (command.action === "combined") throw new Error("combined gh command uses multiple machine calls");
   const key = `${command.kind}:${command.action}` as const;
   const fields = command.wide ? WIDE_FIELDS[key] : DEFAULT_FIELDS[key];
   return [command.kind, command.action, ...command.passthrough, "--json", fields.join(",")];
 }
 
 async function collectGhContract(command: GhCommand): Promise<RecordedGitContract> {
+  if (command.action === "combined") return await collectCombinedPrContract(command);
   const child = spawn("gh", machineArgs(command), { stdio: ["ignore", "pipe", "pipe"] });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+  return await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        status,
+        signal,
+      });
+    });
+  });
+}
+
+async function collectCombinedPrContract(command: GhCommand): Promise<RecordedGitContract> {
+  const target = command.target ?? "";
+  const viewFields = ["number", "title", "state", "body", "author", "labels", "url", "baseRefName", "headRefName"];
+  const commentsFields = ["comments"];
+  const [view, checks, comments] = await Promise.all([
+    collectRawGh(["pr", "view", target, "--json", viewFields.join(",")]),
+    collectRawGh(["pr", "checks", target, "--json", "name,state,bucket,conclusion,link,startedAt,completedAt,workflow"]),
+    collectRawGh(["pr", "view", target, "--comments", "--json", commentsFields.join(",")]),
+  ]);
+  const failed = [view, checks, comments].find((result) => (result.status ?? 0) !== 0 || result.signal);
+  if (failed) return failed;
+  return {
+    stdout: JSON.stringify({ view: parseJson(view.stdout), checks: parseJson(checks.stdout), comments: parseJson(comments.stdout) }),
+    stderr: [view.stderr, checks.stderr, comments.stderr].filter(Boolean).join(""),
+    status: 0,
+    signal: null,
+  };
+}
+
+async function collectRawGh(args: readonly string[]): Promise<RecordedGitContract> {
+  const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"] });
   const stdout: Buffer[] = [];
   const stderr: Buffer[] = [];
   child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
@@ -192,24 +241,62 @@ function renderGhPayload(command: GhCommand, commandArgv: readonly string[], par
   switch (`${command.kind}:${command.action}`) {
     case "pr:list": {
       const rows = arrayOfRecords(parsed).map((row) => projectPr(row, command.wide));
-      return { ...base, prs: rows, summary: `${rows.length} ${stateWord(rows, "open")} PRs` };
+      const filteredRows = filterRows(rows, command.query);
+      return helpIfQueried({ ...base, prs: filteredRows as JsonValue, summary: `${countLabel(filteredRows.length, rows.length, command.query)} ${stateWord(filteredRows, "open")} PRs` }, command, ["rsp gh pr <number>", "rsp gh pr list --query <title-or-label>"]);
     }
     case "pr:view":
-      return { ...base, pr: projectPrView(recordOf(parsed), command), summary: `PR #${numberField(recordOf(parsed), "number")}` };
+      return helpIfQueried({ ...base, pr: projectPrView(recordOf(parsed), command), summary: `PR #${numberField(recordOf(parsed), "number")}` }, command, ["rsp gh pr <number>", "rsp gh pr view <number> --full"]);
+    case "pr:combined":
+      return renderCombinedPrPayload(command, commandArgv, recordOf(parsed));
     case "issue:list": {
       const rows = arrayOfRecords(parsed).map((row) => projectIssue(row, command.wide));
-      return { ...base, issues: rows, summary: `${rows.length} ${stateWord(rows, "open")} issues` };
+      const filteredRows = filterRows(rows, command.query);
+      return helpIfQueried({ ...base, issues: filteredRows as JsonValue, summary: `${countLabel(filteredRows.length, rows.length, command.query)} ${stateWord(filteredRows, "open")} issues` }, command, ["rsp gh issue view <number>", "rsp gh issue list --query <label-or-title>"]);
     }
     case "issue:view":
-      return { ...base, issue: projectIssueView(recordOf(parsed), command), summary: `issue #${numberField(recordOf(parsed), "number")}` };
+      return helpIfQueried({ ...base, issue: projectIssueView(recordOf(parsed), command), summary: `issue #${numberField(recordOf(parsed), "number")}` }, command, ["rsp gh issue view <number> --full"]);
     case "run:list": {
       const rows = arrayOfRecords(parsed).map((row) => projectRun(row, command.wide));
-      return { ...base, runs: rows, summary: `${rows.length} runs` };
+      const filteredRows = filterRows(rows, command.query);
+      return helpIfQueried({ ...base, runs: filteredRows as JsonValue, summary: `${countLabel(filteredRows.length, rows.length, command.query)} runs` }, command, ["rsp gh run view <id>", "rsp gh run list --query <workflow-or-status>"]);
     }
     case "run:view":
-      return { ...base, run: projectRunView(recordOf(parsed), command), summary: `run ${numberField(recordOf(parsed), "databaseId")}` };
+      return helpIfQueried({ ...base, run: projectRunView(recordOf(parsed), command), summary: `run ${numberField(recordOf(parsed), "databaseId")}` }, command, ["rsp gh run view <id> --full"]);
   }
   throw new Error(`unsupported gh command: ${command.kind} ${command.action}`);
+}
+
+function renderCombinedPrPayload(command: GhCommand, commandArgv: readonly string[], parsed: Record<string, unknown>): JsonObject {
+  const view = projectPrView(recordOf(parsed.view), { ...command, action: "view", wide: true });
+  const checks = filterRows(arrayOfRecords(parsed.checks).map(projectCheck), command.query);
+  const commentsSource = recordOf(parsed.comments).comments;
+  const comments = filterRows(arrayOfRecords(commentsSource).map(projectComment).slice(-3), command.query);
+  return withHelp({
+    command: commandArgv.join(" "),
+    pr: view,
+    checks: checks as JsonValue,
+    comments: comments as JsonValue,
+    summary: `PR #${numberField(recordOf(parsed.view), "number")}: ${checks.length} checks, ${comments.length} comments`,
+  }, ["rsp gh pr view <number> --full", "rsp gh pr <number> --query <check-or-comment>", "rsp gh run view <id>"]);
+}
+
+function projectCheck(row: Record<string, unknown>): JsonObject {
+  return {
+    name: stringField(row, "name"),
+    state: stateClass(row),
+    bucket: stringField(row, "bucket"),
+    conclusion: stringField(row, "conclusion"),
+    workflow: stringField(row, "workflow"),
+    link: stringField(row, "link"),
+  };
+}
+
+function projectComment(row: Record<string, unknown>): JsonObject {
+  return {
+    author: authorLogin(row.author),
+    body: textField(row, "body", BODY_LIMIT, false),
+    created: stringField(row, "createdAt"),
+  };
 }
 
 function emptyState(kind: GhKind): string {
@@ -331,6 +418,14 @@ function tersePayload(payload: JsonObject): { payload: JsonObject; rowsElided: n
 function stateWord(rows: readonly JsonObject[], preferred: string): string {
   if (rows.every((row) => row.state === preferred)) return preferred;
   return "returned";
+}
+
+function countLabel(filtered: number, total: number, query?: string): string {
+  return query ? `${filtered}/${total}` : String(filtered);
+}
+
+function helpIfQueried(payload: JsonObject, command: GhCommand, help: readonly string[]): JsonObject {
+  return command.query ? withHelp(payload, help) : payload;
 }
 
 function stateClass(row: Record<string, unknown>): string {

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
 export type GitSubcommand = "status" | "log" | "diff" | "commit" | "push";
 
@@ -29,8 +30,9 @@ export interface GitRenderResult {
 }
 
 export async function runGitWrapper(argv: readonly string[], options: GitRenderOptions): Promise<GitRenderResult> {
-  const subcommand = parseGitSubcommand(argv);
-  const contract = await collectGitContract(subcommand, argv.slice(1));
+  const parsed = extractQueryArg(argv);
+  const subcommand = parseGitSubcommand(parsed.argv);
+  const contract = await collectGitContract(subcommand, parsed.argv.slice(1));
   return renderGitContract(argv, contract, options);
 }
 
@@ -39,17 +41,18 @@ export async function renderGitContract(
   contract: RecordedGitContract,
   options: GitRenderOptions,
 ): Promise<GitRenderResult> {
+  const parsedCommand = extractQueryArg(command);
   if ((contract.status ?? 0) !== 0 || contract.signal) {
     return {
-      stdout: Buffer.from(contract.stdout),
+      stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
       stderr: Buffer.from(contract.stderr),
       status: contract.status,
       signal: contract.signal,
     };
   }
 
-  const subcommand = parseGitSubcommand(command);
-  const payload = parseGitPayload(subcommand, command, contract.stdout);
+  const subcommand = parseGitSubcommand(parsedCommand.argv);
+  const payload = parseGitPayload(subcommand, parsedCommand.argv, contract.stdout, parsedCommand.query);
   if (payload === "git empty\n") {
     return {
       stdout: Buffer.from(payload),
@@ -157,22 +160,22 @@ async function collectGitContract(subcommand: GitSubcommand, rest: readonly stri
   });
 }
 
-function parseGitPayload(subcommand: GitSubcommand, command: readonly string[], stdout: string): JsonObject | "git empty\n" {
+function parseGitPayload(subcommand: GitSubcommand, command: readonly string[], stdout: string, query?: string): JsonObject | "git empty\n" {
   switch (subcommand) {
     case "status":
-      return parseStatus(command, stdout);
+      return parseStatus(command, stdout, query);
     case "log":
-      return parseLog(command, stdout);
+      return parseLog(command, stdout, query);
     case "diff":
-      return parseDiff(command, stdout);
+      return parseDiff(command, stdout, query);
     case "commit":
-      return parseCommit(command, stdout);
+      return helpIfQueried(parseCommit(command, stdout), query, ["rsp git status --query <path-or-state>"]);
     case "push":
-      return parsePush(command, stdout);
+      return helpIfQueried(parsePush(command, stdout), query, ["rsp gh pr list --query <branch>"]);
   }
 }
 
-function parseStatus(command: readonly string[], stdout: string): JsonObject | "git empty\n" {
+function parseStatus(command: readonly string[], stdout: string, query?: string): JsonObject | "git empty\n" {
   let branch = "";
   const rows: JsonObject[] = [];
   for (const raw of stdout.split("\0")) {
@@ -193,16 +196,17 @@ function parseStatus(command: readonly string[], stdout: string): JsonObject | "
     });
   }
   if (rows.length === 0) return "git empty\n";
-  const counts = countBy(rows, "state");
-  return {
+  const filteredRows = filterRows(rows, query);
+  const counts = countBy(filteredRows, "state");
+  return helpIfQueried({
     command: command.join(" "),
     branch,
-    rows,
-    summary: `${rows.length} changes: ${counts.added ?? 0} added, ${counts.modified ?? 0} modified, ${counts.deleted ?? 0} deleted`,
-  };
+    rows: filteredRows as JsonValue,
+    summary: `${query ? `${filteredRows.length}/${rows.length}` : filteredRows.length} changes: ${counts.added ?? 0} added, ${counts.modified ?? 0} modified, ${counts.deleted ?? 0} deleted`,
+  }, query, ["rsp git diff --query <path>", "rsp git log --query <subject>"]);
 }
 
-function parseLog(command: readonly string[], stdout: string): JsonObject {
+function parseLog(command: readonly string[], stdout: string, query?: string): JsonObject {
   const commits = stdout.split("\0").filter(Boolean).map((record) => {
     const fields = record.replace(/^\x1e/, "").split("\x1f");
     return {
@@ -212,10 +216,15 @@ function parseLog(command: readonly string[], stdout: string): JsonObject {
       subject: fields[3] ?? "",
     };
   });
-  return { command: command.join(" "), commits, summary: `${commits.length} commits` };
+  const filteredCommits = filterRows(commits, query);
+  return helpIfQueried({
+    command: command.join(" "),
+    commits: filteredCommits as JsonValue,
+    summary: `${query ? `${filteredCommits.length}/${commits.length}` : filteredCommits.length} commits`,
+  }, query, ["rsp git diff --query <path>", "rsp gh pr list --query <branch>"]);
 }
 
-function parseDiff(command: readonly string[], stdout: string): JsonObject {
+function parseDiff(command: readonly string[], stdout: string, query?: string): JsonObject {
   const fields = stdout.split("\0").filter(Boolean);
   const files = fields.map((entry) => {
     const [added, deleted, path] = entry.split("\t");
@@ -225,12 +234,17 @@ function parseDiff(command: readonly string[], stdout: string): JsonObject {
       deleted: deleted === "-" ? null : Number(deleted ?? 0),
     };
   });
-  const totals = files.reduce((acc, file) => {
+  const filteredFiles = filterRows(files, query);
+  const totals = filteredFiles.reduce((acc, file) => {
     acc.added += typeof file.added === "number" ? file.added : 0;
     acc.deleted += typeof file.deleted === "number" ? file.deleted : 0;
     return acc;
   }, { added: 0, deleted: 0 });
-  return { command: command.join(" "), files, summary: `${files.length} files, +${totals.added} -${totals.deleted}` };
+  return helpIfQueried({
+    command: command.join(" "),
+    files: filteredFiles as JsonValue,
+    summary: `${query ? `${filteredFiles.length}/${files.length}` : filteredFiles.length} files, +${totals.added} -${totals.deleted}`,
+  }, query, ["rsp git status --query <path>", "rsp git log --query <subject>"]);
 }
 
 function parseCommit(command: readonly string[], stdout: string): JsonObject {
@@ -273,6 +287,10 @@ function parsePush(command: readonly string[], stdout: string): JsonObject {
     refs,
     summary: `pushed ${branch} -> ${remote} +${commitCount} commits`,
   };
+}
+
+function helpIfQueried(payload: JsonObject, query: string | undefined, help: readonly string[]): JsonObject {
+  return query ? withHelp(payload, help) : payload;
 }
 
 function scalarFastPath(subcommand: GitSubcommand, payload: JsonObject): string | null {

--- a/apps/rsp/src/output-levers.ts
+++ b/apps/rsp/src/output-levers.ts
@@ -1,0 +1,54 @@
+import type { JsonObject, JsonValue } from "@reddb-io/toon";
+
+export interface QueryParseResult {
+  argv: string[];
+  query?: string;
+}
+
+export function extractQueryArg(argv: readonly string[]): QueryParseResult {
+  const out: string[] = [];
+  let query: string | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--query") {
+      query = argv[++i];
+      continue;
+    }
+    if (arg.startsWith("--query=")) {
+      query = arg.slice("--query=".length);
+      continue;
+    }
+    out.push(arg);
+  }
+  return { argv: out, query: query?.trim() || undefined };
+}
+
+export function matchesQuery(value: unknown, query?: string): boolean {
+  if (!query) return true;
+  const haystack = queryText(value).toLowerCase();
+  return query.toLowerCase().split(/\s+/).filter(Boolean).every((part) => haystack.includes(part));
+}
+
+export function filterRows<T>(rows: readonly T[], query?: string): T[] {
+  if (!query) return [...rows];
+  return rows.filter((row) => matchesQuery(row, query));
+}
+
+export function filterTextLines(text: string, query?: string): string {
+  if (!query) return text;
+  const lines = text.split("\n");
+  const kept = lines.filter((line) => line && matchesQuery(line, query));
+  return kept.length > 0 ? `${kept.join("\n")}\n` : "";
+}
+
+export function withHelp(payload: JsonObject, help: readonly string[]): JsonObject {
+  const clean = help.filter(Boolean);
+  if (clean.length === 0) return payload;
+  return { ...payload, help: clean as JsonValue };
+}
+
+function queryText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(queryText).join(" ");
+  if (typeof value === "object" && value !== null) return Object.values(value).map(queryText).join(" ");
+  return String(value ?? "");
+}

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
 import type { GitRenderResult, RecordedGitContract } from "./git-wrapper.js";
+import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
 export interface TestRenderOptions {
   level: RspLossLevel;
@@ -41,7 +42,8 @@ const TERSE_EXCERPT_LIMIT_BYTES = 160;
 const TERSE_TOP_K_FAILURES = 3;
 
 export async function runTestWrapper(argv: readonly string[], options: TestRenderOptions): Promise<GitRenderResult> {
-  const contract = await collectTestContract(argv);
+  const parsed = extractQueryArg(argv);
+  const contract = await collectTestContract(parsed.argv);
   return await renderTestContract(argv, contract, options);
 }
 
@@ -50,13 +52,14 @@ export async function renderTestContract(
   contract: RecordedGitContract,
   options: TestRenderOptions,
 ): Promise<GitRenderResult> {
-  const runner = parseTestRunner(command);
+  const parsedCommand = extractQueryArg(command);
+  const runner = parseTestRunner(parsedCommand.argv);
   const parsed = runner === "vitest" ? parseVitest(contract.stdout) : parseCargoTest(contract.stdout);
   const status = contract.status;
 
   if (!parsed || ((status ?? 0) !== 0 && parsed.failed === 0)) {
     return {
-      stdout: Buffer.from(contract.stdout),
+      stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
       stderr: Buffer.from(contract.stderr),
       status: contract.status,
       signal: contract.signal,
@@ -64,31 +67,38 @@ export async function renderTestContract(
   }
 
   const summary = `${parsed.failed}/${parsed.total} failed · ${parsed.suites} suites · ${formatDuration(parsed.durationSeconds)}`;
+  const filteredFailures = filterRows(parsed.failures, parsedCommand.query);
 
   if (options.level === "terse") {
-    return await renderTerse(command, contract, parsed, status, summary, options);
+    return await renderTerse(parsedCommand.argv, contract, { ...parsed, failures: filteredFailures }, status, summary, options, parsedCommand.query);
   }
 
   const failures: TestFailure[] = [];
   let mintedHandle: `el:${string}` | undefined;
   let bytesElided = 0;
 
-  for (const failure of parsed.failures) {
-    const excerpt = await renderExcerpt(failure.excerpt, command.join(" "), options.store);
+  for (const failure of filteredFailures) {
+    const excerpt = await renderExcerpt(failure.excerpt, parsedCommand.argv.join(" "), options.store);
     failures.push({ suite: failure.suite, name: failure.name, excerpt: excerpt.text });
     mintedHandle ??= excerpt.handle;
     bytesElided += excerpt.bytesElided;
   }
 
-  const payload: TestPayload = { exit_code: status, summary };
+  const payload: TestPayload = {
+    exit_code: status,
+    summary: parsedCommand.query ? `${summary} · ${filteredFailures.length}/${parsed.failures.length} failures matched` : summary,
+  };
   if (failures.length > 0) payload.failures = failures;
+  const renderedPayload = parsedCommand.query
+    ? withHelp(payload as unknown as JsonObject, ["rsp show <handle>", "rsp vitest --query <suite-or-test>"]) as unknown as TestPayload
+    : payload;
 
   return {
-    stdout: Buffer.from(encode(payload as unknown as JsonObject)),
+    stdout: Buffer.from(encode(renderedPayload as unknown as JsonObject)),
     stderr: Buffer.from(contract.stderr),
     status: contract.status,
     signal: contract.signal,
-    payload: payload as unknown as JsonObject,
+    payload: renderedPayload as unknown as JsonObject,
     mintedHandle,
     bytesElided: bytesElided > 0 ? bytesElided : undefined,
     rowsElided: failures.length > 0 ? Math.max(0, parsed.total - failures.length) : undefined,
@@ -102,6 +112,7 @@ async function renderTerse(
   status: number | null,
   summary: string,
   options: TestRenderOptions,
+  query?: string,
 ): Promise<GitRenderResult> {
   const inline: TestFailure[] = parsed.failures.slice(0, TERSE_TOP_K_FAILURES).map((failure) => ({
     suite: failure.suite,
@@ -109,9 +120,12 @@ async function renderTerse(
     excerpt: terseExcerpt(failure.excerpt),
   }));
 
-  const tersePayload: TestPayload = { exit_code: status, summary };
+  const tersePayload: TestPayload = { exit_code: status, summary: query ? `${summary} · ${parsed.failures.length} failures matched` : summary };
   if (inline.length > 0) tersePayload.failures = inline;
-  const terseToon = encode(tersePayload as unknown as JsonObject);
+  const renderedTersePayload = query
+    ? withHelp(tersePayload as unknown as JsonObject, ["rsp show <handle>", "rsp vitest --query <suite-or-test>"]) as unknown as TestPayload
+    : tersePayload;
+  const terseToon = encode(renderedTersePayload as unknown as JsonObject);
 
   const elidedFailures = Math.max(0, parsed.failures.length - inline.length);
   const excerptTrimmed = inline.some((row, index) => row.excerpt !== parsed.failures[index].excerpt);
@@ -123,7 +137,7 @@ async function renderTerse(
       stderr: Buffer.from(contract.stderr),
       status: contract.status,
       signal: contract.signal,
-      payload: tersePayload as unknown as JsonObject,
+      payload: renderedTersePayload as unknown as JsonObject,
     };
   }
 
@@ -151,7 +165,7 @@ async function renderTerse(
     stderr: Buffer.from(contract.stderr),
     status: contract.status,
     signal: contract.signal,
-    payload: tersePayload as unknown as JsonObject,
+    payload: renderedTersePayload as unknown as JsonObject,
     mintedHandle: handle,
     bytesElided,
     rowsElided: elidedFailures,

--- a/apps/rsp/tests/gh-wrapper.test.ts
+++ b/apps/rsp/tests/gh-wrapper.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
 import { discoverFidelityFixtures, runFidelityFixture } from "../src/fidelity.js";
 import { RspElisionStore } from "../src/elision-store.js";
+import { renderGhContract } from "../src/gh-wrapper.js";
 
 const roots: string[] = [];
 const fixtureRoot = join(import.meta.dirname, "fixtures", "gh");
@@ -160,6 +161,60 @@ describe("rsp gh admission harness", () => {
     } finally {
       await store.close();
     }
+  });
+});
+
+describe("rsp gh token levers", () => {
+  it("filters list rows with --query and appends next-step help", async () => {
+    const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "pr-list-default")!;
+    const result = await renderGhContract(["gh", "pr", "list", "--query", "Draft"], fixture.recorded, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as { prs: Array<{ title: string }>; summary: string; help: string[] };
+
+    expect(decoded.prs).toEqual([expect.objectContaining({ title: "Draft docs" })]);
+    expect(decoded.summary).toBe("1/2 open PRs");
+    expect(decoded.help).toContain("rsp gh pr <number>");
+  });
+
+  it("combines PR view, checks, and latest comments in one output", async () => {
+    const recorded = {
+      stdout: JSON.stringify({
+        view: {
+          number: 42,
+          title: "Add rsp gh wrapper",
+          state: "OPEN",
+          isDraft: false,
+          body: "Combined operation body",
+          labels: [{ name: "ready-for-agent" }],
+          author: { login: "octocat" },
+          url: "https://example.invalid/pr/42",
+          baseRefName: "main",
+          headRefName: "feature",
+        },
+        checks: [
+          { name: "test", state: "SUCCESS", bucket: "pass", conclusion: "SUCCESS", workflow: "ci", link: "https://example.invalid/check" },
+          { name: "lint", state: "PENDING", bucket: "pending", conclusion: "", workflow: "ci", link: "https://example.invalid/lint" },
+        ],
+        comments: {
+          comments: [
+            { author: { login: "a" }, body: "first", createdAt: "2026-01-01T00:00:00Z" },
+            { author: { login: "b" }, body: "second", createdAt: "2026-01-02T00:00:00Z" },
+            { author: { login: "c" }, body: "third", createdAt: "2026-01-03T00:00:00Z" },
+            { author: { login: "d" }, body: "fourth", createdAt: "2026-01-04T00:00:00Z" },
+          ],
+        },
+      }),
+      stderr: "",
+      status: 0,
+      signal: null,
+    };
+
+    const result = await renderGhContract(["gh", "pr", "42"], recorded, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as { pr: { number: number }; checks: unknown[]; comments: Array<{ body: string }>; help: string[] };
+
+    expect(decoded.pr.number).toBe(42);
+    expect(decoded.checks).toHaveLength(2);
+    expect(decoded.comments.map((row) => row.body)).toEqual(["second", "third", "fourth"]);
+    expect(decoded.help).toContain("rsp gh pr <number> --query <check-or-comment>");
   });
 });
 

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
 import { runFidelityFixture, discoverFidelityFixtures } from "../src/fidelity.js";
 import { RspElisionStore } from "../src/elision-store.js";
+import { renderGitContract } from "../src/git-wrapper.js";
 
 const roots: string[] = [];
 const fixtureRoot = join(import.meta.dirname, "fixtures", "git");
@@ -156,6 +157,18 @@ describe("rsp git admission harness", () => {
     } finally {
       await store.close();
     }
+  });
+});
+
+describe("rsp git token levers", () => {
+  it("filters row payloads with --query and appends contextual help", async () => {
+    const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "status-working-tree")!;
+    const result = await renderGitContract(["git", "status", "--query", "modified"], fixture.recorded, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as { rows: Array<{ path: string; state: string }>; summary: string; help: string[] };
+
+    expect(decoded.rows).toEqual([expect.objectContaining({ state: "modified" })]);
+    expect(decoded.summary).toMatch(/^1\/3 changes:/);
+    expect(decoded.help).toContain("rsp git diff --query <path>");
   });
 });
 

--- a/apps/rsp/tests/test-wrapper.test.ts
+++ b/apps/rsp/tests/test-wrapper.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
 import { discoverFidelityFixtures, runFidelityFixture } from "../src/fidelity.js";
 import { RspElisionStore } from "../src/elision-store.js";
+import { renderTestContract } from "../src/test-wrapper.js";
 
 const roots: string[] = [];
 const fixtureRoot = join(import.meta.dirname, "fixtures", "test-runners");
@@ -183,6 +184,18 @@ describe("rsp vitest terse failure budget", () => {
     } finally {
       await store.close();
     }
+  });
+});
+
+describe("rsp test runner token levers", () => {
+  it("filters failure rows with --query and appends contextual help", async () => {
+    const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-many-failures")!;
+    const result = await renderTestContract(["vitest", "--query", "beta case five"], fixture.recorded, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as { summary: string; failures: Array<{ name: string }>; help: string[] };
+
+    expect(decoded.failures).toEqual([expect.objectContaining({ name: "beta case five" })]);
+    expect(decoded.summary).toContain("1/5 failures matched");
+    expect(decoded.help).toContain("rsp vitest --query <suite-or-test>");
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1465. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1465

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786375616&installation_id=129708444&pr_number=1479&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1479&signature=90648142e662d008d4c8e9cb61eac8f622c0a751ff8cc7874e66037802e99e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->