### PR TITLE
merge: #1481 afk worker crashes on mixed-blocked issue state, stranding the issue

### DIFF
--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -26,7 +26,7 @@
 
 /** The literal `## Blocked by` heading line, allowing only trailing whitespace.
  * Mirrors awk `/^## Blocked by[[:space:]]*$/`. */
-import { LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT, LABEL_DEPENDENCY, LABEL_READY, LABEL_HUMAN } from "./triage-labels.js";
+import { LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT, LABEL_DEPENDENCY, LABEL_READY, LABEL_RUNNING, LABEL_HUMAN } from "./triage-labels.js";
 import {
   renderIssueReferenceList,
   resolveIssueReferences,
@@ -346,6 +346,74 @@ export async function stragglerCounts(lookup: StragglerCountLookup): Promise<Str
  * `[[ $unlabeled -gt 0 || $needs_triage -gt 0 || $needs_info -gt 0 ]]`. */
 export function shouldWarnStragglers(counts: StragglerCounts): boolean {
   return counts.unlabeled > 0 || counts.needsTriage > 0 || counts.needsInfo > 0;
+}
+
+// ---------- mixed-blocked normalizer (#1481) ----------
+
+/** A candidate the mixed-blocked normalizer examines: number + full label set. */
+export interface MixedBlockedCandidate {
+  number: number;
+  labels: string[];
+}
+
+/** One planned heal: strip the stale `blocked:*` labels off a queued/active issue
+ * so it can never trip a worker's lifecycle FSM into the illegal state. */
+export interface MixedBlockedNormalizePlan {
+  number: number;
+  /** The `blocked:*` labels to remove (sorted-unique). */
+  remove: string[];
+}
+
+/**
+ * Plan the mixed-blocked normalizer over `candidates`. An issue is MIXED-BLOCKED
+ * when it carries a queued/active label (`ready-for-agent` or `running`) TOGETHER
+ * with one or more `blocked:*` labels — the illegal FSM state that crashed workers
+ * mid-setup before #1481. The heal is to shed every `blocked:*` label, restoring a
+ * clean queued/active state. Issues that are cleanly queued (no blocked:*), cleanly
+ * blocked (no ready/running), or otherwise legal produce no plan. Pure and
+ * idempotent: a healed issue no longer matches, so a replay no-ops.
+ */
+export function planMixedBlockedNormalize(
+  candidates: readonly MixedBlockedCandidate[],
+): MixedBlockedNormalizePlan[] {
+  const plans: MixedBlockedNormalizePlan[] = [];
+  for (const c of candidates) {
+    const queuedOrActive = c.labels.includes(LABEL_READY) || c.labels.includes(LABEL_RUNNING);
+    if (!queuedOrActive) continue;
+    const blocked = [...new Set(c.labels.filter((l) => l.startsWith("blocked:")))].sort();
+    if (blocked.length === 0) continue;
+    plans.push({ number: c.number, remove: blocked });
+  }
+  return plans;
+}
+
+/** The minimal gh surface the normalizer MUTATES: strip the stale blocked:* labels
+ * (REMOVE first, ADD second — BootDeps.gh order). */
+export interface MixedBlockedNormalizeGh {
+  editLabels(issue: number, remove: string[], add: string[]): Promise<void>;
+}
+
+/**
+ * Run the mixed-blocked normalizer end-to-end: {@link planMixedBlockedNormalize}
+ * the candidates, then strip each planned issue's stale `blocked:*` labels in one
+ * edit. Returns the healed issue numbers. Best-effort: a failed edit skips that
+ * issue and leaves it for the next sweep — a normalizer must never abort the boot.
+ */
+export async function executeMixedBlockedNormalize(
+  candidates: readonly MixedBlockedCandidate[],
+  gh: MixedBlockedNormalizeGh,
+): Promise<number[]> {
+  const plans = planMixedBlockedNormalize(candidates);
+  const healed: number[] = [];
+  for (const p of plans) {
+    try {
+      await gh.editLabels(p.number, p.remove, []);
+      healed.push(p.number);
+    } catch {
+      // Best-effort: a failed heal leaves the issue for the next boot's sweep.
+    }
+  }
+  return healed;
 }
 
 // ---------- reconcile sweep ----------

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -30,11 +30,13 @@ import {
   type IssueLookup,
 } from "./branch-cleanup.js";
 import {
+  executeMixedBlockedNormalize,
   executeUnblockSweep,
   planReconcileSweep,
   stragglerCounts,
   shouldWarnStragglers,
   type BlockerStateLookup,
+  type MixedBlockedCandidate,
   type StragglerCountLookup,
   type StragglerCounts,
   type UnblockCandidate,
@@ -306,6 +308,11 @@ export interface BootOptions {
    * reconcile sweep (step 7) will attempt to validate-and-land. When absent the
    * sweep is a no-op. Optional for back-compat. */
   reconcileSweepCandidates?: readonly ReconcileSweepCandidate[];
+  /** Open issues found in the illegal MIXED-BLOCKED state (`ready-for-agent` or
+   * `running` together with a `blocked:*` label) that the normalizer sweep (#1481)
+   * will heal by shedding the stale `blocked:*` labels. When absent the sweep is a
+   * no-op. Optional for back-compat. */
+  mixedBlockedCandidates?: readonly MixedBlockedCandidate[];
   /**
    * Skip every shared boot sweep (#623). When true, `runBoot` runs precheck +
    * bootstrap only and returns before orphan cleanup / attempt cap / branch
@@ -345,6 +352,11 @@ export interface UnblockSweepResult {
   promoted: number[];
 }
 
+export interface MixedBlockedNormalizeResult {
+  /** Issues healed out of the illegal mixed-blocked state (stale blocked:* shed). */
+  healed: number[];
+}
+
 export interface StragglerResult {
   counts: StragglerCounts;
   warn: boolean;
@@ -374,6 +386,7 @@ export interface BootResult {
   attemptCap?: AttemptCapResult;
   branchCleanup?: BranchCleanupResult;
   unblockSweep?: UnblockSweepResult;
+  mixedBlockedNormalize?: MixedBlockedNormalizeResult;
   staleClaimSweep?: StaleClaimSweepResult;
   reconcileSweep?: ReconcileSweepResult;
   straggler?: StragglerResult;
@@ -448,6 +461,9 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   // ---- 6. unblock sweep ----
   const unblockSweep = await runUnblockSweep(deps, options.unblockCandidates);
 
+  // ---- 6a0. mixed-blocked normalizer (#1481) ----
+  const mixedBlockedNormalize = await runMixedBlockedNormalize(deps, options);
+
   // ---- 6a. cross-host stale-claim sweep (#627) ----
   const staleClaimSweep = await runStaleClaimSweep(deps);
 
@@ -464,6 +480,7 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
     attemptCap,
     branchCleanup,
     unblockSweep,
+    mixedBlockedNormalize,
     staleClaimSweep,
     reconcileSweep,
     straggler,
@@ -699,6 +716,22 @@ async function runUnblockSweep(
   // periodic supervisor sweep (#844) promote through exactly one code path.
   const promoted = await executeUnblockSweep(candidates, deps.lookups.blockerState, deps.gh);
   return { promoted };
+}
+
+/** Step 6a0: mixed-blocked normalizer (#1481). Heal any issue found in the illegal
+ * MIXED-BLOCKED state (`ready-for-agent`/`running` together with a `blocked:*`
+ * label) by shedding the stale `blocked:*` labels, so it can never trip a worker's
+ * lifecycle FSM into the illegal state that crashed workers mid-setup. Sequenced
+ * right after the unblock sweep and before the stale-claim sweep so a healed issue
+ * rejoins the executable pool cleanly. A no-op when no candidates are provided. */
+async function runMixedBlockedNormalize(
+  deps: BootDeps,
+  options: BootOptions,
+): Promise<MixedBlockedNormalizeResult> {
+  const candidates = options.mixedBlockedCandidates ?? [];
+  if (candidates.length === 0) return { healed: [] };
+  const healed = await executeMixedBlockedNormalize(candidates, deps.gh);
+  return { healed };
 }
 
 /** Step 7: reconcile sweep (ADR 0055). For each owned parked-mechanical branch,

--- a/apps/dev/src/core/issue-lifecycle.ts
+++ b/apps/dev/src/core/issue-lifecycle.ts
@@ -84,7 +84,15 @@ export const ISSUE_LIFECYCLE_TRANSITIONS: readonly IssueLifecycleTransition[] = 
   { edge: "retry", from: "claimed/active", to: "ready-for-agent" },
   { edge: "dependency-unblocked", from: "blocked:dependency", to: "ready-for-agent" },
   { edge: "dependency-blocked", from: "ready-for-agent", to: "blocked:dependency" },
-  { edge: "preflight-blocked", from: "ready-for-agent", to: "ready-for-human" },
+  // `preflight-blocked` parks a queued issue to a human gate when preflight
+  // refuses to run it (an active `## Current blocker`, an untrusted author with no
+  // sandbox). Like `claim` and `human-delegable` it must tolerate an illegal
+  // mixed-blocked start set (`ready-for-agent`/`running` + a stale `blocked:*`),
+  // shedding the conflicting labels in the SAME park edit — hence `from: "*"`.
+  // Before #1481 this was `from: "ready-for-agent"` only, so a mixed-blocked issue
+  // classified as `illegal` found no row and killed the worker mid-setup with an
+  // uncaught session-error, stranding the issue.
+  { edge: "preflight-blocked", from: "*", to: "ready-for-human" },
   { edge: "validation-blocked", from: "claimed/active", to: "blocked:validation" },
   { edge: "human-blocked", from: "*", to: "ready-for-human" },
   { edge: "human-blocked", from: "*", to: "blocked:validation" },

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -888,7 +888,11 @@ import {
   LABEL_SENSITIVE_PATH,
   LABEL_SPEC,
 } from "./triage-labels.js";
-import { validateIssueLifecycleTransition, type IssueLifecycleEdge } from "./issue-lifecycle.js";
+import {
+  IllegalIssueLifecycleTransitionError,
+  validateIssueLifecycleTransition,
+  type IssueLifecycleEdge,
+} from "./issue-lifecycle.js";
 
 /**
  * The typed `blocked:*` labels present in a label set (#402). Promoting an issue
@@ -925,6 +929,16 @@ async function editLabelsTagged(
   return deps.gh.editLabels(issue, remove, [...add, typed]);
 }
 
+/**
+ * Apply one lifecycle label transition, validating it against the FSM first. A
+ * malformed (illegal mixed-blocked) start state must NEVER crash the worker (#1481):
+ * when the FSM rejects the transition, RECONCILE it by shedding every stale
+ * `blocked:*` label (except any we are explicitly adding) in the SAME edit —
+ * mirroring the `claim`/`human-delegable` normalisation — then re-validate and
+ * apply. If the reconciled edit is still illegal we log and apply it best-effort
+ * so the issue is at least parked and the worker survives, rather than dying with
+ * an uncaught session-error before it can log.
+ */
 async function editIssueLifecycleLabels(
   deps: ProcessIssueDeps,
   issue: number,
@@ -933,8 +947,23 @@ async function editIssueLifecycleLabels(
   add: string[],
   edge: IssueLifecycleEdge,
 ): Promise<boolean> {
-  validateIssueLifecycleTransition({ edge, fromLabels, removeLabels: remove, addLabels: add });
-  return deps.gh.editLabels(issue, remove, add);
+  try {
+    validateIssueLifecycleTransition({ edge, fromLabels, removeLabels: remove, addLabels: add });
+    return await deps.gh.editLabels(issue, remove, add);
+  } catch (err) {
+    if (!(err instanceof IllegalIssueLifecycleTransitionError)) throw err;
+    const shed = blockedLabelsIn([...fromLabels]).filter((l) => !add.includes(l));
+    const reconciledRemove = [...new Set([...remove, ...shed])];
+    try {
+      validateIssueLifecycleTransition({ edge, fromLabels, removeLabels: reconciledRemove, addLabels: add });
+    } catch (reErr) {
+      const reason = reErr instanceof Error ? reErr.message : String(reErr);
+      deps.appendIterLog(
+        `warn: lifecycle transition "${edge}" for #${issue} still malformed after reconcile (${reason}); applying best-effort park.`,
+      );
+    }
+    return await deps.gh.editLabels(issue, reconciledRemove, add);
+  }
 }
 
 /**

--- a/apps/dev/tests/boot-sweep.test.ts
+++ b/apps/dev/tests/boot-sweep.test.ts
@@ -7,8 +7,11 @@ import {
   isParkedMechanical,
   issueFromAFKBranch,
   parseBlockedBy,
+  executeMixedBlockedNormalize,
   parseReqLabels,
   planCloseCascade,
+  planMixedBlockedNormalize,
+  type MixedBlockedCandidate,
   planReconcileSweep,
   planUnblockSweep,
   refToNumber,
@@ -564,5 +567,48 @@ describe("planReconcileSweep", () => {
     ];
     const plans = planReconcileSweep(candidates, branches);
     expect(plans.map((p) => p.number)).toEqual([101, 202]);
+  });
+});
+
+describe("planMixedBlockedNormalize", () => {
+  it("heals a queued issue carrying a stale blocked:* label", () => {
+    const candidates: MixedBlockedCandidate[] = [
+      { number: 1, labels: ["ready-for-agent", "blocked:spec"] },
+    ];
+    expect(planMixedBlockedNormalize(candidates)).toEqual([{ number: 1, remove: ["blocked:spec"] }]);
+  });
+
+  it("heals a running issue and sheds every blocked:* label", () => {
+    const candidates: MixedBlockedCandidate[] = [
+      { number: 2, labels: ["running", "blocked:validation", "blocked:spec"] },
+    ];
+    expect(planMixedBlockedNormalize(candidates)).toEqual([
+      { number: 2, remove: ["blocked:spec", "blocked:validation"] },
+    ]);
+  });
+
+  it("leaves legal states untouched", () => {
+    const candidates: MixedBlockedCandidate[] = [
+      { number: 3, labels: ["ready-for-agent"] },        // cleanly queued
+      { number: 4, labels: ["blocked:dependency"] },     // cleanly blocked
+      { number: 5, labels: ["ready-for-human", "blocked:spec"] }, // legal human park
+    ];
+    expect(planMixedBlockedNormalize(candidates)).toEqual([]);
+  });
+
+  it("executes the plan, stripping blocked:* and returning healed numbers", async () => {
+    const edits: { issue: number; remove: string[]; add: string[] }[] = [];
+    const gh = {
+      async editLabels(issue: number, remove: string[], add: string[]) {
+        edits.push({ issue, remove, add });
+      },
+    };
+    const candidates: MixedBlockedCandidate[] = [
+      { number: 11, labels: ["ready-for-agent", "blocked:spec"] },
+      { number: 12, labels: ["ready-for-agent"] }, // clean → no edit
+    ];
+    const healed = await executeMixedBlockedNormalize(candidates, gh);
+    expect(healed).toEqual([11]);
+    expect(edits).toEqual([{ issue: 11, remove: ["blocked:spec"], add: [] }]);
   });
 });

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -658,6 +658,30 @@ describe("runBoot unblock sweep promotes + comments", () => {
   });
 });
 
+describe("runBoot mixed-blocked normalizer (#1481)", () => {
+  it("heals a pre-existing mixed-blocked issue by shedding its stale blocked:*", async () => {
+    const { deps, ghCalls } = makeDeps();
+    const r = await runBoot(
+      deps,
+      options({
+        mixedBlockedCandidates: [
+          { number: 42, labels: ["ready-for-agent", "blocked:spec"] },
+          { number: 43, labels: ["ready-for-agent"] }, // clean → untouched
+        ],
+      }),
+    );
+    expect(ghCalls.editLabels).toEqual([{ issue: 42, remove: ["blocked:spec"], add: [] }]);
+    expect(r.mixedBlockedNormalize).toEqual({ healed: [42] });
+  });
+
+  it("is a no-op when no mixed-blocked candidates are provided", async () => {
+    const { deps, ghCalls } = makeDeps();
+    const r = await runBoot(deps, options());
+    expect(ghCalls.editLabels).toEqual([]);
+    expect(r.mixedBlockedNormalize).toEqual({ healed: [] });
+  });
+});
+
 describe("runBoot cross-host stale-claim sweep (#627)", () => {
   // A claim record from `worker` whose latest refresh was `ageS` ago.
   const claim = (commentId: number, worker: string, ageS: number) => ({

--- a/apps/dev/tests/issue-lifecycle.test.ts
+++ b/apps/dev/tests/issue-lifecycle.test.ts
@@ -115,6 +115,30 @@ describe("issue lifecycle transition table", () => {
     ).toEqual(["ready-for-agent"]);
   });
 
+  it("parks a mixed-blocked issue cleanly through preflight-blocked (#1481)", () => {
+    // A queued issue carrying a stale `blocked:spec` classifies as illegal. The
+    // preflight park sheds every blocked:* in the same edit and lands on a clean
+    // ready-for-human — the `from: "*"` row must accept the illegal start state.
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "preflight-blocked",
+        fromLabels: ["ready-for-agent", "blocked:validation"],
+        removeLabels: ["ready-for-agent", "blocked:validation"],
+        addLabels: ["ready-for-human", "blocked:spec"],
+      }).sort(),
+    ).toEqual(["blocked:spec", "ready-for-human"]);
+
+    // The plain queued → parked case still works (no blocked:* to shed).
+    expect(
+      validateIssueLifecycleTransition({
+        edge: "preflight-blocked",
+        fromLabels: ["ready-for-agent"],
+        removeLabels: ["ready-for-agent"],
+        addLabels: ["ready-for-human"],
+      }),
+    ).toEqual(["ready-for-human"]);
+  });
+
   it("rejects illegal mixed blocked states through a table edge", () => {
     expect(() =>
       validateIssueLifecycleTransition({

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -1672,6 +1672,38 @@ describe("processIssue — active Current blocker preflight", () => {
     expect(trace.released).toEqual([9]);
   });
 
+  it("parks a MIXED-BLOCKED issue cleanly instead of crashing the worker (#1481)", async () => {
+    // An illegal mixed-blocked issue: ready-for-agent dragging a stale
+    // blocked:validation, with an active non-mechanical Current blocker so
+    // preflight decides to park. Before #1481 the preflight-blocked transition
+    // classified the start state as `illegal`, found no legal row, and killed the
+    // worker with an uncaught session-error. Now it reconciles: sheds every stale
+    // blocked:* in the same park edit and lands cleanly on ready-for-human.
+    const body = upsertCurrentBlocker("## Agent brief\nDo it.", {
+      status: "blocked",
+      kind: "decision",
+      ref: "#856",
+      summary: "Measurement did not prove a win.",
+      next: "Decide whether to stop, redesign, or continue anyway.",
+    });
+    const { deps, input, trace } = harness({
+      body,
+      labels: ["ready-for-agent", "blocked:validation"],
+    });
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("blocked");
+    expect(trace.runAgentCalls).toEqual([]);
+    const parkEdit = trace.labelEdits.at(-1)!;
+    // Stale blocked:validation shed AND ready-for-agent removed in the same edit.
+    expect(parkEdit.remove).toContain("ready-for-agent");
+    expect(parkEdit.remove).toContain("blocked:validation");
+    // Parks to a clean human gate with the blocking-reason label.
+    expect(parkEdit.add).toContain("ready-for-human");
+    expect(parkEdit.add).toContain("blocked:spec");
+    expect(trace.released).toEqual([9]);
+  });
+
   it("does not escalate a mechanical Current blocker before reconcile can handle it", async () => {
     const body = upsertCurrentBlocker("## Agent brief\nDo it.", {
       status: "blocked",


### PR DESCRIPTION
Automated AFK landing for #1481. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1481

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786380621&installation_id=129708444&pr_number=1483&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1483&signature=b848e6489fe83df610f46006d70415655ff0f2c0e0b978f4ab1ba7a1242d5245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->