### PR TITLE
rsp interception hook: fail-closed rewrite table + Claude pre-exec wiring

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -5,6 +5,7 @@ import { RspElisionStore } from "./elision-store.js";
 import { resolveRspConfig } from "./config.js";
 import { runGitWrapper } from "./git-wrapper.js";
 import { runGhWrapper } from "./gh-wrapper.js";
+import { runClaudePreExecHook } from "./intercept.js";
 import { runTestWrapper } from "./test-wrapper.js";
 
 interface ParsedArgs {
@@ -17,6 +18,10 @@ interface ParsedArgs {
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
   const args = parseArgs(argv);
+  if (args.command === "hook" && args.positional[1] === "claude-pre-exec") {
+    return await runClaudePreExecHook();
+  }
+
   const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
     process.stdout.write("error: rsp repo store is not provisioned - run /setup-red-skills\n");

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs";
+import { resolveRspConfig } from "./config.js";
+
+export interface RspWrapperCapability {
+  id: string;
+  command: readonly string[];
+  wrapper: readonly string[];
+}
+
+export type RewriteDecision =
+  | { kind: "rewrite"; command: string; capabilityId: string }
+  | { kind: "passthrough"; reason?: string };
+
+export interface HookDecisionOptions {
+  cwd: string;
+  isEnabled?: (cwd: string) => boolean | Promise<boolean>;
+  rewrite?: (command: string) => RewriteDecision;
+}
+
+export const RSP_WRAPPER_CAPABILITIES: readonly RspWrapperCapability[] = [
+  { id: "git:status", command: ["git", "status"], wrapper: ["git", "status"] },
+  { id: "git:log", command: ["git", "log"], wrapper: ["git", "log"] },
+  { id: "git:diff", command: ["git", "diff"], wrapper: ["git", "diff"] },
+  { id: "git:commit", command: ["git", "commit"], wrapper: ["git", "commit"] },
+  { id: "git:push", command: ["git", "push"], wrapper: ["git", "push"] },
+  { id: "gh:pr:list", command: ["gh", "pr", "list"], wrapper: ["gh", "pr", "list"] },
+  { id: "gh:pr:view", command: ["gh", "pr", "view"], wrapper: ["gh", "pr", "view"] },
+  { id: "gh:issue:list", command: ["gh", "issue", "list"], wrapper: ["gh", "issue", "list"] },
+  { id: "gh:issue:view", command: ["gh", "issue", "view"], wrapper: ["gh", "issue", "view"] },
+  { id: "gh:run:list", command: ["gh", "run", "list"], wrapper: ["gh", "run", "list"] },
+  { id: "gh:run:view", command: ["gh", "run", "view"], wrapper: ["gh", "run", "view"] },
+  { id: "vitest", command: ["vitest"], wrapper: ["vitest"] },
+  { id: "vitest:run", command: ["vitest", "run"], wrapper: ["vitest", "run"] },
+  { id: "cargo:test", command: ["cargo", "test"], wrapper: ["cargo", "test"] },
+];
+
+const DEFAULT_REWRITE_TABLE = rewriteTableFromCapabilities(RSP_WRAPPER_CAPABILITIES);
+
+export function rewriteTableFromCapabilities(capabilities: readonly RspWrapperCapability[]): Map<string, readonly string[]> {
+  const table = new Map<string, readonly string[]>();
+  for (const entry of capabilities) table.set(commandKey(entry.command), ["rsp", ...entry.wrapper]);
+  return table;
+}
+
+export function rewriteCommand(command: string): RewriteDecision {
+  const tokens = tokenizeCertainSimpleCommand(command);
+  if (!tokens) return { kind: "passthrough" };
+  if (tokens.length > 0 && isEnvAssignment(tokens[0]!)) return { kind: "passthrough" };
+
+  const rewritten = DEFAULT_REWRITE_TABLE.get(commandKey(tokens));
+  if (!rewritten) return { kind: "passthrough" };
+  const capability = RSP_WRAPPER_CAPABILITIES.find((entry) => commandKey(entry.command) === commandKey(tokens));
+  return {
+    kind: "rewrite",
+    command: rewritten.join(" "),
+    capabilityId: capability?.id ?? commandKey(tokens),
+  };
+}
+
+export async function hookDecisionFromClaudePreExecJson(
+  raw: string,
+  options: HookDecisionOptions,
+): Promise<RewriteDecision> {
+  const payload = parseJsonRecord(raw);
+  const cwd = stringAt(payload, ["cwd"]) || stringAt(payload, ["tool_input", "cwd"]) || options.cwd;
+  const enabled = await (options.isEnabled ?? isRspHookEnabled)(cwd);
+  if (!enabled) return { kind: "passthrough", reason: "disabled" };
+
+  const command = extractHookCommand(payload);
+  if (!command) return { kind: "passthrough", reason: "missing-command" };
+  return (options.rewrite ?? rewriteCommand)(command);
+}
+
+export function formatHookDecision(decision: RewriteDecision): { stdout: string; status: number } {
+  if (decision.kind === "rewrite") return { stdout: `${decision.command}\n`, status: 0 };
+  return { stdout: "", status: 1 };
+}
+
+export async function runClaudePreExecHook(stdinPath?: string): Promise<number> {
+  const raw = stdinPath ? readFileSync(stdinPath, "utf8") : readFileSync(0, "utf8");
+  const decision = await hookDecisionFromClaudePreExecJson(raw, { cwd: process.cwd() });
+  const formatted = formatHookDecision(decision);
+  if (formatted.stdout) process.stdout.write(formatted.stdout);
+  return formatted.status;
+}
+
+function isRspHookEnabled(cwd: string): boolean {
+  return resolveRspConfig(cwd, process.env).enabled;
+}
+
+function extractHookCommand(payload: Record<string, unknown>): string {
+  return (
+    stringAt(payload, ["tool_input", "command"]) ||
+    stringAt(payload, ["tool_input", "cmd"]) ||
+    stringAt(payload, ["tool_input", "args", "command"]) ||
+    stringAt(payload, ["input", "command"]) ||
+    stringAt(payload, ["input", "cmd"]) ||
+    stringAt(payload, ["arguments", "command"]) ||
+    stringAt(payload, ["arguments", "cmd"]) ||
+    stringAt(payload, ["command"]) ||
+    stringAt(payload, ["cmd"])
+  );
+}
+
+function tokenizeCertainSimpleCommand(command: string): string[] | null {
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+  if (/[\n\r|&;()$<>`'"]/.test(trimmed)) return null;
+  const tokens = trimmed.split(/[ \t]+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+  if (tokens.some((token) => token.includes("=") && isEnvAssignment(token))) return null;
+  return tokens;
+}
+
+function isEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token);
+}
+
+function commandKey(tokens: readonly string[]): string {
+  return tokens.join("\0");
+}
+
+function parseJsonRecord(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringAt(record: Record<string, unknown>, path: readonly string[]): string {
+  let cursor: unknown = record;
+  for (const key of path) {
+    if (!isRecord(cursor)) return "";
+    cursor = cursor[key];
+  }
+  return typeof cursor === "string" ? cursor : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -1,0 +1,125 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  RSP_WRAPPER_CAPABILITIES,
+  formatHookDecision,
+  hookDecisionFromClaudePreExecJson,
+  rewriteCommand,
+  rewriteTableFromCapabilities,
+} from "../src/intercept.js";
+
+const roots: string[] = [];
+const cli = join(import.meta.dirname, "..", "src", "cli.ts");
+const tsxLoader = createRequire(import.meta.url).resolve("tsx");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-intercept-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp interception pure rewrite table", () => {
+  it("rewrites every wrapper capability form from the table", () => {
+    for (const entry of RSP_WRAPPER_CAPABILITIES) {
+      const decision = rewriteCommand(entry.command.join(" "));
+      expect(decision, entry.id).toEqual({
+        kind: "rewrite",
+        command: ["rsp", ...entry.wrapper].join(" "),
+        capabilityId: entry.id,
+      });
+    }
+  });
+
+  it("keeps the rewrite allowlist derived from the capability table", () => {
+    const extended = [
+      ...RSP_WRAPPER_CAPABILITIES,
+      { id: "fixture:echo", command: ["echo", "ok"], wrapper: ["fixture", "echo"] },
+    ];
+
+    expect(rewriteTableFromCapabilities(extended).get("echo\0ok")).toEqual(["rsp", "fixture", "echo"]);
+  });
+
+  it.each([
+    ["upstream-subcommand-identity-not-dropped", "git -C repo status"],
+    ["upstream-space-arg-not-skipped-into-rewrite", "gh issue view \"two words\""],
+    ["upstream-paren-arg-not-skipped-into-rewrite", "gh issue view 'needs (triage)'"],
+    ["env-prefix-is-ambiguous", "GIT_DIR=.git git status"],
+    ["silent-predicate-grep-q", "grep -q needle file"],
+    ["redirection-is-ambiguous", "git status > status.txt"],
+    ["subshell-is-ambiguous", "$(git status)"],
+    ["compound-command-is-ambiguous", "git status && echo done"],
+    ["quoted-command-name-is-ambiguous", "\"git\" status"],
+  ])("passes through adversarial fixture %s", (_name, command) => {
+    expect(rewriteCommand(command)).toEqual({ kind: "passthrough" });
+  });
+});
+
+describe("rsp Claude pre-execution hook integration", () => {
+  it("accepts Claude hook JSON on stdin through the CLI and returns the stdout/exit contract", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-pre-exec"], {
+      cwd: root,
+      input: Buffer.from(JSON.stringify({ cwd: root, tool_input: { command: "git status" } })),
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(Buffer.from("rsp git status\n"));
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
+  it("prints only the rewritten command and exits 0 on a certain match", async () => {
+    const root = await tempRoot();
+    const result = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+      { cwd: root, isEnabled: () => true },
+    );
+
+    expect(formatHookDecision(result)).toEqual({ stdout: "rsp git status\n", status: 0 });
+  });
+
+  it("prints nothing and exits non-zero on passthrough", async () => {
+    const root = await tempRoot();
+    const result = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "git status --short" } }),
+      { cwd: root, isEnabled: () => true },
+    );
+
+    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+  });
+
+  it("makes disabled directories inert before rewrite work", async () => {
+    const root = await tempRoot();
+    let gateCalls = 0;
+    let rewriteCalls = 0;
+    const result = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+      {
+        cwd: root,
+        isEnabled: () => {
+          gateCalls += 1;
+          return false;
+        },
+        rewrite: () => {
+          rewriteCalls += 1;
+          return { kind: "rewrite", command: "rsp git status", capabilityId: "unexpected" };
+        },
+      },
+    );
+
+    expect(result).toEqual({ kind: "passthrough", reason: "disabled" });
+    expect(gateCalls).toBe(1);
+    expect(rewriteCalls).toBe(0);
+    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+  });
+});

--- a/plugins/dev/hooks/claude.hooks.json
+++ b/plugins/dev/hooks/claude.hooks.json
@@ -16,6 +16,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CLAUDE_PLUGIN_ROOT}\"; for f in \"$root/../../dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\"; do [ -f \"$f\" ] && { timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" hook claude-pre-exec <\"$tmp\"; exit $?; }; done; exit 1'"
+          },
+          {
+            "type": "command",
             "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; hook=\"${CLAUDE_PLUGIN_ROOT}/skills/misc/branch-lock/scripts/branch-lock-hook.sh\"; if [ -f \"$hook\" ]; then bash \"$hook\" <\"$tmp\" || printf \"{}\"; else printf \"{}\"; fi'"
           },
           {


### PR DESCRIPTION
Lands the keystone of the elision program (Spec #1403, ADR 0095 Decisions 1.2 & 7): the stateless `rewrite(command) → rewritten | passthrough` decision compiled into the rsp binary and wired as a Claude Code pre-execution hook, gated per-repo.

## What's here
- `apps/rsp/src/intercept.ts` — pure rewrite decision function (fail-closed: any un-tokenizable / env-assignment / non-matching command passes through untouched)
- `apps/rsp/tests/intercept.test.ts` — table-driven suite + adversarial fixtures (quoting, parens, `grep -q`, compound/redirect) named for the upstream mis-rewrite classes they prevent
- `apps/rsp/src/cli.ts` — exposes `rsp hook claude-pre-exec`
- `plugins/dev/hooks/claude.hooks.json` — wires the pre-exec command hook, mirroring the existing branch-lock hook's defensive pattern (mktemp + trap cleanup + stdin/exec timeouts + fail path)

## Safety
- **Per-repo gated** (ADR 0067): `intercept.ts` returns `passthrough (disabled)` when no rsp enablement flag is present. This repo's `.red/config.yaml` has no such flag, so the hook is inert passthrough here until explicitly enabled.
- **Fail-closed**: missing bundle -> `exit 1` -> host treats as passthrough; nothing is ever partially rewritten.

Unblocks #1417 and #1418 (`req:1416`).

Closes #1416

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786381150&installation_id=129708444&pr_number=1484&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1484&signature=f93cbc685597edd7aed9f2ac2a56c8e1b7a7bc2c933c7e316711a0b48cc97e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->