### PR TITLE
feat: #1488 two-axis benchmark: report shipped admission config (passthrough filters = 0% overhead)

### DIFF
--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -32,6 +32,11 @@ export interface TwoAxisFilterRow {
   brief: BaselineAxis;
   terse: BaselineAxis;
   rtk: BaselineAxis;
+  /** Measured delta if this filter were forced active; equals brief/terse for active filters, non-zero for passthrough. */
+  hypothetical_active: {
+    brief: BaselineAxis;
+    terse: BaselineAxis;
+  };
 }
 
 export interface TwoAxisParityRow {
@@ -188,10 +193,10 @@ export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
     "",
     `Production mode uses admission threshold ${ADMISSION_THRESHOLD_PCT}%; passthrough filters count as 0% token delta because rsp returns the original command output.`,
     "",
-    "| Filter | Mode | Fixtures | brief median/p90 token delta | brief fidelity | terse median/p90 token delta | terse fidelity | RTK median/p90 token delta | RTK fidelity |",
-    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Filter | Mode | Fixtures | brief shipped delta | brief fidelity | brief hyp-active delta | terse shipped delta | terse fidelity | terse hyp-active delta | RTK median/p90 token delta | RTK fidelity |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ...report.filters.map((row) =>
-      `| ${row.filter} | ${row.mode} | ${row.fixture_count} | ${fmt(row.brief.median_delta_pct)}/${fmt(row.brief.p90_delta_pct)}% | ${fmt(row.brief.fidelity_pass_rate_pct)}% | ${fmt(row.terse.median_delta_pct)}/${fmt(row.terse.p90_delta_pct)}% | ${fmt(row.terse.fidelity_pass_rate_pct)}% | ${fmt(row.rtk.median_delta_pct)}/${fmt(row.rtk.p90_delta_pct)}% | ${fmt(row.rtk.fidelity_pass_rate_pct)}% |`
+      `| ${row.filter} | ${row.mode} | ${row.fixture_count} | ${fmt(row.brief.median_delta_pct)}/${fmt(row.brief.p90_delta_pct)}% | ${fmt(row.brief.fidelity_pass_rate_pct)}% | ${fmt(row.hypothetical_active.brief.median_delta_pct)}/${fmt(row.hypothetical_active.brief.p90_delta_pct)}% | ${fmt(row.terse.median_delta_pct)}/${fmt(row.terse.p90_delta_pct)}% | ${fmt(row.terse.fidelity_pass_rate_pct)}% | ${fmt(row.hypothetical_active.terse.median_delta_pct)}/${fmt(row.hypothetical_active.terse.p90_delta_pct)}% | ${fmt(row.rtk.median_delta_pct)}/${fmt(row.rtk.p90_delta_pct)}% | ${fmt(row.rtk.fidelity_pass_rate_pct)}% |`
     ),
     "",
     `Large-output filters: ${report.corpus.large_output_filters.join(", ") || "none"}.`,
@@ -247,18 +252,17 @@ function parityRow(domain: TwoAxisParityRow["domain"], filter: string, rows: rea
 function filterRow(filter: string, rows: readonly FixtureMeasurement[], admission?: AdmissionFilterReport): TwoAxisFilterRow {
   const mode = admission?.mode ?? "passthrough";
   const active = mode === "active";
+  const measuredBrief = axis(rows.map((row) => row.briefDelta), rows.map((row) => row.briefFidelity), "measured");
+  const measuredTerse = axis(rows.map((row) => row.terseDelta), rows.map((row) => row.terseFidelity), "measured");
   return {
     filter,
     mode,
     fixture_count: rows.length,
     raw: axis(rows.map((row) => row.rawDelta), rows.map((row) => row.rawFidelity), "recorded"),
-    brief: active
-      ? axis(rows.map((row) => row.briefDelta), rows.map((row) => row.briefFidelity), "measured")
-      : passthroughAxis(rows.length),
-    terse: active
-      ? axis(rows.map((row) => row.terseDelta), rows.map((row) => row.terseFidelity), "measured")
-      : passthroughAxis(rows.length),
+    brief: active ? measuredBrief : passthroughAxis(rows.length),
+    terse: active ? measuredTerse : passthroughAxis(rows.length),
     rtk: axis(rows.map((row) => row.rtkDelta), rows.map((row) => row.rtkFidelity), "recorded"),
+    hypothetical_active: { brief: measuredBrief, terse: measuredTerse },
   };
 }
 

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -34,6 +34,10 @@ describe("rsp two-axis benchmark report", () => {
       brief: { median_delta_pct: 0, p90_delta_pct: 0, fidelity_pass_rate_pct: 100 },
       terse: { median_delta_pct: 0, p90_delta_pct: 0, fidelity_pass_rate_pct: 100 },
       rtk: { fidelity_pass_rate_pct: 100, source: "recorded" },
+      hypothetical_active: {
+        brief: { source: "measured" },
+        terse: { source: "measured" },
+      },
     });
     expect(typeof gitCommit?.brief.median_delta_pct).toBe("number");
 
@@ -67,6 +71,6 @@ describe("rsp two-axis benchmark report", () => {
 
     await expect(readFile(toonPath, "utf8")).resolves.toBe(report.toon);
     await expect(readFile(summaryPath, "utf8")).resolves.toBe(renderTwoAxisSummary(report));
-    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Filter | Mode | Fixtures | brief median/p90 token delta | brief fidelity | terse median/p90 token delta | terse fidelity | RTK median/p90 token delta | RTK fidelity |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Filter | Mode | Fixtures | brief shipped delta | brief fidelity | brief hyp-active delta | terse shipped delta | terse fidelity | terse hyp-active delta | RTK median/p90 token delta | RTK fidelity |");
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1488. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1488

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786383576&installation_id=129708444&pr_number=1494&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1494&signature=07d323be498dea84e4918b7e07e2dd7e39fcddc2530e88b0f31e7bf5931161d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->