### PR TITLE
fix: #1492 /go: Add a user-selectable statusline preset to the dev plugin statusline. Ne

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -20,7 +20,7 @@ import { existsSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { resolveBase } from "../core/base-resolver.js";
-import { type ClaudeInput, type ProjectInput } from "../core/statusline.js";
+import { type ClaudeInput, type ProjectInput, type StatuslinePreset } from "../core/statusline.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
@@ -123,6 +123,20 @@ export function statuslineEnabled(root: string): boolean {
   return true;
 }
 
+function coerceStatuslinePreset(raw: string): StatuslinePreset | undefined {
+  return raw === "full" || raw === "short" ? raw : undefined;
+}
+
+export function resolveStatuslinePreset(cfg: ReturnType<typeof loadConfig>): StatuslinePreset {
+  return (
+    coerceStatuslinePreset(getConfig(cfg, "plugins.dev.statusline.preset")) ??
+    coerceStatuslinePreset(getConfig(cfg, "dev.statusline.preset")) ??
+    coerceStatuslinePreset(getConfig(cfg, "afk.statusline.preset")) ??
+    coerceStatuslinePreset(getConfig(cfg, "statusline.preset")) ??
+    "full"
+  );
+}
+
 /** The block-1 project input: basename, the resolved git ref (branch or detached
  * short sha), and the running `dev` plugin version (build-info → dim `v<version>`
  * tag on the themed header). */
@@ -200,6 +214,7 @@ export async function statuslineCommand(
   // #1217) and thread it into both collectors — the hot render path never loads
   // config a second time per collector.
   const cfg = loadConfig(join(root, ".red", "config.yaml"), { warn: () => undefined });
+  const preset = resolveStatuslinePreset(cfg);
   const cacheTtlS = resolveStatuslineCacheTtl(process.env, (key) => getConfig(cfg, key));
   const base = await resolveBase(
     { issueBody: "" },
@@ -233,6 +248,7 @@ export async function statuslineCommand(
     columns: Number.isFinite(columns) && columns > 0 ? columns : undefined,
     workers,
     now: nowS,
+    preset,
   });
   stdout.write(`${line}\n`);
   return 0;

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -33,13 +33,14 @@ import {
   formatCacheAge,
   humanizeCount,
   humanizeTokens,
-  renderStatusline,
+  renderStatuslineWithPreset,
   renderFleetBlock,
   shortModel,
   type ClaudeInput,
   type FleetInput,
   type ProjectInput,
   type RepoInput,
+  type StatuslinePreset,
   type StatuslineInput,
 } from "./statusline.js";
 import { formatDiff, workerFields, type CompactWorker } from "./monitor.js";
@@ -75,6 +76,7 @@ const WORKER_COLUMNS: readonly WorkerColumn[] = [
   "rsn",
   "txt",
 ];
+const SHORT_WORKER_COLUMNS: readonly WorkerColumn[] = ["workerId", "iss", "phase", "elapsed"];
 type WorkerCells = Record<WorkerColumn, string>;
 type WorkerWidths = Record<WorkerColumn, number>;
 const NO_AGENT_ORIGINS = new Set(["requeue"]);
@@ -110,7 +112,7 @@ function tokenDisplay(f: ReturnType<typeof workerFields>): string {
 // ---------- identity zone (wine background) ----------
 
 /** `» bold-project dim-(branch) dim-vX`. Branch truncated like the plain renderer. */
-function projectContent(project: ProjectInput): string {
+function projectContent(project: ProjectInput, includeVersion = true): string {
   let ref = "";
   if (project.branch) {
     const b = project.branch.length > BRANCH_MAX ? `${project.branch.slice(0, 27)}…` : project.branch;
@@ -118,7 +120,7 @@ function projectContent(project: ProjectInput): string {
   } else if (project.detachedSha) {
     ref = ` ${DIM}(detached ${project.detachedSha})${WHITE}`;
   }
-  const ver = project.version ? ` ${DIM}v${project.version}${WHITE}` : "";
+  const ver = includeVersion && project.version ? ` ${DIM}v${project.version}${WHITE}` : "";
   return `${GOLD}»${WHITE} ${BOLD}${project.basename}${NOBOLD}${ref}${ver}`;
 }
 
@@ -195,19 +197,28 @@ export function renderHeaderLine(
   claude: ClaudeInput | undefined,
   repo: RepoInput | undefined,
   fleet?: FleetInput,
+  preset: StatuslinePreset = "full",
 ): string {
-  let s = `${WINE2}${WHITE} ${projectContent(project)} `;
+  let s = `${WINE2}${WHITE} ${projectContent(project, preset === "full")} `;
   const model = modelContent(claude);
-  if (model !== null) s += `${WINE}${WHITE} ${model} `;
+  if (preset === "full" && model !== null) s += `${WINE}${WHITE} ${model} `;
   // Drop the background: from here on the line is transparent.
   s += `${NOBG}${SOFT}`;
-  const tail = [
-    ctxKv(claude),
-    ...usageKvs(claude),
-    ...repoCountsKv(repo),
-    ...localDiffKv(repo),
-    ...fleetKv(fleet),
-  ].filter((x): x is string => x !== null);
+  const tail = preset === "short"
+    ? [
+        ctxKv(claude),
+        repo && repo.openIssues && repo.openIssues > 0
+          ? kv("iss", String(repo.openIssues)) +
+            (repo.cacheAgeS !== undefined ? ` (${formatCacheAge(repo.cacheAgeS)})` : "")
+          : null,
+      ].filter((x): x is string => x !== null)
+    : [
+        ctxKv(claude),
+        ...usageKvs(claude),
+        ...repoCountsKv(repo),
+        ...localDiffKv(repo),
+        ...fleetKv(fleet),
+      ].filter((x): x is string => x !== null);
   if (tail.length) s += ` ${tail.join("  ")}`;
   return `${s}${RESET}`;
 }
@@ -251,10 +262,10 @@ function workerCells(worker: CompactWorker, now: number): WorkerCells {
   };
 }
 
-function workerWidths(rows: readonly WorkerCells[]): WorkerWidths {
+function workerWidths(rows: readonly WorkerCells[], columns: readonly WorkerColumn[] = WORKER_COLUMNS): WorkerWidths {
   const widths = Object.fromEntries(WORKER_COLUMNS.map((column) => [column, 0])) as WorkerWidths;
   for (const row of rows) {
-    for (const column of WORKER_COLUMNS) widths[column] = Math.max(widths[column], visibleWidth(row[column]));
+    for (const column of columns) widths[column] = Math.max(widths[column], visibleWidth(row[column]));
   }
   return widths;
 }
@@ -266,15 +277,24 @@ function colorWorkerCell(column: WorkerColumn, raw: string): string {
   return raw;
 }
 
-function formatWorkerCells(row: WorkerCells, widths: WorkerWidths): string {
-  const parts = WORKER_COLUMNS.map((column) => colorWorkerCell(column, padVisible(row[column], widths[column])));
+function formatWorkerCells(
+  row: WorkerCells,
+  widths: WorkerWidths,
+  columns: readonly WorkerColumn[] = WORKER_COLUMNS,
+): string {
+  const parts = columns.map((column) => colorWorkerCell(column, padVisible(row[column], widths[column])));
   return `${NOBG}${SOFT}${parts.join(WORKER_GUTTER)}${RESET}`;
 }
 
-function renderWorkerLines(workers: ReadonlyArray<CompactWorker>, now: number): string[] {
+function renderWorkerLines(
+  workers: ReadonlyArray<CompactWorker>,
+  now: number,
+  preset: StatuslinePreset = "full",
+): string[] {
   const rows = workers.map((worker) => workerCells(worker, now));
-  const widths = workerWidths(rows);
-  return rows.map((row) => formatWorkerCells(row, widths));
+  const columns = preset === "short" ? SHORT_WORKER_COLUMNS : WORKER_COLUMNS;
+  const widths = workerWidths(rows, columns);
+  return rows.map((row) => formatWorkerCells(row, widths, columns));
 }
 
 /** The TERSE per-worker line for the Claude Code statusline (issue #1175, #1176):
@@ -295,8 +315,18 @@ function renderWorkerLines(workers: ReadonlyArray<CompactWorker>, now: number): 
  * line (`renderWorkerCompactLine`) keeps them. The two share only the field data
  * ({@link workerFields}), never a renderer, so the terse form cannot bleed into
  * the monitor. `now` is an epoch in seconds. */
-export function renderWorkerLine(worker: CompactWorker, now: number): string {
+export function renderWorkerLine(worker: CompactWorker, now: number, preset: StatuslinePreset = "full"): string {
   const f = workerFields(worker, now);
+  if (preset === "short") {
+    const parts: string[] = [`${BOLD}${f.workerId}${NOBOLD}`];
+    if (f.issue !== null) {
+      parts.push(kv("iss", String(f.issue)));
+      const progress = progressCell(f.phase, f.activity);
+      if (progress) parts.push(progress);
+    }
+    parts.push(f.elapsed);
+    return `${NOBG}${SOFT}${parts.join("  ")}${RESET}`;
+  }
   const runVal = [f.runner, f.model ? shortModel(f.model) : undefined, f.effort]
     .filter((x): x is string => Boolean(x))
     .join(" ");
@@ -338,15 +368,17 @@ export interface StyleOptions {
   columns?: number;
   workers?: ReadonlyArray<CompactWorker>;
   now?: number;
+  preset?: StatuslinePreset;
 }
 
 /** The full themed statusline: the header line, plus one line per live worker
  * (Claude Code renders each `\n`-separated segment as its own row). Zero workers
  * → only the header line. */
 export function styleStatusline(input: StatuslineInput, opts: StyleOptions = {}): string {
-  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet)];
+  const preset = opts.preset ?? "full";
+  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet, preset)];
   const now = opts.now ?? 0;
-  lines.push(...renderWorkerLines(opts.workers ?? [], now));
+  lines.push(...renderWorkerLines(opts.workers ?? [], now, preset));
   return lines.join("\n");
 }
 
@@ -358,5 +390,6 @@ export function renderStatuslineThemed(
   color: boolean,
   opts: StyleOptions = {},
 ): string {
-  return color ? styleStatusline(input, opts) : renderStatusline(input);
+  const preset = opts.preset ?? "full";
+  return color ? styleStatusline(input, opts) : renderStatuslineWithPreset(input, preset);
 }

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -172,6 +172,8 @@ export interface StatuslineInput {
   afk?: AfkInput;
 }
 
+export type StatuslinePreset = "full" | "short";
+
 const BRANCH_MAX = 28;
 
 /**
@@ -402,6 +404,13 @@ export function renderRepoBlock(repo: RepoInput | undefined): string | null {
   return parts.length ? parts.join(" ") : null;
 }
 
+/** Short preset line-1 repo token: only the open issue count survives. */
+export function renderShortRepoBlock(repo: RepoInput | undefined): string | null {
+  if (!repo || !repo.openIssues || repo.openIssues <= 0) return null;
+  const ageSuffix = repo.cacheAgeS !== undefined ? ` (${formatCacheAge(repo.cacheAgeS)})` : "";
+  return `iss=${repo.openIssues}${ageSuffix}`;
+}
+
 /** Supervisor fleet cell: rendered only after IO proves pid-live and fresh. */
 export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   if (!fleet) return null;
@@ -454,6 +463,19 @@ export function renderAfkBlock(afk: AfkInput | undefined): string | null {
  *     as `origin=N` tokens read from the same `state.origin` the monitor uses.
  */
 export function renderStatusline(input: StatuslineInput): string {
+  return renderStatuslineWithPreset(input, "full");
+}
+
+export function renderStatuslineWithPreset(input: StatuslineInput, preset: StatuslinePreset = "full"): string {
+  if (preset === "short") {
+    const sections: string[] = [renderProjectBlock(input.project)];
+    const context = renderContextBlock(input.claude);
+    if (context !== null) sections.push(`ctx=${context}`);
+    const repo = renderShortRepoBlock(input.repo);
+    if (repo !== null) sections.push(repo);
+    return sections.join(" · ");
+  }
+
   const sections: string[] = [renderProjectBlock(input.project)];
   const model = renderModelBlock(input.claude);
   if (model !== null) sections.push(model);

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import {
   statuslineCommand,
   resolveRoot,
+  resolveStatuslinePreset,
   statuslineEnabled,
 } from "../src/commands/statusline.js";
+import { loadConfig } from "../src/core/config.js";
 
 /** Strip ANSI SGR escapes so assertions read the plain rendered text. The
  * command now themes the line (wine background + black-chipped KPI numbers);
@@ -214,6 +216,30 @@ describe("statusline command — pure helpers", () => {
     expect(statuslineEnabled(on)).toBe(true);
 
     await Promise.all([top, nested, on].map((d) => rm(d, { recursive: true, force: true })));
+  });
+
+  it("resolves statusline preset from namespaced and legacy config keys", async () => {
+    const cases = [
+      ["plugins:\n  dev:\n    statusline:\n      preset: short\n", "short"],
+      ["afk:\n  statusline:\n    preset: short\n", "short"],
+      ["statusline:\n  preset: short\n", "short"],
+      ["plugins:\n  dev:\n    statusline:\n      preset: compact\n", "full"],
+      ["", "full"],
+    ] as const;
+
+    const dirs: string[] = [];
+    try {
+      for (const [yaml, expected] of cases) {
+        const dir = await mkdtemp(join(tmpdir(), "sl-cfg-"));
+        dirs.push(dir);
+        await mkdir(join(dir, ".red"), { recursive: true });
+        await writeFile(join(dir, ".red", "config.yaml"), yaml, "utf8");
+        const cfg = loadConfig(join(dir, ".red", "config.yaml"), { warn: () => undefined });
+        expect(resolveStatuslinePreset(cfg)).toBe(expected);
+      }
+    } finally {
+      await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+    }
   });
 });
 

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -139,6 +139,20 @@ describe("statusline style — header line", () => {
     expect(stripAnsi(h)).toBe(" » c3 ");
     expect(h).not.toContain(WINE);
   });
+
+  it("short preset keeps only project identity, ctx, and iss", () => {
+    const h = renderHeaderLine(input.project, claude, repo, undefined, "short");
+    const t = stripAnsi(h);
+    expect(t).toContain("» red-skills (main)");
+    expect(t).toContain("ctx=47k 24%");
+    expect(t).toContain("iss=24");
+    expect(t).not.toContain("v1.2.3");
+    expect(t).not.toContain("Opus·high");
+    expect(t).not.toContain("5h=");
+    expect(t).not.toContain("7d=");
+    expect(t).not.toContain("prs=");
+    expect(t).not.toContain("loc=+142 -36");
+  });
 });
 
 describe("statusline style — terse per-worker line (issue #1175)", () => {
@@ -196,6 +210,21 @@ describe("statusline style — terse per-worker line (issue #1175)", () => {
     // An explicit afk origin still renders org=afk.
     const afk = worker({ state: { ...worker().state, origin: "afk" } });
     expect(stripAnsi(renderWorkerLine(afk, NOW))).toContain("org=afk");
+  });
+
+  it("short preset keeps only worker id, issue, status, and timer", () => {
+    const t = stripAnsi(renderWorkerLine(worker(), NOW, "short"));
+    expect(t).toContain("w1");
+    expect(t).toContain("iss=17");
+    expect(t).toContain("impl");
+    expect(t).toContain("00:05:00");
+    expect(t).not.toContain("run=");
+    expect(t).not.toContain("org=");
+    expect(t).not.toContain("loc=");
+    expect(t).not.toContain("tks=");
+    expect(t).not.toContain("tls=");
+    expect(t).not.toContain("rsn=");
+    expect(t).not.toContain("txt=");
   });
 
   it.each(["gate", "push-pr", "merge", "cascade"])(
@@ -367,6 +396,21 @@ describe("statusline style — full themed assembly", () => {
     expect(out).not.toContain("\n");
     expect(stripAnsi(out)).toContain("Opus·high");
     expect(stripAnsi(out)).toContain("prs=3");
+  });
+
+  it("threads the short preset through themed assembly", () => {
+    const out = styleStatusline(input, { workers: [worker()], now: NOW, preset: "short" });
+    const rows = out.split("\n").map(stripAnsi);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toContain("ctx=47k 24%");
+    expect(rows[0]).toContain("iss=24");
+    expect(rows[0]).not.toContain("Opus·high");
+    expect(rows[0]).not.toContain("prs=");
+    expect(rows[1]).toContain("w1");
+    expect(rows[1]).toContain("iss=17");
+    expect(rows[1]).toContain("00:05:00");
+    expect(rows[1]).not.toContain("run=");
+    expect(rows[1]).not.toContain("loc=");
   });
 
   it("aligns multi-worker rows by visible cell width while preserving ANSI color", () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -12,6 +12,7 @@ import {
   renderProjectBlock,
   renderRepoBlock,
   renderStatusline,
+  renderStatuslineWithPreset,
   renderUsageBlock,
   type AfkInput,
   type StatuslineInput,
@@ -482,6 +483,18 @@ describe("statusline — full assembly", () => {
     expect(renderStatusline(input)).toBe(
       "red-skills (main) · Opus·high · 47k 24% · 5h=23% 7d=41% · prs=3 iss=24 loc=+142 -36 · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
     );
+    expect(renderStatuslineWithPreset(input, "full")).toBe(renderStatusline(input));
+  });
+
+  it("short preset keeps only project identity, ctx, and iss in the Codex/plain form", () => {
+    const input: StatuslineInput = {
+      project: { basename: "red-skills", branch: "main" },
+      claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24, usage5h: 23, usage7d: 41 },
+      repo: { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 },
+      fleet: { runner: "codex", busy: 1, total: 4, queue: 9 },
+      afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
+    };
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24");
   });
 
   it("keeps the pre-#1165 line byte-for-byte when repo and usage are absent", () => {


### PR DESCRIPTION
Automated AFK landing for #1492. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1492

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786383825&installation_id=129708444&pr_number=1496&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1496&signature=d3dd8695c94a0105b7b9c3611fbef2988f9bba872699ed4df44c4d8e215fe8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->