### PR TITLE
feat: #1491 generate rsp ambient SKILL.md from the no-args home view (mechanism for #1415)

### DIFF
--- a/apps/rsp/generated/AMBIENT-SKILL.md
+++ b/apps/rsp/generated/AMBIENT-SKILL.md
@@ -1,0 +1,37 @@
+# rsp — token-efficient command wrappers
+
+<!-- GENERATED FILE — do not edit by hand.
+     Source: apps/rsp/src/intercept.ts (RSP_WRAPPER_CAPABILITIES),
+     rendered by apps/rsp/src/ambient-skill.ts.
+     Regenerate: pnpm --filter @reddb-io/rsp gen:ambient-skill -->
+
+`rsp` wraps noisy development commands and stores their full output in a
+reversible elision store, so the agent reads a compact summary and can
+recover the original bytes on demand with `rsp show el:<id>`.
+
+## Wrapped commands
+
+When you would run one of these commands, run it through `rsp` instead:
+
+| Command | rsp wrapper |
+| --- | --- |
+| `git status` | `rsp git status` |
+| `git log` | `rsp git log` |
+| `git diff` | `rsp git diff` |
+| `git commit` | `rsp git commit` |
+| `git push` | `rsp git push` |
+| `gh pr list` | `rsp gh pr list` |
+| `gh pr view` | `rsp gh pr view` |
+| `gh issue list` | `rsp gh issue list` |
+| `gh issue view` | `rsp gh issue view` |
+| `gh run list` | `rsp gh run list` |
+| `gh run view` | `rsp gh run view` |
+| `vitest` | `rsp vitest` |
+| `vitest run` | `rsp vitest run` |
+| `cargo test` | `rsp cargo test` |
+
+## Recovering elided output
+
+`rsp show el:<id>` writes the original bytes verbatim to stdout. Expired or
+evicted handles print `expired <ISO date> — re-run: <original command>` and
+exit 1, so the exact command to reproduce the output is always in reach.

--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -17,6 +17,7 @@
     "build": "tsc -p tsconfig.build.json && pnpm bundle",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/rsp.bundle.min.mjs --asset rsp.bundle.min.mjs --minify --reddb-from-package",
     "bench:two-axis": "node --import tsx src/two-axis-benchmark-cli.ts",
+    "gen:ambient-skill": "node --import tsx scripts/gen-ambient-skill.mjs",
     "test": "vitest run",
     "dev": "node --import tsx src/cli.ts"
   },

--- a/apps/rsp/scripts/gen-ambient-skill.mjs
+++ b/apps/rsp/scripts/gen-ambient-skill.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Regenerate the committed ambient-instruction artifact from the rsp wrapper
+// capability table. Run: pnpm --filter @reddb-io/rsp gen:ambient-skill
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const { AMBIENT_SKILL_RELATIVE_PATH, renderAmbientSkill } = await import("../src/ambient-skill.ts");
+
+const target = join(packageRoot, AMBIENT_SKILL_RELATIVE_PATH);
+writeFileSync(target, renderAmbientSkill());
+process.stdout.write(`wrote ${AMBIENT_SKILL_RELATIVE_PATH}\n`);

--- a/apps/rsp/src/ambient-skill.ts
+++ b/apps/rsp/src/ambient-skill.ts
@@ -1,0 +1,51 @@
+import { RSP_WRAPPER_CAPABILITIES, type RspWrapperCapability } from "./intercept.js";
+
+// Path of the committed artifact this generator renders, relative to the rsp
+// package root. The drift test and the regeneration script share this constant
+// so the source of truth for the file location lives in one place.
+export const AMBIENT_SKILL_RELATIVE_PATH = "generated/AMBIENT-SKILL.md";
+
+/**
+ * Render the ambient-instruction surface (the RTK.md-replacement doc) FROM the
+ * rsp wrapper capability table, so the ambient surface can never drift from the
+ * actual wrappers — the table is the single source. Regenerate the committed
+ * artifact whenever the capability table changes; the drift test fails until it
+ * is regenerated.
+ */
+export function renderAmbientSkill(
+  capabilities: readonly RspWrapperCapability[] = RSP_WRAPPER_CAPABILITIES,
+): string {
+  const rows = capabilities.map((capability) => {
+    const command = capability.command.join(" ");
+    const wrapper = ["rsp", ...capability.wrapper].join(" ");
+    return `| \`${command}\` | \`${wrapper}\` |`;
+  });
+
+  return [
+    "# rsp — token-efficient command wrappers",
+    "",
+    "<!-- GENERATED FILE — do not edit by hand.",
+    "     Source: apps/rsp/src/intercept.ts (RSP_WRAPPER_CAPABILITIES),",
+    "     rendered by apps/rsp/src/ambient-skill.ts.",
+    "     Regenerate: pnpm --filter @reddb-io/rsp gen:ambient-skill -->",
+    "",
+    "`rsp` wraps noisy development commands and stores their full output in a",
+    "reversible elision store, so the agent reads a compact summary and can",
+    "recover the original bytes on demand with `rsp show el:<id>`.",
+    "",
+    "## Wrapped commands",
+    "",
+    "When you would run one of these commands, run it through `rsp` instead:",
+    "",
+    "| Command | rsp wrapper |",
+    "| --- | --- |",
+    ...rows,
+    "",
+    "## Recovering elided output",
+    "",
+    "`rsp show el:<id>` writes the original bytes verbatim to stdout. Expired or",
+    "evicted handles print `expired <ISO date> — re-run: <original command>` and",
+    "exit 1, so the exact command to reproduce the output is always in reach.",
+    "",
+  ].join("\n");
+}

--- a/apps/rsp/tests/ambient-skill.test.ts
+++ b/apps/rsp/tests/ambient-skill.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { RSP_WRAPPER_CAPABILITIES } from "../src/intercept.js";
+import { AMBIENT_SKILL_RELATIVE_PATH, renderAmbientSkill } from "../src/ambient-skill.js";
+
+const packageRoot = join(import.meta.dirname, "..");
+
+describe("rsp ambient skill generator", () => {
+  it("renders one table row per wrapper capability from the single source", () => {
+    const markdown = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES);
+    for (const capability of RSP_WRAPPER_CAPABILITIES) {
+      const command = capability.command.join(" ");
+      const wrapper = ["rsp", ...capability.wrapper].join(" ");
+      expect(markdown).toContain(`| \`${command}\` | \`${wrapper}\` |`);
+    }
+  });
+
+  it("committed artifact matches the generator output (drift check)", () => {
+    const committed = readFileSync(join(packageRoot, AMBIENT_SKILL_RELATIVE_PATH), "utf8");
+    expect(committed).toEqual(renderAmbientSkill(RSP_WRAPPER_CAPABILITIES));
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1491. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1491

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384371&installation_id=129708444&pr_number=1497&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1497&signature=4a6fe9f57ecb29cde848f0a16219176d814ec72b77bcd1b38296b9676ffe11b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->