### PR TITLE
rsp normalization allowlist + Claude post-exec hook (ADR 0095)

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -6,6 +6,7 @@ import { resolveRspConfig } from "./config.js";
 import { runGitWrapper } from "./git-wrapper.js";
 import { runGhWrapper } from "./gh-wrapper.js";
 import { runClaudePreExecHook } from "./intercept.js";
+import { runClaudePostExecHook } from "./normalize.js";
 import { runTestWrapper } from "./test-wrapper.js";
 
 interface ParsedArgs {
@@ -21,6 +22,9 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const args = parseArgs(argv);
   if (args.command === "hook" && args.positional[1] === "claude-pre-exec") {
     return await runClaudePreExecHook();
+  }
+  if (args.command === "hook" && args.positional[1] === "claude-post-exec") {
+    return await runClaudePostExecHook();
   }
 
   const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);

--- a/apps/rsp/src/normalize.ts
+++ b/apps/rsp/src/normalize.ts
@@ -1,0 +1,246 @@
+import { readFileSync } from "node:fs";
+import { decode, encode } from "@reddb-io/toon";
+import { resolveRspConfig } from "./config.js";
+
+export interface NormalizeEntry {
+  readonly id: string;
+  readonly apply: (input: string) => string;
+}
+
+// Entry 1: Strip ANSI/VT escape sequences (colours, cursor movement, OSC, C1 CSI).
+// Covers OSC (ESC ] text BEL/ST) and CSI sequences (ESC [ params final, or C1 0x9b params final).
+export const NORMALIZE_ANSI: NormalizeEntry = {
+  id: "ansi",
+  apply: stripAnsi,
+};
+
+// Entry 2: Collapse CR-based progress bars to their final frame.
+// CRLF line endings are also converted to LF as a side effect.
+export const NORMALIZE_CR_PROGRESS: NormalizeEntry = {
+  id: "cr-progress",
+  apply: (input) =>
+    input
+      .split("\n")
+      .map((line) => {
+        // Strip trailing \r first so CRLF endings don't look like overwrite frames
+        const base = line.endsWith("\r") ? line.slice(0, -1) : line;
+        const lastCr = base.lastIndexOf("\r");
+        return lastCr >= 0 ? base.slice(lastCr + 1) : base;
+      })
+      .join("\n"),
+};
+
+// Entry 3: Strip trailing spaces and tabs from every line
+export const NORMALIZE_TRAILING_WHITESPACE: NormalizeEntry = {
+  id: "trailing-whitespace",
+  apply: (input) =>
+    input
+      .split("\n")
+      .map((line) => line.replace(/[ \t]+$/, ""))
+      .join("\n"),
+};
+
+// Entry 4: Collapse three or more consecutive newlines to two (one blank line)
+export const NORMALIZE_BLANK_LINES: NormalizeEntry = {
+  id: "blank-lines",
+  apply: (input) => input.replace(/\n{3,}/g, "\n\n"),
+};
+
+// Entry 5: Lossless JSON→TOON transcode, guarded per-invocation by a round-trip check.
+// Any encode/decode failure or deep-equality mismatch ⇒ byte-identical passthrough.
+export function transcodeJsonToToon(
+  input: string,
+  deps?: { encode?: (value: unknown) => string; decode?: (input: string) => unknown },
+): string {
+  const enc = deps?.encode ?? encode;
+  const dec = deps?.decode ?? decode;
+
+  const trimmed = input.trimEnd();
+  if (!trimmed) return input;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return input;
+  }
+  let encoded: string;
+  try {
+    encoded = enc(parsed);
+  } catch {
+    return input;
+  }
+  let roundTripped: unknown;
+  try {
+    roundTripped = dec(encoded);
+  } catch {
+    return input;
+  }
+  if (!deepEqual(parsed, roundTripped)) return input;
+  return encoded;
+}
+
+export const NORMALIZE_JSON_TOON: NormalizeEntry = {
+  id: "json-to-toon",
+  apply: (input) => transcodeJsonToToon(input),
+};
+
+export const NORMALIZATION_ALLOWLIST: readonly NormalizeEntry[] = [
+  NORMALIZE_ANSI,
+  NORMALIZE_CR_PROGRESS,
+  NORMALIZE_TRAILING_WHITESPACE,
+  NORMALIZE_BLANK_LINES,
+  NORMALIZE_JSON_TOON,
+];
+
+export function normalizeOutput(input: string): string {
+  let out = input;
+  for (const entry of NORMALIZATION_ALLOWLIST) out = entry.apply(out);
+  return out;
+}
+
+// ───── PostToolUse hook integration ──────────────────────────────────────────
+
+export interface NormalizeHookOptions {
+  cwd: string;
+  isEnabled?: (cwd: string) => boolean | Promise<boolean>;
+  normalize?: (output: string) => string;
+}
+
+export type NormalizeDecision =
+  | { kind: "normalized"; output: string }
+  | { kind: "passthrough"; reason?: string };
+
+export async function hookDecisionFromClaudePostExecJson(
+  raw: string,
+  options: NormalizeHookOptions,
+): Promise<NormalizeDecision> {
+  const payload = parseJsonRecord(raw);
+  const cwd = stringAt(payload, ["cwd"]) || options.cwd;
+  const enabled = await (options.isEnabled ?? isRspNormalizeEnabled)(cwd);
+  if (!enabled) return { kind: "passthrough", reason: "disabled" };
+
+  const toolResponse = recordAt(payload, "tool_response");
+  if (!toolResponse) return { kind: "passthrough", reason: "missing-output" };
+  if (typeof toolResponse["output"] !== "string") return { kind: "passthrough", reason: "missing-output" };
+  const output = toolResponse["output"] as string;
+
+  const doNormalize = options.normalize ?? normalizeOutput;
+  const normalized = doNormalize(output);
+  if (normalized === output) return { kind: "passthrough", reason: "no-change" };
+
+  return { kind: "normalized", output: normalized };
+}
+
+export function formatNormalizeDecision(decision: NormalizeDecision): { stdout: string; status: number } {
+  if (decision.kind === "normalized") {
+    return { stdout: JSON.stringify({ tool_response: { output: decision.output } }), status: 0 };
+  }
+  return { stdout: "", status: 0 };
+}
+
+export async function runClaudePostExecHook(stdinPath?: string): Promise<number> {
+  const raw = stdinPath ? readFileSync(stdinPath, "utf8") : readFileSync(0, "utf8");
+  const decision = await hookDecisionFromClaudePostExecJson(raw, { cwd: process.cwd() });
+  const formatted = formatNormalizeDecision(decision);
+  if (formatted.stdout) process.stdout.write(formatted.stdout);
+  return formatted.status;
+}
+
+// ───── Private helpers ────────────────────────────────────────────────────────
+
+function stripAnsi(input: string): string {
+  let out = "";
+  let i = 0;
+  while (i < input.length) {
+    const ch = input.charCodeAt(i);
+    // ESC (0x1b) — start of a VT sequence
+    if (ch === 0x1b) {
+      const next = input.charCodeAt(i + 1);
+      if (next === 0x5d) {
+        // OSC: ESC ] ... BEL (0x07) or ST (ESC \)
+        i += 2;
+        while (i < input.length) {
+          const c = input.charCodeAt(i);
+          if (c === 0x07) { i++; break; }
+          if (c === 0x1b && input.charCodeAt(i + 1) === 0x5c) { i += 2; break; }
+          i++;
+        }
+        continue;
+      }
+      if (next === 0x5b) {
+        // CSI: ESC [ <params> <final>
+        i += 2;
+        while (i < input.length && isAnsiParam(input.charCodeAt(i))) i++;
+        if (i < input.length) i++; // consume final byte
+        continue;
+      }
+      // Other two-char ESC sequences — skip both
+      i += next >= 0x20 ? 2 : 1;
+      continue;
+    }
+    // C1 CSI (0x9b) — equivalent to ESC [
+    if (ch === 0x9b) {
+      i++;
+      while (i < input.length && isAnsiParam(input.charCodeAt(i))) i++;
+      if (i < input.length) i++; // consume final byte
+      continue;
+    }
+    out += input[i++];
+  }
+  return out;
+}
+
+// ANSI parameter bytes: 0x20–0x3f (includes digits, semicolons, intro chars like ?)
+function isAnsiParam(code: number): boolean {
+  return code >= 0x20 && code <= 0x3f;
+}
+
+function isRspNormalizeEnabled(cwd: string): boolean {
+  return resolveRspConfig(cwd, process.env).enabled;
+}
+
+function parseJsonRecord(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function stringAt(record: Record<string, unknown>, path: readonly string[]): string {
+  let cursor: unknown = record;
+  for (const key of path) {
+    if (!isRecord(cursor)) return "";
+    cursor = (cursor as Record<string, unknown>)[key];
+  }
+  return typeof cursor === "string" ? cursor : "";
+}
+
+function recordAt(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const val = record[key];
+  return isRecord(val) ? val : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    const bArr = b as unknown[];
+    if (a.length !== bArr.length) return false;
+    return a.every((item, i) => deepEqual(item, bArr[i]));
+  }
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
+}

--- a/apps/rsp/tests/normalize.test.ts
+++ b/apps/rsp/tests/normalize.test.ts
@@ -1,0 +1,402 @@
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  NORMALIZATION_ALLOWLIST,
+  NORMALIZE_ANSI,
+  NORMALIZE_BLANK_LINES,
+  NORMALIZE_CR_PROGRESS,
+  NORMALIZE_JSON_TOON,
+  NORMALIZE_TRAILING_WHITESPACE,
+  formatNormalizeDecision,
+  hookDecisionFromClaudePostExecJson,
+  normalizeOutput,
+  transcodeJsonToToon,
+} from "../src/normalize.js";
+
+const roots: string[] = [];
+const cli = join(import.meta.dirname, "..", "src", "cli.ts");
+const tsxLoader = createRequire(import.meta.url).resolve("tsx");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-normalize-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+// ─── Per-entry fixtures ───────────────────────────────────────────────────────
+
+describe("NORMALIZE_ANSI — per-entry fixtures", () => {
+  it("strips basic SGR colour sequences", () => {
+    expect(NORMALIZE_ANSI.apply("\x1b[32mhello\x1b[0m")).toBe("hello");
+  });
+
+  it("strips bold+colour combined SGR", () => {
+    expect(NORMALIZE_ANSI.apply("\x1b[1;31mERROR\x1b[0m: message")).toBe("ERROR: message");
+  });
+
+  it("strips erase-line and cursor-up sequences", () => {
+    expect(NORMALIZE_ANSI.apply("text\x1b[2K\x1b[1A")).toBe("text");
+  });
+
+  it("strips cursor-visibility sequence (private mode)", () => {
+    expect(NORMALIZE_ANSI.apply("\x1b[?25hvisible")).toBe("visible");
+  });
+
+  it("strips OSC terminal-title sequence ending in BEL", () => {
+    expect(NORMALIZE_ANSI.apply("\x1b]0;My Title\x07rest")).toBe("rest");
+  });
+
+  it("strips OSC sequence ending in ST (ESC backslash)", () => {
+    expect(NORMALIZE_ANSI.apply("\x1b]8;;https://example.com\x1b\\link text\x1b]8;;\x1b\\")).toBe("link text");
+  });
+
+  it("passes through text with no ANSI codes unchanged", () => {
+    expect(NORMALIZE_ANSI.apply("plain text\nno escapes")).toBe("plain text\nno escapes");
+  });
+
+  it("strips codes embedded in multi-line output, byte-exact", () => {
+    const input = "\x1b[33mwarning:\x1b[0m file not found\n\x1b[32mok\x1b[0m";
+    expect(NORMALIZE_ANSI.apply(input)).toBe("warning: file not found\nok");
+  });
+
+  it("strips C1 CSI (0x9b) sequences", () => {
+    expect(NORMALIZE_ANSI.apply("\x9b32mhello\x9b0m")).toBe("hello");
+  });
+});
+
+describe("NORMALIZE_CR_PROGRESS — per-entry fixtures", () => {
+  it("collapses single CR overwrite to its final frame", () => {
+    expect(NORMALIZE_CR_PROGRESS.apply("Progress: 10%\rProgress: 100%")).toBe("Progress: 100%");
+  });
+
+  it("collapses multiple CR overwrites to final frame", () => {
+    expect(NORMALIZE_CR_PROGRESS.apply("10%\r20%\r30%\r100%")).toBe("100%");
+  });
+
+  it("preserves trailing newline and collapses mid-line CRs", () => {
+    expect(NORMALIZE_CR_PROGRESS.apply("Downloading\r\n|===  30%  ===|\r|=======100%=======|\n")).toBe(
+      "Downloading\n|=======100%=======|\n",
+    );
+  });
+
+  it("converts CRLF to LF (trailing \\r before \\n treated as line ending, not overwrite)", () => {
+    expect(NORMALIZE_CR_PROGRESS.apply("Hello\r\nWorld\r\n")).toBe("Hello\nWorld\n");
+  });
+
+  it("passes through text with no CR unchanged", () => {
+    expect(NORMALIZE_CR_PROGRESS.apply("line one\nline two\n")).toBe("line one\nline two\n");
+  });
+});
+
+describe("NORMALIZE_TRAILING_WHITESPACE — per-entry fixtures", () => {
+  it("strips trailing spaces from lines", () => {
+    expect(NORMALIZE_TRAILING_WHITESPACE.apply("hello   \nworld")).toBe("hello\nworld");
+  });
+
+  it("strips trailing tabs from lines", () => {
+    expect(NORMALIZE_TRAILING_WHITESPACE.apply("col1\tcol2\t\nend")).toBe("col1\tcol2\nend");
+  });
+
+  it("strips mixed trailing spaces and tabs", () => {
+    expect(NORMALIZE_TRAILING_WHITESPACE.apply("text \t \nclean")).toBe("text\nclean");
+  });
+
+  it("preserves internal whitespace and only strips trailing", () => {
+    expect(NORMALIZE_TRAILING_WHITESPACE.apply("  indented  \n")).toBe("  indented\n");
+  });
+
+  it("passes through text with no trailing whitespace unchanged", () => {
+    expect(NORMALIZE_TRAILING_WHITESPACE.apply("clean\nlines\n")).toBe("clean\nlines\n");
+  });
+});
+
+describe("NORMALIZE_BLANK_LINES — per-entry fixtures", () => {
+  it("collapses three consecutive newlines to two", () => {
+    expect(NORMALIZE_BLANK_LINES.apply("a\n\n\nb")).toBe("a\n\nb");
+  });
+
+  it("collapses four or more consecutive newlines to two", () => {
+    expect(NORMALIZE_BLANK_LINES.apply("a\n\n\n\n\nb")).toBe("a\n\nb");
+  });
+
+  it("leaves exactly two consecutive newlines (one blank line) unchanged", () => {
+    expect(NORMALIZE_BLANK_LINES.apply("a\n\nb")).toBe("a\n\nb");
+  });
+
+  it("leaves exactly one newline (no blank line) unchanged", () => {
+    expect(NORMALIZE_BLANK_LINES.apply("a\nb")).toBe("a\nb");
+  });
+
+  it("passes through text with no blank lines unchanged", () => {
+    expect(NORMALIZE_BLANK_LINES.apply("line1\nline2\nline3")).toBe("line1\nline2\nline3");
+  });
+});
+
+// ─── JSON→TOON transcode fixtures ────────────────────────────────────────────
+
+describe("NORMALIZE_JSON_TOON / transcodeJsonToToon — fixtures", () => {
+  it("transcodes a JSON object to TOON (byte-exact spec output)", () => {
+    const input = '{"project":{"id":"p1","meta":{"owner":"ops","ok":true}}}';
+    const expected = "project:\n  id: p1\n  meta:\n    owner: ops\n    ok: true";
+    expect(transcodeJsonToToon(input)).toBe(expected);
+  });
+
+  it("transcodes a uniform JSON array of objects to TOON tabular form", () => {
+    const input =
+      '{"users":[{"id":1,"name":"Alice","active":true},{"id":2,"name":"Bob","active":false}]}';
+    const expected = "users[2]{id,name,active}:\n  1,Alice,true\n  2,Bob,false";
+    expect(transcodeJsonToToon(input)).toBe(expected);
+  });
+
+  it("transcodes a JSON string scalar via encode/decode round-trip", () => {
+    // JSON string "hello" → encode("hello") = "hello", decode("hello") = "hello"
+    expect(transcodeJsonToToon('"hello"')).toBe("hello");
+  });
+
+  it("guard-failure via encode throwing ⇒ byte-identical passthrough", () => {
+    const input = '{"k":"v"}';
+    const result = transcodeJsonToToon(input, {
+      encode: () => {
+        throw new Error("encode exploded");
+      },
+    });
+    expect(result).toBe(input);
+  });
+
+  it("guard-failure via decode throwing ⇒ byte-identical passthrough", () => {
+    const input = '{"k":"v"}';
+    const result = transcodeJsonToToon(input, {
+      decode: () => {
+        throw new Error("decode exploded");
+      },
+    });
+    expect(result).toBe(input);
+  });
+
+  it("guard-failure via round-trip deep-equality mismatch ⇒ byte-identical passthrough", () => {
+    const input = '{"k":"v"}';
+    const result = transcodeJsonToToon(input, {
+      encode: () => "encoded",
+      decode: () => ({ different: "object" }), // mismatch
+    });
+    expect(result).toBe(input);
+  });
+
+  it("non-JSON body passes through byte-identical", () => {
+    const input = "plain text output\nno json here\n";
+    expect(transcodeJsonToToon(input)).toBe(input);
+  });
+
+  it("partial JSON (invalid) passes through byte-identical", () => {
+    const input = '{"key": "val';
+    expect(transcodeJsonToToon(input)).toBe(input);
+  });
+
+  it("empty string passes through", () => {
+    expect(transcodeJsonToToon("")).toBe("");
+  });
+
+  it("whitespace-only string passes through", () => {
+    expect(transcodeJsonToToon("   \n")).toBe("   \n");
+  });
+
+  it("NORMALIZE_JSON_TOON entry delegates to transcodeJsonToToon", () => {
+    const input = '{"k":"v"}';
+    expect(NORMALIZE_JSON_TOON.apply(input)).toBe(transcodeJsonToToon(input));
+  });
+});
+
+// ─── Structural invariant ─────────────────────────────────────────────────────
+
+describe("structural invariant: no mint API access", () => {
+  it("normalize module source does not import from the elision store (cannot reach mint)", () => {
+    const src = readFileSync(join(import.meta.dirname, "..", "src", "normalize.ts"), "utf8");
+    expect(src).not.toMatch(/elision-store/);
+    expect(src).not.toMatch(/RspElisionStore/);
+  });
+
+  it("normalization allowlist has exactly five entries with the expected ids", () => {
+    expect(NORMALIZATION_ALLOWLIST.map((e) => e.id)).toEqual([
+      "ansi",
+      "cr-progress",
+      "trailing-whitespace",
+      "blank-lines",
+      "json-to-toon",
+    ]);
+  });
+});
+
+// ─── Exit-code/stderr invariance ─────────────────────────────────────────────
+
+describe("exit-code and stderr invariance", () => {
+  it("hook output targets only tool_response.output — exitCode and error fields are absent", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({
+        cwd: root,
+        tool_response: { output: "\x1b[32mhello\x1b[0m", error: "stderr text", exitCode: 2 },
+      }),
+      { cwd: root, isEnabled: () => true },
+    );
+    expect(decision).toEqual({ kind: "normalized", output: "hello" });
+    const formatted = formatNormalizeDecision(decision);
+    expect(formatted.status).toBe(0);
+    const body = JSON.parse(formatted.stdout) as Record<string, unknown>;
+    const resp = body["tool_response"] as Record<string, unknown>;
+    expect(resp["output"]).toBe("hello");
+    expect(resp).not.toHaveProperty("exitCode");
+    expect(resp).not.toHaveProperty("error");
+  });
+
+  it("passthrough decision: no stdout written regardless of exit code in payload", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({ cwd: root, tool_response: { output: "clean", error: null, exitCode: 0 } }),
+      { cwd: root, isEnabled: () => true },
+    );
+    expect(decision).toEqual({ kind: "passthrough", reason: "no-change" });
+    expect(formatNormalizeDecision(decision)).toEqual({ stdout: "", status: 0 });
+  });
+
+  it("all normalizeOutput transforms leave exit code information untouched on clean input", () => {
+    // A clean string with no normalizable content round-trips unchanged
+    expect(normalizeOutput("clean output\n")).toBe("clean output\n");
+  });
+});
+
+// ─── Hook integration ─────────────────────────────────────────────────────────
+
+describe("rsp Claude post-execution hook integration", () => {
+  it("returns normalized output and exit 0 when ANSI codes are present", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({ cwd: root, tool_response: { output: "\x1b[32mhello\x1b[0m" } }),
+      { cwd: root, isEnabled: () => true },
+    );
+    expect(decision).toEqual({ kind: "normalized", output: "hello" });
+    expect(formatNormalizeDecision(decision)).toEqual({
+      stdout: JSON.stringify({ tool_response: { output: "hello" } }),
+      status: 0,
+    });
+  });
+
+  it("returns passthrough with empty stdout and exit 0 when output is already clean", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({ cwd: root, tool_response: { output: "clean output" } }),
+      { cwd: root, isEnabled: () => true },
+    );
+    expect(decision).toEqual({ kind: "passthrough", reason: "no-change" });
+    expect(formatNormalizeDecision(decision)).toEqual({ stdout: "", status: 0 });
+  });
+
+  it("returns passthrough when tool_response.output is missing", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({ cwd: root, tool_response: {} }),
+      { cwd: root, isEnabled: () => true },
+    );
+    expect(decision).toEqual({ kind: "passthrough", reason: "missing-output" });
+  });
+
+  it("returns passthrough when tool_response is absent", async () => {
+    const root = await tempRoot();
+    const decision = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({ cwd: root }),
+      { cwd: root, isEnabled: () => true },
+    );
+    expect(decision).toEqual({ kind: "passthrough", reason: "missing-output" });
+  });
+
+  it("makes disabled directories inert before normalization work", async () => {
+    const root = await tempRoot();
+    let gateCalls = 0;
+    let normalizeCalls = 0;
+    const result = await hookDecisionFromClaudePostExecJson(
+      JSON.stringify({ cwd: root, tool_response: { output: "\x1b[32mhello\x1b[0m" } }),
+      {
+        cwd: root,
+        isEnabled: () => {
+          gateCalls++;
+          return false;
+        },
+        normalize: (s) => {
+          normalizeCalls++;
+          return s;
+        },
+      },
+    );
+    expect(result).toEqual({ kind: "passthrough", reason: "disabled" });
+    expect(gateCalls).toBe(1);
+    expect(normalizeCalls).toBe(0);
+    expect(formatNormalizeDecision(result)).toEqual({ stdout: "", status: 0 });
+  });
+
+  it("accepts PostToolUse JSON on stdin through the CLI and returns modified tool_response.output", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+
+    const payload = JSON.stringify({
+      cwd: root,
+      tool_response: { output: "\x1b[32mhello\x1b[0m", error: "", exitCode: 0 },
+    });
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-post-exec"], {
+      cwd: root,
+      input: Buffer.from(payload),
+      encoding: "buffer",
+    });
+
+    expect(res.status).toBe(0);
+    const body = JSON.parse(res.stdout.toString()) as { tool_response: { output: string } };
+    expect(body.tool_response.output).toBe("hello");
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
+  it("CLI emits empty stdout and exits 0 when output is already clean", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+
+    const payload = JSON.stringify({ cwd: root, tool_response: { output: "clean output\n", error: "", exitCode: 0 } });
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-post-exec"], {
+      cwd: root,
+      input: Buffer.from(payload),
+      encoding: "buffer",
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(Buffer.alloc(0));
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
+  it("CLI exits 0 and emits nothing when rsp is disabled", async () => {
+    const root = await tempRoot();
+    // No .red/config.yaml → rsp.enabled defaults to false
+
+    const payload = JSON.stringify({
+      cwd: root,
+      tool_response: { output: "\x1b[32mhello\x1b[0m", error: "", exitCode: 0 },
+    });
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-post-exec"], {
+      cwd: root,
+      input: Buffer.from(payload),
+      encoding: "buffer",
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(Buffer.alloc(0));
+  });
+});

--- a/plugins/dev/hooks/claude.hooks.json
+++ b/plugins/dev/hooks/claude.hooks.json
@@ -37,6 +37,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CLAUDE_PLUGIN_ROOT}\"; for f in \"$root/../../dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\"; do [ -f \"$f\" ] && { timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" hook claude-post-exec <\"$tmp\" || exit 0; exit 0; }; done; exit 0'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Lands the normalization half of the elision program (Spec #1403): a per-entry normalization allowlist compiled into the rsp binary and wired as a Claude Code PostToolUse Bash hook, gated per-repo. Unblocked by #1416.

## What's here
- `apps/rsp/src/normalize.ts` — allowlist (ANSI strip, CR-progress collapse, trailing-whitespace/newline) + a lossless JSON->TOON transcode guarded per-invocation by a round-trip check: any encode/decode failure or deep-equality mismatch falls back to byte-identical passthrough
- `apps/rsp/tests/normalize.test.ts` — per-entry fixtures + round-trip-guard fault injection (402 lines)
- `apps/rsp/src/cli.ts` — exposes `rsp hook claude-post-exec`
- `plugins/dev/hooks/claude.hooks.json` — wires the PostToolUse Bash hook, mirroring the existing hook defensive pattern (mktemp + trap cleanup + stdin/exec timeouts)

## Safety
- **Fail-safe**: every hook path exits 0 (including bundle-not-found) — a PostToolUse can never block or mutate on failure.
- **Per-repo gated** (ADR 0067): `normalize.ts` returns `passthrough (disabled)` with no rsp enablement flag; this repo has none, so the hook is inert here.
- **Fidelity-guarded**: the JSON->TOON transcode round-trips before it is allowed to alter output; any mismatch is byte-identical passthrough.

Closes #1417

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384393&installation_id=129708444&pr_number=1498&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1498&signature=d9d171d2db6d73fd5d36710569005d00db8488ab757e973a6c48a077e52ae631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->