### PR TITLE
fix: rsp claude-pre-exec hook exits 0 on missing/failing bundle (no more PreToolUse error)

### DIFF
--- a/apps/dev/tests/claude-rsp-hook.test.ts
+++ b/apps/dev/tests/claude-rsp-hook.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const here = new URL(import.meta.url).pathname;
+const repoRoot = here.slice(0, here.indexOf("/apps/dev/"));
+const manifestPath = join(repoRoot, "plugins", "dev", "hooks", "claude.hooks.json");
+
+function claudeRspPreExecCommand(): string {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const bashHooks = manifest.hooks.PreToolUse.find((entry: { matcher?: string }) => entry.matcher === "Bash");
+  const hook = bashHooks.hooks.find((entry: { command?: string }) =>
+    entry.command?.includes("hook claude-pre-exec"),
+  );
+  if (!hook?.command) throw new Error("claude rsp pre-exec hook command not found");
+  return hook.command;
+}
+
+function runHook(command: string, pluginRoot: string): ReturnType<typeof spawnSync> {
+  return spawnSync("bash", ["-lc", command], {
+    input: JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "echo ok" },
+    }),
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+      RED_SKILLS_HOOK_TIMEOUT_S: "2s",
+      RED_SKILLS_HOOK_STDIN_TIMEOUT_S: "2s",
+    },
+  });
+}
+
+describe("claude rsp pre-exec hook", () => {
+  it("exits 0 when the rsp bundle is absent", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "claude-rsp-hook-"));
+    try {
+      const pluginRoot = join(tmp, "plugins", "dev");
+      mkdirSync(pluginRoot, { recursive: true });
+
+      const result = runHook(claudeRspPreExecCommand(), pluginRoot);
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 0 when the rsp bundle exits non-zero", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "claude-rsp-hook-"));
+    try {
+      const pluginRoot = join(tmp, "plugins", "dev");
+      const dist = join(pluginRoot, "dist");
+      mkdirSync(dist, { recursive: true });
+      writeFileSync(join(dist, "rsp.bundle.min.mjs"), "process.exit(42);\n");
+
+      const result = runHook(claudeRspPreExecCommand(), pluginRoot);
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/dev/hooks/claude.hooks.json
+++ b/plugins/dev/hooks/claude.hooks.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CLAUDE_PLUGIN_ROOT}\"; for f in \"$root/../../dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\"; do [ -f \"$f\" ] && { timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" hook claude-pre-exec <\"$tmp\"; exit $?; }; done; exit 1'"
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CLAUDE_PLUGIN_ROOT}\"; for f in \"$root/../../dist/rsp.bundle.min.mjs\" \"$root/dist/rsp.bundle.min.mjs\"; do [ -f \"$f\" ] && { timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" hook claude-pre-exec <\"$tmp\" || exit 0; exit 0; }; done; exit 0'"
           },
           {
             "type": "command",


### PR DESCRIPTION
Fixes the regression where the rsp `claude-pre-exec` PreToolUse Bash hook surfaced `PreToolUse:Bash hook error / Failed with non-blocking status code` on every Bash command in any repo where the rsp bundle is not present at the expected `dist/` path.

## Change
`plugins/dev/hooks/claude.hooks.json` — the rsp pre-exec hook now exits 0 on every path:
- bundle-found + node exits non-zero → `|| exit 0` (was: propagated the non-zero code)
- after a found bundle runs → `exit 0` (was: `exit $?`)
- bundle-missing fallback → `exit 0` (was: `exit 1`)

A missing or failing rsp bundle is now a silent passthrough, matching every sibling dev PreToolUse hook (branch-lock, command-guard, route-model-tier all fail-safe to `printf "{}"` / exit 0) and the rsp post-exec hook (#1417), which already exits 0 everywhere. #1416's "fail-closed => passthrough" intent was wrong about Claude Code hook semantics: a non-zero PreToolUse exit surfaces a non-blocking error, it does not silently pass through.

## Test
`apps/dev/tests/claude-rsp-hook.test.ts` — regression coverage asserting the pre-exec hook command exits 0 when the bundle is absent and when the bundle itself exits non-zero. vitest + tsc green. (`audit:hooks` is a local-only check, not a CI gate; its red is on pre-existing opencode-host findings unrelated to this manifest change.)

Fixes #1499
Closes #1500

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786390030&installation_id=129708444&pr_number=1501&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1501&signature=45cbdd559d233c8baab19f993f1107bdd0a0ab0a90bd0a5418a9ef41b41019b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->