### PR TITLE
merge: #1493 fleet supervisor leaves a worker slot zombie-busy after a clean worker completion, stalling the queue

### DIFF
--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -1058,7 +1058,10 @@ export interface TickResult {
   abandoned: boolean;
 }
 
-function fleetSlotCounts(state: SupervisorState): Pick<FleetHeartbeat, "slotsBusy" | "slotsFree" | "slotsTotal" | "slotsParked"> {
+function fleetSlotCounts(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+): Pick<FleetHeartbeat, "slotsBusy" | "slotsFree" | "slotsTotal" | "slotsParked"> {
   let slotsBusy = 0;
   let slotsFree = 0;
   let slotsParked = 0;
@@ -1066,6 +1069,8 @@ function fleetSlotCounts(state: SupervisorState): Pick<FleetHeartbeat, "slotsBus
     if (slot.parked || slot.idleParked) {
       slotsParked += 1;
     } else if (slot.pid === null) {
+      slotsFree += 1;
+    } else if (!deps.proc.isAlive(slot.pid)) {
       slotsFree += 1;
     } else {
       slotsBusy += 1;
@@ -1118,7 +1123,7 @@ async function emitFleetHeartbeat(
     lastProgressEpoch: state.lastProgressEpoch,
     runner,
     readyForAgent,
-    ...fleetSlotCounts(state),
+    ...fleetSlotCounts(state, deps),
     spawnsThisTick: result.respawned.length,
     ...(result.drainBudget ? { drainBudget: result.drainBudget } : {}),
     slotDetails: buildSlotDetails(state, config),
@@ -1650,6 +1655,7 @@ export async function handleDeadSlot(
   if (cleanExit) {
     if (queueDepth === 0) {
       // Clean drain with empty queue → idle-park (no sweep, no discard envelope).
+      state.pid = null;
       state.idleParked = true;
       return { parked: true };
     }
@@ -1700,6 +1706,7 @@ export async function handleDeadSlot(
     state.parked = true;
     state.tripEpoch = now;
     await sweepParkedSlot(slot, state, deps, config);
+    state.pid = null;
     return { parked: true };
   }
 
@@ -1933,6 +1940,9 @@ export async function superviseTick(
     if ((slot.parked && !slot.halfOpen) || slot.idleParked || slot.spawning) continue;
     const pid = slot.pid;
     if (pid === null || !deps.proc.isAlive(pid)) {
+      if (pid !== null) {
+        deps.log?.(`dead slot reconciled: slot ${i} pid=${pid}`);
+      }
       // Dispatch on_slot_death before the slot is recycled. Best-effort.
       if (deps.dispatchFleetHook) {
         try {

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -1500,6 +1500,31 @@ describe("runSupervisor", () => {
       spawnsThisTick: 0,
     });
   });
+
+  it("does not report a cleanly exited worker pid as busy in the heartbeat", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => false),
+      readyQueueDepth: vi.fn(async () => 0),
+      lastExitCode: vi.fn(() => 0),
+    });
+    const state = initSupervisorState(1);
+    let probes = 0;
+    const stop = () => ++probes >= 2;
+
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15 }), stop);
+
+    expect(io.spawnSlot).toHaveBeenCalledTimes(1);
+    expect(io.killTree).not.toHaveBeenCalled();
+    expect(io.logLines.some((line) => line.includes("dead slot reconciled: slot 0"))).toBe(true);
+    expect(io.emitFleetHeartbeat.mock.calls[0]![0]).toMatchObject({
+      slotsBusy: 0,
+      slotsFree: 0,
+      slotsParked: 1,
+      spawnsThisTick: 0,
+    });
+    expect(state.slots[0]!.pid).toBeNull();
+    expect(state.slots[0]!.idleParked).toBe(true);
+  });
 });
 
 // ---------- envelope builders ----------
@@ -1595,6 +1620,7 @@ describe("idle-drain: exit 0 idle-parks without tripping the circuit breaker", (
     expect(result.respawned).toEqual([]);
     expect(slot.idleParked).toBe(true);
     expect(slot.parked).toBe(false);
+    expect(slot.pid).toBeNull();
     // Death ring untouched — a clean exit is never a fast-death.
     expect(slot.deaths).toEqual([]);
     // No spawn, no discard envelope, no label edits.


### PR DESCRIPTION
Automated AFK landing for #1493. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1493

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786391917&installation_id=129708444&pr_number=1503&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1503&signature=0e390af8d41cf041935dbd3474655e19da50d3ca5de26e05500872db72d71134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->