### PR TITLE
merge: #1502 dead worker's dangling claim freezes an issue; boot stale-claim sweep misses it

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -118,6 +118,7 @@ import type { Runner } from "../types/runner.js";
 import { runnerSupportsStructuredOutput, toAgentRunner } from "./runner-spec.js";
 import type { HistoryClock } from "./history.js";
 import { DEFAULT_GO_VERIFY_RETRIES, LABEL_GO_LANE } from "./go.js";
+import { setActiveClaimFinalizer } from "./process-safety.js";
 
 type ContainerSandboxMode = Exclude<SandboxMode, "none">;
 
@@ -1278,7 +1279,11 @@ export async function processIssue(
   const releaseClaim = async () => {
     if (ownsCommentClaim) {
       ownsCommentClaim = false;
-      await releaseOwnedClaim(deps, input);
+      try {
+        await releaseOwnedClaim(deps, input);
+      } finally {
+        setActiveClaimFinalizer(null);
+      }
       return;
     }
     await deps.claimLock.release(issue);
@@ -1356,6 +1361,11 @@ export async function processIssue(
       return claimLost(issue, hooksFired, deps, decision);
     }
     ownsCommentClaim = true;
+    setActiveClaimFinalizer(async () => {
+      if (!ownsCommentClaim) return;
+      ownsCommentClaim = false;
+      await releaseOwnedClaim(deps, input);
+    });
   } else if (labels.includes(LABEL_RUNNING)) {
     // Legacy lock (no claimGh): `running` present means another worker holds it.
     await deps.claimLock.release(issue);

--- a/apps/dev/src/core/process-safety.ts
+++ b/apps/dev/src/core/process-safety.ts
@@ -93,6 +93,8 @@ export interface ProcessSafety {
   };
 }
 
+export type ActiveClaimFinalizer = () => void | Promise<void>;
+
 /** Options for {@link installProcessSafety}. */
 export interface ProcessSafetyOptions {
   workerId?: string;
@@ -127,12 +129,28 @@ export type DeathClass =
 /** The current safety installation status, exported for tests + diagnostics.
  * `null` when no handlers are installed (the default state). */
 let activeSafety: ProcessSafety | null = null;
+let activeClaimFinalizer: ActiveClaimFinalizer | null = null;
 
 /** Return the active safety installation (or null). Useful for tests and for
  * code that wants to coordinate with the handlers (e.g. a graceful-shutdown
  * path that should also uninstall the death detectors). */
 export function getActiveSafety(): ProcessSafety | null {
   return activeSafety;
+}
+
+export function setActiveClaimFinalizer(finalizer: ActiveClaimFinalizer | null): void {
+  activeClaimFinalizer = finalizer;
+}
+
+function runActiveClaimFinalizer(): void {
+  const finalizer = activeClaimFinalizer;
+  if (!finalizer) return;
+  activeClaimFinalizer = null;
+  try {
+    void finalizer();
+  } catch {
+    // best-effort shutdown cleanup; a broken finalizer must not hide the signal
+  }
 }
 
 /**
@@ -166,16 +184,27 @@ export function installProcessSafety(
 
   const onUncaught = (err: Error): void => {
     write("uncaughtException", `message=${JSON.stringify(err.message)} stack=${JSON.stringify(err.stack ?? "")}`);
+    runActiveClaimFinalizer();
   };
   const onUnhandled = (reason: unknown): void => {
     const r = reason instanceof Error
       ? `message=${JSON.stringify(reason.message)} stack=${JSON.stringify(reason.stack ?? "")}`
       : `value=${JSON.stringify(reason)}`;
     write("unhandledRejection", r);
+    runActiveClaimFinalizer();
   };
-  const onSigTerm = (): void => write("SIGTERM", "received");
-  const onSigInt = (): void => write("SIGINT", "received");
-  const onSigHup = (): void => write("SIGHUP", "received");
+  const onSigTerm = (): void => {
+    write("SIGTERM", "received");
+    runActiveClaimFinalizer();
+  };
+  const onSigInt = (): void => {
+    write("SIGINT", "received");
+    runActiveClaimFinalizer();
+  };
+  const onSigHup = (): void => {
+    write("SIGHUP", "received");
+    runActiveClaimFinalizer();
+  };
   const onExit = (code: number | null): void => {
     // The exit handler is best-effort: a process is already on its way out
     // when this fires, so we use the synchronous file write and accept that
@@ -218,6 +247,7 @@ export function installProcessSafety(
       process.off("exit", onExit);
       if (timer) clearIntervalFn(timer);
       timer = null;
+      activeClaimFinalizer = null;
       activeSafety = null;
     },
     handlers: {

--- a/apps/dev/tests/claim-staleness.test.ts
+++ b/apps/dev/tests/claim-staleness.test.ts
@@ -262,6 +262,15 @@ describe("planStaleClaimSweep", () => {
     expect(releases).toEqual([]);
   });
 
+  it("releases a dead-owner claim immediately, regardless of age grace", () => {
+    const releases = planStaleClaimSweep(
+      [{ issue: 7, records: [claimAt(10, "dead:host", 30)], deadOwners: ["dead:host"] }],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([{ issue: 7, staleOwners: ["dead:host"] }]);
+  });
+
   it("never releases a stale claim whose attempt branch has a recent commit", () => {
     const releases = planStaleClaimSweep(
       [
@@ -275,6 +284,22 @@ describe("planStaleClaimSweep", () => {
       cfg,
     );
     expect(releases).toEqual([]);
+  });
+
+  it("does not let recent branch commits protect a dead-owner claim", () => {
+    const releases = planStaleClaimSweep(
+      [
+        {
+          issue: 7,
+          records: [claimAt(10, "dead:host", 30)],
+          deadOwners: ["dead:host"],
+          attemptBranchCommitS: T0 - 10,
+        },
+      ],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([{ issue: 7, staleOwners: ["dead:host"] }]);
   });
 
   it("still releases a stale claim when no commit landed inside the protection window", () => {

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -14,6 +14,7 @@ import type { IssueClassificationMetadata } from "../src/core/issue-classifier.j
 import type { TrustProvenance } from "../src/core/trust-gate.js";
 import { parseCurrentBlocker, upsertCurrentBlocker } from "../src/core/blocker-state.js";
 import type { AttemptProgressInfo } from "../src/core/execution.js";
+import { installProcessSafety, noopSafetyLogger } from "../src/core/process-safety.js";
 
 // Everything injected is a fake — no real gh / git / sandcastle / pnpm / fs ever
 // runs. The harness records the side-effect sequence (label edits, comments,
@@ -83,6 +84,8 @@ interface HarnessOptions {
   timeoutReason?: RunAgentResult["timeoutReason"];
   /** Scripted per-call outcomes (overrides `outcome`); one entry per runAgent call. */
   outcomes?: RunAgentResult["outcome"][];
+  /** Test hook invoked inside the fake runner while the issue claim is active. */
+  onRunAgent?: () => void | Promise<void>;
   feedbackOk?: boolean;
   /** When true, the feedback baseline probe fails the same check as the worker. */
   baselineFails?: boolean;
@@ -500,6 +503,7 @@ function harness(opts: HarnessOptions = {}): {
     async runAgent(input) {
       const callIdx = trace.runAgentCalls.length;
       trace.runAgentCalls.push(input);
+      await opts.onRunAgent?.();
       const thisOutcome = opts.outcomes ? (opts.outcomes[callIdx] ?? outcome) : outcome;
       return {
         outcome: thisOutcome,
@@ -2098,6 +2102,23 @@ describe("processIssue — claim lost", () => {
     // running was PROJECTED (label edit applied) but is not the lock.
     expect(trace.labelEdits.some((e) => e.add.includes("running"))).toBe(true);
     expect(trace.comments.some((c) => /AFK claim by worker/.test(c.body))).toBe(true);
+  });
+
+  it("concedes the active GitHub-native claim when a SIGTERM arrives mid-attempt", async () => {
+    const safety = installProcessSafety(noopSafetyLogger, { workerId: "wAAAA", heartbeatMs: 0 });
+    try {
+      const { deps, input, trace } = harness({
+        claim: { winner: "self" },
+        onRunAgent: () => {
+          safety.handlers.sigTerm();
+        },
+      });
+      const result = await processIssue(deps, input);
+      expect(result.outcome).toBe("done");
+      expect(trace.comments.some((c) => /kind=concede/.test(c.body))).toBe(true);
+    } finally {
+      safety.uninstall();
+    }
   });
 });
 

--- a/apps/dev/tests/process-safety.test.ts
+++ b/apps/dev/tests/process-safety.test.ts
@@ -9,6 +9,7 @@ import {
   installProcessSafety,
   noopSafetyLogger,
   safetyLogPath,
+  setActiveClaimFinalizer,
   splitClaimIdentity,
   type SafetyLogger,
 } from "../src/core/process-safety.js";
@@ -125,10 +126,29 @@ describe("installProcessSafety — event log lines (via direct handler call)", (
     expect(line).toMatch(/received/);
   });
 
+  it("SIGTERM handler invokes the active claim finalizer once", () => {
+    let calls = 0;
+    setActiveClaimFinalizer(() => {
+      calls += 1;
+    });
+    handlers.sigTerm();
+    handlers.sigTerm();
+    expect(calls).toBe(1);
+  });
+
   it("SIGINT handler records the signal name", () => {
     handlers.sigInt();
     const line = log.find((l) => l.includes("event=SIGINT"));
     expect(line).toBeDefined();
+  });
+
+  it("uncaughtException handler invokes the active claim finalizer", () => {
+    let calls = 0;
+    setActiveClaimFinalizer(() => {
+      calls += 1;
+    });
+    handlers.uncaughtException(new Error("simulated boom"));
+    expect(calls).toBe(1);
   });
 
   it("SIGHUP handler records the signal name", () => {


### PR DESCRIPTION
Automated AFK landing for #1502. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1502

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786392569&installation_id=129708444&pr_number=1504&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1504&signature=07aacebdbb7fdebead626ed8b4a4fc88fd7557e8c168eef5531e313412df4d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->