### PR TITLE
feat: #1487 rsp vitest terse mode: bounded excerpt budget + top-K failures elided to handle

### DIFF
--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -36,9 +36,9 @@ interface TestFailureSource {
 }
 
 const EXCERPT_LIMIT_BYTES = 320;
-// Under `terse` the excerpt budget tightens to first + last line, capped at half the
-// lossless budget, and only the top-K failures stay inline — the rest collapse to a handle.
+// Under `terse` the excerpt budget is shared across the top-K inline failures.
 const TERSE_EXCERPT_LIMIT_BYTES = 160;
+const TERSE_EXCERPT_BUDGET_BYTES = EXCERPT_LIMIT_BYTES;
 const TERSE_TOP_K_FAILURES = 3;
 
 export async function runTestWrapper(argv: readonly string[], options: TestRenderOptions): Promise<GitRenderResult> {
@@ -114,11 +114,7 @@ async function renderTerse(
   options: TestRenderOptions,
   query?: string,
 ): Promise<GitRenderResult> {
-  const inline: TestFailure[] = parsed.failures.slice(0, TERSE_TOP_K_FAILURES).map((failure) => ({
-    suite: failure.suite,
-    name: failure.name,
-    excerpt: terseExcerpt(failure.excerpt),
-  }));
+  const inline = renderTerseInlineFailures(parsed.failures);
 
   const tersePayload: TestPayload = { exit_code: status, summary: query ? `${summary} · ${parsed.failures.length} failures matched` : summary };
   if (inline.length > 0) tersePayload.failures = inline;
@@ -172,12 +168,26 @@ async function renderTerse(
   };
 }
 
-function terseExcerpt(excerpt: string): string {
+function renderTerseInlineFailures(failures: readonly TestFailureSource[]): TestFailure[] {
+  const inline: TestFailure[] = [];
+  let remainingBudget = TERSE_EXCERPT_BUDGET_BYTES;
+
+  for (const failure of failures.slice(0, TERSE_TOP_K_FAILURES)) {
+    const excerpt = terseExcerpt(failure.excerpt, Math.min(TERSE_EXCERPT_LIMIT_BYTES, remainingBudget));
+    remainingBudget = Math.max(0, remainingBudget - Buffer.byteLength(excerpt));
+    inline.push({ suite: failure.suite, name: failure.name, excerpt });
+  }
+
+  return inline;
+}
+
+function terseExcerpt(excerpt: string, limitBytes: number): string {
+  if (limitBytes <= 0) return "";
   const lines = excerpt.split("\n");
   const compact = lines.length <= 2 ? excerpt : `${lines[0]}\n…\n${lines[lines.length - 1]}`;
   const bytes = Buffer.from(compact);
-  if (bytes.length <= TERSE_EXCERPT_LIMIT_BYTES) return compact;
-  return bytes.subarray(0, TERSE_EXCERPT_LIMIT_BYTES).toString("utf8").replace(/�$/, "");
+  if (bytes.length <= limitBytes) return compact;
+  return bytes.subarray(0, limitBytes).toString("utf8").replace(/�$/, "");
 }
 
 function parseTestRunner(command: readonly string[]): "vitest" | "cargo" {

--- a/apps/rsp/tests/test-wrapper.test.ts
+++ b/apps/rsp/tests/test-wrapper.test.ts
@@ -113,6 +113,10 @@ function decodeTerse(stdout: string): unknown {
   return decode(stdout.split("\n").filter((line) => !line.startsWith("… elided ")).join("\n"));
 }
 
+function inlineExcerptBytes(failures: Array<{ excerpt: string }>): number {
+  return failures.reduce((sum, failure) => sum + Buffer.byteLength(failure.excerpt), 0);
+}
+
 describe("rsp vitest terse failure budget", () => {
   it("caps inline failures to top-K and elides the remainder behind a retrievable handle", async () => {
     const root = await tempRoot();
@@ -121,11 +125,12 @@ describe("rsp vitest terse failure budget", () => {
       const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-many-failures")!;
       const result = await runFidelityFixture(fixture, { level: "terse", store });
       const stdout = result.stdout.toString("utf8");
-      const decoded = decodeTerse(stdout) as { summary: string; failures: unknown[] };
+      const decoded = decodeTerse(stdout) as { summary: string; failures: Array<{ excerpt: string }> };
 
       // Rollup preserved; only the top-3 failures stay inline.
       expect(decoded.summary).toBe("5/8 failed · 2 suites · 3.2s");
       expect(decoded.failures).toHaveLength(3);
+      expect(inlineExcerptBytes(decoded.failures)).toBeLessThanOrEqual(320);
       expect(result.rowsElided).toBe(2);
 
       // A single handle behind an elision marker collapses the remaining failures.
@@ -174,13 +179,14 @@ describe("rsp vitest terse failure budget", () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
     try {
-      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-green")!;
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-large-green")!;
       const result = await runFidelityFixture(fixture, { level: "terse", store });
 
       expect(result.status).toBe(0);
       expect(result.mintedHandle).toBeUndefined();
       expect(result.stdout.toString("utf8")).not.toContain("… elided");
       expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+      expect(Buffer.byteLength(result.stdout)).toBeLessThan(Buffer.byteLength(fixture.recorded.stdout) / 100);
     } finally {
       await store.close();
     }


### PR DESCRIPTION
Automated AFK landing for #1487. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1487

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786396453&installation_id=129708444&pr_number=1508&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1508&signature=e428949cb53209aa4a676bece040b9ce4b2d15ac0efb87c1303f5bbbc9dc9d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->