### PR TITLE
feat: #1486 rsp scalar fast-path for tiny git outputs (commit, push): never cost more than raw

### DIFF
--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -296,12 +296,14 @@ function helpIfQueried(payload: JsonObject, query: string | undefined, help: rea
 }
 
 function scalarFastPath(subcommand: GitSubcommand, payload: JsonObject): string | null {
-  if (subcommand === "commit") return String(payload.summary ?? "");
+  if (subcommand === "commit" && typeof payload.commit === "string" && payload.commit.length > 0) {
+    return String(payload.summary ?? "");
+  }
   if (subcommand === "push") {
     const refsValue = payload.refs;
     const refs = Array.isArray(refsValue) ? refsValue : [];
     const realPushes = refs.filter((ref) => isRecord(ref) && ref.flag !== "=");
-    if (realPushes.length <= 1) return String(payload.summary ?? "");
+    if (realPushes.length === 1) return String(payload.summary ?? "");
     return null;
   }
   return null;

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -114,6 +114,43 @@ describe("rsp git fidelity fixtures", () => {
     }
   });
 
+  it("keeps commit-created and push-ref-update fixtures compact without exceeding raw tokens", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixtures = await discoverFidelityFixtures(fixtureRoot);
+      for (const name of ["commit-created", "push-porcelain"]) {
+        const fixture = fixtures.find((candidate) => candidate.name === name)!;
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+        const rawTokens = tokenizer.encode(fixture.recorded.stdout).length;
+        const wrappedTokens = tokenizer.encode(result.stdout.toString("utf8")).length;
+
+        expect(result.oneLine).toBe(true);
+        expect(result.stdout.toString("utf8")).toBe(fixture.expected);
+        expect(wrappedTokens).toBeLessThanOrEqual(rawTokens);
+        expect(result.tokenDelta).toBeGreaterThanOrEqual(0);
+        expect(result.assertionFailures).toEqual([]);
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("keeps rejected push fixtures at full fidelity while bypassing the scalar fast-path", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "push-rejected")!;
+      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+      expect(result.oneLine).toBeUndefined();
+      expect(result.stdout.toString("utf8")).toBe(fixture.expected);
+      expect(result.assertionFailures).toEqual([]);
+    } finally {
+      await store.close();
+    }
+  });
+
   it("fails the suite when a fixture assertion is false even with positive token delta", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });


### PR DESCRIPTION
Automated AFK landing for #1486. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1486

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786397891&installation_id=129708444&pr_number=1509&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1509&signature=ffda75cd03b7e1b21b684f07eb96ba2b42d562115ea9596f9a09e430c91bdecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->