### PR TITLE
feat: #1511 rsp heavy git filters truncate-with-handle by default above a size threshold (C4)

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -46,7 +46,11 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "git") {
-      const result = await runGitWrapper(args.positional, { level: args.level, store });
+      const result = await runGitWrapper(args.positional, {
+        level: args.level,
+        store,
+        heavyGitByteThreshold: config.heavyGitByteThreshold,
+      });
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
       if (result.signal) {

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -2,11 +2,14 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "./elision-store.js";
 
+export const DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD = 8 * 1024;
+
 export interface RspRuntimeConfig {
   enabled: boolean;
   storeUri: string;
   ttlDays: number;
   byteBudget: number;
+  heavyGitByteThreshold: number;
 }
 
 export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitStoreUri?: string): RspRuntimeConfig {
@@ -16,9 +19,13 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
   const enabled = readYamlPath(yaml, "rsp.enabled") === "true";
   const ttlDays = positiveNumber(readNumericYamlPath(yaml, "rsp.ttlDays"), DEFAULT_RSP_TTL_DAYS);
   const byteBudget = positiveNumber(readNumericYamlPath(yaml, "rsp.byteBudget"), DEFAULT_RSP_BYTE_BUDGET);
+  const heavyGitByteThreshold = positiveNumber(
+    numericEnv(env.RSP_HEAVY_GIT_BYTE_THRESHOLD) ?? readNumericYamlPath(yaml, "rsp.heavyGitByteThreshold"),
+    DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
+  );
   const storeUri = explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${join(resolve(root), ".red", "red.rdb")}`;
 
-  return { enabled, storeUri, ttlDays, byteBudget };
+  return { enabled, storeUri, ttlDays, byteBudget, heavyGitByteThreshold };
 }
 
 function findUp(start: string, relativePath: string): string | null {
@@ -67,4 +74,10 @@ function stripInlineComment(value: string): string {
 
 function positiveNumber(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function numericEnv(value: string | undefined): number | undefined {
+  if (value == null || value.trim() === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
 }

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -1,7 +1,10 @@
 import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
 import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
 import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
+
+export { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
 
 export type GitSubcommand = "status" | "log" | "diff" | "commit" | "push";
 
@@ -17,6 +20,7 @@ export interface RecordedGitContract {
 export interface GitRenderOptions {
   level: RspLossLevel;
   store?: RspElisionStore;
+  heavyGitByteThreshold?: number;
 }
 
 export interface GitRenderResult {
@@ -32,7 +36,7 @@ export interface GitRenderResult {
 }
 
 export async function runGitWrapper(argv: readonly string[], options: GitRenderOptions): Promise<GitRenderResult> {
-  const parsed = extractQueryArg(argv);
+  const parsed = parseGitRenderCommand(argv);
   const subcommand = parseGitSubcommand(parsed.argv);
   const contract = await collectGitContract(subcommand, parsed.argv.slice(1));
   return renderGitContract(argv, contract, options);
@@ -43,7 +47,7 @@ export async function renderGitContract(
   contract: RecordedGitContract,
   options: GitRenderOptions,
 ): Promise<GitRenderResult> {
-  const parsedCommand = extractQueryArg(command);
+  const parsedCommand = parseGitRenderCommand(command);
   if ((contract.status ?? 0) !== 0 || contract.signal) {
     return {
       stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
@@ -77,7 +81,7 @@ export async function renderGitContract(
   }
 
   const fullToon = encode(payload);
-  if (options.level !== "terse") {
+  if (shouldEmitFull(subcommand, fullToon, parsedCommand.full, options)) {
     return {
       stdout: Buffer.from(fullToon),
       stderr: Buffer.from(contract.stderr),
@@ -116,6 +120,45 @@ export async function renderGitContract(
     bytesElided,
     rowsElided: terse.rowsElided,
   };
+}
+
+interface ParsedGitRenderCommand {
+  argv: string[];
+  query?: string;
+  full: boolean;
+}
+
+function parseGitRenderCommand(command: readonly string[]): ParsedGitRenderCommand {
+  const parsed = extractQueryArg(command);
+  const argv: string[] = [];
+  let full = false;
+  for (const arg of parsed.argv) {
+    if (arg === "--full") {
+      full = true;
+      continue;
+    }
+    argv.push(arg);
+  }
+  return { argv, query: parsed.query, full };
+}
+
+function shouldEmitFull(
+  subcommand: GitSubcommand,
+  fullToon: string,
+  fullRequested: boolean,
+  options: GitRenderOptions,
+): boolean {
+  if (options.level === "terse") return false;
+  if (fullRequested || options.level === "full") return true;
+  if (!isHeavyGitSubcommand(subcommand)) return true;
+  if (options.level !== "lossless") return true;
+
+  const threshold = positiveNumber(options.heavyGitByteThreshold, DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD);
+  return Buffer.byteLength(fullToon) <= threshold;
+}
+
+function isHeavyGitSubcommand(subcommand: GitSubcommand): boolean {
+  return subcommand === "diff" || subcommand === "log";
 }
 
 function parseGitSubcommand(argv: readonly string[]): GitSubcommand {
@@ -328,6 +371,10 @@ function countBy(rows: readonly JsonObject[], field: string): Record<string, num
     out[key] = (out[key] ?? 0) + 1;
   }
   return out;
+}
+
+function positiveNumber(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 function tersePayload(payload: JsonObject): { payload: JsonObject; rowsElided: number } | null {

--- a/apps/rsp/src/setup.ts
+++ b/apps/rsp/src/setup.ts
@@ -2,6 +2,7 @@ import { constants } from "node:fs";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { connect } from "@reddb-io/sdk";
+import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "./elision-store.js";
 
 export const REPO_STORE_PATH = ".red/red.rdb";
@@ -9,6 +10,7 @@ export const REPO_STORE_PATH = ".red/red.rdb";
 export interface RspProvisionOptions {
   ttlDays?: number;
   byteBudget?: number;
+  heavyGitByteThreshold?: number;
 }
 
 export interface RspProvisionResult {
@@ -36,6 +38,7 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
     enabled: true,
     ttlDays: opts.ttlDays ?? DEFAULT_RSP_TTL_DAYS,
     byteBudget: opts.byteBudget ?? DEFAULT_RSP_BYTE_BUDGET,
+    heavyGitByteThreshold: opts.heavyGitByteThreshold ?? DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   });
   const configChanged = next !== existing;
   if (configChanged) await writeFile(configPath, next, "utf8");
@@ -53,6 +56,7 @@ export interface RspConfigBlock {
   enabled: boolean;
   ttlDays: number;
   byteBudget: number;
+  heavyGitByteThreshold: number;
 }
 
 export function mergeRspBlock(existingText: string, block: RspConfigBlock): string {
@@ -61,6 +65,7 @@ export function mergeRspBlock(existingText: string, block: RspConfigBlock): stri
     `  enabled: ${block.enabled ? "true" : "false"}`,
     `  ttlDays: ${positiveNumber(block.ttlDays, DEFAULT_RSP_TTL_DAYS)}`,
     `  byteBudget: ${positiveNumber(block.byteBudget, DEFAULT_RSP_BYTE_BUDGET)}`,
+    `  heavyGitByteThreshold: ${positiveNumber(block.heavyGitByteThreshold, DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD)}`,
   ];
   const lines = existingText === "" ? [] : existingText.replace(/\n+$/, "").split("\n");
   const start = findTopLevelBlock(lines, "rsp");

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { resolveRspConfig } from "../src/config.js";
+import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD, resolveRspConfig } from "../src/config.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/elision-store.js";
 
 const roots: string[] = [];
@@ -21,13 +21,14 @@ describe("resolveRspConfig", () => {
   it("reads retention knobs from the top-level rsp block", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });
-    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  ttlDays: 3\n  byteBudget: 42\n", "utf8");
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  heavyGitByteThreshold: 99\n", "utf8");
 
     expect(resolveRspConfig(join(root, "nested"), {}, undefined)).toEqual({
       enabled: false,
       storeUri: `file://${join(root, ".red", "red.rdb")}`,
       ttlDays: 3,
       byteBudget: 42,
+      heavyGitByteThreshold: 99,
     });
   });
 
@@ -41,7 +42,15 @@ describe("resolveRspConfig", () => {
       storeUri: `file://${join(root, ".red", "red.rdb")}`,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
     });
+  });
+
+  it("lets env override the heavy git truncation threshold", async () => {
+    const root = await tempRoot();
+    const config = resolveRspConfig(root, { RSP_HEAVY_GIT_BYTE_THRESHOLD: "123" }, undefined);
+
+    expect(config.heavyGitByteThreshold).toBe(123);
   });
 
   it("does not create .red or red.rdb while resolving runtime config", async () => {

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { evaluateAdmission, runAdmittedFixture } from "../src/admission.js";
 import { runFidelityFixture, discoverFidelityFixtures } from "../src/fidelity.js";
 import { RspElisionStore } from "../src/elision-store.js";
-import { GIT_LOG_MACHINE_FIELDS, renderGitContract } from "../src/git-wrapper.js";
+import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD, GIT_LOG_MACHINE_FIELDS, renderGitContract } from "../src/git-wrapper.js";
 
 const roots: string[] = [];
 const fixtureRoot = join(import.meta.dirname, "fixtures", "git");
@@ -47,7 +47,7 @@ describe("rsp git fidelity fixtures", () => {
     try {
       for (const fixture of await discoverFidelityFixtures(fixtureRoot)) {
         if (fixture.name === "status-clean" || fixture.name === "push-rejected") continue;
-        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+        const result = await runFidelityFixture(fixture, { level: "full", store });
         expect(result.status).toBe(fixture.recorded.status);
         expect(result.stderr).toEqual(Buffer.from(fixture.recorded.stderr, "utf8"));
         expect(result.assertionFailures).toEqual([]);
@@ -91,6 +91,82 @@ describe("rsp git fidelity fixtures", () => {
       expect(marker).toBe(`… elided 2 rows (+${result.bytesElided}) — rsp show ${result.mintedHandle}`);
       expect(result.mintedHandle).toBeDefined();
 
+      const record = await store.get(result.mintedHandle!);
+      if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+      expect(decode(record.original.toString("utf8"))).toEqual(fixture.expected);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("keeps small heavy git outputs full by default", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixtures = await discoverFidelityFixtures(fixtureRoot);
+      for (const name of ["diff-numstat", "log-contract"]) {
+        const fixture = fixtures.find((candidate) => candidate.name === name)!;
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+        expect(result.mintedHandle).toBeUndefined();
+        expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+      }
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("truncates large heavy git outputs by default while show recovers the full TOON", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixtures = await discoverFidelityFixtures(fixtureRoot);
+      for (const name of ["diff-large-numstat", "log-large-history"]) {
+        const fixture = fixtures.find((candidate) => candidate.name === name)!;
+        const result = await runFidelityFixture(fixture, { level: "lossless", store });
+        const stdout = result.stdout.toString("utf8");
+        const marker = stdout.split("\n").at(-2)!;
+
+        expect(marker).toMatch(/^… elided \d+ rows \(\+\d+\) — rsp show el:[a-f0-9]{12}$/);
+        expect(result.mintedHandle).toBeDefined();
+        expect(result.bytesElided).toBeGreaterThan(DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD);
+
+        const record = await store.get(result.mintedHandle!);
+        if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
+        expect(decode(record.original.toString("utf8"))).toEqual(fixture.expected);
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("--full keeps large heavy git outputs lossless and skips handle minting", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = {
+        ...(await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "diff-large-numstat")!,
+        command: ["git", "diff", "--full"],
+      };
+      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+
+      expect(result.mintedHandle).toBeUndefined();
+      expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("keeps --terse as an always-elide mode even below the default size threshold", async () => {
+    const root = await tempRoot();
+    const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
+    try {
+      const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "diff-numstat")!;
+      const result = await runFidelityFixture(fixture, { level: "terse", store });
+
+      expect(result.mintedHandle).toBeDefined();
       const record = await store.get(result.mintedHandle!);
       if (!record || !("original" in record) || !record.original) throw new Error("expected live elision record");
       expect(decode(record.original.toString("utf8"))).toEqual(fixture.expected);
@@ -212,7 +288,7 @@ describe("rsp git token levers", () => {
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
     try {
       const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "log-large-history")!;
-      const result = await runFidelityFixture(fixture, { level: "lossless", store });
+      const result = await runFidelityFixture(fixture, { level: "full", store });
       const previousRedundantStdout = toPreviousRedundantLogStdout(fixture.recorded.stdout);
 
       expect(result.assertionFailures).toEqual([]);

--- a/apps/rsp/tests/setup.test.ts
+++ b/apps/rsp/tests/setup.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "../src/config.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/elision-store.js";
 import { mergeRspBlock, provisionRspRepoStore } from "../src/setup.js";
 
@@ -23,6 +24,7 @@ describe("mergeRspBlock", () => {
       enabled: true,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
     })).toBe([
       "plugins:",
       "  dev:",
@@ -32,6 +34,7 @@ describe("mergeRspBlock", () => {
       "  enabled: true",
       "  ttlDays: 7",
       "  byteBudget: 67108864",
+      "  heavyGitByteThreshold: 8192",
       "",
     ].join("\n"));
   });
@@ -48,10 +51,10 @@ describe("mergeRspBlock", () => {
       "",
     ].join("\n");
 
-    const out = mergeRspBlock(existing, { enabled: true, ttlDays: 7, byteBudget: 64 });
+    const out = mergeRspBlock(existing, { enabled: true, ttlDays: 7, byteBudget: 64, heavyGitByteThreshold: 128 });
 
     expect(out).toContain("plugins:\n  dev:\n    enabled: true");
-    expect(out).toContain("rsp:\n  enabled: true\n  ttlDays: 7\n  byteBudget: 64");
+    expect(out).toContain("rsp:\n  enabled: true\n  ttlDays: 7\n  byteBudget: 64\n  heavyGitByteThreshold: 128");
     expect(out).toContain("other: kept");
     expect(out).not.toContain("ttlDays: 1");
   });


### PR DESCRIPTION
Automated AFK landing for #1511. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1511

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786406050&installation_id=129708444&pr_number=1512&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1512&signature=46dbc5e22bedc97a4f6e84f0e1b5aaa90efc714541e4178e61b6649f0bc42f3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->