### PR TITLE
fix: #1514 runtime shim never puts rsp on PATH, so the merged rsp guidance is a dead letter

### DIFF
--- a/apps/dev/tests/label-vocabulary-docs.test.ts
+++ b/apps/dev/tests/label-vocabulary-docs.test.ts
@@ -36,6 +36,15 @@ function writeFakeRuntime(root: string, label: string): void {
   );
 }
 
+function writeFakeRspBundle(root: string, label: string): void {
+  const dist = join(root, "dist");
+  mkdirSync(dist, { recursive: true });
+  writeFileSync(
+    join(dist, "rsp.bundle.min.mjs"),
+    `#!/usr/bin/env node\nconsole.log(JSON.stringify({ label: ${JSON.stringify(label)}, args: process.argv.slice(2) }));\n`,
+  );
+}
+
 function shimEnv(home: string, extra: Record<string, string> = {}): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, HOME: home };
   delete env.CLAUDE_PLUGIN_ROOT;
@@ -164,6 +173,8 @@ describe("red-setup docs", () => {
     expect(skill).toContain("red-skills-dev go");
     expect(skill).toContain("Do not export `CLAUDE_PLUGIN_ROOT` or `CODEX_PLUGIN_ROOT` globally");
     expect(script).toContain("RED_SKILLS_DEV_PLUGIN_ROOT");
+    expect(script).toContain("rsp_target=");
+    expect(script).toContain("dist/rsp.bundle.min.mjs");
     expect(script).toContain(".codex/plugins/cache/red-skills/dev");
     expect(script).toContain(".claude/plugins/cache/red-skills/dev");
     expect(script).toContain(".cache/red-skills/bundles");
@@ -196,6 +207,66 @@ describe("red-setup docs", () => {
         encoding: "utf8",
       }).trim();
       expect(JSON.parse(cacheOutput)).toEqual({ label: "claude9", args: ["dashboard", "--json"] });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("installs an rsp shim that resolves without npm or network", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "red-rsp-shim-"));
+    const bin = join(tmp, "bin");
+    const home = join(tmp, "home");
+    const envRoot = join(tmp, "env-root");
+    const script = join(ROOT, "plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh");
+
+    try {
+      writeFakeRspBundle(envRoot, "env-rsp");
+      execFileSync("bash", [script], { env: { ...process.env, XDG_BIN_HOME: bin }, encoding: "utf8" });
+
+      const commandPath = execFileSync("bash", ["-lc", "command -v rsp"], {
+        env: shimEnv(home, {
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RED_SKILLS_DEV_PLUGIN_ROOT: envRoot,
+        }),
+        encoding: "utf8",
+      }).trim();
+      expect(commandPath).toBe(join(bin, "rsp"));
+
+      const envOutput = execFileSync("rsp", ["git", "status"], {
+        env: shimEnv(home, {
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RED_SKILLS_DEV_PLUGIN_ROOT: envRoot,
+        }),
+        encoding: "utf8",
+      }).trim();
+      expect(JSON.parse(envOutput)).toEqual({ label: "env-rsp", args: ["git", "status"] });
+
+      rmSync(home, { recursive: true, force: true });
+      writeFakeRspBundle(join(home, ".codex", "plugins", "cache", "red-skills", "dev", "1.0.0"), "codex-rsp");
+      writeFakeRspBundle(join(home, ".claude", "plugins", "cache", "red-skills", "dev", "9.0.0"), "claude-rsp");
+
+      const cacheOutput = execFileSync("rsp", ["show", "el:123"], {
+        env: shimEnv(home, { PATH: `${bin}:${process.env.PATH ?? ""}` }),
+        encoding: "utf8",
+      }).trim();
+      expect(JSON.parse(cacheOutput)).toEqual({ label: "claude-rsp", args: ["show", "el:123"] });
+
+      rmSync(home, { recursive: true, force: true });
+      const bundleRoot = join(tmp, "bundle-cache");
+      mkdirSync(bundleRoot, { recursive: true });
+      writeFileSync(
+        join(bundleRoot, "rsp-2.0.0.bundle.min.mjs"),
+        `#!/usr/bin/env node\nconsole.log(JSON.stringify({ label: "bundle-rsp", args: process.argv.slice(2) }));\n`,
+      );
+
+      const bundleOutput = execFileSync("rsp", ["gh", "pr", "list"], {
+        env: shimEnv(home, {
+          PATH: `${bin}:${process.env.PATH ?? ""}`,
+          RED_SKILLS_CACHE_DIR: bundleRoot,
+        }),
+        encoding: "utf8",
+      }).trim();
+      expect(JSON.parse(bundleOutput)).toEqual({ label: "bundle-rsp", args: ["gh", "pr", "list"] });
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
+++ b/plugins/dev/skills/engineering/red-setup/INTERVIEW.md
@@ -120,7 +120,7 @@ Offer to install the host-level runtime shim:
 bash plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh
 ```
 
-The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev`. The shim:
+The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev` and `${XDG_BIN_HOME:-$HOME/.local/bin}/rsp`. The `red-skills-dev` shim:
 
 - prefers the active CLI plugin-root env var when the host exposes one;
 - otherwise finds the latest installed dev plugin under `~/.codex/plugins/cache/red-skills/dev/*` or `~/.claude/plugins/cache/red-skills/dev/*`;
@@ -128,11 +128,15 @@ The script writes `${XDG_BIN_HOME:-$HOME/.local/bin}/red-skills-dev`. The shim:
 - forwards all arguments to the dev runtime, so skills can say `red-skills-dev go ...`, `red-skills-dev dashboard`, or `RED_AFK_RUNNER=codex red-skills-dev monitor --once`;
 - stores no secrets and does not replace the `.red/config.yaml` opt-in gate.
 
+The `rsp` shim uses the same local-first shape: active plugin-root env var, installed host plugin cache, then the warmed rsp bundle under `${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}`. It never runs npm, installs a global package, or performs network resolution during session startup.
+
 After installing, verify:
 
 ```bash
 command -v red-skills-dev
+command -v rsp
 red-skills-dev dashboard --json
+rsp git status
 ```
 
 If `command -v` cannot find it, add `${XDG_BIN_HOME:-$HOME/.local/bin}` to the shell `PATH`. Do not export `CLAUDE_PLUGIN_ROOT` or `CODEX_PLUGIN_ROOT` globally as a substitute.

--- a/plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh
+++ b/plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 bin_dir="${XDG_BIN_HOME:-$HOME/.local/bin}"
 name="${1:-red-skills-dev}"
-target="$bin_dir/$name"
+dev_target="$bin_dir/$name"
+rsp_target="$bin_dir/rsp"
 
 mkdir -p "$bin_dir"
 
-cat >"$target" <<'SH'
+cat >"$dev_target" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -75,5 +76,89 @@ EOF
 exit 127
 SH
 
-chmod 0755 "$target"
-printf 'installed %s\n' "$target"
+cat >"$rsp_target" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+env_bundle() {
+  local root bundle
+  for root in \
+    "${RED_SKILLS_DEV_PLUGIN_ROOT:-}" \
+    "${CLAUDE_PLUGIN_ROOT:-}" \
+    "${CODEX_PLUGIN_ROOT:-}" \
+    "${OPENCODE_PLUGIN_ROOT:-}"
+  do
+    [ -n "$root" ] || continue
+    for bundle in \
+      "$root/../../dist/rsp.bundle.min.mjs" \
+      "$root/dist/rsp.bundle.min.mjs"
+    do
+      if [ -f "$bundle" ]; then
+        printf '%s\n' "$bundle"
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
+latest_cache_bundle() {
+  local dir bundle
+  for dir in "$HOME"/.codex/plugins/cache/red-skills/dev/* "$HOME"/.claude/plugins/cache/red-skills/dev/*; do
+    [ -d "$dir" ] || continue
+    for bundle in "$dir/../../dist/rsp.bundle.min.mjs" "$dir/dist/rsp.bundle.min.mjs"; do
+      [ -f "$bundle" ] &&
+        printf '%s\t%s\n' "$(basename "$dir")" "$bundle"
+    done
+  done | sort -V | tail -1 | cut -f2-
+}
+
+latest_bundle() {
+  local cache_root bundle version
+  cache_root="${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}"
+
+  if [ -f "$cache_root/rsp.bundle.min.mjs" ]; then
+    printf '%s\n' "$cache_root/rsp.bundle.min.mjs"
+    return 0
+  fi
+
+  for bundle in "$cache_root"/rsp-*.bundle.min.mjs; do
+    [ -f "$bundle" ] || continue
+    version="${bundle##*/rsp-}"
+    version="${version%.bundle.min.mjs}"
+    printf '%s\t%s\n' "$version" "$bundle"
+  done | sort -V | tail -1 | cut -f2-
+}
+
+bundle="$(env_bundle || true)"
+if [ -n "$bundle" ]; then
+  exec node "$bundle" "$@"
+fi
+
+bundle="$(latest_cache_bundle || true)"
+if [ -n "$bundle" ]; then
+  exec node "$bundle" "$@"
+fi
+
+bundle="$(latest_bundle || true)"
+if [ -n "$bundle" ]; then
+  exec node "$bundle" "$@"
+fi
+
+cat >&2 <<'EOF'
+rsp: no RedSkills rsp runtime found.
+
+Expected one of:
+- an installed dev plugin with dist/rsp.bundle.min.mjs under ~/.codex/plugins/cache/red-skills/dev/*
+- an installed dev plugin with dist/rsp.bundle.min.mjs under ~/.claude/plugins/cache/red-skills/dev/*
+- a warmed rsp bundle under ${RED_SKILLS_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/red-skills/bundles}
+
+Run /red-setup in a repo with plugins.dev.enabled: true, then restart the
+agent session so the plugin SessionStart hook can warm the runtime cache.
+EOF
+exit 127
+SH
+
+chmod 0755 "$dev_target" "$rsp_target"
+printf 'installed %s\n' "$dev_target"
+printf 'installed %s\n' "$rsp_target"


### PR DESCRIPTION
Automated AFK landing for #1514. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1514

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786419589&installation_id=129708444&pr_number=1516&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1516&signature=aa578295769ad7d7c2716560dd84bdadef181f65c5395d170c7fe4799b506fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->