### PR TITLE
fix: #1522 rsp wrappers exit 1 when the store is unavailable, breaking every command the hook rewrites

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { closeSync, existsSync, openSync, readSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { RspElisionStore } from "./elision-store.js";
 import { resolveRspConfig } from "./config.js";
@@ -34,15 +35,25 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   }
 
   const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
+  const wrapperCommand = isWrapperCommand(args.command);
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
+    if (wrapperCommand) return await passthrough(args.positional);
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
     return 1;
   }
-  const store = await RspElisionStore.open({
-    uri: config.storeUri,
-    ttlDays: config.ttlDays,
-    byteBudget: config.byteBudget,
-  });
+  if (wrapperCommand && isUnreadableFileStore(config.storeUri)) return await passthrough(args.positional);
+  let store: RspElisionStore;
+  try {
+    const openStore = () => RspElisionStore.open({
+      uri: config.storeUri,
+      ttlDays: config.ttlDays,
+      byteBudget: config.byteBudget,
+    });
+    store = wrapperCommand ? await suppressRspStderr(openStore) : await openStore();
+  } catch (err) {
+    if (wrapperCommand) return await passthrough(args.positional);
+    throw err;
+  }
 
   try {
     if (!args.command) {
@@ -52,11 +63,11 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "git") {
-      const result = await runGitWrapper(args.positional, {
+      const result = await suppressRspStderr(() => runGitWrapper(args.positional, {
         level: args.level,
         store,
         heavyGitByteThreshold: config.heavyGitByteThreshold,
-      });
+      }));
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
       if (result.signal) {
@@ -67,7 +78,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "gh") {
-      const result = await runGhWrapper(args.positional, { level: args.level, store });
+      const result = await suppressRspStderr(() => runGhWrapper(args.positional, { level: args.level, store }));
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
       if (result.signal) {
@@ -78,7 +89,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "vitest" || args.command === "cargo") {
-      const result = await runTestWrapper(args.positional, { level: args.level, store });
+      const result = await suppressRspStderr(() => runTestWrapper(args.positional, { level: args.level, store }));
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
       if (result.signal) {
@@ -104,9 +115,61 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
 
     process.stdout.write("error: usage rsp show el:<id>\n");
     return 2;
+  } catch (err) {
+    if (wrapperCommand) return await passthrough(args.positional);
+    throw err;
   } finally {
     await store.close();
   }
+}
+
+async function suppressRspStderr<T>(fn: () => Promise<T>): Promise<T> {
+  const write = process.stderr.write;
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+  try {
+    return await fn();
+  } finally {
+    process.stderr.write = write;
+  }
+}
+
+function isWrapperCommand(command: string | undefined): boolean {
+  return command === "git" || command === "gh" || command === "vitest" || command === "cargo";
+}
+
+function isUnreadableFileStore(uri: string): boolean {
+  if (!uri.startsWith("file://")) return false;
+  let fd: number | undefined;
+  try {
+    fd = openSync(fileURLToPath(uri), "r");
+    const header = Buffer.alloc(64);
+    const bytesRead = readSync(fd, header, 0, header.length, 0);
+    return !header.subarray(0, bytesRead).includes("RDDB");
+  } catch {
+    return true;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+async function passthrough(argv: readonly string[]): Promise<number> {
+  const command = argv[0];
+  if (!command) return 2;
+  const child = spawn(command, argv.slice(1), { stdio: "inherit" });
+  return await new Promise((resolve) => {
+    child.on("error", (err) => {
+      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+      resolve(127);
+    });
+    child.on("close", (status, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        resolve(128);
+        return;
+      }
+      resolve(status ?? 0);
+    });
+  });
 }
 
 function parseArgs(argv: string[]): ParsedArgs {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
@@ -37,6 +37,17 @@ function runRspFromCwd(cwd: string, args: string[], env: Record<string, string>)
   });
 }
 
+function runGit(args: string[]) {
+  return spawnSync("git", args, { encoding: "buffer" });
+}
+
+async function initGitRepo(): Promise<string> {
+  const root = await tempRoot();
+  const init = runGit(["-C", root, "init"]);
+  expect(init.status).toBe(0);
+  return root;
+}
+
 describe("rsp cli", () => {
   it("fails closed instead of creating the default Repo store when setup has not provisioned it", async () => {
     const root = await tempRoot();
@@ -47,6 +58,62 @@ describe("rsp cli", () => {
     expect(res.status).toBe(1);
     expect(res.stdout).toEqual(Buffer.from("error: rsp repo store is not provisioned - run /red-setup\n"));
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("passes through a successful wrapper when the repo store has not been provisioned", async () => {
+    const root = await initGitRepo();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, "untracked.txt"), "raw stdout\n", "utf8");
+    const direct = runGit(["-C", root, "status", "--short"]);
+
+    const res = runRspFromCwd(root, ["git", "-C", root, "status", "--short"], {});
+
+    expect(res.status).toBe(direct.status);
+    expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr).toEqual(direct.stderr);
+    await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("passes through a failing wrapper with the underlying exit code and raw stderr when the store is absent", async () => {
+    const root = await initGitRepo();
+    await mkdir(join(root, ".red"), { recursive: true });
+    const args = ["-C", root, "definitely-not-a-git-subcommand"];
+    const direct = runGit(args);
+
+    const res = runRspFromCwd(root, ["git", ...args], {});
+
+    expect(res.status).toBe(direct.status);
+    expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr).toEqual(direct.stderr);
+  });
+
+  it("passes through wrappers when the configured store is unreadable", async () => {
+    const root = await initGitRepo();
+    const storeRoot = await tempRoot();
+    const storePath = join(storeRoot, "red.rdb");
+    await writeFile(storePath, "not a reddb store", "utf8");
+    await writeFile(join(root, "raw.txt"), "raw\n", "utf8");
+    const direct = runGit(["-C", root, "status", "--short"]);
+
+    const res = runRspFromCwd(root, ["git", "-C", root, "status", "--short"], { RSP_STORE_URI: `file://${storePath}` });
+
+    expect(res.status).toBe(direct.status);
+    expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr).toEqual(direct.stderr);
+  });
+
+  it("passes through wrappers when rsp hits an internal wrapper error after opening the store", async () => {
+    const root = await tempRoot();
+    const storeUri = `file://${join(root, "red.rdb")}`;
+    const store = await RspElisionStore.open({ uri: storeUri });
+    await store.close();
+    const direct = runGit(["--version"]);
+
+    const res = runRsp(root, ["git", "--version"], { RSP_STORE_URI: storeUri });
+
+    expect(res.status).toBe(direct.status);
+    expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr).toEqual(direct.stderr);
   });
 
   it("prints store stats instead of help when called without arguments", async () => {

--- a/apps/rsp/tests/setup.test.ts
+++ b/apps/rsp/tests/setup.test.ts
@@ -121,8 +121,9 @@ describe("rsp setup CLI", () => {
       cwd: root,
       encoding: "utf8",
     });
-    expect(before.status).toBe(1);
-    expect(before.stdout).toContain("rsp repo store is not provisioned");
+    expect(before.status).not.toBe(0);
+    expect(before.stdout).not.toContain("rsp repo store is not provisioned");
+    expect(before.stderr).toContain("not a git repository");
 
     const setup = spawnSync(process.execPath, ["--import", tsxLoader, cli, "setup"], {
       cwd: root,


### PR DESCRIPTION
Automated AFK landing for #1522. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1522

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786425109&installation_id=129708444&pr_number=1524&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1524&signature=89fde1a9ed4e410cd840cdf81c1c941439acbf763edd3e95f4e4997edc139819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->