### PR TITLE
fix: #1531 rsp pays ~900ms of store-session overhead on every wrapped command

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -44,27 +44,25 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     return 1;
   }
   if (wrapperCommand && isUnreadableFileStore(config.storeUri)) return await degradeToPassthrough("store unreadable", args.positional);
-  let store: RspElisionStore;
-  try {
-    const openStore = () => RspElisionStore.open({
-      uri: config.storeUri,
-      ttlDays: config.ttlDays,
-      byteBudget: config.byteBudget,
-    });
-    store = wrapperCommand ? await suppressRspStderr(openStore) : await openStore();
-  } catch (err) {
-    if (wrapperCommand) return await degradeToPassthrough("store open failed", args.positional, err);
-    throw err;
-  }
 
+  const openStore = () => RspElisionStore.open({
+    uri: config.storeUri,
+    ttlDays: config.ttlDays,
+    byteBudget: config.byteBudget,
+  });
+  let closeStore: (() => Promise<void>) | undefined;
   try {
     if (!args.command) {
+      const store = await openStore();
+      closeStore = () => store.close();
       const stats = await store.stats();
       process.stdout.write(renderStats(stats));
       return 0;
     }
 
     if (args.command === "git") {
+      const store = new LazyRspElisionStore(() => suppressRspStderr(openStore));
+      closeStore = () => store.close();
       const result = await suppressRspStderr(() => runGitWrapper(args.positional, {
         level: args.level,
         store,
@@ -80,6 +78,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "gh") {
+      const store = new LazyRspElisionStore(() => suppressRspStderr(openStore));
+      closeStore = () => store.close();
       const result = await suppressRspStderr(() => runGhWrapper(args.positional, { level: args.level, store }));
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
@@ -91,6 +91,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "vitest" || args.command === "cargo") {
+      const store = new LazyRspElisionStore(() => suppressRspStderr(openStore));
+      closeStore = () => store.close();
       const result = await suppressRspStderr(() => runTestWrapper(args.positional, { level: args.level, store }));
       process.stdout.write(result.stdout);
       process.stderr.write(result.stderr);
@@ -102,6 +104,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
 
     if (args.command === "show" && args.handle) {
+      const store = await openStore();
+      closeStore = () => store.close();
       const record = await store.get(args.handle);
       if (record && "original" in record && record.original) {
         process.stdout.write(record.original);
@@ -121,7 +125,33 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     if (wrapperCommand) return await degradeToPassthrough("wrapper failed", args.positional, err);
     throw err;
   } finally {
+    await closeStore?.();
+  }
+}
+
+class LazyRspElisionStore implements Pick<RspElisionStore, "mint" | "close"> {
+  private store?: Promise<RspElisionStore>;
+
+  constructor(private readonly openStore: () => Promise<RspElisionStore>) {}
+
+  async mint(...args: Parameters<RspElisionStore["mint"]>): ReturnType<RspElisionStore["mint"]> {
+    return await (await this.open()).mint(...args);
+  }
+
+  async close(): Promise<void> {
+    if (!this.store) return;
+    let store: RspElisionStore;
+    try {
+      store = await this.store;
+    } catch {
+      return;
+    }
     await store.close();
+  }
+
+  private open(): Promise<RspElisionStore> {
+    this.store ??= this.openStore();
+    return this.store;
   }
 }
 

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -93,6 +93,9 @@ export class RspElisionStore {
   }) {}
 
   static async open(opts: RspElisionStoreOptions): Promise<RspElisionStore> {
+    if (process.env.RSP_FAIL_IF_STORE_OPEN === "1") {
+      throw new Error("RSP_FAIL_IF_STORE_OPEN blocked store open");
+    }
     const store = new RspElisionStore({
       uri: opts.uri,
       ttlDays: positiveNumber(opts.ttlDays, DEFAULT_RSP_TTL_DAYS),

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -9,7 +9,7 @@ export type GhAction = "list" | "view" | "combined";
 
 export interface GhRenderOptions {
   level: RspLossLevel;
-  store?: RspElisionStore;
+  store?: Pick<RspElisionStore, "mint">;
 }
 
 export interface GhRenderResult {

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -19,7 +19,7 @@ export interface RecordedGitContract {
 
 export interface GitRenderOptions {
   level: RspLossLevel;
-  store?: RspElisionStore;
+  store?: Pick<RspElisionStore, "mint">;
   heavyGitByteThreshold?: number;
 }
 

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -6,7 +6,7 @@ import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output
 
 export interface TestRenderOptions {
   level: RspLossLevel;
-  store?: RspElisionStore;
+  store?: Pick<RspElisionStore, "mint">;
 }
 
 interface TestFailure extends JsonObject {
@@ -329,7 +329,7 @@ function parseCargoTest(stdout: string): ParsedTestRun | null {
 async function renderExcerpt(
   excerpt: string,
   command: string,
-  store?: RspElisionStore,
+  store?: Pick<RspElisionStore, "mint">,
 ): Promise<{ text: string; handle?: `el:${string}`; bytesElided: number }> {
   const bytes = Buffer.from(excerpt);
   if (bytes.length <= EXCERPT_LIMIT_BYTES) return { text: excerpt, bytesElided: 0 };

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -54,6 +54,18 @@ function runBundleFromCwd(cwd: string, args: string[], env: Record<string, strin
   });
 }
 
+function timedStatus(command: () => ReturnType<typeof spawnSync>): { status: number | null; elapsedMs: number; stderr: Buffer } {
+  const started = process.hrtime.bigint();
+  const result = command();
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  return { status: result.status, elapsedMs, stderr: result.stderr as Buffer };
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)] ?? 0;
+}
+
 function buildBundleOnce() {
   if (bundleBuilt) return;
   const res = spawnSync("pnpm", ["-C", "apps/rsp", "build"], {
@@ -95,17 +107,64 @@ async function seedWarmRedCache(): Promise<string> {
 }
 
 describe("rsp cli", () => {
+  it("built bundle does not open the store for small git status output", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const storeUri = `file://${join(await tempRoot(), "red.rdb")}`;
+    const store = await RspElisionStore.open({ uri: storeUri });
+    await store.close();
+
+    const res = runBundleFromCwd(root, ["--store-uri", storeUri, "git", "status"], {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_FAIL_IF_STORE_OPEN: "1",
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout.toString("utf8")).toBe("git empty\n");
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  }, 120_000);
+
+  it("built bundle keeps small git status wrapper overhead under 100ms", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const storeUri = `file://${join(await tempRoot(), "red.rdb")}`;
+    const store = await RspElisionStore.open({ uri: storeUri });
+    await store.close();
+    const env = { RED_SKILLS_CACHE_DIR: cacheDir };
+
+    expect(runBundleFromCwd(root, ["--store-uri", storeUri, "git", "status"], env).status).toBe(0);
+    expect(runGit(["-C", root, "status"]).status).toBe(0);
+
+    const rawSamples: number[] = [];
+    const wrappedSamples: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      const raw = timedStatus(() => runGit(["-C", root, "status"]));
+      const wrapped = timedStatus(() => runBundleFromCwd(root, ["--store-uri", storeUri, "git", "status"], env));
+      expect(raw.status).toBe(0);
+      expect(wrapped.status).toBe(0);
+      expect(wrapped.stderr).toEqual(Buffer.alloc(0));
+      rawSamples.push(raw.elapsedMs);
+      wrappedSamples.push(wrapped.elapsedMs);
+    }
+
+    const rawMedian = median(rawSamples);
+    const wrappedMedian = median(wrappedSamples);
+    const overheadMs = wrappedMedian - rawMedian;
+    expect(overheadMs, `raw=${rawMedian.toFixed(1)}ms wrapped=${wrappedMedian.toFixed(1)}ms overhead=${overheadMs.toFixed(1)}ms`).toBeLessThanOrEqual(100);
+  }, 120_000);
+
   it("built bundle compresses git log, mints a handle, round-trips it, and reports degraded passthrough", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
     await commitMany(root, 12);
     const cacheDir = await seedWarmRedCache();
-    const storeUri = `file://${join(await tempRoot(), "red.rdb")}`;
-    const store = await RspElisionStore.open({ uri: storeUri });
-    await store.close();
     const raw = runGit(["-C", root, "log"]);
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
 
-    const compressed = runBundleFromCwd(root, ["--store-uri", storeUri, "git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
     expect(compressed.status).toBe(raw.status);
     expect(compressed.stderr).toEqual(Buffer.alloc(0));
@@ -114,7 +173,7 @@ describe("rsp cli", () => {
     const handle = /rsp show (el:[a-f0-9]{12})/.exec(text)?.[1];
     expect(handle).toBeTruthy();
 
-    const shown = runBundleFromCwd(root, ["--store-uri", storeUri, "show", handle!], { RED_SKILLS_CACHE_DIR: cacheDir });
+    const shown = runBundleFromCwd(root, ["show", handle!], { RED_SKILLS_CACHE_DIR: cacheDir });
 
     expect(shown.status).toBe(0);
     expect(shown.stdout.length).toBeGreaterThan(compressed.stdout.length);


### PR DESCRIPTION
Automated AFK landing for #1531. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1531

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786429804&installation_id=129708444&pr_number=1532&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1532&signature=4bd2374cb7a827c6684080a1296f1006c47aaead66d7550f34521f08e803cb3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->