### PR TITLE
fix: let the release carry an intentional reddb pin bump

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -238,14 +238,18 @@ jobs:
             'macos-aarch64': 'red-macos-aarch64',
             'windows-x86_64': 'red-windows-x86_64.exe',
           };
+          // Checksums carried forward from the last manifest, usable only while the
+          // pin is unchanged. When the pin moves, the old checksums describe a
+          // different binary, so there is no fallback and every asset must resolve
+          // live from the new tag. Carrying them across a bump is how a dead pointer
+          // survived unnoticed: reddb aged out the pinned release, the live .sha256
+          // 404'd, and the stale checksums were copied forward release after release.
           async function previousRedAssets() {
             const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/memory-runtime-manifest.json';
             const response = await fetch(url, { redirect: 'follow' });
             if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
             const previous = await response.json();
-            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) {
-              throw new Error(`latest memory runtime manifest points at ${previous?.reddb?.tag ?? 'unknown'} / ${previous?.reddb?.sdk ?? 'unknown'}, expected ${reddb.tag} / ${sdk}`);
-            }
+            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) return {};
             return previous.reddb.assets ?? {};
           }
           const fallbackAssets = await previousRedAssets();
@@ -312,14 +316,13 @@ jobs:
             'macos-aarch64': 'red-macos-aarch64',
             'windows-x86_64': 'red-windows-x86_64.exe',
           };
+          // No fallback across a pin bump — see the memory manifest step above.
           async function previousRedAssets() {
             const url = 'https://github.com/reddb-io/red-skills/releases/latest/download/brain-runtime-manifest.json';
             const response = await fetch(url, { redirect: 'follow' });
             if (!response.ok) throw new Error(`GET ${url} -> ${response.status}`);
             const previous = await response.json();
-            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) {
-              throw new Error(`latest brain runtime manifest points at ${previous?.reddb?.tag ?? 'unknown'} / ${previous?.reddb?.sdk ?? 'unknown'}, expected ${reddb.tag} / ${sdk}`);
-            }
+            if (previous?.reddb?.sdk !== sdk || previous?.reddb?.tag !== reddb.tag) return {};
             return previous.reddb.assets ?? {};
           }
           const fallbackAssets = await previousRedAssets();


### PR DESCRIPTION
The release fails on main:

```
Error: latest memory runtime manifest points at v1.7.0 / 1.7.0, expected v1.23.1 / 1.23.1
```

#1526 bumped `@reddb-io/sdk` to 1.23.1 to repoint the red binary at a reddb release that still exists. The release workflow rejects that bump, so the whole rsp chain cannot ship.

## Why the guard was wrong

The runtime-manifest steps do two things at once: they reuse the **previously published checksums** as a fallback when a live `.sha256` fetch fails, and they **refuse to build** when the pin differs from the last release.

That pairing is precisely how the dead pointer survived. reddb aged out the pinned `v1.7.0` release; the live checksum fetch started 404ing; the fallback quietly copied the stale checksums forward, release after release — while rejecting the one change that would fix it.

## Change

The fallback is carried forward **only while the pin is unchanged**. When the pin moves, the old checksums describe a different binary, so there is no fallback: every asset must resolve live from the new tag. A bump to a tag that publishes nothing still fails the release — the property #1526's asset verifier adds — this just stops the guard from blocking the legitimate case too.

Both the memory and brain manifest steps are fixed. Release contract tests pass locally (`test-red-release-reddb-assets-contract.sh`, `test-red-release-npm-publish-contract.sh`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786430078&installation_id=129708444&pr_number=1534&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1534&signature=34a13c6c38333f12c4f6419c24ba169c1d93c90d254f0154814a617d7f8adcb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->