### PR TITLE
fix: #1529 rsp store readability pre-check sniffs a magic string reddb no longer writes (RDDB vs RDBSBLK1)

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { closeSync, existsSync, openSync, readSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { RspElisionStore } from "./elision-store.js";
 import { resolveRspConfig } from "./config.js";
@@ -43,8 +43,6 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
     return 1;
   }
-  if (wrapperCommand && isUnreadableFileStore(config.storeUri)) return await degradeToPassthrough("store unreadable", args.positional);
-
   const openStore = () => RspElisionStore.open({
     uri: config.storeUri,
     ttlDays: config.ttlDays,
@@ -175,22 +173,6 @@ async function suppressRspStderr<T>(fn: () => Promise<T>): Promise<T> {
 
 function isWrapperCommand(command: string | undefined): boolean {
   return command === "git" || command === "gh" || command === "vitest" || command === "cargo";
-}
-
-function isUnreadableFileStore(uri: string): boolean {
-  if (!uri.startsWith("file://")) return false;
-  let fd: number | undefined;
-  try {
-    fd = openSync(fileURLToPath(uri), "r");
-    const header = Buffer.alloc(64);
-    const bytesRead = readSync(fd, header, 0, header.length, 0);
-    const bytes = header.subarray(0, bytesRead);
-    return !bytes.includes("RDDB") && !bytes.includes("RDBS");
-  } catch {
-    return true;
-  } finally {
-    if (fd !== undefined) closeSync(fd);
-  }
 }
 
 async function passthrough(argv: readonly string[]): Promise<number> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -179,12 +179,12 @@ describe("rsp cli", () => {
     expect(shown.stdout.length).toBeGreaterThan(compressed.stdout.length);
     expect(shown.stderr).toEqual(Buffer.alloc(0));
 
-    const missingStoreUri = `file://${join(await tempRoot(), "missing.rdb")}`;
-    const degraded = runBundleFromCwd(root, ["--store-uri", missingStoreUri, "git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    await rm(join(root, ".red", "red.rdb"));
+    const degraded = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
     expect(degraded.status).toBe(raw.status);
     expect(degraded.stdout).toEqual(raw.stdout);
-    expect(degraded.stderr.toString("utf8")).toBe("rsp: store unreadable, passing through\n");
+    expect(degraded.stderr.toString("utf8")).toBe("rsp: store not provisioned, passing through\n");
   }, 120_000);
 
   it("fails closed instead of creating the default Repo store when setup has not provisioned it", async () => {
@@ -237,22 +237,7 @@ describe("rsp cli", () => {
 
     expect(res.status).toBe(direct.status);
     expect(res.stdout).toEqual(direct.stdout);
-    expect(res.stderr.toString("utf8")).toBe(`rsp: store unreadable, passing through\n${direct.stderr.toString("utf8")}`);
-  });
-
-  it("accepts the current red store header instead of falling back to passthrough", async () => {
-    const root = await initGitRepo();
-    const storeRoot = await tempRoot();
-    const storePath = join(storeRoot, "red.rdb");
-    const store = await RspElisionStore.open({ uri: `file://${storePath}` });
-    await store.close();
-    await writeFile(join(root, "toon.txt"), "toon\n", "utf8");
-
-    const res = runRspFromCwd(root, ["git", "status"], { RSP_STORE_URI: `file://${storePath}` });
-
-    expect(res.status).toBe(0);
-    expect(res.stdout.toString("utf8")).toContain("git empty");
-    expect(res.stdout.toString("utf8")).not.toContain("On branch");
+    expect(res.stderr.toString("utf8")).toBe(`rsp: wrapper failed, passing through\n${direct.stderr.toString("utf8")}`);
   });
 
   it("passes through wrappers when rsp hits an internal wrapper error after opening the store", async () => {


### PR DESCRIPTION
Automated AFK landing for #1529. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1529

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786430165&installation_id=129708444&pr_number=1535&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1535&signature=93f3070bcd0894317a426c33d029d57cc4e8fcb764433a347b140164a0789ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->