### PR TITLE
fix: #1533 the rsp eliding path still pays ~2.3s of store-session cost

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,8 +1,9 @@
 import { createHash } from "node:crypto";
-import { connect, type RedDB } from "@reddb-io/sdk";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const RSP_ELISION_COLLECTION = "rsp_elisions_v1";
-const INDEX_KEY = "__rsp_elision_index_v1";
 
 export const DEFAULT_RSP_TTL_DAYS = 7;
 export const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
@@ -52,22 +53,13 @@ export interface RspElisionStoreOptions {
 interface StoredRecord {
   collection: typeof RSP_ELISION_COLLECTION;
   handle: `el:${string}`;
-  original?: string;
-  original_chunks?: number;
+  original: string;
   original_encoding: "base64";
   original_bytes: number;
   command: string;
   created_at: string;
   expires_at: string;
   loss: RspLossMeta;
-}
-
-interface StoredChunk {
-  collection: typeof RSP_ELISION_COLLECTION;
-  handle: `el:${string}`;
-  index: number;
-  original: string;
-  original_encoding: "base64";
 }
 
 interface IndexEntry {
@@ -84,13 +76,23 @@ interface IndexDocument {
   records: IndexEntry[];
 }
 
+interface StoreDocument {
+  version: 1;
+  records: Record<string, StoredRecord>;
+  tombstones: Record<string, RspExpiredHandle>;
+  index: IndexDocument;
+}
+
 export class RspElisionStore {
-  private db!: RedDB;
+  private document!: StoreDocument;
+  private readonly path: string;
 
   private constructor(private readonly opts: Required<Omit<RspElisionStoreOptions, "ttlDays" | "byteBudget">> & {
     ttlDays: number;
     byteBudget: number;
-  }) {}
+  }) {
+    this.path = fileStorePath(opts.uri);
+  }
 
   static async open(opts: RspElisionStoreOptions): Promise<RspElisionStore> {
     if (process.env.RSP_FAIL_IF_STORE_OPEN === "1") {
@@ -102,13 +104,11 @@ export class RspElisionStore {
       byteBudget: positiveNumber(opts.byteBudget, DEFAULT_RSP_BYTE_BUDGET),
       now: opts.now ?? (() => new Date()),
     });
-    store.db = await connect(store.opts.uri);
+    store.document = await readStoreDocument(store.path);
     return store;
   }
 
-  async close(): Promise<void> {
-    await this.db.close();
-  }
+  async close(): Promise<void> {}
 
   async mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
     const bytes = Buffer.from(original);
@@ -118,11 +118,10 @@ export class RspElisionStore {
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
 
-    const chunks = chunkBytes(bytes);
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
       handle,
-      ...(chunks.length === 1 ? { original: chunks[0] } : { original_chunks: chunks.length }),
+      original: bytes.toString("base64"),
       original_encoding: "base64",
       original_bytes: bytes.length,
       command: meta.command,
@@ -131,20 +130,9 @@ export class RspElisionStore {
       loss: meta.loss,
     };
 
-    await this.deleteChunks(handle);
-    for (let i = 0; i < chunks.length; i++) {
-      if (chunks.length === 1) break;
-      await this.kv().put(chunkKey(handle, i), {
-        collection: RSP_ELISION_COLLECTION,
-        handle,
-        index: i,
-        original: chunks[i],
-        original_encoding: "base64",
-      } satisfies StoredChunk);
-    }
-    await this.kv().put(key, record);
-    await this.removeTombstone(handle);
-    await this.upsertIndex({
+    delete this.document.tombstones[tombstoneKey(handle)];
+    this.document.records[key] = record;
+    this.upsertIndex({
       handle,
       key,
       bytes: bytes.length,
@@ -152,21 +140,22 @@ export class RspElisionStore {
       created_at: createdAt,
       expires_at: expiresAt,
     });
-    await this.prune();
+    this.prune();
+    await this.flush();
     return handle;
   }
 
   async get(handle: string): Promise<RspElisionRecord | RspExpiredHandle | null> {
     if (!isHandle(handle)) return null;
-    const tombstone = await this.tombstone(handle);
+    const tombstone = this.tombstone(handle);
     if (tombstone) return tombstone;
 
-    const raw = parseStoredValue(await this.kv().get(recordKey(handle)));
+    const raw = this.document.records[recordKey(handle)];
     if (!isStoredRecord(raw)) return null;
 
     if (Date.parse(raw.expires_at) <= this.opts.now().getTime()) {
       const expired = { status: "expired" as const, expired_at: raw.expires_at, command: raw.command };
-      await this.expireEntry({
+      this.expireEntry({
         handle: raw.handle,
         key: recordKey(raw.handle),
         bytes: raw.original_bytes,
@@ -174,10 +163,11 @@ export class RspElisionStore {
         created_at: raw.created_at,
         expires_at: raw.expires_at,
       }, raw.expires_at);
+      await this.flush();
       return expired;
     }
 
-    const original = await this.readOriginal(raw);
+    const original = this.readOriginal(raw);
     if (!original) return null;
 
     return {
@@ -191,8 +181,9 @@ export class RspElisionStore {
   }
 
   async stats(): Promise<RspStoreStats> {
-    await this.prune();
-    const index = await this.readIndex();
+    this.prune();
+    await this.flush();
+    const index = this.readIndex();
     const records = index.records;
     return {
       records: records.length,
@@ -205,36 +196,30 @@ export class RspElisionStore {
     };
   }
 
-  private kv() {
-    return this.db.kv(RSP_ELISION_COLLECTION);
+  private readIndex(): IndexDocument {
+    return this.document.index;
   }
 
-  private async readIndex(): Promise<IndexDocument> {
-    const raw = parseStoredValue(await this.kv().get(INDEX_KEY));
-    if (!isIndexDocument(raw)) return { version: 1, records: [] };
-    return raw;
+  private writeIndex(index: IndexDocument): void {
+    this.document.index = index;
   }
 
-  private async writeIndex(index: IndexDocument): Promise<void> {
-    await this.kv().put(INDEX_KEY, index);
-  }
-
-  private async upsertIndex(entry: IndexEntry): Promise<void> {
-    const index = await this.readIndex();
+  private upsertIndex(entry: IndexEntry): void {
+    const index = this.readIndex();
     const withoutExisting = index.records.filter((record) => record.handle !== entry.handle);
     withoutExisting.push(entry);
-    await this.writeIndex({ version: 1, records: withoutExisting });
+    this.writeIndex({ version: 1, records: withoutExisting });
   }
 
-  private async prune(): Promise<void> {
+  private prune(): void {
     const nowMs = this.opts.now().getTime();
     const nowIso = new Date(nowMs).toISOString();
-    const index = await this.readIndex();
+    const index = this.readIndex();
     const live: IndexEntry[] = [];
 
     for (const entry of index.records) {
       if (Date.parse(entry.expires_at) <= nowMs) {
-        await this.expireEntry(entry, entry.expires_at);
+        this.expireEntry(entry, entry.expires_at);
       } else {
         live.push(entry);
       }
@@ -245,47 +230,33 @@ export class RspElisionStore {
     while (bytes > this.opts.byteBudget && live.length > 0) {
       const evicted = live.shift()!;
       bytes -= evicted.bytes;
-      await this.expireEntry(evicted, nowIso);
+      this.expireEntry(evicted, nowIso);
     }
 
-    await this.writeIndex({ version: 1, records: live });
+    this.writeIndex({ version: 1, records: live });
   }
 
-  private async expireEntry(entry: IndexEntry, expiredAt: string): Promise<void> {
-    await this.deleteChunks(entry.handle);
-    await this.kv().delete(entry.key);
-    await this.kv().put(tombstoneKey(entry.handle), {
+  private expireEntry(entry: IndexEntry, expiredAt: string): void {
+    delete this.document.records[entry.key];
+    this.document.tombstones[tombstoneKey(entry.handle)] = {
       status: "expired",
       expired_at: expiredAt,
       command: entry.command,
-    });
+    };
   }
 
-  private async tombstone(handle: `el:${string}`): Promise<RspExpiredHandle | null> {
-    const raw = parseStoredValue(await this.kv().get(tombstoneKey(handle)));
+  private tombstone(handle: `el:${string}`): RspExpiredHandle | null {
+    const raw = this.document.tombstones[tombstoneKey(handle)];
     return isExpiredHandle(raw) ? raw : null;
   }
 
-  private async removeTombstone(handle: `el:${string}`): Promise<void> {
-    await this.kv().delete(tombstoneKey(handle));
-  }
-
-  private async readOriginal(record: StoredRecord): Promise<Buffer | null> {
+  private readOriginal(record: StoredRecord): Buffer | null {
     if (record.original) return Buffer.from(record.original, "base64");
-    if (!record.original_chunks) return null;
-    const chunks: Buffer[] = [];
-    for (let i = 0; i < record.original_chunks; i++) {
-      const raw = parseStoredValue(await this.kv().get(chunkKey(record.handle, i)));
-      if (!isStoredChunk(raw) || raw.handle !== record.handle || raw.index !== i) return null;
-      chunks.push(Buffer.from(raw.original, "base64"));
-    }
-    return Buffer.concat(chunks);
+    return null;
   }
 
-  private async deleteChunks(handle: `el:${string}`): Promise<void> {
-    const existing = parseStoredValue(await this.kv().get(recordKey(handle)));
-    if (!isStoredRecord(existing) || !existing.original_chunks) return;
-    await Promise.all(Array.from({ length: existing.original_chunks }, (_, i) => this.kv().delete(chunkKey(handle, i))));
+  private async flush(): Promise<void> {
+    await writeStoreDocument(this.path, this.document);
   }
 }
 
@@ -304,10 +275,6 @@ function recordKey(handle: `el:${string}`): string {
   return `record:${handle.slice(3)}`;
 }
 
-function chunkKey(handle: `el:${string}`, index: number): string {
-  return `chunk:${handle.slice(3)}:${index}`;
-}
-
 function tombstoneKey(handle: `el:${string}`): string {
   return `expired:${handle.slice(3)}`;
 }
@@ -320,38 +287,18 @@ function positiveNumber(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function chunkBytes(bytes: Buffer): string[] {
-  const chunks: string[] = [];
-  const chunkSize = 2048;
-  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-    chunks.push(bytes.subarray(offset, offset + chunkSize).toString("base64"));
-  }
-  return chunks.length > 0 ? chunks : [""];
-}
-
 function isStoredRecord(value: unknown): value is StoredRecord {
   if (!isRecord(value)) return false;
   return value.collection === RSP_ELISION_COLLECTION &&
     typeof value.handle === "string" &&
     isHandle(value.handle) &&
-    (typeof value.original === "string" || (typeof value.original_chunks === "number" && Number.isInteger(value.original_chunks) && value.original_chunks > 0)) &&
+    typeof value.original === "string" &&
     value.original_encoding === "base64" &&
     typeof value.original_bytes === "number" &&
     typeof value.command === "string" &&
     typeof value.created_at === "string" &&
     typeof value.expires_at === "string" &&
     isLossMeta(value.loss);
-}
-
-function isStoredChunk(value: unknown): value is StoredChunk {
-  return isRecord(value) &&
-    value.collection === RSP_ELISION_COLLECTION &&
-    typeof value.handle === "string" &&
-    isHandle(value.handle) &&
-    typeof value.index === "number" &&
-    Number.isInteger(value.index) &&
-    typeof value.original === "string" &&
-    value.original_encoding === "base64";
 }
 
 function isIndexDocument(value: unknown): value is IndexDocument {
@@ -385,11 +332,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseStoredValue(value: unknown): unknown {
-  if (typeof value !== "string") return value;
+async function readStoreDocument(path: string): Promise<StoreDocument> {
   try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return value;
+    const text = await readFile(path, "utf8");
+    if (text.trim() === "") return emptyStoreDocument();
+    const parsed = JSON.parse(text) as unknown;
+    if (isStoreDocument(parsed)) return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      const document = emptyStoreDocument();
+      await writeStoreDocument(path, document);
+      return document;
+    }
+    throw err;
   }
+  throw new Error("rsp elision store is unreadable");
+}
+
+async function writeStoreDocument(path: string, document: StoreDocument): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(document)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+function emptyStoreDocument(): StoreDocument {
+  return { version: 1, records: {}, tombstones: {}, index: { version: 1, records: [] } };
+}
+
+function isStoreDocument(value: unknown): value is StoreDocument {
+  return isRecord(value) &&
+    value.version === 1 &&
+    isRecord(value.records) &&
+    Object.values(value.records).every(isStoredRecord) &&
+    isRecord(value.tombstones) &&
+    Object.values(value.tombstones).every(isExpiredHandle) &&
+    isIndexDocument(value.index);
+}
+
+function fileStorePath(uri: string): string {
+  if (!uri.startsWith("file://")) {
+    throw new Error("rsp elision store requires a file:// URI");
+  }
+  return fileURLToPath(uri);
 }

--- a/apps/rsp/src/setup.ts
+++ b/apps/rsp/src/setup.ts
@@ -5,7 +5,6 @@ import { chmod } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { join, resolve } from "node:path";
-import { connect } from "@reddb-io/sdk";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { ensureRedBinary, type RedRuntimeIO } from "@reddb-io/shared/red-runtime.js";
 import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
@@ -65,8 +64,7 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
   const storeCreated = !(await exists(storePath));
   const redRuntime = await configureRspRedBinary({ mayFetch: true, ...(opts.redRuntime ?? {}) });
   if (storeCreated) {
-    const db = await connect(`file://${storePath}`);
-    await db.close();
+    await writeFile(storePath, "", "utf8");
   }
 
   return {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -54,11 +54,16 @@ function runBundleFromCwd(cwd: string, args: string[], env: Record<string, strin
   });
 }
 
-function timedStatus(command: () => ReturnType<typeof spawnSync>): { status: number | null; elapsedMs: number; stderr: Buffer } {
+function timedStatus(command: () => ReturnType<typeof spawnSync>): {
+  status: number | null;
+  elapsedMs: number;
+  stdout: Buffer;
+  stderr: Buffer;
+} {
   const started = process.hrtime.bigint();
   const result = command();
   const elapsedMs = Number(process.hrtime.bigint() - started) / 1_000_000;
-  return { status: result.status, elapsedMs, stderr: result.stderr as Buffer };
+  return { status: result.status, elapsedMs, stdout: result.stdout as Buffer, stderr: result.stderr as Buffer };
 }
 
 function median(values: number[]): number {
@@ -185,6 +190,40 @@ describe("rsp cli", () => {
     expect(degraded.status).toBe(raw.status);
     expect(degraded.stdout).toEqual(raw.stdout);
     expect(degraded.stderr.toString("utf8")).toBe("rsp: store not provisioned, passing through\n");
+  }, 120_000);
+
+  it("built bundle keeps git log terse elision latency under budget", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const env = { RED_SKILLS_CACHE_DIR: cacheDir };
+
+    expect(runBundleFromCwd(root, ["git", "log", "--terse"], env).status).toBe(0);
+    expect(runGit(["-C", root, "log"]).status).toBe(0);
+
+    const rawSamples: number[] = [];
+    const wrappedSamples: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const raw = timedStatus(() => runGit(["-C", root, "log"]));
+      const wrapped = timedStatus(() => runBundleFromCwd(root, ["git", "log", "--terse"], env));
+      expect(raw.status).toBe(0);
+      expect(wrapped.status).toBe(0);
+      expect(wrapped.stderr).toEqual(Buffer.alloc(0));
+      expect(wrapped.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
+      rawSamples.push(raw.elapsedMs);
+      wrappedSamples.push(wrapped.elapsedMs);
+    }
+
+    const rawMedian = median(rawSamples);
+    const wrappedMedian = median(wrappedSamples);
+    const overheadMs = wrappedMedian - rawMedian;
+    expect(
+      wrappedMedian,
+      `raw=${rawMedian.toFixed(1)}ms wrapped=${wrappedMedian.toFixed(1)}ms overhead=${overheadMs.toFixed(1)}ms`,
+    ).toBeLessThanOrEqual(750);
   }, 120_000);
 
   it("fails closed instead of creating the default Repo store when setup has not provisioned it", async () => {

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -72,6 +72,31 @@ describe("RspElisionStore", () => {
     }
   });
 
+  it("opens and writes without a RedDB subprocess", async () => {
+    const root = await tempRoot();
+    const previous = process.env.REDDB_BIN;
+    process.env.REDDB_BIN = join(root, "missing-red-binary");
+    try {
+      const store = await RspElisionStore.open({
+        uri: `file://${join(root, "red.rdb")}`,
+        now: () => new Date("2026-07-10T12:00:00.000Z"),
+      });
+      try {
+        const handle = await store.mint(Buffer.from("fast local write"), {
+          command: "git log --terse",
+          loss: { level: "terse", bytes_elided: 16 },
+        });
+
+        expect((await store.get(handle))?.original).toEqual(Buffer.from("fast local write"));
+      } finally {
+        await store.close();
+      }
+    } finally {
+      if (previous === undefined) delete process.env.REDDB_BIN;
+      else process.env.REDDB_BIN = previous;
+    }
+  });
+
   it("expires records by TTL on amortized write and reports the original command", async () => {
     let now = new Date("2026-07-10T12:00:00.000Z");
     const root = await tempRoot();


### PR DESCRIPTION
Automated AFK landing for #1533. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1533

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786431389&installation_id=129708444&pr_number=1536&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1536&signature=edbcb4ad0d8e9ffb13ab5d93e41b1bea21d53ea7befc8d38bafc0906e0d01b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->