### PR TITLE
fix: stop turbo from restoring a stale shared dist/

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
     },
     "bundle": {
       "dependsOn": ["^build"],
-      "outputs": ["../../dist/**"]
+      "cache": false
     },
     "@reddb-io/dev#bundle": {
       "dependsOn": [
@@ -19,18 +19,18 @@
         "@reddb-io/shared#build",
         "@reddb-io/toon#build"
       ],
-      "outputs": ["../../dist/**"]
+      "cache": false
     },
     "@reddb-io/rsp#bundle": {
       "dependsOn": [
         "@reddb-io/build-info#build",
         "@reddb-io/toon#build"
       ],
-      "outputs": ["../../dist/**"]
+      "cache": false
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "../../dist/**"]
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
Closes #1541.

v2.32.8 published the **previous** `rsp.bundle.min.mjs` under a correct tag: the source at the tag has the fix, rebuilding the tag locally produces the right bundle, and the release built from the right commit and succeeded — yet the npm package carries the old artifact.

## Root cause

Every bundle/build task declared the **same shared output directory**:

```json
"bundle":               { "outputs": ["../../dist/**"] },
"@reddb-io/dev#bundle": { "outputs": ["../../dist/**"] },
"@reddb-io/rsp#bundle": { "outputs": ["../../dist/**"] },
"build":                { "outputs": ["dist/**", "../../dist/**"] }
```

`../../dist/` is the repo-root `dist/`, shared by every app — so one package's cache entry snapshots the **whole** `dist/` tree, every other app's bundle included.

A change confined to `apps/rsp` therefore makes `@reddb-io/dev#bundle` a cache **hit**, and restoring that hit rewrites `../../dist/**` from dev's older snapshot — clobbering the `rsp.bundle.min.mjs` that was just built. Turbo runs tasks in parallel, so whether the stale restore lands before or after the fresh build is a **race**. The release is silently non-deterministic, and when it loses, it publishes an artifact it did not build.

This is the pipeline-level form of the bug class that ate the whole rsp chain (#1514 → #1537): source right, CI green, artifact wrong.

## Change

Bundles are release artifacts and esbuild emits them in ~10ms, so caching them buys nothing and costs correctness — build them every time (`"cache": false`). `build` is included because the app `build` scripts also emit into the shared `dist/`, so leaving it cached would let a cache hit skip producing a bundle entirely.

## Verified

From a clean `dist/`, `pnpm build` + `pnpm bundle` produce all ten bundles, and the rsp bundle carries the current source (`.red/tmp/rsp-elisions.json`). Gate green: test 11/11, typecheck 12/12.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786449807&installation_id=129708444&pr_number=1542&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1542&signature=ad4e65a08c445f07d9afd67af6a4a41398e869005feaf5a3f26886132a44a4c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->