### PR TITLE
merge: #1545 the engine accepts DONE without verifying any work happened

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1140,6 +1140,39 @@ function appendGoVerifyRetryHandoff(
   ].join("\n");
 }
 
+const NON_SOURCE_EXTENSIONS = new Set([
+  ".adoc",
+  ".avif",
+  ".gif",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".md",
+  ".mdx",
+  ".pdf",
+  ".png",
+  ".rst",
+  ".svg",
+  ".txt",
+  ".webp",
+]);
+
+function pathExtension(path: string): string {
+  const leaf = path.split("/").pop() ?? path;
+  const idx = leaf.lastIndexOf(".");
+  return idx > 0 ? leaf.slice(idx).toLowerCase() : "";
+}
+
+function hasLikelySourceChanges(paths: readonly string[]): boolean {
+  return paths.some((path) => !NON_SOURCE_EXTENSIONS.has(pathExtension(path)));
+}
+
+function formatNoSourceChangeWarning(paths: readonly string[]): string {
+  const sample = paths.slice(0, 8).map((path) => `\`${path}\``).join(", ");
+  const suffix = paths.length > 8 ? `, and ${paths.length - 8} more` : "";
+  return `DONE diff warning: attempt changed no source files; changed files: ${sample}${suffix}.`;
+}
+
 interface UntrustedSandboxDecision {
   sandboxMode: SandboxMode;
   authorTrusted: boolean;
@@ -1617,6 +1650,7 @@ export async function processIssue(
   };
   let validationSidecar: string[] = [];
   let lastValidationScope: ValidationScope | undefined = undefined;
+  let noSourceDiffWarning: string | undefined;
   let mainRed = false;
   let mainRedRepairSyncFailure: string | null = null;
   let currentHandoff = handoff;
@@ -2191,6 +2225,24 @@ export async function processIssue(
     // Macro phase → `validating` (issue #811): the feedback gate is starting.
     deps.markPhase?.("validating");
     const changedFiles = await deps.lookups.changedFiles(workerBranch, baseRef);
+    if (changedFiles.length === 0) {
+      const validationText =
+        "DONE rejected: attempt branch has no diff against the merge-base; no work changed, so the completion claim was not accepted.";
+      deps.appendIterLog(`🤖 /afk: ${validationText}`);
+      if (await retryGoMachineGate("feedback", validationText)) {
+        continue;
+      }
+      return await terminalFailure(common, "feedback-failed", "feedback", {
+        notes: "Inner agent emitted DONE, but the attempt branch has no diff against the merge-base. The worker branch was not merged.",
+        validation: validationText,
+      }, { validationSummary: validationText });
+    }
+    noSourceDiffWarning = hasLikelySourceChanges(changedFiles)
+      ? undefined
+      : formatNoSourceChangeWarning(changedFiles);
+    if (noSourceDiffWarning) {
+      deps.appendIterLog(`🤖 /afk: ${noSourceDiffWarning}`);
+    }
     // Compute the validation scope: expand to the full dependency cone when a
     // workspace graph is injected, otherwise keep the directly-touched package
     // cone. Root-config and explicit core-module changes always escalate to
@@ -2548,7 +2600,7 @@ export async function processIssue(
   // Write the machine-readable validation sidecar ($ITER_DIR/validation.jsonl,
   // SKILL.md) the Memory bridge consumes. Best-effort: never fails the close.
   await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
-  const posted = await emitDone(common, mergeSha, durationS, validationSidecar, lastValidationScope);
+  const posted = await emitDone(common, mergeSha, durationS, validationSidecar, lastValidationScope, noSourceDiffWarning);
   // ADR 0017: record the reasoning attempt into Memory AFTER the terminal
   // (done) envelope. Best-effort, gated, no-op when memory is absent. The ADR 0083
   // §4 exit-barrier receipt (#1020), when present, rides the attempt record so the
@@ -2556,7 +2608,7 @@ export async function processIssue(
   await recordAttemptBestEffort(common, "done", {
     durationS,
     mergeSha,
-    validationSummary: validationSidecar.join("\n"),
+    validationSummary: [noSourceDiffWarning, validationSidecar.join("\n")].filter(Boolean).join("\n"),
     notes: exitReceipt
       ? `exit-barrier receipt: branch \`${exitReceipt.branch}\` pushed to origin at ${exitReceipt.pushedAt} (head ${exitReceipt.head || "?"}, salvaged ${exitReceipt.salvagedFiles} file(s)).`
       : undefined,
@@ -3058,9 +3110,13 @@ async function emitDone(
   durationS: number,
   validationSidecar: string[],
   validationScope?: ValidationScope,
+  validationNotice?: string,
 ): Promise<boolean> {
   const { deps, input } = c;
   const scopeHeader = validationScope ? `${formatValidationScope(validationScope)}\n` : "";
+  const validationBody = [validationNotice, `${scopeHeader}${validationSidecar.join("\n")}`]
+    .filter((part) => part && part.trim().length > 0)
+    .join("\n");
   const result = await emitEnvelope(deps.envelope, {
     status: "done",
     issue: input.issue,
@@ -3071,7 +3127,7 @@ async function emitDone(
     mergeSha,
     diff: "merged",
     sections: {
-      validation: `${scopeHeader}${validationSidecar.join("\n")}`,
+      validation: validationBody,
       ...(c.resolvedBase ? { base: formatBaseResolution(c.resolvedBase) } : {}),
     },
     historyPath: deps.historyPath,

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -129,6 +129,9 @@ interface HarnessOptions {
    * context's `{env:{…}}` slice — proving it threads onto the runAgent input. */
   preWorktreeEnv?: Record<string, string>;
   changedFiles?: string[];
+  /** Per-call changed-file results. Useful when a bounded retry changes whether
+   * the worker branch actually differs from base. */
+  changedFilesSequence?: string[][];
   changedFilesByBase?: Record<string, string[]>;
   packageScopes?: string[];
   /** FIX E: result of the worker-branch presence check. Defaults to true
@@ -263,6 +266,7 @@ function harness(opts: HarnessOptions = {}): {
   // verification reads above key off it to model "the agent resolved the merge".
   let mergeResolved = false;
   let pnpmCalls = 0;
+  let changedFilesCalls = 0;
   let currentMainRedRepairIssue: { number: number; title?: string; body?: string; labels?: readonly string[] } | null =
     opts.mainRedRepairIssue ? { number: 123 } : null;
 
@@ -593,6 +597,11 @@ function harness(opts: HarnessOptions = {}): {
       },
       async changedFiles(branch, base) {
         trace.changedFileCalls.push({ branch, base });
+        const seq = opts.changedFilesSequence;
+        if (seq) {
+          const idx = changedFilesCalls++;
+          return seq[idx] ?? seq.at(-1) ?? [];
+        }
         return opts.changedFilesByBase?.[base] ?? opts.changedFiles ?? ["packages/x/src/a.ts"];
       },
       async diffstat() {
@@ -1732,6 +1741,59 @@ describe("processIssue — active Current blocker preflight", () => {
 });
 
 describe("processIssue — feedback fail", () => {
+  it("rejects a DONE attempt whose worker branch has no diff against base", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      changedFiles: [],
+      feedbackOk: true,
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("feedback-failed");
+    expect(trace.closed).toEqual([]);
+    expect(trace.pnpmArgs).toEqual([]);
+    expect(trace.pushedAttempt).toEqual([]);
+    expect(trace.postedEnvelopes).toEqual([{ issue: 9, status: "blocked" }]);
+    expect(trace.envelopeBodies.at(-1) ?? "").toContain("attempt branch has no diff against the merge-base");
+    expect(labelTrace(trace)).toEqual(["-ready-for-agent|+running", "-running|+ready-for-human+blocked:validation"]);
+  });
+
+  it("/go retries a DONE empty-diff attempt under the existing machine-gate retry cap", async () => {
+    const { deps, input, trace } = harness({
+      labels: ["lane:go"],
+      laneLabel: "lane:go",
+      outcome: "done",
+      changedFilesSequence: [[], ["packages/x/src/a.ts"]],
+      feedbackOk: true,
+      recoveryEnv: { RED_GO_VERIFY_RETRIES: "1" },
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.runAgentCalls).toHaveLength(2);
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("<go-machine-gate-retry>");
+    expect(trace.runAgentCalls[1]?.handoffContent).toContain("attempt branch has no diff against the merge-base");
+    expect(trace.closed).toEqual([9]);
+  });
+
+  it("surfaces a docs-only DONE attempt as changed-no-source in the public envelope", async () => {
+    const { deps, input, trace } = harness({
+      outcome: "done",
+      changedFiles: ["README.md", "docs/setup.md"],
+      feedbackOk: true,
+      locked: false,
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    expect(trace.closed).toEqual([9]);
+    expect(trace.iterLogs.some((line) => line.includes("changed no source files"))).toBe(true);
+    expect(trace.envelopeBodies.at(-1) ?? "").toContain("changed no source files");
+  });
+
   it("flips to ready-for-human with a failure envelope when validation fails", async () => {
     const { deps, input, trace } = harness({ outcome: "done", feedbackOk: false });
     const result = await processIssue(deps, input);


### PR DESCRIPTION
Automated AFK landing for #1545. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1545

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786455161&installation_id=129708444&pr_number=1548&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1548&signature=bb49524b66a341c6b9579d774dccecc0f71ce06f0eeab81941d33ba2afd978c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->