### PR TITLE
fix: #1546 /go has no --request lever, so per-dispatch enforcement must be smuggled into the demand text

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -29,15 +29,26 @@ import { runCommand } from "./run.js";
 import * as ghx from "../runtime/gh.js";
 import type { GhContext } from "../runtime/gh.js";
 
+interface ParsedGoArgs {
+  demand: string;
+  runner?: string;
+  mode: GoMode;
+  yolo: boolean;
+  scout?: boolean;
+  dod?: string;
+  verifyCommand?: string;
+  request?: string;
+}
+
 /** Parse `/go` args: the demand is every non-flag token joined; `--runner X`
- * (or `-r X`) optionally pins the backend; `--mode {no-mistakes|direct-PR|
- * local-only}` selects the dispatch mode (default `direct-PR`); the opt-in
- * `+yolo` token bumps autonomy; `--scout` switches to read-only investigation
- * mode. A leading `--` is tolerated so `/go -- --literal` passes a dashed
- * demand through. */
+ * optionally pins the backend; `--request X` forwards per-dispatch steering to
+ * the inner agent prompt; `--mode {no-mistakes|direct-PR|local-only}` selects
+ * the dispatch mode (default `direct-PR`); the opt-in `+yolo` token bumps
+ * autonomy; `--scout` switches to read-only investigation mode. A leading `--`
+ * is tolerated so `/go -- --literal` passes a dashed demand through. */
 export function parseGoArgs(
   args: readonly string[],
-): { demand: string; runner?: string; mode: GoMode; yolo: boolean; scout?: boolean; dod?: string; verifyCommand?: string } {
+): ParsedGoArgs {
   const positional: string[] = [];
   let runner: string | undefined;
   let mode: GoMode = DEFAULT_GO_MODE;
@@ -45,11 +56,12 @@ export function parseGoArgs(
   let scout = false;
   let dod: string | undefined;
   let verifyCommand: string | undefined;
+  let request: string | undefined;
   let sawDoubleDash = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
     if (!sawDoubleDash && arg === "--") { sawDoubleDash = true; continue; }
-    if (!sawDoubleDash && (arg === "--runner" || arg === "-r")) {
+    if (!sawDoubleDash && arg === "--runner") {
       runner = args[++i];
       if (runner === undefined) throw new Error(`${arg} requires a value`);
       continue;
@@ -88,24 +100,33 @@ export function parseGoArgs(
       verifyCommand = arg.slice("--verify=".length);
       continue;
     }
-    // Unknown `--flag` before the `--` separator is an error, never demand text
+    if (!sawDoubleDash && arg === "--request") {
+      request = args[++i];
+      if (request === undefined) throw new Error("--request requires a value");
+      continue;
+    }
+    if (!sawDoubleDash && arg.startsWith("--request=")) {
+      request = arg.slice("--request=".length);
+      continue;
+    }
+    // Unknown flag before the `--` separator is an error, never demand text
     // (#1045): folding e.g. `--resume 1043` into the demand silently minted a
     // junk issue about a flag the user meant as a command. A literal dashed
     // demand still works via the `--` separator (`/go -- --literal`).
-    if (!sawDoubleDash && arg.startsWith("--")) {
+    if (!sawDoubleDash && arg.startsWith("-")) {
       throw new Error(
-        `unknown flag ${JSON.stringify(arg)}: expected --runner/-r, --mode, --scout, or +yolo. ` +
+        `unknown flag ${JSON.stringify(arg)}: expected --runner, --request, --mode, --scout, or +yolo. ` +
           `Also accepted for standard /go: --dod and --verify. ` +
           `Pass a literal dashed demand after a "--" separator.`,
       );
     }
     positional.push(arg);
   }
-  return { demand: positional.join(" ").trim(), runner, mode, yolo, scout, dod, verifyCommand };
+  return { demand: positional.join(" ").trim(), runner, mode, yolo, scout, dod, verifyCommand, request };
 }
 
 export async function goCommand(args: string[], cwd = process.cwd()): Promise<number> {
-  let parsed: { demand: string; runner?: string; mode: GoMode; yolo: boolean; scout?: boolean; dod?: string; verifyCommand?: string };
+  let parsed: ParsedGoArgs;
   try {
     parsed = parseGoArgs(args);
   } catch (error) {
@@ -172,6 +193,7 @@ export async function goCommand(args: string[], cwd = process.cwd()): Promise<nu
         task: parsed.demand,
         dod: parsed.dod,
         verifyCommand: parsed.verifyCommand,
+        request: parsed.request,
         hasHarness: configuredBackpressure.length > 0,
       } satisfies { runner?: string; mode: GoMode; yolo: boolean } & GoDodSpec,
     );

--- a/apps/dev/src/core/go.ts
+++ b/apps/dev/src/core/go.ts
@@ -107,6 +107,8 @@ export interface GoDodSpec {
   dod?: string;
   /** Optional one-shot machine gate appended to backpressure for this dispatch. */
   verifyCommand?: string;
+  /** Optional per-dispatch steering block forwarded to the inner agent prompt. */
+  request?: string;
   /** True when the repo already has a configured harness/backpressure gate. */
   hasHarness?: boolean;
 }
@@ -182,6 +184,7 @@ export function buildGoEngineArgs(opts: {
   mode?: GoMode;
   yolo?: boolean;
   verifyCommand?: string;
+  request?: string;
   hasHarness?: boolean;
   verifyRetries?: number;
 }): string[] {
@@ -204,6 +207,8 @@ export function buildGoEngineArgs(opts: {
   if (opts.yolo) args.push(GO_YOLO_FLAG);
   const verifyCommand = opts.verifyCommand?.trim();
   if (verifyCommand) args.push(GO_VERIFY_FLAG, verifyCommand);
+  const request = opts.request?.trim();
+  if (request) args.push("--request", request);
   if (opts.hasHarness === false && !verifyCommand) args.push("-n", String(GO_NO_HARNESS_ITER_CAP));
   if (opts.verifyRetries !== undefined) args.push("--go-verify-retries", String(opts.verifyRetries));
   if (opts.runner) args.push("--runner", opts.runner);
@@ -248,6 +253,7 @@ export async function dispatchGo(
       mode: opts.mode,
       yolo: opts.yolo,
       verifyCommand: opts.verifyCommand,
+      request: opts.request,
       hasHarness: opts.hasHarness,
     }),
   );

--- a/apps/dev/tests/go-command.test.ts
+++ b/apps/dev/tests/go-command.test.ts
@@ -11,6 +11,7 @@ describe("parseGoArgs", () => {
       scout: false,
       dod: undefined,
       verifyCommand: undefined,
+      request: undefined,
     });
   });
 
@@ -18,10 +19,24 @@ describe("parseGoArgs", () => {
     expect(parseGoArgs(["fix the flaky login test"]).demand).toBe("fix the flaky login test");
   });
 
-  it("extracts --runner / -r without folding it into the demand", () => {
+  it("extracts --runner without folding it into the demand", () => {
     expect(parseGoArgs(["do it", "--runner", "codex"])).toMatchObject({ demand: "do it", runner: "codex" });
-    expect(parseGoArgs(["-r", "claude", "do it"])).toMatchObject({ demand: "do it", runner: "claude" });
     expect(parseGoArgs(["--runner=codex", "do it"])).toMatchObject({ demand: "do it", runner: "codex" });
+  });
+
+  it("parses long-only --request without folding it into the demand", () => {
+    expect(parseGoArgs(["do it", "--request", "stay strict"])).toMatchObject({
+      demand: "do it",
+      request: "stay strict",
+    });
+    expect(parseGoArgs(["--request=stay strict", "do it"])).toMatchObject({
+      demand: "do it",
+      request: "stay strict",
+    });
+  });
+
+  it("does not bind -r to runner or request in /go", () => {
+    expect(() => parseGoArgs(["-r", "claude", "do it"])).toThrow(/unknown flag/);
   });
 
   it("passes a dashed demand through after --", () => {
@@ -61,9 +76,10 @@ describe("parseGoArgs", () => {
     });
   });
 
-  it("throws when --dod or --verify has no value", () => {
+  it("throws when --dod, --verify, or --request has no value", () => {
     expect(() => parseGoArgs(["do it", "--dod"])).toThrow(/requires a value/);
     expect(() => parseGoArgs(["do it", "--verify"])).toThrow(/requires a value/);
+    expect(() => parseGoArgs(["do it", "--request"])).toThrow(/requires a value/);
   });
 
   it("throws when --runner has no value", () => {

--- a/apps/dev/tests/go.test.ts
+++ b/apps/dev/tests/go.test.ts
@@ -123,6 +123,12 @@ describe("buildGoEngineArgs", () => {
     expect(args).toContain("npm run test -- login");
   });
 
+  it("threads a per-dispatch request into the reused engine", () => {
+    const args = buildGoEngineArgs({ issue: 7, request: "inspect the actual diff before DONE" });
+    expect(args).toContain("--request");
+    expect(args).toContain("inspect the actual diff before DONE");
+  });
+
   it("tightens the iteration cap when no harness exists and no inline check was approved", () => {
     const args = buildGoEngineArgs({ issue: 7, hasHarness: false });
     expect(args).toContain("-n");
@@ -217,6 +223,23 @@ describe("dispatchGo", () => {
     expect(spec.body).toContain("Done when the approved acceptance statement is satisfied.");
     expect(runEngine).toHaveBeenCalledWith(
       buildGoEngineArgs({ issue: 77, verifyCommand: "npm run test -- go" }),
+    );
+  });
+
+  it("keeps --request out of the disposable issue while forwarding it to the reused engine", async () => {
+    const createIssue = vi.fn(async (_spec: DisposableIssueSpec) => 88);
+    const runEngine = vi.fn(async (_args: string[]) => 0);
+    await dispatchGo(
+      { ensureLabel: async () => {}, createIssue, runEngine },
+      "ship it",
+      { request: "inspect the actual diff before DONE" },
+    );
+
+    const spec = createIssue.mock.calls[0]![0];
+    expect(spec.body).toContain("ship it");
+    expect(spec.body).not.toContain("inspect the actual diff before DONE");
+    expect(runEngine).toHaveBeenCalledWith(
+      buildGoEngineArgs({ issue: 88, request: "inspect the actual diff before DONE" }),
     );
   });
 

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go
 description: Middle tier of the dispatch spectrum — `/goal` → `/go` → `/afk`. Use for genuinely untracked, ad-hoc, one-off demands only; anything that is or should be a tracked issue belongs to `/afk`. Mints a disposable issue, spins a dedicated worker, and brings back a PR. Add `--scout "<question>"` for a read-only investigation that posts a report comment and mutates nothing.
-argument-hint: "\"<approved-task>\" --dod \"<definition-of-done>\" [--verify \"<cmd>\"] [--mode no-mistakes|direct-PR|local-only] [--runner claude|codex|opencode] [+yolo] | --scout \"<question>\" [--runner ...]"
+argument-hint: "\"<approved-task>\" --dod \"<definition-of-done>\" [--request \"<inner-agent-instruction>\"] [--verify \"<cmd>\"] [--mode no-mistakes|direct-PR|local-only] [--runner claude|codex|opencode] [+yolo] | --scout \"<question>\" [--runner ...]"
 disable-model-invocation: true
 ---
 
@@ -37,13 +37,13 @@ Invoke the dev CLI's `go` command with the demand as a single quoted argument:
 
 ```
 # Standard /go — ships a PR (direct-PR is the default mode)
-RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
+RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go "<approved-task>" --dod "<definition-of-done>" [--request "<inner-agent-instruction>"] [--verify "<cmd>"] [--mode <mode>] [--runner <runner>] [+yolo]
 
 # Scout mode — read-only investigation, posts a report comment, no branch/PR/merge
 RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev go --scout "<question>" [--runner <runner>]
 ```
 
-Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex` from Codex). Use `--runner` only when the user explicitly pinned a backend.
+Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex` from Codex). Use `--runner` only when the user explicitly pinned a backend. `/go` does not accept a short `-r` form; use long `--runner` for backend pinning and long `--request` for per-dispatch inner-agent instructions.
 
 **Dispatch mode — `--mode {no-mistakes|direct-PR|local-only}`** selects HOW the reused engine finishes the run. Omit it and `/go` uses `direct-PR`:
 
@@ -54,6 +54,8 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 **`+yolo`** is an opt-in autonomy bump — pass the literal token to raise the engine's autonomy for this one dispatch. It composes with any mode.
 
 **`--dod "<condition>"`** records the approved semantic Definition of Done on the disposable issue and in the handoff. It is confirmation sugar only; it never bypasses the required approval turn.
+
+**`--request "<instruction>"`** forwards a special per-dispatch instruction block to the inner agent prompt, matching `/afk --request`. It is not part of the approved Task and is not recorded on the disposable `lane:go` issue.
 
 **`--verify "<cmd>"`** adds a one-off inline machine check for this dispatch. Use it only when the repo lacks a configured harness/backpressure and the maintainer approved the command during the confirmation gate.
 


### PR DESCRIPTION
Automated AFK landing for #1546. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1546

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786456496&installation_id=129708444&pr_number=1550&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1550&signature=55abd442d491de6c0f418269fa62789f15be2cc321cd0748816afe14140941a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->