### PR TITLE
fix: #1549 the rsp MCP must be inert unless the repo opted in (rsp.enabled in .red/config.yaml)

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -33,31 +33,39 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     await runRspMcpServer();
     return 0;
   }
+  const { resolveRspConfig } = await import("./config.js");
+  const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
+  const wrapperCommand = isWrapperCommand(args.command);
+  if (!config.enabled) {
+    if (wrapperCommand) return await degradeToPassthrough(rspDisabledReason(), args.positional);
+    process.stdout.write(`${rspDisabledReason()}\n`);
+    return 0;
+  }
   if (args.command === "git" && isFastGitStatus(args.positional) && residentSocketExists(process.cwd())) {
     return await runFastGitStatus();
   }
   const { resolveResidentPaths, ResidentRspElisionStore, ensureResidentServer } = await import("./resident-client.js");
   if (args.command === "server") {
     const { runResidentServer } = await import("./resident-server.js");
-    const { resolveRspConfig } = await import("./config.js");
     const socket = valueAfter(args.positional, "--socket") ?? resolveResidentPaths(process.cwd()).socketPath;
-    const config = resolveRspConfig(process.cwd(), process.env, args.storeUri ?? valueAfter(args.positional, "--store-uri"));
+    const serverConfig = resolveRspConfig(process.cwd(), process.env, args.storeUri ?? valueAfter(args.positional, "--store-uri"));
+    if (!serverConfig.enabled) {
+      process.stdout.write(`${rspDisabledReason()}\n`);
+      return 0;
+    }
     await runResidentServer({
       socketPath: socket,
-      storeUri: config.storeUri,
-      ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? config.ttlDays,
-      byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? config.byteBudget,
+      storeUri: serverConfig.storeUri,
+      ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? serverConfig.ttlDays,
+      byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? serverConfig.byteBudget,
       idleMs: numericValueAfter(args.positional, "--idle-ms"),
     });
     return 0;
   }
 
-  const { resolveRspConfig } = await import("./config.js");
   const { existsSync } = await import("node:fs");
   const { fileURLToPath } = await import("node:url");
-  const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
   const residentPaths = resolveResidentPaths(process.cwd());
-  const wrapperCommand = isWrapperCommand(args.command);
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
     if (wrapperCommand) return await degradeToPassthrough("store not provisioned", args.positional);
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
@@ -292,6 +300,10 @@ async function degradeToPassthrough(reason: string, argv: readonly string[], err
   }
   process.stderr.write(`rsp: ${reason}, passing through\n`);
   return await passthrough(argv);
+}
+
+function rspDisabledReason(): string {
+  return "rsp is not enabled in this directory; run /red-setup";
 }
 
 async function suppressRspStderr<T>(fn: () => Promise<T>): Promise<T> {

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { findUp, flatConfigValue } from "@reddb-io/shared/plugin-gate.js";
 
 export const DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD = 8 * 1024;
 export const DEFAULT_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
@@ -15,10 +16,10 @@ export interface RspRuntimeConfig {
 }
 
 export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitStoreUri?: string): RspRuntimeConfig {
-  const configPath = findUp(cwd, join(".red", "config.yaml"));
+  const configPath = findUp(resolve(cwd), join(".red", "config.yaml"));
   const root = configPath ? dirname(dirname(configPath)) : cwd;
   const yaml = configPath ? readFileSync(configPath, "utf8") : "";
-  const enabled = readYamlPath(yaml, "rsp.enabled") === "true";
+  const enabled = flatConfigValue(yaml, "rsp.enabled") === "true";
   const ttlDays = positiveNumber(readNumericYamlPath(yaml, "rsp.ttlDays"), DEFAULT_RSP_TTL_DAYS);
   const byteBudget = positiveNumber(readNumericYamlPath(yaml, "rsp.byteBudget"), DEFAULT_RSP_BYTE_BUDGET);
   const heavyGitByteThreshold = positiveNumber(
@@ -30,48 +31,11 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
   return { enabled, storeUri, ttlDays, byteBudget, heavyGitByteThreshold };
 }
 
-function findUp(start: string, relativePath: string): string | null {
-  let dir = resolve(start);
-  for (let i = 0; i < 32; i++) {
-    const candidate = join(dir, relativePath);
-    if (existsSync(candidate)) return candidate;
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-  return null;
-}
-
 function readNumericYamlPath(yaml: string, dottedPath: string): number | undefined {
-  const value = readYamlPath(yaml, dottedPath);
+  const value = flatConfigValue(yaml, dottedPath);
   if (value == null) return undefined;
   const n = Number(value);
   return Number.isFinite(n) ? n : undefined;
-}
-
-function readYamlPath(yaml: string, dottedPath: string): string | undefined {
-  const target = dottedPath.split(".");
-  const stack: Array<{ indent: number; key: string }> = [];
-  for (const rawLine of yaml.split("\n")) {
-    const line = rawLine.replace(/\r$/, "");
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const colon = line.indexOf(":");
-    if (colon < 0) continue;
-    const indent = line.length - line.trimStart().length;
-    const key = line.slice(0, colon).trim();
-    if (!key) continue;
-    const value = stripInlineComment(line.slice(colon + 1));
-    while (stack.length > 0 && stack[stack.length - 1]!.indent >= indent) stack.pop();
-    stack.push({ indent, key });
-    if (value !== "" && stack.map((entry) => entry.key).join(".") === target.join(".")) return value;
-  }
-  return undefined;
-}
-
-function stripInlineComment(value: string): string {
-  const hash = value.indexOf(" #");
-  return (hash >= 0 ? value.slice(0, hash) : value).trim();
 }
 
 function positiveNumber(value: number | undefined, fallback: number): number {

--- a/apps/rsp/src/mcp-server.ts
+++ b/apps/rsp/src/mcp-server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createInterface } from "node:readline";
-import { resolveRspConfig } from "./config.js";
+import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
 import { ResidentRspElisionStore, resolveResidentPaths } from "./resident-client.js";
 
 interface JsonRpcRequest {
@@ -11,13 +11,14 @@ interface JsonRpcRequest {
 }
 
 export async function runRspMcpServer(): Promise<void> {
+  const config = resolveRspConfig(process.cwd(), process.env);
   const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
   for await (const line of rl) {
     if (!line.trim()) continue;
     let request: JsonRpcRequest;
     try {
       request = JSON.parse(line) as JsonRpcRequest;
-      const result = await handle(request);
+      const result = await handle(request, config);
       write({ jsonrpc: "2.0", id: request.id ?? null, result });
     } catch (err) {
       write({
@@ -29,7 +30,7 @@ export async function runRspMcpServer(): Promise<void> {
   }
 }
 
-async function handle(request: JsonRpcRequest): Promise<unknown> {
+async function handle(request: JsonRpcRequest, config: RspRuntimeConfig): Promise<unknown> {
   if (request.method === "initialize") {
     return {
       protocolVersion: "2024-11-05",
@@ -38,8 +39,24 @@ async function handle(request: JsonRpcRequest): Promise<unknown> {
     };
   }
   if (request.method === "tools/list") {
+    if (!config.enabled) {
+      return {
+        tools: [
+          {
+            name: "rsp_status",
+            description: "Explain whether rsp is enabled in this directory.",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      };
+    }
     return {
       tools: [
+        {
+          name: "rsp_status",
+          description: "Explain whether rsp is enabled in this directory.",
+          inputSchema: { type: "object", properties: {} },
+        },
         {
           name: "rsp_stats",
           description: "Read resident rsp elision store stats.",
@@ -59,7 +76,13 @@ async function handle(request: JsonRpcRequest): Promise<unknown> {
   }
   if (request.method === "tools/call") {
     const params = request.params as { name?: string; arguments?: Record<string, unknown> } | undefined;
-    const store = residentStore();
+    if (params?.name === "rsp_status") {
+      return { content: [{ type: "text", text: renderStatus(config) }] };
+    }
+    if (!config.enabled) {
+      return { content: [{ type: "text", text: renderStatus(config) }], isError: true };
+    }
+    const store = residentStore(config);
     if (params?.name === "rsp_stats") {
       return { content: [{ type: "text", text: JSON.stringify(await store.stats()) }] };
     }
@@ -74,13 +97,17 @@ async function handle(request: JsonRpcRequest): Promise<unknown> {
   return {};
 }
 
-function residentStore(): ResidentRspElisionStore {
-  const config = resolveRspConfig(process.cwd(), process.env);
+function residentStore(config: RspRuntimeConfig): ResidentRspElisionStore {
   return new ResidentRspElisionStore(resolveResidentPaths(process.cwd()), {
     storeUri: config.storeUri,
     ttlDays: config.ttlDays,
     byteBudget: config.byteBudget,
   });
+}
+
+function renderStatus(config: RspRuntimeConfig): string {
+  if (!config.enabled) return "rsp is not enabled in this directory; run /red-setup";
+  return "rsp is enabled in this directory";
 }
 
 function write(value: unknown): void {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -28,7 +28,7 @@ afterEach(async () => {
 
 function runRsp(root: string, args: string[], env: Record<string, string>) {
   return spawnSync(process.execPath, ["--import", tsxLoader, cli, ...args], {
-    cwd: packageRoot,
+    cwd: root,
     env: { ...process.env, ...env },
     encoding: "buffer",
   });
@@ -110,12 +110,67 @@ async function initGitRepo(): Promise<string> {
   return root;
 }
 
+async function enableRsp(root: string): Promise<void> {
+  await mkdir(join(root, ".red"), { recursive: true });
+  await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+}
+
 async function commitMany(root: string, count: number): Promise<void> {
   for (let i = 1; i <= count; i++) {
     await writeFile(join(root, `file-${i}.txt`), `line ${i}\n`, "utf8");
     expect(runGit(["-C", root, "add", `file-${i}.txt`]).status).toBe(0);
     expect(runGit(["-C", root, "commit", "-m", `commit ${i}`]).status).toBe(0);
   }
+}
+
+async function runMcpRequests(cwd: string, requests: Array<Record<string, unknown>>): Promise<Array<Record<string, unknown>>> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", tsxLoader, cli, "mcp"], {
+      cwd,
+      env: { ...process.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const responses: Array<Record<string, unknown>> = [];
+    let stdout = "";
+    let stderr = "";
+    let buffer = "";
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`timed out waiting for rsp mcp responses; stderr=${stderr}`));
+    }, 10_000);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      buffer += chunk;
+      let idx: number;
+      while ((idx = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (!line) continue;
+        responses.push(JSON.parse(line) as Record<string, unknown>);
+        if (responses.length >= requests.filter((request) => "id" in request).length) {
+          clearTimeout(timeout);
+          child.kill();
+          resolve(responses);
+        }
+      }
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on("close", (status) => {
+      if (responses.length < requests.filter((request) => "id" in request).length) {
+        clearTimeout(timeout);
+        reject(new Error(`rsp mcp exited early with ${status}; stdout=${stdout}; stderr=${stderr}`));
+      }
+    });
+    for (const request of requests) child.stdin.write(`${JSON.stringify(request)}\n`);
+  });
 }
 
 async function seedWarmRedCache(): Promise<string> {
@@ -132,6 +187,85 @@ async function seedWarmRedCache(): Promise<string> {
 }
 
 describe("rsp cli", () => {
+  it("passes wrappers through without creating .red when rsp is not enabled", async () => {
+    const root = await initGitRepo();
+    await writeFile(join(root, "untracked.txt"), "raw stdout\n", "utf8");
+    const direct = runGit(["-C", root, "status", "--short"]);
+
+    const res = runRspFromCwd(root, ["git", "status", "--short"], {});
+
+    expect(res.status).toBe(direct.status);
+    expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr.toString("utf8")).toBe(`rsp: rsp is not enabled in this directory; run /red-setup, passing through\n${direct.stderr.toString("utf8")}`);
+    await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("server exits inert without creating a socket when rsp is not enabled", async () => {
+    const root = await tempRoot();
+
+    const res = runRspFromCwd(root, ["server", "--idle-ms", "10"], {});
+
+    expect(res.status).toBe(0);
+    expect(res.stdout.toString("utf8")).toBe("rsp is not enabled in this directory; run /red-setup\n");
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+    await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("mcp boots inert with no config and answers status without side effects", async () => {
+    const root = await tempRoot();
+
+    const responses = await runMcpRequests(root, [
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "0" } },
+      },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      { jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "rsp_status", arguments: {} } },
+    ]);
+
+    const list = responses.find((response) => response.id === 2) as { result: { tools: Array<{ name: string }> } };
+    const status = responses.find((response) => response.id === 3) as { result: { content: Array<{ text: string }> } };
+    expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status"]);
+    expect(status.result.content[0]!.text).toBe("rsp is not enabled in this directory; run /red-setup");
+    await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("mcp stays inert when config lacks an rsp block or disables rsp", async () => {
+    const noRsp = await tempRoot();
+    await mkdir(join(noRsp, ".red"), { recursive: true });
+    await writeFile(join(noRsp, ".red", "config.yaml"), "plugins:\n  dev:\n    enabled: true\n", "utf8");
+    const disabled = await tempRoot();
+    await mkdir(join(disabled, ".red"), { recursive: true });
+    await writeFile(join(disabled, ".red", "config.yaml"), "rsp:\n  enabled: false\n", "utf8");
+
+    for (const root of [noRsp, disabled]) {
+      const responses = await runMcpRequests(root, [
+        { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+        { jsonrpc: "2.0", id: 2, method: "tools/list" },
+      ]);
+      const list = responses.find((response) => response.id === 2) as { result: { tools: Array<{ name: string }> } };
+      expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status"]);
+      await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("mcp exposes resident tools when rsp is enabled", async () => {
+    const root = await tempRoot();
+    await enableRsp(root);
+
+    const responses = await runMcpRequests(root, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    ]);
+
+    const list = responses.find((response) => response.id === 2) as { result: { tools: Array<{ name: string }> } };
+    expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status", "rsp_stats", "rsp_show"]);
+  });
+
   it("built bundle starts the resident on cold small git status", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
@@ -154,6 +288,7 @@ describe("rsp cli", () => {
   it("built bundle keeps small git status wrapper work under 100ms", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
+    await enableRsp(root);
     await writeFile(join(root, ".gitignore"), ".red/\n", "utf8");
     expect(runGit(["-C", root, "add", ".gitignore"]).status).toBe(0);
     expect(runGit(["-C", root, "commit", "-m", "baseline"]).status).toBe(0);
@@ -300,7 +435,7 @@ describe("rsp cli", () => {
 
   it("fails closed instead of creating the default Repo store when setup has not provisioned it", async () => {
     const root = await tempRoot();
-    await mkdir(join(root, ".red"), { recursive: true });
+    await enableRsp(root);
 
     const res = runRspFromCwd(root, [], {});
 
@@ -312,7 +447,7 @@ describe("rsp cli", () => {
 
   it("passes through a successful wrapper when the repo store has not been provisioned", async () => {
     const root = await initGitRepo();
-    await mkdir(join(root, ".red"), { recursive: true });
+    await enableRsp(root);
     await writeFile(join(root, "untracked.txt"), "raw stdout\n", "utf8");
     const direct = runGit(["-C", root, "status", "--short"]);
 
@@ -327,7 +462,7 @@ describe("rsp cli", () => {
 
   it("passes through a failing wrapper with the underlying exit code and raw stderr when the store is absent", async () => {
     const root = await initGitRepo();
-    await mkdir(join(root, ".red"), { recursive: true });
+    await enableRsp(root);
     const args = ["-C", root, "definitely-not-a-git-subcommand"];
     const direct = runGit(args);
 
@@ -340,6 +475,7 @@ describe("rsp cli", () => {
 
   it("passes through wrappers when the configured store is unreadable non-RedDB data", async () => {
     const root = await initGitRepo();
+    await enableRsp(root);
     const storeRoot = await tempRoot();
     const storePath = join(storeRoot, "rsp-elisions.json");
     await writeFile(storePath, "not a reddb store", "utf8");
@@ -376,9 +512,9 @@ describe("rsp cli", () => {
     buildBundleOnce();
     const root = await initGitRepo();
     await commitMany(root, 12);
+    await enableRsp(root);
     const legacyPath = join(root, ".red", "red.rdb");
     const legacyBytes = Buffer.concat([Buffer.from("RDBSBLK1", "ascii"), Buffer.from("legacy graph bytes")]);
-    await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(legacyPath, legacyBytes);
 
     const compressed = runBundleFromCwd(root, ["--store-uri", `file://${legacyPath}`, "git", "log", "--terse"]);
@@ -392,6 +528,7 @@ describe("rsp cli", () => {
 
   it("passes through wrappers when rsp hits an internal wrapper error after opening the store", async () => {
     const root = await tempRoot();
+    await enableRsp(root);
     const storeUri = `file://${join(root, "red.rdb")}`;
     const store = await RspElisionStore.open({ uri: storeUri });
     await store.close();
@@ -410,6 +547,7 @@ describe("rsp cli", () => {
 
   it("prints store stats instead of help when called without arguments", async () => {
     const root = await tempRoot();
+    await enableRsp(root);
     const storeUri = `file://${join(root, "red.rdb")}`;
     const store = await RspElisionStore.open({
       uri: storeUri,
@@ -433,6 +571,7 @@ describe("rsp cli", () => {
 
   it("rsp show prints original bytes verbatim on hit", async () => {
     const root = await tempRoot();
+    await enableRsp(root);
     const storeUri = `file://${join(root, "red.rdb")}`;
     const original = Buffer.from([0x1b, 0x5b, 0x33, 0x32, 0x6d, 0x00, 0x62, 0xff]);
     const store = await RspElisionStore.open({ uri: storeUri });
@@ -455,6 +594,7 @@ describe("rsp cli", () => {
 
   it("rsp show prints structured expiry with the original command and exits 1", async () => {
     const root = await tempRoot();
+    await enableRsp(root);
     const storeUri = `file://${join(root, "red.rdb")}`;
     let now = new Date("2026-07-10T12:00:00.000Z");
     const store = await RspElisionStore.open({ uri: storeUri, ttlDays: 1, now: () => now });


### PR DESCRIPTION
Automated AFK landing for #1549. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1549

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786464067&installation_id=129708444&pr_number=1554&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1554&signature=873a8a7d4f4348faa73c595e09e8f08a37d73fdfbcadb95ad0c43bf8d21f53ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->