### PR TITLE
merge: #1415 Ambient instruction surface: teach agents to call rsp directly (Codex lane, generated from the capability table)

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -19,6 +19,7 @@ import { reviewCommand } from "./commands/review.js";
 import { stopCommand } from "./commands/stop.js";
 import { respondCommand } from "./commands/respond.js";
 import { routeModelTierCommand } from "./commands/route-model-tier.js";
+import { rspInstructionsCommand } from "./commands/rsp-instructions.js";
 import { statuslineCommand, statuslineRefreshCountsCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { triageCommand } from "./commands/triage.js";
@@ -47,6 +48,7 @@ export type CliCommand =
   | "codex-monitor-agent"
   | "codex-statusline"
   | "route-model-tier"
+  | "rsp-instructions"
   | "statusline"
   | "statusline-refresh-counts"
   | "inject-development-workflow"
@@ -90,6 +92,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     "codex-monitor-agent": {},
     "codex-statusline": {},
     "route-model-tier": {},
+    "rsp-instructions": {},
     statusline: {},
     "statusline-refresh-counts": {},
     "inject-development-workflow": {},
@@ -142,6 +145,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "codex-monitor-agent") return codexMonitorAgentCommand(parsed.args);
   if (parsed.command === "codex-statusline") return codexStatuslineCommand(parsed.args);
   if (parsed.command === "route-model-tier") return routeModelTierCommand(parsed.args);
+  if (parsed.command === "rsp-instructions") return rspInstructionsCommand(parsed.args);
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);
   if (parsed.command === "statusline-refresh-counts") return statuslineRefreshCountsCommand(parsed.args);
   if (parsed.command === "inject-development-workflow") return injectDevelopmentWorkflowCommand(parsed.args);

--- a/apps/dev/src/commands/rsp-instructions.ts
+++ b/apps/dev/src/commands/rsp-instructions.ts
@@ -1,0 +1,26 @@
+import { renderAmbientSkill, type RspInstructionRunner } from "../../../rsp/src/ambient-skill.js";
+
+function runnerFromArgs(args: readonly string[]): RspInstructionRunner {
+  const index = args.indexOf("--runner");
+  const runner = index >= 0 ? args[index + 1] : undefined;
+  return runner === "claude" ? "claude" : "codex";
+}
+
+export function renderRspInstructionsHookOutput(runner: RspInstructionRunner): string {
+  const instructions = renderAmbientSkill(undefined, { runner });
+  if (runner === "codex") return JSON.stringify({ systemMessage: instructions });
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: instructions,
+    },
+  });
+}
+
+export async function rspInstructionsCommand(args: readonly string[]): Promise<number> {
+  const runner = runnerFromArgs(args);
+  const instructions = renderAmbientSkill(undefined, { runner });
+  process.stdout.write(args.includes("--hook") ? renderRspInstructionsHookOutput(runner) : instructions);
+  if (args.includes("--hook")) process.stdout.write("\n");
+  return 0;
+}

--- a/apps/dev/src/core/handoff.ts
+++ b/apps/dev/src/core/handoff.ts
@@ -22,6 +22,7 @@
 //   <prior-attempt-context> · <thread-discussion> · <agent-notes>
 
 import { AGENT_OUTPUT_TAG } from "@reddb-io/red-castle";
+import { renderAmbientSkill, type RspInstructionRunner } from "../../../rsp/src/ambient-skill.js";
 import { classifyComment, extractDirectives } from "./comment-classification.js";
 import { isTrustedSource, type SourceTrustLevel } from "./source-trust.js";
 
@@ -453,9 +454,21 @@ export const AGENT_OUTPUT_INSTRUCTION = [
  * clause spliced in before `</exit-protocol>`; a non-schema runner gets the
  * plain {@link EXIT_PROTOCOL} (text-sentinel-only) — the coexist fallback.
  */
-export function exitProtocolFor(opts: { runMode?: string; structuredOutput?: boolean }): string {
+export function rspInstructionRunner(runner: string | undefined): RspInstructionRunner | undefined {
+  if (runner === "codex") return "codex";
+  if (runner === "claude" || runner === "claude-minimax") return "claude";
+  return undefined;
+}
+
+function withRspInstructions(protocol: string, runner: string | undefined): string {
+  const instructionRunner = rspInstructionRunner(runner);
+  if (!instructionRunner) return protocol;
+  return `${protocol}\n\n${renderAmbientSkill(undefined, { runner: instructionRunner })}`;
+}
+
+export function exitProtocolFor(opts: { runMode?: string; structuredOutput?: boolean; runner?: string }): string {
   if (opts.runMode === "scout") return SCOUT_EXIT_PROTOCOL;
-  if (!opts.structuredOutput) return EXIT_PROTOCOL;
+  if (!opts.structuredOutput) return withRspInstructions(EXIT_PROTOCOL, opts.runner);
   const closing = "</exit-protocol>";
-  return EXIT_PROTOCOL.replace(closing, `${AGENT_OUTPUT_INSTRUCTION}\n${closing}`);
+  return withRspInstructions(EXIT_PROTOCOL.replace(closing, `${AGENT_OUTPUT_INSTRUCTION}\n${closing}`), opts.runner);
 }

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1723,6 +1723,7 @@ export async function processIssue(
       systemPrompt: exitProtocolFor({
         runMode: input.runMode,
         structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(activeRunner)),
+        runner: activeRunner,
       }),
       branch,
       base: baseRef,
@@ -1851,6 +1852,7 @@ export async function processIssue(
         systemPrompt: exitProtocolFor({
           runMode: input.runMode,
           structuredOutput: runnerSupportsStructuredOutput(toAgentRunner(other)),
+          runner: other,
         }),
         branch,
         base,

--- a/apps/dev/tests/cli.test.ts
+++ b/apps/dev/tests/cli.test.ts
@@ -20,4 +20,11 @@ describe("cli parser", () => {
     });
     expect(parseCli(["triage", "99", "--summon"])).toEqual({ command: "triage", args: ["99", "--summon"] });
   });
+
+  it("routes rsp-instructions as a dev maintenance command", () => {
+    expect(parseCli(["rsp-instructions", "--runner", "codex", "--hook"])).toEqual({
+      command: "rsp-instructions",
+      args: ["--runner", "codex", "--hook"],
+    });
+  });
 });

--- a/apps/dev/tests/handoff.test.ts
+++ b/apps/dev/tests/handoff.test.ts
@@ -11,6 +11,7 @@ import {
   SCOUT_EXIT_PROTOCOL,
   AGENT_OUTPUT_INSTRUCTION,
   exitProtocolFor,
+  rspInstructionRunner,
   UNTRUSTED_PAYLOAD_NOTICE,
   type HandoffComment,
 } from "../src/core/handoff.js";
@@ -390,6 +391,27 @@ describe("buildHandoff", () => {
 
   it("exitProtocolFor: scout mode always wins over structured output", () => {
     expect(exitProtocolFor({ runMode: "scout", structuredOutput: true })).toBe(SCOUT_EXIT_PROTOCOL);
+  });
+
+  it("exitProtocolFor adds generated rsp guidance for Codex without interception claims", () => {
+    const p = exitProtocolFor({ runner: "codex", structuredOutput: false });
+    expect(p).toContain("Codex lane");
+    expect(p).toContain("rsp git status");
+    expect(p).toContain("rsp show el:<id>");
+    expect(p.toLowerCase()).not.toContain("interception");
+  });
+
+  it("exitProtocolFor adds generated rsp guidance for Claude and marks interception present", () => {
+    const p = exitProtocolFor({ runner: "claude", structuredOutput: true });
+    expect(p).toContain("Claude lane");
+    expect(p).toContain("pre-execution interception is available");
+    expect(p).toContain("direct calls still help");
+    expect(p).toContain("<agent-output>");
+  });
+
+  it("maps claude-minimax to the Claude rsp instruction lane and leaves other runners alone", () => {
+    expect(rspInstructionRunner("claude-minimax")).toBe("claude");
+    expect(rspInstructionRunner("opencode")).toBeUndefined();
   });
 
   it("case5: malformed envelope → no previous-attempts, no human-guidance, surfaces in discussion", () => {

--- a/apps/dev/tests/rsp-instructions.test.ts
+++ b/apps/dev/tests/rsp-instructions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { renderRspInstructionsHookOutput } from "../src/commands/rsp-instructions.js";
+
+describe("rsp instruction session content", () => {
+  it("emits Claude SessionStart additionalContext with interception guidance", () => {
+    const parsed = JSON.parse(renderRspInstructionsHookOutput("claude"));
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    expect(parsed.hookSpecificOutput.additionalContext).toContain("Claude lane");
+    expect(parsed.hookSpecificOutput.additionalContext).toContain("pre-execution interception is available");
+  });
+
+  it("emits Codex session content without interception claims", () => {
+    const parsed = JSON.parse(renderRspInstructionsHookOutput("codex"));
+    expect(parsed.systemMessage).toContain("Codex lane");
+    expect(parsed.systemMessage).toContain("rsp show el:<id>");
+    expect(parsed.systemMessage.toLowerCase()).not.toContain("interception");
+  });
+});

--- a/apps/dev/tsconfig.json
+++ b/apps/dev/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src", "tests", "../../packages/shared/**/*.ts"],
+  "include": ["src", "tests", "../../packages/shared/**/*.ts", "../../apps/rsp/src/**/*.ts"],
   "comment-exclude": "Shared source is typechecked here (dev imports it); shared *.test.ts run under vitest and resolve their own deps, so they are not compiled by dev's tsc.",
   "exclude": ["../../packages/shared/**/*.test.ts"]
 }

--- a/apps/rsp/generated/AMBIENT-SKILL.md
+++ b/apps/rsp/generated/AMBIENT-SKILL.md
@@ -30,8 +30,44 @@ When you would run one of these commands, run it through `rsp` instead:
 | `vitest run` | `rsp vitest run` |
 | `cargo test` | `rsp cargo test` |
 
+## When to prefer rsp
+
+- For `git status`, prefer `rsp git status` when the summarized output is enough.
+- For `git log`, prefer `rsp git log` when the summarized output is enough.
+- For `git diff`, prefer `rsp git diff` when the summarized output is enough.
+- For `git commit`, prefer `rsp git commit` when the summarized output is enough.
+- For `git push`, prefer `rsp git push` when the summarized output is enough.
+- For `gh pr list`, prefer `rsp gh pr list` when the summarized output is enough.
+- For `gh pr view`, prefer `rsp gh pr view` when the summarized output is enough.
+- For `gh issue list`, prefer `rsp gh issue list` when the summarized output is enough.
+- For `gh issue view`, prefer `rsp gh issue view` when the summarized output is enough.
+- For `gh run list`, prefer `rsp gh run list` when the summarized output is enough.
+- For `gh run view`, prefer `rsp gh run view` when the summarized output is enough.
+- For `vitest`, prefer `rsp vitest` when the summarized output is enough.
+- For `vitest run`, prefer `rsp vitest run` when the summarized output is enough.
+- For `cargo test`, prefer `rsp cargo test` when the summarized output is enough.
+
+Use raw commands when exact stdout/stderr is the behavior under test, when
+a wrapper does not support the command shape, or when resolving low-level
+git conflicts where every byte matters.
+
+## Loss levels
+
+Use `--brief` for compact summaries that keep enough inline context for
+normal debugging. Use `--terse` for large or repetitive output; lossy output
+mints an `el:<id>` handle, and `rsp show el:<id>` writes the original bytes
+back to stdout. Use `--full` when exact inline output is required.
+
+Large `rsp git diff` and `rsp git log` output is threshold-gated and may
+truncate by default; pass `--full` when exact inline output is required.
+
 ## Recovering elided output
 
 `rsp show el:<id>` writes the original bytes verbatim to stdout. Expired or
 evicted handles print `expired <ISO date> — re-run: <original command>` and
 exit 1, so the exact command to reproduce the output is always in reach.
+
+## Failure behavior
+
+If an rsp wrapper is disabled, lacks its store, or fails, it passes through to the raw command
+with the raw command's stdout, stderr, and exit status intact.

--- a/apps/rsp/src/ambient-skill.ts
+++ b/apps/rsp/src/ambient-skill.ts
@@ -5,6 +5,12 @@ import { RSP_WRAPPER_CAPABILITIES, type RspWrapperCapability } from "./intercept
 // so the source of truth for the file location lives in one place.
 export const AMBIENT_SKILL_RELATIVE_PATH = "generated/AMBIENT-SKILL.md";
 
+export type RspInstructionRunner = "claude" | "codex";
+
+export interface AmbientSkillRenderOptions {
+  runner?: RspInstructionRunner;
+}
+
 /**
  * Render the ambient-instruction surface (the RTK.md-replacement doc) FROM the
  * rsp wrapper capability table, so the ambient surface can never drift from the
@@ -14,12 +20,19 @@ export const AMBIENT_SKILL_RELATIVE_PATH = "generated/AMBIENT-SKILL.md";
  */
 export function renderAmbientSkill(
   capabilities: readonly RspWrapperCapability[] = RSP_WRAPPER_CAPABILITIES,
+  options: AmbientSkillRenderOptions = {},
 ): string {
   const rows = capabilities.map((capability) => {
     const command = capability.command.join(" ");
     const wrapper = ["rsp", ...capability.wrapper].join(" ");
     return `| \`${command}\` | \`${wrapper}\` |`;
   });
+  const preferences = capabilities.map((capability) => {
+    const wrapper = ["rsp", ...capability.wrapper].join(" ");
+    const command = capability.command.join(" ");
+    return `- For \`${command}\`, prefer \`${wrapper}\` when the summarized output is enough.`;
+  });
+  const runnerLines = renderRunnerLines(options.runner);
 
   return [
     "# rsp — token-efficient command wrappers",
@@ -33,6 +46,8 @@ export function renderAmbientSkill(
     "reversible elision store, so the agent reads a compact summary and can",
     "recover the original bytes on demand with `rsp show el:<id>`.",
     "",
+    ...runnerLines,
+    ...(runnerLines.length > 0 ? [""] : []),
     "## Wrapped commands",
     "",
     "When you would run one of these commands, run it through `rsp` instead:",
@@ -41,11 +56,54 @@ export function renderAmbientSkill(
     "| --- | --- |",
     ...rows,
     "",
+    "## When to prefer rsp",
+    "",
+    ...preferences,
+    "",
+    "Use raw commands when exact stdout/stderr is the behavior under test, when",
+    "a wrapper does not support the command shape, or when resolving low-level",
+    "git conflicts where every byte matters.",
+    "",
+    "## Loss levels",
+    "",
+    "Use `--brief` for compact summaries that keep enough inline context for",
+    "normal debugging. Use `--terse` for large or repetitive output; lossy output",
+    "mints an `el:<id>` handle, and `rsp show el:<id>` writes the original bytes",
+    "back to stdout. Use `--full` when exact inline output is required.",
+    "",
+    "Large `rsp git diff` and `rsp git log` output is threshold-gated and may",
+    "truncate by default; pass `--full` when exact inline output is required.",
+    "",
     "## Recovering elided output",
     "",
     "`rsp show el:<id>` writes the original bytes verbatim to stdout. Expired or",
     "evicted handles print `expired <ISO date> — re-run: <original command>` and",
     "exit 1, so the exact command to reproduce the output is always in reach.",
     "",
+    "## Failure behavior",
+    "",
+    "If an rsp wrapper is disabled, lacks its store, or fails, it passes through to the raw command",
+    "with the raw command's stdout, stderr, and exit status intact.",
+    "",
   ].join("\n");
+}
+
+function renderRunnerLines(runner: RspInstructionRunner | undefined): string[] {
+  if (runner === "codex") {
+    return [
+      "## Codex lane",
+      "",
+      "This ambient instruction is the primary Codex lane: call `rsp` directly",
+      "when one of the wrapped command forms applies.",
+    ];
+  }
+  if (runner === "claude") {
+    return [
+      "## Claude lane",
+      "",
+      "Claude Code pre-execution interception is available for simple wrapped",
+      "commands, and direct calls still help when composing commands deliberately.",
+    ];
+  }
+  return [];
 }

--- a/apps/rsp/tests/ambient-skill.test.ts
+++ b/apps/rsp/tests/ambient-skill.test.ts
@@ -16,6 +16,40 @@ describe("rsp ambient skill generator", () => {
     }
   });
 
+  it("renders added fixture capabilities without changing the generator", () => {
+    const markdown = renderAmbientSkill([
+      ...RSP_WRAPPER_CAPABILITIES,
+      { id: "fixture:doctor", command: ["doctor", "check"], wrapper: ["doctor", "check"] },
+    ]);
+
+    expect(markdown).toContain("| `doctor check` | `rsp doctor check` |");
+    expect(markdown).toContain("prefer `rsp doctor check` when the summarized output is enough");
+  });
+
+  it("documents call forms, loss levels, retrieval, truncation, and passthrough behavior", () => {
+    const markdown = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES);
+    for (const capability of RSP_WRAPPER_CAPABILITIES) {
+      const wrapper = ["rsp", ...capability.wrapper].join(" ");
+      expect(markdown).toContain(`prefer \`${wrapper}\` when the summarized output is enough`);
+    }
+    expect(markdown).toContain("Use `--brief` for compact summaries");
+    expect(markdown).toContain("Use `--terse` for large or repetitive output");
+    expect(markdown).toContain("Use `--full` when exact inline output is required");
+    expect(markdown).toContain("Large `rsp git diff` and `rsp git log` output is threshold-gated");
+    expect(markdown).toContain("If an rsp wrapper is disabled, lacks its store, or fails, it passes through to the raw command");
+    expect(markdown).toContain("`rsp show el:<id>` writes the original bytes verbatim to stdout");
+  });
+
+  it("renders runner-specific guidance without claiming interception for Codex", () => {
+    const codex = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES, { runner: "codex" });
+    const claude = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES, { runner: "claude" });
+
+    expect(codex).toContain("Codex lane");
+    expect(codex.toLowerCase()).not.toContain("interception");
+    expect(claude).toContain("Claude lane");
+    expect(claude).toContain("pre-execution interception is available");
+  });
+
   it("committed artifact matches the generator output (drift check)", () => {
     const committed = readFileSync(join(packageRoot, AMBIENT_SKILL_RELATIVE_PATH), "utf8");
     expect(committed).toEqual(renderAmbientSkill(RSP_WRAPPER_CAPABILITIES));

--- a/plugins/dev/hooks/claude.hooks.json
+++ b/plugins/dev/hooks/claude.hooks.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "sh -c 'root=\"${CLAUDE_PLUGIN_ROOT}\"; ver=\"$(timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node -e \"process.stdout.write(require(process.argv[1]).version)\" \"$root/.claude-plugin/plugin.json\" 2>/dev/null)\"; if [ -n \"$ver\" ]; then for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" dev \"$ver\" >/dev/null 2>&1 || true; timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" code-nav \"$ver\" >/dev/null 2>&1 || true; break; }; done; fi; printf \"{}\"'"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'root=\"${CLAUDE_PLUGIN_ROOT}\"; out=\"\"; for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { out=\"$(timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" run dev rsp-instructions --runner claude --hook 2>/dev/null)\"; break; }; done; if [ -n \"$out\" ]; then printf \"%s\" \"$out\"; else printf \"{}\"; fi'"
           }
         ]
       }

--- a/plugins/dev/hooks/codex.hooks.json
+++ b/plugins/dev/hooks/codex.hooks.json
@@ -10,6 +10,10 @@
           {
             "type": "command",
             "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CODEX_PLUGIN_ROOT}\"; for f in \"$root/hooks/ensure-codex-statusline.mjs\" \"$root/dist/ensure-codex-statusline.mjs\"; do [ -f \"$f\" ] && { timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" </dev/null >/dev/null 2>&1 || true; break; }; done; printf \"{}\"'"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'tmp=\"$(mktemp)\"; trap \"rm -f \\\"$tmp\\\"\" EXIT; timeout \"${RED_SKILLS_HOOK_STDIN_TIMEOUT_S:-5s}\" cat >\"$tmp\" 2>/dev/null || true; root=\"${CODEX_PLUGIN_ROOT}\"; out=\"\"; for f in \"$root/hooks/red-fetch.mjs\" \"$root/dist/red-fetch.mjs\" \"$root/../../dist/red-fetch.mjs\"; do [ -f \"$f\" ] && { out=\"$(timeout \"${RED_SKILLS_HOOK_TIMEOUT_S:-30s}\" node \"$f\" run dev rsp-instructions --runner codex --hook <\"$tmp\" 2>/dev/null)\"; break; }; done; if [ -n \"$out\" ]; then printf \"%s\" \"$out\"; else printf \"{}\"; fi'"
           }
         ]
       }

--- a/plugins/dev/hooks/tests/command-guard.test.sh
+++ b/plugins/dev/hooks/tests/command-guard.test.sh
@@ -65,10 +65,14 @@ run_hook() {
 manifest_hook="$(jq -r '.hooks.PreToolUse[0].hooks[] | select(.command | contains("command-guard.sh")) | .command' "$CLAUDE_MANIFEST")"
 expect_contains "claude manifest: wires command-guard.sh" "command-guard.sh" "$manifest_hook"
 expect_contains "claude manifest: wrapper drains stdin" 'cat >"$tmp"' "$manifest_hook"
+manifest_hook="$(jq -r '.hooks.SessionStart[0].hooks[] | select(.command | contains("rsp-instructions")) | .command' "$CLAUDE_MANIFEST")"
+expect_contains "claude manifest: wires rsp instructions" "rsp-instructions --runner claude --hook" "$manifest_hook"
 
 manifest_hook="$(jq -r '.hooks.PreToolUse[0].hooks[] | select(.command | contains("command-guard.sh")) | .command' "$CODEX_MANIFEST")"
 expect_contains "codex manifest: wires command-guard.sh" "command-guard.sh" "$manifest_hook"
 expect_contains "codex manifest: wrapper drains stdin" 'cat >"$tmp"' "$manifest_hook"
+manifest_hook="$(jq -r '.hooks.SessionStart[0].hooks[] | select(.command | contains("rsp-instructions")) | .command' "$CODEX_MANIFEST")"
+expect_contains "codex manifest: wires rsp instructions" "rsp-instructions --runner codex --hook" "$manifest_hook"
 
 missing_root="$tmp/missing-plugin-root"
 mkdir -p "$missing_root"


### PR DESCRIPTION
Automated AFK landing for #1415. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1415

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786468889&installation_id=129708444&pr_number=1557&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1557&signature=2d1f2ad3c0cf5e20a8a71c027263a64825cf585e6588f159c783c7308bec88d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->