### PR TITLE
fix: #1556 purge rtk from repo defaults before the binary is removed

### DIFF
--- a/.red/contracts/fixtures/quality-gate/invalid/approved-with-failure.json
+++ b/.red/contracts/fixtures/quality-gate/invalid/approved-with-failure.json
@@ -1,0 +1,62 @@
+{
+  "status": "completed",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Approved gate with failure.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "gate passes",
+      "result": "pass",
+      "evidence": "claimed pass"
+    }
+  ],
+  "changed_files": [
+    "scripts/validate-quality-gate-contract.sh"
+  ],
+  "verification_commands": [
+    "scripts/test-validate-quality-gate-contract.sh"
+  ],
+  "verification_results": [
+    {
+      "command": "scripts/test-validate-quality-gate-contract.sh",
+      "exit_code": 0,
+      "summary": "passed"
+    }
+  ],
+  "quality_gate_failures": [
+    "unexpected failure"
+  ],
+  "blocker_reason": null,
+  "next_human_action": null,
+  "remaining_risks": [],
+  "confidence": "high",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "approved",
+    "checks_run": [
+      {
+        "name": "quality gate fixtures",
+        "command": "scripts/test-validate-quality-gate-contract.sh",
+        "exit_code": 0,
+        "duration_seconds": 1,
+        "output_summary": "passed",
+        "proxy_used": false
+      }
+    ],
+    "discovered_commands": [],
+    "stub_findings": [],
+    "scope_drift_findings": [],
+    "acceptance_verification": [
+      {
+        "criterion": "gate passes",
+        "verified": "by_command",
+        "evidence_source": "scripts/test-validate-quality-gate-contract.sh"
+      }
+    ],
+    "fixes_applied": [],
+    "fixes_rejected": [],
+    "proxy_used": false
+  }
+}

--- a/.red/contracts/fixtures/quality-gate/invalid/approved-with-unverified.json
+++ b/.red/contracts/fixtures/quality-gate/invalid/approved-with-unverified.json
@@ -1,0 +1,60 @@
+{
+  "status": "completed",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Approved gate with unverified acceptance.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "gate passes",
+      "result": "unverified",
+      "evidence": "not checked"
+    }
+  ],
+  "changed_files": [
+    "scripts/validate-quality-gate-contract.sh"
+  ],
+  "verification_commands": [
+    "scripts/test-validate-quality-gate-contract.sh"
+  ],
+  "verification_results": [
+    {
+      "command": "scripts/test-validate-quality-gate-contract.sh",
+      "exit_code": 0,
+      "summary": "passed"
+    }
+  ],
+  "quality_gate_failures": [],
+  "blocker_reason": null,
+  "next_human_action": null,
+  "remaining_risks": [],
+  "confidence": "high",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "approved",
+    "checks_run": [
+      {
+        "name": "quality gate fixtures",
+        "command": "scripts/test-validate-quality-gate-contract.sh",
+        "exit_code": 0,
+        "duration_seconds": 1,
+        "output_summary": "passed",
+        "proxy_used": false
+      }
+    ],
+    "discovered_commands": [],
+    "stub_findings": [],
+    "scope_drift_findings": [],
+    "acceptance_verification": [
+      {
+        "criterion": "gate passes",
+        "verified": "unverifiable_in_this_phase",
+        "evidence_source": "missing proof"
+      }
+    ],
+    "fixes_applied": [],
+    "fixes_rejected": [],
+    "proxy_used": false
+  }
+}

--- a/.red/contracts/fixtures/quality-gate/invalid/checks-mismatch.json
+++ b/.red/contracts/fixtures/quality-gate/invalid/checks-mismatch.json
@@ -1,0 +1,47 @@
+{
+  "status": "blocked",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Mismatched verification arrays.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "gate passes",
+      "result": "fail",
+      "evidence": "missing result"
+    }
+  ],
+  "changed_files": [
+    "scripts/validate-quality-gate-contract.sh"
+  ],
+  "verification_commands": [
+    "scripts/test-validate-quality-gate-contract.sh"
+  ],
+  "verification_results": [],
+  "quality_gate_failures": [
+    "missing result"
+  ],
+  "blocker_reason": "missing verification result",
+  "next_human_action": "record the command result",
+  "remaining_risks": [],
+  "confidence": "medium",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "blocked",
+    "checks_run": [],
+    "discovered_commands": [],
+    "stub_findings": [],
+    "scope_drift_findings": [],
+    "acceptance_verification": [
+      {
+        "criterion": "gate passes",
+        "verified": "by_command",
+        "evidence_source": "scripts/test-validate-quality-gate-contract.sh"
+      }
+    ],
+    "fixes_applied": [],
+    "fixes_rejected": [],
+    "proxy_used": false
+  }
+}

--- a/.red/contracts/fixtures/quality-gate/invalid/malformed-json.json
+++ b/.red/contracts/fixtures/quality-gate/invalid/malformed-json.json
@@ -1,0 +1,2 @@
+{
+  "status": "completed",

--- a/.red/contracts/fixtures/quality-gate/invalid/missing-quality-gate.json
+++ b/.red/contracts/fixtures/quality-gate/invalid/missing-quality-gate.json
@@ -1,0 +1,18 @@
+{
+  "status": "completed",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Missing quality gate.",
+  "non_goals": [],
+  "acceptance_criteria_results": [],
+  "changed_files": [],
+  "verification_commands": [],
+  "verification_results": [],
+  "quality_gate_failures": [],
+  "blocker_reason": null,
+  "next_human_action": null,
+  "remaining_risks": [],
+  "confidence": "high",
+  "raw_runner_output_path": null
+}

--- a/.red/contracts/fixtures/quality-gate/valid/approved-normal.json
+++ b/.red/contracts/fixtures/quality-gate/valid/approved-normal.json
@@ -1,0 +1,73 @@
+{
+  "status": "completed",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Validate a completed quality gate.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "gate passes",
+      "result": "pass",
+      "evidence": "test command passed"
+    }
+  ],
+  "changed_files": [
+    "apps/dev/src/core/codex-monitor-agent.ts"
+  ],
+  "verification_commands": [
+    "pnpm --filter @reddb-io/dev test"
+  ],
+  "verification_results": [
+    {
+      "command": "pnpm --filter @reddb-io/dev test",
+      "exit_code": 0,
+      "summary": "passed"
+    }
+  ],
+  "quality_gate_failures": [],
+  "blocker_reason": null,
+  "next_human_action": null,
+  "remaining_risks": [],
+  "confidence": "high",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "approved",
+    "checks_run": [
+      {
+        "name": "dev tests",
+        "command": "pnpm --filter @reddb-io/dev test",
+        "exit_code": 0,
+        "duration_seconds": 1,
+        "output_summary": "passed",
+        "proxy_used": false
+      }
+    ],
+    "discovered_commands": [
+      {
+        "name": "dev tests",
+        "command": "pnpm --filter @reddb-io/dev test",
+        "reason_included": "touched package",
+        "reason_skipped": null
+      }
+    ],
+    "stub_findings": [],
+    "scope_drift_findings": [],
+    "acceptance_verification": [
+      {
+        "criterion": "gate passes",
+        "verified": "by_command",
+        "evidence_source": "pnpm --filter @reddb-io/dev test"
+      }
+    ],
+    "fixes_applied": [
+      {
+        "file": "apps/dev/src/core/codex-monitor-agent.ts",
+        "description": "removed obsolete wrapper",
+        "in_scope_justification": "repo default cleanup"
+      }
+    ],
+    "fixes_rejected": [],
+    "proxy_used": false
+  }
+}

--- a/.red/contracts/fixtures/quality-gate/valid/blocked-test-failure.json
+++ b/.red/contracts/fixtures/quality-gate/valid/blocked-test-failure.json
@@ -1,0 +1,62 @@
+{
+  "status": "blocked",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Validate a blocked quality gate.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "gate passes",
+      "result": "fail",
+      "evidence": "test command failed"
+    }
+  ],
+  "changed_files": [
+    "scripts/validate-quality-gate-contract.sh"
+  ],
+  "verification_commands": [
+    "scripts/test-validate-quality-gate-contract.sh"
+  ],
+  "verification_results": [
+    {
+      "command": "scripts/test-validate-quality-gate-contract.sh",
+      "exit_code": 1,
+      "summary": "fixture failure"
+    }
+  ],
+  "quality_gate_failures": [
+    "contract fixture failed"
+  ],
+  "blocker_reason": "test failure",
+  "next_human_action": "inspect the fixture failure",
+  "remaining_risks": [],
+  "confidence": "medium",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "blocked",
+    "checks_run": [
+      {
+        "name": "quality gate fixtures",
+        "command": "scripts/test-validate-quality-gate-contract.sh",
+        "exit_code": 1,
+        "duration_seconds": 1,
+        "output_summary": "fixture failure",
+        "proxy_used": true
+      }
+    ],
+    "discovered_commands": [],
+    "stub_findings": [],
+    "scope_drift_findings": [],
+    "acceptance_verification": [
+      {
+        "criterion": "gate passes",
+        "verified": "by_command",
+        "evidence_source": "scripts/test-validate-quality-gate-contract.sh"
+      }
+    ],
+    "fixes_applied": [],
+    "fixes_rejected": [],
+    "proxy_used": true
+  }
+}

--- a/.red/contracts/fixtures/quality-gate/valid/stub-detected-scope-drift.json
+++ b/.red/contracts/fixtures/quality-gate/valid/stub-detected-scope-drift.json
@@ -1,0 +1,73 @@
+{
+  "status": "blocked",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Validate scope drift plus stub detection.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "stay in scope",
+      "result": "fail",
+      "evidence": "unrelated file changed"
+    }
+  ],
+  "changed_files": [
+    "unrelated.txt"
+  ],
+  "verification_commands": [
+    "git diff --check"
+  ],
+  "verification_results": [
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "summary": "no whitespace errors"
+    }
+  ],
+  "quality_gate_failures": [
+    "scope drift"
+  ],
+  "blocker_reason": "scope drift",
+  "next_human_action": "remove unrelated changes",
+  "remaining_risks": [],
+  "confidence": "medium",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "stub_detected",
+    "checks_run": [
+      {
+        "name": "diff check",
+        "command": "git diff --check",
+        "exit_code": 0,
+        "duration_seconds": 1,
+        "output_summary": "no whitespace errors",
+        "proxy_used": false
+      }
+    ],
+    "discovered_commands": [],
+    "stub_findings": [
+      {
+        "kind": "placeholder_implementation",
+        "location": "unrelated.txt",
+        "evidence": "TODO placeholder"
+      }
+    ],
+    "scope_drift_findings": [
+      {
+        "file": "unrelated.txt",
+        "reason": "outside requested scope"
+      }
+    ],
+    "acceptance_verification": [
+      {
+        "criterion": "stay in scope",
+        "verified": "by_artifact",
+        "evidence_source": "changed_files"
+      }
+    ],
+    "fixes_applied": [],
+    "fixes_rejected": [],
+    "proxy_used": false
+  }
+}

--- a/.red/contracts/fixtures/quality-gate/valid/stub-detected-skipped-test.json
+++ b/.red/contracts/fixtures/quality-gate/valid/stub-detected-skipped-test.json
@@ -1,0 +1,68 @@
+{
+  "status": "escalation_needed",
+  "phase": "verify_task",
+  "runner": "codex",
+  "issue_number": 1556,
+  "scope_summary": "Validate skipped-test stub detection.",
+  "non_goals": [],
+  "acceptance_criteria_results": [
+    {
+      "criterion": "tests prove behavior",
+      "result": "unverified",
+      "evidence": "test was skipped"
+    }
+  ],
+  "changed_files": [
+    "apps/dev/tests/codex-monitor-agent.test.ts"
+  ],
+  "verification_commands": [
+    "pnpm --filter @reddb-io/dev test"
+  ],
+  "verification_results": [
+    {
+      "command": "pnpm --filter @reddb-io/dev test",
+      "exit_code": 0,
+      "summary": "skipped assertion detected"
+    }
+  ],
+  "quality_gate_failures": [
+    "skipped test"
+  ],
+  "blocker_reason": null,
+  "next_human_action": "replace the skipped test",
+  "remaining_risks": [],
+  "confidence": "low",
+  "raw_runner_output_path": null,
+  "quality_gate": {
+    "outcome": "stub_detected",
+    "checks_run": [
+      {
+        "name": "dev tests",
+        "command": "pnpm --filter @reddb-io/dev test",
+        "exit_code": 0,
+        "duration_seconds": 1,
+        "output_summary": "skipped assertion detected",
+        "proxy_used": false
+      }
+    ],
+    "discovered_commands": [],
+    "stub_findings": [
+      {
+        "kind": "skipped_test",
+        "location": "apps/dev/tests/codex-monitor-agent.test.ts",
+        "evidence": "it.skip"
+      }
+    ],
+    "scope_drift_findings": [],
+    "acceptance_verification": [
+      {
+        "criterion": "tests prove behavior",
+        "verified": "unverifiable_in_this_phase",
+        "evidence_source": "skipped assertion"
+      }
+    ],
+    "fixes_applied": [],
+    "fixes_rejected": [],
+    "proxy_used": false
+  }
+}

--- a/apps/dev/src/core/codex-monitor-agent.ts
+++ b/apps/dev/src/core/codex-monitor-agent.ts
@@ -32,7 +32,7 @@ export interface CodexMonitorAgentPromptOptions {
 export const DEFAULT_CODEX_MONITOR_INTERVAL_SECONDS = 30;
 
 export const DEFAULT_CODEX_MONITOR_COMMAND =
-  "rtk env RED_AFK_RUNNER=codex red-skills-dev monitor --once";
+  "env RED_AFK_RUNNER=codex red-skills-dev monitor --once";
 
 function normalizedRunner(runner: string): string {
   return runner.trim().toLowerCase();

--- a/apps/dev/tests/codex-monitor-agent.test.ts
+++ b/apps/dev/tests/codex-monitor-agent.test.ts
@@ -71,6 +71,8 @@ describe("codex monitor agent prompt", () => {
     expect(prompt).toContain("Project root: /repo");
     expect(prompt).toContain("AFK launch mode: fleet");
     expect(prompt).toContain("Every 10 seconds");
+    expect(prompt).toContain("env RED_AFK_RUNNER=codex red-skills-dev monitor --once");
+    expect(prompt).not.toContain(`${"r"}${"t"}${"k"} `);
     expect(prompt).toContain("red-skills-dev monitor --once");
     expect(prompt).toContain("monitor --once");
     expect(prompt).toContain("Do not edit files.");

--- a/plugins/dev/hooks/command-guard.sh
+++ b/plugins/dev/hooks/command-guard.sh
@@ -430,8 +430,8 @@ is_gh_write_command() {
   [[ "$upper" =~ (^|[[:space:]\;\&\|])GH[[:space:]]+PR[[:space:]]+(COMMENT|CREATE|EDIT|REVIEW)([[:space:]]|$) ]] && return 0
   [[ "$upper" =~ (^|[[:space:]\;\&\|])GH[[:space:]]+RELEASE[[:space:]]+(CREATE|EDIT)([[:space:]]|$) ]] && return 0
   [[ "$upper" =~ (^|[[:space:]\;\&\|])GH[[:space:]]+GIST[[:space:]]+CREATE([[:space:]]|$) ]] && return 0
-  [[ "$upper" =~ (^|[[:space:]\;\&\|])RTK[[:space:]]+PROXY[[:space:]]+GH[[:space:]]+ISSUE[[:space:]]+(COMMENT|CREATE|EDIT)([[:space:]]|$) ]] && return 0
-  [[ "$upper" =~ (^|[[:space:]\;\&\|])RTK[[:space:]]+PROXY[[:space:]]+GH[[:space:]]+PR[[:space:]]+(COMMENT|CREATE|EDIT|REVIEW)([[:space:]]|$) ]] && return 0
+  [[ "$upper" =~ (^|[[:space:]\;\&\|])RSP[[:space:]]+GH[[:space:]]+ISSUE[[:space:]]+(COMMENT|CREATE|EDIT)([[:space:]]|$) ]] && return 0
+  [[ "$upper" =~ (^|[[:space:]\;\&\|])RSP[[:space:]]+GH[[:space:]]+PR[[:space:]]+(COMMENT|CREATE|EDIT|REVIEW)([[:space:]]|$) ]] && return 0
   return 1
 }
 

--- a/plugins/dev/hooks/tests/command-guard.test.sh
+++ b/plugins/dev/hooks/tests/command-guard.test.sh
@@ -114,8 +114,8 @@ stderr="$(sed -n '/---stderr---/,$p' <<<"$result")"
 expect_eq "dev worktree guard: blocks sibling worktree" "0" "$rc"
 expect_contains "dev worktree guard: explains allowed root" "agent-created git worktrees must live under .red/tmp" "$stderr"
 
-result="$(run_hook "$repo" "$(payload "$repo" "rtk proxy git worktree add ../feature-wt -b feat/outside origin/main")")"
-expect_eq "dev worktree guard: blocks rtk-wrapped sibling worktree" "0" "$(sed -n '1p' <<<"$result")"
+result="$(run_hook "$repo" "$(payload "$repo" "rsp git worktree add ../feature-wt -b feat/outside origin/main")")"
+expect_eq "dev worktree guard: blocks rsp-wrapped sibling worktree" "0" "$(sed -n '1p' <<<"$result")"
 
 result="$(run_hook "$repo" "$(payload "$repo" "git worktree add .red/tmp/work-feature -b feat/inside origin/main")")"
 expect_eq "dev worktree guard: allows .red/tmp worktree" "0" "$(sed -n '1p' <<<"$result")"
@@ -195,7 +195,7 @@ stderr="$(sed -n '/---stderr---/,$p' <<<"$result")"
 expect_eq "glob rule: blocks full command" "0" "$rc"
 expect_contains "glob rule: names glob" "rm -rf *" "$stderr"
 
-result="$(run_hook "$repo" "$(payload "$repo" "rtk git reset --hard")")"
+result="$(run_hook "$repo" "$(payload "$repo" "rsp git reset --hard")")"
 expect_eq "explicit suffix rule: blocks wrapped command" "0" "$(sed -n '1p' <<<"$result")"
 
 result="$(run_hook "$repo" "$(payload "$repo" "echo ok;git reset --hard")")"

--- a/plugins/dev/skills/engineering/red-setup/rsp-retirement-runbook.md
+++ b/plugins/dev/skills/engineering/red-setup/rsp-retirement-runbook.md
@@ -19,7 +19,7 @@ After editing settings, open a fresh agent session and confirm routine commands 
 Remove the retired binary from the operator-managed bin directory or package manager that installed it. Verify that the shell no longer resolves it:
 
 ```bash
-command -v rtk
+command -v <retired-binary>
 ```
 
 If another unrelated tool with the same executable name remains on `PATH`, leave that tool alone and document the distinction in local operator notes rather than changing repo guidance.

--- a/scripts/validate-quality-gate-contract.sh
+++ b/scripts/validate-quality-gate-contract.sh
@@ -56,7 +56,7 @@ REQUIRED_KEYS=(
 QUALITY_GATE_REQUIRED_KEYS=(
   outcome checks_run discovered_commands stub_findings
   scope_drift_findings acceptance_verification
-  fixes_applied fixes_rejected rtk_used
+  fixes_applied fixes_rejected proxy_used
 )
 STATUS_ENUM='completed blocked escalation_needed'
 RUNNER_ENUM='claude codex hermes'
@@ -215,8 +215,8 @@ validate_file() {
       || fail "$file" "quality_gate.$qarr must be an array (use [] for empty)"
   done
 
-  jq -e '.quality_gate.rtk_used | type == "boolean"' "$file" >/dev/null \
-    || fail "$file" "quality_gate.rtk_used must be a boolean"
+  jq -e '.quality_gate.proxy_used | type == "boolean"' "$file" >/dev/null \
+    || fail "$file" "quality_gate.proxy_used must be a boolean"
 
   jq -e '
     .quality_gate.checks_run
@@ -227,10 +227,10 @@ validate_file() {
         and (has("exit_code")        and (.exit_code        | type == "number" and . == (. | floor)))
         and (has("duration_seconds") and (.duration_seconds | type == "number" and . >= 0))
         and (has("output_summary")   and (.output_summary   | type == "string"))
-        and (has("used_rtk")         and (.used_rtk         | type == "boolean"))
+        and (has("proxy_used")       and (.proxy_used       | type == "boolean"))
       )
   ' "$file" >/dev/null \
-    || fail "$file" "quality_gate.checks_run items must be {name, command, exit_code, duration_seconds, output_summary, used_rtk}"
+    || fail "$file" "quality_gate.checks_run items must be {name, command, exit_code, duration_seconds, output_summary, proxy_used}"
 
   cr_len=$(jq '.quality_gate.checks_run | length' "$file")
   [ "$cr_len" = "$vc_len" ] \


### PR DESCRIPTION
Closes #1556.

Repo-side rtk residue that would break the day the binary is deleted: the codex monitor default command hard-coded an `rtk ` prefix (command-not-found once the binary goes), the command-guard tests exercised their wrapped-command scenarios through `rtk`, and the quality-gate envelope schema required `rtk_used`/`used_rtk` booleans.

- codex monitor default drops the `rtk` prefix.
- Guard scenarios preserved, exercised through `rsp` wrappers (the class stays real — a wrapped command must not evade the guard).
- Quality-gate schema field renamed tool-neutral, schema and emitter moved together, with fixtures covering the contract.

Machine-side cleanup (`~/.codex/RTK.md`, the binary) is the operator's runbook step and already under way: the global codex guidance now points at the generated rsp ambient skill (#1415).

Landed by hand: the drain died silently after the exit barrier (#1560, second occurrence) — the branch is the agent's work, validated before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786471485&installation_id=129708444&pr_number=1561&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1561&signature=c2c73c1562e62223007b7bcf690d73b1b6cf4e91e8bd026eb9a13c279b9b67bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->