### PR TITLE
merge: #1555 memory becomes a client of the resident rsp: shared store without a second embedded writer

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -312,6 +312,7 @@ export class RspElisionStore {
     const withoutExisting = index.records.filter((entry) => entry.handle !== handle);
     withoutExisting.push({ handle, key, bytes: bytes.length, command: meta.command, created_at: createdAt, expires_at: expiresAt });
     await this.pruneRedDb({ version: 1, records: withoutExisting });
+    await this.assertRedDbMintPersisted(handle, bytes.length);
     return handle;
   }
 
@@ -407,6 +408,18 @@ export class RspElisionStore {
       expired_at: expiredAt,
       command: entry.command,
     });
+  }
+
+  private async assertRedDbMintPersisted(handle: `el:${string}`, bytes: number): Promise<void> {
+    const raw = await this.kv().get(recordKey(handle));
+    if (!isStoredRecord(raw)) {
+      throw new Error(`rsp resident failed to persist elision record ${handle}`);
+    }
+    const index = await this.readRedDbIndex();
+    const entry = index.records.find((candidate) => candidate.handle === handle);
+    if (!entry || entry.bytes !== bytes) {
+      throw new Error(`rsp resident failed to persist elision index ${handle}`);
+    }
   }
 }
 

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -384,6 +384,10 @@ describe("rsp cli", () => {
     const handle = /rsp show (el:[a-f0-9]{12})/.exec(text)?.[1];
     expect(handle).toBeTruthy();
 
+    const stats = runBundleFromCwd(root, [], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(stats.status).toBe(0);
+    expect(stats.stdout.toString("utf8")).toContain("records: 1\n");
+
     const shown = runBundleFromCwd(root, ["show", handle!], { RED_SKILLS_CACHE_DIR: cacheDir });
 
     expect(shown.status).toBe(0);


### PR DESCRIPTION
Automated AFK landing for #1555. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1555

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786471961&installation_id=129708444&pr_number=1562&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1562&signature=c76af69b5a2145217e455df88309b8da4ccea79074c295f822a2e3fce6af6a04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->