### PR TITLE
fix: #1558 the resident socket path exceeds the unix limit in deep repos, so the resident can never start there

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
 import type { RspElisionStore } from "./elision-store.js";
 
 interface ParsedArgs {
@@ -41,7 +40,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     process.stdout.write(`${rspDisabledReason()}\n`);
     return 0;
   }
-  if (args.command === "git" && isFastGitStatus(args.positional) && residentSocketExists(process.cwd())) {
+  if (args.command === "git" && isFastGitStatus(args.positional) && await residentSocketExists(process.cwd())) {
     return await runFastGitStatus();
   }
   const { resolveResidentPaths, ResidentRspElisionStore, ensureResidentServer } = await import("./resident-client.js");
@@ -206,12 +205,9 @@ function isFastGitStatus(argv: readonly string[]): boolean {
   return argv.length === 2 && argv[0] === "git" && argv[1] === "status";
 }
 
-function residentSocketExists(cwd: string): boolean {
-  const direct = join(cwd, ".red", "tmp", "rsp.sock");
-  if (existsSync(direct)) return true;
-  const root = findRepoRoot(cwd) ?? resolve(cwd);
-  if (root === cwd) return false;
-  return existsSync(join(root, ".red", "tmp", "rsp.sock"));
+async function residentSocketExists(cwd: string): Promise<boolean> {
+  const { resolveResidentPaths } = await import("./resident-client.js");
+  return existsSync(resolveResidentPaths(cwd).socketPath);
 }
 
 async function runFastGitStatus(): Promise<number> {
@@ -243,26 +239,6 @@ function isEmptyUnbornGitRepo(cwd: string): boolean {
     return readdirSync(cwd).every((entry) => entry === ".git");
   } catch {
     return false;
-  }
-}
-
-function findRepoRoot(start: string): string | null {
-  let dir = resolve(start);
-  for (let i = 0; i < 32; i++) {
-    if (readFileSyncSafe(join(dir, ".red", "config.yaml")) != null) return dir;
-    if (readFileSyncSafe(join(dir, ".git", "HEAD")) != null) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-  return null;
-}
-
-function readFileSyncSafe(path: string): string | null {
-  try {
-    return readFileSync(path, "utf8");
-  } catch {
-    return null;
   }
 }
 

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -1,8 +1,9 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
 import { constants } from "node:fs";
 import { readFileSync } from "node:fs";
 import { mkdir, open, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
@@ -20,12 +21,15 @@ export interface RspResidentPaths {
   lockPath: string;
 }
 
+const UNIX_SOCKET_PATH_LIMIT = 108;
+
 export function resolveResidentPaths(cwd: string): RspResidentPaths {
   const rootDir = findRepoRoot(cwd) ?? resolve(cwd);
+  const socketDir = resolveRuntimeSocketDir(rootDir);
   return {
     rootDir,
-    socketPath: join(rootDir, ".red", "tmp", "rsp.sock"),
-    lockPath: join(rootDir, ".red", "tmp", "rsp.lock"),
+    socketPath: join(socketDir, "rsp.sock"),
+    lockPath: join(socketDir, "rsp.lock"),
   };
 }
 
@@ -82,7 +86,7 @@ type ResidentRequestWithoutId = RspResidentRequest extends infer Request
   : never;
 
 export async function ensureResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
-  await mkdir(dirname(paths.socketPath), { recursive: true });
+  await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
   if (await ping(paths.socketPath)) return;
 
   const lock = await tryAcquireLock(paths.lockPath);
@@ -124,7 +128,7 @@ async function waitForServer(socketPath: string, child?: ChildProcess): Promise<
 }
 
 async function tryAcquireLock(lockPath: string) {
-  await mkdir(dirname(lockPath), { recursive: true });
+  await mkdir(dirname(lockPath), { recursive: true, mode: 0o700 });
   try {
     return await open(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR);
   } catch (err) {
@@ -155,6 +159,17 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
   });
   child.unref();
   return child;
+}
+
+function resolveRuntimeSocketDir(rootDir: string): string {
+  const hash = createHash("sha256").update(rootDir).digest("hex").slice(0, 20);
+  const xdg = process.env.XDG_RUNTIME_DIR;
+  if (xdg) {
+    const candidate = join(xdg, "red-skills", hash);
+    if (join(candidate, "rsp.sock").length < UNIX_SOCKET_PATH_LIMIT) return candidate;
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : "nouid";
+  return join(tmpdir(), `red-skills-${uid}`, hash);
 }
 
 function findRepoRoot(start: string): string | null {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1,13 +1,15 @@
 import { copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
 import { afterEach, describe, expect, it } from "vitest";
 import { RspElisionStore } from "../src/elision-store.js";
+import { resolveResidentPaths } from "../src/resident-client.js";
 
 const roots: string[] = [];
+const residentDirs: string[] = [];
 const cli = join(import.meta.dirname, "..", "src", "cli.ts");
 const packageRoot = join(import.meta.dirname, "..");
 const repoRoot = join(packageRoot, "..", "..");
@@ -24,7 +26,14 @@ async function tempRoot(): Promise<string> {
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  await Promise.all(residentDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });
+
+function trackedResidentPaths(root: string) {
+  const paths = resolveResidentPaths(root);
+  residentDirs.push(dirname(paths.socketPath));
+  return paths;
+}
 
 function runRsp(root: string, args: string[], env: Record<string, string>) {
   return spawnSync(process.execPath, ["--import", tsxLoader, cli, ...args], {
@@ -278,11 +287,49 @@ describe("rsp cli", () => {
       RSP_FAIL_IF_STORE_OPEN: "1",
     });
     const direct = runGit(["-C", root, "status", "--porcelain=v1"]);
+    const paths = trackedResidentPaths(root);
 
     expect(res.status).toBe(0);
     expect(res.stdout).toEqual(direct.stdout);
     expect(res.stderr).toEqual(Buffer.alloc(0));
-    await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+  }, 120_000);
+
+  it("built bundle starts the resident for a repo root longer than the Unix socket path limit", async () => {
+    buildBundleOnce();
+    const base = await tempRoot();
+    let root = base;
+    let segment = 0;
+    while (root.length <= 120) {
+      root = join(root, `deep-segment-${segment++}`);
+    }
+    await mkdir(root, { recursive: true });
+    const init = runGit(["-C", root, "init"]);
+    expect(init.status).toBe(0);
+    expect(runGit(["-C", root, "config", "user.email", "rsp-test@example.invalid"]).status).toBe(0);
+    expect(runGit(["-C", root, "config", "user.name", "Rsp Test"]).status).toBe(0);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+
+    const paths = trackedResidentPaths(root);
+    expect(join(root, ".red", "tmp", "rsp.sock").length).toBeGreaterThan(108);
+    expect(paths.socketPath.length).toBeLessThan(108);
+    expect(paths.socketPath).not.toBe(join(root, ".red", "tmp", "rsp.sock"));
+
+    const res = runBundleFromCwd(root, ["git", "status"], {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_FAIL_IF_STORE_OPEN: "1",
+    });
+    const direct = runGit(["-C", root, "status", "--porcelain=v1"]);
+
+    expect(res.status, `${res.stdout.toString("utf8")}${res.stderr.toString("utf8")}`).toBe(0);
+    expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+    await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+    expect(((await stat(dirname(paths.socketPath))).mode & 0o777)).toBe(0o700);
+    await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
   }, 120_000);
 
   it("built bundle keeps small git status wrapper work under 100ms", async () => {
@@ -339,7 +386,7 @@ describe("rsp cli", () => {
     expect(res.status, `${res.stdout.toString("utf8")}${res.stderr.toString("utf8")}`).toBe(0);
     expect(res.stdout).toEqual(Buffer.alloc(0));
     expect(res.stderr).toEqual(Buffer.alloc(0));
-    await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(trackedResidentPaths(root).socketPath)).rejects.toMatchObject({ code: "ENOENT" });
   }, 120_000);
 
   it("built bundle handles concurrent cold wrappers with one resident socket and usable store", async () => {
@@ -358,8 +405,9 @@ describe("rsp cli", () => {
       expect(res.stdout.toString("utf8")).toBe("git empty\n");
       expect(res.stderr).toEqual(Buffer.alloc(0));
     }
-    await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).resolves.toMatchObject({ size: expect.any(Number) });
-    await expect(stat(join(root, ".red", "tmp", "rsp.lock"))).rejects.toMatchObject({ code: "ENOENT" });
+    const paths = trackedResidentPaths(root);
+    await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(paths.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], env);
     expect(compressed.status).toBe(0);
     expect(compressed.stderr).toEqual(Buffer.alloc(0));


### PR DESCRIPTION
Automated AFK landing for #1558. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1558

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786472502&installation_id=129708444&pr_number=1563&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1563&signature=e75b09249f14811e9bd4a9c28ebc22d8fdfd1465df58de4d9be9885d25d795de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->