### PR TITLE
merge: #1560 the drain dies silently after the exit barrier, stranding completed work in running

### DIFF
--- a/apps/dev/src/core/boot-sweep.ts
+++ b/apps/dev/src/core/boot-sweep.ts
@@ -453,8 +453,7 @@ export function findOwnedBranch(branches: readonly string[], issue: number): str
 const PARKED_MECHANICAL_LABELS = new Set([LABEL_STALLED, LABEL_CRASHED, LABEL_MERGE_CONFLICT]);
 
 /**
- * True when the label set carries a parked-mechanical routing label
- * (`blocked:stalled` or `blocked:crashed`). Pure.
+ * True when the label set carries a parked-mechanical routing label. Pure.
  */
 export function isParkedMechanical(labels: readonly string[]): boolean {
   return labels.some((l) => PARKED_MECHANICAL_LABELS.has(l));
@@ -493,10 +492,13 @@ export interface ReconcileSweepPlan {
 export function planReconcileSweep(
   candidates: readonly ReconcileSweepCandidate[],
   remoteBranches: readonly string[],
+  staleReleasedRunningIssues: readonly number[] = [],
 ): ReconcileSweepPlan[] {
   const plans: ReconcileSweepPlan[] = [];
+  const releasedRunning = new Set(staleReleasedRunningIssues);
   for (const c of candidates) {
-    if (!isParkedMechanical(c.labels)) continue;
+    const staleReleasedRunning = c.labels.includes(LABEL_RUNNING) && releasedRunning.has(c.number);
+    if (!isParkedMechanical(c.labels) && !staleReleasedRunning) continue;
     const branch = findOwnedBranch(remoteBranches, c.number);
     if (!branch) continue;
     plans.push({ number: c.number, title: c.title, body: c.body, labels: c.labels, branch });

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -468,7 +468,7 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   const staleClaimSweep = await runStaleClaimSweep(deps);
 
   // ---- 7. reconcile sweep (ADR 0055) ----
-  const reconcileSweep = await runReconcileSweep(deps, options);
+  const reconcileSweep = await runReconcileSweep(deps, options, staleClaimSweep.released);
 
   // ---- 8. straggler check ----
   const straggler = await runStragglerCheck(deps);
@@ -739,7 +739,11 @@ async function runMixedBlockedNormalize(
  * agent. A no-op when no `reconcileRunner` is wired in or no candidates are
  * provided. Sequenced AFTER the unblock sweep so any dependency-promotion from
  * step 6 is already in place before we attempt to land dependents. */
-async function runReconcileSweep(deps: BootDeps, options: BootOptions): Promise<ReconcileSweepResult> {
+async function runReconcileSweep(
+  deps: BootDeps,
+  options: BootOptions,
+  staleReleasedRunningIssues: readonly number[] = [],
+): Promise<ReconcileSweepResult> {
   const result: ReconcileSweepResult = { landed: [], parked: [], skipped: [] };
   if (!deps.reconcileRunner) return result;
   const candidates = options.reconcileSweepCandidates ?? [];
@@ -748,7 +752,7 @@ async function runReconcileSweep(deps: BootDeps, options: BootOptions): Promise<
   // The remote live refs already list every `afk/{worker}/{N}-{slug}` branch
   // on origin — reuse them rather than fetching again. Extract the branch names.
   const remoteBranches = options.branches.remoteLiveRefs.map((r) => r.branch);
-  const plans = planReconcileSweep(candidates, remoteBranches);
+  const plans = planReconcileSweep(candidates, remoteBranches, staleReleasedRunningIssues);
 
   for (const plan of plans) {
     try {

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -75,6 +75,7 @@ import type { LandLock } from "./land-lock.js";
 import { doLanding } from "./landing.js";
 import { reconcile, type ReconcileInput } from "./reconcile.js";
 import { ExitBarrierError, type ExitReceipt, type TerminalReceipt } from "./exit-barrier.js";
+import { markProcessSafetyStep } from "./process-safety.js";
 import {
   emitEnvelope,
   type EmitEnvelopeDeps,
@@ -1915,8 +1916,11 @@ export async function processIssue(
     // (no-sentinel / budget-exceeded), whose barrier wiring is the follow-up slice.
     if (deps.exitBarrier && run.outcome === "done") {
       try {
+        markProcessSafetyStep("exit-barrier:start");
         exitReceipt = await deps.exitBarrier(workerBranch);
+        markProcessSafetyStep("exit-barrier:pushed");
       } catch (err) {
+        markProcessSafetyStep("exit-barrier:failed");
         if (err instanceof ExitBarrierError) {
           // The barrier could not push the attempt branch to origin after its
           // retry — "work is saved iff its branch ref is pushed" is NOT satisfied,
@@ -2189,6 +2193,7 @@ export async function processIssue(
     // first); if it is still absent, do NOT proceed to feedback/merge — route to the
     // merge-conflict / ready-for-human terminal path with a clear reason.
     if (deps.lookups.branchPresent && !(await deps.lookups.branchPresent(workerBranch))) {
+      markProcessSafetyStep("post-barrier:branch-present-failed");
       deps.appendIterLog(
         `🤖 /afk: worker branch \`${workerBranch}\` absent on host — sandcastle commits did not reach the host; escalating.`,
       );
@@ -2205,6 +2210,7 @@ export async function processIssue(
     // hooks). Absent executor or empty command list → no-op.
     const postAttemptFormatCommands = deps.postAttemptFormatCommands ?? [];
     if (deps.postAttemptFormat && postAttemptFormatCommands.length > 0) {
+      markProcessSafetyStep("post-barrier:post-attempt-format");
       const pfmt = await runPostAttemptFormat(deps.postAttemptFormat, {
         worktree: workerBranch,
         commands: postAttemptFormatCommands,
@@ -2226,6 +2232,7 @@ export async function processIssue(
     // happy path costs nothing.
     // Macro phase → `validating` (issue #811): the feedback gate is starting.
     deps.markPhase?.("validating");
+    markProcessSafetyStep("post-barrier:feedback-start");
     const changedFiles = await deps.lookups.changedFiles(workerBranch, baseRef);
     if (changedFiles.length === 0) {
       const validationText =
@@ -2274,6 +2281,7 @@ export async function processIssue(
       baselineWorktree: base,
       validationScope,
     });
+    markProcessSafetyStep("post-barrier:feedback-done");
     // on_baseline_probe (#832): the "already failing on main?" probe (ADR 0071)
     // runs ONLY when the gate failed AND a baseline worktree was supplied. Report
     // whether it downgraded any pre-existing-on-baseline failures.
@@ -2376,12 +2384,14 @@ export async function processIssue(
     const backpressureCommands = deps.backpressureCommands ?? [];
     let backpressureSidecar: string[] = [];
     if (deps.backpressure && backpressureCommands.length > 0) {
+      markProcessSafetyStep("post-barrier:backpressure-start");
       const backpressure = await runBackpressure(deps.backpressure, {
         worktree: workerBranch,
         commands: backpressureCommands,
         now: deps.nowEpoch,
       });
       backpressureSidecar = backpressure.sidecar;
+      markProcessSafetyStep("post-barrier:backpressure-done");
       // Capture the checks so the landing/handoff paths can render the
       // non-blocking evidence ledger (#1279) once the PR number is known. This is
       // observability only — the merge/park decision below stays owned by
@@ -2412,6 +2422,7 @@ export async function processIssue(
   }
 
   // ---- 6. push the worker branch, integrate, then land per the flag ----
+  markProcessSafetyStep("post-barrier:landing-start");
   // The entire flag-toggled landing (push → pre_merge → integrate → land →
   // direct conflict self-resolve → post_merge) is owned by doLanding (landing.ts,
   // ADR 0030 amended by #842 / 0031). A non-ok result maps to the merge-conflict

--- a/apps/dev/src/core/process-safety.ts
+++ b/apps/dev/src/core/process-safety.ts
@@ -130,6 +130,8 @@ export type DeathClass =
  * `null` when no handlers are installed (the default state). */
 let activeSafety: ProcessSafety | null = null;
 let activeClaimFinalizer: ActiveClaimFinalizer | null = null;
+let activeStepWriter: ((step: string) => void) | null = null;
+let activeLastStep = "startup";
 
 /** Return the active safety installation (or null). Useful for tests and for
  * code that wants to coordinate with the handlers (e.g. a graceful-shutdown
@@ -140,6 +142,14 @@ export function getActiveSafety(): ProcessSafety | null {
 
 export function setActiveClaimFinalizer(finalizer: ActiveClaimFinalizer | null): void {
   activeClaimFinalizer = finalizer;
+}
+
+/** Record the worker's current macro step in the process-safety diagnostic log.
+ * The value is intentionally short and local to AFK internals; public comments
+ * consume only the classified cause, not these raw breadcrumbs. */
+export function markProcessSafetyStep(step: string): void {
+  activeLastStep = step;
+  activeStepWriter?.(step);
 }
 
 function runActiveClaimFinalizer(): void {
@@ -181,28 +191,30 @@ export function installProcessSafety(
   const write = (event: string, detail: string): void => {
     logger.log(`pid=${pid} worker=${wid} event=${event} ${detail}`);
   };
+  activeLastStep = "startup";
+  activeStepWriter = (step) => write("step", `name=${JSON.stringify(step)}`);
 
   const onUncaught = (err: Error): void => {
-    write("uncaughtException", `message=${JSON.stringify(err.message)} stack=${JSON.stringify(err.stack ?? "")}`);
+    write("uncaughtException", `last_step=${JSON.stringify(activeLastStep)} message=${JSON.stringify(err.message)} stack=${JSON.stringify(err.stack ?? "")}`);
     runActiveClaimFinalizer();
   };
   const onUnhandled = (reason: unknown): void => {
     const r = reason instanceof Error
       ? `message=${JSON.stringify(reason.message)} stack=${JSON.stringify(reason.stack ?? "")}`
       : `value=${JSON.stringify(reason)}`;
-    write("unhandledRejection", r);
+    write("unhandledRejection", `last_step=${JSON.stringify(activeLastStep)} ${r}`);
     runActiveClaimFinalizer();
   };
   const onSigTerm = (): void => {
-    write("SIGTERM", "received");
+    write("SIGTERM", `last_step=${JSON.stringify(activeLastStep)} received`);
     runActiveClaimFinalizer();
   };
   const onSigInt = (): void => {
-    write("SIGINT", "received");
+    write("SIGINT", `last_step=${JSON.stringify(activeLastStep)} received`);
     runActiveClaimFinalizer();
   };
   const onSigHup = (): void => {
-    write("SIGHUP", "received");
+    write("SIGHUP", `last_step=${JSON.stringify(activeLastStep)} received`);
     runActiveClaimFinalizer();
   };
   const onExit = (code: number | null): void => {
@@ -210,7 +222,7 @@ export function installProcessSafety(
     // when this fires, so we use the synchronous file write and accept that
     // a hard kill may skip it. The other handlers above are the durable
     // signal; this one is the "we made it to a clean exit code N" notice.
-    write("exit", `code=${code ?? "null"}`);
+    write("exit", `last_step=${JSON.stringify(activeLastStep)} code=${code ?? "null"}`);
   };
   // The heartbeat is the SIGKILL counter-measure: a SIGKILL/OOM death fires no
   // handler, so the only forensic trace is "installed + heartbeats, then
@@ -218,7 +230,7 @@ export function installProcessSafety(
   // climbing toward the OOM wall before the silence.
   const onHeartbeat = (): void => {
     const rssMb = Math.round(process.memoryUsage().rss / (1024 * 1024));
-    write("alive", `rss_mb=${rssMb}`);
+    write("alive", `last_step=${JSON.stringify(activeLastStep)} rss_mb=${rssMb}`);
   };
 
   process.on("uncaughtException", onUncaught);
@@ -228,7 +240,7 @@ export function installProcessSafety(
   process.on("SIGHUP", onSigHup);
   process.on("exit", onExit);
 
-  write("installed", `node=${process.version} platform=${process.platform}`);
+  write("installed", `last_step=${JSON.stringify(activeLastStep)} node=${process.version} platform=${process.platform}`);
 
   let timer: { unref?: () => void } | null = null;
   if (heartbeatMs > 0) {
@@ -248,6 +260,8 @@ export function installProcessSafety(
       if (timer) clearIntervalFn(timer);
       timer = null;
       activeClaimFinalizer = null;
+      activeStepWriter = null;
+      activeLastStep = "startup";
       activeSafety = null;
     },
     handlers: {

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -1046,23 +1046,25 @@ export async function issueClosed(ctx: GhContext, n: number): Promise<boolean> {
   return (await blockerState(ctx, n)) === "CLOSED";
 }
 
-/** List open issues labelled `blocked:stalled`, `blocked:crashed`, OR
- * `blocked:merge-conflict` — the parked-mechanical candidates the boot reconcile
+/** List open issues labelled `blocked:stalled`, `blocked:crashed`,
+ * `blocked:merge-conflict`, OR `running` — the mechanical candidates the boot reconcile
  * sweep processes (merge-conflict added in #1095: a land-time trunk conflict is
- * mechanical, not a human decision). The `gh issue list` calls run concurrently
+ * mechanical, not a human decision; running is filtered by the stale-claim sweep
+ * result before reconcile can run). The `gh issue list` calls run concurrently
  * and are de-duplicated by issue number. A failed probe for any label returns []
  * for that label; the surviving set is still processed. */
 export async function listParkedMechanicalCandidates(
   ctx: GhContext,
 ): Promise<ReconcileSweepCandidate[]> {
-  const [stalled, crashed, mergeConflict] = await Promise.all([
+  const [stalled, crashed, mergeConflict, running] = await Promise.all([
     listIssuesByLabel(ctx, LABEL_STALLED),
     listIssuesByLabel(ctx, LABEL_CRASHED),
     listIssuesByLabel(ctx, LABEL_MERGE_CONFLICT),
+    listIssuesByLabel(ctx, LABEL_RUNNING),
   ]);
   const seen = new Set<number>();
   const result: ReconcileSweepCandidate[] = [];
-  for (const c of [...stalled, ...crashed, ...mergeConflict]) {
+  for (const c of [...stalled, ...crashed, ...mergeConflict, ...running]) {
     if (seen.has(c.number)) continue;
     seen.add(c.number);
     result.push(c);

--- a/apps/dev/tests/boot-sweep.test.ts
+++ b/apps/dev/tests/boot-sweep.test.ts
@@ -539,6 +539,16 @@ describe("planReconcileSweep", () => {
     expect(planReconcileSweep(candidates, branches)).toEqual([]);
   });
 
+  it("plans a running issue only after the stale-claim sweep released it", () => {
+    const candidates: ReconcileSweepCandidate[] = [
+      { number: 101, title: "Add feature", body: "", labels: ["running"] },
+    ];
+    expect(planReconcileSweep(candidates, branches)).toEqual([]);
+    expect(planReconcileSweep(candidates, branches, [101])).toEqual([
+      { number: 101, title: "Add feature", body: "", labels: ["running"], branch: "afk/wA1B5/101-add-feature" },
+    ]);
+  });
+
   it("plans blocked:crashed candidates", () => {
     const candidates: ReconcileSweepCandidate[] = [
       { number: 202, title: "Fix bug", body: "", labels: ["blocked:crashed"] },

--- a/apps/dev/tests/process-safety.test.ts
+++ b/apps/dev/tests/process-safety.test.ts
@@ -7,6 +7,7 @@ import {
   fileSafetyLogger,
   getActiveSafety,
   installProcessSafety,
+  markProcessSafetyStep,
   noopSafetyLogger,
   safetyLogPath,
   setActiveClaimFinalizer,
@@ -162,6 +163,13 @@ describe("installProcessSafety — event log lines (via direct handler call)", (
     const line = log.find((l) => l.includes("event=exit"));
     expect(line).toBeDefined();
     expect(line).toMatch(/code=0/);
+  });
+
+  it("records the last AFK step on catchable death receipts", () => {
+    markProcessSafetyStep("post-barrier:feedback-start");
+    handlers.sigHup();
+    const line = log.find((l) => l.includes("event=SIGHUP"));
+    expect(line).toContain('last_step="post-barrier:feedback-start"');
   });
 
   it("exit handler records null exit code (process killed by signal)", () => {


### PR DESCRIPTION
Automated AFK landing for #1560. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1560

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786472967&installation_id=129708444&pr_number=1564&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1564&signature=04c8a0d7563a8d34640bd11ca4372ca86518ba44eeb173efb3b300050e6f4cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->