### PR TITLE
fix: #1559 the issue lifecycle has no requeue edge from landing:manual, stranding re-runnable work

### DIFF
--- a/apps/dev/src/core/issue-lifecycle.ts
+++ b/apps/dev/src/core/issue-lifecycle.ts
@@ -151,15 +151,15 @@ export function classifyIssueLifecycleState(labels: readonly string[]): IssueLif
   if (hasReady && hasRunning) return "illegal";
   // `landing:manual` is a MODE flag that must ride a real state: queued
   // (ready-for-agent), active (running, #1049 works the issue before parking it),
-  // or human-parked. Alone it is illegal.
-  if (hasManualLanding && !hasHuman && !hasReady && !hasRunning) return "illegal";
+  // or human-parked/blocked. Alone it is illegal.
+  if (hasManualLanding && !hasHuman && !hasReady && !hasRunning && !hasBlocked) return "illegal";
 
   if (hasContested) return "contested";
-  if (hasManualLanding && hasHuman) return "landing:manual";
   if (hasRunning) return "claimed/active";
   if (hasReady) return "ready-for-agent";
   if (blocked[0] === LABEL_DEPENDENCY) return "blocked:dependency";
   if (blocked[0] === LABEL_VALIDATION || blocked[0] === LABEL_VALIDATION_INFRA) return "blocked:validation";
+  if (hasManualLanding && hasHuman) return "landing:manual";
   if (hasHuman) return "ready-for-human";
   if (hasBlocked) return "ready-for-human";
   return "ready-for-human";
@@ -189,9 +189,10 @@ export function explainIllegalIssueLifecycleLabels(labels: readonly string[]): s
     labels.includes(LABEL_LANDING_MANUAL) &&
     !labels.includes(LABEL_HUMAN) &&
     !labels.includes(LABEL_READY) &&
-    !labels.includes(LABEL_RUNNING)
+    !labels.includes(LABEL_RUNNING) &&
+    blocked.length === 0
   ) {
-    return `${LABEL_LANDING_MANUAL} must ride a queued, active, or human-parked issue`;
+    return `${LABEL_LANDING_MANUAL} must ride a queued, active, human-parked, or blocked issue`;
   }
   return null;
 }

--- a/apps/dev/tests/requeue.test.ts
+++ b/apps/dev/tests/requeue.test.ts
@@ -90,6 +90,23 @@ describe("requeue — supported kinds (validation, spec)", () => {
     expect(plan.addLabels).toEqual(["ready-for-agent"]);
   });
 
+  it("requeues a manual-landing validation park without stripping the landing mode", () => {
+    const plan = planRequeue({
+      body: parkedBody,
+      labels: ["ready-for-human", "landing:manual", "blocked:validation"],
+      guidance: "Validation failure fixed; rerun the agent.",
+    });
+    expect(plan.requeueable).toBe(true);
+    expect(plan.refuseForHitl).toBe(false);
+    expect(plan.activeBlocker?.kind).toBe("validation");
+    expect(plan.bodyChanged).toBe(true);
+    expect(plan.body).not.toContain("<!-- red:blocker-state v1 -->");
+    expect(plan.body).toContain("## Resolved blockers");
+    expect(plan.removeLabels).toEqual(expect.arrayContaining(["ready-for-human", "blocked:validation"]));
+    expect(plan.removeLabels).not.toContain("landing:manual");
+    expect(plan.addLabels).toEqual(["ready-for-agent"]);
+  });
+
   it("accepts blocked:spec with a consistent body blocker", () => {
     const plan = planRequeue({
       body: specBody,


### PR DESCRIPTION
Automated AFK landing for #1559. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1559

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786473497&installation_id=129708444&pr_number=1565&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1565&signature=919ea7f807b9a040a5bfe6bf5261705f7e2fcf8b849c942faf00818a29d7bd4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->