### PR TITLE
fix: #1567 the pre-exec hook rewrites before the resident is healthy, taxing every command during warm-up

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -61,6 +61,24 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     });
     return 0;
   }
+  if (args.command === "warm-resident") {
+    const warmPaths = resolveResidentPaths(process.cwd());
+    const socket = valueAfter(args.positional, "--socket") ?? warmPaths.socketPath;
+    const wakeLock = valueAfter(args.positional, "--wake-lock") ?? warmPaths.wakeLockPath;
+    const warmConfig = resolveRspConfig(process.cwd(), process.env, args.storeUri ?? valueAfter(args.positional, "--store-uri"));
+    if (!warmConfig.enabled) return 0;
+    const { warmResidentServer } = await import("./resident-client.js");
+    await warmResidentServer({
+      ...warmPaths,
+      socketPath: socket,
+      wakeLockPath: wakeLock,
+    }, {
+      storeUri: warmConfig.storeUri,
+      ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? warmConfig.ttlDays,
+      byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? warmConfig.byteBudget,
+    });
+    return 0;
+  }
 
   const { existsSync } = await import("node:fs");
   const { fileURLToPath } = await import("node:url");

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -1,5 +1,12 @@
 import { readFileSync } from "node:fs";
-import { resolveRspConfig } from "./config.js";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
+import {
+  kickResidentServer,
+  pingResident,
+  resolveResidentPaths,
+} from "./resident-client.js";
 
 export interface RspWrapperCapability {
   id: string;
@@ -14,6 +21,8 @@ export type RewriteDecision =
 export interface HookDecisionOptions {
   cwd: string;
   isEnabled?: (cwd: string) => boolean | Promise<boolean>;
+  isResidentHealthy?: (cwd: string) => boolean | Promise<boolean>;
+  wakeResident?: (cwd: string) => void | Promise<void>;
   rewrite?: (command: string) => RewriteDecision;
 }
 
@@ -68,7 +77,14 @@ export async function hookDecisionFromClaudePreExecJson(
 
   const command = extractHookCommand(payload);
   if (!command) return { kind: "passthrough", reason: "missing-command" };
-  return (options.rewrite ?? rewriteCommand)(command);
+  const decision = (options.rewrite ?? rewriteCommand)(command);
+  if (decision.kind !== "rewrite") return decision;
+
+  const healthy = await (options.isResidentHealthy ?? isRspResidentHealthy)(cwd);
+  if (healthy) return decision;
+
+  await (options.wakeResident ?? wakeRspResident)(cwd);
+  return { kind: "passthrough", reason: "resident-unhealthy" };
 }
 
 export function formatHookDecision(decision: RewriteDecision): { stdout: string; status: number } {
@@ -86,6 +102,36 @@ export async function runClaudePreExecHook(stdinPath?: string): Promise<number> 
 
 function isRspHookEnabled(cwd: string): boolean {
   return resolveRspConfig(cwd, process.env).enabled;
+}
+
+async function isRspResidentHealthy(cwd: string): Promise<boolean> {
+  const paths = resolveResidentPaths(cwd);
+  return await pingResident(paths.socketPath, 50);
+}
+
+async function wakeRspResident(cwd: string): Promise<void> {
+  const config = resolveRspConfig(cwd, process.env);
+  if (!config.enabled) return;
+  if (!storeIsProvisioned(config)) return;
+  const paths = resolveResidentPaths(cwd);
+  await kickResidentServer(paths, toResidentConfig(config));
+}
+
+function toResidentConfig(config: RspRuntimeConfig) {
+  return {
+    storeUri: config.storeUri,
+    ttlDays: config.ttlDays,
+    byteBudget: config.byteBudget,
+  };
+}
+
+function storeIsProvisioned(config: RspRuntimeConfig): boolean {
+  if (!config.storeUri.startsWith("file://")) return true;
+  try {
+    return existsSync(fileURLToPath(config.storeUri));
+  } catch {
+    return false;
+  }
 }
 
 function extractHookCommand(payload: Record<string, unknown>): string {

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -19,6 +19,7 @@ export interface RspResidentPaths {
   rootDir: string;
   socketPath: string;
   lockPath: string;
+  wakeLockPath: string;
 }
 
 const UNIX_SOCKET_PATH_LIMIT = 108;
@@ -30,6 +31,7 @@ export function resolveResidentPaths(cwd: string): RspResidentPaths {
     rootDir,
     socketPath: join(socketDir, "rsp.sock"),
     lockPath: join(socketDir, "rsp.lock"),
+    wakeLockPath: join(socketDir, "rsp.wake.lock"),
   };
 }
 
@@ -87,12 +89,12 @@ type ResidentRequestWithoutId = RspResidentRequest extends infer Request
 
 export async function ensureResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
   await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
-  if (await ping(paths.socketPath)) return;
+  if (await pingResident(paths.socketPath)) return;
 
   const lock = await tryAcquireLock(paths.lockPath);
   if (lock) {
     try {
-      if (await ping(paths.socketPath)) return;
+      if (await pingResident(paths.socketPath)) return;
       const child = spawnResident(paths, config);
       await waitForServer(paths.socketPath, child);
       return;
@@ -105,12 +107,53 @@ export async function ensureResidentServer(paths: RspResidentPaths, config: RspR
   await waitForServer(paths.socketPath);
 }
 
-async function ping(socketPath: string): Promise<boolean> {
+export async function pingResident(socketPath: string, timeoutMs = 200): Promise<boolean> {
   try {
-    const response = await sendResidentRequest({ socketPath, timeoutMs: 200 }, { id: randomUUID(), op: "ping" });
+    const response = await sendResidentRequest({ socketPath, timeoutMs }, { id: randomUUID(), op: "ping" });
     return response.ok;
   } catch {
     return false;
+  }
+}
+
+export async function kickResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<boolean> {
+  await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
+  if (await pingResident(paths.socketPath, 50)) return false;
+
+  const lock = await tryAcquireLock(paths.wakeLockPath);
+  if (!lock) return false;
+  await lock.close();
+
+  const entry = process.argv[1] ? resolve(process.argv[1]) : fileURLToPath(import.meta.url);
+  const child = spawn(process.execPath, [
+    ...process.execArgv,
+    entry,
+    "warm-resident",
+    "--socket",
+    paths.socketPath,
+    "--store-uri",
+    config.storeUri,
+    "--ttl-days",
+    String(config.ttlDays),
+    "--byte-budget",
+    String(config.byteBudget),
+    "--wake-lock",
+    paths.wakeLockPath,
+  ], {
+    cwd: paths.rootDir,
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, RSP_RESIDENT_WARMER: "1" },
+  });
+  child.unref();
+  return true;
+}
+
+export async function warmResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
+  try {
+    await ensureResidentServer(paths, config);
+  } finally {
+    await rm(paths.wakeLockPath, { force: true });
   }
 }
 
@@ -118,7 +161,7 @@ async function waitForServer(socketPath: string, child?: ChildProcess): Promise<
   const deadline = Date.now() + 5_000;
   let last: unknown;
   while (Date.now() < deadline) {
-    if (await ping(socketPath)) return;
+    if (await pingResident(socketPath)) return;
     if (child && child.exitCode != null) {
       throw new Error(`resident rsp server exited before ready (${child.exitCode})`);
     }

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -67,6 +67,15 @@ function runBundleFromCwd(cwd: string, args: string[], env: Record<string, strin
   });
 }
 
+function runBundleHookFromCwd(cwd: string, command: string, env: Record<string, string> = {}) {
+  return spawnSync(process.execPath, [bundle, "hook", "claude-pre-exec"], {
+    cwd,
+    env: { ...process.env, ...env },
+    input: Buffer.from(JSON.stringify({ cwd, tool_input: { command } })),
+    encoding: "buffer",
+  });
+}
+
 function runBundleFromCwdAsync(cwd: string, args: string[], env: Record<string, string> = {}) {
   return new Promise<{ status: number | null; stdout: Buffer; stderr: Buffer }>((resolve, reject) => {
     const child = spawn(process.execPath, [bundle, ...args], {
@@ -195,6 +204,19 @@ async function seedWarmRedCache(): Promise<string> {
   return cacheDir;
 }
 
+async function waitForResidentSocket(root: string): Promise<void> {
+  const paths = trackedResidentPaths(root);
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    try {
+      await stat(paths.socketPath);
+      return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  await stat(paths.socketPath);
+}
+
 describe("rsp cli", () => {
   it("passes wrappers through without creating .red when rsp is not enabled", async () => {
     const root = await initGitRepo();
@@ -293,6 +315,45 @@ describe("rsp cli", () => {
     expect(res.stdout).toEqual(direct.stdout);
     expect(res.stderr).toEqual(Buffer.alloc(0));
     await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+  }, 120_000);
+
+  it("built bundle pre-exec hook passes through while cold, warms once, then rewrites when healthy", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const env = { RED_SKILLS_CACHE_DIR: cacheDir };
+    const paths = trackedResidentPaths(root);
+
+    const cold = timedStatus(() => runBundleHookFromCwd(root, "git status", env));
+
+    expect(cold.status).toBe(1);
+    expect(cold.stdout).toEqual(Buffer.alloc(0));
+    expect(cold.stderr).toEqual(Buffer.alloc(0));
+    expect(cold.elapsedMs).toBeLessThan(200);
+    await expect(stat(paths.wakeLockPath)).resolves.toMatchObject({ size: expect.any(Number) });
+
+    for (let i = 0; i < 4; i++) {
+      const repeat = runBundleHookFromCwd(root, "git status", env);
+      expect([0, 1]).toContain(repeat.status);
+      if (repeat.status === 0) {
+        expect(repeat.stdout).toEqual(Buffer.from("rsp git status\n"));
+      } else {
+        expect(repeat.stdout).toEqual(Buffer.alloc(0));
+      }
+      expect(repeat.stderr).toEqual(Buffer.alloc(0));
+    }
+
+    await waitForResidentSocket(root);
+    await expect(stat(paths.wakeLockPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const warm = timedStatus(() => runBundleHookFromCwd(root, "git status", env));
+
+    expect(warm.status).toBe(0);
+    expect(warm.stdout).toEqual(Buffer.from("rsp git status\n"));
+    expect(warm.stderr).toEqual(Buffer.alloc(0));
+    expect(warm.elapsedMs).toBeLessThan(100);
   }, 120_000);
 
   it("built bundle starts the resident for a repo root longer than the Unix socket path limit", async () => {

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -73,29 +73,81 @@ describe("rsp Claude pre-execution hook integration", () => {
       input: Buffer.from(JSON.stringify({ cwd: root, tool_input: { command: "git status" } })),
     });
 
-    expect(res.status).toBe(0);
-    expect(res.stdout).toEqual(Buffer.from("rsp git status\n"));
+    expect(res.status).toBe(1);
+    expect(res.stdout).toEqual(Buffer.alloc(0));
     expect(res.stderr).toEqual(Buffer.alloc(0));
+    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("prints only the rewritten command and exits 0 on a certain match", async () => {
+  it("prints only the rewritten command and exits 0 on a certain match when the resident is healthy", async () => {
     const root = await tempRoot();
+    let healthCalls = 0;
+    let wakeCalls = 0;
     const result = await hookDecisionFromClaudePreExecJson(
       JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
-      { cwd: root, isEnabled: () => true },
+      {
+        cwd: root,
+        isEnabled: () => true,
+        isResidentHealthy: async () => {
+          healthCalls += 1;
+          return true;
+        },
+        wakeResident: () => {
+          wakeCalls += 1;
+        },
+      },
     );
 
     expect(formatHookDecision(result)).toEqual({ stdout: "rsp git status\n", status: 0 });
+    expect(healthCalls).toBe(1);
+    expect(wakeCalls).toBe(0);
   });
 
   it("prints nothing and exits non-zero on passthrough", async () => {
     const root = await tempRoot();
+    let healthCalls = 0;
+    let wakeCalls = 0;
     const result = await hookDecisionFromClaudePreExecJson(
       JSON.stringify({ cwd: root, tool_input: { command: "git status --short" } }),
-      { cwd: root, isEnabled: () => true },
+      {
+        cwd: root,
+        isEnabled: () => true,
+        isResidentHealthy: async () => {
+          healthCalls += 1;
+          return true;
+        },
+        wakeResident: () => {
+          wakeCalls += 1;
+        },
+      },
     );
 
     expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+    expect(healthCalls).toBe(0);
+    expect(wakeCalls).toBe(0);
+  });
+
+  it("passes through and wakes the resident when the resident is not healthy", async () => {
+    const root = await tempRoot();
+    let wakeCalls = 0;
+    const started = performance.now();
+    const result = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "git status" } }),
+      {
+        cwd: root,
+        isEnabled: () => true,
+        isResidentHealthy: async () => false,
+        wakeResident: () => {
+          wakeCalls += 1;
+        },
+      },
+    );
+    const elapsedMs = performance.now() - started;
+
+    expect(result).toEqual({ kind: "passthrough", reason: "resident-unhealthy" });
+    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+    expect(wakeCalls).toBe(1);
+    expect(elapsedMs).toBeLessThan(50);
   });
 
   it("makes disabled directories inert before rewrite work", async () => {


### PR DESCRIPTION
Automated AFK landing for #1567. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1567

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786481306&installation_id=129708444&pr_number=1569&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1569&signature=18afa51e1614bc79a721c486e71e6e1046f110aa8b87ce08c68926a5bedcb3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->