### PR TITLE
feat: #1568 statusline shows whether rsp is active and healthy

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -20,11 +20,13 @@ import { existsSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { resolveBase } from "../core/base-resolver.js";
-import { type ClaudeInput, type ProjectInput, type StatuslinePreset } from "../core/statusline.js";
+import { type ClaudeInput, type ProjectInput, type RspStatusInput, type StatuslinePreset } from "../core/statusline.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
 import { branchLockPath, readLockedBranch } from "../runtime/lock.js";
+import { resolveRspConfig } from "../../../rsp/src/config.js";
+import { pingResident, resolveResidentPaths } from "../../../rsp/src/resident-client.js";
 import {
   collectStatuslineAfk,
   collectStatuslineFleet,
@@ -137,6 +139,13 @@ export function resolveStatuslinePreset(cfg: ReturnType<typeof loadConfig>): Sta
   );
 }
 
+export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv = process.env): Promise<RspStatusInput | undefined> {
+  const config = resolveRspConfig(root, env);
+  if (!config.enabled) return undefined;
+  const paths = resolveResidentPaths(root);
+  return await pingResident(paths.socketPath, 50) ? "on" : "warming";
+}
+
 /** The block-1 project input: basename, the resolved git ref (branch or detached
  * short sha), and the running `dev` plugin version (build-info → dim `v<version>`
  * tag on the themed header). */
@@ -230,11 +239,12 @@ export async function statuslineCommand(
   // the per-worker records feed the themed multi-line form (Claude Code). Both
   // read the same worker states — cheap file reads — so the two forms stay in
   // sync while each renders its own layout.
-  const [repo, afk, fleet, workers] = await Promise.all([
+  const [repo, afk, fleet, workers, rsp] = await Promise.all([
     collectStatuslineRepo(repoCtx, cacheTtlS, repoLocBaseRef),
     collectStatuslineAfk(repoCtx, cacheTtlS).then((a) => a ?? undefined),
     collectStatuslineFleet(repoCtx),
     collectStatuslineWorkers(repoCtx),
+    resolveStatuslineRsp(root),
   ]);
 
   // Theme on by default (the multi-line wine layout: a repo-global header line
@@ -244,7 +254,7 @@ export async function statuslineCommand(
   const color = !process.env.NO_COLOR;
   const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
   const nowS = Math.floor(Date.now() / 1000);
-  const line = renderStatuslineThemed({ project, claude, repo, fleet, afk }, color, {
+  const line = renderStatuslineThemed({ project, claude, repo, fleet, afk, rsp }, color, {
     columns: Number.isFinite(columns) && columns > 0 ? columns : undefined,
     workers,
     now: nowS,

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -33,13 +33,15 @@ import {
   formatCacheAge,
   humanizeCount,
   humanizeTokens,
-  renderStatuslineWithPreset,
   renderFleetBlock,
+  renderRspBlock,
+  renderStatuslineWithPreset,
   shortModel,
   type ClaudeInput,
   type FleetInput,
   type ProjectInput,
   type RepoInput,
+  type RspStatusInput,
   type StatuslinePreset,
   type StatuslineInput,
 } from "./statusline.js";
@@ -54,6 +56,7 @@ const KEY = "\x1b[38;2;255;214;214m"; // transparent-zone KEY: very light red �
 const VAL = "\x1b[39m"; // transparent-zone VALUE: terminal default foreground
 const SOFT = "\x1b[38;2;224;138;148m"; // transparent-zone general font: a lighter red (runner, +/-/# sigils, ·phase)
 const DIM = "\x1b[38;2;201;150;158m"; // identity-zone branch/version
+const GREEN = "\x1b[38;2;96;214;128m"; // healthy rsp resident
 const GOLD = "\x1b[38;2;240;200;120m"; // » accent
 const BOLD = "\x1b[1m";
 const NOBOLD = "\x1b[22m";
@@ -191,6 +194,12 @@ function fleetKv(fleet: FleetInput | undefined): string[] {
   return block ? [block] : [];
 }
 
+function rspKv(rsp: RspStatusInput | undefined): string[] {
+  const block = renderRspBlock(rsp);
+  if (!block) return [];
+  return rsp === "on" ? [`${GREEN}${block}${SOFT}`] : [`${DIM}${block}${SOFT}`];
+}
+
 /** Line 1 — wine identity zone (project + model) then a transparent KPI tail. */
 export function renderHeaderLine(
   project: ProjectInput,
@@ -198,6 +207,7 @@ export function renderHeaderLine(
   repo: RepoInput | undefined,
   fleet?: FleetInput,
   preset: StatuslinePreset = "full",
+  rsp?: RspStatusInput,
 ): string {
   let s = `${WINE2}${WHITE} ${projectContent(project, preset === "full")} `;
   const model = modelContent(claude);
@@ -211,6 +221,7 @@ export function renderHeaderLine(
           ? kv("iss", String(repo.openIssues)) +
             (repo.cacheAgeS !== undefined ? ` (${formatCacheAge(repo.cacheAgeS)})` : "")
           : null,
+        ...rspKv(rsp),
       ].filter((x): x is string => x !== null)
     : [
         ctxKv(claude),
@@ -218,6 +229,7 @@ export function renderHeaderLine(
         ...repoCountsKv(repo),
         ...localDiffKv(repo),
         ...fleetKv(fleet),
+        ...rspKv(rsp),
       ].filter((x): x is string => x !== null);
   if (tail.length) s += ` ${tail.join("  ")}`;
   return `${s}${RESET}`;
@@ -376,7 +388,7 @@ export interface StyleOptions {
  * → only the header line. */
 export function styleStatusline(input: StatuslineInput, opts: StyleOptions = {}): string {
   const preset = opts.preset ?? "full";
-  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet, preset)];
+  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet, preset, input.rsp)];
   const now = opts.now ?? 0;
   lines.push(...renderWorkerLines(opts.workers ?? [], now, preset));
   return lines.join("\n");

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -163,6 +163,8 @@ export interface FleetInput {
   parked?: number;
 }
 
+export type RspStatusInput = "warming" | "on";
+
 /** All the resolved inputs for one statusline render. */
 export interface StatuslineInput {
   project: ProjectInput;
@@ -170,6 +172,7 @@ export interface StatuslineInput {
   repo?: RepoInput;
   fleet?: FleetInput;
   afk?: AfkInput;
+  rsp?: RspStatusInput;
 }
 
 export type StatuslinePreset = "full" | "short";
@@ -425,6 +428,11 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   return parts.join(" · ");
 }
 
+export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
+  if (!rsp) return null;
+  return rsp === "on" ? "rsp●" : "rsp○";
+}
+
 /**
  * Block 4: the space-joined AFK token run in plain text. Null when there are no
  * live workers, matching the bash `(( total_workers > 0 ))` gate around the
@@ -473,6 +481,8 @@ export function renderStatuslineWithPreset(input: StatuslineInput, preset: Statu
     if (context !== null) sections.push(`ctx=${context}`);
     const repo = renderShortRepoBlock(input.repo);
     if (repo !== null) sections.push(repo);
+    const rsp = renderRspBlock(input.rsp);
+    if (rsp !== null) sections.push(rsp);
     return sections.join(" · ");
   }
 
@@ -487,6 +497,8 @@ export function renderStatuslineWithPreset(input: StatuslineInput, preset: Statu
   if (repo !== null) sections.push(repo);
   const fleet = renderFleetBlock(input.fleet);
   if (fleet !== null) sections.push(fleet);
+  const rsp = renderRspBlock(input.rsp);
+  if (rsp !== null) sections.push(rsp);
   const afk = renderAfkBlock(input.afk);
   if (afk !== null) sections.push(afk);
   return sections.join(" · ");

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -1,16 +1,19 @@
 import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { createServer, type Server, type Socket } from "node:net";
 import { Readable } from "node:stream";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import {
   statuslineCommand,
   resolveRoot,
+  resolveStatuslineRsp,
   resolveStatuslinePreset,
   statuslineEnabled,
 } from "../src/commands/statusline.js";
 import { loadConfig } from "../src/core/config.js";
+import { resolveResidentPaths } from "../../rsp/src/resident-client.js";
 
 /** Strip ANSI SGR escapes so assertions read the plain rendered text. The
  * command now themes the line (wine background + black-chipped KPI numbers);
@@ -114,6 +117,48 @@ async function writeFleetSnapshot(
     }),
     "utf8",
   );
+}
+
+async function listenRspSocket(root: string, mode: "reply" | "hang"): Promise<Server> {
+  const { socketPath } = resolveResidentPaths(root);
+  await mkdir(dirname(socketPath), { recursive: true });
+  await rm(socketPath, { force: true });
+  const sockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    if (mode === "hang") return;
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const raw = buffer.slice(0, newline);
+      const request = JSON.parse(raw) as { id: string };
+      socket.end(`${JSON.stringify({ id: request.id, ok: true, value: "pong" })}\n`);
+    });
+  });
+  (server as Server & { __sockets?: Set<Socket> }).__sockets = sockets;
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  for (const socket of (server as Server & { __sockets?: Set<Socket> }).__sockets ?? []) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
 }
 
 const PAYLOAD = JSON.stringify({
@@ -632,6 +677,68 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
     expect(out.text()).toBe("");
+  });
+
+  it("omits rsp when rsp.enabled is not true", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).not.toContain("rsp");
+    expect(await resolveStatuslineRsp(root, {})).toBeUndefined();
+  });
+
+  it("renders rsp warming quickly when enabled and no resident socket answers", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+
+    const started = Date.now();
+    const rsp = await resolveStatuslineRsp(root, {});
+    const elapsed = Date.now() - started;
+    expect(rsp).toBe("warming");
+    expect(elapsed).toBeLessThan(50);
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("rsp○");
+  });
+
+  it("renders rsp on when an enabled repo has a live resident socket", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    const server = await listenRspSocket(root, "reply");
+    try {
+      expect(await resolveStatuslineRsp(root, {})).toBe("on");
+
+      const out = sink();
+      const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+      expect(code).toBe(0);
+      expect(stripAnsi(out.text())).toContain("rsp●");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("renders rsp warming after the ping cap when a resident socket hangs", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    const server = await listenRspSocket(root, "hang");
+    try {
+      const started = Date.now();
+      const rsp = await resolveStatuslineRsp(root, {});
+      const elapsed = Date.now() - started;
+      expect(rsp).toBe("warming");
+      expect(elapsed).toBeGreaterThanOrEqual(45);
+      expect(elapsed).toBeLessThan(120);
+    } finally {
+      await closeServer(server);
+    }
   });
 
   it("local facts are read live: a mutated state file is reflected on the next render", async () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -491,10 +491,24 @@ describe("statusline — full assembly", () => {
       project: { basename: "red-skills", branch: "main" },
       claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24, usage5h: 23, usage7d: 41 },
       repo: { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 },
+      rsp: "on",
       fleet: { runner: "codex", busy: 1, total: 4, queue: 9 },
       afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
     };
-    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24 · rsp●");
+  });
+
+  it("renders rsp as one optional token in full and short presets", () => {
+    const input: StatuslineInput = {
+      project: { basename: "red-skills", branch: "main" },
+      rsp: "warming",
+    };
+    expect(renderStatusline(input)).toBe("red-skills (main) · rsp○");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp○");
+  });
+
+  it("omits rsp when the gather side leaves the status absent", () => {
+    expect(renderStatusline({ project: { basename: "red-skills" } })).toBe("red-skills");
   });
 
   it("keeps the pre-#1165 line byte-for-byte when repo and usage are absent", () => {


### PR DESCRIPTION
Automated AFK landing for #1568. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1568

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786481816&installation_id=129708444&pr_number=1570&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1570&signature=d856e72cea606914dc3b8c9b31dfcef4954ff2ef4497261ee40b31449ffedf79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->