### PR TITLE
fix: #1566 recover from an orphaned resident socket

### DIFF
--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -95,6 +95,7 @@ export async function ensureResidentServer(paths: RspResidentPaths, config: RspR
   if (lock) {
     try {
       if (await pingResident(paths.socketPath)) return;
+      await removeUnresponsiveSocket(paths.socketPath);
       const child = spawnResident(paths, config);
       await waitForServer(paths.socketPath, child);
       return;
@@ -168,6 +169,10 @@ async function waitForServer(socketPath: string, child?: ChildProcess): Promise<
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw last instanceof Error ? last : new Error("resident rsp server did not start");
+}
+
+async function removeUnresponsiveSocket(socketPath: string): Promise<void> {
+  await rm(socketPath, { force: true });
 }
 
 async function tryAcquireLock(lockPath: string) {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -13,7 +13,6 @@ export interface ResidentServerOptions extends RspResidentConfig {
 
 export async function runResidentServer(opts: ResidentServerOptions): Promise<void> {
   await mkdir(dirname(opts.socketPath), { recursive: true });
-  await rm(opts.socketPath, { force: true });
 
   const openedAt = process.hrtime.bigint();
   const store = await RspElisionStore.open({

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -475,6 +475,29 @@ describe("rsp cli", () => {
     expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
   }, 120_000);
 
+  it("built bundle recovers an orphaned resident socket before spawning", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const paths = trackedResidentPaths(root);
+    await mkdir(dirname(paths.socketPath), { recursive: true });
+    await writeFile(paths.socketPath, "orphaned resident socket\n", "utf8");
+
+    const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_FAIL_IF_STORE_OPEN: "1",
+    });
+
+    expect(compressed.status, `${compressed.stdout.toString("utf8")}${compressed.stderr.toString("utf8")}`).toBe(0);
+    expect(compressed.stderr).toEqual(Buffer.alloc(0));
+    expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
+    await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(paths.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  }, 120_000);
+
   it("built bundle compresses git log, mints a handle, round-trips it, and reports degraded passthrough", async () => {
     buildBundleOnce();
     const root = await initGitRepo();


### PR DESCRIPTION
Closes #1566.

A resident killed hard (SIGKILL/OOM/crash) leaves its socket file behind, and unix `bind` fails `EADDRINUSE` on an existing file — so every subsequent auto-start died and the repo sat in permanent silent passthrough until someone deleted the file by hand.

The spawner now removes the unresponsive socket **while holding the exclusive ensure-lock, after a failed ping** — only the lock holder may unlink, and only when nobody answered, so a live resident's socket can never be removed by a racer. Covered by an end-to-end test that SIGKILLs the resident and asserts the next wrapper invocation recovers.

Landed by hand via the manual lane; the worker's orchestrator was reaped by the launch channel (see #1560 — root cause now identified as the assistant-session process sweep, not red-castle nor the orchestrator).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786481953&installation_id=129708444&pr_number=1571&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1571&signature=7b6c5dbb86098c5d69f112ae2ffa54040c8b033bb70277089a51db4ca1c92b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->