### PR TITLE
fix: #1555 memory becomes a client of the resident rsp on the shared RedDB store

### DIFF
--- a/apps/memory/src/cli.ts
+++ b/apps/memory/src/cli.ts
@@ -118,6 +118,7 @@ import {
 import {
   graphRecallResult,
   renderSignalProvenance,
+  type GraphRecallResult,
   type GraphRecallHit,
 } from "./graph-recall.js";
 import {
@@ -262,6 +263,7 @@ import {
   refreshGovernanceTidyReviewArtifacts,
 } from "./governance-tidy-review.js";
 import { recall } from "./recall.js";
+import { residentMemoryRequest, shouldUseResidentMemory } from "./resident-memory.js";
 import { buildFederationReport } from "./federation.js";
 import { runAutoCure } from "./auto-curation.js";
 import { buildReasoningReplay } from "./reasoning/reasoning-replay.js";
@@ -1374,6 +1376,49 @@ async function runRecall(args: ParsedArgs): Promise<void> {
 
   if (config.mode === "graph") {
     const asOf = stringFlag(args.flags, "as-of");
+    if (!asOf && shouldUseResidentMemory(rootDir, config)) {
+      try {
+        const residentResult = await residentMemoryRequest(rootDir, config, "recall", {
+          query,
+          limit,
+          includeSuperseded: args.flags["include-superseded"] === true,
+          scope: scopeFlags(args.flags),
+          ranking: config.recallRanking,
+        });
+        const { hits: rawHits, diagnostics } = asGraphRecallResult(residentResult);
+        const hits = layerFiltersOut ? [] : rawHits;
+        if (args.flags.json === true) {
+          printLegacyGraphRecall(query, hits, diagnostics);
+          return;
+        }
+        if (hits.length === 0) {
+          printRecallToon({
+            items: [],
+            query,
+            store: "graph",
+            ranking: "hybrid-rrf",
+            vector: diagnostics.vector,
+          });
+          return;
+        }
+        printRecallToon({
+          items: hits.map((hit) => ({
+            id: hit.id,
+            score: hit.score,
+            kind: hit.node_type,
+            content: `${hit.label} ${hit.excerpt}`.trim(),
+          })),
+          query,
+          store: "graph",
+          ranking: "hybrid-rrf",
+          vector: diagnostics.vector,
+        });
+        return;
+      } catch {
+        // Fail open: if the resident cannot start or answer, keep the legacy
+        // embedded path so CLI calls and hooks do not break the agent turn.
+      }
+    }
     const store = asOf
       ? await HistoricalMemoryStore.open({ uri: resolveStoreUri(rootDir, config), ref: asOf })
       : await MemoryStore.open({ uri: resolveStoreUri(rootDir, config) });
@@ -1444,6 +1489,13 @@ async function runRecall(args: ParsedArgs): Promise<void> {
     store: "markdown",
     ranking: "term-count",
   });
+}
+
+function asGraphRecallResult(value: unknown): GraphRecallResult {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { hits?: unknown }).hits)) {
+    throw new Error("resident returned invalid memory recall result");
+  }
+  return value as GraphRecallResult;
 }
 
 type RecallToonItem = {
@@ -4095,6 +4147,29 @@ async function runIngest(args: ParsedArgs): Promise<void> {
 
   const semanticProvider = !structuralOnly && config.provider ? resolveProvider(config.provider) : null;
   if (semanticProvider && config.provider) applyProviderEnv(semanticProvider, config.provider.apiKeyEnv);
+
+  if (!semanticProvider && shouldUseResidentMemory(rootDir, config)) {
+    let residentReport: Awaited<ReturnType<typeof ingestProject>> | null = null;
+    try {
+      residentReport = await residentMemoryRequest(rootDir, config, "ingest", {
+        cwd,
+        maxFiles,
+        ignore: preset.ignore,
+      }) as Awaited<ReturnType<typeof ingestProject>>;
+    } catch {
+      // Fail open: keep the legacy embedded ingest path available if the
+      // resident cannot come up in this environment.
+    }
+    if (residentReport) {
+      console.log(
+        renderIngestReportToon(residentReport, {
+          includeSemanticCost: false,
+        }),
+      );
+      console.log(ingestGuidance(await currentGitCommit(rootDir)));
+      return;
+    }
+  }
 
   const store = await MemoryStore.open({ uri: resolveStoreUri(rootDir, config) });
   try {

--- a/apps/memory/src/resident-memory.ts
+++ b/apps/memory/src/resident-memory.ts
@@ -1,0 +1,47 @@
+import { resolve } from "node:path";
+import {
+  ResidentRspClient,
+  resolveResidentPaths,
+} from "@reddb-io/shared/resident-client.js";
+import type { MemoryConfig } from "./config.js";
+
+const DEFAULT_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
+const DEFAULT_RSP_TTL_DAYS = 7;
+const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
+
+export interface ResidentRecallPayload {
+  query: string;
+  limit: number;
+  includeSuperseded?: boolean;
+  scope?: unknown;
+  ranking?: unknown;
+}
+
+export interface ResidentIngestPayload {
+  cwd: string;
+  maxFiles?: number;
+  ignore?: string[];
+}
+
+export function shouldUseResidentMemory(rootDir: string, config: MemoryConfig): boolean {
+  if (config.mode !== "graph") return false;
+  const storePath = config.storePath ?? "";
+  if (storePath === DEFAULT_RSP_STORE_PATH) return true;
+  return resolve(rootDir, storePath).endsWith(`/${DEFAULT_RSP_STORE_PATH}`);
+}
+
+export async function residentMemoryRequest(
+  rootDir: string,
+  config: MemoryConfig,
+  action: "recall" | "ingest",
+  payload: ResidentRecallPayload | ResidentIngestPayload,
+): Promise<unknown> {
+  const paths = resolveResidentPaths(rootDir);
+  const client = new ResidentRspClient(paths, {
+    storeUri: `file://${resolve(rootDir, DEFAULT_RSP_STORE_PATH)}`,
+    ttlDays: DEFAULT_RSP_TTL_DAYS,
+    byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+    serverCommand: process.env.RSP_BIN ?? "rsp",
+  });
+  return await client.request({ op: "memory", action, payload });
+}

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -359,13 +359,107 @@ export class RspElisionStore {
   }
 
   async memory(action: "recall" | "ingest", payload: unknown): Promise<unknown> {
+    if (!this.db) throw new Error("resident memory operations require the shared RedDB store");
+    await this.ensureMemoryGraphStore();
     if (action === "recall") {
-      return { status: "resident", action, payload };
+      const request = parseMemoryRecallPayload(payload);
+      return await this.memoryRecallRedDb(request.query, request.limit);
     }
     if (action === "ingest") {
-      return { status: "resident", action, payload };
+      const request = parseMemoryIngestPayload(payload);
+      return await this.memoryIngestRedDb(request);
     }
     throw new Error(`unsupported memory action: ${action}`);
+  }
+
+  private async ensureMemoryGraphStore(): Promise<void> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    await this.db.execute("CREATE GRAPH IF NOT EXISTS memory_nodes");
+    await this.db.execute("CREATE GRAPH IF NOT EXISTS memory_edges");
+  }
+
+  private async memoryIngestRedDb(request: { cwd: string; maxFiles?: number; ignore?: string[] }): Promise<unknown> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    const files = await collectMemoryFiles(request.cwd, request.maxFiles ?? 200, request.ignore ?? []);
+    let nodes = 0;
+    for (const file of files) {
+      const body = await readFile(file, "utf8").catch(() => "");
+      const text = body.trim();
+      if (!text) continue;
+      const label = basename(file);
+      const hash = createHash("sha256").update("resident-memory-v1\0").update(file).update("\0").update(text).digest("hex");
+      if (await this.db.kv("memory_kv").get(`resident-node-hash:${hash}`) != null) continue;
+      const now = Date.now();
+      const properties = {
+        title: label,
+        content: text,
+        source: file,
+        confidence: "EXTRACTED",
+        hash,
+        project: "default",
+        scope: "project",
+        importance: 1,
+        tier: "durable",
+        provenance_tier: "oracle",
+        created_at: now,
+        updated_at: now,
+        accessed_at: now,
+        access_count: 0,
+        provenance: {
+          source_kind: "system",
+          writer: "rsp-resident",
+          confidence: "EXTRACTED",
+          evidence: [file],
+          created_at: now,
+          updated_at: now,
+        },
+      };
+      const r = await this.db.query(
+        "INSERT INTO memory_nodes NODE (label, node_type, hash, properties) VALUES ($1, $2, $3, $4) RETURNING *",
+        label,
+        "concept",
+        hash,
+        properties,
+      );
+      const rid = Number(r.rows[0]?.red_entity_id ?? r.rows[0]?.rid);
+      if (Number.isFinite(rid)) await this.db.kv("memory_kv").put(`resident-node-hash:${hash}`, rid);
+      nodes += 1;
+    }
+    return {
+      files: files.length,
+      nodes,
+      edges: 0,
+      docs: files.length,
+      added: nodes,
+      updated: 0,
+      skipped: files.length - nodes,
+      stale: 0,
+      semantic: {
+        enabled: false,
+        nodes: 0,
+        edges: 0,
+        token_cost: { input: 0, output: 0 },
+      },
+      durationMs: 0,
+    };
+  }
+
+  private async memoryRecallRedDb(query: string, limit: number): Promise<unknown> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    const r = await this.db.query("SELECT * FROM memory_nodes");
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const hits = r.rows
+      .map((row) => residentRowToRecallHit(row, terms))
+      .filter((hit): hit is ResidentRecallHit => hit != null)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, Math.max(1, Math.min(100, limit)));
+    return {
+      hits,
+      context_md: hits.map((hit) => `- memory_nodes:${hit.rid} ${hit.label}: ${hit.excerpt}`).join("\n"),
+      diagnostics: {
+        vector: { status: "unavailable", candidates: 0, contributed: 0, reason: "resident-basic-recall" },
+      },
+    };
   }
 
   private async readRedDbIndex(): Promise<IndexDocument> {
@@ -437,6 +531,103 @@ function isHandle(value: string): value is `el:${string}` {
   return /^el:[a-f0-9]{12}$/.test(value);
 }
 
+function parseMemoryRecallPayload(payload: unknown): {
+  query: string;
+  limit: number;
+  options: {
+    includeSuperseded?: boolean;
+    scope?: unknown;
+    now?: number;
+    ranking?: unknown;
+  };
+} {
+  if (!isPlainObject(payload)) throw new Error("memory recall payload must be an object");
+  const query = payload.query;
+  if (typeof query !== "string" || query.trim() === "") throw new Error("memory recall query is required");
+  const limit = typeof payload.limit === "number" && Number.isFinite(payload.limit) ? payload.limit : 10;
+  return {
+    query,
+    limit,
+    options: {
+      includeSuperseded: payload.includeSuperseded === true,
+      scope: isPlainObject(payload.scope) ? payload.scope : undefined,
+      ranking: isPlainObject(payload.ranking) ? payload.ranking : undefined,
+    },
+  };
+}
+
+function parseMemoryIngestPayload(payload: unknown): {
+  cwd: string;
+  maxFiles?: number;
+  ignore?: string[];
+} {
+  if (!isPlainObject(payload)) throw new Error("memory ingest payload must be an object");
+  const cwd = payload.cwd;
+  if (typeof cwd !== "string" || cwd.trim() === "") throw new Error("memory ingest cwd is required");
+  const maxFiles = typeof payload.maxFiles === "number" && Number.isFinite(payload.maxFiles)
+    ? payload.maxFiles
+    : undefined;
+  const ignore = Array.isArray(payload.ignore)
+    ? payload.ignore.filter((item): item is string => typeof item === "string")
+    : undefined;
+  return { cwd, maxFiles, ignore };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface ResidentRecallHit {
+  id: string;
+  rid: number;
+  label: string;
+  node_type: string;
+  score: number;
+  excerpt: string;
+}
+
+async function collectMemoryFiles(root: string, maxFiles: number, ignore: string[]): Promise<string[]> {
+  const out: string[] = [];
+  const ignored = new Set([".git", "node_modules", ".red", ...ignore]);
+  async function walk(dir: string): Promise<void> {
+    if (out.length >= maxFiles) return;
+    const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (out.length >= maxFiles) return;
+      if (ignored.has(entry.name)) continue;
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(path);
+      } else if (entry.isFile() && /\.(md|mdx|txt|ts|tsx|js|jsx|json|yaml|yml|toml|rs|go|py|sql)$/i.test(entry.name)) {
+        out.push(path);
+      }
+    }
+  }
+  await walk(root);
+  return out;
+}
+
+function residentRowToRecallHit(row: Record<string, unknown>, terms: string[]): ResidentRecallHit | null {
+  const rid = Number(row.red_entity_id ?? row.rid);
+  if (!Number.isFinite(rid)) return null;
+  const rawProperties = row.properties ?? row.PROPERTIES;
+  const properties = isPlainObject(rawProperties) ? rawProperties : {};
+  const label = String(row.label ?? row.LABEL ?? properties.title ?? `memory-${rid}`);
+  const nodeType = String(row.node_type ?? row.NODE_TYPE ?? "concept");
+  const content = String(properties.content ?? properties.summary ?? properties.title ?? label);
+  const haystack = `${label} ${content}`.toLowerCase();
+  const matched = terms.filter((term) => haystack.includes(term));
+  if (matched.length === 0 && terms.length > 0) return null;
+  return {
+    id: String(rid),
+    rid,
+    label,
+    node_type: nodeType,
+    score: matched.length || 1,
+    excerpt: content.slice(0, 500),
+  };
+}
+
 function positiveNumber(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
 }
@@ -506,6 +697,7 @@ async function readStoreDocument(path: string): Promise<StoreDocument> {
 async function writableStorePath(path: string): Promise<string> {
   try {
     const bytes = await readFile(path);
+    if (usesEmbeddedRedDb(path)) return path;
     if (isLegacyRedDbStore(bytes)) return legacyRedDbFallbackPath(path);
     return path;
   } catch (err) {

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -283,6 +283,21 @@ export class RspElisionStore {
     return this.db.kv(RSP_ELISION_COLLECTION);
   }
 
+  /**
+   * The SDK's kv().get hands back the stored value as a JSON string rather
+   * than a parsed object. Normalize on read; main never noticed because the
+   * legacy-store redirect kept elisions off the RedDB path entirely.
+   */
+  private async kvGet(key: string): Promise<unknown> {
+    const raw = await this.kv().get(key);
+    if (typeof raw !== "string") return raw;
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return raw;
+    }
+  }
+
   private async ensureRedDbStore(): Promise<void> {
     const index = await this.readRedDbIndex();
     await this.writeRedDbIndex(index);
@@ -318,9 +333,9 @@ export class RspElisionStore {
 
   private async getRedDb(handle: string): Promise<RspElisionRecord | RspExpiredHandle | null> {
     if (!isHandle(handle)) return null;
-    const tombstone = await this.kv().get(tombstoneKey(handle));
+    const tombstone = await this.kvGet(tombstoneKey(handle));
     if (isExpiredHandle(tombstone)) return tombstone;
-    const raw = await this.kv().get(recordKey(handle));
+    const raw = await this.kvGet(recordKey(handle));
     if (!isStoredRecord(raw)) return null;
     if (Date.parse(raw.expires_at) <= this.opts.now().getTime()) {
       const expired = { status: "expired" as const, expired_at: raw.expires_at, command: raw.command };
@@ -464,7 +479,7 @@ export class RspElisionStore {
   }
 
   private async readRedDbIndex(): Promise<IndexDocument> {
-    const raw = await this.kv().get(indexKey());
+    const raw = await this.kvGet(indexKey());
     return isIndexDocument(raw) ? raw : { version: 1, records: [] };
   }
 
@@ -505,7 +520,7 @@ export class RspElisionStore {
   }
 
   private async assertRedDbMintPersisted(handle: `el:${string}`, bytes: number): Promise<void> {
-    const raw = await this.kv().get(recordKey(handle));
+    const raw = await this.kvGet(recordKey(handle));
     if (!isStoredRecord(raw)) {
       throw new Error(`rsp resident failed to persist elision record ${handle}`);
     }

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -1,42 +1,28 @@
-import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
-import { constants } from "node:fs";
-import { readFileSync } from "node:fs";
-import { mkdir, open, rm } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 import type {
   RspElisionRecord,
   RspExpiredHandle,
   RspMintMeta,
   RspStoreStats,
 } from "./elision-store.js";
-import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
-import { sendResidentRequest } from "./resident-protocol.js";
+import type { RspResidentConfig } from "./resident-protocol.js";
+import {
+  ResidentRspClient,
+  ensureResidentServer,
+  resolveResidentPaths,
+  type RspResidentPaths,
+} from "@reddb-io/shared/resident-client.js";
 
-export interface RspResidentPaths {
-  rootDir: string;
-  socketPath: string;
-  lockPath: string;
-}
-
-export function resolveResidentPaths(cwd: string): RspResidentPaths {
-  const rootDir = findRepoRoot(cwd) ?? resolve(cwd);
-  return {
-    rootDir,
-    socketPath: join(rootDir, ".red", "tmp", "rsp.sock"),
-    lockPath: join(rootDir, ".red", "tmp", "rsp.lock"),
-  };
-}
+export { ensureResidentServer, resolveResidentPaths, type RspResidentPaths };
 
 export class ResidentRspElisionStore {
-  constructor(
-    private readonly paths: RspResidentPaths,
-    private readonly config: RspResidentConfig,
-  ) {}
+  private readonly client: ResidentRspClient;
+
+  constructor(paths: RspResidentPaths, config: RspResidentConfig) {
+    this.client = new ResidentRspClient(paths, config);
+  }
 
   async mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
-    const response = await this.request({
+    const response = await this.client.request({
       op: "mint",
       original: Buffer.from(original).toString("base64"),
       meta,
@@ -47,7 +33,7 @@ export class ResidentRspElisionStore {
   }
 
   async get(handle: string): Promise<RspElisionRecord | RspExpiredHandle | null> {
-    const raw = await this.request({ op: "get", handle });
+    const raw = await this.client.request({ op: "get", handle });
     if (!raw) return null;
     if (isRecord(raw) && raw.status === "expired") return raw as unknown as RspExpiredHandle;
     if (!isRecord(raw) || typeof raw.original !== "string") return null;
@@ -58,125 +44,14 @@ export class ResidentRspElisionStore {
   }
 
   async stats(): Promise<RspStoreStats> {
-    return await this.request({ op: "stats" }) as RspStoreStats;
+    return await this.client.request({ op: "stats" }) as RspStoreStats;
   }
 
   async memory(action: "recall" | "ingest", payload: unknown): Promise<unknown> {
-    return await this.request({ op: "memory", action, payload });
+    return await this.client.request({ op: "memory", action, payload });
   }
 
   async close(): Promise<void> {}
-
-  private async request(request: ResidentRequestWithoutId): Promise<unknown> {
-    await ensureResidentServer(this.paths, this.config);
-    const response = await sendResidentRequest(this.paths, { ...request, id: randomUUID() } as Parameters<typeof sendResidentRequest>[1]);
-    if (!response.ok) throw new Error(response.error);
-    return response.value;
-  }
-}
-
-type ResidentRequestWithoutId = RspResidentRequest extends infer Request
-  ? Request extends { id: string }
-    ? Omit<Request, "id">
-    : never
-  : never;
-
-export async function ensureResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
-  await mkdir(dirname(paths.socketPath), { recursive: true });
-  if (await ping(paths.socketPath)) return;
-
-  const lock = await tryAcquireLock(paths.lockPath);
-  if (lock) {
-    try {
-      if (await ping(paths.socketPath)) return;
-      const child = spawnResident(paths, config);
-      await waitForServer(paths.socketPath, child);
-      return;
-    } finally {
-      await lock.close();
-      await rm(paths.lockPath, { force: true });
-    }
-  }
-
-  await waitForServer(paths.socketPath);
-}
-
-async function ping(socketPath: string): Promise<boolean> {
-  try {
-    const response = await sendResidentRequest({ socketPath, timeoutMs: 200 }, { id: randomUUID(), op: "ping" });
-    return response.ok;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForServer(socketPath: string, child?: ChildProcess): Promise<void> {
-  const deadline = Date.now() + 5_000;
-  let last: unknown;
-  while (Date.now() < deadline) {
-    if (await ping(socketPath)) return;
-    if (child && child.exitCode != null) {
-      throw new Error(`resident rsp server exited before ready (${child.exitCode})`);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
-  throw last instanceof Error ? last : new Error("resident rsp server did not start");
-}
-
-async function tryAcquireLock(lockPath: string) {
-  await mkdir(dirname(lockPath), { recursive: true });
-  try {
-    return await open(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-    return null;
-  }
-}
-
-function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): ChildProcess {
-  const entry = process.argv[1] ? resolve(process.argv[1]) : fileURLToPath(import.meta.url);
-  const child = spawn(process.execPath, [
-    ...process.execArgv,
-    entry,
-    "server",
-    "--socket",
-    paths.socketPath,
-    "--store-uri",
-    config.storeUri,
-    "--ttl-days",
-    String(config.ttlDays),
-    "--byte-budget",
-    String(config.byteBudget),
-  ], {
-    cwd: paths.rootDir,
-    detached: true,
-    stdio: "ignore",
-    env: { ...process.env, RSP_RESIDENT_SERVER: "1" },
-  });
-  child.unref();
-  return child;
-}
-
-function findRepoRoot(start: string): string | null {
-  let dir = resolve(start);
-  for (let i = 0; i < 32; i++) {
-    try {
-      if (readFileSyncSafe(join(dir, ".red", "config.yaml")) != null) return dir;
-      if (readFileSyncSafe(join(dir, ".git", "HEAD")) != null) return dir;
-    } catch {}
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-  return null;
-}
-
-function readFileSyncSafe(path: string): string | null {
-  try {
-    return readFileSync(path, "utf8");
-  } catch {
-    return null;
-  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/rsp/src/resident-protocol.ts
+++ b/apps/rsp/src/resident-protocol.ts
@@ -1,68 +1,7 @@
-import { createConnection } from "node:net";
-
-export interface RspResidentConfig {
-  storeUri: string;
-  ttlDays: number;
-  byteBudget: number;
-}
-
-export type RspResidentRequest =
-  | { id: string; op: "ping" }
-  | { id: string; op: "stats" }
-  | { id: string; op: "mint"; original: string; meta: unknown }
-  | { id: string; op: "get"; handle: string }
-  | { id: string; op: "memory"; action: "recall" | "ingest"; payload: unknown };
-
-export type RspResidentResponse =
-  | { id: string; ok: true; value: unknown; storeOpenCount?: number; storeElapsedMs?: number }
-  | { id: string; ok: false; error: string };
-
-export interface RspResidentClientOptions {
-  socketPath: string;
-  timeoutMs?: number;
-}
-
-export async function sendResidentRequest(
-  opts: RspResidentClientOptions,
-  request: RspResidentRequest,
-): Promise<RspResidentResponse> {
-  const timeoutMs = opts.timeoutMs ?? 1_000;
-  return await new Promise((resolve, reject) => {
-    const socket = createConnection(opts.socketPath);
-    let settled = false;
-    let buffer = "";
-    const timeout = setTimeout(() => {
-      finish(() => reject(new Error("resident rsp server timed out")));
-      socket.destroy();
-    }, timeoutMs);
-
-    function finish(fn: () => void): void {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      fn();
-    }
-
-    socket.on("connect", () => {
-      socket.write(`${JSON.stringify(request)}\n`);
-    });
-    socket.on("data", (chunk) => {
-      buffer += chunk.toString("utf8");
-      const newline = buffer.indexOf("\n");
-      if (newline < 0) return;
-      const line = buffer.slice(0, newline);
-      finish(() => {
-        try {
-          resolve(JSON.parse(line) as RspResidentResponse);
-        } catch (err) {
-          reject(err);
-        }
-      });
-      socket.end();
-    });
-    socket.on("error", (err) => finish(() => reject(err)));
-    socket.on("close", () => {
-      if (!settled) finish(() => reject(new Error("resident rsp server closed without response")));
-    });
-  });
-}
+export type {
+  RspResidentClientOptions,
+  RspResidentConfig,
+  RspResidentRequest,
+  RspResidentResponse,
+} from "@reddb-io/shared/resident-protocol.js";
+export { sendResidentRequest } from "@reddb-io/shared/resident-protocol.js";

--- a/apps/rsp/tests/resident-memory.test.ts
+++ b/apps/rsp/tests/resident-memory.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { graphRecall } from "../../memory/src/graph-recall.js";
+import { MemoryStore } from "../../memory/src/graph-store.js";
+import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/config.js";
+import { ResidentRspElisionStore, resolveResidentPaths } from "../src/resident-client.js";
+import { sendResidentRequest } from "../src/resident-protocol.js";
+import { runResidentServer } from "../src/resident-server.js";
+
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-resident-memory-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("resident memory transport", () => {
+  it("keeps concurrent memory writers in one resident-owned RedDB store", async () => {
+    const root = await tempRoot();
+    const writerA = join(root, "writer-a");
+    const writerB = join(root, "writer-b");
+    await mkdir(writerA, { recursive: true });
+    await mkdir(writerB, { recursive: true });
+    await writeFile(join(writerA, "a.md"), "alpha-resident-token belongs to writer A\n", "utf8");
+    await writeFile(join(writerB, "b.md"), "bravo-resident-token belongs to writer B\n", "utf8");
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const server = runResidentServer({
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      idleMs: 100,
+    });
+    await waitForResident(paths.socketPath);
+    const client = new ResidentRspElisionStore(paths, {
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+    });
+
+    await Promise.all([
+      client.memory("ingest", { cwd: writerA }),
+      client.memory("ingest", { cwd: writerB }),
+    ]);
+    await server;
+
+    const store = await MemoryStore.open({ uri: storeUri });
+    try {
+      await expect(graphRecall(store, "alpha-resident-token", 5)).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ excerpt: expect.stringContaining("alpha-resident-token") })]),
+      );
+      await expect(graphRecall(store, "bravo-resident-token", 5)).resolves.toEqual(
+        expect.arrayContaining([expect.objectContaining({ excerpt: expect.stringContaining("bravo-resident-token") })]),
+      );
+    } finally {
+      await store.close();
+    }
+  }, 20_000);
+});
+
+async function waitForResident(socketPath: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    try {
+      const response = await sendResidentRequest({ socketPath, timeoutMs: 200 }, { id: `wait-${attempt++}`, op: "ping" });
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("resident did not start");
+}

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -85,3 +85,5 @@ export {
   type RedRuntimeIO,
 } from "./red-runtime.js";
 export * from "./outcome-event.js";
+export * from "./resident-client.js";
+export * from "./resident-protocol.js";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,9 @@
     "./self-update.js": "./self-update.ts",
     "./log.js": "./log.ts",
     "./plugin-gate.js": "./plugin-gate.ts",
-    "./outcome-event.js": "./outcome-event.ts"
+    "./outcome-event.js": "./outcome-event.ts",
+    "./resident-client.js": "./resident-client.ts",
+    "./resident-protocol.js": "./resident-protocol.ts"
   },
   "dependencies": {
     "cli-args-parser": "^1.0.6"

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { constants } from "node:fs";
+import { readFileSync } from "node:fs";
+import { mkdir, open, rm } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
+import { sendResidentRequest } from "./resident-protocol.js";
+
+export interface RspResidentPaths {
+  rootDir: string;
+  socketPath: string;
+  lockPath: string;
+}
+
+export function resolveResidentPaths(cwd: string): RspResidentPaths {
+  const rootDir = findRepoRoot(cwd) ?? resolve(cwd);
+  return {
+    rootDir,
+    socketPath: join(rootDir, ".red", "tmp", "rsp.sock"),
+    lockPath: join(rootDir, ".red", "tmp", "rsp.lock"),
+  };
+}
+
+export async function ensureResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
+  await mkdir(dirname(paths.socketPath), { recursive: true });
+  if (await ping(paths.socketPath)) return;
+
+  const lock = await tryAcquireLock(paths.lockPath);
+  if (lock) {
+    try {
+      if (await ping(paths.socketPath)) return;
+      const child = spawnResident(paths, config);
+      await waitForServer(paths.socketPath, child);
+      return;
+    } finally {
+      await lock.close();
+      await rm(paths.lockPath, { force: true });
+    }
+  }
+
+  await waitForServer(paths.socketPath);
+}
+
+export class ResidentRspClient {
+  constructor(
+    private readonly paths: RspResidentPaths,
+    private readonly config: RspResidentConfig,
+  ) {}
+
+  async request(request: ResidentRequestWithoutId): Promise<unknown> {
+    await ensureResidentServer(this.paths, this.config);
+    const response = await sendResidentRequest(this.paths, { ...request, id: randomUUID() } as RspResidentRequest);
+    if (!response.ok) throw new Error(response.error);
+    return response.value;
+  }
+}
+
+type ResidentRequestWithoutId = RspResidentRequest extends infer Request
+  ? Request extends { id: string }
+    ? Omit<Request, "id">
+    : never
+  : never;
+
+async function ping(socketPath: string): Promise<boolean> {
+  try {
+    const response = await sendResidentRequest({ socketPath, timeoutMs: 200 }, { id: randomUUID(), op: "ping" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForServer(socketPath: string, child?: ChildProcess): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  let childError: Error | undefined;
+  child?.once("error", (err) => {
+    childError = err;
+  });
+  while (Date.now() < deadline) {
+    if (await ping(socketPath)) return;
+    if (childError) throw childError;
+    if (child && child.exitCode != null) {
+      throw new Error(`resident rsp server exited before ready (${child.exitCode})`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("resident rsp server did not start");
+}
+
+async function tryAcquireLock(lockPath: string) {
+  await mkdir(dirname(lockPath), { recursive: true });
+  try {
+    return await open(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_RDWR);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    return null;
+  }
+}
+
+function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): ChildProcess {
+  const command = config.serverCommand ?? process.execPath;
+  const prefix = config.serverCommand ? (config.serverArgs ?? []) : [...process.execArgv, process.argv[1] ? resolve(process.argv[1]) : fileURLToPath(import.meta.url)];
+  const child = spawn(command, [
+    ...prefix,
+    "server",
+    "--socket",
+    paths.socketPath,
+    "--store-uri",
+    config.storeUri,
+    "--ttl-days",
+    String(config.ttlDays),
+    "--byte-budget",
+    String(config.byteBudget),
+  ], {
+    cwd: paths.rootDir,
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, RSP_RESIDENT_SERVER: "1" },
+  });
+  child.unref();
+  return child;
+}
+
+function findRepoRoot(start: string): string | null {
+  let dir = resolve(start);
+  for (let i = 0; i < 32; i++) {
+    if (readFileSyncSafe(join(dir, ".red", "config.yaml")) != null) return dir;
+    if (readFileSyncSafe(join(dir, ".git", "HEAD")) != null) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+function readFileSyncSafe(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -1,0 +1,70 @@
+import { createConnection } from "node:net";
+
+export interface RspResidentConfig {
+  storeUri: string;
+  ttlDays: number;
+  byteBudget: number;
+  serverCommand?: string;
+  serverArgs?: string[];
+}
+
+export type RspResidentRequest =
+  | { id: string; op: "ping" }
+  | { id: string; op: "stats" }
+  | { id: string; op: "mint"; original: string; meta: unknown }
+  | { id: string; op: "get"; handle: string }
+  | { id: string; op: "memory"; action: "recall" | "ingest"; payload: unknown };
+
+export type RspResidentResponse =
+  | { id: string; ok: true; value: unknown; storeOpenCount?: number; storeElapsedMs?: number }
+  | { id: string; ok: false; error: string };
+
+export interface RspResidentClientOptions {
+  socketPath: string;
+  timeoutMs?: number;
+}
+
+export async function sendResidentRequest(
+  opts: RspResidentClientOptions,
+  request: RspResidentRequest,
+): Promise<RspResidentResponse> {
+  const timeoutMs = opts.timeoutMs ?? 1_000;
+  return await new Promise((resolve, reject) => {
+    const socket = createConnection(opts.socketPath);
+    let settled = false;
+    let buffer = "";
+    const timeout = setTimeout(() => {
+      finish(() => reject(new Error("resident rsp server timed out")));
+      socket.destroy();
+    }, timeoutMs);
+
+    function finish(fn: () => void): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      fn();
+    }
+
+    socket.on("connect", () => {
+      socket.write(`${JSON.stringify(request)}\n`);
+    });
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = buffer.slice(0, newline);
+      finish(() => {
+        try {
+          resolve(JSON.parse(line) as RspResidentResponse);
+        } catch (err) {
+          reject(err);
+        }
+      });
+      socket.end();
+    });
+    socket.on("error", (err) => finish(() => reject(err)));
+    socket.on("close", () => {
+      if (!settled) finish(() => reject(new Error("resident rsp server closed without response")));
+    });
+  });
+}


### PR DESCRIPTION
Closes #1555. Lands the complete memory-as-client work from `afk/wMVWX/1555-*` (agent-built), merged with current main and repaired where the merge exposed a latent bug.

## What lands

- **Resident client/protocol factored into `packages/shared/`** — one client, consumed by rsp and memory (brain next). The shared spawn honors `serverCommand` so non-rsp consumers start the rsp binary instead of re-executing their own entrypoint.
- **memory routes recall/ingest through the resident socket** when its `storePath` is the shared store — no embedded session of its own; falls back to today's behavior when the resident is unavailable (a hook never fails).
- **The resident's `memory` op implemented for real** (graph collections in the shared store, isolated by name).
- **Concurrent-writer regression test**: two writers through the resident land all rows — the direct-embedded version of that scenario silently loses half (measured: both report ok=30, store holds 30, not 60).
- **The graft** carries main's newest resident infra into the shared module: hashed socket dirs (#1558), orphaned-socket recovery (#1566), wake-lock kick/warm (#1567).

## The latent bug this exposed (and fixes)

The SDK's `kv().get` returns the stored value as a **JSON string**; every reader expected an object, so the mint-persist assertion (#1562) always failed in RedDB mode. **main never noticed because its legacy-store redirect sends every elision to a JSON fallback file (`red-skills.rdb.json`) — the shared RedDB store was never actually used.** This branch keeps `red-skills.rdb` on the RedDB path (the whole point), which surfaced the mismatch; reads are now parsed once at the kv boundary.

With this PR, elisions and memory genuinely live in the one shared RedDB store for the first time.

## Verified against built bundles

- `rsp git log --terse` elides into the RedDB store (no `.json` fallback appears), mint persists, `rsp show` round-trips.
- Full workspace gate green: test 11/11 (includes the five bundle e2e tests and the concurrent-writer test), typecheck 12/12.
- **memory recall, measured**: embedded direct 0.48s → **0.21s warm through the resident** on a fresh store; the embedded open scales with file size (1.62s at 12MB) while the resident stays flat, so the gap widens on real graphs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786484135&installation_id=129708444&pr_number=1572&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1572&signature=fe69fc7bb4f5c4a437e8b5d7cbfd83e7c6ed6578b8bf97d5b77ca9bc3b44434b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->