### PR TITLE
fix: resolve the warm-cache red binary from the default cache location

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connect, type RedDB } from "@reddb-io/sdk";
@@ -748,8 +749,15 @@ function usesEmbeddedRedDb(path: string): boolean {
 }
 
 async function ensureReddbBinaryFromWarmCache(): Promise<void> {
-  if (process.env.REDDB_BIN || !process.env.RED_SKILLS_CACHE_DIR) return;
-  const root = join(process.env.RED_SKILLS_CACHE_DIR, "reddb");
+  if (process.env.REDDB_BIN) return;
+  // Same default cascade as the launcher fetch: an unset RED_SKILLS_CACHE_DIR
+  // means the standard cache location, not "no cache".
+  const cacheDir =
+    process.env.RED_SKILLS_CACHE_DIR ??
+    (process.env.XDG_CACHE_HOME
+      ? join(process.env.XDG_CACHE_HOME, "red-skills", "bundles")
+      : join(homedir(), ".cache", "red-skills", "bundles"));
+  const root = join(cacheDir, "reddb");
   let versions: string[];
   try {
     versions = await readdir(root);

--- a/apps/rsp/src/setup.ts
+++ b/apps/rsp/src/setup.ts
@@ -59,13 +59,21 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
       memoryStoreMigrated = true;
     } else {
       const { RspElisionStore } = await import("./elision-store.js");
-      const store = await RspElisionStore.open({
-        uri: `file://${storePath}`,
-        ttlDays: opts.ttlDays ?? DEFAULT_RSP_TTL_DAYS,
-        byteBudget: opts.byteBudget ?? DEFAULT_RSP_BYTE_BUDGET,
-        allowResidentOpen: true,
-      });
-      await store.close();
+      // Provisioning must not leak env into the caller: the store open may
+      // resolve REDDB_BIN from the warm cache, so restore whatever was there.
+      const priorReddbBin = process.env.REDDB_BIN;
+      try {
+        const store = await RspElisionStore.open({
+          uri: `file://${storePath}`,
+          ttlDays: opts.ttlDays ?? DEFAULT_RSP_TTL_DAYS,
+          byteBudget: opts.byteBudget ?? DEFAULT_RSP_BYTE_BUDGET,
+          allowResidentOpen: true,
+        });
+        await store.close();
+      } finally {
+        if (priorReddbBin === undefined) delete process.env.REDDB_BIN;
+        else process.env.REDDB_BIN = priorReddbBin;
+      }
     }
   }
   const memoryConfig = repointMemoryStore(next, REPO_STORE_PATH);

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -204,6 +204,20 @@ async function seedWarmRedCache(): Promise<string> {
   return cacheDir;
 }
 
+async function waitForGone(path: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await stat(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`still present after ${timeoutMs}ms: ${path}`);
+}
+
 async function waitForResidentSocket(root: string): Promise<void> {
   const paths = trackedResidentPaths(root);
   const deadline = Date.now() + 5_000;
@@ -346,7 +360,9 @@ describe("rsp cli", () => {
     }
 
     await waitForResidentSocket(root);
-    await expect(stat(paths.wakeLockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    // The warmer removes the wake lock only after ensure returns, which is
+    // also the moment the socket starts answering — poll instead of racing it.
+    await waitForGone(paths.wakeLockPath);
 
     const warm = timedStatus(() => runBundleHookFromCwd(root, "git status", env));
 


### PR DESCRIPTION
Found verifying v2.34.2 from npm in a bare shell: `rsp git log --terse` silently passed through. `RSP_DEBUG` traced it to the resident failing its store open — `ensureReddbBinaryFromWarmCache` treats an **unset** `RED_SKILLS_CACHE_DIR` as "no cache" and returns early, so the provisioned red binary at `~/.cache/red-skills/bundles/reddb/<v>/red` is never found unless the env var happens to be exported. The launcher fetch already defaults this exact cascade (`XDG_CACHE_HOME` → `~/.cache`); the resolver now uses the same one.

Also in this PR:

- **Provisioning no longer leaks `REDDB_BIN`** into the caller's env (the store open during `rsp setup` may now resolve the binary anywhere, so the prior value is restored — keeps the existing `does not set REDDB_BIN while provisioning` contract green).
- **Deflakes the hook warm-up e2e**: it asserted the wake lock was gone at the instant the socket started answering, but the warmer removes the lock only after ensure returns — inherently racy (fails on plain main ~half the runs; verified by stashing this change and re-running). The test now polls for the lock's removal.

Verified with a fully bare environment (`env -i HOME=... PATH=...`): `rsp setup` + `rsp git log --terse` elides into the shared RedDB store with zero env vars set. Gate green: test 11/11, typecheck 12/12.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786485368&installation_id=129708444&pr_number=1573&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1573&signature=27d13afe498fe2fb3e0245086e81af5e7ba63c948b401d8fef840ea96622ef11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->