### PR TITLE
feat: #1575 rsp telemetry: spool, resident drain, and per-collection retention

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -57,6 +57,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       storeUri: serverConfig.storeUri,
       ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? serverConfig.ttlDays,
       byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? serverConfig.byteBudget,
+      telemetryTtlDays: numericValueAfter(args.positional, "--telemetry-ttl-days") ?? serverConfig.telemetryTtlDays,
+      telemetryByteBudget: numericValueAfter(args.positional, "--telemetry-byte-budget") ?? serverConfig.telemetryByteBudget,
       idleMs: numericValueAfter(args.positional, "--idle-ms"),
     });
     return 0;
@@ -76,6 +78,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       storeUri: warmConfig.storeUri,
       ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? warmConfig.ttlDays,
       byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? warmConfig.byteBudget,
+      telemetryTtlDays: numericValueAfter(args.positional, "--telemetry-ttl-days") ?? warmConfig.telemetryTtlDays,
+      telemetryByteBudget: numericValueAfter(args.positional, "--telemetry-byte-budget") ?? warmConfig.telemetryByteBudget,
     });
     return 0;
   }
@@ -92,11 +96,15 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     storeUri: config.storeUri,
     ttlDays: config.ttlDays,
     byteBudget: config.byteBudget,
+    telemetryTtlDays: config.telemetryTtlDays,
+    telemetryByteBudget: config.telemetryByteBudget,
   }));
   const warmResidentStore = () => ensureResidentServer(residentPaths, {
     storeUri: config.storeUri,
     ttlDays: config.ttlDays,
     byteBudget: config.byteBudget,
+    telemetryTtlDays: config.telemetryTtlDays,
+    telemetryByteBudget: config.telemetryByteBudget,
   });
   const openDirectStore = async (): Promise<ElisionStoreLike & Pick<RspElisionStore, "get" | "stats">> => {
     const { RspElisionStore } = await import("./elision-store.js");

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -6,12 +6,16 @@ export const DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD = 8 * 1024;
 export const DEFAULT_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
 export const DEFAULT_RSP_TTL_DAYS = 7;
 export const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
+export const DEFAULT_RSP_TELEMETRY_TTL_DAYS = 90;
+export const DEFAULT_RSP_TELEMETRY_BYTE_BUDGET = 4 * 1024 * 1024;
 
 export interface RspRuntimeConfig {
   enabled: boolean;
   storeUri: string;
   ttlDays: number;
   byteBudget: number;
+  telemetryTtlDays: number;
+  telemetryByteBudget: number;
   heavyGitByteThreshold: number;
 }
 
@@ -22,13 +26,21 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
   const enabled = flatConfigValue(yaml, "rsp.enabled") === "true";
   const ttlDays = positiveNumber(readNumericYamlPath(yaml, "rsp.ttlDays"), DEFAULT_RSP_TTL_DAYS);
   const byteBudget = positiveNumber(readNumericYamlPath(yaml, "rsp.byteBudget"), DEFAULT_RSP_BYTE_BUDGET);
+  const telemetryTtlDays = positiveNumber(
+    readNumericYamlPath(yaml, "rsp.telemetryTtlDays"),
+    DEFAULT_RSP_TELEMETRY_TTL_DAYS,
+  );
+  const telemetryByteBudget = positiveNumber(
+    readNumericYamlPath(yaml, "rsp.telemetryByteBudget") ?? readNumericYamlPath(yaml, "rsp.byteBudget"),
+    DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
+  );
   const heavyGitByteThreshold = positiveNumber(
     numericEnv(env.RSP_HEAVY_GIT_BYTE_THRESHOLD) ?? readNumericYamlPath(yaml, "rsp.heavyGitByteThreshold"),
     DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   );
   const storeUri = explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${join(resolve(root), DEFAULT_RSP_STORE_PATH)}`;
 
-  return { enabled, storeUri, ttlDays, byteBudget, heavyGitByteThreshold };
+  return { enabled, storeUri, ttlDays, byteBudget, telemetryTtlDays, telemetryByteBudget, heavyGitByteThreshold };
 }
 
 function readNumericYamlPath(yaml: string, dottedPath: string): number | undefined {

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -127,6 +127,10 @@ export class RspElisionStore {
     await this.db?.close();
   }
 
+  redDb(): RedDB | undefined {
+    return this.db;
+  }
+
   async mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
     if (this.db) return await this.mintRedDb(original, meta);
     const bytes = Buffer.from(original);

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -122,6 +122,8 @@ function toResidentConfig(config: RspRuntimeConfig) {
     storeUri: config.storeUri,
     ttlDays: config.ttlDays,
     byteBudget: config.byteBudget,
+    telemetryTtlDays: config.telemetryTtlDays,
+    telemetryByteBudget: config.telemetryByteBudget,
   };
 }
 

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -2,12 +2,23 @@ import { randomUUID } from "node:crypto";
 import { mkdir, rm } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
 import { dirname } from "node:path";
+import type { RedDB } from "@reddb-io/sdk";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
 import type { RspResidentConfig, RspResidentRequest, RspResidentResponse } from "./resident-protocol.js";
+import {
+  parseTelemetryEvent,
+  RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+  RSP_TELEMETRY_INDEX_COLLECTION,
+  RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+  takeTelemetrySpool,
+  type RspTelemetryEvent,
+} from "./telemetry.js";
+import { DEFAULT_RSP_TELEMETRY_BYTE_BUDGET, DEFAULT_RSP_TELEMETRY_TTL_DAYS } from "./config.js";
 
 export interface ResidentServerOptions extends RspResidentConfig {
   socketPath: string;
+  rootDir?: string;
   idleMs?: number;
 }
 
@@ -23,6 +34,12 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   });
   const storeElapsedMs = Number(process.hrtime.bigint() - openedAt) / 1_000_000;
   let storeOpenCount = 1;
+  const telemetry = new ResidentTelemetryDrain(store, {
+    rootDir: opts.rootDir ?? process.cwd(),
+    ttlDays: opts.telemetryTtlDays ?? DEFAULT_RSP_TELEMETRY_TTL_DAYS,
+    byteBudget: opts.telemetryByteBudget ?? opts.byteBudget ?? DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
+  });
+  await telemetry.drainAndSweep();
 
   const idleMs = opts.idleMs ?? 30_000;
   let idleTimer: NodeJS.Timeout | undefined;
@@ -38,7 +55,9 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
 
   function touch(): void {
     if (idleTimer) clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => server.close(), idleMs);
+    idleTimer = setTimeout(() => {
+      void telemetry.drainAndSweep().finally(() => server.close());
+    }, idleMs);
     idleTimer.unref();
   }
 
@@ -56,6 +75,133 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   if (idleTimer) clearTimeout(idleTimer);
   await store.close();
   await rm(opts.socketPath, { force: true });
+}
+
+interface ResidentTelemetryOptions {
+  rootDir: string;
+  ttlDays: number;
+  byteBudget: number;
+}
+
+interface TelemetryIndexEntry {
+  collection: typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION;
+  key: string;
+  created_at: string;
+  expires_at: string;
+  bytes: number;
+}
+
+interface TelemetryIndexDocument {
+  version: 1;
+  records: TelemetryIndexEntry[];
+}
+
+class ResidentTelemetryDrain {
+  private running?: Promise<void>;
+
+  constructor(
+    private readonly store: RspElisionStore,
+    private readonly opts: ResidentTelemetryOptions,
+  ) {}
+
+  async drainAndSweep(): Promise<void> {
+    this.running ??= this.drainAndSweepOnce().finally(() => {
+      this.running = undefined;
+    });
+    await this.running;
+  }
+
+  private async drainAndSweepOnce(): Promise<void> {
+    const db = this.store.redDb();
+    if (!db) return;
+    const lines = await takeTelemetrySpool(this.opts.rootDir);
+    const index = await this.readIndex(db);
+    const nextRecords = [...index.records];
+    for (const line of lines) {
+      const event = parseTelemetryEvent(line);
+      if (!event) continue;
+      const entry = await this.writeEvent(db, event);
+      nextRecords.push(entry);
+    }
+    await this.prune(db, { version: 1, records: nextRecords });
+  }
+
+  private async writeEvent(db: RedDB, event: RspTelemetryEvent): Promise<TelemetryIndexEntry> {
+    const now = new Date();
+    const createdAt = typeof event.created_at === "string" ? event.created_at : now.toISOString();
+    const expiresAt = new Date(Date.parse(createdAt) + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
+    const key = typeof event.id === "string" && event.id.trim() !== "" ? event.id : randomUUID();
+    const record = { ...event, id: key, created_at: createdAt, expires_at: expiresAt };
+    await db.kv(event.collection).put(key, record);
+    return {
+      collection: event.collection,
+      key,
+      created_at: createdAt,
+      expires_at: expiresAt,
+      bytes: typeof event.bytes === "number" && Number.isFinite(event.bytes)
+        ? Math.max(0, event.bytes)
+        : Buffer.byteLength(JSON.stringify(record), "utf8"),
+    };
+  }
+
+  private async readIndex(db: RedDB): Promise<TelemetryIndexDocument> {
+    const raw = await db.kv(RSP_TELEMETRY_INDEX_COLLECTION).get("index:v1");
+    const parsed = typeof raw === "string" ? safeJson(raw) : raw;
+    return isTelemetryIndex(parsed) ? parsed : { version: 1, records: [] };
+  }
+
+  private async writeIndex(db: RedDB, index: TelemetryIndexDocument): Promise<void> {
+    await db.kv(RSP_TELEMETRY_INDEX_COLLECTION).put("index:v1", index);
+  }
+
+  private async prune(db: RedDB, index: TelemetryIndexDocument): Promise<void> {
+    const nowMs = Date.now();
+    const live: TelemetryIndexEntry[] = [];
+    for (const entry of index.records) {
+      if (Date.parse(entry.expires_at) <= nowMs) {
+        await db.kv(entry.collection).delete(entry.key);
+      } else {
+        live.push(entry);
+      }
+    }
+    let bytes = live.reduce((sum, entry) => sum + entry.bytes, 0);
+    live.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    while (bytes > this.opts.byteBudget && live.length > 0) {
+      const evicted = live.shift()!;
+      bytes -= evicted.bytes;
+      await db.kv(evicted.collection).delete(evicted.key);
+    }
+    await this.writeIndex(db, { version: 1, records: live });
+  }
+}
+
+function safeJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function isTelemetryIndex(value: unknown): value is TelemetryIndexDocument {
+  return isRecord(value) &&
+    value.version === 1 &&
+    Array.isArray(value.records) &&
+    value.records.every((entry) =>
+      isRecord(entry) &&
+      (
+        entry.collection === RSP_TELEMETRY_INVOCATIONS_COLLECTION ||
+        entry.collection === RSP_TELEMETRY_DEGRADATIONS_COLLECTION
+      ) &&
+      typeof entry.key === "string" &&
+      typeof entry.created_at === "string" &&
+      typeof entry.expires_at === "string" &&
+      typeof entry.bytes === "number"
+    );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function handleSocket(socket: Socket, handler: (request: RspResidentRequest) => Promise<void>): void {

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -1,0 +1,73 @@
+import { constants } from "node:fs";
+import { mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
+export const RSP_TELEMETRY_INVOCATIONS_COLLECTION = "rsp_telemetry_invocations_v1";
+export const RSP_TELEMETRY_DEGRADATIONS_COLLECTION = "rsp_telemetry_degradations_v1";
+export const RSP_TELEMETRY_INDEX_COLLECTION = "rsp_telemetry_index_v1";
+
+export interface RspTelemetryEvent {
+  collection: typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION;
+  id?: string;
+  created_at?: string;
+  bytes?: number;
+  [key: string]: unknown;
+}
+
+export function telemetrySpoolPath(rootDir: string): string {
+  return join(rootDir, RSP_TELEMETRY_SPOOL);
+}
+
+export async function appendTelemetryEvent(rootDir: string, event: RspTelemetryEvent): Promise<void> {
+  try {
+    const path = telemetrySpoolPath(rootDir);
+    await mkdir(dirname(path), { recursive: true });
+    const handle = await open(path, constants.O_CREAT | constants.O_APPEND | constants.O_WRONLY, 0o600);
+    try {
+      await handle.write(`${JSON.stringify(event)}\n`, undefined, "utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch {}
+}
+
+export async function takeTelemetrySpool(rootDir: string): Promise<string[]> {
+  const path = telemetrySpoolPath(rootDir);
+  const drainingPath = `${path}.${process.pid}.${Date.now()}.drain`;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await rename(path, drainingPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    return [];
+  }
+
+  try {
+    await writeFile(path, "", { flag: "wx" }).catch(() => undefined);
+    const text = await readFile(drainingPath, "utf8").catch(() => "");
+    return text.split(/\r?\n/).filter((line) => line.trim() !== "");
+  } finally {
+    await rm(drainingPath, { force: true });
+  }
+}
+
+export function parseTelemetryEvent(line: string): RspTelemetryEvent | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isRecord(parsed)) return null;
+    if (
+      parsed.collection !== RSP_TELEMETRY_INVOCATIONS_COLLECTION &&
+      parsed.collection !== RSP_TELEMETRY_DEGRADATIONS_COLLECTION
+    ) return null;
+    return parsed as RspTelemetryEvent;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -2,7 +2,12 @@ import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
-import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD, resolveRspConfig } from "../src/config.js";
+import {
+  DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
+  DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
+  DEFAULT_RSP_TELEMETRY_TTL_DAYS,
+  resolveRspConfig,
+} from "../src/config.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/elision-store.js";
 
 const roots: string[] = [];
@@ -21,13 +26,19 @@ describe("resolveRspConfig", () => {
   it("reads retention knobs from the top-level rsp block", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });
-    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  heavyGitByteThreshold: 99\n", "utf8");
+    await writeFile(
+      join(root, ".red", "config.yaml"),
+      "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  telemetryTtlDays: 11\n  telemetryByteBudget: 100\n  heavyGitByteThreshold: 99\n",
+      "utf8",
+    );
 
     expect(resolveRspConfig(join(root, "nested"), {}, undefined)).toEqual({
       enabled: false,
       storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
       ttlDays: 3,
       byteBudget: 42,
+      telemetryTtlDays: 11,
+      telemetryByteBudget: 100,
       heavyGitByteThreshold: 99,
     });
   });
@@ -42,6 +53,8 @@ describe("resolveRspConfig", () => {
       storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      telemetryTtlDays: DEFAULT_RSP_TELEMETRY_TTL_DAYS,
+      telemetryByteBudget: DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
       heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
     });
   });

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -1,0 +1,219 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { connect } from "@reddb-io/sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  appendTelemetryEvent,
+  RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+  RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+  telemetrySpoolPath,
+} from "../src/telemetry.js";
+import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/config.js";
+import { resolveResidentPaths } from "../src/resident-client.js";
+import { sendResidentRequest } from "../src/resident-protocol.js";
+import { runResidentServer } from "../src/resident-server.js";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-telemetry-"));
+  roots.push(root);
+  await mkdir(join(root, ".red", "tmp"), { recursive: true });
+  await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp telemetry spool", () => {
+  it("appends JSONL without throwing when the target is unavailable", async () => {
+    const root = await tempRoot();
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "ok",
+      command: "git status",
+    });
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toContain('"id":"ok"');
+
+    await writeFile(join(root, ".red", "tmp", "not-a-dir"), "x", "utf8");
+    await expect(appendTelemetryEvent(join(root, "not-there"), {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "lost",
+    })).resolves.toBeUndefined();
+  });
+
+  it("drains boot and idle telemetry into RedDB while skipping malformed lines", async () => {
+    const root = await tempRoot();
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "boot-event",
+      command: "git status",
+      bytes: 100,
+    });
+    await writeFile(telemetrySpoolPath(root), "not-json\n", { flag: "a" });
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const server = runResidentServer({
+      rootDir: root,
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      telemetryTtlDays: 90,
+      telemetryByteBudget: 1_000,
+      idleMs: 100,
+    });
+    await waitForResident(paths.socketPath);
+
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+      id: "idle-event",
+      reason: "resident unavailable",
+      bytes: 100,
+    });
+    await server;
+
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "boot-event")).resolves.toMatchObject({
+      id: "boot-event",
+      command: "git status",
+    });
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_DEGRADATIONS_COLLECTION, "idle-event")).resolves.toMatchObject({
+      id: "idle-event",
+      reason: "resident unavailable",
+    });
+  }, 20_000);
+
+  it("enforces telemetry ttl and byte budget without pruning elisions", async () => {
+    const root = await tempRoot();
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "expired",
+      created_at: "2000-01-01T00:00:00.000Z",
+      bytes: 10,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "oldest",
+      created_at: "2099-01-01T00:00:00.000Z",
+      bytes: 60,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "newest",
+      created_at: "2099-01-02T00:00:00.000Z",
+      bytes: 60,
+    });
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const server = runResidentServer({
+      rootDir: root,
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      telemetryTtlDays: 1,
+      telemetryByteBudget: 75,
+      idleMs: 100,
+    });
+    await waitForResident(paths.socketPath);
+    await server;
+
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "expired")).resolves.toBeNull();
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "oldest")).resolves.toBeNull();
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "newest")).resolves.toMatchObject({
+      id: "newest",
+    });
+  }, 20_000);
+
+  it("drains a hand-written spool through the built bundle resident", async () => {
+    const root = await tempRoot();
+    const bundle = await ensureRspBundle();
+    await writeFile(telemetrySpoolPath(root), `${JSON.stringify({
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "bundle-event",
+      command: "git log",
+    })}\n`, "utf8");
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const child = execFile(process.execPath, [
+      bundle,
+      "server",
+      "--socket",
+      paths.socketPath,
+      "--store-uri",
+      storeUri,
+      "--ttl-days",
+      String(DEFAULT_RSP_TTL_DAYS),
+      "--byte-budget",
+      String(DEFAULT_RSP_BYTE_BUDGET),
+      "--idle-ms",
+      "100",
+    ], { cwd: root });
+    await waitForResident(paths.socketPath);
+    await new Promise<void>((resolve, reject) => {
+      child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`bundle resident exited ${code}`)));
+      child.once("error", reject);
+    });
+
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "bundle-event")).resolves.toMatchObject({
+      id: "bundle-event",
+      command: "git log",
+    });
+  }, 40_000);
+});
+
+async function readTelemetry(storeUri: string, collection: string, key: string): Promise<unknown> {
+  const db = await connect(storeUri);
+  try {
+    const raw = await db.kv(collection).get(key);
+    return typeof raw === "string" ? JSON.parse(raw) as unknown : raw;
+  } finally {
+    await db.close();
+  }
+}
+
+async function waitForResident(socketPath: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    try {
+      const response = await sendResidentRequest({ socketPath, timeoutMs: 200 }, { id: `wait-${attempt++}`, op: "ping" });
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("resident did not start");
+}
+
+async function ensureRspBundle(): Promise<string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const appRoot = resolve(here, "..");
+  const repoRoot = resolve(appRoot, "..", "..");
+  const bundle = join(repoRoot, "dist", "rsp.bundle.min.mjs");
+  if (existsSync(bundle)) return bundle;
+  await execFileAsync(process.execPath, [
+    join(repoRoot, "scripts", "bundle-app.mjs"),
+    "--entry",
+    "src/cli.ts",
+    "--outfile",
+    "../../dist/rsp.bundle.min.mjs",
+    "--asset",
+    "rsp.bundle.min.mjs",
+    "--minify",
+    "--reddb-from-package",
+  ], { cwd: appRoot });
+  return bundle;
+}

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -104,6 +104,10 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
     String(config.ttlDays),
     "--byte-budget",
     String(config.byteBudget),
+    "--telemetry-ttl-days",
+    String(config.telemetryTtlDays ?? 90),
+    "--telemetry-byte-budget",
+    String(config.telemetryByteBudget ?? config.byteBudget),
     "--wake-lock",
     paths.wakeLockPath,
   ], {
@@ -164,6 +168,10 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
     String(config.ttlDays),
     "--byte-budget",
     String(config.byteBudget),
+    "--telemetry-ttl-days",
+    String(config.telemetryTtlDays ?? 90),
+    "--telemetry-byte-budget",
+    String(config.telemetryByteBudget ?? config.byteBudget),
   ], {
     cwd: paths.rootDir,
     detached: true,

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -4,6 +4,8 @@ export interface RspResidentConfig {
   storeUri: string;
   ttlDays: number;
   byteBudget: number;
+  telemetryTtlDays?: number;
+  telemetryByteBudget?: number;
   serverCommand?: string;
   serverArgs?: string[];
 }


### PR DESCRIPTION
Automated AFK landing for #1575. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786487806&installation_id=129708444&pr_number=1578&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1578&signature=5999e0b951d14e15b92b095b2c0e694fbbcde3563e490cae1ab35257602cbe7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->