### PR TITLE
feat: #1576 rsp telemetry: instrument wrappers and resident for invocation and degradation events

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { existsSync, readdirSync } from "node:fs";
 import type { RspElisionStore } from "./elision-store.js";
+import type { ResidentResponseMetrics } from "./resident-client.js";
 
 interface ParsedArgs {
   command?: string;
@@ -88,7 +89,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const { fileURLToPath } = await import("node:url");
   const residentPaths = resolveResidentPaths(process.cwd());
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
-    if (wrapperCommand) return await degradeToPassthrough("store not provisioned", args.positional);
+    if (wrapperCommand) return await degradeToPassthrough("store not provisioned", args.positional, undefined, residentPaths.rootDir);
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
     return 1;
   }
@@ -131,62 +132,47 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       try {
         await suppressRspStderr(warmResidentStore);
       } catch (err) {
-        return await degradeToPassthrough("resident unavailable", args.positional, err);
+        return await degradeToPassthrough("resident unavailable", args.positional, err, residentPaths.rootDir);
       }
       if (isFastGitStatus(args.positional)) return await runFastGitStatus();
       const { runGitWrapper } = await import("./git-wrapper.js");
       const store = new LazyRspElisionStore(() => suppressRspStderr(openResidentStore));
       closeStore = () => store.close();
+      const started = process.hrtime.bigint();
       const result = await suppressRspStderr(() => runGitWrapper(args.positional, {
         level: args.level,
         store,
         heavyGitByteThreshold: config.heavyGitByteThreshold,
       }));
-      process.stdout.write(result.stdout);
-      process.stderr.write(result.stderr);
-      if (result.signal) {
-        process.kill(process.pid, result.signal);
-        return 128;
-      }
-      return result.status ?? 0;
+      return await emitWrappedResult(args, result, started, store);
     }
 
     if (args.command === "gh") {
       try {
         await suppressRspStderr(warmResidentStore);
       } catch (err) {
-        return await degradeToPassthrough("resident unavailable", args.positional, err);
+        return await degradeToPassthrough("resident unavailable", args.positional, err, residentPaths.rootDir);
       }
       const { runGhWrapper } = await import("./gh-wrapper.js");
       const store = new LazyRspElisionStore(() => suppressRspStderr(openResidentStore));
       closeStore = () => store.close();
+      const started = process.hrtime.bigint();
       const result = await suppressRspStderr(() => runGhWrapper(args.positional, { level: args.level, store }));
-      process.stdout.write(result.stdout);
-      process.stderr.write(result.stderr);
-      if (result.signal) {
-        process.kill(process.pid, result.signal);
-        return 128;
-      }
-      return result.status ?? 0;
+      return await emitWrappedResult(args, result, started, store);
     }
 
     if (args.command === "vitest" || args.command === "cargo") {
       try {
         await suppressRspStderr(warmResidentStore);
       } catch (err) {
-        return await degradeToPassthrough("resident unavailable", args.positional, err);
+        return await degradeToPassthrough("resident unavailable", args.positional, err, residentPaths.rootDir);
       }
       const { runTestWrapper } = await import("./test-wrapper.js");
       const store = new LazyRspElisionStore(() => suppressRspStderr(openResidentStore));
       closeStore = () => store.close();
+      const started = process.hrtime.bigint();
       const result = await suppressRspStderr(() => runTestWrapper(args.positional, { level: args.level, store }));
-      process.stdout.write(result.stdout);
-      process.stderr.write(result.stderr);
-      if (result.signal) {
-        process.kill(process.pid, result.signal);
-        return 128;
-      }
-      return result.status ?? 0;
+      return await emitWrappedResult(args, result, started, store);
     }
 
     if (args.command === "show" && args.handle) {
@@ -208,7 +194,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     process.stdout.write("error: usage rsp show el:<id>\n");
     return 2;
   } catch (err) {
-    if (wrapperCommand) return await degradeToPassthrough("wrapper failed", args.positional, err);
+    if (wrapperCommand) return await degradeToPassthrough("wrapper failed", args.positional, err, residentPaths.rootDir);
     throw err;
   } finally {
     await closeStore?.();
@@ -268,15 +254,31 @@ function isEmptyUnbornGitRepo(cwd: string): boolean {
   }
 }
 
-type ElisionStoreLike = Pick<RspElisionStore, "mint" | "close">;
+type ElisionStoreLike = Pick<RspElisionStore, "mint" | "close"> & {
+  lastResponseMetrics?: () => ResidentResponseMetrics | undefined;
+};
+
+interface WrappedCommandResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  mintedHandle?: `el:${string}`;
+  bytesElided?: number;
+  rawOutput?: Buffer;
+}
 
 class LazyRspElisionStore implements ElisionStoreLike {
   private store?: Promise<ElisionStoreLike>;
+  private metrics?: ResidentResponseMetrics;
 
   constructor(private readonly openStore: () => Promise<ElisionStoreLike>) {}
 
   async mint(...args: Parameters<RspElisionStore["mint"]>): ReturnType<RspElisionStore["mint"]> {
-    return await (await this.open()).mint(...args);
+    const store = await this.open();
+    const handle = await store.mint(...args);
+    this.metrics = store.lastResponseMetrics?.();
+    return handle;
   }
 
   async close(): Promise<void> {
@@ -294,14 +296,71 @@ class LazyRspElisionStore implements ElisionStoreLike {
     this.store ??= this.openStore();
     return this.store;
   }
+
+  lastResponseMetrics(): ResidentResponseMetrics | undefined {
+    return this.metrics;
+  }
 }
 
-async function degradeToPassthrough(reason: string, argv: readonly string[], err?: unknown): Promise<number> {
+async function emitWrappedResult(
+  args: ParsedArgs,
+  result: WrappedCommandResult,
+  started: bigint,
+  store: LazyRspElisionStore,
+): Promise<number> {
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  const wrapperMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  await appendInvocationTelemetry(args, result, wrapperMs, store.lastResponseMetrics());
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return 128;
+  }
+  return result.status ?? 0;
+}
+
+async function appendInvocationTelemetry(
+  args: ParsedArgs,
+  result: WrappedCommandResult,
+  wrapperMs: number,
+  metrics?: ResidentResponseMetrics,
+): Promise<void> {
+  const emitted = Buffer.concat([result.stdout, result.stderr]);
+  const raw = Buffer.concat([result.rawOutput ?? result.stdout, result.stderr]);
+  const { appendTelemetryEvent, RSP_TELEMETRY_INVOCATIONS_COLLECTION } = await import("./telemetry.js");
+  await appendTelemetryEvent(process.cwd(), {
+    collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+    ts: new Date().toISOString(),
+    command: args.positional.join(" "),
+    wrapper: args.command,
+    loss: args.level,
+    elided: Boolean(result.mintedHandle || result.bytesElided),
+    raw_bytes: raw.length,
+    emitted_bytes: emitted.length,
+    raw_text: raw.toString("utf8"),
+    emitted_text: emitted.toString("utf8"),
+    wrapper_ms: wrapperMs,
+    store_open_count: metrics?.storeOpenCount,
+    store_elapsed_ms: metrics?.storeElapsedMs,
+  });
+}
+
+async function degradeToPassthrough(reason: string, argv: readonly string[], err?: unknown, telemetryRoot?: string): Promise<number> {
   if (process.env.RSP_DEBUG === "1") {
     throw err instanceof Error ? err : new Error(reason);
   }
   process.stderr.write(`rsp: ${reason}, passing through\n`);
-  return await passthrough(argv);
+  const status = await passthrough(argv);
+  if (telemetryRoot) {
+    const { appendTelemetryEvent, RSP_TELEMETRY_DEGRADATIONS_COLLECTION } = await import("./telemetry.js");
+    await appendTelemetryEvent(telemetryRoot, {
+      collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+      ts: new Date().toISOString(),
+      command: argv.join(" "),
+      reason,
+    });
+  }
+  return status;
 }
 
 function rspDisabledReason(): string {

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -21,6 +21,7 @@ export interface GhRenderResult {
   mintedHandle?: `el:${string}`;
   bytesElided?: number;
   rowsElided?: number;
+  rawOutput?: Buffer;
 }
 
 interface GhCommand {
@@ -143,6 +144,7 @@ export async function renderGhContract(
     mintedHandle: handle,
     bytesElided,
     rowsElided: terse.rowsElided,
+    rawOutput: Buffer.from(fullToon),
   };
 }
 

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -33,6 +33,7 @@ export interface GitRenderResult {
   bytesElided?: number;
   rowsElided?: number;
   oneLine?: boolean;
+  rawOutput?: Buffer;
 }
 
 export async function runGitWrapper(argv: readonly string[], options: GitRenderOptions): Promise<GitRenderResult> {
@@ -119,6 +120,7 @@ export async function renderGitContract(
     mintedHandle: handle,
     bytesElided,
     rowsElided: terse.rowsElided,
+    rawOutput: Buffer.from(fullToon),
   };
 }
 

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -17,6 +17,11 @@ import {
   type RspResidentPaths,
 } from "@reddb-io/shared/resident-client.js";
 
+export interface ResidentResponseMetrics {
+  storeOpenCount?: number;
+  storeElapsedMs?: number;
+}
+
 export {
   ensureResidentServer,
   kickResidentServer,
@@ -28,10 +33,16 @@ export {
 
 /** rsp-side adapter: the elision-store surface, served by the resident. */
 export class ResidentRspElisionStore {
+  private metrics?: ResidentResponseMetrics;
+
   constructor(
     private readonly paths: RspResidentPaths,
     private readonly config: RspResidentConfig,
   ) {}
+
+  lastResponseMetrics(): ResidentResponseMetrics | undefined {
+    return this.metrics;
+  }
 
   async mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
     const response = await this.request({
@@ -69,6 +80,10 @@ export class ResidentRspElisionStore {
     await ensureResidentServer(this.paths, this.config);
     const response = await sendResidentRequest(this.paths, { ...request, id: randomUUID() } as RspResidentRequest);
     if (!response.ok) throw new Error(response.error);
+    this.metrics = {
+      storeOpenCount: response.storeOpenCount,
+      storeElapsedMs: response.storeElapsedMs,
+    };
     return response.value;
   }
 }

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { RedDB } from "@reddb-io/sdk";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
@@ -96,6 +98,8 @@ interface TelemetryIndexDocument {
   records: TelemetryIndexEntry[];
 }
 
+const TOKENIZATION_CAP_BYTES = 256 * 1024;
+
 class ResidentTelemetryDrain {
   private running?: Promise<void>;
 
@@ -131,7 +135,12 @@ class ResidentTelemetryDrain {
     const createdAt = typeof event.created_at === "string" ? event.created_at : now.toISOString();
     const expiresAt = new Date(Date.parse(createdAt) + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
     const key = typeof event.id === "string" && event.id.trim() !== "" ? event.id : randomUUID();
-    const record = { ...event, id: key, created_at: createdAt, expires_at: expiresAt };
+    const record = {
+      ...await enrichTelemetryEvent(event),
+      id: key,
+      created_at: createdAt,
+      expires_at: expiresAt,
+    };
     await db.kv(event.collection).put(key, record);
     return {
       collection: event.collection,
@@ -173,6 +182,59 @@ class ResidentTelemetryDrain {
     }
     await this.writeIndex(db, { version: 1, records: live });
   }
+}
+
+async function enrichTelemetryEvent(event: RspTelemetryEvent): Promise<RspTelemetryEvent> {
+  if (event.collection !== RSP_TELEMETRY_INVOCATIONS_COLLECTION) return event;
+  const raw = await tokenCount(event.raw_text, numericField(event.raw_bytes));
+  const emitted = await tokenCount(event.emitted_text, numericField(event.emitted_bytes));
+  const { raw_text: _rawText, emitted_text: _emittedText, ...persisted } = event;
+  return {
+    ...persisted,
+    tokens_raw: raw.tokens,
+    tokens_emitted: emitted.tokens,
+    estimated: raw.estimated || emitted.estimated,
+  };
+}
+
+async function tokenCount(text: unknown, fallbackBytes: number | undefined): Promise<{ tokens: number; estimated: boolean }> {
+  if (typeof text === "string") {
+    const bytes = Buffer.byteLength(text, "utf8");
+    if (bytes <= TOKENIZATION_CAP_BYTES) {
+      const getEncoding = await loadGetEncoding();
+      return { tokens: getEncoding("cl100k_base").encode(text).length, estimated: false };
+    }
+    return { tokens: Math.ceil(bytes / 4), estimated: true };
+  }
+  if (fallbackBytes != null) return { tokens: Math.ceil(fallbackBytes / 4), estimated: true };
+  return { tokens: 0, estimated: false };
+}
+
+type GetEncoding = (encoding: "cl100k_base") => { encode(text: string): number[] };
+let getEncodingLoader: Promise<GetEncoding> | undefined;
+
+async function loadGetEncoding(): Promise<GetEncoding> {
+  getEncodingLoader ??= import(pathToFileURL(resolveJsTiktoken()).href).then((module) => {
+    const getEncoding = (module as { getEncoding?: GetEncoding }).getEncoding;
+    if (!getEncoding) throw new Error("js-tiktoken getEncoding export not found");
+    return getEncoding;
+  });
+  return await getEncodingLoader;
+}
+
+function resolveJsTiktoken(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, "..", "node_modules", "js-tiktoken", "dist", "index.js"),
+    join(here, "..", "apps", "rsp", "node_modules", "js-tiktoken", "dist", "index.js"),
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) throw new Error("js-tiktoken dependency not found");
+  return found;
+}
+
+function numericField(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 function safeJson(value: string): unknown {

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -1,5 +1,5 @@
-import { constants } from "node:fs";
-import { mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
@@ -12,6 +12,13 @@ export interface RspTelemetryEvent {
   id?: string;
   created_at?: string;
   bytes?: number;
+  raw_text?: string;
+  emitted_text?: string;
+  raw_bytes?: number;
+  emitted_bytes?: number;
+  tokens_raw?: number;
+  tokens_emitted?: number;
+  estimated?: boolean;
   [key: string]: unknown;
 }
 
@@ -22,13 +29,8 @@ export function telemetrySpoolPath(rootDir: string): string {
 export async function appendTelemetryEvent(rootDir: string, event: RspTelemetryEvent): Promise<void> {
   try {
     const path = telemetrySpoolPath(rootDir);
-    await mkdir(dirname(path), { recursive: true });
-    const handle = await open(path, constants.O_CREAT | constants.O_APPEND | constants.O_WRONLY, 0o600);
-    try {
-      await handle.write(`${JSON.stringify(event)}\n`, undefined, "utf8");
-    } finally {
-      await handle.close();
-    }
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600 });
   } catch {}
 }
 

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -165,6 +165,7 @@ async function renderTerse(
     mintedHandle: handle,
     bytesElided,
     rowsElided: elidedFailures,
+    rawOutput: Buffer.from(fullToon),
   };
 }
 

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -4,9 +4,14 @@ import { tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
+import { connect } from "@reddb-io/sdk";
 import { afterEach, describe, expect, it } from "vitest";
 import { RspElisionStore } from "../src/elision-store.js";
 import { resolveResidentPaths } from "../src/resident-client.js";
+import {
+  RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+  RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+} from "../src/telemetry.js";
 
 const roots: string[] = [];
 const residentDirs: string[] = [];
@@ -229,6 +234,20 @@ async function waitForResidentSocket(root: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   await stat(paths.socketPath);
+}
+
+async function readTelemetryRecords(storeUri: string, collection: string): Promise<unknown[]> {
+  const db = await connect(storeUri);
+  try {
+    const raw = await db.kv(collection).list({ limit: 1000 });
+    return raw.items.map((entry) => typeof entry.value === "string" ? JSON.parse(entry.value) as unknown : entry.value);
+  } finally {
+    await db.close();
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 describe("rsp cli", () => {
@@ -549,6 +568,61 @@ describe("rsp cli", () => {
     expect(degraded.status).toBe(raw.status);
     expect(degraded.stdout).toEqual(raw.stdout);
     expect(degraded.stderr.toString("utf8")).toBe("rsp: store not provisioned, passing through\n");
+  }, 120_000);
+
+  it("built bundle records invocation and degradation telemetry through the resident", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const resident = runBundleFromCwdAsync(root, ["server", "--idle-ms", "1000"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    await waitForResidentSocket(root);
+
+    const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(compressed.status).toBe(0);
+    expect(compressed.stderr).toEqual(Buffer.alloc(0));
+    expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
+    const residentResult = await resident;
+    expect(residentResult.status, `${residentResult.stdout.toString("utf8")}${residentResult.stderr.toString("utf8")}`).toBe(0);
+
+    const degradedResident = runBundleFromCwdAsync(root, ["server", "--idle-ms", "1000"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    await waitForResidentSocket(root);
+    const degraded = runBundleFromCwd(root, ["git", "--version"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    const direct = runGit(["--version"]);
+    expect(degraded.status).toBe(direct.status);
+    expect(degraded.stdout).toEqual(direct.stdout);
+    expect(degraded.stderr.toString("utf8")).toBe("rsp: wrapper failed, passing through\n");
+    const degradedResidentResult = await degradedResident;
+    expect(
+      degradedResidentResult.status,
+      `${degradedResidentResult.stdout.toString("utf8")}${degradedResidentResult.stderr.toString("utf8")}`,
+    ).toBe(0);
+
+    const invocations = await readTelemetryRecords(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION);
+    const invocation = invocations.find((record) => isRecord(record) && record.command === "git log");
+    expect(invocation).toMatchObject({
+      command: "git log",
+      wrapper: "git",
+      loss: "terse",
+      elided: true,
+      raw_bytes: expect.any(Number),
+      emitted_bytes: compressed.stdout.length,
+      wrapper_ms: expect.any(Number),
+      store_open_count: expect.any(Number),
+      store_elapsed_ms: expect.any(Number),
+      tokens_raw: expect.any(Number),
+      tokens_emitted: expect.any(Number),
+      estimated: false,
+    });
+
+    const degradations = await readTelemetryRecords(storeUri, RSP_TELEMETRY_DEGRADATIONS_COLLECTION);
+    expect(degradations).toContainEqual(expect.objectContaining({
+      command: "git --version",
+      reason: "wrapper failed",
+    }));
   }, 120_000);
 
   it("built bundle keeps git log terse elision latency under budget", async () => {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -56,6 +56,8 @@ describe("rsp telemetry spool", () => {
       collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
       id: "boot-event",
       command: "git status",
+      raw_text: "hello world",
+      emitted_text: "hello",
       bytes: 100,
     });
     await writeFile(telemetrySpoolPath(root), "not-json\n", { flag: "a" });
@@ -86,10 +88,59 @@ describe("rsp telemetry spool", () => {
     await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "boot-event")).resolves.toMatchObject({
       id: "boot-event",
       command: "git status",
+      tokens_raw: expect.any(Number),
+      tokens_emitted: expect.any(Number),
+      estimated: false,
     });
     await expect(readTelemetry(storeUri, RSP_TELEMETRY_DEGRADATIONS_COLLECTION, "idle-event")).resolves.toMatchObject({
       id: "idle-event",
       reason: "resident unavailable",
+    });
+  }, 20_000);
+
+  it("computes telemetry tokens at drain time and estimates oversized payloads", async () => {
+    const root = await tempRoot();
+    const huge = "x".repeat(300 * 1024);
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "exact",
+      command: "git status",
+      raw_text: "alpha beta",
+      emitted_text: "alpha",
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "estimated",
+      command: "git log",
+      raw_text: huge,
+      emitted_text: huge,
+    });
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const server = runResidentServer({
+      rootDir: root,
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      telemetryTtlDays: 90,
+      telemetryByteBudget: 1_000_000,
+      idleMs: 100,
+    });
+    await waitForResident(paths.socketPath);
+    await server;
+
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "exact")).resolves.toMatchObject({
+      tokens_raw: expect.any(Number),
+      tokens_emitted: expect.any(Number),
+      estimated: false,
+    });
+    const estimated = await readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "estimated");
+    expect(estimated).toMatchObject({
+      tokens_raw: Math.ceil(Buffer.byteLength(huge, "utf8") / 4),
+      tokens_emitted: Math.ceil(Buffer.byteLength(huge, "utf8") / 4),
+      estimated: true,
     });
   }, 20_000);
 


### PR DESCRIPTION
Automated AFK landing for #1576. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1576

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786489446&installation_id=129708444&pr_number=1579&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1579&signature=d8f129303bfc956f25c29a62c9f4047dd51bdce46ee3549c2c157fe7aad69b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->