### PR TITLE
feat: #1577 rsp telemetry: savings, health, and latency in rsp stats

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -2,6 +2,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import type { RspElisionStore } from "./elision-store.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
+import type { RspTelemetryStats } from "./telemetry.js";
 
 interface ParsedArgs {
   command?: string;
@@ -120,11 +121,14 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     : openResidentStore();
   let closeStore: (() => Promise<void>) | undefined;
   try {
-    if (!args.command) {
+    if (!args.command || args.command === "stats") {
       const store = await openReadStore();
       closeStore = () => store.close();
       const stats = await store.stats();
-      process.stdout.write(renderStats(stats));
+      const telemetry = hasTelemetryStats(store)
+        ? await store.telemetryStats(statsSinceDays(args.positional))
+        : emptyTelemetryStats(statsSinceDays(args.positional));
+      process.stdout.write(renderStats(stats, telemetry, statsFull(args.positional)));
       return 0;
     }
 
@@ -257,6 +261,17 @@ function isEmptyUnbornGitRepo(cwd: string): boolean {
 type ElisionStoreLike = Pick<RspElisionStore, "mint" | "close"> & {
   lastResponseMetrics?: () => ResidentResponseMetrics | undefined;
 };
+
+type TelemetryStatsStore = {
+  telemetryStats: (sinceDays: number) => Promise<RspTelemetryStats>;
+};
+
+function hasTelemetryStats(store: unknown): store is TelemetryStatsStore {
+  return typeof store === "object" &&
+    store !== null &&
+    "telemetryStats" in store &&
+    typeof (store as { telemetryStats?: unknown }).telemetryStats === "function";
+}
 
 interface WrappedCommandResult {
   stdout: Buffer;
@@ -423,14 +438,117 @@ function parseArgs(argv: string[]): ParsedArgs {
   return out;
 }
 
-function renderStats(stats: { records: number; bytes: number; oldest: string | null; budget: number }): string {
+function statsSinceDays(args: readonly string[]): number {
+  const raw = valueAfter(args, "--since") ?? args.find((arg) => arg.startsWith("--since="))?.slice("--since=".length);
+  if (!raw) return 30;
+  const match = /^(\d+)(d)?$/.exec(raw);
+  if (!match) return 30;
+  const days = Number(match[1]);
+  return Number.isFinite(days) && days > 0 ? days : 30;
+}
+
+function statsFull(args: readonly string[]): boolean {
+  return args.includes("--full");
+}
+
+function renderStats(
+  stats: { records: number; bytes: number; oldest: string | null; budget: number },
+  telemetry = emptyTelemetryStats(30),
+  full = false,
+): string {
+  const topCommands = telemetry.savings.top_commands.slice(0, full ? 10 : 3);
+  const daily = full ? telemetry.savings.daily_tokens_saved : telemetry.savings.daily_tokens_saved.slice(-7);
   return [
     `records: ${stats.records}`,
     `bytes: ${stats.bytes}`,
     `oldest: ${stats.oldest ?? "none"}`,
     `budget: ${stats.budget}`,
+    "savings:",
+    `  window_days: ${telemetry.window_days}`,
+    `  empty: ${telemetry.empty}`,
+    `  invocations: ${telemetry.savings.invocations}`,
+    `  elided: ${telemetry.savings.elided}`,
+    `  raw_bytes: ${telemetry.savings.raw_bytes}`,
+    `  emitted_bytes: ${telemetry.savings.emitted_bytes}`,
+    `  bytes_saved: ${telemetry.savings.bytes_saved}`,
+    `  tokens_saved: ${telemetry.savings.tokens_saved}`,
+    "  daily_tokens_saved:",
+    ...renderDaily(daily),
+    ...(!full && telemetry.savings.daily_tokens_saved.length > daily.length
+      ? [`    elided_days: ${telemetry.savings.daily_tokens_saved.length - daily.length}`, "    hint: --full"]
+      : []),
+    "  top_commands:",
+    ...renderTopCommands(topCommands),
+    "health:",
+    `  degradations: ${telemetry.health.degradations}`,
+    `  degradation_rate: ${formatRate(telemetry.health.degradation_rate)}`,
+    `  most_recent_degradation_at: ${telemetry.health.most_recent?.timestamp ?? "none"}`,
+    `  most_recent_degradation_reason: ${telemetry.health.most_recent?.reason ?? "none"}`,
+    "  degradations_by_reason:",
+    ...renderReasons(telemetry.health.by_reason),
+    "latency:",
+    `  wrapper_ms_p50: ${formatNullable(telemetry.latency.wrapper_ms_p50)}`,
+    `  wrapper_ms_p95: ${formatNullable(telemetry.latency.wrapper_ms_p95)}`,
+    `  store_open_count_sum: ${telemetry.latency.store_open_count_sum}`,
+    `  store_elapsed_ms_sum: ${telemetry.latency.store_elapsed_ms_sum}`,
+    `  store_elapsed_ms_avg: ${formatNullable(telemetry.latency.store_elapsed_ms_avg)}`,
     "",
   ].join("\n");
+}
+
+function renderDaily(series: Array<{ date: string; tokens_saved: number }>): string[] {
+  if (series.length === 0) return ["    empty: true"];
+  return series.map((entry) => `    ${entry.date}: ${entry.tokens_saved}`);
+}
+
+function renderTopCommands(commands: Array<{ command: string; invocations: number; bytes_saved: number; tokens_saved: number }>): string[] {
+  if (commands.length === 0) return ["    empty: true"];
+  return commands.map((entry) =>
+    `    - command: ${entry.command} invocations: ${entry.invocations} bytes_saved: ${entry.bytes_saved} tokens_saved: ${entry.tokens_saved}`
+  );
+}
+
+function renderReasons(reasons: Array<{ reason: string; count: number }>): string[] {
+  if (reasons.length === 0) return ["    empty: true"];
+  return reasons.map((entry) => `    ${entry.reason}: ${entry.count}`);
+}
+
+function formatNullable(value: number | null): string {
+  return value == null ? "none" : String(value);
+}
+
+function formatRate(value: number): string {
+  return value.toFixed(4).replace(/0+$/, "").replace(/\.$/, ".0");
+}
+
+function emptyTelemetryStats(windowDays: number): RspTelemetryStats {
+  return {
+    window_days: windowDays,
+    empty: true,
+    savings: {
+      invocations: 0,
+      elided: 0,
+      raw_bytes: 0,
+      emitted_bytes: 0,
+      bytes_saved: 0,
+      tokens_saved: 0,
+      daily_tokens_saved: [],
+      top_commands: [],
+    },
+    health: {
+      degradations: 0,
+      degradation_rate: 0,
+      by_reason: [],
+      most_recent: null,
+    },
+    latency: {
+      wrapper_ms_p50: null,
+      wrapper_ms_p95: null,
+      store_open_count_sum: 0,
+      store_elapsed_ms_sum: 0,
+      store_elapsed_ms_avg: null,
+    },
+  };
 }
 
 function renderSetupResult(result: { configChanged: boolean; storeCreated: boolean }): string {

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -5,6 +5,7 @@ import type {
   RspMintMeta,
   RspStoreStats,
 } from "./elision-store.js";
+import type { RspTelemetryStats } from "./telemetry.js";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
 import {
@@ -68,6 +69,10 @@ export class ResidentRspElisionStore {
 
   async stats(): Promise<RspStoreStats> {
     return await this.request({ op: "stats" }) as RspStoreStats;
+  }
+
+  async telemetryStats(sinceDays: number): Promise<RspTelemetryStats> {
+    return await this.request({ op: "telemetry-stats", sinceDays }) as RspTelemetryStats;
   }
 
   async memory(action: "recall" | "ingest", payload: unknown): Promise<unknown> {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -10,6 +10,7 @@ import { RspElisionStore } from "./elision-store.js";
 import type { RspResidentConfig, RspResidentRequest, RspResidentResponse } from "./resident-protocol.js";
 import {
   parseTelemetryEvent,
+  readTelemetryStats,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INDEX_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -298,6 +299,11 @@ function handleSocket(socket: Socket, handler: (request: RspResidentRequest) => 
 async function handleRequest(store: RspElisionStore, request: RspResidentRequest): Promise<unknown> {
   if (request.op === "ping") return { pong: true };
   if (request.op === "stats") return await store.stats();
+  if (request.op === "telemetry-stats") {
+    const db = store.redDb();
+    if (!db) throw new Error("rsp telemetry stats require the shared RedDB store");
+    return await readTelemetryStats(db, request.sinceDays);
+  }
   if (request.op === "mint") {
     return {
       handle: await store.mint(Buffer.from(request.original, "base64"), request.meta as Parameters<RspElisionStore["mint"]>[1]),

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import type { RedDB } from "@reddb-io/sdk";
 
 export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
 export const RSP_TELEMETRY_INVOCATIONS_COLLECTION = "rsp_telemetry_invocations_v1";
@@ -20,6 +21,34 @@ export interface RspTelemetryEvent {
   tokens_emitted?: number;
   estimated?: boolean;
   [key: string]: unknown;
+}
+
+export interface RspTelemetryStats {
+  window_days: number;
+  empty: boolean;
+  savings: {
+    invocations: number;
+    elided: number;
+    raw_bytes: number;
+    emitted_bytes: number;
+    bytes_saved: number;
+    tokens_saved: number;
+    daily_tokens_saved: Array<{ date: string; tokens_saved: number }>;
+    top_commands: Array<{ command: string; invocations: number; bytes_saved: number; tokens_saved: number }>;
+  };
+  health: {
+    degradations: number;
+    degradation_rate: number;
+    by_reason: Array<{ reason: string; count: number }>;
+    most_recent: { timestamp: string; reason: string; command: string } | null;
+  };
+  latency: {
+    wrapper_ms_p50: number | null;
+    wrapper_ms_p95: number | null;
+    store_open_count_sum: number;
+    store_elapsed_ms_sum: number;
+    store_elapsed_ms_avg: number | null;
+  };
 }
 
 export function telemetrySpoolPath(rootDir: string): string {
@@ -68,6 +97,153 @@ export function parseTelemetryEvent(line: string): RspTelemetryEvent | null {
   } catch {
     return null;
   }
+}
+
+export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new Date()): Promise<RspTelemetryStats> {
+  const windowDays = Number.isFinite(sinceDays) && sinceDays > 0 ? sinceDays : 30;
+  const sinceMs = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+  const invocations = (await readCollection(db, RSP_TELEMETRY_INVOCATIONS_COLLECTION))
+    .filter((record) => timestampMs(record) >= sinceMs);
+  const degradations = (await readCollection(db, RSP_TELEMETRY_DEGRADATIONS_COLLECTION))
+    .filter((record) => timestampMs(record) >= sinceMs);
+
+  let elided = 0;
+  let rawBytes = 0;
+  let emittedBytes = 0;
+  let tokensSaved = 0;
+  const byDay = new Map<string, number>();
+  const byCommand = new Map<string, { command: string; invocations: number; bytes_saved: number; tokens_saved: number }>();
+  const wrapperMs: number[] = [];
+  let storeOpenCountSum = 0;
+  let storeElapsedMsSum = 0;
+  let storeElapsedMsCount = 0;
+
+  for (const record of invocations) {
+    if (record.elided === true) elided++;
+    const raw = numeric(record.raw_bytes);
+    const emitted = numeric(record.emitted_bytes);
+    const bytesSaved = Math.max(0, raw - emitted);
+    const tokenDelta = Math.max(0, numeric(record.tokens_raw) - numeric(record.tokens_emitted));
+    rawBytes += raw;
+    emittedBytes += emitted;
+    tokensSaved += tokenDelta;
+    const date = timestampString(record).slice(0, 10);
+    if (date) byDay.set(date, (byDay.get(date) ?? 0) + tokenDelta);
+    const command = stringField(record.command) || "unknown";
+    const current = byCommand.get(command) ?? { command, invocations: 0, bytes_saved: 0, tokens_saved: 0 };
+    current.invocations++;
+    current.bytes_saved += bytesSaved;
+    current.tokens_saved += tokenDelta;
+    byCommand.set(command, current);
+    const latency = optionalNumeric(record.wrapper_ms);
+    if (latency != null) wrapperMs.push(latency);
+    storeOpenCountSum += numeric(record.store_open_count);
+    const storeMs = optionalNumeric(record.store_elapsed_ms);
+    if (storeMs != null) {
+      storeElapsedMsSum += storeMs;
+      storeElapsedMsCount++;
+    }
+  }
+
+  const byReason = new Map<string, number>();
+  let mostRecent: RspTelemetryStats["health"]["most_recent"] = null;
+  for (const record of degradations) {
+    const reason = stringField(record.reason) || "unknown";
+    byReason.set(reason, (byReason.get(reason) ?? 0) + 1);
+    const timestamp = timestampString(record);
+    if (!mostRecent || timestamp > mostRecent.timestamp) {
+      mostRecent = {
+        timestamp,
+        reason,
+        command: stringField(record.command) || "unknown",
+      };
+    }
+  }
+
+  const totalAttempts = invocations.length + degradations.length;
+  return {
+    window_days: windowDays,
+    empty: invocations.length === 0 && degradations.length === 0,
+    savings: {
+      invocations: invocations.length,
+      elided,
+      raw_bytes: rawBytes,
+      emitted_bytes: emittedBytes,
+      bytes_saved: Math.max(0, rawBytes - emittedBytes),
+      tokens_saved: tokensSaved,
+      daily_tokens_saved: [...byDay.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, saved]) => ({ date, tokens_saved: saved })),
+      top_commands: [...byCommand.values()]
+        .sort((a, b) => b.bytes_saved - a.bytes_saved || b.tokens_saved - a.tokens_saved || a.command.localeCompare(b.command)),
+    },
+    health: {
+      degradations: degradations.length,
+      degradation_rate: totalAttempts === 0 ? 0 : degradations.length / totalAttempts,
+      by_reason: [...byReason.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([reason, count]) => ({ reason, count })),
+      most_recent: mostRecent,
+    },
+    latency: {
+      wrapper_ms_p50: percentile(wrapperMs, 0.5),
+      wrapper_ms_p95: percentile(wrapperMs, 0.95),
+      store_open_count_sum: storeOpenCountSum,
+      store_elapsed_ms_sum: round(storeElapsedMsSum),
+      store_elapsed_ms_avg: storeElapsedMsCount === 0 ? null : round(storeElapsedMsSum / storeElapsedMsCount),
+    },
+  };
+}
+
+async function readCollection(db: RedDB, collection: string): Promise<Array<Record<string, unknown>>> {
+  const listed = await db.kv(collection).list({ limit: 10_000 }).catch((err: unknown) => {
+    if (err instanceof Error && /\bnot found\b/i.test(err.message)) return { items: [] };
+    throw err;
+  });
+  return listed.items
+    .map((entry) => parseRecord(entry.value))
+    .filter((value): value is Record<string, unknown> => isRecord(value));
+}
+
+function parseRecord(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function timestampMs(record: Record<string, unknown>): number {
+  const parsed = Date.parse(timestampString(record));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function timestampString(record: Record<string, unknown>): string {
+  return stringField(record.created_at) || stringField(record.ts) || "";
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numeric(value: unknown): number {
+  return optionalNumeric(value) ?? 0;
+}
+
+function optionalNumeric(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1));
+  return round(sorted[index]!);
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -623,6 +623,27 @@ describe("rsp cli", () => {
       command: "git --version",
       reason: "wrapper failed",
     }));
+
+    const stats = runBundleFromCwd(root, ["stats", "--since", "7d", "--full"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    const statsText = stats.stdout.toString("utf8");
+    expect(stats.status, `${statsText}${stats.stderr.toString("utf8")}`).toBe(0);
+    expect(statsText).toContain("records: 1\n");
+    expect(statsText).toContain("savings:\n");
+    expect(statsText).toContain("  window_days: 7\n");
+    expect(statsText).toMatch(/  invocations: [1-9]\d*\n/);
+    expect(statsText).toContain("  elided: 1\n");
+    expect(statsText).toMatch(/  raw_bytes: [1-9]\d*\n/);
+    expect(statsText).toMatch(/  emitted_bytes: [1-9]\d*\n/);
+    expect(statsText).toMatch(/  tokens_saved: [1-9]\d*\n/);
+    expect(statsText).toContain("  top_commands:\n");
+    expect(statsText).toContain("command: git log");
+    expect(statsText).toContain("health:\n");
+    expect(statsText).toContain("  degradations: 1\n");
+    expect(statsText).toContain("  degradation_rate: 0.5\n");
+    expect(statsText).toContain("  most_recent_degradation_reason: wrapper failed\n");
+    expect(statsText).toContain("latency:\n");
+    expect(statsText).toMatch(/  wrapper_ms_p50: [0-9.]+\n/);
+    expect(statsText).toMatch(/  wrapper_ms_p95: [0-9.]+\n/);
   }, 120_000);
 
   it("built bundle keeps git log terse elision latency under budget", async () => {
@@ -791,7 +812,31 @@ describe("rsp cli", () => {
     const res = runRsp(root, [], { RSP_STORE_URI: storeUri });
 
     expect(res.status).toBe(0);
-    expect(res.stdout).toEqual(Buffer.from("records: 1\nbytes: 3\noldest: 2026-07-10T12:00:00.000Z\nbudget: 67108864\n"));
+    const text = res.stdout.toString("utf8");
+    expect(text).toContain("records: 1\nbytes: 3\noldest: 2026-07-10T12:00:00.000Z\nbudget: 67108864\n");
+    expect(text).toContain("savings:\n  window_days: 30\n  empty: true\n  invocations: 0\n");
+    expect(text).toContain("health:\n  degradations: 0\n  degradation_rate: 0.0\n");
+    expect(text).toContain("latency:\n  wrapper_ms_p50: none\n");
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
+  it("prints a definitive empty telemetry state through rsp stats", async () => {
+    const root = await tempRoot();
+    await enableRsp(root);
+    const storeUri = `file://${join(root, "red.rdb")}`;
+    const store = await RspElisionStore.open({ uri: storeUri });
+    await store.close();
+
+    const res = runRsp(root, ["stats", "--since=7d"], { RSP_STORE_URI: storeUri });
+    const text = res.stdout.toString("utf8");
+
+    expect(res.status).toBe(0);
+    expect(text).toContain("records: 0\nbytes: 0\noldest: none\n");
+    expect(text).toContain("savings:\n  window_days: 7\n  empty: true\n  invocations: 0\n");
+    expect(text).toContain("  top_commands:\n    empty: true\n");
+    expect(text).toContain("health:\n  degradations: 0\n  degradation_rate: 0.0\n");
+    expect(text).toContain("  most_recent_degradation_at: none\n");
+    expect(text).toContain("latency:\n  wrapper_ms_p50: none\n  wrapper_ms_p95: none\n");
     expect(res.stderr).toEqual(Buffer.alloc(0));
   });
 

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -187,6 +187,82 @@ describe("rsp telemetry spool", () => {
     });
   }, 20_000);
 
+  it("serves telemetry stats from resident collections without mutating the spool", async () => {
+    const root = await tempRoot();
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "saved",
+      created_at: new Date().toISOString(),
+      command: "git log",
+      elided: true,
+      raw_bytes: 1000,
+      emitted_bytes: 100,
+      raw_text: "alpha ".repeat(100),
+      emitted_text: "alpha",
+      wrapper_ms: 12,
+      store_open_count: 1,
+      store_elapsed_ms: 4,
+      bytes: 200,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+      id: "degraded",
+      created_at: new Date().toISOString(),
+      command: "git --version",
+      reason: "wrapper failed",
+      bytes: 100,
+    });
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const server = runResidentServer({
+      rootDir: root,
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      telemetryTtlDays: 90,
+      telemetryByteBudget: 1_000,
+      idleMs: 100,
+    });
+    await waitForResident(paths.socketPath);
+
+    const response = await sendResidentRequest({ socketPath: paths.socketPath }, {
+      id: "stats",
+      op: "telemetry-stats",
+      sinceDays: 7,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.ok && response.value).toMatchObject({
+      window_days: 7,
+      empty: false,
+      savings: {
+        invocations: 1,
+        elided: 1,
+        raw_bytes: 1000,
+        emitted_bytes: 100,
+        bytes_saved: 900,
+        top_commands: [expect.objectContaining({ command: "git log", invocations: 1, bytes_saved: 900 })],
+      },
+      health: {
+        degradations: 1,
+        degradation_rate: 0.5,
+        by_reason: [{ reason: "wrapper failed", count: 1 }],
+        most_recent: expect.objectContaining({ reason: "wrapper failed", command: "git --version" }),
+      },
+      latency: {
+        wrapper_ms_p50: 12,
+        wrapper_ms_p95: 12,
+        store_open_count_sum: 1,
+        store_elapsed_ms_sum: 4,
+        store_elapsed_ms_avg: 4,
+      },
+    });
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
+    await server;
+  }, 20_000);
+
   it("drains a hand-written spool through the built bundle resident", async () => {
     const root = await tempRoot();
     const bundle = await ensureRspBundle();

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -13,6 +13,7 @@ export interface RspResidentConfig {
 export type RspResidentRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "stats" }
+  | { id: string; op: "telemetry-stats"; sinceDays: number }
   | { id: string; op: "mint"; original: string; meta: unknown }
   | { id: string; op: "get"; handle: string }
   | { id: string; op: "memory"; action: "recall" | "ingest"; payload: unknown };


### PR DESCRIPTION
Closes #1577. Final slice of Spec #1574.

`rsp stats` now answers the three operator questions over a configurable window: **savings** (invocations, elided count, bytes and tokens saved, per-day series), **health** (degradation count by reason, degradation rate, most recent degradation), and **latency** (wrapper p50/p95, resident store aggregates). TOON, small by default, `--full` for the long form, definitive empty state on a fresh repo.

The drain parked this as `blocked:validation`, but the failure was the known cross-package flake: `@reddb-io/rsp` suite passes (158/158) and the failing `@reddb-io/dev` suite passes clean on rerun (193 files, 3511 tests). Landed by hand after verifying both.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786492477&installation_id=129708444&pr_number=1580&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1580&signature=d3e3cdd6fc77615d546f283b6765520c48016dd85fc475cd4b4826793c28f142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->