### PR TITLE
chore: enable the rsp surface in the repo config

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -9,3 +9,10 @@ plugins:
       primary-branch: true       # primary-checkout branch-switch guard
   internal:
     enabled: true                # maintainer-only repo operations plugin (ADR 0067)
+
+# rsp token-efficiency surface (per-repo opt-in; hook stays inert without enabled: true)
+rsp:
+  enabled: true
+  ttlDays: 7
+  byteBudget: 67108864
+  heavyGitByteThreshold: 8192


### PR DESCRIPTION
Commits the `rsp:` activation block (per the red-setup config template) that until now existed only as uncommitted local state in the primary checkout.

Why it matters beyond dogfooding: the chronically dirty `.red/config.yaml` made the AFK finalizer skip its post-landing local-main fast-forward (ADR 0083 clean-tree guard) on every landing, so the primary checkout silently drifted 537 commits behind origin/main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786494564&installation_id=129708444&pr_number=1582&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1582&signature=ddd03e094d00e9548956154532bbe47318bcdf1ad22008134dac7a7c81c66584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->