### PR TITLE
fix: #1587 telemetry drain hangs on raw_text events and silently loses the rest of the batch

### DIFF
--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -15,7 +15,7 @@ import {
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INDEX_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
-  takeTelemetrySpool,
+  drainTelemetrySpool,
   type RspTelemetryEvent,
 } from "./telemetry.js";
 import { DEFAULT_RSP_TELEMETRY_BYTE_BUDGET, DEFAULT_RSP_TELEMETRY_TTL_DAYS } from "./config.js";
@@ -109,6 +109,8 @@ interface TelemetryIndexDocument {
 }
 
 const TOKENIZATION_CAP_BYTES = 256 * 1024;
+const TOKENIZATION_TIMEOUT_MS = 500;
+const TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
 
 class ResidentTelemetryDrain {
   private running?: Promise<void>;
@@ -128,15 +130,36 @@ class ResidentTelemetryDrain {
   private async drainAndSweepOnce(): Promise<void> {
     const db = this.store.redDb();
     if (!db) return;
-    const lines = await takeTelemetrySpool(this.opts.rootDir);
     const index = await this.readIndex(db);
     const nextRecords = [...index.records];
-    for (const line of lines) {
+    await drainTelemetrySpool(this.opts.rootDir, async (line) => {
       const event = parseTelemetryEvent(line);
-      if (!event) continue;
-      const entry = await this.writeEvent(db, event);
-      nextRecords.push(entry);
-    }
+      if (!event) {
+        const entry = await this.writeDrainDegradation(db, {
+          reason: "telemetry parse failed",
+          command: "unknown",
+          bytes: Buffer.byteLength(line, "utf8"),
+        });
+        nextRecords.push(entry);
+        return true;
+      }
+      try {
+        const entry = await this.writeEvent(db, event);
+        nextRecords.push(entry);
+        return true;
+      } catch (err) {
+        const entry = await this.writeDrainDegradation(db, {
+          reason: "telemetry event dropped",
+          command: stringField(event.command) || "unknown",
+          source_id: stringField(event.id),
+          source_collection: stringField(event.collection),
+          error: err instanceof Error ? err.message : String(err),
+          bytes: Buffer.byteLength(line, "utf8"),
+        });
+        nextRecords.push(entry);
+        return true;
+      }
+    });
     await this.prune(db, { version: 1, records: nextRecords });
   }
 
@@ -161,6 +184,30 @@ class ResidentTelemetryDrain {
         ? Math.max(0, event.bytes)
         : Buffer.byteLength(JSON.stringify(record), "utf8"),
     };
+  }
+
+  private async writeDrainDegradation(
+    db: RedDB,
+    event: {
+      reason: string;
+      command: string;
+      bytes: number;
+      source_id?: string;
+      source_collection?: string;
+      error?: string;
+    },
+  ): Promise<TelemetryIndexEntry> {
+    return await this.writeEvent(db, {
+      collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+      id: randomUUID(),
+      created_at: new Date().toISOString(),
+      reason: event.reason,
+      command: event.command,
+      bytes: event.bytes,
+      source_id: event.source_id,
+      source_collection: event.source_collection,
+      error: event.error,
+    });
   }
 
   private async readIndex(db: RedDB): Promise<TelemetryIndexDocument> {
@@ -196,7 +243,7 @@ class ResidentTelemetryDrain {
 
 async function safeDrainTelemetry(telemetry: ResidentTelemetryDrain): Promise<void> {
   try {
-    await telemetry.drainAndSweep();
+    await withTimeout(telemetry.drainAndSweep(), TELEMETRY_DRAIN_TIMEOUT_MS, "telemetry drain timed out");
   } catch (err) {
     process.stderr.write(`rsp resident: telemetry drain failed: ${err instanceof Error ? err.message : String(err)}\n`);
   }
@@ -219,8 +266,14 @@ async function tokenCount(text: unknown, fallbackBytes: number | undefined): Pro
   if (typeof text === "string") {
     const bytes = Buffer.byteLength(text, "utf8");
     if (bytes <= TOKENIZATION_CAP_BYTES) {
-      const getEncoding = await loadGetEncoding();
-      return { tokens: getEncoding("cl100k_base").encode(text).length, estimated: false };
+      try {
+        return await withTimeout((async () => {
+          const getEncoding = await loadGetEncoding();
+          return { tokens: getEncoding("cl100k_base").encode(text).length, estimated: false };
+        })(), TOKENIZATION_TIMEOUT_MS, "telemetry tokenization timed out");
+      } catch {
+        return { tokens: Math.ceil(bytes / 4), estimated: true };
+      }
     }
     return { tokens: Math.ceil(bytes / 4), estimated: true };
   }
@@ -253,6 +306,25 @@ function resolveJsTiktoken(): string {
 
 function numericField(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+        timer.unref();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function safeJson(value: string): unknown {

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { RedDB } from "@reddb-io/sdk";
@@ -131,6 +131,48 @@ export async function takeTelemetrySpool(rootDir: string): Promise<string[]> {
     return text.split(/\r?\n/).filter((line) => line.trim() !== "");
   } finally {
     await rm(drainingPath, { force: true });
+  }
+}
+
+export async function drainTelemetrySpool(
+  rootDir: string,
+  drainLine: (line: string) => Promise<boolean>,
+): Promise<void> {
+  const path = telemetrySpoolPath(rootDir);
+  const drainingPath = `${path}.${process.pid}.${Date.now()}.drain`;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await rename(path, drainingPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    return;
+  }
+
+  const retryLines: string[] = [];
+  try {
+    await writeFile(path, "", { flag: "wx" }).catch(() => undefined);
+    const text = await readFile(drainingPath, "utf8").catch(() => "");
+    const lines = text.split(/\r?\n/).filter((line) => line.trim() !== "");
+    for (const line of lines) {
+      try {
+        if (await drainLine(line)) continue;
+      } catch {}
+      retryLines.push(line);
+    }
+  } finally {
+    if (retryLines.length > 0) {
+      const current = safeReadFileSync(path);
+      await writeFile(path, `${retryLines.join("\n")}\n${current}`, "utf8");
+    }
+    await rm(drainingPath, { force: true });
+  }
+}
+
+function safeReadFileSync(path: string): string {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
   }
 }
 

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -12,6 +12,7 @@ import { resolveResidentPaths } from "../src/resident-client.js";
 import {
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+  telemetrySpoolPath,
 } from "../src/telemetry.js";
 
 const roots: string[] = [];
@@ -222,6 +223,23 @@ async function waitForGone(path: string, timeoutMs = 5_000): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`still present after ${timeoutMs}ms: ${path}`);
+}
+
+async function closeWithTimeout(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<number | null> {
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.once("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.once("close", (status) => {
+      clearTimeout(timer);
+      resolve(status);
+    });
+  });
 }
 
 async function waitForResidentSocket(root: string): Promise<void> {
@@ -720,6 +738,112 @@ describe("rsp cli", () => {
     expect(decoded.window.invocations).toBe(2);
     expect(decoded.window.degradations).toBe(1);
     expect(decoded.savings.single_biggest_elision).toMatchObject({ command_family: "git log", tokens_saved: 1800 });
+  }, 120_000);
+
+  it("built bundle drains raw-text telemetry without losing the trailing event", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await enableRsp(root);
+    const cacheDir = await seedWarmRedCache();
+    const env = { RED_SKILLS_CACHE_DIR: cacheDir };
+    const setup = runBundleFromCwd(root, ["setup"], env);
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+
+    const now = new Date().toISOString();
+    await mkdir(join(root, ".red", "tmp"), { recursive: true });
+    await writeFile(telemetrySpoolPath(root), [
+      JSON.stringify({
+        collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+        id: "leading",
+        created_at: now,
+        command: "git status",
+        elided: false,
+        raw_bytes: 80,
+        emitted_bytes: 80,
+        wrapper_ms: 1,
+      }),
+      "{not-json",
+      JSON.stringify({
+        collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+        id: "raw-text",
+        created_at: now,
+        command: "git log --terse",
+        elided: true,
+        raw_bytes: 1200,
+        emitted_bytes: 120,
+        raw_text: "alpha beta gamma delta epsilon zeta eta theta iota kappa",
+        emitted_text: "alpha beta",
+        wrapper_ms: 2,
+      }),
+      JSON.stringify({
+        collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+        id: "trailing",
+        created_at: now,
+        command: "gh pr list",
+        elided: false,
+        raw_bytes: 200,
+        emitted_bytes: 200,
+        wrapper_ms: 3,
+      }),
+      "",
+    ].join("\n"), "utf8");
+
+    const child = spawn(process.execPath, [
+      bundle,
+      "server",
+      "--idle-ms",
+      "250",
+      "--telemetry-drain-interval-ms",
+      "50",
+    ], {
+      cwd: root,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+    const status = await closeWithTimeout(child, 5_000);
+    expect(status, `${Buffer.concat(stdout).toString("utf8")}${Buffer.concat(stderr).toString("utf8")}`).toBe(0);
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
+
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const invocations = await readTelemetryRecords(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION);
+    expect(invocations).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "leading", command: "git status" }),
+      expect.objectContaining({
+        id: "raw-text",
+        command: "git log --terse",
+        tokens_raw: expect.any(Number),
+        tokens_emitted: expect.any(Number),
+      }),
+      expect.objectContaining({ id: "trailing", command: "gh pr list" }),
+    ]));
+    const degradations = await readTelemetryRecords(storeUri, RSP_TELEMETRY_DEGRADATIONS_COLLECTION);
+    expect(degradations).toContainEqual(expect.objectContaining({ reason: "telemetry parse failed" }));
+
+    const stats = runBundleFromCwd(root, ["stats", "--since", "7d", "--full"], env);
+    const statsText = stats.stdout.toString("utf8");
+    expect(stats.status, `${statsText}${stats.stderr.toString("utf8")}`).toBe(0);
+    expect(statsText).toContain("invocations: 3\n");
+    expect(statsText).toMatch(/tokens_saved: [1-9]\d*\n/);
+    expect(statsText).toContain("command: git log --terse invocations: 1");
+    expect(statsText).toContain("command: gh pr list invocations: 1");
+    expect(statsText).toContain("degradations: 1\n");
+
+    const gains = runBundleFromCwd(root, ["gains", "--since", "7d"], env);
+    const gainsText = gains.stdout.toString("utf8");
+    expect(gains.status, `${gainsText}${gains.stderr.toString("utf8")}`).toBe(0);
+    const decoded = decode(gainsText) as {
+      window: { invocations: number; degradations: number };
+      savings: { single_biggest_elision: { command_family: string; tokens_saved: number } | null };
+    };
+    expect(decoded.window).toMatchObject({ invocations: 3, degradations: 1 });
+    expect(decoded.savings.single_biggest_elision).toMatchObject({
+      command_family: "git log",
+      tokens_saved: expect.any(Number),
+    });
   }, 120_000);
 
   it("built bundle keeps git log terse elision latency under budget", async () => {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -8,6 +8,7 @@ import { connect } from "@reddb-io/sdk";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   appendTelemetryEvent,
+  drainTelemetrySpool,
   readTelemetryGainsReport,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -48,6 +49,26 @@ describe("rsp telemetry spool", () => {
       collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
       id: "lost",
     })).resolves.toBeUndefined();
+  });
+
+  it("keeps spool lines that do not drain durably", async () => {
+    const root = await tempRoot();
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "retry-me",
+      command: "git log",
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "ok",
+      command: "git status",
+    });
+
+    await drainTelemetrySpool(root, async (line) => !line.includes("retry-me"));
+
+    const spool = await readFile(telemetrySpoolPath(root), "utf8");
+    expect(spool).toContain('"id":"retry-me"');
+    expect(spool).not.toContain('"id":"ok"');
   });
 
   it("drains boot and idle telemetry into RedDB while skipping malformed lines", async () => {


### PR DESCRIPTION
Automated AFK landing for #1587. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1587

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786498084&installation_id=129708444&pr_number=1588&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1588&signature=47728d7f0043b319d18b132274b0c1a6536efdbaaf97d36499e7a30303cffc2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->