### PR TITLE
fix: #1589 resident version handover: a live old resident keeps serving newer clients until idle

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -2,6 +2,7 @@
 import { appendFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { encode, type JsonObject } from "@reddb-io/toon";
+import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspElisionStore } from "./elision-store.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
 import type { RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
@@ -16,6 +17,7 @@ interface ParsedArgs {
 }
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
+  const buildInfo = readBuildInfo("rsp");
   const args = parseArgs(argv);
   if (args.command === "hook" && args.positional[1] === "claude-pre-exec") {
     const { runClaudePreExecHook } = await import("./intercept.js");
@@ -67,6 +69,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       telemetryDrainIntervalMs: numericValueAfter(args.positional, "--telemetry-drain-interval-ms") ??
         serverConfig.telemetryDrainIntervalMs,
       idleMs: numericValueAfter(args.positional, "--idle-ms"),
+      residentVersion: valueAfter(args.positional, "--resident-version") ?? buildInfo.version,
     });
     return 0;
   }
@@ -89,6 +92,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       telemetryByteBudget: numericValueAfter(args.positional, "--telemetry-byte-budget") ?? warmConfig.telemetryByteBudget,
       telemetryDrainIntervalMs: numericValueAfter(args.positional, "--telemetry-drain-interval-ms") ??
         warmConfig.telemetryDrainIntervalMs,
+      clientVersion: buildInfo.version,
     });
     return 0;
   }
@@ -108,6 +112,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     telemetryTtlDays: config.telemetryTtlDays,
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    clientVersion: buildInfo.version,
   }));
   const warmResidentStore = () => ensureResidentServer(residentPaths, {
     storeUri: config.storeUri,
@@ -116,6 +121,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     telemetryTtlDays: config.telemetryTtlDays,
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    clientVersion: buildInfo.version,
   });
   const openDirectStore = async (): Promise<ElisionStoreLike & Pick<RspElisionStore, "get" | "stats">> => {
     const { RspElisionStore } = await import("./elision-store.js");

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -24,6 +24,7 @@ export interface ResidentServerOptions extends RspResidentConfig {
   socketPath: string;
   rootDir?: string;
   idleMs?: number;
+  residentVersion?: string;
   telemetryDrainIntervalMs?: number;
 }
 
@@ -57,9 +58,10 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
     touch();
     handleSocket(socket, async (request) => {
       touch();
-      const value = await handleRequest(store, request);
+      const value = await handleRequest(store, request, opts.residentVersion ?? "0.0.0-dev");
       const response: RspResidentResponse = { id: request.id, ok: true, value, storeOpenCount, storeElapsedMs };
       socket.write(`${JSON.stringify(response)}\n`);
+      if (request.op === "handover") setImmediate(() => server.close());
     });
   });
 
@@ -385,8 +387,9 @@ function handleSocket(socket: Socket, handler: (request: RspResidentRequest) => 
   });
 }
 
-async function handleRequest(store: RspElisionStore, request: RspResidentRequest): Promise<unknown> {
-  if (request.op === "ping") return { pong: true };
+async function handleRequest(store: RspElisionStore, request: RspResidentRequest, residentVersion: string): Promise<unknown> {
+  if (request.op === "ping") return { pong: true, version: residentVersion };
+  if (request.op === "handover") return { handover: true, version: residentVersion, clientVersion: request.clientVersion };
   if (request.op === "stats") return await store.stats();
   if (request.op === "telemetry-stats") {
     const db = store.redDb();

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -4,11 +4,13 @@ import { tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
+import { createServer, type Server, type Socket } from "node:net";
 import { connect } from "@reddb-io/sdk";
 import { decode } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
 import { RspElisionStore } from "../src/elision-store.js";
 import { resolveResidentPaths } from "../src/resident-client.js";
+import { sendResidentRequest } from "../src/resident-protocol.js";
 import {
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -279,6 +281,55 @@ async function waitForResidentSocket(root: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   await stat(paths.socketPath);
+}
+
+async function readResidentVersion(root: string): Promise<string | undefined> {
+  const socketPath = trackedResidentPaths(root).socketPath;
+  const deadline = Date.now() + 5_000;
+  let last: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const response = await sendResidentRequest(
+        { socketPath, timeoutMs: 500 },
+        { id: "version", op: "ping" },
+      );
+      const value = response.ok && isRecord(response.value) ? response.value : {};
+      return typeof value.version === "string" ? value.version : undefined;
+    } catch (err) {
+      last = err;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw last instanceof Error ? last : new Error("resident version probe failed");
+}
+
+async function startHungOldResident(socketPath: string, version: string): Promise<Server> {
+  await mkdir(dirname(socketPath), { recursive: true });
+  const server = createServer((socket) => handleHungOldResidentSocket(socket, version));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return server;
+}
+
+function handleHungOldResidentSocket(socket: Socket, version: string): void {
+  let buffer = "";
+  socket.setEncoding("utf8");
+  socket.on("error", () => {});
+  socket.on("data", (chunk) => {
+    buffer += chunk;
+    const newline = buffer.indexOf("\n");
+    if (newline < 0) return;
+    const request = JSON.parse(buffer.slice(0, newline)) as { id?: string; op?: string };
+    if (request.op === "ping") {
+      socket.write(`${JSON.stringify({ id: request.id, ok: true, value: { pong: true, version } })}\n`, () => {});
+      socket.end();
+    }
+  });
 }
 
 async function readTelemetryRecords(storeUri: string, collection: string): Promise<unknown[]> {
@@ -659,6 +710,60 @@ describe("rsp cli", () => {
     expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
     await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
     await expect(stat(paths.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  }, 120_000);
+
+  it("built bundle hands over from an older live resident and keeps serving requests", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const oldVersion = "2.23.0";
+    const oldResident = runBundleFromCwdAsync(
+      root,
+      ["server", "--idle-ms", "10000", "--resident-version", oldVersion],
+      { RED_SKILLS_CACHE_DIR: cacheDir },
+    );
+    await waitForResidentSocket(root);
+    expect(await readResidentVersion(root)).toBe(oldVersion);
+
+    const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
+
+    expect(compressed.status, `${compressed.stdout.toString("utf8")}${compressed.stderr.toString("utf8")}`).toBe(0);
+    expect(compressed.stderr).toEqual(Buffer.alloc(0));
+    const handle = /rsp show (el:[a-f0-9]{12})/.exec(compressed.stdout.toString("utf8"))?.[1];
+    expect(handle).toBeTruthy();
+    const shown = runBundleFromCwd(root, ["show", handle!], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(shown.status, `${shown.stdout.toString("utf8")}${shown.stderr.toString("utf8")}`).toBe(0);
+    expect(shown.stdout.length).toBeGreaterThan(compressed.stdout.length);
+    expect(await readResidentVersion(root)).not.toBe(oldVersion);
+    expect(await oldResident).toMatchObject({ status: 0 });
+  }, 120_000);
+
+  it("built bundle removes a hung old resident socket after handover timeout", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const paths = trackedResidentPaths(root);
+    const oldVersion = "2.23.0";
+    const hung = await startHungOldResident(paths.socketPath, oldVersion);
+    try {
+      expect(await readResidentVersion(root)).toBe(oldVersion);
+
+      const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
+
+      expect(compressed.status, `${compressed.stdout.toString("utf8")}${compressed.stderr.toString("utf8")}`).toBe(0);
+      expect(compressed.stderr).toEqual(Buffer.alloc(0));
+      expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
+      expect(await readResidentVersion(root)).not.toBe(oldVersion);
+      await expect(stat(paths.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      hung.close();
+    }
   }, 120_000);
 
   it("built bundle compresses git log, mints a handle, round-trips it, and reports degraded passthrough", async () => {

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -56,12 +56,12 @@ export type ResidentRequestWithoutId = RspResidentRequest extends infer Request
 
 export async function ensureResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
   await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
-  if (await pingResident(paths.socketPath)) return;
+  if (await isResidentUsable(paths.socketPath, config)) return;
 
   const lock = await tryAcquireLock(paths.lockPath);
   if (lock) {
     try {
-      if (await pingResident(paths.socketPath)) return;
+      if (await isResidentUsable(paths.socketPath, config)) return;
       await removeUnresponsiveSocket(paths.socketPath);
       const child = spawnResident(paths, config);
       await waitForServer(paths.socketPath, child);
@@ -77,11 +77,20 @@ export async function ensureResidentServer(paths: RspResidentPaths, config: RspR
 
 export async function pingResident(socketPath: string, timeoutMs = 200): Promise<boolean> {
   try {
-    const response = await sendResidentRequest({ socketPath, timeoutMs }, { id: randomUUID(), op: "ping" });
-    return response.ok;
+    return await pingResidentHello(socketPath, timeoutMs) != null;
   } catch {
     return false;
   }
+}
+
+export interface ResidentHello {
+  version?: string;
+}
+
+export async function pingResidentHello(socketPath: string, timeoutMs = 200): Promise<ResidentHello | null> {
+  const response = await sendResidentRequest({ socketPath, timeoutMs }, { id: randomUUID(), op: "ping" });
+  if (!response.ok) return null;
+  return isRecord(response.value) ? { version: stringValue(response.value.version) } : {};
 }
 
 export async function kickResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<boolean> {
@@ -110,6 +119,8 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
     String(config.telemetryByteBudget ?? config.byteBudget),
     "--telemetry-drain-interval-ms",
     String(config.telemetryDrainIntervalMs ?? 30_000),
+    "--resident-version",
+    config.clientVersion ?? "0.0.0-dev",
     "--wake-lock",
     paths.wakeLockPath,
   ], {
@@ -176,6 +187,8 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
     String(config.telemetryByteBudget ?? config.byteBudget),
     "--telemetry-drain-interval-ms",
     String(config.telemetryDrainIntervalMs ?? 30_000),
+    "--resident-version",
+    config.clientVersion ?? "0.0.0-dev",
   ], {
     cwd: paths.rootDir,
     detached: true,
@@ -222,5 +235,58 @@ function readFileSyncSafe(path: string): string | null {
     return readFileSync(path, "utf8");
   } catch {
     return null;
+  }
+}
+
+async function isResidentUsable(socketPath: string, config: RspResidentConfig): Promise<boolean> {
+  const hello = await pingResidentHello(socketPath).catch(() => null);
+  if (!hello) return false;
+  if (!shouldHandover(config.clientVersion, hello.version)) return true;
+
+  await requestResidentHandover(socketPath, config.clientVersion!);
+  await waitForResidentExit(socketPath);
+  return false;
+}
+
+async function requestResidentHandover(socketPath: string, clientVersion: string): Promise<void> {
+  try {
+    await sendResidentRequest({ socketPath, timeoutMs: 200 }, { id: randomUUID(), op: "handover", clientVersion });
+  } catch {
+    // A hung or pre-handover resident should fall through to the existing
+    // unresponsive-socket removal path under the spawn lock.
+  }
+}
+
+function shouldHandover(clientVersion: string | undefined, residentVersion: string | undefined): boolean {
+  if (!clientVersion || !residentVersion) return false;
+  return compareSemver(clientVersion, residentVersion) > 0;
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) return 0;
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+function parseSemver(version: string): { major: number; minor: number; patch: number } | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(version).trim());
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+async function waitForResidentExit(socketPath: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (!await pingResident(socketPath, 50)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
 }

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -4,6 +4,7 @@ export interface RspResidentConfig {
   storeUri: string;
   ttlDays: number;
   byteBudget: number;
+  clientVersion?: string;
   telemetryTtlDays?: number;
   telemetryByteBudget?: number;
   telemetryDrainIntervalMs?: number;
@@ -13,6 +14,7 @@ export interface RspResidentConfig {
 
 export type RspResidentRequest =
   | { id: string; op: "ping" }
+  | { id: string; op: "handover"; clientVersion: string }
   | { id: string; op: "stats" }
   | { id: string; op: "telemetry-stats"; sinceDays: number }
   | { id: string; op: "telemetry-gains"; sinceDays: number }


### PR DESCRIPTION
Automated AFK landing for #1589. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1589

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786500349&installation_id=129708444&pr_number=1593&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1593&signature=30b27fe6fbcfd80af5dd690ce6310d3ca1132658523aa22d89cc7c7e61b03238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->