### PR TITLE
fix: #1592 /go: Replace the confusing rsp statusline indicator (rsp●/rsp○) with a live s

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -16,7 +16,7 @@
 // `.workspace.project_dir` (the fixed session root — survives `cd` into subdirs),
 // else `.workspace.current_dir // .cwd`, else `process.cwd()`.
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { resolveBase } from "../core/base-resolver.js";
@@ -26,7 +26,7 @@ import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
 import { branchLockPath, readLockedBranch } from "../runtime/lock.js";
 import { resolveRspConfig } from "../../../rsp/src/config.js";
-import { pingResident, resolveResidentPaths } from "../../../rsp/src/resident-client.js";
+import { resolveResidentPaths } from "../../../rsp/src/resident-client.js";
 import {
   collectStatuslineAfk,
   collectStatuslineFleet,
@@ -139,11 +139,54 @@ export function resolveStatuslinePreset(cfg: ReturnType<typeof loadConfig>): Sta
   );
 }
 
+const RSP_WARMUP_GRACE_MS = 15_000;
+const RSP_MIN_SUMMARY_FRESH_MS = 90_000;
+
+interface RspSummaryFile {
+  version: number;
+  tokens_saved_today: number;
+  updated_at: string;
+}
+
+function parseRspSummary(path: string): RspSummaryFile | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { version?: unknown }).version === 1 &&
+      typeof (parsed as { tokens_saved_today?: unknown }).tokens_saved_today === "number" &&
+      typeof (parsed as { updated_at?: unknown }).updated_at === "string"
+    ) {
+      return parsed as RspSummaryFile;
+    }
+  } catch {}
+  return undefined;
+}
+
+function isRecentFile(path: string, nowMs: number, maxAgeMs: number): boolean {
+  try {
+    return nowMs - statSync(path).mtimeMs <= maxAgeMs;
+  } catch {
+    return false;
+  }
+}
+
 export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv = process.env): Promise<RspStatusInput | undefined> {
   const config = resolveRspConfig(root, env);
   if (!config.enabled) return undefined;
   const paths = resolveResidentPaths(root);
-  return await pingResident(paths.socketPath, 50) ? "on" : "warming";
+  const nowMs = Date.now();
+  const summaryFreshMs = Math.max(RSP_MIN_SUMMARY_FRESH_MS, config.telemetryDrainIntervalMs * 3);
+  const summary = parseRspSummary(paths.summaryPath);
+  if (summary) {
+    const updatedAtMs = Date.parse(summary.updated_at);
+    if (Number.isFinite(updatedAtMs) && nowMs - updatedAtMs <= summaryFreshMs) {
+      return { state: "ready", tokensSavedToday: Math.max(0, Math.floor(summary.tokens_saved_today)) };
+    }
+  }
+  if (isRecentFile(paths.wakeLockPath, nowMs, RSP_WARMUP_GRACE_MS)) return { state: "warming" };
+  return { state: "error" };
 }
 
 /** The block-1 project input: basename, the resolved git ref (branch or detached

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -57,6 +57,7 @@ const VAL = "\x1b[39m"; // transparent-zone VALUE: terminal default foreground
 const SOFT = "\x1b[38;2;224;138;148m"; // transparent-zone general font: a lighter red (runner, +/-/# sigils, ·phase)
 const DIM = "\x1b[38;2;201;150;158m"; // identity-zone branch/version
 const GREEN = "\x1b[38;2;96;214;128m"; // healthy rsp resident
+const RED = "\x1b[38;2;255;95;95m"; // unreachable rsp resident
 const GOLD = "\x1b[38;2;240;200;120m"; // » accent
 const BOLD = "\x1b[1m";
 const NOBOLD = "\x1b[22m";
@@ -196,8 +197,10 @@ function fleetKv(fleet: FleetInput | undefined): string[] {
 
 function rspKv(rsp: RspStatusInput | undefined): string[] {
   const block = renderRspBlock(rsp);
-  if (!block) return [];
-  return rsp === "on" ? [`${GREEN}${block}${SOFT}`] : [`${DIM}${block}${SOFT}`];
+  if (!rsp || !block) return [];
+  if (rsp.state === "ready") return [`${GREEN}${block}${SOFT}`];
+  if (rsp.state === "error") return [`${RED}${block}${SOFT}`];
+  return [`${DIM}${block}${SOFT}`];
 }
 
 /** Line 1 — wine identity zone (project + model) then a transparent KPI tail. */

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -163,7 +163,10 @@ export interface FleetInput {
   parked?: number;
 }
 
-export type RspStatusInput = "warming" | "on";
+export type RspStatusInput =
+  | { state: "ready"; tokensSavedToday: number }
+  | { state: "warming" }
+  | { state: "error" };
 
 /** All the resolved inputs for one statusline render. */
 export interface StatuslineInput {
@@ -430,7 +433,9 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
 
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
-  return rsp === "on" ? "rsp●" : "rsp○";
+  if (rsp.state === "ready") return `rsp ↓${humanizeCount(rsp.tokensSavedToday)}`;
+  if (rsp.state === "warming") return "rsp …";
+  return "rsp !";
 }
 
 /**

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -689,56 +689,67 @@ describe("statusline command — rendered line", () => {
     expect(await resolveStatuslineRsp(root, {})).toBeUndefined();
   });
 
-  it("renders rsp warming quickly when enabled and no resident socket answers", async () => {
+  it("renders rsp warming quickly when enabled and the warmup marker is recent", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await mkdir(dirname(resolveResidentPaths(root).wakeLockPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).wakeLockPath, "", "utf8");
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 0, 0);
 
     const started = Date.now();
     const rsp = await resolveStatuslineRsp(root, {});
     const elapsed = Date.now() - started;
-    expect(rsp).toBe("warming");
+    expect(rsp).toEqual({ state: "warming" });
     expect(elapsed).toBeLessThan(50);
 
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp○");
+    expect(stripAnsi(out.text())).toContain("rsp …");
   });
 
-  it("renders rsp on when an enabled repo has a live resident socket", async () => {
+  it("renders rsp savings when an enabled repo has a fresh resident summary", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 0, 0);
-    const server = await listenRspSocket(root, "reply");
-    try {
-      expect(await resolveStatuslineRsp(root, {})).toBe("on");
+    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
+      version: 1,
+      tokens_saved_today: 1300000,
+      updated_at: new Date().toISOString(),
+    }), "utf8");
+    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 1300000 });
 
-      const out = sink();
-      const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
-      expect(code).toBe(0);
-      expect(stripAnsi(out.text())).toContain("rsp●");
-    } finally {
-      await closeServer(server);
-    }
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("rsp ↓1.3M");
   });
 
-  it("renders rsp warming after the ping cap when a resident socket hangs", async () => {
+  it("renders rsp error when enabled and no fresh summary or warmup marker exists", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
-    const server = await listenRspSocket(root, "hang");
-    try {
-      const started = Date.now();
-      const rsp = await resolveStatuslineRsp(root, {});
-      const elapsed = Date.now() - started;
-      expect(rsp).toBe("warming");
-      expect(elapsed).toBeGreaterThanOrEqual(45);
-      expect(elapsed).toBeLessThan(120);
-    } finally {
-      await closeServer(server);
-    }
+    const started = Date.now();
+    const rsp = await resolveStatuslineRsp(root, {});
+    const elapsed = Date.now() - started;
+    expect(rsp).toEqual({ state: "error" });
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  it("renders rsp warming when the summary is stale but the warmup marker is recent", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
+      version: 1,
+      tokens_saved_today: 1200,
+      updated_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    }), "utf8");
+    await writeFile(resolveResidentPaths(root).wakeLockPath, "", "utf8");
+
+    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "warming" });
   });
 
   it("local facts are read live: a mutated state file is reflected on the next render", async () => {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -21,6 +21,9 @@ const WINE2 = "\x1b[48;2;88;36;42m";
 const NOBG = "\x1b[49m";
 const SOFT = "\x1b[38;2;224;138;148m";
 const KEY = "\x1b[38;2;255;214;214m";
+const DIM = "\x1b[38;2;201;150;158m";
+const GREEN = "\x1b[38;2;96;214;128m";
+const RED = "\x1b[38;2;255;95;95m";
 const BOLD = "\x1b[1m";
 const RESET = "\x1b[0m";
 
@@ -152,6 +155,23 @@ describe("statusline style — header line", () => {
     expect(t).not.toContain("7d=");
     expect(t).not.toContain("prs=");
     expect(t).not.toContain("loc=+142 -36");
+  });
+
+  it("styles rsp states from the shared render model", () => {
+    const healthy = renderHeaderLine(input.project, claude, repo, undefined, "full", {
+      state: "ready",
+      tokensSavedToday: 124000,
+    });
+    expect(healthy).toContain(`${GREEN}rsp ↓124k${SOFT}`);
+    expect(stripAnsi(healthy)).toContain("rsp ↓124k");
+
+    const warming = renderHeaderLine(input.project, claude, repo, undefined, "full", { state: "warming" });
+    expect(warming).toContain(`${DIM}rsp …${SOFT}`);
+    expect(stripAnsi(warming)).toContain("rsp …");
+
+    const error = renderHeaderLine(input.project, claude, repo, undefined, "full", { state: "error" });
+    expect(error).toContain(`${RED}rsp !${SOFT}`);
+    expect(stripAnsi(error)).toContain("rsp !");
   });
 });
 

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -491,20 +491,44 @@ describe("statusline — full assembly", () => {
       project: { basename: "red-skills", branch: "main" },
       claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24, usage5h: 23, usage7d: 41 },
       repo: { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 },
-      rsp: "on",
+      rsp: { state: "ready", tokensSavedToday: 1200 },
       fleet: { runner: "codex", busy: 1, total: 4, queue: 9 },
       afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
     };
-    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24 · rsp●");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24 · rsp ↓1.2k");
   });
 
-  it("renders rsp as one optional token in full and short presets", () => {
+  it("renders rsp healthy savings as one optional token in full and short presets", () => {
     const input: StatuslineInput = {
       project: { basename: "red-skills", branch: "main" },
-      rsp: "warming",
+      rsp: { state: "ready", tokensSavedToday: 847 },
     };
-    expect(renderStatusline(input)).toBe("red-skills (main) · rsp○");
-    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp○");
+    expect(renderStatusline(input)).toBe("red-skills (main) · rsp ↓847");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp ↓847");
+  });
+
+  it("renders rsp warming and error states without ambiguous on/off glyphs", () => {
+    expect(renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      rsp: { state: "warming" },
+    })).toBe("red-skills (main) · rsp …");
+    expect(renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      rsp: { state: "error" },
+    })).toBe("red-skills (main) · rsp !");
+  });
+
+  it("formats rsp savings with compact count tiers", () => {
+    const rendered = [0, 847, 1200, 124000, 1300000].map((tokensSavedToday) =>
+      renderStatusline({ project: { basename: "red-skills" }, rsp: { state: "ready", tokensSavedToday } })
+    );
+    expect(rendered).toEqual([
+      "red-skills · rsp ↓0",
+      "red-skills · rsp ↓847",
+      "red-skills · rsp ↓1.2k",
+      "red-skills · rsp ↓124k",
+      "red-skills · rsp ↓1.3M",
+    ]);
   });
 
   it("omits rsp when the gather side leaves the status absent", () => {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -113,6 +113,7 @@ interface TelemetryIndexDocument {
 const TOKENIZATION_CAP_BYTES = 256 * 1024;
 const TOKENIZATION_TIMEOUT_MS = 500;
 const TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
+const RSP_STATUS_SUMMARY = join(".red", "tmp", "rsp-status-summary.json");
 
 class ResidentTelemetryDrain {
   private running?: Promise<void>;
@@ -163,6 +164,7 @@ class ResidentTelemetryDrain {
       }
     });
     await this.prune(db, { version: 1, records: nextRecords });
+    await writeStatusSummary(db, this.opts.rootDir);
   }
 
   private async writeEvent(db: RedDB, event: RspTelemetryEvent): Promise<TelemetryIndexEntry> {
@@ -241,6 +243,21 @@ class ResidentTelemetryDrain {
     }
     await this.writeIndex(db, { version: 1, records: live });
   }
+}
+
+async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()): Promise<void> {
+  const stats = await readTelemetryStats(db, 1, now);
+  const today = now.toISOString().slice(0, 10);
+  const tokensSavedToday = stats.savings.daily_tokens_saved.find((row) => row.date === today)?.tokens_saved ?? 0;
+  const path = join(rootDir, RSP_STATUS_SUMMARY);
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tmp, JSON.stringify({
+    version: 1,
+    tokens_saved_today: tokensSavedToday,
+    updated_at: now.toISOString(),
+  }), { encoding: "utf8", mode: 0o600 });
+  await rename(tmp, path);
 }
 
 async function safeDrainTelemetry(telemetry: ResidentTelemetryDrain): Promise<void> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1041,6 +1041,14 @@ describe("rsp cli", () => {
     expect(statsText).toContain("command: git log --terse invocations: 1");
     expect(statsText).toContain("command: gh pr list invocations: 1");
     expect(statsText).toContain("degradations: 1\n");
+    const summary = JSON.parse(await readFile(resolveResidentPaths(root).summaryPath, "utf8")) as {
+      version: number;
+      tokens_saved_today: number;
+      updated_at: string;
+    };
+    expect(summary.version).toBe(1);
+    expect(summary.tokens_saved_today).toBeGreaterThan(0);
+    expect(Date.parse(summary.updated_at)).not.toBeNaN();
 
     const gains = runBundleFromCwd(root, ["gains", "--since", "7d"], env);
     const gainsText = gains.stdout.toString("utf8");

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -14,6 +14,7 @@ export interface RspResidentPaths {
   socketPath: string;
   lockPath: string;
   wakeLockPath: string;
+  summaryPath: string;
 }
 
 const UNIX_SOCKET_PATH_LIMIT = 108;
@@ -25,7 +26,8 @@ export function resolveResidentPaths(cwd: string): RspResidentPaths {
     rootDir,
     socketPath: join(socketDir, "rsp.sock"),
     lockPath: join(socketDir, "rsp.lock"),
-    wakeLockPath: join(socketDir, "rsp.wake.lock"),
+    wakeLockPath: join(rootDir, ".red", "tmp", "rsp.wake.lock"),
+    summaryPath: join(rootDir, ".red", "tmp", "rsp-status-summary.json"),
   };
 }
 


### PR DESCRIPTION
Automated AFK landing for #1592. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1592

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786501327&installation_id=129708444&pr_number=1594&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1594&signature=cef4eca12229ef0e6fa94cfe3282c2b7faf4f03b895e216e43b367b06797d773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->