### PR TITLE
feat: #1591 brain joins the shared resident as its third client

### DIFF
--- a/apps/brain/src/dashboard.ts
+++ b/apps/brain/src/dashboard.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from "node:http";
 import type { KpiResult } from "./kpi-query.js";
 import type { StoredBrainArtifact, StoredBrainConnection } from "./schema.js";
-import type { BrainStore } from "./store.js";
+import type { BrainStoreLike } from "./store.js";
 
 export interface BrainDashboardOptions {
   project: string;
@@ -71,7 +71,7 @@ export interface BrainDashboardArtifact {
 }
 
 export async function buildBrainDashboard(
-  store: BrainStore,
+  store: BrainStoreLike,
   options: BrainDashboardOptions,
 ): Promise<BrainDashboard> {
   const artifacts = await store.listArtifacts();

--- a/apps/brain/src/hook-runtime.ts
+++ b/apps/brain/src/hook-runtime.ts
@@ -1,19 +1,15 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { resolveBrainConfig } from "./config.js";
-import { BrainStore } from "./store.js";
+import { withBrainRuntime } from "./runtime.js";
 
 export type Runner = "codex" | "claude" | "hermes" | "unknown";
 
 export async function handleHook(lifecycle: string, runner: Runner): Promise<Record<string, unknown>> {
   if (lifecycle !== "SessionStart") return {};
-  const config = await resolveBrainConfig(process.cwd());
-  const store = await BrainStore.open({ uri: config.connectionString });
-  try {
+  const config = await withBrainRuntime(async ({ config, store }) => {
     await store.status();
-  } finally {
-    await store.close();
-  }
+    return config;
+  });
   const stateDir = join(config.rootDir, ".red", "brain", "sessions");
   await mkdir(stateDir, { recursive: true });
   await writeFile(

--- a/apps/brain/src/ingest-events.ts
+++ b/apps/brain/src/ingest-events.ts
@@ -1,10 +1,10 @@
 import type { ChannelBridge } from "./channel-bridge.js";
 import { EventArtifactMapper } from "./event-artifact-mapper.js";
-import type { BrainStore } from "./store.js";
+import type { BrainStoreLike } from "./store.js";
 
 export interface IngestEventsInput {
   bridge: ChannelBridge;
-  store: BrainStore;
+  store: BrainStoreLike;
   afterCursor?: number | string;
   sessionKey?: string;
   limit?: number;

--- a/apps/brain/src/resident-brain.ts
+++ b/apps/brain/src/resident-brain.ts
@@ -1,0 +1,141 @@
+import { resolve } from "node:path";
+import {
+  ResidentRspClient,
+  resolveResidentPaths,
+} from "@reddb-io/shared/resident-client.js";
+import type { BrainResidentAction, RspResidentConfig } from "@reddb-io/shared/resident-protocol.js";
+import type { OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
+import type { KpiQueryInput, KpiResult } from "./kpi-query.js";
+import type { ModelTierBanditDocument } from "./model-tier-bandit.js";
+import type {
+  BrainStoreLike,
+  BrainThinkResult,
+  CaptureInput,
+  SearchHit,
+  SearchOptions,
+  ThinkOptions,
+} from "./store.js";
+import type { StoredBrainArtifact, StoredBrainConnection } from "./schema.js";
+import type { ResolvedBrainConfig } from "./config.js";
+
+export const SHARED_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
+const DEFAULT_RSP_TTL_DAYS = 7;
+const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
+
+export function shouldUseResidentBrain(config: ResolvedBrainConfig): boolean {
+  if (!config.connectionString.startsWith("file://")) return false;
+  return config.connectionString.slice("file://".length) === sharedStorePath(config.rootDir);
+}
+
+export async function openResidentBrainStore(config: ResolvedBrainConfig): Promise<BrainStoreLike> {
+  const paths = resolveResidentPaths(config.rootDir);
+  const client = new ResidentRspClient(paths, residentConfig(config.rootDir));
+  await client.request({ op: "ping" });
+  return new ResidentBrainStore(client);
+}
+
+export function sharedStoreUri(rootDir: string): string {
+  return `file://${sharedStorePath(rootDir)}`;
+}
+
+function sharedStorePath(rootDir: string): string {
+  return resolve(rootDir, SHARED_RSP_STORE_PATH);
+}
+
+function residentConfig(rootDir: string): RspResidentConfig {
+  return {
+    storeUri: sharedStoreUri(rootDir),
+    ttlDays: DEFAULT_RSP_TTL_DAYS,
+    byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+    serverCommand: process.env.RSP_BIN ?? "rsp",
+  };
+}
+
+class ResidentBrainStore implements BrainStoreLike {
+  constructor(private readonly client: ResidentRspClient) {}
+
+  async close(): Promise<void> {}
+
+  async status(): Promise<Record<string, unknown>> {
+    const value = await this.request("status");
+    return isRecord(value) ? value : {};
+  }
+
+  async capture(input: CaptureInput): Promise<StoredBrainArtifact> {
+    return await this.request("capture", input) as StoredBrainArtifact;
+  }
+
+  async getArtifact(ridOrId: number | string): Promise<StoredBrainArtifact | null> {
+    return await this.request("getArtifact", { ridOrId }) as StoredBrainArtifact | null;
+  }
+
+  async listArtifacts(): Promise<StoredBrainArtifact[]> {
+    return await this.request("listArtifacts") as StoredBrainArtifact[];
+  }
+
+  async search(query: string, limit = 10, options: SearchOptions = {}): Promise<SearchHit[]> {
+    return await this.request("search", { query, limit, options: serializableSearchOptions(options) }) as SearchHit[];
+  }
+
+  async think(query: string, limit = 8, options: ThinkOptions = {}): Promise<BrainThinkResult> {
+    return await this.request("think", { query, limit, options: serializableSearchOptions(options) }) as BrainThinkResult;
+  }
+
+  async link(input: {
+    from: number | string;
+    to: number | string;
+    kind?: string;
+    reason?: string;
+    confidence?: "explicit" | "derived" | "inferred";
+    metadata?: Record<string, unknown>;
+  }): Promise<StoredBrainConnection> {
+    return await this.request("link", input) as StoredBrainConnection;
+  }
+
+  async backlinks(target: number | string): Promise<StoredBrainConnection[]> {
+    return await this.request("backlinks", { target }) as StoredBrainConnection[];
+  }
+
+  async listConnections(): Promise<StoredBrainConnection[]> {
+    return await this.request("listConnections") as StoredBrainConnection[];
+  }
+
+  async eventKpis(input: KpiQueryInput = {}): Promise<KpiResult> {
+    return await this.request("eventKpis", input) as KpiResult;
+  }
+
+  async appendOutcomeEvent(event: OutcomeEvent): Promise<OutcomeEvent> {
+    return await this.request("appendOutcomeEvent", event) as OutcomeEvent;
+  }
+
+  async replayOutcomeEvents(): Promise<OutcomeEvent[]> {
+    return await this.request("replayOutcomeEvents") as OutcomeEvent[];
+  }
+
+  async loadModelTierBanditDocument(): Promise<ModelTierBanditDocument | null> {
+    return await this.request("loadModelTierBanditDocument") as ModelTierBanditDocument | null;
+  }
+
+  async saveModelTierBanditDocument(document: ModelTierBanditDocument): Promise<ModelTierBanditDocument> {
+    return await this.request("saveModelTierBanditDocument", document) as ModelTierBanditDocument;
+  }
+
+  async refreshModelTierBanditDocument(): Promise<ModelTierBanditDocument> {
+    return await this.request("refreshModelTierBanditDocument") as ModelTierBanditDocument;
+  }
+
+  private async request(action: BrainResidentAction, payload?: unknown): Promise<unknown> {
+    return await this.client.request({ op: "brain", action, payload });
+  }
+}
+
+function serializableSearchOptions(options: SearchOptions): Record<string, unknown> {
+  return {
+    ...options,
+    excludeRids: options.excludeRids ? [...options.excludeRids] : undefined,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/brain/src/runtime.ts
+++ b/apps/brain/src/runtime.ts
@@ -1,16 +1,30 @@
 import { basename } from "node:path";
+import { pingResident, resolveResidentPaths } from "@reddb-io/shared/resident-client.js";
 import { createConfiguredAfkHeadlessAutoLinkProvider } from "./auto-linker.js";
 import { resolveBrainConfig, type ResolvedBrainConfig } from "./config.js";
-import { BrainStore } from "./store.js";
+import { openResidentBrainStore, shouldUseResidentBrain } from "./resident-brain.js";
+import { BrainStore, type BrainStoreLike } from "./store.js";
 
 export interface BrainRuntime {
   config: ResolvedBrainConfig;
-  store: BrainStore;
+  store: BrainStoreLike;
   project: string;
 }
 
 export async function openBrainRuntime(startDir = process.cwd()): Promise<BrainRuntime> {
   const config = await resolveBrainConfig(startDir);
+  if (shouldUseResidentBrain(config)) {
+    try {
+      return {
+        config,
+        store: await openResidentBrainStore(config),
+        project: basename(config.rootDir),
+      };
+    } catch (err) {
+      const paths = resolveResidentPaths(config.rootDir);
+      if (await pingResident(paths.socketPath, 50)) throw err;
+    }
+  }
   const store = await BrainStore.open({
     uri: config.connectionString,
     autoLinker: createConfiguredAfkHeadlessAutoLinkProvider(),

--- a/apps/brain/src/scheduled-ingestion.ts
+++ b/apps/brain/src/scheduled-ingestion.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { ChannelBridge } from "./channel-bridge.js";
 import { ingestEvents } from "./ingest-events.js";
-import type { BrainStore } from "./store.js";
+import type { BrainStoreLike } from "./store.js";
 
 export interface IngestionState {
   cursor?: number | string;
@@ -11,7 +11,7 @@ export interface IngestionState {
 
 export interface ScheduledIngestInput {
   bridge: ChannelBridge;
-  store: BrainStore;
+  store: BrainStoreLike;
   state: IngestionState;
   sessionKey?: string;
   limit?: number;

--- a/apps/brain/src/store.ts
+++ b/apps/brain/src/store.ts
@@ -37,6 +37,32 @@ export interface BrainStoreOptions {
   autoLinkErrors?: "ignore" | "throw";
 }
 
+export interface BrainStoreLike {
+  close(): Promise<void>;
+  status(): Promise<Record<string, unknown>>;
+  capture(input: CaptureInput): Promise<StoredBrainArtifact>;
+  getArtifact(ridOrId: number | string): Promise<StoredBrainArtifact | null>;
+  listArtifacts(): Promise<StoredBrainArtifact[]>;
+  search(query: string, limit?: number, options?: SearchOptions): Promise<SearchHit[]>;
+  think(query: string, limit?: number, options?: ThinkOptions): Promise<BrainThinkResult>;
+  link(input: {
+    from: number | string;
+    to: number | string;
+    kind?: string;
+    reason?: string;
+    confidence?: "explicit" | "derived" | "inferred";
+    metadata?: Record<string, unknown>;
+  }): Promise<StoredBrainConnection>;
+  backlinks(target: number | string): Promise<StoredBrainConnection[]>;
+  listConnections(): Promise<StoredBrainConnection[]>;
+  eventKpis(input?: KpiQueryInput): Promise<KpiResult>;
+  appendOutcomeEvent(event: OutcomeEvent): Promise<OutcomeEvent>;
+  replayOutcomeEvents(): Promise<OutcomeEvent[]>;
+  loadModelTierBanditDocument(): Promise<ModelTierBanditDocument | null>;
+  saveModelTierBanditDocument(document: ModelTierBanditDocument): Promise<ModelTierBanditDocument>;
+  refreshModelTierBanditDocument(): Promise<ModelTierBanditDocument>;
+}
+
 export interface CaptureInput {
   title: string;
   content: string;

--- a/apps/rsp/src/resident-brain.ts
+++ b/apps/rsp/src/resident-brain.ts
@@ -1,0 +1,626 @@
+import { createHash } from "node:crypto";
+import type { QueryParam, RedDB } from "@reddb-io/sdk";
+import { isOutcomeEvent, type OutcomeEvent } from "@reddb-io/shared/outcome-event.js";
+import type { BrainResidentAction } from "./resident-protocol.js";
+
+const COLLECTIONS = {
+  artifacts: "brain_artifacts",
+  connections: "brain_connections",
+  outcomeEvents: "brain_outcome_events",
+  kv: "brain_kv",
+} as const;
+
+const ARTIFACT_KINDS = new Set([
+  "pillar",
+  "decision",
+  "concept",
+  "question",
+  "playbook",
+  "task",
+  "event",
+  "pattern",
+  "hypothesis",
+  "fact",
+  "source",
+  "bookmark",
+  "note",
+  "reference",
+  "custom",
+  "project",
+  "idea",
+  "meeting",
+  "claim",
+  "organization",
+  "person",
+]);
+
+const CONNECTION_KINDS = new Set([
+  "supports",
+  "contradicts",
+  "depends_on",
+  "derived_from",
+  "related_to",
+  "part_of",
+  "preceded_by",
+  "followed_by",
+  "authored",
+  "tagged",
+]);
+
+export class ResidentBrainStore {
+  constructor(
+    private readonly db: RedDB,
+    private readonly uri: string,
+  ) {}
+
+  async request(action: BrainResidentAction, payload: unknown): Promise<unknown> {
+    await this.bootstrap();
+    if (action === "status") return await this.status();
+    if (action === "capture") return await this.capture(payloadRecord(payload));
+    if (action === "getArtifact") return await this.getArtifact(recordField(payload, "ridOrId") as string | number);
+    if (action === "listArtifacts") return await this.listArtifacts();
+    if (action === "search") {
+      const request = payloadRecord(payload);
+      return await this.search(
+        stringPayloadField(request, "query"),
+        numberPayloadField(request, "limit") ?? 10,
+        searchOptionsPayload(request.options),
+      );
+    }
+    if (action === "think") {
+      const request = payloadRecord(payload);
+      return await this.think(
+        stringPayloadField(request, "query"),
+        numberPayloadField(request, "limit") ?? 8,
+        searchOptionsPayload(request.options),
+      );
+    }
+    if (action === "link") return await this.link(payloadRecord(payload));
+    if (action === "backlinks") return await this.backlinks(recordField(payload, "target") as string | number);
+    if (action === "listConnections") return await this.listConnections();
+    if (action === "eventKpis") return await this.eventKpis(payloadRecord(payload));
+    if (action === "appendOutcomeEvent") return await this.appendOutcomeEvent(payload);
+    if (action === "replayOutcomeEvents") return await this.replayOutcomeEvents();
+    if (action === "loadModelTierBanditDocument") return await this.loadModelTierBanditDocument();
+    if (action === "saveModelTierBanditDocument") return await this.saveModelTierBanditDocument(payload);
+    if (action === "refreshModelTierBanditDocument") return await this.refreshModelTierBanditDocument();
+    throw new Error(`unsupported resident brain action: ${action}`);
+  }
+
+  private async bootstrap(): Promise<void> {
+    await this.db.execute(`CREATE GRAPH IF NOT EXISTS ${COLLECTIONS.artifacts}`);
+    await this.db.execute(`CREATE GRAPH IF NOT EXISTS ${COLLECTIONS.connections}`);
+    await this.db.execute(`CREATE GRAPH IF NOT EXISTS ${COLLECTIONS.outcomeEvents}`);
+  }
+
+  private async status(): Promise<Record<string, unknown>> {
+    const artifacts = await this.listArtifacts();
+    const connections = await this.listConnections();
+    return {
+      uri: this.uri,
+      artifacts: artifacts.length,
+      connections: connections.length,
+      kinds: countBy(artifacts.map((artifact) => artifact.kind)),
+    };
+  }
+
+  private async capture(input: Record<string, unknown>): Promise<StoredBrainArtifact> {
+    const title = stringValue(input.title) || "Untitled artifact";
+    const content = stringValue(input.content);
+    if (!content) throw new Error("brain capture requires content");
+    const kind = normalizeArtifactKind(stringValue(input.kind) || "note");
+    const tags = normalizeTags(Array.isArray(input.tags) ? input.tags.map(String) : []);
+    const now = Date.now();
+    const hash = contentHash([kind, title, content, tags, stringValue(input.sourcePath), stringValue(input.sourceSession)]);
+    const existingRid = await this.kv().get(artifactHashKey(hash));
+    if (existingRid != null) {
+      const existing = await this.getArtifact(Number(existingRid));
+      if (existing) return existing;
+    }
+    const id = `${slugify(title)}-${hash.slice(0, 8)}`;
+    const properties = {
+      id,
+      title,
+      content,
+      tags,
+      source_agent: stringValue(input.sourceAgent),
+      source_runner: stringValue(input.sourceRunner),
+      source_session: stringValue(input.sourceSession),
+      source_path: stringValue(input.sourcePath),
+      created_at: now,
+      updated_at: now,
+      hash,
+      metadata: isRecord(input.metadata) ? input.metadata : undefined,
+    };
+    const result = await this.db.query(
+      `INSERT INTO ${COLLECTIONS.artifacts} NODE (label, node_type, hash, properties) VALUES ($1, $2, $3, $4) RETURNING *`,
+      id,
+      kind,
+      hash,
+      properties,
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error("INSERT artifact returned no row");
+    const artifact = rowToArtifact(row);
+    if (!artifact) throw new Error("INSERT artifact returned invalid row");
+    await this.kv().put(artifactHashKey(hash), artifact.rid);
+    await this.materializeTagConnections(artifact);
+    return artifact;
+  }
+
+  private async getArtifact(ridOrId: number | string): Promise<StoredBrainArtifact | null> {
+    const artifacts = await this.listArtifacts();
+    if (typeof ridOrId === "number") return artifacts.find((artifact) => artifact.rid === ridOrId) ?? null;
+    return artifacts.find((artifact) => artifact.properties.id === ridOrId || artifact.label === ridOrId) ?? null;
+  }
+
+  private async listArtifacts(): Promise<StoredBrainArtifact[]> {
+    const result = await this.db.query(`SELECT * FROM ${COLLECTIONS.artifacts}`);
+    return result.rows.map(rowToArtifact).filter(notNull);
+  }
+
+  private async search(query: string, limit: number, options: { excludeRids?: number[] } = {}): Promise<SearchHit[]> {
+    const terms = tokenize(query);
+    const excluded = new Set(options.excludeRids ?? []);
+    const artifacts = await this.listArtifacts();
+    const connections = await this.listConnections();
+    const artifactsByRid = new Map(artifacts.map((artifact) => [artifact.rid, artifact]));
+    return artifacts
+      .filter((artifact) => !excluded.has(artifact.rid))
+      .map((artifact) => {
+        const base = scoreArtifact(artifact, terms);
+        const score_breakdown = withTotal({
+          ...base,
+          connections: scoreConnections(artifact, terms, connections, artifactsByRid),
+          vector: 0,
+        });
+        return {
+          artifact,
+          score: score_breakdown.total,
+          score_breakdown,
+          excerpt: excerpt(artifact.properties.content, terms),
+        };
+      })
+      .filter((hit) => hit.score > 0)
+      .sort((a, b) => b.score - a.score || b.artifact.properties.updated_at - a.artifact.properties.updated_at)
+      .slice(0, Math.max(1, Math.min(100, limit)));
+  }
+
+  private async think(query: string, limit: number, options: { excludeRids?: number[] } = {}): Promise<BrainThinkResult> {
+    const hits = (await this.search(query, Math.max(limit * 2, limit + 5), options)).slice(0, limit);
+    return renderThinkResult(query, hits);
+  }
+
+  private async link(input: Record<string, unknown>): Promise<StoredBrainConnection> {
+    const from = await this.getArtifact(parseRidOrId(input.from));
+    const to = await this.getArtifact(parseRidOrId(input.to));
+    if (!from) throw new Error(`Brain artifact not found: ${String(input.from)}`);
+    if (!to) throw new Error(`Brain artifact not found: ${String(input.to)}`);
+    const kind = normalizeConnectionKind(stringValue(input.kind) || "related_to");
+    const existing = await this.findConnection(from.rid, to.rid, kind);
+    if (existing != null) {
+      const found = (await this.listConnections()).find((connection) => connection.rid === existing);
+      if (found) return found;
+    }
+    const properties = {
+      reason: stringValue(input.reason),
+      confidence: stringValue(input.confidence) || "explicit",
+      created_at: Date.now(),
+      metadata: isRecord(input.metadata) ? input.metadata : undefined,
+    };
+    const result = await this.db.query(
+      `INSERT INTO ${COLLECTIONS.connections} EDGE (label, from, to, weight, properties) VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+      kind,
+      from.rid,
+      to.rid,
+      1.0,
+      properties,
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error("INSERT connection returned no row");
+    const connection = rowToConnection(row);
+    if (!connection) throw new Error("INSERT connection returned invalid row");
+    await this.kv().put(connectionKey(from.rid, to.rid, kind), connection.rid);
+    return connection;
+  }
+
+  private async backlinks(target: number | string): Promise<StoredBrainConnection[]> {
+    const artifact = await this.getArtifact(target);
+    if (!artifact) throw new Error(`Brain artifact not found: ${target}`);
+    return (await this.listConnections()).filter((connection) => connection.to_rid === artifact.rid);
+  }
+
+  private async listConnections(): Promise<StoredBrainConnection[]> {
+    const result = await this.db.query(`SELECT * FROM ${COLLECTIONS.connections}`);
+    return result.rows.map(rowToConnection).filter(notNull);
+  }
+
+  private async eventKpis(input: Record<string, unknown>): Promise<KpiResult> {
+    const artifacts = (await this.listArtifacts()).filter((artifact) => artifact.kind === "event");
+    const interval = normalizeInterval(stringValue(input.interval) || "day");
+    const timeField = stringValue(input.timeField) === "ingested" ? "ingested" : "event";
+    return {
+      kind: "event",
+      interval,
+      timeField,
+      range: { from: null, to: null },
+      total: artifacts.length,
+      series: [{ group: null, total: artifacts.length, buckets: [] }],
+    };
+  }
+
+  private async appendOutcomeEvent(value: unknown): Promise<OutcomeEvent> {
+    if (!isOutcomeEvent(value)) throw new Error("invalid Brain outcome event");
+    const result = await this.db.query(
+      `INSERT INTO ${COLLECTIONS.outcomeEvents} NODE (label, node_type, properties) VALUES ($1, $2, $3) RETURNING *`,
+      value.id,
+      `outcome_event.v${value.schemaVersion}`,
+      value as unknown as QueryParam,
+    );
+    if (!result.rows[0]) throw new Error("INSERT outcome event returned no row");
+    return value;
+  }
+
+  private async replayOutcomeEvents(): Promise<OutcomeEvent[]> {
+    const result = await this.db.query(`SELECT * FROM ${COLLECTIONS.outcomeEvents}`);
+    return result.rows
+      .map(rowToOutcomeEvent)
+      .filter(notNull)
+      .sort((a, b) => a.rid - b.rid)
+      .map(({ event }) => event);
+  }
+
+  private async loadModelTierBanditDocument(): Promise<unknown> {
+    const stored = await this.kv().get(modelTierBanditKey());
+    return typeof stored === "string" ? JSON.parse(stored) as unknown : stored;
+  }
+
+  private async saveModelTierBanditDocument(document: unknown): Promise<unknown> {
+    await this.kv().put(modelTierBanditKey(), JSON.stringify(document));
+    return document;
+  }
+
+  private async refreshModelTierBanditDocument(): Promise<unknown> {
+    const existing = await this.loadModelTierBanditDocument();
+    if (existing != null) return existing;
+    const document = { schema_version: "brain.model-tier-bandit.v1", updated_at: new Date().toISOString(), arms: {} };
+    await this.saveModelTierBanditDocument(document);
+    return document;
+  }
+
+  private async materializeTagConnections(artifact: StoredBrainArtifact): Promise<void> {
+    if (artifact.properties.metadata?.derived_kind === "tag") return;
+    for (const tag of artifact.properties.tags) {
+      const tagArtifact = await this.capture({
+        title: tag,
+        content: `Tag: ${tag}`,
+        kind: "custom",
+        tags: ["tag"],
+        metadata: { derived: true, derived_kind: "tag" },
+      });
+      await this.link({
+        from: artifact.rid,
+        to: tagArtifact.rid,
+        kind: "tagged",
+        confidence: "derived",
+      });
+    }
+  }
+
+  private async findConnection(from: number, to: number, kind: string): Promise<number | null> {
+    const rid = await this.kv().get(connectionKey(from, to, kind));
+    return rid != null ? Number(rid) : null;
+  }
+
+  private kv() {
+    return this.db.kv(COLLECTIONS.kv);
+  }
+}
+
+export function createResidentBrainStore(db: RedDB, uri: string): ResidentBrainStore {
+  return new ResidentBrainStore(db, uri);
+}
+
+interface StoredBrainArtifact {
+  rid: number;
+  label: string;
+  kind: string;
+  properties: {
+    id: string;
+    title: string;
+    content: string;
+    tags: string[];
+    source_agent?: string;
+    source_runner?: string;
+    source_session?: string;
+    source_path?: string;
+    created_at: number;
+    updated_at: number;
+    hash: string;
+    metadata?: Record<string, unknown>;
+  };
+}
+
+interface StoredBrainConnection {
+  rid: number;
+  kind: string;
+  from_rid: number;
+  to_rid: number;
+  weight: number;
+  properties: Record<string, unknown>;
+}
+
+interface SearchHit {
+  artifact: StoredBrainArtifact;
+  score: number;
+  score_breakdown: SearchScoreBreakdown;
+  excerpt: string;
+}
+
+interface SearchScoreBreakdown {
+  lexical: number;
+  tags: number;
+  kind: number;
+  connections: number;
+  vector: number;
+  total: number;
+}
+
+interface BrainThinkResult {
+  answer: string;
+  hits: SearchHit[];
+  citations: unknown[];
+  confidence: "none" | "low" | "medium" | "high";
+  missing_evidence: string[];
+}
+
+interface KpiResult {
+  kind: "event";
+  interval: "hour" | "day" | "week" | "month";
+  timeField: "event" | "ingested";
+  range: { from: number | null; to: number | null };
+  total: number;
+  series: Array<{ group: string | null; total: number; buckets: unknown[] }>;
+}
+
+function rowToArtifact(row: Record<string, unknown>): StoredBrainArtifact | null {
+  const rid = Number(row.red_entity_id ?? row.rid);
+  const properties = parseProperties(row.properties ?? row.PROPERTIES);
+  const kind = normalizeArtifactKind(String(row.node_type ?? row.NODE_TYPE ?? properties.kind ?? "note"));
+  if (!Number.isFinite(rid)) return null;
+  const id = String(properties.id ?? row.label ?? row.LABEL ?? rid);
+  const title = String(properties.title ?? row.label ?? row.LABEL ?? id);
+  const content = String(properties.content ?? "");
+  const tags = Array.isArray(properties.tags) ? properties.tags.map(String) : [];
+  const now = Date.now();
+  return {
+    rid,
+    label: String(row.label ?? row.LABEL ?? id),
+    kind,
+    properties: {
+      ...properties,
+      id,
+      title,
+      content,
+      tags,
+      created_at: Number(properties.created_at ?? now),
+      updated_at: Number(properties.updated_at ?? properties.created_at ?? now),
+      hash: String(properties.hash ?? ""),
+    },
+  };
+}
+
+function rowToConnection(row: Record<string, unknown>): StoredBrainConnection | null {
+  const rid = Number(row.red_entity_id ?? row.rid);
+  const from = Number(row.from ?? row.FROM ?? row.from_rid ?? row.source);
+  const to = Number(row.to ?? row.TO ?? row.to_rid ?? row.target);
+  const kind = normalizeConnectionKind(String(row.label ?? row.LABEL ?? "related_to"));
+  if (!Number.isFinite(rid) || !Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return {
+    rid,
+    kind,
+    from_rid: from,
+    to_rid: to,
+    weight: Number(row.weight ?? 1),
+    properties: parseProperties(row.properties ?? row.PROPERTIES),
+  };
+}
+
+function rowToOutcomeEvent(row: Record<string, unknown>): { rid: number; event: OutcomeEvent } | null {
+  const rid = Number(row.red_entity_id ?? row.rid);
+  const properties = parseProperties(row.properties ?? row.PROPERTIES);
+  if (!Number.isFinite(rid) || !isOutcomeEvent(properties)) return null;
+  return { rid, event: properties };
+}
+
+function parseProperties(value: unknown): Record<string, unknown> {
+  if (value == null) return {};
+  if (typeof value === "string") return JSON.parse(value) as Record<string, unknown>;
+  return isRecord(value) ? value : {};
+}
+
+function normalizeArtifactKind(value: string): string {
+  const mapped = value === "contact" ? "person" : value;
+  if (ARTIFACT_KINDS.has(mapped)) return mapped;
+  throw new Error(`invalid Brain artifact kind: ${value}`);
+}
+
+function normalizeConnectionKind(value: string): string {
+  if (CONNECTION_KINDS.has(value)) return value;
+  throw new Error(`invalid Brain connection kind: ${value}`);
+}
+
+function normalizeInterval(value: string): KpiResult["interval"] {
+  return value === "hour" || value === "week" || value === "month" ? value : "day";
+}
+
+function parseRidOrId(value: unknown): number | string {
+  if (typeof value === "number") return value;
+  const text = String(value ?? "");
+  return /^\d+$/.test(text) ? Number(text) : text;
+}
+
+function payloadRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function recordField(value: unknown, key: string): unknown {
+  return payloadRecord(value)[key];
+}
+
+function stringPayloadField(value: Record<string, unknown>, key: string): string {
+  const field = value[key];
+  if (typeof field !== "string") throw new Error(`brain ${key} must be a string`);
+  return field;
+}
+
+function numberPayloadField(value: Record<string, unknown>, key: string): number | undefined {
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function searchOptionsPayload(value: unknown): { excludeRids?: number[] } {
+  const options = payloadRecord(value);
+  const excludeRids = Array.isArray(options.excludeRids)
+    ? options.excludeRids.map(Number).filter(Number.isFinite)
+    : undefined;
+  return { excludeRids };
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function notNull<T>(value: T | null): value is T {
+  return value != null;
+}
+
+function normalizeTags(tags: string[]): string[] {
+  return Array.from(new Set(tags.map((tag) => tag.trim()).filter(Boolean))).sort();
+}
+
+function contentHash(parts: unknown[]): string {
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex");
+}
+
+function slugify(value: string): string {
+  const slug = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug || "artifact";
+}
+
+function artifactHashKey(hash: string): string {
+  return `artifact-hash:${hash}`;
+}
+
+function connectionKey(from: number, to: number, kind: string): string {
+  return `connection:${from}:${to}:${kind}`;
+}
+
+function modelTierBanditKey(): string {
+  return "model-tier-bandit:v1";
+}
+
+function tokenize(query: string): string[] {
+  return query.toLowerCase().split(/[^a-z0-9_]+/).map((term) => term.trim()).filter((term) => term.length > 1);
+}
+
+function occurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index >= 0) {
+    count++;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function scoreArtifact(artifact: StoredBrainArtifact, terms: string[]): Omit<SearchScoreBreakdown, "connections" | "vector" | "total"> {
+  const title = artifact.properties.title.toLowerCase();
+  const content = artifact.properties.content.toLowerCase();
+  const tags = artifact.properties.tags.map((tag) => tag.toLowerCase());
+  const kind = artifact.kind.toLowerCase();
+  return {
+    lexical: terms.reduce((sum, term) => sum + occurrences(title, term) * 3 + occurrences(content, term), 0),
+    tags: terms.reduce((sum, term) => sum + tags.reduce((tagSum, tag) => tagSum + (tag === term ? 4 : tag.includes(term) || term.includes(tag) ? 2 : 0), 0), 0),
+    kind: terms.reduce((sum, term) => sum + (kind === term ? 3 : kind.includes(term) || term.includes(kind) ? 1 : 0), 0),
+  };
+}
+
+function scoreConnections(
+  artifact: StoredBrainArtifact,
+  terms: string[],
+  connections: StoredBrainConnection[],
+  artifactsByRid: Map<number, StoredBrainArtifact>,
+): number {
+  let score = 0;
+  for (const connection of connections) {
+    const otherRid = connection.from_rid === artifact.rid
+      ? connection.to_rid
+      : connection.to_rid === artifact.rid
+        ? connection.from_rid
+        : null;
+    if (otherRid == null) continue;
+    const other = artifactsByRid.get(otherRid);
+    if (!other) continue;
+    const otherScore = withTotal({ ...scoreArtifact(other, terms), connections: 0, vector: 0 }).total;
+    if (otherScore > 0) score += Math.min(otherScore, 12) * 0.35;
+  }
+  return roundScore(score);
+}
+
+function withTotal(parts: Omit<SearchScoreBreakdown, "total">): SearchScoreBreakdown {
+  return {
+    ...parts,
+    lexical: roundScore(parts.lexical),
+    tags: roundScore(parts.tags),
+    kind: roundScore(parts.kind),
+    connections: roundScore(parts.connections),
+    vector: roundScore(parts.vector),
+    total: roundScore(parts.lexical + parts.tags + parts.kind + parts.connections + parts.vector),
+  };
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function excerpt(content: string, terms: string[]): string {
+  if (content.length <= 220) return content;
+  const lower = content.toLowerCase();
+  const first = terms.map((term) => lower.indexOf(term)).filter((idx) => idx >= 0).sort((a, b) => a - b)[0] ?? 0;
+  const start = Math.max(0, first - 80);
+  return `${start > 0 ? "..." : ""}${content.slice(start, start + 220)}${start + 220 < content.length ? "..." : ""}`;
+}
+
+function renderThinkResult(query: string, hits: SearchHit[]): BrainThinkResult {
+  const confidence = hits.length === 0 ? "none" : hits[0]!.score >= 5 ? "high" : hits[0]!.score >= 3 ? "medium" : "low";
+  const missing_evidence = hits.length === 0 ? [`No Brain artifacts matched "${query}".`] : [];
+  return {
+    answer: hits.length === 0
+      ? `Brain has no cited evidence for "${query}".`
+      : `Brain found ${hits.length} cited artifact${hits.length === 1 ? "" : "s"} for "${query}".`,
+    hits,
+    citations: hits.map((hit, index) => ({
+      ref: `B${index + 1}`,
+      rid: hit.artifact.rid,
+      id: hit.artifact.properties.id,
+      title: hit.artifact.properties.title,
+      kind: hit.artifact.kind,
+      score: hit.score,
+      score_breakdown: hit.score_breakdown,
+      excerpt: hit.excerpt,
+    })),
+    confidence,
+    missing_evidence,
+  };
+}
+
+function countBy(values: string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const value of values) out[value] = (out[value] ?? 0) + 1;
+  return out;
+}

--- a/apps/rsp/src/resident-protocol.ts
+++ b/apps/rsp/src/resident-protocol.ts
@@ -1,4 +1,5 @@
 export type {
+  BrainResidentAction,
   RspResidentClientOptions,
   RspResidentConfig,
   RspResidentRequest,

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -7,6 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import type { RedDB } from "@reddb-io/sdk";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
+import { createResidentBrainStore } from "./resident-brain.js";
 import type { RspResidentConfig, RspResidentRequest, RspResidentResponse } from "./resident-protocol.js";
 import {
   parseTelemetryEvent,
@@ -58,7 +59,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
     touch();
     handleSocket(socket, async (request) => {
       touch();
-      const value = await handleRequest(store, request, opts.residentVersion ?? "0.0.0-dev");
+      const value = await handleRequest(store, request, opts.storeUri, opts.residentVersion ?? "0.0.0-dev");
       const response: RspResidentResponse = { id: request.id, ok: true, value, storeOpenCount, storeElapsedMs };
       socket.write(`${JSON.stringify(response)}\n`);
       if (request.op === "handover") setImmediate(() => server.close());
@@ -404,7 +405,12 @@ function handleSocket(socket: Socket, handler: (request: RspResidentRequest) => 
   });
 }
 
-async function handleRequest(store: RspElisionStore, request: RspResidentRequest, residentVersion: string): Promise<unknown> {
+async function handleRequest(
+  store: RspElisionStore,
+  request: RspResidentRequest,
+  storeUri: string,
+  residentVersion: string,
+): Promise<unknown> {
   if (request.op === "ping") return { pong: true, version: residentVersion };
   if (request.op === "handover") return { handover: true, version: residentVersion, clientVersion: request.clientVersion };
   if (request.op === "stats") return await store.stats();
@@ -425,7 +431,19 @@ async function handleRequest(store: RspElisionStore, request: RspResidentRequest
   }
   if (request.op === "get") return encodeRecord(await store.get(request.handle));
   if (request.op === "memory") return await store.memory(request.action, request.payload);
+  if (request.op === "brain") return await handleBrainRequest(store, storeUri, request.action, request.payload);
   throw new Error(`unsupported resident op: ${(request as { op?: string }).op ?? "unknown"}`);
+}
+
+async function handleBrainRequest(
+  store: RspElisionStore,
+  storeUri: string,
+  action: Extract<RspResidentRequest, { op: "brain" }>["action"],
+  payload: unknown,
+): Promise<unknown> {
+  const db = store.redDb();
+  if (!db) throw new Error("resident brain operations require the shared RedDB store");
+  return await createResidentBrainStore(db, storeUri).request(action, payload);
 }
 
 function encodeRecord(record: RspElisionRecord | RspExpiredHandle | null): unknown {

--- a/apps/rsp/tests/resident-memory.test.ts
+++ b/apps/rsp/tests/resident-memory.test.ts
@@ -1,9 +1,11 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { graphRecall } from "../../memory/src/graph-recall.js";
 import { MemoryStore } from "../../memory/src/graph-store.js";
+import { withBrainRuntime } from "../../brain/src/runtime.js";
+import { BrainStore } from "../../brain/src/store.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/config.js";
 import { ResidentRspElisionStore, resolveResidentPaths } from "../src/resident-client.js";
 import { sendResidentRequest } from "../src/resident-protocol.js";
@@ -64,6 +66,81 @@ describe("resident memory transport", () => {
     } finally {
       await store.close();
     }
+  }, 20_000);
+
+  it("shares one resident-owned RedDB store across rsp, memory, and brain clients", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red", "brain"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await writeFile(
+      join(root, ".red", "brain", "config.yaml"),
+      "connection_string: file://./.red/tmp/red-skills.rdb\n",
+      "utf8",
+    );
+    const docs = join(root, "docs");
+    await mkdir(docs, { recursive: true });
+    await writeFile(join(docs, "memory.md"), "memory-shared-resident-token\n", "utf8");
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const server = runResidentServer({
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      idleMs: 5_000,
+    });
+    await waitForResident(paths.socketPath);
+    const client = new ResidentRspElisionStore(paths, {
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+    });
+
+    const handle = await client.mint(Buffer.from("rsp-shared-resident-token"), {
+      command: "rsp test",
+      loss: { level: "brief", bytes_elided: 25 },
+    });
+    await client.memory("ingest", { cwd: docs });
+
+    const openSpy = vi.spyOn(BrainStore, "open");
+    try {
+      await withBrainRuntime(async ({ store }) => {
+        await store.capture({
+          title: "Brain shared resident note",
+          content: "brain-shared-resident-token cites memory-shared-resident-token and rsp-shared-resident-token",
+          kind: "note",
+          tags: ["shared-resident"],
+        });
+        await expect(store.search("brain-shared-resident-token", 5)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              artifact: expect.objectContaining({
+                properties: expect.objectContaining({
+                  content: expect.stringContaining("brain-shared-resident-token"),
+                }),
+              }),
+            }),
+          ]),
+        );
+      }, root);
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+
+    await expect(client.get(handle)).resolves.toEqual(
+      expect.objectContaining({ original: Buffer.from("rsp-shared-resident-token") }),
+    );
+    await expect(client.memory("recall", { query: "memory-shared-resident-token", limit: 5 })).resolves.toEqual(
+      expect.objectContaining({
+        hits: expect.arrayContaining([
+          expect.objectContaining({ excerpt: expect.stringContaining("memory-shared-resident-token") }),
+        ]),
+      }),
+    );
+
+    await server;
   }, 20_000);
 });
 

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -20,7 +20,25 @@ export type RspResidentRequest =
   | { id: string; op: "telemetry-gains"; sinceDays: number }
   | { id: string; op: "mint"; original: string; meta: unknown }
   | { id: string; op: "get"; handle: string }
-  | { id: string; op: "memory"; action: "recall" | "ingest"; payload: unknown };
+  | { id: string; op: "memory"; action: "recall" | "ingest"; payload: unknown }
+  | { id: string; op: "brain"; action: BrainResidentAction; payload?: unknown };
+
+export type BrainResidentAction =
+  | "status"
+  | "capture"
+  | "getArtifact"
+  | "listArtifacts"
+  | "search"
+  | "think"
+  | "link"
+  | "backlinks"
+  | "listConnections"
+  | "eventKpis"
+  | "appendOutcomeEvent"
+  | "replayOutcomeEvents"
+  | "loadModelTierBanditDocument"
+  | "saveModelTierBanditDocument"
+  | "refreshModelTierBanditDocument";
 
 export type RspResidentResponse =
   | { id: string; ok: true; value: unknown; storeOpenCount?: number; storeElapsedMs?: number }


### PR DESCRIPTION
Automated AFK landing for #1591. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1591

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786501994&installation_id=129708444&pr_number=1596&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1596&signature=a3e6f9fe6914e10d61011425fb8d05d3dcbdb4b26d8cd92417c0af46a61fced5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->