### PR TITLE
fix: #1597 rsp statusline ticker renders err for an idle resident — idle is not failure

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -140,7 +140,6 @@ export function resolveStatuslinePreset(cfg: ReturnType<typeof loadConfig>): Sta
 }
 
 const RSP_WARMUP_GRACE_MS = 15_000;
-const RSP_MIN_SUMMARY_FRESH_MS = 90_000;
 
 interface RspSummaryFile {
   version: number;
@@ -172,21 +171,38 @@ function isRecentFile(path: string, nowMs: number, maxAgeMs: number): boolean {
   }
 }
 
+function fileExists(path: string): boolean {
+  try {
+    statSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function utcDay(iso: string): string | undefined {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return undefined;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function tokensSavedForCurrentDay(summary: RspSummaryFile, nowMs: number): number {
+  if (utcDay(summary.updated_at) !== new Date(nowMs).toISOString().slice(0, 10)) return 0;
+  return Math.max(0, Math.floor(summary.tokens_saved_today));
+}
+
 export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv = process.env): Promise<RspStatusInput | undefined> {
   const config = resolveRspConfig(root, env);
   if (!config.enabled) return undefined;
   const paths = resolveResidentPaths(root);
   const nowMs = Date.now();
-  const summaryFreshMs = Math.max(RSP_MIN_SUMMARY_FRESH_MS, config.telemetryDrainIntervalMs * 3);
   const summary = parseRspSummary(paths.summaryPath);
   if (summary) {
-    const updatedAtMs = Date.parse(summary.updated_at);
-    if (Number.isFinite(updatedAtMs) && nowMs - updatedAtMs <= summaryFreshMs) {
-      return { state: "ready", tokensSavedToday: Math.max(0, Math.floor(summary.tokens_saved_today)) };
-    }
+    return { state: "ready", tokensSavedToday: tokensSavedForCurrentDay(summary, nowMs) };
   }
   if (isRecentFile(paths.wakeLockPath, nowMs, RSP_WARMUP_GRACE_MS)) return { state: "warming" };
-  return { state: "error" };
+  if (fileExists(paths.wakeLockPath)) return { state: "error" };
+  return undefined;
 }
 
 /** The block-1 project input: basename, the resolved git ref (branch or detached

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, readFile, utimes } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -728,9 +728,53 @@ describe("statusline command — rendered line", () => {
     expect(stripAnsi(out.text())).toContain("rsp ↓1.3M");
   });
 
-  it("renders rsp error when enabled and no fresh summary or warmup marker exists", async () => {
+  it("renders rsp savings from an old summary when the resident is idle", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
+      version: 1,
+      tokens_saved_today: 4242,
+      updated_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    }), "utf8");
+
+    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 4242 });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("rsp ↓4.2k");
+  });
+
+  it("renders rsp savings as zero when the newest summary belongs to yesterday", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
+      version: 1,
+      tokens_saved_today: 4242,
+      updated_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    }), "utf8");
+
+    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 0 });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("rsp ↓0");
+  });
+
+  it("renders rsp error when enabled and a stale wake marker produced no summary", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await mkdir(dirname(resolveResidentPaths(root).wakeLockPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).wakeLockPath, "", "utf8");
+    const stale = new Date(Date.now() - 60 * 1000);
+    await utimes(resolveResidentPaths(root).wakeLockPath, stale, stale);
     const started = Date.now();
     const rsp = await resolveStatuslineRsp(root, {});
     const elapsed = Date.now() - started;
@@ -738,15 +782,10 @@ describe("statusline command — rendered line", () => {
     expect(elapsed).toBeLessThan(50);
   });
 
-  it("renders rsp warming when the summary is stale but the warmup marker is recent", async () => {
+  it("renders rsp warming when a recent wake marker has no summary yet", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
-    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
-    await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
-      version: 1,
-      tokens_saved_today: 1200,
-      updated_at: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
-    }), "utf8");
+    await mkdir(dirname(resolveResidentPaths(root).wakeLockPath), { recursive: true });
     await writeFile(resolveResidentPaths(root).wakeLockPath, "", "utf8");
 
     expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "warming" });


### PR DESCRIPTION
Automated AFK landing for #1597. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1597

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786504058&installation_id=129708444&pr_number=1598&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1598&signature=00528632d19dbab17a79a99967398911cc0f99d1cee4b4577f55f1322b962069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->