### PR TITLE
feat: #1601 benchmark: corpus expansion — every shipped wrapper measured, RTK coverage honest

### DIFF
--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -1,13 +1,16 @@
-rsp two-axis benchmark: 18 fixtures across 7 filters
+rsp two-axis benchmark: 27 fixtures across 10 filters
 
 Production mode uses admission threshold 60%; passthrough filters count as 0% token delta because rsp returns the original command output.
 
 | Filter | Mode | Fixtures | brief shipped delta | brief fidelity | brief hyp-active delta | terse shipped delta | terse fidelity | terse hyp-active delta | RTK median/p90 token delta | RTK fidelity |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | cargo:test | active | 3 | 61.9/84.2% | 100% | 61.9/84.2% | 57.7/84.2% | 100% | 57.7/84.2% | 67.8/82.4% | 100% |
+| gh:issue | passthrough | 3 | 0/0% | 100% | -36.4/0% | 0/0% | 100% | -25.5/0% | rtk: not-covered | rtk: not-covered |
+| gh:pr | passthrough | 3 | 0/0% | 100% | -68.7/-15% | 0/0% | 100% | -68.7/-45% | rtk: not-covered | rtk: not-covered |
+| gh:run | passthrough | 3 | 0/0% | 100% | -7.3/0% | 0/0% | 100% | -34.1/0% | rtk: not-covered | rtk: not-covered |
 | git:commit | passthrough | 1 | 0/0% | 100% | 42.4/42.4% | 0/0% | 100% | 42.4/42.4% | -78.8/-78.8% | 100% |
-| git:diff | passthrough | 2 | 0/0% | 100% | -56/-0.4% | 0/0% | 100% | -21.6/99.1% | 38.3/99.6% | 100% |
-| git:log | passthrough | 2 | 0/0% | 100% | -35.4/-5% | 0/0% | 100% | 13.7/98.4% | 52.3/99.3% | 100% |
+| git:diff | passthrough | 2 | 0/0% | 100% | -6.2/99.1% | 0/0% | 100% | -21.6/99.1% | 38.3/99.6% | 100% |
+| git:log | passthrough | 2 | 0/0% | 100% | 16.3/98.4% | 0/0% | 100% | 13.7/98.4% | 52.3/99.3% | 100% |
 | git:push | active | 2 | 31.9/63.8% | 100% | 31.9/63.8% | 31.9/63.8% | 100% | 31.9/63.8% | 13.8/27.6% | 100% |
 | git:status | active | 2 | 60.5/75% | 100% | 60.5/75% | 60.5/75% | 50% | 60.5/75% | 23.7/72.3% | 100% |
 | vitest:run | active | 6 | 58.8/100% | 100% | 58.8/100% | 70/100% | 100% | 70/100% | 86.3/100% | 100% |

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -1,7 +1,7 @@
 benchmark: rsp-two-axis
 corpus:
-  fixture_count: 18
-  filters[7]: "cargo:test","git:commit","git:diff","git:log","git:push","git:status","vitest:run"
+  fixture_count: 27
+  filters[10]: "cargo:test","gh:issue","gh:pr","gh:run","git:commit","git:diff","git:log","git:push","git:status","vitest:run"
   large_output_filters[3]: "git:diff","git:log","vitest:run"
 method:
   tokenizer: "js-tiktoken:gpt-4o"
@@ -13,7 +13,7 @@ method:
     captured_at: "2026-07-10T00:00:00.000Z"
   external_claims[1]{layer,claim,status,measured_locally,note}:
     external-context-optimization,Host/provider conversation-history optimization and cache-prefix alignment can reduce repeated context spend.,cited_unverified,false,The rsp benchmark measures shell-output fixtures only; external history-layer claims are not reproduced here.
-filters[7]:
+filters[10]:
   - filter: "cargo:test"
     mode: active
     fixture_count: 3
@@ -46,6 +46,105 @@ filters[7]:
       terse:
         median_delta_pct: 57.7
         p90_delta_pct: 84.2
+        fidelity_pass_rate_pct: 100
+        source: measured
+  - filter: "gh:issue"
+    mode: passthrough
+    fixture_count: 3
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      coverage: not-covered
+      label: "rtk: not-covered"
+      source: not-covered
+    hypothetical_active:
+      brief:
+        median_delta_pct: -36.4
+        p90_delta_pct: 0
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: -25.5
+        p90_delta_pct: 0
+        fidelity_pass_rate_pct: 100
+        source: measured
+  - filter: "gh:pr"
+    mode: passthrough
+    fixture_count: 3
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      coverage: not-covered
+      label: "rtk: not-covered"
+      source: not-covered
+    hypothetical_active:
+      brief:
+        median_delta_pct: -68.7
+        p90_delta_pct: -15
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: -68.7
+        p90_delta_pct: -45
+        fidelity_pass_rate_pct: 100
+        source: measured
+  - filter: "gh:run"
+    mode: passthrough
+    fixture_count: 3
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      coverage: not-covered
+      label: "rtk: not-covered"
+      source: not-covered
+    hypothetical_active:
+      brief:
+        median_delta_pct: -7.3
+        p90_delta_pct: 0
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: -34.1
+        p90_delta_pct: 0
         fidelity_pass_rate_pct: 100
         source: measured
   - filter: "git:commit"
@@ -107,9 +206,9 @@ filters[7]:
       source: recorded
     hypothetical_active:
       brief:
-        median_delta_pct: -56
-        p90_delta_pct: -0.4
-        fidelity_pass_rate_pct: 100
+        median_delta_pct: -6.2
+        p90_delta_pct: 99.1
+        fidelity_pass_rate_pct: 50
         source: measured
       terse:
         median_delta_pct: -21.6
@@ -141,9 +240,9 @@ filters[7]:
       source: recorded
     hypothetical_active:
       brief:
-        median_delta_pct: -35.4
-        p90_delta_pct: -5
-        fidelity_pass_rate_pct: 100
+        median_delta_pct: 16.3
+        p90_delta_pct: 98.4
+        fidelity_pass_rate_pct: 50
         source: measured
       terse:
         median_delta_pct: 13.7
@@ -255,4 +354,4 @@ filters[7]:
 parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
   cargo-test,"cargo:test",61.9,67.8,100,100,fail
   git-commit,"git:commit",0,-78.8,100,100,pass
-summary: "18 fixtures, 7 filters; shipped modes apply admission threshold 60%"
+summary: "27 fixtures, 10 filters; shipped modes apply admission threshold 60%"

--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -24,6 +24,14 @@ export interface BaselineAxis {
   source: "recorded" | "measured";
 }
 
+export interface NotCoveredAxis {
+  coverage: "not-covered";
+  label: string;
+  source: "not-covered";
+}
+
+export type ComparatorAxis = BaselineAxis | NotCoveredAxis;
+
 export interface TwoAxisFilterRow {
   filter: string;
   mode: "active" | "passthrough";
@@ -31,7 +39,7 @@ export interface TwoAxisFilterRow {
   raw: BaselineAxis;
   brief: BaselineAxis;
   terse: BaselineAxis;
-  rtk: BaselineAxis;
+  rtk: ComparatorAxis;
   /** Measured delta if this filter were forced active; equals brief/terse for active filters, non-zero for passthrough. */
   hypothetical_active: {
     brief: BaselineAxis;
@@ -102,8 +110,8 @@ interface FixtureMeasurement {
   briefFidelity: boolean;
   terseDelta: number;
   terseFidelity: boolean;
-  rtkDelta: number;
-  rtkFidelity: boolean;
+  rtkDelta?: number;
+  rtkFidelity?: boolean;
 }
 
 const tokenizer = encodingForModel("gpt-4o");
@@ -132,7 +140,6 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
   try {
     for (const fixture of fixtures) {
       const rtkFixture = byName.get(fixture.name);
-      if (!rtkFixture) throw new Error(`missing recorded RTK baseline for ${fixture.name}`);
       const brief = await runFidelityFixture(fixture, { level: "lossless", store });
       const terse = await runFidelityFixture(fixture, { level: "terse", store });
       measurements.push({
@@ -144,8 +151,8 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
         briefFidelity: brief.status === fixture.recorded.status && brief.assertionFailures.length === 0,
         terseDelta: terse.tokenDelta,
         terseFidelity: terse.status === fixture.recorded.status && terse.assertionFailures.length === 0,
-        rtkDelta: tokenDelta(fixture.recorded.stdout, rtkFixture.stdout),
-        rtkFidelity: rtkFixture.fidelity_assertions_passed,
+        rtkDelta: rtkFixture ? tokenDelta(fixture.recorded.stdout, rtkFixture.stdout) : undefined,
+        rtkFidelity: rtkFixture?.fidelity_assertions_passed,
       });
     }
   } finally {
@@ -203,7 +210,7 @@ export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
     "| Filter | Mode | Fixtures | brief shipped delta | brief fidelity | brief hyp-active delta | terse shipped delta | terse fidelity | terse hyp-active delta | RTK median/p90 token delta | RTK fidelity |",
     "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
     ...report.filters.map((row) =>
-      `| ${row.filter} | ${row.mode} | ${row.fixture_count} | ${fmt(row.brief.median_delta_pct)}/${fmt(row.brief.p90_delta_pct)}% | ${fmt(row.brief.fidelity_pass_rate_pct)}% | ${fmt(row.hypothetical_active.brief.median_delta_pct)}/${fmt(row.hypothetical_active.brief.p90_delta_pct)}% | ${fmt(row.terse.median_delta_pct)}/${fmt(row.terse.p90_delta_pct)}% | ${fmt(row.terse.fidelity_pass_rate_pct)}% | ${fmt(row.hypothetical_active.terse.median_delta_pct)}/${fmt(row.hypothetical_active.terse.p90_delta_pct)}% | ${fmt(row.rtk.median_delta_pct)}/${fmt(row.rtk.p90_delta_pct)}% | ${fmt(row.rtk.fidelity_pass_rate_pct)}% |`
+      `| ${row.filter} | ${row.mode} | ${row.fixture_count} | ${fmt(row.brief.median_delta_pct)}/${fmt(row.brief.p90_delta_pct)}% | ${fmt(row.brief.fidelity_pass_rate_pct)}% | ${fmt(row.hypothetical_active.brief.median_delta_pct)}/${fmt(row.hypothetical_active.brief.p90_delta_pct)}% | ${fmt(row.terse.median_delta_pct)}/${fmt(row.terse.p90_delta_pct)}% | ${fmt(row.terse.fidelity_pass_rate_pct)}% | ${fmt(row.hypothetical_active.terse.median_delta_pct)}/${fmt(row.hypothetical_active.terse.p90_delta_pct)}% | ${fmtComparatorDelta(row.rtk)} | ${fmtComparatorFidelity(row.rtk)} |`
     ),
     "",
     `Large-output filters: ${report.corpus.large_output_filters.join(", ") || "none"}.`,
@@ -222,7 +229,7 @@ export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
 }
 
 async function discoverBenchmarkFixtures(fixtureRoot: string): Promise<FidelityFixture[]> {
-  const roots = [join(fixtureRoot, "git"), join(fixtureRoot, "test-runners")];
+  const roots = [join(fixtureRoot, "gh"), join(fixtureRoot, "git"), join(fixtureRoot, "test-runners")];
   const groups = await Promise.all(roots.map((root) => discoverFidelityFixtures(root)));
   return groups.flat().sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -252,15 +259,16 @@ function buildParity(rows: readonly TwoAxisFilterRow[]): TwoAxisParityRow[] {
 function parityRow(domain: TwoAxisParityRow["domain"], filter: string, rows: readonly TwoAxisFilterRow[]): TwoAxisParityRow {
   const row = rows.find((candidate) => candidate.filter === filter);
   if (!row) throw new Error(`missing parity filter ${filter}`);
-  const pass = row.brief.fidelity_pass_rate_pct >= row.rtk.fidelity_pass_rate_pct &&
-    row.brief.median_delta_pct >= row.rtk.median_delta_pct;
+  const rtk = coveredComparatorAxis("rtk", filter, row.rtk);
+  const pass = row.brief.fidelity_pass_rate_pct >= rtk.fidelity_pass_rate_pct &&
+    row.brief.median_delta_pct >= rtk.median_delta_pct;
   return {
     domain,
     filter,
     rsp_median_delta_pct: row.brief.median_delta_pct,
-    rtk_median_delta_pct: row.rtk.median_delta_pct,
+    rtk_median_delta_pct: rtk.median_delta_pct,
     rsp_fidelity_pass_rate_pct: row.brief.fidelity_pass_rate_pct,
-    rtk_fidelity_pass_rate_pct: row.rtk.fidelity_pass_rate_pct,
+    rtk_fidelity_pass_rate_pct: rtk.fidelity_pass_rate_pct,
     parity_gate: pass ? "pass" : "fail",
   };
 }
@@ -277,7 +285,7 @@ function filterRow(filter: string, rows: readonly FixtureMeasurement[], admissio
     raw: axis(rows.map((row) => row.rawDelta), rows.map((row) => row.rawFidelity), "recorded"),
     brief: active ? measuredBrief : passthroughAxis(rows.length),
     terse: active ? measuredTerse : passthroughAxis(rows.length),
-    rtk: axis(rows.map((row) => row.rtkDelta), rows.map((row) => row.rtkFidelity), "recorded"),
+    rtk: comparatorAxis("rtk", rows.map((row) => ({ delta: row.rtkDelta, fidelity: row.rtkFidelity }))),
     hypothetical_active: { brief: measuredBrief, terse: measuredTerse },
   };
 }
@@ -311,6 +319,30 @@ function axis(deltas: readonly number[], fidelity: readonly boolean[], source: B
   };
 }
 
+function comparatorAxis(
+  label: string,
+  rows: readonly { delta?: number; fidelity?: boolean }[],
+): ComparatorAxis {
+  const covered = rows.filter((row): row is { delta: number; fidelity: boolean } =>
+    typeof row.delta === "number" && typeof row.fidelity === "boolean"
+  );
+  if (covered.length === 0) return notCoveredAxis(label);
+  return axis(covered.map((row) => row.delta), covered.map((row) => row.fidelity), "recorded");
+}
+
+function notCoveredAxis(label: string): NotCoveredAxis {
+  return {
+    coverage: "not-covered",
+    label: `${label}: not-covered`,
+    source: "not-covered",
+  };
+}
+
+function coveredComparatorAxis(label: string, filter: string, value: ComparatorAxis): BaselineAxis {
+  if (value.source === "not-covered") throw new Error(`${label} baseline not covered for parity filter ${filter}`);
+  return value;
+}
+
 function filterName(fixture: FidelityFixture): string {
   return fixture.command.slice(0, 2).join(":");
 }
@@ -342,6 +374,16 @@ function round(value: number): number {
 
 function fmt(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function fmtComparatorDelta(value: ComparatorAxis): string {
+  if (value.source === "not-covered") return value.label;
+  return `${fmt(value.median_delta_pct)}/${fmt(value.p90_delta_pct)}%`;
+}
+
+function fmtComparatorFidelity(value: ComparatorAxis): string {
+  if (value.source === "not-covered") return value.label;
+  return `${fmt(value.fidelity_pass_rate_pct)}%`;
 }
 
 function externalClaims(): ExternalClaim[] {

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -23,12 +23,30 @@ describe("rsp two-axis benchmark report", () => {
     const report = await buildTwoAxisBenchmarkReport({ fixtureRoot });
 
     expect(report.corpus).toMatchObject({
-      fixture_count: 18,
+      fixture_count: 27,
       large_output_filters: ["git:diff", "git:log", "vitest:run"],
     });
+    expect(report.corpus.filters).toEqual([
+      "cargo:test",
+      "gh:issue",
+      "gh:pr",
+      "gh:run",
+      "git:commit",
+      "git:diff",
+      "git:log",
+      "git:push",
+      "git:status",
+      "vitest:run",
+    ]);
     expect(report.method.tokenizer).toBe("js-tiktoken:gpt-4o");
     expect(report.method.rtk_source).toMatchObject({ kind: "recorded-fixtures", version: expect.stringMatching(/^rtk /) });
     expect(report.method.external_claims[0]).toMatchObject({ status: "cited_unverified", measured_locally: false });
+
+    const ghPr = report.filters.find((row) => row.filter === "gh:pr");
+    expect(ghPr).toMatchObject({
+      fixture_count: 3,
+      rtk: { coverage: "not-covered", label: "rtk: not-covered" },
+    });
 
     const gitCommit = report.filters.find((row) => row.filter === "git:commit");
     expect(gitCommit).toMatchObject({
@@ -75,5 +93,7 @@ describe("rsp two-axis benchmark report", () => {
     await expect(readFile(toonPath, "utf8")).resolves.toBe(report.toon);
     await expect(readFile(summaryPath, "utf8")).resolves.toBe(renderTwoAxisSummary(report));
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Filter | Mode | Fixtures | brief shipped delta | brief fidelity | brief hyp-active delta | terse shipped delta | terse fidelity | terse hyp-active delta | RTK median/p90 token delta | RTK fidelity |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| gh:pr |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("rtk: not-covered");
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1601. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1601

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786507432&installation_id=129708444&pr_number=1605&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1605&signature=7b126e28d48136e2206d35fa261ef03b7d8c65fe8f89ceb8efd508e510360334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->