### PR TITLE
feat: #1602 benchmark CI regression gate on PRs touching apps/rsp

### DIFF
--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -1,0 +1,34 @@
+name: red-rsp-benchmark-ci
+
+on:
+  pull_request:
+    paths:
+      - apps/rsp/**
+      - .github/workflows/red-rsp-benchmark-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Install workspace dependencies
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
+        run: pnpm install --frozen-lockfile
+
+      - name: Check rsp two-axis benchmark
+        run: pnpm -C apps/rsp bench:two-axis:check
+
+      - name: Require committed benchmark results
+        run: git diff --exit-code -- apps/rsp/bench/results/rsp-two-axis.toon apps/rsp/bench/results/rsp-two-axis.md

--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -17,6 +17,7 @@
     "build": "tsc -p tsconfig.build.json && pnpm bundle",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/rsp.bundle.min.mjs --asset rsp.bundle.min.mjs --minify --reddb-from-package",
     "bench:two-axis": "node --import tsx src/two-axis-benchmark-cli.ts",
+    "bench:two-axis:check": "node --import tsx src/two-axis-benchmark-cli.ts --check --out bench/results/rsp-two-axis.toon --summary bench/results/rsp-two-axis.md",
     "gen:ambient-skill": "node --import tsx scripts/gen-ambient-skill.mjs",
     "test": "vitest run",
     "dev": "node --import tsx src/cli.ts"

--- a/apps/rsp/src/two-axis-benchmark-cli.ts
+++ b/apps/rsp/src/two-axis-benchmark-cli.ts
@@ -1,28 +1,74 @@
 #!/usr/bin/env node
-import { writeTwoAxisBenchmarkReport } from "./two-axis-benchmark.js";
+import { readFile } from "node:fs/promises";
+import { decode } from "@reddb-io/toon";
+import { writeTwoAxisBenchmarkReport, type TwoAxisBenchmarkReport } from "./two-axis-benchmark.js";
+import {
+  compareTwoAxisBenchmarkReports,
+  TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT,
+  type TwoAxisRegressionViolation,
+} from "./two-axis-thresholds.js";
 
 interface Args {
   out?: string;
   summary?: string;
+  check: boolean;
 }
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
   const args = parseArgs(argv);
+  const baseline = args.check && args.out ? await readBenchmarkReport(args.out) : undefined;
   const report = await writeTwoAxisBenchmarkReport({ toonPath: args.out, summaryPath: args.summary });
   process.stdout.write(report.toon);
   if (!report.toon.endsWith("\n")) process.stdout.write("\n");
+  if (baseline) {
+    const violations = compareTwoAxisBenchmarkReports(baseline, report);
+    if (violations.length > 0) {
+      process.stderr.write(renderViolations(violations));
+      return 1;
+    }
+  }
   return 0;
 }
 
 function parseArgs(argv: readonly string[]): Args {
-  const out: Args = {};
+  const out: Args = { check: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--out") out.out = argv[++i];
     else if (arg === "--summary") out.summary = argv[++i];
+    else if (arg === "--check") out.check = true;
     else throw new Error(`unknown argument: ${arg}`);
   }
+  if (out.check && !out.out) throw new Error("--check requires --out");
   return out;
+}
+
+async function readBenchmarkReport(path: string): Promise<TwoAxisBenchmarkReport> {
+  const decoded = decode(await readFile(path, "utf8"));
+  if (!isTwoAxisBenchmarkReport(decoded)) throw new Error(`invalid rsp two-axis benchmark result: ${path}`);
+  return decoded;
+}
+
+function renderViolations(violations: readonly TwoAxisRegressionViolation[]): string {
+  const lines = [
+    `rsp two-axis benchmark regression gate failed (${violations.length} violation${violations.length === 1 ? "" : "s"}):`,
+    ...violations.map((violation) => {
+      if (violation.kind === "token-regression") {
+        return `- ${violation.filter} ${violation.axis}: token delta ${violation.current}% regressed from ${violation.baseline}% by more than ${TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT}pp`;
+      }
+      return `- ${violation.filter} ${violation.axis}: fidelity pass rate ${violation.current}% regressed from ${violation.baseline}%`;
+    }),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function isTwoAxisBenchmarkReport(value: unknown): value is TwoAxisBenchmarkReport {
+  return typeof value === "object" &&
+    value !== null &&
+    "benchmark" in value &&
+    value.benchmark === "rsp-two-axis" &&
+    "filters" in value &&
+    Array.isArray(value.filters);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/apps/rsp/src/two-axis-thresholds.ts
+++ b/apps/rsp/src/two-axis-thresholds.ts
@@ -1,0 +1,62 @@
+import type { BaselineAxis, TwoAxisBenchmarkReport } from "./two-axis-benchmark.js";
+
+export const TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT = 2;
+export const TWO_AXIS_ALLOWED_FIDELITY_REGRESSION_PCT = 0;
+
+export interface TwoAxisRegressionViolation {
+  kind: "token-regression" | "fidelity-regression";
+  filter: string;
+  axis: "brief" | "terse";
+  baseline: number;
+  current: number;
+  threshold: number;
+}
+
+export function compareTwoAxisBenchmarkReports(
+  baseline: TwoAxisBenchmarkReport,
+  current: TwoAxisBenchmarkReport,
+): TwoAxisRegressionViolation[] {
+  const baselineByFilter = new Map(baseline.filters.map((row) => [row.filter, row]));
+  const violations: TwoAxisRegressionViolation[] = [];
+  for (const currentRow of current.filters) {
+    const baselineRow = baselineByFilter.get(currentRow.filter);
+    if (!baselineRow) continue;
+    violations.push(
+      ...compareAxis(currentRow.filter, "brief", baselineRow.brief, currentRow.brief),
+      ...compareAxis(currentRow.filter, "terse", baselineRow.terse, currentRow.terse),
+    );
+  }
+  return violations;
+}
+
+function compareAxis(
+  filter: string,
+  axis: "brief" | "terse",
+  baseline: BaselineAxis,
+  current: BaselineAxis,
+): TwoAxisRegressionViolation[] {
+  const violations: TwoAxisRegressionViolation[] = [];
+  const tokenRegression = baseline.median_delta_pct - current.median_delta_pct;
+  if (tokenRegression > TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT) {
+    violations.push({
+      kind: "token-regression",
+      filter,
+      axis,
+      baseline: baseline.median_delta_pct,
+      current: current.median_delta_pct,
+      threshold: TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT,
+    });
+  }
+  const fidelityRegression = baseline.fidelity_pass_rate_pct - current.fidelity_pass_rate_pct;
+  if (fidelityRegression > TWO_AXIS_ALLOWED_FIDELITY_REGRESSION_PCT) {
+    violations.push({
+      kind: "fidelity-regression",
+      filter,
+      axis,
+      baseline: baseline.fidelity_pass_rate_pct,
+      current: current.fidelity_pass_rate_pct,
+      threshold: TWO_AXIS_ALLOWED_FIDELITY_REGRESSION_PCT,
+    });
+  }
+  return violations;
+}

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { decode } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
-import { buildTwoAxisBenchmarkReport, renderTwoAxisSummary, writeTwoAxisBenchmarkReport } from "../src/two-axis-benchmark.js";
+import { buildTwoAxisBenchmarkReport, renderTwoAxisSummary, writeTwoAxisBenchmarkReport, type TwoAxisBenchmarkReport } from "../src/two-axis-benchmark.js";
+import { compareTwoAxisBenchmarkReports, TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT } from "../src/two-axis-thresholds.js";
 
 const roots: string[] = [];
 const fixtureRoot = join(import.meta.dirname, "fixtures");
@@ -95,5 +96,21 @@ describe("rsp two-axis benchmark report", () => {
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Filter | Mode | Fixtures | brief shipped delta | brief fidelity | brief hyp-active delta | terse shipped delta | terse fidelity | terse hyp-active delta | RTK median/p90 token delta | RTK fidelity |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| gh:pr |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("rtk: not-covered");
+  });
+
+  it("flags synthetic shipped token regressions beyond the threshold", async () => {
+    const baseline = await buildTwoAxisBenchmarkReport({ fixtureRoot });
+    const current = structuredClone(baseline) as TwoAxisBenchmarkReport;
+    const row = current.filters.find((candidate) => candidate.filter === "vitest:run");
+    expect(row).toBeDefined();
+    row!.brief.median_delta_pct -= TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT + 0.1;
+
+    expect(compareTwoAxisBenchmarkReports(baseline, current)).toEqual([
+      expect.objectContaining({
+        kind: "token-regression",
+        filter: "vitest:run",
+        axis: "brief",
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
Closes #1602. Slice 3 of Spec #1599.

Adds the red-prefixed workflow that runs the two-axis benchmark on PRs touching `apps/rsp/`, failing on >2pp shipped-delta regression or any fidelity break, and requiring the regenerated `bench/results` to match the committed table (trends live in git history). Thresholds live in one module shared by the workflow check and the local runner; includes the synthetic-regression comparator test.

Validation park was environmental: the same 5 rsp tests fail on ORIGIN/MAIN on this machine (latency budgets + the 2s telemetry-drain timeout vs ~1.6s embedded open on slower hardware; green on CI runners). Verified: branch suite matches main's failure set exactly, and the branch-only suspect (mcp boots inert) fails identically on main when isolated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786509986&installation_id=129708444&pr_number=1606&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1606&signature=ae6486859a8dd8a6baf63a0ede62f637ddf80ebc466428fe01ba886b4f9b784e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->