### PR TITLE
fix: #1607 rsp bundle latency and drain budgets fail deterministically on slower hardware — the local AFK gate parks every rsp slice

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -68,6 +68,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       telemetryByteBudget: numericValueAfter(args.positional, "--telemetry-byte-budget") ?? serverConfig.telemetryByteBudget,
       telemetryDrainIntervalMs: numericValueAfter(args.positional, "--telemetry-drain-interval-ms") ??
         serverConfig.telemetryDrainIntervalMs,
+      telemetryDrainTimeoutMs: numericValueAfter(args.positional, "--telemetry-drain-timeout-ms") ??
+        serverConfig.telemetryDrainTimeoutMs,
       idleMs: numericValueAfter(args.positional, "--idle-ms"),
       residentVersion: valueAfter(args.positional, "--resident-version") ?? buildInfo.version,
     });
@@ -92,6 +94,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       telemetryByteBudget: numericValueAfter(args.positional, "--telemetry-byte-budget") ?? warmConfig.telemetryByteBudget,
       telemetryDrainIntervalMs: numericValueAfter(args.positional, "--telemetry-drain-interval-ms") ??
         warmConfig.telemetryDrainIntervalMs,
+      telemetryDrainTimeoutMs: numericValueAfter(args.positional, "--telemetry-drain-timeout-ms") ??
+        warmConfig.telemetryDrainTimeoutMs,
       clientVersion: buildInfo.version,
     });
     return 0;
@@ -112,6 +116,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     telemetryTtlDays: config.telemetryTtlDays,
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
     clientVersion: buildInfo.version,
   }));
   const warmResidentStore = () => ensureResidentServer(residentPaths, {
@@ -121,6 +126,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     telemetryTtlDays: config.telemetryTtlDays,
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
     clientVersion: buildInfo.version,
   });
   const openDirectStore = async (): Promise<ElisionStoreLike & Pick<RspElisionStore, "get" | "stats">> => {

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -9,6 +9,7 @@ export const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
 export const DEFAULT_RSP_TELEMETRY_TTL_DAYS = 90;
 export const DEFAULT_RSP_TELEMETRY_BYTE_BUDGET = 4 * 1024 * 1024;
 export const DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS = 30_000;
+export const DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
 
 export interface RspRuntimeConfig {
   enabled: boolean;
@@ -18,6 +19,7 @@ export interface RspRuntimeConfig {
   telemetryTtlDays: number;
   telemetryByteBudget: number;
   telemetryDrainIntervalMs: number;
+  telemetryDrainTimeoutMs: number;
   heavyGitByteThreshold: number;
 }
 
@@ -40,6 +42,10 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     numericEnv(env.RSP_TELEMETRY_DRAIN_INTERVAL_MS) ?? readNumericYamlPath(yaml, "rsp.telemetryDrainIntervalMs"),
     DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
   );
+  const telemetryDrainTimeoutMs = positiveNumber(
+    numericEnv(env.RSP_TELEMETRY_DRAIN_TIMEOUT_MS) ?? readNumericYamlPath(yaml, "rsp.telemetryDrainTimeoutMs"),
+    DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
+  );
   const heavyGitByteThreshold = positiveNumber(
     numericEnv(env.RSP_HEAVY_GIT_BYTE_THRESHOLD) ?? readNumericYamlPath(yaml, "rsp.heavyGitByteThreshold"),
     DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
@@ -54,6 +60,7 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     telemetryTtlDays,
     telemetryByteBudget,
     telemetryDrainIntervalMs,
+    telemetryDrainTimeoutMs,
     heavyGitByteThreshold,
   };
 }

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -125,6 +125,7 @@ function toResidentConfig(config: RspRuntimeConfig) {
     telemetryTtlDays: config.telemetryTtlDays,
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
   };
 }
 

--- a/apps/rsp/src/mcp-server.ts
+++ b/apps/rsp/src/mcp-server.ts
@@ -105,6 +105,7 @@ function residentStore(config: RspRuntimeConfig): ResidentRspElisionStore {
     telemetryTtlDays: config.telemetryTtlDays,
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+    telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
   });
 }
 

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -27,6 +27,7 @@ export interface ResidentServerOptions extends RspResidentConfig {
   idleMs?: number;
   residentVersion?: string;
   telemetryDrainIntervalMs?: number;
+  telemetryDrainTimeoutMs?: number;
 }
 
 export async function runResidentServer(opts: ResidentServerOptions): Promise<void> {
@@ -46,13 +47,14 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
     ttlDays: opts.telemetryTtlDays ?? DEFAULT_RSP_TELEMETRY_TTL_DAYS,
     byteBudget: opts.telemetryByteBudget ?? opts.byteBudget ?? DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
   });
-  await safeDrainTelemetry(telemetry);
+  const telemetryDrainTimeoutMs = opts.telemetryDrainTimeoutMs ?? TELEMETRY_DRAIN_TIMEOUT_MS;
+  await safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
 
   const idleMs = opts.idleMs ?? 30_000;
   let idleTimer: NodeJS.Timeout | undefined;
   const telemetryDrainIntervalMs = opts.telemetryDrainIntervalMs ?? 30_000;
   const telemetryTimer = setInterval(() => {
-    void safeDrainTelemetry(telemetry);
+    void safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
   }, telemetryDrainIntervalMs);
   telemetryTimer.unref();
   const server = createServer((socket) => {
@@ -87,7 +89,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   storeOpenCount = 0;
   if (idleTimer) clearTimeout(idleTimer);
   clearInterval(telemetryTimer);
-  await safeDrainTelemetry(telemetry);
+  await safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
   await store.close();
   await rm(opts.socketPath, { force: true });
 }
@@ -261,9 +263,9 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
   await rename(tmp, path);
 }
 
-async function safeDrainTelemetry(telemetry: ResidentTelemetryDrain): Promise<void> {
+async function safeDrainTelemetry(telemetry: ResidentTelemetryDrain, timeoutMs = TELEMETRY_DRAIN_TIMEOUT_MS): Promise<void> {
   try {
-    await withTimeout(telemetry.drainAndSweep(), TELEMETRY_DRAIN_TIMEOUT_MS, "telemetry drain timed out");
+    await withTimeout(telemetry.drainAndSweep(), timeoutMs, "telemetry drain timed out");
   } catch (err) {
     process.stderr.write(`rsp resident: telemetry drain failed: ${err instanceof Error ? err.message : String(err)}\n`);
   }

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -71,7 +71,7 @@ function runNodeNoop() {
 function runBundleFromCwd(cwd: string, args: string[], env: Record<string, string> = {}) {
   return spawnSync(process.execPath, [bundle, ...args], {
     cwd,
-    env: { ...process.env, ...env },
+    env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
     encoding: "buffer",
   });
 }
@@ -79,7 +79,7 @@ function runBundleFromCwd(cwd: string, args: string[], env: Record<string, strin
 function runBundleHookFromCwd(cwd: string, command: string, env: Record<string, string> = {}) {
   return spawnSync(process.execPath, [bundle, "hook", "claude-pre-exec"], {
     cwd,
-    env: { ...process.env, ...env },
+    env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
     input: Buffer.from(JSON.stringify({ cwd, tool_input: { command } })),
     encoding: "buffer",
   });
@@ -89,7 +89,7 @@ function runBundleFromCwdAsync(cwd: string, args: string[], env: Record<string, 
   return new Promise<{ status: number | null; stdout: Buffer; stderr: Buffer }>((resolve, reject) => {
     const child = spawn(process.execPath, [bundle, ...args], {
       cwd,
-      env: { ...process.env, ...env },
+      env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout: Buffer[] = [];
@@ -118,11 +118,25 @@ function median(values: number[]): number {
   return sorted[Math.floor(sorted.length / 2)] ?? 0;
 }
 
-type LatencyBudgetSample = { valueMs: number; details: string };
+type LatencyBudgetSample = { valueMs: number; baselineMs: number; details: string };
 
-function budgetSample(valueMs: number, details: string): LatencyBudgetSample {
-  return { valueMs, details };
+function budgetSample(valueMs: number, baselineMs: number, details: string): LatencyBudgetSample {
+  return { valueMs, baselineMs, details };
 }
+
+function latencyRatio(sample: LatencyBudgetSample): number {
+  return sample.valueMs / Math.max(1, sample.baselineMs);
+}
+
+function latencyBudgetDetails(sample: LatencyBudgetSample): string {
+  return `${sample.details}; ratio=${latencyRatio(sample).toFixed(2)}x baseline=${sample.baselineMs.toFixed(1)}ms`;
+}
+
+function normalizedTimeoutMs(baselineMs: number, multiplier: number, minMs: number): number {
+  return Math.max(minMs, Math.ceil(Math.max(1, baselineMs) * multiplier));
+}
+
+const TEST_TELEMETRY_DRAIN_TIMEOUT_MS = normalizedTimeoutMs(timedStatus(runNodeNoop).elapsedMs, 250, 2_000);
 
 async function idleBeat(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 50));
@@ -131,17 +145,18 @@ async function idleBeat(): Promise<void> {
 async function expectLatencyBudget(
   label: string,
   first: LatencyBudgetSample,
-  budgetMs: number,
+  maxRatio: number,
   retry: () => LatencyBudgetSample | Promise<LatencyBudgetSample>,
 ): Promise<void> {
-  if (first.valueMs <= budgetMs) return;
+  if (latencyRatio(first) <= maxRatio) return;
 
   await idleBeat();
   const second = await retry();
   expect(
-    second.valueMs,
-    `${label} exceeded ${budgetMs}ms twice; first ${first.details}; retry ${second.details}`,
-  ).toBeLessThanOrEqual(budgetMs);
+    latencyRatio(second),
+    `${label} exceeded ${maxRatio.toFixed(2)}x baseline twice; ` +
+      `first ${latencyBudgetDetails(first)}; retry ${latencyBudgetDetails(second)}`,
+  ).toBeLessThanOrEqual(maxRatio);
 }
 
 function buildBundleOnce() {
@@ -178,6 +193,7 @@ async function commitMany(root: string, count: number): Promise<void> {
 
 async function runMcpRequests(cwd: string, requests: Array<Record<string, unknown>>): Promise<Array<Record<string, unknown>>> {
   return await new Promise((resolve, reject) => {
+    const timeoutMs = normalizedTimeoutMs(timedStatus(runNodeNoop).elapsedMs, 250, 10_000);
     const child = spawn(process.execPath, ["--import", tsxLoader, cli, "mcp"], {
       cwd,
       env: { ...process.env },
@@ -190,7 +206,7 @@ async function runMcpRequests(cwd: string, requests: Array<Record<string, unknow
     const timeout = setTimeout(() => {
       child.kill();
       reject(new Error(`timed out waiting for rsp mcp responses; stderr=${stderr}`));
-    }, 10_000);
+    }, timeoutMs);
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => {
@@ -347,17 +363,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 describe("rsp cli", () => {
-  it("retries a latency budget once after an idle beat before failing", async () => {
+  it("normalizes latency budgets to the sampled baseline and still catches regressions", async () => {
     let attempts = 0;
-    await expectLatencyBudget("test budget", budgetSample(125, "first=125.0ms"), 100, async () => {
+    await expectLatencyBudget("test budget", budgetSample(200, 50, "first=200.0ms"), 3, async () => {
       attempts++;
-      return budgetSample(75, "retry=75.0ms");
+      return budgetSample(130, 50, "retry=130.0ms");
     });
 
     expect(attempts).toBe(1);
-    await expect(expectLatencyBudget("test budget", budgetSample(125, "first=125.0ms"), 100, async () => {
-      return budgetSample(130, "retry=130.0ms");
-    })).rejects.toThrow(/exceeded 100ms twice/);
+    await expect(expectLatencyBudget("test budget", budgetSample(250, 50, "first=250.0ms"), 3, async () => {
+      return budgetSample(220, 50, "retry=220.0ms");
+    })).rejects.toThrow(/exceeded 3\.00x baseline twice/);
   });
 
   it("passes wrappers through without creating .red when rsp is not enabled", async () => {
@@ -479,9 +495,10 @@ describe("rsp cli", () => {
       "cold pre-exec hook work",
       budgetSample(
         coldHookWorkMs,
+        coldNodeBaseline.elapsedMs,
         `node=${coldNodeBaseline.elapsedMs.toFixed(1)}ms cold=${cold.elapsedMs.toFixed(1)}ms hookWork=${coldHookWorkMs.toFixed(1)}ms`,
       ),
-      200,
+      8,
       async () => {
         const retryRoot = await initGitRepo();
         const retryCacheDir = await seedWarmRedCache();
@@ -497,6 +514,7 @@ describe("rsp cli", () => {
         expect(retryCold.stderr).toEqual(Buffer.alloc(0));
         return budgetSample(
           retryColdHookWorkMs,
+          retryNodeBaseline.elapsedMs,
           `node=${retryNodeBaseline.elapsedMs.toFixed(1)}ms cold=${retryCold.elapsedMs.toFixed(1)}ms hookWork=${retryColdHookWorkMs.toFixed(1)}ms`,
         );
       },
@@ -547,14 +565,16 @@ describe("rsp cli", () => {
       "warm pre-exec hook work",
       budgetSample(
         measuredWarm.hookWorkMs,
+        measuredWarm.nodeMedian,
         `node=${measuredWarm.nodeMedian.toFixed(1)}ms warm=${measuredWarm.warmMedian.toFixed(1)}ms ` +
           `hookWork=${measuredWarm.hookWorkMs.toFixed(1)}ms`,
       ),
-      200,
+      8,
       () => {
         const retry = measureWarmHookWork();
         return budgetSample(
           retry.hookWorkMs,
+          retry.nodeMedian,
           `node=${retry.nodeMedian.toFixed(1)}ms warm=${retry.warmMedian.toFixed(1)}ms ` +
             `hookWork=${retry.hookWorkMs.toFixed(1)}ms`,
         );
@@ -649,12 +669,13 @@ describe("rsp cli", () => {
       `wrapped=${measured.wrappedMedian.toFixed(1)}ms wrapperWork=${measured.wrapperWorkMs.toFixed(1)}ms`;
     await expectLatencyBudget(
       "small git status wrapper work",
-      budgetSample(measured.wrapperWorkMs, measuredDetails),
-      150,
+      budgetSample(measured.wrapperWorkMs, measured.nodeMedian + measured.rawMedian, measuredDetails),
+      8,
       () => {
         const retry = measureWrapperWork();
         return budgetSample(
           retry.wrapperWorkMs,
+          retry.nodeMedian + retry.rawMedian,
           `raw=${retry.rawMedian.toFixed(1)}ms node=${retry.nodeMedian.toFixed(1)}ms ` +
             `wrapped=${retry.wrappedMedian.toFixed(1)}ms wrapperWork=${retry.wrapperWorkMs.toFixed(1)}ms`,
         );
@@ -1090,25 +1111,65 @@ describe("rsp cli", () => {
     expect(runGit(["-C", root, "log"]).status).toBe(0);
 
     const rawSamples: number[] = [];
+    const nodeSamples: number[] = [];
     const wrappedSamples: number[] = [];
     for (let i = 0; i < 5; i++) {
       const raw = timedStatus(() => runGit(["-C", root, "log"]));
+      const node = timedStatus(() => runNodeNoop());
       const wrapped = timedStatus(() => runBundleFromCwd(root, ["git", "log", "--terse"], env));
       expect(raw.status).toBe(0);
+      expect(node.status).toBe(0);
       expect(wrapped.status).toBe(0);
       expect(wrapped.stderr).toEqual(Buffer.alloc(0));
       expect(wrapped.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
       rawSamples.push(raw.elapsedMs);
+      nodeSamples.push(node.elapsedMs);
       wrappedSamples.push(wrapped.elapsedMs);
     }
 
     const rawMedian = median(rawSamples);
+    const nodeMedian = median(nodeSamples);
     const wrappedMedian = median(wrappedSamples);
     const overheadMs = wrappedMedian - rawMedian;
-    expect(
-      wrappedMedian,
-      `raw=${rawMedian.toFixed(1)}ms wrapped=${wrappedMedian.toFixed(1)}ms overhead=${overheadMs.toFixed(1)}ms`,
-    ).toBeLessThanOrEqual(750);
+    await expectLatencyBudget(
+      "git log terse elision overhead",
+      budgetSample(
+        overheadMs,
+        rawMedian + nodeMedian,
+        `raw=${rawMedian.toFixed(1)}ms node=${nodeMedian.toFixed(1)}ms ` +
+          `wrapped=${wrappedMedian.toFixed(1)}ms overhead=${overheadMs.toFixed(1)}ms`,
+      ),
+      12,
+      () => {
+        const retryRawSamples: number[] = [];
+        const retryNodeSamples: number[] = [];
+        const retryWrappedSamples: number[] = [];
+        for (let i = 0; i < 5; i++) {
+          const raw = timedStatus(() => runGit(["-C", root, "log"]));
+          const node = timedStatus(() => runNodeNoop());
+          const wrapped = timedStatus(() => runBundleFromCwd(root, ["git", "log", "--terse"], env));
+          expect(raw.status).toBe(0);
+          expect(node.status).toBe(0);
+          expect(wrapped.status).toBe(0);
+          expect(wrapped.stderr).toEqual(Buffer.alloc(0));
+          expect(wrapped.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
+          retryRawSamples.push(raw.elapsedMs);
+          retryNodeSamples.push(node.elapsedMs);
+          retryWrappedSamples.push(wrapped.elapsedMs);
+        }
+
+        const retryRawMedian = median(retryRawSamples);
+        const retryNodeMedian = median(retryNodeSamples);
+        const retryWrappedMedian = median(retryWrappedSamples);
+        const retryOverheadMs = retryWrappedMedian - retryRawMedian;
+        return budgetSample(
+          retryOverheadMs,
+          retryRawMedian + retryNodeMedian,
+          `raw=${retryRawMedian.toFixed(1)}ms node=${retryNodeMedian.toFixed(1)}ms ` +
+            `wrapped=${retryWrappedMedian.toFixed(1)}ms overhead=${retryOverheadMs.toFixed(1)}ms`,
+        );
+      },
+    );
   }, 120_000);
 
   it("fails closed instead of creating the default Repo store when setup has not provisioned it", async () => {

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
   DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
+  DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
   DEFAULT_RSP_TELEMETRY_TTL_DAYS,
   resolveRspConfig,
 } from "../src/config.js";
@@ -29,7 +30,7 @@ describe("resolveRspConfig", () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(
       join(root, ".red", "config.yaml"),
-      "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  telemetryTtlDays: 11\n  telemetryByteBudget: 100\n  heavyGitByteThreshold: 99\n",
+      "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  telemetryTtlDays: 11\n  telemetryByteBudget: 100\n  telemetryDrainTimeoutMs: 456\n  heavyGitByteThreshold: 99\n",
       "utf8",
     );
 
@@ -41,6 +42,7 @@ describe("resolveRspConfig", () => {
       telemetryTtlDays: 11,
       telemetryByteBudget: 100,
       telemetryDrainIntervalMs: DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
+      telemetryDrainTimeoutMs: 456,
       heavyGitByteThreshold: 99,
     });
   });
@@ -58,6 +60,7 @@ describe("resolveRspConfig", () => {
       telemetryTtlDays: DEFAULT_RSP_TELEMETRY_TTL_DAYS,
       telemetryByteBudget: DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
       telemetryDrainIntervalMs: DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
+      telemetryDrainTimeoutMs: DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
       heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
     });
   });
@@ -74,6 +77,13 @@ describe("resolveRspConfig", () => {
     const config = resolveRspConfig(root, { RSP_TELEMETRY_DRAIN_INTERVAL_MS: "123" }, undefined);
 
     expect(config.telemetryDrainIntervalMs).toBe(123);
+  });
+
+  it("lets env override the telemetry drain timeout", async () => {
+    const root = await tempRoot();
+    const config = resolveRspConfig(root, { RSP_TELEMETRY_DRAIN_TIMEOUT_MS: "456" }, undefined);
+
+    expect(config.telemetryDrainTimeoutMs).toBe(456);
   });
 
   it("does not create .red or red-skills.rdb while resolving runtime config", async () => {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -93,6 +93,7 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 90,
       telemetryByteBudget: 1_000,
+      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
       idleMs: 100,
     });
     await waitForResident(paths.socketPath);
@@ -147,6 +148,7 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 90,
       telemetryByteBudget: 1_000_000,
+      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
       idleMs: 100,
     });
     await waitForResident(paths.socketPath);
@@ -196,6 +198,7 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 1,
       telemetryByteBudget: 75,
+      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
       idleMs: 100,
     });
     await waitForResident(paths.socketPath);
@@ -244,6 +247,7 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 90,
       telemetryByteBudget: 1_000,
+      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
       idleMs: 100,
     });
     await waitForResident(paths.socketPath);
@@ -306,6 +310,8 @@ describe("rsp telemetry spool", () => {
       String(DEFAULT_RSP_TTL_DAYS),
       "--byte-budget",
       String(DEFAULT_RSP_BYTE_BUDGET),
+      "--telemetry-drain-timeout-ms",
+      String(await calibratedTelemetryDrainTimeoutMs(root)),
       "--idle-ms",
       "100",
     ], { cwd: root });
@@ -338,6 +344,8 @@ describe("rsp telemetry spool", () => {
       String(DEFAULT_RSP_TTL_DAYS),
       "--byte-budget",
       String(DEFAULT_RSP_BYTE_BUDGET),
+      "--telemetry-drain-timeout-ms",
+      String(await calibratedTelemetryDrainTimeoutMs(root)),
       "--idle-ms",
       "2000",
       "--telemetry-drain-interval-ms",
@@ -517,6 +525,15 @@ async function waitForResident(socketPath: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error("resident did not start");
+}
+
+async function calibratedTelemetryDrainTimeoutMs(root: string): Promise<number> {
+  const baselineUri = `file://${join(root, ".red", "tmp", `telemetry-baseline-${process.pid}.rdb`)}`;
+  const started = process.hrtime.bigint();
+  const db = await connect(baselineUri);
+  await db.close();
+  const storeOpenMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  return Math.max(2_000, Math.ceil(Math.max(1, storeOpenMs) * 6));
 }
 
 async function waitForResidentTelemetry(socketPath: string, command: string): Promise<void> {

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -121,6 +121,8 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
     String(config.telemetryByteBudget ?? config.byteBudget),
     "--telemetry-drain-interval-ms",
     String(config.telemetryDrainIntervalMs ?? 30_000),
+    "--telemetry-drain-timeout-ms",
+    String(config.telemetryDrainTimeoutMs ?? 2_000),
     "--resident-version",
     config.clientVersion ?? "0.0.0-dev",
     "--wake-lock",
@@ -189,6 +191,8 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
     String(config.telemetryByteBudget ?? config.byteBudget),
     "--telemetry-drain-interval-ms",
     String(config.telemetryDrainIntervalMs ?? 30_000),
+    "--telemetry-drain-timeout-ms",
+    String(config.telemetryDrainTimeoutMs ?? 2_000),
     "--resident-version",
     config.clientVersion ?? "0.0.0-dev",
   ], {

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -8,6 +8,7 @@ export interface RspResidentConfig {
   telemetryTtlDays?: number;
   telemetryByteBudget?: number;
   telemetryDrainIntervalMs?: number;
+  telemetryDrainTimeoutMs?: number;
   serverCommand?: string;
   serverArgs?: string[];
 }


### PR DESCRIPTION
Automated AFK landing for #1607. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1607

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786511937&installation_id=129708444&pr_number=1609&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1609&signature=9a4f9a04a1fd8b9032060208c7238cf2d97c75d8593fb98c197b1ee8b7f47666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->