### PR TITLE
feat: #1604 benchmark: anti-suppression audit — wrappers must render data as compact TOON, not scalar verdicts

### DIFF
--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -8,14 +8,14 @@ Production mode uses admission threshold 60%; passthrough filters count as 0% to
 | gh:issue | passthrough | 3 | 123 | 123 | rtk: not-covered | 80 | 0% | rtk: not-covered | 0/0% | 100% | 0/0% | 100% |
 | gh:pr | passthrough | 3 | 108 | 108 | rtk: not-covered | 64 | 0% | rtk: not-covered | 0/0% | 100% | 0/0% | 100% |
 | gh:run | passthrough | 3 | 121 | 121 | rtk: not-covered | 49 | 0% | rtk: not-covered | 0/0% | 100% | 0/0% | 100% |
-| git:commit | passthrough | 1 | 33 | 33 | 59 | 23 | 0% | 0% | 0/0% | 100% | 0/0% | 100% |
+| git:commit | passthrough | 1 | 33 | 33 | 59 | 69 | 47.8% | 85.5% | 0/0% | 100% | 0/0% | 100% |
 | git:diff | passthrough | 2 | 7526 | 7526 | 62 | 7584 | 99.2% | 0.8% | 0/0% | 100% | 0/0% | 100% |
 | git:log | passthrough | 2 | 4467 | 4467 | 68 | 4717 | 94.7% | 1.4% | 0/0% | 100% | 0/0% | 100% |
-| git:push | active | 2 | 58 | 21 | 63 | 28 | 75% | 0% | 31.9/63.8% | 100% | 31.9/63.8% | 100% |
+| git:push | passthrough | 2 | 58 | 58 | 63 | 102 | 56.9% | 61.8% | 0/0% | 100% | 0/0% | 100% |
 | git:status | active | 2 | 153 | 79 | 54 | 83 | 95.2% | 65.1% | 60.5/75% | 100% | 60.5/75% | 50% |
 | vitest:run | active | 6 | 51368 | 654 | 208 | 442 | 99.6% | 47.1% | 58.8/100% | 100% | 70/100% | 100% |
 
-Aggregate oracle ceiling: raw 64435 tokens (0% capture), rsp 13334 tokens (99.9% capture), RTK 646 tokens (4.9% capture), oracle 13273 tokens.
+Aggregate oracle ceiling: raw 64435 tokens (0% capture), rsp 13371 tokens (99.8% capture), RTK 646 tokens (4.9% capture), oracle 13393 tokens.
 
 Large-output filters: git:diff, git:log, vitest:run.
 
@@ -23,6 +23,29 @@ Large-output filters: git:diff, git:log, vitest:run.
 | --- | --- | --- | ---: | ---: |
 | cargo-test | cargo:test | fail | 100% | 100% |
 | git-commit | git:commit | pass | 100% | 100% |
+
+| Anti-suppression audit | Level | Verdict | Note |
+| --- | --- | --- | --- |
+| cargo:test | brief | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
+| cargo:test | terse | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
+| gh:issue | brief | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
+| gh:issue | terse | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
+| gh:pr | brief | audited: justified | empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON |
+| gh:pr | terse | audited: justified | empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON |
+| gh:run | brief | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
+| gh:run | terse | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
+| git:commit | brief | audited: fixed | success output now renders commit id, branch, subject, and change counts as compact TOON |
+| git:commit | terse | audited: fixed | success output now renders commit id, branch, subject, and change counts as compact TOON |
+| git:diff | brief | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:diff | terse | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:log | brief | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:log | terse | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:push | brief | audited: fixed | success output now renders pushed refs and remote as compact TOON; rejected pushes remain byte-intact faults |
+| git:push | terse | audited: fixed | success output now renders pushed refs and remote as compact TOON; rejected pushes remain byte-intact faults |
+| git:status | brief | audited: justified | clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON |
+| git:status | terse | audited: justified | clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON |
+| vitest:run | brief | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
+| vitest:run | terse | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
 
 RTK baseline is replayed from checked-in recorded fixtures only; RTK is not executed by this command.
 External context-optimization claims are cited literature only and were not locally reproduced.

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -258,33 +258,33 @@ filters[10]:
     oracle_capture:
       raw:
         token_count: 33
-        capture_pct: 0
+        capture_pct: 47.8
         source: recorded
       rsp:
         token_count: 33
-        capture_pct: 0
+        capture_pct: 47.8
         source: measured
       terse:
         token_count: 33
-        capture_pct: 0
+        capture_pct: 47.8
         source: measured
       rtk:
         token_count: 59
-        capture_pct: 0
+        capture_pct: 85.5
         source: recorded
       oracle_ceiling:
-        token_count: 23
+        token_count: 69
         capture_pct: 100
         source: fixture-oracle
     hypothetical_active:
       brief:
-        median_delta_pct: 42.4
-        p90_delta_pct: 42.4
+        median_delta_pct: -109.1
+        p90_delta_pct: -109.1
         fidelity_pass_rate_pct: 100
         source: measured
       terse:
-        median_delta_pct: 42.4
-        p90_delta_pct: 42.4
+        median_delta_pct: -109.1
+        p90_delta_pct: -109.1
         fidelity_pass_rate_pct: 100
         source: measured
   - filter: "git:diff"
@@ -398,7 +398,7 @@ filters[10]:
         fidelity_pass_rate_pct: 0
         source: measured
   - filter: "git:push"
-    mode: active
+    mode: passthrough
     fixture_count: 2
     raw:
       median_delta_pct: 0
@@ -406,13 +406,13 @@ filters[10]:
       fidelity_pass_rate_pct: 100
       source: recorded
     brief:
-      median_delta_pct: 31.9
-      p90_delta_pct: 63.8
+      median_delta_pct: 0
+      p90_delta_pct: 0
       fidelity_pass_rate_pct: 100
       source: measured
     terse:
-      median_delta_pct: 31.9
-      p90_delta_pct: 63.8
+      median_delta_pct: 0
+      p90_delta_pct: 0
       fidelity_pass_rate_pct: 100
       source: measured
     rtk:
@@ -423,34 +423,34 @@ filters[10]:
     oracle_capture:
       raw:
         token_count: 58
-        capture_pct: 0
+        capture_pct: 56.9
         source: recorded
       rsp:
-        token_count: 21
-        capture_pct: 75
+        token_count: 58
+        capture_pct: 56.9
         source: measured
       terse:
-        token_count: 21
-        capture_pct: 75
+        token_count: 58
+        capture_pct: 56.9
         source: measured
       rtk:
         token_count: 63
-        capture_pct: 0
+        capture_pct: 61.8
         source: recorded
       oracle_ceiling:
-        token_count: 28
+        token_count: 102
         capture_pct: 100
         source: fixture-oracle
     hypothetical_active:
       brief:
-        median_delta_pct: 31.9
-        p90_delta_pct: 63.8
+        median_delta_pct: -37.1
+        p90_delta_pct: 0
         fidelity_pass_rate_pct: 100
         source: measured
       terse:
-        median_delta_pct: 31.9
-        p90_delta_pct: 63.8
-        fidelity_pass_rate_pct: 100
+        median_delta_pct: -32.8
+        p90_delta_pct: 0
+        fidelity_pass_rate_pct: 50
         source: measured
   - filter: "git:status"
     mode: active
@@ -569,22 +569,43 @@ aggregate:
     capture_pct: 0
     source: recorded
   rsp:
-    token_count: 13334
-    capture_pct: 99.9
+    token_count: 13371
+    capture_pct: 99.8
     source: measured
   terse:
-    token_count: 13150
-    capture_pct: 99.1
+    token_count: 13187
+    capture_pct: 98.5
     source: measured
   rtk:
     token_count: 646
     capture_pct: 4.9
     source: recorded
   oracle_ceiling:
-    token_count: 13273
+    token_count: 13393
     capture_pct: 100
     source: fixture-oracle
 parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
   cargo-test,"cargo:test",61.9,67.8,100,100,fail
   git-commit,"git:commit",0,-78.8,100,100,pass
+anti_suppression_audit[20]{filter,level,audited,note}:
+  "cargo:test",brief,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
+  "cargo:test",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
+  "gh:issue",brief,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
+  "gh:issue",terse,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
+  "gh:pr",brief,justified,empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON
+  "gh:pr",terse,justified,empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON
+  "gh:run",brief,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
+  "gh:run",terse,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
+  "git:commit",brief,fixed,"success output now renders commit id, branch, subject, and change counts as compact TOON"
+  "git:commit",terse,fixed,"success output now renders commit id, branch, subject, and change counts as compact TOON"
+  "git:diff",brief,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:diff",terse,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:log",brief,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:log",terse,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:push",brief,fixed,success output now renders pushed refs and remote as compact TOON; rejected pushes remain byte-intact faults
+  "git:push",terse,fixed,success output now renders pushed refs and remote as compact TOON; rejected pushes remain byte-intact faults
+  "git:status",brief,justified,clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON
+  "git:status",terse,justified,clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON
+  "vitest:run",brief,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
+  "vitest:run",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
 summary: "27 fixtures, 10 filters; shipped modes apply admission threshold 60%"

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -69,18 +69,6 @@ export async function renderGitContract(
     };
   }
 
-  const scalar = scalarFastPath(subcommand, payload);
-  if (scalar) {
-    return {
-      stdout: Buffer.from(`${scalar}\n`),
-      stderr: Buffer.from(contract.stderr),
-      status: contract.status,
-      signal: contract.signal,
-      payload,
-      oneLine: true,
-    };
-  }
-
   const fullToon = encode(payload);
   if (shouldEmitFull(subcommand, fullToon, parsedCommand.full, options)) {
     return {
@@ -340,23 +328,6 @@ function helpIfQueried(payload: JsonObject, query: string | undefined, help: rea
   return query ? withHelp(payload, help) : payload;
 }
 
-function scalarFastPath(subcommand: GitSubcommand, payload: JsonObject): string | null {
-  if (subcommand === "commit" && typeof payload.commit === "string" && payload.commit.length > 0) {
-    return String(payload.summary ?? "");
-  }
-  if (subcommand === "push") {
-    const refsValue = payload.refs;
-    const refs = Array.isArray(refsValue) ? refsValue : [];
-    const realPushes = refs.filter((ref) => isRecord(ref) && ref.flag !== "=");
-    if (realPushes.length === 1) return String(payload.summary ?? "");
-    return null;
-  }
-  return null;
-}
-
-function isRecord(value: JsonValue | undefined): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function statusState(xy: string): string {
   if (xy.includes("A")) return "added";

--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -80,6 +80,13 @@ export interface TwoAxisParityRow {
   parity_gate: "pass" | "fail";
 }
 
+export interface AntiSuppressionAuditRow {
+  filter: string;
+  level: "brief" | "terse";
+  audited: "ok" | "fixed" | "justified";
+  note: string;
+}
+
 export interface TwoAxisBenchmarkReport {
   benchmark: "rsp-two-axis";
   corpus: {
@@ -102,6 +109,7 @@ export interface TwoAxisBenchmarkReport {
   filters: TwoAxisFilterRow[];
   aggregate: OracleCaptureRow & { fixture_count: number };
   parity: TwoAxisParityRow[];
+  anti_suppression_audit: AntiSuppressionAuditRow[];
   summary: string;
   toon: string;
 }
@@ -203,6 +211,7 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
     filterRow(filter, rows, admissionByFilter.get(filter))
   );
   const parity = buildParity(rows);
+  const antiSuppressionAudit = buildAntiSuppressionAudit(rows);
   const payload = {
     benchmark: "rsp-two-axis",
     corpus: {
@@ -225,6 +234,7 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
     filters: rows,
     aggregate: aggregateOracleCapture(measurements),
     parity,
+    anti_suppression_audit: antiSuppressionAudit,
     summary: `${measurements.length} fixtures, ${rows.length} filters; shipped modes apply admission threshold ${ADMISSION_THRESHOLD_PCT}%`,
   } satisfies Omit<TwoAxisBenchmarkReport, "toon">;
 
@@ -264,6 +274,12 @@ export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
       `| ${row.domain} | ${row.filter} | ${row.parity_gate} | ${fmt(row.rsp_fidelity_pass_rate_pct)}% | ${fmt(row.rtk_fidelity_pass_rate_pct)}% |`
     ),
     "",
+    "| Anti-suppression audit | Level | Verdict | Note |",
+    "| --- | --- | --- | --- |",
+    ...report.anti_suppression_audit.map((row) =>
+      `| ${row.filter} | ${row.level} | audited: ${row.audited} | ${row.note} |`
+    ),
+    "",
     "RTK baseline is replayed from checked-in recorded fixtures only; RTK is not executed by this command.",
     "External context-optimization claims are cited literature only and were not locally reproduced.",
     "",
@@ -297,6 +313,42 @@ function buildParity(rows: readonly TwoAxisFilterRow[]): TwoAxisParityRow[] {
     parityRow("cargo-test", "cargo:test", rows),
     parityRow("git-commit", "git:commit", rows),
   ];
+}
+
+function buildAntiSuppressionAudit(rows: readonly TwoAxisFilterRow[]): AntiSuppressionAuditRow[] {
+  return rows.flatMap((row) => (["brief", "terse"] as const).map((level) => {
+    const verdict = antiSuppressionVerdict(row.filter);
+    return {
+      filter: row.filter,
+      level,
+      audited: verdict.audited,
+      note: verdict.note,
+    };
+  }));
+}
+
+function antiSuppressionVerdict(filter: string): Pick<AntiSuppressionAuditRow, "audited" | "note"> {
+  switch (filter) {
+    case "git:commit":
+      return { audited: "fixed", note: "success output now renders commit id, branch, subject, and change counts as compact TOON" };
+    case "git:push":
+      return { audited: "fixed", note: "success output now renders pushed refs and remote as compact TOON; rejected pushes remain byte-intact faults" };
+    case "git:status":
+      return { audited: "justified", note: "clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON" };
+    case "gh:pr":
+      return { audited: "justified", note: "empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON" };
+    case "git:diff":
+    case "git:log":
+      return { audited: "ok", note: "large row sets keep compact TOON plus an elision handle for full detail" };
+    case "gh:issue":
+    case "gh:run":
+      return { audited: "ok", note: "successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough" };
+    case "cargo:test":
+    case "vitest:run":
+      return { audited: "ok", note: "test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail" };
+    default:
+      throw new Error(`missing anti-suppression audit verdict for ${filter}`);
+  }
 }
 
 function parityRow(domain: TwoAxisParityRow["domain"], filter: string, rows: readonly TwoAxisFilterRow[]): TwoAxisParityRow {

--- a/apps/rsp/tests/fixtures/git/commit/created.json
+++ b/apps/rsp/tests/fixtures/git/commit/created.json
@@ -10,6 +10,41 @@
     "status": 0,
     "signal": null
   },
-  "expected": "commit 1234567 on feature/rsp: 2 files, +40 -1\n",
-  "assertions": []
+  "expected": {
+    "command": "git commit",
+    "branch": "feature/rsp",
+    "commit": "1234567",
+    "subject": "Refs #1412 add wrapper",
+    "files_changed": 2,
+    "insertions": 40,
+    "deletions": 1,
+    "summary": "commit 1234567 on feature/rsp: 2 files, +40 -1"
+  },
+  "assertions": [
+    {
+      "question": "which commit was created?",
+      "path": "commit",
+      "expected": "1234567"
+    },
+    {
+      "question": "what branch received the commit?",
+      "path": "branch",
+      "expected": "feature/rsp"
+    },
+    {
+      "question": "how many files changed?",
+      "path": "files_changed",
+      "expected": 2
+    },
+    {
+      "question": "how many insertions were committed?",
+      "path": "insertions",
+      "expected": 40
+    },
+    {
+      "question": "how many deletions were committed?",
+      "path": "deletions",
+      "expected": 1
+    }
+  ]
 }

--- a/apps/rsp/tests/fixtures/git/commit/created.oracle.toon
+++ b/apps/rsp/tests/fixtures/git/commit/created.oracle.toon
@@ -1,2 +1,9 @@
 # oracle: preserves decision-relevant rows and columns from commit-created; keep as compact TOON, not a scalar verdict.
-value: "commit 1234567 on feature/rsp: 2 files, +40 -1\n"
+command: git commit
+branch: feature/rsp
+commit: "1234567"
+subject: "Refs #1412 add wrapper"
+files_changed: 2
+insertions: 40
+deletions: 1
+summary: "commit 1234567 on feature/rsp: 2 files, +40 -1"

--- a/apps/rsp/tests/fixtures/git/push/porcelain.json
+++ b/apps/rsp/tests/fixtures/git/push/porcelain.json
@@ -10,6 +10,45 @@
     "status": 0,
     "signal": null
   },
-  "expected": "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits\n",
-  "assertions": []
+  "expected": {
+    "command": "git push",
+    "remote": "github.com:reddb-io/red-skills.git",
+    "refs": [
+      {
+        "flag": "=",
+        "from": "refs/heads/main",
+        "to": "refs/heads/main",
+        "summary": "[up to date]"
+      },
+      {
+        "flag": " ",
+        "from": "refs/heads/feature/rsp",
+        "to": "refs/heads/feature/rsp",
+        "summary": "1111111..2222222"
+      }
+    ],
+    "summary": "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits"
+  },
+  "assertions": [
+    {
+      "question": "which branch was pushed?",
+      "path": "refs.1.to",
+      "expected": "refs/heads/feature/rsp"
+    },
+    {
+      "question": "which ref range was pushed?",
+      "path": "refs.1.summary",
+      "expected": "1111111..2222222"
+    },
+    {
+      "question": "which refs are present in the porcelain output?",
+      "path": "refs.length",
+      "expected": 2
+    },
+    {
+      "question": "which remote received the push?",
+      "path": "remote",
+      "expected": "github.com:reddb-io/red-skills.git"
+    }
+  ]
 }

--- a/apps/rsp/tests/fixtures/git/push/porcelain.oracle.toon
+++ b/apps/rsp/tests/fixtures/git/push/porcelain.oracle.toon
@@ -1,2 +1,7 @@
 # oracle: preserves decision-relevant rows and columns from push-porcelain; keep as compact TOON, not a scalar verdict.
-value: "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits\n"
+command: git push
+remote: github.com:reddb-io/red-skills.git
+refs[2]{flag,from,to,summary}:
+  "=",refs/heads/main,refs/heads/main,[up to date]
+  " ",refs/heads/feature/rsp,refs/heads/feature/rsp,1111111..2222222
+summary: "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits"

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -190,7 +190,7 @@ describe("rsp git fidelity fixtures", () => {
     }
   });
 
-  it("keeps commit-created and push-ref-update fixtures compact without exceeding raw tokens", async () => {
+  it("keeps commit-created and push-ref-update fixtures as compact TOON instead of scalar verdicts", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
     try {
@@ -198,13 +198,9 @@ describe("rsp git fidelity fixtures", () => {
       for (const name of ["commit-created", "push-porcelain"]) {
         const fixture = fixtures.find((candidate) => candidate.name === name)!;
         const result = await runFidelityFixture(fixture, { level: "lossless", store });
-        const rawTokens = tokenizer.encode(fixture.recorded.stdout).length;
-        const wrappedTokens = tokenizer.encode(result.stdout.toString("utf8")).length;
 
-        expect(result.oneLine).toBe(true);
-        expect(result.stdout.toString("utf8")).toBe(fixture.expected);
-        expect(wrappedTokens).toBeLessThanOrEqual(rawTokens);
-        expect(result.tokenDelta).toBeGreaterThanOrEqual(0);
+        expect(result.oneLine).toBeUndefined();
+        expect(decode(result.stdout.toString("utf8"))).toEqual(fixture.expected);
         expect(result.assertionFailures).toEqual([]);
       }
     } finally {
@@ -239,7 +235,7 @@ describe("rsp git fidelity fixtures", () => {
         {
           question: "which branch was pushed?",
           expected: "main",
-          actual: "pushed feature/rsp -> github.com:reddb-io/red-skills.git +1 commits",
+          actual: "refs/heads/feature/rsp",
         },
       ]);
     } finally {
@@ -255,11 +251,11 @@ describe("rsp git admission harness", () => {
     const commitRow = report.filters.find((row) => row.filter === "git:commit")!;
     const pushRow = report.filters.find((row) => row.filter === "git:push")!;
 
-    expect(report.summary).toBe("2/5 filters active at threshold 60%");
-    // git:commit's one-line fast-path is a modest positive win that stays below the admission threshold.
+    expect(report.summary).toBe("1/5 filters active at threshold 60%");
+    // git:commit's compact TOON rendering stays below the admission threshold.
     expect(commitRow).toMatchObject({ median_delta_pct: expect.any(Number), active: false, mode: "passthrough" });
-    // git:push clears the threshold now that the fast-path replaces the negative-delta TOON framing.
-    expect(pushRow).toMatchObject({ active: true, mode: "active" });
+    // git:push also stays passthrough when preserving pushed-ref rows would be a token regression.
+    expect(pushRow).toMatchObject({ median_delta_pct: expect.any(Number), active: false, mode: "passthrough" });
 
     const tmp = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(tmp, "red.rdb")}` });

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -87,6 +87,18 @@ describe("rsp two-axis benchmark report", () => {
       expect.objectContaining({ domain: "cargo-test", filter: "cargo:test", rsp_fidelity_pass_rate_pct: 100 }),
       expect.objectContaining({ domain: "git-commit", filter: "git:commit", rsp_fidelity_pass_rate_pct: 100 }),
     ]));
+    expect(report.anti_suppression_audit).toHaveLength(report.corpus.filters.length * 2);
+    expect(report.anti_suppression_audit.map((row) => `${row.filter}:${row.level}`).sort()).toEqual(
+      report.corpus.filters.flatMap((filter) => [`${filter}:brief`, `${filter}:terse`]).sort(),
+    );
+    expect(report.anti_suppression_audit).toEqual(expect.arrayContaining([
+      expect.objectContaining({ filter: "git:commit", level: "brief", audited: "fixed" }),
+      expect.objectContaining({ filter: "git:commit", level: "terse", audited: "fixed" }),
+      expect.objectContaining({ filter: "git:push", level: "brief", audited: "fixed" }),
+      expect.objectContaining({ filter: "git:push", level: "terse", audited: "fixed" }),
+      expect.objectContaining({ filter: "gh:pr", level: "brief", audited: "justified" }),
+      expect.objectContaining({ filter: "git:status", level: "terse", audited: "justified" }),
+    ]));
 
     const decoded = decode(report.toon);
     expect(decoded).toMatchObject({
@@ -111,6 +123,9 @@ describe("rsp two-axis benchmark report", () => {
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| gh:pr |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("rtk: not-covered");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("Aggregate oracle ceiling:");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Anti-suppression audit | Level | Verdict | Note |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| git:commit | brief | audited: fixed |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| git:push | terse | audited: fixed |");
   });
 
   it("flags synthetic shipped token regressions beyond the threshold", async () => {


### PR DESCRIPTION
Automated AFK landing for #1604. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1604

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786514309&installation_id=129708444&pr_number=1618&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1618&signature=a84e981bbb25cf70c7f0528c2cbcb9bc18f3e53c46c018600888bae16be3a68f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->