### PR TITLE
fix: #1611 cold-path compression: a cold rsp must compress like RTK did, not pass through raw

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -3,7 +3,8 @@ import { appendFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
-import type { RspElisionStore } from "./elision-store.js";
+import type { RspRuntimeConfig } from "./config.js";
+import type { RspElisionStore, RspMintMeta } from "./elision-store.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
 import type { RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
 
@@ -105,7 +106,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const { fileURLToPath } = await import("node:url");
   const residentPaths = resolveResidentPaths(process.cwd());
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
-    if (wrapperCommand) return await degradeToPassthrough("store not provisioned", args.positional, undefined, residentPaths.rootDir);
+    if (wrapperCommand) return await runColdWrappedCommand(args, config, residentPaths.rootDir);
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
     return 1;
   }
@@ -169,7 +170,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       try {
         await suppressRspStderr(warmResidentStore);
       } catch (err) {
-        return await degradeToPassthrough("resident unavailable", args.positional, err, residentPaths.rootDir);
+        return await runColdWrappedCommand(args, config, residentPaths.rootDir, err);
       }
       if (isFastGitStatus(args.positional)) {
         const started = process.hrtime.bigint();
@@ -191,7 +192,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       try {
         await suppressRspStderr(warmResidentStore);
       } catch (err) {
-        return await degradeToPassthrough("resident unavailable", args.positional, err, residentPaths.rootDir);
+        return await runColdWrappedCommand(args, config, residentPaths.rootDir, err);
       }
       const { runGhWrapper } = await import("./gh-wrapper.js");
       const store = new LazyRspElisionStore(() => suppressRspStderr(openResidentStore));
@@ -205,7 +206,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       try {
         await suppressRspStderr(warmResidentStore);
       } catch (err) {
-        return await degradeToPassthrough("resident unavailable", args.positional, err, residentPaths.rootDir);
+        return await runColdWrappedCommand(args, config, residentPaths.rootDir, err);
       }
       const { runTestWrapper } = await import("./test-wrapper.js");
       const store = new LazyRspElisionStore(() => suppressRspStderr(openResidentStore));
@@ -311,8 +312,13 @@ function isEmptyUnbornGitRepo(cwd: string): boolean {
   }
 }
 
-type ElisionStoreLike = Pick<RspElisionStore, "mint" | "close"> & {
+type ElisionStoreLike = Pick<RspElisionStore, "close"> & {
+  mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<string>;
   lastResponseMetrics?: () => ResidentResponseMetrics | undefined;
+};
+
+type InvocationTelemetryStore = {
+  lastResponseMetrics: () => ResidentResponseMetrics | undefined;
 };
 
 type TelemetryStatsStore = {
@@ -342,7 +348,7 @@ interface WrappedCommandResult {
   stderr: Buffer;
   status: number | null;
   signal: NodeJS.Signals | null;
-  mintedHandle?: `el:${string}`;
+  mintedHandle?: string;
   bytesElided?: number;
   rawOutput?: Buffer;
 }
@@ -353,7 +359,7 @@ class LazyRspElisionStore implements ElisionStoreLike {
 
   constructor(private readonly openStore: () => Promise<ElisionStoreLike>) {}
 
-  async mint(...args: Parameters<RspElisionStore["mint"]>): ReturnType<RspElisionStore["mint"]> {
+  async mint(...args: Parameters<RspElisionStore["mint"]>): Promise<string> {
     const store = await this.open();
     const handle = await store.mint(...args);
     this.metrics = store.lastResponseMetrics?.();
@@ -381,11 +387,69 @@ class LazyRspElisionStore implements ElisionStoreLike {
   }
 }
 
+class ColdRspElisionStore implements ElisionStoreLike {
+  async mint(_original: Uint8Array | Buffer, meta: RspMintMeta): Promise<string> {
+    return `recovery unavailable (cold store) — re-run: ${meta.command}`;
+  }
+
+  lastResponseMetrics(): ResidentResponseMetrics | undefined {
+    return undefined;
+  }
+
+  async close(): Promise<void> {}
+}
+
+async function runColdWrappedCommand(
+  args: ParsedArgs,
+  config: Pick<RspRuntimeConfig, "heavyGitByteThreshold">,
+  telemetryRoot: string,
+  err?: unknown,
+): Promise<number> {
+  if (process.env.RSP_DEBUG === "1") {
+    throw err instanceof Error ? err : new Error("cold store");
+  }
+
+  const store = new ColdRspElisionStore();
+  const started = process.hrtime.bigint();
+  try {
+    if (args.command === "git") {
+      if (isFastGitStatus(args.positional)) {
+        return await emitWrappedResult(args, await runFastGitStatus(), started, store);
+      }
+      const { runGitWrapper } = await import("./git-wrapper.js");
+      const result = await runGitWrapper(args.positional, {
+        level: args.level,
+        store,
+        heavyGitByteThreshold: config.heavyGitByteThreshold,
+      });
+      return await emitWrappedResult(args, result, started, store);
+    }
+
+    if (args.command === "gh") {
+      const { runGhWrapper } = await import("./gh-wrapper.js");
+      const result = await runGhWrapper(args.positional, { level: args.level, store });
+      return await emitWrappedResult(args, result, started, store);
+    }
+
+    if (args.command === "vitest" || args.command === "cargo") {
+      const { runTestWrapper } = await import("./test-wrapper.js");
+      const result = await runTestWrapper(args.positional, { level: args.level, store });
+      return await emitWrappedResult(args, result, started, store);
+    }
+  } catch (coldErr) {
+    return await degradeToPassthrough("wrapper failed", args.positional, coldErr, telemetryRoot);
+  } finally {
+    await store.close();
+  }
+
+  return await degradeToPassthrough("wrapper failed", args.positional, err, telemetryRoot);
+}
+
 async function emitWrappedResult(
   args: ParsedArgs,
   result: WrappedCommandResult,
   started: bigint,
-  store?: LazyRspElisionStore,
+  store?: InvocationTelemetryStore,
 ): Promise<number> {
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
-import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
-import type { RecordedGitContract } from "./git-wrapper.js";
+import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
+import { recoveryInstruction, type RecordedGitContract } from "./git-wrapper.js";
 import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
 export type GhKind = "pr" | "issue" | "run";
@@ -9,7 +9,11 @@ export type GhAction = "list" | "view" | "combined";
 
 export interface GhRenderOptions {
   level: RspLossLevel;
-  store?: Pick<RspElisionStore, "mint">;
+  store?: RspMintStore;
+}
+
+interface RspMintStore {
+  mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<string>;
 }
 
 export interface GhRenderResult {
@@ -18,7 +22,7 @@ export interface GhRenderResult {
   status: number | null;
   signal: NodeJS.Signals | null;
   payload?: JsonObject;
-  mintedHandle?: `el:${string}`;
+  mintedHandle?: string;
   bytesElided?: number;
   rowsElided?: number;
   rawOutput?: Buffer;
@@ -134,7 +138,7 @@ export async function renderGhContract(
   });
   if (!handle) throw new Error("terse gh output requires an elision store");
 
-  const marker = `… elided ${terse.rowsElided} rows (+${bytesElided}) — rsp show ${handle}\n`;
+  const marker = `… elided ${terse.rowsElided} rows (+${bytesElided}) — ${recoveryInstruction(handle)}\n`;
   return {
     stdout: Buffer.from(`${encode(terse.payload)}\n${marker}`),
     stderr: Buffer.from(contract.stderr),
@@ -390,7 +394,7 @@ function textField(row: Record<string, unknown>, field: string, limit: number, f
   return out;
 }
 
-function findHandleRequest(payload: JsonObject): { target: { truncated: { handle: `el:${string}` | "" } }; original: string; bytes: number } | null {
+function findHandleRequest(payload: JsonObject): { target: { truncated: { handle: string } }; original: string; bytes: number } | null {
   const stack: unknown[] = [payload];
   while (stack.length > 0) {
     const value = stack.pop();

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
-import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
+import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
 import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
 export { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
@@ -19,8 +19,12 @@ export interface RecordedGitContract {
 
 export interface GitRenderOptions {
   level: RspLossLevel;
-  store?: Pick<RspElisionStore, "mint">;
+  store?: RspMintStore;
   heavyGitByteThreshold?: number;
+}
+
+export interface RspMintStore {
+  mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<string>;
 }
 
 export interface GitRenderResult {
@@ -29,7 +33,7 @@ export interface GitRenderResult {
   status: number | null;
   signal: NodeJS.Signals | null;
   payload?: JsonObject;
-  mintedHandle?: `el:${string}`;
+  mintedHandle?: string;
   bytesElided?: number;
   rowsElided?: number;
   oneLine?: boolean;
@@ -98,7 +102,7 @@ export async function renderGitContract(
   });
   if (!handle) throw new Error("terse git output requires an elision store");
 
-  const marker = `… elided ${terse.rowsElided} rows (+${bytesElided}) — rsp show ${handle}\n`;
+  const marker = `… elided ${terse.rowsElided} rows (+${bytesElided}) — ${recoveryInstruction(handle)}\n`;
   return {
     stdout: Buffer.from(`${encode(terse.payload)}\n${marker}`),
     stderr: Buffer.from(contract.stderr),
@@ -110,6 +114,10 @@ export async function renderGitContract(
     rowsElided: terse.rowsElided,
     rawOutput: Buffer.from(fullToon),
   };
+}
+
+export function recoveryInstruction(handle: string): string {
+  return handle.startsWith("el:") ? `rsp show ${handle}` : handle;
 }
 
 interface ParsedGitRenderCommand {

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -1,12 +1,16 @@
 import { spawn } from "node:child_process";
 import { encode, type JsonObject } from "@reddb-io/toon";
-import { RspElisionStore, type RspLossLevel } from "./elision-store.js";
-import type { GitRenderResult, RecordedGitContract } from "./git-wrapper.js";
+import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
+import { recoveryInstruction, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
 import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
 export interface TestRenderOptions {
   level: RspLossLevel;
-  store?: Pick<RspElisionStore, "mint">;
+  store?: RspMintStore;
+}
+
+interface RspMintStore {
+  mint(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<string>;
 }
 
 interface TestFailure extends JsonObject {
@@ -74,7 +78,7 @@ export async function renderTestContract(
   }
 
   const failures: TestFailure[] = [];
-  let mintedHandle: `el:${string}` | undefined;
+  let mintedHandle: string | undefined;
   let bytesElided = 0;
 
   for (const failure of filteredFailures) {
@@ -155,7 +159,7 @@ async function renderTerse(
   if (!handle) throw new Error("terse test output requires an elision store");
 
   const label = elidedFailures > 0 ? `${elidedFailures} failures` : "full detail";
-  const marker = `… elided ${label} (+${bytesElided}) — rsp show ${handle}`;
+  const marker = `… elided ${label} (+${bytesElided}) — ${recoveryInstruction(handle)}`;
   return {
     stdout: Buffer.from(`${terseToon}\n${marker}`),
     stderr: Buffer.from(contract.stderr),
@@ -330,8 +334,8 @@ function parseCargoTest(stdout: string): ParsedTestRun | null {
 async function renderExcerpt(
   excerpt: string,
   command: string,
-  store?: Pick<RspElisionStore, "mint">,
-): Promise<{ text: string; handle?: `el:${string}`; bytesElided: number }> {
+  store?: RspMintStore,
+): Promise<{ text: string; handle?: string; bytesElided: number }> {
   const bytes = Buffer.from(excerpt);
   if (bytes.length <= EXCERPT_LIMIT_BYTES) return { text: excerpt, bytesElided: 0 };
   if (!store) throw new Error("over-limit test failure excerpt requires an elision store");
@@ -343,7 +347,7 @@ async function renderExcerpt(
   const head = bytes.subarray(0, EXCERPT_LIMIT_BYTES).toString("utf8").replace(/\uFFFD$/, "");
   const omitted = bytes.length - Buffer.byteLength(head);
   return {
-    text: `${head}\n… elided ${omitted} bytes (+${bytes.length}) — rsp show ${handle}`,
+    text: `${head}\n… elided ${omitted} bytes (+${bytes.length}) — ${recoveryInstruction(handle)}`,
     handle,
     bytesElided: bytes.length,
   };

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -800,7 +800,7 @@ describe("rsp cli", () => {
     }
   }, 120_000);
 
-  it("built bundle compresses git log, mints a handle, round-trips it, and reports degraded passthrough", async () => {
+  it("built bundle compresses git log warm and cold, with recovery only for warm handles", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
     await commitMany(root, 12);
@@ -830,11 +830,16 @@ describe("rsp cli", () => {
 
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
     await rm(join(root, ".red", "tmp", "red-skills.rdb"));
-    const degraded = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    const cold = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
-    expect(degraded.status).toBe(raw.status);
-    expect(degraded.stdout).toEqual(raw.stdout);
-    expect(degraded.stderr.toString("utf8")).toBe("rsp: store not provisioned, passing through\n");
+    expect(cold.status).toBe(raw.status);
+    expect(cold.stderr).toEqual(Buffer.alloc(0));
+    expect(cold.stdout.length).toBeLessThan(raw.stdout.length);
+    const coldText = cold.stdout.toString("utf8");
+    expect(coldText).toContain("summary: 12 commits");
+    expect(coldText).toContain("recovery unavailable (cold store) — re-run: git log");
+    expect(coldText).not.toMatch(/rsp show el:[a-f0-9]{12}/);
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toContain('"command":"git log"');
   }, 120_000);
 
   it("built bundle records invocation and degradation telemetry through the resident", async () => {
@@ -1184,7 +1189,7 @@ describe("rsp cli", () => {
     await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("passes through a successful wrapper when the repo store has not been provisioned", async () => {
+  it("passes through a successful wrapper when the repo store is absent and the cold summarizer cannot handle it", async () => {
     const root = await initGitRepo();
     await enableRsp(root);
     await writeFile(join(root, "untracked.txt"), "raw stdout\n", "utf8");
@@ -1194,7 +1199,7 @@ describe("rsp cli", () => {
 
     expect(res.status).toBe(direct.status);
     expect(res.stdout).toEqual(direct.stdout);
-    expect(res.stderr.toString("utf8")).toBe(`rsp: store not provisioned, passing through\n${direct.stderr.toString("utf8")}`);
+    expect(res.stderr.toString("utf8")).toBe(`rsp: wrapper failed, passing through\n${direct.stderr.toString("utf8")}`);
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
@@ -1209,7 +1214,7 @@ describe("rsp cli", () => {
 
     expect(res.status).toBe(direct.status);
     expect(res.stdout).toEqual(direct.stdout);
-    expect(res.stderr.toString("utf8")).toBe(`rsp: store not provisioned, passing through\n${direct.stderr.toString("utf8")}`);
+    expect(res.stderr.toString("utf8")).toBe(`rsp: wrapper failed, passing through\n${direct.stderr.toString("utf8")}`);
   });
 
   it("passes through wrappers when the configured store is unreadable non-RedDB data", async () => {
@@ -1225,7 +1230,7 @@ describe("rsp cli", () => {
 
     expect(res.status).toBe(direct.status);
     expect(res.stdout).toEqual(direct.stdout);
-    expect(res.stderr.toString("utf8")).toBe(`rsp: resident unavailable, passing through\n${direct.stderr.toString("utf8")}`);
+    expect(res.stderr.toString("utf8")).toBe(`rsp: wrapper failed, passing through\n${direct.stderr.toString("utf8")}`);
   });
 
   it("built bundle never writes .red/red.rdb and preserves a RedDB-format file there", async () => {


### PR DESCRIPTION
Automated AFK landing for #1611. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1611

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786515927&installation_id=129708444&pr_number=1623&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1623&signature=e4bee9324594e72b55743f6963d02091d29c8b6f830a919f9b8486a2f0cb5a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->