### PR TITLE
fix: #1610 resident idle timeout of 30s defeats human-paced usage — cold passthrough means sporadic commands never count

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -71,7 +71,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
         serverConfig.telemetryDrainIntervalMs,
       telemetryDrainTimeoutMs: numericValueAfter(args.positional, "--telemetry-drain-timeout-ms") ??
         serverConfig.telemetryDrainTimeoutMs,
-      idleMs: numericValueAfter(args.positional, "--idle-ms"),
+      idleMs: numericValueAfter(args.positional, "--idle-ms") ?? serverConfig.idleMs,
       residentVersion: valueAfter(args.positional, "--resident-version") ?? buildInfo.version,
     });
     return 0;
@@ -97,6 +97,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
         warmConfig.telemetryDrainIntervalMs,
       telemetryDrainTimeoutMs: numericValueAfter(args.positional, "--telemetry-drain-timeout-ms") ??
         warmConfig.telemetryDrainTimeoutMs,
+      idleMs: numericValueAfter(args.positional, "--idle-ms") ?? warmConfig.idleMs,
       clientVersion: buildInfo.version,
     });
     return 0;
@@ -118,6 +119,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
     telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
+    idleMs: config.idleMs,
     clientVersion: buildInfo.version,
   }));
   const warmResidentStore = () => ensureResidentServer(residentPaths, {
@@ -128,6 +130,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
     telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
+    idleMs: config.idleMs,
     clientVersion: buildInfo.version,
   });
   const openDirectStore = async (): Promise<ElisionStoreLike & Pick<RspElisionStore, "get" | "stats">> => {

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -10,6 +10,8 @@ export const DEFAULT_RSP_TELEMETRY_TTL_DAYS = 90;
 export const DEFAULT_RSP_TELEMETRY_BYTE_BUDGET = 4 * 1024 * 1024;
 export const DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS = 30_000;
 export const DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
+export const DEFAULT_RSP_IDLE_MS = 5 * 60_000;
+export const MIN_RSP_IDLE_MS = 5_000;
 
 export interface RspRuntimeConfig {
   enabled: boolean;
@@ -20,6 +22,7 @@ export interface RspRuntimeConfig {
   telemetryByteBudget: number;
   telemetryDrainIntervalMs: number;
   telemetryDrainTimeoutMs: number;
+  idleMs: number;
   heavyGitByteThreshold: number;
 }
 
@@ -46,6 +49,11 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     numericEnv(env.RSP_TELEMETRY_DRAIN_TIMEOUT_MS) ?? readNumericYamlPath(yaml, "rsp.telemetryDrainTimeoutMs"),
     DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
   );
+  const idleMs = minNumber(
+    numericEnv(env.RSP_IDLE_MS) ?? readNumericYamlPath(yaml, "rsp.idleMs"),
+    DEFAULT_RSP_IDLE_MS,
+    MIN_RSP_IDLE_MS,
+  );
   const heavyGitByteThreshold = positiveNumber(
     numericEnv(env.RSP_HEAVY_GIT_BYTE_THRESHOLD) ?? readNumericYamlPath(yaml, "rsp.heavyGitByteThreshold"),
     DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
@@ -61,6 +69,7 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     telemetryByteBudget,
     telemetryDrainIntervalMs,
     telemetryDrainTimeoutMs,
+    idleMs,
     heavyGitByteThreshold,
   };
 }
@@ -74,6 +83,11 @@ function readNumericYamlPath(yaml: string, dottedPath: string): number | undefin
 
 function positiveNumber(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function minNumber(value: number | undefined, fallback: number, min: number): number {
+  const n = positiveNumber(value, fallback);
+  return Math.max(n, min);
 }
 
 function numericEnv(value: string | undefined): number | undefined {

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -126,6 +126,7 @@ function toResidentConfig(config: RspRuntimeConfig) {
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
     telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
+    idleMs: config.idleMs,
   };
 }
 

--- a/apps/rsp/src/mcp-server.ts
+++ b/apps/rsp/src/mcp-server.ts
@@ -106,6 +106,7 @@ function residentStore(config: RspRuntimeConfig): ResidentRspElisionStore {
     telemetryByteBudget: config.telemetryByteBudget,
     telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
     telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
+    idleMs: config.idleMs,
   });
 }
 

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -19,7 +19,7 @@ import {
   drainTelemetrySpool,
   type RspTelemetryEvent,
 } from "./telemetry.js";
-import { DEFAULT_RSP_TELEMETRY_BYTE_BUDGET, DEFAULT_RSP_TELEMETRY_TTL_DAYS } from "./config.js";
+import { DEFAULT_RSP_IDLE_MS, DEFAULT_RSP_TELEMETRY_BYTE_BUDGET, DEFAULT_RSP_TELEMETRY_TTL_DAYS } from "./config.js";
 
 export interface ResidentServerOptions extends RspResidentConfig {
   socketPath: string;
@@ -50,7 +50,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   const telemetryDrainTimeoutMs = opts.telemetryDrainTimeoutMs ?? TELEMETRY_DRAIN_TIMEOUT_MS;
   await safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
 
-  const idleMs = opts.idleMs ?? 30_000;
+  const idleMs = opts.idleMs ?? DEFAULT_RSP_IDLE_MS;
   let idleTimer: NodeJS.Timeout | undefined;
   const telemetryDrainIntervalMs = opts.telemetryDrainIntervalMs ?? 30_000;
   const telemetryTimer = setInterval(() => {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -582,6 +582,35 @@ describe("rsp cli", () => {
     );
   }, 120_000);
 
+  it("built bundle keeps the warmed resident alive until the configured idle timeout", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const env = { RED_SKILLS_CACHE_DIR: cacheDir, RSP_IDLE_MS: "5000" };
+    const paths = trackedResidentPaths(root);
+
+    const cold = runBundleHookFromCwd(root, "git status", env);
+    expect(cold.status).toBe(1);
+    expect(cold.stdout).toEqual(Buffer.alloc(0));
+    expect(cold.stderr).toEqual(Buffer.alloc(0));
+    await waitForResidentSocket(root);
+    await waitForGone(paths.wakeLockPath);
+
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    const warm = runBundleHookFromCwd(root, "git status", env);
+    expect(warm.status).toBe(0);
+    expect(warm.stdout).toEqual(Buffer.from("rsp git status\n"));
+    expect(warm.stderr).toEqual(Buffer.alloc(0));
+
+    await waitForGone(paths.socketPath, 10_000);
+    const expired = runBundleHookFromCwd(root, "git status", env);
+    expect(expired.status).toBe(1);
+    expect(expired.stdout).toEqual(Buffer.alloc(0));
+    expect(expired.stderr).toEqual(Buffer.alloc(0));
+  }, 120_000);
+
   it("built bundle starts the resident for a repo root longer than the Unix socket path limit", async () => {
     buildBundleOnce();
     const base = await tempRoot();

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -3,11 +3,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_RSP_IDLE_MS,
   DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
   DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
   DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
   DEFAULT_RSP_TELEMETRY_TTL_DAYS,
+  MIN_RSP_IDLE_MS,
   resolveRspConfig,
 } from "../src/config.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/elision-store.js";
@@ -30,7 +32,7 @@ describe("resolveRspConfig", () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(
       join(root, ".red", "config.yaml"),
-      "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  telemetryTtlDays: 11\n  telemetryByteBudget: 100\n  telemetryDrainTimeoutMs: 456\n  heavyGitByteThreshold: 99\n",
+      "rsp:\n  ttlDays: 3\n  byteBudget: 42\n  telemetryTtlDays: 11\n  telemetryByteBudget: 100\n  telemetryDrainTimeoutMs: 456\n  idleMs: 10000\n  heavyGitByteThreshold: 99\n",
       "utf8",
     );
 
@@ -43,6 +45,7 @@ describe("resolveRspConfig", () => {
       telemetryByteBudget: 100,
       telemetryDrainIntervalMs: DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
       telemetryDrainTimeoutMs: 456,
+      idleMs: 10_000,
       heavyGitByteThreshold: 99,
     });
   });
@@ -61,6 +64,7 @@ describe("resolveRspConfig", () => {
       telemetryByteBudget: DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
       telemetryDrainIntervalMs: DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS,
       telemetryDrainTimeoutMs: DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
+      idleMs: DEFAULT_RSP_IDLE_MS,
       heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
     });
   });
@@ -84,6 +88,22 @@ describe("resolveRspConfig", () => {
     const config = resolveRspConfig(root, { RSP_TELEMETRY_DRAIN_TIMEOUT_MS: "456" }, undefined);
 
     expect(config.telemetryDrainTimeoutMs).toBe(456);
+  });
+
+  it("lets env override the resident idle timeout", async () => {
+    const root = await tempRoot();
+    const config = resolveRspConfig(root, { RSP_IDLE_MS: "6000" }, undefined);
+
+    expect(config.idleMs).toBe(6_000);
+  });
+
+  it("floors configured resident idle timeout at five seconds", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  idleMs: 1000\n", "utf8");
+
+    expect(resolveRspConfig(root, {}, undefined).idleMs).toBe(MIN_RSP_IDLE_MS);
+    expect(resolveRspConfig(root, { RSP_IDLE_MS: "2000" }, undefined).idleMs).toBe(MIN_RSP_IDLE_MS);
   });
 
   it("does not create .red or red-skills.rdb while resolving runtime config", async () => {

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -123,6 +123,8 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
     String(config.telemetryDrainIntervalMs ?? 30_000),
     "--telemetry-drain-timeout-ms",
     String(config.telemetryDrainTimeoutMs ?? 2_000),
+    "--idle-ms",
+    String(config.idleMs ?? 300_000),
     "--resident-version",
     config.clientVersion ?? "0.0.0-dev",
     "--wake-lock",
@@ -193,6 +195,8 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
     String(config.telemetryDrainIntervalMs ?? 30_000),
     "--telemetry-drain-timeout-ms",
     String(config.telemetryDrainTimeoutMs ?? 2_000),
+    "--idle-ms",
+    String(config.idleMs ?? 300_000),
     "--resident-version",
     config.clientVersion ?? "0.0.0-dev",
   ], {

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -9,6 +9,7 @@ export interface RspResidentConfig {
   telemetryByteBudget?: number;
   telemetryDrainIntervalMs?: number;
   telemetryDrainTimeoutMs?: number;
+  idleMs?: number;
   serverCommand?: string;
   serverArgs?: string[];
 }


### PR DESCRIPTION
Automated AFK landing for #1610. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1610

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786517069&installation_id=129708444&pr_number=1624&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1624&signature=3bcd5e605f1740ef1f84e23a8b7ad00a871fd788577c294a1de22e97ea830566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->