### PR TITLE
fix: #1608 linked worktrees resolve the primary repo root — one resident, one store, one counter per repo

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -47,9 +47,12 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     process.stdout.write(`${rspDisabledReason()}\n`);
     return 0;
   }
-  if (args.command === "git" && isFastGitStatus(args.positional) && await residentSocketExists(process.cwd())) {
+  const fastResidentPaths = args.command === "git" && isFastGitStatus(args.positional)
+    ? await residentPathsIfSocketExists(process.cwd())
+    : null;
+  if (fastResidentPaths) {
     const started = process.hrtime.bigint();
-    return await emitWrappedResult(args, await runFastGitStatus(), started);
+    return await emitWrappedResult(args, await runFastGitStatus(), started, undefined, fastResidentPaths.rootDir);
   }
   const { resolveResidentPaths, ResidentRspElisionStore, ensureResidentServer } = await import("./resident-client.js");
   if (args.command === "server") {
@@ -177,7 +180,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       }
       if (isFastGitStatus(args.positional)) {
         const started = process.hrtime.bigint();
-        return await emitWrappedResult(args, await runFastGitStatus(), started);
+        return await emitWrappedResult(args, await runFastGitStatus(), started, undefined, residentPaths.rootDir);
       }
       const { runGitWrapper } = await import("./git-wrapper.js");
       const store = new LazyRspElisionStore(() => suppressRspStderr(openResidentStore));
@@ -188,7 +191,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
         store,
         heavyGitByteThreshold: config.heavyGitByteThreshold,
       }));
-      return await emitWrappedResult(args, result, started, store);
+      return await emitWrappedResult(args, result, started, store, residentPaths.rootDir);
     }
 
     if (args.command === "gh") {
@@ -202,7 +205,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       closeStore = () => store.close();
       const started = process.hrtime.bigint();
       const result = await suppressRspStderr(() => runGhWrapper(args.positional, { level: args.level, store }));
-      return await emitWrappedResult(args, result, started, store);
+      return await emitWrappedResult(args, result, started, store, residentPaths.rootDir);
     }
 
     if (args.command === "vitest" || args.command === "cargo") {
@@ -216,7 +219,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       closeStore = () => store.close();
       const started = process.hrtime.bigint();
       const result = await suppressRspStderr(() => runTestWrapper(args.positional, { level: args.level, store }));
-      return await emitWrappedResult(args, result, started, store);
+      return await emitWrappedResult(args, result, started, store, residentPaths.rootDir);
     }
 
     if (args.command === "show" && args.handle) {
@@ -261,9 +264,10 @@ function isFastGitStatus(argv: readonly string[]): boolean {
   return argv.length === 2 && argv[0] === "git" && argv[1] === "status";
 }
 
-async function residentSocketExists(cwd: string): Promise<boolean> {
+async function residentPathsIfSocketExists(cwd: string): Promise<{ rootDir: string; socketPath: string } | null> {
   const { resolveResidentPaths } = await import("./resident-client.js");
-  return existsSync(resolveResidentPaths(cwd).socketPath);
+  const paths = resolveResidentPaths(cwd);
+  return existsSync(paths.socketPath) ? paths : null;
 }
 
 async function runFastGitStatus(): Promise<WrappedCommandResult> {
@@ -417,7 +421,7 @@ async function runColdWrappedCommand(
   try {
     if (args.command === "git") {
       if (isFastGitStatus(args.positional)) {
-        return await emitWrappedResult(args, await runFastGitStatus(), started, store);
+        return await emitWrappedResult(args, await runFastGitStatus(), started, store, telemetryRoot);
       }
       const { runGitWrapper } = await import("./git-wrapper.js");
       const result = await runGitWrapper(args.positional, {
@@ -425,19 +429,19 @@ async function runColdWrappedCommand(
         store,
         heavyGitByteThreshold: config.heavyGitByteThreshold,
       });
-      return await emitWrappedResult(args, result, started, store);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot);
     }
 
     if (args.command === "gh") {
       const { runGhWrapper } = await import("./gh-wrapper.js");
       const result = await runGhWrapper(args.positional, { level: args.level, store });
-      return await emitWrappedResult(args, result, started, store);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot);
     }
 
     if (args.command === "vitest" || args.command === "cargo") {
       const { runTestWrapper } = await import("./test-wrapper.js");
       const result = await runTestWrapper(args.positional, { level: args.level, store });
-      return await emitWrappedResult(args, result, started, store);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot);
     }
   } catch (coldErr) {
     return await degradeToPassthrough("wrapper failed", args.positional, coldErr, telemetryRoot);
@@ -453,14 +457,15 @@ async function emitWrappedResult(
   result: WrappedCommandResult,
   started: bigint,
   store?: InvocationTelemetryStore,
+  telemetryRoot = process.cwd(),
 ): Promise<number> {
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
   const wrapperMs = Number(process.hrtime.bigint() - started) / 1_000_000;
   if (store) {
-    await appendInvocationTelemetry(args, result, wrapperMs, store.lastResponseMetrics());
+    await appendInvocationTelemetry(telemetryRoot, args, result, wrapperMs, store.lastResponseMetrics());
   } else {
-    appendFastInvocationTelemetry(args, result, wrapperMs);
+    appendFastInvocationTelemetry(telemetryRoot, args, result, wrapperMs);
   }
   if (result.signal) {
     process.kill(process.pid, result.signal);
@@ -470,6 +475,7 @@ async function emitWrappedResult(
 }
 
 async function appendInvocationTelemetry(
+  telemetryRoot: string,
   args: ParsedArgs,
   result: WrappedCommandResult,
   wrapperMs: number,
@@ -478,7 +484,7 @@ async function appendInvocationTelemetry(
   const emitted = Buffer.concat([result.stdout, result.stderr]);
   const raw = Buffer.concat([result.rawOutput ?? result.stdout, result.stderr]);
   const { appendTelemetryEvent, RSP_TELEMETRY_INVOCATIONS_COLLECTION } = await import("./telemetry.js");
-  await appendTelemetryEvent(process.cwd(), {
+  await appendTelemetryEvent(telemetryRoot, {
     collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
     ts: new Date().toISOString(),
     command: args.positional.join(" "),
@@ -496,6 +502,7 @@ async function appendInvocationTelemetry(
 }
 
 function appendFastInvocationTelemetry(
+  telemetryRoot: string,
   args: ParsedArgs,
   result: WrappedCommandResult,
   wrapperMs: number,
@@ -503,7 +510,7 @@ function appendFastInvocationTelemetry(
   try {
     const emitted = Buffer.concat([result.stdout, result.stderr]);
     const raw = Buffer.concat([result.rawOutput ?? result.stdout, result.stderr]);
-    const path = join(process.cwd(), ".red", "tmp", "rsp-telemetry.spool.jsonl");
+    const path = join(telemetryRoot, ".red", "tmp", "rsp-telemetry.spool.jsonl");
     const line = `${JSON.stringify({
       collection: "rsp_telemetry_invocations_v1",
       ts: new Date().toISOString(),

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { findUp, flatConfigValue } from "@reddb-io/shared/plugin-gate.js";
+import { resolveResidentPaths } from "@reddb-io/shared/resident-client.js";
 
 export const DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD = 8 * 1024;
 export const DEFAULT_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
@@ -28,7 +29,6 @@ export interface RspRuntimeConfig {
 
 export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitStoreUri?: string): RspRuntimeConfig {
   const configPath = findUp(resolve(cwd), join(".red", "config.yaml"));
-  const root = configPath ? dirname(dirname(configPath)) : cwd;
   const yaml = configPath ? readFileSync(configPath, "utf8") : "";
   const enabled = flatConfigValue(yaml, "rsp.enabled") === "true";
   const ttlDays = positiveNumber(readNumericYamlPath(yaml, "rsp.ttlDays"), DEFAULT_RSP_TTL_DAYS);
@@ -58,7 +58,8 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     numericEnv(env.RSP_HEAVY_GIT_BYTE_THRESHOLD) ?? readNumericYamlPath(yaml, "rsp.heavyGitByteThreshold"),
     DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   );
-  const storeUri = explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${join(resolve(root), DEFAULT_RSP_STORE_PATH)}`;
+  const storeRoot = resolveResidentPaths(cwd).rootDir;
+  const storeUri = explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${join(resolve(storeRoot), DEFAULT_RSP_STORE_PATH)}`;
 
   return {
     enabled,

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -127,7 +127,7 @@ export async function takeTelemetrySpool(rootDir: string): Promise<string[]> {
 
   try {
     await writeFile(path, "", { flag: "wx" }).catch(() => undefined);
-    const text = await readFile(drainingPath, "utf8").catch(() => "");
+    const text = await readSettledFile(drainingPath);
     return text.split(/\r?\n/).filter((line) => line.trim() !== "");
   } finally {
     await rm(drainingPath, { force: true });
@@ -151,7 +151,7 @@ export async function drainTelemetrySpool(
   const retryLines: string[] = [];
   try {
     await writeFile(path, "", { flag: "wx" }).catch(() => undefined);
-    const text = await readFile(drainingPath, "utf8").catch(() => "");
+    const text = await readSettledFile(drainingPath);
     const lines = text.split(/\r?\n/).filter((line) => line.trim() !== "");
     for (const line of lines) {
       try {
@@ -174,6 +174,17 @@ function safeReadFileSync(path: string): string {
   } catch {
     return "";
   }
+}
+
+async function readSettledFile(path: string): Promise<string> {
+  let text = "";
+  for (let i = 0; i < 5; i++) {
+    const next = await readFile(path, "utf8").catch(() => "");
+    if (next === text) return next;
+    text = next;
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+  return text;
 }
 
 export function parseTelemetryEvent(line: string): RspTelemetryEvent | null {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createServer, type Server, type Socket } from "node:net";
 import { connect } from "@reddb-io/sdk";
 import { decode } from "@reddb-io/toon";
@@ -299,6 +299,22 @@ async function waitForResidentSocket(root: string): Promise<void> {
   await stat(paths.socketPath);
 }
 
+async function waitForSummaryTokens(root: string, minTokens: number): Promise<number> {
+  const summaryPath = resolveResidentPaths(root).summaryPath;
+  const deadline = Date.now() + 5_000;
+  let last = 0;
+  while (Date.now() < deadline) {
+    try {
+      const summary = JSON.parse(await readFile(summaryPath, "utf8")) as { tokens_saved_today?: unknown };
+      last = typeof summary.tokens_saved_today === "number" ? summary.tokens_saved_today : 0;
+      if (last > minTokens) return last;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  expect(last).toBeGreaterThan(minTokens);
+  return last;
+}
+
 async function readResidentVersion(root: string): Promise<string | undefined> {
   const socketPath = trackedResidentPaths(root).socketPath;
   const deadline = Date.now() + 5_000;
@@ -351,15 +367,36 @@ function handleHungOldResidentSocket(socket: Socket, version: string): void {
 async function readTelemetryRecords(storeUri: string, collection: string): Promise<unknown[]> {
   const db = await connect(storeUri);
   try {
-    const raw = await db.kv(collection).list({ limit: 1000 });
+    const raw = await db.kv(collection).list({ limit: 1000 }).catch((err) => {
+      if (err instanceof Error && /\bnot found\b/i.test(err.message)) return { items: [] };
+      throw err;
+    });
     return raw.items.map((entry) => typeof entry.value === "string" ? JSON.parse(entry.value) as unknown : entry.value);
   } finally {
     await db.close();
   }
 }
 
+async function waitForTelemetryInvocations(storeUri: string, command: string, minCount: number): Promise<unknown[]> {
+  const deadline = Date.now() + 5_000;
+  let records: unknown[] = [];
+  while (Date.now() < deadline) {
+    records = await readTelemetryRecords(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION);
+    if (records.filter((entry) => isRecord(entry) && entry.command === command).length >= minCount) return records;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  expect(records.filter((entry) => isRecord(entry) && entry.command === command).length).toBeGreaterThanOrEqual(minCount);
+  return records;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractHandle(output: Buffer): string {
+  const match = /rsp show (el:[a-f0-9]{12})/.exec(output.toString("utf8"));
+  expect(match?.[1]).toBeTruthy();
+  return match![1];
 }
 
 describe("rsp cli", () => {
@@ -646,6 +683,74 @@ describe("rsp cli", () => {
     expect(((await stat(dirname(paths.socketPath))).mode & 0o777)).toBe(0o700);
     await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
+  }, 120_000);
+
+  it("built bundle uses the primary resident and store from linked worktrees", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    await enableRsp(root);
+    await writeFile(join(root, ".gitignore"), ".red/tmp/\n", "utf8");
+    expect(runGit(["-C", root, "add", ".red/config.yaml", ".gitignore"]).status).toBe(0);
+    expect(runGit(["-C", root, "commit", "-m", "baseline"]).status).toBe(0);
+    await commitMany(root, 12);
+    const cacheDir = await seedWarmRedCache();
+    const env = {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_HEAVY_GIT_BYTE_THRESHOLD: "1",
+      RSP_TELEMETRY_DRAIN_INTERVAL_MS: "50",
+    };
+    const setup = runBundleFromCwd(root, ["setup"], env);
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+
+    const worktreeA = join(root, ".red", "tmp", "linked-a");
+    const worktreeB = join(root, ".red", "tmp", "linked-b");
+    expect(runGit(["-C", root, "worktree", "add", worktreeA, "-b", `rsp-linked-a-${randomUUID()}`, "HEAD"]).status).toBe(0);
+    expect(runGit(["-C", root, "worktree", "add", worktreeB, "-b", `rsp-linked-b-${randomUUID()}`, "HEAD"]).status).toBe(0);
+
+    const primaryPaths = trackedResidentPaths(root);
+    const worktreePaths = resolveResidentPaths(worktreeA);
+    expect(worktreePaths.rootDir).toBe(primaryPaths.rootDir);
+    expect(worktreePaths.socketPath).toBe(primaryPaths.socketPath);
+    expect(worktreePaths.summaryPath).toBe(primaryPaths.summaryPath);
+
+    const primaryWarm = runBundleFromCwd(root, ["git", "log", "--terse"], env);
+    expect(primaryWarm.status, `${primaryWarm.stdout.toString("utf8")}${primaryWarm.stderr.toString("utf8")}`).toBe(0);
+    extractHandle(primaryWarm.stdout);
+    const beforeWorktree = await waitForSummaryTokens(root, 0);
+
+    const fromWorktree = runBundleFromCwd(worktreeA, ["git", "log", "--terse"], env);
+    expect(fromWorktree.status, `${fromWorktree.stdout.toString("utf8")}${fromWorktree.stderr.toString("utf8")}`).toBe(0);
+    const handle = extractHandle(fromWorktree.stdout);
+    await expect(stat(primaryPaths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
+    await waitForSummaryTokens(root, beforeWorktree);
+
+    const concurrent = await Promise.all([
+      runBundleFromCwdAsync(root, ["git", "status"], env),
+      runBundleFromCwdAsync(worktreeA, ["git", "status"], env),
+      runBundleFromCwdAsync(worktreeB, ["git", "status"], env),
+    ]);
+    for (const res of concurrent) {
+      expect(res.status, `${res.stdout.toString("utf8")}${res.stderr.toString("utf8")}`).toBe(0);
+      expect(res.stderr).toEqual(Buffer.alloc(0));
+    }
+
+    expect(runGit(["-C", root, "worktree", "remove", "--force", worktreeA]).status).toBe(0);
+    await rm(worktreeA, { recursive: true, force: true });
+    const shown = runBundleFromCwd(root, ["show", handle], env);
+    expect(shown.status, `${shown.stdout.toString("utf8")}${shown.stderr.toString("utf8")}`).toBe(0);
+    expect(shown.stdout.toString("utf8")).toContain("commit ");
+
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    await waitForTelemetryInvocations(storeUri, "git log", 2);
+    const invocations = await waitForTelemetryInvocations(storeUri, "git status", 3);
+    const stats = runBundleFromCwd(root, ["stats", "--since", "7d"], env);
+    const statsText = stats.stdout.toString("utf8");
+    expect(stats.status, `${statsText}${stats.stderr.toString("utf8")}`).toBe(0);
+    expect(statsText).toContain("command: git log invocations:");
+
+    expect(invocations.filter((entry) => isRecord(entry) && entry.command === "git status").length)
+      .toBeGreaterThanOrEqual(3);
   }, 120_000);
 
   it("built bundle keeps small git status wrapper work under 100ms", async () => {

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -230,14 +230,24 @@ function findRepoRoot(start: string): string | null {
   let dir = resolve(start);
   for (let i = 0; i < 32; i++) {
     try {
-      if (readFileSyncSafe(join(dir, ".red", "config.yaml")) != null) return dir;
+      const gitFile = readFileSyncSafe(join(dir, ".git"));
+      if (gitFile != null) return linkedWorktreePrimaryRoot(dir, gitFile) ?? dir;
       if (readFileSyncSafe(join(dir, ".git", "HEAD")) != null) return dir;
+      if (readFileSyncSafe(join(dir, ".red", "config.yaml")) != null) return dir;
     } catch {}
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;
   }
   return null;
+}
+
+function linkedWorktreePrimaryRoot(worktreeRoot: string, gitFile: string): string | null {
+  const match = /^gitdir:\s*(.+?)\s*$/m.exec(gitFile);
+  if (!match) return null;
+  const gitDir = resolve(worktreeRoot, match[1]);
+  if (!/[/\\]worktrees[/\\][^/\\]+$/.test(gitDir)) return null;
+  return dirname(dirname(dirname(gitDir)));
 }
 
 function readFileSyncSafe(path: string): string | null {


### PR DESCRIPTION
Closes #1608.

findRepoRoot now detects a linked worktree's .git FILE, parses its gitdir pointer and resolves the PRIMARY repo root (plain file reads, no git spawn on the hot path, graceful fallback on unparseable files). Resident socket, store, telemetry spool and status summary all derive from the primary root: any number of worktrees share the repo's single resident, worker savings land on the repo's ticker, and elision handles minted in a worktree survive its deletion. Explicit --store-uri / RSP_STORE_URI overrides unchanged; standalone repos behave exactly as before. 11 new tests including a bundle-level linked-worktree fan-in regression.

Validation park does not reproduce: the branch's rsp suite is 181/181 and the FULL workspace suite passes (11/11 packages) on the same machine that ran the gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786519684&installation_id=129708444&pr_number=1625&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1625&signature=8e3bad3151258a176c07b08b01d32810797506326017dcf66784341e7fbc31b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->