### PR TITLE
feat: #1615 hook rewrites compound and piped commands to rsp exec

### DIFF
--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -53,11 +53,11 @@ export function rewriteTableFromCapabilities(capabilities: readonly RspWrapperCa
 
 export function rewriteCommand(command: string): RewriteDecision {
   const tokens = tokenizeCertainSimpleCommand(command);
-  if (!tokens) return { kind: "passthrough" };
-  if (tokens.length > 0 && isEnvAssignment(tokens[0]!)) return { kind: "passthrough" };
+  if (!tokens) return rewriteCompoundCommand(command);
+  if (tokens.length > 0 && isEnvAssignment(tokens[0]!)) return rewriteCompoundCommand(command);
 
   const rewritten = DEFAULT_REWRITE_TABLE.get(commandKey(tokens));
-  if (!rewritten) return { kind: "passthrough" };
+  if (!rewritten) return rewriteCompoundCommand(command);
   const capability = RSP_WRAPPER_CAPABILITIES.find((entry) => commandKey(entry.command) === commandKey(tokens));
   return {
     kind: "rewrite",
@@ -161,6 +161,101 @@ function tokenizeCertainSimpleCommand(command: string): string[] | null {
   if (tokens.length === 0) return null;
   if (tokens.some((token) => token.includes("=") && isEnvAssignment(token))) return null;
   return tokens;
+}
+
+function rewriteCompoundCommand(command: string): RewriteDecision {
+  const trimmed = command.trim();
+  if (!isSafeNoisyCompoundCommand(trimmed)) return { kind: "passthrough" };
+  return {
+    kind: "rewrite",
+    command: `rsp exec -- ${shellSingleQuote(trimmed)}`,
+    capabilityId: "exec:compound",
+  };
+}
+
+function isSafeNoisyCompoundCommand(command: string): boolean {
+  if (!command) return false;
+  if (!hasCompoundOperator(command)) return false;
+  if (!hasKnownNoisyFamily(command)) return false;
+  if (hasSingleAmpersand(command)) return false;
+  if (/<<-?/.test(command)) return false;
+  if (/\$\(|`/.test(command)) return false;
+  if (/[<>]/.test(command)) return false;
+  if (containsCommandWord(command, "rsp")) return false;
+  if (containsAnyCommandWord(command, INTERACTIVE_COMMANDS)) return false;
+  if (containsQuietGrep(command)) return false;
+  return true;
+}
+
+const INTERACTIVE_COMMANDS = new Set([
+  "bash",
+  "fish",
+  "htop",
+  "less",
+  "more",
+  "nano",
+  "node",
+  "python",
+  "python3",
+  "ssh",
+  "top",
+  "vi",
+  "vim",
+  "zsh",
+]);
+
+function hasCompoundOperator(command: string): boolean {
+  return /&&|[;|]/.test(command);
+}
+
+function hasSingleAmpersand(command: string): boolean {
+  for (let index = 0; index < command.length; index += 1) {
+    if (command[index] !== "&") continue;
+    if (command[index - 1] === "&" || command[index + 1] === "&") continue;
+    return true;
+  }
+  return false;
+}
+
+function hasKnownNoisyFamily(command: string): boolean {
+  return commandSegments(command).some((segment) => {
+    const tokens = shellishWords(segment);
+    if (tokens.length === 0) return false;
+    if (tokens[0] === "git") return ["log", "diff", "show", "blame"].includes(tokens[1] ?? "");
+    if (tokens[0] === "gh") return tokens.some((token, index) => index > 0 && (token === "list" || token === "view"));
+    if (tokens[0] === "vitest") return true;
+    return tokens[0] === "cargo" && tokens[1] === "test";
+  });
+}
+
+function containsAnyCommandWord(command: string, words: ReadonlySet<string>): boolean {
+  return commandSegments(command).some((segment) => {
+    const first = shellishWords(segment)[0];
+    return first ? words.has(first) : false;
+  });
+}
+
+function containsCommandWord(command: string, word: string): boolean {
+  return containsAnyCommandWord(command, new Set([word]));
+}
+
+function containsQuietGrep(command: string): boolean {
+  return commandSegments(command).some((segment) => {
+    const tokens = shellishWords(segment);
+    return tokens[0] === "grep" && tokens.includes("-q");
+  });
+}
+
+function commandSegments(command: string): string[] {
+  return command.split(/&&|[;|]/).map((segment) => segment.trim()).filter(Boolean);
+}
+
+function shellishWords(segment: string): string[] {
+  return segment.split(/[ \t]+/).filter(Boolean).map((token) => token.replace(/^env$/, ""));
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function isEnvAssignment(token: string): boolean {

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -55,9 +55,34 @@ describe("rsp interception pure rewrite table", () => {
     ["silent-predicate-grep-q", "grep -q needle file"],
     ["redirection-is-ambiguous", "git status > status.txt"],
     ["subshell-is-ambiguous", "$(git status)"],
-    ["compound-command-is-ambiguous", "git status && echo done"],
     ["quoted-command-name-is-ambiguous", "\"git\" status"],
   ])("passes through adversarial fixture %s", (_name, command) => {
+    expect(rewriteCommand(command)).toEqual({ kind: "passthrough" });
+  });
+
+  it.each([
+    ["chained-cd-git-log", "cd apps && git log --oneline"],
+    ["piped-git-log-tail", "git log | tail -5"],
+    ["semicolon-gh-list", "cd apps; gh pr list --limit 5"],
+    ["piped-vitest", "vitest run | tail -20"],
+    ["chained-cargo-test", "cd crates/core && cargo test"],
+  ])("rewrites safe compound noisy command %s through rsp exec", (_name, command) => {
+    expect(rewriteCommand(command)).toEqual({
+      kind: "rewrite",
+      command: `rsp exec -- '${command}'`,
+      capabilityId: "exec:compound",
+    });
+  });
+
+  it.each([
+    ["interactive-editor", "vim ."],
+    ["background-process", "sleep 10 &"],
+    ["command-substitution-capture", "foo $(git log)"],
+    ["already-rsp", "cd apps && rsp git log"],
+    ["here-doc", "cat <<EOF"],
+    ["single-noisy-command-with-args", "git log --oneline"],
+    ["silent-predicate", "git log | grep -q fix"],
+  ])("passes through unsafe compound fixture %s", (_name, command) => {
     expect(rewriteCommand(command)).toEqual({ kind: "passthrough" });
   });
 });
@@ -101,6 +126,23 @@ describe("rsp Claude pre-execution hook integration", () => {
     expect(formatHookDecision(result)).toEqual({ stdout: "rsp git status\n", status: 0 });
     expect(healthCalls).toBe(1);
     expect(wakeCalls).toBe(0);
+  });
+
+  it("prints a shell-safe rsp exec rewrite for compound noisy commands when the resident is healthy", async () => {
+    const root = await tempRoot();
+    const result = await hookDecisionFromClaudePreExecJson(
+      JSON.stringify({ cwd: root, tool_input: { command: "cd apps && git log --oneline" } }),
+      {
+        cwd: root,
+        isEnabled: () => true,
+        isResidentHealthy: async () => true,
+      },
+    );
+
+    expect(formatHookDecision(result)).toEqual({
+      stdout: "rsp exec -- 'cd apps && git log --oneline'\n",
+      status: 0,
+    });
   });
 
   it("prints nothing and exits non-zero on passthrough", async () => {


### PR DESCRIPTION
Automated AFK landing for #1615. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1615

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786520533&installation_id=129708444&pr_number=1627&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1627&signature=dcd6536e4f2810ec3910eff5604a4506a702b492ac1dfc53ae6b20a1e336b8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->