### PR TITLE
feat: #1617 rsp shell-init: opt-in human-shell distribution (fish/bash/zsh)

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -39,6 +39,16 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     await runRspMcpServer();
     return 0;
   }
+  if (args.command === "shell-init") {
+    const shell = args.positional[1];
+    if (shell !== "fish" && shell !== "bash" && shell !== "zsh") {
+      process.stdout.write("error: usage rsp shell-init fish|bash|zsh\n");
+      return 2;
+    }
+    const { renderShellInit } = await import("./shell-init.js");
+    process.stdout.write(renderShellInit(shell));
+    return 0;
+  }
   const { resolveRspConfig } = await import("./config.js");
   const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
   const wrapperCommand = isWrapperCommand(args.command);

--- a/apps/rsp/src/shell-init.ts
+++ b/apps/rsp/src/shell-init.ts
@@ -1,0 +1,136 @@
+import { RSP_WRAPPER_CAPABILITIES, type RspWrapperCapability } from "./intercept.js";
+
+export type RspShell = "fish" | "bash" | "zsh";
+
+export function renderShellInit(
+  shell: RspShell,
+  capabilities: readonly RspWrapperCapability[] = RSP_WRAPPER_CAPABILITIES,
+): string {
+  if (shell === "fish") return renderFishInit(capabilities);
+  if (shell === "bash" || shell === "zsh") return renderPosixishInit(shell, capabilities);
+  throw new Error(`unsupported shell: ${shell}`);
+}
+
+function renderFishInit(capabilities: readonly RspWrapperCapability[]): string {
+  const commandWords = [...new Set(capabilities.map((entry) => entry.command[0]).filter(isShellWord))];
+  return [
+    "# rsp shell-init fish",
+    "# Opt-in only: source this output from config.fish; remove that line to restore raw commands.",
+    "if type -q rsp",
+    ...commandWords.map((word) => `    abbr --add --position command -- ${word} '${fishSingleQuote(`rsp ${word}`)}'`),
+    "    function rspx --description 'Run a shell pipeline through rsp exec'",
+    "        rsp exec -- $argv",
+    "    end",
+    "else",
+    "    # rsp is not on PATH; rsp abbreviations and rspx were not installed.",
+    "end",
+    "",
+  ].join("\n");
+}
+
+function renderPosixishInit(shell: "bash" | "zsh", capabilities: readonly RspWrapperCapability[]): string {
+  const groups = groupedCapabilities(capabilities);
+  return [
+    `# rsp shell-init ${shell}`,
+    `# Opt-in only: source this output from ${shell} startup files; remove that line to restore raw commands.`,
+    ...renderCommandFunction("git", groups.get("git") ?? []),
+    ...renderCommandFunction("gh", groups.get("gh") ?? []),
+    ...renderCommandFunction("vitest", groups.get("vitest") ?? []),
+    ...renderCommandFunction("cargo", groups.get("cargo") ?? []),
+    "rspx() {",
+    "  if command -v rsp >/dev/null 2>&1; then",
+    "    command rsp exec -- \"$@\"",
+    "    return",
+    "  fi",
+    "  printf '%s\\n' 'rspx requires rsp with exec support on PATH' >&2",
+    "  return 127",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function renderCommandFunction(command: string, capabilities: readonly RspWrapperCapability[]): string[] {
+  if (capabilities.length === 0) return [];
+  if (capabilities.some((entry) => entry.command.length === 1)) {
+    return [
+      `${command}() {`,
+      "  if command -v rsp >/dev/null 2>&1; then",
+      `    command rsp ${command} "$@"`,
+      "    return",
+      "  fi",
+      `  command ${command} "$@"`,
+      "}",
+    ];
+  }
+  const singleSubcommands = capabilities
+    .map((entry) => entry.command.slice(1))
+    .filter((tail) => tail.length === 1)
+    .map((tail) => tail[0])
+    .filter(isShellWord);
+  const multiSubcommands = capabilities
+    .map((entry) => entry.command.slice(1))
+    .filter((tail) => tail.length > 1 && tail.every(isShellWord));
+  const lines = [
+    `${command}() {`,
+    "  if ! command -v rsp >/dev/null 2>&1; then",
+    `    command ${command} "$@"`,
+    "    return",
+    "  fi",
+    "  case \"$1\" in",
+  ];
+  if (singleSubcommands.length > 0) {
+    const pattern = singleSubcommands.map((word) => shellPatternWord(word)).join("|");
+    lines.push(`    ${pattern}) command rsp ${command} "$@" ;;`);
+  }
+  for (const [first, tails] of groupMultiSubcommands(multiSubcommands)) {
+    const tests = tails.map((tail) => tail
+      .map((word, index) => `[ "\$${index + 2}" = '${shellSingleQuote(word)}' ]`)
+      .join(" && ")).join(" || ");
+    lines.push(`    ${shellPatternWord(first)}) if ${tests}; then command rsp ${command} "$@"; else command ${command} "$@"; fi ;;`);
+  }
+  lines.push(
+    `    *) command ${command} "$@" ;;`,
+    "  esac",
+    "}",
+  );
+  return lines;
+}
+
+function groupMultiSubcommands(tails: readonly string[][]): Map<string, string[][]> {
+  const groups = new Map<string, string[][]>();
+  for (const [first, ...rest] of tails) {
+    if (!first) continue;
+    const group = groups.get(first) ?? [];
+    group.push(rest);
+    groups.set(first, group);
+  }
+  return groups;
+}
+
+function groupedCapabilities(capabilities: readonly RspWrapperCapability[]): Map<string, RspWrapperCapability[]> {
+  const groups = new Map<string, RspWrapperCapability[]>();
+  for (const entry of capabilities) {
+    const command = entry.command[0];
+    if (!command || !isShellWord(command)) continue;
+    const group = groups.get(command) ?? [];
+    group.push(entry);
+    groups.set(command, group);
+  }
+  return groups;
+}
+
+function isShellWord(value: string | undefined): value is string {
+  return Boolean(value && /^[A-Za-z0-9_./:-]+$/.test(value));
+}
+
+function shellPatternWord(value: string): string {
+  return value.replace(/[\\|)&;]/g, "\\$&");
+}
+
+function shellSingleQuote(value: string): string {
+  return value.replace(/'/g, "'\\''");
+}
+
+function fishSingleQuote(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}

--- a/apps/rsp/tests/shell-init.test.ts
+++ b/apps/rsp/tests/shell-init.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { renderShellInit } from "../src/shell-init.js";
+
+const roots: string[] = [];
+const cli = join(import.meta.dirname, "..", "src", "cli.ts");
+const tsxLoader = createRequire(import.meta.url).resolve("tsx");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-shell-init-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp shell-init snippets", () => {
+  it("renders fish abbreviations and rspx helper", () => {
+    const snippet = renderShellInit("fish");
+
+    expect(snippet).toContain("abbr --add --position command -- git 'rsp git'");
+    expect(snippet).toContain("abbr --add --position command -- gh 'rsp gh'");
+    expect(snippet).toContain("function rspx");
+    expect(snippet).toContain("rsp exec -- $argv");
+  });
+
+  it("prints a shell snippet from the CLI without requiring an enabled repo", async () => {
+    const root = await tempRoot();
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "shell-init", "fish"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain("abbr --add --position command -- git 'rsp git'");
+    expect(res.stdout).toContain("function rspx");
+  });
+
+  it("renders bash/zsh functions that intercept known wrapper families only", () => {
+    const bash = renderShellInit("bash");
+    const zsh = renderShellInit("zsh");
+
+    for (const snippet of [bash, zsh]) {
+      expect(snippet).toContain("git() {");
+      expect(snippet).toContain("status|log|diff|commit|push|blame|show) command rsp git \"$@\" ;;");
+      expect(snippet).toContain("branch) if [ \"$2\" = '-av' ]; then command rsp git \"$@\"; else command git \"$@\"; fi ;;");
+      expect(snippet).toContain("pr) if [ \"$2\" = 'list' ] || [ \"$2\" = 'view' ]; then command rsp gh \"$@\"; else command gh \"$@\"; fi ;;");
+      expect(snippet).toContain("rspx() {");
+      expect(snippet).toContain("command rsp exec -- \"$@\"");
+    }
+  });
+
+  it("emits fish syntax accepted by fish -n", async () => {
+    const root = await tempRoot();
+    const path = join(root, "rsp-init.fish");
+    await writeFile(path, renderShellInit("fish"), "utf8");
+
+    const res = spawnSync("fish", ["-n", path], { encoding: "utf8" });
+
+    expect(res.status, res.stderr).toBe(0);
+  });
+
+  it("fish snippet installs command-word abbreviations and rspx when sourced", async () => {
+    const root = await tempRoot();
+    const bin = join(root, "bin");
+    await writeFile(join(root, "rsp-init.fish"), renderShellInit("fish"), "utf8");
+    await mkdir(bin);
+    await writeFile(join(bin, "rsp"), "#!/bin/sh\nprintf 'rsp %s\\n' \"$*\"\n", { mode: 0o755 });
+    await writeFile(join(root, "script.fish"), [
+      `set -gx PATH '${bin}' $PATH`,
+      `source '${join(root, "rsp-init.fish")}'`,
+      "abbr --show git",
+      "rspx 'git log | tail'",
+      "",
+    ].join("\n"), "utf8");
+
+    const res = spawnSync("fish", [join(root, "script.fish")], { encoding: "utf8" });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain("abbr -a -- git 'rsp git'");
+    expect(res.stdout).toContain("rsp exec -- git log | tail");
+  });
+
+  it("bash snippet routes git status and rspx through rsp while preserving other git commands", async () => {
+    const root = await tempRoot();
+    const bin = join(root, "bin");
+    await mkdir(bin);
+    await writeFile(join(bin, "rsp"), "#!/bin/sh\nprintf 'rsp %s\\n' \"$*\"\n", { mode: 0o755 });
+    await writeFile(join(bin, "git"), "#!/bin/sh\nprintf 'git %s\\n' \"$*\"\n", { mode: 0o755 });
+    await writeFile(join(root, "rsp-init.sh"), renderShellInit("bash"), "utf8");
+
+    const res = spawnSync("bash", ["-c", [
+      `PATH='${bin}':$PATH`,
+      `source '${join(root, "rsp-init.sh")}'`,
+      "git status",
+      "git checkout topic",
+      "rspx 'git log | tail'",
+    ].join("; ")], { encoding: "utf8" });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain("rsp git status");
+    expect(res.stdout).toContain("git checkout topic");
+    expect(res.stdout).toContain("rsp exec -- git log | tail");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1617. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1617

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786522097&installation_id=129708444&pr_number=1629&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1629&signature=63b5ab44f17966cc321a64cedc8306525bf9cc895d292526e692f9838be84c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->