### PR TITLE
feat: #1620 rsp gains dollar-saved reporting and confidence ranges

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -144,6 +144,7 @@ const RSP_WARMUP_GRACE_MS = 15_000;
 interface RspSummaryFile {
   version: number;
   tokens_saved_today: number;
+  dollars_saved_today_usd?: number;
   updated_at: string;
 }
 
@@ -191,6 +192,12 @@ function tokensSavedForCurrentDay(summary: RspSummaryFile, nowMs: number): numbe
   return Math.max(0, Math.floor(summary.tokens_saved_today));
 }
 
+function dollarsSavedForCurrentDay(summary: RspSummaryFile, nowMs: number): number | undefined {
+  if (utcDay(summary.updated_at) !== new Date(nowMs).toISOString().slice(0, 10)) return undefined;
+  if (typeof summary.dollars_saved_today_usd !== "number") return undefined;
+  return Math.max(0, summary.dollars_saved_today_usd);
+}
+
 export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv = process.env): Promise<RspStatusInput | undefined> {
   const config = resolveRspConfig(root, env);
   if (!config.enabled) return undefined;
@@ -198,7 +205,11 @@ export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv 
   const nowMs = Date.now();
   const summary = parseRspSummary(paths.summaryPath);
   if (summary) {
-    return { state: "ready", tokensSavedToday: tokensSavedForCurrentDay(summary, nowMs) };
+    return {
+      state: "ready",
+      tokensSavedToday: tokensSavedForCurrentDay(summary, nowMs),
+      dollarsSavedTodayUsd: dollarsSavedForCurrentDay(summary, nowMs),
+    };
   }
   if (isRecentFile(paths.wakeLockPath, nowMs, RSP_WARMUP_GRACE_MS)) return { state: "warming" };
   if (fileExists(paths.wakeLockPath)) return { state: "error" };

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -164,7 +164,7 @@ export interface FleetInput {
 }
 
 export type RspStatusInput =
-  | { state: "ready"; tokensSavedToday: number }
+  | { state: "ready"; tokensSavedToday: number; dollarsSavedTodayUsd?: number }
   | { state: "warming" }
   | { state: "error" };
 
@@ -433,9 +433,20 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
 
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
-  if (rsp.state === "ready") return `rsp ↓${humanizeCount(rsp.tokensSavedToday)}`;
+  if (rsp.state === "ready") {
+    const dollars = rsp.dollarsSavedTodayUsd && rsp.dollarsSavedTodayUsd > 0
+      ? ` ${formatRspDollars(rsp.dollarsSavedTodayUsd)}`
+      : "";
+    return `rsp ↓${humanizeCount(rsp.tokensSavedToday)}${dollars}`;
+  }
   if (rsp.state === "warming") return "rsp …";
   return "rsp !";
+}
+
+function formatRspDollars(value: number): string {
+  if (value >= 1) return `$${value.toFixed(2)}`;
+  if (value >= 0.01) return `$${value.toFixed(3)}`;
+  return `$${value.toFixed(6)}`;
 }
 
 /**

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -718,14 +718,15 @@ describe("statusline command — rendered line", () => {
     await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
       version: 1,
       tokens_saved_today: 1300000,
+      dollars_saved_today_usd: 1.625,
       updated_at: new Date().toISOString(),
     }), "utf8");
-    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 1300000 });
+    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 1300000, dollarsSavedTodayUsd: 1.625 });
 
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp ↓1.3M");
+    expect(stripAnsi(out.text())).toContain("rsp ↓1.3M $1.63");
   });
 
   it("renders rsp savings from an old summary when the resident is idle", async () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -505,6 +505,10 @@ describe("statusline — full assembly", () => {
     };
     expect(renderStatusline(input)).toBe("red-skills (main) · rsp ↓847");
     expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp ↓847");
+    expect(renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      rsp: { state: "ready", tokensSavedToday: 2000, dollarsSavedTodayUsd: 0.0025 },
+    })).toBe("red-skills (main) · rsp ↓2k $0.002500");
   });
 
   it("renders rsp warming and error states without ambiguous on/off glyphs", () => {

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -5,6 +5,7 @@ import { encode, type JsonObject } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspRuntimeConfig } from "./config.js";
 import type { RspElisionStore, RspMintMeta } from "./elision-store.js";
+import { formatUsd } from "./pricing.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
 import type { RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
 
@@ -724,7 +725,11 @@ function renderStats(
     `  raw_bytes: ${telemetry.savings.raw_bytes}`,
     `  emitted_bytes: ${telemetry.savings.emitted_bytes}`,
     `  bytes_saved: ${telemetry.savings.bytes_saved}`,
-    `  tokens_saved: ${telemetry.savings.tokens_saved}`,
+    `  tokens_saved: ${formatTokensSaved(telemetry.savings)}`,
+    `  dollars_saved_estimate_usd: ${formatDollarsSaved(telemetry.savings)}`,
+    `  pricing_model_family: ${telemetry.savings.pricing_model_family}`,
+    `  pricing_input_usd_per_million_tokens: ${telemetry.savings.pricing_input_usd_per_million_tokens}`,
+    `  pricing_note: ${telemetry.savings.pricing_note}`,
     "  daily_tokens_saved:",
     ...renderDaily(daily),
     ...(!full && telemetry.savings.daily_tokens_saved.length > daily.length
@@ -751,6 +756,18 @@ function renderStats(
 
 function renderGainsReportToon(report: RspTelemetryGainsReport): string {
   return `${encode(report as unknown as JsonObject)}\n`;
+}
+
+function formatTokensSaved(savings: RspTelemetryStats["savings"]): string {
+  if (!savings.tokens_saved_estimated) return String(savings.tokens_saved);
+  return `${savings.tokens_saved_low}-${savings.tokens_saved_high} (estimate_midpoint: ${savings.tokens_saved}, range_pct: ${savings.token_estimate_range_pct})`;
+}
+
+function formatDollarsSaved(savings: RspTelemetryStats["savings"]): string {
+  if (savings.dollars_saved_low_usd == null || savings.dollars_saved_high_usd == null) {
+    return formatUsd(savings.dollars_saved_estimate_usd);
+  }
+  return `${formatUsd(savings.dollars_saved_low_usd)}-${formatUsd(savings.dollars_saved_high_usd)} (estimate_midpoint: ${formatUsd(savings.dollars_saved_estimate_usd)})`;
 }
 
 function renderDaily(series: Array<{ date: string; tokens_saved: number }>): string[] {
@@ -789,6 +806,16 @@ function emptyTelemetryStats(windowDays: number): RspTelemetryStats {
       emitted_bytes: 0,
       bytes_saved: 0,
       tokens_saved: 0,
+      tokens_saved_estimated: false,
+      token_estimate_range_pct: null,
+      tokens_saved_low: null,
+      tokens_saved_high: null,
+      dollars_saved_estimate_usd: 0,
+      dollars_saved_low_usd: null,
+      dollars_saved_high_usd: null,
+      pricing_model_family: "gpt-5",
+      pricing_input_usd_per_million_tokens: 1.25,
+      pricing_note: "estimate derived from byte-based token estimate when token counts are estimated",
       daily_tokens_saved: [],
       top_commands: [],
     },

--- a/apps/rsp/src/pricing.ts
+++ b/apps/rsp/src/pricing.ts
@@ -1,0 +1,68 @@
+export const TOKEN_ESTIMATE_RANGE_PCT = 0.25;
+
+export interface TokenSavingsEstimate {
+  tokens_saved: number;
+  tokens_saved_estimated: boolean;
+  token_estimate_range_pct: number | null;
+  tokens_saved_low: number | null;
+  tokens_saved_high: number | null;
+  dollars_saved_estimate_usd: number;
+  dollars_saved_low_usd: number | null;
+  dollars_saved_high_usd: number | null;
+  pricing_model_family: string;
+  pricing_input_usd_per_million_tokens: number;
+  pricing_note: string;
+}
+
+export const DEFAULT_RSP_PRICING_MODEL_FAMILY = "gpt-5";
+
+export const RSP_INPUT_TOKEN_PRICE_USD_PER_MILLION: Record<string, number> = {
+  "gpt-5": 1.25,
+  "gpt-5-mini": 0.25,
+  "gpt-5-nano": 0.05,
+  "gpt-4.1": 2,
+  "gpt-4.1-mini": 0.4,
+  "gpt-4o": 2.5,
+  "gpt-4o-mini": 0.15,
+};
+
+const PRICING_NOTE = "estimate derived from byte-based token estimate when token counts are estimated";
+
+export function tokenSavingsEstimate(
+  tokensSaved: number,
+  estimated: boolean,
+  modelFamily = DEFAULT_RSP_PRICING_MODEL_FAMILY,
+): TokenSavingsEstimate {
+  const tokens = Math.max(0, Math.floor(tokensSaved));
+  const normalizedModel = modelFamily in RSP_INPUT_TOKEN_PRICE_USD_PER_MILLION
+    ? modelFamily
+    : DEFAULT_RSP_PRICING_MODEL_FAMILY;
+  const price = RSP_INPUT_TOKEN_PRICE_USD_PER_MILLION[normalizedModel]!;
+  const low = estimated ? Math.floor(tokens * (1 - TOKEN_ESTIMATE_RANGE_PCT)) : null;
+  const high = estimated ? Math.ceil(tokens * (1 + TOKEN_ESTIMATE_RANGE_PCT)) : null;
+  return {
+    tokens_saved: tokens,
+    tokens_saved_estimated: estimated,
+    token_estimate_range_pct: estimated ? TOKEN_ESTIMATE_RANGE_PCT : null,
+    tokens_saved_low: low,
+    tokens_saved_high: high,
+    dollars_saved_estimate_usd: dollarsForTokens(tokens, price),
+    dollars_saved_low_usd: low == null ? null : dollarsForTokens(low, price),
+    dollars_saved_high_usd: high == null ? null : dollarsForTokens(high, price),
+    pricing_model_family: normalizedModel,
+    pricing_input_usd_per_million_tokens: price,
+    pricing_note: PRICING_NOTE,
+  };
+}
+
+export function dollarsForTokens(tokens: number, usdPerMillionTokens: number): number {
+  return roundUsd((Math.max(0, tokens) / 1_000_000) * usdPerMillionTokens);
+}
+
+export function formatUsd(value: number): string {
+  return `$${value.toFixed(6)}`;
+}
+
+function roundUsd(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -252,12 +252,16 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
   const stats = await readTelemetryStats(db, 1, now);
   const today = now.toISOString().slice(0, 10);
   const tokensSavedToday = stats.savings.daily_tokens_saved.find((row) => row.date === today)?.tokens_saved ?? 0;
+  const dollarsSavedToday = stats.savings.tokens_saved > 0
+    ? (tokensSavedToday / stats.savings.tokens_saved) * stats.savings.dollars_saved_estimate_usd
+    : 0;
   const path = join(rootDir, RSP_STATUS_SUMMARY);
   const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
   await mkdir(dirname(path), { recursive: true });
   await writeFile(tmp, JSON.stringify({
     version: 1,
     tokens_saved_today: tokensSavedToday,
+    dollars_saved_today_usd: Math.round(dollarsSavedToday * 1_000_000) / 1_000_000,
     updated_at: now.toISOString(),
   }), { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -2,6 +2,7 @@ import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { RedDB } from "@reddb-io/sdk";
+import { tokenSavingsEstimate, type TokenSavingsEstimate } from "./pricing.js";
 
 export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
 export const RSP_TELEMETRY_INVOCATIONS_COLLECTION = "rsp_telemetry_invocations_v1";
@@ -33,6 +34,16 @@ export interface RspTelemetryStats {
     emitted_bytes: number;
     bytes_saved: number;
     tokens_saved: number;
+    tokens_saved_estimated: boolean;
+    token_estimate_range_pct: number | null;
+    tokens_saved_low: number | null;
+    tokens_saved_high: number | null;
+    dollars_saved_estimate_usd: number;
+    dollars_saved_low_usd: number | null;
+    dollars_saved_high_usd: number | null;
+    pricing_model_family: string;
+    pricing_input_usd_per_million_tokens: number;
+    pricing_note: string;
     daily_tokens_saved: Array<{ date: string; tokens_saved: number }>;
     top_commands: Array<{ command: string; invocations: number; bytes_saved: number; tokens_saved: number }>;
   };
@@ -74,6 +85,7 @@ export interface RspTelemetryGainsReport {
     hour_weekday_heatmap: Array<{ weekday: string; hour: number; requests: number }>;
   };
   savings: {
+    tokens: TokenSavingsEstimate;
     weekly_tokens_saved: Array<{ week_start: string; tokens_saved: number; wow_delta_pct: number | null }>;
     elision_rate: number;
     top_commands_by_tokens_saved: Array<{ command_family: string; invocations: number; tokens_saved: number; bytes_saved: number }>;
@@ -213,6 +225,7 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
   let rawBytes = 0;
   let emittedBytes = 0;
   let tokensSaved = 0;
+  let tokensEstimated = false;
   const byDay = new Map<string, number>();
   const byCommand = new Map<string, { command: string; invocations: number; bytes_saved: number; tokens_saved: number }>();
   const wrapperMs: number[] = [];
@@ -226,6 +239,7 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
     const emitted = numeric(record.emitted_bytes);
     const bytesSaved = Math.max(0, raw - emitted);
     const tokenDelta = Math.max(0, numeric(record.tokens_raw) - numeric(record.tokens_emitted));
+    tokensEstimated ||= record.estimated === true && tokenDelta > 0;
     rawBytes += raw;
     emittedBytes += emitted;
     tokensSaved += tokenDelta;
@@ -263,6 +277,7 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
   }
 
   const totalAttempts = invocations.length + degradations.length;
+  const savingsEstimate = tokenSavingsEstimate(tokensSaved, tokensEstimated);
   return {
     window_days: windowDays,
     empty: invocations.length === 0 && degradations.length === 0,
@@ -273,6 +288,16 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
       emitted_bytes: emittedBytes,
       bytes_saved: Math.max(0, rawBytes - emittedBytes),
       tokens_saved: tokensSaved,
+      tokens_saved_estimated: savingsEstimate.tokens_saved_estimated,
+      token_estimate_range_pct: savingsEstimate.token_estimate_range_pct,
+      tokens_saved_low: savingsEstimate.tokens_saved_low,
+      tokens_saved_high: savingsEstimate.tokens_saved_high,
+      dollars_saved_estimate_usd: savingsEstimate.dollars_saved_estimate_usd,
+      dollars_saved_low_usd: savingsEstimate.dollars_saved_low_usd,
+      dollars_saved_high_usd: savingsEstimate.dollars_saved_high_usd,
+      pricing_model_family: savingsEstimate.pricing_model_family,
+      pricing_input_usd_per_million_tokens: savingsEstimate.pricing_input_usd_per_million_tokens,
+      pricing_note: savingsEstimate.pricing_note,
       daily_tokens_saved: [...byDay.entries()]
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([date, saved]) => ({ date, tokens_saved: saved })),
@@ -319,6 +344,8 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
   const heatmap = new Map<string, number>();
   const weeklyTokens = new Map<string, number>();
   const commandTotals = new Map<string, { command_family: string; invocations: number; tokens_saved: number; bytes_saved: number }>();
+  let totalTokensSaved = 0;
+  let tokensEstimated = false;
   let elided = 0;
   let biggest: RspTelemetryGainsReport["savings"]["single_biggest_elision"] = null;
   let recordsWithStoreMetric = 0;
@@ -330,6 +357,8 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
     const minute = timestamp.slice(0, 16);
     const family = commandFamily(stringField(record.command));
     const tokensSaved = Math.max(0, numeric(record.tokens_raw) - numeric(record.tokens_emitted));
+    totalTokensSaved += tokensSaved;
+    tokensEstimated ||= record.estimated === true && tokensSaved > 0;
     const bytesSaved = Math.max(0, numeric(record.raw_bytes) - numeric(record.emitted_bytes));
     const latency = optionalNumeric(record.wrapper_ms);
     if (latency != null) {
@@ -402,6 +431,7 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
       hour_weekday_heatmap: renderHeatmapRows(heatmap),
     },
     savings: {
+      tokens: tokenSavingsEstimate(totalTokensSaved, tokensEstimated),
       weekly_tokens_saved: weeklySeries(weeklyTokens),
       elision_rate: invocations.length === 0 ? 0 : round(elided / invocations.length),
       top_commands_by_tokens_saved: [...commandTotals.values()]

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1117,6 +1117,8 @@ describe("rsp cli", () => {
     expect(statsText).toMatch(/  raw_bytes: [1-9]\d*\n/);
     expect(statsText).toMatch(/  emitted_bytes: [1-9]\d*\n/);
     expect(statsText).toMatch(/  tokens_saved: [1-9]\d*\n/);
+    expect(statsText).toContain("  dollars_saved_estimate_usd: $");
+    expect(statsText).toContain("  pricing_model_family: gpt-5\n");
     expect(statsText).toContain("  top_commands:\n");
     expect(statsText).toContain("command: git log");
     expect(statsText).toContain("health:\n");
@@ -1145,6 +1147,7 @@ describe("rsp cli", () => {
         emitted_bytes: 800,
         tokens_raw: 2000,
         tokens_emitted: 200,
+        estimated: true,
         wrapper_ms: 15,
         store_open_count: 1,
       });
@@ -1180,11 +1183,15 @@ describe("rsp cli", () => {
     expect(text).not.toContain("{\n");
     const decoded = decode(text) as {
       window: { requested_days: number; invocations: number; degradations: number };
-      savings: { single_biggest_elision: { command_family: string; tokens_saved: number } };
+      savings: {
+        tokens: { tokens_saved_low: number; tokens_saved_high: number; dollars_saved_estimate_usd: number };
+        single_biggest_elision: { command_family: string; tokens_saved: number };
+      };
     };
     expect(decoded.window.requested_days).toBe(28);
     expect(decoded.window.invocations).toBe(2);
     expect(decoded.window.degradations).toBe(1);
+    expect(decoded.savings.tokens).toMatchObject({ tokens_saved_low: 1350, tokens_saved_high: 2250, dollars_saved_estimate_usd: 0.00225 });
     expect(decoded.savings.single_biggest_elision).toMatchObject({ command_family: "git log", tokens_saved: 1800 });
   }, 120_000);
 

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -15,6 +15,7 @@ import {
   telemetrySpoolPath,
 } from "../src/telemetry.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/config.js";
+import { tokenSavingsEstimate } from "../src/pricing.js";
 import { resolveResidentPaths } from "../src/resident-client.js";
 import { sendResidentRequest } from "../src/resident-protocol.js";
 import { runResidentServer } from "../src/resident-server.js";
@@ -35,6 +36,27 @@ afterEach(async () => {
 });
 
 describe("rsp telemetry spool", () => {
+  it("prices estimated token savings with a documented confidence range", () => {
+    expect(tokenSavingsEstimate(1000, true, "gpt-5")).toMatchObject({
+      tokens_saved: 1000,
+      tokens_saved_estimated: true,
+      token_estimate_range_pct: 0.25,
+      tokens_saved_low: 750,
+      tokens_saved_high: 1250,
+      dollars_saved_estimate_usd: 0.00125,
+      dollars_saved_low_usd: 0.000938,
+      dollars_saved_high_usd: 0.001563,
+      pricing_model_family: "gpt-5",
+    });
+    expect(tokenSavingsEstimate(1000, false, "gpt-5")).toMatchObject({
+      tokens_saved: 1000,
+      tokens_saved_estimated: false,
+      tokens_saved_low: null,
+      tokens_saved_high: null,
+      dollars_saved_estimate_usd: 0.00125,
+    });
+  });
+
   it("appends JSONL without throwing when the target is unavailable", async () => {
     const root = await tempRoot();
     await appendTelemetryEvent(root, {
@@ -419,6 +441,7 @@ describe("rsp telemetry spool", () => {
         emitted_bytes: 1000,
         tokens_raw: 500,
         tokens_emitted: 250,
+        estimated: true,
         wrapper_ms: 100,
         store_open_count: 0,
       });
@@ -461,6 +484,13 @@ describe("rsp telemetry spool", () => {
         { week_start: "2026-06-29", tokens_saved: 900, wow_delta_pct: null },
         { week_start: "2026-07-06", tokens_saved: 250, wow_delta_pct: -72.22 },
       ]);
+      expect(report.savings.tokens).toMatchObject({
+        tokens_saved: 1150,
+        tokens_saved_estimated: true,
+        tokens_saved_low: 862,
+        tokens_saved_high: 1438,
+        dollars_saved_estimate_usd: 0.001438,
+      });
       expect(report.savings.elision_rate).toBe(0.67);
       expect(report.savings.top_commands_by_tokens_saved[0]).toMatchObject({ command_family: "git log", invocations: 2, tokens_saved: 1150 });
       expect(report.savings.top_commands_by_invocation_count[0]).toMatchObject({ command_family: "git log", invocations: 2 });


### PR DESCRIPTION
Closes #1620.

Adds dollar-saved estimates (static per-model price table, no network) and confidence ranges for byte-estimated token counts to rsp gains/stats, with the statusline summary consuming the new optional field backward-compatibly.

Validation park does not reproduce: the full workspace suite passes 11/11 on the same machine that ran the gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786523662&installation_id=129708444&pr_number=1630&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1630&signature=22ba15edd1b6b8a53856b9a8b996da5e0bead028ae1a226764ea6f0e197c79fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->