### PR TITLE
feat: #1631 disabled-directory passthrough should be silent — the stderr notice is for failures, not intent

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -54,7 +54,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
   const wrapperCommand = isWrapperCommand(args.command);
   if (!config.enabled) {
-    if (wrapperCommand) return await degradeToPassthrough(rspDisabledReason(), args.positional);
+    if (wrapperCommand) return await passthroughDisabledDirectory(args.positional);
     process.stdout.write(`${rspDisabledReason()}\n`);
     return 0;
   }
@@ -587,6 +587,13 @@ async function degradeToPassthrough(reason: string, argv: readonly string[], err
     });
   }
   return status;
+}
+
+async function passthroughDisabledDirectory(argv: readonly string[]): Promise<number> {
+  if (process.env.RSP_DEBUG === "1") {
+    process.stderr.write(`rsp: ${rspDisabledReason()}, passing through\n`);
+  }
+  return await passthrough(argv);
 }
 
 function rspDisabledReason(): string {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -434,9 +434,55 @@ describe("rsp cli", () => {
 
     expect(res.status).toBe(direct.status);
     expect(res.stdout).toEqual(direct.stdout);
+    expect(res.stderr).toEqual(direct.stderr);
+    await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("restores the disabled passthrough notice under RSP_DEBUG", async () => {
+    const root = await initGitRepo();
+    await writeFile(join(root, "untracked.txt"), "raw stdout\n", "utf8");
+    const direct = runGit(["-C", root, "status", "--short"]);
+
+    const res = runRspFromCwd(root, ["git", "status", "--short"], { RSP_DEBUG: "1" });
+
+    expect(res.status).toBe(direct.status);
+    expect(res.stdout).toEqual(direct.stdout);
     expect(res.stderr.toString("utf8")).toBe(`rsp: rsp is not enabled in this directory; run /red-setup, passing through\n${direct.stderr.toString("utf8")}`);
     await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it("built bundle keeps disabled passthrough silent, debuggable, and distinct from enabled degradation", async () => {
+    buildBundleOnce();
+    const disabledRoot = await initGitRepo();
+    await writeFile(join(disabledRoot, "untracked.txt"), "raw stdout\n", "utf8");
+    const disabledDirect = runGit(["-C", disabledRoot, "status"]);
+
+    const disabled = runBundleFromCwd(disabledRoot, ["git", "status"], { RSP_DEBUG: "0" });
+
+    expect(disabled.status).toBe(disabledDirect.status);
+    expect(disabled.stdout).toEqual(disabledDirect.stdout);
+    expect(disabled.stderr).toEqual(disabledDirect.stderr);
+    await expect(stat(join(disabledRoot, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    const debug = runBundleFromCwd(disabledRoot, ["git", "status"], { RSP_DEBUG: "1" });
+
+    expect(debug.status).toBe(disabledDirect.status);
+    expect(debug.stdout).toEqual(disabledDirect.stdout);
+    expect(debug.stderr.toString("utf8")).toBe(`rsp: rsp is not enabled in this directory; run /red-setup, passing through\n${disabledDirect.stderr.toString("utf8")}`);
+
+    const degradedRoot = await initGitRepo();
+    await enableRsp(degradedRoot);
+    await writeFile(join(degradedRoot, "untracked.txt"), "raw stdout\n", "utf8");
+    const degradedDirect = runGit(["-C", degradedRoot, "status", "--short"]);
+
+    const degraded = runBundleFromCwd(degradedRoot, ["git", "-C", degradedRoot, "status", "--short"], {
+      RSP_DEBUG: "0",
+    });
+
+    expect(degraded.status).toBe(degradedDirect.status);
+    expect(degraded.stdout).toEqual(degradedDirect.stdout);
+    expect(degraded.stderr.toString("utf8")).toBe(`rsp: wrapper failed, passing through\n${degradedDirect.stderr.toString("utf8")}`);
+  }, 120_000);
 
   it("server exits inert without creating a socket when rsp is not enabled", async () => {
     const root = await tempRoot();


### PR DESCRIPTION
Automated AFK landing for #1631. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1631

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786531684&installation_id=129708444&pr_number=1632&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1632&signature=d7fbf6363159698fa2befb1dfe98724e2c7a1ee6d941100e45bca79b14be2518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->