### PR TITLE
feat: #1639 statusline rsp ticker with three significant digits

### DIFF
--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -216,6 +216,30 @@ export function humanizeCount(n: number): string {
   return String(n > 0 ? n : 0);
 }
 
+function threeSigFixed(value: number): string {
+  if (value >= 100) return value.toFixed(0);
+  if (value >= 10) return value.toFixed(1);
+  if (value >= 1) return value.toFixed(2);
+  const decimals = Math.max(2, Math.ceil(-Math.log10(value)) + 2);
+  return value.toFixed(decimals);
+}
+
+function formatThreeSigValue(value: number): string {
+  const n = Number.isFinite(value) && value > 0 ? value : 0;
+  if (n === 0) return "0";
+  if (n >= 1e9) return `${threeSigFixed(n / 1e9)}B`;
+  if (n >= 1e6) return `${threeSigFixed(n / 1e6)}M`;
+  if (n >= 1e3) return `${threeSigFixed(n / 1e3)}k`;
+  return threeSigFixed(n);
+}
+
+export function formatRspTickerValue(tokens: number): string {
+  const n = Math.max(0, Math.floor(tokens));
+  if (n < 1e3) return String(n);
+  if (n < 1e6) return `${(Math.floor(n / 100) / 10).toFixed(1)}k`;
+  return formatThreeSigValue(n);
+}
+
 /**
  * Shortens a model identifier to its friendly family token for the themed
  * per-worker `run=` label (issue #1175): `claude-opus-4-8` → `opus`, `Opus` →
@@ -437,16 +461,14 @@ export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
     const dollars = rsp.dollarsSavedTodayUsd && rsp.dollarsSavedTodayUsd > 0
       ? ` ${formatRspDollars(rsp.dollarsSavedTodayUsd)}`
       : "";
-    return `rsp ↓${humanizeCount(rsp.tokensSavedToday)}${dollars}`;
+    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}${dollars}`;
   }
-  if (rsp.state === "warming") return "rsp …";
-  return "rsp !";
+  if (rsp.state === "warming") return "rsp=…";
+  return "rsp=!";
 }
 
 function formatRspDollars(value: number): string {
-  if (value >= 1) return `$${value.toFixed(2)}`;
-  if (value >= 0.01) return `$${value.toFixed(3)}`;
-  return `$${value.toFixed(6)}`;
+  return `$${formatThreeSigValue(value)}`;
 }
 
 /**

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -706,7 +706,7 @@ describe("statusline command — rendered line", () => {
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp …");
+    expect(stripAnsi(out.text())).toContain("rsp=…");
   });
 
   it("renders rsp savings when an enabled repo has a fresh resident summary", async () => {
@@ -717,16 +717,16 @@ describe("statusline command — rendered line", () => {
     await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
     await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
       version: 1,
-      tokens_saved_today: 1300000,
+      tokens_saved_today: 1320000,
       dollars_saved_today_usd: 1.625,
       updated_at: new Date().toISOString(),
     }), "utf8");
-    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 1300000, dollarsSavedTodayUsd: 1.625 });
+    expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 1320000, dollarsSavedTodayUsd: 1.625 });
 
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp ↓1.3M $1.63");
+    expect(stripAnsi(out.text())).toContain("rsp=↓1.32M $1.63");
   });
 
   it("renders rsp savings from an old summary when the resident is idle", async () => {
@@ -746,7 +746,7 @@ describe("statusline command — rendered line", () => {
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp ↓4.2k");
+    expect(stripAnsi(out.text())).toContain("rsp=↓4.2k");
   });
 
   it("renders rsp savings as zero when the newest summary belongs to yesterday", async () => {
@@ -766,7 +766,7 @@ describe("statusline command — rendered line", () => {
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp ↓0");
+    expect(stripAnsi(out.text())).toContain("rsp=↓0");
   });
 
   it("renders rsp error when enabled and a stale wake marker produced no summary", async () => {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -160,18 +160,18 @@ describe("statusline style — header line", () => {
   it("styles rsp states from the shared render model", () => {
     const healthy = renderHeaderLine(input.project, claude, repo, undefined, "full", {
       state: "ready",
-      tokensSavedToday: 124000,
+      tokensSavedToday: 1320000,
     });
-    expect(healthy).toContain(`${GREEN}rsp ↓124k${SOFT}`);
-    expect(stripAnsi(healthy)).toContain("rsp ↓124k");
+    expect(healthy).toContain(`${GREEN}rsp=↓1.32M${SOFT}`);
+    expect(stripAnsi(healthy)).toContain("rsp=↓1.32M");
 
     const warming = renderHeaderLine(input.project, claude, repo, undefined, "full", { state: "warming" });
-    expect(warming).toContain(`${DIM}rsp …${SOFT}`);
-    expect(stripAnsi(warming)).toContain("rsp …");
+    expect(warming).toContain(`${DIM}rsp=…${SOFT}`);
+    expect(stripAnsi(warming)).toContain("rsp=…");
 
     const error = renderHeaderLine(input.project, claude, repo, undefined, "full", { state: "error" });
-    expect(error).toContain(`${RED}rsp !${SOFT}`);
-    expect(stripAnsi(error)).toContain("rsp !");
+    expect(error).toContain(`${RED}rsp=!${SOFT}`);
+    expect(stripAnsi(error)).toContain("rsp=!");
   });
 });
 

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatCacheAge,
+  formatRspTickerValue,
   humanizeAlive,
   humanizeCount,
   humanizeTokens,
@@ -132,6 +133,27 @@ describe("statusline — humanizeCount (issue #1175)", () => {
   it("renders the B tier", () => {
     expect(humanizeCount(1000000000)).toBe("1B");
     expect(humanizeCount(2300000000)).toBe("2.3B");
+  });
+});
+
+describe("statusline — formatRspTickerValue", () => {
+  it("keeps raw tokens below one thousand", () => {
+    expect(formatRspTickerValue(847)).toBe("847");
+    expect(formatRspTickerValue(999)).toBe("999");
+  });
+
+  it("renders the k tier with one decimal through the 999.9k edge", () => {
+    expect(formatRspTickerValue(1000)).toBe("1.0k");
+    expect(formatRspTickerValue(12400)).toBe("12.4k");
+    expect(formatRspTickerValue(876300)).toBe("876.3k");
+    expect(formatRspTickerValue(999949)).toBe("999.9k");
+    expect(formatRspTickerValue(999999)).toBe("999.9k");
+  });
+
+  it("renders the M tier with three significant digits", () => {
+    expect(formatRspTickerValue(1320000)).toBe("1.32M");
+    expect(formatRspTickerValue(13200000)).toBe("13.2M");
+    expect(formatRspTickerValue(132000000)).toBe("132M");
   });
 });
 
@@ -495,7 +517,7 @@ describe("statusline — full assembly", () => {
       fleet: { runner: "codex", busy: 1, total: 4, queue: 9 },
       afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
     };
-    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24 · rsp ↓1.2k");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24 · rsp=↓1.2k");
   });
 
   it("renders rsp healthy savings as one optional token in full and short presets", () => {
@@ -503,35 +525,35 @@ describe("statusline — full assembly", () => {
       project: { basename: "red-skills", branch: "main" },
       rsp: { state: "ready", tokensSavedToday: 847 },
     };
-    expect(renderStatusline(input)).toBe("red-skills (main) · rsp ↓847");
-    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp ↓847");
+    expect(renderStatusline(input)).toBe("red-skills (main) · rsp=↓847");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp=↓847");
     expect(renderStatusline({
       project: { basename: "red-skills", branch: "main" },
       rsp: { state: "ready", tokensSavedToday: 2000, dollarsSavedTodayUsd: 0.0025 },
-    })).toBe("red-skills (main) · rsp ↓2k $0.002500");
+    })).toBe("red-skills (main) · rsp=↓2.0k $0.00250");
   });
 
   it("renders rsp warming and error states without ambiguous on/off glyphs", () => {
     expect(renderStatusline({
       project: { basename: "red-skills", branch: "main" },
       rsp: { state: "warming" },
-    })).toBe("red-skills (main) · rsp …");
+    })).toBe("red-skills (main) · rsp=…");
     expect(renderStatusline({
       project: { basename: "red-skills", branch: "main" },
       rsp: { state: "error" },
-    })).toBe("red-skills (main) · rsp !");
+    })).toBe("red-skills (main) · rsp=!");
   });
 
   it("formats rsp savings with compact count tiers", () => {
-    const rendered = [0, 847, 1200, 124000, 1300000].map((tokensSavedToday) =>
+    const rendered = [0, 847, 1200, 124000, 1320000].map((tokensSavedToday) =>
       renderStatusline({ project: { basename: "red-skills" }, rsp: { state: "ready", tokensSavedToday } })
     );
     expect(rendered).toEqual([
-      "red-skills · rsp ↓0",
-      "red-skills · rsp ↓847",
-      "red-skills · rsp ↓1.2k",
-      "red-skills · rsp ↓124k",
-      "red-skills · rsp ↓1.3M",
+      "red-skills · rsp=↓0",
+      "red-skills · rsp=↓847",
+      "red-skills · rsp=↓1.2k",
+      "red-skills · rsp=↓124.0k",
+      "red-skills · rsp=↓1.32M",
     ]);
   });
 


### PR DESCRIPTION
Increase the statusline rsp ticker resolution so progress is visible: render rsp=<state-glyph><value> with three significant digits at every scale (847, 12.4k, 876.3k, 1.32M) on both plain and styled surfaces.

Worker attempt validated by the shared gate; landing was parked only by the local baseline probe (environmental rsp cli.test.ts latency failures on this host — main is green on CI).

Closes #1639

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786539719&installation_id=129708444&pr_number=1642&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1642&signature=75fe5a390f3622184641cdeb05e1c5f74f3d0667a2ac2c5dd563fb37f618f4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->