### PR TITLE
feat: #1637 rsp_compress: agent-invocable MCP compression surface

### DIFF
--- a/apps/rsp/src/mcp-server.ts
+++ b/apps/rsp/src/mcp-server.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { createInterface } from "node:readline";
 import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
+import type { RspLossLevel } from "./elision-store.js";
+import { normalizeOutput, renderGenericJsonLane } from "./normalize.js";
 import { ResidentRspElisionStore, resolveResidentPaths } from "./resident-client.js";
 
 interface JsonRpcRequest {
@@ -71,6 +73,24 @@ async function handle(request: JsonRpcRequest, config: RspRuntimeConfig): Promis
             required: ["handle"],
           },
         },
+        {
+          name: "rsp_compress",
+          description: "Compress arbitrary text or JSON through rsp normalization, JSON selection, TOON rendering, and reversible elision.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              payload: {
+                description: "Text, JSON value, or JSON-serializable payload to compress.",
+              },
+              level: {
+                type: "string",
+                enum: ["brief", "terse"],
+                description: "Compression level. Defaults to brief.",
+              },
+            },
+            required: ["payload"],
+          },
+        },
       ],
     };
   }
@@ -93,8 +113,82 @@ async function handle(request: JsonRpcRequest, config: RspRuntimeConfig): Promis
       if ("status" in record) return { content: [{ type: "text", text: JSON.stringify(record) }], isError: true };
       return { content: [{ type: "text", text: record.original.toString("utf8") }] };
     }
+    if (params?.name === "rsp_compress") {
+      return { content: [{ type: "text", text: await compressPayloadForMcp(params.arguments, store) }] };
+    }
   }
   return {};
+}
+
+async function compressPayloadForMcp(
+  args: Record<string, unknown> | undefined,
+  store: Pick<ResidentRspElisionStore, "mint">,
+): Promise<string> {
+  const input = payloadToText(args?.payload);
+  const level = mcpCompressLevel(args?.level);
+  const jsonLane = await renderGenericJsonLane(input, {
+    level,
+    command: "rsp mcp compress",
+    store,
+  });
+  if (jsonLane.detected) return ensureTrailingNewline(jsonLane.output);
+
+  const normalized = normalizeOutput(input);
+  if (level === "brief" && Buffer.byteLength(normalized) <= 2 * 1024) {
+    return ensureTrailingNewline(normalized);
+  }
+
+  const bytes = Buffer.from(input);
+  const handle = await store.mint(bytes, {
+    command: "rsp mcp compress",
+    loss: { level, bytes_elided: bytes.length },
+  });
+  return renderTextSummary(normalized, bytes.length, handle, level);
+}
+
+function payloadToText(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  if (payload == null) return "";
+  return JSON.stringify(payload);
+}
+
+function mcpCompressLevel(value: unknown): Extract<RspLossLevel, "brief" | "terse"> {
+  return value === "terse" ? "terse" : "brief";
+}
+
+function renderTextSummary(text: string, rawBytes: number, handle: string, level: "brief" | "terse"): string {
+  const inlineBytes = level === "terse" ? 1024 : 2 * 1024;
+  const bytes = Buffer.from(text);
+  const half = Math.max(1, Math.floor(inlineBytes / 2));
+  const head = truncateUtf8(bytes.subarray(0, half));
+  const tail = truncateUtf8(bytes.subarray(Math.max(0, bytes.length - half)));
+  const parts = [
+    "payload summary",
+    `bytes: ${rawBytes}`,
+    `lines: ${countLines(bytes)}`,
+    "head:",
+    head,
+  ];
+  if (tail && tail !== head) parts.push("tail:", tail);
+  parts.push(`… elided payload (+${rawBytes}) — rsp show ${handle}`);
+  return `${parts.join("\n")}\n`;
+}
+
+function ensureTrailingNewline(text: string): string {
+  return text.endsWith("\n") ? text : `${text}\n`;
+}
+
+function truncateUtf8(bytes: Buffer): string {
+  return bytes.toString("utf8").replace(/�$/g, "");
+}
+
+function countLines(bytes: Buffer): number {
+  if (bytes.length === 0) return 0;
+  let lines = 0;
+  for (const byte of bytes) {
+    if (byte === 0x0a) lines++;
+  }
+  return bytes[bytes.length - 1] === 0x0a ? lines : lines + 1;
 }
 
 function residentStore(config: RspRuntimeConfig): ResidentRspElisionStore {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -203,10 +203,17 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-async function runMcpRequests(cwd: string, requests: Array<Record<string, unknown>>): Promise<Array<Record<string, unknown>>> {
+async function runMcpRequests(
+  cwd: string,
+  requests: Array<Record<string, unknown>>,
+  entry: "source" | "bundle" = "source",
+): Promise<Array<Record<string, unknown>>> {
   return await new Promise((resolve, reject) => {
     const timeoutMs = normalizedTimeoutMs(timedStatus(runNodeNoop).elapsedMs, 250, 10_000);
-    const child = spawn(process.execPath, ["--import", tsxLoader, cli, "mcp"], {
+    const expectedResponses = requests.filter((request) => "id" in request).length;
+    if (entry === "bundle") buildBundleOnce();
+    const childArgs = entry === "bundle" ? [bundle, "mcp"] : ["--import", tsxLoader, cli, "mcp"];
+    const child = spawn(process.execPath, childArgs, {
       cwd,
       env: { ...process.env },
       stdio: ["pipe", "pipe", "pipe"],
@@ -233,7 +240,7 @@ async function runMcpRequests(cwd: string, requests: Array<Record<string, unknow
         buffer = buffer.slice(idx + 1);
         if (!line) continue;
         responses.push(JSON.parse(line) as Record<string, unknown>);
-        if (responses.length >= requests.filter((request) => "id" in request).length) {
+        if (responses.filter((response) => response.id != null).length >= expectedResponses) {
           clearTimeout(timeout);
           child.kill();
           resolve(responses);
@@ -245,7 +252,7 @@ async function runMcpRequests(cwd: string, requests: Array<Record<string, unknow
       reject(err);
     });
     child.on("close", (status) => {
-      if (responses.length < requests.filter((request) => "id" in request).length) {
+      if (responses.filter((response) => response.id != null).length < expectedResponses) {
         clearTimeout(timeout);
         reject(new Error(`rsp mcp exited early with ${status}; stdout=${stdout}; stderr=${stderr}`));
       }
@@ -508,12 +515,23 @@ describe("rsp cli", () => {
       { jsonrpc: "2.0", method: "notifications/initialized" },
       { jsonrpc: "2.0", id: 2, method: "tools/list" },
       { jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "rsp_status", arguments: {} } },
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "rsp_compress", arguments: { payload: Array.from({ length: 30 }, (_, i) => ({ id: i })) } },
+      },
     ]);
 
     const list = responses.find((response) => response.id === 2) as { result: { tools: Array<{ name: string }> } };
     const status = responses.find((response) => response.id === 3) as { result: { content: Array<{ text: string }> } };
+    const compress = responses.find((response) => response.id === 4) as {
+      result: { content: Array<{ text: string }>; isError?: boolean };
+    };
     expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status"]);
     expect(status.result.content[0]!.text).toBe("rsp is not enabled in this directory; run /red-setup");
+    expect(compress.result.isError).toBe(true);
+    expect(compress.result.content[0]!.text).toBe("rsp is not enabled in this directory; run /red-setup");
     await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -547,8 +565,106 @@ describe("rsp cli", () => {
     ]);
 
     const list = responses.find((response) => response.id === 2) as { result: { tools: Array<{ name: string }> } };
-    expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status", "rsp_stats", "rsp_show"]);
+    expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status", "rsp_stats", "rsp_show", "rsp_compress"]);
   });
+
+  it("mcp compresses large JSON and rsp_show round-trips the elided original", async () => {
+    const root = await tempRoot();
+    await enableRsp(root);
+    const payload = Array.from({ length: 60 }, (_, i) => ({
+      id: i,
+      status: i === 27 ? 500 : 200,
+      latency: i === 33 ? 4_500 : i,
+      label: `row-${i}`,
+    }));
+    const original = JSON.stringify(payload);
+
+    const compressedResponses = await runMcpRequests(root, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "rsp_compress", arguments: { payload: original, level: "terse" } },
+      },
+    ]);
+
+    const compressed = compressedResponses.find((response) => response.id === 2) as {
+      result: { content: Array<{ text: string }> };
+    };
+    const text = compressed.result.content[0]!.text;
+    expect(text).toContain("items: 15 of 60 kept");
+    expect(text).toContain("items[15]{id,status,latency,label}");
+    const handle = /rsp show (el:[a-f0-9]{12})/.exec(text)?.[1];
+    expect(handle).toBeTruthy();
+
+    const shownResponses = await runMcpRequests(root, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "rsp_show", arguments: { handle } },
+      },
+    ]);
+
+    const shown = shownResponses.find((response) => response.id === 2) as {
+      result: { content: Array<{ text: string }> };
+    };
+    expect(shown.result.content[0]!.text).toBe(original);
+  });
+
+  it("built bundle mcp compress honors disabled gates and round-trips large JSON", async () => {
+    const disabledRoot = await tempRoot();
+    const disabledResponses = await runMcpRequests(disabledRoot, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "rsp_compress", arguments: { payload: [{ id: 1 }], level: "brief" } },
+      },
+    ], "bundle");
+    const disabled = disabledResponses.find((response) => response.id === 2) as {
+      result: { content: Array<{ text: string }>; isError?: boolean };
+    };
+    expect(disabled.result.isError).toBe(true);
+    expect(disabled.result.content[0]!.text).toBe("rsp is not enabled in this directory; run /red-setup");
+    await expect(stat(join(disabledRoot, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    const root = await tempRoot();
+    await enableRsp(root);
+    const payload = Array.from({ length: 60 }, (_, i) => ({ id: i, value: i, error: i === 41 ? "boom" : "" }));
+    const original = JSON.stringify(payload);
+    const compressedResponses = await runMcpRequests(root, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "rsp_compress", arguments: { payload: original, level: "terse" } },
+      },
+    ], "bundle");
+    const compressed = compressedResponses.find((response) => response.id === 2) as {
+      result: { content: Array<{ text: string }> };
+    };
+    const handle = /rsp show (el:[a-f0-9]{12})/.exec(compressed.result.content[0]!.text)?.[1];
+    expect(handle).toBeTruthy();
+
+    const shownResponses = await runMcpRequests(root, [
+      { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "rsp_show", arguments: { handle } },
+      },
+    ], "bundle");
+    const shown = shownResponses.find((response) => response.id === 2) as {
+      result: { content: Array<{ text: string }> };
+    };
+    expect(shown.result.content[0]!.text).toBe(original);
+  }, 120_000);
 
   it("built bundle starts the resident on cold small git status", async () => {
     buildBundleOnce();


### PR DESCRIPTION
Automated AFK landing for #1637. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1637

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786540028&installation_id=129708444&pr_number=1643&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1643&signature=99ed264bee0066324a5ba19f63c760dc04428c5f95591bcd96f0bef68927bdff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->