### PR TITLE
fix: #1646 rsp resident drain permanently fails on veteran stores: INVALID_OPERATION model mismatch (expected kv, got table)

### DIFF
--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -113,10 +113,20 @@ interface TelemetryIndexDocument {
   records: TelemetryIndexEntry[];
 }
 
+interface TelemetryCollectionHeal {
+  collection: typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION | typeof RSP_TELEMETRY_INDEX_COLLECTION;
+  previousModel: string;
+}
+
 const TOKENIZATION_CAP_BYTES = 256 * 1024;
 const TOKENIZATION_TIMEOUT_MS = 500;
 const TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
 const RSP_STATUS_SUMMARY = join(".red", "tmp", "rsp-status-summary.json");
+const TELEMETRY_KV_COLLECTIONS = [
+  RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+  RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+  RSP_TELEMETRY_INDEX_COLLECTION,
+] as const;
 
 class ResidentTelemetryDrain {
   private running?: Promise<void>;
@@ -136,8 +146,18 @@ class ResidentTelemetryDrain {
   private async drainAndSweepOnce(): Promise<void> {
     const db = this.store.redDb();
     if (!db) return;
+    const healed = await ensureTelemetryKvCollections(db);
     const index = await this.readIndex(db);
     const nextRecords = [...index.records];
+    for (const entry of healed) {
+      nextRecords.push(await this.writeDrainDegradation(db, {
+        reason: "telemetry collection model mismatch",
+        command: "rsp resident telemetry drain",
+        source_collection: entry.collection,
+        error: `expected kv, got ${entry.previousModel}`,
+        bytes: 0,
+      }));
+    }
     await drainTelemetrySpool(this.opts.rootDir, async (line) => {
       const event = parseTelemetryEvent(line);
       if (!event) {
@@ -273,6 +293,60 @@ async function safeDrainTelemetry(telemetry: ResidentTelemetryDrain, timeoutMs =
   } catch (err) {
     process.stderr.write(`rsp resident: telemetry drain failed: ${err instanceof Error ? err.message : String(err)}\n`);
   }
+}
+
+async function ensureTelemetryKvCollections(db: RedDB): Promise<TelemetryCollectionHeal[]> {
+  const healed: TelemetryCollectionHeal[] = [];
+  for (const collection of TELEMETRY_KV_COLLECTIONS) {
+    const probe = await probeTelemetryKvCollection(db, collection);
+    if (probe.ok) continue;
+    if (probe.previousModel) {
+      if (probe.previousModel !== "collection") await dropTelemetryCollection(db, collection, probe.previousModel);
+      healed.push({ collection, previousModel: probe.previousModel });
+    }
+    await db.query(`CREATE KV IF NOT EXISTS ${sqlIdentifier(collection)}`);
+  }
+  return healed;
+}
+
+async function probeTelemetryKvCollection(
+  db: RedDB,
+  collection: typeof TELEMETRY_KV_COLLECTIONS[number],
+): Promise<{ ok: true } | { ok: false; previousModel: string | null }> {
+  try {
+    await db.kv(collection).get("__rsp_telemetry_model_probe__");
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/\bnot found\b/i.test(message)) return { ok: false, previousModel: null };
+    const mismatch = message.match(/model mismatch: expected kv, got ([A-Za-z_][A-Za-z0-9_]*)/i);
+    if (mismatch?.[1]) return { ok: false, previousModel: mismatch[1].toLowerCase() };
+    if (/does not allow 'kv' operations/i.test(message)) return { ok: false, previousModel: "collection" };
+    const meta = (await db.list()).find((entry) => entry.name === collection);
+    if (meta && meta.model !== "kv") return { ok: false, previousModel: meta.model };
+    throw err;
+  }
+}
+
+async function dropTelemetryCollection(db: RedDB, collection: string, model: string): Promise<void> {
+  const kind = ddlKind(model);
+  if (!kind) throw new Error(`cannot self-heal telemetry collection ${collection}: unsupported model ${model}`);
+  await db.query(`DROP ${kind} ${sqlIdentifier(collection)}`);
+}
+
+function ddlKind(model: string): string | null {
+  const normalized = model.toLowerCase();
+  if (normalized === "table") return "TABLE";
+  if (normalized === "kv") return "KV";
+  if (normalized === "graph") return "GRAPH";
+  if (normalized === "queue") return "QUEUE";
+  if (normalized === "document" || normalized === "documents") return "DOCUMENT";
+  return null;
+}
+
+function sqlIdentifier(value: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`invalid telemetry collection name: ${value}`);
+  return value;
 }
 
 async function enrichTelemetryEvent(event: RspTelemetryEvent): Promise<RspTelemetryEvent> {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -11,6 +11,7 @@ import {
   drainTelemetrySpool,
   readTelemetryGainsReport,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+  RSP_TELEMETRY_INDEX_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
   telemetrySpoolPath,
 } from "../src/telemetry.js";
@@ -350,6 +351,68 @@ describe("rsp telemetry spool", () => {
     });
   }, 40_000);
 
+  it("self-heals old-model telemetry collections in the built bundle resident", async () => {
+    const root = await tempRoot();
+    const bundle = await ensureRspBundle();
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const seeded = await connect(storeUri);
+    try {
+      await seeded.query(`CREATE TABLE ${RSP_TELEMETRY_INVOCATIONS_COLLECTION} (id TEXT)`);
+      await seeded.query(`CREATE TABLE ${RSP_TELEMETRY_DEGRADATIONS_COLLECTION} (id TEXT)`);
+      await seeded.query(`CREATE TABLE ${RSP_TELEMETRY_INDEX_COLLECTION} (id TEXT)`);
+    } finally {
+      await seeded.close();
+    }
+
+    await writeFile(telemetrySpoolPath(root), `${JSON.stringify({
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "legacy-model-event",
+      command: "git log",
+    })}\n`, "utf8");
+
+    const paths = resolveResidentPaths(root);
+    const child = execFile(process.execPath, [
+      bundle,
+      "server",
+      "--socket",
+      paths.socketPath,
+      "--store-uri",
+      storeUri,
+      "--ttl-days",
+      String(DEFAULT_RSP_TTL_DAYS),
+      "--byte-budget",
+      String(DEFAULT_RSP_BYTE_BUDGET),
+      "--telemetry-drain-timeout-ms",
+      String(await calibratedTelemetryDrainTimeoutMs(root)),
+      "--idle-ms",
+      "100",
+    ], { cwd: root });
+    await waitForResident(paths.socketPath);
+    await new Promise<void>((resolve, reject) => {
+      child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`bundle resident exited ${code}`)));
+      child.once("error", reject);
+    });
+
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
+    await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "legacy-model-event")).resolves.toMatchObject({
+      id: "legacy-model-event",
+      command: "git log",
+    });
+    await expect(readTelemetryRecords(storeUri, RSP_TELEMETRY_DEGRADATIONS_COLLECTION)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reason: "telemetry collection model mismatch",
+          source_collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+        }),
+      ]),
+    );
+    await expect(readTelemetryCollectionModels(storeUri)).resolves.toMatchObject({
+      [RSP_TELEMETRY_INVOCATIONS_COLLECTION]: "kv",
+      [RSP_TELEMETRY_DEGRADATIONS_COLLECTION]: "kv",
+      [RSP_TELEMETRY_INDEX_COLLECTION]: "kv",
+    });
+  }, 40_000);
+
   it("periodically drains telemetry spooled while the built bundle resident is alive and reports stats", async () => {
     const root = await tempRoot();
     const bundle = await ensureRspBundle();
@@ -539,6 +602,33 @@ async function readTelemetry(storeUri: string, collection: string, key: string):
   try {
     const raw = await db.kv(collection).get(key);
     return typeof raw === "string" ? JSON.parse(raw) as unknown : raw;
+  } finally {
+    await db.close();
+  }
+}
+
+async function readTelemetryRecords(storeUri: string, collection: string): Promise<unknown[]> {
+  const db = await connect(storeUri);
+  try {
+    const raw = await db.kv(collection).list({ limit: 1000 });
+    return raw.items.map((entry) => typeof entry.value === "string" ? JSON.parse(entry.value) as unknown : entry.value);
+  } finally {
+    await db.close();
+  }
+}
+
+async function readTelemetryCollectionModels(storeUri: string): Promise<Record<string, string>> {
+  const db = await connect(storeUri);
+  try {
+    return Object.fromEntries(
+      (await db.list())
+        .filter((entry) => [
+          RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+          RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+          RSP_TELEMETRY_INDEX_COLLECTION,
+        ].includes(entry.name))
+        .map((entry) => [entry.name, entry.model]),
+    );
   } finally {
     await db.close();
   }


### PR DESCRIPTION
Automated AFK landing for #1646. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1646

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786548639&installation_id=129708444&pr_number=1650&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1650&signature=a973b1863d65e22bb6c968440baccc6f54dfd40e88ea6f679038b7dd0c6080be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->