### PR TITLE
fix: #1645 rsp cold-path telemetry never surfaces: spooled savings stay invisible until a store-needing command happens to warm the resident

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { appendFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
@@ -455,7 +455,7 @@ class ColdRspElisionStore implements ElisionStoreLike {
 
 async function runColdWrappedCommand(
   args: ParsedArgs,
-  config: Pick<RspRuntimeConfig, "heavyGitByteThreshold">,
+  config: RspRuntimeConfig,
   telemetryRoot: string,
   err?: unknown,
 ): Promise<number> {
@@ -468,7 +468,7 @@ async function runColdWrappedCommand(
   try {
     if (args.command === "git") {
       if (isFastGitStatus(args.positional)) {
-        return await emitWrappedResult(args, await runFastGitStatus(), started, store, telemetryRoot);
+        return await emitWrappedResult(args, await runFastGitStatus(), started, store, telemetryRoot, config);
       }
       const { runGitWrapper } = await import("./git-wrapper.js");
       const result = await runGitWrapper(args.positional, {
@@ -476,19 +476,19 @@ async function runColdWrappedCommand(
         store,
         heavyGitByteThreshold: config.heavyGitByteThreshold,
       });
-      return await emitWrappedResult(args, result, started, store, telemetryRoot);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot, config);
     }
 
     if (args.command === "gh") {
       const { runGhWrapper } = await import("./gh-wrapper.js");
       const result = await runGhWrapper(args.positional, { level: args.level, store });
-      return await emitWrappedResult(args, result, started, store, telemetryRoot);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot, config);
     }
 
     if (args.command === "vitest" || args.command === "cargo") {
       const { runTestWrapper } = await import("./test-wrapper.js");
       const result = await runTestWrapper(args.positional, { level: args.level, store });
-      return await emitWrappedResult(args, result, started, store, telemetryRoot);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot, config);
     }
 
     if (args.command === "cat") {
@@ -498,7 +498,7 @@ async function runColdWrappedCommand(
         store,
         heavyByteThreshold: config.heavyGitByteThreshold,
       });
-      return await emitWrappedResult(args, result, started, store, telemetryRoot);
+      return await emitWrappedResult(args, result, started, store, telemetryRoot, config);
     }
 
     if (args.command === "exec") {
@@ -525,12 +525,14 @@ async function emitWrappedResult(
   started: bigint,
   store?: InvocationTelemetryStore,
   telemetryRoot = process.cwd(),
+  coldNudgeConfig?: RspRuntimeConfig,
 ): Promise<number> {
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
   const wrapperMs = Number(process.hrtime.bigint() - started) / 1_000_000;
   if (store) {
     await appendInvocationTelemetry(telemetryRoot, args, result, wrapperMs, store.lastResponseMetrics());
+    if (coldNudgeConfig) await nudgeColdTelemetryDrain(telemetryRoot, coldNudgeConfig);
   } else {
     appendFastInvocationTelemetry(telemetryRoot, args, result, wrapperMs);
   }
@@ -539,6 +541,44 @@ async function emitWrappedResult(
     return 128;
   }
   return result.status ?? 0;
+}
+
+async function nudgeColdTelemetryDrain(telemetryRoot: string, config: RspRuntimeConfig): Promise<void> {
+  try {
+    const spoolPath = join(telemetryRoot, ".red", "tmp", "rsp-telemetry.spool.jsonl");
+    const stat = statSync(spoolPath);
+    const staleMs = config.telemetryDrainIntervalMs * 2;
+    if (stat.size < config.telemetryByteBudget && !spoolHasEventOlderThan(spoolPath, Date.now() - staleMs)) return;
+    const { kickResidentServer, resolveResidentPaths } = await import("./resident-client.js");
+    await kickResidentServer(resolveResidentPaths(telemetryRoot), {
+      storeUri: config.storeUri,
+      ttlDays: config.ttlDays,
+      byteBudget: config.byteBudget,
+      telemetryTtlDays: config.telemetryTtlDays,
+      telemetryByteBudget: config.telemetryByteBudget,
+      telemetryDrainIntervalMs: config.telemetryDrainIntervalMs,
+      telemetryDrainTimeoutMs: config.telemetryDrainTimeoutMs,
+      idleMs: config.idleMs,
+    });
+  } catch {}
+}
+
+function spoolHasEventOlderThan(path: string, cutoffMs: number): boolean {
+  try {
+    const text = readFileSync(path, "utf8");
+    for (const line of text.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        const parsed = JSON.parse(line) as { created_at?: unknown; ts?: unknown };
+        const timestamp = typeof parsed.created_at === "string" ? parsed.created_at : parsed.ts;
+        if (typeof timestamp === "string") {
+          const ms = Date.parse(timestamp);
+          if (Number.isFinite(ms) && ms <= cutoffMs) return true;
+        }
+      } catch {}
+    }
+  } catch {}
+  return false;
 }
 
 async function appendInvocationTelemetry(

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -33,7 +33,12 @@ async function tempRoot(): Promise<string> {
 }
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  await Promise.all(roots.splice(0).map((root) => rm(root, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 50,
+  })));
 });
 
 describe("rsp telemetry spool", () => {
@@ -469,6 +474,50 @@ describe("rsp telemetry spool", () => {
       child.once("error", reject);
     });
   }, 40_000);
+
+  it("nudges the built bundle resident after cold-path-only telemetry gets stale", async () => {
+    const root = await tempRoot();
+    const bundle = await ensureRspBundle();
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const staleCreatedAt = new Date(Date.now() - 60_000).toISOString();
+    await writeFile(telemetrySpoolPath(root), `${JSON.stringify({
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "stale-cold-event",
+      created_at: staleCreatedAt,
+      ts: staleCreatedAt,
+      command: "git log --terse",
+      elided: true,
+      raw_bytes: 1000,
+      emitted_bytes: 100,
+      raw_text: "alpha ".repeat(100),
+      emitted_text: "alpha",
+    })}\n`, "utf8");
+
+    try {
+      const { stdout } = await execFileAsync(process.execPath, [
+        bundle,
+        "cat",
+        ".red/config.yaml",
+      ], {
+        cwd: root,
+        env: {
+          ...process.env,
+          RSP_STORE_URI: storeUri,
+          RSP_TELEMETRY_DRAIN_INTERVAL_MS: "50",
+          RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(await calibratedTelemetryDrainTimeoutMs(root)),
+        },
+      });
+      expect(stdout).toContain("rsp:");
+
+      await waitForResidentTelemetry(paths.socketPath, "git log --terse");
+      await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
+      await expect(readFile(paths.summaryPath, "utf8")).resolves.toContain("tokens_saved_today");
+    } finally {
+      await shutdownResident(paths.socketPath);
+    }
+  }, 40_000);
+
   it("aggregates rsp gains percentiles, buckets, rankings, and health", async () => {
     const root = await tempRoot();
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
@@ -675,6 +724,24 @@ async function waitForResidentTelemetry(socketPath: string, command: string): Pr
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`telemetry ${command} did not drain`);
+}
+
+async function shutdownResident(socketPath: string): Promise<void> {
+  await sendResidentRequest({ socketPath, timeoutMs: 500 }, {
+    id: "shutdown",
+    op: "handover",
+    clientVersion: "test-shutdown",
+  }).catch(() => null);
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const alive = await sendResidentRequest({ socketPath, timeoutMs: 100 }, {
+      id: "shutdown-poll",
+      op: "ping",
+    }).then((response) => response.ok, () => false);
+    if (!alive) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("resident did not shut down");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
Automated AFK landing for #1645. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1645

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786549151&installation_id=129708444&pr_number=1652&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1652&signature=20829462e8b9e7a3aaa2ddc4431c5e71c8c50965a4d313677ddc022a74a9b22b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->