### PR TITLE
fix: #1648 rsp process hygiene — resident teardown, idle watchdog, rpc child reaping

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -76,6 +76,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     }
     await runResidentServer({
       socketPath: socket,
+      pidPath: valueAfter(args.positional, "--pid-file") ?? resolveResidentPaths(process.cwd()).pidPath,
       storeUri: serverConfig.storeUri,
       ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? serverConfig.ttlDays,
       byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? serverConfig.byteBudget,

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
@@ -23,6 +24,7 @@ import { DEFAULT_RSP_IDLE_MS, DEFAULT_RSP_TELEMETRY_BYTE_BUDGET, DEFAULT_RSP_TEL
 
 export interface ResidentServerOptions extends RspResidentConfig {
   socketPath: string;
+  pidPath?: string;
   rootDir?: string;
   idleMs?: number;
   residentVersion?: string;
@@ -32,6 +34,8 @@ export interface ResidentServerOptions extends RspResidentConfig {
 
 export async function runResidentServer(opts: ResidentServerOptions): Promise<void> {
   await mkdir(dirname(opts.socketPath), { recursive: true });
+  const redRpcGuard = startRedRpcParentDeathGuard();
+  installRedRpcExitCleanup();
 
   const openedAt = process.hrtime.bigint();
   const store = await RspElisionStore.open({
@@ -52,29 +56,53 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
 
   const idleMs = opts.idleMs ?? DEFAULT_RSP_IDLE_MS;
   let idleTimer: NodeJS.Timeout | undefined;
+  let idleShutdownWatchdog: NodeJS.Timeout | undefined;
+  let idleShutdownStarted = false;
+  const activeSockets = new Set<Socket>();
   const telemetryDrainIntervalMs = opts.telemetryDrainIntervalMs ?? 30_000;
   const telemetryTimer = setInterval(() => {
     void safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
   }, telemetryDrainIntervalMs);
   telemetryTimer.unref();
   const server = createServer((socket) => {
+    activeSockets.add(socket);
+    socket.once("close", () => activeSockets.delete(socket));
     touch();
     handleSocket(socket, async (request) => {
       touch();
       const value = await handleRequest(store, request, opts.storeUri, opts.residentVersion ?? "0.0.0-dev");
       const response: RspResidentResponse = { id: request.id, ok: true, value, storeOpenCount, storeElapsedMs };
       socket.write(`${JSON.stringify(response)}\n`);
-      if (request.op === "handover") setImmediate(() => server.close());
+      if (request.op === "handover") setImmediate(() => beginShutdown());
     });
   });
+
+  function beginShutdown(): void {
+    idleShutdownStarted = true;
+    idleShutdownWatchdog = armIdleShutdownWatchdog(idleShutdownWatchdog);
+    server.close();
+    for (const socket of activeSockets) socket.destroy();
+  }
 
   function touch(): void {
     if (idleTimer) clearTimeout(idleTimer);
     idleTimer = setTimeout(() => {
-      server.close();
+      beginShutdown();
     }, idleMs);
     idleTimer.unref();
   }
+
+  const shutdownSignals = ["SIGINT", "SIGTERM"] as const;
+  const signalHandlers = shutdownSignals.map((signal) => {
+    const handler = () => {
+      cleanupRedRpcChildrenSync();
+      server.close();
+      for (const socket of activeSockets) socket.destroy();
+      setTimeout(() => process.exit(0), 1_000);
+    };
+    process.once(signal, handler);
+    return { signal, handler };
+  });
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -83,15 +111,23 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
       resolve();
     });
   });
+  if (opts.pidPath) {
+    await writeFile(opts.pidPath, `${process.pid}\n`, { encoding: "utf8", mode: 0o600 });
+  }
   touch();
 
   await new Promise<void>((resolve) => server.once("close", resolve));
   storeOpenCount = 0;
   if (idleTimer) clearTimeout(idleTimer);
   clearInterval(telemetryTimer);
-  await safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
-  await store.close();
   await rm(opts.socketPath, { force: true });
+  await safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs, idleShutdownStarted);
+  await store.close();
+  if (idleShutdownWatchdog) clearTimeout(idleShutdownWatchdog);
+  for (const { signal, handler } of signalHandlers) process.off(signal, handler);
+  redRpcGuard?.kill("SIGTERM");
+  cleanupRedRpcChildrenSync();
+  if (opts.pidPath) await rm(opts.pidPath, { force: true });
 }
 
 interface ResidentTelemetryOptions {
@@ -121,6 +157,10 @@ interface TelemetryCollectionHeal {
 const TOKENIZATION_CAP_BYTES = 256 * 1024;
 const TOKENIZATION_TIMEOUT_MS = 500;
 const TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
+const IDLE_SHUTDOWN_WATCHDOG_MS = Math.max(
+  1,
+  Number(process.env.RSP_TEST_IDLE_SHUTDOWN_WATCHDOG_MS ?? "10000"),
+);
 const RSP_STATUS_SUMMARY = join(".red", "tmp", "rsp-status-summary.json");
 const TELEMETRY_KV_COLLECTIONS = [
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -287,8 +327,15 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
   await rename(tmp, path);
 }
 
-async function safeDrainTelemetry(telemetry: ResidentTelemetryDrain, timeoutMs = TELEMETRY_DRAIN_TIMEOUT_MS): Promise<void> {
+async function safeDrainTelemetry(
+  telemetry: ResidentTelemetryDrain,
+  timeoutMs = TELEMETRY_DRAIN_TIMEOUT_MS,
+  allowTestHang = false,
+): Promise<void> {
   try {
+    if (allowTestHang && process.env.RSP_TEST_HANG_TELEMETRY_DRAIN === "1") {
+      await new Promise(() => undefined);
+    }
     await withTimeout(telemetry.drainAndSweep(), timeoutMs, "telemetry drain timed out");
   } catch (err) {
     process.stderr.write(`rsp resident: telemetry drain failed: ${err instanceof Error ? err.message : String(err)}\n`);
@@ -347,6 +394,102 @@ function ddlKind(model: string): string | null {
 function sqlIdentifier(value: string): string {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`invalid telemetry collection name: ${value}`);
   return value;
+}
+
+function armIdleShutdownWatchdog(existing: NodeJS.Timeout | undefined): NodeJS.Timeout {
+  if (existing) clearTimeout(existing);
+  return setTimeout(() => {
+    cleanupRedRpcChildrenSync();
+    process.exit(0);
+  }, IDLE_SHUTDOWN_WATCHDOG_MS);
+}
+
+let redRpcExitCleanupInstalled = false;
+
+function installRedRpcExitCleanup(): void {
+  if (redRpcExitCleanupInstalled) return;
+  redRpcExitCleanupInstalled = true;
+  process.on("exit", () => cleanupRedRpcChildrenSync());
+}
+
+function startRedRpcParentDeathGuard(): ReturnType<typeof spawn> | undefined {
+  if (process.platform === "win32") return undefined;
+  const script = `
+const { execFileSync } = require("node:child_process");
+const parentPid = Number(process.argv[1]);
+const known = new Set();
+function rows() {
+  try {
+    return String(execFileSync("ps", ["-eo", "pid=,ppid=,args="], { encoding: "utf8" }))
+      .split(/\\n/)
+      .map((line) => /^\\s*(\\d+)\\s+(\\d+)\\s+([\\s\\S]*)$/.exec(line))
+      .filter(Boolean)
+      .map((m) => ({ pid: Number(m[1]), ppid: Number(m[2]), args: m[3] || "" }));
+  } catch {
+    return [];
+  }
+}
+function isRedRpc(args) {
+  return /(^|\\s)\\S*red(?:\\.exe)?\\s+rpc\\s+--stdio(\\s|$)/.test(args);
+}
+function alive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+const timer = setInterval(() => {
+  const parentAlive = alive(parentPid);
+  const snapshot = rows();
+  for (const row of snapshot) {
+    if (row.ppid === parentPid && isRedRpc(row.args)) known.add(row.pid);
+  }
+  if (parentAlive) return;
+  for (const row of snapshot) {
+    if (known.has(row.pid) && isRedRpc(row.args)) {
+      try { process.kill(row.pid, "SIGKILL"); } catch {}
+    }
+  }
+  clearInterval(timer);
+  process.exit(0);
+}, 500);
+`;
+  const child = spawn(process.execPath, ["-e", script, String(process.pid)], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child;
+}
+
+function cleanupRedRpcChildrenSync(): void {
+  for (const pid of redRpcChildPidsSync()) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {}
+  }
+}
+
+function redRpcChildPidsSync(): number[] {
+  if (process.platform === "win32") return [];
+  let output = "";
+  try {
+    output = execFileSync("ps", ["-eo", "pid=,ppid=,args="], { encoding: "utf8" });
+  } catch {
+    return [];
+  }
+  const pids: number[] = [];
+  for (const line of output.split(/\n/)) {
+    const match = /^\s*(\d+)\s+(\d+)\s+([\s\S]*)$/.exec(line);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    const ppid = Number(match[2]);
+    const args = match[3] ?? "";
+    if (ppid === process.pid && /(^|\s)\S*red(?:\.exe)?\s+rpc\s+--stdio(\s|$)/.test(args)) pids.push(pid);
+  }
+  return pids;
 }
 
 async function enrichTelemetryEvent(event: RspTelemetryEvent): Promise<RspTelemetryEvent> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -7,7 +7,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { createServer, type Server, type Socket } from "node:net";
 import { connect } from "@reddb-io/sdk";
 import { decode } from "@reddb-io/toon";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { RspElisionStore } from "../src/elision-store.js";
 import { resolveResidentPaths } from "../src/resident-client.js";
 import { sendResidentRequest } from "../src/resident-protocol.js";
@@ -19,6 +19,7 @@ import {
 
 const roots: string[] = [];
 const residentDirs: string[] = [];
+const residentPathsBySocket = new Map<string, ReturnType<typeof resolveResidentPaths>>();
 const cli = join(import.meta.dirname, "..", "src", "cli.ts");
 const packageRoot = join(import.meta.dirname, "..");
 const repoRoot = join(packageRoot, "..", "..");
@@ -35,13 +36,19 @@ async function tempRoot(): Promise<string> {
 
 afterEach(async () => {
   const rootsToRemove = roots.splice(0);
+  await stopTrackedResidents(rootsToRemove);
   const residentDirsToRemove = residentDirs.splice(0);
   await Promise.all(rootsToRemove.map((root) => rm(root, { recursive: true, force: true })));
   await Promise.all(residentDirsToRemove.map((dir) => rm(dir, { recursive: true, force: true })));
 });
 
+afterAll(async () => {
+  await stopTrackedResidents([]);
+});
+
 function trackedResidentPaths(root: string) {
   const paths = resolveResidentPaths(root);
+  residentPathsBySocket.set(paths.socketPath, paths);
   residentDirs.push(dirname(paths.socketPath));
   return paths;
 }
@@ -439,6 +446,93 @@ function extractHandle(output: Buffer): string {
   return match![1];
 }
 
+async function stopTrackedResidents(extraRoots: string[]): Promise<void> {
+  const paths = uniqueResidentPaths(extraRoots);
+  residentPathsBySocket.clear();
+  await Promise.all(paths.map((path) => stopResident(path)));
+}
+
+function uniqueResidentPaths(extraRoots: string[]): Array<ReturnType<typeof resolveResidentPaths>> {
+  const paths = new Map(residentPathsBySocket);
+  for (const root of extraRoots) {
+    const resolved = resolveResidentPaths(root);
+    paths.set(resolved.socketPath, resolved);
+  }
+  return [...paths.values()];
+}
+
+async function countTrackedResidentProcesses(extraRoots: string[] = []): Promise<number> {
+  let count = 0;
+  for (const paths of uniqueResidentPaths(extraRoots)) {
+    const pid = await readPid(paths.pidPath);
+    if (pid != null && isPidAlive(pid)) count++;
+  }
+  return count;
+}
+
+async function stopResident(paths: ReturnType<typeof resolveResidentPaths>): Promise<void> {
+  const pid = await readPid(paths.pidPath);
+  if (await pathExists(paths.socketPath)) {
+    await sendResidentRequest(
+      { socketPath: paths.socketPath, timeoutMs: 500 },
+      { id: randomUUID(), op: "handover", clientVersion: "9999.0.0" },
+    ).catch(() => undefined);
+    await waitForGone(paths.socketPath, normalizedDurationMs(2_000)).catch(() => undefined);
+  }
+  if (pid != null && pid !== process.pid && isPidAlive(pid)) {
+    killResidentPid(pid, "SIGTERM");
+    await waitForPidGone(pid, normalizedDurationMs(1_000)).catch(() => {
+      killResidentPid(pid, "SIGKILL");
+    });
+    await waitForPidGone(pid, normalizedDurationMs(1_000)).catch(() => undefined);
+  }
+  await rm(paths.socketPath, { force: true });
+  await rm(paths.pidPath, { force: true });
+}
+
+async function readPid(path: string): Promise<number | null> {
+  const text = await readFile(path, "utf8").catch(() => "");
+  const pid = Number(text.trim());
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killResidentPid(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {}
+  }
+}
+
+async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  if (isPidAlive(pid)) throw new Error(`process ${pid} still alive after ${timeoutMs}ms`);
+}
+
 describe("rsp cli", () => {
   it("normalizes latency budgets to the sampled baseline and still catches regressions", async () => {
     expect(localBaselineRatio(100)).toBe(4);
@@ -709,6 +803,69 @@ describe("rsp cli", () => {
     expect(res.stdout).toEqual(direct.stdout);
     expect(res.stderr).toEqual(Buffer.alloc(0));
     await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+  }, 120_000);
+
+  it("built bundle teardown stops every spawned resident process", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const paths = trackedResidentPaths(root);
+
+    const res = runBundleFromCwd(root, ["git", "status"], {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_FAIL_IF_STORE_OPEN: "1",
+      RSP_IDLE_MS: String(normalizedDurationMs(30_000)),
+    });
+
+    expect(res.status, `${res.stdout.toString("utf8")}${res.stderr.toString("utf8")}`).toBe(0);
+    await waitForResidentSocket(root);
+    await expect(readPid(paths.pidPath)).resolves.toEqual(expect.any(Number));
+    expect(await countTrackedResidentProcesses()).toBe(1);
+
+    await stopTrackedResidents([]);
+
+    expect(await countTrackedResidentProcesses([root])).toBe(0);
+  }, 120_000);
+
+  it("built bundle idle resident exits even when final telemetry drain hangs", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+    const paths = trackedResidentPaths(root);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    const started = Date.now();
+    const child = spawn(process.execPath, [
+      bundle,
+      "server",
+      "--idle-ms",
+      "100",
+      "--telemetry-drain-timeout-ms",
+      "60000",
+    ], {
+      cwd: root,
+      env: {
+        ...process.env,
+        RED_SKILLS_CACHE_DIR: cacheDir,
+        RSP_TEST_HANG_TELEMETRY_DRAIN: "1",
+        RSP_TEST_IDLE_SHUTDOWN_WATCHDOG_MS: String(normalizedDurationMs(500)),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+
+    await waitForResidentSocket(root);
+    const status = await closeWithTimeout(child, normalizedDurationMs(5_000));
+
+    expect(status, `${Buffer.concat(stdout).toString("utf8")}${Buffer.concat(stderr).toString("utf8")}`).toBe(0);
+    expect(Date.now() - started).toBeLessThan(normalizedDurationMs(10_000));
+    await expect(stat(paths.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await countTrackedResidentProcesses()).toBe(0);
   }, 120_000);
 
   it("built bundle pre-exec hook passes through while cold, warms once, then rewrites when healthy", async () => {

--- a/apps/rsp/tests/setup.test.ts
+++ b/apps/rsp/tests/setup.test.ts
@@ -1,11 +1,14 @@
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "../src/config.js";
 import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/elision-store.js";
+import { resolveResidentPaths } from "../src/resident-client.js";
+import { sendResidentRequest } from "../src/resident-protocol.js";
 import { mergeRspBlock, provisionRspRepoStore } from "../src/setup.js";
 
 const roots: string[] = [];
@@ -19,9 +22,75 @@ async function tempRoot(): Promise<string> {
 }
 
 afterEach(async () => {
-  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  const rootsToRemove = roots.splice(0);
+  await Promise.all(rootsToRemove.map((root) => stopResidentForRoot(root)));
+  await Promise.all(rootsToRemove.map((root) => rm(root, { recursive: true, force: true })));
   delete process.env.REDDB_BIN;
 });
+
+afterAll(async () => {
+  await Promise.all(roots.splice(0).map((root) => stopResidentForRoot(root)));
+});
+
+async function stopResidentForRoot(root: string): Promise<void> {
+  const paths = resolveResidentPaths(root);
+  const pid = await readPid(paths.pidPath);
+  if (await pathExists(paths.socketPath)) {
+    await sendResidentRequest(
+      { socketPath: paths.socketPath, timeoutMs: 500 },
+      { id: randomUUID(), op: "handover", clientVersion: "9999.0.0" },
+    ).catch(() => undefined);
+  }
+  if (pid != null && isPidAlive(pid)) {
+    killResidentPid(pid, "SIGTERM");
+    await waitForPidGone(pid, 1_000).catch(() => killResidentPid(pid, "SIGKILL"));
+  }
+  await rm(paths.socketPath, { force: true });
+  await rm(paths.pidPath, { force: true });
+}
+
+async function readPid(path: string): Promise<number | null> {
+  const text = await readFile(path, "utf8").catch(() => "");
+  const pid = Number(text.trim());
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killResidentPid(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {}
+  }
+}
+
+async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  if (isPidAlive(pid)) throw new Error(`process ${pid} still alive after ${timeoutMs}ms`);
+}
 
 describe("mergeRspBlock", () => {
   it("adds an explicit rsp enablement block with retention defaults", () => {

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -12,6 +12,7 @@ import { sendResidentRequest } from "./resident-protocol.js";
 export interface RspResidentPaths {
   rootDir: string;
   socketPath: string;
+  pidPath: string;
   lockPath: string;
   wakeLockPath: string;
   summaryPath: string;
@@ -25,6 +26,7 @@ export function resolveResidentPaths(cwd: string): RspResidentPaths {
   return {
     rootDir,
     socketPath: join(socketDir, "rsp.sock"),
+    pidPath: join(socketDir, "rsp.pid"),
     lockPath: join(socketDir, "rsp.lock"),
     wakeLockPath: join(rootDir, ".red", "tmp", "rsp.wake.lock"),
     summaryPath: join(rootDir, ".red", "tmp", "rsp-status-summary.json"),
@@ -109,6 +111,8 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
     "warm-resident",
     "--socket",
     paths.socketPath,
+    "--pid-file",
+    paths.pidPath,
     "--store-uri",
     config.storeUri,
     "--ttl-days",
@@ -181,6 +185,8 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
     "server",
     "--socket",
     paths.socketPath,
+    "--pid-file",
+    paths.pidPath,
     "--store-uri",
     config.storeUri,
     "--ttl-days",


### PR DESCRIPTION
Eliminates the resident/rpc zombie accumulation observed 2026-07-13 (24 leaked residents + 25 red rpc orphans, ~2GB RSS, load avg 13):

1. Test suites that spawn built-bundle residents now tear every one of them down deterministically (PID/socket tracking, SIGKILL fallback) — a full suite run leaves zero resident processes.
2. Resident idle shutdown is unconditional: a bounded watchdog hard-exits the process even when a drain or store operation hangs.
3. The resident reaps its red rpc --stdio child on every exit path, plus a parent-death guard so rpc children cannot outlive a killed resident. reddb-side follow-up (rpc should exit on stdin EOF) noted for the reddb repo.

Hand-rebased over PR #1650 (additive conflict in resident-server.ts: heal functions + hygiene functions coexist). Validated: apps/rsp suite 221/221 green on the rebased branch.

Closes #1648

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786549322&installation_id=129708444&pr_number=1653&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1653&signature=9ac49b696cf9c2dbac571a258107b058f58e5bf366b93b1fa5fc29c2fa7dae7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->