### PR TITLE
fix: #1651 rsp veteran-store self-heal incomplete: boot-path model mismatch on rsp_elisions_v1 defeats the #1646 drain heal

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -116,6 +116,7 @@ export class RspElisionStore {
     if (usesEmbeddedRedDb(path)) {
       await ensureReddbBinaryFromWarmCache();
       store.db = await connect(`file://${path}`);
+      await store.ensureRedDbCollections();
       await store.ensureRedDbStore();
     } else {
       store.document = await readStoreDocument(store.path);
@@ -306,6 +307,58 @@ export class RspElisionStore {
   private async ensureRedDbStore(): Promise<void> {
     const index = await this.readRedDbIndex();
     await this.writeRedDbIndex(index);
+  }
+
+  private async ensureRedDbCollections(): Promise<void> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    const meta = (await this.db.list()).find((entry) => entry.name === RSP_ELISION_COLLECTION);
+    if (!meta) {
+      await this.db.query(`CREATE KV IF NOT EXISTS ${RSP_ELISION_COLLECTION}`);
+      return;
+    }
+    if (meta.model === "kv") return;
+    if (meta.model !== "table") {
+      throw new Error(`cannot self-heal elision collection ${RSP_ELISION_COLLECTION}: unsupported model ${meta.model}`);
+    }
+
+    const migrated = await this.readLegacyElisionTableRows();
+    await this.db.query(`DROP TABLE ${RSP_ELISION_COLLECTION}`);
+    await this.db.query(`CREATE KV IF NOT EXISTS ${RSP_ELISION_COLLECTION}`);
+    for (const entry of migrated) {
+      await this.kv().put(entry.key, entry.value);
+    }
+    await this.ensureMigratedRedDbIndex(migrated);
+  }
+
+  private async readLegacyElisionTableRows(): Promise<Array<{ key: string; value: unknown }>> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    const result = await this.db.query(`SELECT * FROM ${RSP_ELISION_COLLECTION}`);
+    const migrated: Array<{ key: string; value: unknown }> = [];
+    for (const row of result.rows) {
+      const entry = legacyElisionRowToKvEntry(row);
+      if (entry) migrated.push(entry);
+    }
+    return migrated;
+  }
+
+  private async ensureMigratedRedDbIndex(migrated: Array<{ key: string; value: unknown }>): Promise<void> {
+    const hasIndex = migrated.some((entry) => entry.key === indexKey() && isIndexDocument(parseKvValue(entry.value)));
+    if (hasIndex) return;
+    const records = migrated
+      .map((entry): IndexEntry | null => {
+        const record = parseKvValue(entry.value);
+        if (!isStoredRecord(record)) return null;
+        return {
+          handle: record.handle,
+          key: recordKey(record.handle),
+          bytes: record.original_bytes,
+          command: record.command,
+          created_at: record.created_at,
+          expires_at: record.expires_at,
+        };
+      })
+      .filter((entry): entry is IndexEntry => entry != null);
+    await this.writeRedDbIndex({ version: 1, records });
   }
 
   private async mintRedDb(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
@@ -608,6 +661,30 @@ function parseMemoryIngestPayload(payload: unknown): {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function legacyElisionRowToKvEntry(row: unknown): { key: string; value: unknown } | null {
+  if (!isPlainObject(row)) return null;
+  if (typeof row.key === "string" && row.key.trim() !== "") {
+    return { key: row.key, value: parseKvValue(row.value) };
+  }
+  if (typeof row.record_key === "string" && row.record_key.trim() !== "") {
+    return { key: row.record_key, value: parseKvValue(row.value) };
+  }
+  if (isStoredRecord(row)) return { key: recordKey(row.handle), value: row };
+  if (isExpiredHandle(row) && typeof row.handle === "string" && isHandle(row.handle)) {
+    return { key: tombstoneKey(row.handle), value: row };
+  }
+  return null;
+}
+
+function parseKvValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
 }
 
 interface ResidentRecallHit {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -46,10 +46,12 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   });
   const storeElapsedMs = Number(process.hrtime.bigint() - openedAt) / 1_000_000;
   let storeOpenCount = 1;
+  const bootTelemetryHeals = store.redDb() ? await ensureTelemetryKvCollections(store.redDb()!) : [];
   const telemetry = new ResidentTelemetryDrain(store, {
     rootDir: opts.rootDir ?? process.cwd(),
     ttlDays: opts.telemetryTtlDays ?? DEFAULT_RSP_TELEMETRY_TTL_DAYS,
     byteBudget: opts.telemetryByteBudget ?? opts.byteBudget ?? DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
+    bootHeals: bootTelemetryHeals,
   });
   const telemetryDrainTimeoutMs = opts.telemetryDrainTimeoutMs ?? TELEMETRY_DRAIN_TIMEOUT_MS;
   await safeDrainTelemetry(telemetry, telemetryDrainTimeoutMs);
@@ -134,6 +136,7 @@ interface ResidentTelemetryOptions {
   rootDir: string;
   ttlDays: number;
   byteBudget: number;
+  bootHeals?: TelemetryCollectionHeal[];
 }
 
 interface TelemetryIndexEntry {
@@ -170,11 +173,14 @@ const TELEMETRY_KV_COLLECTIONS = [
 
 class ResidentTelemetryDrain {
   private running?: Promise<void>;
+  private pendingHeals: TelemetryCollectionHeal[];
 
   constructor(
     private readonly store: RspElisionStore,
     private readonly opts: ResidentTelemetryOptions,
-  ) {}
+  ) {
+    this.pendingHeals = [...(opts.bootHeals ?? [])];
+  }
 
   async drainAndSweep(): Promise<void> {
     this.running ??= this.drainAndSweepOnce().finally(() => {
@@ -187,6 +193,8 @@ class ResidentTelemetryDrain {
     const db = this.store.redDb();
     if (!db) return;
     const healed = await ensureTelemetryKvCollections(db);
+    healed.unshift(...this.pendingHeals);
+    this.pendingHeals = [];
     const index = await this.readIndex(db);
     const nextRecords = [...index.records];
     for (const entry of healed) {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -15,7 +15,7 @@ import {
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
   telemetrySpoolPath,
 } from "../src/telemetry.js";
-import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS } from "../src/config.js";
+import { DEFAULT_RSP_BYTE_BUDGET, DEFAULT_RSP_TTL_DAYS, RSP_ELISION_COLLECTION } from "../src/elision-store.js";
 import { tokenSavingsEstimate } from "../src/pricing.js";
 import { resolveResidentPaths } from "../src/resident-client.js";
 import { sendResidentRequest } from "../src/resident-protocol.js";
@@ -356,12 +356,30 @@ describe("rsp telemetry spool", () => {
     });
   }, 40_000);
 
-  it("self-heals old-model telemetry collections in the built bundle resident", async () => {
+  it("self-heals old-model rsp collections in the built bundle resident without losing elisions", async () => {
     const root = await tempRoot();
     const bundle = await ensureRspBundle();
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const legacyHandle = "el:123456789abc";
+    const legacyRecord = {
+      collection: RSP_ELISION_COLLECTION,
+      handle: legacyHandle,
+      original: Buffer.from("legacy recoverable elision").toString("base64"),
+      original_encoding: "base64",
+      original_bytes: Buffer.byteLength("legacy recoverable elision"),
+      command: "git diff --stat",
+      created_at: "2026-07-13T12:00:00.000Z",
+      expires_at: "2026-07-20T12:00:00.000Z",
+      loss: { level: "terse", bytes_elided: 27 },
+    };
     const seeded = await connect(storeUri);
     try {
+      await seeded.query(`CREATE TABLE ${RSP_ELISION_COLLECTION} (record_key TEXT, value JSON)`);
+      await seeded.query(
+        `INSERT INTO ${RSP_ELISION_COLLECTION} (record_key, value) VALUES ($1, $2)`,
+        "record:123456789abc",
+        legacyRecord,
+      );
       await seeded.query(`CREATE TABLE ${RSP_TELEMETRY_INVOCATIONS_COLLECTION} (id TEXT)`);
       await seeded.query(`CREATE TABLE ${RSP_TELEMETRY_DEGRADATIONS_COLLECTION} (id TEXT)`);
       await seeded.query(`CREATE TABLE ${RSP_TELEMETRY_INDEX_COLLECTION} (id TEXT)`);
@@ -393,6 +411,17 @@ describe("rsp telemetry spool", () => {
       "100",
     ], { cwd: root });
     await waitForResident(paths.socketPath);
+    await expect(sendResidentRequest(
+      { socketPath: paths.socketPath, timeoutMs: 1_000 },
+      { id: "recover-legacy-elision", op: "get", handle: legacyHandle },
+    )).resolves.toMatchObject({
+      ok: true,
+      value: expect.objectContaining({
+        handle: legacyHandle,
+        original: Buffer.from("legacy recoverable elision").toString("base64"),
+        original_encoding: "base64",
+      }),
+    });
     await new Promise<void>((resolve, reject) => {
       child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`bundle resident exited ${code}`)));
       child.once("error", reject);
@@ -412,6 +441,7 @@ describe("rsp telemetry spool", () => {
       ]),
     );
     await expect(readTelemetryCollectionModels(storeUri)).resolves.toMatchObject({
+      [RSP_ELISION_COLLECTION]: "kv",
       [RSP_TELEMETRY_INVOCATIONS_COLLECTION]: "kv",
       [RSP_TELEMETRY_DEGRADATIONS_COLLECTION]: "kv",
       [RSP_TELEMETRY_INDEX_COLLECTION]: "kv",
@@ -512,7 +542,7 @@ describe("rsp telemetry spool", () => {
 
       await waitForResidentTelemetry(paths.socketPath, "git log --terse");
       await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
-      await expect(readFile(paths.summaryPath, "utf8")).resolves.toContain("tokens_saved_today");
+      await waitForStatusSummary(paths.summaryPath);
     } finally {
       await shutdownResident(paths.socketPath);
     }
@@ -672,6 +702,7 @@ async function readTelemetryCollectionModels(storeUri: string): Promise<Record<s
     return Object.fromEntries(
       (await db.list())
         .filter((entry) => [
+          RSP_ELISION_COLLECTION,
           RSP_TELEMETRY_INVOCATIONS_COLLECTION,
           RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
           RSP_TELEMETRY_INDEX_COLLECTION,
@@ -724,6 +755,16 @@ async function waitForResidentTelemetry(socketPath: string, command: string): Pr
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`telemetry ${command} did not drain`);
+}
+
+async function waitForStatusSummary(summaryPath: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const summary = await readFile(summaryPath, "utf8").catch(() => "");
+    if (summary.includes("tokens_saved_today")) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("rsp status summary did not refresh");
 }
 
 async function shutdownResident(socketPath: string): Promise<void> {


### PR DESCRIPTION
Automated AFK landing for #1651. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1651

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550697&installation_id=129708444&pr_number=1655&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1655&signature=617fe803a465413d398a301bd23890208fe6d690cf7d21cf027b6a1d7bda21f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->