### PR TITLE
feat: #1649 rsp resident PID registry under .red/tmp

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -68,7 +68,8 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const { resolveResidentPaths, ResidentRspElisionStore, ensureResidentServer } = await import("./resident-client.js");
   if (args.command === "server") {
     const { runResidentServer } = await import("./resident-server.js");
-    const socket = valueAfter(args.positional, "--socket") ?? resolveResidentPaths(process.cwd()).socketPath;
+    const serverPaths = resolveResidentPaths(process.cwd());
+    const socket = valueAfter(args.positional, "--socket") ?? serverPaths.socketPath;
     const serverConfig = resolveRspConfig(process.cwd(), process.env, args.storeUri ?? valueAfter(args.positional, "--store-uri"));
     if (!serverConfig.enabled) {
       process.stdout.write(`${rspDisabledReason()}\n`);
@@ -77,6 +78,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     await runResidentServer({
       socketPath: socket,
       pidPath: valueAfter(args.positional, "--pid-file") ?? resolveResidentPaths(process.cwd()).pidPath,
+      rootDir: serverPaths.rootDir,
       storeUri: serverConfig.storeUri,
       ttlDays: numericValueAfter(args.positional, "--ttl-days") ?? serverConfig.ttlDays,
       byteBudget: numericValueAfter(args.positional, "--byte-budget") ?? serverConfig.byteBudget,
@@ -88,6 +90,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
         serverConfig.telemetryDrainTimeoutMs,
       idleMs: numericValueAfter(args.positional, "--idle-ms") ?? serverConfig.idleMs,
       residentVersion: valueAfter(args.positional, "--resident-version") ?? buildInfo.version,
+      registryPath: valueAfter(args.positional, "--registry") ?? serverPaths.registryPath,
     });
     return 0;
   }
@@ -121,6 +124,14 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const { existsSync } = await import("node:fs");
   const { fileURLToPath } = await import("node:url");
   const residentPaths = resolveResidentPaths(process.cwd());
+  if (args.command === "status" || args.command === "sweep") {
+    const { residentRegistryStatus, sweepResidentRegistry } = await import("./resident-client.js");
+    const status = args.command === "sweep"
+      ? await sweepResidentRegistry(residentPaths)
+      : await residentRegistryStatus(residentPaths);
+    process.stdout.write(`${encode(status as unknown as JsonObject)}\n`);
+    return 0;
+  }
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
     if (wrapperCommand) return await runColdWrappedCommand(args, config, residentPaths.rootDir);
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -12,9 +12,16 @@ import {
   ensureResidentServer,
   kickResidentServer,
   pingResident,
+  readResidentRegistry,
+  removeResidentRegistry,
+  residentRegistryStatus,
   resolveResidentPaths,
+  sweepResidentRegistry,
   warmResidentServer,
+  writeResidentRegistry,
   type ResidentRequestWithoutId,
+  type RspResidentRegistryEntry,
+  type RspResidentRegistryStatus,
   type RspResidentPaths,
 } from "@reddb-io/shared/resident-client.js";
 
@@ -27,9 +34,16 @@ export {
   ensureResidentServer,
   kickResidentServer,
   pingResident,
+  readResidentRegistry,
+  removeResidentRegistry,
+  residentRegistryStatus,
   resolveResidentPaths,
+  sweepResidentRegistry,
   warmResidentServer,
+  writeResidentRegistry,
   type RspResidentPaths,
+  type RspResidentRegistryEntry,
+  type RspResidentRegistryStatus,
 };
 
 /** rsp-side adapter: the elision-store surface, served by the resident. */

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -6,6 +6,7 @@ import { createServer, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { RedDB } from "@reddb-io/sdk";
+import { removeResidentRegistry, writeResidentRegistry } from "@reddb-io/shared/resident-client.js";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
 import { createResidentBrainStore } from "./resident-brain.js";
@@ -28,6 +29,7 @@ export interface ResidentServerOptions extends RspResidentConfig {
   rootDir?: string;
   idleMs?: number;
   residentVersion?: string;
+  registryPath?: string;
   telemetryDrainIntervalMs?: number;
   telemetryDrainTimeoutMs?: number;
 }
@@ -116,6 +118,15 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   if (opts.pidPath) {
     await writeFile(opts.pidPath, `${process.pid}\n`, { encoding: "utf8", mode: 0o600 });
   }
+  const residentVersion = opts.residentVersion ?? "0.0.0-dev";
+  const registryPath = opts.registryPath ?? join(opts.rootDir ?? process.cwd(), ".red", "tmp", "rsp-resident.pid.json");
+  try {
+    await writeResidentRegistry(registryPath, {
+      socket_path: opts.socketPath,
+      store_uri: opts.storeUri,
+      resident_version: residentVersion,
+    });
+  } catch {}
   touch();
 
   await new Promise<void>((resolve) => server.once("close", resolve));
@@ -130,6 +141,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   redRpcGuard?.kill("SIGTERM");
   cleanupRedRpcChildrenSync();
   if (opts.pidPath) await rm(opts.pidPath, { force: true });
+  await removeResidentRegistry(registryPath);
 }
 
 interface ResidentTelemetryOptions {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -803,6 +803,26 @@ describe("rsp cli", () => {
     expect(res.stdout).toEqual(direct.stdout);
     expect(res.stderr).toEqual(Buffer.alloc(0));
     await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
+    const entry = JSON.parse(await readFile(paths.registryPath, "utf8")) as {
+      pid: number;
+      socket_path: string;
+      store_uri: string;
+      resident_version: string;
+      started_at: string;
+    };
+    expect(entry).toMatchObject({
+      socket_path: paths.socketPath,
+      store_uri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
+    });
+    expect(entry.pid).toBeGreaterThan(0);
+    expect(entry.resident_version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(Date.parse(entry.started_at)).toBeGreaterThan(0);
+    const status = runBundleFromCwd(root, ["status"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(status.status, `${status.stdout.toString("utf8")}${status.stderr.toString("utf8")}`).toBe(0);
+    expect(decode(status.stdout.toString("utf8"))).toMatchObject({
+      state: "registered-alive-socket-healthy",
+      entry: { pid: entry.pid, socket_path: paths.socketPath },
+    });
   }, 120_000);
 
   it("built bundle teardown stops every spawned resident process", async () => {
@@ -999,6 +1019,7 @@ describe("rsp cli", () => {
     expect(warm.stderr).toEqual(Buffer.alloc(0));
 
     await waitForGone(paths.socketPath, idleMs + normalizedDurationMs(5_000));
+    await waitForGone(paths.registryPath);
     const expired = runBundleHookFromCwd(root, "git status", env);
     expect(expired.status).toBe(1);
     expect(expired.stdout).toEqual(Buffer.alloc(0));
@@ -1252,6 +1273,11 @@ describe("rsp cli", () => {
     );
     await waitForResidentSocket(root);
     expect(await readResidentVersion(root)).toBe(oldVersion);
+    const oldRegistry = JSON.parse(await readFile(trackedResidentPaths(root).registryPath, "utf8")) as {
+      pid: number;
+      resident_version: string;
+    };
+    expect(oldRegistry.resident_version).toBe(oldVersion);
 
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
@@ -1263,6 +1289,12 @@ describe("rsp cli", () => {
     expect(shown.status, `${shown.stdout.toString("utf8")}${shown.stderr.toString("utf8")}`).toBe(0);
     expect(shown.stdout.length).toBeGreaterThan(compressed.stdout.length);
     expect(await readResidentVersion(root)).not.toBe(oldVersion);
+    const nextRegistry = JSON.parse(await readFile(trackedResidentPaths(root).registryPath, "utf8")) as {
+      pid: number;
+      resident_version: string;
+    };
+    expect(nextRegistry.pid).not.toBe(oldRegistry.pid);
+    expect(nextRegistry.resident_version).not.toBe(oldVersion);
     expect(await oldResident).toMatchObject({ status: 0 });
   }, 120_000);
 

--- a/apps/rsp/tests/resident-memory.test.ts
+++ b/apps/rsp/tests/resident-memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -24,6 +24,36 @@ afterEach(async () => {
 });
 
 describe("resident memory transport", () => {
+  it("writes the resident PID registry while serving and removes it on idle exit", async () => {
+    const root = await tempRoot();
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+
+    const server = runResidentServer({
+      socketPath: paths.socketPath,
+      rootDir: paths.rootDir,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      idleMs: 100,
+      residentVersion: "9.8.7-test",
+      registryPath: paths.registryPath,
+    });
+
+    await waitForResident(paths.socketPath);
+    const entry = await waitForRegistry(paths.registryPath);
+    expect(entry).toMatchObject({
+      pid: process.pid,
+      socket_path: paths.socketPath,
+      store_uri: storeUri,
+      resident_version: "9.8.7-test",
+    });
+    expect(Date.parse(entry.started_at)).toBeGreaterThan(0);
+
+    await server;
+    await expect(readFile(paths.registryPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  }, 20_000);
+
   it("keeps concurrent memory writers in one resident-owned RedDB store", async () => {
     const root = await tempRoot();
     const writerA = join(root, "writer-a");
@@ -155,4 +185,30 @@ async function waitForResident(socketPath: string): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error("resident did not start");
+}
+
+async function waitForRegistry(path: string): Promise<{
+  pid: number;
+  socket_path: string;
+  store_uri: string;
+  resident_version: string;
+  started_at: string;
+}> {
+  const deadline = Date.now() + 5_000;
+  let last: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return JSON.parse(await readFile(path, "utf8")) as {
+        pid: number;
+        socket_path: string;
+        store_uri: string;
+        resident_version: string;
+        started_at: string;
+      };
+    } catch (err) {
+      last = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw last instanceof Error ? last : new Error("resident registry did not appear");
 }

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { spawn, type ChildProcess } from "node:child_process";
 import { constants } from "node:fs";
 import { readFileSync } from "node:fs";
-import { mkdir, open, rm } from "node:fs/promises";
+import { mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,9 +16,32 @@ export interface RspResidentPaths {
   lockPath: string;
   wakeLockPath: string;
   summaryPath: string;
+  registryPath: string;
 }
 
 const UNIX_SOCKET_PATH_LIMIT = 108;
+const RESIDENT_REGISTRY_VERSION = 1;
+
+export interface RspResidentRegistryEntry {
+  version: typeof RESIDENT_REGISTRY_VERSION;
+  pid: number;
+  socket_path: string;
+  store_uri: string;
+  resident_version: string;
+  started_at: string;
+}
+
+export interface RspResidentRegistryStatus {
+  registry_path: string;
+  state:
+    | "missing"
+    | "registered-alive-socket-healthy"
+    | "registered-alive-socket-dead"
+    | "registered-alive-store-missing"
+    | "registered-dead"
+    | "invalid";
+  entry?: RspResidentRegistryEntry;
+}
 
 export function resolveResidentPaths(cwd: string): RspResidentPaths {
   const rootDir = findRepoRoot(cwd) ?? resolve(cwd);
@@ -30,6 +53,7 @@ export function resolveResidentPaths(cwd: string): RspResidentPaths {
     lockPath: join(socketDir, "rsp.lock"),
     wakeLockPath: join(rootDir, ".red", "tmp", "rsp.wake.lock"),
     summaryPath: join(rootDir, ".red", "tmp", "rsp-status-summary.json"),
+    registryPath: join(rootDir, ".red", "tmp", "rsp-resident.pid.json"),
   };
 }
 
@@ -61,11 +85,13 @@ export type ResidentRequestWithoutId = RspResidentRequest extends infer Request
 export async function ensureResidentServer(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
   await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
   if (await isResidentUsable(paths.socketPath, config)) return;
+  await reconcileResidentRegistry(paths, config);
 
   const lock = await tryAcquireLock(paths.lockPath);
   if (lock) {
     try {
       if (await isResidentUsable(paths.socketPath, config)) return;
+      await reconcileResidentRegistry(paths, config);
       await removeUnresponsiveSocket(paths.socketPath);
       const child = spawnResident(paths, config);
       await waitForServer(paths.socketPath, child);
@@ -131,6 +157,8 @@ export async function kickResidentServer(paths: RspResidentPaths, config: RspRes
     String(config.idleMs ?? 300_000),
     "--resident-version",
     config.clientVersion ?? "0.0.0-dev",
+    "--registry",
+    paths.registryPath,
     "--wake-lock",
     paths.wakeLockPath,
   ], {
@@ -149,6 +177,84 @@ export async function warmResidentServer(paths: RspResidentPaths, config: RspRes
   } finally {
     await rm(paths.wakeLockPath, { force: true });
   }
+}
+
+export async function readResidentRegistry(path: string): Promise<RspResidentRegistryEntry | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+    return isResidentRegistryEntry(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeResidentRegistry(
+  path: string,
+  entry: Omit<RspResidentRegistryEntry, "version" | "pid" | "started_at"> & {
+    pid?: number;
+    started_at?: string;
+  },
+): Promise<void> {
+  const payload: RspResidentRegistryEntry = {
+    version: RESIDENT_REGISTRY_VERSION,
+    pid: entry.pid ?? process.pid,
+    socket_path: entry.socket_path,
+    store_uri: entry.store_uri,
+    resident_version: entry.resident_version,
+    started_at: entry.started_at ?? new Date().toISOString(),
+  };
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(payload)}\n`, { encoding: "utf8", mode: 0o600 });
+  await rename(tmp, path);
+}
+
+export async function removeResidentRegistry(path: string, pid = process.pid): Promise<void> {
+  try {
+    const entry = await readResidentRegistry(path);
+    if (entry && entry.pid !== pid) return;
+    await rm(path, { force: true });
+  } catch {}
+}
+
+export async function residentRegistryStatus(paths: RspResidentPaths): Promise<RspResidentRegistryStatus> {
+  const entry = await readResidentRegistry(paths.registryPath);
+  if (!entry) {
+    try {
+      await readFile(paths.registryPath, "utf8");
+      return { registry_path: paths.registryPath, state: "invalid" };
+    } catch {
+      return { registry_path: paths.registryPath, state: "missing" };
+    }
+  }
+  if (!isPidAlive(entry.pid)) return { registry_path: paths.registryPath, state: "registered-dead", entry };
+  const socketHealthy = await pingResident(entry.socket_path, 100);
+  if (socketHealthy && await isStorePathMissing(entry.store_uri)) {
+    return { registry_path: paths.registryPath, state: "registered-alive-store-missing", entry };
+  }
+  return {
+    registry_path: paths.registryPath,
+    state: socketHealthy ? "registered-alive-socket-healthy" : "registered-alive-socket-dead",
+    entry,
+  };
+}
+
+export async function sweepResidentRegistry(paths: RspResidentPaths): Promise<RspResidentRegistryStatus> {
+  const status = await residentRegistryStatus(paths);
+  if (status.state === "registered-dead" || status.state === "invalid") {
+    await rm(paths.registryPath, { force: true });
+    return await residentRegistryStatus(paths);
+  }
+  if (
+    (status.state === "registered-alive-socket-dead" || status.state === "registered-alive-store-missing") &&
+    status.entry
+  ) {
+    await terminatePid(status.entry.pid);
+    await rm(paths.registryPath, { force: true });
+    await rm(status.entry.socket_path, { force: true });
+    return await residentRegistryStatus(paths);
+  }
+  return status;
 }
 
 async function waitForServer(socketPath: string, child?: ChildProcess): Promise<void> {
@@ -205,6 +311,8 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
     String(config.idleMs ?? 300_000),
     "--resident-version",
     config.clientVersion ?? "0.0.0-dev",
+    "--registry",
+    paths.registryPath,
   ], {
     cwd: paths.rootDir,
     detached: true,
@@ -213,6 +321,73 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
   });
   child.unref();
   return child;
+}
+
+async function reconcileResidentRegistry(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {
+  try {
+    const entry = await readResidentRegistry(paths.registryPath);
+    if (!entry) return;
+    if (entry.socket_path !== paths.socketPath || entry.store_uri !== config.storeUri) return;
+    if (!isPidAlive(entry.pid)) {
+      await rm(paths.registryPath, { force: true });
+      return;
+    }
+    if (await pingResident(entry.socket_path, 100)) return;
+    if (shouldHandover(config.clientVersion, entry.resident_version)) {
+      await waitForPidExit(entry.pid, 1_500);
+      if (!isPidAlive(entry.pid)) {
+        await rm(paths.registryPath, { force: true });
+        return;
+      }
+    }
+    await terminatePid(entry.pid);
+    await rm(paths.registryPath, { force: true });
+  } catch {}
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function terminatePid(pid: number): Promise<void> {
+  if (!isPidAlive(pid)) return;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return;
+  }
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {}
+}
+
+async function waitForPidExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function isStorePathMissing(storeUri: string): Promise<boolean> {
+  if (!storeUri.startsWith("file://")) return false;
+  try {
+    await stat(fileURLToPath(storeUri));
+    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT";
+  }
 }
 
 function spawnTarget(config: RspResidentConfig): [string, string[]] {
@@ -307,6 +482,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isResidentRegistryEntry(value: unknown): value is RspResidentRegistryEntry {
+  return isRecord(value) &&
+    value.version === RESIDENT_REGISTRY_VERSION &&
+    Number.isInteger(value.pid) &&
+    typeof value.socket_path === "string" &&
+    typeof value.store_uri === "string" &&
+    typeof value.resident_version === "string" &&
+    typeof value.started_at === "string";
 }
 
 async function waitForResidentExit(socketPath: string): Promise<void> {


### PR DESCRIPTION
Resident writes an atomic registry entry (pid, socket, store uri, version, started_at) under .red/tmp on boot and removes it on every exit path; boot reconciliation kills stale PIDs with dead sockets; rsp status reports registry vs reality. Invariant: no resident process without a live registry entry.

Hand-rebased over PRs #1653/#1655 (additive conflicts: pidPath + registry coexist in resident-server.ts and cli.ts). Validated: apps/rsp suite 223/223 green on the rebased branch.

Closes #1649

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786551169&installation_id=129708444&pr_number=1656&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1656&signature=4babc3c76f26a20e9b2e414ee86d69f0c1685d15945dc9f7aa2921252ba69f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->