### PR TITLE
fix: #1657 /go: Remove the dollars-saved segment from the statusline rsp block. The stat

### DIFF
--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -458,17 +458,10 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
   if (rsp.state === "ready") {
-    const dollars = rsp.dollarsSavedTodayUsd && rsp.dollarsSavedTodayUsd > 0
-      ? ` ${formatRspDollars(rsp.dollarsSavedTodayUsd)}`
-      : "";
-    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}${dollars}`;
+    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}`;
   }
   if (rsp.state === "warming") return "rsp=…";
   return "rsp=!";
-}
-
-function formatRspDollars(value: number): string {
-  return `$${formatThreeSigValue(value)}`;
 }
 
 /**

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -709,7 +709,7 @@ describe("statusline command — rendered line", () => {
     expect(stripAnsi(out.text())).toContain("rsp=…");
   });
 
-  it("renders rsp savings when an enabled repo has a fresh resident summary", async () => {
+  it("renders rsp token savings without dollars when an enabled repo has a fresh resident summary", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
     await seedFreshRepoCache(root, 0, 0);
@@ -726,7 +726,8 @@ describe("statusline command — rendered line", () => {
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp=↓1.32M $1.63");
+    expect(stripAnsi(out.text())).toContain("rsp=↓1.32M");
+    expect(stripAnsi(out.text())).not.toContain("$1.63");
   });
 
   it("renders rsp savings from an old summary when the resident is idle", async () => {

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -161,9 +161,11 @@ describe("statusline style — header line", () => {
     const healthy = renderHeaderLine(input.project, claude, repo, undefined, "full", {
       state: "ready",
       tokensSavedToday: 1320000,
+      dollarsSavedTodayUsd: 1.625,
     });
     expect(healthy).toContain(`${GREEN}rsp=↓1.32M${SOFT}`);
     expect(stripAnsi(healthy)).toContain("rsp=↓1.32M");
+    expect(stripAnsi(healthy)).not.toContain("$1.63");
 
     const warming = renderHeaderLine(input.project, claude, repo, undefined, "full", { state: "warming" });
     expect(warming).toContain(`${DIM}rsp=…${SOFT}`);

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -520,7 +520,7 @@ describe("statusline — full assembly", () => {
     expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · ctx=47k 24% · iss=24 · rsp=↓1.2k");
   });
 
-  it("renders rsp healthy savings as one optional token in full and short presets", () => {
+  it("renders rsp healthy token savings without the dollar segment in full and short presets", () => {
     const input: StatuslineInput = {
       project: { basename: "red-skills", branch: "main" },
       rsp: { state: "ready", tokensSavedToday: 847 },
@@ -530,7 +530,7 @@ describe("statusline — full assembly", () => {
     expect(renderStatusline({
       project: { basename: "red-skills", branch: "main" },
       rsp: { state: "ready", tokensSavedToday: 2000, dollarsSavedTodayUsd: 0.0025 },
-    })).toBe("red-skills (main) · rsp=↓2.0k $0.00250");
+    })).toBe("red-skills (main) · rsp=↓2.0k");
   });
 
   it("renders rsp warming and error states without ambiguous on/off glyphs", () => {


### PR DESCRIPTION
Automated AFK landing for #1657. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1657

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555176&installation_id=129708444&pr_number=1659&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1659&signature=4ec81a40b0fc34fd8d69db1ec6028a754ef72a3a64023addd41fbf52d85b2d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->