### PR TITLE
fix: #1654 main-red repair: baseline probe failures on main

### DIFF
--- a/apps/rsp/tests/resident-memory.test.ts
+++ b/apps/rsp/tests/resident-memory.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { connect } from "@reddb-io/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { graphRecall } from "../../memory/src/graph-recall.js";
 import { MemoryStore } from "../../memory/src/graph-store.js";
@@ -28,6 +29,7 @@ describe("resident memory transport", () => {
     const root = await tempRoot();
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedResidentTiming(root);
 
     const server = runResidentServer({
       socketPath: paths.socketPath,
@@ -40,8 +42,8 @@ describe("resident memory transport", () => {
       registryPath: paths.registryPath,
     });
 
-    await waitForResident(paths.socketPath);
-    const entry = await waitForRegistry(paths.registryPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
+    const entry = await waitForRegistry(paths.registryPath, timing.waitTimeoutMs);
     expect(entry).toMatchObject({
       pid: process.pid,
       socket_path: paths.socketPath,
@@ -52,7 +54,7 @@ describe("resident memory transport", () => {
 
     await server;
     await expect(readFile(paths.registryPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-  }, 20_000);
+  }, 60_000);
 
   it("keeps concurrent memory writers in one resident-owned RedDB store", async () => {
     const root = await tempRoot();
@@ -65,24 +67,29 @@ describe("resident memory transport", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedResidentTiming(root);
     const server = runResidentServer({
       socketPath: paths.socketPath,
       storeUri,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
-      idleMs: 100,
+      idleMs: timing.waitTimeoutMs,
     });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
     const client = new ResidentRspElisionStore(paths, {
       storeUri,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
     });
 
-    await Promise.all([
-      client.memory("ingest", { cwd: writerA }),
-      client.memory("ingest", { cwd: writerB }),
-    ]);
+    try {
+      await Promise.all([
+        client.memory("ingest", { cwd: writerA }),
+        client.memory("ingest", { cwd: writerB }),
+      ]);
+    } finally {
+      await shutdownResident(paths.socketPath, timing.waitTimeoutMs);
+    }
     await server;
 
     const store = await MemoryStore.open({ uri: storeUri });
@@ -96,7 +103,7 @@ describe("resident memory transport", () => {
     } finally {
       await store.close();
     }
-  }, 20_000);
+  }, 60_000);
 
   it("shares one resident-owned RedDB store across rsp, memory, and brain clients", async () => {
     const root = await tempRoot();
@@ -113,69 +120,91 @@ describe("resident memory transport", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedResidentTiming(root);
     const server = runResidentServer({
       socketPath: paths.socketPath,
       storeUri,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
-      idleMs: 5_000,
+      idleMs: timing.waitTimeoutMs,
     });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
     const client = new ResidentRspElisionStore(paths, {
       storeUri,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
     });
 
-    const handle = await client.mint(Buffer.from("rsp-shared-resident-token"), {
-      command: "rsp test",
-      loss: { level: "brief", bytes_elided: 25 },
-    });
-    await client.memory("ingest", { cwd: docs });
-
-    const openSpy = vi.spyOn(BrainStore, "open");
     try {
-      await withBrainRuntime(async ({ store }) => {
-        await store.capture({
-          title: "Brain shared resident note",
-          content: "brain-shared-resident-token cites memory-shared-resident-token and rsp-shared-resident-token",
-          kind: "note",
-          tags: ["shared-resident"],
-        });
-        await expect(store.search("brain-shared-resident-token", 5)).resolves.toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              artifact: expect.objectContaining({
-                properties: expect.objectContaining({
-                  content: expect.stringContaining("brain-shared-resident-token"),
+      const handle = await client.mint(Buffer.from("rsp-shared-resident-token"), {
+        command: "rsp test",
+        loss: { level: "brief", bytes_elided: 25 },
+      });
+      await client.memory("ingest", { cwd: docs });
+
+      const openSpy = vi.spyOn(BrainStore, "open");
+      try {
+        await withBrainRuntime(async ({ store }) => {
+          await store.capture({
+            title: "Brain shared resident note",
+            content: "brain-shared-resident-token cites memory-shared-resident-token and rsp-shared-resident-token",
+            kind: "note",
+            tags: ["shared-resident"],
+          });
+          await expect(store.search("brain-shared-resident-token", 5)).resolves.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                artifact: expect.objectContaining({
+                  properties: expect.objectContaining({
+                    content: expect.stringContaining("brain-shared-resident-token"),
+                  }),
                 }),
               }),
-            }),
+            ]),
+          );
+        }, root);
+        expect(openSpy).not.toHaveBeenCalled();
+      } finally {
+        openSpy.mockRestore();
+      }
+
+      await expect(client.get(handle)).resolves.toEqual(
+        expect.objectContaining({ original: Buffer.from("rsp-shared-resident-token") }),
+      );
+      await expect(client.memory("recall", { query: "memory-shared-resident-token", limit: 5 })).resolves.toEqual(
+        expect.objectContaining({
+          hits: expect.arrayContaining([
+            expect.objectContaining({ excerpt: expect.stringContaining("memory-shared-resident-token") }),
           ]),
-        );
-      }, root);
-      expect(openSpy).not.toHaveBeenCalled();
+        }),
+      );
     } finally {
-      openSpy.mockRestore();
+      await shutdownResident(paths.socketPath, timing.waitTimeoutMs);
     }
 
-    await expect(client.get(handle)).resolves.toEqual(
-      expect.objectContaining({ original: Buffer.from("rsp-shared-resident-token") }),
-    );
-    await expect(client.memory("recall", { query: "memory-shared-resident-token", limit: 5 })).resolves.toEqual(
-      expect.objectContaining({
-        hits: expect.arrayContaining([
-          expect.objectContaining({ excerpt: expect.stringContaining("memory-shared-resident-token") }),
-        ]),
-      }),
-    );
-
     await server;
-  }, 20_000);
+  }, 60_000);
 });
 
-async function waitForResident(socketPath: string): Promise<void> {
-  const deadline = Date.now() + 5_000;
+interface ResidentTiming {
+  waitTimeoutMs: number;
+}
+
+const BASELINE_STORE_OPEN_MS = 100;
+
+async function calibratedResidentTiming(root: string): Promise<ResidentTiming> {
+  await mkdir(join(root, ".red", "tmp"), { recursive: true });
+  const baselineUri = `file://${join(root, ".red", "tmp", `resident-baseline-${process.pid}-${Date.now()}.rdb`)}`;
+  const started = process.hrtime.bigint();
+  const db = await connect(baselineUri);
+  await db.close();
+  const storeOpenMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  const scale = Math.min(4, Math.max(1, Math.ceil(Math.max(1, storeOpenMs) / BASELINE_STORE_OPEN_MS)));
+  return { waitTimeoutMs: 5_000 * scale };
+}
+
+async function waitForResident(socketPath: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   let attempt = 0;
   while (Date.now() < deadline) {
     try {
@@ -187,14 +216,14 @@ async function waitForResident(socketPath: string): Promise<void> {
   throw new Error("resident did not start");
 }
 
-async function waitForRegistry(path: string): Promise<{
+async function waitForRegistry(path: string, timeoutMs = 5_000): Promise<{
   pid: number;
   socket_path: string;
   store_uri: string;
   resident_version: string;
   started_at: string;
 }> {
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + timeoutMs;
   let last: unknown;
   while (Date.now() < deadline) {
     try {
@@ -211,4 +240,22 @@ async function waitForRegistry(path: string): Promise<{
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw last instanceof Error ? last : new Error("resident registry did not appear");
+}
+
+async function shutdownResident(socketPath: string, timeoutMs = 5_000): Promise<void> {
+  await sendResidentRequest({ socketPath, timeoutMs: 500 }, {
+    id: "shutdown",
+    op: "handover",
+    clientVersion: "test-shutdown",
+  }).catch(() => null);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const alive = await sendResidentRequest({ socketPath, timeoutMs: 100 }, {
+      id: "shutdown-poll",
+      op: "ping",
+    }).then((response) => response.ok, () => false);
+    if (!alive) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("resident did not shut down");
 }

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -113,6 +113,7 @@ describe("rsp telemetry spool", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const server = runResidentServer({
       rootDir: root,
       socketPath: paths.socketPath,
@@ -121,10 +122,10 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 90,
       telemetryByteBudget: 1_000,
-      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
+      telemetryDrainTimeoutMs: timing.drainTimeoutMs,
       idleMs: 100,
     });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
 
     await appendTelemetryEvent(root, {
       collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
@@ -146,7 +147,7 @@ describe("rsp telemetry spool", () => {
       id: "idle-event",
       reason: "resident unavailable",
     });
-  }, 20_000);
+  }, 60_000);
 
   it("computes telemetry tokens at drain time and estimates oversized payloads", async () => {
     const root = await tempRoot();
@@ -168,6 +169,7 @@ describe("rsp telemetry spool", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const server = runResidentServer({
       rootDir: root,
       socketPath: paths.socketPath,
@@ -176,10 +178,10 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 90,
       telemetryByteBudget: 1_000_000,
-      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
+      telemetryDrainTimeoutMs: timing.drainTimeoutMs,
       idleMs: 100,
     });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
     await server;
 
     await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "exact")).resolves.toMatchObject({
@@ -193,7 +195,7 @@ describe("rsp telemetry spool", () => {
       tokens_emitted: Math.ceil(Buffer.byteLength(huge, "utf8") / 4),
       estimated: true,
     });
-  }, 20_000);
+  }, 60_000);
 
   it("enforces telemetry ttl and byte budget without pruning elisions", async () => {
     const root = await tempRoot();
@@ -218,6 +220,7 @@ describe("rsp telemetry spool", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const server = runResidentServer({
       rootDir: root,
       socketPath: paths.socketPath,
@@ -226,10 +229,10 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 1,
       telemetryByteBudget: 75,
-      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
+      telemetryDrainTimeoutMs: timing.drainTimeoutMs,
       idleMs: 100,
     });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
     await server;
 
     await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "expired")).resolves.toBeNull();
@@ -237,7 +240,7 @@ describe("rsp telemetry spool", () => {
     await expect(readTelemetry(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION, "newest")).resolves.toMatchObject({
       id: "newest",
     });
-  }, 20_000);
+  }, 60_000);
 
   it("serves telemetry stats from resident collections without mutating the spool", async () => {
     const root = await tempRoot();
@@ -267,6 +270,7 @@ describe("rsp telemetry spool", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const server = runResidentServer({
       rootDir: root,
       socketPath: paths.socketPath,
@@ -275,10 +279,10 @@ describe("rsp telemetry spool", () => {
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,
       telemetryTtlDays: 90,
       telemetryByteBudget: 1_000,
-      telemetryDrainTimeoutMs: await calibratedTelemetryDrainTimeoutMs(root),
+      telemetryDrainTimeoutMs: timing.drainTimeoutMs,
       idleMs: 100,
     });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
 
     const response = await sendResidentRequest({ socketPath: paths.socketPath }, {
       id: "stats",
@@ -314,7 +318,7 @@ describe("rsp telemetry spool", () => {
     });
     await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
     await server;
-  }, 20_000);
+  }, 60_000);
 
   it("drains a hand-written spool through the built bundle resident", async () => {
     const root = await tempRoot();
@@ -327,6 +331,7 @@ describe("rsp telemetry spool", () => {
 
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const child = execFile(process.execPath, [
       bundle,
       "server",
@@ -339,11 +344,11 @@ describe("rsp telemetry spool", () => {
       "--byte-budget",
       String(DEFAULT_RSP_BYTE_BUDGET),
       "--telemetry-drain-timeout-ms",
-      String(await calibratedTelemetryDrainTimeoutMs(root)),
+      String(timing.drainTimeoutMs),
       "--idle-ms",
       "100",
     ], { cwd: root });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
     await new Promise<void>((resolve, reject) => {
       child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`bundle resident exited ${code}`)));
       child.once("error", reject);
@@ -394,6 +399,7 @@ describe("rsp telemetry spool", () => {
     })}\n`, "utf8");
 
     const paths = resolveResidentPaths(root);
+    const timing = await calibratedTelemetryTiming(root);
     const child = execFile(process.execPath, [
       bundle,
       "server",
@@ -406,11 +412,11 @@ describe("rsp telemetry spool", () => {
       "--byte-budget",
       String(DEFAULT_RSP_BYTE_BUDGET),
       "--telemetry-drain-timeout-ms",
-      String(await calibratedTelemetryDrainTimeoutMs(root)),
+      String(timing.drainTimeoutMs),
       "--idle-ms",
       "100",
     ], { cwd: root });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
     await expect(sendResidentRequest(
       { socketPath: paths.socketPath, timeoutMs: 1_000 },
       { id: "recover-legacy-elision", op: "get", handle: legacyHandle },
@@ -453,6 +459,7 @@ describe("rsp telemetry spool", () => {
     const bundle = await ensureRspBundle();
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const child = execFile(process.execPath, [
       bundle,
       "server",
@@ -465,13 +472,13 @@ describe("rsp telemetry spool", () => {
       "--byte-budget",
       String(DEFAULT_RSP_BYTE_BUDGET),
       "--telemetry-drain-timeout-ms",
-      String(await calibratedTelemetryDrainTimeoutMs(root)),
+      String(timing.drainTimeoutMs),
       "--idle-ms",
       "2000",
       "--telemetry-drain-interval-ms",
       "50",
     ], { cwd: root });
-    await waitForResident(paths.socketPath);
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
 
     await appendTelemetryEvent(root, {
       collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -483,7 +490,7 @@ describe("rsp telemetry spool", () => {
       wrapper_ms: 5,
     });
 
-    await waitForResidentTelemetry(paths.socketPath, "git log --terse");
+    await waitForResidentTelemetry(paths.socketPath, "git log --terse", timing.waitTimeoutMs);
     await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
 
     const { stdout } = await execFileAsync(process.execPath, [
@@ -510,7 +517,9 @@ describe("rsp telemetry spool", () => {
     const bundle = await ensureRspBundle();
     const paths = resolveResidentPaths(root);
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
     const staleCreatedAt = new Date(Date.now() - 60_000).toISOString();
+    const summaryMtimeBefore = await fileMtimeMs(paths.summaryPath);
     await writeFile(telemetrySpoolPath(root), `${JSON.stringify({
       collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
       id: "stale-cold-event",
@@ -535,14 +544,14 @@ describe("rsp telemetry spool", () => {
           ...process.env,
           RSP_STORE_URI: storeUri,
           RSP_TELEMETRY_DRAIN_INTERVAL_MS: "50",
-          RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(await calibratedTelemetryDrainTimeoutMs(root)),
+          RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(timing.drainTimeoutMs),
         },
       });
       expect(stdout).toContain("rsp:");
 
-      await waitForResidentTelemetry(paths.socketPath, "git log --terse");
+      await waitForResidentTelemetry(paths.socketPath, "git log --terse", timing.waitTimeoutMs);
       await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
-      await waitForStatusSummary(paths.summaryPath);
+      await waitForStatusSummary(paths.summaryPath, summaryMtimeBefore, timing.waitTimeoutMs);
     } finally {
       await shutdownResident(paths.socketPath);
     }
@@ -714,8 +723,28 @@ async function readTelemetryCollectionModels(storeUri: string): Promise<Record<s
   }
 }
 
-async function waitForResident(socketPath: string): Promise<void> {
-  const deadline = Date.now() + 5_000;
+interface TelemetryTiming {
+  drainTimeoutMs: number;
+  waitTimeoutMs: number;
+}
+
+const BASELINE_STORE_OPEN_MS = 100;
+
+async function calibratedTelemetryTiming(root: string): Promise<TelemetryTiming> {
+  const baselineUri = `file://${join(root, ".red", "tmp", `telemetry-baseline-${process.pid}-${Date.now()}.rdb`)}`;
+  const started = process.hrtime.bigint();
+  const db = await connect(baselineUri);
+  await db.close();
+  const storeOpenMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  const scale = Math.min(4, Math.max(1, Math.ceil(Math.max(1, storeOpenMs) / BASELINE_STORE_OPEN_MS)));
+  return {
+    drainTimeoutMs: Math.min(20_000, Math.max(2_000, Math.ceil(storeOpenMs * 8), 2_000 * scale)),
+    waitTimeoutMs: 5_000 * scale,
+  };
+}
+
+async function waitForResident(socketPath: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   let attempt = 0;
   while (Date.now() < deadline) {
     try {
@@ -727,17 +756,8 @@ async function waitForResident(socketPath: string): Promise<void> {
   throw new Error("resident did not start");
 }
 
-async function calibratedTelemetryDrainTimeoutMs(root: string): Promise<number> {
-  const baselineUri = `file://${join(root, ".red", "tmp", `telemetry-baseline-${process.pid}.rdb`)}`;
-  const started = process.hrtime.bigint();
-  const db = await connect(baselineUri);
-  await db.close();
-  const storeOpenMs = Number(process.hrtime.bigint() - started) / 1_000_000;
-  return Math.max(2_000, Math.ceil(Math.max(1, storeOpenMs) * 6));
-}
-
-async function waitForResidentTelemetry(socketPath: string, command: string): Promise<void> {
-  const deadline = Date.now() + 5_000;
+async function waitForResidentTelemetry(socketPath: string, command: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   let attempt = 0;
   while (Date.now() < deadline) {
     const response = await sendResidentRequest({ socketPath, timeoutMs: 200 }, {
@@ -757,14 +777,21 @@ async function waitForResidentTelemetry(socketPath: string, command: string): Pr
   throw new Error(`telemetry ${command} did not drain`);
 }
 
-async function waitForStatusSummary(summaryPath: string): Promise<void> {
-  const deadline = Date.now() + 5_000;
+async function waitForStatusSummary(summaryPath: string, minMtimeMs = 0, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const summary = await readFile(summaryPath, "utf8").catch(() => "");
-    if (summary.includes("tokens_saved_today")) return;
+    const [summary, mtimeMs] = await Promise.all([
+      readFile(summaryPath, "utf8").catch(() => ""),
+      fileMtimeMs(summaryPath),
+    ]);
+    if (summary.includes("tokens_saved_today") && mtimeMs > minMtimeMs) return;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error("rsp status summary did not refresh");
+}
+
+async function fileMtimeMs(path: string): Promise<number> {
+  return await stat(path).then((s) => s.mtimeMs, () => 0);
 }
 
 async function shutdownResident(socketPath: string): Promise<void> {


### PR DESCRIPTION
Automated AFK landing for #1654. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1654

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555525&installation_id=129708444&pr_number=1660&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1660&signature=9d922a3d3d3dae8ca78ccd8fdf37d7f56a5fa8f5b406886ade5579081b48d013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->