### PR TITLE
docs: land memory context glossary stranded in the primary checkout

### DIFF
--- a/.red/contexts/memory/CONTEXT.md
+++ b/.red/contexts/memory/CONTEXT.md
@@ -1,0 +1,41 @@
+# RedSkills Memory
+
+The `memory` context names the persistent-project-memory language for
+RedSkills: governed operational memory, recall, extraction evidence, and —
+since the 2026-07-13 session-continuity review — captured conversation
+history.
+
+## Language
+
+**Session Transcript**:
+The verbatim, per-repo record of one agent conversation, persisted in TOON —
+never JSONL — with permanent retention; pruning is a deliberate operator act,
+never automatic expiry.
+_Avoid_: session log, chat dump, conversation JSONL
+
+**Session Summary**:
+The deterministic, indexable digest of a **Session Transcript** (decisions,
+open threads, dates) that joins the recall graph as a first-class node and
+ranks inside the same hybrid recall fusion as every other memory source;
+optionally enriched later by a batch LLM pass, never by a per-turn one.
+_Avoid_: session note, auto-summary
+
+**Session Backfill**:
+The one-time import of pre-existing agent conversation history — Claude Code
+and Codex from day one — into **Session Transcripts** and **Session
+Summaries**, so continuity starts from the operator's real history instead of
+from zero.
+_Avoid_: history migration, session import script
+
+**Transcript Citation**:
+The recall contract for conversation history: an answer grounded in a
+**Session Transcript** cites the session, the date, and the verbatim wording,
+and states plainly when no transcript supports the claim instead of
+paraphrasing from ranking artifacts.
+_Avoid_: source link, reference blob
+
+**Verbatim-with-outbound-scrub**:
+The storage posture for **Session Transcripts**: bytes persist exactly as
+spoken, locally and unpublished; redaction happens only on surfaces that
+export or publish, never on ingest.
+_Avoid_: input scrubbing, redact-on-write


### PR DESCRIPTION
The `.red/contexts/memory/CONTEXT.md` glossary (session-continuity language minted 2026-07-13) existed only as an untracked file in the maintainer's primary checkout, invisible to AFK workers branching from `origin/main` — and `.red/CONTEXT-MAP.md` already links to it, so the link was dangling on main.

Lands the file through the standard docs lane (ADR 0092 doc-landing procedure). Docs-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786558500&installation_id=129708444&pr_number=1675&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1675&signature=0e07a2b03d6cd37f5fc40c4afa86f4371d52aa9fbfb6622177d10548bc41b4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->