### PR TITLE
fix: #1671 rsp truthful docs: rewrite apps/rsp/README.md, add architecture doc, add bench README

### DIFF
--- a/apps/rsp/README.md
+++ b/apps/rsp/README.md
@@ -1,19 +1,96 @@
 # @reddb-io/rsp
 
-`rsp` is the neutral RedSkills binary for reversible command-output elision.
-This package currently carries the elision store and retrieval command from ADR
-0095; wrappers and hook interception land in later slices.
+`rsp` is the RedSkills command-output reducer for agent terminal work. It wraps
+high-noise commands, emits compact decision-preserving output, and keeps the
+original bytes recoverable through `el:<id>` handles.
 
-Elision handles are stable short content-addressed ids rendered as `el:<id>`,
-where `<id>` is 12 lowercase hexadecimal characters. The only write API is
-`RspElisionStore.mint(original, meta)`, which stores the original bytes and
-returns the handle, preserving the handle/elision invariant.
+Benchmark headline: `rsp` reaches **99.4% decision-oracle capture** versus
+**RTK 4.9%** and **Headroom 0.6%** on the two-axis benchmark. The checked-in
+summary is at [bench/results/rsp-two-axis.md](bench/results/rsp-two-axis.md),
+and the benchmark guide is at [bench/README.md](bench/README.md).
 
-The store is an rsp-owned JSON document at `.red/rsp-elisions.json`. Retention
-defaults are `ttlDays: 7` and `byteBudget: 67108864`; top-level `.red/config.yaml`
-keys `rsp.ttlDays` and `rsp.byteBudget` override them.
+## What rsp Does
 
-`rsp show el:<id>` writes the original bytes verbatim to stdout. Expired or
-evicted handles write `expired <ISO date> — re-run: <original command>` to stdout
-and exit 1. Calling `rsp` with no arguments prints live store stats as scalar
-TOON fields instead of help text.
+`rsp` is both an explicit CLI and a hook target:
+
+- `rsp git status`, `rsp git diff`, `rsp git log`, `rsp git show`,
+  `rsp git blame`, `rsp git branch -av`, `rsp git commit`, and `rsp git push`
+  render git output as compact TOON when that keeps the decision signal.
+- `rsp gh pr|issue|run list|view` keeps GitHub rows, bodies, and failure states
+  readable while avoiding repetitive raw payloads.
+- `rsp vitest run` and `rsp cargo test` keep exit code, summary, and failing
+  rows instead of streaming full green-suite logs.
+- `rsp cat <file>` and `rsp cat --head N|--tail N <file>` provide bounded file
+  reads. Code files include a symbol outline plus head/tail context; binary
+  files pass through unchanged.
+- `rsp exec -- "<command>"` runs a shell command, summarizes structured or large
+  stdout, and preserves the command's stderr and exit status.
+- `rsp wait ...` standardizes long waits for commands, GitHub PRs, workflow
+  runs, and releases without handwritten polling loops.
+- `rsp show el:<id>` writes the original bytes for an elided handle.
+- `rsp`, `rsp stats`, and `rsp gains` report elision-store and telemetry gains.
+- `rsp mcp` exposes the resident-backed compression surface for MCP clients.
+- `rsp hook claude-pre-exec` and `rsp hook claude-post-exec` are the hook interception
+  surfaces used by supported agent hosts.
+
+The generated ambient instruction that agents read is
+[generated/AMBIENT-SKILL.md](generated/AMBIENT-SKILL.md). Regenerate it after
+wrapper capability changes with:
+
+```sh
+pnpm --filter @reddb-io/rsp gen:ambient-skill
+```
+
+## Recovery Model
+
+When `rsp` omits bytes, it prints an `el:<id>` handle. Handles are short,
+content-addressed identifiers minted by `RspElisionStore.mint(original, meta)`.
+The resident writes the original bytes into the rsp-owned RedDB KV collection
+and records the command, loss level, creation time, expiry time, and byte count.
+
+Recover a handle with:
+
+```sh
+rsp show el:<id>
+```
+
+Expired or evicted handles print an expiry line with the original command to
+rerun. Defaults are seven days of elision retention and a 64 MiB byte budget;
+`.red/config.yaml` can override `rsp.ttlDays` and `rsp.byteBudget`.
+
+## Resident and Telemetry
+
+`rsp` uses a resident process so wrappers do not repeatedly open the embedded
+RedDB store. Clients talk to the resident over a local socket. The resident owns
+the single embedded writer, serves mint/get/stats/gains requests, drains
+telemetry from a spool into RedDB, writes a statusline summary, and exits after
+an idle timeout.
+
+The full lifecycle is documented in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+That document covers the socket protocol, PID registry, version handover,
+idle shutdown watchdog, telemetry spool and drain path, gains report, elision
+store, wait registry, and the fail-open invariant.
+
+## Configuration
+
+`rsp` is enabled per repository with `.red/config.yaml`:
+
+```yaml
+rsp:
+  enabled: true
+```
+
+Useful optional keys:
+
+- `rsp.ttlDays`: elision handle retention days.
+- `rsp.byteBudget`: elision byte budget.
+- `rsp.telemetryTtlDays`: telemetry retention days.
+- `rsp.telemetryByteBudget`: telemetry byte budget.
+- `rsp.telemetryDrainIntervalMs`: resident drain interval.
+- `rsp.telemetryDrainTimeoutMs`: per-drain timeout.
+- `rsp.idleMs`: resident idle timeout, with a five-second minimum.
+- `rsp.heavyGitByteThreshold`: threshold for large git/file/exec output.
+
+If `rsp.enabled` is absent or false, wrapper commands pass through or report
+that rsp is disabled. If a wrapper or resident path fails, `rsp` degrades to the
+raw command whenever it can, preserving stdout, stderr, and exit status.

--- a/apps/rsp/bench/README.md
+++ b/apps/rsp/bench/README.md
@@ -1,0 +1,112 @@
+# rsp Two-Axis Benchmark
+
+The rsp benchmark measures two separate questions:
+
+1. **Decision-oracle capture**: how close the emitted output is to the
+   hand-reviewed compact oracle for each fixture, measured with
+   `js-tiktoken:gpt-4o` token counts.
+2. **Fidelity-first behavior**: whether the emitted output still preserves the
+   command facts an agent needs, such as exit status, failure rows, commit ids,
+   PR rows, and recovery handles.
+
+The headline used by the rsp docs is **99.4% decision-oracle capture** for rsp
+versus **RTK 4.9%** and **Headroom 0.6%**. The generated result artifacts live
+in [bench/results/rsp-two-axis.md](results/rsp-two-axis.md) and
+[bench/results/rsp-two-axis.toon](results/rsp-two-axis.toon).
+
+## Run It
+
+From the repo root:
+
+```sh
+pnpm --filter @reddb-io/rsp bench:two-axis
+```
+
+This regenerates the default artifacts:
+
+- `apps/rsp/bench/results/rsp-two-axis.toon`
+- `apps/rsp/bench/results/rsp-two-axis.md`
+
+To write to explicit paths:
+
+```sh
+pnpm --filter @reddb-io/rsp exec node --import tsx src/two-axis-benchmark-cli.ts \
+  --out /tmp/rsp-two-axis.toon \
+  --summary /tmp/rsp-two-axis.md
+```
+
+To run the checked-in regression gate:
+
+```sh
+pnpm --filter @reddb-io/rsp bench:two-axis:check
+```
+
+The check command reads the current `--out` artifact as the baseline, reruns the
+benchmark, rewrites the artifacts, and fails when a current filter regresses by
+more than the configured token threshold or loses fidelity. The thresholds live
+in `src/two-axis-thresholds.ts`.
+
+## Corpus
+
+The benchmark discovers fidelity fixtures under `apps/rsp/tests/fixtures`:
+
+- `file-read`
+- `gh`
+- `git`
+- `test-runners`
+
+Each fixture records raw command output and expected decision facts. Most
+fixtures have an adjacent `.oracle.toon` file that represents the hand-reviewed
+compact oracle. The benchmark requires large-output fixtures for git diff,
+git log, vitest green output, and vitest failure output so the result continues
+to cover the cases where reduction matters most.
+
+The RTK and Headroom comparators are recorded baselines:
+
+- `apps/rsp/tests/fixtures/rtk/baselines.json`
+- `apps/rsp/tests/fixtures/headroom/baselines.json`
+
+The benchmark does not execute RTK or Headroom during normal runs. Headroom
+capture is isolated in `apps/rsp/scripts/capture-headroom-baselines.py`.
+
+## Read the Summary
+
+`bench/results/rsp-two-axis.md` starts with the corpus size and admission
+threshold. Production mode applies the admission threshold before activating a
+filter; passthrough filters count as 0% token delta because rsp returns the
+original output for those command shapes.
+
+The main table has one row per filter:
+
+- `Mode`: whether the filter is active in production or passthrough.
+- `raw tokens`: token count of recorded command output.
+- `rsp tokens`: token count emitted by the production rsp mode.
+- `RTK tokens` and `Headroom tokens`: recorded comparator token counts, or
+  `not-covered`.
+- `oracle tokens`: token count of the hand-reviewed oracle.
+- `rsp capture`, `RTK capture`, `Headroom capture`: decision-oracle capture
+  percentages. Higher is closer to the oracle.
+- `brief shipped delta` and `terse shipped delta`: median and p90 token
+  reduction for the shipped rsp modes.
+- `fidelity-first score`: percentage of fixtures whose decision assertions
+  still pass.
+
+The aggregate line combines all fixtures. It is the fastest way to compare rsp,
+RTK, Headroom, raw output, and the oracle ceiling.
+
+## Read the TOON Artifact
+
+`bench/results/rsp-two-axis.toon` is the machine-readable report. It includes:
+
+- `method`: tokenizer, raw source, rsp source, oracle source, comparator source,
+  and unverified external literature claims.
+- `filters`: per-filter rows with raw/brief/terse axes, comparator axes,
+  oracle-capture axes, and hypothetical active-mode results for passthrough
+  filters.
+- `aggregate`: corpus-wide oracle-capture counts and percentages.
+- `parity`: direct fidelity gates for selected parity domains.
+- `anti_suppression_audit`: notes explaining why each filter does not hide the
+  decision signal.
+
+Use the Markdown summary for human review and the TOON artifact for regression
+checks or downstream analysis.

--- a/apps/rsp/docs/ARCHITECTURE.md
+++ b/apps/rsp/docs/ARCHITECTURE.md
@@ -1,0 +1,211 @@
+# rsp Architecture
+
+`rsp` has three jobs:
+
+1. Replace noisy command output with compact, decision-preserving output.
+2. Keep omitted bytes recoverable through `el:<id>` handles.
+3. Record telemetry so RedSkills can measure savings, degradation, and warm
+   resident behavior.
+
+The implementation is intentionally fail-open: a broken reducer should not
+block the command the operator asked to run.
+
+## CLI and Wrappers
+
+`apps/rsp/src/cli.ts` is the entry point. It parses the top-level command,
+resolves `.red/config.yaml`, starts or contacts the resident when needed, and
+dispatches to wrapper modules:
+
+- `git-wrapper.ts` for git status, diff, log, show, blame, branch, commit, and
+  push.
+- `gh-wrapper.ts` for GitHub PR, issue, and workflow run list/view output.
+- `test-wrapper.ts` for `vitest` and `cargo test`.
+- `cat-wrapper.ts` for bounded file reads and code outlines.
+- `exec-wrapper.ts` for arbitrary shell commands.
+- `wait.ts` for standardized wait operations.
+
+Each wrapper returns stdout, stderr, status, signal, and optional raw output
+metadata. `emitWrappedResult()` writes the wrapper output first, then appends
+telemetry best-effort.
+
+## Resident Lifecycle
+
+The resident is started through `rsp server` or warmed by client calls through
+`ensureResidentServer()` and `warmResidentServer()`. Runtime paths come from the
+shared resident-client package and include a socket path, PID file, wake-lock
+path, and PID registry under the repository's `.red/tmp` area.
+
+The resident process:
+
+- Listens on a local socket and accepts one JSON request per newline-framed
+  connection.
+- Opens the configured RedDB store once with `allowResidentOpen: true`.
+- Acts as the single embedded writer for elision, telemetry stats, telemetry
+  gains, memory, and brain requests.
+- Writes a PID file and a PID registry entry containing the socket path,
+  store URI, and resident version.
+- Resets an idle timer on each accepted socket and request.
+- Starts shutdown after the idle timeout, closes the server, destroys active
+  sockets, performs a final telemetry drain, closes the store, removes the
+  socket, removes the PID file, and removes the PID registry entry.
+- Arms an idle shutdown watchdog so a stuck shutdown cannot leave the resident
+  alive indefinitely.
+- Cleans up child `red rpc --stdio` processes on exit and also runs a small
+  parent-death guard on non-Windows platforms.
+
+The version handover path is explicit. When a client asks for `handover`, the resident
+returns the running resident version and the client version, then schedules its
+own shutdown. A newer client can then start a fresh resident with the new code.
+
+## Socket Protocol
+
+The socket protocol is newline-delimited JSON. Requests carry an `id` and an
+operation. Responses echo the `id`, include `ok: true` and a `value`, or
+`ok: false` and an error string. Successful responses also include resident
+metrics such as store-open count and store-open elapsed milliseconds; wrapper
+telemetry records those metrics to distinguish cold boots from warm hits.
+
+Supported resident operations include:
+
+- `ping`
+- `handover`
+- `stats`
+- `telemetry-stats`
+- `telemetry-gains`
+- `mint`
+- `get`
+- `memory`
+- `brain`
+
+## Elision Store and Handles
+
+The default store URI points at the repo-local shared RedDB file. The elision
+collection is `rsp_elisions_v1`, stored as a RedDB KV collection. The resident
+keeps an `index:v1` document beside the records so pruning can enforce both
+time-to-live and byte-budget limits.
+
+Minting an elision:
+
+1. Hashes the original bytes and metadata into a stable `el:<id>` handle.
+2. Stores the original bytes as base64 with command metadata, loss level,
+   creation time, expiry time, and byte count.
+3. Deletes any old tombstone for the same handle.
+4. Updates the index.
+5. Prunes expired records and oldest records over the byte budget.
+6. Verifies that the RedDB record and index entry were persisted.
+
+Reading an elision returns the original bytes when live. If a record has
+expired or has been evicted, `rsp` returns an expired tombstone with the expiry
+time and original command. `rsp show el:<id>` writes live original bytes
+verbatim and prints the expired tombstone message otherwise.
+
+The store also retains a JSON-document fallback for non-RedDB URIs and legacy
+migration code for older table-shaped elision collections, but the normal
+repository path is the resident-backed RedDB KV store.
+
+## Telemetry Chain
+
+Wrappers do not write telemetry directly into RedDB. They append compact JSONL
+events to `.red/tmp/rsp-telemetry.spool.jsonl`. Appending is best-effort and
+swallows write errors so the user command remains authoritative.
+
+The resident owns the drain:
+
+1. `appendTelemetryEvent()` writes compact invocation events to the spool.
+   Large raw/emitted text fields are replaced by byte counts before spooling.
+2. `ResidentTelemetryDrain` periodically renames the spool to a process-local
+   drain file.
+3. Each line is parsed and written to a RedDB KV telemetry collection.
+4. Bad lines or write failures become degradation events rather than blocking
+   the drain.
+5. The telemetry index is pruned by telemetry TTL and byte budget.
+6. `writeStatusSummary()` writes `.red/tmp/rsp-status-summary.json` for the
+   statusline summary.
+
+Telemetry collections:
+
+- `rsp_telemetry_invocations_v1`
+- `rsp_telemetry_degradations_v1`
+- `rsp_telemetry_index_v1`
+
+The resident self-heals telemetry collections that exist with an incompatible
+model when it can safely drop and recreate them. Collection model mismatches
+are also recorded as degradation events.
+
+## Stats, Gains, and Statusline Summary
+
+`rsp` and `rsp stats` read elision-store stats plus a telemetry window. The
+telemetry stats include invocation count, elision count, raw/emitted bytes,
+estimated tokens saved, estimated dollar savings, top commands, degradation
+rate, most recent degradation, latency percentiles, and resident cold/warm
+metrics.
+
+`rsp gains` reads a wider telemetry report designed for operational review. It
+groups latency by command family, builds request throughput rows, reports a
+weekday/hour heatmap, aggregates weekly token savings, lists top commands by
+tokens saved and invocation count, identifies the biggest single elision, and
+summarizes degradation history.
+
+The statusline summary is a small JSON file with today's token and dollar
+savings estimate plus an update timestamp. It lets shells and agents display a
+cheap status without opening the store.
+
+## Wait Registry
+
+The wait registry is the repo-local record of active `rsp wait` processes.
+
+`rsp wait` provides bounded waits for:
+
+- `rsp wait cmd -- "<command>"`
+- `rsp wait pr <number>`
+- `rsp wait run <run-id>`
+- `rsp wait run --branch <branch> --latest`
+- `rsp wait release --tag "<glob>"`
+- `rsp wait ls`
+
+Every active wait writes a registry entry under `.red/tmp/waits/`. Entries
+record the wait kind, target, reason, PID, started time, poll tier, timeout,
+and current status. The process exit code is the signal:
+
+- `0`: success verdict.
+- `1`: failure verdict.
+- `2`: timeout or indeterminate verdict.
+
+The registry entry is updated while the wait runs and removed on every exit
+path. `rsp wait ls` reads the registry, filters out dead PIDs, and reports the
+live waits.
+
+## Hook Interception
+
+`rsp hook claude-pre-exec` reads a host hook payload and rewrites only simple,
+known-safe command shapes to their `rsp` equivalents. It covers the generated
+wrapper capabilities plus plain `cat`, `head`, and `tail` file reads. Compound
+commands, environment assignment prefixes, unsupported commands, disabled
+repositories, missing commands, or unhealthy residents pass through.
+
+When the resident is unhealthy, the hook wakes it and returns passthrough for
+that command. The next command can use the wrapper after the resident is ready.
+`rsp hook claude-post-exec` is the normalization hook for host-provided command
+output.
+
+## Fail-Open Invariant
+
+The invariant is simple: `rsp` may save tokens, but it must not make the user
+lose the command result.
+
+Important fail-open paths:
+
+- Disabled repositories do not force wrapper behavior.
+- Missing store provisioning lets wrapper commands run cold where possible.
+- Wrapper exceptions call the raw command path through passthrough degradation.
+- `gh` auth/rate-limit and other fault outputs preserve the byte-level fault
+  output.
+- Binary file reads pass through unchanged.
+- Telemetry append, telemetry drain, status summary, and cold drain nudges are
+  best-effort.
+- `rsp exec` preserves stderr and exit status even when stdout is summarized.
+- `rsp wait` returns explicit success/failure/timeout status instead of hiding
+  indeterminate waits.
+
+This is why wrapper code records raw output separately from emitted output and
+why telemetry is written after stdout/stderr are already emitted.

--- a/apps/rsp/tests/docs-surface.test.ts
+++ b/apps/rsp/tests/docs-surface.test.ts
@@ -1,0 +1,63 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function doc(relativePath: string): Promise<string> {
+  return await readFile(join(packageRoot, relativePath), "utf8");
+}
+
+describe("rsp docs surface", () => {
+  it("describes the shipped rsp surface without stale future-tense claims", async () => {
+    const readme = await doc("README.md");
+
+    expect(readme).toContain("99.4% decision-oracle capture");
+    expect(readme).toContain("RTK 4.9%");
+    expect(readme).toContain("Headroom 0.6%");
+    expect(readme).toContain("docs/ARCHITECTURE.md");
+    expect(readme).toContain("bench/README.md");
+    expect(readme).toContain("wrappers");
+    expect(readme).toContain("hook interception");
+    expect(readme).toContain("resident");
+    expect(readme).toContain("telemetry");
+    expect(readme).toContain("rsp wait");
+    expect(readme).not.toMatch(/land in later slices|currently carries only|will ship/i);
+  });
+
+  it("documents resident lifecycle, telemetry, elisions, wait, and fail-open behavior", async () => {
+    const architecture = await doc("docs/ARCHITECTURE.md");
+
+    for (const required of [
+      "socket",
+      "single embedded writer",
+      "idle shutdown",
+      "watchdog",
+      "PID registry",
+      "version handover",
+      "spool",
+      "drain",
+      "store",
+      "gains",
+      "statusline summary",
+      "el:",
+      "wait registry",
+      "fail-open",
+    ]) {
+      expect(architecture).toContain(required);
+    }
+  });
+
+  it("explains how to run and interpret the two-axis benchmark", async () => {
+    const bench = await doc("bench/README.md");
+
+    expect(bench).toContain("pnpm --filter @reddb-io/rsp bench:two-axis");
+    expect(bench).toContain("pnpm --filter @reddb-io/rsp bench:two-axis:check");
+    expect(bench).toContain("decision-oracle capture");
+    expect(bench).toContain("fidelity-first score");
+    expect(bench).toContain("bench/results/rsp-two-axis.md");
+    expect(bench).toContain("RTK");
+    expect(bench).toContain("Headroom");
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1671. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1671

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786565224&installation_id=129708444&pr_number=1703&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1703&signature=3b2f7fc105fab71308d606e948f58d9a11440c1a7ee5e648d07a21ea968987cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->