### PR TITLE
opencode rsp slice-2 default-on, release-time generated tree, ambient opencode lane

### DIFF
--- a/.github/workflows/red-release.yml
+++ b/.github/workflows/red-release.yml
@@ -431,6 +431,14 @@ jobs:
         run: |
           set -euo pipefail
           pnpm build
+          node ../../dist/opencode-host.bundle.min.mjs \
+            --config ../../.red/config.yaml \
+            --plugins-root ../../plugins \
+            --out ../../dist/opencode.json \
+            --out-dir ../../dist/opencode \
+            --copy
+          touch ../../dist/opencode/.release-generated
+          tar -czf ../../dist/opencode-host.generated.tgz -C ../.. dist/opencode
 
       - name: Build benchmark-code-understanding bundle + manifest
         if: steps.fleet.outputs.running == '0' && steps.bump.outputs.kind != 'none'
@@ -688,6 +696,7 @@ jobs:
             dist/benchmark-memory.bundle.min.mjs \
             dist/benchmark-memory.manifest.json \
             dist/opencode-host.bundle.min.mjs \
+            dist/opencode-host.generated.tgz \
             dist/benchmark-code-understanding.bundle.min.mjs \
             dist/benchmark-code-understanding.manifest.json \
             dist/memory.bundle.min.mjs \
@@ -722,6 +731,7 @@ jobs:
             dist/benchmark-memory.bundle.min.mjs
             dist/benchmark-memory.manifest.json
             dist/opencode-host.bundle.min.mjs
+            dist/opencode-host.generated.tgz
             dist/benchmark-code-understanding.bundle.min.mjs
             dist/benchmark-code-understanding.manifest.json
             dist/memory.bundle.min.mjs

--- a/apps/dev/src/commands/rsp-instructions.ts
+++ b/apps/dev/src/commands/rsp-instructions.ts
@@ -3,12 +3,13 @@ import { renderAmbientSkill, type RspInstructionRunner } from "../../../rsp/src/
 function runnerFromArgs(args: readonly string[]): RspInstructionRunner {
   const index = args.indexOf("--runner");
   const runner = index >= 0 ? args[index + 1] : undefined;
+  if (runner === "opencode") return "opencode";
   return runner === "claude" ? "claude" : "codex";
 }
 
 export function renderRspInstructionsHookOutput(runner: RspInstructionRunner): string {
   const instructions = renderAmbientSkill(undefined, { runner });
-  if (runner === "codex") return JSON.stringify({ systemMessage: instructions });
+  if (runner === "codex" || runner === "opencode") return JSON.stringify({ systemMessage: instructions });
   return JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "SessionStart",

--- a/apps/dev/tests/rsp-instructions.test.ts
+++ b/apps/dev/tests/rsp-instructions.test.ts
@@ -16,4 +16,11 @@ describe("rsp instruction session content", () => {
     expect(parsed.systemMessage).toContain("pre-execution rewrite hook is available");
     expect(parsed.systemMessage).toContain("Codex PostToolUse cannot");
   });
+
+  it("emits OpenCode session content with the opencode runner target", () => {
+    const parsed = JSON.parse(renderRspInstructionsHookOutput("opencode"));
+    expect(parsed.systemMessage).toContain("OpenCode lane");
+    expect(parsed.systemMessage).toContain("rsp wait");
+    expect(parsed.systemMessage).toContain("opencode plugin surface");
+  });
 });

--- a/apps/opencode-host/src/generate.ts
+++ b/apps/opencode-host/src/generate.ts
@@ -16,7 +16,7 @@
  *   - checks the ADR 0067 strict opt-in gate (`plugins.dev.enabled: true`),
  *   - builds the Slice 1 + Slice 2 plan for the named plugins
  *     (default: every plugin under `plugins/`),
- *   - writes the dist tree to `<out>` (default `./dist/opencode`).
+ *   - writes the dist tree to `<out-dir>` (default `./dist/opencode`).
  *
  * Exit codes:
  *   0  — wrote the tree (errors may have been logged; check stderr).
@@ -92,7 +92,7 @@ function parseArgs(argv: ReadonlyArray<string>): CliArgs {
     printJson: false,
     copySkills: false,
     pluginFilter: null,
-    slice2: false,
+    slice2: true,
   };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -133,6 +133,8 @@ function parseArgs(argv: ReadonlyArray<string>): CliArgs {
       args.pluginFilter = [...(args.pluginFilter ?? []), next];
     } else if (arg === "--with-slice-2" || arg === "--slice-2") {
       args.slice2 = true;
+    } else if (arg === "--no-slice-2") {
+      args.slice2 = false;
     } else if (arg === "--copy") {
       args.copySkills = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -153,7 +155,7 @@ Slice 1: opencode.json (provider block) at <out>
 Slice 2: dist tree at <out-dir>/<plugin>/{opencode.json, .opencode/...}
 
 Usage:
-  opencode-host generate [--config <path>] [--out <path>] [--out-dir <path>] [--plugins-root <path>] [--plugin <name>] [--copy] [--print] [--with-slice-2]
+  opencode-host generate [--config <path>] [--out <path>] [--out-dir <path>] [--plugins-root <path>] [--plugin <name>] [--copy] [--print] [--no-slice-2]
   opencode-host generate --help
 
 Options:
@@ -163,7 +165,8 @@ Options:
   -p, --plugins-root <path>  path to the plugins/ tree (default: ./plugins)
       --plugin <name>        emit only this plugin (repeatable; Slice 2 only)
       --copy                 copy SKILL.md instead of symlinking
-      --with-slice-2         also emit the Slice 2 dist tree (skills + hooks); off by default
+      --with-slice-2         emit the Slice 2 dist tree (default; kept for compatibility)
+      --no-slice-2           opt out of the Slice 2 dist tree
   --print                    print Slice 1 JSON to stdout (Slice 2 not written)
   -h, --help                 show this help
 

--- a/apps/opencode-host/src/hooks-to-events.ts
+++ b/apps/opencode-host/src/hooks-to-events.ts
@@ -83,7 +83,8 @@ export function rewritePluginRoot(command: string, plugin: string): string {
   // JS template that uses the surrounding function's `directory` arg.
   return command
     .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, `\${__pluginRoot}`)
-    .replace(/\$\{CODEX_PLUGIN_ROOT\}/g, `\${__pluginRoot}`);
+    .replace(/\$\{CODEX_PLUGIN_ROOT\}/g, `\${__pluginRoot}`)
+    .replace(/\brsp-instructions --runner (claude|codex) --hook\b/g, "rsp-instructions --runner opencode --hook");
 }
 
 /** The TypeScript template for a single `tool.execute.before` module. */
@@ -146,7 +147,7 @@ function toolExecuteBeforeTemplate(input: {
   const rspRewriteHelper = hasRspHook
     ? [
         "      const __runRspRewrite = async (inner: string): Promise<string | null> => {",
-        "        const proc = Bun.$`sh -c ${inner}`.env({ __pluginRoot, CLAUDE_PLUGIN_ROOT: __pluginRoot, CODEX_PLUGIN_ROOT: __pluginRoot }).quiet().nothrow();",
+        "        const proc = Bun.$`sh -c ${inner}`.env({ __pluginRoot, CLAUDE_PLUGIN_ROOT: __pluginRoot, CODEX_PLUGIN_ROOT: __pluginRoot, OPENCODE_PLUGIN_ROOT: __pluginRoot }).quiet().nothrow();",
         "        const writer = proc.stdin.getWriter();",
         "        await writer.write(__encoder.encode(__payload));",
         "        await writer.close();",
@@ -182,7 +183,7 @@ function toolExecuteBeforeTemplate(input: {
     "      const __shellQuote = (value: string): string => `'${value.replaceAll(\"'\", \"'\\\\''\")}'`;",
     "      const __denyCommand = (reason: string, code: number): string => `printf '%s\\\\n' ${__shellQuote(reason)} >&2; exit ${code}`;",
     "      const __runHook = async (inner: string): Promise<boolean> => {",
-    "        const proc = Bun.$`sh -c ${inner}`.env({ __pluginRoot, CLAUDE_PLUGIN_ROOT: __pluginRoot, CODEX_PLUGIN_ROOT: __pluginRoot }).quiet().nothrow();",
+    "        const proc = Bun.$`sh -c ${inner}`.env({ __pluginRoot, CLAUDE_PLUGIN_ROOT: __pluginRoot, CODEX_PLUGIN_ROOT: __pluginRoot, OPENCODE_PLUGIN_ROOT: __pluginRoot }).quiet().nothrow();",
     "        const writer = proc.stdin.getWriter();",
     "        await writer.write(__encoder.encode(__payload));",
     "        await writer.close();",

--- a/apps/opencode-host/tests/generate-cli.test.ts
+++ b/apps/opencode-host/tests/generate-cli.test.ts
@@ -8,13 +8,49 @@
  * half in provider-block.test.ts).
  */
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const REPO = resolve(__dirname, "../../..");
 const GENERATE_ENTRY = resolve(REPO, "apps/opencode-host/src/generate.ts");
+
+function writeFixturePlugins(root: string): void {
+  const dev = join(root, "dev");
+  mkdirSync(join(dev, ".claude-plugin"), { recursive: true });
+  mkdirSync(join(dev, "hooks"), { recursive: true });
+  writeFileSync(join(dev, ".claude-plugin", "plugin.json"), "{}\n", "utf8");
+  writeFileSync(
+    join(dev, "hooks", "claude.hooks.json"),
+    JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: "sh -c 'red-fetch.mjs run dev rsp-instructions --runner claude --hook'",
+              },
+            ],
+          },
+        ],
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              {
+                type: "command",
+                command: "sh -c 'node \"${CLAUDE_PLUGIN_ROOT}/../../dist/rsp.bundle.min.mjs\" hook claude-pre-exec'",
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    "utf8",
+  );
+}
 
 function runGenerate(args: string[], env: Record<string, string | undefined>): {
   status: number;
@@ -69,7 +105,7 @@ describe("opencode-host generate (CLI smoke)", () => {
     writeFileSync(config, "plugins:\n  dev:\n    enabled: false\n", "utf8");
     const out = join(dir, "opencode.json");
     try {
-      const r = runGenerate(["--config", config, "--out", out], {});
+      const r = runGenerate(["--config", config, "--out", out, "--no-slice-2"], {});
       expect(r.status).toBe(1);
       expect(r.stderr).toMatch(/refusing to emit/);
       expect(r.stderr).toMatch(/plugins\.dev\.enabled/);
@@ -84,7 +120,7 @@ describe("opencode-host generate (CLI smoke)", () => {
     writeFileSync(config, "plugins:\n  dev:\n    enabled: true\n", "utf8");
     const out = join(dir, "opencode.json");
     try {
-      const r = runGenerate(["--config", config, "--out", out], {});
+      const r = runGenerate(["--config", config, "--out", out, "--no-slice-2"], {});
       expect(r.status).toBe(0);
       const written = readFileSync(out, "utf8");
       const jsonStart = written.indexOf("{");
@@ -120,7 +156,7 @@ describe("opencode-host generate (CLI smoke)", () => {
     );
     const out = join(dir, "opencode.json");
     try {
-      const r = runGenerate(["--config", config, "--out", out], { MINIMAX_API_KEY: "mn-test" });
+      const r = runGenerate(["--config", config, "--out", out, "--no-slice-2"], { MINIMAX_API_KEY: "mn-test" });
       expect(r.status).toBe(0);
       const written = readFileSync(out, "utf8");
       expect(written).toContain("\"model\": \"minimax/MiniMax-M3\"");
@@ -153,6 +189,41 @@ describe("opencode-host generate (CLI smoke)", () => {
       const jsonStart = r.stdout.indexOf("{");
       const parsed = JSON.parse(r.stdout.slice(jsonStart)) as { model: string };
       expect(parsed.model).toBe("openrouter/anthropic/claude-3.5-sonnet");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits the Slice 2 dist tree by default and allows opting out", () => {
+    const dir = mkdtempSync(join(tmpdir(), "opencode-host-"));
+    const config = join(dir, "config.yaml");
+    const plugins = join(dir, "plugins");
+    const out = join(dir, "opencode.json");
+    const outDir = join(dir, "dist", "opencode");
+    writeFileSync(config, "plugins:\n  dev:\n    enabled: true\n", "utf8");
+    writeFixturePlugins(plugins);
+    try {
+      const defaultRun = runGenerate(["--config", config, "--plugins-root", plugins, "--out", out, "--out-dir", outDir], {});
+      expect(defaultRun.status).toBe(0);
+      const preToolUse = readFileSync(join(outDir, "dev", ".opencode", "plugin", "pre-tool-use.ts"), "utf8");
+      const sessionStart = readFileSync(join(outDir, "dev", ".opencode", "plugin", "session-start.ts"), "utf8");
+      expect(preToolUse).toContain("__runRspRewrite");
+      expect(sessionStart).toContain("--runner opencode --hook");
+
+      rmSync(outDir, { recursive: true, force: true });
+      const optOutRun = runGenerate([
+        "--config",
+        config,
+        "--plugins-root",
+        plugins,
+        "--out",
+        out,
+        "--out-dir",
+        outDir,
+        "--no-slice-2",
+      ], {});
+      expect(optOutRun.status).toBe(0);
+      expect(() => readFileSync(join(outDir, "dev", ".opencode", "plugin", "pre-tool-use.ts"), "utf8")).toThrow();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/opencode-host/tests/hooks-to-events.test.ts
+++ b/apps/opencode-host/tests/hooks-to-events.test.ts
@@ -101,6 +101,8 @@ describe("planPluginHooks (real claude.hooks.json shape)", () => {
     const session = plans.find((p) => p.opencodeEvent === "config")!;
     expect(session.source).toContain("red-fetch.mjs dev");
     expect(session.source).toContain("rsp-instructions");
+    expect(session.source).toContain("--runner opencode --hook");
+    expect(session.source).not.toContain("--runner claude --hook");
     expect(session.source).toContain("ensure-codex-statusline");
     expect(session.source).toContain('"experimental.chat.system.transform"');
     expect(session.source).toContain("hookSpecificOutput?.additionalContext");

--- a/apps/rsp/src/ambient-skill.ts
+++ b/apps/rsp/src/ambient-skill.ts
@@ -5,7 +5,7 @@ import { RSP_WRAPPER_CAPABILITIES, type RspWrapperCapability } from "./intercept
 // so the source of truth for the file location lives in one place.
 export const AMBIENT_SKILL_RELATIVE_PATH = "generated/AMBIENT-SKILL.md";
 
-export type RspInstructionRunner = "claude" | "codex";
+export type RspInstructionRunner = "claude" | "codex" | "opencode";
 
 export interface AmbientSkillRenderOptions {
   runner?: RspInstructionRunner;
@@ -133,6 +133,15 @@ function renderRunnerLines(runner: RspInstructionRunner | undefined): string[] {
       "",
       "Claude Code pre-execution interception is available for simple wrapped",
       "commands, and direct calls still help when composing commands deliberately.",
+    ];
+  }
+  if (runner === "opencode") {
+    return [
+      "## OpenCode lane",
+      "",
+      "OpenCode receives this guidance through the generated opencode plugin surface.",
+      "The plugin can rewrite simple shell-tool commands before execution, and direct",
+      "`rsp` calls still help when composing commands deliberately.",
     ];
   }
   return [];

--- a/apps/rsp/tests/ambient-skill.test.ts
+++ b/apps/rsp/tests/ambient-skill.test.ts
@@ -48,12 +48,15 @@ describe("rsp ambient skill generator", () => {
   it("renders runner-specific guidance for Claude and Codex interception", () => {
     const codex = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES, { runner: "codex" });
     const claude = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES, { runner: "claude" });
+    const opencode = renderAmbientSkill(RSP_WRAPPER_CAPABILITIES, { runner: "opencode" });
 
     expect(codex).toContain("Codex lane");
     expect(codex).toContain("pre-execution rewrite hook is available");
     expect(codex).toContain("Codex PostToolUse cannot");
     expect(claude).toContain("Claude lane");
     expect(claude).toContain("pre-execution interception is available");
+    expect(opencode).toContain("OpenCode lane");
+    expect(opencode).toContain("opencode plugin surface");
   });
 
   it("committed artifact matches the generator output (drift check)", () => {

--- a/scripts/install-opencode.sh
+++ b/scripts/install-opencode.sh
@@ -58,6 +58,7 @@ DRY_RUN="false"
 CONFIG_PATH="$REPO_ROOT/.red/config.yaml"
 PLUGINS_ROOT="$REPO_ROOT/plugins"
 OUT_DIR="$REPO_ROOT/dist/opencode"
+PREGENERATED_TREE_MARKER="$OUT_DIR/.release-generated"
 MANIFEST_FILE=""
 MANIFEST_TMP=""
 
@@ -307,15 +308,21 @@ else
   GENERATOR="node $BUNDLE"
 fi
 
-# 2. generate the dist tree
-GEN_ARGS=(--config "$CONFIG_PATH" --with-slice-2 --plugins-root "$PLUGINS_ROOT" --out-dir "$OUT_DIR")
-[ "$COPY" = "true" ] && GEN_ARGS+=(--copy)
-
-log "generating dist tree under $OUT_DIR"
-if [ "$DRY_RUN" = "true" ]; then
-  log "(dry-run) $GENERATOR ${GEN_ARGS[*]}"
+# 2. prepare the dist tree. Release installs prefer the pre-generated tree
+# extracted by scripts/install.sh; source checkouts regenerate from the current
+# tree so local development stays fresh.
+if [ -f "$PREGENERATED_TREE_MARKER" ]; then
+  log "using release-generated dist tree under $OUT_DIR"
 else
-  (cd "$REPO_ROOT" && $GENERATOR "${GEN_ARGS[@]}")
+  GEN_ARGS=(--config "$CONFIG_PATH" --plugins-root "$PLUGINS_ROOT" --out-dir "$OUT_DIR")
+  [ "$COPY" = "true" ] && GEN_ARGS+=(--copy)
+
+  log "generating dist tree under $OUT_DIR"
+  if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run) $GENERATOR ${GEN_ARGS[*]}"
+  else
+    (cd "$REPO_ROOT" && $GENERATOR "${GEN_ARGS[@]}")
+  fi
 fi
 
 # 3. discover the plugins that have a dist subtree

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -175,14 +175,29 @@ download_release_asset_if_available() {
     return 0
   fi
 
-  [[ "$REFRESH" == "true" || ! -f "$out" ]] || return 0
   mkdir -p "$source/dist"
-  if curl_file "$url" "$out.tmp"; then
-    mv "$out.tmp" "$out"
-    log "downloaded optional release asset $asset"
-  else
-    rm -f "$out.tmp"
-    warn "optional release asset $asset is unavailable for $tag; OpenCode install may build from source"
+  if [[ "$REFRESH" == "true" || ! -f "$out" ]]; then
+    if curl_file "$url" "$out.tmp"; then
+      mv "$out.tmp" "$out"
+      log "downloaded optional release asset $asset"
+    else
+      rm -f "$out.tmp"
+      warn "optional release asset $asset is unavailable for $tag; OpenCode install may build from source"
+    fi
+  fi
+
+  local generated_asset="opencode-host.generated.tgz"
+  local generated_out="$source/dist/$generated_asset"
+  local generated_url="https://github.com/$REPO/releases/download/$tag/$generated_asset"
+  if [[ "$REFRESH" == "true" || ! -f "$source/dist/opencode/.release-generated" ]]; then
+    if curl_file "$generated_url" "$generated_out.tmp"; then
+      mv "$generated_out.tmp" "$generated_out"
+      tar -xzf "$generated_out" -C "$source"
+      log "downloaded optional release asset $generated_asset"
+    else
+      rm -f "$generated_out.tmp"
+      warn "optional release asset $generated_asset is unavailable for $tag; OpenCode install may generate from source"
+    fi
   fi
 }
 


### PR DESCRIPTION
Closes #1668.

Defaults opencode slice-2 generation on (--no-slice-2 as explicit opt-out), adds the opencode ambient instruction lane to rsp (--runner opencode in hook rewrites), renders rsp instructions for opencode sessions, and makes release installs consume a prebuilt generated opencode tree: red-release.yml builds and publishes dist/opencode-host.generated.tgz, and the installers prefer that asset with install-time generation as fallback.

Sensitive-path note: the protected diff (.github/workflows/red-release.yml, +10 lines: generated-tree build step + two asset-list entries, no trigger/permission changes) was reviewed and approved by the maintainer via /hitl on 2026-07-13. The AFK salvage commit that captured a machine-local generated opencode.json at the repo root was deliberately dropped from this landing branch (environment-specific artifact, not repo content).

Landing via PR + CI (local no-agent gate OOMs this workstation).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786574546&installation_id=129708444&pr_number=1718&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1718&signature=05c1b76005f97a56f7db58b1e0ea8a9305d3eecfa223d6e6fcbd78b6a1072db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->