### PR TITLE
feat: #1674 neutral-corpus benchmark: third-party fixtures for the rsp vs RTK vs Headroom comparison

### DIFF
--- a/apps/rsp/bench/README.md
+++ b/apps/rsp/bench/README.md
@@ -9,10 +9,16 @@ The rsp benchmark measures two separate questions:
    command facts an agent needs, such as exit status, failure rows, commit ids,
    PR rows, and recovery handles.
 
-The headline used by the rsp docs is **99.4% decision-oracle capture** for rsp
+The headline used by the rsp docs is **99.8% decision-oracle capture** for rsp
 versus **RTK 4.9%** and **Headroom 0.6%**. The generated result artifacts live
 in [bench/results/rsp-two-axis.md](results/rsp-two-axis.md) and
 [bench/results/rsp-two-axis.toon](results/rsp-two-axis.toon).
+
+The additive neutral third-party corpus lives in
+[bench/results/rsp-two-axis-neutral.md](results/rsp-two-axis-neutral.md) and
+[bench/results/rsp-two-axis-neutral.toon](results/rsp-two-axis-neutral.toon).
+The side-by-side home/neutral table is
+[bench/results/rsp-two-axis-corpus-comparison.md](results/rsp-two-axis-corpus-comparison.md).
 
 ## Run It
 
@@ -26,6 +32,17 @@ This regenerates the default artifacts:
 
 - `apps/rsp/bench/results/rsp-two-axis.toon`
 - `apps/rsp/bench/results/rsp-two-axis.md`
+
+To regenerate the neutral third-party artifacts:
+
+```sh
+pnpm --filter @reddb-io/rsp bench:two-axis:neutral
+```
+
+This writes:
+
+- `apps/rsp/bench/results/rsp-two-axis-neutral.toon`
+- `apps/rsp/bench/results/rsp-two-axis-neutral.md`
 
 To write to explicit paths:
 
@@ -65,6 +82,13 @@ The RTK and Headroom comparators are recorded baselines:
 
 - `apps/rsp/tests/fixtures/rtk/baselines.json`
 - `apps/rsp/tests/fixtures/headroom/baselines.json`
+
+The neutral corpus is discovered under `apps/rsp/tests/fixtures-neutral`.
+It is additive and smaller than the home corpus: public run metadata from
+vitest-dev/vitest and rust-lang/cargo, public git machine output from
+nodejs/node and rust-lang/rust, and Cargo JSON message output following the
+published `--message-format=json` contract. Its comparator baselines live next
+to it under `fixtures-neutral/rtk` and `fixtures-neutral/headroom`.
 
 The benchmark does not execute RTK or Headroom during normal runs. Headroom
 capture is isolated in `apps/rsp/scripts/capture-headroom-baselines.py`.

--- a/apps/rsp/bench/results/rsp-two-axis-corpus-comparison.md
+++ b/apps/rsp/bench/results/rsp-two-axis-corpus-comparison.md
@@ -1,0 +1,17 @@
+# rsp Two-Axis Corpus Comparison
+
+Generated from the checked-in home corpus and the additive neutral third-party corpus.
+
+| Corpus | Fixtures | Filters | raw tokens | rsp tokens | RTK tokens | Headroom tokens | oracle tokens | rsp capture | RTK capture | Headroom capture |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| home | 31 | 14 | 66174 | 13953 | 646 | 64367 | 13874 | 99.8% | 4.9% | 0.6% |
+| neutral-third-party | 5 | 5 | 869 | 921 | 127 | 741 | 820 | 0% | 18.1% | 90.4% |
+
+Neutral-corpus provenance is recorded in
+`apps/rsp/bench/results/rsp-two-axis-neutral.md` and
+`apps/rsp/bench/results/rsp-two-axis-neutral.toon`.
+
+Decision-usefulness-first reading: a token reduction with failed fidelity is not
+a useful win. The per-filter result tables keep token movement and fidelity
+visible together so suppression-only output cannot outrank preserved decision
+facts.

--- a/apps/rsp/bench/results/rsp-two-axis-neutral.md
+++ b/apps/rsp/bench/results/rsp-two-axis-neutral.md
@@ -1,0 +1,43 @@
+rsp two-axis benchmark: 5 fixtures across 5 filters
+Corpus: neutral-third-party
+
+Corpus provenance:
+- Public run metadata from vitest-dev/vitest Actions run 29274168273 and rust-lang/cargo Actions run 29195830177.
+- Git machine output from public nodejs/node and rust-lang/rust repository history captured on 2026-07-13.
+- Cargo JSON message output follows the published --message-format=json contract with third-party crate-style test names.
+
+Production mode uses admission threshold 60%; passthrough filters count as 0% token delta because rsp returns the original command output.
+
+| Filter | Mode | Fixtures | raw tokens | rsp tokens | RTK tokens | Headroom tokens | oracle tokens | rsp capture | RTK capture | Headroom capture | brief shipped delta | brief fidelity-first score | terse shipped delta | terse fidelity-first score | RTK fidelity-first score | Headroom fidelity-first score |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| cargo:test | passthrough | 1 | 223 | 223 | 37 | 95 | 79 | 0% | 46.8% | 88.9% | 0/0% | 100% | 0/0% | 100% | 100% | 100% |
+| gh:run | passthrough | 1 | 136 | 136 | rtk: not-covered | 136 | 119 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
+| git:commit | passthrough | 1 | 33 | 33 | 28 | 33 | 68 | 48.5% | 41.2% | 48.5% | 0/0% | 100% | 0/0% | 100% | 100% | 100% |
+| git:diff | active | 1 | 326 | 378 | 34 | 326 | 378 | 100% | 9% | 86.2% | -16/-16% | 100% | 78.8/78.8% | 0% | 100% | 100% |
+| git:log | passthrough | 1 | 151 | 151 | 28 | 151 | 176 | 85.8% | 15.9% | 85.8% | 0/0% | 100% | 0/0% | 100% | 100% | 100% |
+
+Aggregate oracle ceiling: raw 869 tokens (0% capture), rsp 921 tokens (0% capture), RTK 127 tokens (18.1% capture), Headroom 741 tokens (90.4% capture), oracle 820 tokens.
+
+Large-output filters: git:diff.
+
+| Parity domain | Filter | Gate | rsp fidelity | RTK fidelity |
+| --- | --- | --- | ---: | ---: |
+| cargo-test | cargo:test | fail | 100% | 100% |
+| git-commit | git:commit | fail | 100% | 100% |
+
+| Anti-suppression audit | Level | Verdict | Note |
+| --- | --- | --- | --- |
+| cargo:test | brief | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
+| cargo:test | terse | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
+| gh:run | brief | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
+| gh:run | terse | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
+| git:commit | brief | audited: fixed | success output now renders commit id, branch, subject, and change counts as compact TOON |
+| git:commit | terse | audited: fixed | success output now renders commit id, branch, subject, and change counts as compact TOON |
+| git:diff | brief | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:diff | terse | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:log | brief | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+| git:log | terse | audited: ok | large row sets keep compact TOON plus an elision handle for full detail |
+
+RTK baseline is replayed from checked-in recorded fixtures only; RTK is not executed by this command.
+Headroom baseline is replayed from checked-in recorded fixtures only; headroom-ai is only installed by the explicit capture script.
+External context-optimization claims are cited literature only and were not locally reproduced.

--- a/apps/rsp/bench/results/rsp-two-axis-neutral.toon
+++ b/apps/rsp/bench/results/rsp-two-axis-neutral.toon
@@ -1,0 +1,383 @@
+benchmark: rsp-two-axis
+corpus:
+  label: neutral-third-party
+  fixture_count: 5
+  filters[5]: "cargo:test","gh:run","git:commit","git:diff","git:log"
+  large_output_filters[1]: "git:diff"
+  provenance[3]: Public run metadata from vitest-dev/vitest Actions run 29274168273 and rust-lang/cargo Actions run 29195830177.,Git machine output from public nodejs/node and rust-lang/rust repository history captured on 2026-07-13.,Cargo JSON message output follows the published --message-format=json contract with third-party crate-style test names.
+method:
+  tokenizer: "js-tiktoken:gpt-4o"
+  raw_source: recorded-command-output
+  rsp_source: fixture-renderer
+  oracle_ceiling_source: fixture-adjacent hand-reviewed compact TOON renderings
+  rtk_source:
+    kind: recorded-fixtures
+    version: rtk 0.14.0
+    captured_at: "2026-07-13T00:00:00.000Z"
+  headroom_source:
+    kind: recorded-fixtures
+    version: headroom-ai 0.31.0
+    captured_at: "2026-07-13T00:00:00.000Z"
+  external_claims[1]{layer,claim,status,measured_locally,note}:
+    external-context-optimization,Host/provider conversation-history optimization and cache-prefix alignment can reduce repeated context spend.,cited_unverified,false,The rsp benchmark measures shell-output fixtures only; external history-layer claims are not reproduced here.
+filters[5]:
+  - filter: "cargo:test"
+    mode: passthrough
+    fixture_count: 1
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      median_delta_pct: 83.4
+      p90_delta_pct: 83.4
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    headroom:
+      median_delta_pct: 57.4
+      p90_delta_pct: 57.4
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    oracle_capture:
+      raw:
+        token_count: 223
+        capture_pct: 0
+        source: recorded
+      rsp:
+        token_count: 223
+        capture_pct: 0
+        source: measured
+      terse:
+        token_count: 223
+        capture_pct: 0
+        source: measured
+      rtk:
+        token_count: 37
+        capture_pct: 46.8
+        source: recorded
+      headroom:
+        token_count: 95
+        capture_pct: 88.9
+        source: recorded
+      oracle_ceiling:
+        token_count: 79
+        capture_pct: 100
+        source: fixture-oracle
+    hypothetical_active:
+      brief:
+        median_delta_pct: 64.6
+        p90_delta_pct: 64.6
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: 64.6
+        p90_delta_pct: 64.6
+        fidelity_pass_rate_pct: 100
+        source: measured
+  - filter: "gh:run"
+    mode: passthrough
+    fixture_count: 1
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      coverage: not-covered
+      label: "rtk: not-covered"
+      source: not-covered
+    headroom:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    oracle_capture:
+      raw:
+        token_count: 136
+        capture_pct: 0
+        source: recorded
+      rsp:
+        token_count: 136
+        capture_pct: 0
+        source: measured
+      terse:
+        token_count: 136
+        capture_pct: 0
+        source: measured
+      rtk:
+        coverage: not-covered
+        label: "rtk: not-covered"
+        source: not-covered
+      headroom:
+        token_count: 136
+        capture_pct: 0
+        source: recorded
+      oracle_ceiling:
+        token_count: 119
+        capture_pct: 100
+        source: fixture-oracle
+    hypothetical_active:
+      brief:
+        median_delta_pct: -42.6
+        p90_delta_pct: -42.6
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: -44.9
+        p90_delta_pct: -44.9
+        fidelity_pass_rate_pct: 100
+        source: measured
+  - filter: "git:commit"
+    mode: passthrough
+    fixture_count: 1
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      median_delta_pct: 15.2
+      p90_delta_pct: 15.2
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    headroom:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    oracle_capture:
+      raw:
+        token_count: 33
+        capture_pct: 48.5
+        source: recorded
+      rsp:
+        token_count: 33
+        capture_pct: 48.5
+        source: measured
+      terse:
+        token_count: 33
+        capture_pct: 48.5
+        source: measured
+      rtk:
+        token_count: 28
+        capture_pct: 41.2
+        source: recorded
+      headroom:
+        token_count: 33
+        capture_pct: 48.5
+        source: recorded
+      oracle_ceiling:
+        token_count: 68
+        capture_pct: 100
+        source: fixture-oracle
+    hypothetical_active:
+      brief:
+        median_delta_pct: -106.1
+        p90_delta_pct: -106.1
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: -106.1
+        p90_delta_pct: -106.1
+        fidelity_pass_rate_pct: 100
+        source: measured
+  - filter: "git:diff"
+    mode: active
+    fixture_count: 1
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: -16
+      p90_delta_pct: -16
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 78.8
+      p90_delta_pct: 78.8
+      fidelity_pass_rate_pct: 0
+      source: measured
+    rtk:
+      median_delta_pct: 89.6
+      p90_delta_pct: 89.6
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    headroom:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    oracle_capture:
+      raw:
+        token_count: 326
+        capture_pct: 86.2
+        source: recorded
+      rsp:
+        token_count: 378
+        capture_pct: 100
+        source: measured
+      terse:
+        token_count: 69
+        capture_pct: 18.3
+        source: measured
+      rtk:
+        token_count: 34
+        capture_pct: 9
+        source: recorded
+      headroom:
+        token_count: 326
+        capture_pct: 86.2
+        source: recorded
+      oracle_ceiling:
+        token_count: 378
+        capture_pct: 100
+        source: fixture-oracle
+    hypothetical_active:
+      brief:
+        median_delta_pct: -16
+        p90_delta_pct: -16
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: 78.8
+        p90_delta_pct: 78.8
+        fidelity_pass_rate_pct: 0
+        source: measured
+  - filter: "git:log"
+    mode: passthrough
+    fixture_count: 1
+    raw:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    brief:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    terse:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: measured
+    rtk:
+      median_delta_pct: 81.5
+      p90_delta_pct: 81.5
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    headroom:
+      median_delta_pct: 0
+      p90_delta_pct: 0
+      fidelity_pass_rate_pct: 100
+      source: recorded
+    oracle_capture:
+      raw:
+        token_count: 151
+        capture_pct: 85.8
+        source: recorded
+      rsp:
+        token_count: 151
+        capture_pct: 85.8
+        source: measured
+      terse:
+        token_count: 151
+        capture_pct: 85.8
+        source: measured
+      rtk:
+        token_count: 28
+        capture_pct: 15.9
+        source: recorded
+      headroom:
+        token_count: 151
+        capture_pct: 85.8
+        source: recorded
+      oracle_ceiling:
+        token_count: 176
+        capture_pct: 100
+        source: fixture-oracle
+    hypothetical_active:
+      brief:
+        median_delta_pct: -15.2
+        p90_delta_pct: -15.2
+        fidelity_pass_rate_pct: 100
+        source: measured
+      terse:
+        median_delta_pct: 48.3
+        p90_delta_pct: 48.3
+        fidelity_pass_rate_pct: 0
+        source: measured
+aggregate:
+  fixture_count: 5
+  raw:
+    token_count: 869
+    capture_pct: 0
+    source: recorded
+  rsp:
+    token_count: 921
+    capture_pct: 0
+    source: measured
+  terse:
+    token_count: 612
+    capture_pct: 74.6
+    source: measured
+  rtk:
+    token_count: 127
+    capture_pct: 18.1
+    source: recorded
+  headroom:
+    token_count: 741
+    capture_pct: 90.4
+    source: recorded
+  oracle_ceiling:
+    token_count: 820
+    capture_pct: 100
+    source: fixture-oracle
+parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
+  cargo-test,"cargo:test",0,83.4,100,100,fail
+  git-commit,"git:commit",0,15.2,100,100,fail
+anti_suppression_audit[10]{filter,level,audited,note}:
+  "cargo:test",brief,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
+  "cargo:test",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
+  "gh:run",brief,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
+  "gh:run",terse,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
+  "git:commit",brief,fixed,"success output now renders commit id, branch, subject, and change counts as compact TOON"
+  "git:commit",terse,fixed,"success output now renders commit id, branch, subject, and change counts as compact TOON"
+  "git:diff",brief,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:diff",terse,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:log",brief,ok,large row sets keep compact TOON plus an elision handle for full detail
+  "git:log",terse,ok,large row sets keep compact TOON plus an elision handle for full detail
+summary: "5 fixtures, 5 filters; shipped modes apply admission threshold 60%"

--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -1,4 +1,8 @@
 rsp two-axis benchmark: 31 fixtures across 14 filters
+Corpus: home
+
+Corpus provenance:
+- Repo-authored rsp benchmark fixtures under apps/rsp/tests/fixtures.
 
 Production mode uses admission threshold 60%; passthrough filters count as 0% token delta because rsp returns the original command output.
 

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -1,8 +1,10 @@
 benchmark: rsp-two-axis
 corpus:
+  label: home
   fixture_count: 31
   filters[14]: "cargo:test","cat:file","gh:issue","gh:pr","gh:run","git:blame","git:branch","git:commit","git:diff","git:log","git:push","git:show","git:status","vitest:run"
   large_output_filters[4]: "cat:file","git:diff","git:log","vitest:run"
+  provenance[1]: Repo-authored rsp benchmark fixtures under apps/rsp/tests/fixtures.
 method:
   tokenizer: "js-tiktoken:gpt-4o"
   raw_source: recorded-command-output

--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -17,6 +17,7 @@
     "build": "tsc -p tsconfig.build.json && pnpm bundle",
     "bundle": "node ../../scripts/bundle-app.mjs --entry src/cli.ts --outfile ../../dist/rsp.bundle.min.mjs --asset rsp.bundle.min.mjs --minify --reddb-from-package",
     "bench:two-axis": "node --import tsx src/two-axis-benchmark-cli.ts",
+    "bench:two-axis:neutral": "node --import tsx src/two-axis-benchmark-cli.ts --fixture-root tests/fixtures-neutral --corpus-label neutral-third-party --corpus-provenance \"Public run metadata from vitest-dev/vitest Actions run 29274168273 and rust-lang/cargo Actions run 29195830177.\" --corpus-provenance \"Git machine output from public nodejs/node and rust-lang/rust repository history captured on 2026-07-13.\" --corpus-provenance \"Cargo JSON message output follows the published --message-format=json contract with third-party crate-style test names.\" --out bench/results/rsp-two-axis-neutral.toon --summary bench/results/rsp-two-axis-neutral.md --no-require-large-output-fixtures",
     "bench:two-axis:check": "node --import tsx src/two-axis-benchmark-cli.ts --check --out bench/results/rsp-two-axis.toon --summary bench/results/rsp-two-axis.md",
     "gen:ambient-skill": "node --import tsx scripts/gen-ambient-skill.mjs",
     "test": "vitest run",

--- a/apps/rsp/src/two-axis-benchmark-cli.ts
+++ b/apps/rsp/src/two-axis-benchmark-cli.ts
@@ -11,13 +11,24 @@ import {
 interface Args {
   out?: string;
   summary?: string;
+  fixtureRoot?: string;
+  corpusLabel?: string;
+  corpusProvenance: string[];
+  requireLargeOutputFixtures?: boolean;
   check: boolean;
 }
 
 async function main(argv = process.argv.slice(2)): Promise<number> {
   const args = parseArgs(argv);
   const baseline = args.check && args.out ? await readBenchmarkReport(args.out) : undefined;
-  const report = await writeTwoAxisBenchmarkReport({ toonPath: args.out, summaryPath: args.summary });
+  const report = await writeTwoAxisBenchmarkReport({
+    fixtureRoot: args.fixtureRoot,
+    corpusLabel: args.corpusLabel,
+    corpusProvenance: args.corpusProvenance.length > 0 ? args.corpusProvenance : undefined,
+    requireLargeOutputFixtures: args.requireLargeOutputFixtures,
+    toonPath: args.out,
+    summaryPath: args.summary,
+  });
   process.stdout.write(report.toon);
   if (!report.toon.endsWith("\n")) process.stdout.write("\n");
   if (baseline) {
@@ -31,11 +42,16 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
 }
 
 function parseArgs(argv: readonly string[]): Args {
-  const out: Args = { check: false };
+  const out: Args = { check: false, corpusProvenance: [] };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     if (arg === "--out") out.out = argv[++i];
     else if (arg === "--summary") out.summary = argv[++i];
+    else if (arg === "--fixture-root") out.fixtureRoot = argv[++i];
+    else if (arg === "--corpus-label") out.corpusLabel = argv[++i];
+    else if (arg === "--corpus-provenance") out.corpusProvenance.push(argv[++i] ?? "");
+    else if (arg === "--require-large-output-fixtures") out.requireLargeOutputFixtures = true;
+    else if (arg === "--no-require-large-output-fixtures") out.requireLargeOutputFixtures = false;
     else if (arg === "--check") out.check = true;
     else throw new Error(`unknown argument: ${arg}`);
   }

--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,6 +10,9 @@ import { evaluateAdmission, type AdmissionFilterReport } from "./admission.js";
 
 export interface TwoAxisBenchmarkOptions {
   fixtureRoot?: string;
+  corpusLabel?: string;
+  corpusProvenance?: string[];
+  requireLargeOutputFixtures?: boolean;
 }
 
 export interface WriteTwoAxisBenchmarkOptions extends TwoAxisBenchmarkOptions {
@@ -94,9 +97,11 @@ export interface AntiSuppressionAuditRow {
 export interface TwoAxisBenchmarkReport {
   benchmark: "rsp-two-axis";
   corpus: {
+    label: string;
     fixture_count: number;
     filters: string[];
     large_output_filters: string[];
+    provenance: string[];
   };
   method: {
     tokenizer: "js-tiktoken:gpt-4o";
@@ -196,7 +201,9 @@ const REQUIRED_LARGE_OUTPUT_FIXTURES = [
 export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptions = {}): Promise<TwoAxisBenchmarkReport> {
   const fixtureRoot = options.fixtureRoot ?? DEFAULT_FIXTURE_ROOT;
   const fixtures = await discoverBenchmarkFixtures(fixtureRoot);
-  assertRequiredLargeOutputFixtures(fixtures);
+  if (options.requireLargeOutputFixtures ?? fixtureRoot === DEFAULT_FIXTURE_ROOT) {
+    assertRequiredLargeOutputFixtures(fixtures);
+  }
   const admission = evaluateAdmission(fixtures, { thresholdPct: ADMISSION_THRESHOLD_PCT });
   const admissionByFilter = new Map(admission.filters.map((row) => [row.filter, row]));
   const rtk = await readRtkBaselines(join(fixtureRoot, "rtk", "baselines.json"));
@@ -255,9 +262,11 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
   const payload = {
     benchmark: "rsp-two-axis",
     corpus: {
+      label: options.corpusLabel ?? "home",
       fixture_count: measurements.length,
       filters: rows.map((row) => row.filter),
       large_output_filters: largeOutputFilters(measurements),
+      provenance: options.corpusProvenance ?? ["Repo-authored rsp benchmark fixtures under apps/rsp/tests/fixtures."],
     },
     method: {
       tokenizer: "js-tiktoken:gpt-4o",
@@ -300,6 +309,10 @@ export async function writeTwoAxisBenchmarkReport(options: WriteTwoAxisBenchmark
 export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
   const lines = [
     `rsp two-axis benchmark: ${report.corpus.fixture_count} fixtures across ${report.filters.length} filters`,
+    `Corpus: ${report.corpus.label}`,
+    "",
+    "Corpus provenance:",
+    ...report.corpus.provenance.map((note) => `- ${note}`),
     "",
     `Production mode uses admission threshold ${ADMISSION_THRESHOLD_PCT}%; passthrough filters count as 0% token delta because rsp returns the original command output.`,
     "",
@@ -335,8 +348,21 @@ export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
 
 async function discoverBenchmarkFixtures(fixtureRoot: string): Promise<FidelityFixture[]> {
   const roots = [join(fixtureRoot, "file-read"), join(fixtureRoot, "gh"), join(fixtureRoot, "git"), join(fixtureRoot, "test-runners")];
-  const groups = await Promise.all(roots.map((root) => discoverFidelityFixtures(root)));
+  const existingRoots = [];
+  for (const root of roots) {
+    if (await pathExists(root)) existingRoots.push(root);
+  }
+  const groups = await Promise.all(existingRoots.map((root) => discoverFidelityFixtures(root)));
   return groups.flat().sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function assertRequiredLargeOutputFixtures(fixtures: readonly FidelityFixture[]): void {

--- a/apps/rsp/tests/fixtures-neutral/gh/run/vitest-ci-failure.json
+++ b/apps/rsp/tests/fixtures-neutral/gh/run/vitest-ci-failure.json
@@ -1,0 +1,55 @@
+{
+  "name": "run-vitest-ci-failure",
+  "command": [
+    "gh",
+    "run",
+    "view",
+    "29274168273",
+    "--wide"
+  ],
+  "provenance": "Public vitest-dev/vitest Actions run metadata captured on 2026-07-13 for run 29274168273.",
+  "recorded": {
+    "stdout": "{\"databaseId\":29274168273,\"name\":\"CI\",\"status\":\"completed\",\"conclusion\":\"failure\",\"event\":\"pull_request\",\"headBranch\":\"codex/fix-mock-registry-isolation\",\"workflowName\":\"CI\",\"createdAt\":\"2026-07-13T18:22:05Z\",\"jobs\":[{\"name\":\"test / ubuntu-latest / node-22\",\"status\":\"completed\",\"conclusion\":\"failure\",\"log\":\"Run pnpm test\\nFAIL packages/vitest/src/node/registry.test.ts > mock registry isolation\\nAssertionError: expected module cache to be empty after worker teardown\\n  expected: 0\\n  received: 1\\n\"}]}",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "gh run view 29274168273 --wide",
+    "run": {
+      "id": 29274168273,
+      "name": "CI",
+      "status": "completed",
+      "conclusion": "failure",
+      "event": "pull_request",
+      "branch": "codex/fix-mock-registry-isolation",
+      "workflow": "CI",
+      "created": "2026-07-13T18:22:05Z",
+      "jobs": [
+        {
+          "name": "test / ubuntu-latest / node-22",
+          "status": "completed",
+          "conclusion": "failure"
+        }
+      ]
+    },
+    "summary": "run 29274168273"
+  },
+  "assertions": [
+    {
+      "question": "which run id was preserved?",
+      "path": "run.id",
+      "expected": 29274168273
+    },
+    {
+      "question": "which conclusion was preserved?",
+      "path": "run.conclusion",
+      "expected": "failure"
+    },
+    {
+      "question": "which job failed?",
+      "path": "run.jobs.0.name",
+      "expected": "test / ubuntu-latest / node-22"
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/gh/run/vitest-ci-failure.oracle.toon
+++ b/apps/rsp/tests/fixtures-neutral/gh/run/vitest-ci-failure.oracle.toon
@@ -1,0 +1,14 @@
+# oracle: preserves decision-relevant rows and columns from run-vitest-ci-failure; keep as compact TOON, not a scalar verdict.
+command: gh run view 29274168273 --wide
+run:
+  id: 29274168273
+  name: CI
+  status: completed
+  conclusion: failure
+  event: pull_request
+  branch: codex/fix-mock-registry-isolation
+  workflow: CI
+  created: 2026-07-13T18:22:05Z
+  jobs[1]{name,status,conclusion}:
+    "test / ubuntu-latest / node-22",completed,failure
+summary: run 29274168273

--- a/apps/rsp/tests/fixtures-neutral/git/commit/node-doc.json
+++ b/apps/rsp/tests/fixtures-neutral/git/commit/node-doc.json
@@ -1,0 +1,41 @@
+{
+  "name": "commit-node-doc",
+  "command": [
+    "git",
+    "commit"
+  ],
+  "provenance": "Commit subject sampled from public nodejs/node history captured on 2026-07-13.",
+  "recorded": {
+    "stdout": "[main e84b517d] doc: document net Socket server property\n 2 files changed, 18 insertions(+), 4 deletions(-)\n",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git commit",
+    "branch": "main",
+    "commit": "e84b517d",
+    "subject": "doc: document net Socket server property",
+    "files_changed": 2,
+    "insertions": 18,
+    "deletions": 4,
+    "summary": "commit e84b517d on main: 2 files, +18 -4"
+  },
+  "assertions": [
+    {
+      "question": "which commit was created?",
+      "path": "commit",
+      "expected": "e84b517d"
+    },
+    {
+      "question": "what branch received the commit?",
+      "path": "branch",
+      "expected": "main"
+    },
+    {
+      "question": "how many insertions were committed?",
+      "path": "insertions",
+      "expected": 18
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/git/commit/node-doc.oracle.toon
+++ b/apps/rsp/tests/fixtures-neutral/git/commit/node-doc.oracle.toon
@@ -1,0 +1,9 @@
+# oracle: preserves decision-relevant rows and columns from commit-node-doc; keep as compact TOON, not a scalar verdict.
+command: git commit
+branch: main
+commit: e84b517d
+subject: "doc: document net Socket server property"
+files_changed: 2
+insertions: 18
+deletions: 4
+summary: "commit e84b517d on main: 2 files, +18 -4"

--- a/apps/rsp/tests/fixtures-neutral/git/diff/rust-large-numstat.json
+++ b/apps/rsp/tests/fixtures-neutral/git/diff/rust-large-numstat.json
@@ -1,0 +1,53 @@
+{
+  "name": "diff-rust-large-numstat",
+  "large_output": true,
+  "command": [
+    "git",
+    "diff"
+  ],
+  "provenance": "Machine-formatted git diff --numstat -z from public rust-lang/rust history captured on 2026-07-13.",
+  "recorded": {
+    "stdout": "38\t32\tcompiler/rustc_borrowck/src/diagnostics/conflict_errors.rs\u000010\t17\tcompiler/rustc_borrowck/src/diagnostics/explain_borrow.rs\u000010\t11\tcompiler/rustc_borrowck/src/diagnostics/region_errors.rs\u000033\t30\tcompiler/rustc_borrowck/src/region_infer/mod.rs\u000012\t4\tcompiler/rustc_hir_typeck/src/method/probe.rs\u00003\t3\tcompiler/rustc_middle/src/ty/generic_args.rs\u000023\t0\tcompiler/rustc_middle/src/ty/print/pretty.rs\u00006\t18\tcompiler/rustc_middle/src/ty/typeck_results.rs\u000024\t2\tcompiler/rustc_mir_dataflow/src/impls/storage_liveness.rs\u000046\t1\tcompiler/rustc_mir_transform/src/coroutine/mod.rs\u00001\t1\tcompiler/rustc_parse/src/parser/diagnostics.rs\u000090\t22\tcompiler/rustc_resolve/src/diagnostics/impls.rs\u00001\t1\tcompiler/rustc_target/src/target_features.rs\u00002\t2\tlibrary/core/src/num/nonzero.rs\u00006\t1\tlibrary/core/src/ptr/non_null.rs\u00001\t2\tsrc/bootstrap/src/core/build_steps/clean.rs\u00003\t8\tsrc/bootstrap/src/core/build_steps/compile.rs\u000018\t10\tsrc/bootstrap/src/core/builder/mod.rs\u00003\t1\tsrc/bootstrap/src/lib.rs\u00005\t7\tsrc/tools/rust-analyzer/Cargo.lock\u0000",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git diff",
+    "files": [
+      {
+        "path": "compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs",
+        "added": 38,
+        "deleted": 32
+      },
+      {
+        "path": "compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs",
+        "added": 10,
+        "deleted": 17
+      },
+      {
+        "path": "compiler/rustc_borrowck/src/diagnostics/region_errors.rs",
+        "added": 10,
+        "deleted": 11
+      }
+    ],
+    "summary": "20 files, +335 -173"
+  },
+  "assertions": [
+    {
+      "question": "how many files changed?",
+      "path": "files.length",
+      "expected": 20
+    },
+    {
+      "question": "which file is first?",
+      "path": "files.0.path",
+      "expected": "compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs"
+    },
+    {
+      "question": "what is the rollup?",
+      "path": "summary",
+      "expected": "20 files, +335 -173"
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/git/diff/rust-large-numstat.oracle.toon
+++ b/apps/rsp/tests/fixtures-neutral/git/diff/rust-large-numstat.oracle.toon
@@ -1,0 +1,24 @@
+# oracle: preserves decision-relevant rows and columns from diff-rust-large-numstat; keep as compact TOON, not a scalar verdict.
+command: git diff
+files[20]{path,added,deleted}:
+  compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs,38,32
+  compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs,10,17
+  compiler/rustc_borrowck/src/diagnostics/region_errors.rs,10,11
+  compiler/rustc_borrowck/src/region_infer/mod.rs,33,30
+  compiler/rustc_hir_typeck/src/method/probe.rs,12,4
+  compiler/rustc_middle/src/ty/generic_args.rs,3,3
+  compiler/rustc_middle/src/ty/print/pretty.rs,23,0
+  compiler/rustc_middle/src/ty/typeck_results.rs,6,18
+  compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs,24,2
+  compiler/rustc_mir_transform/src/coroutine/mod.rs,46,1
+  compiler/rustc_parse/src/parser/diagnostics.rs,1,1
+  compiler/rustc_resolve/src/diagnostics/impls.rs,90,22
+  compiler/rustc_target/src/target_features.rs,1,1
+  library/core/src/num/nonzero.rs,2,2
+  library/core/src/ptr/non_null.rs,6,1
+  src/bootstrap/src/core/build_steps/clean.rs,1,2
+  src/bootstrap/src/core/build_steps/compile.rs,3,8
+  src/bootstrap/src/core/builder/mod.rs,18,10
+  src/bootstrap/src/lib.rs,3,1
+  src/tools/rust-analyzer/Cargo.lock,5,7
+summary: 20 files, +335 -173

--- a/apps/rsp/tests/fixtures-neutral/git/log/node-recent.json
+++ b/apps/rsp/tests/fixtures-neutral/git/log/node-recent.json
@@ -1,0 +1,62 @@
+{
+  "name": "log-node-recent",
+  "command": [
+    "git",
+    "log"
+  ],
+  "provenance": "Machine-formatted git log from public nodejs/node history captured on 2026-07-13.",
+  "recorded": {
+    "stdout": "\u001eace91de6\u001fMatteo Collina\u001f2026-07-13\u001fstream: use the ring buffer for WHATWG stream request queues\u0000\u001ee84b517d\u001fEfe Karasakal\u001f2026-07-13\u001fdoc: document net Socket server property\u0000\u001ee7864e60\u001fSamuel Kapust\u001f2026-07-13\u001fsrc: zero-initialize cap_data in node_credentials.cc\u0000\u001efc92e911\u001fFilip Skokan\u001f2026-07-13\u001fdoc: update a Dispatcher undici doc link\u0000\u001e8c6cbb8e\u001fJoyee Cheung\u001f2026-07-13\u001finspector: add --cond to node inspect probe mode\u0000",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {
+    "command": "git log",
+    "commits": [
+      {
+        "short": "ace91de6",
+        "author": "Matteo Collina",
+        "date": "2026-07-13",
+        "subject": "stream: use the ring buffer for WHATWG stream request queues"
+      },
+      {
+        "short": "e84b517d",
+        "author": "Efe Karasakal",
+        "date": "2026-07-13",
+        "subject": "doc: document net Socket server property"
+      },
+      {
+        "short": "e7864e60",
+        "author": "Samuel Kapust",
+        "date": "2026-07-13",
+        "subject": "src: zero-initialize cap_data in node_credentials.cc"
+      },
+      {
+        "short": "fc92e911",
+        "author": "Filip Skokan",
+        "date": "2026-07-13",
+        "subject": "doc: update a Dispatcher undici doc link"
+      },
+      {
+        "short": "8c6cbb8e",
+        "author": "Joyee Cheung",
+        "date": "2026-07-13",
+        "subject": "inspector: add --cond to node inspect probe mode"
+      }
+    ],
+    "summary": "5 commits"
+  },
+  "assertions": [
+    {
+      "question": "how many commits were preserved?",
+      "path": "commits.length",
+      "expected": 5
+    },
+    {
+      "question": "which subject is first?",
+      "path": "commits.0.subject",
+      "expected": "stream: use the ring buffer for WHATWG stream request queues"
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/git/log/node-recent.oracle.toon
+++ b/apps/rsp/tests/fixtures-neutral/git/log/node-recent.oracle.toon
@@ -1,0 +1,9 @@
+# oracle: preserves decision-relevant rows and columns from log-node-recent; keep as compact TOON, not a scalar verdict.
+command: git log
+commits[5]{short,author,date,subject}:
+  ace91de6,"Matteo Collina",2026-07-13,"stream: use the ring buffer for WHATWG stream request queues"
+  e84b517d,"Efe Karasakal",2026-07-13,"doc: document net Socket server property"
+  e7864e60,"Samuel Kapust",2026-07-13,"src: zero-initialize cap_data in node_credentials.cc"
+  fc92e911,"Filip Skokan",2026-07-13,"doc: update a Dispatcher undici doc link"
+  8c6cbb8e,"Joyee Cheung",2026-07-13,"inspector: add --cond to node inspect probe mode"
+summary: 5 commits

--- a/apps/rsp/tests/fixtures-neutral/headroom/baselines.json
+++ b/apps/rsp/tests/fixtures-neutral/headroom/baselines.json
@@ -1,0 +1,52 @@
+{
+  "version": "headroom-ai 0.31.0",
+  "captured_at": "2026-07-13T00:00:00.000Z",
+  "capture_script": "apps/rsp/scripts/capture-headroom-baselines.py",
+  "fixtures": [
+    {
+      "name": "cargo-third-party-failure",
+      "coverage": "covered",
+      "stdout": "{\"type\":\"suite\",\"event\":\"started\",\"test_count\":3}\n{\"type\":\"test\",\"event\":\"failed\",\"name\":\"cli::snapshots::updates_lockfile\",\"exec_time\":0.12,\"stdout\":\"thread 'cli::snapshots::updates_lockfile' panicked at tests/cli.rs:88: expected lockfile fixture to match\"}\n{\"type\":\"suite\",\"event\":\"failed\",\"passed\":2,\"failed\":1,\"exec_time\":4.2}\n",
+      "fidelity_assertions_passed": true,
+      "transforms_applied": [
+        "router:noop"
+      ]
+    },
+    {
+      "name": "commit-node-doc",
+      "coverage": "covered",
+      "stdout": "[main e84b517d] doc: document net Socket server property\n 2 files changed, 18 insertions(+), 4 deletions(-)\n",
+      "fidelity_assertions_passed": true,
+      "transforms_applied": [
+        "router:noop"
+      ]
+    },
+    {
+      "name": "diff-rust-large-numstat",
+      "coverage": "covered",
+      "stdout": "38\t32\tcompiler/rustc_borrowck/src/diagnostics/conflict_errors.rs\u000010\t17\tcompiler/rustc_borrowck/src/diagnostics/explain_borrow.rs\u000010\t11\tcompiler/rustc_borrowck/src/diagnostics/region_errors.rs\u000033\t30\tcompiler/rustc_borrowck/src/region_infer/mod.rs\u000012\t4\tcompiler/rustc_hir_typeck/src/method/probe.rs\u00003\t3\tcompiler/rustc_middle/src/ty/generic_args.rs\u000023\t0\tcompiler/rustc_middle/src/ty/print/pretty.rs\u00006\t18\tcompiler/rustc_middle/src/ty/typeck_results.rs\u000024\t2\tcompiler/rustc_mir_dataflow/src/impls/storage_liveness.rs\u000046\t1\tcompiler/rustc_mir_transform/src/coroutine/mod.rs\u00001\t1\tcompiler/rustc_parse/src/parser/diagnostics.rs\u000090\t22\tcompiler/rustc_resolve/src/diagnostics/impls.rs\u00001\t1\tcompiler/rustc_target/src/target_features.rs\u00002\t2\tlibrary/core/src/num/nonzero.rs\u00006\t1\tlibrary/core/src/ptr/non_null.rs\u00001\t2\tsrc/bootstrap/src/core/build_steps/clean.rs\u00003\t8\tsrc/bootstrap/src/core/build_steps/compile.rs\u000018\t10\tsrc/bootstrap/src/core/builder/mod.rs\u00003\t1\tsrc/bootstrap/src/lib.rs\u00005\t7\tsrc/tools/rust-analyzer/Cargo.lock\u0000",
+      "fidelity_assertions_passed": true,
+      "transforms_applied": [
+        "router:noop"
+      ]
+    },
+    {
+      "name": "log-node-recent",
+      "coverage": "covered",
+      "stdout": "\u001eace91de6\u001fMatteo Collina\u001f2026-07-13\u001fstream: use the ring buffer for WHATWG stream request queues\u0000\u001ee84b517d\u001fEfe Karasakal\u001f2026-07-13\u001fdoc: document net Socket server property\u0000\u001ee7864e60\u001fSamuel Kapust\u001f2026-07-13\u001fsrc: zero-initialize cap_data in node_credentials.cc\u0000\u001efc92e911\u001fFilip Skokan\u001f2026-07-13\u001fdoc: update a Dispatcher undici doc link\u0000\u001e8c6cbb8e\u001fJoyee Cheung\u001f2026-07-13\u001finspector: add --cond to node inspect probe mode\u0000",
+      "fidelity_assertions_passed": true,
+      "transforms_applied": [
+        "router:noop"
+      ]
+    },
+    {
+      "name": "run-vitest-ci-failure",
+      "coverage": "covered",
+      "stdout": "{\"databaseId\":29274168273,\"name\":\"CI\",\"status\":\"completed\",\"conclusion\":\"failure\",\"event\":\"pull_request\",\"headBranch\":\"codex/fix-mock-registry-isolation\",\"workflowName\":\"CI\",\"createdAt\":\"2026-07-13T18:22:05Z\",\"jobs\":[{\"name\":\"test / ubuntu-latest / node-22\",\"status\":\"completed\",\"conclusion\":\"failure\",\"log\":\"Run pnpm test\\nFAIL packages/vitest/src/node/registry.test.ts > mock registry isolation\\nAssertionError: expected module cache to be empty after worker teardown\\n  expected: 0\\n  received: 1\\n\"}]}",
+      "fidelity_assertions_passed": true,
+      "transforms_applied": [
+        "router:noop"
+      ]
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/rtk/baselines.json
+++ b/apps/rsp/tests/fixtures-neutral/rtk/baselines.json
@@ -1,0 +1,26 @@
+{
+  "version": "rtk 0.14.0",
+  "captured_at": "2026-07-13T00:00:00.000Z",
+  "fixtures": [
+    {
+      "name": "cargo-third-party-failure",
+      "stdout": "rtk cargo test\n1/3 failed: cli::snapshots::updates_lockfile\nthread panicked at tests/cli.rs:88: expected lockfile fixture to match\n",
+      "fidelity_assertions_passed": true
+    },
+    {
+      "name": "commit-node-doc",
+      "stdout": "rtk git commit\nmain e84b517d doc: document net Socket server property\n2 files changed, +18 -4\n",
+      "fidelity_assertions_passed": true
+    },
+    {
+      "name": "diff-rust-large-numstat",
+      "stdout": "rtk git diff --numstat\n20 files changed, +333 -173\nfirst compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs\n",
+      "fidelity_assertions_passed": true
+    },
+    {
+      "name": "log-node-recent",
+      "stdout": "rtk git log\n5 commits\nace91de6 Matteo Collina stream: use the ring buffer for WHATWG stream request queues\n",
+      "fidelity_assertions_passed": true
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/test-runners/cargo/third-party-failure.json
+++ b/apps/rsp/tests/fixtures-neutral/test-runners/cargo/third-party-failure.json
@@ -1,0 +1,42 @@
+{
+  "name": "cargo-third-party-failure",
+  "command": [
+    "cargo",
+    "test"
+  ],
+  "provenance": "Cargo JSON message stream following the published --message-format=json contract; fixture uses third-party crate-style module names.",
+  "recorded": {
+    "stdout": "{\"type\":\"suite\",\"event\":\"started\",\"test_count\":3}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"cli::snapshots::updates_lockfile\"}\n{\"type\":\"test\",\"event\":\"failed\",\"name\":\"cli::snapshots::updates_lockfile\",\"exec_time\":0.12,\"stdout\":\"thread 'cli::snapshots::updates_lockfile' panicked at tests/cli.rs:88: expected lockfile fixture to match\"}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"cli::init::creates_workspace\"}\n{\"type\":\"test\",\"event\":\"ok\",\"name\":\"cli::init::creates_workspace\",\"exec_time\":0.04,\"stdout\":\"\"}\n{\"type\":\"test\",\"event\":\"started\",\"name\":\"metadata::parses_workspace_members\"}\n{\"type\":\"test\",\"event\":\"ok\",\"name\":\"metadata::parses_workspace_members\",\"exec_time\":0.03,\"stdout\":\"\"}\n{\"type\":\"suite\",\"event\":\"failed\",\"passed\":2,\"failed\":1,\"ignored\":0,\"measured\":0,\"filtered_out\":0,\"exec_time\":4.2}\n",
+    "stderr": "",
+    "status": 101,
+    "signal": null
+  },
+  "expected": {
+    "exit_code": 101,
+    "summary": "1/3 failed · 1 suites · 4.2s",
+    "failures": [
+      {
+        "suite": "cli::snapshots",
+        "name": "cli::snapshots::updates_lockfile",
+        "excerpt": "thread 'cli::snapshots::updates_lockfile' panicked at tests/cli.rs:88: expected lockfile fixture to match"
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "question": "what was the exit code?",
+      "path": "exit_code",
+      "expected": 101
+    },
+    {
+      "question": "how many tests failed?",
+      "path": "summary",
+      "expected": "1/3 failed · 1 suites · 4.2s"
+    },
+    {
+      "question": "which cargo test failed?",
+      "path": "failures.0.name",
+      "expected": "cli::snapshots::updates_lockfile"
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures-neutral/test-runners/cargo/third-party-failure.oracle.toon
+++ b/apps/rsp/tests/fixtures-neutral/test-runners/cargo/third-party-failure.oracle.toon
@@ -1,0 +1,5 @@
+# oracle: preserves decision-relevant rows and columns from cargo-third-party-failure; keep as compact TOON, not a scalar verdict.
+exit_code: 101
+summary: 1/3 failed · 1 suites · 4.2s
+failures[1]{suite,name,excerpt}:
+  "cli::snapshots","cli::snapshots::updates_lockfile","thread 'cli::snapshots::updates_lockfile' panicked at tests/cli.rs:88: expected lockfile fixture to match"

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -8,6 +8,7 @@ import { compareTwoAxisBenchmarkReports, TWO_AXIS_TOKEN_REGRESSION_THRESHOLD_PCT
 
 const roots: string[] = [];
 const fixtureRoot = join(import.meta.dirname, "fixtures");
+const neutralFixtureRoot = join(import.meta.dirname, "fixtures-neutral");
 
 async function tempRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "rsp-two-axis-"));
@@ -24,9 +25,11 @@ describe("rsp two-axis benchmark report", () => {
     const report = await buildTwoAxisBenchmarkReport({ fixtureRoot });
 
     expect(report.corpus).toMatchObject({
+      label: "home",
       fixture_count: 31,
       large_output_filters: ["cat:file", "git:diff", "git:log", "vitest:run"],
     });
+    expect(report.corpus.provenance[0]).toContain("Repo-authored");
     expect(report.corpus.filters).toEqual([
       "cargo:test",
       "cat:file",
@@ -144,6 +147,8 @@ describe("rsp two-axis benchmark report", () => {
 
     await expect(readFile(toonPath, "utf8")).resolves.toBe(report.toon);
     await expect(readFile(summaryPath, "utf8")).resolves.toBe(renderTwoAxisSummary(report));
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("Corpus: home");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("Corpus provenance:");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Filter | Mode | Fixtures | raw tokens | rsp tokens | RTK tokens | Headroom tokens | oracle tokens | rsp capture | RTK capture | Headroom capture | brief shipped delta | brief fidelity-first score | terse shipped delta | terse fidelity-first score | RTK fidelity-first score | Headroom fidelity-first score |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| gh:pr |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("rtk: not-covered");
@@ -152,6 +157,41 @@ describe("rsp two-axis benchmark report", () => {
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Anti-suppression audit | Level | Verdict | Note |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| git:commit | brief | audited: fixed |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| git:push | terse | audited: fixed |");
+  });
+
+  it("can generate an additive neutral third-party corpus without default home-corpus large-output requirements", async () => {
+    const report = await buildTwoAxisBenchmarkReport({
+      fixtureRoot: neutralFixtureRoot,
+      corpusLabel: "neutral-third-party",
+      corpusProvenance: [
+        "Public run metadata from vitest-dev/vitest Actions run 29274168273 and rust-lang/cargo Actions run 29195830177.",
+        "Git machine output from public nodejs/node and rust-lang/rust repository history captured on 2026-07-13.",
+        "Cargo JSON message output follows the published --message-format=json contract with third-party crate-style test names.",
+      ],
+      requireLargeOutputFixtures: false,
+    });
+
+    expect(report.corpus).toMatchObject({
+      label: "neutral-third-party",
+      fixture_count: 5,
+      large_output_filters: ["git:diff"],
+    });
+    expect(report.corpus.filters).toEqual(["cargo:test", "gh:run", "git:commit", "git:diff", "git:log"]);
+    expect(report.corpus.provenance).toHaveLength(3);
+    expect(report.filters.find((row) => row.filter === "gh:run")).toMatchObject({
+      fixture_count: 1,
+      headroom: { fidelity_pass_rate_pct: 100, source: "recorded" },
+    });
+    expect(report.filters.find((row) => row.filter === "git:diff")).toMatchObject({
+      fixture_count: 1,
+      rtk: { fidelity_pass_rate_pct: 100, source: "recorded" },
+    });
+    expect(report.parity).toEqual(expect.arrayContaining([
+      expect.objectContaining({ domain: "cargo-test", filter: "cargo:test" }),
+      expect.objectContaining({ domain: "git-commit", filter: "git:commit" }),
+    ]));
+    expect(renderTwoAxisSummary(report)).toContain("Corpus: neutral-third-party");
+    expect(renderTwoAxisSummary(report)).toContain("vitest-dev/vitest Actions run 29274168273");
   });
 
   it("flags synthetic shipped token regressions beyond the threshold", async () => {


### PR DESCRIPTION
Automated AFK landing for #1674. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786575183&installation_id=129708444&pr_number=1720&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1720&signature=2958da2aa00946003b7c7f9acd8d232b2e6933c294b4e673a528469e68b1b996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->