### PR TITLE
fix: #1706 rsp telemetry drain orphans .drain spool files after a crash; 108 midday events (24 degradations) never ingested into stats

### DIFF
--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -1,6 +1,6 @@
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import type { RedDB } from "@reddb-io/sdk";
 import { tokenSavingsEstimate, type TokenSavingsEstimate } from "./pricing.js";
 
@@ -173,18 +173,56 @@ export async function drainTelemetrySpool(
   drainLine: (line: string) => Promise<boolean>,
 ): Promise<void> {
   const path = telemetrySpoolPath(rootDir);
-  const drainingPath = `${path}.${process.pid}.${Date.now()}.drain`;
-  try {
-    await mkdir(dirname(path), { recursive: true });
-    await rename(path, drainingPath);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-    return;
+  await mkdir(dirname(path), { recursive: true }).catch(() => undefined);
+
+  for (const orphan of await orphanedDrainFiles(path)) {
+    await drainFile(path, orphan, drainLine);
   }
 
+  const drainingPath = `${path}.${process.pid}.${Date.now()}.drain`;
+  try {
+    await rename(path, drainingPath);
+  } catch {
+    return;
+  }
+  await writeFile(path, "", { flag: "wx" }).catch(() => undefined);
+  await drainFile(path, drainingPath, drainLine);
+}
+
+/**
+ * A crash between the spool rename and the ingest leaves a `<spool>.<pid>.<ts>.drain` file behind.
+ * Adopt those leftovers, skipping any still owned by a live process other than us.
+ */
+async function orphanedDrainFiles(spoolPath: string): Promise<string[]> {
+  const dir = dirname(spoolPath);
+  const prefix = `${basename(spoolPath)}.`;
+  const names = await readdir(dir).catch(() => [] as string[]);
+  return names
+    .filter((name) => name.startsWith(prefix) && name.endsWith(".drain"))
+    .filter((name) => {
+      const pid = Number(name.slice(prefix.length).split(".")[0]);
+      return !(Number.isInteger(pid) && pid !== process.pid && isProcessAlive(pid));
+    })
+    .sort()
+    .map((name) => join(dir, name));
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function drainFile(
+  spoolPath: string,
+  drainingPath: string,
+  drainLine: (line: string) => Promise<boolean>,
+): Promise<void> {
   const retryLines: string[] = [];
   try {
-    await writeFile(path, "", { flag: "wx" }).catch(() => undefined);
     const text = await readSettledFile(drainingPath);
     const lines = text.split(/\r?\n/).filter((line) => line.trim() !== "");
     for (const line of lines) {
@@ -195,8 +233,8 @@ export async function drainTelemetrySpool(
     }
   } finally {
     if (retryLines.length > 0) {
-      const current = safeReadFileSync(path);
-      await writeFile(path, `${retryLines.join("\n")}\n${current}`, "utf8");
+      const current = safeReadFileSync(spoolPath);
+      await writeFile(spoolPath, `${retryLines.join("\n")}\n${current}`, "utf8");
     }
     await rm(drainingPath, { force: true });
   }

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -99,6 +99,59 @@ describe("rsp telemetry spool", () => {
     expect(spool).not.toContain('"id":"ok"');
   });
 
+  it("ingests orphaned .drain files left behind by a crashed drain", async () => {
+    const root = await tempRoot();
+    const spool = telemetrySpoolPath(root);
+    const orphan = `${spool}.999999.1783958744462.drain`;
+    await writeFile(
+      orphan,
+      `${JSON.stringify({ collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION, id: "orphaned", command: "git log" })}\n`,
+      "utf8",
+    );
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "live",
+      command: "git status",
+    });
+
+    const drained: string[] = [];
+    await drainTelemetrySpool(root, async (line) => {
+      drained.push(line);
+      return true;
+    });
+
+    expect(drained.join("\n")).toContain('"id":"orphaned"');
+    expect(drained.join("\n")).toContain('"id":"live"');
+    await expect(readFile(orphan, "utf8")).rejects.toThrow();
+  });
+
+  it("sweeps orphaned .drain files even when the live spool is gone, and leaves live-owner drains alone", async () => {
+    const root = await tempRoot();
+    const spool = telemetrySpoolPath(root);
+    const orphan = `${spool}.999999.1783958744462.drain`;
+    const inFlight = `${spool}.${process.ppid}.1783958744463.drain`;
+    await writeFile(
+      orphan,
+      `${JSON.stringify({ collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION, id: "orphaned", command: "git log" })}\n`,
+      "utf8",
+    );
+    await writeFile(
+      inFlight,
+      `${JSON.stringify({ collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION, id: "not-mine", command: "git log" })}\n`,
+      "utf8",
+    );
+
+    const drained: string[] = [];
+    await drainTelemetrySpool(root, async (line) => {
+      drained.push(line);
+      return true;
+    });
+
+    expect(drained.join("\n")).toContain('"id":"orphaned"');
+    expect(drained.join("\n")).not.toContain('"id":"not-mine"');
+    await expect(readFile(inFlight, "utf8")).resolves.toContain('"id":"not-mine"');
+  });
+
   it("keeps oversized raw and emitted text out of the spool while preserving byte estimates", async () => {
     const root = await tempRoot();
     const huge = "x".repeat(300 * 1024);


### PR DESCRIPTION
Automated AFK landing for #1706. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1706

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786588423&installation_id=129708444&pr_number=1724&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1724&signature=c8c16e02aed641f67d25cb02728f7184f4506b95db5aa0c49bddfd99c6b1b473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->