### PR TITLE
fix: #1710 rsp store: idle sweep write-free — no index rewrite or content-store write on a no-change tick

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -91,6 +91,7 @@ export class RspElisionStore {
   private document!: StoreDocument;
   private db?: RedDB;
   private readonly path: string;
+  private dirty = false;
 
   private constructor(path: string, private readonly opts: Omit<RspElisionStoreOptions, "ttlDays" | "byteBudget"> & {
     uri: string;
@@ -234,6 +235,7 @@ export class RspElisionStore {
     const withoutExisting = index.records.filter((record) => record.handle !== entry.handle);
     withoutExisting.push(entry);
     this.writeIndex({ version: 1, records: withoutExisting });
+    this.dirty = true;
   }
 
   private prune(): void {
@@ -258,7 +260,9 @@ export class RspElisionStore {
       this.expireEntry(evicted, nowIso);
     }
 
-    this.writeIndex({ version: 1, records: live });
+    if (live.length < index.records.length) {
+      this.writeIndex({ version: 1, records: live });
+    }
   }
 
   private expireEntry(entry: IndexEntry, expiredAt: string): void {
@@ -268,6 +272,7 @@ export class RspElisionStore {
       expired_at: expiredAt,
       command: entry.command,
     };
+    this.dirty = true;
   }
 
   private tombstone(handle: `el:${string}`): RspExpiredHandle | null {
@@ -281,7 +286,9 @@ export class RspElisionStore {
   }
 
   private async flush(): Promise<void> {
+    if (!this.dirty) return;
     await writeStoreDocument(this.path, this.document);
+    this.dirty = false;
   }
 
   private kv() {
@@ -384,7 +391,7 @@ export class RspElisionStore {
     const index = await this.readRedDbIndex();
     const withoutExisting = index.records.filter((entry) => entry.handle !== handle);
     withoutExisting.push({ handle, key, bytes: bytes.length, command: meta.command, created_at: createdAt, expires_at: expiresAt });
-    await this.pruneRedDb({ version: 1, records: withoutExisting });
+    await this.pruneRedDb({ version: 1, records: withoutExisting }, true);
     await this.assertRedDbMintPersisted(handle, bytes.length);
     return handle;
   }
@@ -545,7 +552,7 @@ export class RspElisionStore {
     await this.kv().put(indexKey(), index);
   }
 
-  private async pruneRedDb(index: IndexDocument): Promise<IndexDocument> {
+  private async pruneRedDb(index: IndexDocument, hadAdditions = false): Promise<IndexDocument> {
     const nowMs = this.opts.now().getTime();
     const nowIso = new Date(nowMs).toISOString();
     const live: IndexEntry[] = [];
@@ -564,7 +571,9 @@ export class RspElisionStore {
       await this.expireRedDbEntry(evicted, nowIso);
     }
     const next = { version: 1 as const, records: live };
-    await this.writeRedDbIndex(next);
+    if (hadAdditions || live.length < index.records.length) {
+      await this.writeRedDbIndex(next);
+    }
     return next;
   }
 

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -252,6 +252,7 @@ class ResidentTelemetryDrain {
     healed.unshift(...this.pendingHeals);
     this.pendingHeals = [];
     const index = await this.readIndex(db);
+    const originalCount = index.records.length;
     const nextRecords = [...index.records];
     for (const entry of healed) {
       nextRecords.push(await this.writeDrainDegradation(db, {
@@ -290,7 +291,8 @@ class ResidentTelemetryDrain {
         return true;
       }
     });
-    await this.prune(db, { version: 1, records: nextRecords });
+    const hadAdditions = nextRecords.length > originalCount;
+    await this.prune(db, { version: 1, records: nextRecords }, hadAdditions);
     await writeStatusSummary(db, this.opts.rootDir);
   }
 
@@ -351,7 +353,7 @@ class ResidentTelemetryDrain {
     await db.kv(RSP_TELEMETRY_INDEX_COLLECTION).put("index:v1", index);
   }
 
-  private async prune(db: RedDB, index: TelemetryIndexDocument): Promise<void> {
+  private async prune(db: RedDB, index: TelemetryIndexDocument, hadAdditions = false): Promise<void> {
     const nowMs = Date.now();
     const live: TelemetryIndexEntry[] = [];
     for (const entry of index.records) {
@@ -368,7 +370,9 @@ class ResidentTelemetryDrain {
       bytes -= evicted.bytes;
       await db.kv(evicted.collection).delete(evicted.key);
     }
-    await this.writeIndex(db, { version: 1, records: live });
+    if (hadAdditions || live.length < index.records.length) {
+      await this.writeIndex(db, { version: 1, records: live });
+    }
   }
 }
 

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -151,6 +151,65 @@ describe("RspElisionStore", () => {
         command: "first",
       });
       expect((await store.get(second))?.original).toEqual(Buffer.from("abcdef"));
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("performs zero writes to the content store on a no-expiration sweep", async () => {
+    const root = await tempRoot();
+    const storePath = join(root, "red.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      ttlDays: 7,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    try {
+      await store.mint(Buffer.from("sweep test"), {
+        command: "git log",
+        loss: { level: "terse", bytes_elided: 10 },
+      });
+
+      const afterMint = await readFile(storePath, "utf8");
+      const mtimeAfterMint = (await stat(storePath)).mtimeMs;
+
+      await store.stats();
+      await store.stats();
+      await store.stats();
+
+      const afterSweeps = await readFile(storePath, "utf8");
+      const mtimeAfterSweeps = (await stat(storePath)).mtimeMs;
+
+      expect(afterSweeps).toBe(afterMint);
+      expect(mtimeAfterSweeps).toBe(mtimeAfterMint);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("still writes the store when a sweep expires records", async () => {
+    let now = new Date("2026-07-10T12:00:00.000Z");
+    const root = await tempRoot();
+    const storePath = join(root, "red.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      ttlDays: 1,
+      now: () => now,
+    });
+    try {
+      await store.mint(Buffer.from("will expire"), {
+        command: "git diff",
+        loss: { level: "terse", bytes_elided: 11 },
+      });
+
+      const afterMint = await readFile(storePath, "utf8");
+
+      now = new Date("2026-07-12T12:00:00.000Z");
+      await store.stats();
+
+      const afterExpiry = await readFile(storePath, "utf8");
+      expect(afterExpiry).not.toBe(afterMint);
+      expect(await store.stats()).toMatchObject({ records: 0 });
     } finally {
       await store.close();
     }


### PR DESCRIPTION
Automated AFK landing for #1710. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1710

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786589413&installation_id=129708444&pr_number=1725&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1725&signature=23c0c979458cb1473d205e2a4eea60ee309a76c012b04ba63235b0cd0235d319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->