### PR TITLE
fix: #1705 rsp cat --full breaks the wrapper and passes through to raw 'cat --full' (invalid flag); 28.6% of today's invocations degraded as 'wrapper failed'

### DIFF
--- a/apps/rsp/src/cat-wrapper.ts
+++ b/apps/rsp/src/cat-wrapper.ts
@@ -19,6 +19,7 @@ interface ParsedCatCommand {
   file: string;
   mode: "full" | "head" | "tail";
   limit?: number;
+  inlineFull?: boolean;
 }
 
 type FileSymbol = JsonObject & {
@@ -96,9 +97,14 @@ export function parseCatCommand(argv: readonly string[]): ParsedCatCommand {
   const args = argv.slice(1);
   let mode: ParsedCatCommand["mode"] = "full";
   let limit: number | undefined;
+  let inlineFull = false;
   const files: string[] = [];
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]!;
+    if (arg === "--full") {
+      inlineFull = true;
+      continue;
+    }
     if (arg === "--head" || arg === "--tail") {
       mode = arg.slice(2) as "head" | "tail";
       limit = positiveInteger(args[++index], DEFAULT_SLICE_LINES);
@@ -112,8 +118,8 @@ export function parseCatCommand(argv: readonly string[]): ParsedCatCommand {
     }
     files.push(arg);
   }
-  if (files.length !== 1) throw new Error("usage: rsp cat [--head N|--tail N] <file>");
-  return { file: files[0]!, mode, ...(limit ? { limit } : {}) };
+  if (files.length !== 1) throw new Error("usage: rsp cat [--full] [--head N|--tail N] <file>");
+  return { file: files[0]!, mode, ...(limit ? { limit } : {}), ...(inlineFull ? { inlineFull } : {}) };
 }
 
 async function renderCatBytes(
@@ -124,6 +130,15 @@ async function renderCatBytes(
 ): Promise<GitRenderResult> {
   const text = bytes.toString("utf8");
   const sliced = applySlice(text, parsed);
+  if (parsed.inlineFull) {
+    return {
+      stdout: Buffer.from(sliced.text),
+      stderr: Buffer.alloc(0),
+      status: 0,
+      signal: null,
+      rawOutput: bytes,
+    };
+  }
   const shouldElide = options.level !== "lossless" ||
     bytes.length > positiveNumber(options.heavyByteThreshold, DEFAULT_CAT_HEAVY_BYTE_THRESHOLD) ||
     sliced.truncated;

--- a/apps/rsp/tests/cat-wrapper.test.ts
+++ b/apps/rsp/tests/cat-wrapper.test.ts
@@ -87,6 +87,23 @@ describe("rsp cat wrapper", () => {
     expect(result.bytesElided).toBeUndefined();
   });
 
+  it("accepts --full and emits text files inline byte-for-byte", async () => {
+    const root = await tempRoot();
+    const path = join(root, "notes.md");
+    const text = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n") + "\n";
+    await writeFile(path, text, "utf8");
+
+    const result = await runCatWrapper(["cat", "--full", path], {
+      level: "terse",
+      heavyByteThreshold: 1,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.toString("utf8")).toBe(text);
+    expect(result.mintedHandle).toBeUndefined();
+    expect(result.bytesElided).toBeUndefined();
+  });
+
   it("renders text head/tail slices with original-byte recovery", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "store.rdb")}` });


### PR DESCRIPTION
Automated AFK landing for #1705. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1705

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786594379&installation_id=129708444&pr_number=1729&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1729&signature=6fe159464bd4bfb83fd284bc40fb4e4fea84bc3d7dbba54a764093ccd20fd205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->