### PR TITLE
fix: #1726 rsp resident won't start in red-skills repo on 2.55.1 — 'resident rsp server did not start' with zero diagnostic even under RSP_DEBUG=1

### DIFF
--- a/packages/shared/resident-client.test.ts
+++ b/packages/shared/resident-client.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureResidentServer, resolveResidentPaths } from "./resident-client.js";
+
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "resident-client-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  const previousDebug = originalRspDebug;
+  if (previousDebug == null) delete process.env.RSP_DEBUG;
+  else process.env.RSP_DEBUG = previousDebug;
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const originalRspDebug = process.env.RSP_DEBUG;
+
+describe("resident client startup diagnostics", () => {
+  it("includes exit code and stderr tail when a debug resident child exits before ready", async () => {
+    const root = await tempRoot();
+    const paths = resolveResidentPaths(root);
+    process.env.RSP_DEBUG = "1";
+
+    await expect(ensureResidentServer(paths, {
+      storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
+      ttlDays: 7,
+      byteBudget: 1024,
+      serverCommand: process.execPath,
+      serverArgs: ["-e", "process.stderr.write('resident child boom\\n'); process.exit(42);"],
+    })).rejects.toThrow(/resident rsp server exited before ready\nexit code: 42\nstderr tail:\nresident child boom/);
+  });
+});

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -257,17 +257,28 @@ export async function sweepResidentRegistry(paths: RspResidentPaths): Promise<Rs
   return status;
 }
 
-async function waitForServer(socketPath: string, child?: ChildProcess): Promise<void> {
+interface ResidentSpawn {
+  child: ChildProcess;
+  stderrTail(): string;
+  spawnError(): Error | undefined;
+}
+
+async function waitForServer(socketPath: string, spawnHandle?: ResidentSpawn): Promise<void> {
   const deadline = Date.now() + 5_000;
   let last: unknown;
   while (Date.now() < deadline) {
     if (await pingResident(socketPath)) return;
-    if (child && child.exitCode != null) {
-      throw new Error(`resident rsp server exited before ready (${child.exitCode})`);
+    if (spawnHandle) {
+      const spawnError = spawnHandle.spawnError();
+      if (spawnError) throw new Error(formatResidentStartFailure("resident rsp server spawn failed", spawnHandle, spawnError));
+      if (spawnHandle.child.exitCode != null || spawnHandle.child.signalCode != null) {
+        throw new Error(formatResidentStartFailure("resident rsp server exited before ready", spawnHandle));
+      }
     }
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
-  throw last instanceof Error ? last : new Error("resident rsp server did not start");
+  if (last instanceof Error) throw last;
+  throw new Error(spawnHandle ? formatResidentStartFailure("resident rsp server did not start", spawnHandle) : "resident rsp server did not start");
 }
 
 async function removeUnresponsiveSocket(socketPath: string): Promise<void> {
@@ -284,8 +295,11 @@ async function tryAcquireLock(lockPath: string) {
   }
 }
 
-function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): ChildProcess {
+function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): ResidentSpawn {
   const [command, prefix] = spawnTarget(config);
+  const captureDiagnostics = process.env.RSP_DEBUG === "1";
+  let spawnError: Error | undefined;
+  let stderrTail = "";
   const child = spawn(command, [
     ...prefix,
     "server",
@@ -316,11 +330,42 @@ function spawnResident(paths: RspResidentPaths, config: RspResidentConfig): Chil
   ], {
     cwd: paths.rootDir,
     detached: true,
-    stdio: "ignore",
+    stdio: captureDiagnostics ? ["ignore", "ignore", "pipe"] : "ignore",
     env: { ...process.env, RSP_RESIDENT_SERVER: "1" },
   });
+  child.on("error", (err) => {
+    spawnError = err;
+  });
+  if (captureDiagnostics) {
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderrTail = tailString(`${stderrTail}${chunk}`, RESIDENT_START_STDERR_TAIL_BYTES);
+    });
+  }
   child.unref();
-  return child;
+  return {
+    child,
+    stderrTail: () => stderrTail,
+    spawnError: () => spawnError,
+  };
+}
+
+const RESIDENT_START_STDERR_TAIL_BYTES = 8 * 1024;
+
+function formatResidentStartFailure(reason: string, spawnHandle: ResidentSpawn, err?: Error): string {
+  const parts = [reason];
+  if (err) parts.push(`error: ${err.message}`);
+  if (spawnHandle.child.exitCode != null) parts.push(`exit code: ${spawnHandle.child.exitCode}`);
+  if (spawnHandle.child.signalCode != null) parts.push(`signal: ${spawnHandle.child.signalCode}`);
+  const stderrTail = spawnHandle.stderrTail().trimEnd();
+  if (stderrTail) parts.push(`stderr tail:\n${stderrTail}`);
+  return parts.join("\n");
+}
+
+function tailString(value: string, maxBytes: number): string {
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes <= maxBytes) return value;
+  return Buffer.from(value, "utf8").subarray(bytes - maxBytes).toString("utf8").replace(/^\uFFFD+/, "");
 }
 
 async function reconcileResidentRegistry(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {


### PR DESCRIPTION
Automated AFK landing for #1726. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1726

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786620413&installation_id=129708444&pr_number=1735&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1735&signature=1f1838bb04580ff2f64e70b6893b1b5f9a01efdc16718f81b552ab23a71117d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->