### PR TITLE
fix: #1723 AFK feedback gate: cli.test.ts resident-cold failures (16 tests) in nested feedback checkout that pass in any normal worktree

### DIFF
--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -109,6 +109,10 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
   void (async () => {
     const openedAt = process.hrtime.bigint();
     if (process.env.RSP_TEST_HANG_RESIDENT_STORE_OPEN === "1") await new Promise(() => undefined);
+    const testDelayMs = Number(process.env.RSP_TEST_DELAY_RESIDENT_STORE_OPEN_MS ?? "0");
+    if (Number.isFinite(testDelayMs) && testDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, testDelayMs));
+    }
     const store = await RspElisionStore.open({
       uri: opts.storeUri,
       ttlDays: opts.ttlDays,

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -399,11 +399,12 @@ async function waitForResidentReady(root: string): Promise<void> {
   throw last instanceof Error ? last : new Error("resident ready probe failed");
 }
 
-function expectWarmResident(root: string, env: Record<string, string> = {}): void {
+async function expectWarmResident(root: string, env: Record<string, string> = {}): Promise<void> {
   const warm = runBundleFromCwd(root, ["warm-resident"], env);
   expect(warm.status, `${warm.stdout.toString("utf8")}${warm.stderr.toString("utf8")}`).toBe(0);
   expect(warm.stdout).toEqual(Buffer.alloc(0));
   expect(warm.stderr).toEqual(Buffer.alloc(0));
+  await waitForResidentReady(root);
 }
 
 async function waitForSummaryTokens(root: string, minTokens: number): Promise<number> {
@@ -1302,7 +1303,7 @@ describe("rsp cli", () => {
     };
     const setup = runBundleFromCwd(root, ["setup"], env);
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    expectWarmResident(root, env);
+    await expectWarmResident(root, env);
 
     const worktreeA = join(root, ".red", "tmp", "linked-a");
     const worktreeB = join(root, ".red", "tmp", "linked-b");
@@ -1453,7 +1454,7 @@ describe("rsp cli", () => {
     const paths = trackedResidentPaths(root);
     await expect(stat(paths.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(paths.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
-    expectWarmResident(root, env);
+    await expectWarmResident(root, env);
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], env);
     expect(compressed.status).toBe(0);
     expect(compressed.stderr).toEqual(Buffer.alloc(0));
@@ -1471,7 +1472,7 @@ describe("rsp cli", () => {
     const paths = trackedResidentPaths(root);
     await mkdir(dirname(paths.socketPath), { recursive: true });
     await writeFile(paths.socketPath, "orphaned resident socket\n", "utf8");
-    expectWarmResident(root, {
+    await expectWarmResident(root, {
       RED_SKILLS_CACHE_DIR: cacheDir,
       RSP_FAIL_IF_STORE_OPEN: "1",
     });
@@ -1508,7 +1509,7 @@ describe("rsp cli", () => {
       resident_version: string;
     };
     expect(oldRegistry.resident_version).toBe(oldVersion);
-    expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+    await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
 
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
@@ -1541,7 +1542,7 @@ describe("rsp cli", () => {
     const hung = await startHungOldResident(paths.socketPath, oldVersion);
     try {
       expect(await readResidentVersion(root)).toBe(oldVersion);
-      expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+      await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
 
       const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
@@ -1563,7 +1564,7 @@ describe("rsp cli", () => {
     const raw = runGit(["-C", root, "log"]);
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+    await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
 
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
@@ -1605,7 +1606,7 @@ describe("rsp cli", () => {
     const cacheDir = await seedWarmRedCache();
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+    await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
     const command = "git log | head -c 400000";
     const direct = runShellFromCwd(root, command);
 
@@ -1633,7 +1634,7 @@ describe("rsp cli", () => {
     const cacheDir = await seedWarmRedCache();
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+    await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
     const source = [
       "export function greet(name: string): string {",
       "  return `hello ${name}`;",
@@ -1672,7 +1673,7 @@ describe("rsp cli", () => {
     const cacheDir = await seedWarmRedCache();
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+    await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
 
     const redirected = runBundleFromCwd(root, ["exec", "--", "printf 'redirected\\n' > out.txt"], {
       RED_SKILLS_CACHE_DIR: cacheDir,
@@ -1971,7 +1972,7 @@ describe("rsp cli", () => {
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
     const env = { RED_SKILLS_CACHE_DIR: cacheDir };
-    expectWarmResident(root, env);
+    await expectWarmResident(root, env);
 
     expect(runBundleFromCwd(root, ["git", "log", "--terse"], env).status).toBe(0);
     expect(runGit(["-C", root, "log"]).status).toBe(0);
@@ -2103,7 +2104,7 @@ describe("rsp cli", () => {
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
     const redBytes = Buffer.concat([Buffer.from("RDBSBLK1", "ascii"), Buffer.from([0, 1, 2, 3])]);
     await writeFile(join(root, ".red", "red.rdb"), redBytes);
-    expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
+    await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
 
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -56,7 +56,7 @@ function trackedResidentPaths(root: string) {
 function runRsp(root: string, args: string[], env: Record<string, string>) {
   return spawnSync(process.execPath, ["--import", tsxLoader, cli, ...args], {
     cwd: root,
-    env: { ...process.env, ...env },
+    env: testChildEnv(env),
     encoding: "buffer",
   });
 }
@@ -64,7 +64,7 @@ function runRsp(root: string, args: string[], env: Record<string, string>) {
 function runRspFromCwd(cwd: string, args: string[], env: Record<string, string>) {
   return spawnSync(process.execPath, ["--import", tsxLoader, cli, ...args], {
     cwd,
-    env: { ...process.env, ...env },
+    env: testChildEnv(env),
     encoding: "buffer",
   });
 }
@@ -88,7 +88,7 @@ function runNodeNoop() {
 function runBundleFromCwd(cwd: string, args: string[], env: Record<string, string> = {}) {
   return spawnSync(process.execPath, [bundle, ...args], {
     cwd,
-    env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
+    env: testChildEnv(env),
     encoding: "buffer",
   });
 }
@@ -96,7 +96,7 @@ function runBundleFromCwd(cwd: string, args: string[], env: Record<string, strin
 function runBundleHookFromCwd(cwd: string, command: string, env: Record<string, string> = {}) {
   return spawnSync(process.execPath, [bundle, "hook", "claude-pre-exec"], {
     cwd,
-    env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
+    env: testChildEnv(env),
     input: Buffer.from(JSON.stringify({ cwd, tool_input: { command } })),
     encoding: "buffer",
   });
@@ -105,7 +105,7 @@ function runBundleHookFromCwd(cwd: string, command: string, env: Record<string, 
 function runBundleCodexHookFromCwd(cwd: string, command: string, env: Record<string, string> = {}) {
   return spawnSync(process.execPath, [bundle, "hook", "codex-pre-exec"], {
     cwd,
-    env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
+    env: testChildEnv(env),
     input: Buffer.from(JSON.stringify({ cwd, tool_name: "bash", tool_input: { command } })),
     encoding: "buffer",
   });
@@ -115,7 +115,7 @@ function runBundleFromCwdAsync(cwd: string, args: string[], env: Record<string, 
   return new Promise<{ status: number | null; stdout: Buffer; stderr: Buffer }>((resolve, reject) => {
     const child = spawn(process.execPath, [bundle, ...args], {
       cwd,
-      env: { ...process.env, RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS), ...env },
+      env: testChildEnv(env),
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdout: Buffer[] = [];
@@ -182,6 +182,16 @@ function normalizedDeadlineMs(durationMs = 5_000): number {
 }
 
 const TEST_TELEMETRY_DRAIN_TIMEOUT_MS = normalizedTimeoutMs(TEST_NODE_NOOP_BASELINE_MS, 250, 2_000);
+const TEST_RESIDENT_READY_TIMEOUT_MS = normalizedDurationMs(10_000);
+
+function testChildEnv(env: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    RSP_TELEMETRY_DRAIN_TIMEOUT_MS: String(TEST_TELEMETRY_DRAIN_TIMEOUT_MS),
+    RSP_RESIDENT_READY_TIMEOUT_MS: String(TEST_RESIDENT_READY_TIMEOUT_MS),
+    ...env,
+  };
+}
 
 async function idleBeat(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 50));
@@ -935,6 +945,24 @@ describe("rsp cli", () => {
     if (child.exitCode == null) child.kill("SIGTERM");
     const status = await closeWithTimeout(child, normalizedDurationMs(5_000)).catch(() => null);
     expect(status === 0 || status === null).toBe(true);
+  }, 120_000);
+
+  it("built bundle warm-resident waits through a slow resident store open", async () => {
+    buildBundleOnce();
+    const root = await initGitRepo();
+    const cacheDir = await seedWarmRedCache();
+    const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
+    expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
+
+    const warm = runBundleFromCwd(root, ["warm-resident", "--idle-ms", String(normalizedDurationMs(30_000))], {
+      RED_SKILLS_CACHE_DIR: cacheDir,
+      RSP_TEST_DELAY_RESIDENT_STORE_OPEN_MS: "5500",
+    });
+
+    expect(warm.status, `${warm.stdout.toString("utf8")}${warm.stderr.toString("utf8")}`).toBe(0);
+    expect(warm.stdout).toEqual(Buffer.alloc(0));
+    expect(warm.stderr).toEqual(Buffer.alloc(0));
+    await waitForResidentReady(root);
   }, 120_000);
 
   it("built bundle elision falls back fast when the resident store is not ready", async () => {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -2192,7 +2192,7 @@ describe("rsp cli", () => {
 
   it("wait ls shows a live registry entry while a command wait is active", async () => {
     const root = await tempRoot();
-    const command = `${shellQuote(process.execPath)} -e "setTimeout(() => process.exit(0), 700)"`;
+    const command = `${shellQuote(process.execPath)} -e "setTimeout(() => process.exit(0), 3000)"`;
     const child = spawn(process.execPath, ["--import", tsxLoader, cli, "wait", "cmd", "--reason", "registry probe", "--", command], {
       cwd: root,
       env: { ...process.env },
@@ -2208,7 +2208,7 @@ describe("rsp cli", () => {
     expect(listed.status).toBe("running");
     expect(listed.poll_tier).toBe("local-cmd:2-5s");
 
-    const status = await closeWithTimeout(child, normalizedDurationMs(5_000));
+    const status = await closeWithTimeout(child, normalizedDurationMs(10_000));
     expect(status, Buffer.concat(stderr).toString("utf8")).toBe(0);
     const decoded = decode(Buffer.concat(stdout).toString("utf8")) as { wait: { status: string } };
     expect(decoded.wait.status).toBe("success");

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -21,6 +21,7 @@ export interface RspResidentPaths {
 
 const UNIX_SOCKET_PATH_LIMIT = 108;
 const RESIDENT_REGISTRY_VERSION = 1;
+const DEFAULT_RESIDENT_READY_TIMEOUT_MS = 5_000;
 
 export interface RspResidentRegistryEntry {
   version: typeof RESIDENT_REGISTRY_VERSION;
@@ -264,7 +265,7 @@ interface ResidentSpawn {
 }
 
 async function waitForServer(socketPath: string, spawnHandle?: ResidentSpawn): Promise<void> {
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + residentReadyTimeoutMs();
   let last: unknown;
   while (Date.now() < deadline) {
     if (await pingResident(socketPath)) return;
@@ -279,6 +280,11 @@ async function waitForServer(socketPath: string, spawnHandle?: ResidentSpawn): P
   }
   if (last instanceof Error) throw last;
   throw new Error(spawnHandle ? formatResidentStartFailure("resident rsp server did not start", spawnHandle) : "resident rsp server did not start");
+}
+
+function residentReadyTimeoutMs(): number {
+  const value = Number(process.env.RSP_RESIDENT_READY_TIMEOUT_MS ?? "");
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_RESIDENT_READY_TIMEOUT_MS;
 }
 
 async function removeUnresponsiveSocket(socketPath: string): Promise<void> {


### PR DESCRIPTION
Automated AFK landing for #1723. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1723

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786621473&installation_id=129708444&pr_number=1736&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1736&signature=a000b67d60ac3992e5d8b6dafb450b7a657a6c1c39a47703c6bba76c20cec240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->