### PR TITLE
fix: #1731 rsp pre-exec interception is dead: claude-pre-exec exits silently (0/1) without rewriting eligible commands, in every repo, with zero diagnostics under RSP_DEBUG

### DIFF
--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from "node:url";
 import { resolveRspConfig, type RspRuntimeConfig } from "./config.js";
 import {
   kickResidentServer,
-  pingResident,
   resolveResidentPaths,
 } from "./resident-client.js";
 
@@ -17,6 +16,10 @@ export interface RspWrapperCapability {
 export type RewriteDecision =
   | { kind: "rewrite"; command: string; capabilityId: string }
   | { kind: "passthrough"; reason?: string };
+
+type HookPayloadParse =
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; reason: string };
 
 export interface HookDecisionOptions {
   cwd: string;
@@ -114,7 +117,9 @@ async function hookDecisionFromPreExecJson(
   raw: string,
   options: HookDecisionOptions,
 ): Promise<RewriteDecision> {
-  const payload = parseJsonRecord(raw);
+  const parsed = parseJsonRecord(raw);
+  if (!parsed.ok) return { kind: "passthrough", reason: parsed.reason };
+  const payload = parsed.payload;
   const cwd = stringAt(payload, ["cwd"]) || stringAt(payload, ["tool_input", "cwd"]) || options.cwd;
   const enabled = await (options.isEnabled ?? isRspHookEnabled)(cwd);
   if (!enabled) return { kind: "passthrough", reason: "disabled" };
@@ -122,28 +127,29 @@ async function hookDecisionFromPreExecJson(
   const command = extractHookCommand(payload);
   if (!command) return { kind: "passthrough", reason: "missing-command" };
   const decision = (options.rewrite ?? rewriteCommand)(command);
-  if (decision.kind !== "rewrite") return decision;
+  if (decision.kind !== "rewrite") return decision.reason ? decision : { ...decision, reason: "unsupported-command" };
 
-  const healthy = await (options.isResidentHealthy ?? isRspResidentHealthy)(cwd);
-  if (healthy) return decision;
-
-  await (options.wakeResident ?? wakeRspResident)(cwd);
-  return { kind: "passthrough", reason: "resident-unhealthy" };
+  await wakeResidentForRewrite(cwd, options.wakeResident ?? wakeRspResident);
+  return decision;
 }
 
 export function formatHookDecision(decision: RewriteDecision): { stdout: string; status: number } {
-  if (decision.kind === "rewrite") return { stdout: `${decision.command}\n`, status: 0 };
-  return { stdout: "", status: 1 };
+  if (decision.kind === "rewrite") return formatUpdatedInputDecision(decision.command);
+  return { stdout: "", status: 0 };
 }
 
 export function formatCodexHookDecision(decision: RewriteDecision): { stdout: string; status: number } {
-  if (decision.kind !== "rewrite") return { stdout: "", status: 0 };
+  if (decision.kind === "rewrite") return formatUpdatedInputDecision(decision.command);
+  return { stdout: "", status: 0 };
+}
+
+function formatUpdatedInputDecision(command: string): { stdout: string; status: number } {
   return {
     stdout: `${JSON.stringify({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "allow",
-        updatedInput: { command: decision.command },
+        updatedInput: { command },
       },
     })}\n`,
     status: 0,
@@ -151,28 +157,35 @@ export function formatCodexHookDecision(decision: RewriteDecision): { stdout: st
 }
 
 export async function runClaudePreExecHook(stdinPath?: string): Promise<number> {
-  const raw = stdinPath ? readFileSync(stdinPath, "utf8") : readFileSync(0, "utf8");
-  const decision = await hookDecisionFromClaudePreExecJson(raw, { cwd: process.cwd() });
-  const formatted = formatHookDecision(decision);
-  if (formatted.stdout) process.stdout.write(formatted.stdout);
-  return formatted.status;
+  try {
+    const raw = stdinPath ? readFileSync(stdinPath, "utf8") : readFileSync(0, "utf8");
+    const decision = await hookDecisionFromClaudePreExecJson(raw, { cwd: process.cwd() });
+    debugHookDecision("claude-pre-exec", decision);
+    const formatted = formatHookDecision(decision);
+    if (formatted.stdout) process.stdout.write(formatted.stdout);
+    return formatted.status;
+  } catch (err) {
+    debugHookException("claude-pre-exec", err);
+    return 0;
+  }
 }
 
 export async function runCodexPreExecHook(stdinPath?: string): Promise<number> {
-  const raw = stdinPath ? readFileSync(stdinPath, "utf8") : readFileSync(0, "utf8");
-  const decision = await hookDecisionFromCodexPreExecJson(raw, { cwd: process.cwd() });
-  const formatted = formatCodexHookDecision(decision);
-  if (formatted.stdout) process.stdout.write(formatted.stdout);
-  return formatted.status;
+  try {
+    const raw = stdinPath ? readFileSync(stdinPath, "utf8") : readFileSync(0, "utf8");
+    const decision = await hookDecisionFromCodexPreExecJson(raw, { cwd: process.cwd() });
+    debugHookDecision("codex-pre-exec", decision);
+    const formatted = formatCodexHookDecision(decision);
+    if (formatted.stdout) process.stdout.write(formatted.stdout);
+    return formatted.status;
+  } catch (err) {
+    debugHookException("codex-pre-exec", err);
+    return 0;
+  }
 }
 
 function isRspHookEnabled(cwd: string): boolean {
   return resolveRspConfig(cwd, process.env).enabled;
-}
-
-async function isRspResidentHealthy(cwd: string): Promise<boolean> {
-  const paths = resolveResidentPaths(cwd);
-  return await pingResident(paths.socketPath, 50);
 }
 
 async function wakeRspResident(cwd: string): Promise<void> {
@@ -181,6 +194,41 @@ async function wakeRspResident(cwd: string): Promise<void> {
   if (!storeIsProvisioned(config)) return;
   const paths = resolveResidentPaths(cwd);
   await kickResidentServer(paths, toResidentConfig(config));
+}
+
+async function wakeResidentForRewrite(
+  cwd: string,
+  wakeResident: (cwd: string) => void | Promise<void>,
+): Promise<void> {
+  try {
+    await Promise.resolve(wakeResident(cwd));
+  } catch (err) {
+    debugHookWakeFailure(err);
+  }
+}
+
+function debugHookDecision(hook: string, decision: RewriteDecision): void {
+  if (process.env.RSP_DEBUG !== "1") return;
+  if (decision.kind === "rewrite") {
+    process.stderr.write(`rsp hook ${hook}: rewrite ${decision.capabilityId}\n`);
+    return;
+  }
+  process.stderr.write(`rsp hook ${hook}: passthrough ${decision.reason ?? "unsupported-command"}\n`);
+}
+
+function debugHookException(hook: string, err: unknown): void {
+  if (process.env.RSP_DEBUG !== "1") return;
+  process.stderr.write(`rsp hook ${hook}: exception ${errorLabel(err)}\n`);
+}
+
+function debugHookWakeFailure(err: unknown): void {
+  if (process.env.RSP_DEBUG !== "1") return;
+  process.stderr.write(`rsp hook pre-exec: resident-wake-failed ${errorLabel(err)}\n`);
+}
+
+function errorLabel(err: unknown): string {
+  if (err instanceof Error) return err.name || "Error";
+  return typeof err;
 }
 
 function toResidentConfig(config: RspRuntimeConfig) {
@@ -332,12 +380,12 @@ function commandKey(tokens: readonly string[]): string {
   return tokens.join("\0");
 }
 
-function parseJsonRecord(raw: string): Record<string, unknown> {
+function parseJsonRecord(raw: string): HookPayloadParse {
   try {
     const parsed = JSON.parse(raw);
-    return isRecord(parsed) ? parsed : {};
+    return isRecord(parsed) ? { ok: true, payload: parsed } : { ok: false, reason: "payload-not-object" };
   } catch {
-    return {};
+    return { ok: false, reason: "payload-parse-error" };
   }
 }
 

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1065,7 +1065,7 @@ describe("rsp cli", () => {
     expect(await countTrackedResidentProcesses()).toBe(0);
   }, 120_000);
 
-  it("built bundle pre-exec hook passes through while cold, warms once, then rewrites when healthy", async () => {
+  it("built bundle Claude pre-exec hook rewrites while cold and warms once", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
     const cacheDir = await seedWarmRedCache();
@@ -1078,8 +1078,14 @@ describe("rsp cli", () => {
     const cold = timedStatus(() => runBundleHookFromCwd(root, "git status", env));
     const coldHookWorkMs = Math.max(0, cold.elapsedMs - coldNodeBaseline.elapsedMs);
 
-    expect(cold.status).toBe(1);
-    expect(cold.stdout).toEqual(Buffer.alloc(0));
+    expect(cold.status).toBe(0);
+    expect(JSON.parse(cold.stdout.toString("utf8"))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: "rsp git status" },
+      },
+    });
     expect(cold.stderr).toEqual(Buffer.alloc(0));
     await expectLatencyBudget(
       "cold pre-exec hook work",
@@ -1099,8 +1105,14 @@ describe("rsp cli", () => {
         const retryCold = timedStatus(() => runBundleHookFromCwd(retryRoot, "git status", retryEnv));
         const retryColdHookWorkMs = Math.max(0, retryCold.elapsedMs - retryNodeBaseline.elapsedMs);
 
-        expect(retryCold.status).toBe(1);
-        expect(retryCold.stdout).toEqual(Buffer.alloc(0));
+        expect(retryCold.status).toBe(0);
+        expect(JSON.parse(retryCold.stdout.toString("utf8"))).toMatchObject({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            updatedInput: { command: "rsp git status" },
+          },
+        });
         expect(retryCold.stderr).toEqual(Buffer.alloc(0));
         return budgetSample(
           retryColdHookWorkMs,
@@ -1109,23 +1121,23 @@ describe("rsp cli", () => {
         );
       },
     );
-    await expect(stat(paths.wakeLockPath)).resolves.toMatchObject({ size: expect.any(Number) });
+    await waitForResidentSocket(root);
+    // The wake lock is transient; the observable contract is that the hook's
+    // kick brings the resident online.
+    await waitForGone(paths.wakeLockPath);
 
     for (let i = 0; i < 4; i++) {
       const repeat = runBundleHookFromCwd(root, "git status", env);
-      expect([0, 1]).toContain(repeat.status);
-      if (repeat.status === 0) {
-        expect(repeat.stdout).toEqual(Buffer.from("rsp git status\n"));
-      } else {
-        expect(repeat.stdout).toEqual(Buffer.alloc(0));
-      }
+      expect(repeat.status).toBe(0);
+      expect(JSON.parse(repeat.stdout.toString("utf8"))).toMatchObject({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          updatedInput: { command: "rsp git status" },
+        },
+      });
       expect(repeat.stderr).toEqual(Buffer.alloc(0));
     }
-
-    await waitForResidentSocket(root);
-    // The warmer removes the wake lock only after ensure returns, which is
-    // also the moment the socket starts answering — poll instead of racing it.
-    await waitForGone(paths.wakeLockPath);
 
     const measureWarmHookWork = () => {
       const nodeSamples: number[] = [];
@@ -1135,7 +1147,13 @@ describe("rsp cli", () => {
         const warm = timedStatus(() => runBundleHookFromCwd(root, "git status", env));
 
         expect(warm.status).toBe(0);
-        expect(warm.stdout).toEqual(Buffer.from("rsp git status\n"));
+        expect(JSON.parse(warm.stdout.toString("utf8"))).toMatchObject({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            updatedInput: { command: "rsp git status" },
+          },
+        });
         expect(warm.stderr).toEqual(Buffer.alloc(0));
         nodeSamples.push(node.elapsedMs);
         warmSamples.push(warm.elapsedMs);
@@ -1183,8 +1201,14 @@ describe("rsp cli", () => {
     const paths = trackedResidentPaths(root);
 
     const cold = runBundleHookFromCwd(root, "git status", env);
-    expect(cold.status).toBe(1);
-    expect(cold.stdout).toEqual(Buffer.alloc(0));
+    expect(cold.status).toBe(0);
+    expect(JSON.parse(cold.stdout.toString("utf8"))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: "rsp git status" },
+      },
+    });
     expect(cold.stderr).toEqual(Buffer.alloc(0));
     await waitForResidentSocket(root);
     await waitForGone(paths.wakeLockPath);
@@ -1192,14 +1216,26 @@ describe("rsp cli", () => {
     await new Promise((resolve) => setTimeout(resolve, normalizedDurationMs(2_000)));
     const warm = runBundleHookFromCwd(root, "git status", env);
     expect(warm.status).toBe(0);
-    expect(warm.stdout).toEqual(Buffer.from("rsp git status\n"));
+    expect(JSON.parse(warm.stdout.toString("utf8"))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: "rsp git status" },
+      },
+    });
     expect(warm.stderr).toEqual(Buffer.alloc(0));
 
     await waitForGone(paths.socketPath, idleMs + normalizedDurationMs(5_000));
     await waitForGone(paths.registryPath);
     const expired = runBundleHookFromCwd(root, "git status", env);
-    expect(expired.status).toBe(1);
-    expect(expired.stdout).toEqual(Buffer.alloc(0));
+    expect(expired.status).toBe(0);
+    expect(JSON.parse(expired.stdout.toString("utf8"))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: "rsp git status" },
+      },
+    });
     expect(expired.stderr).toEqual(Buffer.alloc(0));
   }, 120_000);
 

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -103,7 +103,7 @@ describe("rsp interception pure rewrite table", () => {
 });
 
 describe("rsp Claude pre-execution hook integration", () => {
-  it("accepts Claude hook JSON on stdin through the CLI and returns the stdout/exit contract", async () => {
+  it("accepts Claude hook JSON on stdin through the CLI and emits updatedInput", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
@@ -113,13 +113,44 @@ describe("rsp Claude pre-execution hook integration", () => {
       input: Buffer.from(JSON.stringify({ cwd: root, tool_input: { command: "git status" } })),
     });
 
-    expect(res.status).toBe(1);
-    expect(res.stdout).toEqual(Buffer.alloc(0));
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout.toString("utf8"))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: "rsp git status" },
+      },
+    });
     expect(res.stderr).toEqual(Buffer.alloc(0));
     await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("prints only the rewritten command and exits 0 on a certain match when the resident is healthy", async () => {
+  it("reports rewrite and parse decisions under RSP_DEBUG", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+
+    const rewrite = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-pre-exec"], {
+      cwd: root,
+      env: { ...process.env, RSP_DEBUG: "1" },
+      input: Buffer.from(JSON.stringify({ cwd: root, tool_input: { command: "git status" } })),
+    });
+
+    expect(rewrite.status).toBe(0);
+    expect(rewrite.stderr.toString("utf8")).toContain("rsp hook claude-pre-exec: rewrite git:status\n");
+
+    const parseFailure = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "claude-pre-exec"], {
+      cwd: root,
+      env: { ...process.env, RSP_DEBUG: "1" },
+      input: Buffer.from("{"),
+    });
+
+    expect(parseFailure.status).toBe(0);
+    expect(parseFailure.stdout).toEqual(Buffer.alloc(0));
+    expect(parseFailure.stderr.toString("utf8")).toContain("rsp hook claude-pre-exec: passthrough payload-parse-error\n");
+  });
+
+  it("prints Claude updatedInput JSON and exits 0 on a certain match", async () => {
     const root = await tempRoot();
     let healthCalls = 0;
     let wakeCalls = 0;
@@ -138,12 +169,21 @@ describe("rsp Claude pre-execution hook integration", () => {
       },
     );
 
-    expect(formatHookDecision(result)).toEqual({ stdout: "rsp git status\n", status: 0 });
-    expect(healthCalls).toBe(1);
-    expect(wakeCalls).toBe(0);
+    expect(formatHookDecision(result)).toEqual({
+      stdout: JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          updatedInput: { command: "rsp git status" },
+        },
+      }) + "\n",
+      status: 0,
+    });
+    expect(healthCalls).toBe(0);
+    expect(wakeCalls).toBe(1);
   });
 
-  it("prints a shell-safe rsp exec rewrite for compound noisy commands when the resident is healthy", async () => {
+  it("prints a shell-safe rsp exec updatedInput for compound noisy commands", async () => {
     const root = await tempRoot();
     const result = await hookDecisionFromClaudePreExecJson(
       JSON.stringify({ cwd: root, tool_input: { command: "cd apps && git log --oneline" } }),
@@ -155,7 +195,13 @@ describe("rsp Claude pre-execution hook integration", () => {
     );
 
     expect(formatHookDecision(result)).toEqual({
-      stdout: "rsp exec -- 'cd apps && git log --oneline'\n",
+      stdout: JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          updatedInput: { command: "rsp exec -- 'cd apps && git log --oneline'" },
+        },
+      }) + "\n",
       status: 0,
     });
   });
@@ -179,13 +225,14 @@ describe("rsp Claude pre-execution hook integration", () => {
       },
     );
 
-    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 0 });
     expect(healthCalls).toBe(0);
     expect(wakeCalls).toBe(0);
   });
 
-  it("passes through and wakes the resident when the resident is not healthy", async () => {
+  it("rewrites and wakes the resident without health-gating the decision", async () => {
     const root = await tempRoot();
+    let healthCalls = 0;
     let wakeCalls = 0;
     const started = performance.now();
     const result = await hookDecisionFromClaudePreExecJson(
@@ -193,7 +240,10 @@ describe("rsp Claude pre-execution hook integration", () => {
       {
         cwd: root,
         isEnabled: () => true,
-        isResidentHealthy: async () => false,
+        isResidentHealthy: async () => {
+          healthCalls += 1;
+          return false;
+        },
         wakeResident: () => {
           wakeCalls += 1;
         },
@@ -201,8 +251,9 @@ describe("rsp Claude pre-execution hook integration", () => {
     );
     const elapsedMs = performance.now() - started;
 
-    expect(result).toEqual({ kind: "passthrough", reason: "resident-unhealthy" });
-    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+    expect(result).toEqual({ kind: "rewrite", command: "rsp git status", capabilityId: "git:status" });
+    expect(formatHookDecision(result).status).toBe(0);
+    expect(healthCalls).toBe(0);
     expect(wakeCalls).toBe(1);
     expect(elapsedMs).toBeLessThan(50);
   });
@@ -229,7 +280,7 @@ describe("rsp Claude pre-execution hook integration", () => {
     expect(result).toEqual({ kind: "passthrough", reason: "disabled" });
     expect(gateCalls).toBe(1);
     expect(rewriteCalls).toBe(0);
-    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 1 });
+    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 0 });
   });
 });
 
@@ -288,7 +339,13 @@ describe("rsp Codex pre-execution hook integration", () => {
     });
 
     expect(res.status).toBe(0);
-    expect(res.stdout).toEqual(Buffer.alloc(0));
+    expect(JSON.parse(res.stdout.toString("utf8"))).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        updatedInput: { command: "rsp git status" },
+      },
+    });
     expect(res.stderr).toEqual(Buffer.alloc(0));
     await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });


### PR DESCRIPTION
Automated AFK landing for #1731. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1731

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786621570&installation_id=129708444&pr_number=1737&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1737&signature=a1f98860e03ed198995e724788925e86db9f298e7af6dcd35eec8d14e8ef57d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->