### PR TITLE
fix: #1695 scout: completed report discarded when AgentOutput missing — run mis-parked as blocked:crashed despite DONE sentinel in log

### DIFF
--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -35,6 +35,7 @@ import {
   type AgentEffort,
   type AgentStreamEvent,
   type AttemptProgressInfo,
+  DONE_SIGNAL,
   type RunAgentInput,
   type RunAgentResult,
   type SandboxMode,
@@ -909,6 +910,23 @@ import {
  */
 function blockedLabelsIn(labels: string[]): string[] {
   return labels.filter((l) => l.startsWith("blocked:"));
+}
+
+function stripScoutDoneSignal(text: string): string {
+  const escaped = DONE_SIGNAL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return text.replace(new RegExp(`\\s*${escaped}\\s*$`), "").trim();
+}
+
+function scoutReportFrom(chunks: readonly string[], stdout: string | undefined): string {
+  const captured = chunks.join("").trim() || (stdout ?? "").trim();
+  const report = stripScoutDoneSignal(captured);
+  return report || "_Scout completed without output. Check the attempt log for details._";
+}
+
+function scoutCapturedDone(run: RunAgentResult, chunks: readonly string[]): boolean {
+  if (run.completionSignal === DONE_SIGNAL) return true;
+  const captured = chunks.join("").trim() || (run.stdout ?? "").trim();
+  return captured.length > 0 && stripScoutDoneSignal(captured) !== captured;
 }
 
 const MECHANICAL_BLOCKER_KINDS = new Set(["stalled", "crashed", "merge-conflict"]);
@@ -1906,6 +1924,13 @@ export async function processIssue(
       effort: initialTier.effort,
     } satisfies StageCommon;
 
+    if (input.runMode === "scout" && run.outcome === "no-sentinel" && scoutCapturedDone(run, scoutTextChunks)) {
+      deps.appendIterLog(
+        "🤖 /scout: AgentOutput was missing, but the captured agent stream ended with DONE — posting the recovered scout report.",
+      );
+      run = { ...run, outcome: "done", completionSignal: run.completionSignal ?? DONE_SIGNAL };
+    }
+
     // ---- commit-leftovers salvage (codex DONE/partial-commit leftovers, ADR 0050) ----
     // The inner agent (observed: codex) can edit, pass the gates, and emit
     // `<promise>DONE</promise>` without committing every dirty path. This includes
@@ -2176,8 +2201,7 @@ export async function processIssue(
     // output as a report comment and close the disposable issue. No branch is
     // ever pushed to the remote; the worktree was ephemeral.
     if (input.runMode === "scout") {
-      const report = scoutTextChunks.join("").trim() ||
-        "_Scout completed without output. Check the attempt log for details._";
+      const report = scoutReportFrom(scoutTextChunks, run.stdout);
       await deps.gh.comment(issue, `## 🔍 Scout Report\n\n${report}`);
       await deps.gh.close(issue);
       await releaseClaim();

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -185,6 +185,10 @@ interface HarnessOptions {
    * to one commit on a real outcome / none on exhaustion. Set `[]` to model the
    * codex DONE-without-commit case the salvage port rescues. */
   commits?: { sha: string }[];
+  /** Text chunks emitted through the agent stream callback before runAgent returns. */
+  agentTextEvents?: string[];
+  /** Override the fake runAgent completion signal. */
+  completionSignal?: string;
   /** When set, register the commit-leftovers `salvageUncommitted` port and have
    * it return this count (files committed). undefined omits the port (legacy
    * caller — no salvage). */
@@ -511,6 +515,9 @@ function harness(opts: HarnessOptions = {}): {
       trace.runAgentCalls.push(input);
       await opts.onRunAgent?.();
       const thisOutcome = opts.outcomes ? (opts.outcomes[callIdx] ?? outcome) : outcome;
+      for (const message of opts.agentTextEvents ?? []) {
+        input.onAgentEvent?.({ type: "text", message, iteration: 1, timestamp: new Date(0) });
+      }
       return {
         outcome: thisOutcome,
         branch: input.branch,
@@ -518,11 +525,12 @@ function harness(opts: HarnessOptions = {}): {
           opts.commits ??
           (thisOutcome === "exhausted" || thisOutcome === "runner-transient" ? [] : [{ sha: "deadbee" }]),
         completionSignal:
-          thisOutcome === "done"
+          opts.completionSignal ??
+          (thisOutcome === "done"
             ? "<promise>DONE</promise>"
             : thisOutcome === "blocked"
               ? "<promise>BLOCKED</promise>"
-              : undefined,
+              : undefined),
         timeoutReason: thisOutcome === "timeout" ? opts.timeoutReason : undefined,
         stdout: thisOutcome === "no-sentinel" ? "Edit src/x.ts\nlast line, no sentinel" : "",
       };
@@ -3613,6 +3621,26 @@ describe("processIssue — scout mode (runMode: 'scout')", () => {
     const humanLabel = trace.labelEdits.find((e) => e.add.includes("ready-for-human"));
     expect(humanLabel).toBeDefined();
     expect(trace.closed).not.toContain(9);
+  });
+
+  it("recovers a scout report when AgentOutput enforcement downgraded a captured DONE stream", async () => {
+    const { deps, input, trace } = harness({
+      runMode: "scout",
+      outcome: "no-sentinel",
+      commits: [],
+      completionSignal: "<promise>DONE</promise>",
+      agentTextEvents: ["# Findings\n\nReport body.\n", "<promise>DONE</promise>"],
+    });
+
+    const result = await processIssue(deps, input);
+
+    expect(result.outcome).toBe("done");
+    const report = trace.comments.find((c) => c.issue === 9 && c.body.includes("Scout Report"));
+    expect(report?.body).toContain("# Findings");
+    expect(report?.body).toContain("Report body.");
+    expect(report?.body).not.toContain("<promise>DONE</promise>");
+    expect(trace.closed).toContain(9);
+    expect(trace.pushedAttempt).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1695. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1695

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786622386&installation_id=129708444&pr_number=1738&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1738&signature=979289612e4ca893701d28d9564d017fc0dc919c16af1ce18c642fe0dcfdb583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->