### PR TITLE
fix: #1711 rsp accounting timeseries: dedicated volume/savings lane + show hit-rate, read by stats and statusline

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -145,6 +145,8 @@ interface RspSummaryFile {
   version: number;
   tokens_saved_today: number;
   dollars_saved_today_usd?: number;
+  show_total_today?: number;
+  show_hit_rate?: number;
   updated_at: string;
 }
 
@@ -209,6 +211,9 @@ export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv 
       state: "ready",
       tokensSavedToday: tokensSavedForCurrentDay(summary, nowMs),
       dollarsSavedTodayUsd: dollarsSavedForCurrentDay(summary, nowMs),
+      showHitRate: summary.show_total_today && summary.show_total_today > 0 && typeof summary.show_hit_rate === "number"
+        ? summary.show_hit_rate
+        : undefined,
     };
   }
   if (isRecentFile(paths.wakeLockPath, nowMs, RSP_WARMUP_GRACE_MS)) return { state: "warming" };

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -164,7 +164,7 @@ export interface FleetInput {
 }
 
 export type RspStatusInput =
-  | { state: "ready"; tokensSavedToday: number; dollarsSavedTodayUsd?: number }
+  | { state: "ready"; tokensSavedToday: number; dollarsSavedTodayUsd?: number; showHitRate?: number }
   | { state: "warming" }
   | { state: "error" };
 
@@ -458,7 +458,8 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
   if (rsp.state === "ready") {
-    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}`;
+    const hitRate = typeof rsp.showHitRate === "number" ? ` hit=${Math.round(rsp.showHitRate * 100)}%` : "";
+    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}${hitRate}`;
   }
   if (rsp.state === "warming") return "rsp=…";
   return "rsp=!";

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -4,13 +4,15 @@ import { createHash } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { connect } from "@reddb-io/sdk";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspRuntimeConfig } from "./config.js";
 import type { RspElisionStore, RspMintMeta } from "./elision-store.js";
 import { formatUsd } from "./pricing.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
-import type { RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
+import type { RspAccountingLaneStats, RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
 
 interface ParsedArgs {
   command?: string;
@@ -133,8 +135,6 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     return 0;
   }
 
-  const { existsSync } = await import("node:fs");
-  const { fileURLToPath } = await import("node:url");
   const residentPaths = resolveResidentPaths(process.cwd());
   if (args.command === "status" || args.command === "sweep") {
     const { residentRegistryStatus, sweepResidentRegistry } = await import("./resident-client.js");
@@ -185,12 +185,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   let closeStore: (() => Promise<void>) | undefined;
   try {
     if (!args.command || args.command === "stats") {
-      const store = await openReadStore();
-      closeStore = () => store.close();
-      const stats = await store.stats();
-      const telemetry = hasTelemetryStats(store)
-        ? await store.telemetryStats(sinceDays(args.positional, 30))
-        : emptyTelemetryStats(sinceDays(args.positional, 30));
+      const { stats, telemetry } = await readStatsSnapshot(config, sinceDays(args.positional, 30));
       process.stdout.write(renderStats(stats, telemetry, statsFull(args.positional)));
       return 0;
     }
@@ -279,13 +274,18 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
       const record = await store.get(args.handle);
       if (record && "original" in record && record.original) {
         process.stdout.write(record.original);
+        await appendShowAccountingEvent(residentPaths.rootDir, args.handle, true, record.original.length);
         return 0;
       }
       if (record?.status === "expired") {
-        process.stdout.write(`expired ${record.expired_at} — re-run: ${record.command}\n`);
+        const text = `expired ${record.expired_at} — re-run: ${record.command}\n`;
+        process.stdout.write(text);
+        await appendShowAccountingEvent(residentPaths.rootDir, args.handle, false, Buffer.byteLength(text, "utf8"));
         return 1;
       }
-      process.stdout.write(`expired unknown — re-run: ${args.handle}\n`);
+      const text = `expired unknown — re-run: ${args.handle}\n`;
+      process.stdout.write(text);
+      await appendShowAccountingEvent(residentPaths.rootDir, args.handle, false, Buffer.byteLength(text, "utf8"));
       return 1;
     }
 
@@ -386,6 +386,10 @@ type TelemetryStatsStore = {
   telemetryStats: (sinceDays: number) => Promise<RspTelemetryStats>;
 };
 
+type AccountingStatsStore = {
+  accountingStats: (byteBudget: number) => Promise<RspAccountingLaneStats>;
+};
+
 type TelemetryGainsStore = {
   telemetryGains: (sinceDays: number) => Promise<RspTelemetryGainsReport>;
 };
@@ -402,6 +406,13 @@ function hasTelemetryGains(store: unknown): store is TelemetryGainsStore {
     store !== null &&
     "telemetryGains" in store &&
     typeof (store as { telemetryGains?: unknown }).telemetryGains === "function";
+}
+
+function hasAccountingStats(store: unknown): store is AccountingStatsStore {
+  return typeof store === "object" &&
+    store !== null &&
+    "accountingStats" in store &&
+    typeof (store as { accountingStats?: unknown }).accountingStats === "function";
 }
 
 interface WrappedCommandResult {
@@ -530,6 +541,48 @@ async function runColdWrappedCommand(
   return await degradeToPassthrough("wrapper failed", args.positional, err, telemetryRoot);
 }
 
+async function readStatsSnapshot(
+  config: RspRuntimeConfig,
+  sinceDaysValue: number,
+): Promise<{ stats: RspAccountingLaneStats; telemetry: RspTelemetryStats }> {
+  const empty = {
+    stats: emptyAccountingStats(config.telemetryByteBudget),
+    telemetry: emptyTelemetryStats(sinceDaysValue),
+  };
+  if (!config.storeUri.startsWith("file://")) return empty;
+  const path = fileURLToPath(config.storeUri);
+  if (!existsSync(path)) return empty;
+  if (!path.endsWith("red-skills.rdb")) {
+    const { RspElisionStore } = await import("./elision-store.js");
+    const store = await RspElisionStore.open({
+      uri: config.storeUri,
+      ttlDays: config.ttlDays,
+      byteBudget: config.byteBudget,
+    });
+    try {
+      return {
+        stats: await store.stats(),
+        telemetry: emptyTelemetryStats(sinceDaysValue),
+      };
+    } finally {
+      await store.close();
+    }
+  }
+
+  const { ensureReddbBinaryFromWarmCache } = await import("./elision-store.js");
+  await ensureReddbBinaryFromWarmCache();
+  const { readAccountingLaneStats, readTelemetryStats } = await import("./telemetry.js");
+  const db = await connect(config.storeUri);
+  try {
+    return {
+      stats: await readAccountingLaneStats(db, config.telemetryByteBudget),
+      telemetry: await readTelemetryStats(db, sinceDaysValue),
+    };
+  } finally {
+    await db.close();
+  }
+}
+
 async function emitWrappedResult(
   args: ParsedArgs,
   result: WrappedCommandResult,
@@ -652,7 +705,26 @@ async function appendInvocationTelemetry(
 ): Promise<void> {
   const emitted = Buffer.concat([result.stdout, result.stderr]);
   const raw = Buffer.concat([result.rawOutput ?? result.stdout, result.stderr]);
-  const { appendTelemetryEvent, RSP_TELEMETRY_INVOCATIONS_COLLECTION } = await import("./telemetry.js");
+  const {
+    appendTelemetryEvent,
+    RSP_ACCOUNTING_EVENTS_COLLECTION,
+    RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+  } = await import("./telemetry.js");
+  await appendTelemetryEvent(telemetryRoot, {
+    collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+    event_type: "invocation",
+    ts: new Date().toISOString(),
+    command: telemetryCommand(args),
+    command_class: args.command ?? "unknown",
+    wrapper: args.command,
+    loss: args.level,
+    elided: Boolean(result.mintedHandle || result.bytesElided),
+    raw_bytes: raw.length,
+    emitted_bytes: emitted.length,
+    wrapper_ms: wrapperMs,
+    store_open_count: metrics?.storeOpenCount,
+    store_elapsed_ms: metrics?.storeElapsedMs,
+  });
   await appendTelemetryEvent(telemetryRoot, {
     collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
     ts: new Date().toISOString(),
@@ -667,6 +739,7 @@ async function appendInvocationTelemetry(
     wrapper_ms: wrapperMs,
     store_open_count: metrics?.storeOpenCount,
     store_elapsed_ms: metrics?.storeElapsedMs,
+    accounting_recorded: true,
   });
 }
 
@@ -680,7 +753,20 @@ function appendFastInvocationTelemetry(
     const emitted = Buffer.concat([result.stdout, result.stderr]);
     const raw = Buffer.concat([result.rawOutput ?? result.stdout, result.stderr]);
     const path = join(telemetryRoot, ".red", "tmp", "rsp-telemetry.spool.jsonl");
-    const line = `${JSON.stringify({
+    const accountingLine = JSON.stringify({
+      collection: "rsp_accounting_events_v1",
+      event_type: "invocation",
+      ts: new Date().toISOString(),
+      command: telemetryCommand(args),
+      command_class: args.command ?? "unknown",
+      wrapper: args.command,
+      loss: args.level,
+      elided: Boolean(result.mintedHandle || result.bytesElided),
+      raw_bytes: raw.length,
+      emitted_bytes: emitted.length,
+      wrapper_ms: wrapperMs,
+    });
+    const legacyLine = JSON.stringify({
       collection: "rsp_telemetry_invocations_v1",
       ts: new Date().toISOString(),
       command: telemetryCommand(args),
@@ -690,7 +776,9 @@ function appendFastInvocationTelemetry(
       raw_bytes: raw.length,
       emitted_bytes: emitted.length,
       wrapper_ms: wrapperMs,
-    })}\n`;
+      accounting_recorded: true,
+    });
+    const line = `${accountingLine}\n${legacyLine}\n`;
     try {
       appendFileSync(path, line, { encoding: "utf8", mode: 0o600 });
     } catch (err) {
@@ -708,12 +796,28 @@ async function degradeToPassthrough(reason: string, argv: readonly string[], err
   process.stderr.write(`rsp: ${reason}, passing through\n`);
   const status = await passthrough(argv);
   if (telemetryRoot) {
-    const { appendTelemetryEvent, RSP_TELEMETRY_DEGRADATIONS_COLLECTION } = await import("./telemetry.js");
+    const {
+      appendTelemetryEvent,
+      RSP_ACCOUNTING_EVENTS_COLLECTION,
+      RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
+    } = await import("./telemetry.js");
+    fireAndForget(appendTelemetryEvent(telemetryRoot, {
+      collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+      event_type: "invocation",
+      ts: new Date().toISOString(),
+      command: passthroughTelemetryCommand(argv),
+      command_class: argv[0] ?? "unknown",
+      loss: "lossless",
+      raw_bytes: 0,
+      emitted_bytes: 0,
+      degradation_reason: reason,
+    }));
     fireAndForget(appendTelemetryEvent(telemetryRoot, {
       collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
       ts: new Date().toISOString(),
       command: passthroughTelemetryCommand(argv),
       reason,
+      accounting_recorded: true,
     }));
   }
   return status;
@@ -721,6 +825,27 @@ async function degradeToPassthrough(reason: string, argv: readonly string[], err
 
 function fireAndForget(promise: Promise<unknown>): void {
   promise.catch(() => undefined);
+}
+
+async function appendShowAccountingEvent(
+  telemetryRoot: string,
+  handle: string,
+  hit: boolean,
+  emittedBytes: number,
+): Promise<void> {
+  const { appendTelemetryEvent, RSP_ACCOUNTING_EVENTS_COLLECTION } = await import("./telemetry.js");
+  await appendTelemetryEvent(telemetryRoot, {
+    collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+    event_type: "show",
+    ts: new Date().toISOString(),
+    command: "rsp show",
+    command_class: "show",
+    handle,
+    hit,
+    loss: "lossless",
+    raw_bytes: hit ? emittedBytes : 0,
+    emitted_bytes: emittedBytes,
+  });
 }
 
 async function passthroughDisabledDirectory(argv: readonly string[]): Promise<number> {
@@ -871,6 +996,10 @@ function renderStats(
     "health:",
     `  degradations: ${telemetry.health.degradations}`,
     `  degradation_rate: ${formatRate(telemetry.health.degradation_rate)}`,
+    `  show_total: ${telemetry.health.show_total}`,
+    `  show_hits: ${telemetry.health.show_hits}`,
+    `  show_misses: ${telemetry.health.show_misses}`,
+    `  show_hit_rate: ${formatRate(telemetry.health.show_hit_rate)}`,
     `  most_recent_degradation_at: ${telemetry.health.most_recent?.timestamp ?? "none"}`,
     `  most_recent_degradation_reason: ${telemetry.health.most_recent?.reason ?? "none"}`,
     "  degradations_by_reason:",
@@ -953,6 +1082,10 @@ function emptyTelemetryStats(windowDays: number): RspTelemetryStats {
     health: {
       degradations: 0,
       degradation_rate: 0,
+      show_total: 0,
+      show_hits: 0,
+      show_misses: 0,
+      show_hit_rate: 0,
       by_reason: [],
       most_recent: null,
     },
@@ -963,6 +1096,15 @@ function emptyTelemetryStats(windowDays: number): RspTelemetryStats {
       store_elapsed_ms_sum: 0,
       store_elapsed_ms_avg: null,
     },
+  };
+}
+
+function emptyAccountingStats(byteBudget: number): RspAccountingLaneStats {
+  return {
+    records: 0,
+    bytes: 0,
+    oldest: null,
+    budget: byteBudget,
   };
 }
 

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -838,7 +838,7 @@ function usesEmbeddedRedDb(path: string): boolean {
   return basename(path) === "red-skills.rdb";
 }
 
-async function ensureReddbBinaryFromWarmCache(): Promise<void> {
+export async function ensureReddbBinaryFromWarmCache(): Promise<void> {
   if (process.env.REDDB_BIN) return;
   // Same default cascade as the launcher fetch: an unset RED_SKILLS_CACHE_DIR
   // means the standard cache location, not "no cache".

--- a/apps/rsp/src/mcp-server.ts
+++ b/apps/rsp/src/mcp-server.ts
@@ -61,7 +61,7 @@ async function handle(request: JsonRpcRequest, config: RspRuntimeConfig): Promis
         },
         {
           name: "rsp_stats",
-          description: "Read resident rsp elision store stats.",
+          description: "Read resident rsp accounting stats.",
           inputSchema: { type: "object", properties: {} },
         },
         {
@@ -104,7 +104,7 @@ async function handle(request: JsonRpcRequest, config: RspRuntimeConfig): Promis
     }
     const store = residentStore(config);
     if (params?.name === "rsp_stats") {
-      return { content: [{ type: "text", text: JSON.stringify(await store.stats()) }] };
+      return { content: [{ type: "text", text: JSON.stringify(await store.accountingStats(config.telemetryByteBudget)) }] };
     }
     if (params?.name === "rsp_show") {
       const handle = String(params.arguments?.handle ?? "");

--- a/apps/rsp/src/resident-client.ts
+++ b/apps/rsp/src/resident-client.ts
@@ -5,6 +5,7 @@ import type {
   RspMintMeta,
   RspStoreStats,
 } from "./elision-store.js";
+import type { RspAccountingLaneStats } from "./telemetry.js";
 import type { RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
@@ -84,6 +85,10 @@ export class ResidentRspElisionStore {
 
   async stats(): Promise<RspStoreStats> {
     return await this.request({ op: "stats" }) as RspStoreStats;
+  }
+
+  async accountingStats(byteBudget: number): Promise<RspAccountingLaneStats> {
+    return await this.request({ op: "accounting-stats", byteBudget }) as RspAccountingLaneStats;
   }
 
   async telemetryStats(sinceDays: number): Promise<RspTelemetryStats> {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -13,8 +13,10 @@ import { createResidentBrainStore } from "./resident-brain.js";
 import type { RspResidentConfig, RspResidentRequest, RspResidentResponse } from "./resident-protocol.js";
 import {
   parseTelemetryEvent,
+  readAccountingLaneStats,
   readTelemetryGainsReport,
   readTelemetryStats,
+  RSP_ACCOUNTING_EVENTS_COLLECTION,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INDEX_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -184,7 +186,10 @@ interface ResidentTelemetryOptions {
 }
 
 interface TelemetryIndexEntry {
-  collection: typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION;
+  collection:
+    | typeof RSP_ACCOUNTING_EVENTS_COLLECTION
+    | typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION
+    | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION;
   key: string;
   created_at: string;
   expires_at: string;
@@ -197,7 +202,11 @@ interface TelemetryIndexDocument {
 }
 
 interface TelemetryCollectionHeal {
-  collection: typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION | typeof RSP_TELEMETRY_INDEX_COLLECTION;
+  collection:
+    | typeof RSP_ACCOUNTING_EVENTS_COLLECTION
+    | typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION
+    | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION
+    | typeof RSP_TELEMETRY_INDEX_COLLECTION;
   previousModel: string;
 }
 
@@ -215,6 +224,7 @@ const IDLE_SHUTDOWN_WATCHDOG_MS = Math.max(
 );
 const RSP_STATUS_SUMMARY = join(".red", "tmp", "rsp-status-summary.json");
 const TELEMETRY_KV_COLLECTIONS = [
+  RSP_ACCOUNTING_EVENTS_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INDEX_COLLECTION,
@@ -281,6 +291,8 @@ class ResidentTelemetryDrain {
       try {
         const entry = await this.writeEvent(db, event);
         nextRecords.push(entry);
+        const mirror = await this.writeAccountingMirror(db, event);
+        if (mirror) nextRecords.push(mirror);
         return true;
       } catch (err) {
         const entry = await this.writeDrainDegradation(db, {
@@ -317,10 +329,53 @@ class ResidentTelemetryDrain {
       key,
       created_at: createdAt,
       expires_at: expiresAt,
-      bytes: typeof event.bytes === "number" && Number.isFinite(event.bytes)
+      bytes: event.collection === RSP_ACCOUNTING_EVENTS_COLLECTION
+        ? 0
+        : typeof event.bytes === "number" && Number.isFinite(event.bytes)
         ? Math.max(0, event.bytes)
         : Buffer.byteLength(JSON.stringify(record), "utf8"),
     };
+  }
+
+  private async writeAccountingMirror(db: RedDB, event: RspTelemetryEvent): Promise<TelemetryIndexEntry | null> {
+    if (event.collection === RSP_ACCOUNTING_EVENTS_COLLECTION) return null;
+    if (event.accounting_recorded === true) return null;
+    if (event.collection === RSP_TELEMETRY_INVOCATIONS_COLLECTION) {
+      return await this.writeEvent(db, {
+        collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+        id: `mirror:${stringField(event.id) || randomUUID()}`,
+        created_at: stringField(event.created_at) || stringField(event.ts) || new Date().toISOString(),
+        event_type: "invocation",
+        command: stringField(event.command) || "unknown",
+        command_class: commandClass(stringField(event.command) || "unknown"),
+        wrapper: event.wrapper,
+        loss: event.loss,
+        elided: event.elided,
+        raw_bytes: event.raw_bytes,
+        emitted_bytes: event.emitted_bytes,
+        tokens_raw: event.tokens_raw,
+        tokens_emitted: event.tokens_emitted,
+        estimated: event.estimated,
+        wrapper_ms: event.wrapper_ms,
+        store_open_count: event.store_open_count,
+        store_elapsed_ms: event.store_elapsed_ms,
+      });
+    }
+    if (event.collection === RSP_TELEMETRY_DEGRADATIONS_COLLECTION) {
+      return await this.writeEvent(db, {
+        collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+        id: `mirror:${stringField(event.id) || randomUUID()}`,
+        created_at: stringField(event.created_at) || stringField(event.ts) || new Date().toISOString(),
+        event_type: "invocation",
+        command: stringField(event.command) || "unknown",
+        command_class: commandClass(stringField(event.command) || "unknown"),
+        loss: "lossless",
+        raw_bytes: 0,
+        emitted_bytes: 0,
+        degradation_reason: stringField(event.reason) || "unknown",
+      });
+    }
+    return null;
   }
 
   private async writeDrainDegradation(
@@ -334,7 +389,7 @@ class ResidentTelemetryDrain {
       error?: string;
     },
   ): Promise<TelemetryIndexEntry> {
-    return await this.writeEvent(db, {
+    const entry = await this.writeEvent(db, {
       collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
       id: randomUUID(),
       created_at: new Date().toISOString(),
@@ -345,6 +400,22 @@ class ResidentTelemetryDrain {
       source_collection: event.source_collection,
       error: event.error,
     });
+    await this.writeEvent(db, {
+      collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+      id: `mirror:${randomUUID()}`,
+      created_at: entry.created_at,
+      event_type: "invocation",
+      command: event.command,
+      command_class: commandClass(event.command),
+      loss: "lossless",
+      raw_bytes: 0,
+      emitted_bytes: 0,
+      degradation_reason: event.reason,
+      source_id: event.source_id,
+      source_collection: event.source_collection,
+      error: event.error,
+    });
+    return entry;
   }
 
   private async readIndex(db: RedDB): Promise<TelemetryIndexDocument> {
@@ -394,6 +465,8 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
     version: 1,
     tokens_saved_today: tokensSavedToday,
     dollars_saved_today_usd: Math.round(dollarsSavedToday * 1_000_000) / 1_000_000,
+    show_total_today: stats.health.show_total,
+    show_hit_rate: stats.health.show_total > 0 ? stats.health.show_hit_rate : undefined,
     updated_at: now.toISOString(),
   }), { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);
@@ -627,6 +700,10 @@ function stringField(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }
 
+function commandClass(command: string): string {
+  return command.trim().split(/\s+/).filter(Boolean)[0] ?? "unknown";
+}
+
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
   try {
@@ -657,6 +734,7 @@ function isTelemetryIndex(value: unknown): value is TelemetryIndexDocument {
     value.records.every((entry) =>
       isRecord(entry) &&
       (
+        entry.collection === RSP_ACCOUNTING_EVENTS_COLLECTION ||
         entry.collection === RSP_TELEMETRY_INVOCATIONS_COLLECTION ||
         entry.collection === RSP_TELEMETRY_DEGRADATIONS_COLLECTION
       ) &&
@@ -720,6 +798,11 @@ async function handleRequest(
   const store = state.store;
   if (request.op === "ping") return { pong: true, version: residentVersion };
   if (request.op === "stats") return await store.stats();
+  if (request.op === "accounting-stats") {
+    const db = store.redDb();
+    if (!db) throw new Error("rsp accounting stats require the shared RedDB store");
+    return await readAccountingLaneStats(db, request.byteBudget);
+  }
   if (request.op === "telemetry-stats") {
     const db = store.redDb();
     if (!db) throw new Error("rsp telemetry stats require the shared RedDB store");

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -5,12 +5,16 @@ import type { RedDB } from "@reddb-io/sdk";
 import { tokenSavingsEstimate, type TokenSavingsEstimate } from "./pricing.js";
 
 export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
+export const RSP_ACCOUNTING_EVENTS_COLLECTION = "rsp_accounting_events_v1";
 export const RSP_TELEMETRY_INVOCATIONS_COLLECTION = "rsp_telemetry_invocations_v1";
 export const RSP_TELEMETRY_DEGRADATIONS_COLLECTION = "rsp_telemetry_degradations_v1";
 export const RSP_TELEMETRY_INDEX_COLLECTION = "rsp_telemetry_index_v1";
 
 export interface RspTelemetryEvent {
-  collection: typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION;
+  collection:
+    | typeof RSP_ACCOUNTING_EVENTS_COLLECTION
+    | typeof RSP_TELEMETRY_INVOCATIONS_COLLECTION
+    | typeof RSP_TELEMETRY_DEGRADATIONS_COLLECTION;
   id?: string;
   created_at?: string;
   bytes?: number;
@@ -22,6 +26,13 @@ export interface RspTelemetryEvent {
   tokens_emitted?: number;
   estimated?: boolean;
   [key: string]: unknown;
+}
+
+export interface RspAccountingLaneStats {
+  records: number;
+  bytes: number;
+  oldest: string | null;
+  budget: number;
 }
 
 export interface RspTelemetryStats {
@@ -50,6 +61,10 @@ export interface RspTelemetryStats {
   health: {
     degradations: number;
     degradation_rate: number;
+    show_total: number;
+    show_hits: number;
+    show_misses: number;
+    show_hit_rate: number;
     by_reason: Array<{ reason: string; count: number }>;
     most_recent: { timestamp: string; reason: string; command: string } | null;
   };
@@ -264,6 +279,7 @@ export function parseTelemetryEvent(line: string): RspTelemetryEvent | null {
     const parsed = JSON.parse(line) as unknown;
     if (!isRecord(parsed)) return null;
     if (
+      parsed.collection !== RSP_ACCOUNTING_EVENTS_COLLECTION &&
       parsed.collection !== RSP_TELEMETRY_INVOCATIONS_COLLECTION &&
       parsed.collection !== RSP_TELEMETRY_DEGRADATIONS_COLLECTION
     ) return null;
@@ -276,10 +292,12 @@ export function parseTelemetryEvent(line: string): RspTelemetryEvent | null {
 export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new Date()): Promise<RspTelemetryStats> {
   const windowDays = Number.isFinite(sinceDays) && sinceDays > 0 ? sinceDays : 30;
   const sinceMs = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
-  const invocations = (await readCollection(db, RSP_TELEMETRY_INVOCATIONS_COLLECTION))
-    .filter((record) => timestampMs(record) >= sinceMs);
-  const degradations = (await readCollection(db, RSP_TELEMETRY_DEGRADATIONS_COLLECTION))
-    .filter((record) => timestampMs(record) >= sinceMs);
+  const accounting = await readAccountingRecords(db, sinceMs);
+  const invocations = accounting.filter((record) =>
+    stringField(record.event_type) !== "show" && stringField(record.degradation_reason) === ""
+  );
+  const showEvents = accounting.filter((record) => stringField(record.event_type) === "show");
+  const degradations = accounting.filter((record) => stringField(record.degradation_reason) !== "");
 
   let elided = 0;
   let rawBytes = 0;
@@ -298,8 +316,10 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
     const raw = numeric(record.raw_bytes);
     const emitted = numeric(record.emitted_bytes);
     const bytesSaved = Math.max(0, raw - emitted);
-    const tokenDelta = Math.max(0, numeric(record.tokens_raw) - numeric(record.tokens_emitted));
-    tokensEstimated ||= record.estimated === true && tokenDelta > 0;
+    const rawTokens = tokenCountFromCounters(record, "raw");
+    const emittedTokens = tokenCountFromCounters(record, "emitted");
+    const tokenDelta = Math.max(0, rawTokens.tokens - emittedTokens.tokens);
+    tokensEstimated ||= (record.estimated === true || rawTokens.estimated || emittedTokens.estimated) && tokenDelta > 0;
     rawBytes += raw;
     emittedBytes += emitted;
     tokensSaved += tokenDelta;
@@ -324,7 +344,7 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
   const byReason = new Map<string, number>();
   let mostRecent: RspTelemetryStats["health"]["most_recent"] = null;
   for (const record of degradations) {
-    const reason = stringField(record.reason) || "unknown";
+    const reason = stringField(record.degradation_reason) || stringField(record.reason) || "unknown";
     byReason.set(reason, (byReason.get(reason) ?? 0) + 1);
     const timestamp = timestampString(record);
     if (!mostRecent || timestamp > mostRecent.timestamp) {
@@ -337,10 +357,11 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
   }
 
   const totalAttempts = invocations.length + degradations.length;
+  const showHits = showEvents.filter((record) => record.hit === true).length;
   const savingsEstimate = tokenSavingsEstimate(tokensSaved, tokensEstimated);
   return {
     window_days: windowDays,
-    empty: invocations.length === 0 && degradations.length === 0,
+    empty: accounting.length === 0,
     savings: {
       invocations: invocations.length,
       elided,
@@ -367,6 +388,10 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
     health: {
       degradations: degradations.length,
       degradation_rate: totalAttempts === 0 ? 0 : degradations.length / totalAttempts,
+      show_total: showEvents.length,
+      show_hits: showHits,
+      show_misses: Math.max(0, showEvents.length - showHits),
+      show_hit_rate: showEvents.length === 0 ? 0 : round(showHits / showEvents.length),
       by_reason: [...byReason.entries()]
         .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
         .map(([reason, count]) => ({ reason, count })),
@@ -382,15 +407,36 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
   };
 }
 
+export async function readAccountingLaneStats(
+  db: RedDB,
+  byteBudget: number,
+  now = new Date(),
+): Promise<RspAccountingLaneStats> {
+  const records = await readCollection(db, RSP_ACCOUNTING_EVENTS_COLLECTION);
+  const live = records.filter((record) => timestampMs(record) <= now.getTime() || timestampString(record) === "");
+  return {
+    records: live.length,
+    bytes: live.reduce((sum, record) => sum + Buffer.byteLength(JSON.stringify(record), "utf8"), 0),
+    oldest: live.reduce<string | null>((oldest, record) => {
+      const ts = timestampString(record);
+      if (!ts) return oldest;
+      if (oldest == null) return ts;
+      return ts < oldest ? ts : oldest;
+    }, null),
+    budget: byteBudget,
+  };
+}
+
 export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now = new Date()): Promise<RspTelemetryGainsReport> {
   const windowDays = Number.isFinite(sinceDays) && sinceDays > 0 ? sinceDays : 28;
   const until = now.toISOString();
   const since = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000).toISOString();
   const sinceMs = Date.parse(since);
-  const invocations = (await readCollection(db, RSP_TELEMETRY_INVOCATIONS_COLLECTION))
-    .filter((record) => timestampMs(record) >= sinceMs);
-  const degradations = (await readCollection(db, RSP_TELEMETRY_DEGRADATIONS_COLLECTION))
-    .filter((record) => timestampMs(record) >= sinceMs);
+  const accounting = await readAccountingRecords(db, sinceMs);
+  const invocations = accounting.filter((record) =>
+    stringField(record.event_type) !== "show" && stringField(record.degradation_reason) === ""
+  );
+  const degradations = accounting.filter((record) => stringField(record.degradation_reason) !== "");
   const allTimestamps = [...invocations, ...degradations]
     .map(timestampMs)
     .filter((value) => Number.isFinite(value) && value > 0);
@@ -416,7 +462,10 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
     const date = timestamp.slice(0, 10);
     const minute = timestamp.slice(0, 16);
     const family = commandFamily(stringField(record.command));
-    const tokensSaved = Math.max(0, numeric(record.tokens_raw) - numeric(record.tokens_emitted));
+    const tokensSaved = Math.max(
+      0,
+      tokenCountFromCounters(record, "raw").tokens - tokenCountFromCounters(record, "emitted").tokens,
+    );
     totalTokensSaved += tokensSaved;
     tokensEstimated ||= record.estimated === true && tokensSaved > 0;
     const bytesSaved = Math.max(0, numeric(record.raw_bytes) - numeric(record.emitted_bytes));
@@ -452,7 +501,7 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
     .map((record) => ({
       timestamp: timestampString(record),
       command_family: commandFamily(stringField(record.command)),
-      reason: stringField(record.reason) || "unknown",
+      reason: stringField(record.degradation_reason) || stringField(record.reason) || "unknown",
     }))
     .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   const byReason = new Map<string, number>();
@@ -511,6 +560,31 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
       warm_hits: recordsWithStoreMetric === 0 ? null : Math.max(0, recordsWithStoreMetric - coldBoots),
     },
   };
+}
+
+async function readAccountingRecords(db: RedDB, sinceMs: number): Promise<Array<Record<string, unknown>>> {
+  const accounting = (await readCollection(db, RSP_ACCOUNTING_EVENTS_COLLECTION))
+    .filter((record) => timestampMs(record) >= sinceMs);
+  if (accounting.length > 0) return accounting;
+
+  const legacyInvocations = (await readCollection(db, RSP_TELEMETRY_INVOCATIONS_COLLECTION))
+    .filter((record) => timestampMs(record) >= sinceMs)
+    .map((record) => ({ ...record, event_type: "invocation" }));
+  const legacyDegradations = (await readCollection(db, RSP_TELEMETRY_DEGRADATIONS_COLLECTION))
+    .filter((record) => timestampMs(record) >= sinceMs)
+    .map((record) => ({
+      ...record,
+      event_type: "invocation",
+      degradation_reason: stringField(record.reason) || "unknown",
+    }));
+  return [...legacyInvocations, ...legacyDegradations];
+}
+
+function tokenCountFromCounters(record: Record<string, unknown>, field: "raw" | "emitted"): { tokens: number; estimated: boolean } {
+  const exact = optionalNumeric(record[field === "raw" ? "tokens_raw" : "tokens_emitted"]);
+  if (exact != null) return { tokens: exact, estimated: false };
+  const bytes = numeric(record[field === "raw" ? "raw_bytes" : "emitted_bytes"]);
+  return { tokens: Math.ceil(bytes / 4), estimated: bytes > 0 };
 }
 
 async function readCollection(db: RedDB, collection: string): Promise<Array<Record<string, unknown>>> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -12,6 +12,7 @@ import { RspElisionStore } from "../src/elision-store.js";
 import { resolveResidentPaths } from "../src/resident-client.js";
 import { sendResidentRequest } from "../src/resident-protocol.js";
 import {
+  RSP_ACCOUNTING_EVENTS_COLLECTION,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
   telemetrySpoolPath,
@@ -490,7 +491,7 @@ async function waitForTelemetryInvocations(storeUri: string, command: string, mi
   const deadline = normalizedDeadlineMs();
   let records: unknown[] = [];
   while (Date.now() < deadline) {
-    records = await readTelemetryRecords(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION);
+    records = await readTelemetryRecords(storeUri, RSP_ACCOUNTING_EVENTS_COLLECTION);
     if (records.filter((entry) => isRecord(entry) && entry.command === command).length >= minCount) return records;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
@@ -1613,7 +1614,7 @@ describe("rsp cli", () => {
 
     const stats = runBundleFromCwd(root, [], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(stats.status).toBe(0);
-    expect(stats.stdout.toString("utf8")).toContain("records: 1\n");
+    expect(stats.stdout.toString("utf8")).toContain("savings:\n");
 
     const shown = runBundleFromCwd(root, ["show", handle!], { RED_SKILLS_CACHE_DIR: cacheDir });
 
@@ -1800,14 +1801,14 @@ describe("rsp cli", () => {
     const stats = runBundleFromCwd(root, ["stats", "--since", "7d", "--full"], { RED_SKILLS_CACHE_DIR: cacheDir });
     const statsText = stats.stdout.toString("utf8");
     expect(stats.status, `${statsText}${stats.stderr.toString("utf8")}`).toBe(0);
-    expect(statsText).toContain("records: 1\n");
+    expect(statsText).toContain("records: 3\n");
     expect(statsText).toContain("savings:\n");
     expect(statsText).toContain("  window_days: 7\n");
     expect(statsText).toMatch(/  invocations: [1-9]\d*\n/);
     expect(statsText).toContain("  elided: 1\n");
     expect(statsText).toMatch(/  raw_bytes: [1-9]\d*\n/);
     expect(statsText).toMatch(/  emitted_bytes: [1-9]\d*\n/);
-    expect(statsText).toMatch(/  tokens_saved: [1-9]\d*\n/);
+    expect(statsText).toMatch(/  tokens_saved: (?:[1-9]\d*|[1-9]\d*-[1-9]\d* .*)\n/);
     expect(statsText).toContain("  dollars_saved_estimate_usd: $");
     expect(statsText).toContain("  pricing_model_family: gpt-5\n");
     expect(statsText).toContain("  top_commands:\n");

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -10,6 +10,7 @@ import {
   appendTelemetryEvent,
   drainTelemetrySpool,
   readTelemetryGainsReport,
+  RSP_ACCOUNTING_EVENTS_COLLECTION,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INDEX_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -394,6 +395,98 @@ describe("rsp telemetry spool", () => {
     });
     await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
     await server;
+  }, 60_000);
+
+  it("serves stats from counters-only accounting events and reports show hit-rate", async () => {
+    const root = await tempRoot();
+    await appendTelemetryEvent(root, {
+      collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+      id: "accounted-invocation",
+      created_at: new Date().toISOString(),
+      event_type: "invocation",
+      command: "git log",
+      command_class: "git",
+      loss: "terse",
+      elided: true,
+      raw_bytes: 1000,
+      emitted_bytes: 100,
+      bytes: 120,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+      id: "show-hit",
+      created_at: new Date().toISOString(),
+      event_type: "show",
+      command: "rsp show",
+      command_class: "show",
+      hit: true,
+      raw_bytes: 900,
+      emitted_bytes: 900,
+      bytes: 80,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+      id: "show-miss",
+      created_at: new Date().toISOString(),
+      event_type: "show",
+      command: "rsp show",
+      command_class: "show",
+      hit: false,
+      raw_bytes: 0,
+      emitted_bytes: 40,
+      bytes: 80,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+      id: "legacy-ignored",
+      created_at: new Date().toISOString(),
+      command: "git status",
+      raw_bytes: 9999,
+      emitted_bytes: 1,
+      accounting_recorded: true,
+      bytes: 100,
+    });
+
+    const paths = resolveResidentPaths(root);
+    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const timing = await calibratedTelemetryTiming(root);
+    const server = runResidentServer({
+      rootDir: root,
+      socketPath: paths.socketPath,
+      storeUri,
+      ttlDays: DEFAULT_RSP_TTL_DAYS,
+      byteBudget: DEFAULT_RSP_BYTE_BUDGET,
+      telemetryTtlDays: 90,
+      telemetryByteBudget: 1_000,
+      telemetryDrainTimeoutMs: timing.drainTimeoutMs,
+      idleMs: 100,
+    });
+    await waitForResident(paths.socketPath, timing.waitTimeoutMs);
+
+    const response = await sendResidentRequest({ socketPath: paths.socketPath }, {
+      id: "stats",
+      op: "telemetry-stats",
+      sinceDays: 7,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.ok && response.value).toMatchObject({
+      savings: {
+        invocations: 1,
+        elided: 1,
+        raw_bytes: 1000,
+        emitted_bytes: 100,
+        top_commands: [expect.objectContaining({ command: "git log", invocations: 1 })],
+      },
+      health: {
+        show_total: 2,
+        show_hits: 1,
+        show_misses: 1,
+        show_hit_rate: 0.5,
+      },
+    });
+    await server;
+    await expect(readTelemetry(storeUri, RSP_ACCOUNTING_EVENTS_COLLECTION, "accounted-invocation")).resolves.not.toHaveProperty("raw_text");
   }, 60_000);
 
   it("drains a hand-written spool through the built bundle resident", async () => {

--- a/packages/shared/resident-protocol.ts
+++ b/packages/shared/resident-protocol.ts
@@ -18,6 +18,7 @@ export type RspResidentRequest =
   | { id: string; op: "ping" }
   | { id: string; op: "handover"; clientVersion: string }
   | { id: string; op: "stats" }
+  | { id: string; op: "accounting-stats"; byteBudget: number }
   | { id: string; op: "telemetry-stats"; sinceDays: number }
   | { id: string; op: "telemetry-gains"; sinceDays: number }
   | { id: string; op: "mint"; original: string; meta: unknown }


### PR DESCRIPTION
Automated AFK landing for #1711. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1711

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786625374&installation_id=129708444&pr_number=1750&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1750&signature=20dc2b22a5b29fa7eaaaf8d38f8e8042ac1b2808414fe66a67e27b834c7472d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->