### PR TITLE
fix: #1712 rsp storage classes (expand): tag every mint derivable / re-executable / ephemeral, per-class stats breakdown

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -9,7 +9,7 @@ import { connect } from "@reddb-io/sdk";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspRuntimeConfig } from "./config.js";
-import type { RspElisionStore, RspMintMeta } from "./elision-store.js";
+import type { RspElisionStore, RspMintMeta, RspStorageClassStats } from "./elision-store.js";
 import { formatUsd } from "./pricing.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
 import type { RspAccountingLaneStats, RspTelemetryGainsReport, RspTelemetryStats } from "./telemetry.js";
@@ -962,17 +962,20 @@ function statsFull(args: readonly string[]): boolean {
 }
 
 function renderStats(
-  stats: { records: number; bytes: number; oldest: string | null; budget: number },
+  stats: { records: number; bytes: number; oldest: string | null; budget: number; storage_classes?: RspStorageClassStats },
   telemetry = emptyTelemetryStats(30),
   full = false,
 ): string {
   const topCommands = telemetry.savings.top_commands.slice(0, full ? 10 : 3);
   const daily = full ? telemetry.savings.daily_tokens_saved : telemetry.savings.daily_tokens_saved.slice(-7);
+  const storageClasses = stats.storage_classes ?? emptyStorageClassStats();
   return [
     `records: ${stats.records}`,
     `bytes: ${stats.bytes}`,
     `oldest: ${stats.oldest ?? "none"}`,
     `budget: ${stats.budget}`,
+    "storage_classes:",
+    ...renderStorageClasses(storageClasses),
     "savings:",
     `  window_days: ${telemetry.window_days}`,
     `  empty: ${telemetry.empty}`,
@@ -1047,6 +1050,12 @@ function renderReasons(reasons: Array<{ reason: string; count: number }>): strin
   return reasons.map((entry) => `    ${entry.reason}: ${entry.count}`);
 }
 
+function renderStorageClasses(stats: RspStorageClassStats): string[] {
+  return (["derivable", "re-executable", "ephemeral"] as const).map((storageClass) =>
+    `  ${storageClass}: records: ${stats[storageClass].records} bytes: ${stats[storageClass].bytes}`
+  );
+}
+
 function formatNullable(value: number | null): string {
   return value == null ? "none" : String(value);
 }
@@ -1105,6 +1114,15 @@ function emptyAccountingStats(byteBudget: number): RspAccountingLaneStats {
     bytes: 0,
     oldest: null,
     budget: byteBudget,
+    storage_classes: emptyStorageClassStats(),
+  };
+}
+
+function emptyStorageClassStats(): RspStorageClassStats {
+  return {
+    derivable: { records: 0, bytes: 0 },
+    "re-executable": { records: 0, bytes: 0 },
+    ephemeral: { records: 0, bytes: 0 },
   };
 }
 

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -23,6 +23,10 @@ export interface RspMintMeta {
   loss: RspLossMeta;
 }
 
+export type RspStorageClass = "derivable" | "re-executable" | "ephemeral";
+
+export type RspStorageClassStats = Record<RspStorageClass, { records: number; bytes: number }>;
+
 export interface RspElisionRecord {
   collection: typeof RSP_ELISION_COLLECTION;
   handle: `el:${string}`;
@@ -30,6 +34,7 @@ export interface RspElisionRecord {
   command: string;
   created_at: string;
   loss: RspLossMeta;
+  storage_class: RspStorageClass;
 }
 
 export interface RspExpiredHandle {
@@ -44,6 +49,7 @@ export interface RspStoreStats {
   bytes: number;
   oldest: string | null;
   budget: number;
+  storage_classes: RspStorageClassStats;
 }
 
 export interface RspElisionStoreOptions {
@@ -64,6 +70,7 @@ interface StoredRecord {
   created_at: string;
   expires_at: string;
   loss: RspLossMeta;
+  storage_class?: RspStorageClass;
 }
 
 interface IndexEntry {
@@ -73,6 +80,7 @@ interface IndexEntry {
   command: string;
   created_at: string;
   expires_at: string;
+  storage_class?: RspStorageClass;
 }
 
 interface IndexDocument {
@@ -141,6 +149,7 @@ export class RspElisionStore {
     const expiresAt = new Date(now.getTime() + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
+    const storageClass = storageClassForCommand(meta.command);
 
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
@@ -152,6 +161,7 @@ export class RspElisionStore {
       created_at: createdAt,
       expires_at: expiresAt,
       loss: meta.loss,
+      storage_class: storageClass,
     };
 
     delete this.document.tombstones[tombstoneKey(handle)];
@@ -163,6 +173,7 @@ export class RspElisionStore {
       command: meta.command,
       created_at: createdAt,
       expires_at: expiresAt,
+      storage_class: storageClass,
     });
     this.prune();
     await this.flush();
@@ -202,6 +213,7 @@ export class RspElisionStore {
       command: raw.command,
       created_at: raw.created_at,
       loss: raw.loss,
+      storage_class: storageClassForRecord(raw),
     };
   }
 
@@ -219,6 +231,7 @@ export class RspElisionStore {
         return entry.created_at < oldest ? entry.created_at : oldest;
       }, null),
       budget: this.opts.byteBudget,
+      storage_classes: storageStatsForIndex(records),
     };
   }
 
@@ -362,6 +375,7 @@ export class RspElisionStore {
           command: record.command,
           created_at: record.created_at,
           expires_at: record.expires_at,
+          storage_class: storageClassForRecord(record),
         };
       })
       .filter((entry): entry is IndexEntry => entry != null);
@@ -375,6 +389,7 @@ export class RspElisionStore {
     const expiresAt = new Date(now.getTime() + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
+    const storageClass = storageClassForCommand(meta.command);
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
       handle,
@@ -385,12 +400,21 @@ export class RspElisionStore {
       created_at: createdAt,
       expires_at: expiresAt,
       loss: meta.loss,
+      storage_class: storageClass,
     };
     await this.kv().delete(tombstoneKey(handle));
     await this.kv().put(key, record);
     const index = await this.readRedDbIndex();
     const withoutExisting = index.records.filter((entry) => entry.handle !== handle);
-    withoutExisting.push({ handle, key, bytes: bytes.length, command: meta.command, created_at: createdAt, expires_at: expiresAt });
+    withoutExisting.push({
+      handle,
+      key,
+      bytes: bytes.length,
+      command: meta.command,
+      created_at: createdAt,
+      expires_at: expiresAt,
+      storage_class: storageClass,
+    });
     await this.pruneRedDb({ version: 1, records: withoutExisting }, true);
     await this.assertRedDbMintPersisted(handle, bytes.length);
     return handle;
@@ -423,6 +447,7 @@ export class RspElisionStore {
       command: raw.command,
       created_at: raw.created_at,
       loss: raw.loss,
+      storage_class: storageClassForRecord(raw),
     };
   }
 
@@ -436,6 +461,7 @@ export class RspElisionStore {
         return entry.created_at < oldest ? entry.created_at : oldest;
       }, null),
       budget: this.opts.byteBudget,
+      storage_classes: storageStatsForIndex(index.records),
     };
   }
 
@@ -622,6 +648,48 @@ function indexKey(): string {
   return "index:v1";
 }
 
+export function storageClassForCommand(command: string): RspStorageClass {
+  const argv = command.trim().split(/\s+/).filter(Boolean);
+  const executable = argv[0] ?? "";
+  if (executable === "cat") return "derivable";
+  if (executable === "git") {
+    const subcommand = argv[1] ?? "";
+    if (subcommand === "log" || subcommand === "diff" || subcommand === "blame" || subcommand === "show") {
+      return "derivable";
+    }
+    if (subcommand === "status" || subcommand === "branch") return "re-executable";
+    return "ephemeral";
+  }
+  if (executable === "gh") return "re-executable";
+  return "ephemeral";
+}
+
+function storageClassForRecord(record: Pick<StoredRecord, "command" | "storage_class">): RspStorageClass {
+  return isStorageClass(record.storage_class) ? record.storage_class : storageClassForCommand(record.command);
+}
+
+function storageClassForIndexEntry(entry: Pick<IndexEntry, "command" | "storage_class">): RspStorageClass {
+  return isStorageClass(entry.storage_class) ? entry.storage_class : storageClassForCommand(entry.command);
+}
+
+function storageStatsForIndex(records: readonly IndexEntry[]): RspStorageClassStats {
+  const stats = emptyStorageClassStats();
+  for (const entry of records) {
+    const storageClass = storageClassForIndexEntry(entry);
+    stats[storageClass].records += 1;
+    stats[storageClass].bytes += entry.bytes;
+  }
+  return stats;
+}
+
+function emptyStorageClassStats(): RspStorageClassStats {
+  return {
+    derivable: { records: 0, bytes: 0 },
+    "re-executable": { records: 0, bytes: 0 },
+    ephemeral: { records: 0, bytes: 0 },
+  };
+}
+
 function isHandle(value: string): value is `el:${string}` {
   return /^el:[a-f0-9]{12}$/.test(value);
 }
@@ -762,7 +830,8 @@ function isStoredRecord(value: unknown): value is StoredRecord {
     typeof value.command === "string" &&
     typeof value.created_at === "string" &&
     typeof value.expires_at === "string" &&
-    isLossMeta(value.loss);
+    isLossMeta(value.loss) &&
+    (value.storage_class === undefined || isStorageClass(value.storage_class));
 }
 
 function isIndexDocument(value: unknown): value is IndexDocument {
@@ -775,7 +844,8 @@ function isIndexDocument(value: unknown): value is IndexDocument {
     typeof entry.bytes === "number" &&
     typeof entry.command === "string" &&
     typeof entry.created_at === "string" &&
-    typeof entry.expires_at === "string"
+    typeof entry.expires_at === "string" &&
+    (entry.storage_class === undefined || isStorageClass(entry.storage_class))
   );
 }
 
@@ -790,6 +860,10 @@ function isLossMeta(value: unknown): value is RspLossMeta {
   return isRecord(value) &&
     typeof value.level === "string" &&
     typeof value.bytes_elided === "number";
+}
+
+function isStorageClass(value: unknown): value is RspStorageClass {
+  return value === "derivable" || value === "re-executable" || value === "ephemeral";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -2,6 +2,7 @@ import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import type { RedDB } from "@reddb-io/sdk";
+import { storageClassForCommand, type RspStorageClass, type RspStorageClassStats } from "./elision-store.js";
 import { tokenSavingsEstimate, type TokenSavingsEstimate } from "./pricing.js";
 
 export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
@@ -33,6 +34,7 @@ export interface RspAccountingLaneStats {
   bytes: number;
   oldest: string | null;
   budget: number;
+  storage_classes: RspStorageClassStats;
 }
 
 export interface RspTelemetryStats {
@@ -424,6 +426,7 @@ export async function readAccountingLaneStats(
       return ts < oldest ? ts : oldest;
     }, null),
     budget: byteBudget,
+    storage_classes: accountingStorageClassStats(live),
   };
 }
 
@@ -585,6 +588,31 @@ function tokenCountFromCounters(record: Record<string, unknown>, field: "raw" | 
   if (exact != null) return { tokens: exact, estimated: false };
   const bytes = numeric(record[field === "raw" ? "raw_bytes" : "emitted_bytes"]);
   return { tokens: Math.ceil(bytes / 4), estimated: bytes > 0 };
+}
+
+function accountingStorageClassStats(records: readonly Record<string, unknown>[]): RspStorageClassStats {
+  const stats = emptyStorageClassStats();
+  for (const record of records) {
+    if (stringField(record.event_type) === "show") continue;
+    if (stringField(record.degradation_reason) !== "") continue;
+    if (record.elided !== true) continue;
+    const storageClass = storageClassField(record.storage_class) ?? storageClassForCommand(stringField(record.command));
+    stats[storageClass].records += 1;
+    stats[storageClass].bytes += numeric(record.raw_bytes);
+  }
+  return stats;
+}
+
+function storageClassField(value: unknown): RspStorageClass | null {
+  return value === "derivable" || value === "re-executable" || value === "ephemeral" ? value : null;
+}
+
+function emptyStorageClassStats(): RspStorageClassStats {
+  return {
+    derivable: { records: 0, bytes: 0 },
+    "re-executable": { records: 0, bytes: 0 },
+    ephemeral: { records: 0, bytes: 0 },
+  };
 }
 
 async function readCollection(db: RedDB, collection: string): Promise<Array<Record<string, unknown>>> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -2276,6 +2276,7 @@ describe("rsp cli", () => {
     expect(res.status).toBe(0);
     const text = res.stdout.toString("utf8");
     expect(text).toContain("records: 1\nbytes: 3\noldest: 2026-07-10T12:00:00.000Z\nbudget: 67108864\n");
+    expect(text).toContain("storage_classes:\n  derivable: records: 0 bytes: 0\n  re-executable: records: 0 bytes: 0\n  ephemeral: records: 1 bytes: 3\n");
     expect(text).toContain("savings:\n  window_days: 30\n  empty: true\n  invocations: 0\n");
     expect(text).toContain("health:\n  degradations: 0\n  degradation_rate: 0.0\n");
     expect(text).toContain("latency:\n  wrapper_ms_p50: none\n");
@@ -2294,6 +2295,7 @@ describe("rsp cli", () => {
 
     expect(res.status).toBe(0);
     expect(text).toContain("records: 0\nbytes: 0\noldest: none\n");
+    expect(text).toContain("storage_classes:\n  derivable: records: 0 bytes: 0\n  re-executable: records: 0 bytes: 0\n  ephemeral: records: 0 bytes: 0\n");
     expect(text).toContain("savings:\n  window_days: 7\n  empty: true\n  invocations: 0\n");
     expect(text).toContain("  top_commands:\n    empty: true\n");
     expect(text).toContain("health:\n  degradations: 0\n  degradation_rate: 0.0\n");

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -232,8 +232,62 @@ describe("RspElisionStore", () => {
         bytes: 3,
         oldest: "2026-07-10T12:00:00.000Z",
         budget: DEFAULT_RSP_BYTE_BUDGET,
+        storage_classes: {
+          derivable: { records: 0, bytes: 0 },
+          "re-executable": { records: 0, bytes: 0 },
+          ephemeral: { records: 1, bytes: 3 },
+        },
       });
       expect(DEFAULT_RSP_TTL_DAYS).toBe(7);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("records exactly one storage class per minted handle and reports the class breakdown", async () => {
+    const root = await tempRoot();
+    const storePath = join(root, "red.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    try {
+      await store.mint(Buffer.from("git history"), {
+        command: "git log --oneline",
+        loss: { level: "terse", bytes_elided: 11 },
+      });
+      await store.mint(Buffer.from("remote pr"), {
+        command: "gh pr view 42",
+        loss: { level: "brief", bytes_elided: 9 },
+      });
+      await store.mint(Buffer.from("test output"), {
+        command: "vitest run",
+        loss: { level: "terse", bytes_elided: 11 },
+      });
+
+      const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+        index: { records: Array<{ storage_class?: string }> };
+        records: Record<string, { storage_class?: string }>;
+      };
+      expect(raw.index.records.map((entry) => entry.storage_class).sort()).toEqual([
+        "derivable",
+        "ephemeral",
+        "re-executable",
+      ]);
+      expect(Object.values(raw.records).map((record) => record.storage_class).sort()).toEqual([
+        "derivable",
+        "ephemeral",
+        "re-executable",
+      ]);
+      expect(await store.stats()).toMatchObject({
+        records: 3,
+        bytes: 31,
+        storage_classes: {
+          derivable: { records: 1, bytes: 11 },
+          "re-executable": { records: 1, bytes: 9 },
+          ephemeral: { records: 1, bytes: 11 },
+        },
+      });
     } finally {
       await store.close();
     }

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -414,6 +414,19 @@ describe("rsp telemetry spool", () => {
     });
     await appendTelemetryEvent(root, {
       collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
+      id: "accounted-ephemeral",
+      created_at: new Date().toISOString(),
+      event_type: "invocation",
+      command: "vitest run",
+      command_class: "vitest",
+      loss: "terse",
+      elided: true,
+      raw_bytes: 400,
+      emitted_bytes: 40,
+      bytes: 90,
+    });
+    await appendTelemetryEvent(root, {
+      collection: RSP_ACCOUNTING_EVENTS_COLLECTION,
       id: "show-hit",
       created_at: new Date().toISOString(),
       event_type: "show",
@@ -472,17 +485,33 @@ describe("rsp telemetry spool", () => {
     expect(response.ok).toBe(true);
     expect(response.ok && response.value).toMatchObject({
       savings: {
-        invocations: 1,
-        elided: 1,
-        raw_bytes: 1000,
-        emitted_bytes: 100,
-        top_commands: [expect.objectContaining({ command: "git log", invocations: 1 })],
+        invocations: 2,
+        elided: 2,
+        raw_bytes: 1400,
+        emitted_bytes: 140,
+        top_commands: [
+          expect.objectContaining({ command: "git log", invocations: 1 }),
+          expect.objectContaining({ command: "vitest run", invocations: 1 }),
+        ],
       },
       health: {
         show_total: 2,
         show_hits: 1,
         show_misses: 1,
         show_hit_rate: 0.5,
+      },
+    });
+    const accountingResponse = await sendResidentRequest({ socketPath: paths.socketPath }, {
+      id: "accounting-stats",
+      op: "accounting-stats",
+      byteBudget: 1_000,
+    });
+    expect(accountingResponse.ok).toBe(true);
+    expect(accountingResponse.ok && accountingResponse.value).toMatchObject({
+      storage_classes: {
+        derivable: { records: 1, bytes: 1000 },
+        "re-executable": { records: 0, bytes: 0 },
+        ephemeral: { records: 1, bytes: 400 },
       },
     });
     await server;


### PR DESCRIPTION
Automated AFK landing for #1712. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1712

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786626377&installation_id=129708444&pr_number=1751&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1751&signature=71c45090a9e3dacdd66ec160dc711953d87d9e4fe5dcfdb62225f7c94b55f6bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->