### PR TITLE
fix: #1713 rsp derivable class: recipe-only storage, byte-identical re-derivation from the git object database

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -63,14 +64,16 @@ export interface RspElisionStoreOptions {
 interface StoredRecord {
   collection: typeof RSP_ELISION_COLLECTION;
   handle: `el:${string}`;
-  original: string;
-  original_encoding: "base64";
+  original?: string;
+  original_encoding?: "base64";
   original_bytes: number;
+  stored_bytes?: number;
   command: string;
   created_at: string;
   expires_at: string;
   loss: RspLossMeta;
   storage_class?: RspStorageClass;
+  derivation_recipe?: RspDerivationRecipe;
 }
 
 interface IndexEntry {
@@ -81,6 +84,15 @@ interface IndexEntry {
   created_at: string;
   expires_at: string;
   storage_class?: RspStorageClass;
+}
+
+interface RspDerivationRecipe {
+  kind: "git-blob";
+  command: string;
+  cwd: string;
+  object_ids: string[];
+  working_tree_fingerprint: string;
+  original_bytes: number;
 }
 
 interface IndexDocument {
@@ -150,18 +162,22 @@ export class RspElisionStore {
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
     const storageClass = storageClassForCommand(meta.command);
+    const derivationRecipe = storageClass === "derivable" ? deriveGitBlobRecipe(bytes, meta.command) : null;
+    const storedBytes = storedBytesFor(bytes, derivationRecipe);
 
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
       handle,
-      original: bytes.toString("base64"),
-      original_encoding: "base64",
       original_bytes: bytes.length,
+      stored_bytes: storedBytes,
       command: meta.command,
       created_at: createdAt,
       expires_at: expiresAt,
       loss: meta.loss,
       storage_class: storageClass,
+      ...(derivationRecipe
+        ? { derivation_recipe: derivationRecipe }
+        : { original: bytes.toString("base64"), original_encoding: "base64" as const }),
     };
 
     delete this.document.tombstones[tombstoneKey(handle)];
@@ -169,7 +185,7 @@ export class RspElisionStore {
     this.upsertIndex({
       handle,
       key,
-      bytes: bytes.length,
+      bytes: storedBytes,
       command: meta.command,
       created_at: createdAt,
       expires_at: expiresAt,
@@ -194,7 +210,7 @@ export class RspElisionStore {
       this.expireEntry({
         handle: raw.handle,
         key: recordKey(raw.handle),
-        bytes: raw.original_bytes,
+        bytes: storedBytesForRecord(raw),
         command: raw.command,
         created_at: raw.created_at,
         expires_at: raw.expires_at,
@@ -204,6 +220,9 @@ export class RspElisionStore {
     }
 
     const original = this.readOriginal(raw);
+    if (!original && raw.derivation_recipe) {
+      return { status: "expired", expired_at: raw.expires_at, command: raw.command };
+    }
     if (!original) return null;
 
     return {
@@ -295,6 +314,7 @@ export class RspElisionStore {
 
   private readOriginal(record: StoredRecord): Buffer | null {
     if (record.original) return Buffer.from(record.original, "base64");
+    if (record.derivation_recipe) return readGitBlobRecipe(record.derivation_recipe);
     return null;
   }
 
@@ -371,7 +391,7 @@ export class RspElisionStore {
         return {
           handle: record.handle,
           key: recordKey(record.handle),
-          bytes: record.original_bytes,
+          bytes: storedBytesForRecord(record),
           command: record.command,
           created_at: record.created_at,
           expires_at: record.expires_at,
@@ -390,17 +410,21 @@ export class RspElisionStore {
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
     const storageClass = storageClassForCommand(meta.command);
+    const derivationRecipe = storageClass === "derivable" ? deriveGitBlobRecipe(bytes, meta.command) : null;
+    const storedBytes = storedBytesFor(bytes, derivationRecipe);
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
       handle,
-      original: bytes.toString("base64"),
-      original_encoding: "base64",
       original_bytes: bytes.length,
+      stored_bytes: storedBytes,
       command: meta.command,
       created_at: createdAt,
       expires_at: expiresAt,
       loss: meta.loss,
       storage_class: storageClass,
+      ...(derivationRecipe
+        ? { derivation_recipe: derivationRecipe }
+        : { original: bytes.toString("base64"), original_encoding: "base64" as const }),
     };
     await this.kv().delete(tombstoneKey(handle));
     await this.kv().put(key, record);
@@ -409,14 +433,14 @@ export class RspElisionStore {
     withoutExisting.push({
       handle,
       key,
-      bytes: bytes.length,
+      bytes: storedBytes,
       command: meta.command,
       created_at: createdAt,
       expires_at: expiresAt,
       storage_class: storageClass,
     });
     await this.pruneRedDb({ version: 1, records: withoutExisting }, true);
-    await this.assertRedDbMintPersisted(handle, bytes.length);
+    await this.assertRedDbMintPersisted(handle, storedBytes);
     return handle;
   }
 
@@ -431,7 +455,7 @@ export class RspElisionStore {
       await this.expireRedDbEntry({
         handle: raw.handle,
         key: recordKey(raw.handle),
-        bytes: raw.original_bytes,
+        bytes: storedBytesForRecord(raw),
         command: raw.command,
         created_at: raw.created_at,
         expires_at: raw.expires_at,
@@ -439,6 +463,9 @@ export class RspElisionStore {
       return expired;
     }
     const original = this.readOriginal(raw);
+    if (!original && raw.derivation_recipe) {
+      return { status: "expired", expired_at: raw.expires_at, command: raw.command };
+    }
     if (!original) return null;
     return {
       collection: RSP_ELISION_COLLECTION,
@@ -682,6 +709,65 @@ function storageStatsForIndex(records: readonly IndexEntry[]): RspStorageClassSt
   return stats;
 }
 
+function deriveGitBlobRecipe(bytes: Buffer, command: string): RspDerivationRecipe | null {
+  const cwd = process.cwd();
+  const inside = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, encoding: "utf8" });
+  if (inside.status !== 0 || inside.stdout.trim() !== "true") return null;
+  const object = spawnSync("git", ["hash-object", "-w", "--stdin"], { cwd, input: bytes, encoding: "buffer" });
+  if (object.status !== 0) return null;
+  const objectId = object.stdout.toString("utf8").trim();
+  if (!/^[0-9a-f]{40,64}$/.test(objectId)) return null;
+  return {
+    kind: "git-blob",
+    command,
+    cwd,
+    object_ids: [objectId],
+    working_tree_fingerprint: gitWorkingTreeFingerprint(cwd),
+    original_bytes: bytes.length,
+  };
+}
+
+function gitWorkingTreeFingerprint(cwd: string): string {
+  const head = gitOutput(cwd, ["rev-parse", "HEAD"]) || "unborn";
+  const index = gitOutput(cwd, ["write-tree"]) || "no-index";
+  const status = gitOutput(cwd, ["status", "--porcelain=v1", "-z"]) || "";
+  return createHash("sha256")
+    .update(head)
+    .update("\0")
+    .update(index)
+    .update("\0")
+    .update(status)
+    .digest("hex");
+}
+
+function gitOutput(cwd: string, args: string[]): string | null {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function storedBytesFor(bytes: Buffer, recipe: RspDerivationRecipe | null): number {
+  return recipe ? Buffer.byteLength(JSON.stringify(recipe), "utf8") : bytes.length;
+}
+
+function storedBytesForRecord(record: StoredRecord): number {
+  if (typeof record.stored_bytes === "number") return record.stored_bytes;
+  if (record.derivation_recipe) return Buffer.byteLength(JSON.stringify(record.derivation_recipe), "utf8");
+  return record.original_bytes;
+}
+
+function readGitBlobRecipe(recipe: RspDerivationRecipe): Buffer | null {
+  const objectId = recipe.object_ids[0];
+  if (!objectId) return null;
+  const result = spawnSync("git", ["cat-file", "-p", objectId], {
+    cwd: recipe.cwd,
+    encoding: "buffer",
+    maxBuffer: Math.max(recipe.original_bytes + 1024, 1024 * 1024),
+  });
+  if (result.status !== 0) return null;
+  if (result.stdout.length !== recipe.original_bytes) return null;
+  return result.stdout;
+}
+
 function emptyStorageClassStats(): RspStorageClassStats {
   return {
     derivable: { records: 0, bytes: 0 },
@@ -821,12 +907,14 @@ function positiveNumber(value: number | undefined, fallback: number): number {
 
 function isStoredRecord(value: unknown): value is StoredRecord {
   if (!isRecord(value)) return false;
+  const hasOriginal = typeof value.original === "string" && value.original_encoding === "base64";
+  const hasRecipe = isDerivationRecipe(value.derivation_recipe);
   return value.collection === RSP_ELISION_COLLECTION &&
     typeof value.handle === "string" &&
     isHandle(value.handle) &&
-    typeof value.original === "string" &&
-    value.original_encoding === "base64" &&
+    (hasOriginal || hasRecipe) &&
     typeof value.original_bytes === "number" &&
+    (value.stored_bytes === undefined || typeof value.stored_bytes === "number") &&
     typeof value.command === "string" &&
     typeof value.created_at === "string" &&
     typeof value.expires_at === "string" &&
@@ -864,6 +952,17 @@ function isLossMeta(value: unknown): value is RspLossMeta {
 
 function isStorageClass(value: unknown): value is RspStorageClass {
   return value === "derivable" || value === "re-executable" || value === "ephemeral";
+}
+
+function isDerivationRecipe(value: unknown): value is RspDerivationRecipe {
+  return isRecord(value) &&
+    value.kind === "git-blob" &&
+    typeof value.command === "string" &&
+    typeof value.cwd === "string" &&
+    Array.isArray(value.object_ids) &&
+    value.object_ids.every((item) => typeof item === "string" && /^[0-9a-f]{40,64}$/.test(item)) &&
+    typeof value.working_tree_fingerprint === "string" &&
+    typeof value.original_bytes === "number";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -22,6 +23,86 @@ afterEach(async () => {
 });
 
 describe("RspElisionStore", () => {
+  it("stores derivable handles as git object recipes and re-derives byte-identical output", async () => {
+    const root = await tempRoot();
+    git(root, ["init"]);
+    git(root, ["config", "user.email", "agent@example.invalid"]);
+    git(root, ["config", "user.name", "Agent"]);
+    await writeFile(join(root, "tracked.txt"), "tracked content\n", "utf8");
+    git(root, ["add", "tracked.txt"]);
+    git(root, ["commit", "-m", "seed"]);
+
+    const storePath = join(root, "store.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    const previousCwd = process.cwd();
+    process.chdir(root);
+    try {
+      const original = Buffer.from(Array.from({ length: 12_000 }, (_, index) => `line ${index}\n`).join(""));
+      const handle = await store.mint(original, {
+        command: "git log --oneline",
+        loss: { level: "terse", bytes_elided: original.length },
+      });
+
+      const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+        records: Record<string, { original?: string; derivation_recipe?: { object_ids?: string[] } }>;
+        index: { records: Array<{ bytes: number }> };
+      };
+      const [record] = Object.values(raw.records);
+      expect(record?.original).toBeUndefined();
+      expect(record?.derivation_recipe?.object_ids).toHaveLength(1);
+      expect(raw.index.records[0]?.bytes).toBeLessThan(500);
+      expect(raw.index.records[0]?.bytes).toBeLessThan(original.length / 10);
+
+      const recovered = await store.get(handle);
+      if (!recovered || "status" in recovered) throw new Error("expected live derivable record");
+      expect(recovered.original).toEqual(original);
+      await expect(store.stats()).resolves.toMatchObject({
+        storage_classes: { derivable: { records: 1, bytes: raw.index.records[0]?.bytes } },
+      });
+    } finally {
+      process.chdir(previousCwd);
+      await store.close();
+    }
+  });
+
+  it("reports the unchanged expired contract when a derivable recipe object is unreachable", async () => {
+    const root = await tempRoot();
+    git(root, ["init"]);
+
+    const storePath = join(root, "store.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    const previousCwd = process.cwd();
+    process.chdir(root);
+    try {
+      const original = Buffer.from("temporary derivable output\n");
+      const handle = await store.mint(original, {
+        command: "git diff",
+        loss: { level: "terse", bytes_elided: original.length },
+      });
+      const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+        records: Record<string, { derivation_recipe?: { object_ids?: string[] } }>;
+      };
+      const oid = Object.values(raw.records)[0]?.derivation_recipe?.object_ids?.[0];
+      if (!oid) throw new Error("missing derivation object id");
+      await rm(join(root, ".git", "objects", oid.slice(0, 2), oid.slice(2)), { force: true });
+
+      await expect(store.get(handle)).resolves.toEqual({
+        status: "expired",
+        expired_at: "2026-07-17T12:00:00.000Z",
+        command: "git diff",
+      });
+    } finally {
+      process.chdir(previousCwd);
+      await store.close();
+    }
+  });
+
   it("mints elision handles and round-trips original bytes exactly", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({
@@ -66,7 +147,11 @@ describe("RspElisionStore", () => {
 
       if (!record || "status" in record) throw new Error("expected live elision record");
       expect(record.original).toEqual(original);
-      await expect(store.stats()).resolves.toMatchObject({ records: 1, bytes: original.length });
+      const stats = await store.stats();
+      expect(stats.records).toBe(1);
+      expect(stats.bytes).toBeLessThan(500);
+      expect(stats.bytes).toBeLessThan(original.length / 10);
+      expect(stats.storage_classes.derivable).toEqual({ records: 1, bytes: stats.bytes });
     } finally {
       await store.close();
     }
@@ -279,17 +364,26 @@ describe("RspElisionStore", () => {
         "ephemeral",
         "re-executable",
       ]);
-      expect(await store.stats()).toMatchObject({
-        records: 3,
-        bytes: 31,
-        storage_classes: {
-          derivable: { records: 1, bytes: 11 },
-          "re-executable": { records: 1, bytes: 9 },
-          ephemeral: { records: 1, bytes: 11 },
-        },
-      });
+      const stats = await store.stats();
+      expect(stats.records).toBe(3);
+      expect(stats.storage_classes.derivable.records).toBe(1);
+      expect(stats.storage_classes.derivable.bytes).toBeLessThan(500);
+      expect(stats.storage_classes["re-executable"]).toEqual({ records: 1, bytes: 9 });
+      expect(stats.storage_classes.ephemeral).toEqual({ records: 1, bytes: 11 });
+      expect(stats.bytes).toBe(
+        stats.storage_classes.derivable.bytes +
+          stats.storage_classes["re-executable"].bytes +
+          stats.storage_classes.ephemeral.bytes,
+      );
     } finally {
       await store.close();
     }
   });
 });
+
+function git(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+  }
+}


### PR DESCRIPTION
Automated AFK landing for #1713. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1713

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786627182&installation_id=129708444&pr_number=1753&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1753&signature=e966ac4465ea8e01d6f9433ff3a0c72d225d5e07d7bfbb479506198c93ea3f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->