### PR TITLE
fix: #1714 rsp re-executable class: recipe + content hash, re-run on show with state-moved marking

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -67,6 +67,7 @@ interface StoredRecord {
   original?: string;
   original_encoding?: "base64";
   original_bytes: number;
+  content_hash?: string;
   stored_bytes?: number;
   command: string;
   created_at: string;
@@ -74,6 +75,7 @@ interface StoredRecord {
   loss: RspLossMeta;
   storage_class?: RspStorageClass;
   derivation_recipe?: RspDerivationRecipe;
+  reexecution_recipe?: RspReexecutionRecipe;
 }
 
 interface IndexEntry {
@@ -93,6 +95,15 @@ interface RspDerivationRecipe {
   object_ids: string[];
   working_tree_fingerprint: string;
   original_bytes: number;
+}
+
+interface RspReexecutionRecipe {
+  kind: "command";
+  command: string;
+  cwd: string;
+  argv: string[];
+  original_bytes: number;
+  content_hash: string;
 }
 
 interface IndexDocument {
@@ -161,9 +172,11 @@ export class RspElisionStore {
     const expiresAt = new Date(now.getTime() + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
-    const storageClass = storageClassForCommand(meta.command);
-    const derivationRecipe = storageClass === "derivable" ? deriveGitBlobRecipe(bytes, meta.command) : null;
-    const storedBytes = storedBytesFor(bytes, derivationRecipe);
+    const requestedStorageClass = storageClassForCommand(meta.command);
+    const derivationRecipe = requestedStorageClass === "derivable" ? deriveGitBlobRecipe(bytes, meta.command) : null;
+    const reexecutionRecipe = requestedStorageClass === "re-executable" ? deriveReexecutionRecipe(bytes, meta.command) : null;
+    const storageClass = requestedStorageClass === "re-executable" && !reexecutionRecipe ? "ephemeral" : requestedStorageClass;
+    const storedBytes = storedBytesFor(bytes, derivationRecipe, reexecutionRecipe);
 
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
@@ -175,9 +188,12 @@ export class RspElisionStore {
       expires_at: expiresAt,
       loss: meta.loss,
       storage_class: storageClass,
+      content_hash: contentHash(bytes),
       ...(derivationRecipe
         ? { derivation_recipe: derivationRecipe }
-        : { original: bytes.toString("base64"), original_encoding: "base64" as const }),
+        : reexecutionRecipe
+          ? { reexecution_recipe: reexecutionRecipe }
+          : { original: bytes.toString("base64"), original_encoding: "base64" as const }),
     };
 
     delete this.document.tombstones[tombstoneKey(handle)];
@@ -220,7 +236,7 @@ export class RspElisionStore {
     }
 
     const original = this.readOriginal(raw);
-    if (!original && raw.derivation_recipe) {
+    if (!original && (raw.derivation_recipe || raw.reexecution_recipe)) {
       return { status: "expired", expired_at: raw.expires_at, command: raw.command };
     }
     if (!original) return null;
@@ -315,6 +331,7 @@ export class RspElisionStore {
   private readOriginal(record: StoredRecord): Buffer | null {
     if (record.original) return Buffer.from(record.original, "base64");
     if (record.derivation_recipe) return readGitBlobRecipe(record.derivation_recipe);
+    if (record.reexecution_recipe) return readReexecutionRecipe(record.reexecution_recipe);
     return null;
   }
 
@@ -409,9 +426,11 @@ export class RspElisionStore {
     const expiresAt = new Date(now.getTime() + this.opts.ttlDays * 24 * 60 * 60 * 1000).toISOString();
     const handle = contentHandle(bytes, meta);
     const key = recordKey(handle);
-    const storageClass = storageClassForCommand(meta.command);
-    const derivationRecipe = storageClass === "derivable" ? deriveGitBlobRecipe(bytes, meta.command) : null;
-    const storedBytes = storedBytesFor(bytes, derivationRecipe);
+    const requestedStorageClass = storageClassForCommand(meta.command);
+    const derivationRecipe = requestedStorageClass === "derivable" ? deriveGitBlobRecipe(bytes, meta.command) : null;
+    const reexecutionRecipe = requestedStorageClass === "re-executable" ? deriveReexecutionRecipe(bytes, meta.command) : null;
+    const storageClass = requestedStorageClass === "re-executable" && !reexecutionRecipe ? "ephemeral" : requestedStorageClass;
+    const storedBytes = storedBytesFor(bytes, derivationRecipe, reexecutionRecipe);
     const record: StoredRecord = {
       collection: RSP_ELISION_COLLECTION,
       handle,
@@ -422,9 +441,12 @@ export class RspElisionStore {
       expires_at: expiresAt,
       loss: meta.loss,
       storage_class: storageClass,
+      content_hash: contentHash(bytes),
       ...(derivationRecipe
         ? { derivation_recipe: derivationRecipe }
-        : { original: bytes.toString("base64"), original_encoding: "base64" as const }),
+        : reexecutionRecipe
+          ? { reexecution_recipe: reexecutionRecipe }
+          : { original: bytes.toString("base64"), original_encoding: "base64" as const }),
     };
     await this.kv().delete(tombstoneKey(handle));
     await this.kv().put(key, record);
@@ -463,7 +485,7 @@ export class RspElisionStore {
       return expired;
     }
     const original = this.readOriginal(raw);
-    if (!original && raw.derivation_recipe) {
+    if (!original && (raw.derivation_recipe || raw.reexecution_recipe)) {
       return { status: "expired", expired_at: raw.expires_at, command: raw.command };
     }
     if (!original) return null;
@@ -684,10 +706,9 @@ export function storageClassForCommand(command: string): RspStorageClass {
     if (subcommand === "log" || subcommand === "diff" || subcommand === "blame" || subcommand === "show") {
       return "derivable";
     }
-    if (subcommand === "status" || subcommand === "branch") return "re-executable";
+    if (isReExecutableArgv(argv)) return "re-executable";
     return "ephemeral";
   }
-  if (executable === "gh") return "re-executable";
   return "ephemeral";
 }
 
@@ -745,13 +766,48 @@ function gitOutput(cwd: string, args: string[]): string | null {
   return result.status === 0 ? result.stdout.trim() : null;
 }
 
-function storedBytesFor(bytes: Buffer, recipe: RspDerivationRecipe | null): number {
-  return recipe ? Buffer.byteLength(JSON.stringify(recipe), "utf8") : bytes.length;
+function deriveReexecutionRecipe(bytes: Buffer, command: string): RspReexecutionRecipe | null {
+  const argv = command.trim().split(/\s+/).filter(Boolean);
+  if (!isReExecutableArgv(argv)) return null;
+  const current = runReexecutionCommand(process.cwd(), argv, bytes.length);
+  if (!current || contentHash(current) !== contentHash(bytes)) return null;
+  return {
+    kind: "command",
+    command,
+    cwd: process.cwd(),
+    argv,
+    original_bytes: bytes.length,
+    content_hash: contentHash(bytes),
+  };
+}
+
+function isReExecutableArgv(argv: readonly string[]): boolean {
+  if (argv[0] === "git") {
+    if (argv[1] === "status") return true;
+    if (argv[1] !== "branch") return false;
+    return argv.length === 2 || argv.slice(2).every((arg) => /^-[avvr]+$/.test(arg));
+  }
+  return false;
+}
+
+function contentHash(bytes: Buffer): string {
+  return createHash("sha256").update("rsp-reexecutable-content-v1\0").update(bytes).digest("hex");
+}
+
+function storedBytesFor(
+  bytes: Buffer,
+  derivationRecipe: RspDerivationRecipe | null,
+  reexecutionRecipe?: RspReexecutionRecipe | null,
+): number {
+  if (derivationRecipe) return Buffer.byteLength(JSON.stringify(derivationRecipe), "utf8");
+  if (reexecutionRecipe) return Buffer.byteLength(JSON.stringify(reexecutionRecipe), "utf8");
+  return bytes.length;
 }
 
 function storedBytesForRecord(record: StoredRecord): number {
   if (typeof record.stored_bytes === "number") return record.stored_bytes;
   if (record.derivation_recipe) return Buffer.byteLength(JSON.stringify(record.derivation_recipe), "utf8");
+  if (record.reexecution_recipe) return Buffer.byteLength(JSON.stringify(record.reexecution_recipe), "utf8");
   return record.original_bytes;
 }
 
@@ -765,6 +821,29 @@ function readGitBlobRecipe(recipe: RspDerivationRecipe): Buffer | null {
   });
   if (result.status !== 0) return null;
   if (result.stdout.length !== recipe.original_bytes) return null;
+  return result.stdout;
+}
+
+function readReexecutionRecipe(recipe: RspReexecutionRecipe): Buffer | null {
+  if (!isReExecutableArgv(recipe.argv)) return null;
+  const current = runReexecutionCommand(recipe.cwd, recipe.argv, recipe.original_bytes);
+  if (!current) return null;
+  if (contentHash(current) === recipe.content_hash) return current;
+  return Buffer.concat([
+    Buffer.from("reconstructed after state moved - current snapshot follows\n", "utf8"),
+    current,
+  ]);
+}
+
+function runReexecutionCommand(cwd: string, argv: readonly string[], originalBytes: number): Buffer | null {
+  const executable = argv[0];
+  if (!executable) return null;
+  const result = spawnSync(executable, argv.slice(1), {
+    cwd,
+    encoding: "buffer",
+    maxBuffer: Math.max(originalBytes + 1024, 1024 * 1024),
+  });
+  if (result.status !== 0 || result.signal) return null;
   return result.stdout;
 }
 
@@ -909,11 +988,13 @@ function isStoredRecord(value: unknown): value is StoredRecord {
   if (!isRecord(value)) return false;
   const hasOriginal = typeof value.original === "string" && value.original_encoding === "base64";
   const hasRecipe = isDerivationRecipe(value.derivation_recipe);
+  const hasReexecutionRecipe = isReexecutionRecipe(value.reexecution_recipe);
   return value.collection === RSP_ELISION_COLLECTION &&
     typeof value.handle === "string" &&
     isHandle(value.handle) &&
-    (hasOriginal || hasRecipe) &&
+    (hasOriginal || hasRecipe || hasReexecutionRecipe) &&
     typeof value.original_bytes === "number" &&
+    (value.content_hash === undefined || isSha256(value.content_hash)) &&
     (value.stored_bytes === undefined || typeof value.stored_bytes === "number") &&
     typeof value.command === "string" &&
     typeof value.created_at === "string" &&
@@ -963,6 +1044,22 @@ function isDerivationRecipe(value: unknown): value is RspDerivationRecipe {
     value.object_ids.every((item) => typeof item === "string" && /^[0-9a-f]{40,64}$/.test(item)) &&
     typeof value.working_tree_fingerprint === "string" &&
     typeof value.original_bytes === "number";
+}
+
+function isReexecutionRecipe(value: unknown): value is RspReexecutionRecipe {
+  return isRecord(value) &&
+    value.kind === "command" &&
+    typeof value.command === "string" &&
+    typeof value.cwd === "string" &&
+    Array.isArray(value.argv) &&
+    value.argv.every((item) => typeof item === "string") &&
+    isReExecutableArgv(value.argv) &&
+    typeof value.original_bytes === "number" &&
+    isSha256(value.content_hash);
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -2327,6 +2327,42 @@ describe("rsp cli", () => {
     expect(res.stderr).toEqual(Buffer.alloc(0));
   });
 
+  it("rsp show re-runs re-executable recipes and marks moved state", async () => {
+    const root = await tempRoot();
+    await enableRsp(root);
+    const storeRoot = await tempRoot();
+    const storeUri = `file://${join(storeRoot, "red.rdb")}`;
+    runGit(["-C", root, "init"]);
+    await writeFile(join(root, ".gitignore"), ".red/\n", "utf8");
+    await writeFile(join(root, "tracked.txt"), "tracked content\n", "utf8");
+    runGit(["-C", root, "add", ".gitignore"]);
+    runGit(["-C", root, "add", "tracked.txt"]);
+
+    const store = await RspElisionStore.open({ uri: storeUri });
+    let handle = "";
+    const previousCwd = process.cwd();
+    process.chdir(root);
+    try {
+      const original = Buffer.from("A  .gitignore\nA  tracked.txt\n");
+      handle = await store.mint(original, {
+        command: "git status --short",
+        loss: { level: "terse", bytes_elided: original.length },
+      });
+    } finally {
+      process.chdir(previousCwd);
+      await store.close();
+    }
+    await writeFile(join(root, "moved.txt"), "state moved\n", "utf8");
+
+    const res = runRsp(root, ["show", handle], { RSP_STORE_URI: storeUri });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout.toString("utf8")).toBe(
+      "reconstructed after state moved - current snapshot follows\nA  .gitignore\nA  tracked.txt\n?? moved.txt\n",
+    );
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+  });
+
   it("rsp show prints structured expiry with the original command and exits 1", async () => {
     const root = await tempRoot();
     await enableRsp(root);

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_RSP_TTL_DAYS,
   RSP_ELISION_COLLECTION,
   RspElisionStore,
+  storageClassForCommand,
 } from "../src/elision-store.js";
 
 const roots: string[] = [];
@@ -32,7 +33,8 @@ describe("RspElisionStore", () => {
     git(root, ["add", "tracked.txt"]);
     git(root, ["commit", "-m", "seed"]);
 
-    const storePath = join(root, "store.rdb");
+    const storeRoot = await tempRoot();
+    const storePath = join(storeRoot, "store.rdb");
     const store = await RspElisionStore.open({
       uri: `file://${storePath}`,
       now: () => new Date("2026-07-10T12:00:00.000Z"),
@@ -72,7 +74,8 @@ describe("RspElisionStore", () => {
     const root = await tempRoot();
     git(root, ["init"]);
 
-    const storePath = join(root, "store.rdb");
+    const storeRoot = await tempRoot();
+    const storePath = join(storeRoot, "store.rdb");
     const store = await RspElisionStore.open({
       uri: `file://${storePath}`,
       now: () => new Date("2026-07-10T12:00:00.000Z"),
@@ -101,6 +104,69 @@ describe("RspElisionStore", () => {
       process.chdir(previousCwd);
       await store.close();
     }
+  });
+
+  it("stores re-executable handles as recipe plus hash and marks moved state on show", async () => {
+    const root = await tempRoot();
+    git(root, ["init"]);
+    await writeFile(join(root, "tracked.txt"), "tracked content\n", "utf8");
+    git(root, ["add", "tracked.txt"]);
+
+    const storeRoot = await tempRoot();
+    const storePath = join(storeRoot, "store.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    const previousCwd = process.cwd();
+    process.chdir(root);
+    try {
+      const original = Buffer.from("A  tracked.txt\n");
+      const handle = await store.mint(original, {
+        command: "git status --short",
+        loss: { level: "terse", bytes_elided: original.length },
+      });
+
+      const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+        records: Record<string, {
+          original?: string;
+          content_hash?: string;
+          reexecution_recipe?: { argv?: string[]; content_hash?: string };
+        }>;
+        index: { records: Array<{ bytes: number; storage_class?: string }> };
+      };
+      const [stored] = Object.values(raw.records);
+      expect(stored?.original).toBeUndefined();
+      expect(stored?.content_hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(stored?.reexecution_recipe?.argv).toEqual(["git", "status", "--short"]);
+      expect(stored?.reexecution_recipe?.content_hash).toBe(stored?.content_hash);
+      expect(raw.index.records[0]?.storage_class).toBe("re-executable");
+      expect(raw.index.records[0]?.bytes).toBeLessThan(500);
+
+      const matching = await store.get(handle);
+      if (!matching || "status" in matching) throw new Error("expected live re-executable record");
+      expect(matching.original).toEqual(original);
+
+      await writeFile(join(root, "moved.txt"), "state moved\n", "utf8");
+      const moved = await store.get(handle);
+      if (!moved || "status" in moved) throw new Error("expected reconstructed re-executable record");
+      expect(moved.original.toString("utf8")).toBe(
+        "reconstructed after state moved - current snapshot follows\nA  tracked.txt\n?? moved.txt\n",
+      );
+    } finally {
+      process.chdir(previousCwd);
+      await store.close();
+    }
+  });
+
+  it("classifies only cheap read commands as re-executable", () => {
+    expect(storageClassForCommand("git status --short")).toBe("re-executable");
+    expect(storageClassForCommand("git branch -av")).toBe("re-executable");
+    expect(storageClassForCommand("gh pr view 42")).toBe("ephemeral");
+    expect(storageClassForCommand("gh issue list --label ready-for-agent")).toBe("ephemeral");
+    expect(storageClassForCommand("gh pr checkout 42")).toBe("ephemeral");
+    expect(storageClassForCommand("gh run watch 123")).toBe("ephemeral");
+    expect(storageClassForCommand("git commit -m msg")).toBe("ephemeral");
   });
 
   it("mints elision handles and round-trips original bytes exactly", async () => {
@@ -331,19 +397,26 @@ describe("RspElisionStore", () => {
 
   it("records exactly one storage class per minted handle and reports the class breakdown", async () => {
     const root = await tempRoot();
-    const storePath = join(root, "red.rdb");
+    git(root, ["init"]);
+    await writeFile(join(root, "tracked.txt"), "tracked content\n", "utf8");
+    git(root, ["add", "tracked.txt"]);
+
+    const storeRoot = await tempRoot();
+    const storePath = join(storeRoot, "red.rdb");
     const store = await RspElisionStore.open({
       uri: `file://${storePath}`,
       now: () => new Date("2026-07-10T12:00:00.000Z"),
     });
+    const previousCwd = process.cwd();
+    process.chdir(root);
     try {
       await store.mint(Buffer.from("git history"), {
         command: "git log --oneline",
         loss: { level: "terse", bytes_elided: 11 },
       });
-      await store.mint(Buffer.from("remote pr"), {
-        command: "gh pr view 42",
-        loss: { level: "brief", bytes_elided: 9 },
+      await store.mint(Buffer.from("A  tracked.txt\n"), {
+        command: "git status --short",
+        loss: { level: "brief", bytes_elided: 15 },
       });
       await store.mint(Buffer.from("test output"), {
         command: "vitest run",
@@ -368,7 +441,9 @@ describe("RspElisionStore", () => {
       expect(stats.records).toBe(3);
       expect(stats.storage_classes.derivable.records).toBe(1);
       expect(stats.storage_classes.derivable.bytes).toBeLessThan(500);
-      expect(stats.storage_classes["re-executable"]).toEqual({ records: 1, bytes: 9 });
+      expect(stats.storage_classes["re-executable"].records).toBe(1);
+      expect(stats.storage_classes["re-executable"].bytes).toBeGreaterThan(15);
+      expect(stats.storage_classes["re-executable"].bytes).toBeLessThan(500);
       expect(stats.storage_classes.ephemeral).toEqual({ records: 1, bytes: 11 });
       expect(stats.bytes).toBe(
         stats.storage_classes.derivable.bytes +
@@ -376,6 +451,7 @@ describe("RspElisionStore", () => {
           stats.storage_classes.ephemeral.bytes,
       );
     } finally {
+      process.chdir(previousCwd);
       await store.close();
     }
   });


### PR DESCRIPTION
Automated AFK landing for #1714. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1714

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786628481&installation_id=129708444&pr_number=1754&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1754&signature=ea1c8f3bf0b4c17e1379e25099d5c6a6d66a7e31717bdd57b945af7fcc586df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->