### PR TITLE
fix: #1748 rsp statusline contribution signal: N/M intercepted from the decisions lane

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -147,6 +147,10 @@ interface RspSummaryFile {
   dollars_saved_today_usd?: number;
   show_total_today?: number;
   show_hit_rate?: number;
+  decisions?: {
+    seen?: number;
+    contributed?: number;
+  };
   updated_at: string;
 }
 
@@ -200,6 +204,17 @@ function dollarsSavedForCurrentDay(summary: RspSummaryFile, nowMs: number): numb
   return Math.max(0, summary.dollars_saved_today_usd);
 }
 
+function decisionsFromSummary(summary: RspSummaryFile): Extract<RspStatusInput, { state: "ready" }>["decisions"] {
+  const seen = summary.decisions?.seen;
+  const contributed = summary.decisions?.contributed;
+  if (typeof seen !== "number" || !Number.isFinite(seen) || seen <= 0) return undefined;
+  if (typeof contributed !== "number" || !Number.isFinite(contributed)) return undefined;
+  return {
+    seen: Math.floor(seen),
+    contributed: Math.max(0, Math.floor(contributed)),
+  };
+}
+
 export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv = process.env): Promise<RspStatusInput | undefined> {
   const config = resolveRspConfig(root, env);
   if (!config.enabled) return undefined;
@@ -214,6 +229,7 @@ export async function resolveStatuslineRsp(root: string, env: NodeJS.ProcessEnv 
       showHitRate: summary.show_total_today && summary.show_total_today > 0 && typeof summary.show_hit_rate === "number"
         ? summary.show_hit_rate
         : undefined,
+      decisions: decisionsFromSummary(summary),
     };
   }
   if (isRecentFile(paths.wakeLockPath, nowMs, RSP_WARMUP_GRACE_MS)) return { state: "warming" };

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -164,7 +164,13 @@ export interface FleetInput {
 }
 
 export type RspStatusInput =
-  | { state: "ready"; tokensSavedToday: number; dollarsSavedTodayUsd?: number; showHitRate?: number }
+  | {
+      state: "ready";
+      tokensSavedToday: number;
+      dollarsSavedTodayUsd?: number;
+      showHitRate?: number;
+      decisions?: { contributed: number; seen: number };
+    }
   | { state: "warming" }
   | { state: "error" };
 
@@ -458,8 +464,12 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
   if (rsp.state === "ready") {
+    const decisions =
+      rsp.decisions && Number.isFinite(rsp.decisions.seen) && rsp.decisions.seen > 0
+        ? ` int=${Math.max(0, Math.floor(rsp.decisions.contributed))}/${Math.floor(rsp.decisions.seen)}`
+        : "";
     const hitRate = typeof rsp.showHitRate === "number" ? ` hit=${Math.round(rsp.showHitRate * 100)}%` : "";
-    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}${hitRate}`;
+    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}${decisions}${hitRate}`;
   }
   if (rsp.state === "warming") return "rsp=…";
   return "rsp=!";

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -730,6 +730,30 @@ describe("statusline command — rendered line", () => {
     expect(stripAnsi(out.text())).not.toContain("$1.63");
   });
 
+  it("renders cached rsp decisions contribution from the resident summary when present", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
+      version: 1,
+      tokens_saved_today: 1320000,
+      decisions: { contributed: 0, seen: 12 },
+      updated_at: new Date().toISOString(),
+    }), "utf8");
+    expect(await resolveStatuslineRsp(root, {})).toEqual({
+      state: "ready",
+      tokensSavedToday: 1320000,
+      decisions: { contributed: 0, seen: 12 },
+    });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("rsp=↓1.32M int=0/12");
+  });
+
   it("renders rsp savings from an old summary when the resident is idle", async () => {
     await mkdir(join(root, ".red"), { recursive: true });
     await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -533,6 +533,45 @@ describe("statusline — full assembly", () => {
     })).toBe("red-skills (main) · rsp=↓2.0k");
   });
 
+  it("renders rsp decisions contribution as contributed/seen when cached lane data exists", () => {
+    const input: StatuslineInput = {
+      project: { basename: "red-skills", branch: "main" },
+      rsp: {
+        state: "ready",
+        tokensSavedToday: 1200,
+        decisions: { contributed: 8, seen: 10 },
+      },
+    };
+    expect(renderStatusline(input)).toBe("red-skills (main) · rsp=↓1.2k int=8/10");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp=↓1.2k int=8/10");
+  });
+
+  it("renders zero rsp decisions contribution as a visible zero-over-seen signal", () => {
+    expect(renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      rsp: {
+        state: "ready",
+        tokensSavedToday: 1200,
+        decisions: { contributed: 0, seen: 12 },
+      },
+    })).toBe("red-skills (main) · rsp=↓1.2k int=0/12");
+  });
+
+  it("omits rsp decisions contribution when the cached decisions lane is missing", () => {
+    expect(renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      rsp: { state: "ready", tokensSavedToday: 1200 },
+    })).toBe("red-skills (main) · rsp=↓1.2k");
+    expect(renderStatusline({
+      project: { basename: "red-skills", branch: "main" },
+      rsp: {
+        state: "ready",
+        tokensSavedToday: 1200,
+        decisions: { contributed: 0, seen: 0 },
+      },
+    })).toBe("red-skills (main) · rsp=↓1.2k");
+  });
+
   it("renders rsp warming and error states without ambiguous on/off glyphs", () => {
     expect(renderStatusline({
       project: { basename: "red-skills", branch: "main" },

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -471,6 +471,12 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
     dollars_saved_today_usd: Math.round(dollarsSavedToday * 1_000_000) / 1_000_000,
     show_total_today: stats.health.show_total,
     show_hit_rate: stats.health.show_total > 0 ? stats.health.show_hit_rate : undefined,
+    decisions: stats.decisions.seen > 0
+      ? {
+          seen: stats.decisions.seen,
+          contributed: stats.decisions.contributed,
+        }
+      : undefined,
     updated_at: now.toISOString(),
   }), { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -667,6 +667,10 @@ describe("rsp telemetry spool", () => {
       reason: "matched-capability",
       capability_id: "git:status",
     }));
+    const summary = JSON.parse(await readFile(paths.summaryPath, "utf8")) as {
+      decisions?: { seen?: number; contributed?: number };
+    };
+    expect(summary.decisions).toEqual({ seen: 1, contributed: 1 });
   }, 40_000);
 
   it("self-heals old-model rsp collections in the built bundle resident without losing elisions", async () => {


### PR DESCRIPTION
Automated AFK landing for #1748. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1748

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630294&installation_id=129708444&pr_number=1755&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1755&signature=c07dc85f2e0da3580e33fba2913433d9d77f61d4a62b5392fdf8473906e49ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->