### PR TITLE
fix: #1744 rsp universal proxy routing behind per-repo flag: verbatim byte-identical passthrough + fidelity parity suite

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -138,6 +138,10 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   }
 
   const residentPaths = resolveResidentPaths(process.cwd());
+  if (args.command === "proxy") {
+    const { runProxy } = await import("./proxy.js");
+    return await runProxy(args.positional, { telemetryRoot: residentPaths.rootDir });
+  }
   if (args.command === "status" || args.command === "sweep") {
     const { residentRegistryStatus, sweepResidentRegistry } = await import("./resident-client.js");
     const status = args.command === "sweep"
@@ -868,11 +872,12 @@ function rspDisabledReason(): string {
 }
 
 function isWrapperCommand(command: string | undefined): boolean {
-  return command === "git" || command === "gh" || command === "vitest" || command === "cargo" || command === "cat" || command === "exec";
+  return command === "git" || command === "gh" || command === "vitest" || command === "cargo" || command === "cat" ||
+    command === "exec" || command === "proxy";
 }
 
 async function passthrough(argv: readonly string[]): Promise<number> {
-  if (argv[0] === "exec") return await passthroughShell(argv);
+  if (argv[0] === "exec" || argv[0] === "proxy") return await passthroughShell(argv);
   const command = argv[0];
   if (!command) return 2;
   const { spawn } = await import("node:child_process");
@@ -896,8 +901,13 @@ async function passthrough(argv: readonly string[]): Promise<number> {
 async function passthroughShell(argv: readonly string[]): Promise<number> {
   let commandLine: string;
   try {
-    const { parseExecCommandLine } = await import("./exec-wrapper.js");
-    commandLine = parseExecCommandLine(argv);
+    if (argv[0] === "proxy") {
+      const { parseProxyCommandLine } = await import("./proxy.js");
+      commandLine = parseProxyCommandLine(argv);
+    } else {
+      const { parseExecCommandLine } = await import("./exec-wrapper.js");
+      commandLine = parseExecCommandLine(argv);
+    }
   } catch (err) {
     process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
     return 2;

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -17,6 +17,7 @@ export const MIN_RSP_IDLE_MS = 5_000;
 
 export interface RspRuntimeConfig {
   enabled: boolean;
+  proxyEnabled: boolean;
   storeUri: string;
   ttlDays: number;
   ephemeralTtlHours: number;
@@ -33,6 +34,7 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
   const configPath = findUp(resolve(cwd), join(".red", "config.yaml"));
   const yaml = configPath ? readFileSync(configPath, "utf8") : "";
   const enabled = flatConfigValue(yaml, "rsp.enabled") === "true";
+  const proxyEnabled = flatConfigValue(yaml, "rsp.proxy.enabled") === "true";
   const ttlDays = positiveNumber(readNumericYamlPath(yaml, "rsp.ttlDays"), DEFAULT_RSP_TTL_DAYS);
   const ephemeralTtlHours = positiveNumber(
     numericEnv(env.RSP_EPHEMERAL_TTL_HOURS) ?? readNumericYamlPath(yaml, "rsp.ephemeralTtlHours"),
@@ -69,6 +71,7 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
 
   return {
     enabled,
+    proxyEnabled,
     storeUri,
     ttlDays,
     ephemeralTtlHours,

--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -166,13 +166,16 @@ async function hookDecisionResultFromPreExecJson(
       event: hookDecisionEvent({ hook, command, decision, reason: "missing-command" }),
     };
   }
-  const decision = (options.rewrite ?? rewriteCommand)(command);
+  const started = process.hrtime.bigint();
+  const config = resolveRspConfig(cwd, process.env);
+  const decision = config.proxyEnabled ? proxyCommand(command) : (options.rewrite ?? rewriteCommand)(command);
+  const decisionMs = Number(process.hrtime.bigint() - started) / 1_000_000;
   if (decision.kind !== "rewrite") {
     const passed = decision.reason ? decision : { ...decision, reason: "unsupported-command" };
     return {
       decision: passed,
       telemetryRoot: cwd,
-      event: hookDecisionEvent({ hook, command, decision: passed, reason: passed.reason ?? "unsupported-command" }),
+      event: hookDecisionEvent({ hook, command, decision: passed, reason: passed.reason ?? "unsupported-command", decisionMs }),
     };
   }
 
@@ -180,7 +183,13 @@ async function hookDecisionResultFromPreExecJson(
   return {
     decision,
     telemetryRoot: cwd,
-    event: hookDecisionEvent({ hook, command, decision, reason: "matched-capability" }),
+    event: hookDecisionEvent({
+      hook,
+      command,
+      decision,
+      reason: decision.capabilityId === "proxy:universal" ? "universal-proxy" : "matched-capability",
+      decisionMs,
+    }),
   };
 }
 
@@ -252,6 +261,7 @@ function hookDecisionEvent(input: {
   command: string;
   decision: RewriteDecision;
   reason: string;
+  decisionMs?: number;
 }): RspTelemetryEvent {
   const command = input.command.trim();
   const capabilityId = input.decision.kind === "rewrite" ? input.decision.capabilityId : undefined;
@@ -265,6 +275,7 @@ function hookDecisionEvent(input: {
     decision: capabilityId ? "contributed" : "passed",
     reason: input.reason,
     capability_id: capabilityId,
+    decision_ms: input.decisionMs,
   };
 }
 
@@ -378,6 +389,27 @@ function tokenizeCertainSimpleCommand(command: string): string[] | null {
   return tokens;
 }
 
+function proxyCommand(command: string): RewriteDecision {
+  const reason = universalProxyPassthroughReason(command);
+  if (reason) return { kind: "passthrough", reason };
+  return {
+    kind: "rewrite",
+    command: `rsp proxy -- ${shellSingleQuote(command.trim())}`,
+    capabilityId: "proxy:universal",
+  };
+}
+
+function universalProxyPassthroughReason(command: string): string | undefined {
+  const trimmed = command.trim();
+  if (!trimmed) return "missing-command";
+  if (hasSingleAmpersand(trimmed)) return "background";
+  if (/\b(?:RSP_NO_PROXY|RED_SKILLS_RSP_NO_PROXY)=1\b/.test(trimmed)) return "opt-out";
+  const first = shellishWords(commandSegments(trimmed)[0] ?? "")[0];
+  if (first === "rsp") return "opt-out";
+  if (first && INTERACTIVE_COMMANDS.has(first)) return "interactive";
+  return undefined;
+}
+
 function rewriteCompoundCommand(command: string): RewriteDecision {
   const trimmed = command.trim();
   if (!isSafeNoisyCompoundCommand(trimmed)) return { kind: "passthrough" };
@@ -427,6 +459,7 @@ function hasSingleAmpersand(command: string): boolean {
   for (let index = 0; index < command.length; index += 1) {
     if (command[index] !== "&") continue;
     if (command[index - 1] === "&" || command[index + 1] === "&") continue;
+    if (command[index - 1] === ">" || command[index + 1] === ">") continue;
     return true;
   }
   return false;

--- a/apps/rsp/src/proxy.ts
+++ b/apps/rsp/src/proxy.ts
@@ -1,0 +1,89 @@
+import { spawn } from "node:child_process";
+import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION, RSP_TELEMETRY_INVOCATIONS_COLLECTION } from "./telemetry.js";
+
+export interface ProxyRunOptions {
+  telemetryRoot: string;
+}
+
+export async function runProxy(argv: readonly string[], options: ProxyRunOptions): Promise<number> {
+  let commandLine = "";
+  const started = process.hrtime.bigint();
+  try {
+    commandLine = parseProxyCommandLine(argv);
+    if (process.env.RSP_PROXY_FAIL_INTERNAL === "1") throw new Error("forced proxy failure");
+  } catch (err) {
+    if (commandLine) {
+      await appendProxyFailedOpen(options.telemetryRoot, commandLine, err);
+      return await runShellVerbatim(commandLine);
+    }
+    throw err;
+  }
+
+  const status = await runShellVerbatim(commandLine);
+  const wrapperMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  await appendTelemetryEvent(options.telemetryRoot, {
+    collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
+    ts: new Date().toISOString(),
+    command: commandLine,
+    wrapper: "proxy",
+    loss: "lossless",
+    elided: false,
+    raw_bytes: 0,
+    emitted_bytes: 0,
+    wrapper_ms: wrapperMs,
+    accounting_recorded: false,
+  });
+  return status;
+}
+
+export function parseProxyCommandLine(argv: readonly string[]): string {
+  if (argv[0] !== "proxy") throw new Error("expected rsp proxy -- <command line>");
+  const separator = argv.indexOf("--");
+  const parts = separator >= 0 ? argv.slice(separator + 1) : argv.slice(1);
+  const commandLine = parts.length === 1 ? parts[0]! : parts.join(" ");
+  if (!commandLine.trim()) throw new Error("usage: rsp proxy -- <command line>");
+  return commandLine;
+}
+
+async function appendProxyFailedOpen(rootDir: string, command: string, err: unknown): Promise<void> {
+  await appendTelemetryEvent(rootDir, {
+    collection: RSP_DECISIONS_COLLECTION,
+    event_type: "decision",
+    ts: new Date().toISOString(),
+    hook: "proxy",
+    command,
+    command_family: commandFamily(command),
+    decision: "failed-open",
+    reason: "proxy-internal-error",
+    error: err instanceof Error ? err.name : typeof err,
+  });
+}
+
+async function runShellVerbatim(commandLine: string): Promise<number> {
+  const child = spawn(commandLine, { shell: true, stdio: "inherit" });
+  return await new Promise((resolve) => {
+    child.on("error", (err) => {
+      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+      resolve(127);
+    });
+    child.on("close", (status, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        resolve(128);
+        return;
+      }
+      resolve(status ?? 0);
+    });
+  });
+}
+
+function commandFamily(command: string): string {
+  const parts = command.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "unknown";
+  if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
+  if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
+  if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
+  if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
+  if (parts[0] === "vitest") return "vitest";
+  return parts[0]!;
+}

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -13,6 +13,7 @@ import { resolveResidentPaths } from "../src/resident-client.js";
 import { sendResidentRequest } from "../src/resident-protocol.js";
 import {
   RSP_ACCOUNTING_EVENTS_COLLECTION,
+  RSP_DECISIONS_COLLECTION,
   RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
   RSP_TELEMETRY_INVOCATIONS_COLLECTION,
   telemetrySpoolPath,
@@ -597,6 +598,41 @@ async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
 }
 
 describe("rsp cli", () => {
+  it.each([
+    ["compound-stdout-stderr", "printf 'out\\n'; printf 'err\\n' >&2"],
+    ["pipeline", "printf 'one\\ntwo\\n' | sed -n '2p'"],
+    ["redirect", "printf 'saved\\n' > redirected.txt; cat redirected.txt"],
+    ["failing-exit", "printf 'bad\\n' >&2; exit 7"],
+    ["signal", "kill -TERM $$"],
+  ])("proxies %s with byte-identical shell behavior", async (_label, command) => {
+    const rawRoot = await tempRoot();
+    const proxyRoot = await tempRoot();
+    await enableRsp(proxyRoot);
+
+    const raw = runShellFromCwd(rawRoot, command);
+    const proxied = runRsp(proxyRoot, ["proxy", "--", command], {});
+
+    expect(proxied.stdout).toEqual(raw.stdout);
+    expect(proxied.stderr).toEqual(raw.stderr);
+    expect(proxied.status).toBe(raw.status);
+    expect(proxied.signal).toBe(raw.signal);
+  });
+
+  it("fails open to raw execution on proxy-internal error and records the decision", async () => {
+    const root = await tempRoot();
+    await enableRsp(root);
+
+    const res = runRsp(root, ["proxy", "--", "printf 'ok\\n'"], { RSP_PROXY_FAIL_INTERNAL: "1" });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout.toString("utf8")).toBe("ok\n");
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+    const spool = await readFile(telemetrySpoolPath(root), "utf8");
+    expect(spool).toContain(`"collection":"${RSP_DECISIONS_COLLECTION}"`);
+    expect(spool).toContain('"decision":"failed-open"');
+    expect(spool).toContain('"reason":"proxy-internal-error"');
+  });
+
   it("normalizes latency budgets to the sampled baseline and still catches regressions", async () => {
     expect(localBaselineRatio(100)).toBe(4);
     expect(normalizedDurationMs(1_000, 100)).toBe(4_000);

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -39,6 +39,7 @@ describe("resolveRspConfig", () => {
 
     expect(resolveRspConfig(join(root, "nested"), {}, undefined)).toEqual({
       enabled: false,
+      proxyEnabled: false,
       storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
       ttlDays: 3,
       ephemeralTtlHours: 4,
@@ -59,6 +60,7 @@ describe("resolveRspConfig", () => {
 
     expect(resolveRspConfig(root, {}, undefined)).toEqual({
       enabled: true,
+      proxyEnabled: false,
       storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       ephemeralTtlHours: DEFAULT_RSP_EPHEMERAL_TTL_HOURS,
@@ -70,6 +72,17 @@ describe("resolveRspConfig", () => {
       idleMs: DEFAULT_RSP_IDLE_MS,
       heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
     });
+  });
+
+  it("exposes the universal proxy flag separately from rsp enablement", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+
+    const config = resolveRspConfig(root, {}, undefined);
+
+    expect(config.enabled).toBe(true);
+    expect(config.proxyEnabled).toBe(true);
   });
 
   it("lets env override the heavy git truncation threshold", async () => {

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -107,6 +107,49 @@ describe("rsp interception pure rewrite table", () => {
 });
 
 describe("rsp Claude pre-execution hook integration", () => {
+  it("routes eligible commands through the universal proxy only when the proxy flag is enabled", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+
+    const decision = await hookDecisionFromCodexPreExecJson(
+      JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: "printf ok | sed s/ok/OK/" } }),
+      { cwd: root, wakeResident: () => undefined },
+    );
+
+    expect(decision).toEqual({
+      kind: "rewrite",
+      command: "rsp proxy -- 'printf ok | sed s/ok/OK/'",
+      capabilityId: "proxy:universal",
+    });
+    expect(formatCodexHookDecision(decision)).toEqual({
+      stdout: `${JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          updatedInput: { command: "rsp proxy -- 'printf ok | sed s/ok/OK/'" },
+        },
+      })}\n`,
+      status: 0,
+    });
+  });
+
+  it.each([
+    ["interactive", "vim file.txt", "interactive"],
+    ["background", "sleep 1 &", "background"],
+    ["opt-out-env", "RSP_NO_PROXY=1 git status", "opt-out"],
+    ["recursive-rsp", "rsp git status", "opt-out"],
+  ])("leaves %s commands unproxied under the universal proxy flag", async (_label, command, reason) => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+
+    await expect(hookDecisionFromCodexPreExecJson(
+      JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command } }),
+      { cwd: root },
+    )).resolves.toEqual({ kind: "passthrough", reason });
+  });
+
   it("accepts Claude hook JSON on stdin through the CLI and emits updatedInput", async () => {
     const root = await tempRoot();
     await mkdir(join(root, ".red"), { recursive: true });

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -673,6 +673,41 @@ describe("rsp telemetry spool", () => {
     expect(summary.decisions).toEqual({ seen: 1, contributed: 1 });
   }, 40_000);
 
+  it("routes a real Codex PreToolUse payload through the built bundle proxy and executes verbatim", async () => {
+    const root = await tempRoot();
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+    const bundle = await ensureRspBundle();
+    const command = "printf 'out\\n'; printf 'err\\n' >&2";
+    const payload = {
+      cwd: root,
+      tool_name: "bash",
+      tool_input: { command },
+    };
+
+    const hook = spawnSync(process.execPath, [bundle, "hook", "codex-pre-exec"], {
+      cwd: root,
+      input: Buffer.from(JSON.stringify(payload)),
+      encoding: "buffer",
+    });
+    expect(hook.status, `${hook.stdout.toString("utf8")}${hook.stderr.toString("utf8")}`).toBe(0);
+    const updated = JSON.parse(hook.stdout.toString("utf8")) as {
+      hookSpecificOutput: { updatedInput: { command: string } };
+    };
+    expect(updated.hookSpecificOutput.updatedInput.command).toBe("rsp proxy -- 'printf '\\''out\\n'\\''; printf '\\''err\\n'\\'' >&2'");
+
+    const raw = spawnSync(command, { cwd: root, shell: true, encoding: "buffer" });
+    const proxied = spawnSync(process.execPath, [bundle, "proxy", "--", command], {
+      cwd: root,
+      encoding: "buffer",
+    });
+
+    expect(proxied.stdout).toEqual(raw.stdout);
+    expect(proxied.stderr).toEqual(raw.stderr);
+    expect(proxied.status).toBe(raw.status);
+    expect(proxied.signal).toBe(raw.signal);
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toContain('"reason":"universal-proxy"');
+  }, 40_000);
+
   it("self-heals old-model rsp collections in the built bundle resident without losing elisions", async () => {
     const root = await tempRoot();
     const bundle = await ensureRspBundle();


### PR DESCRIPTION
Automated AFK landing for #1744. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1744

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786653484&installation_id=129708444&pr_number=1760&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1760&signature=1f544106971a6089e29286ef0ebe2dd4a6d4cc07377863611dcf1fb2c0c13c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->