### PR TITLE
fix: #1745 rsp in-proxy segment recognition: apply AXI-equivalent wrappers to noisy segments inside compound commands and pipes

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -140,7 +140,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   const residentPaths = resolveResidentPaths(process.cwd());
   if (args.command === "proxy") {
     const { runProxy } = await import("./proxy.js");
-    return await runProxy(args.positional, { telemetryRoot: residentPaths.rootDir });
+    return await runProxy(args.positional, { telemetryRoot: residentPaths.rootDir, level: args.level });
   }
   if (args.command === "status" || args.command === "sweep") {
     const { residentRegistryStatus, sweepResidentRegistry } = await import("./resident-client.js");

--- a/apps/rsp/src/proxy.ts
+++ b/apps/rsp/src/proxy.ts
@@ -3,14 +3,45 @@ import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION, RSP_TELEMETRY_INVOCATIO
 
 export interface ProxyRunOptions {
   telemetryRoot: string;
+  level?: ProxyLossLevel;
+}
+
+export type ProxyLossLevel = "lossless" | "brief" | "terse";
+
+export interface ProxySegmentMatch {
+  command: string;
+  commandFamily: string;
+  capabilityId: string;
+}
+
+interface ShellSegmentPart {
+  kind: "segment";
+  text: string;
+}
+
+interface ShellOperatorPart {
+  kind: "operator";
+  text: string;
+}
+
+type ShellPart = ShellSegmentPart | ShellOperatorPart;
+
+interface ShellWord {
+  raw: string;
+  value: string;
 }
 
 export async function runProxy(argv: readonly string[], options: ProxyRunOptions): Promise<number> {
   let commandLine = "";
+  let routedCommandLine = "";
+  let segmentMatches: ProxySegmentMatch[] = [];
   const started = process.hrtime.bigint();
   try {
     commandLine = parseProxyCommandLine(argv);
     if (process.env.RSP_PROXY_FAIL_INTERNAL === "1") throw new Error("forced proxy failure");
+    const rewritten = rewriteProxyCommandLine(commandLine, options.level ?? "lossless");
+    routedCommandLine = rewritten.commandLine;
+    segmentMatches = rewritten.matches;
   } catch (err) {
     if (commandLine) {
       await appendProxyFailedOpen(options.telemetryRoot, commandLine, err);
@@ -19,7 +50,10 @@ export async function runProxy(argv: readonly string[], options: ProxyRunOptions
     throw err;
   }
 
-  const status = await runShellVerbatim(commandLine);
+  for (const match of segmentMatches) {
+    await appendProxySegmentDecision(options.telemetryRoot, match);
+  }
+  const status = await runShellVerbatim(routedCommandLine || commandLine);
   const wrapperMs = Number(process.hrtime.bigint() - started) / 1_000_000;
   await appendTelemetryEvent(options.telemetryRoot, {
     collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -34,6 +68,23 @@ export async function runProxy(argv: readonly string[], options: ProxyRunOptions
     accounting_recorded: false,
   });
   return status;
+}
+
+export function rewriteProxyCommandLine(commandLine: string, level: ProxyLossLevel = "lossless"): {
+  commandLine: string;
+  matches: ProxySegmentMatch[];
+} {
+  const parts = splitShellParts(commandLine);
+  const matches: ProxySegmentMatch[] = [];
+  const rewritten = parts.map((part, index) => {
+    if (part.kind === "operator") return part.text;
+    if (nextOperator(parts, index) === "|") return part.text;
+    const rewrittenSegment = rewriteProxySegment(part.text, level);
+    if (!rewrittenSegment) return part.text;
+    matches.push(rewrittenSegment.match);
+    return rewrittenSegment.text;
+  }).join("");
+  return { commandLine: rewritten, matches };
 }
 
 export function parseProxyCommandLine(argv: readonly string[]): string {
@@ -59,6 +110,20 @@ async function appendProxyFailedOpen(rootDir: string, command: string, err: unkn
   });
 }
 
+async function appendProxySegmentDecision(rootDir: string, match: ProxySegmentMatch): Promise<void> {
+  await appendTelemetryEvent(rootDir, {
+    collection: RSP_DECISIONS_COLLECTION,
+    event_type: "decision",
+    ts: new Date().toISOString(),
+    hook: "proxy",
+    command: match.command,
+    command_family: match.commandFamily,
+    decision: "contributed",
+    reason: "proxy-segment",
+    capability_id: match.capabilityId,
+  });
+}
+
 async function runShellVerbatim(commandLine: string): Promise<number> {
   const child = spawn(commandLine, { shell: true, stdio: "inherit" });
   return await new Promise((resolve) => {
@@ -77,6 +142,188 @@ async function runShellVerbatim(commandLine: string): Promise<number> {
   });
 }
 
+function rewriteProxySegment(segment: string, level: ProxyLossLevel): { text: string; match: ProxySegmentMatch } | null {
+  const leading = segment.match(/^\s*/)?.[0] ?? "";
+  const trailing = segment.match(/\s*$/)?.[0] ?? "";
+  const core = segment.trim();
+  if (!core) return null;
+  const words = parseShellWords(core);
+  if (!words) return null;
+  const commandStart = commandWordStart(words);
+  if (commandStart >= words.length) return null;
+  const commandWords = words.slice(commandStart);
+  const match = matchProxyCapability(commandWords);
+  if (!match) return null;
+
+  const prefix = words.slice(0, commandStart).map((word) => word.raw);
+  const loss = level === "lossless" ? [] : [`--${level}`];
+  const rewrittenCore = [...prefix, "rsp", ...loss, ...match.wrapperWords].join(" ");
+  return {
+    text: `${leading}${rewrittenCore}${trailing}`,
+    match: {
+      command: commandWords.map((word) => word.raw).join(" "),
+      commandFamily: commandFamily(commandWords.map((word) => word.value).join(" ")),
+      capabilityId: match.capabilityId,
+    },
+  };
+}
+
+function matchProxyCapability(words: readonly ShellWord[]): { capabilityId: string; wrapperWords: string[] } | null {
+  const values = words.map((word) => word.value);
+  const raw = words.map((word) => word.raw);
+  if (values[0] === "git" && ["status", "log", "diff", "show", "blame"].includes(values[1] ?? "")) {
+    return { capabilityId: `git:${values[1]}`, wrapperWords: raw };
+  }
+  if (values[0] === "gh" && ["pr", "issue", "run"].includes(values[1] ?? "") && ["list", "view"].includes(values[2] ?? "")) {
+    return { capabilityId: `gh:${values[1]}:${values[2]}`, wrapperWords: raw };
+  }
+  if (values[0] === "vitest") {
+    return { capabilityId: values[1] === "run" ? "vitest:run" : "vitest", wrapperWords: raw };
+  }
+  if (values[0] === "cargo" && values[1] === "test") {
+    return { capabilityId: "cargo:test", wrapperWords: raw };
+  }
+  return matchFileDumpCapability(values, raw);
+}
+
+function matchFileDumpCapability(values: readonly string[], raw: readonly string[]): { capabilityId: string; wrapperWords: string[] } | null {
+  if (values[0] === "cat" && values.length === 2 && isPlainFileValue(values[1]!)) {
+    return { capabilityId: "cat:file", wrapperWords: ["cat", raw[1]!] };
+  }
+  if ((values[0] === "head" || values[0] === "tail") && values.length === 2 && isPlainFileValue(values[1]!)) {
+    return { capabilityId: `cat:${values[0]}`, wrapperWords: ["cat", `--${values[0]}`, "10", raw[1]!] };
+  }
+  if (
+    (values[0] === "head" || values[0] === "tail") &&
+    values.length === 4 &&
+    values[1] === "-n" &&
+    /^[1-9][0-9]*$/.test(values[2]!) &&
+    isPlainFileValue(values[3]!)
+  ) {
+    return { capabilityId: `cat:${values[0]}`, wrapperWords: ["cat", `--${values[0]}`, values[2]!, raw[3]!] };
+  }
+  return null;
+}
+
+function isPlainFileValue(value: string): boolean {
+  return Boolean(value) && !value.startsWith("-");
+}
+
+function commandWordStart(words: readonly ShellWord[]): number {
+  let index = 0;
+  while (index < words.length && isEnvAssignment(words[index]!.value)) index += 1;
+  if (words[index]?.value !== "env") return index;
+  index += 1;
+  while (index < words.length && isEnvAssignment(words[index]!.value)) index += 1;
+  return index;
+}
+
+function nextOperator(parts: readonly ShellPart[], index: number): string | undefined {
+  for (let cursor = index + 1; cursor < parts.length; cursor += 1) {
+    if (parts[cursor]!.kind === "operator") return parts[cursor]!.text;
+  }
+  return undefined;
+}
+
+function splitShellParts(commandLine: string): ShellPart[] {
+  const parts: ShellPart[] = [];
+  let start = 0;
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  for (let index = 0; index < commandLine.length; index += 1) {
+    const char = commandLine[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    const op = operatorAt(commandLine, index);
+    if (!op) continue;
+    if (index > start) parts.push({ kind: "segment", text: commandLine.slice(start, index) });
+    parts.push({ kind: "operator", text: op });
+    index += op.length - 1;
+    start = index + 1;
+  }
+  if (start < commandLine.length) parts.push({ kind: "segment", text: commandLine.slice(start) });
+  return parts;
+}
+
+function operatorAt(commandLine: string, index: number): string | undefined {
+  const two = commandLine.slice(index, index + 2);
+  if (two === "&&" || two === "||") return two;
+  const one = commandLine[index];
+  return one === ";" || one === "|" ? one : undefined;
+}
+
+function parseShellWords(segment: string): ShellWord[] | null {
+  const words: ShellWord[] = [];
+  let raw = "";
+  let value = "";
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  let inWord = false;
+
+  const push = () => {
+    if (!inWord) return;
+    words.push({ raw, value });
+    raw = "";
+    value = "";
+    inWord = false;
+  };
+
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    if (escaped) {
+      raw += char;
+      value += char;
+      escaped = false;
+      inWord = true;
+      continue;
+    }
+    if (char === "\\") {
+      raw += char;
+      escaped = true;
+      inWord = true;
+      continue;
+    }
+    if (quote) {
+      raw += char;
+      if (char === quote) quote = undefined;
+      else value += char;
+      inWord = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      raw += char;
+      quote = char;
+      inWord = true;
+      continue;
+    }
+    if (/[ \t]/.test(char)) {
+      push();
+      continue;
+    }
+    if (/[()<>`]/.test(char)) return null;
+    raw += char;
+    value += char;
+    inWord = true;
+  }
+  if (quote || escaped) return null;
+  push();
+  return words;
+}
+
 function commandFamily(command: string): string {
   const parts = command.trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) return "unknown";
@@ -86,4 +333,8 @@ function commandFamily(command: string): string {
   if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
   if (parts[0] === "vitest") return "vitest";
   return parts[0]!;
+}
+
+function isEnvAssignment(token: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token);
 }

--- a/apps/rsp/tests/proxy.test.ts
+++ b/apps/rsp/tests/proxy.test.ts
@@ -1,0 +1,195 @@
+import { execFile, spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_RSP_BYTE_BUDGET,
+  DEFAULT_RSP_EPHEMERAL_TTL_HOURS,
+  DEFAULT_RSP_TELEMETRY_BYTE_BUDGET,
+  DEFAULT_RSP_TELEMETRY_TTL_DAYS,
+  DEFAULT_RSP_TTL_DAYS,
+} from "../src/config.js";
+import { resolveResidentPaths } from "../src/resident-client.js";
+import { sendResidentRequest } from "../src/resident-protocol.js";
+import { telemetrySpoolPath } from "../src/telemetry.js";
+import { rewriteProxyCommandLine } from "../src/proxy.js";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-proxy-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("rsp proxy segment recognition", () => {
+  it("rewrites recognized stdout-tail segments and leaves pipeline producers raw", () => {
+    expect(rewriteProxyCommandLine("cd apps && git log", "terse")).toMatchObject({
+      commandLine: "cd apps && rsp --terse git log",
+      matches: [expect.objectContaining({ capabilityId: "git:log", command: "git log" })],
+    });
+    expect(rewriteProxyCommandLine("printf 'x\\n' | grep x", "brief")).toMatchObject({
+      commandLine: "printf 'x\\n' | grep x",
+      matches: [],
+    });
+    expect(rewriteProxyCommandLine("git log | tail -5", "brief")).toMatchObject({
+      commandLine: "git log | tail -5",
+      matches: [],
+    });
+    expect(rewriteProxyCommandLine("printf before; gh pr list --limit 5", "brief")).toMatchObject({
+      commandLine: "printf before; rsp --brief gh pr list --limit 5",
+      matches: [expect.objectContaining({ capabilityId: "gh:pr:list", command: "gh pr list --limit 5" })],
+    });
+  });
+
+  it("summarizes a contributed tail segment with a recoverable elision handle", async () => {
+    const root = await tempRoot();
+    const bundle = await ensureRspBundle();
+    const setup = spawnSync(process.execPath, [bundle, "setup"], { cwd: root, encoding: "utf8" });
+    expect(setup.status, `${setup.stdout}${setup.stderr}`).toBe(0);
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  proxy:\n    enabled: true\n", "utf8");
+    await installRspShim(root, bundle);
+    initGitRepo(root);
+    const paths = resolveResidentPaths(root);
+    const server = execFile(process.execPath, [
+      bundle,
+      "server",
+      "--socket",
+      paths.socketPath,
+      "--pid-file",
+      paths.pidPath,
+      "--store-uri",
+      `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
+      "--ttl-days",
+      String(DEFAULT_RSP_TTL_DAYS),
+      "--ephemeral-ttl-hours",
+      String(DEFAULT_RSP_EPHEMERAL_TTL_HOURS),
+      "--byte-budget",
+      String(DEFAULT_RSP_BYTE_BUDGET),
+      "--telemetry-ttl-days",
+      String(DEFAULT_RSP_TELEMETRY_TTL_DAYS),
+      "--telemetry-byte-budget",
+      String(DEFAULT_RSP_TELEMETRY_BYTE_BUDGET),
+      "--telemetry-drain-timeout-ms",
+      "2000",
+      "--idle-ms",
+      "5000",
+      "--registry",
+      paths.registryPath,
+    ], { cwd: root });
+    await waitForResident(paths.socketPath);
+
+    const env = { ...process.env, PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}` };
+    try {
+      const proxied = spawnSync(process.execPath, [
+        bundle,
+        "--terse",
+        "proxy",
+        "--",
+        "printf 'prefix\\n'; git log",
+      ], { cwd: root, env, encoding: "utf8" });
+
+      expect(proxied.status, `${proxied.stdout}${proxied.stderr}`).toBe(0);
+      expect(proxied.stdout).toContain("prefix\n");
+      const handle = /rsp show (el:[a-z0-9]+)/.exec(proxied.stdout)?.[1];
+      expect(handle, `${proxied.stdout}${proxied.stderr}`).toBeTruthy();
+
+      const recovered = spawnSync(process.execPath, [bundle, "show", handle!], {
+        cwd: root,
+        env,
+        encoding: "utf8",
+      });
+      expect(recovered.status, recovered.stderr).toBe(0);
+      expect(recovered.stdout).toContain("commits");
+
+      const decisions = await readFile(telemetrySpoolPath(root), "utf8");
+      expect(decisions).toContain('"hook":"proxy"');
+      expect(decisions).toContain('"command":"git log"');
+      expect(decisions).toContain('"command_family":"git log"');
+      expect(decisions).toContain('"decision":"contributed"');
+      expect(decisions).toContain('"capability_id":"git:log"');
+    } finally {
+      await shutdownResident(paths.socketPath);
+      await waitForExit(server);
+    }
+  }, 30_000);
+});
+
+async function installRspShim(root: string, bundle: string): Promise<void> {
+  const binDir = join(root, "bin");
+  await mkdir(binDir, { recursive: true });
+  const shim = [
+    "#!/usr/bin/env bash",
+    `exec "${process.execPath}" "${bundle}" "$@"`,
+    "",
+  ].join("\n");
+  await writeFile(join(binDir, "rsp"), shim, "utf8");
+  await chmod(join(binDir, "rsp"), 0o755);
+}
+
+async function ensureRspBundle(): Promise<string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const appRoot = resolve(here, "..");
+  const repoRoot = resolve(appRoot, "..", "..");
+  const bundle = join(repoRoot, "dist", "rsp.bundle.min.mjs");
+  await execFileAsync(process.execPath, [
+    join(repoRoot, "scripts", "bundle-app.mjs"),
+    "--entry",
+    "src/cli.ts",
+    "--outfile",
+    "../../dist/rsp.bundle.min.mjs",
+    "--asset",
+    "rsp.bundle.min.mjs",
+    "--minify",
+    "--reddb-from-package",
+  ], { cwd: appRoot });
+  return bundle;
+}
+
+function initGitRepo(root: string): void {
+  expect(spawnSync("git", ["init"], { cwd: root }).status).toBe(0);
+  expect(spawnSync("git", ["config", "user.email", "rsp@example.test"], { cwd: root }).status).toBe(0);
+  expect(spawnSync("git", ["config", "user.name", "RSP Test"], { cwd: root }).status).toBe(0);
+  for (let index = 0; index < 5; index += 1) {
+    const file = join(root, `file-${index}.txt`);
+    spawnSync("sh", ["-c", `printf 'line ${index}\\n' > "$1"`, "sh", file], { cwd: root });
+    expect(spawnSync("git", ["add", `file-${index}.txt`], { cwd: root }).status).toBe(0);
+    expect(spawnSync("git", ["commit", "-m", `commit ${index}`], { cwd: root }).status).toBe(0);
+  }
+}
+
+async function waitForResident(socketPath: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const alive = await sendResidentRequest({ socketPath, timeoutMs: 100 }, {
+      id: "proxy-test-ping",
+      op: "ping",
+    }).then((response) => response.ok, () => false);
+    if (alive) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("resident did not start");
+}
+
+async function shutdownResident(socketPath: string): Promise<void> {
+  await sendResidentRequest({ socketPath, timeoutMs: 500 }, {
+    id: "proxy-test-shutdown",
+    op: "handover",
+    clientVersion: "proxy-test",
+  }).catch(() => null);
+}
+
+async function waitForExit(child: ReturnType<typeof execFile>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`resident exited ${code}`)));
+    child.once("error", reject);
+  });
+}


### PR DESCRIPTION
Automated AFK landing for #1745. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1745

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786654674&installation_id=129708444&pr_number=1761&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1761&signature=c34bd3a94c711d73a33bbf8736a5c5c99498ce07ee72288d710749053fa12549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->