### PR TITLE
fix: #1746 rsp family matching that matches reality: prefix-matched families, stderr-redirect allowlist, shell-aware tokenizer

### DIFF
--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -32,6 +32,16 @@ type HookDecisionResult = {
   event: RspTelemetryEvent;
 };
 
+type ShellToken = {
+  text: string;
+  quoted: boolean;
+};
+
+type ParsedSimpleCommand = {
+  tokens: ShellToken[];
+  redirectSuffix: ShellToken[];
+};
+
 export interface HookDecisionOptions {
   cwd: string;
   isEnabled?: (cwd: string) => boolean | Promise<boolean>;
@@ -69,30 +79,38 @@ export function rewriteTableFromCapabilities(capabilities: readonly RspWrapperCa
 }
 
 export function rewriteCommand(command: string): RewriteDecision {
-  const tokens = tokenizeCertainSimpleCommand(command);
-  if (!tokens) return rewriteCompoundCommand(command);
+  const parsed = parseCertainSimpleCommand(command);
+  if (!parsed) return rewriteCompoundCommand(command);
+  const tokens = parsed.tokens.map((token) => token.text);
   if (tokens.length > 0 && isEnvAssignment(tokens[0]!)) return rewriteCompoundCommand(command);
 
-  const fileRead = rewriteFileReadCommand(tokens);
+  const fileRead = rewriteFileReadCommand(parsed);
   if (fileRead) return fileRead;
 
-  const rewritten = DEFAULT_REWRITE_TABLE.get(commandKey(tokens));
-  if (!rewritten) return rewriteCompoundCommand(command);
-  const capability = RSP_WRAPPER_CAPABILITIES.find((entry) => commandKey(entry.command) === commandKey(tokens));
+  if (parsed.tokens.some((token) => token.quoted)) return rewriteCompoundCommand(command);
+
+  const capability = [...RSP_WRAPPER_CAPABILITIES]
+    .sort((left, right) => right.command.length - left.command.length)
+    .find((entry) => tokensStartWith(tokens, entry.command));
+  if (!capability) return rewriteCompoundCommand(command);
+  const rewritten = ["rsp", ...capability.wrapper, ...tokens.slice(capability.command.length)];
+  const redirectSuffix = formatRedirectSuffix(parsed.redirectSuffix);
   return {
     kind: "rewrite",
-    command: rewritten.join(" "),
-    capabilityId: capability?.id ?? commandKey(tokens),
+    command: [...rewritten.map(shellQuoteIfNeeded), ...redirectSuffix].join(" "),
+    capabilityId: capability.id,
   };
 }
 
-function rewriteFileReadCommand(tokens: readonly string[]): RewriteDecision | null {
+function rewriteFileReadCommand(parsed: ParsedSimpleCommand): RewriteDecision | null {
+  const tokens = parsed.tokens.map((token) => token.text);
   const command = tokens[0];
+  const redirectSuffix = formatRedirectSuffix(parsed.redirectSuffix);
   if (command === "cat" && tokens.length === 2 && isPlainFileToken(tokens[1]!)) {
-    return { kind: "rewrite", command: `rsp cat ${tokens[1]}`, capabilityId: "cat:file" };
+    return { kind: "rewrite", command: ["rsp", "cat", shellQuoteIfNeeded(tokens[1]!), ...redirectSuffix].join(" "), capabilityId: "cat:file" };
   }
   if ((command === "head" || command === "tail") && tokens.length === 2 && isPlainFileToken(tokens[1]!)) {
-    return { kind: "rewrite", command: `rsp cat --${command} 10 ${tokens[1]}`, capabilityId: `cat:${command}` };
+    return { kind: "rewrite", command: ["rsp", "cat", `--${command}`, "10", shellQuoteIfNeeded(tokens[1]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
   }
   if (
     (command === "head" || command === "tail") &&
@@ -101,13 +119,21 @@ function rewriteFileReadCommand(tokens: readonly string[]): RewriteDecision | nu
     /^[1-9][0-9]*$/.test(tokens[2]!) &&
     isPlainFileToken(tokens[3]!)
   ) {
-    return { kind: "rewrite", command: `rsp cat --${command} ${tokens[2]} ${tokens[3]}`, capabilityId: `cat:${command}` };
+    return { kind: "rewrite", command: ["rsp", "cat", `--${command}`, tokens[2]!, shellQuoteIfNeeded(tokens[3]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
+  }
+  if (
+    (command === "head" || command === "tail") &&
+    tokens.length === 3 &&
+    /^-[1-9][0-9]*$/.test(tokens[1]!) &&
+    isPlainFileToken(tokens[2]!)
+  ) {
+    return { kind: "rewrite", command: ["rsp", "cat", `--${command}`, tokens[1]!.slice(1), shellQuoteIfNeeded(tokens[2]!), ...redirectSuffix].join(" "), capabilityId: `cat:${command}` };
   }
   return null;
 }
 
 function isPlainFileToken(token: string): boolean {
-  return Boolean(token) && !token.startsWith("-") && !/[ \t]/.test(token);
+  return Boolean(token) && !token.startsWith("-");
 }
 
 export async function hookDecisionFromClaudePreExecJson(
@@ -379,14 +405,90 @@ function extractHookCommand(payload: Record<string, unknown>): string {
   );
 }
 
-function tokenizeCertainSimpleCommand(command: string): string[] | null {
+function parseCertainSimpleCommand(command: string): ParsedSimpleCommand | null {
   const trimmed = command.trim();
   if (!trimmed) return null;
-  if (/[\n\r|&;()$<>`'"]/.test(trimmed)) return null;
-  const tokens = trimmed.split(/[ \t]+/).filter(Boolean);
+  if (/[\n\r|;()$`]/.test(trimmed)) return null;
+  const tokens = shellTokens(trimmed);
   if (tokens.length === 0) return null;
-  if (tokens.some((token) => token.includes("=") && isEnvAssignment(token))) return null;
+  if (tokens[0]?.quoted) return null;
+  if (tokens.some((token) => /[()$`]/.test(token.text))) return null;
+  if (tokens.some((token) => token.text.includes("=") && isEnvAssignment(token.text))) return null;
+  const commandTokens: ShellToken[] = [];
+  const redirectSuffix: ShellToken[] = [];
+  for (const token of tokens) {
+    if (token.text.includes(">") || token.text.includes("<")) {
+      if (token.quoted || (token.text !== "2>/dev/null" && token.text !== "2>&1")) return null;
+      redirectSuffix.push(token);
+      continue;
+    }
+    commandTokens.push(token);
+  }
+  if (commandTokens.length === 0) return null;
+  return { tokens: commandTokens, redirectSuffix };
+}
+
+function shellTokens(command: string): ShellToken[] {
+  const tokens: ShellToken[] = [];
+  let text = "";
+  let quoted = false;
+  let quote: "'" | "\"" | null = null;
+
+  const push = () => {
+    if (!text && !quoted) return;
+    tokens.push({ text, quoted });
+    text = "";
+    quoted = false;
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const ch = command[index]!;
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      if (quote === "\"" && ch === "\\" && index + 1 < command.length) {
+        index += 1;
+        text += command[index]!;
+        continue;
+      }
+      text += ch;
+      continue;
+    }
+    if (ch === "'" || ch === "\"") {
+      quote = ch;
+      quoted = true;
+      continue;
+    }
+    if (ch === "\\" && index + 1 < command.length) {
+      index += 1;
+      text += command[index]!;
+      continue;
+    }
+    if (/[ \t]/.test(ch)) {
+      push();
+      continue;
+    }
+    text += ch;
+  }
+
+  if (quote) return [];
+  push();
   return tokens;
+}
+
+function tokensStartWith(tokens: readonly string[], prefix: readonly string[]): boolean {
+  if (tokens.length < prefix.length) return false;
+  return prefix.every((token, index) => tokens[index] === token);
+}
+
+function formatRedirectSuffix(tokens: readonly ShellToken[]): string[] {
+  return tokens.map((token) => token.text);
+}
+
+function shellQuoteIfNeeded(value: string): string {
+  return /[^\w@%+=:,./-]/.test(value) ? shellSingleQuote(value) : value;
 }
 
 function proxyCommand(command: string): RewriteDecision {

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -55,11 +55,24 @@ describe("rsp interception pure rewrite table", () => {
 
   it.each([
     ["cat-simple-file", "cat apps/rsp/src/cli.ts", "rsp cat apps/rsp/src/cli.ts", "cat:file"],
+    ["cat-quoted-file", "cat 'two words.txt'", "rsp cat 'two words.txt'", "cat:file"],
     ["head-default-file", "head apps/rsp/src/cli.ts", "rsp cat --head 10 apps/rsp/src/cli.ts", "cat:head"],
     ["head-n-file", "head -n 25 apps/rsp/src/cli.ts", "rsp cat --head 25 apps/rsp/src/cli.ts", "cat:head"],
+    ["head-short-n-file", "head -25 apps/rsp/src/cli.ts", "rsp cat --head 25 apps/rsp/src/cli.ts", "cat:head"],
     ["tail-default-file", "tail apps/rsp/src/cli.ts", "rsp cat --tail 10 apps/rsp/src/cli.ts", "cat:tail"],
     ["tail-n-file", "tail -n 25 apps/rsp/src/cli.ts", "rsp cat --tail 25 apps/rsp/src/cli.ts", "cat:tail"],
+    ["tail-short-n-file", "tail -25 apps/rsp/src/cli.ts", "rsp cat --tail 25 apps/rsp/src/cli.ts", "cat:tail"],
   ])("rewrites conservative file dump shape %s", (_name, command, rewritten, capabilityId) => {
+    expect(rewriteCommand(command)).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
+  });
+
+  it.each([
+    ["git-log-format-flags", "git log --oneline --decorate=short", "rsp git log --oneline --decorate=short", "git:log"],
+    ["git-diff-stat-range", "git diff --stat origin/main..HEAD", "rsp git diff --stat origin/main..HEAD", "git:diff"],
+    ["gh-pr-view-selector", "gh pr view 1746 --json number,title", "rsp gh pr view 1746 --json number,title", "gh:pr:view"],
+    ["git-status-stderr-null", "git status --short 2>/dev/null", "rsp git status --short 2>/dev/null", "git:status"],
+    ["git-log-stderr-merge", "git log --oneline 2>&1", "rsp git log --oneline 2>&1", "git:log"],
+  ])("rewrites flagged or stderr-only family shape %s", (_name, command, rewritten, capabilityId) => {
     expect(rewriteCommand(command)).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
   });
 
@@ -70,7 +83,9 @@ describe("rsp interception pure rewrite table", () => {
     ["env-prefix-is-ambiguous", "GIT_DIR=.git git status"],
     ["silent-predicate-grep-q", "grep -q needle file"],
     ["redirection-is-ambiguous", "git status > status.txt"],
-    ["cat-space-path-is-ambiguous", "cat \"two words.txt\""],
+    ["stdout-redirection-is-ambiguous", "git status > status.txt"],
+    ["stdin-redirection-is-ambiguous", "git status < input.txt"],
+    ["stderr-file-redirection-is-ambiguous", "git status 2>err.txt"],
     ["cat-multiple-files-is-ambiguous", "cat a.txt b.txt"],
     ["head-option-shape-is-ambiguous", "head -c 20 file.txt"],
     ["subshell-is-ambiguous", "$(git status)"],
@@ -99,7 +114,6 @@ describe("rsp interception pure rewrite table", () => {
     ["command-substitution-capture", "foo $(git log)"],
     ["already-rsp", "cd apps && rsp git log"],
     ["here-doc", "cat <<EOF"],
-    ["single-noisy-command-with-args", "git log --oneline"],
     ["silent-predicate", "git log | grep -q fix"],
   ])("passes through unsafe compound fixture %s", (_name, command) => {
     expect(rewriteCommand(command)).toEqual({ kind: "passthrough" });
@@ -253,7 +267,7 @@ describe("rsp Claude pre-execution hook integration", () => {
     });
   });
 
-  it("prints nothing and exits non-zero on passthrough", async () => {
+  it("prints updatedInput for flagged family forms", async () => {
     const root = await tempRoot();
     let healthCalls = 0;
     let wakeCalls = 0;
@@ -272,9 +286,18 @@ describe("rsp Claude pre-execution hook integration", () => {
       },
     );
 
-    expect(formatHookDecision(result)).toEqual({ stdout: "", status: 0 });
+    expect(formatHookDecision(result)).toEqual({
+      stdout: JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+          updatedInput: { command: "rsp git status --short" },
+        },
+      }) + "\n",
+      status: 0,
+    });
     expect(healthCalls).toBe(0);
-    expect(wakeCalls).toBe(0);
+    expect(wakeCalls).toBe(1);
   });
 
   it("rewrites and wakes the resident without health-gating the decision", async () => {
@@ -419,5 +442,37 @@ describe("rsp Codex pre-execution hook integration", () => {
       reason: "matched-capability",
       capability_id: "git:status",
     });
+  });
+
+  it("records quarter-plus coverage when replaying representative agent command corpus", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    const corpus = [
+      "git log --oneline --decorate=short",
+      "git diff --stat origin/main..HEAD",
+      "gh pr view 1746 --json number,title",
+      "cat 'two words.txt'",
+      "echo ok",
+      "git status > status.txt",
+      "grep -q needle file.txt",
+      "sleep 1 &",
+    ];
+
+    for (const command of corpus) {
+      const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "codex-pre-exec"], {
+        cwd: root,
+        input: Buffer.from(JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command } })),
+      });
+      expect(res.status, `${res.stdout.toString("utf8")}${res.stderr.toString("utf8")}`).toBe(0);
+    }
+
+    const events = (await readFile(telemetrySpoolPath(root), "utf8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as { decision: string });
+    const contributed = events.filter((event) => event.decision === "contributed").length;
+    expect(events).toHaveLength(corpus.length);
+    expect(contributed / events.length).toBeGreaterThanOrEqual(0.25);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1746. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1746

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786655319&installation_id=129708444&pr_number=1762&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1762&signature=a322faf3a7e89a4789ee782c70dd169f1dc2ba340eee6866b525398d3c79c9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->