### PR TITLE
fix: #1747 rsp lossless gh --json/--jq family: recognize, record decision telemetry, pass through unsummarized

### DIFF
--- a/apps/rsp/src/intercept.ts
+++ b/apps/rsp/src/intercept.ts
@@ -71,6 +71,7 @@ export const RSP_WRAPPER_CAPABILITIES: readonly RspWrapperCapability[] = [
 ];
 
 const DEFAULT_REWRITE_TABLE = rewriteTableFromCapabilities(RSP_WRAPPER_CAPABILITIES);
+const LOSSLESS_GH_JSON_JQ_REASON = "lossless-gh-json-jq";
 
 export function rewriteTableFromCapabilities(capabilities: readonly RspWrapperCapability[]): Map<string, readonly string[]> {
   const table = new Map<string, readonly string[]>();
@@ -79,6 +80,9 @@ export function rewriteTableFromCapabilities(capabilities: readonly RspWrapperCa
 }
 
 export function rewriteCommand(command: string): RewriteDecision {
+  const losslessGh = losslessGhJsonJqPassthrough(command);
+  if (losslessGh) return losslessGh;
+
   const parsed = parseCertainSimpleCommand(command);
   if (!parsed) return rewriteCompoundCommand(command);
   const tokens = parsed.tokens.map((token) => token.text);
@@ -483,6 +487,20 @@ function tokensStartWith(tokens: readonly string[], prefix: readonly string[]): 
   return prefix.every((token, index) => tokens[index] === token);
 }
 
+function losslessGhJsonJqPassthrough(command: string): RewriteDecision | null {
+  const tokens = shellTokens(command.trim()).map((token) => token.text);
+  if (!isGhJsonJqSelection(tokens)) return null;
+  return { kind: "passthrough", reason: LOSSLESS_GH_JSON_JQ_REASON };
+}
+
+function isGhJsonJqSelection(tokens: readonly string[]): boolean {
+  return tokens[0] === "gh" && tokens.some(isJsonJqSelectionFlag);
+}
+
+function isJsonJqSelectionFlag(token: string): boolean {
+  return token === "--json" || token === "--jq" || token.startsWith("--json=") || token.startsWith("--jq=");
+}
+
 function formatRedirectSuffix(tokens: readonly ShellToken[]): string[] {
   return tokens.map((token) => token.text);
 }
@@ -612,6 +630,9 @@ function commandFamily(command: string): string {
   const parts = command.trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) return "unknown";
   if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
+  if (isGhJsonJqSelection(parts) && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]} json-jq`;
+  if (isGhJsonJqSelection(parts) && parts[1]) return `gh ${parts[1]} json-jq`;
+  if (isGhJsonJqSelection(parts)) return "gh json-jq";
   if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
   if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
   if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;

--- a/apps/rsp/src/proxy.ts
+++ b/apps/rsp/src/proxy.ts
@@ -11,7 +11,9 @@ export type ProxyLossLevel = "lossless" | "brief" | "terse";
 export interface ProxySegmentMatch {
   command: string;
   commandFamily: string;
-  capabilityId: string;
+  decision: "contributed" | "passed";
+  reason: string;
+  capabilityId?: string;
 }
 
 interface ShellSegmentPart {
@@ -118,8 +120,8 @@ async function appendProxySegmentDecision(rootDir: string, match: ProxySegmentMa
     hook: "proxy",
     command: match.command,
     command_family: match.commandFamily,
-    decision: "contributed",
-    reason: "proxy-segment",
+    decision: match.decision,
+    reason: match.reason,
     capability_id: match.capabilityId,
   });
 }
@@ -152,6 +154,18 @@ function rewriteProxySegment(segment: string, level: ProxyLossLevel): { text: st
   const commandStart = commandWordStart(words);
   if (commandStart >= words.length) return null;
   const commandWords = words.slice(commandStart);
+  const commandValues = commandWords.map((word) => word.value);
+  if (isGhJsonJqSelection(commandValues)) {
+    return {
+      text: segment,
+      match: {
+        command: commandWords.map((word) => word.raw).join(" "),
+        commandFamily: commandFamily(commandValues.join(" ")),
+        decision: "passed",
+        reason: "lossless-gh-json-jq",
+      },
+    };
+  }
   const match = matchProxyCapability(commandWords);
   if (!match) return null;
 
@@ -162,7 +176,9 @@ function rewriteProxySegment(segment: string, level: ProxyLossLevel): { text: st
     text: `${leading}${rewrittenCore}${trailing}`,
     match: {
       command: commandWords.map((word) => word.raw).join(" "),
-      commandFamily: commandFamily(commandWords.map((word) => word.value).join(" ")),
+      commandFamily: commandFamily(commandValues.join(" ")),
+      decision: "contributed",
+      reason: "proxy-segment",
       capabilityId: match.capabilityId,
     },
   };
@@ -328,11 +344,22 @@ function commandFamily(command: string): string {
   const parts = command.trim().split(/\s+/).filter(Boolean);
   if (parts.length === 0) return "unknown";
   if (parts[0] === "git" && parts[1]) return `git ${parts[1]}`;
+  if (isGhJsonJqSelection(parts) && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]} json-jq`;
+  if (isGhJsonJqSelection(parts) && parts[1]) return `gh ${parts[1]} json-jq`;
+  if (isGhJsonJqSelection(parts)) return "gh json-jq";
   if (parts[0] === "gh" && parts[1] && parts[2]) return `gh ${parts[1]} ${parts[2]}`;
   if (parts[0] === "gh" && parts[1]) return `gh ${parts[1]}`;
   if (parts[0] === "cargo" && parts[1]) return `cargo ${parts[1]}`;
   if (parts[0] === "vitest") return "vitest";
   return parts[0]!;
+}
+
+function isGhJsonJqSelection(tokens: readonly string[]): boolean {
+  return tokens[0] === "gh" && tokens.some(isJsonJqSelectionFlag);
+}
+
+function isJsonJqSelectionFlag(token: string): boolean {
+  return token === "--json" || token === "--jq" || token.startsWith("--json=") || token.startsWith("--jq=");
 }
 
 function isEnvAssignment(token: string): boolean {

--- a/apps/rsp/tests/intercept.test.ts
+++ b/apps/rsp/tests/intercept.test.ts
@@ -69,11 +69,18 @@ describe("rsp interception pure rewrite table", () => {
   it.each([
     ["git-log-format-flags", "git log --oneline --decorate=short", "rsp git log --oneline --decorate=short", "git:log"],
     ["git-diff-stat-range", "git diff --stat origin/main..HEAD", "rsp git diff --stat origin/main..HEAD", "git:diff"],
-    ["gh-pr-view-selector", "gh pr view 1746 --json number,title", "rsp gh pr view 1746 --json number,title", "gh:pr:view"],
     ["git-status-stderr-null", "git status --short 2>/dev/null", "rsp git status --short 2>/dev/null", "git:status"],
     ["git-log-stderr-merge", "git log --oneline 2>&1", "rsp git log --oneline 2>&1", "git:log"],
   ])("rewrites flagged or stderr-only family shape %s", (_name, command, rewritten, capabilityId) => {
     expect(rewriteCommand(command)).toEqual({ kind: "rewrite", command: rewritten, capabilityId });
+  });
+
+  it.each([
+    ["json-fields", "gh pr view 1747 --json number,title"],
+    ["jq-expression", "gh run view 9001 --json databaseId --jq '.databaseId'"],
+    ["api-jq", "gh api repos/reddb-io/red-skills --jq .name"],
+  ])("passes through lossless gh json/jq selector family %s", (_name, command) => {
+    expect(rewriteCommand(command)).toEqual({ kind: "passthrough", reason: "lossless-gh-json-jq" });
   });
 
   it.each([
@@ -441,6 +448,30 @@ describe("rsp Codex pre-execution hook integration", () => {
       decision: "contributed",
       reason: "matched-capability",
       capability_id: "git:status",
+    });
+  });
+
+  it("records gh json/jq selectors as lossless passthrough decisions", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+
+    const res = spawnSync(process.execPath, ["--import", tsxLoader, cli, "hook", "codex-pre-exec"], {
+      cwd: root,
+      input: Buffer.from(JSON.stringify({ cwd: root, tool_name: "bash", tool_input: { command: "gh pr view 1747 --json number,title --jq .number" } })),
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toEqual(Buffer.alloc(0));
+    const lines = (await readFile(telemetrySpoolPath(root), "utf8")).trim().split(/\r?\n/);
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      collection: RSP_DECISIONS_COLLECTION,
+      hook: "codex-pre-exec",
+      command: "gh pr view 1747 --json number,title --jq .number",
+      command_family: "gh pr view json-jq",
+      decision: "passed",
+      reason: "lossless-gh-json-jq",
     });
   });
 

--- a/apps/rsp/tests/proxy.test.ts
+++ b/apps/rsp/tests/proxy.test.ts
@@ -48,6 +48,17 @@ describe("rsp proxy segment recognition", () => {
       commandLine: "printf before; rsp --brief gh pr list --limit 5",
       matches: [expect.objectContaining({ capabilityId: "gh:pr:list", command: "gh pr list --limit 5" })],
     });
+    expect(rewriteProxyCommandLine("printf before; gh pr list --json number,title --jq '.[] | .number'", "brief")).toMatchObject({
+      commandLine: "printf before; gh pr list --json number,title --jq '.[] | .number'",
+      matches: [
+        expect.objectContaining({
+          command: "gh pr list --json number,title --jq '.[] | .number'",
+          commandFamily: "gh pr list json-jq",
+          decision: "passed",
+          reason: "lossless-gh-json-jq",
+        }),
+      ],
+    });
   });
 
   it("summarizes a contributed tail segment with a recoverable elision handle", async () => {
@@ -120,6 +131,34 @@ describe("rsp proxy segment recognition", () => {
       await shutdownResident(paths.socketPath);
       await waitForExit(server);
     }
+  }, 30_000);
+
+  it("executes gh json/jq selector segments byte-identically and records a lossless pass", async () => {
+    const root = await tempRoot();
+    const bundle = await ensureRspBundle();
+    const setup = spawnSync(process.execPath, [bundle, "setup"], { cwd: root, encoding: "utf8" });
+    expect(setup.status, `${setup.stdout}${setup.stderr}`).toBe(0);
+    await mkdir(join(root, "bin"), { recursive: true });
+    await writeFile(join(root, "bin", "gh"), "#!/usr/bin/env sh\nprintf '%s\\n' '[{\"number\":1747,\"title\":\"lossless\"}]'\n", "utf8");
+    await chmod(join(root, "bin", "gh"), 0o755);
+
+    const env = { ...process.env, PATH: `${join(root, "bin")}:${process.env.PATH ?? ""}` };
+    const proxied = spawnSync(process.execPath, [
+      bundle,
+      "--brief",
+      "proxy",
+      "--",
+      "gh pr list --json number,title --jq '.[0]'",
+    ], { cwd: root, env, encoding: "utf8" });
+
+    expect(proxied.status, `${proxied.stdout}${proxied.stderr}`).toBe(0);
+    expect(proxied.stdout).toBe("[{\"number\":1747,\"title\":\"lossless\"}]\n");
+    const decisions = await readFile(telemetrySpoolPath(root), "utf8");
+    expect(decisions).toContain('"hook":"proxy"');
+    expect(decisions).toContain('"command":"gh pr list --json number,title --jq \'.[0]\'"');
+    expect(decisions).toContain('"command_family":"gh pr list json-jq"');
+    expect(decisions).toContain('"decision":"passed"');
+    expect(decisions).toContain('"reason":"lossless-gh-json-jq"');
   }, 30_000);
 });
 

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -541,6 +541,14 @@ describe("rsp telemetry spool", () => {
         decision: "passed",
         reason: "unsupported-command",
       });
+      await db.kv(RSP_DECISIONS_COLLECTION).put("passed-lossless-gh-json-jq", {
+        created_at: "2026-07-10T10:01:30.000Z",
+        hook: "codex-pre-exec",
+        command: "gh pr view 1747 --json number,title",
+        command_family: "gh pr view json-jq",
+        decision: "passed",
+        reason: "lossless-gh-json-jq",
+      });
       await db.kv(RSP_DECISIONS_COLLECTION).put("failed-open", {
         created_at: "2026-07-10T10:02:00.000Z",
         hook: "codex-pre-exec",
@@ -553,14 +561,15 @@ describe("rsp telemetry spool", () => {
       const stats = await readTelemetryStats(db, 7, new Date("2026-07-11T00:00:00.000Z"));
 
       expect(stats.decisions).toEqual({
-        seen: 3,
+        seen: 4,
         contributed: 0,
-        passed: 2,
+        passed: 3,
         failed_open: 1,
         contribution_rate: 0,
         top_pass_reasons: [
           { reason: "disabled", count: 1 },
           { reason: "hook-exception", count: 1 },
+          { reason: "lossless-gh-json-jq", count: 1 },
           { reason: "unsupported-command", count: 1 },
         ],
       });


### PR DESCRIPTION
Automated AFK landing for #1747. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1747

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786656003&installation_id=129708444&pr_number=1763&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1763&signature=f17887aa1f52b8d0864c00ed36894950ebe556a5644b14cd3e2d7830831d6505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->