### PR TITLE
fix: #1778 TOON wave 1 S3: flatten the attempt-firehose type=raw double-encoding

### DIFF
--- a/apps/dev/src/commands/activity-review.ts
+++ b/apps/dev/src/commands/activity-review.ts
@@ -214,12 +214,23 @@ function asPositiveNumber(value: unknown): number | null {
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 
-function collectTokensFromObject(value: unknown): { input: number; output: number; total: number; hits: number } {
+export function collectTokensFromObject(value: unknown): { input: number; output: number; total: number; hits: number } {
   let input = 0;
   let output = 0;
   let total = 0;
   let hits = 0;
   const visit = (node: unknown): void => {
+    if (typeof node === "string") {
+      const trimmed = node.trim();
+      if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return;
+      try {
+        visit(JSON.parse(trimmed));
+      } catch {
+        // Old raw firehose records carried arbitrary text in `msg`; only parse
+        // JSON-looking strings so regular output remains advisory and ignored.
+      }
+      return;
+    }
     if (node === null || typeof node !== "object") return;
     if (Array.isArray(node)) {
       for (const item of node) visit(item);

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1177,9 +1177,11 @@ export function buildProcessDeps(
       // the meter + iteration markers. Returning here also narrows `event` to the
       // non-raw variants for the rest of the handler.
       if (event.type === "raw") {
-        void appendRecord(join(current.attemptDir, "log.jsonl"), "raw", event.line, {
+        void appendRecord(join(current.attemptDir, "log.jsonl"), "raw", {
+          iteration: event.iteration,
+          line: event.line,
+        }, {
           ts,
-          fields: { extra: { kind: "raw", iteration: String(event.iteration) } },
         }).catch(() => {});
         return;
       }

--- a/apps/dev/src/core/jsonl-log.ts
+++ b/apps/dev/src/core/jsonl-log.ts
@@ -7,7 +7,7 @@ import { dirname } from "node:path";
 // uniform envelope so a rollup reader never has to special-case a line's shape.
 // The envelope is defined exactly once, here, with this field order:
 //
-//   {ts, lvl, worker, issue, attempt, type, msg, …extra}
+//   {ts, lvl?, worker?, issue?, attempt?, type, msg, …extra}
 //
 // `ts` (ISO-8601) is the Module's only ambient input in bash; here it is always
 // passed in as an explicit argument so the whole surface is pure and the test
@@ -34,20 +34,28 @@ export interface JsonlLogFields {
   worker?: string;
   issue?: number | string;
   attempt?: number | string;
-  /** Verbatim extra string fields (the "…extra" of the schema). */
-  extra?: Record<string, string>;
+  /** Verbatim extra JSON fields (the "…extra" of the schema). */
+  extra?: Record<string, JsonlLogValue>;
 }
+
+export type JsonlLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonlLogValue[]
+  | { [key: string]: JsonlLogValue };
 
 /** The uniform envelope object, in canonical field order. */
 export interface JsonlLogRecord {
   ts: string;
-  lvl: string;
-  worker: string;
-  issue: number;
-  attempt: number;
+  lvl?: string;
+  worker?: string;
+  issue?: number;
+  attempt?: number;
   type: string;
-  msg: string;
-  [extra: string]: string | number;
+  msg: JsonlLogValue;
+  [extra: string]: JsonlLogValue | undefined;
 }
 
 /** Thrown when input is malformed; `code` mirrors the bash return codes (2/3). */
@@ -88,17 +96,19 @@ function coerceInt(label: string, value: number | string | undefined): number {
  * order, then validated extras ride along verbatim as string fields. Throws a
  * {@link JsonlLogError} on malformed input — nothing is written by callers.
  */
-export function buildRecord(type: string, msg: string, ts: string, fields: JsonlLogFields = {}): JsonlLogRecord {
+export function buildRecord(type: string, msg: JsonlLogValue, ts: string, fields: JsonlLogFields = {}): JsonlLogRecord {
   if (!type) throw new JsonlLogError("[jsonl-log] buildRecord: need <type>", 2);
-  const record: JsonlLogRecord = {
+  const record: Partial<JsonlLogRecord> = {
     ts,
-    lvl: fields.lvl ?? "info",
-    worker: fields.worker ?? "",
-    issue: coerceInt("issue", fields.issue),
-    attempt: coerceInt("attempt", fields.attempt),
-    type,
-    msg,
   };
+  if (fields.lvl !== undefined && fields.lvl !== "info") record.lvl = fields.lvl;
+  if (fields.worker !== undefined && fields.worker !== "") record.worker = fields.worker;
+  const issue = coerceInt("issue", fields.issue);
+  if (issue !== 0) record.issue = issue;
+  const attempt = coerceInt("attempt", fields.attempt);
+  if (attempt !== 0) record.attempt = attempt;
+  record.type = type;
+  record.msg = msg;
   for (const [key, value] of Object.entries(fields.extra ?? {})) {
     if (RESERVED_KEYS.has(key)) {
       throw new JsonlLogError(`[jsonl-log] reserved key ${JSON.stringify(key)} cannot be set via extra`, 3);
@@ -111,7 +121,7 @@ export function buildRecord(type: string, msg: string, ts: string, fields: Jsonl
     }
     record[key] = value;
   }
-  return record;
+  return record as JsonlLogRecord;
 }
 
 /** Serialize a record to its single compact JSONL line (no trailing newline). */
@@ -145,7 +155,7 @@ export interface AppendOptions {
 export async function appendRecord(
   path: string,
   type: string,
-  msg: string,
+  msg: JsonlLogValue,
   options: AppendOptions,
 ): Promise<JsonlLogRecord> {
   if (!path) throw new JsonlLogError("[jsonl-log] appendRecord: need <path>", 2);

--- a/apps/dev/tests/activity-review.test.ts
+++ b/apps/dev/tests/activity-review.test.ts
@@ -7,7 +7,7 @@ import {
   renderActivityReviewReportToon,
   type ActivityReviewIssue,
 } from "../src/core/activity-review.js";
-import { parseGitLogStats } from "../src/commands/activity-review.js";
+import { collectTokensFromObject, parseGitLogStats } from "../src/commands/activity-review.js";
 import type { HistoryRecord } from "../src/core/history.js";
 
 const issue = (over: Partial<ActivityReviewIssue>): ActivityReviewIssue => ({
@@ -185,5 +185,21 @@ describe("activity review", () => {
       "commit:bbb",
       " 1 file changed, 3 deletions(-)",
     ].join("\n"))).toEqual({ commits: 2, added: 10, removed: 4 });
+  });
+
+  it("collects tokens from old raw JSON strings and new structured raw payloads", () => {
+    const oldRaw = {
+      ts: "2026-06-06T12:00:00.000Z",
+      type: "raw",
+      msg: "{\"type\":\"usage\",\"inputTokens\":3,\"outputTokens\":5}",
+    };
+    const newRaw = {
+      ts: "2026-06-06T12:00:01.000Z",
+      type: "raw",
+      msg: { iteration: 1, line: "{\"type\":\"usage\",\"inputTokens\":7,\"outputTokens\":11}" },
+    };
+
+    expect(collectTokensFromObject(oldRaw)).toEqual({ input: 3, output: 5, total: 0, hits: 2 });
+    expect(collectTokensFromObject(newRaw)).toEqual({ input: 7, output: 11, total: 0, hits: 2 });
   });
 });

--- a/apps/dev/tests/jsonl-log.test.ts
+++ b/apps/dev/tests/jsonl-log.test.ts
@@ -17,15 +17,15 @@ import {
 const TS = "2026-05-30T12:00:00+00:00";
 
 describe("jsonl-log record shape", () => {
-  it("builds one well-formed envelope with every standard field and an extra", () => {
+  it("builds one well-formed envelope with non-default standard fields and an extra", () => {
     const record = buildRecord("stage", "writing test for X", TS, {
-      lvl: "info",
+      lvl: "warn",
       worker: "wA1B9",
       issue: 246,
       attempt: 1,
       extra: { stage_n: "3" },
     });
-    expect(record.lvl).toBe("info");
+    expect(record.lvl).toBe("warn");
     expect(record.worker).toBe("wA1B9");
     expect(record.type).toBe("stage");
     expect(record.msg).toBe("writing test for X");
@@ -38,16 +38,16 @@ describe("jsonl-log record shape", () => {
   });
 
   it("emits the canonical field order: ts lvl worker issue attempt type msg …extra", () => {
-    const record = buildRecord("stage", "m", TS, { worker: "wA1B9", issue: 246, attempt: 1, extra: { stage_n: "3" } });
+    const record = buildRecord("stage", "m", TS, { lvl: "warn", worker: "wA1B9", issue: 246, attempt: 1, extra: { stage_n: "3" } });
     expect(Object.keys(record)).toEqual([...ENVELOPE_FIELD_ORDER, "stage_n"]);
   });
 
   it("applies bash defaults when optional fields are omitted", () => {
     const record = buildRecord("note", "bare", TS);
-    expect(record.lvl).toBe("info");
-    expect(record.worker).toBe("");
-    expect(record.issue).toBe(0);
-    expect(record.attempt).toBe(0);
+    expect(record).not.toHaveProperty("lvl");
+    expect(record).not.toHaveProperty("worker");
+    expect(record).not.toHaveProperty("issue");
+    expect(record).not.toHaveProperty("attempt");
   });
 
   it("accepts numeric-string issue/attempt and coerces to JSON numbers", () => {
@@ -61,6 +61,15 @@ describe("jsonl-log record shape", () => {
     const line = JSON.stringify(buildRecord("agent", evil, TS));
     expect(line.includes("\n")).toBe(false);
     expect((JSON.parse(line) as { msg: string }).msg).toBe(evil);
+  });
+
+  it("keeps raw firehose payloads structured and omits dead default fields", () => {
+    const record = buildRecord("raw", { iteration: 2, line: "{\"type\":\"usage\",\"inputTokens\":3}" }, TS);
+    expect(record).toEqual({
+      ts: TS,
+      type: "raw",
+      msg: { iteration: 2, line: "{\"type\":\"usage\",\"inputTokens\":3}" },
+    });
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #1778. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1778

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786672501&installation_id=129708444&pr_number=1788&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1788&signature=6afc74dadf599effa0af7beba59d42b8eb756023991528d33f6e9ffd76f35ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->