### PR TITLE
fix: #1779 TOON wave 1 S4: memory two-regime contract — lossless default, declared --compact

### DIFF
--- a/apps/memory/src/graph-recall.ts
+++ b/apps/memory/src/graph-recall.ts
@@ -5,6 +5,7 @@ import {
   type RecallScope,
   type RecallStore,
 } from "./engine.js";
+import { encode } from "@reddb-io/toon";
 import {
   loadEngineeringCodeCuration,
   resolveEngineeringCodeAlias,
@@ -301,7 +302,7 @@ function renderGraphRecallContext(
     lines.push(`- **${hit.label}** _(${hit.node_type})_`);
     if (hit.excerpt) lines.push(`  ${hit.excerpt.slice(0, 200)}`);
     const signalLines = renderSignalProvenance(hit.signal_provenance);
-    if (signalLines.length > 0) lines.push(...signalLines.map((line) => `  ${line}`));
+    if (signalLines.length > 0) lines.push(...signalLines);
     if (hit.hooks && hit.hooks.length > 0) {
       const parts = hit.hooks.map((hook) => `${hook.lifecycle}=${hook.exit_code}`);
       lines.push(`  _hooks: ${parts.join(", ")}_`);
@@ -320,13 +321,15 @@ export function renderSignalProvenance(
   signals: readonly RecallSignalProvenance[] | undefined,
 ): string[] {
   if (!signals || signals.length === 0) return [];
-  return [
-    `signal_provenance[${signals.length}]{source,rank,contribution}:`,
-    ...signals.map(
-      (signal) =>
-        `  ${signal.source},${signal.rank},${formatSignalContribution(signal.contribution)}`,
-    ),
-  ];
+  return encode({
+    signal_provenance: signals.map((signal) => ({
+      source: signal.source,
+      rank: signal.rank,
+      contribution: Number(formatSignalContribution(signal.contribution)),
+    })),
+  })
+    .trimEnd()
+    .split("\n");
 }
 
 function formatSignalContribution(value: number): string {

--- a/apps/memory/src/toon-output.ts
+++ b/apps/memory/src/toon-output.ts
@@ -9,25 +9,33 @@ import {
 
 type JsonRecord = Record<string, JsonValue>;
 
-function toJsonValue(value: unknown, strictStrings = false, key = ""): JsonValue {
+export interface RenderToonDocumentOptions {
+  compact?: boolean;
+}
+
+function compactString(value: string, key: string): string {
+  const normalized = value.replace(/\\[nrt]/g, " ").replace(/\s+/g, " ").trim();
+  return key === "markdown"
+    ? normalized.replace(/[\[\]{}]/g, " ").replace(/\s+/g, " ").trim()
+    : normalized;
+}
+
+function toJsonValue(value: unknown, opts: RenderToonDocumentOptions = {}, key = ""): JsonValue {
   if (value == null) return null;
   if (typeof value === "string") {
-    const normalized = value.replace(/\\[nrt]/g, " ").replace(/\s+/g, " ").trim();
-    return strictStrings || key === "markdown"
-      ? normalized.replace(/[\[\]{}]/g, " ")
-      : normalized;
+    return opts.compact ? compactString(value, key) : value;
   }
   if (typeof value === "number" || typeof value === "boolean") {
     return Number.isNaN(value) ? null : value;
   }
   if (Array.isArray(value)) {
-    return value.map((child) => toJsonValue(child, strictStrings, key));
+    return value.map((child) => toJsonValue(child, opts, key));
   }
   if (typeof value === "object") {
     const out: JsonRecord = {};
     for (const [key, child] of Object.entries(value)) {
       if (child !== undefined && typeof child !== "function" && typeof child !== "symbol") {
-        out[key] = toJsonValue(child, strictStrings, key);
+        out[key] = toJsonValue(child, opts, key);
       }
     }
     return out;
@@ -63,12 +71,17 @@ export function renderToonOutput<Row extends JsonRecord>({
   return appendSummaryField(value, summary);
 }
 
-export function renderToonDocument(value: unknown): string {
-  const output = encode(toJsonValue(value));
-  try {
-    decode(output);
-    return output;
-  } catch {
-    return encode(toJsonValue(value, true));
-  }
+export function renderToonDocument(value: unknown, opts: RenderToonDocumentOptions = {}): string {
+  const output = opts.compact
+    ? encode({
+        _reduction: {
+          mode: "compact",
+          reduced: "string whitespace collapsed; markdown bracket characters removed",
+          recover: "rerun without --compact",
+        },
+        value: toJsonValue(value, opts),
+      })
+    : encode(toJsonValue(value, opts));
+  decode(output);
+  return output;
 }

--- a/apps/memory/tests/recall-ranking.test.ts
+++ b/apps/memory/tests/recall-ranking.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { decode } from "@reddb-io/toon";
 import type { RecalledNode } from "../src/engine.js";
 import type { StoredNode } from "../src/graph-store.js";
 import {
@@ -229,6 +230,17 @@ describe("recall ranking pipeline", () => {
       { source: "keyword:cache pipeline", rank: 2, contribution: 1 / 62 },
     ]);
     expect(recall.context_md).toContain("signal_provenance[4]{source,rank,contribution}:");
-    expect(recall.context_md).toContain("keyword:cache,1,0.016393");
+    expect(recall.context_md).toContain("\"keyword:cache\",1,0.016393");
+    const lines = recall.context_md.split("\n");
+    const signalStart = lines.findIndex((line) => line.startsWith("signal_provenance["));
+    const signalBlock = lines.slice(signalStart, signalStart + 5);
+    expect(decode(signalBlock.join("\n"))).toEqual({
+      signal_provenance: [
+        { source: "keyword:cache", rank: 1, contribution: 0.016393 },
+        { source: "keyword:pipeline", rank: 1, contribution: 0.016393 },
+        { source: "graph", rank: 1, contribution: 0.016393 },
+        { source: "keyword:cache pipeline", rank: 2, contribution: 0.016129 },
+      ],
+    });
   });
 });

--- a/apps/memory/tests/toon-output.test.ts
+++ b/apps/memory/tests/toon-output.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { encodingForModel } from "js-tiktoken";
+import { decode } from "@reddb-io/toon";
+import { renderToonDocument } from "../src/toon-output.js";
+
+describe("shared TOON document output", () => {
+  test("defaults to lossless strings and lets the encoder quote unsafe cells", () => {
+    const payload = {
+      rows: [
+        {
+          source: "keyword:cache",
+          markdown: "Keep [brackets]\n  and   whitespace.",
+          note: "alpha:beta {raw}",
+        },
+      ],
+    };
+
+    const toon = renderToonDocument(payload);
+
+    expect(toon).toContain("\"keyword:cache\"");
+    expect(decode(toon)).toEqual(payload);
+  });
+
+  test("compact mode declares the reduction and recovery path in-band", () => {
+    const payload = {
+      markdown: "Keep [brackets]\n  and   whitespace.",
+      note: "alpha:beta {raw}",
+    };
+
+    const lossless = renderToonDocument(payload);
+    const compact = renderToonDocument(payload, { compact: true });
+    const decoded = decode(compact) as {
+      _reduction: { mode: string; reduced: string; recover: string };
+      value: { markdown: string; note: string };
+    };
+    const tokenizer = encodingForModel("gpt-4o");
+    const losslessTokens = tokenizer.encode(lossless).length;
+    const compactTokens = tokenizer.encode(compact).length;
+    const reduction = ((losslessTokens - compactTokens) / losslessTokens) * 100;
+    console.info(
+      `memory TOON compact token delta: lossless=${losslessTokens} compact=${compactTokens} reduction=${reduction.toFixed(1)}%`,
+    );
+
+    expect(decoded._reduction).toEqual({
+      mode: "compact",
+      reduced: "string whitespace collapsed; markdown bracket characters removed",
+      recover: "rerun without --compact",
+    });
+    expect(decoded.value).toEqual({
+      markdown: "Keep brackets and whitespace.",
+      note: "alpha:beta {raw}",
+    });
+    expect(Number.isFinite(reduction)).toBe(true);
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1779. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1779

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786677794&installation_id=129708444&pr_number=1791&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1791&signature=c2f6d4eb3d6783f606a045e4288840e0212cdd6573db28849eb9ad80491edc94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->