### PR TITLE
feat: #1780 TOON wave 1 S5 — big-bang migration verb, quiescence guard, detached bootstrap trigger, format-sniff

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -24,6 +24,7 @@ import { rspInstructionsCommand } from "./commands/rsp-instructions.js";
 import { statuslineCommand, statuslineRefreshCountsCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { triageCommand } from "./commands/triage.js";
+import { toonMigrateCommand } from "./commands/toon-migrate.js";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { routeCommand, UnknownCommandError, type RouterSchema } from "@reddb-io/shared/args.js";
 
@@ -54,6 +55,7 @@ export type CliCommand =
   | "statusline"
   | "statusline-refresh-counts"
   | "inject-development-workflow"
+  | "toon-migrate"
   | "version"
   | "__supervise";
 
@@ -99,6 +101,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     statusline: {},
     "statusline-refresh-counts": {},
     "inject-development-workflow": {},
+    "toon-migrate": {},
     version: {},
     __supervise: {},
   },
@@ -153,6 +156,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);
   if (parsed.command === "statusline-refresh-counts") return statuslineRefreshCountsCommand(parsed.args);
   if (parsed.command === "inject-development-workflow") return injectDevelopmentWorkflowCommand(parsed.args);
+  if (parsed.command === "toon-migrate") return toonMigrateCommand(parsed.args);
   if (parsed.command === "__supervise") return superviseCommand(parsed.args);
   return runCommand({ args: parsed.args });
 }

--- a/apps/dev/src/commands/toon-migrate.ts
+++ b/apps/dev/src/commands/toon-migrate.ts
@@ -1,0 +1,92 @@
+import { resolve } from "node:path";
+import {
+  convertRegisteredToonSurfaces,
+  type RegisteredToonSurfacePlugin,
+} from "@reddb-io/shared/toon-migration.js";
+
+interface ToonMigrateIO {
+  stdout: Pick<NodeJS.WritableStream, "write">;
+  stderr: Pick<NodeJS.WritableStream, "write">;
+}
+
+interface ParsedToonMigrateArgs {
+  rootDir: string;
+  plugin?: RegisteredToonSurfacePlugin;
+  json: boolean;
+}
+
+const PLUGINS = new Set<RegisteredToonSurfacePlugin>(["memory", "brain", "dev"]);
+
+export async function toonMigrateCommand(
+  args: readonly string[],
+  io: ToonMigrateIO = { stdout: process.stdout, stderr: process.stderr },
+): Promise<number> {
+  try {
+    const parsed = parseToonMigrateArgs(args);
+    const report = await convertRegisteredToonSurfaces({ rootDir: parsed.rootDir, plugin: parsed.plugin });
+    if (parsed.json) {
+      io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else if (report.status === "refused") {
+      io.stderr.write(`toon-migrate: refused: ${report.reasons.join("; ")}\n`);
+    } else {
+      io.stdout.write(
+        `toon-migrate: ${report.status} converted=${report.converted.length} skipped=${report.skipped.length} missing=${report.missing.length}\n`,
+      );
+    }
+    return report.status === "refused" ? 1 : 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    io.stderr.write(`toon-migrate: ${message}\n`);
+    return 2;
+  }
+}
+
+function parseToonMigrateArgs(args: readonly string[]): ParsedToonMigrateArgs {
+  let rootDir = process.cwd();
+  let plugin: RegisteredToonSurfacePlugin | undefined;
+  let json = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--root") {
+      rootDir = requiredValue(args[++i], "--root");
+      continue;
+    }
+    if (arg.startsWith("--root=")) {
+      rootDir = arg.slice("--root=".length);
+      continue;
+    }
+    if (arg === "--plugin") {
+      plugin = parsePlugin(requiredValue(args[++i], "--plugin"));
+      continue;
+    }
+    if (arg.startsWith("--plugin=")) {
+      plugin = parsePlugin(arg.slice("--plugin=".length));
+      continue;
+    }
+    if (arg === "--triggered-by") {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--triggered-by=")) {
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return { rootDir: resolve(rootDir), plugin, json };
+}
+
+function requiredValue(value: string | undefined, flag: string): string {
+  if (!value) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parsePlugin(value: string): RegisteredToonSurfacePlugin {
+  if (PLUGINS.has(value as RegisteredToonSurfacePlugin)) return value as RegisteredToonSurfacePlugin;
+  throw new Error(`unknown plugin: ${value}`);
+}

--- a/apps/dev/tests/toon-migrate.test.ts
+++ b/apps/dev/tests/toon-migrate.test.ts
@@ -1,0 +1,67 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { parseCli } from "../src/cli.js";
+import { toonMigrateCommand } from "../src/commands/toon-migrate.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function scratch(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  const root = await mkdtemp(join(tmpdir(), "dev-toon-migrate-"));
+  roots.push(root);
+  return root;
+}
+
+async function write(root: string, rel: string, body: string): Promise<void> {
+  const path = join(root, rel);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, body, "utf8");
+}
+
+describe("toon-migrate dev command", () => {
+  test("routes as a dedicated dev CLI verb", () => {
+    expect(parseCli(["toon-migrate", "--plugin", "memory", "--root", "/repo"])).toEqual({
+      command: "toon-migrate",
+      args: ["--plugin", "memory", "--root", "/repo"],
+    });
+  });
+
+  test("converts a plugin-scoped registered surface", async () => {
+    const root = await scratch();
+    await write(root, ".red/memory/config.json", JSON.stringify({ mode: "graph" }));
+    let stdout = "";
+    let stderr = "";
+
+    const code = await toonMigrateCommand(["--plugin", "memory", "--root", root, "--json"], {
+      stdout: { write: (chunk: string) => { stdout += chunk; return true; } },
+      stderr: { write: (chunk: string) => { stderr += chunk; return true; } },
+    });
+
+    expect(code).toBe(0);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toMatchObject({ status: "converted", converted: ["memory.config"] });
+    expect(await readFile(join(root, ".red/memory/config.toon"), "utf8")).toContain("mode: graph");
+  });
+
+  test("refuses when the repo is not quiesced", async () => {
+    const root = await scratch();
+    await write(root, ".red/memory/config.json", JSON.stringify({ mode: "graph" }));
+    await write(root, ".red/tmp/afk-supervisor.pid", `${process.pid}\n`);
+    let stderr = "";
+
+    const code = await toonMigrateCommand(["--plugin", "memory", "--root", root], {
+      stdout: { write: () => true },
+      stderr: { write: (chunk: string) => { stderr += chunk; return true; } },
+    });
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("refused");
+    expect(stderr).toContain("active fleet supervisor");
+  });
+});

--- a/apps/memory/tests/bootstrap-launcher.test.ts
+++ b/apps/memory/tests/bootstrap-launcher.test.ts
@@ -162,6 +162,18 @@ async function warmCache(cacheDir: string): Promise<void> {
   await chmod(red, 0o755);
 }
 
+async function waitForFile(path: string, deadlineMs = 2_000): Promise<string> {
+  const deadline = Date.now() + deadlineMs;
+  for (;;) {
+    try {
+      return await readFile(path, "utf8");
+    } catch {
+      if (Date.now() >= deadline) throw new Error(`file was not written: ${path}`);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
 const cliPath = (cacheDir: string) =>
   join(cacheDir, "reddb-memory", VERSION, "memory-cli.mjs");
 const markerPath = (cacheDir: string) =>
@@ -339,6 +351,52 @@ describe("memory launcher distribution (ADR 0084, #1030)", () => {
       expect(r.stdout).toBe("{}");
       expect(release.hits()).toBe(0);
       expect(existsSync(cliPath(cacheDir))).toBe(false);
+    } finally {
+      await release.close();
+    }
+  });
+
+  test("SessionStart triggers plugin-owned TOON migration through detached dev command", async () => {
+    const cacheDir = await makeCacheDir();
+    await warmCache(cacheDir);
+    const cwd = await enabledCwd();
+    await mkdir(join(cwd, ".red", "memory"), { recursive: true });
+    await writeFile(join(cwd, ".red", "memory", "config.json"), JSON.stringify({ mode: "graph" }), "utf8");
+    const probe = join(cwd, ".red", "tmp", "migration-probe.txt");
+    const fakeDev = join(cwd, ".red", "tmp", "fake-dev-entrypoint.mjs");
+    await mkdir(join(cwd, ".red", "tmp"), { recursive: true });
+    await writeFile(
+      fakeDev,
+      `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(probe)}, process.argv.slice(2).join(" ") + "\\n");
+`,
+      "utf8",
+    );
+    const release = await startRelease();
+    try {
+      const child = spawn(process.execPath, [BOOTSTRAP, "hook", "SessionStart", "--runner", "claude"], {
+        cwd,
+        env: {
+          ...process.env,
+          RED_MEMORY_CACHE_DIR: cacheDir,
+          RED_MEMORY_RELEASE_BASE: release.url,
+          RED_NPM_REGISTRY_BASE: release.url,
+          RED_DEV_ENTRYPOINT: fakeDev,
+          CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
+          NODE_ENV: "test",
+        },
+      });
+      let stdout = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (d) => (stdout += d));
+      const code = await new Promise<number | null>((res) => child.on("close", res));
+
+      expect(code).toBe(0);
+      expect(stdout).toBe("MEMORY-RUNTIME-RAN hook SessionStart --runner claude\n");
+      const observed = await waitForFile(probe);
+      expect(observed).toContain("toon-migrate --plugin memory");
+      expect(observed).toContain("--triggered-by bootstrap");
     } finally {
       await release.close();
     }

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -87,3 +87,4 @@ export {
 export * from "./outcome-event.js";
 export * from "./resident-client.js";
 export * from "./resident-protocol.js";
+export * from "./toon-migration.js";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
     "./entrypoint-cli.js": "./entrypoint-cli.ts",
     "./red-runtime.js": "./red-runtime.ts",
     "./self-update.js": "./self-update.ts",
+    "./toon-migration.js": "./toon-migration.ts",
     "./log.js": "./log.ts",
     "./plugin-gate.js": "./plugin-gate.ts",
     "./outcome-event.js": "./outcome-event.ts",
@@ -20,6 +21,7 @@
     "./resident-protocol.js": "./resident-protocol.ts"
   },
   "dependencies": {
+    "@reddb-io/toon": "catalog:",
     "cli-args-parser": "^1.0.6"
   }
 }

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -1,0 +1,111 @@
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { encode } from "@reddb-io/toon";
+import {
+  MEMORY_TOON_MIGRATION_SURFACES,
+  convertRegisteredToonSurfaces,
+  readRegisteredToonSurface,
+  registeredToonSurfacesForPlugin,
+} from "./toon-migration.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function scratch(): Promise<string> {
+  const root = await mkdtempCompat("shared-toon-migration-");
+  roots.push(root);
+  return root;
+}
+
+async function mkdtempCompat(prefix: string): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return mkdtemp(join(tmpdir(), prefix));
+}
+
+async function write(root: string, rel: string, body: string): Promise<string> {
+  const path = join(root, rel);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, body, "utf8");
+  return path;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("shared TOON migration registry", () => {
+  test("registers a memory-owned proof surface", () => {
+    expect(MEMORY_TOON_MIGRATION_SURFACES).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "memory.config",
+          plugin: "memory",
+          legacyPath: ".red/memory/config.json",
+          toonPath: ".red/memory/config.toon",
+          kind: "toon",
+        }),
+      ]),
+    );
+    expect(registeredToonSurfacesForPlugin("memory").map((surface) => surface.id)).toContain("memory.config");
+  });
+
+  test("refuses while fleet or residents are active and explains why", async () => {
+    const root = await scratch();
+    await write(root, ".red/memory/config.json", JSON.stringify({ mode: "graph" }));
+    await write(root, ".red/tmp/afk-supervisor.pid", `${process.pid}\n`);
+    await write(root, ".red/tmp/rsp-resident.pid.json", JSON.stringify({ pid: process.pid }));
+
+    const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "memory" });
+
+    expect(report.status).toBe("refused");
+    expect(report.reasons.join("\n")).toContain("active fleet supervisor");
+    expect(report.reasons.join("\n")).toContain("active rsp resident");
+    expect(report.converted).toHaveLength(0);
+    expect(await exists(join(root, ".red/memory/config.toon"))).toBe(false);
+  });
+
+  test("converts legacy JSON idempotently when quiesced", async () => {
+    const root = await scratch();
+    const legacy = await write(root, ".red/memory/config.json", `${JSON.stringify({ mode: "graph", hooks: { sessionStart: true } })}\n`);
+
+    const first = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "memory" });
+    const toonPath = join(root, ".red/memory/config.toon");
+    const afterFirst = await readFile(toonPath, "utf8");
+    const legacyAfterFirst = await readFile(legacy, "utf8");
+    const second = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "memory" });
+
+    expect(first.status).toBe("converted");
+    expect(first.converted).toEqual(["memory.config"]);
+    expect(legacyAfterFirst).toBe(`${JSON.stringify({ mode: "graph", hooks: { sessionStart: true } })}\n`);
+    expect(second.status).toBe("noop");
+    expect(second.skipped).toEqual(["memory.config"]);
+    expect(await readFile(toonPath, "utf8")).toBe(afterFirst);
+  });
+
+  test("format-sniff helper reads legacy JSON and converted TOON", async () => {
+    const root = await scratch();
+    await write(root, ".red/memory/config.json", JSON.stringify({ mode: "markdown-only" }));
+
+    await expect(readRegisteredToonSurface(root, "memory.config")).resolves.toMatchObject({
+      format: "json",
+      value: { mode: "markdown-only" },
+    });
+
+    await write(root, ".red/memory/config.toon", encode({ mode: "graph", storePath: ".red/memory/graph.rdb" }));
+
+    await expect(readRegisteredToonSurface(root, "memory.config")).resolves.toMatchObject({
+      format: "toon",
+      value: { mode: "graph", storePath: ".red/memory/graph.rdb" },
+    });
+  });
+});

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -1,0 +1,234 @@
+import { accessSync, constants } from "node:fs";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+
+export type RegisteredToonSurfaceKind = "toon" | "toonl";
+export type RegisteredToonSurfacePlugin = "memory" | "brain" | "dev";
+
+export interface RegisteredToonSurface {
+  id: string;
+  plugin: RegisteredToonSurfacePlugin;
+  legacyPath: string;
+  toonPath: string;
+  kind: RegisteredToonSurfaceKind;
+}
+
+export interface ToonMigrationReport {
+  status: "converted" | "noop" | "refused";
+  converted: string[];
+  skipped: string[];
+  missing: string[];
+  reasons: string[];
+}
+
+export interface ToonSurfaceReadResult {
+  surface: RegisteredToonSurface;
+  path: string;
+  format: "json" | "jsonl" | "toon" | "toonl";
+  value: unknown;
+}
+
+export interface ConvertRegisteredToonSurfacesOptions {
+  rootDir: string;
+  plugin?: RegisteredToonSurfacePlugin;
+  surfaces?: readonly RegisteredToonSurface[];
+}
+
+export const MEMORY_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
+  {
+    id: "memory.config",
+    plugin: "memory",
+    legacyPath: ".red/memory/config.json",
+    toonPath: ".red/memory/config.toon",
+    kind: "toon",
+  },
+];
+
+export const REGISTERED_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
+  ...MEMORY_TOON_MIGRATION_SURFACES,
+];
+
+export function registeredToonSurfacesForPlugin(
+  plugin: RegisteredToonSurfacePlugin,
+  surfaces: readonly RegisteredToonSurface[] = REGISTERED_TOON_MIGRATION_SURFACES,
+): readonly RegisteredToonSurface[] {
+  return surfaces.filter((surface) => surface.plugin === plugin);
+}
+
+export function hasPendingRegisteredToonSurfaces(
+  rootDir: string,
+  plugin: RegisteredToonSurfacePlugin,
+  surfaces: readonly RegisteredToonSurface[] = REGISTERED_TOON_MIGRATION_SURFACES,
+): boolean {
+  return registeredToonSurfacesForPlugin(plugin, surfaces).some((surface) => {
+    const legacy = join(rootDir, surface.legacyPath);
+    const converted = join(rootDir, surface.toonPath);
+    return pathExistsSync(legacy) && !pathExistsSync(converted);
+  });
+}
+
+export async function convertRegisteredToonSurfaces(
+  opts: ConvertRegisteredToonSurfacesOptions,
+): Promise<ToonMigrationReport> {
+  const surfaces = opts.surfaces ?? REGISTERED_TOON_MIGRATION_SURFACES;
+  const selected = opts.plugin === undefined ? surfaces : registeredToonSurfacesForPlugin(opts.plugin, surfaces);
+  const reasons = await quiescenceReasons(opts.rootDir);
+  if (reasons.length > 0) {
+    return { status: "refused", converted: [], skipped: [], missing: [], reasons };
+  }
+
+  const converted: string[] = [];
+  const skipped: string[] = [];
+  const missing: string[] = [];
+
+  for (const surface of selected) {
+    const target = join(opts.rootDir, surface.toonPath);
+    if (await pathExists(target)) {
+      skipped.push(surface.id);
+      continue;
+    }
+
+    const legacy = join(opts.rootDir, surface.legacyPath);
+    if (!(await pathExists(legacy))) {
+      missing.push(surface.id);
+      continue;
+    }
+
+    const value = await readLegacyFile(legacy, surface.kind);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, renderSurface(value, surface.kind), "utf8");
+    converted.push(surface.id);
+  }
+
+  return {
+    status: converted.length > 0 ? "converted" : "noop",
+    converted,
+    skipped,
+    missing,
+    reasons: [],
+  };
+}
+
+export async function readRegisteredToonSurface(
+  rootDir: string,
+  surfaceId: string,
+  surfaces: readonly RegisteredToonSurface[] = REGISTERED_TOON_MIGRATION_SURFACES,
+): Promise<ToonSurfaceReadResult> {
+  const surface = surfaces.find((candidate) => candidate.id === surfaceId);
+  if (!surface) throw new Error(`unknown registered TOON surface: ${surfaceId}`);
+
+  const converted = join(rootDir, surface.toonPath);
+  if (await pathExists(converted)) {
+    return {
+      surface,
+      path: converted,
+      format: surface.kind,
+      value: await readConvertedFile(converted, surface.kind),
+    };
+  }
+
+  const legacy = join(rootDir, surface.legacyPath);
+  return {
+    surface,
+    path: legacy,
+    format: surface.kind === "toonl" ? "jsonl" : "json",
+    value: await readLegacyFile(legacy, surface.kind),
+  };
+}
+
+async function quiescenceReasons(rootDir: string): Promise<string[]> {
+  const reasons: string[] = [];
+  const tmpDir = join(rootDir, ".red", "tmp");
+  const supervisorPid = await readPidFile(join(tmpDir, "afk-supervisor.pid"));
+  if (supervisorPid !== null && isLivePid(supervisorPid)) {
+    reasons.push("active fleet supervisor is running");
+  }
+
+  const rspResidentPid = await readJsonPid(join(tmpDir, "rsp-resident.pid.json"));
+  if (rspResidentPid !== null && isLivePid(rspResidentPid)) {
+    reasons.push("active rsp resident is running");
+  }
+
+  return reasons;
+}
+
+async function readLegacyFile(path: string, kind: RegisteredToonSurfaceKind): Promise<unknown> {
+  const body = await readFile(path, "utf8");
+  if (kind === "toonl") {
+    return body
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+  }
+  return JSON.parse(body);
+}
+
+async function readConvertedFile(path: string, kind: RegisteredToonSurfaceKind): Promise<unknown> {
+  const body = await readFile(path, "utf8");
+  if (kind === "toonl") {
+    return body
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+      .map((line) => decode(line));
+  }
+  return decode(body);
+}
+
+function renderSurface(value: unknown, kind: RegisteredToonSurfaceKind): string {
+  if (kind === "toonl") {
+    const rows = Array.isArray(value) ? value : [value];
+    return `${rows.map((row) => encode(row as JsonValue)).join("\n")}\n`;
+  }
+  return encode(value as JsonValue);
+}
+
+async function readPidFile(path: string): Promise<number | null> {
+  try {
+    return parsePid((await readFile(path, "utf8")).trim());
+  } catch {
+    return null;
+  }
+}
+
+async function readJsonPid(path: string): Promise<number | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as { pid?: unknown };
+    return typeof parsed.pid === "number" ? parsePid(String(parsed.pid)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function parsePid(raw: string): number | null {
+  if (!/^[1-9][0-9]*$/.test(raw)) return null;
+  const pid = Number(raw);
+  return Number.isSafeInteger(pid) ? pid : null;
+}
+
+function isLivePid(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pathExistsSync(path: string): boolean {
+  try {
+    accessSync(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/plugins/memory/scripts/bootstrap.mjs
+++ b/plugins/memory/scripts/bootstrap.mjs
@@ -436,6 +436,44 @@ function spawnBackgroundSelfUpdate() {
   }
 }
 
+function hasPendingToonMigration(cwd) {
+  return (
+    existsSync(join(cwd, ".red", "memory", "config.json")) &&
+    !existsSync(join(cwd, ".red", "memory", "config.toon"))
+  );
+}
+
+function resolveDevEntrypoint() {
+  const override = process.env.RED_DEV_ENTRYPOINT;
+  if (override && existsSync(override)) return override;
+  const candidates = [
+    join(REPO_ROOT, "plugins", "dev", "skills", "engineering", "afk", "bin", "afk.mjs"),
+    resolve(PLUGIN_ROOT, "..", "dev", "skills", "engineering", "afk", "bin", "afk.mjs"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+/** Fire-and-forget the plugin-owned TOON migration trigger; never blocks hooks. */
+function spawnBackgroundToonMigration(cwd) {
+  try {
+    if (!hasPendingToonMigration(cwd)) return;
+    const entrypoint = resolveDevEntrypoint();
+    if (!entrypoint) return;
+    const child = spawn(
+      process.execPath,
+      [entrypoint, "toon-migrate", "--plugin", "memory", "--root", cwd, "--triggered-by", "bootstrap"],
+      {
+        detached: true,
+        stdio: "ignore",
+        env: process.env,
+      },
+    );
+    child.unref();
+  } catch {
+    /* best-effort */
+  }
+}
+
 // ── Per-directory plugin gate (ADR 0067) ─────────────────────────────────────
 // Mirror of packages/shared/plugin-gate.ts (pluginEnabledInConfig + walk-up),
 // inlined because the launcher ships dependency-free in the plugin checkout and
@@ -594,6 +632,7 @@ async function main() {
     // On session start, kick a DETACHED background in-range self-update for the
     // NEXT boot. Detached + unref'd so it never delays the hook or any surface.
     if (argv[0] === "hook" && argv[1] === "SessionStart") spawnBackgroundSelfUpdate();
+    if (argv[0] === "hook" && argv[1] === "SessionStart") spawnBackgroundToonMigration(process.cwd());
     const runtime = await ensureRuntime(version, { mayFetch: mayFetchRuntime(argv) });
     if (!runtime) {
       // Render/hot-path hook on a cold cache: SessionStart will warm it. No-op.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,6 +425,9 @@ importers:
 
   packages/shared:
     dependencies:
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.1.0
       cli-args-parser:
         specifier: ^1.0.6
         version: 1.0.6


### PR DESCRIPTION
Closes #1780

Human-reviewed landing of the sensitive-path park (attempt branch `afk/wJPOC/1780-...`). The re-attempt follows the recorded rejection guidance from the first attempt (`wRT5J`):

- Conversion registry + quiescence guard + format-sniff reader live in `packages/shared/toon-migration.ts` (shared home, per guidance).
- `toon-migrate` verb on the dev CLI (`apps/dev/src/commands/toon-migrate.ts`), refuses under live fleet supervisor or rsp resident and states why; idempotent per file (never rewrites an existing converted file).
- Per-plugin detached bootstrap trigger in `plugins/memory/scripts/bootstrap.mjs` — fire-and-forget, `detached` + `unref`, best-effort try/catch, gated on a pending-legacy check; mirrors the existing `spawnBackgroundSelfUpdate` placement so no SessionStart/hook/statusline path ever waits (regression-guarded by `apps/memory/tests/bootstrap-launcher.test.ts`).
- Proof surface registered: `memory.config` (`.red/memory/config.json` → `.red/memory/config.toon`), plugin-owned.
- Reader flips stay with the later lane slices (#1781–#1785) using the shared format-sniff helper, as scoped.

Sensitive path touched: `plugins/memory/scripts/bootstrap.mjs` (agent plugin launcher) — reviewed; the added code is additive, detached, and cannot block a hook.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786682293&installation_id=129708444&pr_number=1792&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1792&signature=9a77348ebe6d06292c5d59e676e707ab1be978f1a69f139880e78343ccbe8068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->