### PR TITLE
fix: #1793 rsp wait pr fails open: reports success with checks: 0 before the new SHA's checks register

### DIFF
--- a/apps/rsp/src/wait.ts
+++ b/apps/rsp/src/wait.ts
@@ -167,7 +167,15 @@ async function dispatchWait(
     case "cmd":
       return await waitCmd(parsed.commandLine ?? "", parsed.options.timeoutMs, cwd, registryPath, entry);
     case "pr":
-      return await pollUntilDone(() => probePr(parsed.target ?? "", cwd), parsed.options.timeoutMs, 15_000, registryPath, entry);
+      return await pollUntilDone(
+        createPrProbe(parsed.target ?? "", cwd, {
+          emptyChecksGraceMs: envDuration("RSP_WAIT_PR_EMPTY_CHECKS_GRACE_MS", 30_000),
+        }),
+        parsed.options.timeoutMs,
+        envDuration("RSP_WAIT_PR_POLL_MS", 15_000),
+        registryPath,
+        entry,
+      );
     case "run":
       return await pollUntilDone(() => probeRun(parsed, cwd), parsed.options.timeoutMs, 15_000, registryPath, entry);
     case "release":
@@ -238,21 +246,47 @@ async function pollUntilDone(
   return { status: "timeout", exitCode: 2, summary: `timed out after ${formatDuration(timeoutMs)}` };
 }
 
-async function probePr(number: string, cwd: string): Promise<Verdict> {
+function createPrProbe(number: string, cwd: string, options: { emptyChecksGraceMs: number }): () => Promise<Verdict> {
+  const startedAt = Date.now();
+  return () => probePr(number, cwd, options, startedAt);
+}
+
+async function probePr(number: string, cwd: string, options: { emptyChecksGraceMs: number }, startedAt: number): Promise<Verdict> {
   if (!/^[1-9][0-9]*$/.test(number)) return { status: "indeterminate", exitCode: 2, summary: "missing PR number" };
   const result = await ghJson(["pr", "view", number, "--json", "number,state,mergeable,statusCheckRollup,url"], cwd);
   if (result.status !== 0) return { status: "indeterminate", exitCode: 2, summary: result.stderr || "gh pr view failed" };
   const row = parseRecord(result.stdout);
   const checks = Array.isArray(row.statusCheckRollup) ? row.statusCheckRollup : [];
+  const mergeable = String(row.mergeable ?? "");
   const states = checks.map(checkState);
   const failing = states.filter((state) => state === "failure").length;
   const pending = states.filter((state) => state === "pending").length;
   if (String(row.state) !== "OPEN") {
-    return verdict("failure", `PR #${number} is ${String(row.state).toLowerCase()}`, { mergeable: String(row.mergeable ?? "") });
+    return verdict("failure", `PR #${number} is ${String(row.state).toLowerCase()}`, { mergeable });
   }
-  if (failing > 0) return verdict("failure", `PR #${number} has failing checks`, { failing, pending, mergeable: String(row.mergeable ?? "") });
+  if (failing > 0) return verdict("failure", `PR #${number} has failing checks`, { failing, pending, mergeable });
   if (pending > 0) return { status: "running", exitCode: 2, summary: `PR #${number} has ${pending} pending checks` };
-  return verdict("success", `PR #${number} checks passed`, { checks: checks.length, mergeable: String(row.mergeable ?? "") });
+  if (checks.length === 0) {
+    const elapsedMs = Date.now() - startedAt;
+    if (mergeable === "UNKNOWN" || elapsedMs < options.emptyChecksGraceMs) {
+      return {
+        status: "running",
+        exitCode: 2,
+        summary: `PR #${number} has no registered checks yet`,
+        details: { checks: 0, mergeable, empty_checks_elapsed_ms: elapsedMs },
+      };
+    }
+    return verdict("success", `PR #${number} has no checks configured`, { checks: 0, mergeable });
+  }
+  if (mergeable === "UNKNOWN") {
+    return {
+      status: "running",
+      exitCode: 2,
+      summary: `PR #${number} mergeability is still unknown`,
+      details: { checks: checks.length, mergeable },
+    };
+  }
+  return verdict("success", `PR #${number} checks passed`, { checks: checks.length, mergeable });
 }
 
 async function probeRun(parsed: ParsedWait, cwd: string): Promise<Verdict> {
@@ -430,6 +464,16 @@ function parseDuration(value: string): number {
   if (unit === "s") return n * 1_000;
   if (unit === "m") return n * 60_000;
   return n * 60 * 60_000;
+}
+
+function envDuration(name: string, fallbackMs: number): number {
+  const value = process.env[name];
+  if (!value) return fallbackMs;
+  try {
+    return parseDuration(value);
+  } catch {
+    return fallbackMs;
+  }
 }
 
 function normalizeSignal(value: string): NodeJS.Signals {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
@@ -250,6 +250,37 @@ async function commitMany(root: string, count: number): Promise<void> {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+async function fakeGhPath(root: string, responses: Array<Record<string, unknown>>): Promise<{ path: string; responsesDir: string; countFile: string }> {
+  const bin = join(root, "bin");
+  const responsesDir = join(root, "gh-responses");
+  await mkdir(bin, { recursive: true });
+  await mkdir(responsesDir, { recursive: true });
+  for (let i = 0; i < responses.length; i++) {
+    await writeFile(join(responsesDir, `${i + 1}.json`), JSON.stringify(responses[i]), "utf8");
+  }
+  await writeFile(join(responsesDir, "default.json"), JSON.stringify(responses.at(-1) ?? {}), "utf8");
+  const gh = join(bin, "gh");
+  await writeFile(
+    gh,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'count_file="$GH_FAKE_RESPONSES/count"',
+      "count=0",
+      'if [ -f "$count_file" ]; then count="$(cat "$count_file")"; fi',
+      'next="$((count + 1))"',
+      'printf "%s" "$next" > "$count_file"',
+      'response="$GH_FAKE_RESPONSES/$next.json"',
+      'if [ ! -f "$response" ]; then response="$GH_FAKE_RESPONSES/default.json"; fi',
+      'cat "$response"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await chmod(gh, 0o755);
+  return { path: `${bin}:${process.env.PATH ?? ""}`, responsesDir, countFile: join(responsesDir, "count") };
 }
 
 async function runMcpRequests(
@@ -2241,6 +2272,53 @@ describe("rsp cli", () => {
     expect(stdout).toContain("rsp wait release --tag \"v2.*\"");
     expect(stdout).toContain("rsp wait cmd -- \"pnpm -C apps/rsp build\"");
     expect(stdout).toContain("Exit codes: 0 = success verdict, 1 = failure verdict, 2 = timeout/indeterminate.");
+  });
+
+  it("wait pr keeps polling when GitHub has not registered checks for the head SHA yet", async () => {
+    const root = await tempRoot();
+    const fakeGh = await fakeGhPath(root, [
+      { number: 123, state: "OPEN", mergeable: "UNKNOWN", statusCheckRollup: [] },
+      { number: 123, state: "OPEN", mergeable: "MERGEABLE", statusCheckRollup: [{ conclusion: "SUCCESS" }] },
+    ]);
+
+    const actual = runRsp(root, ["wait", "pr", "123", "--timeout", "2s"], {
+      PATH: fakeGh.path,
+      GH_FAKE_RESPONSES: fakeGh.responsesDir,
+      RSP_WAIT_PR_POLL_MS: "10ms",
+      RSP_WAIT_PR_EMPTY_CHECKS_GRACE_MS: "1s",
+    });
+
+    expect(actual.status, actual.stderr.toString("utf8")).toBe(0);
+    expect(Number(await readFile(fakeGh.countFile, "utf8"))).toBeGreaterThan(1);
+    const decoded = decode(actual.stdout.toString("utf8")) as {
+      wait: { status: string };
+      verdict: { summary: string; details: { checks: number; mergeable: string } };
+    };
+    expect(decoded.wait.status).toBe("success");
+    expect(decoded.verdict.summary).toBe("PR #123 checks passed");
+    expect(decoded.verdict.details).toMatchObject({ checks: 1, mergeable: "MERGEABLE" });
+  });
+
+  it("wait pr resolves no-check repositories only through the empty-check grace path", async () => {
+    const root = await tempRoot();
+    const fakeGh = await fakeGhPath(root, [{ number: 123, state: "OPEN", mergeable: "MERGEABLE", statusCheckRollup: [] }]);
+
+    const actual = runRsp(root, ["wait", "pr", "123", "--timeout", "2s"], {
+      PATH: fakeGh.path,
+      GH_FAKE_RESPONSES: fakeGh.responsesDir,
+      RSP_WAIT_PR_POLL_MS: "10ms",
+      RSP_WAIT_PR_EMPTY_CHECKS_GRACE_MS: "1s",
+    });
+
+    expect(actual.status, actual.stderr.toString("utf8")).toBe(0);
+    expect(Number(await readFile(fakeGh.countFile, "utf8"))).toBeGreaterThan(1);
+    const decoded = decode(actual.stdout.toString("utf8")) as {
+      wait: { status: string };
+      verdict: { summary: string; details: { checks: number; mergeable: string } };
+    };
+    expect(decoded.wait.status).toBe("success");
+    expect(decoded.verdict.summary).toBe("PR #123 has no checks configured");
+    expect(decoded.verdict.details).toMatchObject({ checks: 0, mergeable: "MERGEABLE" });
   });
 
   it("wait cmd exits with TOON success and removes its registry entry", async () => {


### PR DESCRIPTION
Automated AFK landing for #1793. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1793

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786683213&installation_id=129708444&pr_number=1794&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1794&signature=5cd38275f2d6261ef36d6fb353fd7d535b4749df6f0cbb13ed10d4b70255d641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->