### PR TITLE
fix: #1781 TOON wave 1 S6: afk-history ledger to TOONL with header-preserving cap

### DIFF
--- a/apps/dev/src/commands/activity-review.ts
+++ b/apps/dev/src/commands/activity-review.ts
@@ -14,7 +14,7 @@ import {
   type ActivityReviewPullRequest,
   type ActivityReviewTokenSummary,
 } from "../core/activity-review.js";
-import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
+import { readHistoryRecords, type HistoryRecord } from "../core/history.js";
 import { collectMonitorInputs, afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
 
@@ -367,7 +367,7 @@ export async function activityReviewCommand(
   const repoArgs = ctx.repo ? ["--repo", ctx.repo] : [];
   const paths = afkPaths(cwd);
 
-  const [issueRows, prRows, gitStats, monitor, historyText, tokenSummary] = await Promise.all([
+  const [issueRows, prRows, gitStats, monitor, history, tokenSummary] = await Promise.all([
     ghJsonArray<unknown>(exec, cwd, [
       "issue",
       "list",
@@ -392,7 +392,7 @@ export async function activityReviewCommand(
     ]),
     collectGitStats(exec, cwd, interval.start, interval.end),
     collectMonitorInputs(cwd),
-    readFile(paths.historyPath, "utf8").catch(() => ""),
+    readHistoryRecords(paths.historyPath, { read: async (path) => readFile(path, "utf8").catch(() => null) }),
     collectTokenSummary(paths.workersRoot, interval.start, interval.end),
   ]);
 
@@ -404,7 +404,6 @@ export async function activityReviewCommand(
     interval.start,
     interval.end,
   );
-  const history = historyText ? parseHistoryLines(historyText) : [] as HistoryRecord[];
   const report = buildActivityReviewReport({
     kind,
     now,

--- a/apps/dev/src/core/history.ts
+++ b/apps/dev/src/core/history.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
 
 // Port of lib/history.sh — the afk-history.jsonl ledger. The pure parts (the
 // JSONL record shape, the 48h `done`-event bucketing, and the sparkline glyph
@@ -48,6 +49,25 @@ export interface HistoryRecord {
   reason?: string;
 }
 
+type HistoryToonRow = Omit<HistoryRecord, "merge_sha" | "reason"> & {
+  merge_sha: string | null;
+  reason: string | null;
+};
+
+const HISTORY_TOON_FIELDS = [
+  "ts",
+  "epoch",
+  "worker",
+  "issue",
+  "event",
+  "duration_s",
+  "runner",
+  "merge_sha",
+  "reason",
+] as const;
+
+const HISTORY_TOON_HEADER_RE = /^\[(\d+)\]\{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason\}:$/;
+
 /**
  * Builds exactly one ledger record. Required fields default to the bash
  * Module's values ("" / 0); merge_sha and reason are omitted entirely when
@@ -76,6 +96,68 @@ export function buildHistoryRecord(
 /** Serialises a record to its single JSONL line (no trailing newline). */
 export function serializeHistoryRecord(record: HistoryRecord): string {
   return JSON.stringify(record);
+}
+
+function historyToonRow(record: HistoryRecord): HistoryToonRow {
+  return {
+    ts: record.ts,
+    epoch: record.epoch,
+    worker: record.worker,
+    issue: record.issue,
+    event: record.event,
+    duration_s: record.duration_s,
+    runner: record.runner,
+    merge_sha: record.merge_sha ?? null,
+    reason: record.reason ?? null,
+  };
+}
+
+function normalizeHistoryRecord(raw: unknown): HistoryRecord | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const rec = raw as Record<string, unknown>;
+  if (typeof rec.ts !== "string") return null;
+  const epoch = Number(rec.epoch);
+  if (!Number.isFinite(epoch)) return null;
+  if (typeof rec.event !== "string" || rec.event.length === 0) return null;
+  const issue = Number(rec.issue ?? 0);
+  const duration = Number(rec.duration_s ?? 0);
+  const record: HistoryRecord = {
+    ts: rec.ts,
+    epoch,
+    worker: typeof rec.worker === "string" ? rec.worker : "",
+    issue: Number.isFinite(issue) ? issue : 0,
+    event: rec.event,
+    duration_s: Number.isFinite(duration) ? duration : 0,
+    runner: typeof rec.runner === "string" ? rec.runner : "",
+  };
+  if (typeof rec.merge_sha === "string" && rec.merge_sha.length > 0) record.merge_sha = rec.merge_sha;
+  if (typeof rec.reason === "string" && rec.reason.length > 0) record.reason = rec.reason;
+  return record;
+}
+
+function renderHistoryToonl(records: readonly HistoryRecord[]): string {
+  if (records.length === 0) return `[0]{${HISTORY_TOON_FIELDS.join(",")}}:\n`;
+  return encode(records.map(historyToonRow) as unknown as JsonValue);
+}
+
+function parseHistoryToonl(text: string): HistoryRecord[] {
+  const lines = text.split(/\r?\n/);
+  const header = lines.find((line) => line.trim().length > 0)?.trim();
+  if (!header || !HISTORY_TOON_HEADER_RE.test(header)) return [];
+
+  const out: HistoryRecord[] = [];
+  for (const raw of lines.slice(lines.indexOf(lines.find((line) => line.trim().length > 0) ?? "") + 1)) {
+    if (raw.trim().length === 0) continue;
+    try {
+      const value = decode(`[1]{${HISTORY_TOON_FIELDS.join(",")}}:\n${raw}\n`);
+      const row = Array.isArray(value) ? value[0] : value;
+      const record = normalizeHistoryRecord(row);
+      if (record) out.push(record);
+    } catch {
+      continue;
+    }
+  }
+  return out;
 }
 
 /**
@@ -145,14 +227,18 @@ export function buildSparkline(
   return renderSparkline(readDoneBuckets(events, fromHour, buckets));
 }
 
-/** Parses ledger text (JSONL) into records, skipping blank lines. */
+/** Parses ledger text (legacy JSONL or TOONL) into records, skipping broken tail rows. */
 export function parseHistoryLines(text: string): HistoryRecord[] {
+  const first = text.split(/\r?\n/).find((line) => line.trim().length > 0)?.trim();
+  if (first && HISTORY_TOON_HEADER_RE.test(first)) return parseHistoryToonl(text);
+
   const out: HistoryRecord[] = [];
   for (const raw of text.split("\n")) {
     const line = raw.trim();
     if (!line) continue;
     try {
-      out.push(JSON.parse(line) as HistoryRecord);
+      const record = normalizeHistoryRecord(JSON.parse(line));
+      if (record) out.push(record);
     } catch {
       continue;
     }
@@ -203,8 +289,26 @@ export async function historyAppend(
   if (!path) throw new Error("history: need <path>");
   const record = buildHistoryRecord(clock, event, fields);
   await io.ensureDir(dirname(path));
+  if (path.endsWith(".toonl")) {
+    const existing = parseHistoryLines((await io.read(path)) ?? "");
+    await io.write(path, renderHistoryToonl([...existing, record]));
+    return record;
+  }
   await io.append(path, `${serializeHistoryRecord(record)}\n`);
   return record;
+}
+
+export async function readHistoryRecords(
+  path: string,
+  io: Pick<HistoryIO, "read"> = defaultHistoryIO,
+): Promise<HistoryRecord[]> {
+  const converted = await io.read(path);
+  if (converted !== null) return parseHistoryLines(converted);
+  if (path.endsWith(".toonl")) {
+    const legacy = await io.read(path.slice(0, -".toonl".length) + ".jsonl");
+    if (legacy !== null) return parseHistoryLines(legacy);
+  }
+  return [];
 }
 
 /**
@@ -219,10 +323,13 @@ export async function historyTrim(
 ): Promise<number | null> {
   const text = await io.read(path);
   if (text === null) return null;
-  const lines = text.split("\n");
-  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
-  if (lines.length <= maxLines) return null;
-  const kept = lines.slice(lines.length - maxLines);
-  await io.write(path, `${kept.join("\n")}\n`);
+  const records = parseHistoryLines(text);
+  if (records.length <= maxLines) return null;
+  const kept = records.slice(records.length - maxLines);
+  if (path.endsWith(".toonl")) {
+    await io.write(path, renderHistoryToonl(kept));
+    return maxLines;
+  }
+  await io.write(path, `${kept.map(serializeHistoryRecord).join("\n")}\n`);
   return maxLines;
 }

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -754,7 +754,7 @@ async function ensurePr(
       "--title",
       scrubOutbound(prTitle),
       "--body",
-      scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the \`afk-attempts/*\` snapshot branches.\n\nCloses #${n}`),
+      scrubOutbound(`${PR_BODY_PREFIX}${n}. Per-attempt history lives in the issue Envelopes, the local ledgers, and the \`afk-attempts/*\` snapshot branches.\n\nCloses #${n}`),
     ]);
     if (create.code !== 0) return undefined;
     prNumber = await listOpenPr(exec, repo, branch, target);

--- a/apps/dev/src/core/proof-by-drain.ts
+++ b/apps/dev/src/core/proof-by-drain.ts
@@ -9,14 +9,14 @@
  * observed over a long enough window, with a low enough failure ratio — before
  * operators move the opt-in dist-tag pointer.
  *
- * The metrics come straight from the `afk-history.jsonl` ledger
+ * The metrics come straight from the AFK history ledger
  * ({@link HistoryRecord} in `history.ts`): `done` events carrying a `merge_sha`
  * are landed work (the drain), while `blocked`/`exhausted` are the failure lane.
  * Thresholds here are the *initial* bar from ADR 0058; tuning them is
  * operational and out of scope for this slice (PRD #614).
  */
 
-import { type HistoryRecord, parseHistoryLines } from "./history.js";
+import { type HistoryRecord, readHistoryRecords } from "./history.js";
 
 /** The initial promotion bar from ADR 0058. Tuning is operational (out of scope). */
 export interface PromotionBar {
@@ -137,7 +137,5 @@ export async function readDrainMetrics(
   io: DrainReadIO,
   sinceEpoch = 0,
 ): Promise<DrainMetrics> {
-  const text = await io.read(path);
-  if (!text) return computeDrainMetrics([], sinceEpoch);
-  return computeDrainMetrics(parseHistoryLines(text), sinceEpoch);
+  return computeDrainMetrics(await readHistoryRecords(path, io), sinceEpoch);
 }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -85,7 +85,7 @@ export function afkPaths(root: string): AfkPaths {
     tmpDir,
     stateDir,
     workersRoot: join(tmpDir, "workers"),
-    historyPath: join(stateDir, "afk-history.jsonl"),
+    historyPath: join(stateDir, "afk-history.toonl"),
     fleetStatePath: join(tmpDir, "afk-supervisor.state.json"),
     fleetFirehosePath: join(tmpDir, "afk-supervisor.log.jsonl"),
     monitorLogCursorPath: join(tmpDir, "monitor-log-cursors.json"),
@@ -469,7 +469,7 @@ import {
 } from "../core/worker-state-reader.js";
 import { planLivenessReclaim, type LivenessReclaimInput } from "../core/reclaim.js";
 import type { WorkerVitals } from "../types/state.js";
-import { parseHistoryLines, type HistoryRecord } from "../core/history.js";
+import { readHistoryRecords, type HistoryRecord } from "../core/history.js";
 
 export interface MonitorInputs {
   workers: CompactWorker[];
@@ -754,8 +754,7 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
     });
   }
 
-  const histText = await fsx.readText(paths.historyPath);
-  const events = histText === null ? [] : parseHistoryLines(histText).map((r) => ({ event: r.event, epoch: r.epoch }));
+  const events = (await readHistoryRecords(paths.historyPath, { read: fsx.readText })).map((r) => ({ event: r.event, epoch: r.epoch }));
   const fleet = await readFleetState(paths.fleetStatePath);
 
   // Remote facts: read the statusline TTL cache passively (no refresh — the monitor

--- a/apps/dev/tests/history.test.ts
+++ b/apps/dev/tests/history.test.ts
@@ -7,6 +7,7 @@ import {
   historyAppend,
   historyTrim,
   parseHistoryLines,
+  readHistoryRecords,
   readDoneBuckets,
   renderSparkline,
   type HistoryRecord,
@@ -83,9 +84,9 @@ describe("history sparkline rendering", () => {
 });
 
 describe("history append", () => {
-  it("appends one JSONL record per call with defaults and numeric fields", async () => {
+  it("appends one TOONL row per call with defaults, numeric fields, and explicit nulls", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
-    const path = join(dir, "nested", "afk-history.jsonl");
+    const path = join(dir, "nested", "afk-history.toonl");
 
     const r1 = await historyAppend(
       path,
@@ -99,7 +100,10 @@ describe("history append", () => {
     expect(typeof r1.issue).toBe("number");
     expect(typeof r1.duration_s).toBe("number");
 
-    const records = parseHistoryLines(await readFile(path, "utf8"));
+    const body = await readFile(path, "utf8");
+    expect(body.split("\n")[0]).toBe("[1]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:");
+    expect(body).toContain(",abcdef1,null");
+    const records = parseHistoryLines(body);
     expect(records.length).toBe(1);
     expect(records[0]?.worker).toBe("wTEST");
     expect(records[0]?.issue).toBe(42);
@@ -127,7 +131,7 @@ describe("history append", () => {
 
   it("round-trips a done event into bucket 0 via the reader", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
-    const path = join(dir, "afk-history.jsonl");
+    const path = join(dir, "afk-history.toonl");
     const nowEpoch = 1700000000;
     await historyAppend(path, { ts: "t", epoch: nowEpoch }, "done", { worker: "wRT", issue: 1 });
     const records = parseHistoryLines(await readFile(path, "utf8"));
@@ -135,7 +139,7 @@ describe("history append", () => {
     expect(total).toBe(1);
   });
 
-  it("skips malformed JSONL lines while keeping valid monitor history", () => {
+  it("skips malformed legacy JSONL lines while keeping valid monitor history", () => {
     const records = parseHistoryLines(
       [
         JSON.stringify({ ts: "t1", epoch: 1, worker: "wA", issue: 1, event: "done", duration_s: 0, runner: "codex" }),
@@ -148,6 +152,22 @@ describe("history append", () => {
     expect(records.map((record) => record.issue)).toEqual([1, 2]);
   });
 
+  it("skips a crash-truncated TOONL tail while keeping complete rows", () => {
+    const records = parseHistoryLines(
+      [
+        "[3]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:",
+        "  t1,1,wA,1,done,0,codex,null,null",
+        "  t2,2,wB,2,blocked,3,claude,null,no-sentinel",
+        "  t3,",
+        "",
+      ].join("\n"),
+    );
+
+    expect(records.map((record) => record.issue)).toEqual([1, 2]);
+    expect(records[0]).not.toHaveProperty("merge_sha");
+    expect(records[0]).not.toHaveProperty("reason");
+  });
+
   it("rejects an empty event", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
     const path = join(dir, "afk-history.jsonl");
@@ -156,18 +176,39 @@ describe("history append", () => {
 });
 
 describe("history trim", () => {
-  it("caps to the bound, keeps newest, and returns the cap", async () => {
+  it("caps to the bound, keeps newest, preserves the TOONL header, and returns the cap", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
-    const path = join(dir, "afk-history.jsonl");
+    const path = join(dir, "afk-history.toonl");
     const clock = (epoch: number) => ({ ts: "t", epoch });
     for (let i = 1; i <= 20; i += 1) {
       await historyAppend(path, clock(i), "done", {});
     }
     const echoed = await historyTrim(path, 5);
     expect(echoed).toBe(5);
-    const records = parseHistoryLines(await readFile(path, "utf8"));
+    const body = await readFile(path, "utf8");
+    expect(body.split("\n")[0]).toBe("[5]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:");
+    const records = parseHistoryLines(body);
     expect(records.length).toBe(5);
     expect(records[0]?.epoch).toBe(16); // newest 5 survive (16..20)
+  });
+
+  it("preserves TOONL header validity around every trim boundary", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
+    const path = join(dir, "afk-history.toonl");
+    for (let i = 1; i <= 12; i += 1) {
+      await historyAppend(path, { ts: "t", epoch: i }, "done", {});
+    }
+
+    for (let cap = 1; cap <= 12; cap += 1) {
+      const copy = join(dir, `copy-${cap}.toonl`);
+      await writeFile(copy, await readFile(path, "utf8"), "utf8");
+      await historyTrim(copy, cap);
+      const body = await readFile(copy, "utf8");
+      expect(body.split("\n")[0]).toBe(`[${cap}]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:`);
+      expect(parseHistoryLines(body).map((record) => record.epoch)).toEqual(
+        Array.from({ length: cap }, (_, index) => 13 - cap + index),
+      );
+    }
   });
 
   it("stays silent and untouched when under bound", async () => {
@@ -196,5 +237,24 @@ describe("history trim", () => {
 
     await expect(historyTrim(path, 2)).rejects.toThrow();
     expect(await readFile(path, "utf8")).toBe(original);
+  });
+});
+
+describe("history format sniffing", () => {
+  it("reads converted TOONL before legacy JSONL and falls back to legacy during migration", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
+    const legacy = join(dir, ".red", "state", "afk-history.jsonl");
+    const converted = join(dir, ".red", "state", "afk-history.toonl");
+    await mkdir(join(dir, ".red", "state"), { recursive: true });
+    await writeFile(
+      legacy,
+      `${JSON.stringify({ ts: "legacy", epoch: 1, worker: "wA", issue: 1, event: "done", duration_s: 0, runner: "codex" })}\n`,
+      "utf8",
+    );
+
+    expect((await readHistoryRecords(converted)).map((record) => record.ts)).toEqual(["legacy"]);
+
+    await historyAppend(converted, { ts: "converted", epoch: 2 }, "blocked", { worker: "wB", issue: 2 });
+    expect((await readHistoryRecords(converted)).map((record) => record.ts)).toEqual(["converted"]);
   });
 });

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -480,7 +480,7 @@ describe("doLanding — conventional landing titles (#1267)", () => {
     expect(r).toEqual({ ok: true, locked: false });
     const j = joined(h.mergeCalls);
     expect(j).toContain(
-      "gh -R o/r pr create --base main --head afk/wAAAA/9-fix-the-thing --title feat: #9 Fix the thing --body Automated AFK landing for #9. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.\n\nCloses #9",
+      "gh -R o/r pr create --base main --head afk/wAAAA/9-fix-the-thing --title feat: #9 Fix the thing --body Automated AFK landing for #9. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.\n\nCloses #9",
     );
     expect(j).toContain("gh -R o/r pr merge 42 --merge --subject feat: #9 Fix the thing");
   });

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -178,7 +178,7 @@ describe("afkPaths", () => {
     expect(p.tmpDir).toBe("/repo/.red/tmp");
     expect(p.stateDir).toBe("/repo/.red/state");
     expect(p.workersRoot).toBe("/repo/.red/tmp/workers");
-    expect(p.historyPath).toBe("/repo/.red/state/afk-history.jsonl");
+    expect(p.historyPath).toBe("/repo/.red/state/afk-history.toonl");
     expect(p.fleetStatePath).toBe("/repo/.red/tmp/afk-supervisor.state.json");
     expect(p.fleetFirehosePath).toBe("/repo/.red/tmp/afk-supervisor.log.jsonl");
     expect(p.configPath).toBe("/repo/.red/config.yaml");

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { encode } from "@reddb-io/toon";
 import {
+  DEV_TOON_MIGRATION_SURFACES,
   MEMORY_TOON_MIGRATION_SURFACES,
   convertRegisteredToonSurfaces,
   readRegisteredToonSurface,
@@ -57,6 +58,18 @@ describe("shared TOON migration registry", () => {
       ]),
     );
     expect(registeredToonSurfacesForPlugin("memory").map((surface) => surface.id)).toContain("memory.config");
+    expect(DEV_TOON_MIGRATION_SURFACES).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "dev.afk-history",
+          plugin: "dev",
+          legacyPath: ".red/state/afk-history.jsonl",
+          toonPath: ".red/state/afk-history.toonl",
+          kind: "toonl",
+        }),
+      ]),
+    );
+    expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.afk-history");
   });
 
   test("refuses while fleet or residents are active and explains why", async () => {
@@ -106,6 +119,46 @@ describe("shared TOON migration registry", () => {
     await expect(readRegisteredToonSurface(root, "memory.config")).resolves.toMatchObject({
       format: "toon",
       value: { mode: "graph", storePath: ".red/memory/graph.rdb" },
+    });
+  });
+
+  test("converts legacy AFK history JSONL to TOONL once and reads the converted file", async () => {
+    const root = await scratch();
+    await write(
+      root,
+      ".red/state/afk-history.jsonl",
+      [
+        JSON.stringify({ ts: "t1", epoch: 1, worker: "wA", issue: 1, event: "done", duration_s: 0, runner: "codex" }),
+        JSON.stringify({ ts: "t2", epoch: 2, worker: "wB", issue: 2, event: "blocked", duration_s: 3, runner: "claude", reason: "no-sentinel" }),
+        "",
+      ].join("\n"),
+    );
+
+    await expect(readRegisteredToonSurface(root, "dev.afk-history")).resolves.toMatchObject({
+      format: "jsonl",
+      value: [
+        expect.objectContaining({ ts: "t1", issue: 1 }),
+        expect.objectContaining({ ts: "t2", issue: 2, reason: "no-sentinel" }),
+      ],
+    });
+
+    const first = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+    const toonPath = join(root, ".red/state/afk-history.toonl");
+    const afterFirst = await readFile(toonPath, "utf8");
+    const second = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+
+    expect(first.status).toBe("converted");
+    expect(first.converted).toEqual(["dev.afk-history"]);
+    expect(afterFirst.split("\n")[0]).toBe("[2]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:");
+    expect(second.status).toBe("noop");
+    expect(second.skipped).toEqual(["dev.afk-history"]);
+    expect(await readFile(toonPath, "utf8")).toBe(afterFirst);
+    await expect(readRegisteredToonSurface(root, "dev.afk-history")).resolves.toMatchObject({
+      format: "toonl",
+      value: [
+        expect.objectContaining({ ts: "t1", issue: 1 }),
+        expect.objectContaining({ ts: "t2", issue: 2, reason: "no-sentinel" }),
+      ],
     });
   });
 });

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -45,8 +45,19 @@ export const MEMORY_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = 
   },
 ];
 
+export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
+  {
+    id: "dev.afk-history",
+    plugin: "dev",
+    legacyPath: ".red/state/afk-history.jsonl",
+    toonPath: ".red/state/afk-history.toonl",
+    kind: "toonl",
+  },
+];
+
 export const REGISTERED_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
   ...MEMORY_TOON_MIGRATION_SURFACES,
+  ...DEV_TOON_MIGRATION_SURFACES,
 ];
 
 export function registeredToonSurfacesForPlugin(
@@ -97,7 +108,7 @@ export async function convertRegisteredToonSurfaces(
 
     const value = await readLegacyFile(legacy, surface.kind);
     await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, renderSurface(value, surface.kind), "utf8");
+    await writeFile(target, renderSurface(value, surface), "utf8");
     converted.push(surface.id);
   }
 
@@ -166,21 +177,33 @@ async function readLegacyFile(path: string, kind: RegisteredToonSurfaceKind): Pr
 
 async function readConvertedFile(path: string, kind: RegisteredToonSurfaceKind): Promise<unknown> {
   const body = await readFile(path, "utf8");
-  if (kind === "toonl") {
-    return body
-      .split(/\r?\n/)
-      .filter((line) => line.trim().length > 0)
-      .map((line) => decode(line));
-  }
   return decode(body);
 }
 
-function renderSurface(value: unknown, kind: RegisteredToonSurfaceKind): string {
-  if (kind === "toonl") {
-    const rows = Array.isArray(value) ? value : [value];
-    return `${rows.map((row) => encode(row as JsonValue)).join("\n")}\n`;
+function renderSurface(value: unknown, surface: RegisteredToonSurface): string {
+  if (surface.kind === "toonl") {
+    const rows = normalizeToonlRows(surface, Array.isArray(value) ? value : [value]);
+    return encode(rows as JsonValue);
   }
   return encode(value as JsonValue);
+}
+
+function normalizeToonlRows(surface: RegisteredToonSurface, rows: unknown[]): unknown[] {
+  if (surface.id !== "dev.afk-history") return rows;
+  return rows.map((row) => {
+    const rec = row && typeof row === "object" ? row as Record<string, unknown> : {};
+    return {
+      ts: typeof rec.ts === "string" ? rec.ts : "",
+      epoch: Number.isFinite(Number(rec.epoch)) ? Number(rec.epoch) : 0,
+      worker: typeof rec.worker === "string" ? rec.worker : "",
+      issue: Number.isFinite(Number(rec.issue)) ? Number(rec.issue) : 0,
+      event: typeof rec.event === "string" ? rec.event : "",
+      duration_s: Number.isFinite(Number(rec.duration_s)) ? Number(rec.duration_s) : 0,
+      runner: typeof rec.runner === "string" ? rec.runner : "",
+      merge_sha: typeof rec.merge_sha === "string" && rec.merge_sha.length > 0 ? rec.merge_sha : null,
+      reason: typeof rec.reason === "string" && rec.reason.length > 0 ? rec.reason : null,
+    };
+  });
 }
 
 async function readPidFile(path: string): Promise<number | null> {


### PR DESCRIPTION
Automated AFK landing for #1781. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1781

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786684178&installation_id=129708444&pr_number=1795&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1795&signature=15e2013bf6166d3bfad1c917e4ceeecaf51b5f231bbf9716bf36e0170e17fbbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->