### PR TITLE
fix: #1782 TOON wave 1 S7: agent lane to TOONL and envelope log tails to TOON fences

### DIFF
--- a/apps/dev/src/core/envelope-emit.ts
+++ b/apps/dev/src/core/envelope-emit.ts
@@ -24,6 +24,8 @@ import { buildEnvelope, type AttemptStatus, type EnvelopeSection } from "./envel
 import { pushAttempt, type GitExec } from "./remote-branch.js";
 import { historyAppend, type HistoryAppendFields, type HistoryClock, type HistoryEvent, type HistoryIO } from "./history.js";
 import { enrichIssueReferences, type IssueReferenceLookup } from "./issue-reference.js";
+import { parseLane } from "./jsonl-log.js";
+import { encode, type JsonValue } from "@reddb-io/toon";
 
 /** Render N seconds as `<m>m<s>s`. Mirrors envelope_fmt_duration. */
 export function fmtDuration(seconds: number): string {
@@ -151,11 +153,11 @@ export function buildSections(
   } else if (status === "no-sentinel") {
     out.push({ name: "notes", body: sections.notes ?? "" });
     out.push({ name: "diff", body: diffBody() });
-    out.push({ name: "log", body: sections.log ?? "", fenced: true });
+    out.push({ name: "log", body: renderLogTailToon(sections.log ?? ""), fenced: true, fenceLang: "toon" });
     if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   } else if (status === "merge-conflict") {
     out.push({ name: "diff", body: diffBody() });
-    out.push({ name: "log", body: sections.log ?? "", fenced: true });
+    out.push({ name: "log", body: renderLogTailToon(sections.log ?? ""), fenced: true, fenceLang: "toon" });
     if (sections.base !== undefined) out.push({ name: "base", body: sections.base });
   }
 
@@ -165,6 +167,12 @@ export function buildSections(
     out.push({ name: "hooks", body: sections.hooks });
   }
   return out;
+}
+
+export function renderLogTailToon(log: string): string {
+  const records = parseLane(log);
+  if (records.length > 0) return encode(records as unknown as JsonValue);
+  return encode({ tail: log } as JsonValue);
 }
 
 /** Injected `gh issue comment` poster. Returns true on a successful (2xx) post.

--- a/apps/dev/src/core/envelope.ts
+++ b/apps/dev/src/core/envelope.ts
@@ -4,6 +4,7 @@ export interface EnvelopeSection {
   name: string;
   body: string;
   fenced?: boolean;
+  fenceLang?: string;
 }
 
 export interface EnvelopeInput {
@@ -25,7 +26,8 @@ export function buildEnvelope(input: EnvelopeInput): string {
   const summary = `worker \`${input.worker}\` · status: ${input.status} · duration: ${input.duration} · diff: ${input.diff} · attempt: ${input.attempt}${merge}`;
   const body = (input.sections ?? [])
     .map((section) => {
-      const content = section.fenced ? `\n\`\`\`\n${section.body}\n\`\`\`\n` : `\n${section.body}\n`;
+      const fence = section.fenced ? `\`\`\`${section.fenceLang ?? ""}` : "";
+      const content = section.fenced ? `\n${fence}\n${section.body}\n\`\`\`\n` : `\n${section.body}\n`;
       return `<details data-section="${escapeHtml(section.name)}"><summary>${escapeHtml(section.name)}</summary>\n${content}\n</details>`;
     })
     .join("\n\n");

--- a/apps/dev/src/core/jsonl-log.ts
+++ b/apps/dev/src/core/jsonl-log.ts
@@ -1,5 +1,6 @@
 import { mkdir, appendFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
 
 // The JSONL Log Module: owns the AFK structured-log lane format end to end.
 //
@@ -129,6 +130,13 @@ export function formatRecordLine(record: JsonlLogRecord): string {
   return JSON.stringify(record);
 }
 
+/** Serialize one agent-lane record as a standalone TOONL segment. Concatenating
+ * segments keeps appends O_APPEND-safe and lets a restart naturally open a new
+ * segment without rewriting earlier rows. */
+export function formatRecordToonl(record: JsonlLogRecord): string {
+  return encode([record] as unknown as JsonValue).trimEnd();
+}
+
 /**
  * The append IO: a thin injectable sink. The default writes to the filesystem
  * with O_APPEND semantics (Node's `appendFile` opens with `a`, so each write is
@@ -190,7 +198,7 @@ export async function appendAgentRecord(
     fields = { ...fields, extra: rest };
   }
   const record = buildRecord("agent", msg, options.ts, fields);
-  await (options.sink ?? fsAppendSink)(path, formatRecordLine(record));
+  await (options.sink ?? fsAppendSink)(path, formatRecordToonl(record));
   return record;
 }
 
@@ -206,8 +214,33 @@ export function filterByType(records: readonly JsonlLogRecord[], type: string): 
 
 /** Parse a lane's contents into records (one per non-empty line). */
 export function parseLane(content: string): JsonlLogRecord[] {
-  return content
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as JsonlLogRecord);
+  const lines = content.split(/\r?\n/);
+  const records: JsonlLogRecord[] = [];
+  let header = "";
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("{")) {
+      try {
+        records.push(JSON.parse(trimmed) as JsonlLogRecord);
+      } catch {
+        // Crash tails can leave a torn final row; keep the parseable prefix.
+      }
+      continue;
+    }
+    if (/^\[[0-9]+\]\{[^}]+\}:$/.test(trimmed)) {
+      header = trimmed;
+      continue;
+    }
+    if (!header) continue;
+    try {
+      const value = decode(header.replace(/^\[[0-9]+\]/, "[1]") + "\n" + line + "\n");
+      const row = Array.isArray(value) ? value[0] : value;
+      if (row && typeof row === "object") records.push(row as JsonlLogRecord);
+    } catch {
+      // TOONL readers are crash-tail tolerant during rollout.
+    }
+  }
+  return records;
 }

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -24,6 +24,7 @@ import {
   type WakeStats,
 } from "./event-wake.js";
 import { buildEnvelope } from "./envelope.js";
+import { renderLogTailToon } from "./envelope-emit.js";
 import { dispose } from "./disposition.js";
 import { type RecoveryEnv } from "./recovery.js";
 import {
@@ -946,7 +947,7 @@ export function buildReaperEnvelope(info: IterDirInfo): string {
     attempt: info.attempt,
     sections: [
       { name: "notes", body: info.notes.length > 0 ? info.notes : "(no agent notes recorded before stall-reap)" },
-      { name: "log", body: info.logTail, fenced: true },
+      { name: "log", body: renderLogTailToon(info.logTail), fenced: true, fenceLang: "toon" },
     ],
   });
 }
@@ -966,7 +967,7 @@ export function buildCrashEnvelope(info: IterDirInfo): string {
     attempt: info.attempt,
     sections: [
       { name: "notes", body: info.notes.length > 0 ? info.notes : "(no agent notes recorded before the orchestrator died)" },
-      { name: "log", body: info.logTail, fenced: true },
+      { name: "log", body: renderLogTailToon(info.logTail), fenced: true, fenceLang: "toon" },
     ],
   });
 }

--- a/apps/dev/tests/envelope-emit.test.ts
+++ b/apps/dev/tests/envelope-emit.test.ts
@@ -161,10 +161,11 @@ describe("buildSections", () => {
     expect(s.map((x) => x.name)).toEqual(["notes", "validation", "diff"]);
   });
 
-  it("no-sentinel → notes + diff + log (log fenced)", () => {
+  it("no-sentinel → notes + diff + log (log fenced as TOON)", () => {
     const s = buildSections("no-sentinel", { notes: "n", log: "line C" }, diff, "remote");
     expect(s.map((x) => x.name)).toEqual(["notes", "diff", "log"]);
     expect(s.find((x) => x.name === "log")?.fenced).toBe(true);
+    expect(s.find((x) => x.name === "log")?.fenceLang).toBe("toon");
   });
 
   it("merge-conflict → diff + log (no notes)", () => {
@@ -272,7 +273,7 @@ describe("emitEnvelope — per-status summary + sections", () => {
     expect(res.body).toContain("grep saw #42");
   });
 
-  it("no-sentinel: notes < diff < log, log fenced", async () => {
+  it("no-sentinel: notes < diff < log, log fenced as TOON", async () => {
     const { deps } = makeDeps();
     const res = await emitEnvelope(deps, {
       status: "no-sentinel",
@@ -291,7 +292,7 @@ describe("emitEnvelope — per-status summary + sections", () => {
     });
     expect(res.body).toContain('<details data-attempt-status="no-sentinel">');
     expect(res.body).toContain('<details data-section="log">');
-    expect(res.body).toContain("```");
+    expect(res.body).toContain("```toon");
     expect(res.body).toContain("line C");
     const n = res.body.indexOf('data-section="notes"');
     const d = res.body.indexOf('data-section="diff"');
@@ -320,6 +321,7 @@ describe("emitEnvelope — per-status summary + sections", () => {
     expect(res.body).toContain('<details data-attempt-status="merge-conflict">');
     expect(res.body).toContain('<details data-section="diff">');
     expect(res.body).toContain('<details data-section="log">');
+    expect(res.body).toContain("```toon");
     expect(res.body).toContain("CONFLICT (content)");
     expect(res.body).not.toContain('data-section="notes"');
   });

--- a/apps/dev/tests/handoff.test.ts
+++ b/apps/dev/tests/handoff.test.ts
@@ -76,6 +76,22 @@ describe("buildPreviousAttempts", () => {
     expect(out).toContain("<log>\nline A\nline B\nline C\n</log>");
   });
 
+  it("strips ```toon fences from a log section during rollout", () => {
+    const env = buildEnvelope({
+      status: "no-sentinel",
+      worker: "wTEST",
+      duration: "3m0s",
+      diff: "+5 -2",
+      attempt: 2,
+      sections: [
+        { name: "notes", body: "no notes" },
+        { name: "log", body: "tail: line C", fenced: true, fenceLang: "toon" },
+      ],
+    });
+    const out = buildPreviousAttempts([{ body: env }]);
+    expect(out).toContain("<log>\ntail: line C\n</log>");
+  });
+
   it("numbers attempts in order across multiple envelopes", () => {
     const e1 = makeEnvelope("blocked", "w1", "1m0s", 1, "first");
     const e2 = makeEnvelope("done", "w2", "2m0s", 2, "second");

--- a/apps/dev/tests/jsonl-log.test.ts
+++ b/apps/dev/tests/jsonl-log.test.ts
@@ -9,6 +9,7 @@ import {
   ENVELOPE_FIELD_ORDER,
   filterByType,
   filterByWorker,
+  formatRecordToonl,
   fsAppendSink,
   JsonlLogError,
   parseLane,
@@ -61,6 +62,12 @@ describe("jsonl-log record shape", () => {
     const line = JSON.stringify(buildRecord("agent", evil, TS));
     expect(line.includes("\n")).toBe(false);
     expect((JSON.parse(line) as { msg: string }).msg).toBe(evil);
+  });
+
+  it("serializes agent records as spec-valid TOONL segments", () => {
+    const segment = formatRecordToonl(buildRecord("agent", "hello", TS, { worker: "wA1B9", extra: { iteration: "1", kind: "text" } }));
+    expect(segment.split("\n")[0]).toBe("[1]{ts,worker,type,msg,iteration,kind}:");
+    expect(parseLane(segment).map((r) => r.msg)).toEqual(["hello"]);
   });
 
   it("keeps raw firehose payloads structured and omits dead default fields", () => {
@@ -147,7 +154,7 @@ describe("jsonl-log lane routing", () => {
 });
 
 describe("jsonl-log append accumulation and readers", () => {
-  it("accumulates appended lines on disk and auto-creates the parent dir", async () => {
+  it("accumulates appended JSONL and TOONL segments on disk and auto-creates the parent dir", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-jsonl-"));
     const lane = join(dir, "a", "b", "c", "lane.jsonl");
     await appendRecord(lane, "stage", "a", { ts: TS, fields: { worker: "wAAAA" } });
@@ -156,6 +163,13 @@ describe("jsonl-log append accumulation and readers", () => {
     const records = parseLane(await readFile(lane, "utf8"));
     expect(records.map((r) => r.msg)).toEqual(["a", "b", "c"]);
     expect(records.map((r) => r.type)).toEqual(["stage", "agent", "stage"]);
+  });
+
+  it("opens a new parseable TOONL segment after restart and skips a torn crash tail", async () => {
+    const first = formatRecordToonl(buildRecord("agent", "before restart", TS, { worker: "wAAAA" }));
+    const second = formatRecordToonl(buildRecord("agent", "after restart", TS, { worker: "wAAAA", extra: { iteration: "2" } }));
+    const records = parseLane(`${first}\n[1]{ts,type,msg}:\nthis is not valid toon\n${second}\n`);
+    expect(records.map((r) => r.msg)).toEqual(["before restart", "after restart"]);
   });
 
   it("default fs sink writes one valid JSON line per append", async () => {

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -1589,6 +1589,7 @@ describe("envelope builders", () => {
     expect(body).toContain("worker `wTEST`");
     expect(body).toContain('data-section="notes"');
     expect(body).toContain('data-section="log"');
+    expect(body).toContain("```toon");
     expect(body).toContain("stalled tool call");
   });
 });

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -67,9 +67,17 @@ describe("shared TOON migration registry", () => {
           toonPath: ".red/state/afk-history.toonl",
           kind: "toonl",
         }),
+        expect.objectContaining({
+          id: "dev.agent-log",
+          plugin: "dev",
+          legacyPath: ".red/tmp/agent.log.jsonl",
+          toonPath: ".red/tmp/agent.log.toonl",
+          kind: "toonl",
+        }),
       ]),
     );
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.afk-history");
+    expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.agent-log");
   });
 
   test("refuses while fleet or residents are active and explains why", async () => {
@@ -158,6 +166,34 @@ describe("shared TOON migration registry", () => {
       value: [
         expect.objectContaining({ ts: "t1", issue: 1 }),
         expect.objectContaining({ ts: "t2", issue: 2, reason: "no-sentinel" }),
+      ],
+    });
+  });
+
+  test("converts legacy agent lane JSONL to TOONL through the registry and skips crash tails", async () => {
+    const root = await scratch();
+    await write(
+      root,
+      ".red/tmp/agent.log.jsonl",
+      [
+        JSON.stringify({ ts: "t1", worker: "wA", type: "agent", msg: "line A", iteration: "1", kind: "text" }),
+        "{torn crash tail",
+        JSON.stringify({ ts: "t2", worker: "wA", issue: 2, attempt: 1, type: "agent", msg: "line B", iteration: "2", kind: "toolCall" }),
+        "",
+      ].join("\n"),
+    );
+
+    const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+    const toonPath = join(root, ".red/tmp/agent.log.toonl");
+    const body = await readFile(toonPath, "utf8");
+
+    expect(report.converted).toContain("dev.agent-log");
+    expect(body.split("\n")[0]).toBe("[2]{ts,lvl,worker,issue,attempt,type,msg,iteration,kind}:");
+    await expect(readRegisteredToonSurface(root, "dev.agent-log")).resolves.toMatchObject({
+      format: "toonl",
+      value: [
+        expect.objectContaining({ ts: "t1", worker: "wA", type: "agent", msg: "line A" }),
+        expect.objectContaining({ ts: "t2", issue: 2, attempt: 1, type: "agent", msg: "line B" }),
       ],
     });
   });

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -53,6 +53,13 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
     toonPath: ".red/state/afk-history.toonl",
     kind: "toonl",
   },
+  {
+    id: "dev.agent-log",
+    plugin: "dev",
+    legacyPath: ".red/tmp/agent.log.jsonl",
+    toonPath: ".red/tmp/agent.log.toonl",
+    kind: "toonl",
+  },
 ];
 
 export const REGISTERED_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
@@ -167,10 +174,18 @@ async function quiescenceReasons(rootDir: string): Promise<string[]> {
 async function readLegacyFile(path: string, kind: RegisteredToonSurfaceKind): Promise<unknown> {
   const body = await readFile(path, "utf8");
   if (kind === "toonl") {
-    return body
-      .split(/\r?\n/)
-      .filter((line) => line.trim().length > 0)
-      .map((line) => JSON.parse(line));
+    const rows: unknown[] = [];
+    for (const raw of body.split(/\r?\n/)) {
+      const line = raw.trim();
+      if (!line) continue;
+      try {
+        rows.push(JSON.parse(line));
+      } catch {
+        // Append-only lanes may end with a torn crash-tail row; convert the
+        // parseable prefix and let the next segment start clean.
+      }
+    }
+    return rows;
   }
   return JSON.parse(body);
 }
@@ -189,6 +204,22 @@ function renderSurface(value: unknown, surface: RegisteredToonSurface): string {
 }
 
 function normalizeToonlRows(surface: RegisteredToonSurface, rows: unknown[]): unknown[] {
+  if (surface.id === "dev.agent-log") {
+    return rows.map((row) => {
+      const rec = row && typeof row === "object" ? row as Record<string, unknown> : {};
+      return {
+        ts: typeof rec.ts === "string" ? rec.ts : "",
+        lvl: typeof rec.lvl === "string" && rec.lvl.length > 0 ? rec.lvl : null,
+        worker: typeof rec.worker === "string" && rec.worker.length > 0 ? rec.worker : null,
+        issue: Number.isFinite(Number(rec.issue)) ? Number(rec.issue) : null,
+        attempt: Number.isFinite(Number(rec.attempt)) ? Number(rec.attempt) : null,
+        type: typeof rec.type === "string" ? rec.type : "",
+        msg: rec.msg === undefined ? "" : rec.msg,
+        iteration: rec.iteration === undefined ? null : rec.iteration,
+        kind: rec.kind === undefined ? null : rec.kind,
+      };
+    });
+  }
   if (surface.id !== "dev.afk-history") return rows;
   return rows.map((row) => {
     const rec = row && typeof row === "object" ? row as Record<string, unknown> : {};


### PR DESCRIPTION
Automated AFK landing for #1782. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1782

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786684833&installation_id=129708444&pr_number=1796&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1796&signature=f7763f37f2bf1597c4dc51aaa10c66620156300bf11b7210dcd988649960919b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->