### PR TITLE
fix: #1783 TOON wave 1 S8: dev snapshot states (attempt state, statusline caches) to TOON

### DIFF
--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { decode as decodeToon, encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { AfkStateSchema, type AfkState } from "../types/state.js";
 
 export function defaultState(): AfkState {
@@ -100,10 +101,18 @@ export function parseState(data: unknown): AfkState {
   return AfkStateSchema.parse(migrateLegacyCurrentKeys(data ?? {}));
 }
 
+export function parseStateDocument(text: string): AfkState {
+  try {
+    return parseState(JSON.parse(text));
+  } catch {
+    return parseState(decodeToon(text));
+  }
+}
+
 export async function readState(path: string): Promise<AfkState> {
   try {
     const text = await readFile(path, "utf8");
-    return parseState(JSON.parse(text));
+    return parseStateDocument(text);
   } catch {
     return defaultState();
   }
@@ -200,8 +209,7 @@ function preserveStampedIdentity(
 export async function writeStateAtomic(path: string, state: AfkState): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
-  await writeFile(tmp, `${JSON.stringify(AfkStateSchema.parse(state))}
-`, "utf8");
+  await writeFile(tmp, encodeToon(AfkStateSchema.parse(state) as unknown as ToonValue), "utf8");
   await rename(tmp, path);
 }
 
@@ -234,7 +242,7 @@ export function initStateSync(path: string, updates: Record<string, unknown> = {
   const parsed = parseState(state);
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp.${process.pid}.sync`;
-  writeFileSync(tmp, `${JSON.stringify(AfkStateSchema.parse(parsed))}\n`, "utf8");
+  writeFileSync(tmp, encodeToon(AfkStateSchema.parse(parsed) as unknown as ToonValue), "utf8");
   renameSync(tmp, path);
   return parsed;
 }

--- a/apps/dev/src/core/worker-state-reader.ts
+++ b/apps/dev/src/core/worker-state-reader.ts
@@ -14,7 +14,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import type { AfkState } from "../types/state.js";
-import { parseState, isStateLive, parseIdentity, readIdentitySync, type PidStartTimeProbe } from "./state.js";
+import { parseStateDocument, isStateLive, parseIdentity, readIdentitySync, type PidStartTimeProbe } from "./state.js";
 import { globWorkerStates } from "../runtime/fs.js";
 import { allWorkersRoots } from "./worker-paths.js";
 import {
@@ -271,7 +271,7 @@ export function readWorkerState(path: string, opts: WorkerStateReadOpts = {}): W
   }
   let state: AfkState;
   try {
-    state = parseState(JSON.parse(text));
+    state = parseStateDocument(text);
   } catch {
     return null;
   }

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -21,7 +21,7 @@ import {
 import { dirname, join } from "node:path";
 import type { FailureMarkers } from "../core/envelope-emit.js";
 import type { OrphanDir, StaleClaimDir } from "../core/boot.js";
-import { updateState } from "../core/state.js";
+import { readState, updateState } from "../core/state.js";
 import { allWorkersRoots } from "../core/worker-paths.js";
 
 export async function ensureDir(path: string): Promise<void> {
@@ -210,11 +210,8 @@ export async function writeEnvelopePosted(attemptDir: string, posted: boolean): 
 /** Read the `envelope.posted` flag from an attempt state file (false when
  * absent/malformed). */
 export async function readEnvelopePosted(attemptDir: string): Promise<boolean> {
-  const text = await readText(join(attemptDir, "afk.state.json"));
-  if (text === null) return false;
   try {
-    const parsed = JSON.parse(text) as { envelope?: { posted?: unknown } };
-    return parsed.envelope?.posted === true;
+    return (await readState(join(attemptDir, "afk.state.json"))).envelope.posted === true;
   } catch {
     return false;
   }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -14,6 +14,7 @@ import type { ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { hostFingerprintPrefix } from "../core/host-identity.js";
+import { decode as decodeToon, encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import { resolveBase } from "../core/base-resolver.js";
 import type { SandboxMode } from "../core/execution.js";
@@ -850,9 +851,17 @@ export function statuslineCountCachePath(root: string): string {
   return join(afkPaths(root).tmpDir, "statusline-cache.json");
 }
 
+function decodeCacheDocument(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return decodeToon(text);
+  }
+}
+
 function readStatuslineCache(path: string): StatuslineCache | null {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<StatuslineCache>;
+    const parsed = decodeCacheDocument(readFileSync(path, "utf8")) as Partial<StatuslineCache>;
     return {
       queue: Number(parsed.queue ?? 0),
       human: Number(parsed.human ?? 0),
@@ -867,7 +876,7 @@ function writeStatuslineCacheAtomic(path: string, cache: StatuslineCache): void 
   try {
     mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp`;
-    writeFileSync(tmp, JSON.stringify(cache), "utf8");
+    writeFileSync(tmp, encodeToon(cache as unknown as ToonValue), "utf8");
     renameSync(tmp, path);
   } catch {
     // best-effort, like the bash `|| true`
@@ -1308,7 +1317,7 @@ interface RepoStatsCache {
 
 function readRepoStatsCache(path: string): RepoStatsCache | null {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<RepoStatsCache>;
+    const parsed = decodeCacheDocument(readFileSync(path, "utf8")) as Partial<RepoStatsCache>;
     return {
       baseRef: typeof parsed.baseRef === "string" && parsed.baseRef.trim() ? parsed.baseRef.trim() : "origin/main",
       openPrs: Number(parsed.openPrs ?? 0),
@@ -1325,8 +1334,9 @@ function readRepoStatsCache(path: string): RepoStatsCache | null {
 
 function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
   try {
+    mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp`;
-    writeFileSync(tmp, JSON.stringify(cache), "utf8");
+    writeFileSync(tmp, encodeToon(cache as unknown as ToonValue), "utf8");
     renameSync(tmp, path);
   } catch {
     // best-effort, like the bash `|| true`

--- a/apps/dev/tests/fs-envelope.test.ts
+++ b/apps/dev/tests/fs-envelope.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
 import { readEnvelopePosted, writeEnvelopePosted } from "../src/runtime/fs.js";
 
 describe("envelope posted state persistence", () => {
@@ -27,7 +28,12 @@ describe("envelope posted state persistence", () => {
 
     await writeEnvelopePosted(attemptDir, true);
 
-    const after = JSON.parse(await readFile(statePath, "utf8"));
+    const after = decode(await readFile(statePath, "utf8")) as {
+      worker_id?: string;
+      pid?: number;
+      runner?: string;
+      current?: Record<string, unknown>;
+    };
     expect(after.worker_id).toBe("wENV");
     expect(after.pid).toBe(123);
     expect(after.runner).toBe("codex");

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
 import {
   initState,
   initStateSync,
@@ -32,7 +33,8 @@ describe("state", () => {
     expect(state.current.activity).toBe("tests");
     expect(state.envelope.posted).toBe(true);
     expect(state.queue).toEqual([2, 3]);
-    expect(await readFile(path, "utf8")).toContain('"version":1');
+    const onDisk = decode(await readFile(path, "utf8")) as { version?: number };
+    expect(onDisk.version).toBe(1);
   });
 
   it("round-trips resolved base provenance fields through state updates", async () => {
@@ -77,9 +79,12 @@ describe("state", () => {
       "current.activity": "setup",
     });
     expect(seeded.pid).toBe(4242);
-    const onDisk = JSON.parse(await readFile(path, "utf8"));
+    const onDisk = decode(await readFile(path, "utf8")) as {
+      worker_id?: string;
+      current?: { number?: number };
+    };
     expect(onDisk.worker_id).toBe("wL30L");
-    expect(onDisk.current.number).toBe(583);
+    expect(onDisk.current?.number).toBe(583);
 
     // A subsequent vitals patch must NOT clobber the identity (the bug was the
     // sink seeding from DEFAULT and stranding the worker with no pid/number).

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { createServer, type Server, type Socket } from "node:net";
 import { Readable } from "node:stream";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { decode } from "@reddb-io/toon";
 import {
   statuslineCommand,
   resolveRoot,
@@ -588,7 +589,7 @@ describe("statusline command — rendered line", () => {
     const text = stripAnsi(out.text());
     expect(text).toContain("loc=+1");
     expect(text).not.toContain("loc=+2");
-    const cache = JSON.parse(await readFile(join(root, ".red", "tmp", "statusline-repo-cache.json"), "utf8")) as {
+    const cache = decode(await readFile(join(root, ".red", "tmp", "statusline-repo-cache.json"), "utf8")) as {
       baseRef: string;
       localAdded: number;
     };

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
+import { decode, encode } from "@reddb-io/toon";
 import {
   afkPaths,
   resolveRunSettings,
@@ -620,6 +621,10 @@ function detachedSpawnRecorder() {
   return { calls, spawn };
 }
 
+function readToonCache<T>(path: string): T {
+  return decode(readFileSync(path, "utf8")) as T;
+}
+
 // ---------------------------------------------------------------------------
 // collectStatuslineAfk — cache discipline (#818)
 // ---------------------------------------------------------------------------
@@ -635,7 +640,9 @@ describe("collectStatuslineAfk — cache discipline", () => {
       const before = nowS();
       await withFakeGh(() => collectStatuslineAfk({ root, repo: "", remote: "origin" }));
 
-      const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { queue: number; human: number; ts: number };
+      const raw = readFileSync(cachePath, "utf8");
+      expect(raw.trimStart().startsWith("{")).toBe(false);
+      const cache = decode(raw) as { queue: number; human: number; ts: number };
       expect(cache.ts).toBeGreaterThanOrEqual(before);
       expect(cache.queue).toBe(0); // fake gh returns []
       expect(cache.human).toBe(0);
@@ -731,6 +738,26 @@ describe("collectStatuslineAfk — cache discipline", () => {
       const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { queue: number; human: number; ts: number };
       expect(cache.ts).toBe(freshTs); // ts unchanged → no write
       expect(cache.queue).toBe(7); // cached value preserved
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fresh TOON cache: reads queue/human without a gh refresh", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const cachePath = join(tmpDir, "statusline-cache.json");
+      const freshTs = nowS();
+      writeFileSync(cachePath, encode({ queue: 11, human: 4, ts: freshTs }), "utf8");
+      writeRenderableAttempt(root, "w1", 55, new Date().toISOString());
+
+      const result = await collectStatuslineAfk({ root, repo: "", remote: "origin" });
+
+      expect(result?.queue).toBe(11);
+      expect(result?.human).toBe(4);
+      expect(readToonCache<{ ts: number }>(cachePath).ts).toBe(freshTs);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -860,16 +887,16 @@ describe("statusline count cache write-through", () => {
       writeFileSync(cachePath, JSON.stringify({ queue: 4, human: 2, ts: 100 }), "utf8");
 
       expect(applyStatuslineCountCacheLabelDelta(cachePath, ["ready-for-agent"], ["running"], 200)).toBe(true);
-      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 3, human: 2, ts: 200 });
+      expect(readToonCache(cachePath)).toEqual({ queue: 3, human: 2, ts: 200 });
 
       expect(applyStatuslineCountCacheLabelDelta(cachePath, ["running"], ["ready-for-human", "blocked:validation"], 300)).toBe(true);
-      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 3, human: 3, ts: 300 });
+      expect(readToonCache(cachePath)).toEqual({ queue: 3, human: 3, ts: 300 });
 
       expect(applyStatuslineCountCacheLabelDelta(cachePath, ["ready-for-human", "blocked:validation"], ["ready-for-agent"], 400)).toBe(true);
-      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 4, human: 2, ts: 400 });
+      expect(readToonCache(cachePath)).toEqual({ queue: 4, human: 2, ts: 400 });
 
       expect(applyStatuslineCountCacheLabelDelta(cachePath, ["ready-for-human"], [], 500)).toBe(true);
-      expect(JSON.parse(readFileSync(cachePath, "utf8"))).toEqual({ queue: 4, human: 1, ts: 500 });
+      expect(readToonCache(cachePath)).toEqual({ queue: 4, human: 1, ts: 500 });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -893,7 +920,7 @@ describe("statusline count cache write-through", () => {
         ["running"],
       );
 
-      const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { queue: number; human: number; ts: number };
+      const cache = readToonCache<{ queue: number; human: number; ts: number }>(cachePath);
       expect(ok).toBe(true);
       expect(edits).toBe(1);
       expect(cache.queue).toBe(0);
@@ -945,7 +972,9 @@ describe("collectStatuslineRepo — cache discipline", () => {
 
       await withFakeGh(() => collectStatuslineRepo({ root, repo: "", remote: "origin" }));
 
-      const cache = JSON.parse(readFileSync(cachePath, "utf8")) as { openPrs: number; openIssues: number; ts: number };
+      const raw = readFileSync(cachePath, "utf8");
+      expect(raw.trimStart().startsWith("{")).toBe(false);
+      const cache = decode(raw) as { openPrs: number; openIssues: number; ts: number };
       expect(cache.ts).toBeGreaterThan(staleTs); // ts advanced beyond the stale value
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -1000,6 +1029,32 @@ describe("collectStatuslineRepo — cache discipline", () => {
     }
   });
 
+  it("fresh TOON repo cache: serves the local diffstat without a refresh", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
+    try {
+      const tmpDir = join(root, ".red", "tmp");
+      mkdirSync(tmpDir, { recursive: true });
+      const cachePath = join(tmpDir, "statusline-repo-cache.json");
+      const freshTs = nowS();
+      writeFileSync(
+        cachePath,
+        encode({ baseRef: "origin/main", openPrs: 6, todayPrs: 2, openIssues: 14, localAdded: 20, localRemoved: 3, ts: freshTs }),
+        "utf8",
+      );
+
+      const result = await collectStatuslineRepo({ root, repo: "", remote: "origin" });
+
+      expect(result.openPrs).toBe(6);
+      expect(result.todayPrs).toBe(2);
+      expect(result.openIssues).toBe(14);
+      expect(result.localAdded).toBe(20);
+      expect(result.localRemoved).toBe(3);
+      expect(readToonCache<{ ts: number }>(cachePath).ts).toBe(freshTs);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("stale cache: folds the local diffstat into the same refresh (#1178)", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
     try {
@@ -1016,11 +1071,11 @@ describe("collectStatuslineRepo — cache discipline", () => {
 
       await withFakeGh(() => collectStatuslineRepo({ root, repo: "", remote: "origin" }));
 
-      const cache = JSON.parse(readFileSync(cachePath, "utf8")) as {
+      const cache = readToonCache<{
         localAdded: number;
         localRemoved: number;
         ts: number;
-      };
+      }>(cachePath);
       expect(cache.ts).toBeGreaterThan(staleTs); // refreshed
       // The diff fields are rewritten by the same refresh (root is not a git
       // repo → freshly-measured 0/0, overwriting the stale 99/11).

--- a/apps/dev/tests/worker-state-reader.test.ts
+++ b/apps/dev/tests/worker-state-reader.test.ts
@@ -2,7 +2,9 @@ import { mkdtemp, mkdir, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import { decode, encode } from "@reddb-io/toon";
 import { readWorkerState, readWorkerStates, readAllWorkerStates, isRenderableLive } from "../src/core/worker-state-reader.js";
+import { initStateSync } from "../src/core/state.js";
 import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 
 const NOW = Date.UTC(2026, 5, 22, 12, 0, 0);
@@ -116,6 +118,50 @@ describe("worker-state-reader", () => {
     expect(rec!.state.current.reasoning_events).toBe(5);
     expect(rec!.state.current.last_commit_at).toBe(fresh);
     expect(rec!.active).toBe(true);
+  });
+
+  it("reads a TOON attempt-state snapshot through the same schema path", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-toon-"));
+    const path = join(base, "afk.state.json");
+    await mkdir(base, { recursive: true });
+    await writeFile(
+      path,
+      encode({
+        worker_id: "wTOON",
+        pid: 4242,
+        current: {
+          number: 1783,
+          loc_added: 12,
+          loc_removed: 2,
+          last_event_at: fresh,
+        },
+      }),
+      "utf8",
+    );
+
+    const rec = readWorkerState(path, { nowMs: NOW, laneRecencyMs: LANE_FRESH_MS });
+    expect(rec).not.toBeNull();
+    expect(rec!.state.worker_id).toBe("wTOON");
+    expect(rec!.state.current.number).toBe(1783);
+    expect(rec!.state.current.loc_added).toBe(12);
+    expect(rec!.active).toBe(true);
+  });
+
+  it("writes the attempt-state snapshot as spec-valid TOON", async () => {
+    const base = await mkdtemp(join(tmpdir(), "wsr-write-toon-"));
+    const path = join(base, "afk.state.json");
+    initStateSync(path, {
+      worker_id: "wWRITE",
+      pid: 4242,
+      "current.number": 1783,
+      "current.activity": "setup",
+    });
+
+    const raw = await import("node:fs/promises").then((fs) => fs.readFile(path, "utf8"));
+    expect(raw.trimStart().startsWith("{")).toBe(false);
+    const decoded = decode(raw) as { worker_id?: string; current?: { number?: number } };
+    expect(decoded.worker_id).toBe("wWRITE");
+    expect(decoded.current?.number).toBe(1783);
   });
 
   it("returns null for a missing file", () => {

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -2,7 +2,7 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
-import { encode } from "@reddb-io/toon";
+import { decode, encode } from "@reddb-io/toon";
 import {
   DEV_TOON_MIGRATION_SURFACES,
   MEMORY_TOON_MIGRATION_SURFACES,
@@ -74,10 +74,32 @@ describe("shared TOON migration registry", () => {
           toonPath: ".red/tmp/agent.log.toonl",
           kind: "toonl",
         }),
+        expect.objectContaining({
+          id: "dev.attempt-state",
+          plugin: "dev",
+          legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
+          toonPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
+          kind: "toon",
+        }),
+        expect.objectContaining({
+          id: "dev.statusline-count-cache",
+          plugin: "dev",
+          legacyPath: ".red/tmp/statusline-cache.json",
+          toonPath: ".red/tmp/statusline-cache.json",
+          kind: "toon",
+        }),
+        expect.objectContaining({
+          id: "dev.statusline-repo-cache",
+          plugin: "dev",
+          legacyPath: ".red/tmp/statusline-repo-cache.json",
+          toonPath: ".red/tmp/statusline-repo-cache.json",
+          kind: "toon",
+        }),
       ]),
     );
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.afk-history");
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.agent-log");
+    expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.attempt-state");
   });
 
   test("refuses while fleet or residents are active and explains why", async () => {
@@ -196,5 +218,40 @@ describe("shared TOON migration registry", () => {
         expect.objectContaining({ ts: "t2", issue: 2, attempt: 1, type: "agent", msg: "line B" }),
       ],
     });
+  });
+
+  test("converts legacy dev snapshot states and statusline caches in place", async () => {
+    const root = await scratch();
+    await write(
+      root,
+      ".red/tmp/workers/wA/1783-a1/afk.state.json",
+      JSON.stringify({ worker_id: "wA", pid: 0, current: { number: 1783, activity: "impl" } }),
+    );
+    await write(root, ".red/tmp/statusline-cache.json", JSON.stringify({ queue: 4, human: 1, ts: 100 }));
+    await write(
+      root,
+      ".red/tmp/statusline-repo-cache.json",
+      JSON.stringify({ baseRef: "origin/main", openPrs: 2, todayPrs: 1, openIssues: 8, localAdded: 5, localRemoved: 2, ts: 100 }),
+    );
+
+    const first = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+    const second = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+
+    expect(first.converted).toEqual(
+      expect.arrayContaining(["dev.attempt-state", "dev.statusline-count-cache", "dev.statusline-repo-cache"]),
+    );
+    const stateRaw = await readFile(join(root, ".red/tmp/workers/wA/1783-a1/afk.state.json"), "utf8");
+    const countRaw = await readFile(join(root, ".red/tmp/statusline-cache.json"), "utf8");
+    const repoRaw = await readFile(join(root, ".red/tmp/statusline-repo-cache.json"), "utf8");
+    expect(stateRaw.trimStart().startsWith("{")).toBe(false);
+    expect(countRaw.trimStart().startsWith("{")).toBe(false);
+    expect(repoRaw.trimStart().startsWith("{")).toBe(false);
+    expect((decode(stateRaw) as { current?: { number?: number } }).current?.number).toBe(1783);
+    expect((decode(countRaw) as { queue?: number }).queue).toBe(4);
+    expect((decode(repoRaw) as { openPrs?: number }).openPrs).toBe(2);
+    expect(second.status).toBe("noop");
+    expect(second.skipped).toEqual(
+      expect.arrayContaining(["dev.attempt-state", "dev.statusline-count-cache", "dev.statusline-repo-cache"]),
+    );
   });
 });

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -1,5 +1,5 @@
 import { accessSync, constants } from "node:fs";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 
@@ -60,6 +60,27 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
     toonPath: ".red/tmp/agent.log.toonl",
     kind: "toonl",
   },
+  {
+    id: "dev.attempt-state",
+    plugin: "dev",
+    legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
+    toonPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
+    kind: "toon",
+  },
+  {
+    id: "dev.statusline-count-cache",
+    plugin: "dev",
+    legacyPath: ".red/tmp/statusline-cache.json",
+    toonPath: ".red/tmp/statusline-cache.json",
+    kind: "toon",
+  },
+  {
+    id: "dev.statusline-repo-cache",
+    plugin: "dev",
+    legacyPath: ".red/tmp/statusline-repo-cache.json",
+    toonPath: ".red/tmp/statusline-repo-cache.json",
+    kind: "toon",
+  },
 ];
 
 export const REGISTERED_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
@@ -101,22 +122,39 @@ export async function convertRegisteredToonSurfaces(
   const missing: string[] = [];
 
   for (const surface of selected) {
-    const target = join(opts.rootDir, surface.toonPath);
-    if (await pathExists(target)) {
-      skipped.push(surface.id);
-      continue;
-    }
-
-    const legacy = join(opts.rootDir, surface.legacyPath);
-    if (!(await pathExists(legacy))) {
+    const targets = await expandSurfaceTargets(opts.rootDir, surface);
+    if (targets.length === 0) {
       missing.push(surface.id);
       continue;
     }
 
-    const value = await readLegacyFile(legacy, surface.kind);
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, renderSurface(value, surface), "utf8");
-    converted.push(surface.id);
+    let convertedAny = false;
+    let skippedAny = false;
+    for (const targetInfo of targets) {
+      const target = targetInfo.toonPath;
+      if (await targetAlreadyConverted(targetInfo)) {
+        skippedAny = true;
+        continue;
+      }
+
+      const legacy = targetInfo.legacyPath;
+      if (!(await pathExists(legacy))) {
+        continue;
+      }
+
+      const value = await readLegacyFile(legacy, surface.kind);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, renderSurface(value, surface), "utf8");
+      convertedAny = true;
+    }
+
+    if (convertedAny) {
+      converted.push(surface.id);
+    } else if (skippedAny) {
+      skipped.push(surface.id);
+    } else {
+      missing.push(surface.id);
+    }
   }
 
   return {
@@ -137,7 +175,7 @@ export async function readRegisteredToonSurface(
   if (!surface) throw new Error(`unknown registered TOON surface: ${surfaceId}`);
 
   const converted = join(rootDir, surface.toonPath);
-  if (await pathExists(converted)) {
+  if (await pathExists(converted) && await isReadableConvertedFile(converted, surface.kind)) {
     return {
       surface,
       path: converted,
@@ -153,6 +191,57 @@ export async function readRegisteredToonSurface(
     format: surface.kind === "toonl" ? "jsonl" : "json",
     value: await readLegacyFile(legacy, surface.kind),
   };
+}
+
+interface SurfaceTarget {
+  surface: RegisteredToonSurface;
+  legacyPath: string;
+  toonPath: string;
+}
+
+async function expandSurfaceTargets(rootDir: string, surface: RegisteredToonSurface): Promise<SurfaceTarget[]> {
+  if (surface.id !== "dev.attempt-state") {
+    return [{ surface, legacyPath: join(rootDir, surface.legacyPath), toonPath: join(rootDir, surface.toonPath) }];
+  }
+  const out: SurfaceTarget[] = [];
+  for (const namespace of ["workers", "go-workers", "scout-workers"]) {
+    const nsRoot = join(rootDir, ".red", "tmp", namespace);
+    let workers: string[];
+    try {
+      workers = await readdir(nsRoot);
+    } catch {
+      continue;
+    }
+    for (const worker of workers) {
+      const workerRoot = join(nsRoot, worker);
+      let attempts: string[];
+      try {
+        attempts = await readdir(workerRoot);
+      } catch {
+        continue;
+      }
+      for (const attempt of attempts) {
+        const path = join(workerRoot, attempt, "afk.state.json");
+        if (await pathExists(path)) out.push({ surface, legacyPath: path, toonPath: path });
+      }
+    }
+  }
+  return out;
+}
+
+async function targetAlreadyConverted(target: SurfaceTarget): Promise<boolean> {
+  if (!(await pathExists(target.toonPath))) return false;
+  if (target.legacyPath !== target.toonPath) return true;
+  return isReadableConvertedFile(target.toonPath, target.surface.kind);
+}
+
+async function isReadableConvertedFile(path: string, kind: RegisteredToonSurfaceKind): Promise<boolean> {
+  try {
+    await readConvertedFile(path, kind);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function quiescenceReasons(rootDir: string): Promise<string[]> {


### PR DESCRIPTION
Automated AFK landing for #1783. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1783

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786685786&installation_id=129708444&pr_number=1797&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1797&signature=8ae83ee2b9b051fe0bca40b4ee259891cd04d09cfba1168024a918a025baa586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->