### PR TITLE
feat: #1784 TOON wave 1 S9 — rsp snapshot surfaces (resident registry, status summary) to TOON

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -19,6 +19,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
+import { decode } from "@reddb-io/toon";
 import { resolveBase } from "../core/base-resolver.js";
 import { type ClaudeInput, type ProjectInput, type RspStatusInput, type StatuslinePreset } from "../core/statusline.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
@@ -156,7 +157,8 @@ interface RspSummaryFile {
 
 function parseRspSummary(path: string): RspSummaryFile | undefined {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    const raw = readFileSync(path, "utf8").trim();
+    const parsed = raw.startsWith("{") ? JSON.parse(raw) as unknown : decode(raw);
     if (
       typeof parsed === "object" &&
       parsed !== null &&

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { createServer, type Server, type Socket } from "node:net";
 import { Readable } from "node:stream";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { decode } from "@reddb-io/toon";
+import { decode, encode } from "@reddb-io/toon";
 import {
   statuslineCommand,
   resolveRoot,
@@ -753,6 +753,26 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
     expect(stripAnsi(out.text())).toContain("rsp=↓1.32M int=0/12");
+  });
+
+  it("reads a TOON rsp resident summary for statusline rendering", async () => {
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 0, 0);
+    await mkdir(dirname(resolveResidentPaths(root).summaryPath), { recursive: true });
+    await writeFile(resolveResidentPaths(root).summaryPath, encode({
+      version: 1,
+      tokens_saved_today: 2048,
+      decisions: { contributed: 2, seen: 3 },
+      updated_at: new Date().toISOString(),
+    }), "utf8");
+
+    expect(await resolveStatuslineRsp(root, {})).toEqual({
+      state: "ready",
+      tokensSavedToday: 2048,
+      decisions: { contributed: 2, seen: 3 },
+    });
   });
 
   it("renders rsp savings from an old summary when the resident is idle", async () => {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -6,6 +6,7 @@ import { createServer, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { RedDB } from "@reddb-io/sdk";
+import { encode, type JsonObject } from "@reddb-io/toon";
 import { removeResidentRegistry, writeResidentRegistry } from "@reddb-io/shared/resident-client.js";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
@@ -465,21 +466,22 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
     : 0;
   const path = join(rootDir, RSP_STATUS_SUMMARY);
   const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(tmp, JSON.stringify({
+  const payload: JsonObject = {
     version: 1,
     tokens_saved_today: tokensSavedToday,
     dollars_saved_today_usd: Math.round(dollarsSavedToday * 1_000_000) / 1_000_000,
     show_total_today: stats.health.show_total,
-    show_hit_rate: stats.health.show_total > 0 ? stats.health.show_hit_rate : undefined,
-    decisions: stats.decisions.seen > 0
-      ? {
-          seen: stats.decisions.seen,
-          contributed: stats.decisions.contributed,
-        }
-      : undefined,
     updated_at: now.toISOString(),
-  }), { encoding: "utf8", mode: 0o600 });
+  };
+  if (stats.health.show_total > 0) payload.show_hit_rate = stats.health.show_hit_rate;
+  if (stats.decisions.seen > 0) {
+    payload.decisions = {
+      seen: stats.decisions.seen,
+      contributed: stats.decisions.contributed,
+    };
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tmp, `${encode(payload)}\n`, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);
 }
 

--- a/apps/rsp/src/wait.ts
+++ b/apps/rsp/src/wait.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
-import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { decode, encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 
 type WaitKind = "cmd" | "pr" | "run" | "release";
 type WaitStatus = "running" | "success" | "failure" | "timeout" | "indeterminate";
@@ -87,7 +87,7 @@ export async function runWait(argv: readonly string[], cwd = process.cwd()): Pro
   let verdict: Verdict = { status: "indeterminate", exitCode: 2, summary: "wait did not start" };
   try {
     await mkdir(await waitRegistryDir(cwd), { recursive: true });
-    await writeFile(registryPath, JSON.stringify(entry, null, 2), "utf8");
+    await writeRegistryEntry(registryPath, entry);
     verdict = await dispatchWait({ ...parsed, kind: waitKind }, cwd, registryPath, entry);
     process.stdout.write(`${encode(renderVerdict(waitKind, entry, verdict))}\n`);
     await signalCompletion(parsed.options);
@@ -350,9 +350,9 @@ async function listWaits(cwd: string): Promise<JsonObject[]> {
   if (!existsSync(dir)) return [];
   const files = await readdir(dir).catch(() => []);
   const waits: JsonObject[] = [];
-  for (const file of files.filter((name) => name.endsWith(".json"))) {
+  for (const file of files.filter((name) => name.endsWith(".json") || name.endsWith(".toon"))) {
     const path = join(dir, file);
-    const entry = parseRecord(await readFile(path, "utf8").catch(() => "{}"));
+    const entry = parseStructuredRecord(await readFile(path, "utf8").catch(() => "{}"));
     const pid = typeof entry.pid === "number" ? entry.pid : 0;
     if (!pid || !pidAlive(pid)) {
       await rm(path, { force: true });
@@ -378,7 +378,11 @@ async function repoRoot(cwd: string): Promise<string> {
 }
 
 async function writeStatus(path: string, entry: WaitRegistryEntry, status: WaitStatus): Promise<void> {
-  await writeFile(path, JSON.stringify({ ...entry, status }, null, 2), "utf8").catch(() => undefined);
+  await writeRegistryEntry(path, { ...entry, status }).catch(() => undefined);
+}
+
+async function writeRegistryEntry(path: string, entry: WaitRegistryEntry): Promise<void> {
+  await writeFile(path, `${encode(entry as unknown as JsonObject)}\n`, "utf8");
 }
 
 async function signalCompletion(options: WaitOptions): Promise<void> {
@@ -449,6 +453,18 @@ function parseRecord(raw: string): Record<string, unknown> {
   const parsed = JSON.parse(raw);
   if (!isRecord(parsed)) throw new Error("expected JSON object");
   return parsed;
+}
+
+function parseStructuredRecord(raw: string): Record<string, unknown> {
+  const body = raw.trim();
+  if (!body) return {};
+  try {
+    return parseRecord(body);
+  } catch {
+    const parsed = decode(body);
+    if (!isRecord(parsed)) throw new Error("expected structured object");
+    return parsed;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { spawn, spawnSync } from "node:child_process";
@@ -446,7 +446,7 @@ async function waitForSummaryTokens(root: string, minTokens: number): Promise<nu
   let last = 0;
   while (Date.now() < deadline) {
     try {
-      const summary = JSON.parse(await readFile(summaryPath, "utf8")) as { tokens_saved_today?: unknown };
+      const summary = parseStructured(await readFile(summaryPath, "utf8")) as { tokens_saved_today?: unknown };
       last = typeof summary.tokens_saved_today === "number" ? summary.tokens_saved_today : 0;
       if (last > minTokens) return last;
     } catch {}
@@ -454,6 +454,16 @@ async function waitForSummaryTokens(root: string, minTokens: number): Promise<nu
   }
   expect(last).toBeGreaterThan(minTokens);
   return last;
+}
+
+function parseStructured(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return decode(body);
+  }
 }
 
 async function readResidentVersion(root: string): Promise<string | undefined> {
@@ -1608,11 +1618,13 @@ describe("rsp cli", () => {
     );
     await waitForResidentSocket(root);
     expect(await readResidentVersion(root)).toBe(oldVersion);
-    const oldRegistry = JSON.parse(await readFile(trackedResidentPaths(root).registryPath, "utf8")) as {
+    const oldRegistryRaw = await readFile(trackedResidentPaths(root).registryPath, "utf8");
+    const oldRegistry = parseStructured(oldRegistryRaw) as {
       pid: number;
       resident_version: string;
     };
     expect(oldRegistry.resident_version).toBe(oldVersion);
+    expect(oldRegistryRaw.trimStart().startsWith("{")).toBe(false);
     await expectWarmResident(root, { RED_SKILLS_CACHE_DIR: cacheDir });
 
     const compressed = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
@@ -1625,7 +1637,7 @@ describe("rsp cli", () => {
     expect(shown.status, `${shown.stdout.toString("utf8")}${shown.stderr.toString("utf8")}`).toBe(0);
     expect(shown.stdout.length).toBeGreaterThan(compressed.stdout.length);
     expect(await readResidentVersion(root)).not.toBe(oldVersion);
-    const nextRegistry = JSON.parse(await readFile(trackedResidentPaths(root).registryPath, "utf8")) as {
+    const nextRegistry = parseStructured(await readFile(trackedResidentPaths(root).registryPath, "utf8")) as {
       pid: number;
       resident_version: string;
     };
@@ -2045,11 +2057,13 @@ describe("rsp cli", () => {
     expect(statsText).toContain("command: git log --terse invocations: 1");
     expect(statsText).toContain("command: gh pr list invocations: 1");
     expect(statsText).toContain("degradations: 1\n");
-    const summary = JSON.parse(await readFile(resolveResidentPaths(root).summaryPath, "utf8")) as {
+    const summaryRaw = await readFile(resolveResidentPaths(root).summaryPath, "utf8");
+    const summary = parseStructured(summaryRaw) as {
       version: number;
       tokens_saved_today: number;
       updated_at: string;
     };
+    expect(summaryRaw.trimStart().startsWith("{")).toBe(false);
     expect(summary.version).toBe(1);
     expect(summary.tokens_saved_today).toBeGreaterThan(0);
     expect(Date.parse(summary.updated_at)).not.toBeNaN();
@@ -2344,7 +2358,8 @@ describe("rsp cli", () => {
 
   it("wait ls shows a live registry entry while a command wait is active", async () => {
     const root = await tempRoot();
-    const command = `${shellQuote(process.execPath)} -e "setTimeout(() => process.exit(0), 3000)"`;
+    await mkdir(join(root, ".red"), { recursive: true });
+    const command = `${shellQuote(process.execPath)} -e "setTimeout(() => process.exit(0), 8000)"`;
     const child = spawn(process.execPath, ["--import", tsxLoader, cli, "wait", "cmd", "--reason", "registry probe", "--", command], {
       cwd: root,
       env: { ...process.env },
@@ -2359,6 +2374,10 @@ describe("rsp cli", () => {
     expect(listed.target).toContain("cmd:");
     expect(listed.status).toBe("running");
     expect(listed.poll_tier).toBe("local-cmd:2-5s");
+    const registryFiles = await readdir(join(root, ".red", "tmp", "waits"));
+    const registryBody = await readFile(join(root, ".red", "tmp", "waits", registryFiles[0]!), "utf8");
+    expect(registryBody.trimStart().startsWith("{")).toBe(false);
+    expect((decode(registryBody) as { reason?: string }).reason).toBe("registry probe");
 
     const status = await closeWithTimeout(child, normalizedDurationMs(10_000));
     expect(status, Buffer.concat(stderr).toString("utf8")).toBe(0);

--- a/apps/rsp/tests/resident-memory.test.ts
+++ b/apps/rsp/tests/resident-memory.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { connect } from "@reddb-io/sdk";
+import { decode } from "@reddb-io/toon";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { graphRecall } from "../../memory/src/graph-recall.js";
 import { MemoryStore } from "../../memory/src/graph-store.js";
@@ -227,7 +228,8 @@ async function waitForRegistry(path: string, timeoutMs = 5_000): Promise<{
   let last: unknown;
   while (Date.now() < deadline) {
     try {
-      return JSON.parse(await readFile(path, "utf8")) as {
+      const raw = await readFile(path, "utf8");
+      return parseRegistryDocument(raw) as {
         pid: number;
         socket_path: string;
         store_uri: string;
@@ -240,6 +242,14 @@ async function waitForRegistry(path: string, timeoutMs = 5_000): Promise<{
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw last instanceof Error ? last : new Error("resident registry did not appear");
+}
+
+function parseRegistryDocument(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return decode(raw.trim());
+  }
 }
 
 async function shutdownResident(socketPath: string, timeoutMs = 5_000): Promise<void> {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { connect } from "@reddb-io/sdk";
+import { decode } from "@reddb-io/toon";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   appendTelemetryEvent,
@@ -676,7 +677,7 @@ describe("rsp telemetry spool", () => {
       reason: "matched-capability",
       capability_id: "git:status",
     }));
-    const summary = JSON.parse(await readFile(paths.summaryPath, "utf8")) as {
+    const summary = parseStructured(await readFile(paths.summaryPath, "utf8")) as {
       decisions?: { seen?: number; contributed?: number };
     };
     expect(summary.decisions).toEqual({ seen: 1, contributed: 1 });
@@ -1158,10 +1159,20 @@ async function waitForStatusSummary(summaryPath: string, minMtimeMs = 0, timeout
       readFile(summaryPath, "utf8").catch(() => ""),
       fileMtimeMs(summaryPath),
     ]);
-    if (summary.includes("tokens_saved_today") && mtimeMs > minMtimeMs) return;
+    if (parseStructured(summary) && mtimeMs > minMtimeMs) return;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error("rsp status summary did not refresh");
+}
+
+function parseStructured(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return decode(body);
+  }
 }
 
 async function fileMtimeMs(path: string): Promise<number> {

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -6,6 +6,7 @@ import { mkdir, open, readFile, rename, rm, stat, writeFile } from "node:fs/prom
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { decode, encode, type JsonObject } from "@reddb-io/toon";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
 
@@ -184,7 +185,7 @@ export async function warmResidentServer(paths: RspResidentPaths, config: RspRes
 
 export async function readResidentRegistry(path: string): Promise<RspResidentRegistryEntry | null> {
   try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+    const parsed = parseStructuredDocument(await readFile(path, "utf8"));
     return isResidentRegistryEntry(parsed) ? parsed : null;
   } catch {
     return null;
@@ -208,7 +209,7 @@ export async function writeResidentRegistry(
   };
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(payload)}\n`, { encoding: "utf8", mode: 0o600 });
+  await writeFile(tmp, `${encode(payload as unknown as JsonObject)}\n`, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);
 }
 
@@ -376,6 +377,16 @@ function tailString(value: string, maxBytes: number): string {
   const bytes = Buffer.byteLength(value, "utf8");
   if (bytes <= maxBytes) return value;
   return Buffer.from(value, "utf8").subarray(bytes - maxBytes).toString("utf8").replace(/^\uFFFD+/, "");
+}
+
+function parseStructuredDocument(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return decode(body);
+  }
 }
 
 async function reconcileResidentRegistry(paths: RspResidentPaths, config: RspResidentConfig): Promise<void> {

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -95,11 +95,33 @@ describe("shared TOON migration registry", () => {
           toonPath: ".red/tmp/statusline-repo-cache.json",
           kind: "toon",
         }),
+        expect.objectContaining({
+          id: "dev.rsp-resident-registry",
+          plugin: "dev",
+          legacyPath: ".red/tmp/rsp-resident.pid.json",
+          toonPath: ".red/tmp/rsp-resident.pid.json",
+          kind: "toon",
+        }),
+        expect.objectContaining({
+          id: "dev.rsp-status-summary",
+          plugin: "dev",
+          legacyPath: ".red/tmp/rsp-status-summary.json",
+          toonPath: ".red/tmp/rsp-status-summary.json",
+          kind: "toon",
+        }),
+        expect.objectContaining({
+          id: "dev.rsp-wait-registry",
+          plugin: "dev",
+          legacyPath: ".red/tmp/waits/*.json",
+          toonPath: ".red/tmp/waits/*.json",
+          kind: "toon",
+        }),
       ]),
     );
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.afk-history");
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.agent-log");
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.attempt-state");
+    expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.rsp-wait-registry");
   });
 
   test("refuses while fleet or residents are active and explains why", async () => {
@@ -233,25 +255,59 @@ describe("shared TOON migration registry", () => {
       ".red/tmp/statusline-repo-cache.json",
       JSON.stringify({ baseRef: "origin/main", openPrs: 2, todayPrs: 1, openIssues: 8, localAdded: 5, localRemoved: 2, ts: 100 }),
     );
+    await write(
+      root,
+      ".red/tmp/rsp-resident.pid.json",
+      JSON.stringify({ version: 1, pid: 0, socket_path: "sock", store_uri: "file://store", resident_version: "old", started_at: "t" }),
+    );
+    await write(root, ".red/tmp/rsp-status-summary.json", JSON.stringify({ version: 1, tokens_saved_today: 12, updated_at: "t" }));
+    await write(
+      root,
+      ".red/tmp/waits/wait-a.json",
+      JSON.stringify({ id: "wait-a", target: "cmd:test", reason: "legacy", pid: 0, started_at: "t", poll_tier: "local", status: "running" }),
+    );
 
     const first = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
     const second = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
 
     expect(first.converted).toEqual(
-      expect.arrayContaining(["dev.attempt-state", "dev.statusline-count-cache", "dev.statusline-repo-cache"]),
+      expect.arrayContaining([
+        "dev.attempt-state",
+        "dev.statusline-count-cache",
+        "dev.statusline-repo-cache",
+        "dev.rsp-resident-registry",
+        "dev.rsp-status-summary",
+        "dev.rsp-wait-registry",
+      ]),
     );
     const stateRaw = await readFile(join(root, ".red/tmp/workers/wA/1783-a1/afk.state.json"), "utf8");
     const countRaw = await readFile(join(root, ".red/tmp/statusline-cache.json"), "utf8");
     const repoRaw = await readFile(join(root, ".red/tmp/statusline-repo-cache.json"), "utf8");
+    const residentRaw = await readFile(join(root, ".red/tmp/rsp-resident.pid.json"), "utf8");
+    const summaryRaw = await readFile(join(root, ".red/tmp/rsp-status-summary.json"), "utf8");
+    const waitRaw = await readFile(join(root, ".red/tmp/waits/wait-a.json"), "utf8");
     expect(stateRaw.trimStart().startsWith("{")).toBe(false);
     expect(countRaw.trimStart().startsWith("{")).toBe(false);
     expect(repoRaw.trimStart().startsWith("{")).toBe(false);
+    expect(residentRaw.trimStart().startsWith("{")).toBe(false);
+    expect(summaryRaw.trimStart().startsWith("{")).toBe(false);
+    expect(waitRaw.trimStart().startsWith("{")).toBe(false);
     expect((decode(stateRaw) as { current?: { number?: number } }).current?.number).toBe(1783);
     expect((decode(countRaw) as { queue?: number }).queue).toBe(4);
     expect((decode(repoRaw) as { openPrs?: number }).openPrs).toBe(2);
+    expect((decode(residentRaw) as { resident_version?: string }).resident_version).toBe("old");
+    expect((decode(summaryRaw) as { tokens_saved_today?: number }).tokens_saved_today).toBe(12);
+    expect((decode(waitRaw) as { reason?: string }).reason).toBe("legacy");
     expect(second.status).toBe("noop");
     expect(second.skipped).toEqual(
-      expect.arrayContaining(["dev.attempt-state", "dev.statusline-count-cache", "dev.statusline-repo-cache"]),
+      expect.arrayContaining([
+        "dev.attempt-state",
+        "dev.statusline-count-cache",
+        "dev.statusline-repo-cache",
+        "dev.rsp-resident-registry",
+        "dev.rsp-status-summary",
+        "dev.rsp-wait-registry",
+      ]),
     );
   });
 });

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -81,6 +81,27 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
     toonPath: ".red/tmp/statusline-repo-cache.json",
     kind: "toon",
   },
+  {
+    id: "dev.rsp-resident-registry",
+    plugin: "dev",
+    legacyPath: ".red/tmp/rsp-resident.pid.json",
+    toonPath: ".red/tmp/rsp-resident.pid.json",
+    kind: "toon",
+  },
+  {
+    id: "dev.rsp-status-summary",
+    plugin: "dev",
+    legacyPath: ".red/tmp/rsp-status-summary.json",
+    toonPath: ".red/tmp/rsp-status-summary.json",
+    kind: "toon",
+  },
+  {
+    id: "dev.rsp-wait-registry",
+    plugin: "dev",
+    legacyPath: ".red/tmp/waits/*.json",
+    toonPath: ".red/tmp/waits/*.json",
+    kind: "toon",
+  },
 ];
 
 export const REGISTERED_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
@@ -200,6 +221,21 @@ interface SurfaceTarget {
 }
 
 async function expandSurfaceTargets(rootDir: string, surface: RegisteredToonSurface): Promise<SurfaceTarget[]> {
+  if (surface.id === "dev.rsp-wait-registry") {
+    const waitsRoot = join(rootDir, ".red", "tmp", "waits");
+    let entries: string[];
+    try {
+      entries = await readdir(waitsRoot);
+    } catch {
+      return [];
+    }
+    return entries
+      .filter((entry) => entry.endsWith(".json"))
+      .map((entry) => {
+        const path = join(waitsRoot, entry);
+        return { surface, legacyPath: path, toonPath: path };
+      });
+  }
   if (surface.id !== "dev.attempt-state") {
     return [{ surface, legacyPath: join(rootDir, surface.legacyPath), toonPath: join(rootDir, surface.toonPath) }];
   }
@@ -336,10 +372,20 @@ async function readPidFile(path: string): Promise<number | null> {
 
 async function readJsonPid(path: string): Promise<number | null> {
   try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as { pid?: unknown };
+    const parsed = readSnapshotDocument(await readFile(path, "utf8")) as { pid?: unknown };
     return typeof parsed.pid === "number" ? parsePid(String(parsed.pid)) : null;
   } catch {
     return null;
+  }
+}
+
+function readSnapshotDocument(raw: string): unknown {
+  const body = raw.trim();
+  if (!body) return null;
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return decode(body);
   }
 }
 


### PR DESCRIPTION
Closes #1784

Human-reviewed landing of the `blocked:validation` park (attempt branch `afk/wWQO4/1784-...`).

The gate failure was diagnosed locally and was real but shallow: the slice converted the resident PID registry write to TOON with a sniffing production reader (JSON first, TOON fallback), and the branch already covered every production reader including the migration quiescence guard — but the `resident-memory` test's own `waitForRegistry` poll still parsed JSON only. The parse failure was swallowed and retried until the 100ms idle exit removed the registry file, so the poll ended on ENOENT (the observed 12s hang). On `main` the file passes 3/3 in ~3s; on the branch it failed deterministically.

One commit added on top of the attempt: the test reader now sniffs JSON first and falls back to TOON decode, mirroring the production contract. The full file passes 3/3 locally on the branch. Whole-workspace validation is delegated to CI (this machine cannot run the full gate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786706331&installation_id=129708444&pr_number=1800&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1800&signature=0c0df41b5e36637a2a698bb8becda73300e2e681e1462b0fb25bdd0c83c4eaff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->