### PR TITLE
fix: install pinned tq in the workspace-ci test job

### DIFF
--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -83,6 +83,15 @@ jobs:
         with:
           node-version: 22
 
+      # The apps/dev suite includes tq-contract tests (toon-docs.test.ts spawns
+      # the real binary against produced TOONL lane files), so the required host
+      # binary must exist here exactly as it does on dev machines (/red-setup)
+      # and in red-rsp-benchmark-ci.yml. Same pinned installer, no fallback.
+      - name: Install pinned tq
+        env:
+          TQ_VERSION: v0.1.0
+        run: curl -fsSL "https://raw.githubusercontent.com/reddb-io/toon/${TQ_VERSION}/install.sh" | sh
+
       - name: Install workspace dependencies
         env:
           # This PR gate typechecks/tests apps/dev; it does not execute the


### PR DESCRIPTION
Main's red-workspace-ci went red at the #1786 landing push and every open PR fails its `test` job with `spawn tq ENOENT`: #1786 added `apps/dev/tests/toon-docs.test.ts`, which spawns the real `tq` binary against produced TOONL lane files, but only `red-rsp-benchmark-ci.yml` installs tq. The fleet's local gate passes because dev machines have tq via `/red-setup` — the gap was CI-only, a completion gap of #1777 ("tq as required host binary in ... CI").

This adds the identical pinned installer step (`TQ_VERSION: v0.1.0`) to the `test` job. No skip-when-absent fallback, per the ADR 0097 required-presence doctrine.

Note for #1799 (pin bump to 0.2.6, in flight): this introduces one more `TQ_VERSION: v0.1.0` site; the bump's grep sweep must cover it — flagged there by comment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786706755&installation_id=129708444&pr_number=1802&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1802&signature=d4a98d41ec93cc57d7222f40ff2c83f4c6df7b2422b3ae25f2683fd6cd433a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->