### PR TITLE
fix: #1785 TOON wave 1 S10: bench run ledger to TOONL

### DIFF
--- a/apps/benchmark-code-understanding/README.md
+++ b/apps/benchmark-code-understanding/README.md
@@ -11,7 +11,7 @@ because they clone external repositories and invoke a headless agent.
 pnpm --filter @reddb-io/benchmark-code-understanding dev doctor
 pnpm --filter @reddb-io/benchmark-code-understanding dev run --dry-run
 pnpm --filter @reddb-io/benchmark-code-understanding dev run --runs 1
-pnpm --filter @reddb-io/benchmark-code-understanding dev report --input .red/tmp/bench/code-understanding/runs.jsonl --human
+pnpm --filter @reddb-io/benchmark-code-understanding dev report --input .red/tmp/bench/code-understanding/runs.toonl --human
 ```
 
 By default, generated benchmark data lives under `.red/tmp/bench/` so it stays

--- a/apps/benchmark-code-understanding/package.json
+++ b/apps/benchmark-code-understanding/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@reddb-io/build-info": "workspace:*",
-    "@reddb-io/shared": "workspace:*"
+    "@reddb-io/shared": "workspace:*",
+    "@reddb-io/toon": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/apps/benchmark-code-understanding/src/cli.ts
+++ b/apps/benchmark-code-understanding/src/cli.ts
@@ -48,7 +48,7 @@ async function runDoctor(args: LooseParsedArgs): Promise<number> {
 async function runRun(args: LooseParsedArgs): Promise<number> {
   const workspace = workspaceRoot(process.cwd());
   const benchRoot = join(workspace, ".red", "tmp", "bench", "code-understanding");
-  const out = stringFlag(args, "out") ?? join(benchRoot, "runs.jsonl");
+  const out = stringFlag(args, "out") ?? join(benchRoot, "runs.toonl");
   const records = await runBenchmark({
     runner: runnerFlag(args),
     corpus: "overlap",

--- a/apps/benchmark-code-understanding/src/report.ts
+++ b/apps/benchmark-code-understanding/src/report.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { decode } from "@reddb-io/toon";
 import type { AggregateRow, ArmId, BenchmarkReport, ComparisonRow, RunRecord, TokenUsage, ToolCounts } from "./types.js";
 
 const ZERO_TOOLS: ToolCounts = { total: 0, read: 0, grep: 0, bash: 0, mcp: 0, byName: {} };
@@ -88,17 +89,51 @@ export async function loadRunRecords(path: string): Promise<RunRecord[]> {
 }
 
 export function parseRunRecords(body: string): RunRecord[] {
+  const first = body.trimStart()[0];
+  if (first === "[") return parseRunRecordsToonl(body);
+  return parseRunRecordsJsonl(body);
+}
+
+function parseRunRecordsJsonl(body: string): RunRecord[] {
   const records: RunRecord[] = [];
   for (const line of body.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     const parsed = JSON.parse(trimmed) as RunRecord;
-    if (parsed.schema_version !== "redskills.code_understanding_bench.run.v1") {
-      throw new Error(`unsupported run record schema: ${String(parsed.schema_version)}`);
-    }
-    records.push(parsed);
+    records.push(assertRunRecord(parsed));
   }
   return records;
+}
+
+function parseRunRecordsToonl(body: string): RunRecord[] {
+  return toonlSegments(body).flatMap((segment) => {
+    const decoded = decode(segment);
+    const rows = Array.isArray(decoded) ? decoded : [decoded];
+    return rows.map((row) => assertRunRecord(row as unknown as RunRecord));
+  });
+}
+
+function toonlSegments(body: string): string[] {
+  const segments: string[] = [];
+  let current: string[] = [];
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.trimEnd();
+    if (!line.trim()) continue;
+    if (/^\[[0-9]+\](?:\{.*\})?:$/.test(line) && current.length > 0) {
+      segments.push(`${current.join("\n")}\n`);
+      current = [];
+    }
+    current.push(line);
+  }
+  if (current.length > 0) segments.push(`${current.join("\n")}\n`);
+  return segments;
+}
+
+function assertRunRecord(parsed: RunRecord): RunRecord {
+  if (parsed.schema_version !== "redskills.code_understanding_bench.run.v1") {
+    throw new Error(`unsupported run record schema: ${String(parsed.schema_version)}`);
+  }
+  return parsed;
 }
 
 export function buildReport(records: RunRecord[], generatedAt = new Date().toISOString()): BenchmarkReport {

--- a/apps/benchmark-code-understanding/src/runner.ts
+++ b/apps/benchmark-code-understanding/src/runner.ts
@@ -1,8 +1,9 @@
 import { spawn } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
+import { encode, type JsonValue } from "@reddb-io/toon";
 import type { CorpusCase, CorpusId } from "./corpus.js";
 import { loadCorpus } from "./corpus.js";
 import { emptyTokenUsage, emptyToolCounts, parseAgentJsonl } from "./report.js";
@@ -44,7 +45,7 @@ export async function runBenchmark(options: RunBenchmarkOptions): Promise<RunRec
       for (let runIndex = 1; runIndex <= options.runs; runIndex += 1) {
         const record = await runOne({ ...options, arm, testCase, repoPath, runIndex });
         records.push(record);
-        await appendJsonl(options.out, record);
+        await appendToonl(options.out, record);
       }
     }
   }
@@ -335,9 +336,8 @@ async function binaryCheck(command: string, label: string, missingStatus: "warn"
   };
 }
 
-async function appendJsonl(path: string, record: RunRecord): Promise<void> {
-  const current = existsSync(path) ? await readFile(path, "utf8") : "";
-  await writeFile(path, `${current}${JSON.stringify(record)}\n`, "utf8");
+async function appendToonl(path: string, record: RunRecord): Promise<void> {
+  await appendFile(path, `${encode([record] as unknown as JsonValue).trimEnd()}\n`, "utf8");
 }
 
 function shellQuote(value: string): string {

--- a/apps/benchmark-code-understanding/tests/cli.test.ts
+++ b/apps/benchmark-code-understanding/tests/cli.test.ts
@@ -1,5 +1,9 @@
 import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "vitest";
+import { parseRunRecords } from "../src/report.js";
 
 function run(args: string[]) {
   return spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
@@ -10,15 +14,25 @@ function run(args: string[]) {
 }
 
 describe("benchmark-code-understanding CLI", () => {
-  test("dry-run emits planned records and a guarded report", () => {
-    const result = run(["run", "--dry-run", "--arms", "none,redskills", "--runs", "1"]);
+  test("dry-run emits planned records, appends TOONL, and reports a measured token delta", async () => {
+    const root = await mkdtemp(join(tmpdir(), "code-understanding-bench-"));
+    const out = join(root, "runs.toonl");
+    const result = run(["run", "--dry-run", "--arms", "none,redskills", "--runs", "1", "--out", out]);
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain('"schema_version": "redskills.code_understanding_bench.report.v1"');
     expect(result.stdout).toContain('"run_count": 8');
+    expect(result.stdout).toContain("| redskills_vs_none | n/a |");
     expect(result.stdout).toContain("redskills-token-savings");
     expect(result.stdout).toContain("Code Understanding Benchmark");
+    const ledger = await readFile(out, "utf8");
+    expect(ledger.trimStart()).toMatch(/^\[[0-9]+\](?:\{|:)/);
+    expect(parseRunRecords(ledger)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ schema_version: "redskills.code_understanding_bench.run.v1", arm: "none" }),
+      expect.objectContaining({ schema_version: "redskills.code_understanding_bench.run.v1", arm: "redskills" }),
+    ]));
+    await rm(root, { recursive: true, force: true });
   });
 
   test("dry-run can fail on unsupported claims for CI claim gates", () => {

--- a/apps/benchmark-code-understanding/tests/report.test.ts
+++ b/apps/benchmark-code-understanding/tests/report.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { encode, type JsonValue } from "@reddb-io/toon";
 import { buildReport, parseAgentJsonl, parseRunRecords, renderReportMarkdown } from "../src/report.js";
 import type { RunRecord } from "../src/types.js";
 
@@ -145,5 +146,42 @@ describe("benchmark report", () => {
     const rows = parseRunRecords(`${JSON.stringify(record({ arm: "codegraph" }))}\n`);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.arm).toBe("codegraph");
+  });
+
+  test("parses spec-valid TOONL run records and aggregates them", () => {
+    const rows = parseRunRecords(encode([
+      record({
+        arm: "none",
+        metrics: {
+          tools: { total: 10, read: 4, grep: 2, bash: 1, mcp: 0, byName: {} },
+          tokens: { input: 900, output: 100, cacheCreation: 0, cacheRead: 0, total: 1000 },
+          cost_usd: 0.4,
+        },
+      }),
+      record({
+        arm: "redskills",
+        metrics: {
+          tools: { total: 4, read: 1, grep: 0, bash: 0, mcp: 2, byName: {} },
+          tokens: { input: 500, output: 100, cacheCreation: 0, cacheRead: 0, total: 600 },
+          cost_usd: 0.2,
+        },
+      }),
+    ] as unknown as JsonValue));
+
+    expect(rows.map((row) => row.arm)).toEqual(["none", "redskills"]);
+    expect(buildReport(rows).comparisons.find((row) => row.id === "redskills_vs_none")).toMatchObject({
+      token_delta_pct: -40,
+      read_grep_delta: -5,
+    });
+  });
+
+  test("parses appended standalone TOONL run segments", () => {
+    const rows = parseRunRecords([
+      encode([record({ arm: "none" })] as unknown as JsonValue).trimEnd(),
+      encode([record({ arm: "redskills", run_index: 2 })] as unknown as JsonValue).trimEnd(),
+      "",
+    ].join("\n"));
+
+    expect(rows.map((row) => `${row.arm}:${row.run_index}`)).toEqual(["none:1", "redskills:2"]);
   });
 });

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -75,6 +75,13 @@ describe("shared TOON migration registry", () => {
           kind: "toonl",
         }),
         expect.objectContaining({
+          id: "dev.code-understanding-bench-runs",
+          plugin: "dev",
+          legacyPath: ".red/tmp/bench/code-understanding/runs.jsonl",
+          toonPath: ".red/tmp/bench/code-understanding/runs.toonl",
+          kind: "toonl",
+        }),
+        expect.objectContaining({
           id: "dev.attempt-state",
           plugin: "dev",
           legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",
@@ -120,6 +127,7 @@ describe("shared TOON migration registry", () => {
     );
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.afk-history");
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.agent-log");
+    expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.code-understanding-bench-runs");
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.attempt-state");
     expect(registeredToonSurfacesForPlugin("dev").map((surface) => surface.id)).toContain("dev.rsp-wait-registry");
   });
@@ -238,6 +246,62 @@ describe("shared TOON migration registry", () => {
       value: [
         expect.objectContaining({ ts: "t1", worker: "wA", type: "agent", msg: "line A" }),
         expect.objectContaining({ ts: "t2", issue: 2, attempt: 1, type: "agent", msg: "line B" }),
+      ],
+    });
+  });
+
+  test("converts legacy code-understanding bench runs JSONL to TOONL through the registry", async () => {
+    const root = await scratch();
+    await write(
+      root,
+      ".red/tmp/bench/code-understanding/runs.jsonl",
+      [
+        JSON.stringify({
+          schema_version: "redskills.code_understanding_bench.run.v1",
+          generated_at: "2026-06-01T00:00:00.000Z",
+          benchmark: "code-understanding",
+          runner: "codex",
+          arm: "none",
+          corpus: "overlap",
+          case_id: "case",
+          language: "typescript",
+          repo: "repo",
+          repo_path: "repo-path",
+          question: "question",
+          run_index: 1,
+          status: "pass",
+          duration_ms: 100,
+          exit_code: 0,
+          signal: null,
+          log_path: null,
+          mcp_config_path: null,
+          command: ["codex"],
+          metrics: {
+            tools: { total: 0, read: 0, grep: 0, bash: 0, mcp: 0, byName: {} },
+            tokens: { input: 10, output: 5, cacheCreation: 0, cacheRead: 0, total: 15 },
+            cost_usd: null,
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+    const toonPath = join(root, ".red/tmp/bench/code-understanding/runs.toonl");
+    const body = await readFile(toonPath, "utf8");
+
+    expect(report.converted).toContain("dev.code-understanding-bench-runs");
+    expect(body.trimStart()).toMatch(/^\[1\](?:\{|:)/);
+    await expect(readRegisteredToonSurface(root, "dev.code-understanding-bench-runs")).resolves.toMatchObject({
+      format: "toonl",
+      value: [
+        expect.objectContaining({
+          schema_version: "redskills.code_understanding_bench.run.v1",
+          arm: "none",
+          metrics: expect.objectContaining({
+            tokens: expect.objectContaining({ total: 15 }),
+          }),
+        }),
       ],
     });
   });

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -61,6 +61,13 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
     kind: "toonl",
   },
   {
+    id: "dev.code-understanding-bench-runs",
+    plugin: "dev",
+    legacyPath: ".red/tmp/bench/code-understanding/runs.jsonl",
+    toonPath: ".red/tmp/bench/code-understanding/runs.toonl",
+    kind: "toonl",
+  },
+  {
     id: "dev.attempt-state",
     plugin: "dev",
     legacyPath: ".red/tmp/{workers,go-workers,scout-workers}/*/*/afk.state.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@reddb-io/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: 0.1.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Automated AFK landing for #1785. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1785

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786708472&installation_id=129708444&pr_number=1804&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1804&signature=00f1646a50697958e532ca25b25e36eecf8509004c6895e95757ce1705c46bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->