### PR TITLE
feat: #1787 red-castle writes TOONL at the source (2-repo flow pin bump)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       '@effect/printer-ansi':
         specifier: ^0.48.0
         version: 0.48.0(@effect/typeclass@0.39.0(effect@3.22.0))(effect@3.22.0)
+      '@reddb-io/toon':
+        specifier: 0.2.6
+        version: 0.2.6
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: link:../../packages/shared
       '@reddb-io/toon':
         specifier: 'catalog:'
-        version: 0.1.0
+        version: 0.2.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Closes #1787

Second half of the 2-repo flow (maintainer-delegated). red-castle main advanced 203c9a2 → a00e648 (fast-forward, lineage preserved) with:

- plain npm dependency on the published `@reddb-io/toon@0.2.6` (exact pin, standalone-installable, own package-lock.json updated);
- the liveness lane (`liveness.lane.jsonl`, filename unchanged) emits spec-valid TOONL via the `encodeLines()` streaming emitter — one atomic append per record, header emitted lazily per lane instance, write cadence and mtime semantics untouched;
- `parseLivenessRecords` sniffs per line: legacy JSONL lines, TOONL segments, and mixed pre/post-upgrade files all read; torn tails and restart-rotated headers verified tolerant;
- deliberately unchanged: the raw agent-output firehose passthrough (`log.jsonl`, agent-owned bytes), prose FileDisplay session log, and snapshot/state files (SessionStore, WorktreeLock, afk.state.json) — out of this slice's scope per the lanes-only contract.

red-castle suite on the new pin: 57 files, 1537 passed, 0 failed; typecheck and build clean. red-skills parses the lane exclusively through the red-castle evaluator/parser (`parseLivenessRecords` import in worker-state-reader, `evaluateLiveness` probes), so this bump carries the reader tolerance with it — no red-skills-side reader edits required. CI on this PR is the consuming-suite gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786708994&installation_id=129708444&pr_number=1805&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1805&signature=4f9ae9ea9914d2da7142342ec66ce310b58244c48ccad4cb3d877c705a4c9cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->