### PR TITLE
fix: #1809 toon sync S1: catalog truth registry and derived-site drift contract test

### DIFF
--- a/apps/dev/src/core/toon-version.ts
+++ b/apps/dev/src/core/toon-version.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, parse } from "node:path";
+
+const require = createRequire(import.meta.url);
+const yaml = require("js-yaml") as { load(input: string): unknown };
+
+const TOON_PACKAGE_NAME = "@reddb-io/toon";
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+export interface CatalogToonVersion {
+  readonly packageName: typeof TOON_PACKAGE_NAME;
+  readonly version: string;
+  readonly tag: string;
+}
+
+interface WorkspaceCatalog {
+  readonly catalog?: Record<string, unknown>;
+}
+
+export function findWorkspaceRoot(start = process.cwd()): string {
+  let dir = start;
+  while (true) {
+    if (existsSync(join(dir, "pnpm-workspace.yaml"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir || parse(dir).root === dir) {
+      throw new Error(`could not find pnpm-workspace.yaml from ${start}`);
+    }
+    dir = parent;
+  }
+}
+
+export function deriveToonVersionFromWorkspaceYaml(input: string): CatalogToonVersion {
+  const doc = yaml.load(input) as WorkspaceCatalog | null;
+  const version = doc?.catalog?.[TOON_PACKAGE_NAME];
+  if (typeof version !== "string" || !SEMVER.test(version)) {
+    throw new Error(`pnpm catalog entry ${TOON_PACKAGE_NAME} must be an x.y.z version`);
+  }
+
+  return {
+    packageName: TOON_PACKAGE_NAME,
+    version,
+    tag: `v${version}`,
+  };
+}
+
+export function readCatalogToonVersion(root = findWorkspaceRoot()): CatalogToonVersion {
+  return deriveToonVersionFromWorkspaceYaml(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8"));
+}

--- a/apps/dev/tests/toon-version-contract.test.ts
+++ b/apps/dev/tests/toon-version-contract.test.ts
@@ -1,0 +1,159 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readCatalogToonVersion, type CatalogToonVersion } from "../src/core/toon-version.js";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+type PinForm = "version" | "tag";
+
+interface ToonPinSite {
+  readonly name: string;
+  readonly path: string;
+  readonly form: PinForm;
+  readonly pattern: RegExp;
+}
+
+const TOON_PIN_SITES: readonly ToonPinSite[] = [
+  {
+    name: "workflow.red-workspace-ci.tq-install-version",
+    path: ".github/workflows/red-workspace-ci.yml",
+    form: "tag",
+    pattern: /TQ_VERSION:\s+(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "workflow.red-rsp-benchmark-ci.tq-install-version",
+    path: ".github/workflows/red-rsp-benchmark-ci.yml",
+    form: "tag",
+    pattern: /TQ_VERSION:\s+(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.interview.tq-install-env",
+    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.interview.tq-install-url",
+    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    form: "tag",
+    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
+  },
+  {
+    name: "red-setup.interview.installed-version",
+    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    form: "version",
+    pattern: /The installed version must be `(\d+\.\d+\.\d+)`/,
+  },
+  {
+    name: "red-setup.reference.tq-install-env",
+    path: "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.reference.host-binary-check",
+    path: "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
+    form: "version",
+    pattern: /pinned to `(\d+\.\d+\.\d+)`/,
+  },
+  {
+    name: "red-setup.write-contract.host-binary-record",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "version",
+    pattern: /host_binaries\.tq\.version: (\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.write-contract.tq-install-env",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.write-contract.tq-install-url",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "tag",
+    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
+  },
+  {
+    name: "red-setup.write-contract.verify-version",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "version",
+    pattern: /`tq --version` reports `(\d+\.\d+\.\d+)`/,
+  },
+  {
+    name: "red-setup.write-contract.config-record",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "version",
+    pattern: /\n\s+version: (\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.config-template.host-binary-record",
+    path: "plugins/dev/skills/engineering/red-setup/config-template.yaml",
+    form: "version",
+    pattern: /\n\s+version: (\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-doctor.skill.host-binary-pin",
+    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    form: "version",
+    pattern: /host_binaries\.tq\.version` \(pin `(\d+\.\d+\.\d+)`\)/,
+  },
+  {
+    name: "red-doctor.skill.remediation-env",
+    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-doctor.skill.remediation-url",
+    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    form: "tag",
+    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
+  },
+];
+
+async function readSitePin(site: ToonPinSite): Promise<string> {
+  const text = await readFile(join(ROOT, site.path), "utf8");
+  const match = site.pattern.exec(text);
+  if (!match?.[1]) {
+    throw new Error(`toon pin site ${site.name} did not match ${site.path}`);
+  }
+  return match[1];
+}
+
+async function toonPinDrift(version: CatalogToonVersion): Promise<string[]> {
+  const failures: string[] = [];
+  for (const site of TOON_PIN_SITES) {
+    const expected = site.form === "tag" ? version.tag : version.version;
+    const actual = await readSitePin(site);
+    if (actual !== expected) {
+      failures.push(`${site.name}: expected ${expected}, found ${actual}`);
+    }
+  }
+  return failures;
+}
+
+describe("toon catalog version contract", () => {
+  it("derives the toon/tq version from the pnpm catalog", () => {
+    expect(readCatalogToonVersion(ROOT)).toEqual({
+      packageName: "@reddb-io/toon",
+      version: "0.3.0",
+      tag: "v0.3.0",
+    });
+  });
+
+  it("keeps every registered derived toon/tq pin aligned with the catalog", async () => {
+    await expect(toonPinDrift(readCatalogToonVersion(ROOT))).resolves.toEqual([]);
+  });
+
+  it("names every stale registered site after a catalog-only bump", async () => {
+    const failures = await toonPinDrift({
+      packageName: "@reddb-io/toon",
+      version: "9.9.9",
+      tag: "v9.9.9",
+    });
+
+    expect(failures).toEqual(TOON_PIN_SITES.map((site) => expect.stringContaining(`${site.name}:`)));
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1809. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1809

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786711731&installation_id=129708444&pr_number=1814&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1814&signature=125d3fadc23dc3ec46fb2fa45ac0ddf5a68b6b9d19c3ca8ab76b0bf10ffe14b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->