### PR TITLE
fix: #1812 toon sync S3: toon-bump dev verb — all-site edit plus lockfile transition hygiene

### DIFF
--- a/apps/dev/src/cli.ts
+++ b/apps/dev/src/cli.ts
@@ -24,6 +24,7 @@ import { rspInstructionsCommand } from "./commands/rsp-instructions.js";
 import { statuslineCommand, statuslineRefreshCountsCommand } from "./commands/statusline.js";
 import { superviseCommand } from "./commands/supervise.js";
 import { triageCommand } from "./commands/triage.js";
+import { toonBumpCommand } from "./commands/toon-bump.js";
 import { toonMigrateCommand } from "./commands/toon-migrate.js";
 import { readBuildInfo, renderVersion } from "@reddb-io/build-info";
 import { routeCommand, UnknownCommandError, type RouterSchema } from "@reddb-io/shared/args.js";
@@ -55,6 +56,7 @@ export type CliCommand =
   | "statusline"
   | "statusline-refresh-counts"
   | "inject-development-workflow"
+  | "toon-bump"
   | "toon-migrate"
   | "version"
   | "__supervise";
@@ -101,6 +103,7 @@ const CLI_ROUTER: RouterSchema<CliCommand> = {
     statusline: {},
     "statusline-refresh-counts": {},
     "inject-development-workflow": {},
+    "toon-bump": {},
     "toon-migrate": {},
     version: {},
     __supervise: {},
@@ -156,6 +159,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (parsed.command === "statusline") return statuslineCommand(parsed.args);
   if (parsed.command === "statusline-refresh-counts") return statuslineRefreshCountsCommand(parsed.args);
   if (parsed.command === "inject-development-workflow") return injectDevelopmentWorkflowCommand(parsed.args);
+  if (parsed.command === "toon-bump") return toonBumpCommand(parsed.args);
   if (parsed.command === "toon-migrate") return toonMigrateCommand(parsed.args);
   if (parsed.command === "__supervise") return superviseCommand(parsed.args);
   return runCommand({ args: parsed.args });

--- a/apps/dev/src/commands/toon-bump.ts
+++ b/apps/dev/src/commands/toon-bump.ts
@@ -1,0 +1,251 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
+import {
+  readCatalogToonVersion,
+  TOON_PIN_SITES,
+  type CatalogToonVersion,
+  type ToonPinSite,
+} from "../core/toon-version.js";
+
+interface ToonBumpIO {
+  stdout: Pick<NodeJS.WritableStream, "write">;
+  stderr: Pick<NodeJS.WritableStream, "write">;
+}
+
+interface ParsedToonBumpArgs {
+  rootDir: string;
+  targetVersion: string;
+  dryRun: boolean;
+}
+
+interface FileEdit {
+  path: string;
+  text: string;
+  replacements: Replacement[];
+}
+
+interface Replacement {
+  site: string;
+  before: string;
+  after: string;
+}
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+const SCHEMA_VERSION = "red.dev.toon_bump.v1";
+
+export async function toonBumpCommand(
+  args: readonly string[],
+  io: ToonBumpIO = { stdout: process.stdout, stderr: process.stderr },
+): Promise<number> {
+  try {
+    const parsed = parseToonBumpArgs(args);
+    const previous = readCatalogToonVersion(parsed.rootDir);
+    const target = toonVersion(parsed.targetVersion);
+    const edits = await planToonBump(parsed.rootDir, previous, target);
+    const status = edits.length === 0 ? "noop" : "changed";
+
+    if (!parsed.dryRun) {
+      for (const edit of edits) {
+        await writeFile(resolve(parsed.rootDir, edit.path), edit.text, "utf8");
+      }
+    }
+
+    io.stdout.write(
+      `${encodeToon({
+        schema_version: SCHEMA_VERSION,
+        status,
+        mode: parsed.dryRun ? "dry-run" : "apply",
+        previous_version: previous.version,
+        target_version: target.version,
+        changes: edits.map((edit) => ({
+          path: edit.path,
+          replacements: edit.replacements,
+        })),
+      } as unknown as ToonValue)}\n`,
+    );
+    return status === "noop" ? 10 : 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    io.stderr.write(`${encodeToon({ schema_version: SCHEMA_VERSION, status: "failed", error: message })}\n`);
+    return 1;
+  }
+}
+
+async function planToonBump(rootDir: string, previous: CatalogToonVersion, target: CatalogToonVersion): Promise<FileEdit[]> {
+  const edits = new Map<string, FileEdit>();
+  await replaceInFile(edits, rootDir, "pnpm-workspace.yaml", (text) =>
+    bumpWorkspaceYaml(text, previous.version, target.version),
+  );
+  await replaceInFile(edits, rootDir, "pnpm-lock.yaml", (text) => bumpLockfile(text, previous.version, target.version));
+
+  for (const site of TOON_PIN_SITES) {
+    await replaceInFile(edits, rootDir, site.path, (text) => bumpRegisteredSite(text, site, target));
+  }
+
+  return [...edits.values()];
+}
+
+async function replaceInFile(
+  edits: Map<string, FileEdit>,
+  rootDir: string,
+  path: string,
+  update: (text: string) => { text: string; replacements: Replacement[] },
+): Promise<void> {
+  const prior = edits.get(path);
+  const original = prior?.text ?? await readFile(resolve(rootDir, path), "utf8");
+  const next = update(original);
+  if (next.replacements.length === 0) return;
+  edits.set(path, {
+    path,
+    text: next.text,
+    replacements: [...(prior?.replacements ?? []), ...next.replacements],
+  });
+}
+
+function bumpWorkspaceYaml(text: string, previous: string, target: string): { text: string; replacements: Replacement[] } {
+  if (previous === target) return { text, replacements: [] };
+  const replacements: Replacement[] = [];
+  let next = replaceFirstCapture(
+    text,
+    /(^\s*["']?@reddb-io\/toon["']?:\s*)(\d+\.\d+\.\d+)(\s*$)/m,
+    target,
+    "workspace.catalog",
+    replacements,
+  );
+
+  const oldExclude = `@reddb-io/toon@${previous}`;
+  const newExclude = `@reddb-io/toon@${target}`;
+  if (next.includes(oldExclude)) {
+    next = next.replace(oldExclude, newExclude);
+    replacements.push({ site: "workspace.minimum-release-age-exclude", before: oldExclude, after: newExclude });
+  } else if (!next.includes(newExclude)) {
+    if (/^minimumReleaseAgeExclude:\s*$/m.test(next)) {
+      next = next.replace(/(^minimumReleaseAgeExclude:\s*$)/m, `$1\n  - '${newExclude}'`);
+    } else {
+      next = `${next.replace(/\s*$/, "\n\n")}minimumReleaseAgeExclude:\n  - '${newExclude}'\n`;
+    }
+    replacements.push({ site: "workspace.minimum-release-age-exclude", before: "", after: newExclude });
+  }
+
+  return { text: next, replacements };
+}
+
+function bumpLockfile(text: string, previous: string, target: string): { text: string; replacements: Replacement[] } {
+  if (previous === target) return { text, replacements: [] };
+  const replacements: Replacement[] = [];
+  let next = text;
+  const oldKey = `@reddb-io/toon@${previous}`;
+  const newKey = `@reddb-io/toon@${target}`;
+
+  if (next.includes(oldKey)) {
+    next = next.split(oldKey).join(newKey);
+    replacements.push({ site: "lockfile.packages-and-snapshots", before: oldKey, after: newKey });
+  }
+
+  const lines = next.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i]!;
+    const match = /^(\s*)'@reddb-io\/toon':\s*$/.exec(line);
+    if (!match) continue;
+
+    const blockIndent = match[1]!.length;
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const child = lines[j]!;
+      if (child.trim() !== "" && indentOf(child) <= blockIndent) break;
+      if (!child.includes(previous)) continue;
+      if (!/^\s+(specifier|version):\s+/.test(child)) continue;
+      lines[j] = child.split(previous).join(target);
+      replacements.push({ site: "lockfile.catalogs-and-importers", before: previous, after: target });
+    }
+  }
+
+  return { text: lines.join("\n"), replacements };
+}
+
+function bumpRegisteredSite(
+  text: string,
+  site: ToonPinSite,
+  target: CatalogToonVersion,
+): { text: string; replacements: Replacement[] } {
+  const expected = site.form === "tag" ? target.tag : target.version;
+  const match = site.pattern.exec(text);
+  if (!match?.[1]) {
+    throw new Error(`toon pin site ${site.name} did not match ${site.path}`);
+  }
+  const actual = match[1];
+  if (actual === expected) return { text, replacements: [] };
+  const matchedText = match[0];
+  const replacementText = matchedText.replace(actual, expected);
+  return {
+    text: `${text.slice(0, match.index)}${replacementText}${text.slice(match.index + matchedText.length)}`,
+    replacements: [{ site: site.name, before: actual, after: expected }],
+  };
+}
+
+function replaceFirstCapture(
+  text: string,
+  pattern: RegExp,
+  target: string,
+  site: string,
+  replacements: Replacement[],
+): string {
+  const match = pattern.exec(text);
+  if (!match?.[2]) throw new Error(`could not find ${site}`);
+  const before = match[2];
+  if (before === target) return text;
+  replacements.push({ site, before, after: target });
+  return `${text.slice(0, match.index)}${match[1]}${target}${match[3]}${text.slice(match.index + match[0].length)}`;
+}
+
+function indentOf(line: string): number {
+  return /^\s*/.exec(line)?.[0].length ?? 0;
+}
+
+function toonVersion(version: string): CatalogToonVersion {
+  if (!SEMVER.test(version)) throw new Error(`target version must be x.y.z, got ${version}`);
+  return { packageName: "@reddb-io/toon", version, tag: `v${version}` };
+}
+
+function parseToonBumpArgs(args: readonly string[]): ParsedToonBumpArgs {
+  let rootDir = process.cwd();
+  let targetVersion = "";
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--root") {
+      rootDir = requiredValue(args[++i], "--root");
+      continue;
+    }
+    if (arg.startsWith("--root=")) {
+      rootDir = arg.slice("--root=".length);
+      continue;
+    }
+    if (arg === "--target") {
+      targetVersion = requiredValue(args[++i], "--target");
+      continue;
+    }
+    if (arg.startsWith("--target=")) {
+      targetVersion = arg.slice("--target=".length);
+      continue;
+    }
+    if (!arg.startsWith("-") && !targetVersion) {
+      targetVersion = arg;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  if (!targetVersion) throw new Error("toon-bump requires a target version");
+  return { rootDir: resolve(rootDir), targetVersion, dryRun };
+}
+
+function requiredValue(value: string | undefined, flag: string): string {
+  if (!value) throw new Error(`${flag} requires a value`);
+  return value;
+}

--- a/apps/dev/src/core/toon-version.ts
+++ b/apps/dev/src/core/toon-version.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join, parse } from "node:path";
 
@@ -13,6 +14,114 @@ export interface CatalogToonVersion {
   readonly version: string;
   readonly tag: string;
 }
+
+export type ToonPinForm = "version" | "tag";
+
+export interface ToonPinSite {
+  readonly name: string;
+  readonly path: string;
+  readonly form: ToonPinForm;
+  readonly pattern: RegExp;
+}
+
+export const TOON_PIN_SITES: readonly ToonPinSite[] = [
+  {
+    name: "workflow.red-workspace-ci.tq-install-version",
+    path: ".github/workflows/red-workspace-ci.yml",
+    form: "tag",
+    pattern: /TQ_VERSION:\s+(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "workflow.red-rsp-benchmark-ci.tq-install-version",
+    path: ".github/workflows/red-rsp-benchmark-ci.yml",
+    form: "tag",
+    pattern: /TQ_VERSION:\s+(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.interview.tq-install-env",
+    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.interview.tq-install-url",
+    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    form: "tag",
+    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
+  },
+  {
+    name: "red-setup.interview.installed-version",
+    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    form: "version",
+    pattern: /The installed version must be `(\d+\.\d+\.\d+)`/,
+  },
+  {
+    name: "red-setup.reference.tq-install-env",
+    path: "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.reference.host-binary-check",
+    path: "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
+    form: "version",
+    pattern: /pinned to `(\d+\.\d+\.\d+)`/,
+  },
+  {
+    name: "red-setup.write-contract.host-binary-record",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "version",
+    pattern: /host_binaries\.tq\.version: (\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.write-contract.tq-install-env",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.write-contract.tq-install-url",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "tag",
+    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
+  },
+  {
+    name: "red-setup.write-contract.verify-version",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "version",
+    pattern: /`tq --version` reports `(\d+\.\d+\.\d+)`/,
+  },
+  {
+    name: "red-setup.write-contract.config-record",
+    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    form: "version",
+    pattern: /\n\s+version: (\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-setup.config-template.host-binary-record",
+    path: "plugins/dev/skills/engineering/red-setup/config-template.yaml",
+    form: "version",
+    pattern: /\n\s+version: (\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-doctor.skill.host-binary-pin",
+    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    form: "version",
+    pattern: /host_binaries\.tq\.version` \(pin `(\d+\.\d+\.\d+)`\)/,
+  },
+  {
+    name: "red-doctor.skill.remediation-env",
+    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    form: "tag",
+    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
+  },
+  {
+    name: "red-doctor.skill.remediation-url",
+    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    form: "tag",
+    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
+  },
+];
 
 interface WorkspaceCatalog {
   readonly catalog?: Record<string, unknown>;
@@ -46,4 +155,25 @@ export function deriveToonVersionFromWorkspaceYaml(input: string): CatalogToonVe
 
 export function readCatalogToonVersion(root = findWorkspaceRoot()): CatalogToonVersion {
   return deriveToonVersionFromWorkspaceYaml(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8"));
+}
+
+export async function readToonPinSite(root: string, site: ToonPinSite): Promise<string> {
+  const text = await readFile(join(root, site.path), "utf8");
+  const match = site.pattern.exec(text);
+  if (!match?.[1]) {
+    throw new Error(`toon pin site ${site.name} did not match ${site.path}`);
+  }
+  return match[1];
+}
+
+export async function collectToonPinDrift(root: string, version: CatalogToonVersion): Promise<string[]> {
+  const failures: string[] = [];
+  for (const site of TOON_PIN_SITES) {
+    const expected = site.form === "tag" ? version.tag : version.version;
+    const actual = await readToonPinSite(root, site);
+    if (actual !== expected) {
+      failures.push(`${site.name}: expected ${expected}, found ${actual}`);
+    }
+  }
+  return failures;
 }

--- a/apps/dev/tests/toon-bump.test.ts
+++ b/apps/dev/tests/toon-bump.test.ts
@@ -1,0 +1,185 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { parseCli } from "../src/cli.js";
+import { toonBumpCommand } from "../src/commands/toon-bump.js";
+import { collectToonPinDrift, TOON_PIN_SITES, type CatalogToonVersion } from "../src/core/toon-version.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function scratch(): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  const root = await mkdtemp(join(tmpdir(), "dev-toon-bump-"));
+  roots.push(root);
+  return root;
+}
+
+async function write(root: string, rel: string, body: string): Promise<void> {
+  const path = join(root, rel);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, body, "utf8");
+}
+
+async function read(root: string, rel: string): Promise<string> {
+  return readFile(join(root, rel), "utf8");
+}
+
+async function writeFixture(root: string, version = "0.2.6"): Promise<void> {
+  await write(
+    root,
+    "pnpm-workspace.yaml",
+    `packages:
+  - "apps/*"
+
+catalog:
+  "@reddb-io/toon": ${version}
+
+minimumReleaseAgeExclude:
+  - "@reddb-io/sdk"
+  - '@reddb-io/toon@${version}'
+`,
+  );
+  await write(
+    root,
+    "pnpm-lock.yaml",
+    `lockfileVersion: '9.0'
+
+catalogs:
+  default:
+    '@reddb-io/toon':
+      specifier: ${version}
+      version: ${version}
+
+importers:
+  apps/dev:
+    dependencies:
+      '@reddb-io/toon':
+        specifier: 'catalog:'
+        version: ${version}
+
+packages:
+  '@reddb-io/toon@${version}':
+    resolution: {integrity: sha512-fixture}
+    engines: {node: '>=18'}
+
+snapshots:
+  '@reddb-io/toon@${version}': {}
+`,
+  );
+  await writeRegisteredSites(root, version);
+}
+
+async function writeRegisteredSites(root: string, version: string): Promise<void> {
+  await write(root, ".github/workflows/red-workspace-ci.yml", `env:\n  TQ_VERSION: v${version}\n`);
+  await write(root, ".github/workflows/red-rsp-benchmark-ci.yml", `env:\n  TQ_VERSION: v${version}\n`);
+  await write(
+    root,
+    "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
+    `TQ_VERSION=v${version}
+curl https://raw.githubusercontent.com/reddb-io/toon/v${version}/install.sh
+The installed version must be \`${version}\`.
+`,
+  );
+  await write(
+    root,
+    "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
+    `TQ_VERSION=v${version}
+host binary is pinned to \`${version}\`.
+`,
+  );
+  await write(
+    root,
+    "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
+    `host_binaries.tq.version: ${version}
+TQ_VERSION=v${version}
+curl https://raw.githubusercontent.com/reddb-io/toon/v${version}/install.sh
+\`tq --version\` reports \`${version}\`
+host_binaries:
+  tq:
+    version: ${version}
+`,
+  );
+  await write(
+    root,
+    "plugins/dev/skills/engineering/red-setup/config-template.yaml",
+    `host_binaries:
+  tq:
+    version: ${version}
+`,
+  );
+  await write(
+    root,
+    "plugins/dev/skills/engineering/red-doctor/SKILL.md",
+    `host_binaries.tq.version\` (pin \`${version}\`)
+TQ_VERSION=v${version}
+curl https://raw.githubusercontent.com/reddb-io/toon/v${version}/install.sh
+`,
+  );
+}
+
+function target(version: string): CatalogToonVersion {
+  return { packageName: "@reddb-io/toon", version, tag: `v${version}` };
+}
+
+describe("toon-bump dev command", () => {
+  test("routes as a dedicated dev CLI verb", () => {
+    expect(parseCli(["toon-bump", "0.3.0", "--root", "/repo", "--dry-run"])).toEqual({
+      command: "toon-bump",
+      args: ["0.3.0", "--root", "/repo", "--dry-run"],
+    });
+  });
+
+  test("bumps every S1 registered site and replaces stale lockfile entries", async () => {
+    const root = await scratch();
+    await writeFixture(root);
+    let stdout = "";
+
+    const code = await toonBumpCommand(["0.3.0", "--root", root], {
+      stdout: { write: (chunk: string) => { stdout += chunk; return true; } },
+      stderr: { write: () => true },
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("schema_version: red.dev.toon_bump.v1");
+    await expect(collectToonPinDrift(root, target("0.3.0"))).resolves.toEqual([]);
+    await expect(read(root, "pnpm-workspace.yaml")).resolves.toContain("'@reddb-io/toon@0.3.0'");
+    const lockfile = await read(root, "pnpm-lock.yaml");
+    expect(lockfile).toContain("'@reddb-io/toon@0.3.0'");
+    expect(lockfile).not.toContain("@reddb-io/toon@0.2.6");
+    expect(lockfile).not.toMatch(/version: 0\.2\.6/);
+  });
+
+  test("dry-run prints the would-be plan without writing", async () => {
+    const root = await scratch();
+    await writeFixture(root);
+    let stdout = "";
+
+    const code = await toonBumpCommand(["0.3.0", "--root", root, "--dry-run"], {
+      stdout: { write: (chunk: string) => { stdout += chunk; return true; } },
+      stderr: { write: () => true },
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("mode: dry-run");
+    expect(stdout).toContain(TOON_PIN_SITES[0]!.path);
+    await expect(collectToonPinDrift(root, target("0.3.0"))).resolves.toHaveLength(TOON_PIN_SITES.length);
+    await expect(read(root, "pnpm-lock.yaml")).resolves.toContain("@reddb-io/toon@0.2.6");
+  });
+
+  test("returns a distinct no-op code when already clean", async () => {
+    const root = await scratch();
+    await writeFixture(root, "0.3.0");
+
+    const code = await toonBumpCommand(["0.3.0", "--root", root], {
+      stdout: { write: () => true },
+      stderr: { write: () => true },
+    });
+
+    expect(code).toBe(10);
+  });
+});

--- a/apps/dev/tests/toon-version-contract.test.ts
+++ b/apps/dev/tests/toon-version-contract.test.ts
@@ -1,138 +1,8 @@
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { readCatalogToonVersion, type CatalogToonVersion } from "../src/core/toon-version.js";
+import { collectToonPinDrift, readCatalogToonVersion, TOON_PIN_SITES } from "../src/core/toon-version.js";
 
 const ROOT = join(import.meta.dirname, "..", "..", "..");
-
-type PinForm = "version" | "tag";
-
-interface ToonPinSite {
-  readonly name: string;
-  readonly path: string;
-  readonly form: PinForm;
-  readonly pattern: RegExp;
-}
-
-const TOON_PIN_SITES: readonly ToonPinSite[] = [
-  {
-    name: "workflow.red-workspace-ci.tq-install-version",
-    path: ".github/workflows/red-workspace-ci.yml",
-    form: "tag",
-    pattern: /TQ_VERSION:\s+(v\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "workflow.red-rsp-benchmark-ci.tq-install-version",
-    path: ".github/workflows/red-rsp-benchmark-ci.yml",
-    form: "tag",
-    pattern: /TQ_VERSION:\s+(v\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-setup.interview.tq-install-env",
-    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
-    form: "tag",
-    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-setup.interview.tq-install-url",
-    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
-    form: "tag",
-    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
-  },
-  {
-    name: "red-setup.interview.installed-version",
-    path: "plugins/dev/skills/engineering/red-setup/INTERVIEW.md",
-    form: "version",
-    pattern: /The installed version must be `(\d+\.\d+\.\d+)`/,
-  },
-  {
-    name: "red-setup.reference.tq-install-env",
-    path: "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
-    form: "tag",
-    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-setup.reference.host-binary-check",
-    path: "plugins/dev/skills/engineering/red-setup/REFERENCE.md",
-    form: "version",
-    pattern: /pinned to `(\d+\.\d+\.\d+)`/,
-  },
-  {
-    name: "red-setup.write-contract.host-binary-record",
-    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
-    form: "version",
-    pattern: /host_binaries\.tq\.version: (\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-setup.write-contract.tq-install-env",
-    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
-    form: "tag",
-    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-setup.write-contract.tq-install-url",
-    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
-    form: "tag",
-    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
-  },
-  {
-    name: "red-setup.write-contract.verify-version",
-    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
-    form: "version",
-    pattern: /`tq --version` reports `(\d+\.\d+\.\d+)`/,
-  },
-  {
-    name: "red-setup.write-contract.config-record",
-    path: "plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md",
-    form: "version",
-    pattern: /\n\s+version: (\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-setup.config-template.host-binary-record",
-    path: "plugins/dev/skills/engineering/red-setup/config-template.yaml",
-    form: "version",
-    pattern: /\n\s+version: (\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-doctor.skill.host-binary-pin",
-    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
-    form: "version",
-    pattern: /host_binaries\.tq\.version` \(pin `(\d+\.\d+\.\d+)`\)/,
-  },
-  {
-    name: "red-doctor.skill.remediation-env",
-    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
-    form: "tag",
-    pattern: /TQ_VERSION=(v\d+\.\d+\.\d+)/,
-  },
-  {
-    name: "red-doctor.skill.remediation-url",
-    path: "plugins/dev/skills/engineering/red-doctor/SKILL.md",
-    form: "tag",
-    pattern: /raw\.githubusercontent\.com\/reddb-io\/toon\/(v\d+\.\d+\.\d+)\/install\.sh/,
-  },
-];
-
-async function readSitePin(site: ToonPinSite): Promise<string> {
-  const text = await readFile(join(ROOT, site.path), "utf8");
-  const match = site.pattern.exec(text);
-  if (!match?.[1]) {
-    throw new Error(`toon pin site ${site.name} did not match ${site.path}`);
-  }
-  return match[1];
-}
-
-async function toonPinDrift(version: CatalogToonVersion): Promise<string[]> {
-  const failures: string[] = [];
-  for (const site of TOON_PIN_SITES) {
-    const expected = site.form === "tag" ? version.tag : version.version;
-    const actual = await readSitePin(site);
-    if (actual !== expected) {
-      failures.push(`${site.name}: expected ${expected}, found ${actual}`);
-    }
-  }
-  return failures;
-}
 
 describe("toon catalog version contract", () => {
   it("derives the toon/tq version from the pnpm catalog", () => {
@@ -144,11 +14,11 @@ describe("toon catalog version contract", () => {
   });
 
   it("keeps every registered derived toon/tq pin aligned with the catalog", async () => {
-    await expect(toonPinDrift(readCatalogToonVersion(ROOT))).resolves.toEqual([]);
+    await expect(collectToonPinDrift(ROOT, readCatalogToonVersion(ROOT))).resolves.toEqual([]);
   });
 
   it("names every stale registered site after a catalog-only bump", async () => {
-    const failures = await toonPinDrift({
+    const failures = await collectToonPinDrift(ROOT, {
       packageName: "@reddb-io/toon",
       version: "9.9.9",
       tag: "v9.9.9",


### PR DESCRIPTION
Automated AFK landing for #1812. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1812

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786713778&installation_id=129708444&pr_number=1817&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1817&signature=6ba4535308383ca406561612f49884c66ab88eed29643b84ca2df4e313d69f79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->