### PR TITLE
feat!: no .sandcastle in the runtime — red-castle directory identity is .red-castle

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1323,7 +1323,7 @@ export function buildProcessDeps(
       const head = info.head ?? "";
       void (async () => {
         // sandcastle creates the agent's worktree at
-        // `{attemptDir}/.sandcastle/worktrees/{slug}`, NOT the legacy
+        // `{attemptDir}/.red-castle/worktrees/{slug}`, NOT the legacy
         // `{attemptDir}/worktree` the state seeds — diffing the latter fails
         // (it never exists) and every tick read a permanent `+0 -0` even with a
         // dirty worktree, which also starved the attempt-progress guard's

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -256,7 +256,7 @@ export interface RunAgentInput {
   /** Isolation: "none" (default, node-only) | "docker" | "podman". */
   sandboxMode?: SandboxMode;
   /**
-   * Absolute host anchor for sandcastle's `.sandcastle/` dir + git operations.
+   * Absolute host anchor for sandcastle's `.red-castle/` dir + git operations.
    * AFK sets this to the attempt dir so nothing lands at the repo root
    * (everything under .red/). Defaults to process.cwd() in sandcastle when
    * omitted. NOTE: sandcastle resolves `promptFile` against process.cwd(), NOT
@@ -892,7 +892,7 @@ export function buildRunOptions(deps: SandcastleDeps, input: RunAgentInput): Run
     // under it are host-visible mid-run — the precondition for arming the guard +
     // heartbeat under docker/podman. `none` ignores `mountPath` (no container).
     sandbox: deps.sandboxFor(input.sandboxMode ?? "none", input.cwd ? { mountPath: input.cwd } : undefined),
-    // Re-anchor sandcastle's `.sandcastle/` dir + git ops at the caller's cwd
+    // Re-anchor sandcastle's `.red-castle/` dir + git ops at the caller's cwd
     // (AFK's per-attempt dir under .red/) so nothing is generated at the repo
     // root. Omitted → sandcastle defaults to process.cwd().
     ...(input.cwd ? { cwd: input.cwd } : {}),

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -1654,7 +1654,7 @@ export async function processIssue(
   // provider) coerces to claude so the spawn always has a real agent.
   let activeRunner: Runner = toAgentRunner(input.runner);
   let attemptN = input.attempt;
-  // Anchor sandcastle at the per-attempt dir so its `.sandcastle/` (worktrees,
+  // Anchor sandcastle at the per-attempt dir so its `.red-castle/` (worktrees,
   // logs, .env, patches) + git ops land under .red/, never at the repo root.
   // attemptDir is always absolute (built from `${root}/.red/tmp/...`), which is
   // also why promptFile/handoffPath must stay absolute — sandcastle resolves

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -486,7 +486,7 @@ export async function worktreePathForBranch(ctx: GitContext, branch: string): Pr
 /**
  * Resolve the worktree path registered under `dirPrefix` (the attempt dir),
  * parsed from `git worktree list --porcelain`. sandcastle creates the agent's
- * worktree at `{attemptDir}/.sandcastle/worktrees/{slug}`, but the state file's
+ * worktree at `{attemptDir}/.red-castle/worktrees/{slug}`, but the state file's
  * `current.worktree` is seeded to the legacy `{attemptDir}/worktree` path that
  * never exists — so a `git diff` there fails and the heartbeat / monitor read a
  * permanent `+0 -0` even with a dirty worktree (the sandcastle-blind hazard). An

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -377,7 +377,7 @@ describe("buildRunOptions", () => {
       makeDeps(async () => fakeResult()),
       { ...baseInput, cwd: "/abs/attempt/dir" },
     );
-    // cwd is forwarded verbatim so sandcastle puts `.sandcastle/` under the
+    // cwd is forwarded verbatim so sandcastle puts `.red-castle/` under the
     // attempt dir (.red/tmp/...), never at the repo root.
     expect(opts.cwd).toBe("/abs/attempt/dir");
   });

--- a/apps/dev/tests/process-issue.test.ts
+++ b/apps/dev/tests/process-issue.test.ts
@@ -823,7 +823,7 @@ describe("processIssue — DONE + green + merged (unlocked, admin-PR landing)", 
     expect(trace.runAgentCalls[0]?.runner).toBe("claude");
     expect(trace.runAgentCalls[0]?.model).toBe("claude-opus-4-8");
     expect(trace.runAgentCalls[0]?.effort).toBe("high");
-    // cwd is anchored at the attempt dir so sandcastle's `.sandcastle/` lands
+    // cwd is anchored at the attempt dir so sandcastle's `.red-castle/` lands
     // under .red/ (the attempt dir), never at the repo root.
     expect(trace.runAgentCalls[0]?.cwd).toBe("/tmp/afk/workers/wAAAA/9-a1");
 

--- a/apps/dev/tests/runtime-git-branch.test.ts
+++ b/apps/dev/tests/runtime-git-branch.test.ts
@@ -320,7 +320,7 @@ describe("worktreePathUnder (sandcastle-blind heartbeat fix)", () => {
     "HEAD aaaaaaa",
     "branch refs/heads/main",
     "",
-    "worktree /repo/.red/tmp/workers/wQDOR/894-a1/.sandcastle/worktrees/afk-wQDOR-894-x",
+    "worktree /repo/.red/tmp/workers/wQDOR/894-a1/.red-castle/worktrees/afk-wQDOR-894-x",
     "HEAD bbbbbbb",
     "branch refs/heads/afk/wQDOR/894-x",
     "",
@@ -330,7 +330,7 @@ describe("worktreePathUnder (sandcastle-blind heartbeat fix)", () => {
     const { exec, calls } = recordingExec(() => ok(porcelain));
     const ctx: GitContext = { cwd: "/repo", exec };
     expect(await worktreePathUnder(ctx, "/repo/.red/tmp/workers/wQDOR/894-a1")).toBe(
-      "/repo/.red/tmp/workers/wQDOR/894-a1/.sandcastle/worktrees/afk-wQDOR-894-x",
+      "/repo/.red/tmp/workers/wQDOR/894-a1/.red-castle/worktrees/afk-wQDOR-894-x",
     );
     expect(calls[0]).toEqual(["git", "worktree", "list", "--porcelain"]);
   });
@@ -338,7 +338,7 @@ describe("worktreePathUnder (sandcastle-blind heartbeat fix)", () => {
   it("tolerates a trailing slash on the prefix", async () => {
     const { exec } = recordingExec(() => ok(porcelain));
     expect(await worktreePathUnder({ cwd: "/repo", exec }, "/repo/.red/tmp/workers/wQDOR/894-a1/")).toBe(
-      "/repo/.red/tmp/workers/wQDOR/894-a1/.sandcastle/worktrees/afk-wQDOR-894-x",
+      "/repo/.red/tmp/workers/wQDOR/894-a1/.red-castle/worktrees/afk-wQDOR-894-x",
     );
   });
 

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -108,7 +108,7 @@ describe("resolveAttemptHead (#1390)", () => {
             "HEAD base",
             "branch refs/heads/main",
             "",
-            "worktree /repo/.red/tmp/workers/w1/1390-a1/.sandcastle/worktrees/afk-w1-1390",
+            "worktree /repo/.red/tmp/workers/w1/1390-a1/.red-castle/worktrees/afk-w1-1390",
             "HEAD moved-head",
             "branch refs/heads/afk/w1/1390-loc",
             "",


### PR DESCRIPTION
Maintainer order: no `.sandcastle` directory may appear in the runtime again.

red-castle side (pin 9674311 → 977af58, main fast-forward): the library's on-disk namespace is `.red-castle` everywhere — `CONFIG_DIR`, host-derived artifacts (`worktrees/`, `logs/`, `patches/`, `.env`), error/scaffold messages, docs, glossary, scaffold templates, and the repo's own dogfood config dir (`git mv`). 425+29 occurrences across 91 files; acceptance grep zero; suite 57 files / 1537 passed; typecheck and build clean. Brand and command names (`sandcastle init`, package `@reddb-io/red-castle`, upstream refs) unchanged. CLAUDE.md records the identity divergence next to the TOON log doctrine, including the cherry-pick adaptation rule. The AFK layout is now `{attemptDir}/.red-castle/…`, nested under the worker's attempt dir — never at a repo root (glossary now states the cwd-anchor contract explicitly).

red-skills side (this PR): the 9 tracked references were comments and worktree-list test fixtures — no functional code matches the literal directory name, so live workers on the previous pin drain unaffected and no transition shim is needed. Touched test files pass (4 files / 421 tests locally); CI is the workspace gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786714292&installation_id=129708444&pr_number=1818&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1818&signature=68a9831494750e523246b7efa7fac5d80dbf0b94cced2722b90fd2dc74475f7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->