### PR TITLE
feat: #1813 toon sync S4 — red-toon-watch workflow, rolling auto-bump PR

### DIFF
--- a/.github/workflows/red-rsp-benchmark-ci.yml
+++ b/.github/workflows/red-rsp-benchmark-ci.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - apps/rsp/**
       - .github/workflows/red-rsp-benchmark-ci.yml
+  push:
+    # The red-toon-watch rolling PR (GITHUB_TOKEN-authored, never triggers
+    # pull_request workflows) bumps TQ_VERSION here — run on its branch push
+    # so the benchmark check lands on the head SHA.
+    branches: [automation/toon-bump]
 
 permissions:
   contents: read

--- a/.github/workflows/red-toon-watch.yml
+++ b/.github/workflows/red-toon-watch.yml
@@ -1,0 +1,151 @@
+name: red-toon-watch
+
+on:
+  schedule:
+    - cron: '25 13 * * *'
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: "Optional stable toon release tag to process instead of releases/latest"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: red-toon-watch
+  cancel-in-progress: false
+
+env:
+  TOON_BUMP_BRANCH: automation/toon-bump
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Resolve stable toon release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_TAG_INPUT: ${{ inputs.target_tag }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$TARGET_TAG_INPUT" ]; then
+            tag="$TARGET_TAG_INPUT"
+            gh api "repos/reddb-io/toon/releases/tags/$tag" > release.json
+          else
+            gh api "repos/reddb-io/toon/releases/latest" > release.json
+            tag="$(jq -r '.tag_name' release.json)"
+          fi
+
+          if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::toon release tag must be stable vX.Y.Z, got '$tag'"
+            exit 1
+          fi
+
+          if [ "$(jq -r '.draft or .prerelease' release.json)" != "false" ]; then
+            echo "::error::toon release '$tag' is not a stable published release"
+            exit 1
+          fi
+
+          target_version="${tag#v}"
+          current_version="$(
+            node <<'NODE'
+          const fs = require("fs");
+          const match = fs
+            .readFileSync("pnpm-workspace.yaml", "utf8")
+            .match(/["@']?@reddb-io\/toon["@']?:\s*([0-9]+\.[0-9]+\.[0-9]+)/);
+          if (!match) process.exit(1);
+          console.log(match[1]);
+          NODE
+          )"
+          newest="$(printf '%s\n%s\n' "$current_version" "$target_version" | sort -V | tail -n 1)"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "target_version=$target_version" >> "$GITHUB_OUTPUT"
+          echo "current_version=$current_version" >> "$GITHUB_OUTPUT"
+
+          if [ "$newest" != "$target_version" ] || [ "$current_version" = "$target_version" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Catalog already pins $current_version; no newer stable toon release to process."
+            exit 0
+          fi
+
+          jq -r '.body // "_No release notes published._"' release.json > toon-release-notes.md
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install workspace dependencies
+        if: steps.release.outputs.changed == 'true'
+        env:
+          REDDB_SKIP_POSTINSTALL: "1"
+        run: pnpm install --frozen-lockfile
+
+      - name: Run toon bump
+        if: steps.release.outputs.changed == 'true'
+        env:
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+        run: |
+          set -euo pipefail
+          pnpm -C apps/dev dev toon-bump "$TARGET_VERSION"
+          pnpm install --lockfile-only
+          if git diff --quiet; then
+            echo "::notice::toon-bump reported newer $TARGET_VERSION but left no diff; stopping without PR."
+            exit 0
+          fi
+
+      - name: Open or update rolling PR
+        if: steps.release.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_TAG: ${{ steps.release.outputs.tag }}
+          TARGET_VERSION: ${{ steps.release.outputs.target_version }}
+          CURRENT_VERSION: ${{ steps.release.outputs.current_version }}
+        run: |
+          set -euo pipefail
+
+          perl -0pe 's#claude\.ai/code/session_[A-Za-z0-9_-]+#[REDACTED_CLAUDE_SESSION]#g; s#/(Users|home)/[A-Za-z0-9._-]+#[REDACTED_HOME]#g; s#https?://([^/\s)]+)#https://[REDACTED_HOST]#g' \
+            toon-release-notes.md > sanitized-toon-release-notes.md
+          SANITIZED_NOTES="$(cat sanitized-toon-release-notes.md)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$TOON_BUMP_BRANCH"
+          git add -- pnpm-workspace.yaml pnpm-lock.yaml .github/workflows/red-workspace-ci.yml .github/workflows/red-rsp-benchmark-ci.yml plugins/dev/skills/engineering/red-setup/INTERVIEW.md plugins/dev/skills/engineering/red-setup/REFERENCE.md plugins/dev/skills/engineering/red-setup/WRITE-CONTRACT.md plugins/dev/skills/engineering/red-setup/config-template.yaml plugins/dev/skills/engineering/red-doctor/SKILL.md
+          git commit -m "chore: bump toon to $TRIGGER_TAG"
+          git push --force-with-lease origin "$TOON_BUMP_BRANCH"
+
+          body_file="$(mktemp)"
+          trap 'rm -f "$body_file"' EXIT
+          {
+            printf 'Automated rolling toon bump.\n\n'
+            printf -- '- trigger tag: `%s`\n' "$TRIGGER_TAG"
+            printf -- '- catalog pin: `%s` -> `%s`\n' "$CURRENT_VERSION" "$TARGET_VERSION"
+            printf -- '- source release: `reddb-io/toon@%s`\n\n' "$TRIGGER_TAG"
+            printf '## Toon release notes\n\n'
+            printf '%s\n' "$SANITIZED_NOTES"
+            printf '\n---\n'
+            printf 'This rolling PR is force-updated by `red-toon-watch`; CI adjudicates readiness and merge remains manual.\n'
+          } > "$body_file"
+
+          title="chore: bump toon to $TRIGGER_TAG"
+          existing="$(gh pr list --head "$GITHUB_REPOSITORY_OWNER:$TOON_BUMP_BRANCH" --state open --json number --jq '.[0].number')"
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "$title" --body-file "$body_file" --base main
+          else
+            gh pr create --title "$title" --body-file "$body_file" --base main --head "$TOON_BUMP_BRANCH"
+          fi

--- a/.github/workflows/red-workspace-ci.yml
+++ b/.github/workflows/red-workspace-ci.yml
@@ -15,7 +15,11 @@ name: red-workspace-ci
 on:
   pull_request:
   push:
-    branches: [main]
+    # automation/toon-bump: the red-toon-watch rolling PR is opened with
+    # GITHUB_TOKEN, whose events never trigger pull_request workflows — the
+    # push trigger attaches these check runs to the head SHA so the rolling
+    # PR still gets real CI adjudication.
+    branches: [main, automation/toon-bump]
 
 permissions:
   contents: read

--- a/apps/dev/tests/red-toon-watch-workflow.test.ts
+++ b/apps/dev/tests/red-toon-watch-workflow.test.ts
@@ -1,0 +1,59 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+async function readWorkflow(): Promise<string> {
+  return readFile(join(ROOT, ".github/workflows/red-toon-watch.yml"), "utf8");
+}
+
+function stepBody(workflow: string, name: string): string {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  expect(start, `missing workflow step: ${name}`).toBeGreaterThanOrEqual(0);
+
+  const next = workflow.indexOf("\n      - name: ", start + marker.length);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
+
+describe("red-toon-watch workflow contract", () => {
+  it("is scheduled, dispatchable, and minimally permissioned for a rolling PR", async () => {
+    const workflow = await readWorkflow();
+
+    expect(workflow).toContain("name: red-toon-watch");
+    expect(workflow).toContain("  schedule:");
+    expect(workflow).toContain("  workflow_dispatch:");
+    expect(workflow).toContain("  contents: write");
+    expect(workflow).toContain("  pull-requests: write");
+    expect(workflow).not.toContain("issues: write");
+    expect(workflow).toContain("group: red-toon-watch");
+    expect(workflow).toContain("TOON_BUMP_BRANCH: automation/toon-bump");
+  });
+
+  it("detects only newer stable release tags before running the S3 bump verb", async () => {
+    const resolveRelease = stepBody(await readWorkflow(), "Resolve stable toon release");
+    const bump = stepBody(await readWorkflow(), "Run toon bump");
+
+    expect(resolveRelease).toContain("repos/reddb-io/toon/releases/latest");
+    expect(resolveRelease).toContain('^v[0-9]+\\.[0-9]+\\.[0-9]+$');
+    expect(resolveRelease).toContain("sort -V");
+    expect(resolveRelease).toContain('echo "changed=false"');
+    expect(bump).toContain("if: steps.release.outputs.changed == 'true'");
+    expect(bump).toContain('pnpm -C apps/dev dev toon-bump "$TARGET_VERSION"');
+    expect(bump).toContain("pnpm install --lockfile-only");
+  });
+
+  it("force-updates one rolling PR with trigger tag and sanitized release notes", async () => {
+    const pr = stepBody(await readWorkflow(), "Open or update rolling PR");
+
+    expect(pr).toContain("git push --force-with-lease origin");
+    expect(pr).toContain('gh pr list --head "$GITHUB_REPOSITORY_OWNER:$TOON_BUMP_BRANCH"');
+    expect(pr).toContain("gh pr edit");
+    expect(pr).toContain("gh pr create");
+    expect(pr).toContain('trigger tag: `%s`');
+    expect(pr).toContain("Toon release notes");
+    expect(pr).toContain("SANITIZED_NOTES");
+    expect(pr).not.toContain("peter-evans/create-pull-request");
+  });
+});


### PR DESCRIPTION
Closes #1813

Human-reviewed landing of the park (attempt branch `afk/wFKOP/1813-...`). The gate's `blocked:validation` was a cross-package flake: the failing package is file-disjoint from this diff (a workflow + one workflow-contract test) and its suite passes on main locally; and a workflow-touching diff would have parked sensitive-path regardless — this PR lane is the intended review gate.

Reviewed workflow security posture: SHA-pinned actions, `contents/pull-requests: write` only, stable-tag regex + draft/prerelease rejection, catalog-as-truth comparison with a clean no-op path, release notes sanitized before entering the PR body (session links, home paths, hosts), rolling branch with `--force-with-lease`, create-or-edit single PR, and it dogfoods the S3 `toon-bump` verb.

One real defect found in review, fixed on top: the rolling PR is authored with `GITHUB_TOKEN`, whose events never trigger `pull_request` workflows — the PR would sit with zero checks, breaking "CI adjudicates". Fixed without new secrets by running workspace CI and the rsp benchmark on pushes to `automation/toon-bump`; check runs attach to the head SHA and count on the PR.

Note: the workflow's hardcoded `git add` site list is guarded by the S1 contract test — if the bump verb ever writes a site missing from the list, the rolling PR's own CI goes red rather than drifting silently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786714882&installation_id=129708444&pr_number=1820&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1820&signature=3e9da2c4dcbfa7f91cf3ecd505e033aa51d13254a3930143bfaf092d2b6bc832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->