### PR TITLE
fix: #1822 afk-history ledger cap converges on the tq trim keep-last verb

### DIFF
--- a/apps/dev/src/core/history.ts
+++ b/apps/dev/src/core/history.ts
@@ -1,5 +1,7 @@
 import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
 import { dirname } from "node:path";
+import { promisify } from "node:util";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 
 // Port of lib/history.sh — the afk-history.jsonl ledger. The pure parts (the
@@ -10,12 +12,15 @@ import { decode, encode, type JsonValue } from "@reddb-io/toon";
 // Module stamps ts/epoch from its only ambient input.
 
 export const HISTORY_MAX_LINES_DEFAULT = 10000;
+export const HISTORY_TQ_TRIM_TIMEOUT_MS = 1000;
 
 export const SPARKLINE_BUCKETS_DEFAULT = 48;
 
 // The glyph ramp matches monitor.sh's render_sparkline byte-for-byte: index 0
 // is the empty middle-dot, indices 1..8 are the eighth-blocks ▁..█.
 export const SPARKLINE_GLYPHS = ["·", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
+
+const execFileAsync = promisify(execFile);
 
 /** A single terminal event in the ledger. */
 export type HistoryEvent = "done" | "blocked" | "exhausted" | (string & {});
@@ -275,6 +280,24 @@ export const defaultHistoryIO: HistoryIO = {
   },
 };
 
+export interface HistoryTrimTool {
+  trimKeepLast(path: string, keepLast: number): Promise<boolean>;
+}
+
+export const defaultHistoryTrimTool: HistoryTrimTool = {
+  async trimKeepLast(path, keepLast) {
+    try {
+      await execFileAsync("tq", ["trim", "--keep-last", String(keepLast), "--in-place", path], {
+        timeout: HISTORY_TQ_TRIM_TIMEOUT_MS,
+        windowsHide: true,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
 /**
  * Appends exactly one JSONL record to the ledger, creating the parent
  * directory if missing. Returns the record that was written.
@@ -320,11 +343,13 @@ export async function historyTrim(
   path: string,
   maxLines: number = HISTORY_MAX_LINES_DEFAULT,
   io: HistoryIO = defaultHistoryIO,
+  tool: HistoryTrimTool = defaultHistoryTrimTool,
 ): Promise<number | null> {
   const text = await io.read(path);
   if (text === null) return null;
   const records = parseHistoryLines(text);
   if (records.length <= maxLines) return null;
+  if (path.endsWith(".toonl") && await tool.trimKeepLast(path, maxLines)) return maxLines;
   const kept = records.slice(records.length - maxLines);
   if (path.endsWith(".toonl")) {
     await io.write(path, renderHistoryToonl(kept));

--- a/apps/dev/tests/history.test.ts
+++ b/apps/dev/tests/history.test.ts
@@ -11,6 +11,7 @@ import {
   readDoneBuckets,
   renderSparkline,
   type HistoryRecord,
+  type HistoryTrimTool,
 } from "../src/core/history.js";
 
 // Mirrors plugins/dev/skills/engineering/afk/scripts/tests/fixtures/history/buckets.jsonl:
@@ -176,6 +177,53 @@ describe("history append", () => {
 });
 
 describe("history trim", () => {
+  it("delegates over-bound TOONL caps to the tq trim runner", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
+    const path = join(dir, "afk-history.toonl");
+    for (let i = 1; i <= 6; i += 1) {
+      await historyAppend(path, { ts: `t${i}`, epoch: i }, "done", {});
+    }
+    const calls: Array<{ path: string; keepLast: number }> = [];
+    const tool: HistoryTrimTool = {
+      async trimKeepLast(calledPath, keepLast) {
+        calls.push({ path: calledPath, keepLast });
+        await writeFile(
+          calledPath,
+          [
+            "[2]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:",
+            "  t5,5,,0,done,0,,null,null",
+            "  t6,6,,0,done,0,,null,null",
+            "",
+          ].join("\n"),
+          "utf8",
+        );
+        return true;
+      },
+    };
+
+    expect(await historyTrim(path, 2, undefined, tool)).toBe(2);
+    expect(calls).toEqual([{ path, keepLast: 2 }]);
+    expect(parseHistoryLines(await readFile(path, "utf8")).map((record) => record.epoch)).toEqual([5, 6]);
+  });
+
+  it("falls back in-process when the tq trim runner is unavailable", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
+    const path = join(dir, "afk-history.toonl");
+    for (let i = 1; i <= 6; i += 1) {
+      await historyAppend(path, { ts: `t${i}`, epoch: i }, "done", {});
+    }
+    const tool: HistoryTrimTool = {
+      async trimKeepLast() {
+        return false;
+      },
+    };
+
+    expect(await historyTrim(path, 3, undefined, tool)).toBe(3);
+    const body = await readFile(path, "utf8");
+    expect(body.split("\n")[0]).toBe("[3]{ts,epoch,worker,issue,event,duration_s,runner,merge_sha,reason}:");
+    expect(parseHistoryLines(body).map((record) => record.epoch)).toEqual([4, 5, 6]);
+  });
+
   it("caps to the bound, keeps newest, preserves the TOONL header, and returns the cap", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
     const path = join(dir, "afk-history.toonl");


### PR DESCRIPTION
Automated AFK landing for #1822. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1822

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786717698&installation_id=129708444&pr_number=1829&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1829&signature=24aee0f49e8d9930eb6d2abf63a7f49c928e4a63cffa08ee10768901a422894e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->