### PR TITLE
fix: #1824 Attempt firehose adopts TOONL tagged-row multiplexing with canonical per-shape field order

### DIFF
--- a/apps/dev/src/commands/activity-review.ts
+++ b/apps/dev/src/commands/activity-review.ts
@@ -14,6 +14,7 @@ import {
   type ActivityReviewPullRequest,
   type ActivityReviewTokenSummary,
 } from "../core/activity-review.js";
+import { parseLane } from "../core/jsonl-log.js";
 import { readHistoryRecords, type HistoryRecord } from "../core/history.js";
 import { collectMonitorInputs, afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
@@ -299,7 +300,7 @@ function logRecordInInterval(value: unknown, start: Date, end: Date): boolean {
   return ts.getTime() >= start.getTime() && ts.getTime() <= end.getTime();
 }
 
-async function collectTokenSummary(workersRoot: string, start: Date, end: Date): Promise<ActivityReviewTokenSummary> {
+export async function collectTokenSummary(workersRoot: string, start: Date, end: Date): Promise<ActivityReviewTokenSummary> {
   let input = 0;
   let output = 0;
   let total = 0;
@@ -312,21 +313,14 @@ async function collectTokenSummary(workersRoot: string, start: Date, end: Date):
     } catch {
       continue;
     }
-    for (const raw of text.split("\n")) {
-      const line = raw.trim();
-      if (!line.startsWith("{")) continue;
-      try {
-        const parsed = JSON.parse(line);
-        if (!logRecordInInterval(parsed, start, end)) continue;
-        const found = collectTokensFromObject(parsed);
-        if (found.hits > 0) {
-          input += found.input;
-          output += found.output;
-          total += found.total;
-          sourceRecords += 1;
-        }
-      } catch {
-        // Ignore malformed log lines. The token section is advisory.
+    for (const parsed of parseLane(text)) {
+      if (!logRecordInInterval(parsed, start, end)) continue;
+      const found = collectTokensFromObject(parsed);
+      if (found.hits > 0) {
+        input += found.input;
+        output += found.output;
+        total += found.total;
+        sourceRecords += 1;
       }
     }
   }

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -83,7 +83,7 @@ import {
 } from "../core/process-safety.js";
 import { join } from "node:path";
 import { hostFingerprintPrefix, workerIdentity } from "../core/host-identity.js";
-import { appendAgentRecord, appendRecord } from "../core/jsonl-log.js";
+import { appendAgentRecord, appendRecordToonlTaggedRow } from "../core/jsonl-log.js";
 import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from "../core/state.js";
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../core/loc-memo.js";
@@ -1177,7 +1177,7 @@ export function buildProcessDeps(
       // the meter + iteration markers. Returning here also narrows `event` to the
       // non-raw variants for the rest of the handler.
       if (event.type === "raw") {
-        void appendRecord(join(current.attemptDir, "log.jsonl"), "raw", {
+        void appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "raw", {
           iteration: event.iteration,
           line: event.line,
         }, {
@@ -1186,7 +1186,7 @@ export function buildProcessDeps(
         return;
       }
       if (event.type === "sessionId") {
-        void appendRecord(join(current.attemptDir, "log.jsonl"), "session", `session ${event.sessionId}`, {
+        void appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "session", `session ${event.sessionId}`, {
           ts,
           fields: {
             extra: {
@@ -1229,7 +1229,7 @@ export function buildProcessDeps(
       if (event.iteration !== lastIter) {
         const emit = (line: string, phase: string, n: number): void => {
           void fsx.appendLine(join(dir0, "afk.log"), line);
-          void appendRecord(join(dir0, "log.jsonl"), "iteration", line, {
+          void appendRecordToonlTaggedRow(join(dir0, "log.jsonl"), "iteration", line, {
             ts,
             fields: { extra: { iteration: String(n), phase } },
           }).catch(() => {});
@@ -1260,7 +1260,7 @@ export function buildProcessDeps(
       // Firehose lane (issue #250): every record in the uniform envelope. The
       // native port left this unopened; restore it so the post-mortem firehose
       // carries the agent turns alongside the (future) heartbeat/hook records.
-      void appendRecord(join(current.attemptDir, "log.jsonl"), "agent", msg, {
+      void appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "agent", msg, {
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },
       }).catch(() => {});
@@ -1391,7 +1391,7 @@ export function buildProcessDeps(
           removed,
           activity,
         });
-        await appendRecord(join(current.attemptDir, "log.jsonl"), "heartbeat", hb.msg, {
+        await appendRecordToonlTaggedRow(join(current.attemptDir, "log.jsonl"), "heartbeat", hb.msg, {
           ts,
           fields: { extra: hb.extra },
         }).catch(() => {});

--- a/apps/dev/src/core/jsonl-log.ts
+++ b/apps/dev/src/core/jsonl-log.ts
@@ -1,6 +1,6 @@
 import { mkdir, appendFile, stat } from "node:fs/promises";
 import { dirname } from "node:path";
-import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { decode, encode, encodeLines, type JsonValue, type ToonlLineEmitter, type ToonlRecord } from "@reddb-io/toon";
 
 // The JSONL Log Module: owns the AFK structured-log lane format end to end.
 //
@@ -163,6 +163,20 @@ export interface AppendOptions {
   sink?: AppendSink;
 }
 
+const taggedRowEmitters = new Map<string, ToonlLineEmitter>();
+
+function toToonlRecord(record: JsonlLogRecord): ToonlRecord {
+  const out: ToonlRecord = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value === undefined) continue;
+    out[key] =
+      value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+        ? value
+        : JSON.stringify(value);
+  }
+  return out;
+}
+
 /**
  * Append one envelope line to a per-attempt lane (single writer).
  * Mirrors bash `jsonl_log_append`.
@@ -229,6 +243,33 @@ export async function appendRecordToonlRow(
 }
 
 /**
+ * Append one record to a TOONL v0.2 tagged-row lane. Tags multiplex record
+ * shapes inside one append-only file: the first row for a tag declares
+ * `[]<tag>{fields}:`, then later rows use `tag:...` until that tag's shape
+ * changes. The emitter canonicalizes field order per shape, avoiding the
+ * old one-header-per-record thrash while keeping legacy `.jsonl` filenames.
+ */
+export async function appendRecordToonlTaggedRow(
+  path: string,
+  type: string,
+  msg: JsonlLogValue,
+  options: AppendOptions,
+): Promise<JsonlLogRecord> {
+  if (!path) throw new JsonlLogError("[jsonl-log] appendRecordToonlTaggedRow: need <path>", 2);
+  if (!type) throw new JsonlLogError("[jsonl-log] appendRecordToonlTaggedRow: need <type>", 2);
+  const record = buildRecord(type, msg, options.ts, options.fields);
+  const emitterKey = options.sink ? `${path}\0sink` : path;
+  let emitter = taggedRowEmitters.get(emitterKey);
+  if (!emitter) {
+    emitter = encodeLines({ trailer: false });
+    taggedRowEmitters.set(emitterKey, emitter);
+  }
+  const chunk = emitter.pushTagged(type, toToonlRecord(record)).trimEnd();
+  await (options.sink ?? fsAppendSink)(path, chunk);
+  return record;
+}
+
+/**
  * Append one `type=agent` envelope to the agent lane. The lane owns its type:
  * a synthetic type, or any explicit type other than `agent`, is a contract
  * violation. Mirrors bash `jsonl_log_append_agent`.
@@ -272,6 +313,7 @@ export function parseLane(content: string): JsonlLogRecord[] {
   const lines = content.split(/\r?\n/);
   const records: JsonlLogRecord[] = [];
   let header = "";
+  const taggedHeaders = new Map<string, string>();
   for (const raw of lines) {
     const line = raw.trimEnd();
     const trimmed = line.trim();
@@ -286,6 +328,24 @@ export function parseLane(content: string): JsonlLogRecord[] {
     }
     if (/^\[(?:[0-9]+)?\]\{[^}]+\}:$/.test(trimmed)) {
       header = trimmed;
+      continue;
+    }
+    const taggedHeader = trimmed.match(/^\[\]<([A-Za-z0-9_-]+)>(\{[^}]+\}:)$/);
+    if (taggedHeader) {
+      taggedHeaders.set(taggedHeader[1]!, `[1]${taggedHeader[2]}`);
+      continue;
+    }
+    const taggedRow = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
+    if (taggedRow) {
+      const tagged = taggedHeaders.get(taggedRow[1]!);
+      if (!tagged) continue;
+      try {
+        const value = decode(`${tagged}\n  ${taggedRow[2]}\n`);
+        const row = Array.isArray(value) ? value[0] : value;
+        if (row && typeof row === "object") records.push(row as JsonlLogRecord);
+      } catch {
+        // TOONL readers are crash-tail tolerant during rollout.
+      }
       continue;
     }
     if (!header) continue;

--- a/apps/dev/tests/activity-review.test.ts
+++ b/apps/dev/tests/activity-review.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { decode } from "@reddb-io/toon";
 import {
@@ -7,7 +10,8 @@ import {
   renderActivityReviewReportToon,
   type ActivityReviewIssue,
 } from "../src/core/activity-review.js";
-import { collectTokensFromObject, parseGitLogStats } from "../src/commands/activity-review.js";
+import { collectTokenSummary, collectTokensFromObject, parseGitLogStats } from "../src/commands/activity-review.js";
+import { appendRecordToonlTaggedRow, buildRecord } from "../src/core/jsonl-log.js";
 import type { HistoryRecord } from "../src/core/history.js";
 
 const issue = (over: Partial<ActivityReviewIssue>): ActivityReviewIssue => ({
@@ -201,5 +205,34 @@ describe("activity review", () => {
 
     expect(collectTokensFromObject(oldRaw)).toEqual({ input: 3, output: 5, total: 0, hits: 2 });
     expect(collectTokensFromObject(newRaw)).toEqual({ input: 7, output: 11, total: 0, hits: 2 });
+  });
+
+  it("activity-review token scan reads legacy JSONL and tagged-row TOONL attempt lanes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "activity-review-firehose-"));
+    const attemptDir = join(root, "wAAAA", "1824-a1");
+    await mkdir(attemptDir, { recursive: true });
+    const log = join(attemptDir, "log.jsonl");
+    const tagged: string[] = [];
+    const sink = async (_p: string, line: string) => void tagged.push(line);
+    await appendRecordToonlTaggedRow(log, "raw", { iteration: 1, line: "{\"inputTokens\":7,\"outputTokens\":11}" }, {
+      ts: "2026-07-15T12:00:00.000Z",
+      fields: { extra: { iteration: "1" } },
+      sink,
+    });
+    await writeFile(
+      log,
+      [
+        JSON.stringify(buildRecord("raw", { iteration: 0, line: "{\"inputTokens\":3,\"outputTokens\":5}" }, "2026-07-15T11:00:00.000Z")),
+        ...tagged,
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const summary = await collectTokenSummary(
+      root,
+      new Date("2026-07-15T00:00:00.000Z"),
+      new Date("2026-07-16T00:00:00.000Z"),
+    );
+    expect(summary).toEqual({ available: true, input: 10, output: 16, total: null, sourceRecords: 2 });
   });
 });

--- a/apps/dev/tests/jsonl-log.test.ts
+++ b/apps/dev/tests/jsonl-log.test.ts
@@ -7,6 +7,7 @@ import {
   appendRecord,
   appendRecordToonl,
   appendRecordToonlRow,
+  appendRecordToonlTaggedRow,
   buildRecord,
   ENVELOPE_FIELD_ORDER,
   filterByType,
@@ -132,6 +133,14 @@ describe("jsonl-log malformed input", () => {
     await expect(appendRecordToonlRow("/lane.jsonl", "", "x", { ts: TS, sink })).rejects.toMatchObject({ code: 2 });
     expect(writes).toEqual([]);
   });
+
+  it("appendRecordToonlTaggedRow requires path and type with code 2 and writes nothing", async () => {
+    const writes: string[] = [];
+    const sink = async (_p: string, line: string) => void writes.push(line);
+    await expect(appendRecordToonlTaggedRow("", "stage", "x", { ts: TS, sink })).rejects.toMatchObject({ code: 2 });
+    await expect(appendRecordToonlTaggedRow("/lane.jsonl", "", "x", { ts: TS, sink })).rejects.toMatchObject({ code: 2 });
+    expect(writes).toEqual([]);
+  });
 });
 
 describe("jsonl-log lane routing", () => {
@@ -169,6 +178,49 @@ describe("jsonl-log lane routing", () => {
     expect(parseLane(firehose.join("\n")).map((r) => r.type)).toEqual(["agent", "heartbeat", "boot", "stage", "hook"]);
     expect(parseLane(agent.join("\n")).map((r) => r.type)).toEqual(["agent"]);
   });
+
+  it("attempt firehose uses tagged-row TOONL multiplexing with canonical per-shape field order", async () => {
+    const firehose: string[] = [];
+    const sink = async (_p: string, line: string) => void firehose.push(line);
+
+    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "raw", { iteration: 1, line: "{\"inputTokens\":3}" }, {
+      ts: TS,
+      fields: { extra: { iteration: "1" } },
+      sink,
+    });
+    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "agent", "hello", {
+      ts: TS,
+      fields: { extra: { iteration: "1", kind: "text" } },
+      sink,
+    });
+    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "raw", { iteration: 2, line: "{\"outputTokens\":5}" }, {
+      ts: TS,
+      fields: { extra: { iteration: "2" } },
+      sink,
+    });
+    await appendRecordToonlTaggedRow("/attempt/log.jsonl", "agent", "again", {
+      ts: TS,
+      fields: { extra: { kind: "text", iteration: "2" } },
+      sink,
+    });
+
+    const content = firehose.join("\n");
+    const lines = content.split("\n").filter(Boolean);
+    const headers = lines.filter((line) => line.startsWith("[]<"));
+    expect(headers).toEqual([
+      "[]<raw>{ts,type,msg,iteration}:",
+      "[]<agent>{ts,type,msg,iteration,kind}:",
+    ]);
+    expect(lines.filter((line) => /^raw:/.test(line))).toHaveLength(2);
+    expect(lines.filter((line) => /^agent:/.test(line))).toHaveLength(2);
+    expect(headers.length / lines.length).toBeLessThanOrEqual(0.34);
+    expect(parseLane(content).map((r) => [r.type, r.iteration, r.kind ?? null])).toEqual([
+      ["raw", "1", null],
+      ["agent", "1", "text"],
+      ["raw", "2", null],
+      ["agent", "2", "text"],
+    ]);
+  });
 });
 
 describe("jsonl-log append accumulation and readers", () => {
@@ -191,6 +243,24 @@ describe("jsonl-log append accumulation and readers", () => {
     expect(parseLane(`${json}\n`).map((r) => r.msg)).toEqual(["legacy"]);
     expect(parseLane(`${toonA}\n${toonB}\n`).map((r) => r.msg)).toEqual(["toon-a", "toon-b"]);
     expect(parseLane(`${json}\n${toonA}\n${toonB}\n`).map((r) => r.msg)).toEqual(["legacy", "toon-a", "toon-b"]);
+  });
+
+  it("parses legacy JSONL mixed with tagged-row attempt firehose files", async () => {
+    const json = JSON.stringify(buildRecord("heartbeat", "legacy", TS, { worker: "wAAAA" }));
+    const tagged: string[] = [];
+    const sink = async (_p: string, line: string) => void tagged.push(line);
+    await appendRecordToonlTaggedRow("/attempt/log-mixed.jsonl", "agent", "toon-a", {
+      ts: TS,
+      fields: { worker: "wAAAA", extra: { iteration: "1", kind: "text" } },
+      sink,
+    });
+    await appendRecordToonlTaggedRow("/attempt/log-mixed.jsonl", "heartbeat", "toon-b", {
+      ts: TS,
+      fields: { worker: "wAAAA", extra: { head: "abc123" } },
+      sink,
+    });
+
+    expect(parseLane(`${json}\n${tagged.join("\n")}\n`).map((r) => r.msg)).toEqual(["legacy", "toon-a", "toon-b"]);
   });
 
   it("writes stable-schema TOONL lanes with one header and appended rows", async () => {


### PR DESCRIPTION
Automated AFK landing for #1824. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1824

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786721411&installation_id=129708444&pr_number=1833&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1833&signature=29c6d939eb758328490d5c95b91fbe437f5f238a3cf43278f7c82c9af3bd2bd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->