### PR TITLE
fix: #1825 TOONL lane tail readers adopt the v0.2 cursor-resume contract

### DIFF
--- a/apps/dev/src/commands/activity-review.ts
+++ b/apps/dev/src/commands/activity-review.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { LABEL_HUMAN } from "../core/triage-labels.js";
 import {
@@ -14,7 +14,11 @@ import {
   type ActivityReviewPullRequest,
   type ActivityReviewTokenSummary,
 } from "../core/activity-review.js";
-import { parseLane } from "../core/jsonl-log.js";
+import {
+  parseLaneSinceCursor,
+  ToonlCursorInvalidationError,
+  type ToonlLaneCursor,
+} from "../core/jsonl-log.js";
 import { readHistoryRecords, type HistoryRecord } from "../core/history.js";
 import { collectMonitorInputs, afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { execTool, type ExecFn } from "../runtime/exec.js";
@@ -259,6 +263,92 @@ export function collectTokensFromObject(value: unknown): { input: number; output
   return { input, output, total, hits };
 }
 
+interface TokenCacheRow {
+  ts: string | null;
+  input: number;
+  output: number;
+  total: number;
+}
+
+interface TokenFileCache {
+  cursor: ToonlLaneCursor;
+  rows: TokenCacheRow[];
+}
+
+type TokenSummaryCache = Record<string, TokenFileCache>;
+
+function tokenCachePath(workersRoot: string): string {
+  return join(workersRoot, ".activity-review-token-cursors.json");
+}
+
+function validTokenCacheRow(value: unknown): TokenCacheRow | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const rec = value as Record<string, unknown>;
+  const input = Number(rec.input);
+  const output = Number(rec.output);
+  const total = Number(rec.total);
+  if (!Number.isFinite(input) || input < 0) return null;
+  if (!Number.isFinite(output) || output < 0) return null;
+  if (!Number.isFinite(total) || total < 0) return null;
+  return {
+    ts: typeof rec.ts === "string" ? rec.ts : null,
+    input,
+    output,
+    total,
+  };
+}
+
+function validToonlCursor(value: unknown): ToonlLaneCursor | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const rec = value as Partial<ToonlLaneCursor>;
+  const byteOffset = Number(rec.byteOffset);
+  const rowsSinceHeader = Number(rec.rowsSinceHeader);
+  if (!Number.isFinite(byteOffset) || byteOffset < 0) return null;
+  if (!Number.isFinite(rowsSinceHeader) || rowsSinceHeader < 0) return null;
+  return {
+    byteOffset,
+    rowsSinceHeader,
+    activeHeader: typeof rec.activeHeader === "string" ? rec.activeHeader : "",
+    taggedHeaders:
+      rec.taggedHeaders !== null && typeof rec.taggedHeaders === "object"
+        ? Object.fromEntries(
+            Object.entries(rec.taggedHeaders as Record<string, unknown>)
+              .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+          )
+        : {},
+  };
+}
+
+function validTokenFileCache(value: unknown): TokenFileCache | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const rec = value as { cursor?: unknown; rows?: unknown };
+  const cursor = validToonlCursor(rec.cursor);
+  if (cursor === null || !Array.isArray(rec.rows)) return null;
+  return {
+    cursor,
+    rows: rec.rows.map(validTokenCacheRow).filter((row): row is TokenCacheRow => row !== null),
+  };
+}
+
+async function readTokenSummaryCache(path: string): Promise<TokenSummaryCache> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: TokenSummaryCache = {};
+    for (const [file, value] of Object.entries(parsed)) {
+      const cache = validTokenFileCache(value);
+      if (cache !== null) out[file] = cache;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+async function writeTokenSummaryCache(path: string, cache: TokenSummaryCache): Promise<void> {
+  await writeFile(path, `${JSON.stringify(cache)}\n`, "utf8");
+}
+
 async function listRetainedLogFiles(workersRoot: string): Promise<string[]> {
   const out: string[] = [];
   let workers: string[];
@@ -306,6 +396,9 @@ export async function collectTokenSummary(workersRoot: string, start: Date, end:
   let total = 0;
   let sourceRecords = 0;
   const files = await listRetainedLogFiles(workersRoot);
+  const cachePath = tokenCachePath(workersRoot);
+  const previous = await readTokenSummaryCache(cachePath);
+  const next: TokenSummaryCache = {};
   for (const file of files) {
     let text: string;
     try {
@@ -313,17 +406,37 @@ export async function collectTokenSummary(workersRoot: string, start: Date, end:
     } catch {
       continue;
     }
-    for (const parsed of parseLane(text)) {
-      if (!logRecordInInterval(parsed, start, end)) continue;
-      const found = collectTokensFromObject(parsed);
+    const prior = previous[file];
+    let parsed: ReturnType<typeof parseLaneSinceCursor>;
+    let rows = prior?.rows ?? [];
+    try {
+      parsed = parseLaneSinceCursor(text, prior?.cursor);
+    } catch (err) {
+      if (!(err instanceof ToonlCursorInvalidationError)) throw err;
+      parsed = parseLaneSinceCursor(text);
+      rows = [];
+    }
+    for (const record of parsed.records) {
+      const found = collectTokensFromObject(record);
       if (found.hits > 0) {
-        input += found.input;
-        output += found.output;
-        total += found.total;
-        sourceRecords += 1;
+        rows.push({
+          ts: timestampFromLogRecord(record)?.toISOString() ?? null,
+          input: found.input,
+          output: found.output,
+          total: found.total,
+        });
       }
     }
+    next[file] = { cursor: parsed.cursor, rows };
+    for (const row of rows) {
+      if (!logRecordInInterval({ ts: row.ts }, start, end)) continue;
+      input += row.input;
+      output += row.output;
+      total += row.total;
+      sourceRecords += 1;
+    }
   }
+  await writeTokenSummaryCache(cachePath, next).catch(() => undefined);
   const available = sourceRecords > 0;
   return {
     available,

--- a/apps/dev/src/core/jsonl-log.ts
+++ b/apps/dev/src/core/jsonl-log.ts
@@ -67,6 +67,26 @@ export class JsonlLogError extends Error {
   }
 }
 
+export interface ToonlLaneCursor {
+  /** Byte offset immediately after the last fully-consumed line. */
+  byteOffset: number;
+  /** The active TOONL header needed to decode positional rows after resume. */
+  activeHeader: string;
+  /** Number of decoded rows since the active header was observed. */
+  rowsSinceHeader: number;
+  /** Tagged-row headers needed to decode `tag:...` rows after resume. */
+  taggedHeaders?: Record<string, string>;
+}
+
+export class ToonlCursorInvalidationError extends Error {
+  readonly code = "TOONL_CURSOR_INVALIDATED";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ToonlCursorInvalidationError";
+  }
+}
+
 /** A non-negative integer string (no sign, allows 0) — the bash `_is_int` rule. */
 function isIntToken(token: string): boolean {
   return /^(0|[1-9][0-9]*)$/.test(token);
@@ -310,17 +330,85 @@ export function filterByType(records: readonly JsonlLogRecord[], type: string): 
 
 /** Parse a lane's contents into records (one per non-empty line). */
 export function parseLane(content: string): JsonlLogRecord[] {
-  const lines = content.split(/\r?\n/);
+  return parseLaneSinceCursor(content).records;
+}
+
+function normalizeCursor(cursor: ToonlLaneCursor | undefined, contentBytes: number): ToonlLaneCursor {
+  if (cursor === undefined) {
+    return { byteOffset: 0, activeHeader: "", rowsSinceHeader: 0, taggedHeaders: {} };
+  }
+  if (!Number.isSafeInteger(cursor.byteOffset) || cursor.byteOffset < 0 || cursor.byteOffset > contentBytes) {
+    throw new ToonlCursorInvalidationError(
+      `[jsonl-log] TOONL cursor invalidated: byte offset ${cursor.byteOffset} outside lane size ${contentBytes}`,
+    );
+  }
+  if (!Number.isSafeInteger(cursor.rowsSinceHeader) || cursor.rowsSinceHeader < 0) {
+    throw new ToonlCursorInvalidationError("[jsonl-log] TOONL cursor invalidated: rowsSinceHeader is invalid");
+  }
+  return {
+    byteOffset: cursor.byteOffset,
+    activeHeader: typeof cursor.activeHeader === "string" ? cursor.activeHeader : "",
+    rowsSinceHeader: cursor.rowsSinceHeader,
+    taggedHeaders: cursor.taggedHeaders && typeof cursor.taggedHeaders === "object" ? { ...cursor.taggedHeaders } : {},
+  };
+}
+
+function completeLinesFrom(content: string, startByteOffset: number, includeFinalLine = false): Array<{ line: string; nextOffset: number }> {
+  const buffer = Buffer.from(content, "utf8");
+  const out: Array<{ line: string; nextOffset: number }> = [];
+  let start = startByteOffset;
+  while (start < buffer.length) {
+    const newline = buffer.indexOf(10, start);
+    if (newline === -1) {
+      if (includeFinalLine) out.push({ line: buffer.subarray(start).toString("utf8"), nextOffset: buffer.length });
+      break;
+    }
+    const end = newline > start && buffer[newline - 1] === 13 ? newline - 1 : newline;
+    out.push({ line: buffer.subarray(start, end).toString("utf8"), nextOffset: newline + 1 });
+    start = newline + 1;
+  }
+  return out;
+}
+
+function decodeToonlRow(header: string, line: string): JsonlLogRecord | null {
+  try {
+    const value = decode(header.replace(/^\[(?:[0-9]+)?\]/, "[1]") + "\n" + line + "\n");
+    const row = Array.isArray(value) ? value[0] : value;
+    return row && typeof row === "object" ? row as JsonlLogRecord : null;
+  } catch {
+    // TOONL readers are crash-tail tolerant during rollout.
+    return null;
+  }
+}
+
+/**
+ * Parse complete records after a reader-owned TOONL cursor. The cursor captures
+ * only reader state: byte offset, active header, and rows-since-header. Losing
+ * it is safe because callers can re-run with no cursor and rescan the lane.
+ */
+export function parseLaneSinceCursor(
+  content: string,
+  cursor?: ToonlLaneCursor,
+): { records: JsonlLogRecord[]; cursor: ToonlLaneCursor } {
+  const contentBytes = Buffer.byteLength(content, "utf8");
+  const normalized = normalizeCursor(cursor, contentBytes);
   const records: JsonlLogRecord[] = [];
-  let header = "";
-  const taggedHeaders = new Map<string, string>();
-  for (const raw of lines) {
-    const line = raw.trimEnd();
+  let header = normalized.activeHeader;
+  let rowsSinceHeader = normalized.rowsSinceHeader;
+  const taggedHeaders = new Map<string, string>(Object.entries(normalized.taggedHeaders ?? {}));
+  let byteOffset = normalized.byteOffset;
+  const lineEntries = completeLinesFrom(content, normalized.byteOffset, cursor === undefined);
+  for (const raw of lineEntries) {
+    const line = raw.line.trimEnd();
     const trimmed = line.trim();
-    if (!trimmed) continue;
+    if (!trimmed) {
+      byteOffset = raw.nextOffset;
+      continue;
+    }
     if (trimmed.startsWith("{")) {
       try {
         records.push(JSON.parse(trimmed) as JsonlLogRecord);
+        byteOffset = raw.nextOffset;
       } catch {
         // Crash tails can leave a torn final row; keep the parseable prefix.
       }
@@ -328,34 +416,45 @@ export function parseLane(content: string): JsonlLogRecord[] {
     }
     if (/^\[(?:[0-9]+)?\]\{[^}]+\}:$/.test(trimmed)) {
       header = trimmed;
+      rowsSinceHeader = 0;
+      byteOffset = raw.nextOffset;
       continue;
     }
     const taggedHeader = trimmed.match(/^\[\]<([A-Za-z0-9_-]+)>(\{[^}]+\}:)$/);
     if (taggedHeader) {
       taggedHeaders.set(taggedHeader[1]!, `[1]${taggedHeader[2]}`);
+      header = trimmed;
+      rowsSinceHeader = 0;
+      byteOffset = raw.nextOffset;
       continue;
     }
     const taggedRow = line.match(/^([A-Za-z0-9_-]+):(.*)$/);
     if (taggedRow) {
       const tagged = taggedHeaders.get(taggedRow[1]!);
       if (!tagged) continue;
-      try {
-        const value = decode(`${tagged}\n  ${taggedRow[2]}\n`);
-        const row = Array.isArray(value) ? value[0] : value;
-        if (row && typeof row === "object") records.push(row as JsonlLogRecord);
-      } catch {
-        // TOONL readers are crash-tail tolerant during rollout.
+      const row = decodeToonlRow(tagged, `  ${taggedRow[2]}`);
+      if (row) {
+        records.push(row);
+        rowsSinceHeader += 1;
+        byteOffset = raw.nextOffset;
       }
       continue;
     }
     if (!header) continue;
-    try {
-      const value = decode(header.replace(/^\[(?:[0-9]+)?\]/, "[1]") + "\n" + line + "\n");
-      const row = Array.isArray(value) ? value[0] : value;
-      if (row && typeof row === "object") records.push(row as JsonlLogRecord);
-    } catch {
-      // TOONL readers are crash-tail tolerant during rollout.
+    const row = decodeToonlRow(header, line);
+    if (row) {
+      records.push(row);
+      rowsSinceHeader += 1;
+      byteOffset = raw.nextOffset;
     }
   }
-  return records;
+  return {
+    records,
+    cursor: {
+      byteOffset,
+      activeHeader: header,
+      rowsSinceHeader,
+      taggedHeaders: Object.fromEntries(taggedHeaders),
+    },
+  };
 }

--- a/apps/dev/src/runtime/log-cursor.ts
+++ b/apps/dev/src/runtime/log-cursor.ts
@@ -1,10 +1,16 @@
 import { createReadStream } from "node:fs";
 import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import {
+  parseLaneSinceCursor,
+  ToonlCursorInvalidationError,
+  type ToonlLaneCursor,
+} from "../core/jsonl-log.js";
 
 export interface LogLineCursor {
   size: number;
   lines: number;
+  toonl?: ToonlLaneCursor;
 }
 
 export type LogLineCursorStore = Record<string, LogLineCursor>;
@@ -16,12 +22,32 @@ export interface LogLineCount {
 
 function validCursor(value: unknown): LogLineCursor | null {
   if (value === null || typeof value !== "object") return null;
-  const rec = value as { size?: unknown; lines?: unknown };
+  const rec = value as { size?: unknown; lines?: unknown; toonl?: unknown };
   const size = Number(rec.size);
   const lines = Number(rec.lines);
   if (!Number.isFinite(size) || size < 0) return null;
   if (!Number.isFinite(lines) || lines < 0) return null;
-  return { size, lines };
+  const out: LogLineCursor = { size, lines };
+  if (rec.toonl !== null && typeof rec.toonl === "object") {
+    const toonl = rec.toonl as Partial<ToonlLaneCursor>;
+    const byteOffset = Number(toonl.byteOffset);
+    const rowsSinceHeader = Number(toonl.rowsSinceHeader);
+    if (Number.isFinite(byteOffset) && byteOffset >= 0 && Number.isFinite(rowsSinceHeader) && rowsSinceHeader >= 0) {
+      out.toonl = {
+        byteOffset,
+        rowsSinceHeader,
+        activeHeader: typeof toonl.activeHeader === "string" ? toonl.activeHeader : "",
+        taggedHeaders:
+          toonl.taggedHeaders !== null && typeof toonl.taggedHeaders === "object"
+            ? Object.fromEntries(
+                Object.entries(toonl.taggedHeaders as Record<string, unknown>)
+                  .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+              )
+            : {},
+      };
+    }
+  }
+  return out;
 }
 
 export async function readLogLineCursors(path: string): Promise<LogLineCursorStore> {
@@ -74,6 +100,25 @@ export async function countLogLinesSinceCursor(
   } catch {
     return null;
   }
+  if (path.endsWith(".jsonl")) {
+    const text = await readFile(path, "utf8");
+    let parsed: ReturnType<typeof parseLaneSinceCursor>;
+    let reset = previous === undefined || size < previous.size || previous.toonl === undefined;
+    const previousCursor = previous?.toonl;
+    try {
+      parsed = parseLaneSinceCursor(text, reset ? undefined : previousCursor);
+    } catch (err) {
+      if (!(err instanceof ToonlCursorInvalidationError)) throw err;
+      reset = true;
+      parsed = parseLaneSinceCursor(text);
+    }
+    const totalLines = reset ? parsed.records.length : (previous?.lines ?? 0) + parsed.records.length;
+    return {
+      count: { lines: totalLines, newLines: parsed.records.length },
+      cursor: { size, lines: totalLines, toonl: parsed.cursor },
+    };
+  }
+
   const reset = previous === undefined || size < previous.size;
   const start = reset ? 0 : previous.size;
   const slice = size > start ? await readUtf8Range(path, start) : "";

--- a/apps/dev/tests/activity-review.test.ts
+++ b/apps/dev/tests/activity-review.test.ts
@@ -235,4 +235,31 @@ describe("activity review", () => {
     );
     expect(summary).toEqual({ available: true, input: 10, output: 16, total: null, sourceRecords: 2 });
   });
+
+  it("activity-review token scan resumes from disposable cursor state without changing results", async () => {
+    const root = await mkdtemp(join(tmpdir(), "activity-review-cursor-"));
+    const attemptDir = join(root, "wAAAA", "1825-a1");
+    await mkdir(attemptDir, { recursive: true });
+    const log = join(attemptDir, "log.jsonl");
+    await appendRecordToonlTaggedRow(log, "raw", { iteration: 1, line: "{\"inputTokens\":7,\"outputTokens\":11}" }, {
+      ts: "2026-07-15T12:00:00.000Z",
+      fields: { extra: { iteration: "1" } },
+    });
+    const start = new Date("2026-07-15T00:00:00.000Z");
+    const end = new Date("2026-07-16T00:00:00.000Z");
+
+    const first = await collectTokenSummary(root, start, end);
+    expect(first).toEqual({ available: true, input: 7, output: 11, total: null, sourceRecords: 1 });
+
+    await appendRecordToonlTaggedRow(log, "raw", { iteration: 2, line: "{\"inputTokens\":13,\"outputTokens\":17}" }, {
+      ts: "2026-07-15T12:05:00.000Z",
+      fields: { extra: { iteration: "2" } },
+    });
+    const resumed = await collectTokenSummary(root, start, end);
+    expect(resumed).toEqual({ available: true, input: 20, output: 28, total: null, sourceRecords: 2 });
+
+    await writeFile(join(root, ".activity-review-token-cursors.json"), "", "utf8");
+    const cold = await collectTokenSummary(root, start, end);
+    expect(cold).toEqual(resumed);
+  });
 });

--- a/apps/dev/tests/jsonl-log.test.ts
+++ b/apps/dev/tests/jsonl-log.test.ts
@@ -16,6 +16,8 @@ import {
   fsAppendSink,
   JsonlLogError,
   parseLane,
+  parseLaneSinceCursor,
+  ToonlCursorInvalidationError,
 } from "../src/core/jsonl-log.js";
 
 const TS = "2026-05-30T12:00:00+00:00";
@@ -311,6 +313,42 @@ describe("jsonl-log append accumulation and readers", () => {
     expect(filterByWorker(records, "wAAAA").map((r) => r.msg)).toEqual(["a", "b", "e"]);
     expect(filterByType(records, "stage").map((r) => r.msg)).toEqual(["a", "c"]);
     expect(filterByType(records, "nonesuch")).toEqual([]);
+  });
+
+  it("resumes tagged-row TOONL reads from a reader-owned cursor across header rotation", async () => {
+    const chunks: string[] = [];
+    const sink = async (_p: string, line: string) => void chunks.push(line);
+    await appendRecordToonlTaggedRow("/attempt/log-cursor.jsonl", "raw", { iteration: 1, line: "{\"inputTokens\":3}" }, {
+      ts: TS,
+      fields: { extra: { iteration: "1" } },
+      sink,
+    });
+    const firstBody = `${chunks.join("\n")}\n`;
+    const first = parseLaneSinceCursor(firstBody);
+    expect(first.records.map((r) => r.iteration)).toEqual(["1"]);
+
+    await appendRecordToonlTaggedRow("/attempt/log-cursor.jsonl", "raw", { iteration: 2, line: "{\"outputTokens\":5}" }, {
+      ts: TS,
+      fields: { extra: { iteration: "2" } },
+      sink,
+    });
+    await appendRecordToonlTaggedRow("/attempt/log-cursor.jsonl", "agent", "new shape", {
+      ts: TS,
+      fields: { extra: { iteration: "2", kind: "text" } },
+      sink,
+    });
+    const resumed = parseLaneSinceCursor(`${chunks.join("\n")}\n`, first.cursor);
+    expect(resumed.records.map((r) => [r.type, r.iteration, r.kind ?? null])).toEqual([
+      ["raw", "2", null],
+      ["agent", "2", "text"],
+    ]);
+    expect(resumed.cursor.byteOffset).toBe(Buffer.byteLength(`${chunks.join("\n")}\n`, "utf8"));
+    expect(resumed.cursor.activeHeader).toContain("<agent>");
+  });
+
+  it("throws the cursor-invalidation error when a lane shrinks before the cursor", () => {
+    const first = parseLaneSinceCursor(`${formatRecordToonl(buildRecord("agent", "before", TS))}\n`);
+    expect(() => parseLaneSinceCursor("", first.cursor)).toThrow(ToonlCursorInvalidationError);
   });
 });
 

--- a/apps/dev/tests/log-cursor.test.ts
+++ b/apps/dev/tests/log-cursor.test.ts
@@ -7,6 +7,7 @@ import {
   countLogLinesSinceCursor,
   readLogLineCursors,
 } from "../src/runtime/log-cursor.js";
+import { appendRecordToonlTaggedRow } from "../src/core/jsonl-log.js";
 
 describe("monitor log cursor", () => {
   it("counts only appended log lines after the first read", async () => {
@@ -49,5 +50,25 @@ describe("monitor log cursor", () => {
     expect(JSON.parse(raw)).toHaveProperty(log);
     const parsed = await readLogLineCursors(cache);
     expect(parsed[log]).toEqual({ size: 5, lines: 1 });
+  });
+
+  it("counts appended TOONL records from a structured-lane cursor", async () => {
+    const root = await mkdtemp(join(tmpdir(), "afk-log-cursor-"));
+    const log = join(root, "log.jsonl");
+    const cache = join(root, "monitor-log-cursors.json");
+    await appendRecordToonlTaggedRow(log, "agent", "first", {
+      ts: "2026-07-15T12:00:00.000Z",
+      fields: { extra: { iteration: "1", kind: "text" } },
+    });
+
+    const first = await collectLogLineCounts(cache, [log]);
+    expect(first.get(log)).toEqual({ lines: 1, newLines: 1 });
+
+    await appendRecordToonlTaggedRow(log, "agent", "second", {
+      ts: "2026-07-15T12:01:00.000Z",
+      fields: { extra: { iteration: "2", kind: "text" } },
+    });
+    const second = await collectLogLineCounts(cache, [log]);
+    expect(second.get(log)).toEqual({ lines: 2, newLines: 1 });
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1825. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1825

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722319&installation_id=129708444&pr_number=1834&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1834&signature=71f3d33482fb1de658207f8f6fc25c886c6502375380ab58ac05cd4f0a84c8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->