### PR TITLE
fix: #1827 Keyed-map collapse on uniform-map rsp snapshot surfaces

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -6,7 +6,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connect } from "@reddb-io/sdk";
-import { encode, type JsonObject } from "@reddb-io/toon";
+import { type JsonObject } from "@reddb-io/toon";
+import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspRuntimeConfig } from "./config.js";
 import type { RspElisionStore, RspMintMeta, RspStorageClassStats } from "./elision-store.js";
@@ -153,7 +154,7 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     const status = args.command === "sweep"
       ? await sweepResidentRegistry(residentPaths)
       : await residentRegistryStatus(residentPaths);
-    process.stdout.write(`${encode(status as unknown as JsonObject)}\n`);
+    process.stdout.write(`${encodeSnapshotToon(status as unknown as JsonObject)}\n`);
     return 0;
   }
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
@@ -1041,7 +1042,7 @@ function renderStats(
 }
 
 function renderGainsReportToon(report: RspTelemetryGainsReport): string {
-  return `${encode(report as unknown as JsonObject)}\n`;
+  return `${encodeSnapshotToon(report as unknown as JsonObject)}\n`;
 }
 
 function formatTokensSaved(savings: RspTelemetryStats["savings"]): string {

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -6,8 +6,9 @@ import { createServer, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { RedDB } from "@reddb-io/sdk";
-import { encode, type JsonObject } from "@reddb-io/toon";
+import { type JsonObject } from "@reddb-io/toon";
 import { removeResidentRegistry, writeResidentRegistry } from "@reddb-io/shared/resident-client.js";
+import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
 import { RspElisionStore } from "./elision-store.js";
 import { createResidentBrainStore } from "./resident-brain.js";
@@ -481,7 +482,7 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
     };
   }
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(tmp, `${encode(payload)}\n`, { encoding: "utf8", mode: 0o600 });
+  await writeFile(tmp, `${encodeSnapshotToon(payload)}\n`, { encoding: "utf8", mode: 0o600 });
   await rename(tmp, path);
 }
 

--- a/apps/rsp/src/wait.ts
+++ b/apps/rsp/src/wait.ts
@@ -3,7 +3,8 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
-import { decode, encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { decode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 
 type WaitKind = "cmd" | "pr" | "run" | "release";
 type WaitStatus = "running" | "success" | "failure" | "timeout" | "indeterminate";
@@ -64,7 +65,7 @@ export async function runWait(argv: readonly string[], cwd = process.cwd()): Pro
     return 0;
   }
   if (parsed.kind === "ls") {
-    process.stdout.write(`${encode({ waits: await listWaits(cwd) })}\n`);
+    process.stdout.write(`${encodeSnapshotToon({ waits: await listWaits(cwd) })}\n`);
     return 0;
   }
   if (!isWaitKind(parsed.kind)) {
@@ -89,7 +90,7 @@ export async function runWait(argv: readonly string[], cwd = process.cwd()): Pro
     await mkdir(await waitRegistryDir(cwd), { recursive: true });
     await writeRegistryEntry(registryPath, entry);
     verdict = await dispatchWait({ ...parsed, kind: waitKind }, cwd, registryPath, entry);
-    process.stdout.write(`${encode(renderVerdict(waitKind, entry, verdict))}\n`);
+    process.stdout.write(`${encodeSnapshotToon(renderVerdict(waitKind, entry, verdict))}\n`);
     await signalCompletion(parsed.options);
     return verdict.exitCode;
   } finally {
@@ -382,7 +383,7 @@ async function writeStatus(path: string, entry: WaitRegistryEntry, status: WaitS
 }
 
 async function writeRegistryEntry(path: string, entry: WaitRegistryEntry): Promise<void> {
-  await writeFile(path, `${encode(entry as unknown as JsonObject)}\n`, "utf8");
+  await writeFile(path, `${encodeSnapshotToon(entry as unknown as JsonObject)}\n`, "utf8");
 }
 
 async function signalCompletion(options: WaitOptions): Promise<void> {

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -2,11 +2,12 @@ import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
-import { decode, encode } from "@reddb-io/toon";
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
 import {
   DEV_TOON_MIGRATION_SURFACES,
   MEMORY_TOON_MIGRATION_SURFACES,
   convertRegisteredToonSurfaces,
+  encodeSnapshotToon,
   readRegisteredToonSurface,
   registeredToonSurfacesForPlugin,
 } from "./toon-migration.js";
@@ -410,5 +411,68 @@ describe("shared TOON migration registry", () => {
         "dev.rsp-wait-registry",
       ]),
     );
+  });
+});
+
+describe("encodeSnapshotToon keyed-map collapse", () => {
+  // A uniform object map: two-plus keys, every value the same primitive shape.
+  const uniformMap = {
+    storage_classes: {
+      derivable: { records: 3, bytes: 40, raw_bytes: 120 },
+      "re-executable": { records: 1, bytes: 10, raw_bytes: 55 },
+      ephemeral: { records: 2, bytes: 22, raw_bytes: 88 },
+    },
+  };
+
+  test("collapses a uniform object map and round-trips losslessly", () => {
+    const collapsed = encodeSnapshotToon(uniformMap);
+    const expanded = encode(uniformMap as JsonValue);
+    // The collapse rewrites the map into a brace-header tabular block, so the
+    // encoded text differs from default encoding and carries the header.
+    expect(collapsed).not.toBe(expanded);
+    expect(collapsed).toContain("storage_classes{records,bytes,raw_bytes}:");
+    expect(decode(collapsed)).toEqual(uniformMap);
+  });
+
+  test("readers decode both the collapsed and the non-collapsed form (fixtures cover both)", () => {
+    const collapsed = encodeSnapshotToon(uniformMap);
+    const nonCollapsed = encode(uniformMap as JsonValue);
+    // Same logical value, two on-disk encodings; the reader is format-blind.
+    expect(decode(collapsed)).toEqual(uniformMap);
+    expect(decode(nonCollapsed)).toEqual(uniformMap);
+    expect(decode(collapsed)).toEqual(decode(nonCollapsed));
+  });
+
+  test("leaves non-qualifying surfaces byte-identical to default encoding", () => {
+    // Flat object: no nested map to collapse.
+    const flat = { version: 1, tokens_saved_today: 12, updated_at: "t" };
+    // Array-wrapped surface: already tabular via §9.3, not a keyed map.
+    const arrayWrapped = {
+      waits: [
+        { id: "a", target: "cmd:test", status: "running" },
+        { id: "b", target: "pr:1", status: "running" },
+      ],
+    };
+    // Single-entry map: below the two-key collapse floor.
+    const singleEntry = { by_class: { derivable: { records: 1, bytes: 2 } } };
+    for (const surface of [flat, arrayWrapped, singleEntry]) {
+      expect(encodeSnapshotToon(surface as JsonValue)).toBe(encode(surface as JsonValue));
+    }
+  });
+
+  test("converts a registered rsp snapshot with a uniform map collapsed and re-readable", async () => {
+    const root = await scratch();
+    // A status-summary-shaped snapshot that carries a uniform object map field.
+    const payload = { version: 1, updated_at: "t", ...uniformMap };
+    await write(root, ".red/tmp/rsp-status-summary.json", JSON.stringify(payload));
+
+    const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
+    expect(report.converted).toContain("dev.rsp-status-summary");
+
+    const written = await readFile(join(root, ".red/tmp/rsp-status-summary.json"), "utf8");
+    expect(written).toContain("storage_classes{records,bytes,raw_bytes}:");
+
+    const read = await readRegisteredToonSurface(root, "dev.rsp-status-summary");
+    expect(read.value).toEqual(payload);
   });
 });

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -3,6 +3,20 @@ import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
 
+/**
+ * Encodes an rsp snapshot surface as TOON with keyed-map collapse enabled
+ * (toon 0.3 line — the lossless tabular form for uniform object maps). Collapse
+ * is opportunistic: the encoder only rewrites a keyed map whose values are two
+ * or more uniform objects, so flat objects and array-wrapped surfaces come out
+ * byte-identical to `encode(value)`. Every reader is `decode`, which parses the
+ * collapsed and non-collapsed forms transparently, so enabling the flag never
+ * breaks a consumer. Use this at every rsp snapshot TOON emit point so a
+ * qualifying shape wins the extra tokens the moment it appears (Spec #1801).
+ */
+export function encodeSnapshotToon(value: JsonValue): string {
+  return encode(value, { keyedMapCollapse: true });
+}
+
 export type RegisteredToonSurfaceKind = "toon" | "toonl";
 export type RegisteredToonSurfacePlugin = "memory" | "brain" | "dev";
 
@@ -389,7 +403,7 @@ function renderSurface(value: unknown, surface: RegisteredToonSurface): string {
     const rows = normalizeToonlRows(surface, Array.isArray(value) ? value : [value]);
     return encode(rows as JsonValue);
   }
-  return encode(value as JsonValue);
+  return encodeSnapshotToon(value as JsonValue);
 }
 
 function normalizeToonlRows(surface: RegisteredToonSurface, rows: unknown[]): unknown[] {


### PR DESCRIPTION
Automated AFK landing for #1827. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1827

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786722779&installation_id=129708444&pr_number=1835&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1835&signature=04e6ed936e6a68b83d984e03303754d7d9c0ce59aecba9be54ae3d7340b30ccf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->