### PR TITLE
fix: #1826 Keyed-map collapse on uniform-map dev snapshot surfaces

### DIFF
--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -1,7 +1,8 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { decode as decodeToon, encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
+import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
+import { encodeDevSnapshotToon } from "./toon-snapshot.js";
 import { AfkStateSchema, type AfkState } from "../types/state.js";
 
 export function defaultState(): AfkState {
@@ -209,7 +210,7 @@ function preserveStampedIdentity(
 export async function writeStateAtomic(path: string, state: AfkState): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
-  await writeFile(tmp, encodeToon(AfkStateSchema.parse(state) as unknown as ToonValue), "utf8");
+  await writeFile(tmp, encodeDevSnapshotToon(AfkStateSchema.parse(state) as unknown as ToonValue), "utf8");
   await rename(tmp, path);
 }
 
@@ -242,7 +243,7 @@ export function initStateSync(path: string, updates: Record<string, unknown> = {
   const parsed = parseState(state);
   mkdirSync(dirname(path), { recursive: true });
   const tmp = `${path}.tmp.${process.pid}.sync`;
-  writeFileSync(tmp, encodeToon(AfkStateSchema.parse(parsed) as unknown as ToonValue), "utf8");
+  writeFileSync(tmp, encodeDevSnapshotToon(AfkStateSchema.parse(parsed) as unknown as ToonValue), "utf8");
   renameSync(tmp, path);
   return parsed;
 }

--- a/apps/dev/src/core/toon-snapshot.ts
+++ b/apps/dev/src/core/toon-snapshot.ts
@@ -1,0 +1,14 @@
+import { decode, encode, type JsonValue } from "@reddb-io/toon";
+
+export function encodeDevSnapshotToon(value: JsonValue): string {
+  return encode(value, { keyedMapCollapse: true });
+}
+
+export function assertDevSnapshotToonLossless(value: JsonValue): string {
+  const toon = encodeDevSnapshotToon(value);
+  const decoded = decode(toon);
+  if (JSON.stringify(decoded) !== JSON.stringify(value)) {
+    throw new Error("dev snapshot TOON round-trip failed");
+  }
+  return toon;
+}

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -14,9 +14,10 @@ import type { ChildProcess } from "node:child_process";
 import { readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { hostFingerprintPrefix } from "../core/host-identity.js";
-import { decode as decodeToon, encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
+import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import { resolveBase } from "../core/base-resolver.js";
+import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { SandboxMode } from "../core/execution.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
 // Value import (pure, no sandcastle pull — the providers load lazily via
@@ -876,7 +877,7 @@ function writeStatuslineCacheAtomic(path: string, cache: StatuslineCache): void 
   try {
     mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp`;
-    writeFileSync(tmp, encodeToon(cache as unknown as ToonValue), "utf8");
+    writeFileSync(tmp, encodeDevSnapshotToon(cache as unknown as ToonValue), "utf8");
     renameSync(tmp, path);
   } catch {
     // best-effort, like the bash `|| true`
@@ -1336,7 +1337,7 @@ function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
   try {
     mkdirSync(dirname(path), { recursive: true });
     const tmp = `${path}.tmp`;
-    writeFileSync(tmp, encodeToon(cache as unknown as ToonValue), "utf8");
+    writeFileSync(tmp, encodeDevSnapshotToon(cache as unknown as ToonValue), "utf8");
     renameSync(tmp, path);
   } catch {
     // best-effort, like the bash `|| true`

--- a/apps/dev/tests/toon-snapshot.test.ts
+++ b/apps/dev/tests/toon-snapshot.test.ts
@@ -1,0 +1,70 @@
+import { decode, encode } from "@reddb-io/toon";
+import { describe, expect, it } from "vitest";
+import { assertDevSnapshotToonLossless, encodeDevSnapshotToon } from "../src/core/toon-snapshot.js";
+
+describe("dev snapshot TOON encoding", () => {
+  it("collapses qualifying keyed maps losslessly", () => {
+    const snapshot = {
+      statusline_counts: {
+        before: { queue: 8, human: 2, ts: 100 },
+        after: { queue: 7, human: 3, ts: 200 },
+      },
+    };
+
+    const toon = assertDevSnapshotToonLossless(snapshot);
+
+    expect(toon).toContain("statusline_counts{queue,human,ts}:");
+    expect(toon).toContain("before: 8,2,100");
+    expect(toon).toContain("after: 7,3,200");
+    expect(decode(toon)).toEqual(snapshot);
+  });
+
+  it("leaves non-qualifying flat statusline caches on default encoding", () => {
+    const cache = { queue: 8, human: 2, ts: 100 };
+
+    expect(encodeDevSnapshotToon(cache)).toBe(encode(cache));
+  });
+
+  it("leaves non-uniform maps on default encoding", () => {
+    const snapshot = {
+      repo_caches: {
+        current: { openPrs: 2, openIssues: 10, ts: 100 },
+        previous: { openPrs: 1, todayPrs: 1, openIssues: 9, ts: 50 },
+      },
+    };
+
+    const toon = assertDevSnapshotToonLossless(snapshot);
+
+    expect(toon).not.toContain("repo_caches{");
+    expect(decode(toon)).toEqual(snapshot);
+  });
+
+  it("decodes collapsed, non-collapsed, and mixed transition documents", () => {
+    const collapsed = "attempts{runner,issue,phase}:\n  wAAAA: codex,1826,tests\n  wBBBB: claude,1827,done\n";
+    const nonCollapsed = encode({
+      attempts: {
+        wAAAA: { runner: "codex", issue: 1826, phase: "tests" },
+        wBBBB: { runner: "claude", issue: 1827, phase: "done" },
+      },
+    });
+    const mixed = [
+      "attempts{runner,issue,phase}:",
+      "  wAAAA: codex,1826,tests",
+      "  wBBBB: claude,1827,done",
+      "repo_cache:",
+      "  openPrs: 4",
+      "  openIssues: 12",
+      "  ts: 300",
+      "",
+    ].join("\n");
+
+    expect(decode(collapsed)).toEqual(decode(nonCollapsed));
+    expect(decode(mixed)).toEqual({
+      attempts: {
+        wAAAA: { runner: "codex", issue: 1826, phase: "tests" },
+        wBBBB: { runner: "claude", issue: 1827, phase: "done" },
+      },
+      repo_cache: { openPrs: 4, openIssues: 12, ts: 300 },
+    });
+  });
+});


### PR DESCRIPTION
Automated AFK landing for #1826. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1826

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786723103&installation_id=129708444&pr_number=1836&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1836&signature=06b8ee022b4edd0890e50c157f9cfa912e70925cbd207b5c7a5ecfadfa57aab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->