### PR TITLE
fix: #1684 red-paths: shared path authority for every .red tier and lane (expand)

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -84,6 +84,7 @@ export {
   type RedBinaryRuntime,
   type RedRuntimeIO,
 } from "./red-runtime.js";
+export * from "./red-paths.js";
 export * from "./outcome-event.js";
 export * from "./resident-client.js";
 export * from "./resident-protocol.js";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "./toon-migration.js": "./toon-migration.ts",
     "./log.js": "./log.ts",
     "./plugin-gate.js": "./plugin-gate.ts",
+    "./red-paths.js": "./red-paths.ts",
     "./outcome-event.js": "./outcome-event.ts",
     "./resident-client.js": "./resident-client.ts",
     "./resident-protocol.js": "./resident-protocol.ts"

--- a/packages/shared/red-paths.test.ts
+++ b/packages/shared/red-paths.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  BRAIN_ROOT_ENV,
+  MEMORY_ROOT_ENV,
+  ROOT_OVERRIDE_ENV_VARS,
+  SHARED_STORE_REL,
+  WORKERS_NAMESPACE_ENV,
+  WORKER_NAMESPACES,
+  activeWorkersDir,
+  adoptWorktreesDir,
+  afkStateDir,
+  brainDir,
+  branchLockFile,
+  cascadeWorktreesDir,
+  claimsDir,
+  classifyLegacyWorktreeName,
+  diagnosticsDir,
+  docsWorktreesDir,
+  feedbackWorktreesDir,
+  goWorkersDir,
+  landingWorktreesDir,
+  logsDir,
+  manualWorktreesDir,
+  memoryDir,
+  rebaseWorktreesDir,
+  redDir,
+  researchesDir,
+  resolveRedRoot,
+  rspStateDir,
+  scoutWorkersDir,
+  scratchDir,
+  sharedStorePath,
+  stateDir,
+  statuslineStateDir,
+  tmpDir,
+  waitsDir,
+  wikiDir,
+  workersDir,
+  workersSegment,
+  worktreesDir,
+} from "./red-paths.js";
+
+const ROOT = "/repo";
+
+describe("tier directories", () => {
+  it("derives the four lifecycle tiers plus researches from a repo root", () => {
+    expect(redDir(ROOT)).toBe("/repo/.red");
+    expect(stateDir(ROOT)).toBe("/repo/.red/state");
+    expect(tmpDir(ROOT)).toBe("/repo/.red/tmp");
+    expect(researchesDir(ROOT)).toBe("/repo/.red/researches");
+  });
+
+  it("normalizes a trailing slash on the root", () => {
+    expect(redDir("/repo/")).toBe("/repo/.red");
+    expect(stateDir("/repo/")).toBe("/repo/.red/state");
+  });
+
+  it("derives plugin store homes", () => {
+    expect(memoryDir(ROOT)).toBe("/repo/.red/memory");
+    expect(brainDir(ROOT)).toBe("/repo/.red/brain");
+    expect(wikiDir(ROOT)).toBe("/repo/.red/wiki");
+  });
+});
+
+describe("state tier lanes", () => {
+  it("derives every durable state lane from the registry", () => {
+    expect(afkStateDir(ROOT)).toBe("/repo/.red/state/afk");
+    expect(rspStateDir(ROOT)).toBe("/repo/.red/state/rsp");
+    expect(statuslineStateDir(ROOT)).toBe("/repo/.red/state/statusline");
+    expect(branchLockFile(ROOT)).toBe("/repo/.red/state/branch-lock.yaml");
+  });
+
+  it("exports the shared RedDB store as a single constant in the state tier", () => {
+    expect(SHARED_STORE_REL).toBe(".red/state/red-skills.rdb");
+    expect(sharedStorePath(ROOT)).toBe("/repo/.red/state/red-skills.rdb");
+  });
+
+  it("keeps the shared store under the state tier, never tmp", () => {
+    expect(sharedStorePath(ROOT).startsWith(stateDir(ROOT))).toBe(true);
+    expect(sharedStorePath(ROOT).startsWith(tmpDir(ROOT))).toBe(false);
+  });
+});
+
+describe("tmp tier lanes", () => {
+  it("derives the flat scratch lanes", () => {
+    expect(claimsDir(ROOT)).toBe("/repo/.red/tmp/claims");
+    expect(waitsDir(ROOT)).toBe("/repo/.red/tmp/waits");
+    expect(scratchDir(ROOT)).toBe("/repo/.red/tmp/scratch");
+    expect(diagnosticsDir(ROOT)).toBe("/repo/.red/tmp/diagnostics");
+  });
+
+  it("derives the fixed worker lanes", () => {
+    expect(workersDir(ROOT)).toBe("/repo/.red/tmp/workers");
+    expect(goWorkersDir(ROOT)).toBe("/repo/.red/tmp/go-workers");
+    expect(scoutWorkersDir(ROOT)).toBe("/repo/.red/tmp/scout-workers");
+    expect(WORKER_NAMESPACES).toEqual(["workers", "go-workers", "scout-workers"]);
+  });
+
+  it("derives the worktrees sub-lanes", () => {
+    expect(worktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees");
+    expect(manualWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/manual");
+    expect(feedbackWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/feedback");
+    expect(landingWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/landing");
+    expect(rebaseWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/rebase");
+    expect(cascadeWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/cascade");
+    expect(adoptWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/adopt");
+    expect(docsWorktreesDir(ROOT)).toBe("/repo/.red/tmp/worktrees/docs");
+  });
+
+  it("derives a date-partitioned logs lane", () => {
+    expect(logsDir(ROOT, "2026-07-15")).toBe("/repo/.red/tmp/logs/2026-07-15");
+  });
+});
+
+describe("workers namespace override", () => {
+  it("defaults the active workers segment to workers", () => {
+    expect(workersSegment({})).toBe("workers");
+    expect(activeWorkersDir(ROOT, {})).toBe("/repo/.red/tmp/workers");
+  });
+
+  it("honors RED_AFK_WORKERS_NAMESPACE for the active workers lane", () => {
+    const env = { [WORKERS_NAMESPACE_ENV]: "go-workers" };
+    expect(workersSegment(env)).toBe("go-workers");
+    expect(activeWorkersDir(ROOT, env)).toBe("/repo/.red/tmp/go-workers");
+  });
+
+  it("rejects an invalid namespace and falls back to workers", () => {
+    expect(workersSegment({ [WORKERS_NAMESPACE_ENV]: "../escape" })).toBe("workers");
+    expect(workersSegment({ [WORKERS_NAMESPACE_ENV]: "" })).toBe("workers");
+  });
+});
+
+describe("root resolution (env overrides honored)", () => {
+  it("walks up to the directory that contains a .red child", () => {
+    expect(resolveRedRoot({ startDir: ROOT, env: {}, exists: (p) => p === "/repo/.red" })).toBe(
+      "/repo",
+    );
+    expect(
+      resolveRedRoot({
+        startDir: "/repo/a/b",
+        env: {},
+        exists: (p) => p === "/repo/.red",
+      }),
+    ).toBe("/repo");
+  });
+
+  it("falls back to startDir when no .red is found", () => {
+    expect(resolveRedRoot({ startDir: "/nope", env: {}, exists: () => false })).toBe("/nope");
+  });
+
+  it("honors MEMORY_ROOT as a root override resolved against startDir", () => {
+    expect(
+      resolveRedRoot({ startDir: "/repo", env: { [MEMORY_ROOT_ENV]: "/other" }, exists: () => false }),
+    ).toBe("/other");
+    expect(
+      resolveRedRoot({ startDir: "/repo", env: { [MEMORY_ROOT_ENV]: "sub" }, exists: () => false }),
+    ).toBe("/repo/sub");
+  });
+
+  it("honors RED_BRAIN_ROOT as a root override", () => {
+    expect(
+      resolveRedRoot({ startDir: "/repo", env: { [BRAIN_ROOT_ENV]: "/brainroot" }, exists: () => false }),
+    ).toBe("/brainroot");
+  });
+
+  it("exposes the ordered override env var list", () => {
+    expect(ROOT_OVERRIDE_ENV_VARS).toEqual([MEMORY_ROOT_ENV, BRAIN_ROOT_ENV]);
+  });
+});
+
+describe("legacy worktree classification", () => {
+  it("classifies a digit-suffixed relic worktree", () => {
+    expect(classifyLegacyWorktreeName("work-1684")).toBe("relic");
+    expect(classifyLegacyWorktreeName("work-1")).toBe("relic");
+  });
+
+  it("classifies a maintainer slug worktree", () => {
+    expect(classifyLegacyWorktreeName("work-afk-first-doctrine")).toBe("maintainer");
+    expect(classifyLegacyWorktreeName("work-fix-bug")).toBe("maintainer");
+  });
+
+  it("classifies anything without the work- prefix as unknown", () => {
+    expect(classifyLegacyWorktreeName("workers")).toBe("unknown");
+    expect(classifyLegacyWorktreeName("1684-a1")).toBe("unknown");
+    expect(classifyLegacyWorktreeName("work-")).toBe("unknown");
+  });
+
+  it("does not treat a leading-zero suffix as a relic (not a valid issue number)", () => {
+    expect(classifyLegacyWorktreeName("work-007")).toBe("maintainer");
+  });
+});

--- a/packages/shared/red-paths.ts
+++ b/packages/shared/red-paths.ts
@@ -1,0 +1,298 @@
+/**
+ * red-paths.ts — the single path authority for the `.red/` directory (ADR 0098).
+ *
+ * Every `.red/` path — the four lifecycle tiers, every named lane from the ADR's
+ * lane registry, the shared RedDB store, and the plugin store homes — derives
+ * from one repo root through this module. Before this authority existed each
+ * runtime spelled its own `join(root, ".red", ...)`, so a taxonomy change (the
+ * shared store moving to the state tier, a lane being renamed) had to be chased
+ * across every app. This module is where the ADR's layout lives in code; the
+ * expand-contract migration (Spec #1681) points every call site here.
+ *
+ * Pure and dependency-free: builders take an explicit `root` (the directory that
+ * CONTAINS `.red`), env-honoring helpers take an explicit `env`, and root
+ * resolution takes an explicit `exists` probe. Nothing reads `process` or the
+ * filesystem on its own, so the whole surface is unit-testable without mocks.
+ *
+ * This is the EXPAND half of an expand-contract chain: it adds the authority
+ * with ZERO behavior change and ZERO consumers. Migrating the runtimes onto it
+ * is the contract half, tracked separately.
+ */
+import { isAbsolute, join, resolve } from "node:path";
+
+/** The `.red` directory name, relative to a repo root. */
+export const RED_DIR = ".red";
+
+/** Env var that overrides the ACTIVE workers lane segment (see {@link workersSegment}). */
+export const WORKERS_NAMESPACE_ENV = "RED_AFK_WORKERS_NAMESPACE";
+
+/** Env var the memory plugin reads to override its repo root. */
+export const MEMORY_ROOT_ENV = "MEMORY_ROOT";
+
+/** Env var the brain plugin reads to override its repo root. */
+export const BRAIN_ROOT_ENV = "RED_BRAIN_ROOT";
+
+/**
+ * Ordered root-override env vars, first non-empty wins in {@link resolveRedRoot}.
+ * Memory takes precedence over brain only because it is listed first; a caller
+ * that wants a single plugin's override should pass its own `overrideEnvVars`.
+ */
+export const ROOT_OVERRIDE_ENV_VARS = [MEMORY_ROOT_ENV, BRAIN_ROOT_ENV] as const;
+
+/** Strip a single trailing slash so `join` never emits a double separator. */
+function normalizeRoot(root: string): string {
+  if (!root) throw new Error("root is required");
+  return root.replace(/\/$/, "");
+}
+
+// ── Lifecycle tiers (ADR 0098 §1) ───────────────────────────────────────────
+
+/** Tier 1 anchor: `<root>/.red`. Tracked knowledge/config lives directly here. */
+export function redDir(root: string): string {
+  return join(normalizeRoot(root), RED_DIR);
+}
+
+/** Tier 3: durable machine state under `<root>/.red/state`. Never mass-deletable. */
+export function stateDir(root: string): string {
+  return join(redDir(root), "state");
+}
+
+/** Tier 4: disposable scratch under `<root>/.red/tmp`. `rm -rf`-safe by contract. */
+export function tmpDir(root: string): string {
+  return join(redDir(root), "tmp");
+}
+
+/** Durable generated knowledge (not tmp, not yet repo truth): `<root>/.red/researches`. */
+export function researchesDir(root: string): string {
+  return join(redDir(root), "researches");
+}
+
+// ── Tier 2: plugin store homes (ADR 0098 §1) ────────────────────────────────
+
+/** The memory plugin store home: `<root>/.red/memory`. */
+export function memoryDir(root: string): string {
+  return join(redDir(root), "memory");
+}
+
+/** The brain plugin store home: `<root>/.red/brain`. */
+export function brainDir(root: string): string {
+  return join(redDir(root), "brain");
+}
+
+/** The LLM Wiki store home: `<root>/.red/wiki`. */
+export function wikiDir(root: string): string {
+  return join(redDir(root), "wiki");
+}
+
+// ── State-tier lanes (ADR 0098 §2) ──────────────────────────────────────────
+
+/** AFK supervisor state, restart counters, circuit-breakers: `.red/state/afk`. */
+export function afkStateDir(root: string): string {
+  return join(stateDir(root), "afk");
+}
+
+/** rsp telemetry spool / status summaries / resident metadata: `.red/state/rsp`. */
+export function rspStateDir(root: string): string {
+  return join(stateDir(root), "rsp");
+}
+
+/** Statusline caches that survive tmp cleanup: `.red/state/statusline`. */
+export function statuslineStateDir(root: string): string {
+  return join(stateDir(root), "statusline");
+}
+
+/** Local branch-lock file: `.red/state/branch-lock.yaml`. */
+export function branchLockFile(root: string): string {
+  return join(stateDir(root), "branch-lock.yaml");
+}
+
+/**
+ * The shared RedDB store, relative to a repo root. ADR 0098 moves it to the
+ * durable state tier, superseding ADR 0095's `.red/red.rdb` root location and
+ * the red-setup write contract's temporary `.red/tmp/red-skills.rdb`.
+ */
+export const SHARED_STORE_REL = ".red/state/red-skills.rdb";
+
+/** Absolute path to the single shared RedDB store used by memory and rsp. */
+export function sharedStorePath(root: string): string {
+  return join(stateDir(root), "red-skills.rdb");
+}
+
+// ── Tmp-tier worker lanes (ADR 0098 §2) ─────────────────────────────────────
+
+/**
+ * The three fixed worker-lane segments under `.red/tmp/`: the `/afk` fleet lives
+ * in `workers`, a `/go` dispatch in `go-workers`, a `--scout` run in
+ * `scout-workers`. Read-only observability surfaces union over all three.
+ */
+export const WORKER_NAMESPACES = ["workers", "go-workers", "scout-workers"] as const;
+
+/** The `/afk` fleet worker lane: `.red/tmp/workers`. */
+export function workersDir(root: string): string {
+  return join(tmpDir(root), "workers");
+}
+
+/** The `/go` dispatch worker lane: `.red/tmp/go-workers`. */
+export function goWorkersDir(root: string): string {
+  return join(tmpDir(root), "go-workers");
+}
+
+/** The `--scout` worker lane: `.red/tmp/scout-workers`. */
+export function scoutWorkersDir(root: string): string {
+  return join(tmpDir(root), "scout-workers");
+}
+
+/**
+ * The ACTIVE workers segment for THIS process. Defaults to `workers`; a `/go` or
+ * `--scout` process sets {@link WORKERS_NAMESPACE_ENV} so its worker dir lands in
+ * its own lane, never colliding with the fleet's. Only a `[A-Za-z0-9_-]+` value
+ * is honoured — anything else (empty, path traversal) falls back to `workers`.
+ */
+export function workersSegment(env: Record<string, string | undefined>): string {
+  const ns = env[WORKERS_NAMESPACE_ENV];
+  return ns && /^[A-Za-z0-9_-]+$/.test(ns) ? ns : "workers";
+}
+
+/** The active workers lane dir for this process, honoring the namespace override. */
+export function activeWorkersDir(root: string, env: Record<string, string | undefined>): string {
+  return join(tmpDir(root), workersSegment(env));
+}
+
+// ── Tmp-tier flat lanes (ADR 0098 §2) ───────────────────────────────────────
+
+/** AFK claim locks: `.red/tmp/claims`. */
+export function claimsDir(root: string): string {
+  return join(tmpDir(root), "claims");
+}
+
+/** Active `rsp wait` registry: `.red/tmp/waits`. */
+export function waitsDir(root: string): string {
+  return join(tmpDir(root), "waits");
+}
+
+/** Free-form short-lived scratch: `.red/tmp/scratch`. */
+export function scratchDir(root: string): string {
+  return join(tmpDir(root), "scratch");
+}
+
+/** Dev-runtime failure diagnostics (age-capped): `.red/tmp/diagnostics`. */
+export function diagnosticsDir(root: string): string {
+  return join(tmpDir(root), "diagnostics");
+}
+
+/** Date-partitioned session logs: `.red/tmp/logs/<yyyy-mm-dd>`. */
+export function logsDir(root: string, date: string): string {
+  if (!date) throw new Error("date is required (yyyy-mm-dd)");
+  return join(tmpDir(root), "logs", date);
+}
+
+// ── Tmp-tier worktree lanes (ADR 0098 §2) ───────────────────────────────────
+
+/** Parent of every temporary worktree lane: `.red/tmp/worktrees`. */
+export function worktreesDir(root: string): string {
+  return join(tmpDir(root), "worktrees");
+}
+
+/** Hand-worked slice worktrees, slug-named: `.red/tmp/worktrees/manual`. */
+export function manualWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "manual");
+}
+
+/** Feedback-gate worktree cache: `.red/tmp/worktrees/feedback`. */
+export function feedbackWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "feedback");
+}
+
+/** Temporary landing worktrees: `.red/tmp/worktrees/landing`. */
+export function landingWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "landing");
+}
+
+/** Temporary pre-merge rebase worktrees: `.red/tmp/worktrees/rebase`. */
+export function rebaseWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "rebase");
+}
+
+/** Cascade rebase/follow-up worktrees: `.red/tmp/worktrees/cascade`. */
+export function cascadeWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "cascade");
+}
+
+/** Adoption / no-agent landing worktrees: `.red/tmp/worktrees/adopt`. */
+export function adoptWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "adopt");
+}
+
+/** `/start` docs-finalizer landing worktrees: `.red/tmp/worktrees/docs`. */
+export function docsWorktreesDir(root: string): string {
+  return join(worktreesDir(root), "docs");
+}
+
+// ── Root resolution (env overrides honored) ─────────────────────────────────
+
+export interface ResolveRedRootOptions {
+  /** Where to start walking from. */
+  startDir: string;
+  /** Env map consulted for `overrideEnvVars`. */
+  env: Record<string, string | undefined>;
+  /** Existence probe for a candidate `.red` path (injected so this stays pure). */
+  exists: (path: string) => boolean;
+  /**
+   * Ordered override env vars; the first non-empty one wins and is resolved
+   * against `startDir`. Defaults to {@link ROOT_OVERRIDE_ENV_VARS} (memory,
+   * brain), mirroring how those plugins honor their own root env today.
+   */
+  overrideEnvVars?: readonly string[];
+}
+
+/**
+ * Resolve the repo root that owns `.red`, honoring the plugin root env overrides.
+ *
+ * 1. If any `overrideEnvVars` entry is set, resolve it against `startDir` and
+ *    return it (an absolute override wins outright). This mirrors brain's
+ *    `resolve(startDir, RED_BRAIN_ROOT)` and memory's `MEMORY_ROOT ?? cwd`.
+ * 2. Otherwise walk UP from `startDir` for the first directory with a `.red`
+ *    child and return that directory.
+ * 3. If none is found, fall back to `startDir` (never throws).
+ */
+export function resolveRedRoot(options: ResolveRedRootOptions): string {
+  const overrideVars = options.overrideEnvVars ?? ROOT_OVERRIDE_ENV_VARS;
+  for (const name of overrideVars) {
+    const value = options.env[name];
+    if (value) return isAbsolute(value) ? value : resolve(options.startDir, value);
+  }
+  let current = resolve(options.startDir);
+  while (true) {
+    if (options.exists(join(current, RED_DIR))) return current;
+    const parent = join(current, "..");
+    const resolvedParent = resolve(parent);
+    if (resolvedParent === current) break;
+    current = resolvedParent;
+  }
+  return options.startDir;
+}
+
+// ── Legacy worktree classification (boot-sweep authority) ────────────────────
+
+/**
+ * How the boot sweep must treat a pre-cutover `.red/tmp/work-*` dir name:
+ * - `relic` — `work-<issue-number>` (digits): the AFK orchestrator made it;
+ *   reclaimable once its pid is dead.
+ * - `maintainer` — `work-<slug>`: a hand-work worktree (CLAUDE.md); ALWAYS spared
+ *   (guards #1052, where a fresh slug worktree was wrongly wiped).
+ * - `unknown` — not a `work-<name>` dir at all; out of the sweep's scope.
+ */
+export type LegacyWorktreeClass = "relic" | "maintainer" | "unknown";
+
+/** Digit-suffixed relic: `work-<issue-number>`, first digit 1-9 (a real issue #). */
+const RELIC_WORK_DIR_RE = /^work-[1-9][0-9]*$/;
+
+/** Any `work-<non-empty>` dir; distinguishes a maintainer slug from a non-work name. */
+const WORK_PREFIX_RE = /^work-.+$/;
+
+/** Classify a `.red/tmp` dir NAME (not path) for the slug-sparing boot sweep. */
+export function classifyLegacyWorktreeName(name: string): LegacyWorktreeClass {
+  if (RELIC_WORK_DIR_RE.test(name)) return "relic";
+  if (WORK_PREFIX_RE.test(name)) return "maintainer";
+  return "unknown";
+}


### PR DESCRIPTION
Automated AFK landing for #1684. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1684

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786724482&installation_id=129708444&pr_number=1839&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1839&signature=c3745ac5d7aab59c49ceabada9863142dadcda9f2abea5dbef961589662a5177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->