### PR TITLE
fix: #1686 Single shared-store constant: RedDB store to the state tier, rsp state lane migration

### DIFF
--- a/apps/brain/src/resident-brain.ts
+++ b/apps/brain/src/resident-brain.ts
@@ -1,4 +1,11 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+  SHARED_STORE_REL,
+  legacySharedStorePath,
+  resolveSharedStorePath,
+  sharedStorePath as sharedStorePathForRoot,
+} from "@reddb-io/shared/red-paths.js";
 import {
   ResidentRspClient,
   resolveResidentPaths,
@@ -18,13 +25,17 @@ import type {
 import type { StoredBrainArtifact, StoredBrainConnection } from "./schema.js";
 import type { ResolvedBrainConfig } from "./config.js";
 
-export const SHARED_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
+/** Canonical shared RedDB store location (state tier); see {@link SHARED_STORE_REL}. */
+export const SHARED_RSP_STORE_PATH = SHARED_STORE_REL;
 const DEFAULT_RSP_TTL_DAYS = 7;
 const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
 
 export function shouldUseResidentBrain(config: ResolvedBrainConfig): boolean {
   if (!config.connectionString.startsWith("file://")) return false;
-  return config.connectionString.slice("file://".length) === sharedStorePath(config.rootDir);
+  const path = config.connectionString.slice("file://".length);
+  // Accept both the canonical state-tier path and the legacy tmp-tier path so a
+  // connection string pointed at either shares the resident during the transition.
+  return path === sharedStorePathForRoot(config.rootDir) || path === legacySharedStorePath(config.rootDir);
 }
 
 export async function openResidentBrainStore(config: ResolvedBrainConfig): Promise<BrainStoreLike> {
@@ -35,11 +46,9 @@ export async function openResidentBrainStore(config: ResolvedBrainConfig): Promi
 }
 
 export function sharedStoreUri(rootDir: string): string {
-  return `file://${sharedStorePath(rootDir)}`;
-}
-
-function sharedStorePath(rootDir: string): string {
-  return resolve(rootDir, SHARED_RSP_STORE_PATH);
+  // Honor the transition window: open the legacy tmp-tier store if it still
+  // exists and setup has not yet migrated it to the state tier.
+  return `file://${resolveSharedStorePath(resolve(rootDir), existsSync)}`;
 }
 
 function residentConfig(rootDir: string): RspResidentConfig {

--- a/apps/brain/tests/resident-brain.test.ts
+++ b/apps/brain/tests/resident-brain.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedBrainConfig } from "../src/config.js";
+import { SHARED_RSP_STORE_PATH, shouldUseResidentBrain } from "../src/resident-brain.js";
+
+const ROOT = "/repo";
+
+function config(connectionString: string): ResolvedBrainConfig {
+  return { rootDir: ROOT, configPath: "", connectionString, rawConnectionString: connectionString };
+}
+
+describe("shouldUseResidentBrain", () => {
+  it("pins the shared store constant to the state tier", () => {
+    expect(SHARED_RSP_STORE_PATH).toBe(".red/state/red-skills.rdb");
+  });
+
+  it("uses the resident for the canonical state-tier shared store", () => {
+    expect(shouldUseResidentBrain(config("file:///repo/.red/state/red-skills.rdb"))).toBe(true);
+  });
+
+  it("still uses the resident for the legacy tmp-tier store during the transition", () => {
+    expect(shouldUseResidentBrain(config("file:///repo/.red/tmp/red-skills.rdb"))).toBe(true);
+  });
+
+  it("does not use the resident for a private brain store", () => {
+    expect(shouldUseResidentBrain(config("file:///repo/.red/brain/brain.rdb"))).toBe(false);
+  });
+});

--- a/apps/memory/src/resident-memory.ts
+++ b/apps/memory/src/resident-memory.ts
@@ -1,11 +1,16 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import {
+  LEGACY_SHARED_STORE_REL,
+  SHARED_STORE_REL,
+  resolveSharedStorePath,
+} from "@reddb-io/shared/red-paths.js";
 import {
   ResidentRspClient,
   resolveResidentPaths,
 } from "@reddb-io/shared/resident-client.js";
 import type { MemoryConfig } from "./config.js";
 
-const DEFAULT_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
 const DEFAULT_RSP_TTL_DAYS = 7;
 const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
 
@@ -26,8 +31,13 @@ export interface ResidentIngestPayload {
 export function shouldUseResidentMemory(rootDir: string, config: MemoryConfig): boolean {
   if (config.mode !== "graph") return false;
   const storePath = config.storePath ?? "";
-  if (storePath === DEFAULT_RSP_STORE_PATH) return true;
-  return resolve(rootDir, storePath).endsWith(`/${DEFAULT_RSP_STORE_PATH}`);
+  // Accept both the canonical state-tier path and the legacy tmp-tier path so a
+  // config pointed at either resolves to the resident during the transition.
+  for (const rel of [SHARED_STORE_REL, LEGACY_SHARED_STORE_REL]) {
+    if (storePath === rel) return true;
+    if (resolve(rootDir, storePath).endsWith(`/${rel}`)) return true;
+  }
+  return false;
 }
 
 export async function residentMemoryRequest(
@@ -38,7 +48,7 @@ export async function residentMemoryRequest(
 ): Promise<unknown> {
   const paths = resolveResidentPaths(rootDir);
   const client = new ResidentRspClient(paths, {
-    storeUri: `file://${resolve(rootDir, DEFAULT_RSP_STORE_PATH)}`,
+    storeUri: `file://${resolveSharedStorePath(resolve(rootDir), existsSync)}`,
     ttlDays: DEFAULT_RSP_TTL_DAYS,
     byteBudget: DEFAULT_RSP_BYTE_BUDGET,
     serverCommand: process.env.RSP_BIN ?? "rsp",

--- a/apps/memory/tests/resident-memory.test.ts
+++ b/apps/memory/tests/resident-memory.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { MemoryConfig } from "../src/config.js";
+import { shouldUseResidentMemory } from "../src/resident-memory.js";
+
+const ROOT = "/repo";
+
+function graphConfig(storePath?: string): MemoryConfig {
+  return { mode: "graph", storePath } as MemoryConfig;
+}
+
+describe("shouldUseResidentMemory", () => {
+  it("uses the resident for the canonical state-tier shared store", () => {
+    expect(shouldUseResidentMemory(ROOT, graphConfig(".red/state/red-skills.rdb"))).toBe(true);
+    expect(shouldUseResidentMemory(ROOT, graphConfig("/repo/.red/state/red-skills.rdb"))).toBe(true);
+  });
+
+  it("still uses the resident for the legacy tmp-tier shared store during the transition", () => {
+    expect(shouldUseResidentMemory(ROOT, graphConfig(".red/tmp/red-skills.rdb"))).toBe(true);
+    expect(shouldUseResidentMemory(ROOT, graphConfig("/repo/.red/tmp/red-skills.rdb"))).toBe(true);
+  });
+
+  it("does not use the resident for a private graph store or in markdown-only mode", () => {
+    expect(shouldUseResidentMemory(ROOT, graphConfig(".red/memory/graph.rdb"))).toBe(false);
+    expect(shouldUseResidentMemory(ROOT, { mode: "markdown-only", storePath: ".red/state/red-skills.rdb" } as MemoryConfig)).toBe(false);
+  });
+});

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -1158,10 +1158,15 @@ function emptyStorageClassStats(): RspStorageClassStats {
   };
 }
 
-function renderSetupResult(result: { configChanged: boolean; storeCreated: boolean }): string {
+function renderSetupResult(result: {
+  configChanged: boolean;
+  storeCreated: boolean;
+  legacyStoreMigrated?: boolean;
+}): string {
+  const storeState = result.legacyStoreMigrated ? "migrated" : result.storeCreated ? "created" : "existing";
   return [
     `config: ${result.configChanged ? "updated" : "unchanged"}`,
-    `store: ${result.storeCreated ? "created" : "existing"}`,
+    `store: ${storeState}`,
     "",
   ].join("\n");
 }

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connect } from "@reddb-io/sdk";
 import { type JsonObject } from "@reddb-io/toon";
+import { rspStateDir } from "@reddb-io/shared/red-paths.js";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import type { RspRuntimeConfig } from "./config.js";
@@ -634,7 +635,7 @@ function nudgeColdTelemetryDrain(telemetryRoot: string, config: RspRuntimeConfig
     const socketDir = fastResidentSocketDir(rootDir);
     const socketPath = join(socketDir, "rsp.sock");
     const pidPath = join(socketDir, "rsp.pid");
-    const registryPath = join(rootDir, ".red", "tmp", "rsp-resident.pid.json");
+    const registryPath = join(rspStateDir(rootDir), "rsp-resident.pid.json");
     const wakeLockPath = join(rootDir, ".red", "tmp", "rsp.wake.lock");
     const child = spawn(process.execPath, [
       ...process.execArgv,

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -1,10 +1,12 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { findUp, flatConfigValue } from "@reddb-io/shared/plugin-gate.js";
+import { SHARED_STORE_REL, resolveSharedStorePath } from "@reddb-io/shared/red-paths.js";
 import { resolveResidentPaths } from "@reddb-io/shared/resident-client.js";
 
 export const DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD = 8 * 1024;
-export const DEFAULT_RSP_STORE_PATH = ".red/tmp/red-skills.rdb";
+/** Canonical shared RedDB store location (state tier); see {@link SHARED_STORE_REL}. */
+export const DEFAULT_RSP_STORE_PATH = SHARED_STORE_REL;
 export const DEFAULT_RSP_TTL_DAYS = 7;
 export const DEFAULT_RSP_EPHEMERAL_TTL_HOURS = 6;
 export const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
@@ -67,7 +69,10 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   );
   const storeRoot = resolveResidentPaths(cwd).rootDir;
-  const storeUri = explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${join(resolve(storeRoot), DEFAULT_RSP_STORE_PATH)}`;
+  // Honor the transition window: open the legacy tmp-tier store if it still
+  // exists and setup has not yet migrated it to the state tier.
+  const storeUri =
+    explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${resolveSharedStorePath(resolve(storeRoot), existsSync)}`;
 
   return {
     enabled,

--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -165,6 +165,9 @@ export class RspElisionStore {
     });
     if (usesEmbeddedRedDb(path)) {
       await ensureReddbBinaryFromWarmCache();
+      // The SDK creates the .rdb file but not its parent directory; the store now
+      // lives in the state tier (.red/state), which may not exist yet.
+      await mkdir(dirname(path), { recursive: true });
       store.db = await connect(`file://${path}`);
       await store.ensureRedDbCollections();
       await store.ensureRedDbStore();

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { RedDB } from "@reddb-io/sdk";
 import { type JsonObject } from "@reddb-io/toon";
+import { rspStateDir } from "@reddb-io/shared/red-paths.js";
 import { removeResidentRegistry, writeResidentRegistry } from "@reddb-io/shared/resident-client.js";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
 import type { RspExpiredHandle, RspElisionRecord } from "./elision-store.js";
@@ -156,7 +157,7 @@ export async function runResidentServer(opts: ResidentServerOptions): Promise<vo
     await writeFile(opts.pidPath, `${process.pid}\n`, { encoding: "utf8", mode: 0o600 });
   }
   const residentVersion = opts.residentVersion ?? "0.0.0-dev";
-  const registryPath = opts.registryPath ?? join(opts.rootDir ?? process.cwd(), ".red", "tmp", "rsp-resident.pid.json");
+  const registryPath = opts.registryPath ?? join(rspStateDir(opts.rootDir ?? process.cwd()), "rsp-resident.pid.json");
   try {
     await writeResidentRegistry(registryPath, {
       socket_path: opts.socketPath,
@@ -228,7 +229,7 @@ const IDLE_SHUTDOWN_WATCHDOG_MS = Math.max(
   1,
   Number(process.env.RSP_TEST_IDLE_SHUTDOWN_WATCHDOG_MS ?? "10000"),
 );
-const RSP_STATUS_SUMMARY = join(".red", "tmp", "rsp-status-summary.json");
+const RSP_STATUS_SUMMARY_FILE = "rsp-status-summary.json";
 const TELEMETRY_KV_COLLECTIONS = [
   RSP_ACCOUNTING_EVENTS_COLLECTION,
   RSP_DECISIONS_COLLECTION,
@@ -465,7 +466,7 @@ async function writeStatusSummary(db: RedDB, rootDir: string, now = new Date()):
   const dollarsSavedToday = stats.savings.tokens_saved > 0
     ? (tokensSavedToday / stats.savings.tokens_saved) * stats.savings.dollars_saved_estimate_usd
     : 0;
-  const path = join(rootDir, RSP_STATUS_SUMMARY);
+  const path = join(rspStateDir(rootDir), RSP_STATUS_SUMMARY_FILE);
   const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
   const payload: JsonObject = {
     version: 1,

--- a/apps/rsp/src/setup.ts
+++ b/apps/rsp/src/setup.ts
@@ -1,6 +1,7 @@
 import { constants } from "node:fs";
-import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { LEGACY_SHARED_STORE_REL } from "@reddb-io/shared/red-paths.js";
 import {
   DEFAULT_RSP_BYTE_BUDGET,
   DEFAULT_RSP_EPHEMERAL_TTL_HOURS,
@@ -10,6 +11,7 @@ import {
 } from "./config.js";
 
 export const REPO_STORE_PATH = DEFAULT_RSP_STORE_PATH;
+const LEGACY_STORE_PATH = LEGACY_SHARED_STORE_REL;
 const LEGACY_MEMORY_STORE_PATH = ".red/memory/graph.rdb";
 
 export interface RspProvisionOptions {
@@ -25,6 +27,7 @@ export interface RspProvisionResult {
   configChanged: boolean;
   storeCreated: boolean;
   memoryStoreMigrated: boolean;
+  legacyStoreMigrated: boolean;
 }
 
 export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionOptions = {}): Promise<RspProvisionResult> {
@@ -33,7 +36,7 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
   const configPath = join(redDir, "config.yaml");
   const storePath = join(root, REPO_STORE_PATH);
   await mkdir(redDir, { recursive: true });
-  // The store lives under .red/tmp/, which need not exist yet.
+  // The store lives under .red/state/, which need not exist yet.
   await mkdir(dirname(storePath), { recursive: true });
 
   let existing = "";
@@ -55,9 +58,16 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
 
   const storeCreated = !(await exists(storePath));
   let memoryStoreMigrated = false;
+  let legacyStoreMigrated = false;
   if (storeCreated) {
+    const legacyStore = join(root, LEGACY_STORE_PATH);
     const legacyMemoryStore = join(root, LEGACY_MEMORY_STORE_PATH);
-    if (await exists(legacyMemoryStore)) {
+    if (await exists(legacyStore)) {
+      // One-time move of the pre-ADR-0098 tmp-tier store into the state tier.
+      // After the move the state store exists, so a rerun is a no-op.
+      await rename(legacyStore, storePath);
+      legacyStoreMigrated = true;
+    } else if (await exists(legacyMemoryStore)) {
       await copyFile(legacyMemoryStore, storePath);
       memoryStoreMigrated = true;
     } else {
@@ -89,6 +99,7 @@ export async function provisionRspRepoStore(rootDir: string, opts: RspProvisionO
     configChanged: configChanged || memoryConfig !== next,
     storeCreated,
     memoryStoreMigrated,
+    legacyStoreMigrated,
   };
 }
 

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -3,13 +3,15 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import type { RedDB } from "@reddb-io/sdk";
+import { rspStateDir } from "@reddb-io/shared/red-paths.js";
 import { encodeLines, parseRecords, type ToonlLineEmitter } from "@reddb-io/toon";
 import { storageClassForCommand, type RspStorageClass, type RspStorageClassStats } from "./elision-store.js";
 import { tokenSavingsEstimate, type TokenSavingsEstimate } from "./pricing.js";
 
-export const RSP_TELEMETRY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.toonl");
-export const RSP_TELEMETRY_LEGACY_SPOOL = join(".red", "tmp", "rsp-telemetry.spool.jsonl");
-export const RSP_TELEMETRY_SPOOL_CORRECTIONS = join(".red", "tmp", "rsp-telemetry.spool.corrections.toonl");
+/** Durable telemetry spool filenames; they live in the rsp state lane (ADR 0098). */
+export const RSP_TELEMETRY_SPOOL_FILE = "rsp-telemetry.spool.toonl";
+export const RSP_TELEMETRY_LEGACY_SPOOL_FILE = "rsp-telemetry.spool.jsonl";
+export const RSP_TELEMETRY_SPOOL_CORRECTIONS_FILE = "rsp-telemetry.spool.corrections.toonl";
 export const RSP_ACCOUNTING_EVENTS_COLLECTION = "rsp_accounting_events_v1";
 export const RSP_DECISIONS_COLLECTION = "rsp_decisions_v1";
 export const RSP_TELEMETRY_INVOCATIONS_COLLECTION = "rsp_telemetry_invocations_v1";
@@ -161,15 +163,15 @@ export interface LatencyPercentiles {
 }
 
 export function telemetrySpoolPath(rootDir: string): string {
-  return join(rootDir, RSP_TELEMETRY_SPOOL);
+  return join(rspStateDir(rootDir), RSP_TELEMETRY_SPOOL_FILE);
 }
 
 export function telemetryLegacySpoolPath(rootDir: string): string {
-  return join(rootDir, RSP_TELEMETRY_LEGACY_SPOOL);
+  return join(rspStateDir(rootDir), RSP_TELEMETRY_LEGACY_SPOOL_FILE);
 }
 
 export function telemetrySpoolCorrectionsPath(rootDir: string): string {
-  return join(rootDir, RSP_TELEMETRY_SPOOL_CORRECTIONS);
+  return join(rspStateDir(rootDir), RSP_TELEMETRY_SPOOL_CORRECTIONS_FILE);
 }
 
 export async function appendTelemetryEvent(rootDir: string, event: RspTelemetryEvent): Promise<void> {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -845,7 +845,7 @@ describe("rsp cli", () => {
       const list = responses.find((response) => response.id === 2) as { result: { tools: Array<{ name: string }> } };
       expect(list.result.tools.map((tool) => tool.name)).toEqual(["rsp_status"]);
       await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
     }
   });
 
@@ -993,8 +993,8 @@ describe("rsp cli", () => {
     expect(runGit(["-C", root, "add", ".gitignore"]).status).toBe(0);
     expect(runGit(["-C", root, "commit", "-m", "baseline"]).status).toBe(0);
     const cacheDir = await seedWarmRedCache();
-    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
-    await mkdir(join(root, ".red", "tmp"), { recursive: true });
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
+    await mkdir(dirname(telemetrySpoolPath(root)), { recursive: true });
     const huge = "x".repeat(512 * 1024);
     await writeFile(telemetrySpoolPath(root), Array.from({ length: 8 }, (_, i) => JSON.stringify({
       collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -1359,7 +1359,7 @@ describe("rsp cli", () => {
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
     const env = { RED_SKILLS_CACHE_DIR: cacheDir };
-    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
     const resident = runBundleFromCwdAsync(root, ["server", "--idle-ms", "1000"], env);
     await waitForResidentSocket(root);
     await waitForResidentReady(root);
@@ -1433,7 +1433,7 @@ describe("rsp cli", () => {
     await expect(stat(paths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
     expect(((await stat(dirname(paths.socketPath))).mode & 0o777)).toBe(0o700);
     await expect(stat(join(root, ".red", "tmp", "rsp.sock"))).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
   }, 120_000);
 
   it("built bundle uses the primary resident and store from linked worktrees", async () => {
@@ -1474,7 +1474,7 @@ describe("rsp cli", () => {
     expect(fromWorktree.status, `${fromWorktree.stdout.toString("utf8")}${fromWorktree.stderr.toString("utf8")}`).toBe(0);
     const handle = extractHandle(fromWorktree.stdout);
     await expect(stat(primaryPaths.socketPath)).resolves.toMatchObject({ size: expect.any(Number) });
-    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
     await waitForSummaryTokens(root, beforeWorktree);
 
     const concurrent = await Promise.all([
@@ -1493,7 +1493,7 @@ describe("rsp cli", () => {
     expect(shown.status, `${shown.stdout.toString("utf8")}${shown.stderr.toString("utf8")}`).toBe(0);
     expect(shown.stdout.toString("utf8")).toContain("commit ");
 
-    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
     await waitForTelemetryInvocations(storeUri, "git log", 2);
     const invocations = await waitForTelemetryInvocations(storeUri, "git status", 3);
     const stats = runBundleFromCwd(root, ["stats", "--since", "7d"], env);
@@ -1737,7 +1737,7 @@ describe("rsp cli", () => {
     expect(shown.stderr).toEqual(Buffer.alloc(0));
 
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
-    await rm(join(root, ".red", "tmp", "red-skills.rdb"));
+    await rm(join(root, ".red", "state", "red-skills.rdb"));
     const cold = runBundleFromCwd(root, ["git", "log", "--terse"], { RED_SKILLS_CACHE_DIR: cacheDir });
 
     expect(cold.status).toBe(raw.status);
@@ -1855,7 +1855,7 @@ describe("rsp cli", () => {
     const cacheDir = await seedWarmRedCache();
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
     const resident = runBundleFromCwdAsync(root, ["server", "--idle-ms", "1000"], { RED_SKILLS_CACHE_DIR: cacheDir });
     await waitForResidentSocket(root);
     await waitForResidentReady(root);
@@ -1946,7 +1946,7 @@ describe("rsp cli", () => {
     const cacheDir = await seedWarmRedCache();
     const setup = runBundleFromCwd(root, ["setup"], { RED_SKILLS_CACHE_DIR: cacheDir });
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
-    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
     const db = await connect(storeUri);
     try {
       await db.kv(RSP_TELEMETRY_INVOCATIONS_COLLECTION).put("big", {
@@ -2015,7 +2015,7 @@ describe("rsp cli", () => {
     expect(setup.status, `${setup.stdout.toString("utf8")}${setup.stderr.toString("utf8")}`).toBe(0);
 
     const now = new Date().toISOString();
-    await mkdir(join(root, ".red", "tmp"), { recursive: true });
+    await mkdir(dirname(telemetrySpoolPath(root)), { recursive: true });
     await writeFile(telemetrySpoolPath(root), [
       JSON.stringify({
         collection: RSP_TELEMETRY_INVOCATIONS_COLLECTION,
@@ -2073,7 +2073,7 @@ describe("rsp cli", () => {
     expect(status, `${Buffer.concat(stdout).toString("utf8")}${Buffer.concat(stderr).toString("utf8")}`).toBe(0);
     await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toBe("");
 
-    const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
     const invocations = await readTelemetryRecords(storeUri, RSP_TELEMETRY_INVOCATIONS_COLLECTION);
     expect(invocations).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: "leading", command: "git status" }),
@@ -2205,7 +2205,7 @@ describe("rsp cli", () => {
     expect(res.status).toBe(1);
     expect(res.stdout).toEqual(Buffer.from("error: rsp repo store is not provisioned - run /red-setup\n"));
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("passes through a successful wrapper when the repo store is absent and the cold summarizer cannot handle it", async () => {
@@ -2220,7 +2220,7 @@ describe("rsp cli", () => {
     expect(res.stdout).toEqual(direct.stdout);
     expect(res.stderr.toString("utf8")).toBe(`rsp: wrapper failed, passing through\n${direct.stderr.toString("utf8")}`);
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("passes through a failing wrapper with the underlying exit code and raw stderr when the store is absent", async () => {
@@ -2269,7 +2269,7 @@ describe("rsp cli", () => {
     expect(compressed.stderr).toEqual(Buffer.alloc(0));
     expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
     await expect(readFile(join(root, ".red", "red.rdb"))).resolves.toEqual(redBytes);
-    await expect(stat(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
   }, 120_000);
 
   it("built bundle redirects a configured legacy RedDB store to JSON without mutating it", async () => {

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -40,7 +40,7 @@ describe("resolveRspConfig", () => {
     expect(resolveRspConfig(join(root, "nested"), {}, undefined)).toEqual({
       enabled: false,
       proxyEnabled: false,
-      storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
+      storeUri: `file://${join(root, ".red", "state", "red-skills.rdb")}`,
       ttlDays: 3,
       ephemeralTtlHours: 4,
       byteBudget: 42,
@@ -61,7 +61,7 @@ describe("resolveRspConfig", () => {
     expect(resolveRspConfig(root, {}, undefined)).toEqual({
       enabled: true,
       proxyEnabled: false,
-      storeUri: `file://${join(root, ".red", "tmp", "red-skills.rdb")}`,
+      storeUri: `file://${join(root, ".red", "state", "red-skills.rdb")}`,
       ttlDays: DEFAULT_RSP_TTL_DAYS,
       ephemeralTtlHours: DEFAULT_RSP_EPHEMERAL_TTL_HOURS,
       byteBudget: DEFAULT_RSP_BYTE_BUDGET,

--- a/apps/rsp/tests/setup.test.ts
+++ b/apps/rsp/tests/setup.test.ts
@@ -143,7 +143,7 @@ describe("mergeRspBlock", () => {
 });
 
 describe("provisionRspRepoStore", () => {
-  it("creates .red/tmp/red-skills.rdb and is idempotent on rerun", async () => {
+  it("creates .red/state/red-skills.rdb and is idempotent on rerun", async () => {
     const root = await tempRoot();
     const first = await provisionRspRepoStore(root);
     const firstStat = await stat(first.storePath);
@@ -154,7 +154,7 @@ describe("provisionRspRepoStore", () => {
     expect(first.storeCreated).toBe(true);
     expect(second.storeCreated).toBe(false);
     expect(firstStat.mtimeMs).toBe(secondStat.mtimeMs);
-    expect(first.storePath).toBe(join(root, ".red", "tmp", "red-skills.rdb"));
+    expect(first.storePath).toBe(join(root, ".red", "state", "red-skills.rdb"));
     await expect(readFile(join(root, ".red", "config.yaml"), "utf8")).resolves.toContain("rsp:\n  enabled: true");
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
@@ -163,12 +163,32 @@ describe("provisionRspRepoStore", () => {
     const root = await tempRoot();
     await provisionRspRepoStore(root);
     const marker = Buffer.from("existing store marker");
-    await writeFile(join(root, ".red", "tmp", "red-skills.rdb"), marker);
+    await writeFile(join(root, ".red", "state", "red-skills.rdb"), marker);
 
     const result = await provisionRspRepoStore(root);
 
     expect(result.storeCreated).toBe(false);
-    await expect(readFile(join(root, ".red", "tmp", "red-skills.rdb"))).resolves.toEqual(marker);
+    await expect(readFile(join(root, ".red", "state", "red-skills.rdb"))).resolves.toEqual(marker);
+  });
+
+  it("moves a legacy tmp-tier store into the state tier once, then is a no-op", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red", "tmp"), { recursive: true });
+    const legacy = join(root, ".red", "tmp", "red-skills.rdb");
+    const marker = Buffer.from("legacy store payload");
+    await writeFile(legacy, marker);
+
+    const first = await provisionRspRepoStore(root);
+    expect(first.storeCreated).toBe(true);
+    expect(first.legacyStoreMigrated).toBe(true);
+    expect(first.storePath).toBe(join(root, ".red", "state", "red-skills.rdb"));
+    await expect(readFile(join(root, ".red", "state", "red-skills.rdb"))).resolves.toEqual(marker);
+    await expect(stat(legacy)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const second = await provisionRspRepoStore(root);
+    expect(second.storeCreated).toBe(false);
+    expect(second.legacyStoreMigrated).toBe(false);
+    await expect(readFile(join(root, ".red", "state", "red-skills.rdb"))).resolves.toEqual(marker);
   });
 
   it("copies and repoints the memory graph store into the shared rsp store", async () => {
@@ -189,8 +209,8 @@ describe("provisionRspRepoStore", () => {
     expect(result.storeCreated).toBe(true);
     expect(result.memoryStoreMigrated).toBe(true);
     await expect(readFile(join(root, ".red", "memory", "graph.rdb"), "utf8")).resolves.toBe("legacy graph data");
-    await expect(readFile(join(root, ".red", "tmp", "red-skills.rdb"), "utf8")).resolves.toBe("legacy graph data");
-    await expect(readFile(join(root, ".red", "config.yaml"), "utf8")).resolves.toContain("    storePath: .red/tmp/red-skills.rdb");
+    await expect(readFile(join(root, ".red", "state", "red-skills.rdb"), "utf8")).resolves.toBe("legacy graph data");
+    await expect(readFile(join(root, ".red", "config.yaml"), "utf8")).resolves.toContain("    storePath: .red/state/red-skills.rdb");
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -34,6 +34,8 @@ async function tempRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "rsp-telemetry-"));
   roots.push(root);
   await mkdir(join(root, ".red", "tmp"), { recursive: true });
+  // Durable telemetry spools live in the rsp state lane (ADR 0098).
+  await mkdir(join(root, ".red", "state", "rsp"), { recursive: true });
   await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n", "utf8");
   return root;
 }

--- a/packages/shared/red-paths.test.ts
+++ b/packages/shared/red-paths.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   BRAIN_ROOT_ENV,
+  LEGACY_SHARED_STORE_REL,
   MEMORY_ROOT_ENV,
   ROOT_OVERRIDE_ENV_VARS,
   SHARED_STORE_REL,
+  legacySharedStorePath,
+  resolveSharedStorePath,
   WORKERS_NAMESPACE_ENV,
   WORKER_NAMESPACES,
   activeWorkersDir,
@@ -78,6 +81,31 @@ describe("state tier lanes", () => {
   it("keeps the shared store under the state tier, never tmp", () => {
     expect(sharedStorePath(ROOT).startsWith(stateDir(ROOT))).toBe(true);
     expect(sharedStorePath(ROOT).startsWith(tmpDir(ROOT))).toBe(false);
+  });
+
+  it("names the legacy tmp-tier shared store as a single constant", () => {
+    expect(LEGACY_SHARED_STORE_REL).toBe(".red/tmp/red-skills.rdb");
+    expect(legacySharedStorePath(ROOT)).toBe("/repo/.red/tmp/red-skills.rdb");
+  });
+});
+
+describe("resolveSharedStorePath (transition-window fallback)", () => {
+  it("prefers the state-tier store when it exists", () => {
+    const resolved = resolveSharedStorePath(ROOT, (p) => p === sharedStorePath(ROOT));
+    expect(resolved).toBe(sharedStorePath(ROOT));
+  });
+
+  it("falls back to the legacy tmp store when only that exists", () => {
+    const resolved = resolveSharedStorePath(ROOT, (p) => p === legacySharedStorePath(ROOT));
+    expect(resolved).toBe(legacySharedStorePath(ROOT));
+  });
+
+  it("defaults to the state-tier store when neither exists", () => {
+    expect(resolveSharedStorePath(ROOT, () => false)).toBe(sharedStorePath(ROOT));
+  });
+
+  it("prefers state over legacy when both exist", () => {
+    expect(resolveSharedStorePath(ROOT, () => true)).toBe(sharedStorePath(ROOT));
   });
 });
 

--- a/packages/shared/red-paths.ts
+++ b/packages/shared/red-paths.ts
@@ -118,6 +118,35 @@ export function sharedStorePath(root: string): string {
   return join(stateDir(root), "red-skills.rdb");
 }
 
+/**
+ * The pre-ADR-0098 shared store location under the disposable tmp tier. Kept as
+ * a named constant so the one-time setup migration and the transition-window
+ * fallback read ({@link resolveSharedStorePath}) point at the SAME legacy path
+ * instead of each re-spelling `.red/tmp/red-skills.rdb`.
+ */
+export const LEGACY_SHARED_STORE_REL = ".red/tmp/red-skills.rdb";
+
+/** Absolute path to the legacy (tmp-tier) shared RedDB store. */
+export function legacySharedStorePath(root: string): string {
+  return join(tmpDir(root), "red-skills.rdb");
+}
+
+/**
+ * Resolve the shared store path a consumer should OPEN, honoring the migration
+ * transition window: prefer the canonical state-tier location, fall back to the
+ * legacy tmp-tier file when only that exists, and default to the state-tier path
+ * when neither is present (so a fresh store is created in the new home).
+ *
+ * `exists` is injected so this stays pure and unit-testable without mocks.
+ */
+export function resolveSharedStorePath(root: string, exists: (path: string) => boolean): string {
+  const primary = sharedStorePath(root);
+  if (exists(primary)) return primary;
+  const legacy = legacySharedStorePath(root);
+  if (exists(legacy)) return legacy;
+  return primary;
+}
+
 // ── Tmp-tier worker lanes (ADR 0098 §2) ─────────────────────────────────────
 
 /**

--- a/packages/shared/resident-client.ts
+++ b/packages/shared/resident-client.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decode, encode, type JsonObject } from "@reddb-io/toon";
+import { rspStateDir } from "./red-paths.js";
 import type { RspResidentConfig, RspResidentRequest } from "./resident-protocol.js";
 import { sendResidentRequest } from "./resident-protocol.js";
 
@@ -48,14 +49,17 @@ export interface RspResidentRegistryStatus {
 export function resolveResidentPaths(cwd: string): RspResidentPaths {
   const rootDir = findRepoRoot(cwd) ?? resolve(cwd);
   const socketDir = resolveRuntimeSocketDir(rootDir);
+  const rspState = rspStateDir(rootDir);
   return {
     rootDir,
     socketPath: join(socketDir, "rsp.sock"),
     pidPath: join(socketDir, "rsp.pid"),
     lockPath: join(socketDir, "rsp.lock"),
+    // The wake lock is a genuinely ephemeral guard, so it stays in the tmp tier.
     wakeLockPath: join(rootDir, ".red", "tmp", "rsp.wake.lock"),
-    summaryPath: join(rootDir, ".red", "tmp", "rsp-status-summary.json"),
-    registryPath: join(rootDir, ".red", "tmp", "rsp-resident.pid.json"),
+    // Durable status + resident metadata live in the rsp state lane (ADR 0098).
+    summaryPath: join(rspState, "rsp-status-summary.json"),
+    registryPath: join(rspState, "rsp-resident.pid.json"),
   };
 }
 

--- a/packages/shared/toon-migration.test.ts
+++ b/packages/shared/toon-migration.test.ts
@@ -114,15 +114,15 @@ describe("shared TOON migration registry", () => {
         expect.objectContaining({
           id: "dev.rsp-resident-registry",
           plugin: "dev",
-          legacyPath: ".red/tmp/rsp-resident.pid.json",
-          toonPath: ".red/tmp/rsp-resident.pid.json",
+          legacyPath: ".red/state/rsp/rsp-resident.pid.json",
+          toonPath: ".red/state/rsp/rsp-resident.pid.json",
           kind: "toon",
         }),
         expect.objectContaining({
           id: "dev.rsp-status-summary",
           plugin: "dev",
-          legacyPath: ".red/tmp/rsp-status-summary.json",
-          toonPath: ".red/tmp/rsp-status-summary.json",
+          legacyPath: ".red/state/rsp/rsp-status-summary.json",
+          toonPath: ".red/state/rsp/rsp-status-summary.json",
           kind: "toon",
         }),
         expect.objectContaining({
@@ -146,7 +146,7 @@ describe("shared TOON migration registry", () => {
     const root = await scratch();
     await write(root, ".red/memory/config.json", JSON.stringify({ mode: "graph" }));
     await write(root, ".red/tmp/afk-supervisor.pid", `${process.pid}\n`);
-    await write(root, ".red/tmp/rsp-resident.pid.json", JSON.stringify({ pid: process.pid }));
+    await write(root, ".red/state/rsp/rsp-resident.pid.json", JSON.stringify({ pid: process.pid }));
 
     const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "memory" });
 
@@ -359,10 +359,10 @@ describe("shared TOON migration registry", () => {
     );
     await write(
       root,
-      ".red/tmp/rsp-resident.pid.json",
+      ".red/state/rsp/rsp-resident.pid.json",
       JSON.stringify({ version: 1, pid: 0, socket_path: "sock", store_uri: "file://store", resident_version: "old", started_at: "t" }),
     );
-    await write(root, ".red/tmp/rsp-status-summary.json", JSON.stringify({ version: 1, tokens_saved_today: 12, updated_at: "t" }));
+    await write(root, ".red/state/rsp/rsp-status-summary.json", JSON.stringify({ version: 1, tokens_saved_today: 12, updated_at: "t" }));
     await write(
       root,
       ".red/tmp/waits/wait-a.json",
@@ -385,8 +385,8 @@ describe("shared TOON migration registry", () => {
     const stateRaw = await readFile(join(root, ".red/tmp/workers/wA/1783-a1/afk.state.json"), "utf8");
     const countRaw = await readFile(join(root, ".red/tmp/statusline-cache.json"), "utf8");
     const repoRaw = await readFile(join(root, ".red/tmp/statusline-repo-cache.json"), "utf8");
-    const residentRaw = await readFile(join(root, ".red/tmp/rsp-resident.pid.json"), "utf8");
-    const summaryRaw = await readFile(join(root, ".red/tmp/rsp-status-summary.json"), "utf8");
+    const residentRaw = await readFile(join(root, ".red/state/rsp/rsp-resident.pid.json"), "utf8");
+    const summaryRaw = await readFile(join(root, ".red/state/rsp/rsp-status-summary.json"), "utf8");
     const waitRaw = await readFile(join(root, ".red/tmp/waits/wait-a.json"), "utf8");
     expect(stateRaw.trimStart().startsWith("{")).toBe(false);
     expect(countRaw.trimStart().startsWith("{")).toBe(false);
@@ -464,12 +464,12 @@ describe("encodeSnapshotToon keyed-map collapse", () => {
     const root = await scratch();
     // A status-summary-shaped snapshot that carries a uniform object map field.
     const payload = { version: 1, updated_at: "t", ...uniformMap };
-    await write(root, ".red/tmp/rsp-status-summary.json", JSON.stringify(payload));
+    await write(root, ".red/state/rsp/rsp-status-summary.json", JSON.stringify(payload));
 
     const report = await convertRegisteredToonSurfaces({ rootDir: root, plugin: "dev" });
     expect(report.converted).toContain("dev.rsp-status-summary");
 
-    const written = await readFile(join(root, ".red/tmp/rsp-status-summary.json"), "utf8");
+    const written = await readFile(join(root, ".red/state/rsp/rsp-status-summary.json"), "utf8");
     expect(written).toContain("storage_classes{records,bytes,raw_bytes}:");
 
     const read = await readRegisteredToonSurface(root, "dev.rsp-status-summary");

--- a/packages/shared/toon-migration.ts
+++ b/packages/shared/toon-migration.ts
@@ -2,6 +2,7 @@ import { accessSync, constants } from "node:fs";
 import { access, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { rspStateDir } from "./red-paths.js";
 
 /**
  * Encodes an rsp snapshot surface as TOON with keyed-map collapse enabled
@@ -114,15 +115,15 @@ export const DEV_TOON_MIGRATION_SURFACES: readonly RegisteredToonSurface[] = [
   {
     id: "dev.rsp-resident-registry",
     plugin: "dev",
-    legacyPath: ".red/tmp/rsp-resident.pid.json",
-    toonPath: ".red/tmp/rsp-resident.pid.json",
+    legacyPath: ".red/state/rsp/rsp-resident.pid.json",
+    toonPath: ".red/state/rsp/rsp-resident.pid.json",
     kind: "toon",
   },
   {
     id: "dev.rsp-status-summary",
     plugin: "dev",
-    legacyPath: ".red/tmp/rsp-status-summary.json",
-    toonPath: ".red/tmp/rsp-status-summary.json",
+    legacyPath: ".red/state/rsp/rsp-status-summary.json",
+    toonPath: ".red/state/rsp/rsp-status-summary.json",
     kind: "toon",
   },
   {
@@ -334,7 +335,7 @@ async function quiescenceReasons(rootDir: string): Promise<string[]> {
     reasons.push("active fleet supervisor is running");
   }
 
-  const rspResidentPid = await readJsonPid(join(tmpDir, "rsp-resident.pid.json"));
+  const rspResidentPid = await readJsonPid(join(rspStateDir(rootDir), "rsp-resident.pid.json"));
   if (rspResidentPid !== null && isLivePid(rspResidentPid)) {
     reasons.push("active rsp resident is running");
   }


### PR DESCRIPTION
Automated AFK landing for #1686. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1686

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786727064&installation_id=129708444&pr_number=1840&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1840&signature=813a56a9106b20c8c8c67c0fa133c813e40ca639f0823759bee75720205fb90e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->