### PR TITLE
feat: #1687 janitor sweep — per-lane TTL GC for the .red/tmp tier

### DIFF
--- a/apps/dev/src/core/tmp-janitor.ts
+++ b/apps/dev/src/core/tmp-janitor.ts
@@ -1,0 +1,180 @@
+// tmp-janitor.ts — per-lane TTL GC for the .red/tmp tier (ADR 0098 §3).
+//
+// PURE: all inputs are pre-stat'd by the caller. No I/O, no process/date reads.
+//
+// Lanes covered by this sweep:
+//   tmp/logs/<yyyy-mm-dd>/   — short TTL; date-dirs older than LOGS_TTL_S are reclaimed
+//   tmp/scratch/             — short TTL; entries older than SCRATCH_TTL_S are reclaimed
+//   tmp/diagnostics/         — age cap; entries older than DIAGNOSTICS_TTL_S are reclaimed
+//   tmp/worktrees/feedback/  — mtime TTL on top of existing SHA invalidation;
+//                              entries older than FEEDBACK_TTL_S are reclaimed
+//
+// Lanes NOT in scope (owned by other sweeps):
+//   tmp/workers/, tmp/go-workers/, tmp/scout-workers/  — AFK orphan/attempt-cap sweep
+//   tmp/claims/                                         — stale-claim sweep
+//   tmp/waits/                                          — rsp wait exit semantics
+//   tmp/worktrees/manual/                               — never auto-deleted
+//   tmp/worktrees/{landing,rebase,cascade,adopt,docs}/  — operation-lifecycle sweeps
+//
+// Unknown dirs or files at the tmp root are REPORTED and LEFT UNTOUCHED. The
+// janitor never deletes outside its known lanes.
+
+// ---------- TTL constants (ADR 0098 §3) ----------
+
+/** Short TTL for session log date-dirs under tmp/logs/<yyyy-mm-dd>/. */
+export const LOGS_TTL_S = 7 * 86400;
+
+/** Short TTL for entries under tmp/scratch/. */
+export const SCRATCH_TTL_S = 3 * 86400;
+
+/** Age cap for failure-diagnostics entries under tmp/diagnostics/. */
+export const DIAGNOSTICS_TTL_S = 30 * 86400;
+
+/** mtime TTL for feedback worktree cache entries under tmp/worktrees/feedback/.
+ * Layered on top of the existing SHA invalidation — the mtime sweep reclaims
+ * entries that have not been touched recently regardless of SHA currency. */
+export const FEEDBACK_TTL_S = 7 * 86400;
+
+// ---------- lane registry (ADR 0098 §2) ----------
+
+/** Named entries that may appear directly under .red/tmp/. Anything not in
+ * this set is an unknown lane: reported by auditTmpRoot, never deleted. */
+export const KNOWN_TMP_LANES = new Set([
+  "workers",
+  "go-workers",
+  "scout-workers",
+  "claims",
+  "waits",
+  "worktrees",
+  "logs",
+  "scratch",
+  "diagnostics",
+]);
+
+// ---------- types ----------
+
+/** One stat'd entry under a janitor-managed lane. */
+export interface JanitorEntry {
+  /** Absolute path of the entry (dir or file). */
+  path: string;
+  /** mtime of the entry in epoch seconds. */
+  mtimeS: number;
+}
+
+/** Split of a lane's entries into those to reclaim vs those to spare. */
+export interface JanitorLanePlan {
+  reclaim: JanitorEntry[];
+  spare: JanitorEntry[];
+}
+
+// ---------- per-lane planners ----------
+
+/** Decide which log date-dirs to reclaim.
+ * Reclaims dirs whose (nowS - mtimeS) strictly exceeds LOGS_TTL_S. */
+export function planLogsJanitor(
+  entries: readonly JanitorEntry[],
+  nowS: number,
+): JanitorLanePlan {
+  return splitByTtl(entries, nowS, LOGS_TTL_S);
+}
+
+/** Decide which scratch entries to reclaim.
+ * Reclaims entries whose (nowS - mtimeS) strictly exceeds SCRATCH_TTL_S. */
+export function planScratchJanitor(
+  entries: readonly JanitorEntry[],
+  nowS: number,
+): JanitorLanePlan {
+  return splitByTtl(entries, nowS, SCRATCH_TTL_S);
+}
+
+/** Decide which diagnostics entries to reclaim.
+ * Reclaims entries whose (nowS - mtimeS) strictly exceeds DIAGNOSTICS_TTL_S. */
+export function planDiagnosticsJanitor(
+  entries: readonly JanitorEntry[],
+  nowS: number,
+): JanitorLanePlan {
+  return splitByTtl(entries, nowS, DIAGNOSTICS_TTL_S);
+}
+
+/** Decide which feedback worktree entries to reclaim by mtime TTL.
+ * Reclaims entries whose (nowS - mtimeS) strictly exceeds FEEDBACK_TTL_S.
+ * SHA invalidation is the caller's concern and runs independently; this
+ * planner only evaluates the mtime-based TTL. */
+export function planFeedbackWorktreeJanitor(
+  entries: readonly JanitorEntry[],
+  nowS: number,
+): JanitorLanePlan {
+  return splitByTtl(entries, nowS, FEEDBACK_TTL_S);
+}
+
+function splitByTtl(
+  entries: readonly JanitorEntry[],
+  nowS: number,
+  ttlS: number,
+): JanitorLanePlan {
+  const reclaim: JanitorEntry[] = [];
+  const spare: JanitorEntry[] = [];
+  for (const e of entries) {
+    if (nowS - e.mtimeS > ttlS) reclaim.push(e);
+    else spare.push(e);
+  }
+  return { reclaim, spare };
+}
+
+// ---------- tmp-root audit ----------
+
+/** Audit result for entries at the tmp root. */
+export interface TmpRootAudit {
+  /** Names at the tmp root that are not in KNOWN_TMP_LANES.
+   * The janitor reports these but never deletes them. */
+  unknown: string[];
+}
+
+/** Classify names present directly under .red/tmp/. Names absent from
+ * KNOWN_TMP_LANES are flagged as unknown; the janitor reports but never
+ * touches them. */
+export function auditTmpRoot(names: readonly string[]): TmpRootAudit {
+  const unknown: string[] = [];
+  for (const name of names) {
+    if (!KNOWN_TMP_LANES.has(name)) unknown.push(name);
+  }
+  return { unknown };
+}
+
+// ---------- combined planner ----------
+
+export interface TmpJanitorInput {
+  /** Current epoch seconds (injected so the planner stays pure). */
+  nowS: number;
+  /** Stat'd entries under tmp/logs/ (the date-dir level). */
+  logEntries: readonly JanitorEntry[];
+  /** Stat'd entries under tmp/scratch/. */
+  scratchEntries: readonly JanitorEntry[];
+  /** Stat'd entries under tmp/diagnostics/. */
+  diagnosticsEntries: readonly JanitorEntry[];
+  /** Stat'd entries under tmp/worktrees/feedback/. */
+  feedbackEntries: readonly JanitorEntry[];
+  /** Names (not full paths) present directly under the tmp root. */
+  tmpRootNames: readonly string[];
+}
+
+export interface TmpJanitorPlan {
+  logs: JanitorLanePlan;
+  scratch: JanitorLanePlan;
+  diagnostics: JanitorLanePlan;
+  feedbackWorktrees: JanitorLanePlan;
+  /** Names at the tmp root not in KNOWN_TMP_LANES: reported, never deleted. */
+  unknownTmpRoots: string[];
+}
+
+/** Plan the full janitor sweep across all covered lanes. */
+export function planTmpJanitor(input: TmpJanitorInput): TmpJanitorPlan {
+  const { nowS } = input;
+  return {
+    logs: planLogsJanitor(input.logEntries, nowS),
+    scratch: planScratchJanitor(input.scratchEntries, nowS),
+    diagnostics: planDiagnosticsJanitor(input.diagnosticsEntries, nowS),
+    feedbackWorktrees: planFeedbackWorktreeJanitor(input.feedbackEntries, nowS),
+    unknownTmpRoots: auditTmpRoot(input.tmpRootNames).unknown,
+  };
+}

--- a/apps/dev/tests/tmp-janitor.test.ts
+++ b/apps/dev/tests/tmp-janitor.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import {
+  auditTmpRoot,
+  DIAGNOSTICS_TTL_S,
+  FEEDBACK_TTL_S,
+  KNOWN_TMP_LANES,
+  LOGS_TTL_S,
+  planDiagnosticsJanitor,
+  planFeedbackWorktreeJanitor,
+  planLogsJanitor,
+  planScratchJanitor,
+  planTmpJanitor,
+  SCRATCH_TTL_S,
+  type JanitorEntry,
+} from "../src/core/tmp-janitor.js";
+
+const NOW = 1_000_000_000;
+
+function entry(path: string, ageS: number): JanitorEntry {
+  return { path, mtimeS: NOW - ageS };
+}
+
+// ---------- planLogsJanitor ----------
+
+describe("planLogsJanitor", () => {
+  it("returns empty plans when there are no entries", () => {
+    expect(planLogsJanitor([], NOW)).toEqual({ reclaim: [], spare: [] });
+  });
+
+  it("reclaims a log dir strictly older than the TTL", () => {
+    const e = entry("/red/tmp/logs/2020-01-01", LOGS_TTL_S + 1);
+    expect(planLogsJanitor([e], NOW)).toEqual({ reclaim: [e], spare: [] });
+  });
+
+  it("spares a log dir younger than the TTL", () => {
+    const e = entry("/red/tmp/logs/2020-01-08", LOGS_TTL_S - 1);
+    expect(planLogsJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("spares a log dir whose age equals the TTL exactly (not strictly greater)", () => {
+    const e = entry("/red/tmp/logs/2020-01-08", LOGS_TTL_S);
+    expect(planLogsJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("partitions a mixed set of log dirs", () => {
+    const old = entry("/red/tmp/logs/old", LOGS_TTL_S + 1);
+    const fresh = entry("/red/tmp/logs/fresh", LOGS_TTL_S - 1);
+    const plan = planLogsJanitor([old, fresh], NOW);
+    expect(plan.reclaim).toEqual([old]);
+    expect(plan.spare).toEqual([fresh]);
+  });
+});
+
+// ---------- planScratchJanitor ----------
+
+describe("planScratchJanitor", () => {
+  it("returns empty plans when there are no entries", () => {
+    expect(planScratchJanitor([], NOW)).toEqual({ reclaim: [], spare: [] });
+  });
+
+  it("reclaims a scratch entry strictly older than the TTL", () => {
+    const e = entry("/red/tmp/scratch/thing.txt", SCRATCH_TTL_S + 1);
+    expect(planScratchJanitor([e], NOW)).toEqual({ reclaim: [e], spare: [] });
+  });
+
+  it("spares a scratch entry younger than the TTL", () => {
+    const e = entry("/red/tmp/scratch/wip.json", SCRATCH_TTL_S - 1);
+    expect(planScratchJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("spares a scratch entry whose age equals the TTL exactly", () => {
+    const e = entry("/red/tmp/scratch/boundary", SCRATCH_TTL_S);
+    expect(planScratchJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("partitions a mixed set of scratch entries", () => {
+    const old = entry("/red/tmp/scratch/stale", SCRATCH_TTL_S + 100);
+    const fresh = entry("/red/tmp/scratch/active", 60);
+    const plan = planScratchJanitor([old, fresh], NOW);
+    expect(plan.reclaim).toEqual([old]);
+    expect(plan.spare).toEqual([fresh]);
+  });
+});
+
+// ---------- planDiagnosticsJanitor ----------
+
+describe("planDiagnosticsJanitor", () => {
+  it("returns empty plans when there are no entries", () => {
+    expect(planDiagnosticsJanitor([], NOW)).toEqual({ reclaim: [], spare: [] });
+  });
+
+  it("reclaims a diagnostics entry past the age cap", () => {
+    const e = entry("/red/tmp/diagnostics/crash-1.log", DIAGNOSTICS_TTL_S + 1);
+    expect(planDiagnosticsJanitor([e], NOW)).toEqual({ reclaim: [e], spare: [] });
+  });
+
+  it("spares a diagnostics entry within the age cap", () => {
+    const e = entry("/red/tmp/diagnostics/recent.log", DIAGNOSTICS_TTL_S - 1);
+    expect(planDiagnosticsJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("spares a diagnostics entry at exactly the age cap", () => {
+    const e = entry("/red/tmp/diagnostics/boundary.log", DIAGNOSTICS_TTL_S);
+    expect(planDiagnosticsJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("partitions a mixed set of diagnostics entries", () => {
+    const old = entry("/red/tmp/diagnostics/old-crash.log", DIAGNOSTICS_TTL_S + 86400);
+    const fresh = entry("/red/tmp/diagnostics/new-crash.log", 3600);
+    const plan = planDiagnosticsJanitor([old, fresh], NOW);
+    expect(plan.reclaim).toEqual([old]);
+    expect(plan.spare).toEqual([fresh]);
+  });
+});
+
+// ---------- planFeedbackWorktreeJanitor ----------
+
+describe("planFeedbackWorktreeJanitor", () => {
+  it("returns empty plans when there are no entries", () => {
+    expect(planFeedbackWorktreeJanitor([], NOW)).toEqual({ reclaim: [], spare: [] });
+  });
+
+  it("reclaims a feedback worktree entry past the mtime TTL", () => {
+    const e = entry("/red/tmp/worktrees/feedback/afk-123", FEEDBACK_TTL_S + 1);
+    expect(planFeedbackWorktreeJanitor([e], NOW)).toEqual({ reclaim: [e], spare: [] });
+  });
+
+  it("spares a feedback worktree entry within the mtime TTL", () => {
+    const e = entry("/red/tmp/worktrees/feedback/afk-456", FEEDBACK_TTL_S - 1);
+    expect(planFeedbackWorktreeJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("spares a feedback worktree entry at exactly the mtime TTL", () => {
+    const e = entry("/red/tmp/worktrees/feedback/afk-789", FEEDBACK_TTL_S);
+    expect(planFeedbackWorktreeJanitor([e], NOW)).toEqual({ reclaim: [], spare: [e] });
+  });
+
+  it("makes the mtime decision independently of SHA state (no git call)", () => {
+    // A fresh-by-mtime entry is spared even if its SHA might be stale;
+    // SHA invalidation is the caller's responsibility, not this planner's.
+    const freshByMtime = entry("/red/tmp/worktrees/feedback/stale-sha-branch", FEEDBACK_TTL_S - 1);
+    expect(planFeedbackWorktreeJanitor([freshByMtime], NOW)).toEqual({
+      reclaim: [],
+      spare: [freshByMtime],
+    });
+  });
+
+  it("partitions a mixed set of feedback entries", () => {
+    const stale = entry("/red/tmp/worktrees/feedback/old-branch", FEEDBACK_TTL_S + 3600);
+    const live = entry("/red/tmp/worktrees/feedback/active-branch", 300);
+    const plan = planFeedbackWorktreeJanitor([stale, live], NOW);
+    expect(plan.reclaim).toEqual([stale]);
+    expect(plan.spare).toEqual([live]);
+  });
+});
+
+// ---------- auditTmpRoot ----------
+
+describe("auditTmpRoot", () => {
+  it("returns no unknowns when names is empty", () => {
+    expect(auditTmpRoot([]).unknown).toEqual([]);
+  });
+
+  it("returns no unknowns when all names are in KNOWN_TMP_LANES", () => {
+    expect(auditTmpRoot([...KNOWN_TMP_LANES]).unknown).toEqual([]);
+  });
+
+  it("flags a dir at the tmp root that is not in the registry", () => {
+    expect(auditTmpRoot(["rogue-lane"]).unknown).toEqual(["rogue-lane"]);
+  });
+
+  it("flags a loose file at the tmp root", () => {
+    expect(auditTmpRoot(["debug.log"]).unknown).toEqual(["debug.log"]);
+  });
+
+  it("passes known lanes through without flagging them", () => {
+    const names = ["workers", "claims"];
+    expect(auditTmpRoot(names).unknown).toEqual([]);
+  });
+
+  it("flags multiple unknowns preserving input order", () => {
+    const names = ["workers", "unknown-a", "claims", "unknown-b"];
+    expect(auditTmpRoot(names).unknown).toEqual(["unknown-a", "unknown-b"]);
+  });
+
+  it("does not delete unknown entries — the result is report-only", () => {
+    // This is a design invariant: auditTmpRoot returns a report; the caller
+    // applies no deletions based on it. The test asserts the function
+    // returns a TmpRootAudit with only an `unknown` list, nothing else.
+    const result = auditTmpRoot(["stray-dir"]);
+    expect(Object.keys(result)).toEqual(["unknown"]);
+  });
+});
+
+// ---------- planTmpJanitor (combined) ----------
+
+describe("planTmpJanitor", () => {
+  it("returns empty plans and no unknowns for a clean state", () => {
+    const plan = planTmpJanitor({
+      nowS: NOW,
+      logEntries: [],
+      scratchEntries: [],
+      diagnosticsEntries: [],
+      feedbackEntries: [],
+      tmpRootNames: [...KNOWN_TMP_LANES],
+    });
+    expect(plan.logs).toEqual({ reclaim: [], spare: [] });
+    expect(plan.scratch).toEqual({ reclaim: [], spare: [] });
+    expect(plan.diagnostics).toEqual({ reclaim: [], spare: [] });
+    expect(plan.feedbackWorktrees).toEqual({ reclaim: [], spare: [] });
+    expect(plan.unknownTmpRoots).toEqual([]);
+  });
+
+  it("plans across all lanes and surfaces unknown tmp root entries", () => {
+    const oldLog = entry("/red/tmp/logs/2020-01-01", LOGS_TTL_S + 1);
+    const freshLog = entry("/red/tmp/logs/2020-01-08", 1);
+    const oldScratch = entry("/red/tmp/scratch/old.txt", SCRATCH_TTL_S + 1);
+    const freshDiag = entry("/red/tmp/diagnostics/recent.log", 1);
+    const oldFeedback = entry("/red/tmp/worktrees/feedback/stale", FEEDBACK_TTL_S + 1);
+    const freshFeedback = entry("/red/tmp/worktrees/feedback/current", 1);
+
+    const plan = planTmpJanitor({
+      nowS: NOW,
+      logEntries: [oldLog, freshLog],
+      scratchEntries: [oldScratch],
+      diagnosticsEntries: [freshDiag],
+      feedbackEntries: [oldFeedback, freshFeedback],
+      tmpRootNames: ["workers", "logs", "rogue-dir", "scratch"],
+    });
+
+    expect(plan.logs.reclaim).toEqual([oldLog]);
+    expect(plan.logs.spare).toEqual([freshLog]);
+    expect(plan.scratch.reclaim).toEqual([oldScratch]);
+    expect(plan.scratch.spare).toEqual([]);
+    expect(plan.diagnostics.reclaim).toEqual([]);
+    expect(plan.diagnostics.spare).toEqual([freshDiag]);
+    expect(plan.feedbackWorktrees.reclaim).toEqual([oldFeedback]);
+    expect(plan.feedbackWorktrees.spare).toEqual([freshFeedback]);
+    expect(plan.unknownTmpRoots).toEqual(["rogue-dir"]);
+  });
+
+  it("does not reclaim entries in unmanaged lanes (workers, claims, waits, worktrees)", () => {
+    // The janitor only acts on its four lanes. Known lanes at the tmp root
+    // do not produce unknownTmpRoots entries even though their contents
+    // are outside this sweep's scope.
+    const plan = planTmpJanitor({
+      nowS: NOW,
+      logEntries: [],
+      scratchEntries: [],
+      diagnosticsEntries: [],
+      feedbackEntries: [],
+      tmpRootNames: ["workers", "go-workers", "claims", "waits", "worktrees"],
+    });
+    expect(plan.unknownTmpRoots).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1687

Adopts the committed progress from the interrupted AFK worker wSYIW (the claude fleet was stopped mid-attempt to switch runners; the work was already committed and pushed). Branch is up to date with main (0 commits behind).

Implements the ADR 0098 lane-specific TTL policy for the .red/tmp tier: the tmp-janitor sweeps per-lane by the registry's TTL rules. Ships with a test suite (256 lines). CI adjudicates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786728500&installation_id=129708444&pr_number=1842&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1842&signature=1f6280b9362d2ab108d1dcb2bd0700f6f1acf0d187ae8cdf0d13a9ba359272ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->