### PR TITLE
fix: #1838 resolve repo root for rsp telemetry writes (no phantom .red creation)

### DIFF
--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -1,7 +1,7 @@
 import { randomUUID, createHash } from "node:crypto";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import type { RedDB } from "@reddb-io/sdk";
 import { rspStateDir } from "@reddb-io/shared/red-paths.js";
 import { encodeLines, parseRecords, type ToonlLineEmitter } from "@reddb-io/toon";
@@ -162,6 +162,28 @@ export interface LatencyPercentiles {
   wrapper_ms_p99: number | null;
 }
 
+/**
+ * Walk up from startDir to find the first directory that already contains a
+ * `.red` child. Returns the repo root if found, null otherwise.
+ *
+ * Never creates or modifies the filesystem — only existsSync probes. Safe for
+ * deleted paths because path.resolve() is string-only and existsSync returns
+ * false (never throws) for absent entries. This upholds ADR 0067: rsp never
+ * mints a `.red/` directory; if none is found in the hierarchy, the caller
+ * must drop the telemetry event.
+ */
+function resolveRootForTelemetryWrite(startDir: string): string | null {
+  if (!startDir) return null;
+  let current = resolve(startDir);
+  while (true) {
+    if (existsSync(join(current, ".red"))) return current;
+    const parent = resolve(join(current, ".."));
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
 export function telemetrySpoolPath(rootDir: string): string {
   return join(rspStateDir(rootDir), RSP_TELEMETRY_SPOOL_FILE);
 }
@@ -180,7 +202,9 @@ export async function appendTelemetryEvent(rootDir: string, event: RspTelemetryE
 
 export function appendTelemetryEventSync(rootDir: string, event: RspTelemetryEvent): void {
   try {
-    const path = telemetrySpoolPath(rootDir);
+    const resolvedRoot = resolveRootForTelemetryWrite(rootDir);
+    if (!resolvedRoot) return;
+    const path = telemetrySpoolPath(resolvedRoot);
     mkdirSync(dirname(path), { recursive: true });
     appendFileSync(path, formatSpoolRow({
       spool_id: randomUUID(),
@@ -210,11 +234,13 @@ function compactTextField(
 }
 
 export async function takeTelemetrySpool(rootDir: string): Promise<string[]> {
-  const path = telemetrySpoolPath(rootDir);
+  const resolvedRoot = resolveRootForTelemetryWrite(rootDir);
+  if (!resolvedRoot) return [];
+  const path = telemetrySpoolPath(resolvedRoot);
   await mkdir(dirname(path), { recursive: true }).catch(() => undefined);
-  const files = await renameActiveSpools(rootDir);
+  const files = await renameActiveSpools(resolvedRoot);
   const entries = [
-    ...await readPendingCorrectionEntries(rootDir),
+    ...await readPendingCorrectionEntries(resolvedRoot),
     ...await readDrainEntries(files),
   ];
   await Promise.all(files.map((file) => rm(file, { force: true })));
@@ -225,20 +251,22 @@ export async function drainTelemetrySpool(
   rootDir: string,
   drainLine: (line: string) => Promise<boolean>,
 ): Promise<void> {
-  const path = telemetrySpoolPath(rootDir);
+  const resolvedRoot = resolveRootForTelemetryWrite(rootDir);
+  if (!resolvedRoot) return;
+  const path = telemetrySpoolPath(resolvedRoot);
   await mkdir(dirname(path), { recursive: true }).catch(() => undefined);
-  await ensureActiveSpoolFiles(rootDir);
+  await ensureActiveSpoolFiles(resolvedRoot);
 
-  for (const orphan of await orphanedDrainFiles(rootDir)) {
-    await drainFile(rootDir, orphan, drainLine);
+  for (const orphan of await orphanedDrainFiles(resolvedRoot)) {
+    await drainFile(resolvedRoot, orphan, drainLine);
   }
 
-  for (const entry of await readPendingCorrectionEntries(rootDir)) {
-    await drainEntry(rootDir, entry, drainLine, true);
+  for (const entry of await readPendingCorrectionEntries(resolvedRoot)) {
+    await drainEntry(resolvedRoot, entry, drainLine, true);
   }
 
-  for (const drainingPath of await renameActiveSpools(rootDir)) {
-    await drainFile(rootDir, drainingPath, drainLine);
+  for (const drainingPath of await renameActiveSpools(resolvedRoot)) {
+    await drainFile(resolvedRoot, drainingPath, drainLine);
   }
 }
 
@@ -351,7 +379,9 @@ function formatSpoolRow(row: RspTelemetrySpoolEntry): string {
 
 function appendCorrection(rootDir: string, correction: RspTelemetryCorrectionRow): void {
   try {
-    const path = telemetrySpoolCorrectionsPath(rootDir);
+    const resolvedRoot = resolveRootForTelemetryWrite(rootDir);
+    if (!resolvedRoot) return;
+    const path = telemetrySpoolCorrectionsPath(resolvedRoot);
     mkdirSync(dirname(path), { recursive: true });
     const correctionEmitter: ToonlLineEmitter = encodeLines();
     appendFileSync(path, correctionEmitter.push({


### PR DESCRIPTION
Closes #1838

Adopts the committed progress from the interrupted AFK worker wLRJR (claude fleet stopped mid-attempt for the runner switch; work was committed and pushed).

Resolves the repo root for the rsp telemetry spool path instead of trusting process cwd, so a deleted-cwd (removed worktree) never mints a phantom nested .red/tmp — honoring ADR 0067 (only /red-setup creates .red/) and ADR 0098 lane discipline. Branch is 10 commits behind main and touches telemetry.ts, which the wave-2 TOONL spool work also modified; checking mergeability.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786728514&installation_id=129708444&pr_number=1843&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1843&signature=7770dbc0131d082c78cd9333476e8b6fc10d1bf361f0d49c174d6dc62c2aa3b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->