### PR TITLE
fix: #1680 Ambient unlanded-docs signal on the Claude and Codex statuslines (cached local state only)

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -31,6 +31,7 @@ import { resolveRspConfig } from "../../../rsp/src/config.js";
 import { resolveResidentPaths } from "../../../rsp/src/resident-client.js";
 import {
   collectStatuslineAfk,
+  collectStatuslineDocs,
   collectStatuslineFleet,
   collectStatuslineRepo,
   collectStatuslineWorkers,
@@ -333,8 +334,9 @@ export async function statuslineCommand(
   // the per-worker records feed the themed multi-line form (Claude Code). Both
   // read the same worker states — cheap file reads — so the two forms stay in
   // sync while each renders its own layout.
-  const [repo, afk, fleet, workers, rsp] = await Promise.all([
+  const [repo, docs, afk, fleet, workers, rsp] = await Promise.all([
     collectStatuslineRepo(repoCtx, cacheTtlS, repoLocBaseRef),
+    collectStatuslineDocs(repoCtx, base),
     collectStatuslineAfk(repoCtx, cacheTtlS).then((a) => a ?? undefined),
     collectStatuslineFleet(repoCtx),
     collectStatuslineWorkers(repoCtx),
@@ -348,7 +350,7 @@ export async function statuslineCommand(
   const color = !process.env.NO_COLOR;
   const columns = Number.parseInt(process.env.COLUMNS ?? "", 10);
   const nowS = Math.floor(Date.now() / 1000);
-  const line = renderStatuslineThemed({ project, claude, repo, fleet, afk, rsp }, color, {
+  const line = renderStatuslineThemed({ project, claude, repo, docs, fleet, afk, rsp }, color, {
     columns: Number.isFinite(columns) && columns > 0 ? columns : undefined,
     workers,
     now: nowS,

--- a/apps/dev/src/core/statusline-legend.ts
+++ b/apps/dev/src/core/statusline-legend.ts
@@ -12,6 +12,7 @@ export const STATUSLINE_LEGEND_ROWS: readonly TokenLegendRow[] = [
   { token: "cpr", name: "created_pull_requests_today", gloss: "Pull requests created on the local calendar day." },
   { token: "iss", name: "issue_number_or_count", gloss: "Header issue count; worker current issue number." },
   { token: "loc", name: "lines_changed", gloss: "Added and removed line delta as +A -R." },
+  { token: "doc", name: "unlanded_docs", gloss: "Unlanded .red glossary/ADR docs from cached local git state." },
   { token: "#", name: "issue", gloss: "Plain monitor current issue marker." },
   { token: "wrk", name: "workers", gloss: "Live AFK worker count in the aggregate statusline block." },
   { token: "rdy", name: "ready_for_agent", gloss: "Cached ready-for-agent queue count." },

--- a/apps/dev/src/core/statusline-style.ts
+++ b/apps/dev/src/core/statusline-style.ts
@@ -35,10 +35,12 @@ import {
   humanizeTokens,
   renderFleetBlock,
   renderRspBlock,
+  renderUnlandedDocsBlock,
   renderStatuslineWithPreset,
   shortModel,
   type ClaudeInput,
   type FleetInput,
+  type DocsInput,
   type ProjectInput,
   type RepoInput,
   type RspStatusInput,
@@ -195,6 +197,11 @@ function fleetKv(fleet: FleetInput | undefined): string[] {
   return block ? [block] : [];
 }
 
+function docsKv(docs: DocsInput | undefined): string[] {
+  const block = renderUnlandedDocsBlock(docs);
+  return block ? [block] : [];
+}
+
 function rspKv(rsp: RspStatusInput | undefined): string[] {
   const block = renderRspBlock(rsp);
   if (!rsp || !block) return [];
@@ -211,6 +218,7 @@ export function renderHeaderLine(
   fleet?: FleetInput,
   preset: StatuslinePreset = "full",
   rsp?: RspStatusInput,
+  docs?: DocsInput,
 ): string {
   let s = `${WINE2}${WHITE} ${projectContent(project, preset === "full")} `;
   const model = modelContent(claude);
@@ -231,6 +239,7 @@ export function renderHeaderLine(
         ...usageKvs(claude),
         ...repoCountsKv(repo),
         ...localDiffKv(repo),
+        ...docsKv(docs),
         ...fleetKv(fleet),
         ...rspKv(rsp),
       ].filter((x): x is string => x !== null);
@@ -391,7 +400,7 @@ export interface StyleOptions {
  * → only the header line. */
 export function styleStatusline(input: StatuslineInput, opts: StyleOptions = {}): string {
   const preset = opts.preset ?? "full";
-  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet, preset, input.rsp)];
+  const lines = [renderHeaderLine(input.project, input.claude, input.repo, input.fleet, preset, input.rsp, input.docs)];
   const now = opts.now ?? 0;
   lines.push(...renderWorkerLines(opts.workers ?? [], now, preset));
   return lines.join("\n");

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -149,6 +149,12 @@ export interface RepoInput {
   cacheAgeS?: number;
 }
 
+/** Cached/local unlanded `.red/` docs count. */
+export interface DocsInput {
+  /** `doc` — unlanded glossary/ADR docs detected from local git state. */
+  count: number;
+}
+
 /** Repo-global fleet-supervisor segment, independent of live worker rows. */
 export interface FleetInput {
   /** Supervisor runner (`codex`, `claude`, `opencode`, ...). */
@@ -179,6 +185,7 @@ export interface StatuslineInput {
   project: ProjectInput;
   claude?: ClaudeInput;
   repo?: RepoInput;
+  docs?: DocsInput;
   fleet?: FleetInput;
   afk?: AfkInput;
   rsp?: RspStatusInput;
@@ -461,6 +468,11 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   return parts.join(" · ");
 }
 
+export function renderUnlandedDocsBlock(docs: DocsInput | undefined): string | null {
+  if (!docs || docs.count <= 0) return null;
+  return `doc=${Math.floor(docs.count)}`;
+}
+
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
   if (rsp.state === "ready") {
@@ -537,6 +549,8 @@ export function renderStatuslineWithPreset(input: StatuslineInput, preset: Statu
   if (usage !== null) sections.push(usage);
   const repo = renderRepoBlock(input.repo);
   if (repo !== null) sections.push(repo);
+  const docs = renderUnlandedDocsBlock(input.docs);
+  if (docs !== null) sections.push(docs);
   const fleet = renderFleetBlock(input.fleet);
   if (fleet !== null) sections.push(fleet);
   const rsp = renderRspBlock(input.rsp);

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -18,7 +18,7 @@ import * as rp from "@reddb-io/shared/red-paths.js";
 import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import { resolveBase } from "../core/base-resolver.js";
-import { classifyDocsPath, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
+import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { SandboxMode } from "../core/execution.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
@@ -852,7 +852,7 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
 
 // ---------- statusline inputs ----------
 
-import type { AfkInput, FleetInput, RepoInput } from "../core/statusline.js";
+import type { AfkInput, DocsInput, FleetInput, RepoInput } from "../core/statusline.js";
 
 /** The DEFAULT TTL (seconds) of every EXPENSIVE FETCHED statusline number — the
  * GitHub-derived queue/human and open-PR/open-issue counts AND the repo-global
@@ -1503,6 +1503,45 @@ export async function collectStatuslineRepo(
   return { openPrs, todayPrs, openIssues, localAdded, localRemoved, cacheAgeS: repoCacheAgeS };
 }
 
+type GitExec = typeof execTool;
+
+export async function collectStatuslineDocs(
+  ctx: RepoContext,
+  base = "main",
+  exec: GitExec = execTool,
+): Promise<DocsInput | undefined> {
+  const gitCtx: gitx.GitContext = { cwd: ctx.root };
+  const baseRef = `${ctx.remote}/${base}`;
+  const precedent = new Map<DocsSweepFileState["group"], boolean>([
+    ["glossary", await docsTrackedPrecedentWithExec(gitCtx, baseRef, "glossary", exec)],
+    ["adr", await docsTrackedPrecedentWithExec(gitCtx, baseRef, "adr", exec)],
+  ]);
+
+  const status = await exec("git", ["status", "--porcelain", "--untracked-files=all", "--ignored=matching", "--", ...DOC_SWEEP_PATHS], { cwd: ctx.root });
+  const files = status.code === 0 ? parseDocsPorcelain(status.stdout, precedent) : [];
+  const byPath = new Map(files.map((f) => [f.path, f]));
+
+  const ahead = await exec("git", ["diff", "--name-only", `${baseRef}...HEAD`, "--", ...DOC_SWEEP_PATHS], { cwd: ctx.root });
+  if (ahead.code === 0) {
+    for (const raw of ahead.stdout.split("\n")) {
+      const path = raw.trim();
+      if (!path || byPath.has(path)) continue;
+      const group = classifyDocsPath(path);
+      if (group !== "glossary" && group !== "adr") continue;
+      byPath.set(path, {
+        path,
+        state: "ahead",
+        group,
+        ignored: false,
+        trackedPrecedent: precedent.get(group) ?? false,
+      });
+    }
+  }
+
+  const plan = planDocsSweep({ base, files: [...byPath.values()] });
+  return plan.files.length > 0 ? { count: plan.files.length } : undefined;
+}
+
 // ---------- reap inputs ----------
 
 import { issueMeta, listIssueStates, type GhContext } from "./gh.js";
@@ -1736,6 +1775,17 @@ function parseDocsPorcelain(stdout: string, precedent: Map<DocsSweepFileState["g
 async function docsTrackedPrecedent(ctx: gitx.GitContext, baseRef: string, group: DocsSweepFileState["group"]): Promise<boolean> {
   if (group !== "glossary" && group !== "adr") return false;
   const r = await execTool("git", ["ls-tree", "-r", "--name-only", baseRef, "--", docsSweepGroupPath(group)], { cwd: ctx.cwd });
+  return r.code === 0 && r.stdout.trim() !== "";
+}
+
+async function docsTrackedPrecedentWithExec(
+  ctx: gitx.GitContext,
+  baseRef: string,
+  group: DocsSweepFileState["group"],
+  exec: typeof execTool,
+): Promise<boolean> {
+  if (group !== "glossary" && group !== "adr") return false;
+  const r = await exec("git", ["ls-tree", "-r", "--name-only", baseRef, "--", docsSweepGroupPath(group)], { cwd: ctx.cwd });
   return r.code === 0 && r.stdout.trim() !== "";
 }
 

--- a/apps/dev/tests/statusline-style.test.ts
+++ b/apps/dev/tests/statusline-style.test.ts
@@ -71,11 +71,12 @@ const input: StatuslineInput = {
   project: { basename: "red-skills", branch: "main", version: "1.2.3" },
   claude,
   repo,
+  docs: { count: 2 },
 };
 
 describe("statusline style — header line", () => {
   it("powerlines » project, model·effort, ctx, 5h/7d usage, prs/iss, +local/-local — reset-terminated", () => {
-    const h = renderHeaderLine(input.project, claude, repo);
+    const h = renderHeaderLine(input.project, claude, repo, undefined, "full", undefined, input.docs);
     expect(h).not.toContain("\n");
     expect(h.endsWith(RESET)).toBe(true);
     expect(h).toContain(WINE2); // project block bg
@@ -91,6 +92,7 @@ describe("statusline style — header line", () => {
     expect(t).toContain("prs=3");
     expect(t).toContain("iss=24");
     expect(t).toContain("loc=+142 -36");
+    expect(t).toContain("doc=2");
   });
 
   it("renders only the usage window that is present (graceful absence)", () => {
@@ -155,6 +157,7 @@ describe("statusline style — header line", () => {
     expect(t).not.toContain("7d=");
     expect(t).not.toContain("prs=");
     expect(t).not.toContain("loc=+142 -36");
+    expect(t).not.toContain("doc=");
   });
 
   it("styles rsp states from the shared render model", () => {
@@ -486,7 +489,7 @@ describe("statusline style — full themed assembly", () => {
       expect(starts[1]).toBe(starts[0]);
     }
     expect(rows[1].indexOf("impl")).toBe(rows[0].indexOf("validation"));
-    expect(header).toBe(renderHeaderLine(input.project, claude, repo));
+    expect(header).toBe(renderHeaderLine(input.project, claude, repo, undefined, "full", undefined, input.docs));
     expect(firstRaw).toContain(KEY);
     expect(secondRaw).toContain(KEY);
     expect(firstRaw).toContain(BOLD);

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -9,6 +9,7 @@ import {
   renderAfkBlock,
   renderContextBlock,
   renderFleetBlock,
+  renderUnlandedDocsBlock,
   renderModelBlock,
   renderProjectBlock,
   renderRepoBlock,
@@ -329,6 +330,14 @@ describe("statusline — fleet block", () => {
   });
 });
 
+describe("statusline — unlanded docs block", () => {
+  it("renders only when the count is non-zero", () => {
+    expect(renderUnlandedDocsBlock({ count: 3 })).toBe("doc=3");
+    expect(renderUnlandedDocsBlock({ count: 0 })).toBeNull();
+    expect(renderUnlandedDocsBlock(undefined)).toBeNull();
+  });
+});
+
 describe("statusline — AFK block", () => {
   it("renders the full token run in the fixed order", () => {
     // case 3: one live worker on #17 with ad12 rm3, blocked 2, cached rq11 rh3.
@@ -500,10 +509,11 @@ describe("statusline — full assembly", () => {
       project: { basename: "red-skills", branch: "main" },
       claude: { model: "Opus", effort: "high", contextTokens: 47000, contextPercent: 24, usage5h: 23, usage7d: 41 },
       repo: { openPrs: 3, openIssues: 24, localAdded: 142, localRemoved: 36 },
+      docs: { count: 2 },
       afk: { workers: 4, queue: 1, human: 11, blocked: 10, added: 12, removed: 3, issues: [17] },
     };
     expect(renderStatusline(input)).toBe(
-      "red-skills (main) · Opus·high · 47k 24% · 5h=23% 7d=41% · prs=3 iss=24 loc=+142 -36 · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
+      "red-skills (main) · Opus·high · 47k 24% · 5h=23% 7d=41% · prs=3 iss=24 loc=+142 -36 · doc=2 · wrk=4 rdy=1 hmn=11 blk=10 loc=+12 -3 #17",
     );
     expect(renderStatuslineWithPreset(input, "full")).toBe(renderStatusline(input));
   });

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -16,6 +16,7 @@ import {
   withTimeout,
   collectStatuslineAfk,
   collectStatuslineRepo,
+  collectStatuslineDocs,
   statuslineCountCachePath,
   STATUSLINE_CACHE_TTL_S,
   applyStatuslineCountCacheLabelDelta,
@@ -1093,6 +1094,35 @@ describe("collectStatuslineRepo — cache discipline", () => {
       // repo → freshly-measured 0/0, overwriting the stale 99/11).
       expect(cache.localAdded).toBe(0);
       expect(cache.localRemoved).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectStatuslineDocs — cached local git state only", () => {
+  it("counts unlanded docs without fetching", async () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-sl-docs-"));
+    try {
+      mkdirSync(join(root, ".red", "contexts", "dev"), { recursive: true });
+      const exec = async (cmd: string, args: readonly string[]): Promise<ExecOutput> => {
+        if (cmd !== "git") return { code: 127, stdout: "", stderr: "unexpected command" };
+        if (args[0] === "fetch") throw new Error("statusline docs collector must not fetch");
+        if (args[0] === "ls-tree") return { code: 0, stdout: ".red/CONTEXT-MAP.md\n", stderr: "" };
+        if (args[0] === "status") {
+          return {
+            code: 0,
+            stdout: " M .red/CONTEXT-MAP.md\n?? .red/contexts/dev/NEW.md\n?? README.md\n",
+            stderr: "",
+          };
+        }
+        if (args[0] === "diff") return { code: 0, stdout: ".red/adr/0100-local.md\nREADME.md\n", stderr: "" };
+        return { code: 1, stdout: "", stderr: "unexpected git command" };
+      };
+
+      await expect(collectStatuslineDocs({ root, repo: "", remote: "origin" }, "main", exec)).resolves.toEqual({
+        count: 3,
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Automated AFK landing for #1680. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1680

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786737354&installation_id=129708444&pr_number=1848&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1848&signature=75a0c19f68f3c40231ef6b39e822a68ec1971a2c6e2831a2c070bf9e243d3e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->