### PR TITLE
fix: #1679 Extract the doc-landing finalizer into a shared procedure referenced by /start, /review-adrs, /context, /reflect

### DIFF
--- a/apps/dev/tests/lane-taxonomy-docs.test.ts
+++ b/apps/dev/tests/lane-taxonomy-docs.test.ts
@@ -22,18 +22,18 @@ describe("writer skill lane taxonomy docs", () => {
   });
 
   it("names the manual and docs worktree lanes explicitly", async () => {
-    const [implement, retake, start] = await Promise.all([
+    const [implement, retake, docLandingFinalizer] = await Promise.all([
       readRepoFile("plugins/dev/skills/engineering/implement/SKILL.md"),
       readRepoFile("plugins/dev/skills/engineering/retake/SKILL.md"),
-      readRepoFile("plugins/dev/skills/engineering/start/SKILL.md"),
+      readRepoFile("plugins/dev/skills/engineering/start/DOC-LANDING-FINALIZER.md"),
     ]);
 
     expect(implement).toContain(".red/tmp/worktrees/manual/<slug>");
     expect(implement).toContain("git worktree add .red/tmp/worktrees/manual/<slug>");
     expect(retake).toContain(".red/tmp/worktrees/manual/<slug>");
     expect(retake).toContain("no-agent landing lane");
-    expect(start).toContain(".red/tmp/worktrees/docs/<slug>");
-    expect(start).toContain("docs-<YYYYMMDD>-<slug>");
+    expect(docLandingFinalizer).toContain(".red/tmp/worktrees/docs/<slug>");
+    expect(docLandingFinalizer).toContain("docs-<YYYYMMDD>-<slug>");
   });
 
   it("points branch-lock docs at the state tier while noting legacy readers", async () => {

--- a/apps/dev/tests/review-adrs-docs.test.ts
+++ b/apps/dev/tests/review-adrs-docs.test.ts
@@ -8,6 +8,10 @@ async function readReviewAdrsSkill(): Promise<string> {
   return readFile(join(ROOT, "plugins/dev/skills/engineering/review-adrs/SKILL.md"), "utf8");
 }
 
+async function readSkill(path: string): Promise<string> {
+  return readFile(join(ROOT, path), "utf8");
+}
+
 describe("review-adrs docs contract", () => {
   it("requires linting fetched origin default branch instead of the working tree", async () => {
     const skill = await readReviewAdrsSkill();
@@ -18,5 +22,17 @@ describe("review-adrs docs contract", () => {
     expect(skill).toContain("git show");
     expect(skill).toContain("do **not** inspect `.red/adr/` from the working tree");
     expect(skill).toContain("Use local `HEAD` only when no `origin` remote/ref exists");
+  });
+
+  it("points doc-writing skills at the shared doc-landing finalizer", async () => {
+    const start = await readSkill("plugins/dev/skills/engineering/start/SKILL.md");
+    const reviewAdrs = await readSkill("plugins/dev/skills/engineering/review-adrs/SKILL.md");
+    const context = await readSkill("plugins/dev/skills/engineering/context/SKILL.md");
+    const reflect = await readSkill("plugins/dev/skills/productivity/reflect/SKILL.md");
+
+    for (const skill of [start, reviewAdrs, context, reflect]) {
+      expect(skill).toContain("shared end-of-session doc-landing finalizer");
+      expect(skill).toContain("DOC-LANDING-FINALIZER.md");
+    }
   });
 });

--- a/apps/dev/tests/start-docs.test.ts
+++ b/apps/dev/tests/start-docs.test.ts
@@ -8,33 +8,45 @@ async function readStartSkill(): Promise<string> {
   return readFile(join(ROOT, "plugins/dev/skills/engineering/start/SKILL.md"), "utf8");
 }
 
+async function readDocLandingProcedure(): Promise<string> {
+  return readFile(join(ROOT, "plugins/dev/skills/engineering/start/DOC-LANDING-FINALIZER.md"), "utf8");
+}
+
 describe("start docs contract", () => {
-  it("requires the end-of-session doc-landing finalizer", async () => {
+  it("references the shared end-of-session doc-landing finalizer", async () => {
     const skill = await readStartSkill();
 
     expect(skill).toContain("end-of-session doc-landing finalizer");
-    expect(skill).toContain("Stop when the user says stop");
-    expect(skill).toContain(".red/CONTEXT-MAP.md");
-    expect(skill).toContain(".red/contexts/**");
-    expect(skill).toContain(".red/adr/**");
-    expect(skill).toContain("Announce the file list");
-    expect(skill).toContain("ADR numbers");
-    expect(skill).toContain("decline leaves the docs unlanded");
-    expect(skill).toContain("base resolved lock > pin > main");
-    expect(skill).toContain("worktree under `.red/tmp/worktrees/docs/<slug>`");
-    expect(skill).toContain("docs-<YYYYMMDD>-<slug>");
-    expect(skill).toContain("docs:");
-    expect(skill).toContain("one batch PR per session");
-    expect(skill).toContain("no doc changes skips the finalizer silently");
+    expect(skill).toContain("DOC-LANDING-FINALIZER.md");
+    expect(skill).not.toContain("create one worktree under `.red/tmp/worktrees/docs/<slug>`");
+  });
+
+  it("keeps the shared end-of-session doc-landing finalizer contract", async () => {
+    const procedure = await readDocLandingProcedure();
+
+    expect(procedure).toContain("end-of-session doc-landing finalizer");
+    expect(procedure).toContain("the user stops or every reachable branch is resolved");
+    expect(procedure).toContain(".red/CONTEXT-MAP.md");
+    expect(procedure).toContain(".red/contexts/**");
+    expect(procedure).toContain(".red/adr/**");
+    expect(procedure).toContain("Announce the file list");
+    expect(procedure).toContain("ADR numbers");
+    expect(procedure).toContain("decline leaves the docs unlanded");
+    expect(procedure).toContain("base resolved lock > pin > main");
+    expect(procedure).toContain("worktree under `.red/tmp/worktrees/docs/<slug>`");
+    expect(procedure).toContain("docs-<YYYYMMDD>-<slug>");
+    expect(procedure).toContain("docs:");
+    expect(procedure).toContain("one batch PR per session");
+    expect(procedure).toContain("no doc changes skips the finalizer silently");
   });
 
   it("keeps the primary-checkout safety prohibitions explicit", async () => {
-    const skill = await readStartSkill();
+    const procedure = await readDocLandingProcedure();
 
-    expect(skill).toContain("never commit in the primary checkout");
-    expect(skill).toContain("never switch its branch");
-    expect(skill).toContain("never stash");
-    expect(skill).toContain("never reset");
+    expect(procedure).toContain("never commit in the primary checkout");
+    expect(procedure).toContain("never switch its branch");
+    expect(procedure).toContain("never stash");
+    expect(procedure).toContain("never reset");
   });
 
   it("carries the facts-vs-decisions distinction in the hard rules", async () => {

--- a/plugins/dev/skills/engineering/context/SKILL.md
+++ b/plugins/dev/skills/engineering/context/SKILL.md
@@ -103,6 +103,10 @@ Before moving into implementation, summarize:
 
 Keep this summary concise. The goal is to prove the agent is grounded, not to dump every artifact.
 
+### 9. End-of-session doc-landing finalizer
+
+When the context session ends, run the shared end-of-session doc-landing finalizer in [`/start`'s DOC-LANDING-FINALIZER.md](../start/DOC-LANDING-FINALIZER.md) before exiting.
+
 ## Hard rules
 
 - Do not let graph or memory output outrank the current worktree.

--- a/plugins/dev/skills/engineering/review-adrs/SKILL.md
+++ b/plugins/dev/skills/engineering/review-adrs/SKILL.md
@@ -88,6 +88,10 @@ Hand the accumulated agreed actions to `/to-spec`:
 
 Publish with `type:spec` + `needs-slicing` (never `ready-for-agent` — `/to-spec` handles the labels). Then in chat: a short receipt of each `Q##` and the action it produced, the link to the published Spec, what was **deferred** (left out), and the single highest-impact finding to reconcile first.
 
+### End-of-session doc-landing finalizer
+
+When the ADR review session ends, run the shared end-of-session doc-landing finalizer in [`/start`'s DOC-LANDING-FINALIZER.md](../start/DOC-LANDING-FINALIZER.md) before exiting.
+
 </what-to-do>
 
 <supporting-info>

--- a/plugins/dev/skills/engineering/start/DOC-LANDING-FINALIZER.md
+++ b/plugins/dev/skills/engineering/start/DOC-LANDING-FINALIZER.md
@@ -1,0 +1,9 @@
+# End-of-session doc-landing finalizer
+
+When a doc-writing session ends (the user stops or every reachable branch is resolved), run one end-of-session doc-landing finalizer before exiting:
+
+1. Detect modified or untracked docs in the primary checkout across the domain glossary (`.red/CONTEXT.md`, `.red/CONTEXT-MAP.md`, `.red/contexts/**`) and ADRs (`.red/adr/**`). A session with no doc changes skips the finalizer silently.
+2. If docs changed, do this first: Announce the file list and ADR numbers to the user, and accept a decline. A decline leaves the docs unlanded; the cascade gate remains the enforcement point.
+3. If accepted, land the docs through the standard docs-worktree lane: create one worktree under `.red/tmp/worktrees/docs/<slug>` from a freshly fetched `origin/{base}` (base resolved lock > pin > main), using the name pattern `docs-<YYYYMMDD>-<slug>` for the worktree slug, copy only the dirty doc files into that worktree, commit them as a `docs:`-typed change, push the branch, open a PR, merge it, and rely on the existing post-landing fast-forward to bring the local base up.
+4. Restate these safety prohibitions before landing: never commit in the primary checkout, never switch its branch, never stash, never reset.
+5. Land at most one batch PR per session.

--- a/plugins/dev/skills/engineering/start/SKILL.md
+++ b/plugins/dev/skills/engineering/start/SKILL.md
@@ -20,13 +20,7 @@ Walk down each branch of the design tree, resolving dependencies between decisio
 
 ## End-of-session doc-landing finalizer
 
-When the grilling session ends (the user stops or every reachable branch is resolved), run one end-of-session doc-landing finalizer before exiting:
-
-1. Detect modified or untracked docs in the primary checkout across the domain glossary (`.red/CONTEXT.md`, `.red/CONTEXT-MAP.md`, `.red/contexts/**`) and ADRs (`.red/adr/**`). A session with no doc changes skips the finalizer silently.
-2. If docs changed, do this first: Announce the file list and ADR numbers to the user, and accept a decline. A decline leaves the docs unlanded; the cascade gate remains the enforcement point.
-3. If accepted, land the docs through the standard docs-worktree lane: create one worktree under `.red/tmp/worktrees/docs/<slug>` from a freshly fetched `origin/{base}` (base resolved lock > pin > main), using the name pattern `docs-<YYYYMMDD>-<slug>` for the worktree slug, copy only the dirty doc files into that worktree, commit them as a `docs:`-typed change, push the branch, open a PR, merge it, and rely on the existing post-landing fast-forward to bring the local base up.
-4. Restate these safety prohibitions before landing: never commit in the primary checkout, never switch its branch, never stash, never reset.
-5. Land at most one batch PR per session.
+When the grilling session ends (the user stops or every reachable branch is resolved), run the shared end-of-session doc-landing finalizer in [DOC-LANDING-FINALIZER.md](./DOC-LANDING-FINALIZER.md) before exiting.
 
 ## Boot behavior (turn 1 — first invocation only)
 

--- a/plugins/dev/skills/productivity/reflect/SKILL.md
+++ b/plugins/dev/skills/productivity/reflect/SKILL.md
@@ -13,4 +13,6 @@ Ask the questions one at a time. Wait for the user's reply before proceeding.
 
 If a question can be answered by exploring the codebase, explore the codebase instead of asking.
 
+When the reflection session ends, run the shared end-of-session doc-landing finalizer in [`/start`'s DOC-LANDING-FINALIZER.md](../../engineering/start/DOC-LANDING-FINALIZER.md) before exiting.
+
 </what-to-do>


### PR DESCRIPTION
Automated AFK landing for #1679. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1679

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786738015&installation_id=129708444&pr_number=1849&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1849&signature=4006b811ac2e647c2df9b31ceb69d2a939e5719674a8e03cb758efa80f9c6b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->