### PR TITLE
fix: #1716 rsp physical store cap: on-disk file bound with generation rotation and clean format cutover

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -388,9 +388,31 @@ export class RspElisionStore {
   }
 
   private async flush(): Promise<void> {
-    if (!this.dirty) return;
+    if (this.dirty) {
+      await writeStoreDocument(this.path, this.document);
+      this.dirty = false;
+    }
+    await this.rotateLocalGenerationIfOversized();
+  }
+
+  private async rotateLocalGenerationIfOversized(): Promise<void> {
+    const currentBytes = await stat(this.path).then((value) => value.size, () => 0);
+    if (currentBytes <= this.opts.byteBudget) return;
+    const live = this.readIndex().records;
+    const liveKeys = new Set(live.map((entry) => entry.key));
+    const liveBlobKeys = new Set(live.map((entry) => entry.blob_key).filter((key): key is string => typeof key === "string"));
+    const compacted: StoreDocument = {
+      version: 1,
+      records: Object.fromEntries(Object.entries(this.document.records).filter(([key]) => liveKeys.has(key))),
+      blobs: Object.fromEntries(Object.entries(this.document.blobs).filter(([key]) => liveBlobKeys.has(key))),
+      tombstones: {},
+      index: { version: 1, records: live },
+    };
+    const compactedBytes = Buffer.byteLength(`${JSON.stringify(compacted)}\n`, "utf8");
+    if (compactedBytes > this.opts.byteBudget) return;
+    if (compactedBytes >= currentBytes) return;
+    this.document = compacted;
     await writeStoreDocument(this.path, this.document);
-    this.dirty = false;
   }
 
   private kv() {
@@ -430,47 +452,8 @@ export class RspElisionStore {
       throw new Error(`cannot self-heal elision collection ${RSP_ELISION_COLLECTION}: unsupported model ${meta.model}`);
     }
 
-    const migrated = await this.readLegacyElisionTableRows();
     await this.db.query(`DROP TABLE ${RSP_ELISION_COLLECTION}`);
     await this.db.query(`CREATE KV IF NOT EXISTS ${RSP_ELISION_COLLECTION}`);
-    for (const entry of migrated) {
-      await this.kv().put(entry.key, entry.value);
-    }
-    await this.ensureMigratedRedDbIndex(migrated);
-  }
-
-  private async readLegacyElisionTableRows(): Promise<Array<{ key: string; value: unknown }>> {
-    if (!this.db) throw new Error("rsp RedDB store is not open");
-    const result = await this.db.query(`SELECT * FROM ${RSP_ELISION_COLLECTION}`);
-    const migrated: Array<{ key: string; value: unknown }> = [];
-    for (const row of result.rows) {
-      const entry = legacyElisionRowToKvEntry(row);
-      if (entry) migrated.push(entry);
-    }
-    return migrated;
-  }
-
-  private async ensureMigratedRedDbIndex(migrated: Array<{ key: string; value: unknown }>): Promise<void> {
-    const hasIndex = migrated.some((entry) => entry.key === indexKey() && isIndexDocument(parseKvValue(entry.value)));
-    if (hasIndex) return;
-    const records = migrated
-      .map((entry): IndexEntry | null => {
-        const record = parseKvValue(entry.value);
-        if (!isStoredRecord(record)) return null;
-        return {
-          handle: record.handle,
-          key: recordKey(record.handle),
-          bytes: storedBytesForRecord(record),
-          raw_bytes: record.original_bytes,
-          command: record.command,
-          created_at: record.created_at,
-          expires_at: record.expires_at,
-          storage_class: storageClassForRecord(record),
-          blob_key: record.blob_key,
-        };
-      })
-      .filter((entry): entry is IndexEntry => entry != null);
-    await this.writeRedDbIndex({ version: 1, records });
   }
 
   private async mintRedDb(original: Uint8Array | Buffer, meta: RspMintMeta): Promise<`el:${string}`> {
@@ -1047,30 +1030,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function legacyElisionRowToKvEntry(row: unknown): { key: string; value: unknown } | null {
-  if (!isPlainObject(row)) return null;
-  if (typeof row.key === "string" && row.key.trim() !== "") {
-    return { key: row.key, value: parseKvValue(row.value) };
-  }
-  if (typeof row.record_key === "string" && row.record_key.trim() !== "") {
-    return { key: row.record_key, value: parseKvValue(row.value) };
-  }
-  if (isStoredRecord(row)) return { key: recordKey(row.handle), value: row };
-  if (isExpiredHandle(row) && typeof row.handle === "string" && isHandle(row.handle)) {
-    return { key: tombstoneKey(row.handle), value: row };
-  }
-  return null;
-}
-
-function parseKvValue(value: unknown): unknown {
-  if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return value;
-  }
-}
-
 interface ResidentRecallHit {
   id: string;
   rid: number;
@@ -1240,30 +1199,22 @@ async function readStoreDocument(path: string): Promise<StoreDocument> {
       await writeStoreDocument(path, document);
       return document;
     }
-    throw err;
+    const document = emptyStoreDocument();
+    await writeStoreDocument(path, document);
+    return document;
   }
-  throw new Error("rsp elision store is unreadable");
+  const document = emptyStoreDocument();
+  await writeStoreDocument(path, document);
+  return document;
 }
 
 async function writableStorePath(path: string): Promise<string> {
   try {
-    const bytes = await readFile(path);
-    if (usesEmbeddedRedDb(path)) return path;
-    if (isLegacyRedDbStore(bytes)) return legacyRedDbFallbackPath(path);
     return path;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return path;
     throw err;
   }
-}
-
-function isLegacyRedDbStore(bytes: Buffer): boolean {
-  return bytes.subarray(0, 8).toString("ascii") === "RDBSBLK1";
-}
-
-function legacyRedDbFallbackPath(path: string): string {
-  if (basename(path) === "red.rdb") return join(dirname(path), "tmp", "rsp-elisions.json");
-  return `${path}.json`;
 }
 
 function usesEmbeddedRedDb(path: string): boolean {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -2272,7 +2272,7 @@ describe("rsp cli", () => {
     await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).resolves.toMatchObject({ size: expect.any(Number) });
   }, 120_000);
 
-  it("built bundle redirects a configured legacy RedDB store to JSON without mutating it", async () => {
+  it("built bundle cuts over a configured legacy RedDB store without a sidecar migration", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
     await commitMany(root, 12);
@@ -2290,8 +2290,9 @@ describe("rsp cli", () => {
     expect(compressed.status).toBe(0);
     expect(compressed.stderr).toEqual(Buffer.alloc(0));
     expect(compressed.stdout.toString("utf8")).toMatch(/rsp show el:[a-f0-9]{12}/);
-    await expect(readFile(legacyPath)).resolves.toEqual(legacyBytes);
-    await expect(stat(join(root, ".red", "tmp", "rsp-elisions.json"))).resolves.toMatchObject({ size: expect.any(Number) });
+    await expect(readFile(legacyPath)).resolves.not.toEqual(legacyBytes);
+    await expect(readFile(legacyPath, "utf8")).resolves.toContain("\"version\":1");
+    await expect(stat(join(root, ".red", "tmp", "rsp-elisions.json"))).rejects.toMatchObject({ code: "ENOENT" });
   }, 120_000);
 
   it("passes through wrappers when rsp hits an internal wrapper error after opening the store", async () => {

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -421,6 +421,108 @@ describe("RspElisionStore", () => {
     }
   });
 
+  it("compacts the on-disk store after repeated mint-expire-sweep cycles", async () => {
+    let now = new Date("2026-07-10T12:00:00.000Z");
+    const root = await tempRoot();
+    const storePath = join(root, "red.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      byteBudget: 2_000,
+      ephemeralTtlHours: 1,
+      now: () => now,
+    });
+    try {
+      for (let cycle = 0; cycle < 24; cycle += 1) {
+        await store.mint(Buffer.from(`cycle ${cycle} ${"x".repeat(256)}`), {
+          command: `node noisy-${cycle}.mjs`,
+          loss: { level: "terse", bytes_elided: 256 },
+        });
+        now = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+        await store.stats();
+      }
+
+      expect((await stat(storePath)).size).toBeLessThanOrEqual(2_000);
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("rotates to a compact generation while preserving live records and degraded old-handle semantics", async () => {
+    let now = new Date("2026-07-10T12:00:00.000Z");
+    const root = await tempRoot();
+    const storePath = join(root, "red.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      byteBudget: 2_400,
+      ephemeralTtlHours: 1,
+      now: () => now,
+    });
+    try {
+      const expired: `el:${string}`[] = [];
+      for (let cycle = 0; cycle < 16; cycle += 1) {
+        expired.push(await store.mint(Buffer.from(`expired ${cycle} ${"x".repeat(128)}`), {
+          command: `node expired-${cycle}.mjs`,
+          loss: { level: "terse", bytes_elided: 128 },
+        }));
+        now = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+        await store.stats();
+      }
+
+      const live = await store.mint(Buffer.from("live record"), {
+        command: "node live.mjs",
+        loss: { level: "terse", bytes_elided: 11 },
+      });
+      await store.stats();
+
+      const recovered = await store.get(live);
+      if (!recovered || "status" in recovered) throw new Error("expected live record after rotation");
+      expect(recovered.original).toEqual(Buffer.from("live record"));
+      expect((await stat(storePath)).size).toBeLessThanOrEqual(2_400);
+      expect(await store.get(expired[0]!)).toBeNull();
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("cuts over an old-format json store by discarding it instead of migrating records", async () => {
+    const root = await tempRoot();
+    const storePath = join(root, "red.rdb");
+    await writeFile(storePath, JSON.stringify({
+      version: 0,
+      records: {
+        "record:123456789abc": {
+          collection: RSP_ELISION_COLLECTION,
+          handle: "el:123456789abc",
+          original: Buffer.from("legacy payload").toString("base64"),
+          original_encoding: "base64",
+          original_bytes: 14,
+          command: "git diff",
+          created_at: "2026-07-10T12:00:00.000Z",
+          expires_at: "2026-07-17T12:00:00.000Z",
+          loss: { level: "terse", bytes_elided: 14 },
+        },
+      },
+      tombstones: {},
+      index: { version: 1, records: [] },
+    }), "utf8");
+
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      now: () => new Date("2026-07-10T12:00:00.000Z"),
+    });
+    try {
+      await expect(store.get("el:123456789abc")).resolves.toBeNull();
+      const handle = await store.mint(Buffer.from("fresh"), {
+        command: "node fresh.mjs",
+        loss: { level: "terse", bytes_elided: 5 },
+      });
+      await expect(store.get(handle)).resolves.toMatchObject({ handle });
+    } finally {
+      await store.close();
+    }
+  });
+
   it("reports live store stats as scalar values", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -767,7 +767,7 @@ describe("rsp telemetry spool", () => {
     );
   }, 40_000);
 
-  it("self-heals old-model rsp collections in the built bundle resident without losing elisions", async () => {
+  it("self-heals old-model rsp collections in the built bundle resident with clean elision cutover", async () => {
     const root = await tempRoot();
     const bundle = await ensureRspBundle();
     const storeUri = `file://${join(root, ".red", "tmp", "red-skills.rdb")}`;
@@ -839,11 +839,7 @@ describe("rsp telemetry spool", () => {
       { id: "recover-legacy-elision", op: "get", handle: legacyHandle },
     )).resolves.toMatchObject({
       ok: true,
-      value: expect.objectContaining({
-        handle: legacyHandle,
-        original: Buffer.from("legacy recoverable elision").toString("base64"),
-        original_encoding: "base64",
-      }),
+      value: null,
     });
     await new Promise<void>((resolve, reject) => {
       child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`bundle resident exited ${code}`)));
@@ -875,6 +871,13 @@ describe("rsp telemetry spool", () => {
       [RSP_TELEMETRY_DEGRADATIONS_COLLECTION]: "kv",
       [RSP_TELEMETRY_INDEX_COLLECTION]: "kv",
     });
+
+    const degraded = spawnSync(process.execPath, [bundle, "--store-uri", storeUri, "show", legacyHandle], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(degraded.status).toBe(1);
+    expect(degraded.stdout).toBe(`expired unknown — re-run: ${legacyHandle}\n`);
   }, 40_000);
 
   it("periodically drains telemetry spooled while the built bundle resident is alive and reports stats", async () => {


### PR DESCRIPTION
Automated AFK landing for #1716. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1716

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786740588&installation_id=129708444&pr_number=1850&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1850&signature=823bacb7aa208ba2f16b265f1e1799262e9790cfe54b282b8d2e3c6dab473024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->