### PR TITLE
fix: #1704 rsp elision store grows unboundedly: 819MB rdb for 80KB live data, no compaction, ~100MB/day idle churn

### DIFF
--- a/apps/rsp/src/elision-store.ts
+++ b/apps/rsp/src/elision-store.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, readdir, rename, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -132,6 +132,11 @@ interface StoreDocument {
   blobs: Record<string, StoredBlob>;
   tombstones: Record<string, RspExpiredHandle>;
   index: IndexDocument;
+}
+
+interface RedDbKvCollectionSnapshot {
+  name: string;
+  items: Array<{ key: string; value: unknown }>;
 }
 
 export class RspElisionStore {
@@ -701,7 +706,92 @@ export class RspElisionStore {
       await this.writeRedDbIndex(next);
     }
     await this.deleteUnreferencedRedDbBlobs(live);
+    await this.rotateRedDbGenerationIfOversized(next);
     return next;
+  }
+
+  private async rotateRedDbGenerationIfOversized(index: IndexDocument): Promise<void> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    const currentBytes = await stat(this.path).then((value) => value.size, () => 0);
+    if (currentBytes <= this.opts.byteBudget) return;
+
+    const snapshot = await this.snapshotRedDbKvCollections(index);
+    if (!snapshot) return;
+
+    const suffix = `${process.pid}.${Date.now()}`;
+    const compactPath = `${this.path}.${suffix}.compact`;
+    const backupPath = `${this.path}.${suffix}.old`;
+    await rm(compactPath, { force: true });
+    await rm(backupPath, { force: true });
+
+    const compactDb = await connect(`file://${compactPath}`);
+    try {
+      for (const collection of snapshot) {
+        await compactDb.query(`CREATE KV IF NOT EXISTS ${redDbIdentifier(collection.name)}`);
+        const kv = compactDb.kv(collection.name);
+        for (const item of collection.items) await kv.put(item.key, item.value);
+      }
+    } finally {
+      await compactDb.close();
+    }
+
+    const compactBytes = await stat(compactPath).then((value) => value.size, () => 0);
+    if (compactBytes === 0 || compactBytes > this.opts.byteBudget || compactBytes >= currentBytes) {
+      await rm(compactPath, { force: true });
+      return;
+    }
+
+    await this.db.close();
+    this.db = undefined;
+    try {
+      await rename(this.path, backupPath);
+      await rename(compactPath, this.path);
+      await rm(backupPath, { force: true });
+    } catch (err) {
+      if (!existsSync(this.path) && existsSync(backupPath)) {
+        await rename(backupPath, this.path);
+      }
+      await rm(compactPath, { force: true });
+      throw err;
+    } finally {
+      this.db = await connect(`file://${this.path}`);
+    }
+  }
+
+  private async snapshotRedDbKvCollections(index: IndexDocument): Promise<RedDbKvCollectionSnapshot[] | null> {
+    if (!this.db) throw new Error("rsp RedDB store is not open");
+    const collections = await this.db.list();
+    if (collections.some((collection) => collection.model !== "kv")) return null;
+
+    const snapshots: RedDbKvCollectionSnapshot[] = [];
+    let sawElisionCollection = false;
+    for (const collection of collections) {
+      const name = String(collection.name ?? "").trim();
+      if (name === RSP_ELISION_COLLECTION) {
+        snapshots.push(await this.snapshotRedDbElisions(index));
+        sawElisionCollection = true;
+        continue;
+      }
+      const listed = await this.db.kv(name).list({ limit: 10_000 });
+      if (listed.items.length >= 10_000) return null;
+      snapshots.push({ name, items: listed.items });
+    }
+    if (!sawElisionCollection) snapshots.push(await this.snapshotRedDbElisions(index));
+    return snapshots;
+  }
+
+  private async snapshotRedDbElisions(index: IndexDocument): Promise<RedDbKvCollectionSnapshot> {
+    const items: Array<{ key: string; value: unknown }> = [{ key: indexKey(), value: index }];
+    const keys = new Set<string>();
+    for (const entry of index.records) {
+      keys.add(entry.key);
+      if (entry.blob_key) keys.add(entry.blob_key);
+    }
+    for (const key of keys) {
+      const value = await this.kvGet(key);
+      if (value != null) items.push({ key, value });
+    }
+    return { name: RSP_ELISION_COLLECTION, items };
   }
 
   private async expireRedDbEntry(entry: IndexEntry, expiredAt: string): Promise<void> {
@@ -761,6 +851,11 @@ function indexKey(): string {
 
 function blobKey(hash: string): string {
   return `blob:${hash}`;
+}
+
+function redDbIdentifier(value: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`invalid RedDB identifier: ${value}`);
+  return value;
 }
 
 export function storageClassForCommand(command: string): RspStorageClass {

--- a/apps/rsp/tests/elision-store.test.ts
+++ b/apps/rsp/tests/elision-store.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -442,6 +443,33 @@ describe("RspElisionStore", () => {
       }
 
       expect((await stat(storePath)).size).toBeLessThanOrEqual(2_000);
+      await expect(store.stats()).resolves.toMatchObject({ records: 0 });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("bounds the embedded RedDB file after repeated mint-expire-sweep cycles", async () => {
+    let now = new Date("2026-07-10T12:00:00.000Z");
+    const root = await tempRoot();
+    const storePath = join(root, "red-skills.rdb");
+    const store = await RspElisionStore.open({
+      uri: `file://${storePath}`,
+      byteBudget: 512 * 1024,
+      ephemeralTtlHours: 1,
+      now: () => now,
+    });
+    try {
+      for (let cycle = 0; cycle < 20; cycle += 1) {
+        await store.mint(randomBytes(64 * 1024), {
+          command: `node noisy-${cycle}.mjs`,
+          loss: { level: "terse", bytes_elided: 64 * 1024 },
+        });
+        now = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+        await store.stats();
+      }
+
+      expect((await stat(storePath)).size).toBeLessThanOrEqual(512 * 1024);
       await expect(store.stats()).resolves.toMatchObject({ records: 0 });
     } finally {
       await store.close();


### PR DESCRIPTION
Automated AFK landing for #1704. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1704

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786741879&installation_id=129708444&pr_number=1852&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1852&signature=9a36ecb19b7d8bc33c624cd5c830c0d6536810963a3df61ce649571b7734d2fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->