### PR TITLE
fix: #1699 upstream pin bump to 66898f60 + record deliberate divergences

### DIFF
--- a/.upstream
+++ b/.upstream
@@ -1,2 +1,2 @@
 repo=mattpocock/skills
-sha=d574778f94cf620fcc8ce741584093bc650a61d3
+sha=66898f60e8c744e269f8ce06c2b2b99ce7660d5f

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,30 @@
 
 Records every change made to skills inherited from [`mattpocock/skills`](https://github.com/mattpocock/skills), plus new skills created by reddb.io. See the rules in [CLAUDE.md](./CLAUDE.md).
 
-Upstream base: `mattpocock/skills@d574778f94cf620fcc8ce741584093bc650a61d3` (v1.1.0 tag commit; see `.upstream`).
+Upstream base: `mattpocock/skills@66898f60e8c744e269f8ce06c2b2b99ce7660d5f` (reviewed 33 commits after v1.1.0; see `.upstream`).
+
+---
+
+## wayfinder (engineering) — research children stay in the AFK fleet (issue #1699)
+
+- **status**: not-adopted
+- **upstream**: `66898f6` (upstream `wayfinder`; 33-commit delta from `d574778f`)
+- **why**: Upstream now starts in-session `/research` subagents in parallel while charting a wayfinder map. RedSkills deliberately routes research children through the AFK fleet instead: isolated worktrees, shared validation gate, and PR-backed results are the stronger contract for repo-affecting autonomous work.
+- **what changed**: Reviewed upstream commit `2602257` and recorded the divergence. No upstream skill content was imported in this slice; future syncs must not replace the AFK fleet route with in-session research subagents.
+
+## skill metadata — per-skill `agents/openai.yaml` files not adopted (issue #1699)
+
+- **status**: not-adopted
+- **upstream**: `66898f6` (upstream `agents/openai.yaml` metadata; 33-commit delta from `d574778f`)
+- **why**: Upstream added hand-authored Codex metadata beside every skill. RedSkills derives Codex plugin manifests from the canonical plugin manifests with `scripts/generate-codex-manifests.mjs`, keeping host metadata generated and checked instead of duplicating per-skill files.
+- **what changed**: Reviewed upstream commit `697d4ce` and recorded the divergence. No `agents/openai.yaml` files were added; future syncs should preserve the generated-manifest path unless that generator contract changes.
+
+## to-tickets (engineering) — upstream local-file mode remains irrelevant (issue #1699)
+
+- **status**: not-adopted
+- **upstream**: `66898f6` (upstream `to-tickets` local tracker; 33-commit delta from `d574778f`)
+- **why**: Upstream changed its local-file tracker to write one markdown file per ticket. RedSkills publishes tracked work to GitHub Issues, adds native sub-issue and dependency edges, and uses `ready-for-agent`, `blocked:dependency`, and `req:N` labels for AFK queue semantics, so upstream's local markdown storage shape is not part of our runtime contract.
+- **what changed**: Reviewed upstream commit `44eed54` and recorded the divergence. No local-file ticket mode was imported in this slice; GitHub Issues remains the supported publication surface for RedSkills backlog slices.
 
 ---
 


### PR DESCRIPTION
Closes #1699.

Bumps `.upstream` to `mattpocock/skills@66898f60` and records the deliberate divergences from the 33-commit delta in `CHANGES.md` (wayfinder research → AFK fleet route; generated Codex manifests vs per-skill `agents/openai.yaml`; to-tickets local-file mode; etc.). Diff is `.upstream` + `CHANGES.md` only — no code.

## Why landed via PR+CI (not the AFK worker gate)
Two AFK attempts parked `blocked:validation` on a single `@reddb-io/rsp` test failure (1 failed / 294 passed) — a load-induced flake in rsp's process-spawning resident/telemetry suite (7min under 2 concurrent workers vs ~2min green in clean CI). This issue touches no rsp code, so the failure is unrelated. CI validates in the clean environment where the flake does not trigger.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786744254&installation_id=129708444&pr_number=1853&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1853&signature=7fbfa4898855c10dbc6f40c3f2c748c16f22177b18ab1eced0fe64bbedd3e008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->