### PR TITLE
docs: #1701 ADR 0094 native blocked-by frontier shadow-check evidence

### DIFF
--- a/.red/adr/evidence/0094-issue-1701-native-frontier-shadow-check.md
+++ b/.red/adr/evidence/0094-issue-1701-native-frontier-shadow-check.md
@@ -1,0 +1,97 @@
+# ADR 0094 evidence: native blocked-by frontier shadow check
+
+Issue: #1701
+Parent Spec: #1697
+Observed window: 2026-07-14T04:02:17Z through 2026-07-14T04:22:25Z
+
+## Scope
+
+This was a read-only replay of one real AFK drain window for the #1697 child
+tracker. The comparison used two frontier definitions:
+
+- Label frontier: a ticket is dependency-unblocked when it has no `req:N`
+  labels, or every `req:N` target was closed at the observation time.
+- Native frontier: a ticket is dependency-unblocked when GitHub's
+  `issue_dependencies_summary.blocked_by` open-blocker count is `0`.
+
+Non-dependency gates such as `blocked:validation` were kept out of the
+dependency-frontier decision. They can keep a ticket out of `ready-for-agent`,
+but they do not change whether dependency blockers are open.
+
+## Evidence
+
+Native edge timing was present before the drain:
+
+- #1700 had native blocked-by #1698 and label `req:1698` before #1698 closed.
+- #1701 had native blocked-by #1700 and label `req:1700` before #1700 closed.
+
+Close and cascade timing:
+
+- #1698 closed at 2026-07-14T04:02:18Z. #1700 shed
+  `blocked:dependency` and `req:1698`, then gained `ready-for-agent`, at
+  2026-07-14T04:02:29Z.
+- #1700 closed at 2026-07-14T04:22:12Z. #1701 shed
+  `blocked:dependency` and `req:1700`, then gained `ready-for-agent`, at
+  2026-07-14T04:22:24Z.
+
+Primary dependency-edge observations:
+
+| Observation | Label frontier | Native frontier | Result |
+| --- | --- | --- | --- |
+| 2026-07-14T04:02:17Z, before #1698 close | #1700 blocked by open `req:1698`; #1701 blocked by open `req:1700` | #1700 blocked by open #1698; #1701 blocked by open #1700 | 2/2 agree |
+| 2026-07-14T04:02:24Z, after #1698 close and before label cascade | #1700 unblocked because `req:1698` pointed at a closed issue; #1701 still blocked by open `req:1700` | #1700 `blocked_by == 0`; #1701 `blocked_by == 1` | 2/2 agree |
+| 2026-07-14T04:02:30Z, after #1700 promotion | #1700 had no `req:N`; #1701 still blocked by open `req:1700` | #1700 `blocked_by == 0`; #1701 `blocked_by == 1` | 2/2 agree |
+| 2026-07-14T04:22:11Z, before #1700 close | #1700 unblocked; #1701 blocked by open `req:1700` | #1700 `blocked_by == 0`; #1701 `blocked_by == 1` | 2/2 agree |
+| 2026-07-14T04:22:18Z, after #1700 close and before label cascade | #1701 unblocked because `req:1700` pointed at a closed issue | #1701 `blocked_by == 0` | 1/1 agree |
+| 2026-07-14T04:22:25Z, after #1701 promotion | #1701 had no `req:N` | #1701 `blocked_by == 0` | 1/1 agree |
+
+Primary dependency-edge total: 10/10 agreements, 0 divergences.
+
+Whole #1697 open-child dependency frontier:
+
+- Including no-dependency siblings that existed during the same observations
+  (#1698 before it closed, and #1699 throughout the window), the replay had
+  17/17 dependency-frontier agreements.
+- The #1699 validation gate was intentionally not counted as a dependency
+  divergence: it had no open `req:N` blockers and no open native blockers.
+
+Current static cross-check after the replay:
+
+- Current open non-Spec tracker tickets checked: 9.
+- Open dependency-frontier agreements: 9/9.
+- Some open tickets retain closed native historical blockers in
+  `total_blocked_by`, but their `blocked_by` open-blocker count is `0`; this
+  matches the label frontier after `req:N` labels are shed or point only at
+  closed blockers.
+
+Combined observed total: 26/26 agreements.
+
+## Divergences
+
+No frontier divergences were found.
+
+- Missing native edge: none observed in the replay window.
+- Stale label causing disagreement: none observed.
+- Timing skew around close cascade: observed twice, but not divergent. During
+  both skew intervals, the remaining `req:N` label already pointed at a closed
+  blocker, so the label frontier became unblocked at the same point as
+  GitHub's open-blocker count.
+
+## Open-blocker semantics
+
+GitHub's `issue_dependencies_summary.blocked_by` behaved as an open-blocker
+count, not as a total edge count. That matched the AFK promote rule at every
+observation point in this drain:
+
+- Before blocker close, both frontiers treated the dependent as blocked.
+- Immediately after blocker close, both frontiers treated the dependent as
+  unblocked, even before the AFK close cascade removed `blocked:dependency`
+  and the `req:N` label.
+- After the cascade, both frontiers remained unblocked.
+
+## Recommendation
+
+Evidence supports drafting a full-native supersession ADR for the dependency
+frontier/promote read path. This report does not itself supersede ADR 0094; a
+future human-authored ADR still needs to specify how authoring parity, edge-list
+audits, and closed native historical blockers relate to label shedding.


### PR DESCRIPTION
Closes #1701.

Evaluate-only shadow-check (ADR 0094 evidence): read-only replay of one real AFK drain window comparing the native GitHub blocked-by frontier vs the `req:N` label frontier. Result: 10/10 primary dependency-edge agreements, 17/17 whole-frontier agreements, 0 divergences. Single new doc under `.red/adr/evidence/` — no code.

## HITL resolution
Prior attempt parked `blocked:crashed` (runner idle-timeout, no output). Retried with guidance to write findings to a tracked report file (evaluate-only tasks must produce a diff). This attempt did so; it then parked `blocked:sensitive-path` because `.red/adr/` is protected. Maintainer reviewed the diff — pure read-only evidence documentation, safe to land. Landing via PR+CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786744505&installation_id=129708444&pr_number=1854&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1854&signature=65a25c84a75c34a502533e414017dbb18a31af62f5866220344e72d424775d27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->