### PR TITLE
fix: #1669 memory PreCompact coverage on codex — documented degradation + manifest test

### DIFF
--- a/apps/memory/tests/hooks-manifest.test.ts
+++ b/apps/memory/tests/hooks-manifest.test.ts
@@ -69,6 +69,15 @@ describe("hook manifests", () => {
     }
   });
 
+  test("Codex documents the PreCompact degradation by wiring Stop and SessionStart only", async () => {
+    const manifest = await loadManifest(hookManifest("codex.hooks.json"));
+
+    expect(Object.keys(manifest.hooks).sort()).toEqual(["PostToolUse", "SessionStart", "Stop"]);
+    expect(manifest.hooks).not.toHaveProperty("PreCompact");
+    expect(commands(manifest).filter((command) => command.includes(" hook Stop "))).toHaveLength(1);
+    expect(commands(manifest).filter((command) => command.includes(" hook SessionStart "))).toHaveLength(1);
+  });
+
   test("Claude hooks fail open to {} when the runtime cannot be resolved", async () => {
     const root = await tempRoot();
     const manifest = await loadManifest(hookManifest("claude.hooks.json"));

--- a/plugins/memory/README.md
+++ b/plugins/memory/README.md
@@ -479,7 +479,7 @@ and exits silently — a dormant hook never touches the engine or the turn.
 | **SessionStart** | session start / resume / `/clear` | recalls memory relevant to the focus (goal/branch/cwd) and injects it as context |
 | **PostToolUse** | a file edit (`Edit`/`Write`, or Codex `apply_patch`) | incrementally re-indexes the changed file into the graph |
 | **Stop** | end of an assistant turn | extracts structured Problem/Fix/Validation/Decision facts, or decision / why-note fallback memories, and stores them |
-| **PreCompact** | before a context compaction / `/clear` | flushes ephemeral session knowledge to memory before compaction |
+| **PreCompact** | before a context compaction / `/clear` where the host exposes that event | flushes ephemeral session knowledge to memory before compaction; unavailable on Codex |
 
 Extraction (Stop / PreCompact) runs through a **bounded-LLM extractor** in
 production; with no LLM key configured it falls back to a deterministic
@@ -607,9 +607,21 @@ CLI entrypoint dispatches both runners, mapping each one's payload and output
 shape internally.
 
 **Known difference: Codex has no `PreCompact` equivalent** — no compaction /
-context-trim event exists, so the anti-goldfish flush-before-context-death
-safety net is absent there. On Codex the flush leans on `Stop` (extract every
-substantive turn) plus `SessionStart`-on-`/clear` recall instead.
+context-trim event exists in the Codex hook vocabulary, so
+`hooks/codex.hooks.json` intentionally does not contain `PreCompact`. No
+Memory config flag can make Codex fire that hook today.
+
+What is lost on Codex: Memory cannot run a last-chance extraction immediately
+before `/clear` or host-driven context trimming. Facts that exist only in the
+soon-to-be-discarded context, and have not already been captured by a prior
+`Stop` hook or explicit `memory store` / `memory extract`, can be lost.
+
+What compensates: Codex still wires `Stop`, so every substantive completed turn
+can extract memories before the next turn starts, and it wires `SessionStart`,
+so a new session or `/clear` can recall stored context after the reset. Hook
+coverage reports this as an effective fallback only when both `Stop` and
+`SessionStart` are enabled; otherwise it reports an actionable Codex
+`PreCompact` fallback gap.
 
 ### Session lifecycle — `.red/memory/sessions/current`
 


### PR DESCRIPTION
Closes #1669.

Codex has no PreCompact hook equivalent (known gap #55), so the acceptance's "wire the equivalent OR ship documented degradation" resolves to the documented-degradation path: a `hooks-manifest.test.ts` assertion for the codex hook manifest coverage plus a `plugins/memory/README.md` note on the degraded PreCompact behavior on codex. Diff touches only `apps/memory` + memory README — no rsp code. `test:apps/memory` green.

## Why landed via PR+CI
Parked `blocked:validation` on the same single `@reddb-io/rsp` test failure (1 failed / 294 passed) that flaked #1699 — a load-induced flake in rsp's process-spawning suite under concurrent workers, unrelated to this memory-only change. `test:apps/memory`, typecheck, and build all pass. CI validates in the clean environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786744761&installation_id=129708444&pr_number=1855&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1855&signature=6502d94435bd470fc944726a1c02946d110e18773faf7baff564bc238e04e0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->