### PR TITLE
docs: reconcile brain glossary + contracts home + ADR 0074 gap (#1690, #1672)

### DIFF
--- a/.red/adr/INDEX.md
+++ b/.red/adr/INDEX.md
@@ -13,6 +13,11 @@ stale notes inline.
 > `daa3cc18`) that never landed on `main`; PRD #614 / issue #629 reassigned the
 > number to **AFK bundle release channels** (the goal-predicate branch must pick
 > a free number if it is ever revived).
+> **0074** has no ADR file in the local history available to this repository:
+> `git log --all -- .red/adr/0074*`, `git log --all --grep` for the number, and
+> a repository text search found no deleted, renamed, or reserved record. Treat
+> it as a documented numbering gap unless future remote history recovers the
+> original intent.
 > 2026-07-04 de-collisions: the duplicate **0067** workflow-naming ADR moved to
 > **0087**; the four duplicate **0082** records were split so **0082** remains the
 > structured-output completion contract, WorkItem moved to **0088**, AXI + TOON to

--- a/.red/contexts/brain/CONTEXT.md
+++ b/.red/contexts/brain/CONTEXT.md
@@ -1,0 +1,96 @@
+# RedSkills Brain
+
+The `brain` context names the project-local knowledge repository language for
+RedSkills: human-facing captures, project brain files, typed connections,
+folder-level brains, and GBrain-style knowledge dumping.
+
+## Language
+
+**Brain**:
+The `brain` plugin's project-local RedDB knowledge repository for durable human
+and project knowledge. It stores typed artifacts plus graph connections for
+later search, synthesis, and visual exploration.
+_Avoid_: memory, agent memory, notes folder
+
+**Capture**:
+The write operation that saves a durable piece of human or project knowledge
+into Brain as a typed artifact. Captures go through `brain capture`, the
+`brain_capture` MCP tool, or the Brain CLI; agents do not hand-write the Brain
+store.
+_Avoid_: memory write, note append, manual Brain edit
+
+**Brain artifact**:
+A typed knowledge item created by a Capture. Its `kind` is one of the canonical
+artifact kinds defined in the Brain schema (`apps/brain/src/schema.ts`):
+`pillar`, `decision`, `concept`, `question`, `playbook`, `task`, `event`,
+`pattern`, `hypothesis`, `fact`, `source`, `bookmark`, `note`, `reference`,
+`custom`, `project`, `idea`, `meeting`, `claim`, `organization`, `person`.
+Brain artifacts are the nodes that search, think, dashboard, and view surfaces
+cite.
+_Avoid_: memory fact, raw note, row
+
+**Project brain file**:
+The RedDB store for a resolved Brain root, normally `.red/brain/brain.rdb` unless
+configuration points to another connection string. It is the source of truth for
+Brain artifacts and connections.
+_Avoid_: graph.rdb, memory database, markdown brain
+
+**Folder-level Brain**:
+A Brain root shared by multiple child repositories through walk-up resolution:
+the plugin prefers an explicit override, then an ancestor `.red/brain` directory
+or `.red/brain.root` marker, then the nearest `.red/` fallback.
+_Avoid_: global brain, monorepo memory, umbrella notes
+
+**Connection**:
+A typed graph edge between Brain artifacts. The canonical connection kinds
+(`apps/brain/src/schema.ts`) are `supports`, `contradicts`, `depends_on`,
+`derived_from`, `related_to`, `part_of`, `preceded_by`, `followed_by`,
+`authored`, and `tagged`.
+_Avoid_: backlink, loose link, relation
+
+**GBrain-style dump**:
+A freeform human-facing knowledge dump routed to Brain for later search,
+connection, and synthesis. It may begin as an unstructured note, but it still
+enters Brain through Capture and can later be split or connected as evidence
+improves.
+_Avoid_: scratchpad, chat memory, operational evidence
+
+**Brain search**:
+The deterministic lookup surface over captured Brain artifacts. Ranking combines
+lexical matches, tags, artifact kind, graph connections, and a reserved vector
+score slot.
+_Avoid_: memory recall, grep, semantic memory
+
+**Brain think**:
+The cited synthesis surface over Brain search results. It returns grounded
+answers with citations, confidence, and missing evidence instead of filling gaps
+from uncited model knowledge.
+_Avoid_: freeform answer, memory summary, unsupported synthesis
+
+## Relationships
+
+- Brain owns human-facing knowledge that the user wants to recall later.
+- Memory owns operational evidence that helps agents work better.
+- A Capture creates one or more Brain artifacts in a Project brain file.
+- A Connection links two Brain artifacts with an explicit relationship kind.
+- A Folder-level Brain lets child repositories share one Project brain file.
+- Brain search returns ranked artifacts; Brain think synthesizes a cited answer
+  from those artifacts.
+- GBrain-style dumps are valid Brain input when they are captured rather than
+  written directly into `.red/brain/`.
+
+## Example dialogue
+
+> **Brain:** "This is a long-lived decision about a person, organization, plan,
+> or open question. Capture it in Brain."
+>
+> **Memory:** "This is a validated operational fact from the current work
+> session. Store it in Memory instead."
+
+## Flagged ambiguities
+
+- "Brain" and "Memory" are intentionally separate contexts. Use **Brain** for
+  human-facing recall and synthesis; use Memory for governed agent-operational
+  evidence.
+- "Connection" is not any markdown backlink. It is a typed Brain graph edge
+  stored with Brain artifacts.

--- a/.red/contexts/dev/CONTEXT.md
+++ b/.red/contexts/dev/CONTEXT.md
@@ -146,6 +146,10 @@ _Avoid_: afk clone, sandbox checkout
 One of the canonical `.red/` lifecycles from ADR 0098: tracked knowledge/config, plugin stores, durable machine state under `.red/state/`, or disposable scratch under `.red/tmp/`. The lifecycle decides whether a path is versioned, plugin-owned, durable-local, or safely deletable.
 _Avoid_: tmp as a catch-all, state mixed with scratch
 
+**Contracts home**:
+The tracked knowledge/config directory at `.red/contracts/`, versioned in the repo and owned by the **dev** plugin. It holds test and validation fixtures (such as `.red/contracts/fixtures/quality-gate/`), contract assertions, and reference data that document interface boundaries and acceptance criteria. Content here is not disposable and must be backed by an Issue/Spec/ADR that states why the fixtures exist.
+_Avoid_: test data (use with care; contracts are *vetted* boundaries, not ad-hoc test input), fixtures root (this is the contracts home, not a general-purpose fixtures directory)
+
 **State tier**:
 The gitignored durable machine-state tier at `.red/state/`. Named lanes include `afk/`, `rsp/`, `statusline/`, `branch-lock.yaml`, and `red-skills.rdb`. It is never mass-deletable and must survive `rm -rf .red/tmp`.
 _Avoid_: cache, tmp state

--- a/apps/dev/tests/adr-governance.test.ts
+++ b/apps/dev/tests/adr-governance.test.ts
@@ -1,9 +1,10 @@
-import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { access, readdir, readFile } from "node:fs/promises";
+import { dirname, join, normalize } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const ROOT = join(import.meta.dirname, "..", "..", "..");
 const ADR_DIR = join(ROOT, ".red", "adr");
+const CONTEXT_MAP = join(ROOT, ".red", "CONTEXT-MAP.md");
 
 describe("ADR governance docs", () => {
   it("keeps ADR filename numbers and index bullets unique", async () => {
@@ -21,6 +22,40 @@ describe("ADR governance docs", () => {
     expect(duplicateIndexNumbers).toEqual([]);
 
     expect(new Set(indexNumbers)).toEqual(new Set(numbersByFilename));
+  });
+
+  it("documents any missing ADR numbers in the index", async () => {
+    const files = (await readdir(ADR_DIR))
+      .filter((file) => /^\d{4}-.+\.md$/.test(file))
+      .sort();
+    const numbers = files.map((file) => Number(file.slice(0, 4)));
+    const present = new Set(numbers);
+    const missing: string[] = [];
+
+    for (let number = Math.min(...numbers); number <= Math.max(...numbers); number += 1) {
+      if (!present.has(number)) missing.push(String(number).padStart(4, "0"));
+    }
+
+    const index = await readFile(join(ADR_DIR, "INDEX.md"), "utf8");
+    const undocumented = missing.filter((number) => !index.includes(`**${number}**`));
+    expect(undocumented).toEqual([]);
+  });
+
+  it("keeps context map local markdown links resolvable", async () => {
+    const text = await readFile(CONTEXT_MAP, "utf8");
+    const links = Array.from(text.matchAll(/\[[^\]]+\]\((\.\/[^)#]+\.md)(?:#[^)]+)?\)/g), (match) => match[1]);
+    const missing: string[] = [];
+
+    for (const link of links) {
+      const resolved = normalize(join(dirname(CONTEXT_MAP), link));
+      try {
+        await access(resolved);
+      } catch {
+        missing.push(link);
+      }
+    }
+
+    expect(missing).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #1690. Closes #1672.

Two sensitive-path slices both created `.red/contexts/brain/CONTEXT.md` with **divergent** brain glossaries (a slicing overlap). Reconciled into one coherent landing:

- **brain/CONTEXT.md** — adopts #1672's framing, **corrected against the real brain schema** (`apps/brain/src/schema.ts`): the 21 canonical artifact kinds (`pillar`…`person`) and 10 connection kinds (`supports`…`tagged`). #1690's version asserted a wrong "thirteen kinds" list including a non-existent `rule` kind and invented connection kinds (`references`, `informs`, `elaborates`), so its glossary was dropped.
- **dev/CONTEXT.md** — keeps #1690's unique **"Contracts home"** term for `.red/contracts/`.
- **INDEX.md** — records #1672's **ADR 0074 numbering-gap** note.
- **adr-governance.test.ts** — adds #1672's two governance tests (every ADR-number gap is documented in INDEX; CONTEXT-MAP local links resolve). Both verified green against current main (only gap 0074, now documented; the CONTEXT-MAP brain link now resolves because this landing creates the file).

## HITL / sensitive-path resolution
Both were parked `blocked:sensitive-path` (protected `.red/contexts/**`, `.red/adr/**`). Maintainer reviewed the diffs and approved the reconciliation approach (adopt the schema-accurate glossary, keep both unique parts). Landing via PR+CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786751154&installation_id=129708444&pr_number=1857&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1857&signature=b4121364abb7199a5e72573f14e12aca9119032e3f5f2897e8820640d82e5b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->