### PR TITLE
fix: #1861 statusline test flakes in the 5 minutes after UTC midnight (updated_at now-5min crosses the UTC day boundary)

### DIFF
--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -22,6 +22,11 @@ import { resolveResidentPaths } from "../../rsp/src/resident-client.js";
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, "");
 
+function startOfCurrentUtcDay(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
 /** A non-TTY readable carrying the Claude Code payload on stdin. */
 function fakeStdin(text: string): NodeJS.ReadableStream & { isTTY?: boolean } {
   const stream = Readable.from([text]) as Readable & { isTTY?: boolean };
@@ -815,7 +820,7 @@ describe("statusline command — rendered line", () => {
     await writeFile(resolveResidentPaths(root).summaryPath, JSON.stringify({
       version: 1,
       tokens_saved_today: 4242,
-      updated_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      updated_at: startOfCurrentUtcDay().toISOString(),
     }), "utf8");
 
     expect(await resolveStatuslineRsp(root, {})).toEqual({ state: "ready", tokensSavedToday: 4242 });


### PR DESCRIPTION
Automated AFK landing for #1861. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786756025&installation_id=129708444&pr_number=1862&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1862&signature=9dbb607b3cbb3867cbcb2351038d0850bf54f335ac39a8e9b56fbcf0bebf7937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->