### PR TITLE
fix: #1864 go TROUBLESHOOTING doc: crashed scout salvage, engine-exit-0-but-parked reading

### DIFF
--- a/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
+++ b/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
@@ -9,6 +9,29 @@ function readRepoFile(path: string) {
 }
 
 describe("skill progressive-disclosure docs", () => {
+  it("keeps /go troubleshooting discoverable and pins the stopgap playbooks", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/engineering/go/SKILL.md");
+    const troubleshooting = await readRepoFile("plugins/dev/skills/engineering/go/TROUBLESHOOTING.md");
+
+    expect(skill).toContain("<supporting-info>");
+    expect(skill).toContain("[TROUBLESHOOTING.md](./TROUBLESHOOTING.md)");
+
+    for (const heading of [
+      "# /go Troubleshooting",
+      "## Crashed-scout salvage",
+      "### Symptom",
+      "### Confirm",
+      "### Recover",
+      "### Root-fix",
+      "## Engine-exit-0-but-parked reading",
+    ]) {
+      expect(troubleshooting).toContain(heading);
+    }
+
+    expect(troubleshooting).toContain("#1695");
+    expect(troubleshooting).toContain("#1864");
+  });
+
   it("keeps red-statusline routing hot while preserving host recipes in HOST-NOTES", async () => {
     const skill = await readRepoFile("plugins/dev/skills/engineering/red-statusline/SKILL.md");
     const hostNotes = await readRepoFile("plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md");

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -92,6 +92,8 @@ Set `RED_AFK_RUNNER` to your own host runner (`claude` from Claude Code, `codex`
 
 <supporting-info>
 
+For failure-state playbooks, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).
+
 ## Where `/go` sits — the dispatch spectrum
 
 | Tier | Input | Artifact | Worker | Gate sink | When to use |

--- a/plugins/dev/skills/engineering/go/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/go/TROUBLESHOOTING.md
@@ -1,0 +1,83 @@
+# /go Troubleshooting
+
+Use these playbooks when `/go` or `/go --scout` reaches a confusing terminal
+state. Each entry uses the fixed Symptom, Confirm, Recover, Root-fix format so
+operators can distinguish salvage from the durable fix.
+
+## Crashed-scout salvage
+
+### Symptom
+
+A `/go --scout` dispatch is reported as crashed, missing a sentinel, or closed
+without the expected report comment, but the agent log shows that the scout
+completed the investigation and produced a final markdown report.
+
+### Confirm
+
+1. Confirm the disposable issue is a scout issue, not a standard `/go` code
+   issue: it should carry `lane:scout` and should not have a branch, PR, or
+   mutation-bearing diff to land.
+2. Inspect the scout worker lane for the attempt and find the final agent
+   output. The useful signal is a completed markdown report near the end of the
+   transcript, even if the outer envelope classified the run as crashed or
+   no-sentinel.
+3. Check that the log does not contain a real unresolved blocker after the
+   report. A report followed only by envelope or sentinel handling failure is a
+   salvage case; a report that explicitly says the scout could not answer is a
+   real block.
+
+### Recover
+
+1. Copy only the scout report content into a GitHub comment on the disposable
+   scout issue. Do not include local paths, hostnames, usernames, environment
+   values, tokens, or agent session URLs.
+2. Close the disposable scout issue after the report is posted. Scout mode has
+   no PR or landing step; the report comment is the deliverable.
+3. If the report found follow-up work, file or link a normal tracked issue for
+   that work instead of reopening the scout lane.
+
+### Root-fix
+
+This manual salvage is a stopgap for the scout envelope and sentinel handling
+tracked in #1695. Once that root fix ships, a completed scout report must post
+and close the disposable issue even when the engine envelope is imperfect.
+
+## Engine-exit-0-but-parked reading
+
+### Symptom
+
+A standard `/go` dispatch exits with status 0, but the disposable issue ends up
+parked, commonly with `ready-for-human`, `blocked:validation`, or a note that
+looks inconsistent with the successful process exit.
+
+### Confirm
+
+1. Treat the process exit code as the launcher result only. It means the engine
+   finished its control loop cleanly; it does not by itself mean the requested
+   work landed.
+2. Read the final issue labels, the worker attempt summary, and any validation
+   tail carried into the parked comment. A real block names an unmet semantic
+   DoD, a failed configured gate, an exhausted bounded correction retry, or an
+   explicit human decision point.
+3. Compare that with the final agent envelope. If the work emitted DONE and the
+   only contradiction is a parse, envelope, or sentinel mismatch, classify the
+   park as an envelope artifact. If the machine gate or DoD still fails, it is a
+   real block even though the engine exited 0.
+
+### Recover
+
+1. For a real block, keep the issue parked and act on the blocker: fix the
+   branch, approve or reject the human decision, or retake the issue through the
+   normal lane.
+2. For an envelope artifact, salvage the useful branch, report, or final notes
+   from the worker lane and reconcile the disposable issue to match the actual
+   deliverable state.
+3. When posting public notes, describe the observable state without leaking
+   local machine details or private transcript links.
+
+### Root-fix
+
+This reading procedure is a stopgap until the `/go` outcome envelope records
+separate launcher, agent, validation, and issue-state outcomes. Track this
+documentation slice in #1864 and the scout envelope hardening in #1695 when the
+misread involves a scout report.


### PR DESCRIPTION
Automated AFK landing for #1864. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1864

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786759224&installation_id=129708444&pr_number=1868&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1868&signature=bab599e9de101e6965ccaa2b8dbed5d91b061b82cd55be301c1b10fbdb142048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->