### PR TITLE
TROUBLESHOOTING playbooks: ask-red registration + fixed-format canonization + docs-contract convention (#1867)

### DIFF
--- a/apps/dev/tests/hitl-troubleshooting-docs.test.ts
+++ b/apps/dev/tests/hitl-troubleshooting-docs.test.ts
@@ -29,7 +29,7 @@ describe("hitl troubleshooting docs contract (#1865)", () => {
     expect(doc).toContain("### Symptom");
     expect(doc).toContain("### Confirm");
     expect(doc).toContain("### Recover");
-    expect(doc).toContain("### Root-fix");
+    expect(doc).toContain("### Root fix");
     expect(doc).toContain("gh pr checks");
     expect(doc).toContain("mergeable");
 

--- a/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
+++ b/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
@@ -28,7 +28,7 @@ describe("skill progressive-disclosure docs", () => {
       "### Symptom",
       "### Confirm",
       "### Recover",
-      "### Root-fix",
+      "### Root fix",
     ]) {
       expect(troubleshooting).toContain(heading);
     }
@@ -51,7 +51,7 @@ describe("skill progressive-disclosure docs", () => {
       "### Symptom",
       "### Confirm",
       "### Recover",
-      "### Root-fix",
+      "### Root fix",
       "## Engine-exit-0-but-parked reading",
     ]) {
       expect(troubleshooting).toContain(heading);

--- a/apps/dev/tests/troubleshooting-playbook-contract.test.ts
+++ b/apps/dev/tests/troubleshooting-playbook-contract.test.ts
@@ -1,0 +1,85 @@
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+
+const TROUBLESHOOTING_DOCS = [
+  {
+    command: "/afk",
+    skill: "plugins/dev/skills/engineering/afk/SKILL.md",
+    troubleshooting: "plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md",
+    headings: [
+      "## Gate census when ready-for-agent is empty",
+      "## False main-red verification",
+      "## Scout and worker salvage after crashed or no-sentinel runs",
+      "## Park-resolution contract",
+      "## Base-stale decision procedure",
+      "## Requeue escalation map",
+      "## Release-pipeline playbook",
+    ],
+  },
+  {
+    command: "/go",
+    skill: "plugins/dev/skills/engineering/go/SKILL.md",
+    troubleshooting: "plugins/dev/skills/engineering/go/TROUBLESHOOTING.md",
+    headings: ["## Crashed-scout salvage", "## Engine-exit-0-but-parked reading"],
+  },
+  {
+    command: "/hitl",
+    skill: "plugins/dev/skills/engineering/hitl/SKILL.md",
+    troubleshooting: "plugins/dev/skills/engineering/hitl/TROUBLESHOOTING.md",
+    headings: ["## Verify-before-trusting", "## HITL card verb sets"],
+  },
+  {
+    command: "rsp",
+    skill: "plugins/dev/skills/engineering/red-gains/SKILL.md",
+    troubleshooting: "apps/rsp/docs/TROUBLESHOOTING.md",
+    headings: ["## Hook silence", "## Resident/store split", "## Store growth"],
+  },
+];
+
+async function readRepoFile(path: string): Promise<string> {
+  return readFile(join(ROOT, path), "utf8");
+}
+
+describe("TROUBLESHOOTING playbook contract (#1867)", () => {
+  it("documents the fixed playbook and docs-contract conventions once", async () => {
+    const skill = await readRepoFile("plugins/dev/skills/productivity/write-a-skill/SKILL.md");
+
+    expect(skill).toContain("Symptom -> Confirm -> Recover -> Root fix");
+    expect(skill).toContain("Docs-contract tests for TROUBLESHOOTING references");
+    expect(skill).toContain("assert file existence, the SKILL.md link, and stable load-bearing headings");
+    expect(skill).toContain("do not assert prose wording");
+  });
+
+  it("registers each TROUBLESHOOTING reference in ask-red inventory and routes", async () => {
+    const askRed = await readRepoFile("plugins/dev/skills/engineering/ask-red/SKILL.md");
+
+    for (const { command, troubleshooting } of TROUBLESHOOTING_DOCS) {
+      expect(askRed).toContain(command);
+      expect(askRed).toContain(troubleshooting);
+    }
+  });
+
+  it("keeps each TROUBLESHOOTING reference discoverable and structurally pinned", async () => {
+    for (const { skill, troubleshooting, headings } of TROUBLESHOOTING_DOCS) {
+      await expect(access(join(ROOT, troubleshooting))).resolves.toBeUndefined();
+
+      const skillDoc = await readRepoFile(skill);
+      const troubleshootingDoc = await readRepoFile(troubleshooting);
+
+      expect(skillDoc).toContain("TROUBLESHOOTING.md");
+      expect(troubleshootingDoc).toContain("Symptom -> Confirm -> Recover -> Root fix");
+      expect(troubleshootingDoc).toContain("write-a-skill");
+
+      for (const heading of ["### Symptom", "### Confirm", "### Recover", "### Root fix"]) {
+        expect(troubleshootingDoc).toContain(heading);
+      }
+
+      for (const heading of headings) {
+        expect(troubleshootingDoc).toContain(heading);
+      }
+    }
+  });
+});

--- a/apps/rsp/docs/TROUBLESHOOTING.md
+++ b/apps/rsp/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # rsp Troubleshooting
 
-Use this reference when rsp hook routing, resident service behavior, or elision storage looks silent, stale, or unbounded. Each entry follows Symptom -> Confirm -> Recover -> Root-fix.
+Use this reference when rsp hook routing, resident service behavior, or elision storage looks silent, stale, or unbounded. Follow the `write-a-skill` TROUBLESHOOTING convention: Symptom -> Confirm -> Recover -> Root fix.
 
 ## Hook silence
 
@@ -24,7 +24,7 @@ The synthetic PreToolUse payload should show whether the shipped hook bundle can
 
 If only the current repo is silent, re-run setup for the repo and restart the host session so the generated hook path and `.red/config.yaml` opt-in are reloaded. If both repos are silent but the synthetic payload rewrites, restart the host session and confirm the hook bundle installed by the host points at the current dev bundle. If the synthetic payload fails, treat the shipped bundle or hook contract as broken and use direct `rsp ...` wrappers until the hook is fixed.
 
-### Root-fix
+### Root fix
 
 This manual split is a stopgap for the hook diagnosis and intercept hardening tracked by #1731 and #1726. The durable fix is for hook telemetry and setup validation to make fail-open silence distinguishable without a hand-built payload/control test.
 
@@ -50,7 +50,7 @@ The registry status should identify whether a resident is registered, reachable,
 
 For daemon failures, stop the stale resident if one is registered and let the next rsp command start a fresh process. For store failures, check that `.red/state/red-skills.rdb` exists, is writable, and was provisioned by setup; keep using raw commands or direct non-eliding wrappers while the shared store is unavailable. Do not delete the durable store as a first recovery step because it also carries other repo state collections.
 
-### Root-fix
+### Root fix
 
 This manual split is a stopgap for the resident and store diagnosis work tracked by #1731 and #1726. The root fix is for registry status, foreground serving, and store health checks to report a single actionable classification.
 
@@ -76,6 +76,6 @@ The live view should show handle counts, bytes retained, and budget/TTL posture.
 
 If logical retained bytes are below budget but the file keeps growing, capture the stats and before/after `du` measurements, then stop producing large elisions in that repo until compaction or rotation catches up. If both logical and physical sizes exceed the configured budget, lower the rsp byte budget temporarily or disable proxy contribution for noisy sessions while preserving the store for diagnosis.
 
-### Root-fix
+### Root fix
 
 This manual bound check is a stopgap for #1704. The root fix is the physical-cap contract: store compaction or rotation must enforce the on-disk ceiling, not only logical expiry.

--- a/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -1,8 +1,6 @@
 # /afk Troubleshooting
 
-Use these playbooks when `/afk` reaches a confusing terminal state. Each entry
-uses the fixed Symptom, Confirm, Recover, Root-fix format so operators can
-separate a durable manual procedure from a stopgap that needs a tracked repair.
+Use these playbooks when `/afk` reaches a confusing terminal state. Follow the `write-a-skill` TROUBLESHOOTING convention: Symptom -> Confirm -> Recover -> Root fix.
 
 ## Gate census when ready-for-agent is empty
 
@@ -29,7 +27,7 @@ not empty.
 3. Re-run the queue view after each batch and continue until every open
    executable issue is either agent-ready or gated for a real pending reason.
 
-### Root-fix
+### Root fix
 
 This manual census is a stopgap for the queue reconciler tracked in #1739.
 
@@ -58,7 +56,7 @@ agent-specific probe environment.
    check the gate does not run.
 3. Resume or requeue the issue only after the real configured gate is green.
 
-### Root-fix
+### Root fix
 
 This manual verification is a stopgap for the queue reconciler and validation
 authority hardening tracked in #1739.
@@ -92,7 +90,7 @@ completed report, useful notes, or finished work.
 4. Record recurrence against the root-fix issue so repeated envelope failures
    are visible.
 
-### Root-fix
+### Root fix
 
 This manual salvage is a stopgap for the scout and worker envelope hardening
 tracked in #1695.
@@ -122,7 +120,7 @@ claim the old state.
 3. Never perform a raw label-only requeue or unblock. The issue body is the
    durable contract that explains why the labels changed.
 
-### Root-fix
+### Root fix
 
 This paired-update procedure is a durable manual procedure. The broader
 automation reconciliation is tracked in #1739.
@@ -152,7 +150,7 @@ An issue or PR is parked as `base-stale`, or an old AFK branch exists after
 3. If generated churn obscures the decision, isolate the human-authored files
    and document what was kept or discarded.
 
-### Root-fix
+### Root fix
 
 This decision tree is a durable manual procedure. Automatic stale-branch
 reconciliation remains part of the broader reconciler tracked in #1739.
@@ -183,7 +181,7 @@ set, or a HITL card refuses `/requeue` for that blocker kind.
    the resolution.
 4. Re-run the gate census so the issue returns to the correct lane.
 
-### Root-fix
+### Root fix
 
 This escalation map is a stopgap for unsupported blocker reconciliation tracked
 in #1739.
@@ -215,7 +213,7 @@ release trigger even though the code diff is already on `main`.
 4. If the tag does not contain the fix, stop and repair the release lineage
    instead of announcing success.
 
-### Root-fix
+### Root fix
 
 This playbook establishes the documentation contract for release troubleshooting
 in #1863; the durable release policy remains the conventional-commit pipeline.

--- a/plugins/dev/skills/engineering/ask-red/SKILL.md
+++ b/plugins/dev/skills/engineering/ask-red/SKILL.md
@@ -43,7 +43,9 @@ back into `/start`, `/to-spec`, `/to-tickets`, `/afk`, or `/hitl`.
   pair it with `/ground-truth`.
 - **Operations state** -> `/dashboard`, `/daily-review`, `/red-gains`, `/audit-skills`, or
   `/context` depending on whether the question is queue health, period review,
-  rsp usage gains, skill quality, or repository context.
+  rsp usage gains, skill quality, or repository context. For operational
+  troubleshooting, route to the owning reference: `/afk`, `/go`, `/hitl`, or
+  rsp.
 - **Design uncertainty** -> `/prototype`; if the uncertainty is too broad for
   one throwaway answer, use `/wayfinder`.
 - **Corpus knowledge graph requests** -> memory plugin surfaces. For "build a
@@ -87,6 +89,12 @@ The router must mention every published dev skill so `/red-doctor` can flag drif
 The LLM Wiki routes ship with the `memory` plugin as `/memory:wiki-init` and
 `/memory:wiki`, not with `dev`, so they stay out of this inventory.
 
+Troubleshooting references registered by owner:
+`/afk` -> `plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md`;
+`/go` -> `plugins/dev/skills/engineering/go/TROUBLESHOOTING.md`;
+`/hitl` -> `plugins/dev/skills/engineering/hitl/TROUBLESHOOTING.md`;
+rsp -> `apps/rsp/docs/TROUBLESHOOTING.md`.
+
 Cross-plugin capability route: `corpus-to-knowledge-graph` lives in the
 `memory` plugin. Route by the capability description, not by implementation
 vocabulary: corpus ingest goes through `/memory:ingest`; graph inspection goes
@@ -99,7 +107,9 @@ through `/memory:view`, `memory docs reference-graph`, and
 - `/red-doctor` checks RedSkills adoption drift, including whether this router still
   covers the registered skill set.
 - `/red-gains` reports whether rsp is paying for itself: latency, throughput,
-  token savings, command-family winners, and degradation health from telemetry.
+  token savings, command-family winners, and degradation health from telemetry;
+  use `apps/rsp/docs/TROUBLESHOOTING.md` for rsp hook silence, resident/store,
+  and store-growth incidents.
 - `/red-setup` and `/red-statusline` are setup/adoption routes, not
   feature-work routes.
 - TOON/TOONL operational reader changes are documentation-maintenance work:

--- a/plugins/dev/skills/engineering/go/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/go/TROUBLESHOOTING.md
@@ -1,8 +1,6 @@
 # /go Troubleshooting
 
-Use these playbooks when `/go` or `/go --scout` reaches a confusing terminal
-state. Each entry uses the fixed Symptom, Confirm, Recover, Root-fix format so
-operators can distinguish salvage from the durable fix.
+Use these playbooks when `/go` or `/go --scout` reaches a confusing terminal state. Follow the `write-a-skill` TROUBLESHOOTING convention: Symptom -> Confirm -> Recover -> Root fix.
 
 ## Crashed-scout salvage
 
@@ -36,7 +34,7 @@ completed the investigation and produced a final markdown report.
 3. If the report found follow-up work, file or link a normal tracked issue for
    that work instead of reopening the scout lane.
 
-### Root-fix
+### Root fix
 
 This manual salvage is a stopgap for the scout envelope and sentinel handling
 tracked in #1695. Once that root fix ships, a completed scout report must post
@@ -75,7 +73,7 @@ looks inconsistent with the successful process exit.
 3. When posting public notes, describe the observable state without leaking
    local machine details or private transcript links.
 
-### Root-fix
+### Root fix
 
 This reading procedure is a stopgap until the `/go` outcome envelope records
 separate launcher, agent, validation, and issue-state outcomes. Track this

--- a/plugins/dev/skills/engineering/hitl/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/hitl/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # /hitl Troubleshooting
 
-Use this reference when a `ready-for-human` park looks stale, inconsistent, or recoverable through the HITL card contract. Each entry follows Symptom -> Confirm -> Recover -> Root-fix.
+Use this reference when a `ready-for-human` park looks stale, inconsistent, or recoverable through the HITL card contract. Follow the `write-a-skill` TROUBLESHOOTING convention: Symptom -> Confirm -> Recover -> Root fix.
 
 ## Verify-before-trusting
 
@@ -31,7 +31,7 @@ When the PR is green and mergeable, resolve the park through the normal `/hitl` 
 
 Do not raw-flip labels without the blocker-state update. AFK preflight re-reads the active blocker and will re-park an issue whose body still says it is blocked.
 
-### Root-fix
+### Root fix
 
 This manual re-check is a stopgap for the broader operational playbook work tracked by #1741 and the sibling AFK troubleshooting/root-fix doc in #1863. Long term, parks caused by transient check visibility should be refreshed from live PR state before the issue is trusted as blocked.
 
@@ -71,6 +71,6 @@ If a park was resolved outside the card contract, repair the full state instead 
 4. Make labels match the disposition: remove stale `blocked:*` labels when the blocker is gone, remove `ready-for-human` when requeued, and add `ready-for-agent` only when the Agent brief is delegable.
 5. Refresh the card status after PR state changes so the next reader sees current checks and mergeability.
 
-### Root-fix
+### Root fix
 
 This manual reconciliation is a stopgap for #1741. The card implementation should keep making the verb-to-transition contract explicit so humans do not have to infer label and blocker-state updates from a raw comment alone.

--- a/plugins/dev/skills/engineering/red-gains/SKILL.md
+++ b/plugins/dev/skills/engineering/red-gains/SKILL.md
@@ -43,4 +43,7 @@ Short windows are normal after setup or pruning. Use the `window.label` value,
 for example "window: 28d, data: 3d", so the reader sees requested history
 versus available history.
 
+For rsp hook silence, resident/store splits, and store-growth recovery, see
+[TROUBLESHOOTING.md](../../../../../apps/rsp/docs/TROUBLESHOOTING.md).
+
 </supporting-info>

--- a/plugins/dev/skills/productivity/write-a-skill/SKILL.md
+++ b/plugins/dev/skills/productivity/write-a-skill/SKILL.md
@@ -152,6 +152,15 @@ In-repo exemplars: `/start` (grill and sharpen the plan) hands off to `/to-spec`
 pull toward shipping; and `writing-fragments` is separate from `writing-shape` /
 `writing-beats` so the raw-material gather isn't rushed toward the finished piece.
 
+## TROUBLESHOOTING references
+
+Operational TROUBLESHOOTING references use one fixed playbook entry format:
+Symptom -> Confirm -> Recover -> Root fix. Define that convention here, and have
+each reference link back to `write-a-skill` instead of re-explaining the format.
+
+Docs-contract tests for TROUBLESHOOTING references assert file existence, the SKILL.md link, and stable load-bearing headings. They do not assert prose wording;
+pinning prose turns a documentation contract into a stale-doc test.
+
 ## SKILL.md writing style
 
 Section structure (`<what-to-do>` / `<supporting-info>`) decides *where* a


### PR DESCRIPTION
Final integration slice of Spec #1741 — registers the TROUBLESHOOTING playbooks with ask-red, canonizes the fixed format, and adds the docs-contract convention test.

Landed via PR+CI: worker gate parked blocked:validation on the @reddb-io/rsp#test root-cone load-flake (441s test duration under fleet load; #1856). CI adjudicates in a clean env — if the rsp docs-contract test is genuinely broken by the apps/rsp/docs/TROUBLESHOOTING.md edit it fails here and gets fixed forward; if it was the load flake it passes and merges.

Closes #1867

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786764872&installation_id=129708444&pr_number=1872&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1872&signature=c156aec298d4acafd3d8556e4344b56446ce82392a8fcc6499510a25498ab314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->