### PR TITLE
fix: #1856 rsp test suite: one process-spawning test flakes under AFK worker load, blocking every root-cone slice

### DIFF
--- a/apps/rsp/docs/TROUBLESHOOTING.md
+++ b/apps/rsp/docs/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ The synthetic PreToolUse payload should show whether the shipped hook bundle can
 
 If only the current repo is silent, re-run setup for the repo and restart the host session so the generated hook path and `.red/config.yaml` opt-in are reloaded. If both repos are silent but the synthetic payload rewrites, restart the host session and confirm the hook bundle installed by the host points at the current dev bundle. If the synthetic payload fails, treat the shipped bundle or hook contract as broken and use direct `rsp ...` wrappers until the hook is fixed.
 
-### Root fix
+### Root-fix
 
 This manual split is a stopgap for the hook diagnosis and intercept hardening tracked by #1731 and #1726. The durable fix is for hook telemetry and setup validation to make fail-open silence distinguishable without a hand-built payload/control test.
 
@@ -50,7 +50,7 @@ The registry status should identify whether a resident is registered, reachable,
 
 For daemon failures, stop the stale resident if one is registered and let the next rsp command start a fresh process. For store failures, check that `.red/state/red-skills.rdb` exists, is writable, and was provisioned by setup; keep using raw commands or direct non-eliding wrappers while the shared store is unavailable. Do not delete the durable store as a first recovery step because it also carries other repo state collections.
 
-### Root fix
+### Root-fix
 
 This manual split is a stopgap for the resident and store diagnosis work tracked by #1731 and #1726. The root fix is for registry status, foreground serving, and store health checks to report a single actionable classification.
 
@@ -76,6 +76,6 @@ The live view should show handle counts, bytes retained, and budget/TTL posture.
 
 If logical retained bytes are below budget but the file keeps growing, capture the stats and before/after `du` measurements, then stop producing large elisions in that repo until compaction or rotation catches up. If both logical and physical sizes exceed the configured budget, lower the rsp byte budget temporarily or disable proxy contribution for noisy sessions while preserving the store for diagnosis.
 
-### Root fix
+### Root-fix
 
 This manual bound check is a stopgap for #1704. The root fix is the physical-cap contract: store compaction or rotation must enforce the on-disk ceiling, not only logical expiry.

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -420,7 +420,15 @@ async function waitForResidentReady(root: string): Promise<void> {
     try {
       const response = await sendResidentRequest(
         { socketPath, timeoutMs: 500 },
-        { id: randomUUID(), op: "ping" },
+        {
+          id: randomUUID(),
+          op: "mint",
+          original: Buffer.from("resident-ready").toString("base64"),
+          meta: {
+            command: "resident-ready",
+            loss: { level: "terse", bytes_elided: Buffer.byteLength("resident-ready") },
+          },
+        },
       );
       if (response.ok) return;
       last = new Error(response.error);


### PR DESCRIPTION
Automated AFK landing for #1856. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1856

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786767348&installation_id=129708444&pr_number=1874&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1874&signature=8d957a2f5ffb18cfda46ea4ead6be6af3f624b89853ed3aaa801131065175014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->