### PR TITLE
fix: #1873 main-red repair: baseline probe failures on main

### DIFF
--- a/apps/rsp/package.json
+++ b/apps/rsp/package.json
@@ -21,6 +21,7 @@
     "bench:two-axis:check": "node --import tsx src/two-axis-benchmark-cli.ts --check --out bench/results/rsp-two-axis.toon --summary bench/results/rsp-two-axis.md",
     "gen:ambient-skill": "node --import tsx scripts/gen-ambient-skill.mjs",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "dev": "node --import tsx src/cli.ts"
   },
   "dependencies": {

--- a/apps/rsp/tests/suite-split.test.ts
+++ b/apps/rsp/tests/suite-split.test.ts
@@ -1,0 +1,50 @@
+import { readdir, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { INTEGRATION_TESTS } from "../vitest.suites.js";
+
+const pkgRoot = resolve(__dirname, "..");
+
+async function packageScripts(): Promise<Record<string, string>> {
+  const raw = await readFile(resolve(pkgRoot, "package.json"), "utf8");
+  return (JSON.parse(raw).scripts ?? {}) as Record<string, string>;
+}
+
+async function allTestFiles(): Promise<string[]> {
+  const entries = await readdir(resolve(pkgRoot, "tests"), { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+describe("apps/rsp suite split (#1873)", () => {
+  test("both test and test:integration scripts exist", async () => {
+    const scripts = await packageScripts();
+    expect(scripts.test, "default `test` gate").toBeTruthy();
+    expect(scripts["test:integration"], "heavy integration suite").toBeTruthy();
+  });
+
+  test("the default gate does not run the integration project", async () => {
+    const scripts = await packageScripts();
+    expect(scripts.test).not.toContain("vitest.integration.config");
+    expect(scripts["test:integration"]).toContain("vitest.integration.config");
+  });
+
+  test("integration list and default project partition every test file", async () => {
+    const files = await allTestFiles();
+    const integration = new Set(INTEGRATION_TESTS);
+
+    for (const name of INTEGRATION_TESTS) {
+      expect(files, `integration entry ${name} must exist on disk`).toContain(name);
+    }
+
+    const unit = files.filter((file) => !integration.has(file));
+    expect(unit.length + integration.size).toBe(files.length);
+    expect(integration.has("suite-split.test.ts")).toBe(false);
+  });
+
+  test("no duplicate entries in the integration list", () => {
+    expect(new Set(INTEGRATION_TESTS).size).toBe(INTEGRATION_TESTS.length);
+  });
+});

--- a/apps/rsp/vitest.config.ts
+++ b/apps/rsp/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { integrationGlobs } from "./vitest.suites.js";
 
 export default defineConfig({
   test: {
+    include: ["tests/**/*.test.ts"],
+    exclude: integrationGlobs(),
     environment: "node",
     pool: "forks",
     fileParallelism: false,
     testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 });

--- a/apps/rsp/vitest.integration.config.ts
+++ b/apps/rsp/vitest.integration.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import { integrationGlobs } from "./vitest.suites.js";
+
+// Heavy subprocess/resident coverage. Run explicitly, not as the AFK feedback
+// package test gate.
+export default defineConfig({
+  test: {
+    include: integrationGlobs(),
+    environment: "node",
+    pool: "forks",
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+    fileParallelism: false,
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});

--- a/apps/rsp/vitest.suites.ts
+++ b/apps/rsp/vitest.suites.ts
@@ -1,0 +1,20 @@
+// Single source of truth for the apps/rsp vitest suite split (#1873).
+//
+// The default AFK feedback gate must stay inside its subprocess budget. Specs
+// that spawn CLIs, drive resident daemons, build large RedDB stores, or assert
+// wall-clock/benchmark behavior run as an explicit integration suite instead.
+
+export const INTEGRATION_TESTS: readonly string[] = [
+  "cli.test.ts",
+  "elision-store.test.ts",
+  "intercept.test.ts",
+  "proxy.test.ts",
+  "resident-memory.test.ts",
+  "setup.test.ts",
+  "shell-init.test.ts",
+  "telemetry.test.ts",
+  "two-axis-benchmark.test.ts",
+];
+
+export const integrationGlobs = (): string[] =>
+  INTEGRATION_TESTS.map((name) => `tests/${name}`);


### PR DESCRIPTION
Automated AFK landing for #1873. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1873

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786768426&installation_id=129708444&pr_number=1876&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1876&signature=fb1e39ebcfebb415e435ed7d0ea2605c9ce6b6193273e63f5cfbe815259ae194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->