### PR TITLE
docs(rsp): restore canonical 'Root fix' headings per playbook contract

### DIFF
--- a/apps/rsp/docs/TROUBLESHOOTING.md
+++ b/apps/rsp/docs/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ The synthetic PreToolUse payload should show whether the shipped hook bundle can
 
 If only the current repo is silent, re-run setup for the repo and restart the host session so the generated hook path and `.red/config.yaml` opt-in are reloaded. If both repos are silent but the synthetic payload rewrites, restart the host session and confirm the hook bundle installed by the host points at the current dev bundle. If the synthetic payload fails, treat the shipped bundle or hook contract as broken and use direct `rsp ...` wrappers until the hook is fixed.
 
-### Root-fix
+### Root fix
 
 This manual split is a stopgap for the hook diagnosis and intercept hardening tracked by #1731 and #1726. The durable fix is for hook telemetry and setup validation to make fail-open silence distinguishable without a hand-built payload/control test.
 
@@ -50,7 +50,7 @@ The registry status should identify whether a resident is registered, reachable,
 
 For daemon failures, stop the stale resident if one is registered and let the next rsp command start a fresh process. For store failures, check that `.red/state/red-skills.rdb` exists, is writable, and was provisioned by setup; keep using raw commands or direct non-eliding wrappers while the shared store is unavailable. Do not delete the durable store as a first recovery step because it also carries other repo state collections.
 
-### Root-fix
+### Root fix
 
 This manual split is a stopgap for the resident and store diagnosis work tracked by #1731 and #1726. The root fix is for registry status, foreground serving, and store health checks to report a single actionable classification.
 
@@ -76,6 +76,6 @@ The live view should show handle counts, bytes retained, and budget/TTL posture.
 
 If logical retained bytes are below budget but the file keeps growing, capture the stats and before/after `du` measurements, then stop producing large elisions in that repo until compaction or rotation catches up. If both logical and physical sizes exceed the configured budget, lower the rsp byte budget temporarily or disable proxy contribution for noisy sessions while preserving the store for diagnosis.
 
-### Root-fix
+### Root fix
 
 This manual bound check is a stopgap for #1704. The root fix is the physical-cap contract: store compaction or rotation must enforce the on-disk ceiling, not only logical expiry.


### PR DESCRIPTION
Main-red repair: PR #1874 renamed the rsp TROUBLESHOOTING headings to 'Root-fix' while #1867 concurrently landed the playbook contract pinning '### Root fix' — a concurrent-landing race. Restores the 3 canonical headings; unblocks every root-cone validation (including the vendoring PR #1894).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786795969&installation_id=129708444&pr_number=1895&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1895&signature=08d5281b5d56679f940704e01909648363ad41417cc008693f9403ac1bb2e8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->