### PR TITLE
fix: #1903 Guard-literal drift test: .red/tmp lockstep between command-guard and sensitive paths

### DIFF
--- a/apps/dev/src/core/shared-gate.ts
+++ b/apps/dev/src/core/shared-gate.ts
@@ -191,6 +191,7 @@ export const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
   /(?:^|\/)\.git\/hooks\//,    // git hooks directory
   /^\.husky\//,                // Husky hooks
   /^\.githooks\//,             // alternative git hooks directory
+  /^\.red\/tmp\//,              // RedSkills runtime worktree lane; lockstep with command-guard.sh
   /^\.red\//,                  // .red/ trust/gate config and gate's own config
   /^plugins\/[^/]+\/hooks\//,  // agent plugin hooks — execute on every agent action
   /^plugins\/[^/]+\/scripts\//, // agent plugin launcher scripts invoked by hooks

--- a/apps/dev/tests/shared-gate.test.ts
+++ b/apps/dev/tests/shared-gate.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   classifyFinding,
@@ -15,6 +18,8 @@ import {
   type SharedGateDeps,
 } from "../src/core/shared-gate.js";
 import { FOWLER_REFACTORING_SMELLS } from "../src/core/review-extract.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
 // shared-gate — closed mechanical allowlist + context-aware escalation (#931).
 //
@@ -315,6 +320,14 @@ describe("SENSITIVE_PATH_PATTERNS — closed auditable set", () => {
       expect(name.length).toBeGreaterThan(0);
     }
   });
+
+  it("keeps the .red/tmp worktree literal in lockstep with command-guard.sh", () => {
+    const commandGuard = readFileSync(join(REPO_ROOT, "plugins/dev/hooks/command-guard.sh"), "utf8");
+    const commandGuardRoot = extractCommandGuardWorktreeRootLiteral(commandGuard);
+    const sensitiveRoot = extractSensitivePathTmpRootLiteral(SENSITIVE_PATH_PATTERNS);
+
+    expect(sensitiveRoot).toBe(commandGuardRoot);
+  });
 });
 
 describe("isSensitivePath — path pattern matching", () => {
@@ -511,3 +524,18 @@ describe("default = intent boundary", () => {
     }
   });
 });
+
+function extractCommandGuardWorktreeRootLiteral(source: string): string {
+  const match = source.match(/allowed_root="\$\(canonical_path "\$REPO_ROOT" "([^"]+)"\)"/);
+  expect(match).not.toBeNull();
+  return `${match![1].replace(/\/+$/, "")}/`;
+}
+
+function extractSensitivePathTmpRootLiteral(patterns: readonly RegExp[]): string {
+  const pattern = patterns.find((p) => p.source.startsWith("^\\.red\\/tmp\\/"));
+  expect(pattern).toBeDefined();
+  return pattern!.source
+    .replace(/^\^/, "")
+    .replace(/\\\//g, "/")
+    .replace(/\\\./g, ".");
+}


### PR DESCRIPTION
Automated AFK landing for #1903. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1903

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786815725&installation_id=129708444&pr_number=1923&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1923&signature=e883197126334e083825afe262610de5497ebea77ecfa7c7b889d06b7960e1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->