### PR TITLE
merge: #1901 Castle contract scaffolding: exported types, .red/contracts docs, drift test

### DIFF
--- a/.red/contracts/red.castle.envelope.v1.md
+++ b/.red/contracts/red.castle.envelope.v1.md
@@ -1,0 +1,20 @@
+# Castle Envelope
+
+schema id: `red.castle.envelope.v1`
+
+Exported TypeScript contract types: `CastleEnvelope`, `CastleEnvelopeSection`,
+`CastleAttemptStatus`.
+
+The castle envelope keeps the existing terminal attempt envelope v1 shape. It
+records the terminal attempt status, summary fields, and optional rendered
+sections.
+
+Fields:
+
+- `status`
+- `worker`
+- `duration`
+- `diff`
+- `attempt`
+- `mergeSha`
+- `sections`

--- a/.red/contracts/red.castle.history.v1.md
+++ b/.red/contracts/red.castle.history.v1.md
@@ -1,0 +1,20 @@
+# Castle History Record
+
+schema id: `red.castle.history.v1`
+
+Exported TypeScript contract types: `CastleHistoryRecord`, `CastleHistoryEvent`.
+
+The castle history record preserves the existing AFK `HistoryRecord` field set
+and moves the lane to `state/castle/history.toonl`.
+
+Fields:
+
+- `ts`
+- `epoch`
+- `worker`
+- `issue`
+- `event`
+- `duration_s`
+- `runner`
+- `merge_sha`
+- `reason`

--- a/.red/contracts/red.castle.hitl-card.v1.md
+++ b/.red/contracts/red.castle.hitl-card.v1.md
@@ -1,0 +1,19 @@
+# Castle HITL Card
+
+schema id: `red.castle.hitl-card.v1`
+
+Exported TypeScript contract types: `CastleHitlCard`,
+`CastleHitlCardPrStatus`, `CastleHitlCardAction`.
+
+The castle HITL card keeps the existing decision card v1 shape for
+ready-for-human issues. Issue and PR content remain display data; command
+parsing only happens on trusted human comments.
+
+Fields:
+
+- `issueNumber`
+- `issueTitle`
+- `issueUrl`
+- `pendingDecision`
+- `prStatus`
+- `updatedAt`

--- a/.red/contracts/red.castle.lane.v1.md
+++ b/.red/contracts/red.castle.lane.v1.md
@@ -1,0 +1,19 @@
+# Castle Lane Record
+
+schema id: `red.castle.lane.v1`
+
+Exported TypeScript contract types: `CastleLaneRecord`, `CastleLaneKind`.
+
+The castle lane is the append-only TOONL record family for engine events. Each
+record carries `at` and `kind`, plus scoped identity fields when the event
+belongs to a worker, supervisor, issue, or attempt.
+
+Fields:
+
+- `at`
+- `kind`
+- `worker_id`
+- `supervisor_id`
+- `issue`
+- `attempt`
+- `payload`

--- a/.red/contracts/red.castle.state.v1.md
+++ b/.red/contracts/red.castle.state.v1.md
@@ -1,0 +1,25 @@
+# Castle State Snapshot
+
+schema id: `red.castle.state.v1`
+
+Exported TypeScript contract types: `CastleStateSnapshot`, `CastleStateKind`.
+
+Castle state snapshots are TOON documents under `state/castle/`. They describe
+the current worker or supervisor state without requiring readers to parse prose
+logs.
+
+Fields:
+
+- `kind`
+- `id`
+- `version`
+- `updated_at`
+- `worker_id`
+- `supervisor_id`
+- `runner`
+- `pid`
+- `started_at`
+- `current`
+- `queue`
+- `completed`
+- `envelope`

--- a/.red/contracts/red.castle.validation.v2.md
+++ b/.red/contracts/red.castle.validation.v2.md
@@ -1,0 +1,19 @@
+# Castle Validation Record
+
+schema id: `red.castle.validation.v2`
+
+Exported TypeScript contract types: `CastleValidationRecord`,
+`CastleValidationStatus`.
+
+The castle validation sidecar preserves the `red.afk.validation.v1` fields and
+serializes them as TOON records in `validation.toonl`.
+
+Fields:
+
+- `schema`
+- `name`
+- `status`
+- `command`
+- `exitCode`
+- `durationMs`
+- `summary`

--- a/packages/red-castle/package.json
+++ b/packages/red-castle/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./engine/contracts": "./src/engine/contracts/index.ts",
     "./sandboxes/docker": "./src/sandboxes/docker.ts",
     "./sandboxes/vercel": "./src/sandboxes/vercel.ts",
     "./sandboxes/podman": "./src/sandboxes/podman.ts",

--- a/packages/red-castle/src/engine/contracts/drift.test.ts
+++ b/packages/red-castle/src/engine/contracts/drift.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CASTLE_PUBLISHED_CONTRACTS } from "./index.js";
+
+const repoRoot = resolve(import.meta.dirname, "../../../../..");
+
+describe("castle published contract docs", () => {
+  it("documents every exported contract schema, type, and field", () => {
+    for (const contract of CASTLE_PUBLISHED_CONTRACTS) {
+      const doc = readFileSync(resolve(repoRoot, contract.docPath), "utf8");
+
+      expect(doc, contract.docPath).toContain(
+        `schema id: \`${contract.schemaId}\``,
+      );
+      for (const typeName of contract.typeNames) {
+        expect(doc, `${contract.docPath} documents ${typeName}`).toContain(
+          `\`${typeName}\``,
+        );
+      }
+      for (const field of contract.fields) {
+        expect(doc, `${contract.docPath} documents ${field}`).toContain(
+          `\`${field}\``,
+        );
+      }
+    }
+  });
+
+  it("keeps the docs set one-to-one with the published contract list", async () => {
+    const docsDir = resolve(repoRoot, ".red/contracts");
+    const docs = (await (await import("node:fs/promises")).readdir(docsDir))
+      .filter((entry) => entry.endsWith(".md"))
+      .sort();
+    expect(docs).toEqual(
+      CASTLE_PUBLISHED_CONTRACTS.map((contract) =>
+        contract.docPath.replace(".red/contracts/", ""),
+      ).sort(),
+    );
+  });
+});

--- a/packages/red-castle/src/engine/contracts/index.ts
+++ b/packages/red-castle/src/engine/contracts/index.ts
@@ -1,0 +1,235 @@
+type FieldMap<T> = { readonly [K in Extract<keyof T, string>]-?: true };
+
+export interface PublishedContract<TField extends string = string> {
+  readonly schemaId: string;
+  readonly docPath: `.red/contracts/${string}.md`;
+  readonly typeNames: readonly string[];
+  readonly fields: readonly TField[];
+}
+
+function fieldsOf<T>(fields: FieldMap<T>): readonly Extract<keyof T, string>[] {
+  return Object.keys(fields) as Extract<keyof T, string>[];
+}
+
+function contract<T>(
+  spec: Omit<PublishedContract<Extract<keyof T, string>>, "fields"> & {
+    readonly fields: FieldMap<T>;
+  },
+): PublishedContract<Extract<keyof T, string>> {
+  return { ...spec, fields: fieldsOf<T>(spec.fields) };
+}
+
+export const CASTLE_LANE_SCHEMA_ID = "red.castle.lane.v1" as const;
+export const CASTLE_STATE_SCHEMA_ID = "red.castle.state.v1" as const;
+export const CASTLE_HISTORY_SCHEMA_ID = "red.castle.history.v1" as const;
+export const CASTLE_VALIDATION_SCHEMA_ID = "red.castle.validation.v2" as const;
+export const CASTLE_ENVELOPE_SCHEMA_ID = "red.castle.envelope.v1" as const;
+export const CASTLE_HITL_CARD_SCHEMA_ID = "red.castle.hitl-card.v1" as const;
+
+export type CastleLaneKind =
+  | "worker.claimed"
+  | "worker.steered"
+  | "worker.heartbeat"
+  | "worker.completed"
+  | "worker.blocked"
+  | "supervisor.scaled"
+  | "supervisor.retired"
+  | (string & {});
+
+export interface CastleLaneRecord {
+  at: string;
+  kind: CastleLaneKind;
+  worker_id?: string;
+  supervisor_id?: string;
+  issue?: number;
+  attempt?: number;
+  payload?: Record<string, unknown>;
+}
+
+export type CastleStateKind = "worker" | "supervisor";
+
+export interface CastleStateSnapshot {
+  kind: CastleStateKind;
+  id: string;
+  version: number;
+  updated_at: string;
+  worker_id?: string;
+  supervisor_id?: string;
+  runner?: string;
+  pid?: number;
+  started_at?: string;
+  current?: Record<string, unknown>;
+  queue?: number[];
+  completed?: number[];
+  envelope?: { posted: boolean };
+}
+
+export type CastleHistoryEvent =
+  "done" | "blocked" | "exhausted" | (string & {});
+
+export interface CastleHistoryRecord {
+  ts: string;
+  epoch: number;
+  worker: string;
+  issue: number;
+  event: CastleHistoryEvent;
+  duration_s: number;
+  runner: string;
+  merge_sha?: string;
+  reason?: string;
+}
+
+export type CastleValidationStatus = "passed" | "failed" | "skipped";
+
+export interface CastleValidationRecord {
+  schema: typeof CASTLE_VALIDATION_SCHEMA_ID;
+  name: string;
+  status: CastleValidationStatus;
+  command?: string;
+  exitCode?: number;
+  durationMs?: number;
+  summary?: string;
+}
+
+export type CastleAttemptStatus =
+  "blocked" | "no-sentinel" | "merge-conflict" | "done" | "discarded";
+
+export interface CastleEnvelopeSection {
+  name: string;
+  body: string;
+  fenced?: boolean;
+  fenceLang?: string;
+}
+
+export interface CastleEnvelope {
+  status: CastleAttemptStatus;
+  worker: string;
+  duration: string;
+  diff: string;
+  attempt: number;
+  mergeSha?: string;
+  sections?: CastleEnvelopeSection[];
+}
+
+export type CastleHitlCardAction =
+  "approve" | "approve-ci" | "reject" | "requeue";
+
+export interface CastleHitlCardPrStatus {
+  number?: number;
+  ci: "pass" | "fail" | "pending" | "none";
+  ciPassed: number;
+  ciTotal: number;
+  mergeability: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  headSha?: string;
+}
+
+export interface CastleHitlCard {
+  issueNumber: number;
+  issueTitle?: string;
+  issueUrl?: string;
+  pendingDecision: string;
+  prStatus: CastleHitlCardPrStatus;
+  updatedAt: string;
+}
+
+export const CASTLE_PUBLISHED_CONTRACTS = [
+  contract<CastleLaneRecord>({
+    schemaId: CASTLE_LANE_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.lane.v1.md",
+    typeNames: ["CastleLaneRecord", "CastleLaneKind"],
+    fields: {
+      at: true,
+      kind: true,
+      worker_id: true,
+      supervisor_id: true,
+      issue: true,
+      attempt: true,
+      payload: true,
+    },
+  }),
+  contract<CastleStateSnapshot>({
+    schemaId: CASTLE_STATE_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.state.v1.md",
+    typeNames: ["CastleStateSnapshot", "CastleStateKind"],
+    fields: {
+      kind: true,
+      id: true,
+      version: true,
+      updated_at: true,
+      worker_id: true,
+      supervisor_id: true,
+      runner: true,
+      pid: true,
+      started_at: true,
+      current: true,
+      queue: true,
+      completed: true,
+      envelope: true,
+    },
+  }),
+  contract<CastleHistoryRecord>({
+    schemaId: CASTLE_HISTORY_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.history.v1.md",
+    typeNames: ["CastleHistoryRecord", "CastleHistoryEvent"],
+    fields: {
+      ts: true,
+      epoch: true,
+      worker: true,
+      issue: true,
+      event: true,
+      duration_s: true,
+      runner: true,
+      merge_sha: true,
+      reason: true,
+    },
+  }),
+  contract<CastleValidationRecord>({
+    schemaId: CASTLE_VALIDATION_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.validation.v2.md",
+    typeNames: ["CastleValidationRecord", "CastleValidationStatus"],
+    fields: {
+      schema: true,
+      name: true,
+      status: true,
+      command: true,
+      exitCode: true,
+      durationMs: true,
+      summary: true,
+    },
+  }),
+  contract<CastleEnvelope>({
+    schemaId: CASTLE_ENVELOPE_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.envelope.v1.md",
+    typeNames: [
+      "CastleEnvelope",
+      "CastleEnvelopeSection",
+      "CastleAttemptStatus",
+    ],
+    fields: {
+      status: true,
+      worker: true,
+      duration: true,
+      diff: true,
+      attempt: true,
+      mergeSha: true,
+      sections: true,
+    },
+  }),
+  contract<CastleHitlCard>({
+    schemaId: CASTLE_HITL_CARD_SCHEMA_ID,
+    docPath: ".red/contracts/red.castle.hitl-card.v1.md",
+    typeNames: [
+      "CastleHitlCard",
+      "CastleHitlCardPrStatus",
+      "CastleHitlCardAction",
+    ],
+    fields: {
+      issueNumber: true,
+      issueTitle: true,
+      issueUrl: true,
+      pendingDecision: true,
+      prStatus: true,
+      updatedAt: true,
+    },
+  }),
+] as const;

--- a/packages/red-castle/src/index.ts
+++ b/packages/red-castle/src/index.ts
@@ -140,3 +140,4 @@ export type {
   MergeToHeadBranchStrategy,
   NamedBranchStrategy,
 } from "./SandboxProvider.js";
+export * from "./engine/contracts/index.js";


### PR DESCRIPTION
Lands the fleet-authored branch for #1901 through PR + CI (local gate OOMs this workstation).

Sensitive-path review (maintainer-approved, 2026-07-16): the protected diff is limited to six new contract docs under .red/contracts/ — purely additive, matching the published-contracts freeze (#1887). Remaining changes are the castle contracts barrel, drift test, and package/barrel exports.

Closes #1901

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786817769&installation_id=129708444&pr_number=1924&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1924&signature=4d4b3ba89419f889021fec40415f8ded8a0a5f46fdbc2569290c43e35d5dce5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->