### PR TITLE
fix: #1902 Readers learn both: dev readers parse legacy JSON and TOON castle lanes

### DIFF
--- a/apps/dev/src/core/output-shaping-report.ts
+++ b/apps/dev/src/core/output-shaping-report.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { encode as encodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
-import { parseState } from "./state.js";
+import { parseStateDocument } from "./state.js";
 import type { OutputShapingVariant } from "./output-shaping.js";
 
 export interface OutputShapingSample {
@@ -32,7 +32,7 @@ export function collectOutputShapingSamples(tmpDir: string): OutputShapingSample
   const samples: OutputShapingSample[] = [];
   for (const path of states) {
     try {
-      const state = parseState(JSON.parse(readFileSync(path, "utf8")));
+      const state = parseStateDocument(readFileSync(path, "utf8"));
       const variant = state.current.output_shaping_variant;
       if (variant !== "steered" && variant !== "holdout") continue;
       samples.push({

--- a/apps/dev/tests/output-shaping-report.test.ts
+++ b/apps/dev/tests/output-shaping-report.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import { encode } from "@reddb-io/toon";
 import {
   buildOutputShapingReport,
   collectOutputShapingSamples,
@@ -49,5 +50,43 @@ describe("AFK output shaping report", () => {
     const root = mkdtempSync(join(tmpdir(), "afk-output-shaping-"));
     writeState(root, "wA", "2-a1", "", 100);
     expect(collectOutputShapingSamples(join(root, ".red", "tmp"))).toEqual([]);
+  });
+
+  it("sniffs TOON state snapshots while keeping legacy JSON state readable", () => {
+    const root = mkdtempSync(join(tmpdir(), "afk-output-shaping-"));
+    const toonDir = join(root, ".red", "tmp", "workers", "wTOON", "8-a1");
+    const legacyDir = join(root, ".red", "tmp", "workers", "wJSON", "9-a1");
+    mkdirSync(toonDir, { recursive: true });
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(toonDir, "afk.state.json"),
+      encode({
+        current: {
+          number: 8,
+          output_shaping_variant: "steered",
+          output_tokens: 77,
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(legacyDir, "afk.state.json"),
+      JSON.stringify({
+        current: {
+          number: 9,
+          output_shaping_variant: "holdout",
+          output_tokens: 88,
+          diff_added: 3,
+        },
+      }),
+      "utf8",
+    );
+
+    expect(
+      collectOutputShapingSamples(join(root, ".red", "tmp")).sort((a, b) => Number(a.issue) - Number(b.issue)),
+    ).toEqual([
+      { issue: 8, variant: "steered", output_tokens: 77 },
+      { issue: 9, variant: "holdout", output_tokens: 88 },
+    ]);
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1902. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1902

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786820626&installation_id=129708444&pr_number=1925&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1925&signature=a9d7ca2c2b5c620b3a6c817df50c535836cd1ce240c31317df47d1292b92229d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->