### PR TITLE
merge: #1904 Engine skeleton: engine area, EnginePaths, direct config reader

### DIFF
--- a/packages/red-castle/src/engine/config.test.ts
+++ b/packages/red-castle/src/engine/config.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  loadEngineConfig,
+  parseEngineConfigYaml,
+  readEngineBackpressure,
+} from "./config.js";
+
+function redRootWithConfig(text?: string): string {
+  const root = mkdtempSync(join(tmpdir(), "castle-config-"));
+  const redRoot = join(root, ".red");
+  mkdirSync(redRoot, { recursive: true });
+  if (text !== undefined)
+    writeFileSync(join(redRoot, "config.yaml"), text, "utf8");
+  return redRoot;
+}
+
+describe("engine config reader", () => {
+  it("keeps the ADR 0067 gate closed without plugins.dev.enabled: true", () => {
+    const redRoot = redRootWithConfig(
+      "plugins:\n  dev:\n    afk:\n      sandbox: docker\n",
+    );
+
+    const cfg = loadEngineConfig(redRoot, { env: {} });
+
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.get("afk.sandbox")).toBe("none");
+  });
+
+  it("folds frozen plugins.dev.afk names over legacy afk names", () => {
+    const redRoot = redRootWithConfig(
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "    afk:",
+        "      sandbox: podman",
+        "      default_runner: codex",
+        "      backpressure:",
+        "        - pnpm test",
+        "        - pnpm lint",
+        "afk:",
+        "  sandbox: docker",
+        "  default_runner: claude",
+        "  backpressure:",
+        "    - npm test",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = loadEngineConfig(redRoot, { env: {} });
+
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.get("afk.sandbox")).toBe("podman");
+    expect(cfg.get("afk.default_runner")).toBe("codex");
+    expect(readEngineBackpressure(cfg)).toEqual(["pnpm test", "pnpm lint"]);
+  });
+
+  it("honors frozen RED_AFK overrides without mutating the parsed key names", () => {
+    const redRoot = redRootWithConfig(
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "afk:",
+        "  sandbox: docker",
+        "  max_iterations: 4",
+        "  attempt_timeout: 99",
+        "  statusline_cache_ttl: 42",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = loadEngineConfig(redRoot, {
+      env: {
+        RED_AFK_SANDBOX: "podman",
+        RED_AFK_RUNNER: "codex",
+        RED_AFK_MAX_ITERATIONS: "8",
+        RED_AFK_ATTEMPT_TIMEOUT_S: "123",
+        RED_AFK_STATUSLINE_CACHE_TTL_S: "77",
+      },
+    });
+
+    expect(cfg.get("afk.sandbox")).toBe("podman");
+    expect(cfg.get("afk.default_runner")).toBe("codex");
+    expect(cfg.get("afk.max_iterations")).toBe("8");
+    expect(cfg.get("afk.attempt_timeout")).toBe("123");
+    expect(cfg.get("afk.statusline_cache_ttl")).toBe("77");
+    expect(cfg.values["RED_AFK_SANDBOX"]).toBeUndefined();
+  });
+
+  it("parses list values into indexed dotted keys", () => {
+    expect(
+      parseEngineConfigYaml(
+        "afk:\n  backpressure:\n    - pnpm test\n    - 'pnpm lint' # comment\n",
+      ),
+    ).toMatchObject({
+      "afk.backpressure.0": "pnpm test",
+      "afk.backpressure.1": "pnpm lint",
+    });
+  });
+});

--- a/packages/red-castle/src/engine/config.ts
+++ b/packages/red-castle/src/engine/config.ts
@@ -1,0 +1,232 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type EngineConfigValues = Record<string, string>;
+export type EngineConfigReader = (path: string) => string | undefined;
+export type EngineConfigWarn = (message: string) => void;
+
+export class MalformedEngineConfigError extends Error {
+  constructor(message = "malformed YAML") {
+    super(message);
+    this.name = "MalformedEngineConfigError";
+  }
+}
+
+export const ENGINE_CONFIG_DEFAULTS = {
+  "afk.default_runner": "claude",
+  "afk.sandbox": "none",
+  "afk.max_iterations": "12",
+  "afk.attempt_timeout": "2700",
+  "afk.statusline_cache_ttl": "180",
+  "afk.worktree_launches_pull_request": "true",
+  "afk.claim_reaper.refresh_s": "300",
+  "afk.claim_reaper.stale_tolerance": "3",
+  "afk.claim_reaper.grace_s": "300",
+  "afk.claim_reaper.recent_commit_s": "2700",
+  "afk.validation.node_max_old_space_mb": "2048",
+  "afk.validation.vitest_max_workers": "1",
+  "afk.validation.heavy_available_memory_mb": "4096",
+} as const;
+
+const RED_AFK_ENV_ACCESSORS = {
+  RED_AFK_RUNNER: "afk.default_runner",
+  RED_AFK_SANDBOX: "afk.sandbox",
+  RED_AFK_MAX_ITERATIONS: "afk.max_iterations",
+  RED_AFK_ATTEMPT_TIMEOUT_S: "afk.attempt_timeout",
+  RED_AFK_STATUSLINE_CACHE_TTL_S: "afk.statusline_cache_ttl",
+  RED_AFK_CLAIM_REFRESH_S: "afk.claim_reaper.refresh_s",
+  RED_AFK_CLAIM_STALE_TOLERANCE: "afk.claim_reaper.stale_tolerance",
+  RED_AFK_CLAIM_REAPER_GRACE_S: "afk.claim_reaper.grace_s",
+  RED_AFK_CLAIM_REAPER_RECENT_COMMIT_S: "afk.claim_reaper.recent_commit_s",
+} as const;
+
+export interface LoadEngineConfigOptions {
+  readonly read?: EngineConfigReader;
+  readonly warn?: EngineConfigWarn;
+  readonly env?: Record<string, string | undefined>;
+}
+
+export interface EngineConfig {
+  readonly enabled: boolean;
+  readonly redRoot: string;
+  readonly configPath: string;
+  readonly values: EngineConfigValues;
+  readonly get: (key: string) => string;
+}
+
+const defaultReader: EngineConfigReader = (path) => {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+};
+
+const defaultWarn: EngineConfigWarn = (message) => {
+  process.stderr.write(`${message}\n`);
+};
+
+function configDefaults(): EngineConfigValues {
+  return { ...ENGINE_CONFIG_DEFAULTS };
+}
+
+function stripCommentOutsideQuotes(text: string): string {
+  let quote: string | undefined;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if ((ch === '"' || ch === "'") && (i === 0 || text[i - 1] !== "\\")) {
+      quote = quote === ch ? undefined : (quote ?? ch);
+      continue;
+    }
+    if (ch === "#" && quote === undefined) return text.slice(0, i);
+  }
+  return text;
+}
+
+function unquoteScalar(value: string): string {
+  if (value.startsWith('"')) {
+    if (!value.endsWith('"') || value.length < 2)
+      throw new MalformedEngineConfigError();
+    return value.slice(1, -1);
+  }
+  if (value.startsWith("'")) {
+    if (!value.endsWith("'") || value.length < 2)
+      throw new MalformedEngineConfigError();
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function parseEngineConfigYaml(text: string): EngineConfigValues {
+  const out: EngineConfigValues = {};
+  const stack: string[] = [];
+  const indents: number[] = [];
+  const seqCounters: Record<string, number> = {};
+
+  for (let raw of text.split("\n")) {
+    raw = raw.replace(/\r$/, "");
+    const stripped = stripCommentOutsideQuotes(raw).replace(/\s+$/, "");
+    if (stripped.trim() === "") continue;
+
+    const indent = stripped.match(/^\s*/)?.[0].length ?? 0;
+    if (indent % 2 !== 0) throw new MalformedEngineConfigError();
+
+    let rest = stripped.slice(indent);
+    while (indents.length > 0 && indents[indents.length - 1]! >= indent) {
+      stack.pop();
+      indents.pop();
+    }
+
+    if (/^-(\s|$)/.test(rest)) {
+      if (stack.length === 0) throw new MalformedEngineConfigError();
+      rest = rest.slice(1).trimStart();
+      if (rest === "") throw new MalformedEngineConfigError();
+
+      const parent = stack.join(".");
+      const idx = seqCounters[parent] ?? 0;
+      seqCounters[parent] = idx + 1;
+      out[`${parent}.${idx}`] = unquoteScalar(rest);
+      continue;
+    }
+
+    if (!/^[a-zA-Z_][a-zA-Z0-9_-]*:/.test(rest)) {
+      throw new MalformedEngineConfigError();
+    }
+
+    const colon = rest.indexOf(":");
+    const key = rest.slice(0, colon);
+    const value = rest.slice(colon + 1).trimStart();
+    const full = stack.length > 0 ? `${stack.join(".")}.${key}` : key;
+
+    if (value === "") {
+      stack.push(key);
+      indents.push(indent);
+    } else {
+      out[full] = unquoteScalar(value);
+    }
+  }
+
+  return out;
+}
+
+function foldDevNamespace(
+  values: EngineConfigValues,
+  parsed: EngineConfigValues,
+): void {
+  for (const [key, value] of Object.entries(parsed)) {
+    values[key] = value;
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    const match = /^plugins\.dev\.(.+)$/.exec(key);
+    if (!match) continue;
+    const rest = match[1]!;
+    const accessor =
+      rest === "afk" || rest.startsWith("afk.") ? rest : `dev.${rest}`;
+    values[accessor] = value;
+  }
+}
+
+function applyEnvOverrides(
+  values: EngineConfigValues,
+  env: Record<string, string | undefined>,
+): void {
+  for (const [envKey, accessor] of Object.entries(RED_AFK_ENV_ACCESSORS)) {
+    const value = env[envKey];
+    if (value !== undefined && value.trim() !== "") values[accessor] = value;
+  }
+}
+
+export function pluginDevEnabled(values: EngineConfigValues): boolean {
+  return values["plugins.dev.enabled"] === "true";
+}
+
+export function loadEngineConfig(
+  redRoot: string,
+  options: LoadEngineConfigOptions = {},
+): EngineConfig {
+  const root = resolve(redRoot);
+  const configPath = resolve(root, "config.yaml");
+  const read = options.read ?? defaultReader;
+  const warn = options.warn ?? defaultWarn;
+  const env = options.env ?? process.env;
+  const values = configDefaults();
+  const text = read(configPath);
+  let parsed: EngineConfigValues = {};
+
+  if (text !== undefined) {
+    try {
+      parsed = parseEngineConfigYaml(text);
+    } catch {
+      warn(
+        `[castle:config] warn: malformed YAML in ${configPath} - using defaults`,
+      );
+    }
+  }
+
+  const enabled = parsed["plugins.dev.enabled"] === "true";
+  if (enabled) {
+    foldDevNamespace(values, parsed);
+    applyEnvOverrides(values, env);
+  }
+
+  return {
+    enabled,
+    redRoot: root,
+    configPath,
+    values,
+    get: (key) => values[key] ?? "",
+  };
+}
+
+export function readEngineBackpressure(config: EngineConfig): string[] {
+  const indexed: string[] = [];
+  for (let i = 0; ; i++) {
+    const value = config.values[`afk.backpressure.${i}`];
+    if (value === undefined) break;
+    if (value.trim() !== "") indexed.push(value);
+  }
+  if (indexed.length > 0) return indexed;
+
+  const scalar = config.values["afk.backpressure"];
+  return scalar && scalar.trim() !== "" ? [scalar] : [];
+}

--- a/packages/red-castle/src/engine/paths.test.ts
+++ b/packages/red-castle/src/engine/paths.test.ts
@@ -1,0 +1,68 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createEnginePaths } from "./paths.js";
+
+describe("EnginePaths", () => {
+  it("resolves castle state and tmp lanes from the injected .red root", () => {
+    const redRoot = resolve("fixture", ".red");
+    const paths = createEnginePaths(redRoot);
+
+    expect(paths.redRoot).toBe(redRoot);
+    expect(paths.stateRoot).toBe(resolve(redRoot, "state"));
+    expect(paths.castleStateRoot).toBe(resolve(redRoot, "state", "castle"));
+    expect(paths.castleHistory).toBe(
+      resolve(redRoot, "state", "castle", "history.toonl"),
+    );
+    expect(paths.castleValidation).toBe(
+      resolve(redRoot, "state", "castle", "validation.toonl"),
+    );
+    expect(paths.tmpRoot).toBe(resolve(redRoot, "tmp"));
+    expect(paths.supervisorsRoot).toBe(resolve(redRoot, "tmp", "supervisors"));
+    expect(paths.supervisor("s1")).toBe(
+      resolve(redRoot, "tmp", "supervisors", "s1"),
+    );
+    expect(paths.workersRoot).toBe(resolve(redRoot, "tmp", "workers"));
+    expect(paths.worker("wAB12")).toBe(
+      resolve(redRoot, "tmp", "workers", "wAB12"),
+    );
+    expect(paths.monitorsRoot).toBe(resolve(redRoot, "tmp", "monitors"));
+    expect(paths.monitor("m1")).toBe(resolve(redRoot, "tmp", "monitors", "m1"));
+  });
+
+  it("resolves worker worktrees and every ratified worktree sub-lane", () => {
+    const redRoot = resolve("other", ".red");
+    const paths = createEnginePaths(redRoot);
+
+    expect(paths.worktreesRoot).toBe(resolve(redRoot, "tmp", "worktrees"));
+    expect(paths.workerWorktreesRoot).toBe(
+      resolve(redRoot, "tmp", "worktrees", "workers"),
+    );
+    expect(paths.workerWorktree("wAB12", 1904)).toBe(
+      resolve(redRoot, "tmp", "worktrees", "workers", "wAB12-1904"),
+    );
+    expect(paths.worktreeLane("manual")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "manual"),
+    );
+    expect(paths.worktreeLane("feedback")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "feedback"),
+    );
+    expect(paths.worktreeLane("landing")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "landing"),
+    );
+    expect(paths.worktreeLane("rebase")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "rebase"),
+    );
+    expect(paths.worktreeLane("cascade")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "cascade"),
+    );
+    expect(paths.worktreeLane("adopt")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "adopt"),
+    );
+    expect(paths.worktreeLane("reconcile")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "reconcile"),
+    );
+    expect(paths.worktreeLane("docs")).toBe(
+      resolve(redRoot, "tmp", "worktrees", "docs"),
+    );
+  });
+});

--- a/packages/red-castle/src/engine/paths.ts
+++ b/packages/red-castle/src/engine/paths.ts
@@ -1,0 +1,68 @@
+import { resolve } from "node:path";
+
+export const CASTLE_WORKTREE_LANES = [
+  "manual",
+  "feedback",
+  "landing",
+  "rebase",
+  "cascade",
+  "adopt",
+  "reconcile",
+  "docs",
+] as const;
+
+export type CastleWorktreeLane = (typeof CASTLE_WORKTREE_LANES)[number];
+
+export interface EnginePaths {
+  readonly redRoot: string;
+  readonly stateRoot: string;
+  readonly castleStateRoot: string;
+  readonly castleHistory: string;
+  readonly castleValidation: string;
+  readonly tmpRoot: string;
+  readonly supervisorsRoot: string;
+  readonly supervisor: (id: string) => string;
+  readonly workersRoot: string;
+  readonly worker: (workerId: string) => string;
+  readonly monitorsRoot: string;
+  readonly monitor: (id: string) => string;
+  readonly worktreesRoot: string;
+  readonly workerWorktreesRoot: string;
+  readonly workerWorktree: (
+    workerId: string,
+    ticketId: number | string,
+  ) => string;
+  readonly worktreeLane: (lane: CastleWorktreeLane) => string;
+}
+
+export function createEnginePaths(redRoot: string): EnginePaths {
+  const root = resolve(redRoot);
+  const stateRoot = resolve(root, "state");
+  const castleStateRoot = resolve(stateRoot, "castle");
+  const tmpRoot = resolve(root, "tmp");
+  const supervisorsRoot = resolve(tmpRoot, "supervisors");
+  const workersRoot = resolve(tmpRoot, "workers");
+  const monitorsRoot = resolve(tmpRoot, "monitors");
+  const worktreesRoot = resolve(tmpRoot, "worktrees");
+  const workerWorktreesRoot = resolve(worktreesRoot, "workers");
+
+  return {
+    redRoot: root,
+    stateRoot,
+    castleStateRoot,
+    castleHistory: resolve(castleStateRoot, "history.toonl"),
+    castleValidation: resolve(castleStateRoot, "validation.toonl"),
+    tmpRoot,
+    supervisorsRoot,
+    supervisor: (id) => resolve(supervisorsRoot, id),
+    workersRoot,
+    worker: (workerId) => resolve(workersRoot, workerId),
+    monitorsRoot,
+    monitor: (id) => resolve(monitorsRoot, id),
+    worktreesRoot,
+    workerWorktreesRoot,
+    workerWorktree: (workerId, ticketId) =>
+      resolve(workerWorktreesRoot, `${workerId}-${ticketId}`),
+    worktreeLane: (lane) => resolve(worktreesRoot, lane),
+  };
+}


### PR DESCRIPTION
Lands the fleet-authored branch for #1904 through PR + CI.

The local gate parked this twice on src/createWorktree.test.ts (lock-contention assertion) — a load-dependent flake: the test passes 5/5 on an idle checkout of main and only fails while the 3-slot fleet loads the workstation, serializing the intended concurrency. CI runs the identical suite on a clean runner and is the same gate authority.

Closes #1904

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786822331&installation_id=129708444&pr_number=1926&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1926&signature=ddefb7b837b12cf070b31605996f502e9a16682fd739c0f34b48f7b334825935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->