### PR TITLE
fix: #1910 Castle gate execution and reverse-dependency validation cone

### DIFF
--- a/packages/red-castle/src/engine/gate-constants.ts
+++ b/packages/red-castle/src/engine/gate-constants.ts
@@ -1,0 +1,52 @@
+export const CASTLE_VALIDATION_SCHEMA = "red.castle.validation.v2" as const;
+
+export const FEEDBACK_SCRIPTS = ["test", "typecheck", "lint", "build"] as const;
+export type FeedbackScript = (typeof FEEDBACK_SCRIPTS)[number];
+
+export const MECHANICAL_KINDS = [
+  "formatter",
+  "import-organizer",
+  "lint-fix",
+  "comment-typo",
+  "trailing-whitespace",
+  "trailing-newline",
+] as const;
+export type MechanicalKind = (typeof MECHANICAL_KINDS)[number];
+
+export const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
+  /^\.github\/workflows\//,
+  /^\.github\/actions\//,
+  /(?:^|\/)\.git\/hooks\//,
+  /^\.husky\//,
+  /^\.githooks\//,
+  /^\.red\/tmp\//,
+  /^\.red\//,
+  /^plugins\/[^/]+\/hooks\//,
+  /^plugins\/[^/]+\/scripts\//,
+];
+
+export const LIFECYCLE_SCRIPT_NAMES = [
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+  "prepublish",
+  "prepublishOnly",
+  "prepack",
+  "pack",
+  "postpack",
+] as const;
+
+export const ROOT_TRIGGER_FILES = [
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "package.json",
+  "turbo.json",
+  "tsconfig.json",
+  "tsconfig.base.json",
+  ".npmrc",
+  ".nvmrc",
+] as const;
+
+export const DEFAULT_BACKPRESSURE_TIMEOUT_MS = 10 * 60 * 1000;
+export const KILLED_EXIT_CODE = 124;

--- a/packages/red-castle/src/engine/gate-executor.test.ts
+++ b/packages/red-castle/src/engine/gate-executor.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { CASTLE_VALIDATION_SCHEMA } from "./gate-constants.js";
+import { makeHeadlessGateSink, makeInteractiveGateSink } from "./gate-sink.js";
+import { checkSensitivePaths, classifyFinding, runCastleGate, type RunCastleGateInput } from "./gate-executor.js";
+
+function baseInput(): RunCastleGateInput {
+  let tick = 0;
+  return {
+    worktree: "/repo",
+    changedFiles: ["packages/core/src/index.ts"],
+    layout: {
+      hasPackage(scope) {
+        return [".", "packages/core", "apps/dev"].includes(scope);
+      },
+      hasScript(scope, script) {
+        return scope === "packages/core" && ["test", "typecheck"].includes(script);
+      },
+    },
+    graph: {
+      packages: [
+        { dir: "packages/core", dependsOn: [] },
+        { dir: "apps/dev", dependsOn: ["packages/core"] },
+      ],
+    },
+    sink: makeInteractiveGateSink({
+      askIntent: async () => "approved",
+      askSensitivePath: async () => "approved",
+    }),
+    feedbackExec: vi.fn(async () => ({ code: 0, stdout: "ok", stderr: "" })),
+    backpressureExec: vi.fn(async () => ({ code: 0, stdout: "ok", stderr: "" })),
+    applyMechanical: vi.fn(async () => {}),
+    now: () => ++tick,
+  };
+}
+
+describe("castle gate executor", () => {
+  it("classifies only versioned mechanical kinds as mechanical", () => {
+    expect(classifyFinding({ kind: "formatter", description: "format" })).toBe("mechanical");
+    expect(classifyFinding({ kind: "refactor", description: "logic changed" })).toBe("intent");
+  });
+
+  it("detects sensitive paths and package lifecycle script changes", () => {
+    expect(checkSensitivePaths([".github/workflows/ci.yml"], "")).toEqual([
+      { path: ".github/workflows/ci.yml", reason: "CI workflow file" },
+    ]);
+    expect(checkSensitivePaths(["packages/core/package.json"], '+    "postinstall": "node build.js",')).toEqual([
+      { path: "packages/core/package.json", reason: "lifecycle script added or altered in package.json" },
+    ]);
+  });
+
+  it("runs scoped feedback, skips missing scripts, then runs configured backpressure", async () => {
+    const input = baseInput();
+    input.backpressureCommands = ["pnpm smoke"];
+
+    const result = await runCastleGate(input);
+
+    expect(result.ok).toBe(true);
+    expect(result.validationScope).toEqual({
+      type: "cone",
+      triggerPackages: ["packages/core"],
+      packages: ["apps/dev", "packages/core"],
+    });
+    expect(input.feedbackExec).toHaveBeenCalledWith(["pnpm", "-C", "/repo/packages/core", "test"]);
+    expect(input.backpressureExec).toHaveBeenCalledWith({
+      command: "pnpm smoke",
+      cwd: "/repo",
+      timeoutMs: 600000,
+    });
+    expect(result.checks.map((check) => check.name)).toContain("backpressure:pnpm smoke");
+    expect(JSON.parse(result.sidecar[0]!).schema).toBe(CASTLE_VALIDATION_SCHEMA);
+  });
+
+  it("blocks through the headless sink on intent findings before validation evidence is recorded", async () => {
+    const input = baseInput();
+    const parkIntent = vi.fn(async () => {});
+    input.sink = makeHeadlessGateSink({
+      parkIntent,
+      parkSensitivePath: async () => {},
+    });
+    input.findings = [{ kind: "behavior", description: "changes semantics" }];
+
+    const result = await runCastleGate(input);
+
+    expect(result.ok).toBe(false);
+    expect(result.sinkOutcomes).toEqual(["parked"]);
+    expect(parkIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run backpressure when feedback fails", async () => {
+    const input = baseInput();
+    input.feedbackExec = vi.fn(async () => ({ code: 1, stdout: "", stderr: "failed" }));
+    input.backpressureCommands = ["pnpm smoke"];
+
+    const result = await runCastleGate(input);
+
+    expect(result.ok).toBe(false);
+    expect(input.backpressureExec).not.toHaveBeenCalled();
+  });
+});

--- a/packages/red-castle/src/engine/gate-executor.ts
+++ b/packages/red-castle/src/engine/gate-executor.ts
@@ -1,0 +1,270 @@
+import {
+  CASTLE_VALIDATION_SCHEMA,
+  DEFAULT_BACKPRESSURE_TIMEOUT_MS,
+  FEEDBACK_SCRIPTS,
+  KILLED_EXIT_CODE,
+  LIFECYCLE_SCRIPT_NAMES,
+  MECHANICAL_KINDS,
+  SENSITIVE_PATH_PATTERNS,
+  type FeedbackScript,
+} from "./gate-constants.js";
+import type { GateFinding, GateSink, GateSinkOutcome, SensitivePathHit } from "./gate-sink.js";
+import { computeValidationScope, scopesForValidationScope, type PackageLayout, type ValidationScope, type WorkspaceGraph } from "./validation-cone.js";
+
+export type ValidationStatus = "passed" | "failed" | "skipped";
+
+export interface ExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type FeedbackExec = (args: string[]) => Promise<ExecResult>;
+export type BackpressureExec = (input: {
+  command: string;
+  cwd: string;
+  timeoutMs: number;
+}) => Promise<ExecResult>;
+
+export interface ScriptLayout extends PackageLayout {
+  hasScript: (scope: string, script: string) => boolean;
+}
+
+export interface ValidationRecord {
+  schema: typeof CASTLE_VALIDATION_SCHEMA;
+  name: string;
+  status: ValidationStatus;
+  command?: string;
+  exitCode?: number;
+  durationMs?: number;
+  summary?: string;
+}
+
+export interface ValidationCheck {
+  name: string;
+  status: ValidationStatus;
+  record: ValidationRecord;
+}
+
+export interface RunCastleGateInput {
+  worktree: string;
+  changedFiles: readonly string[];
+  packageJsonDiff?: string;
+  layout: ScriptLayout;
+  graph: WorkspaceGraph;
+  findings?: readonly GateFinding[];
+  backpressureCommands?: readonly string[];
+  sink: GateSink;
+  feedbackExec: FeedbackExec;
+  backpressureExec: BackpressureExec;
+  applyMechanical: (finding: GateFinding) => Promise<void>;
+  now: () => number;
+  backpressureTimeoutMs?: number;
+}
+
+export interface CastleGateResult {
+  ok: boolean;
+  validationScope: ValidationScope;
+  checks: ValidationCheck[];
+  sidecar: string[];
+  sinkOutcomes: GateSinkOutcome[];
+  mechanicalApplied: number;
+}
+
+export function classifyFinding(finding: GateFinding): "mechanical" | "intent" {
+  return (MECHANICAL_KINDS as readonly string[]).includes(finding.kind) ? "mechanical" : "intent";
+}
+
+export function isSensitivePath(filePath: string): boolean {
+  return SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(filePath));
+}
+
+export function hasLifecycleScriptInDiff(diffText: string): boolean {
+  const names = LIFECYCLE_SCRIPT_NAMES.join("|");
+  return new RegExp(`^\\+\\s*"(${names})"\\s*:`, "m").test(diffText);
+}
+
+export function checkSensitivePaths(
+  changedFiles: readonly string[],
+  packageJsonDiff = "",
+): SensitivePathHit[] {
+  const hits: SensitivePathHit[] = [];
+  for (const file of changedFiles) {
+    if (isSensitivePath(file)) hits.push({ path: file, reason: sensitivePathReason(file) });
+  }
+  if (packageJsonDiff !== "" && hasLifecycleScriptInDiff(packageJsonDiff)) {
+    const packageFiles = changedFiles.filter((file) => /(?:^|\/)package\.json$/.test(file));
+    hits.push({
+      path: packageFiles.length > 0 ? packageFiles.join(", ") : "package.json",
+      reason: "lifecycle script added or altered in package.json",
+    });
+  }
+  return hits;
+}
+
+function sensitivePathReason(filePath: string): string {
+  if (/^\.github\/workflows\//.test(filePath)) return "CI workflow file";
+  if (/^\.github\/actions\//.test(filePath)) return "CI composite action";
+  if (/(?:^|\/)\.git\/hooks\//.test(filePath) || /^\.husky\//.test(filePath) || /^\.githooks\//.test(filePath)) return "git hook";
+  if (/^\.red\//.test(filePath)) return "trust/gate configuration";
+  if (/^plugins\/[^/]+\/hooks\//.test(filePath)) return "agent plugin hook";
+  if (/^plugins\/[^/]+\/scripts\//.test(filePath)) return "agent plugin launcher script";
+  return "sensitive path";
+}
+
+function scopeLabel(scope: string): string {
+  return scope === "." ? "root" : scope;
+}
+
+function scopeDir(worktree: string, scope: string): string {
+  return scope === "." ? worktree : `${worktree}/${scope}`;
+}
+
+function outputSummary(status: ValidationStatus, output: string): string {
+  if (status === "passed") return "command exited 0";
+  const trimmed = output.replace(/\n+$/, "");
+  if (trimmed === "") return "command exited non-zero";
+  return trimmed.split("\n").slice(-20).join(" ").slice(0, 1000);
+}
+
+function validationRecord(input: {
+  name: string;
+  status: ValidationStatus;
+  command?: string;
+  exitCode?: number;
+  durationMs?: number;
+  summary?: string;
+}): ValidationRecord {
+  const record: ValidationRecord = {
+    schema: CASTLE_VALIDATION_SCHEMA,
+    name: input.name,
+    status: input.status,
+  };
+  if (input.command !== undefined && input.command !== "") record.command = input.command;
+  if (input.exitCode !== undefined && Number.isFinite(input.exitCode)) record.exitCode = Math.trunc(input.exitCode);
+  if (input.durationMs !== undefined) record.durationMs = input.durationMs;
+  if (input.summary !== undefined && input.summary !== "") record.summary = input.summary;
+  return record;
+}
+
+function pushCheck(checks: ValidationCheck[], sidecar: string[], check: ValidationCheck): void {
+  checks.push(check);
+  sidecar.push(JSON.stringify(check.record));
+}
+
+async function runFeedbackChecks(
+  input: RunCastleGateInput,
+  scopes: readonly string[],
+  checks: ValidationCheck[],
+  sidecar: string[],
+): Promise<boolean> {
+  let ok = true;
+  for (const script of FEEDBACK_SCRIPTS) {
+    if (scopes.length === 0) {
+      const name = `${script}:no-package`;
+      pushCheck(checks, sidecar, {
+        name,
+        status: "skipped",
+        record: validationRecord({ name, status: "skipped", summary: "no package.json" }),
+      });
+      continue;
+    }
+
+    for (const scope of scopes) {
+      const label = scopeLabel(scope);
+      const name = `${script}:${label}`;
+      if (!input.layout.hasScript(scope, script)) {
+        pushCheck(checks, sidecar, {
+          name,
+          status: "skipped",
+          record: validationRecord({ name, status: "skipped", summary: "script missing" }),
+        });
+        continue;
+      }
+
+      const dir = scopeDir(input.worktree, scope);
+      const command = `pnpm -C ${dir} ${script}`;
+      const start = input.now();
+      const result = await input.feedbackExec(["pnpm", "-C", dir, script]);
+      const durationMs = input.now() - start;
+      const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
+      if (status === "failed") ok = false;
+      pushCheck(checks, sidecar, {
+        name,
+        status,
+        record: validationRecord({
+          name,
+          status,
+          command,
+          exitCode: result.code,
+          durationMs,
+          summary: outputSummary(status, `${result.stdout}${result.stderr}`),
+        }),
+      });
+    }
+  }
+  return ok;
+}
+
+async function runBackpressureChecks(
+  input: RunCastleGateInput,
+  checks: ValidationCheck[],
+  sidecar: string[],
+): Promise<boolean> {
+  let ok = true;
+  const timeoutMs = input.backpressureTimeoutMs ?? DEFAULT_BACKPRESSURE_TIMEOUT_MS;
+  for (const raw of input.backpressureCommands ?? []) {
+    const command = raw.trim();
+    if (command === "") continue;
+    const name = `backpressure:${command}`;
+    const start = input.now();
+    const result = await input.backpressureExec({ command, cwd: input.worktree, timeoutMs });
+    const durationMs = input.now() - start;
+    const status: ValidationStatus = result.code === 0 ? "passed" : "failed";
+    if (status === "failed") ok = false;
+    const summary = result.code === KILLED_EXIT_CODE
+      ? `command timed out after ${timeoutMs}ms`
+      : outputSummary(status, `${result.stdout}${result.stderr}`);
+    pushCheck(checks, sidecar, {
+      name,
+      status,
+      record: validationRecord({ name, status, command, exitCode: result.code, durationMs, summary }),
+    });
+  }
+  return ok;
+}
+
+export async function runCastleGate(input: RunCastleGateInput): Promise<CastleGateResult> {
+  const validationScope = computeValidationScope(input.changedFiles, input.layout, input.graph);
+  const checks: ValidationCheck[] = [];
+  const sidecar: string[] = [];
+  const sinkOutcomes: GateSinkOutcome[] = [];
+  let mechanicalApplied = 0;
+  let ok = true;
+
+  for (const hit of checkSensitivePaths(input.changedFiles, input.packageJsonDiff)) {
+    const outcome = await input.sink.sensitivePath(hit);
+    sinkOutcomes.push(outcome);
+    if (outcome !== "approved") ok = false;
+  }
+
+  for (const finding of input.findings ?? []) {
+    if (classifyFinding(finding) === "mechanical") {
+      await input.applyMechanical(finding);
+      mechanicalApplied++;
+    } else {
+      const outcome = await input.sink.intentFinding(finding);
+      sinkOutcomes.push(outcome);
+      if (outcome !== "approved") ok = false;
+    }
+  }
+
+  const feedbackOk = await runFeedbackChecks(input, scopesForValidationScope(validationScope), checks, sidecar);
+  ok = ok && feedbackOk;
+
+  if (feedbackOk) {
+    ok = ok && await runBackpressureChecks(input, checks, sidecar);
+  }
+
+  return { ok, validationScope, checks, sidecar, sinkOutcomes, mechanicalApplied };
+}

--- a/packages/red-castle/src/engine/gate-sink.test.ts
+++ b/packages/red-castle/src/engine/gate-sink.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { makeHeadlessGateSink, makeInteractiveGateSink } from "./gate-sink.js";
+
+describe("castle gate sinks", () => {
+  it("headless sink parks intent and sensitive-path escalations", async () => {
+    const parkIntent = vi.fn(async () => {});
+    const parkSensitivePath = vi.fn(async () => {});
+    const sink = makeHeadlessGateSink({ parkIntent, parkSensitivePath });
+
+    await expect(sink.intentFinding({ kind: "intent", description: "changes behavior" })).resolves.toBe("parked");
+    await expect(sink.sensitivePath({ path: ".red/config.yaml", reason: "trust/gate configuration" })).resolves.toBe("parked");
+
+    expect(parkIntent).toHaveBeenCalledTimes(1);
+    expect(parkSensitivePath).toHaveBeenCalledTimes(1);
+  });
+
+  it("interactive sink delegates decisions to caller prompts", async () => {
+    const askIntent = vi.fn(async () => "approved" as const);
+    const askSensitivePath = vi.fn(async () => "skipped" as const);
+    const sink = makeInteractiveGateSink({ askIntent, askSensitivePath });
+
+    await expect(sink.intentFinding({ kind: "intent", description: "changes behavior" })).resolves.toBe("approved");
+    await expect(sink.sensitivePath({ path: ".github/workflows/ci.yml", reason: "CI workflow file" })).resolves.toBe("skipped");
+  });
+});

--- a/packages/red-castle/src/engine/gate-sink.ts
+++ b/packages/red-castle/src/engine/gate-sink.ts
@@ -1,0 +1,43 @@
+export interface GateFinding {
+  kind: string;
+  description: string;
+  patch?: string;
+}
+
+export type GateSinkOutcome = "approved" | "skipped" | "parked";
+
+export interface GateSink {
+  intentFinding: (finding: GateFinding) => Promise<GateSinkOutcome>;
+  sensitivePath: (hit: SensitivePathHit) => Promise<GateSinkOutcome>;
+}
+
+export interface SensitivePathHit {
+  path: string;
+  reason: string;
+}
+
+export function makeHeadlessGateSink(input: {
+  parkIntent: (finding: GateFinding) => Promise<void>;
+  parkSensitivePath: (hit: SensitivePathHit) => Promise<void>;
+}): GateSink {
+  return {
+    async intentFinding(finding) {
+      await input.parkIntent(finding);
+      return "parked";
+    },
+    async sensitivePath(hit) {
+      await input.parkSensitivePath(hit);
+      return "parked";
+    },
+  };
+}
+
+export function makeInteractiveGateSink(input: {
+  askIntent: (finding: GateFinding) => Promise<"approved" | "skipped">;
+  askSensitivePath: (hit: SensitivePathHit) => Promise<"approved" | "skipped">;
+}): GateSink {
+  return {
+    intentFinding: input.askIntent,
+    sensitivePath: input.askSensitivePath,
+  };
+}

--- a/packages/red-castle/src/engine/validation-cone.test.ts
+++ b/packages/red-castle/src/engine/validation-cone.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeValidationScope,
+  expandReverseDependencyCone,
+  scopesForValidationScope,
+  type PackageLayout,
+  type WorkspaceGraph,
+} from "./validation-cone.js";
+
+const layout: PackageLayout = {
+  hasPackage(scope) {
+    return [".", "packages/core", "apps/dev", "apps/docs", "packages/red-castle"].includes(scope);
+  },
+};
+
+const graph: WorkspaceGraph = {
+  packages: [
+    { dir: "packages/core", dependsOn: [] },
+    { dir: "apps/dev", dependsOn: ["packages/core", "packages/red-castle"] },
+    { dir: "apps/docs", dependsOn: ["apps/dev"] },
+    { dir: "packages/red-castle", dependsOn: [] },
+  ],
+};
+
+describe("castle validation cone", () => {
+  it("expands package-scoped diffs through reverse-dependent BFS only", () => {
+    expect(expandReverseDependencyCone(["packages/core"], graph)).toEqual([
+      "apps/dev",
+      "apps/docs",
+      "packages/core",
+    ]);
+  });
+
+  it("does not escalate package-scoped castle or shared changes to whole workspace", () => {
+    expect(computeValidationScope(["packages/red-castle/src/engine/gate-executor.ts"], layout, graph)).toEqual({
+      type: "cone",
+      triggerPackages: ["packages/red-castle"],
+      packages: ["apps/dev", "apps/docs", "packages/red-castle"],
+    });
+
+    expect(computeValidationScope(["packages/core/src/index.ts"], layout, graph).type).toBe("cone");
+  });
+
+  it("escalates only root-trigger files to whole workspace", () => {
+    const scope = computeValidationScope(["pnpm-lock.yaml"], layout, graph);
+    expect(scope).toEqual({ type: "whole-workspace", triggerFile: "pnpm-lock.yaml" });
+    expect(scopesForValidationScope(scope)).toEqual(["."]);
+  });
+});

--- a/packages/red-castle/src/engine/validation-cone.ts
+++ b/packages/red-castle/src/engine/validation-cone.ts
@@ -1,0 +1,110 @@
+import { ROOT_TRIGGER_FILES } from "./gate-constants.js";
+
+export interface PackageLayout {
+  hasPackage: (scope: string) => boolean;
+}
+
+export interface WorkspacePackage {
+  dir: string;
+  dependsOn: readonly string[];
+}
+
+export interface WorkspaceGraph {
+  packages: readonly WorkspacePackage[];
+}
+
+export type ValidationScope =
+  | {
+      type: "cone";
+      packages: string[];
+      triggerPackages: string[];
+    }
+  | {
+      type: "whole-workspace";
+      triggerFile: string;
+    };
+
+function stripDotSlash(file: string): string {
+  return file.startsWith("./") ? file.slice(2) : file;
+}
+
+export function isRootTrigger(file: string): boolean {
+  const clean = stripDotSlash(file);
+  if (clean.startsWith(".github/")) return true;
+  if (clean.includes("/")) return false;
+  return (ROOT_TRIGGER_FILES as readonly string[]).includes(clean);
+}
+
+export function nearestPackageScope(layout: PackageLayout, file: string): string | undefined {
+  if (file === "") return undefined;
+  const clean = stripDotSlash(file);
+  let dir = clean.includes("/") ? clean.slice(0, clean.lastIndexOf("/")) : ".";
+
+  while (dir !== "" && dir !== "." && dir !== "/") {
+    if (layout.hasPackage(dir)) return dir;
+    dir = dir.includes("/") ? dir.slice(0, dir.lastIndexOf("/")) : ".";
+  }
+
+  return layout.hasPackage(".") ? "." : undefined;
+}
+
+export function relevantScopes(layout: PackageLayout, changedFiles: readonly string[]): string[] {
+  const seen = new Set<string>();
+  for (const file of changedFiles) {
+    const scope = nearestPackageScope(layout, file);
+    if (scope !== undefined) seen.add(scope);
+  }
+  if (seen.size === 0 && layout.hasPackage(".")) seen.add(".");
+  return [...seen].sort();
+}
+
+export function expandReverseDependencyCone(
+  touchedDirs: readonly string[],
+  graph: WorkspaceGraph,
+): string[] {
+  const reverseDeps = new Map<string, string[]>();
+  for (const pkg of graph.packages) {
+    for (const dep of pkg.dependsOn) {
+      const dependents = reverseDeps.get(dep) ?? [];
+      dependents.push(pkg.dir);
+      reverseDeps.set(dep, dependents);
+    }
+  }
+
+  const cone = new Set(touchedDirs);
+  const queue = [...touchedDirs];
+  while (queue.length > 0) {
+    const dir = queue.shift()!;
+    for (const dependent of reverseDeps.get(dir) ?? []) {
+      if (!cone.has(dependent)) {
+        cone.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return [...cone].sort();
+}
+
+export function computeValidationScope(
+  changedFiles: readonly string[],
+  layout: PackageLayout,
+  graph: WorkspaceGraph,
+): ValidationScope {
+  for (const file of changedFiles) {
+    if (isRootTrigger(file)) {
+      return { type: "whole-workspace", triggerFile: stripDotSlash(file) };
+    }
+  }
+
+  const triggerPackages = relevantScopes(layout, changedFiles);
+  return {
+    type: "cone",
+    packages: expandReverseDependencyCone(triggerPackages, graph),
+    triggerPackages,
+  };
+}
+
+export function scopesForValidationScope(scope: ValidationScope): string[] {
+  return scope.type === "whole-workspace" ? ["."] : scope.packages;
+}

--- a/packages/red-castle/src/index.ts
+++ b/packages/red-castle/src/index.ts
@@ -141,3 +141,7 @@ export type {
   NamedBranchStrategy,
 } from "./SandboxProvider.js";
 export * from "./engine/contracts/index.js";
+export * from "./engine/gate-constants.js";
+export * from "./engine/gate-executor.js";
+export * from "./engine/gate-sink.js";
+export * from "./engine/validation-cone.js";


### PR DESCRIPTION
Automated AFK landing for #1910. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1910

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786823643&installation_id=129708444&pr_number=1929&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1929&signature=89901d125a8072a2487676579ae5ac32d76f2031ff85c2e06da1019b5eae3c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->