### PR TITLE
fix: #1906 GitHub tracker adapter and labels-as-config

### DIFF
--- a/packages/red-castle/src/engine/config.test.ts
+++ b/packages/red-castle/src/engine/config.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   loadEngineConfig,
   parseEngineConfigYaml,
+  readEngineLabelVocabulary,
   readEngineBackpressure,
 } from "./config.js";
 
@@ -99,6 +100,34 @@ describe("engine config reader", () => {
     ).toMatchObject({
       "afk.backpressure.0": "pnpm test",
       "afk.backpressure.1": "pnpm lint",
+    });
+  });
+
+  it("reads tracker label vocabulary from config instead of engine constants", () => {
+    const redRoot = redRootWithConfig(
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "    afk:",
+        "      labels:",
+        "        ready: queue:agent",
+        "        running: state:running",
+        "        human: queue:human",
+        "        dependency_blocked: wait:dependency",
+        "        req_prefix: depends-on:",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = loadEngineConfig(redRoot, { env: {} });
+
+    expect(readEngineLabelVocabulary(cfg)).toEqual({
+      ready: "queue:agent",
+      running: "state:running",
+      human: "queue:human",
+      dependencyBlocked: "wait:dependency",
+      reqPrefix: "depends-on:",
     });
   });
 });

--- a/packages/red-castle/src/engine/config.ts
+++ b/packages/red-castle/src/engine/config.ts
@@ -26,6 +26,11 @@ export const ENGINE_CONFIG_DEFAULTS = {
   "afk.validation.node_max_old_space_mb": "2048",
   "afk.validation.vitest_max_workers": "1",
   "afk.validation.heavy_available_memory_mb": "4096",
+  "afk.labels.ready": "ready-for-agent",
+  "afk.labels.running": "running",
+  "afk.labels.human": "ready-for-human",
+  "afk.labels.dependency_blocked": "blocked:dependency",
+  "afk.labels.req_prefix": "req:",
 } as const;
 
 const RED_AFK_ENV_ACCESSORS = {
@@ -52,6 +57,14 @@ export interface EngineConfig {
   readonly configPath: string;
   readonly values: EngineConfigValues;
   readonly get: (key: string) => string;
+}
+
+export interface EngineLabelVocabulary {
+  readonly ready: string;
+  readonly running: string;
+  readonly human: string;
+  readonly dependencyBlocked: string;
+  readonly reqPrefix: string;
 }
 
 const defaultReader: EngineConfigReader = (path) => {
@@ -229,4 +242,14 @@ export function readEngineBackpressure(config: EngineConfig): string[] {
 
   const scalar = config.values["afk.backpressure"];
   return scalar && scalar.trim() !== "" ? [scalar] : [];
+}
+
+export function readEngineLabelVocabulary(config: EngineConfig): EngineLabelVocabulary {
+  return {
+    ready: config.get("afk.labels.ready"),
+    running: config.get("afk.labels.running"),
+    human: config.get("afk.labels.human"),
+    dependencyBlocked: config.get("afk.labels.dependency_blocked"),
+    reqPrefix: config.get("afk.labels.req_prefix"),
+  };
 }

--- a/packages/red-castle/src/engine/tracker/dependencies.test.ts
+++ b/packages/red-castle/src/engine/tracker/dependencies.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  executeCloseCascade,
+  executeUnblockSweep,
+  labelForDependency,
+  parseDependencyLabels,
+  type TrackerPort,
+} from "./dependencies.js";
+import type { EngineLabelVocabulary } from "../config.js";
+
+const labels: EngineLabelVocabulary = {
+  ready: "queue:agent",
+  running: "state:running",
+  human: "queue:human",
+  dependencyBlocked: "wait:dependency",
+  reqPrefix: "depends-on:",
+};
+
+function fakeTracker(state: {
+  issues: Map<number, { body: string; labels: string[]; closed: boolean; title?: string; url?: string }>;
+  labelIndex: Map<string, number[]>;
+}): TrackerPort & { edits: Array<{ issue: number; remove: string[]; add: string[] }>; comments: Array<{ issue: number; body: string }> } {
+  const edits: Array<{ issue: number; remove: string[]; add: string[] }> = [];
+  const comments: Array<{ issue: number; body: string }> = [];
+  return {
+    edits,
+    comments,
+    async listOpenIssuesByLabel(label) {
+      return (state.labelIndex.get(label) ?? []).map((number) => {
+        const issue = state.issues.get(number);
+        if (!issue) throw new Error(`missing fixture issue ${number}`);
+        return { number, body: issue.body, labels: issue.labels };
+      });
+    },
+    async isIssueClosed(issue) {
+      return state.issues.get(issue)?.closed ?? false;
+    },
+    async editIssueLabels(issue, mutation) {
+      edits.push({ issue, remove: [...mutation.remove], add: [...mutation.add] });
+    },
+    async commentOnIssue(issue, body) {
+      comments.push({ issue, body });
+    },
+    async issueReference(issue) {
+      const row = state.issues.get(issue);
+      return row ? { number: issue, title: row.title, url: row.url } : undefined;
+    },
+  };
+}
+
+describe("tracker dependency labels", () => {
+  it("parses configured req labels only", () => {
+    expect(parseDependencyLabels(["depends-on:10", "req:99", "depends-on:2"], labels)).toEqual([2, 10]);
+    expect(labelForDependency(42, labels)).toBe("depends-on:42");
+  });
+});
+
+describe("tracker close cascade", () => {
+  it("promotes a dependency-blocked issue through the tracker port with configured labels", async () => {
+    const tracker = fakeTracker({
+      issues: new Map([
+        [7, { body: "", labels: [], closed: true, title: "Foundation", url: "https://example.invalid/7" }],
+        [20, { body: "", labels: ["wait:dependency", "depends-on:7"], closed: false }],
+      ]),
+      labelIndex: new Map([["depends-on:7", [20]]]),
+    });
+
+    const promoted = await executeCloseCascade({ closedIssue: 7, tracker, labels });
+
+    expect(promoted).toEqual([20]);
+    expect(tracker.edits).toEqual([{ issue: 20, remove: ["wait:dependency", "depends-on:7"], add: ["queue:agent"] }]);
+    expect(tracker.comments).toEqual([
+      { issue: 20, body: "🤖 /afk unblocked: all dependencies closed ([Foundation (#7)](https://example.invalid/7))." },
+    ]);
+  });
+
+  it("leaves a dependent blocked while any configured dependency remains open", async () => {
+    const tracker = fakeTracker({
+      issues: new Map([
+        [7, { body: "", labels: [], closed: true }],
+        [8, { body: "", labels: [], closed: false }],
+        [20, { body: "", labels: ["wait:dependency", "depends-on:7", "depends-on:8"], closed: false }],
+      ]),
+      labelIndex: new Map([["depends-on:7", [20]]]),
+    });
+
+    await expect(executeCloseCascade({ closedIssue: 7, tracker, labels })).resolves.toEqual([]);
+    expect(tracker.edits).toEqual([]);
+  });
+});
+
+describe("tracker unblock sweep", () => {
+  it("promotes all-closed dependency-blocked candidates discovered through the port", async () => {
+    const tracker = fakeTracker({
+      issues: new Map([
+        [7, { body: "", labels: [], closed: true }],
+        [20, { body: "", labels: ["wait:dependency", "depends-on:7"], closed: false }],
+      ]),
+      labelIndex: new Map([["wait:dependency", [20]]]),
+    });
+
+    await expect(executeUnblockSweep({ tracker, labels })).resolves.toEqual([20]);
+    expect(tracker.edits).toEqual([{ issue: 20, remove: ["wait:dependency", "depends-on:7"], add: ["queue:agent"] }]);
+  });
+});

--- a/packages/red-castle/src/engine/tracker/dependencies.ts
+++ b/packages/red-castle/src/engine/tracker/dependencies.ts
@@ -1,0 +1,155 @@
+import type { EngineLabelVocabulary } from "../config.js";
+import type { TrackerIssue, TrackerPort, TrackerIssueReference } from "./port.js";
+
+export type { TrackerIssue, TrackerPort, TrackerIssueReference } from "./port.js";
+
+const BLOCKED_BY_HEADING_RE = /^## Blocked by[ \t]*$/;
+const ANY_H2_RE = /^## /;
+const REF_TOKEN_RE = /#[0-9]+/g;
+
+export function labelForDependency(issue: number, labels: EngineLabelVocabulary): string {
+  return `${labels.reqPrefix}${issue}`;
+}
+
+function dependencyLabelPattern(labels: EngineLabelVocabulary): RegExp {
+  return new RegExp(`^${escapeRegExp(labels.reqPrefix)}([0-9]+)$`);
+}
+
+export function parseDependencyLabels(issueLabels: readonly string[], labels: EngineLabelVocabulary): number[] {
+  const pattern = dependencyLabelPattern(labels);
+  const seen = new Set<number>();
+  for (const label of issueLabels) {
+    const match = pattern.exec(label.trim());
+    if (match) seen.add(Number(match[1]));
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
+export function parseBlockedBy(body: string): number[] {
+  let inSection = false;
+  const seen = new Set<number>();
+  for (const line of body.split("\n")) {
+    if (inSection) {
+      if (ANY_H2_RE.test(line)) {
+        inSection = false;
+        continue;
+      }
+      const matches = line.match(REF_TOKEN_RE);
+      if (matches) for (const ref of matches) seen.add(Number(ref.slice(1)));
+      continue;
+    }
+    if (BLOCKED_BY_HEADING_RE.test(line)) inSection = true;
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
+export interface DependencyPromotionPlan {
+  readonly issue: number;
+  readonly dependencies: readonly number[];
+  readonly removeLabels: readonly string[];
+  readonly addLabels: readonly string[];
+}
+
+export interface ExecuteCloseCascadeOptions {
+  readonly closedIssue: number;
+  readonly tracker: TrackerPort;
+  readonly labels: EngineLabelVocabulary;
+}
+
+export interface ExecuteUnblockSweepOptions {
+  readonly tracker: TrackerPort;
+  readonly labels: EngineLabelVocabulary;
+}
+
+export async function executeCloseCascade(options: ExecuteCloseCascadeOptions): Promise<number[]> {
+  const dependencyLabel = labelForDependency(options.closedIssue, options.labels);
+  const dependents = await options.tracker.listOpenIssuesByLabel(dependencyLabel);
+  return executePromotions(
+    options.tracker,
+    options.labels,
+    await planPromotions(dependents, options.tracker, options.labels, options.closedIssue),
+  );
+}
+
+export async function executeUnblockSweep(options: ExecuteUnblockSweepOptions): Promise<number[]> {
+  const candidates = await options.tracker.listOpenIssuesByLabel(options.labels.dependencyBlocked);
+  return executePromotions(
+    options.tracker,
+    options.labels,
+    await planPromotions(candidates, options.tracker, options.labels),
+  );
+}
+
+async function planPromotions(
+  candidates: readonly TrackerIssue[],
+  tracker: TrackerPort,
+  labels: EngineLabelVocabulary,
+  justClosedIssue?: number,
+): Promise<DependencyPromotionPlan[]> {
+  const plans: DependencyPromotionPlan[] = [];
+  for (const candidate of candidates) {
+    if (!candidate.labels.includes(labels.dependencyBlocked)) continue;
+
+    const labelDeps = parseDependencyLabels(candidate.labels, labels);
+    const dependencies = labelDeps.length > 0 ? labelDeps : parseBlockedBy(candidate.body);
+    if (dependencies.length === 0) continue;
+
+    let allClosed = true;
+    for (const dependency of dependencies) {
+      if (dependency === justClosedIssue) continue;
+      if (!(await tracker.isIssueClosed(dependency))) {
+        allClosed = false;
+        break;
+      }
+    }
+    if (!allClosed) continue;
+
+    plans.push({
+      issue: candidate.number,
+      dependencies,
+      removeLabels: [
+        labels.dependencyBlocked,
+        ...labelDeps.map((dependency) => labelForDependency(dependency, labels)),
+      ],
+      addLabels: [labels.ready],
+    });
+  }
+  return plans;
+}
+
+async function executePromotions(
+  tracker: TrackerPort,
+  labels: EngineLabelVocabulary,
+  plans: readonly DependencyPromotionPlan[],
+): Promise<number[]> {
+  const promoted: number[] = [];
+  for (const plan of plans) {
+    await tracker.editIssueLabels(plan.issue, {
+      remove: [...plan.removeLabels],
+      add: [...plan.addLabels],
+    });
+    await tracker.commentOnIssue(plan.issue, await dependencyAuditComment(plan.dependencies, tracker.issueReference));
+    promoted.push(plan.issue);
+  }
+  return promoted;
+}
+
+async function dependencyAuditComment(
+  dependencies: readonly number[],
+  lookup?: TrackerPort["issueReference"],
+): Promise<string> {
+  const refs = await Promise.all(
+    dependencies.map(async (number) => (await lookup?.(number)) ?? { number }),
+  );
+  return `🤖 /afk unblocked: all dependencies closed (${refs.map(renderIssueReference).join(", ")}).`;
+}
+
+function renderIssueReference(ref: TrackerIssueReference): string {
+  const plain = `#${ref.number}`;
+  if (!ref.title || !ref.url) return plain;
+  return `[${ref.title} (${plain})](${ref.url})`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}

--- a/packages/red-castle/src/engine/tracker/github/adapter.test.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createGitHubTrackerAdapter, type GhExec } from "./adapter.js";
+
+describe("GitHub tracker adapter", () => {
+  it("quarantines tracker IO behind gh CLI calls", async () => {
+    const calls: string[][] = [];
+    const gh: GhExec = async (args) => {
+      calls.push([...args]);
+      if (args[0] === "issue" && args[1] === "list") {
+        return JSON.stringify([
+          { number: 12, body: "Body", labels: [{ name: "wait:dependency" }, { name: "depends-on:7" }] },
+        ]);
+      }
+      if (args[0] === "issue" && args[1] === "view") {
+        return JSON.stringify({ state: "CLOSED", number: 7, title: "Base", url: "https://example.invalid/7" });
+      }
+      return "";
+    };
+
+    const tracker = createGitHubTrackerAdapter({ gh, repo: "owner/repo" });
+
+    await expect(tracker.listOpenIssuesByLabel("wait:dependency")).resolves.toEqual([
+      { number: 12, body: "Body", labels: ["wait:dependency", "depends-on:7"] },
+    ]);
+    await expect(tracker.isIssueClosed(7)).resolves.toBe(true);
+    await tracker.editIssueLabels(12, { remove: ["wait:dependency"], add: ["queue:agent"] });
+    await tracker.commentOnIssue(12, "done");
+
+    expect(calls).toEqual([
+      ["issue", "list", "--state", "open", "--label", "wait:dependency", "--json", "number,body,labels", "--limit", "1000", "--repo", "owner/repo"],
+      ["issue", "view", "7", "--json", "state", "--repo", "owner/repo"],
+      ["issue", "edit", "12", "--remove-label", "wait:dependency", "--add-label", "queue:agent", "--repo", "owner/repo"],
+      ["issue", "comment", "12", "--body", "done", "--repo", "owner/repo"],
+    ]);
+  });
+});

--- a/packages/red-castle/src/engine/tracker/github/adapter.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.ts
@@ -1,0 +1,121 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { TrackerIssue, TrackerPort, TrackerLabelMutation, TrackerIssueReference } from "../port.js";
+
+const execFileAsync = promisify(execFile);
+
+export type GhExec = (args: readonly string[]) => Promise<string>;
+
+export interface GitHubTrackerAdapterOptions {
+  readonly gh?: GhExec;
+  readonly repo?: string;
+}
+
+interface GhIssueListRow {
+  readonly number?: unknown;
+  readonly body?: unknown;
+  readonly labels?: unknown;
+}
+
+interface GhIssueViewRow {
+  readonly state?: unknown;
+  readonly number?: unknown;
+  readonly title?: unknown;
+  readonly url?: unknown;
+}
+
+export function createGitHubTrackerAdapter(options: GitHubTrackerAdapterOptions = {}): TrackerPort {
+  const gh = options.gh ?? defaultGhExec;
+  const withRepo = (args: string[]): string[] =>
+    options.repo ? [...args, "--repo", options.repo] : args;
+
+  return {
+    async listOpenIssuesByLabel(label) {
+      const stdout = await gh(
+        withRepo([
+          "issue",
+          "list",
+          "--state",
+          "open",
+          "--label",
+          label,
+          "--json",
+          "number,body,labels",
+          "--limit",
+          "1000",
+        ]),
+      );
+      return parseIssueList(stdout);
+    },
+    async isIssueClosed(issue) {
+      const stdout = await gh(withRepo(["issue", "view", String(issue), "--json", "state"]));
+      const row = parseJson<GhIssueViewRow>(stdout);
+      return row.state === "CLOSED";
+    },
+    async editIssueLabels(issue, mutation) {
+      const args = ["issue", "edit", String(issue)];
+      appendLabelArgs(args, "--remove-label", mutation.remove);
+      appendLabelArgs(args, "--add-label", mutation.add);
+      await gh(withRepo(args));
+    },
+    async commentOnIssue(issue, body) {
+      await gh(withRepo(["issue", "comment", String(issue), "--body", body]));
+    },
+    async issueReference(issue) {
+      const stdout = await gh(withRepo(["issue", "view", String(issue), "--json", "number,title,url"]));
+      const row = parseJson<GhIssueViewRow>(stdout);
+      const number = typeof row.number === "number" ? row.number : issue;
+      return {
+        number,
+        title: typeof row.title === "string" ? row.title : undefined,
+        url: typeof row.url === "string" ? row.url : undefined,
+      } satisfies TrackerIssueReference;
+    },
+  };
+}
+
+async function defaultGhExec(args: readonly string[]): Promise<string> {
+  const { stdout } = await execFileAsync("gh", args as string[], { encoding: "utf8" });
+  return stdout;
+}
+
+function appendLabelArgs(args: string[], flag: string, labels: readonly string[]): void {
+  if (labels.length === 0) return;
+  args.push(flag, labels.join(","));
+}
+
+function parseIssueList(stdout: string): TrackerIssue[] {
+  const rows = parseJson<GhIssueListRow[]>(stdout);
+  if (!Array.isArray(rows)) return [];
+  const issues: TrackerIssue[] = [];
+  for (const row of rows) {
+    if (typeof row.number !== "number") continue;
+    issues.push({
+      number: row.number,
+      body: typeof row.body === "string" ? row.body : "",
+      labels: parseLabels(row.labels),
+    });
+  }
+  return issues;
+}
+
+function parseLabels(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const labels: string[] = [];
+  for (const item of value) {
+    if (typeof item === "string") {
+      labels.push(item);
+      continue;
+    }
+    if (item && typeof item === "object" && "name" in item && typeof item.name === "string") {
+      labels.push(item.name);
+    }
+  }
+  return labels;
+}
+
+function parseJson<T>(stdout: string): T {
+  const text = stdout.trim();
+  if (text === "") return undefined as T;
+  return JSON.parse(text) as T;
+}

--- a/packages/red-castle/src/engine/tracker/port.ts
+++ b/packages/red-castle/src/engine/tracker/port.ts
@@ -1,0 +1,24 @@
+export interface TrackerIssue {
+  readonly number: number;
+  readonly body: string;
+  readonly labels: readonly string[];
+}
+
+export interface TrackerIssueReference {
+  readonly number: number;
+  readonly title?: string;
+  readonly url?: string;
+}
+
+export interface TrackerLabelMutation {
+  readonly remove: readonly string[];
+  readonly add: readonly string[];
+}
+
+export interface TrackerPort {
+  listOpenIssuesByLabel(label: string): Promise<TrackerIssue[]>;
+  isIssueClosed(issue: number): Promise<boolean>;
+  editIssueLabels(issue: number, mutation: TrackerLabelMutation): Promise<void>;
+  commentOnIssue(issue: number, body: string): Promise<void>;
+  issueReference?(issue: number): Promise<TrackerIssueReference | undefined>;
+}


### PR DESCRIPTION
Automated AFK landing for #1906. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1906

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786823678&installation_id=129708444&pr_number=1930&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1930&signature=af2d8f9e12fa6226452bc26373924aa2673357cae683b05fafd9b808009aad75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->