### PR TITLE
fix: #1907 Dual-lease claim behind the tracker port

### DIFF
--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -25,3 +25,25 @@ export * from "./runner-detection.js";
 export * from "./runner-spawn.js";
 export * from "./runner-spec.js";
 export * from "./runner-types.js";
+export {
+  acquireIssueLease,
+  createFsIssueLeaseStore,
+  parseTrackerClaimRecords,
+  reconcileTrackerClaims,
+  renderTrackerClaimComment,
+  retireIssueLease,
+  TRACKER_CLAIM_MARKER_VERSION,
+} from "./tracker/claim.js";
+export type {
+  LocalIssueLeaseStore,
+  LocalLeaseDecision,
+  RetireIssueLeaseOptions,
+  TrackerClaimComment,
+  TrackerClaimIdentity,
+  TrackerClaimKind,
+  TrackerClaimRecord,
+  TrackerClaimStore,
+  TrackerClaimVerdict,
+  AcquireIssueLeaseOptions,
+} from "./tracker/claim.js";
+export * from "./tracker/port.js";

--- a/packages/red-castle/src/engine/tracker/claim.test.ts
+++ b/packages/red-castle/src/engine/tracker/claim.test.ts
@@ -1,0 +1,182 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  acquireIssueLease,
+  createFsIssueLeaseStore,
+  parseTrackerClaimRecords,
+  renderTrackerClaimComment,
+  retireIssueLease,
+  type TrackerClaimComment,
+  type TrackerClaimStore,
+} from "./claim.js";
+
+function memoryStore(
+  existing: TrackerClaimComment[] = [],
+): TrackerClaimStore & {
+  posted: string[];
+  conceded: string[];
+} {
+  let nextId = (existing.at(-1)?.id ?? 0) + 1;
+  const posted: string[] = [];
+  const conceded: string[] = [];
+  return {
+    posted,
+    conceded,
+    async postClaim(_issue, body) {
+      posted.push(body);
+      existing.push({ id: nextId, body });
+      return nextId++;
+    },
+    async listClaims() {
+      return existing.slice();
+    },
+    async concede(_issue, body) {
+      conceded.push(body);
+      existing.push({ id: nextId++, body });
+    },
+  };
+}
+
+async function tempLeaseRoot(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "red-castle-tracker-claim-"));
+}
+
+describe("tracker dual lease", () => {
+  it("acquires the local mkdir lease before posting the ADR 0066 claim marker", async () => {
+    const root = await tempLeaseRoot();
+    try {
+      const local = createFsIssueLeaseStore(root);
+      const store = memoryStore();
+
+      const decision = await acquireIssueLease({
+        issue: 1907,
+        identity: { worker: "host:w1", runner: "codex" },
+        local,
+        remote: store,
+        liveness: () => "unknown",
+      });
+
+      expect(decision).toMatchObject({ verdict: "won", winner: "host:w1" });
+      await expect(readFile(join(root, "1907", "owner"), "utf8")).resolves.toBe(
+        "host:w1\n",
+      );
+      expect(store.posted[0]).toContain(
+        "<!-- afk:claim v1 worker=host:w1 kind=claim runner=codex -->",
+      );
+      expect(
+        parseTrackerClaimRecords(await store.listClaims(1907)),
+      ).toMatchObject([{ worker: "host:w1", kind: "claim" }]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not steal a local mkdir lease unless supervisor liveness says dead", async () => {
+    const root = await tempLeaseRoot();
+    try {
+      await mkdir(join(root, "1907"), { recursive: true });
+      await writeFile(join(root, "1907", "owner"), "host:other\n");
+      const local = createFsIssueLeaseStore(root);
+      const store = memoryStore();
+
+      const blocked = await acquireIssueLease({
+        issue: 1907,
+        identity: { worker: "host:w1" },
+        local,
+        remote: store,
+        liveness: () => "alive",
+      });
+
+      expect(blocked).toMatchObject({
+        verdict: "lost",
+        winner: "host:other",
+        reason: "local lease owner is alive",
+      });
+      expect(store.posted).toHaveLength(0);
+      await expect(readFile(join(root, "1907", "owner"), "utf8")).resolves.toBe(
+        "host:other\n",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers an older remote claim only from an injected dead liveness verdict", async () => {
+    const oldClaim = {
+      id: 1,
+      body: renderTrackerClaimComment({ worker: "host:dead" }, "claim"),
+      createdAt: "2000-01-01T00:00:00Z",
+    };
+    const liveStore = memoryStore([oldClaim]);
+    const liveRoot = await tempLeaseRoot();
+    try {
+      const liveDecision = await acquireIssueLease({
+        issue: 1907,
+        identity: { worker: "host:w1" },
+        local: createFsIssueLeaseStore(liveRoot),
+        remote: liveStore,
+        liveness: () => "alive",
+      });
+      expect(liveDecision).toMatchObject({
+        verdict: "lost",
+        winner: "host:dead",
+      });
+      expect(liveStore.conceded).toHaveLength(1);
+    } finally {
+      await rm(liveRoot, { recursive: true, force: true });
+    }
+
+    const deadStore = memoryStore([oldClaim]);
+    const deadRoot = await tempLeaseRoot();
+    try {
+      const deadDecision = await acquireIssueLease({
+        issue: 1907,
+        identity: { worker: "host:w1" },
+        local: createFsIssueLeaseStore(deadRoot),
+        remote: deadStore,
+        liveness: (worker) => (worker === "host:dead" ? "dead" : "alive"),
+      });
+      expect(deadDecision).toMatchObject({
+        verdict: "won",
+        winner: "host:w1",
+        recovered: ["host:dead"],
+      });
+    } finally {
+      await rm(deadRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("graceful retirement concedes the remote claim and releases the local lease", async () => {
+    const root = await tempLeaseRoot();
+    try {
+      const local = createFsIssueLeaseStore(root);
+      const store = memoryStore();
+      await acquireIssueLease({
+        issue: 1907,
+        identity: { worker: "host:w1", runner: "codex" },
+        local,
+        remote: store,
+        liveness: () => "unknown",
+      });
+
+      await retireIssueLease({
+        issue: 1907,
+        identity: { worker: "host:w1", runner: "codex" },
+        local,
+        remote: store,
+      });
+
+      expect(store.conceded).toHaveLength(1);
+      expect(store.conceded[0]).toContain("kind=concede");
+      await expect(
+        readFile(join(root, "1907", "owner"), "utf8"),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/red-castle/src/engine/tracker/claim.ts
+++ b/packages/red-castle/src/engine/tracker/claim.ts
@@ -1,0 +1,361 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const TRACKER_CLAIM_MARKER_VERSION = 1;
+
+export type TrackerClaimKind = "claim" | "concede";
+export type TrackerClaimLiveness = "alive" | "dead" | "unknown";
+export type TrackerClaimVerdict = "won" | "lost";
+
+export interface TrackerClaimIdentity {
+  readonly worker: string;
+  readonly runner?: string;
+}
+
+export interface TrackerClaimComment {
+  readonly id: number;
+  readonly body: string;
+  readonly createdAt?: string;
+}
+
+export interface TrackerClaimRecord {
+  readonly commentId: number;
+  readonly worker: string;
+  readonly kind: TrackerClaimKind;
+  readonly runner?: string;
+  readonly createdAt?: string;
+}
+
+export interface TrackerClaimDecision {
+  readonly verdict: TrackerClaimVerdict;
+  readonly winner: string | null;
+  readonly reason: string;
+  readonly winnerClaimId?: number;
+  readonly recovered: string[];
+}
+
+export interface TrackerClaimStore {
+  postClaim(issue: number, body: string): Promise<number>;
+  listClaims(issue: number): Promise<TrackerClaimComment[]>;
+  concede(issue: number, body: string): Promise<void>;
+}
+
+export interface LocalIssueLeaseStore {
+  acquire(
+    issue: number,
+    owner: string,
+    liveness: (worker: string) => TrackerClaimLiveness,
+  ): Promise<LocalLeaseDecision>;
+  release(issue: number, owner: string): Promise<void>;
+}
+
+export type LocalLeaseDecision =
+  | { readonly acquired: true; readonly previousOwner?: string }
+  | {
+      readonly acquired: false;
+      readonly owner: string;
+      readonly reason:
+        "local lease owner is alive" | "local lease owner liveness unknown";
+    };
+
+export interface AcquireIssueLeaseOptions {
+  readonly issue: number;
+  readonly identity: TrackerClaimIdentity;
+  readonly local: LocalIssueLeaseStore;
+  readonly remote: TrackerClaimStore;
+  readonly liveness: (worker: string) => TrackerClaimLiveness;
+}
+
+export interface RetireIssueLeaseOptions {
+  readonly issue: number;
+  readonly identity: TrackerClaimIdentity;
+  readonly local: LocalIssueLeaseStore;
+  readonly remote: TrackerClaimStore;
+}
+
+const MARKER_OPEN = "<!-- afk:claim";
+const MARKER_RE = /<!--\s*afk:claim\s+([^>]*?)\s*-->/g;
+
+function escapeField(value: string): string {
+  return value.replace(/[\s>]/g, "_");
+}
+
+export function renderTrackerClaimComment(
+  identity: TrackerClaimIdentity,
+  kind: TrackerClaimKind = "claim",
+): string {
+  const fields = [
+    `v${TRACKER_CLAIM_MARKER_VERSION}`,
+    `worker=${escapeField(identity.worker)}`,
+    `kind=${kind}`,
+  ];
+  if (identity.runner) fields.push(`runner=${escapeField(identity.runner)}`);
+  const marker = `${MARKER_OPEN} ${fields.join(" ")} -->`;
+  const human =
+    kind === "claim"
+      ? `AFK claim by worker \`${identity.worker}\`${identity.runner ? ` (runner \`${identity.runner}\`)` : ""}.`
+      : `AFK worker \`${identity.worker}\` conceded this issue.`;
+  return `${marker}\n${human}`;
+}
+
+export function parseTrackerClaimRecords(
+  comments: readonly TrackerClaimComment[],
+): TrackerClaimRecord[] {
+  const out: TrackerClaimRecord[] = [];
+  for (const comment of comments) {
+    if (!Number.isFinite(comment.id) || typeof comment.body !== "string")
+      continue;
+    MARKER_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = MARKER_RE.exec(comment.body)) !== null) {
+      const fields = parseFields(match[1] ?? "");
+      const worker = fields.get("worker");
+      if (!worker) continue;
+      const kind = fields.get("kind") === "concede" ? "concede" : "claim";
+      out.push({
+        commentId: comment.id,
+        worker,
+        kind,
+        runner: fields.get("runner"),
+        createdAt: fields.get("ts") ?? comment.createdAt,
+      });
+    }
+  }
+  return out;
+}
+
+function parseFields(raw: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const token of raw.split(/\s+/)) {
+    const eq = token.indexOf("=");
+    if (eq <= 0) continue;
+    fields.set(token.slice(0, eq), token.slice(eq + 1));
+  }
+  return fields;
+}
+
+export function reconcileTrackerClaims(
+  records: readonly TrackerClaimRecord[],
+  self: { readonly worker: string; readonly commentId: number },
+  liveness: (worker: string) => TrackerClaimLiveness,
+): TrackerClaimDecision {
+  interface Fold {
+    earliestClaimId: number | null;
+    latestId: number;
+    latestKind: TrackerClaimKind;
+  }
+
+  const folds = new Map<string, Fold>();
+  const ingest = (record: TrackerClaimRecord): void => {
+    if (!Number.isFinite(record.commentId) || record.worker === "") return;
+    const existing = folds.get(record.worker);
+    if (!existing) {
+      folds.set(record.worker, {
+        earliestClaimId: record.kind === "claim" ? record.commentId : null,
+        latestId: record.commentId,
+        latestKind: record.kind,
+      });
+      return;
+    }
+    if (
+      record.kind === "claim" &&
+      (existing.earliestClaimId === null ||
+        record.commentId < existing.earliestClaimId)
+    ) {
+      existing.earliestClaimId = record.commentId;
+    }
+    if (record.commentId >= existing.latestId) {
+      existing.latestId = record.commentId;
+      existing.latestKind = record.kind;
+    }
+  };
+
+  for (const record of records) ingest(record);
+  ingest({ commentId: self.commentId, worker: self.worker, kind: "claim" });
+
+  const contenders: Array<{ worker: string; claimId: number }> = [];
+  const dead: Array<{ worker: string; claimId: number }> = [];
+  for (const [worker, fold] of folds) {
+    if (fold.latestKind === "concede" || fold.earliestClaimId === null)
+      continue;
+    const verdict = liveness(worker);
+    if (verdict === "dead") {
+      dead.push({ worker, claimId: fold.earliestClaimId });
+      continue;
+    }
+    contenders.push({ worker, claimId: fold.earliestClaimId });
+  }
+
+  contenders.sort(
+    (a, b) => a.claimId - b.claimId || a.worker.localeCompare(b.worker),
+  );
+  const winner = contenders[0];
+  if (!winner) {
+    return {
+      verdict: "lost",
+      winner: null,
+      reason: "no live claim contends",
+      recovered: [],
+    };
+  }
+
+  const recovered =
+    winner.worker === self.worker
+      ? dead
+          .filter((claim) => claim.claimId < winner.claimId)
+          .map((claim) => claim.worker)
+          .sort()
+      : [];
+  if (winner.worker === self.worker) {
+    return {
+      verdict: "won",
+      winner: self.worker,
+      winnerClaimId: winner.claimId,
+      reason:
+        contenders.length === 1
+          ? "solo claim"
+          : `earliest of ${contenders.length} live claims`,
+      recovered,
+    };
+  }
+  return {
+    verdict: "lost",
+    winner: winner.worker,
+    winnerClaimId: winner.claimId,
+    reason: `worker ${winner.worker} holds earlier claim`,
+    recovered: [],
+  };
+}
+
+export async function acquireIssueLease(
+  options: AcquireIssueLeaseOptions,
+): Promise<TrackerClaimDecision> {
+  const local = await options.local.acquire(
+    options.issue,
+    options.identity.worker,
+    options.liveness,
+  );
+  if (!local.acquired) {
+    return {
+      verdict: "lost",
+      winner: local.owner,
+      reason: local.reason,
+      recovered: [],
+    };
+  }
+
+  const commentId = await options.remote.postClaim(
+    options.issue,
+    renderTrackerClaimComment(options.identity, "claim"),
+  );
+  const records = parseTrackerClaimRecords(
+    await options.remote.listClaims(options.issue),
+  );
+  const decision = reconcileTrackerClaims(
+    records,
+    { worker: options.identity.worker, commentId },
+    options.liveness,
+  );
+  if (decision.verdict === "lost") {
+    await options.remote.concede(
+      options.issue,
+      renderTrackerClaimComment(options.identity, "concede"),
+    );
+    await options.local.release(options.issue, options.identity.worker);
+  }
+  return decision;
+}
+
+export async function retireIssueLease(
+  options: RetireIssueLeaseOptions,
+): Promise<void> {
+  await options.remote.concede(
+    options.issue,
+    renderTrackerClaimComment(options.identity, "concede"),
+  );
+  await options.local.release(options.issue, options.identity.worker);
+}
+
+export function createFsIssueLeaseStore(root: string): LocalIssueLeaseStore {
+  return {
+    acquire: (issue, owner, liveness) =>
+      acquireFsIssueLease(root, issue, owner, liveness),
+    release: (issue, owner) => releaseFsIssueLease(root, issue, owner),
+  };
+}
+
+async function acquireFsIssueLease(
+  root: string,
+  issue: number,
+  owner: string,
+  liveness: (worker: string) => TrackerClaimLiveness,
+): Promise<LocalLeaseDecision> {
+  const leaseDir = issueLeaseDir(root, issue);
+  try {
+    await mkdir(leaseDir, { recursive: false });
+    await writeFile(join(leaseDir, "owner"), `${owner}\n`, { flag: "wx" });
+    return { acquired: true };
+  } catch (err) {
+    if (
+      (err as NodeJS.ErrnoException).code !== "ENOENT" &&
+      (err as NodeJS.ErrnoException).code !== "EEXIST"
+    ) {
+      throw err;
+    }
+  }
+
+  await mkdir(root, { recursive: true });
+  try {
+    await mkdir(leaseDir, { recursive: false });
+    await writeFile(join(leaseDir, "owner"), `${owner}\n`, { flag: "wx" });
+    return { acquired: true };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+  }
+
+  const currentOwner = await readLeaseOwner(leaseDir);
+  if (currentOwner === owner) return { acquired: true };
+  const verdict = currentOwner ? liveness(currentOwner) : "unknown";
+  if (verdict !== "dead") {
+    return {
+      acquired: false,
+      owner: currentOwner ?? "unknown",
+      reason:
+        verdict === "alive"
+          ? "local lease owner is alive"
+          : "local lease owner liveness unknown",
+    };
+  }
+
+  await rm(leaseDir, { recursive: true, force: true });
+  await mkdir(leaseDir, { recursive: false });
+  await writeFile(join(leaseDir, "owner"), `${owner}\n`, { flag: "wx" });
+  return { acquired: true, previousOwner: currentOwner };
+}
+
+async function releaseFsIssueLease(
+  root: string,
+  issue: number,
+  owner: string,
+): Promise<void> {
+  const leaseDir = issueLeaseDir(root, issue);
+  const currentOwner = await readLeaseOwner(leaseDir);
+  if (currentOwner === owner) {
+    await rm(leaseDir, { recursive: true, force: true });
+  }
+}
+
+async function readLeaseOwner(leaseDir: string): Promise<string | undefined> {
+  try {
+    return (
+      (await readFile(join(leaseDir, "owner"), "utf8")).trim() || undefined
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+function issueLeaseDir(root: string, issue: number): string {
+  return join(root, String(issue));
+}

--- a/packages/red-castle/src/engine/tracker/github/adapter.test.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.test.ts
@@ -1,36 +1,152 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createGitHubTrackerAdapter, type GhExec } from "./adapter.js";
 
 describe("GitHub tracker adapter", () => {
   it("quarantines tracker IO behind gh CLI calls", async () => {
     const calls: string[][] = [];
+    const comments: Array<{ id: number; body: string; createdAt: string }> = [];
     const gh: GhExec = async (args) => {
       calls.push([...args]);
       if (args[0] === "issue" && args[1] === "list") {
         return JSON.stringify([
-          { number: 12, body: "Body", labels: [{ name: "wait:dependency" }, { name: "depends-on:7" }] },
+          {
+            number: 12,
+            body: "Body",
+            labels: [{ name: "wait:dependency" }, { name: "depends-on:7" }],
+          },
         ]);
       }
+      if (
+        args[0] === "issue" &&
+        args[1] === "view" &&
+        args.includes("comments")
+      ) {
+        return JSON.stringify({ comments });
+      }
       if (args[0] === "issue" && args[1] === "view") {
-        return JSON.stringify({ state: "CLOSED", number: 7, title: "Base", url: "https://example.invalid/7" });
+        return JSON.stringify({
+          state: "CLOSED",
+          number: 7,
+          title: "Base",
+          url: "https://example.invalid/7",
+        });
+      }
+      if (args[0] === "api") {
+        const bodyArg = args.find((arg) => arg.startsWith("body=")) ?? "body=";
+        const id = 500 + comments.length;
+        comments.push({
+          id,
+          body: bodyArg.slice("body=".length),
+          createdAt: "2026-07-16T00:00:00Z",
+        });
+        return `${id}\n`;
       }
       return "";
     };
 
-    const tracker = createGitHubTrackerAdapter({ gh, repo: "owner/repo" });
+    const claimLockRoot = await mkdtemp(
+      join(tmpdir(), "red-castle-gh-tracker-"),
+    );
+    const tracker = createGitHubTrackerAdapter({
+      gh,
+      repo: "owner/repo",
+      claimLockRoot,
+    });
 
-    await expect(tracker.listOpenIssuesByLabel("wait:dependency")).resolves.toEqual([
-      { number: 12, body: "Body", labels: ["wait:dependency", "depends-on:7"] },
+    try {
+      await expect(
+        tracker.listOpenIssuesByLabel("wait:dependency"),
+      ).resolves.toEqual([
+        {
+          number: 12,
+          body: "Body",
+          labels: ["wait:dependency", "depends-on:7"],
+        },
+      ]);
+      await expect(tracker.isIssueClosed(7)).resolves.toBe(true);
+      await tracker.editIssueLabels(12, {
+        remove: ["wait:dependency"],
+        add: ["queue:agent"],
+      });
+      await tracker.commentOnIssue(12, "done");
+      await expect(
+        tracker.claimIssueLease?.({
+          issue: 12,
+          worker: "host:w1",
+          runner: "codex",
+          liveness: (worker) => (worker === "host:w1" ? "alive" : "unknown"),
+        }),
+      ).resolves.toMatchObject({ verdict: "won", winner: "host:w1" });
+      await tracker.retireIssueLease?.({
+        issue: 12,
+        worker: "host:w1",
+        runner: "codex",
+      });
+    } finally {
+      await rm(claimLockRoot, { recursive: true, force: true });
+    }
+
+    expect(comments.map((comment) => comment.body)).toEqual([
+      expect.stringContaining(
+        "<!-- afk:claim v1 worker=host:w1 kind=claim runner=codex -->",
+      ),
+      expect.stringContaining(
+        "<!-- afk:claim v1 worker=host:w1 kind=concede runner=codex -->",
+      ),
     ]);
-    await expect(tracker.isIssueClosed(7)).resolves.toBe(true);
-    await tracker.editIssueLabels(12, { remove: ["wait:dependency"], add: ["queue:agent"] });
-    await tracker.commentOnIssue(12, "done");
 
     expect(calls).toEqual([
-      ["issue", "list", "--state", "open", "--label", "wait:dependency", "--json", "number,body,labels", "--limit", "1000", "--repo", "owner/repo"],
+      [
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--label",
+        "wait:dependency",
+        "--json",
+        "number,body,labels",
+        "--limit",
+        "1000",
+        "--repo",
+        "owner/repo",
+      ],
       ["issue", "view", "7", "--json", "state", "--repo", "owner/repo"],
-      ["issue", "edit", "12", "--remove-label", "wait:dependency", "--add-label", "queue:agent", "--repo", "owner/repo"],
+      [
+        "issue",
+        "edit",
+        "12",
+        "--remove-label",
+        "wait:dependency",
+        "--add-label",
+        "queue:agent",
+        "--repo",
+        "owner/repo",
+      ],
       ["issue", "comment", "12", "--body", "done", "--repo", "owner/repo"],
+      [
+        "api",
+        "repos/owner/repo/issues/12/comments",
+        "-f",
+        expect.stringContaining(
+          "body=<!-- afk:claim v1 worker=host:w1 kind=claim runner=codex -->",
+        ),
+        "--jq",
+        ".id",
+      ],
+      ["issue", "view", "12", "--json", "comments", "--repo", "owner/repo"],
+      [
+        "api",
+        "repos/owner/repo/issues/12/comments",
+        "-f",
+        expect.stringContaining(
+          "body=<!-- afk:claim v1 worker=host:w1 kind=concede runner=codex -->",
+        ),
+        "--jq",
+        ".id",
+      ],
     ]);
   });
 });

--- a/packages/red-castle/src/engine/tracker/github/adapter.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.ts
@@ -1,6 +1,19 @@
 import { execFile } from "node:child_process";
+import { join } from "node:path";
 import { promisify } from "node:util";
-import type { TrackerIssue, TrackerPort, TrackerLabelMutation, TrackerIssueReference } from "../port.js";
+import type {
+  TrackerIssue,
+  TrackerPort,
+  TrackerLabelMutation,
+  TrackerIssueReference,
+} from "../port.js";
+import {
+  acquireIssueLease,
+  createFsIssueLeaseStore,
+  retireIssueLease as retireClaimLease,
+  type TrackerClaimComment,
+  type TrackerClaimStore,
+} from "../claim.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -9,6 +22,7 @@ export type GhExec = (args: readonly string[]) => Promise<string>;
 export interface GitHubTrackerAdapterOptions {
   readonly gh?: GhExec;
   readonly repo?: string;
+  readonly claimLockRoot?: string;
 }
 
 interface GhIssueListRow {
@@ -22,12 +36,25 @@ interface GhIssueViewRow {
   readonly number?: unknown;
   readonly title?: unknown;
   readonly url?: unknown;
+  readonly comments?: unknown;
 }
 
-export function createGitHubTrackerAdapter(options: GitHubTrackerAdapterOptions = {}): TrackerPort {
+export function createGitHubTrackerAdapter(
+  options: GitHubTrackerAdapterOptions = {},
+): TrackerPort {
   const gh = options.gh ?? defaultGhExec;
   const withRepo = (args: string[]): string[] =>
     options.repo ? [...args, "--repo", options.repo] : args;
+  const localClaims = createFsIssueLeaseStore(
+    options.claimLockRoot ?? join(process.cwd(), ".red", "tmp", "claims"),
+  );
+  const remoteClaims: TrackerClaimStore = {
+    postClaim: (issue, body) => postIssueComment(gh, options.repo, issue, body),
+    listClaims: (issue) => listIssueComments(gh, withRepo, issue),
+    concede: async (issue, body) => {
+      await postIssueComment(gh, options.repo, issue, body);
+    },
+  };
 
   return {
     async listOpenIssuesByLabel(label) {
@@ -48,7 +75,9 @@ export function createGitHubTrackerAdapter(options: GitHubTrackerAdapterOptions 
       return parseIssueList(stdout);
     },
     async isIssueClosed(issue) {
-      const stdout = await gh(withRepo(["issue", "view", String(issue), "--json", "state"]));
+      const stdout = await gh(
+        withRepo(["issue", "view", String(issue), "--json", "state"]),
+      );
       const row = parseJson<GhIssueViewRow>(stdout);
       return row.state === "CLOSED";
     },
@@ -62,7 +91,15 @@ export function createGitHubTrackerAdapter(options: GitHubTrackerAdapterOptions 
       await gh(withRepo(["issue", "comment", String(issue), "--body", body]));
     },
     async issueReference(issue) {
-      const stdout = await gh(withRepo(["issue", "view", String(issue), "--json", "number,title,url"]));
+      const stdout = await gh(
+        withRepo([
+          "issue",
+          "view",
+          String(issue),
+          "--json",
+          "number,title,url",
+        ]),
+      );
       const row = parseJson<GhIssueViewRow>(stdout);
       const number = typeof row.number === "number" ? row.number : issue;
       return {
@@ -71,15 +108,38 @@ export function createGitHubTrackerAdapter(options: GitHubTrackerAdapterOptions 
         url: typeof row.url === "string" ? row.url : undefined,
       } satisfies TrackerIssueReference;
     },
+    async claimIssueLease(request) {
+      return acquireIssueLease({
+        issue: request.issue,
+        identity: { worker: request.worker, runner: request.runner },
+        local: localClaims,
+        remote: remoteClaims,
+        liveness: request.liveness,
+      });
+    },
+    async retireIssueLease(request) {
+      await retireClaimLease({
+        issue: request.issue,
+        identity: { worker: request.worker, runner: request.runner },
+        local: localClaims,
+        remote: remoteClaims,
+      });
+    },
   };
 }
 
 async function defaultGhExec(args: readonly string[]): Promise<string> {
-  const { stdout } = await execFileAsync("gh", args as string[], { encoding: "utf8" });
+  const { stdout } = await execFileAsync("gh", args as string[], {
+    encoding: "utf8",
+  });
   return stdout;
 }
 
-function appendLabelArgs(args: string[], flag: string, labels: readonly string[]): void {
+function appendLabelArgs(
+  args: string[],
+  flag: string,
+  labels: readonly string[],
+): void {
   if (labels.length === 0) return;
   args.push(flag, labels.join(","));
 }
@@ -107,11 +167,82 @@ function parseLabels(value: unknown): string[] {
       labels.push(item);
       continue;
     }
-    if (item && typeof item === "object" && "name" in item && typeof item.name === "string") {
+    if (
+      item &&
+      typeof item === "object" &&
+      "name" in item &&
+      typeof item.name === "string"
+    ) {
       labels.push(item.name);
     }
   }
   return labels;
+}
+
+async function postIssueComment(
+  gh: GhExec,
+  repo: string | undefined,
+  issue: number,
+  body: string,
+): Promise<number> {
+  if (repo) {
+    const stdout = await gh([
+      "api",
+      `repos/${repo}/issues/${issue}/comments`,
+      "-f",
+      `body=${body}`,
+      "--jq",
+      ".id",
+    ]);
+    const id = Number(stdout.trim());
+    if (Number.isFinite(id)) return id;
+  } else {
+    await gh(["issue", "comment", String(issue), "--body", body]);
+  }
+
+  const comments = await listIssueComments(gh, (args) => args, issue);
+  const match = comments
+    .filter((comment) => comment.body === body)
+    .sort((a, b) => b.id - a.id)[0];
+  if (match) return match.id;
+  throw new Error(
+    `unable to resolve posted claim comment id for issue #${issue}`,
+  );
+}
+
+async function listIssueComments(
+  gh: GhExec,
+  withRepo: (args: string[]) => string[],
+  issue: number,
+): Promise<TrackerClaimComment[]> {
+  const stdout = await gh(
+    withRepo(["issue", "view", String(issue), "--json", "comments"]),
+  );
+  const row = parseJson<GhIssueViewRow>(stdout);
+  if (!Array.isArray(row.comments)) return [];
+  const comments: TrackerClaimComment[] = [];
+  for (const item of row.comments) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as {
+      id?: unknown;
+      databaseId?: unknown;
+      body?: unknown;
+      createdAt?: unknown;
+    };
+    const id =
+      typeof rec.id === "number"
+        ? rec.id
+        : typeof rec.databaseId === "number"
+          ? rec.databaseId
+          : NaN;
+    if (!Number.isFinite(id) || typeof rec.body !== "string") continue;
+    comments.push({
+      id,
+      body: rec.body,
+      createdAt: typeof rec.createdAt === "string" ? rec.createdAt : undefined,
+    });
+  }
+  return comments;
 }
 
 function parseJson<T>(stdout: string): T {

--- a/packages/red-castle/src/engine/tracker/port.ts
+++ b/packages/red-castle/src/engine/tracker/port.ts
@@ -15,10 +15,37 @@ export interface TrackerLabelMutation {
   readonly add: readonly string[];
 }
 
+export type TrackerClaimLiveness = "alive" | "dead" | "unknown";
+
+export interface TrackerClaimLeaseRequest {
+  readonly issue: number;
+  readonly worker: string;
+  readonly runner?: string;
+  readonly liveness: (worker: string) => TrackerClaimLiveness;
+}
+
+export interface TrackerClaimRetireRequest {
+  readonly issue: number;
+  readonly worker: string;
+  readonly runner?: string;
+}
+
+export interface TrackerClaimDecision {
+  readonly verdict: "won" | "lost";
+  readonly winner: string | null;
+  readonly reason: string;
+  readonly winnerClaimId?: number;
+  readonly recovered: readonly string[];
+}
+
 export interface TrackerPort {
   listOpenIssuesByLabel(label: string): Promise<TrackerIssue[]>;
   isIssueClosed(issue: number): Promise<boolean>;
   editIssueLabels(issue: number, mutation: TrackerLabelMutation): Promise<void>;
   commentOnIssue(issue: number, body: string): Promise<void>;
   issueReference?(issue: number): Promise<TrackerIssueReference | undefined>;
+  claimIssueLease?(
+    request: TrackerClaimLeaseRequest,
+  ): Promise<TrackerClaimDecision>;
+  retireIssueLease?(request: TrackerClaimRetireRequest): Promise<void>;
 }


### PR DESCRIPTION
Automated AFK landing for #1907. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1907

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786827280&installation_id=129708444&pr_number=1936&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1936&signature=ce7e6eaa9ab163fd628da5da65bc01c9bf2d795f7b15849c91be5780135239da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->