### PR TITLE
fix: #1912 Long-running worker state machine with re-queue recovery

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -2016,7 +2016,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
       isOpen: (r) => runnerCircuitOpen(paths.runnerCircuitDir, r, Math.floor(Date.now() / 1000)),
     },
     buildProcessInput: (candidate: IssueCandidate, c: SessionContext): ProcessIssueInput => {
-      const attempt = nextAttemptSync(c.issueTemplate.tmpDir, candidate.number);
+      const recoveryOrdinal = nextAttemptSync(c.issueTemplate.tmpDir, candidate.number);
+      // Long-running workers key workspaces by workerId+issueId. The retry
+      // ordinal remains separate policy data for per-class recovery caps and
+      // prior-failure prompt context; it no longer shapes the directory name.
+      const attempt = 1;
       const attemptDir = buildWorkerAttemptPath(c.issueTemplate.tmpDir, c.workerId, candidate.number, attempt);
       // Point the session-scoped envelope/iter-log closures at this attempt.
       current.attemptDir = attemptDir;
@@ -2096,6 +2100,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         claimant: workerIdentity(c.workerId),
         tmpDir: c.issueTemplate.tmpDir,
         attempt,
+        recoveryOrdinal,
         attemptDir,
         repo: c.issueTemplate.repo,
         repoDir: c.issueTemplate.repoDir,

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -767,7 +767,14 @@ export interface ProcessIssueInput {
   tmpDir: string;
   /** Attempt number from the attempt-ledger (1-based). */
   attempt: number;
-  /** Resolved attempt dir `<tmp>/workers/{id}/{N}-a{n}`. */
+  /**
+   * Retry-budget ordinal for recovery routing. Unlike {@link attempt}, this is
+   * policy data, not path grammar: long-running workers keep the stable
+   * workerId/issueId directory while the caller may still count prior failures
+   * from retained markers/comments to enforce per-class caps.
+   */
+  recoveryOrdinal?: number;
+  /** Resolved worker issue dir `<tmp>/workers/{workerId}/{issueId}`. */
   attemptDir: string;
   /** Primary checkout (`owner/repo` for gh, dir for git -C). */
   repo: string;
@@ -863,6 +870,12 @@ function stateExitPatch(outcome: ProcessOutcome): Record<string, unknown> {
     };
   }
   return { ...base, "current.last_exit_code": CRASH_EXIT_CODE };
+}
+
+function recoveryOrdinalFor(input: ProcessIssueInput): number {
+  return input.recoveryOrdinal && Number.isInteger(input.recoveryOrdinal) && input.recoveryOrdinal > 0
+    ? input.recoveryOrdinal
+    : input.attempt;
 }
 
 function timeoutReasonForEnvelope(reason: RunAgentResult["timeoutReason"] | undefined): string {
@@ -3109,7 +3122,7 @@ async function terminalFailure(
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   markTerminalState(deps, outcome);
-  const decision = await routeRecovery(deps, input.issue, outcome, input.attempt);
+  const decision = await routeRecovery(deps, input.issue, outcome, recoveryOrdinalFor(input));
   if (decision === "escalate") {
     await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, sections));
   }
@@ -3190,7 +3203,7 @@ async function emitDone(
  * ready-for-human, preserve the attempt dir. Mirrors the do_merge-false branch. */
 async function mergeFailed(c: StageCommon, _reason: string, locked = false): Promise<ProcessIssueResult> {
   const { deps, input } = c;
-  const decision = await routeRecovery(deps, input.issue, "merge-conflict", input.attempt);
+  const decision = await routeRecovery(deps, input.issue, "merge-conflict", recoveryOrdinalFor(input));
   if (decision === "escalate") {
     await writeCurrentBlockerBestEffort(
       deps,
@@ -3246,7 +3259,7 @@ async function ciBlocked(
       : `required status checks were still pending on ${prRef} past the CI-wait timeout`;
   // routeRecovery escalates (ci-* map to no recovery policy → ready-for-human +
   // blocked:ci). The branch is intact, so the open PR is the durable artifact.
-  await routeRecovery(deps, input.issue, outcome, input.attempt);
+  await routeRecovery(deps, input.issue, outcome, recoveryOrdinalFor(input));
   await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, { log: reason }));
   const posted = await emitFailure(c, envelopeStatusFor(outcome), "ci", {
     log:
@@ -3289,7 +3302,7 @@ async function prLandingBlocked(
 ): Promise<ProcessIssueResult> {
   const { deps, input } = c;
   const prRef = prNumber !== undefined ? `PR #${prNumber}` : "the open PR";
-  await routeRecovery(deps, input.issue, outcome, input.attempt, { forceDecision: "escalate" });
+  await routeRecovery(deps, input.issue, outcome, recoveryOrdinalFor(input), { forceDecision: "escalate" });
   await writeCurrentBlockerBestEffort(deps, input, blockerForFailure(outcome, { log: `${prRef}: ${reason}` }));
   const section = outcome === "merge-conflict" ? "merge-conflict" : "ci";
   const posted = await emitFailure(c, envelopeStatusFor(outcome), section, {
@@ -3346,7 +3359,7 @@ async function trunkDivergedBlocked(
     `requeue the issue. The attempt branch is intact — no work was lost.`;
   // routeRecovery escalates (trunk-diverged is non-recoverable): drop running,
   // ensure + add ready-for-human + blocked:trunk-diverged.
-  await routeRecovery(deps, input.issue, "trunk-diverged", input.attempt);
+  await routeRecovery(deps, input.issue, "trunk-diverged", recoveryOrdinalFor(input));
   await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("trunk-diverged", { log: detail }));
   const posted = await emitFailure(c, envelopeStatusFor("trunk-diverged"), "trunk-diverged", { log: detail });
   await deps.gh.comment(input.issue, `🤖 /afk: ${detail}`);
@@ -3388,7 +3401,7 @@ async function sensitivePathGuarded(
   const detail =
     `Landing blocked: the diff touches sensitive path(s) that require human review before auto-landing — ` +
     `${hitList}. The attempt branch is intact. Requeue after reviewing the change.`;
-  await routeRecovery(deps, input.issue, "sensitive-path", input.attempt);
+  await routeRecovery(deps, input.issue, "sensitive-path", recoveryOrdinalFor(input));
   await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("sensitive-path", { log: detail }));
   const posted = await emitFailure(c, envelopeStatusFor("sensitive-path"), "sensitive-path", { log: detail });
   await deps.gh.comment(input.issue, `🤖 /afk: ${detail}`);
@@ -3429,7 +3442,7 @@ async function mainRedUntrackedBlocked(
   const detail =
     `${message} The attempt branch \`${c.branch}\` is intact and validated, but landing is held until the tracked-red ` +
     `repair issue exists.${syncFailureDetail} Requeue after the auto-file path recreates it.`;
-  await routeRecovery(deps, input.issue, "main-red-untracked", input.attempt);
+  await routeRecovery(deps, input.issue, "main-red-untracked", recoveryOrdinalFor(input));
   await writeCurrentBlockerBestEffort(deps, input, blockerForFailure("main-red-untracked", { log: detail }));
   const posted = await emitFailure(c, envelopeStatusFor("main-red-untracked"), "main-red-untracked", { log: detail });
   await deps.gh.comment(input.issue, `🤖 /afk: ${detail}`);
@@ -3788,7 +3801,7 @@ async function abortAfterClaim(
   // A policy-hook abort is BOUNDED-recoverable (recovery.ts, reason "policy"):
   // retry under the cap (restore ready-for-agent) else escalate (ready-for-human
   // + the budget-exhausted comment routeRecovery posts).
-  const decision = await routeRecovery(deps, input.issue, "hook-aborted", input.attempt);
+  const decision = await routeRecovery(deps, input.issue, "hook-aborted", recoveryOrdinalFor(input));
   if (decision === "retry") {
     await deps.gh.comment(
       input.issue,
@@ -3831,7 +3844,7 @@ async function exhausted(
   // Quota exhaustion is BOUNDED-recoverable (recovery.ts, reason "quota"):
   // restore ready-for-agent while under the cap, else escalate to
   // ready-for-human (routeRecovery posts the budget-exhausted comment).
-  await routeRecovery(deps, input.issue, "exhausted", input.attempt);
+  await routeRecovery(deps, input.issue, "exhausted", recoveryOrdinalFor(input));
   await deps.gh.comment(
     input.issue,
     both
@@ -3884,7 +3897,7 @@ async function runnerRecoverable(
   if (outcome === "exhausted") {
     return exhausted(deps, input, branch, base, hooksFired, runner, both);
   }
-  await routeRecovery(deps, input.issue, "runner-transient", input.attempt);
+  await routeRecovery(deps, input.issue, "runner-transient", recoveryOrdinalFor(input));
   await deps.gh.comment(
     input.issue,
     both

--- a/apps/dev/src/core/session.ts
+++ b/apps/dev/src/core/session.ts
@@ -224,6 +224,39 @@ export interface SessionContext {
    * skip is driven by `BootOptions.skipSweeps` in `runBoot`, not here.
    */
   sweepsSkipped?: boolean;
+  /** Long-running worker stop policy. Omitted fields leave that exit disabled. */
+  policy?: SessionStopPolicy;
+}
+
+export type SessionStopReason =
+  | "drain-empty"
+  | "lifetime-cap"
+  | "budget-cap"
+  | "supervisor-kill"
+  | "graceful-retirement"
+  | "iter-cap"
+  | "once"
+  | "runner-unavailable"
+  | "exhausted";
+
+export interface SessionBudgetSnapshot {
+  used: number;
+  cap: number;
+}
+
+export interface SessionStopPolicy {
+  /** Stop after this many successfully claimed/processed issue slots. */
+  maxIssues?: number;
+  /** Stop once wall-clock runtime reaches this many milliseconds. */
+  maxRuntimeMs?: number;
+  /** Optional runtime clock for deterministic tests. Defaults to Date.now. */
+  nowMs?: () => number;
+  /** Stop before claiming when the session budget is spent. */
+  budget?: () => SessionBudgetSnapshot;
+  /** Supervisor-requested hard stop before the next claim. */
+  supervisorKilled?: () => boolean;
+  /** Finish the current issue, then retire without claiming another. */
+  shouldRetire?: () => boolean;
 }
 
 /**
@@ -356,6 +389,8 @@ export interface SessionSummary {
   runnerTransient: boolean;
   /** Session-scoped lifecycle points that fired, in order — the parity target. */
   sessionHooksFired: HookName[];
+  /** Why this long-running worker stopped, when a named stop condition fired. */
+  stopReason?: SessionStopReason;
 }
 
 /** `done` is the only success; blocked/no-sentinel/merge-conflict/feedback flip
@@ -371,6 +406,14 @@ function classify(outcome: ProcessIssueResult["outcome"]): "done" | "blocked" | 
     default:
       return "blocked";
   }
+}
+
+function budgetSpent(snapshot: SessionBudgetSnapshot | undefined): boolean {
+  return snapshot !== undefined && snapshot.cap > 0 && snapshot.used >= snapshot.cap;
+}
+
+function emitStop(deps: SessionDeps, reason: SessionStopReason): void {
+  deps.emit(`worker stop: ${reason}`);
 }
 
 /**
@@ -431,6 +474,8 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
     runnerTransient: false,
     sessionHooksFired,
   };
+  const nowMs = ctx.policy?.nowMs ?? (() => Date.now());
+  const startedMs = nowMs();
 
   // ---- 1. boot (precheck failure aborts the drain) ----
   const boot = await deps.runBoot(deps.bootDeps, deps.bootOptions);
@@ -468,7 +513,7 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
       await fireSessionHook("on_idle", statsContext(0, 0, 0));
       deps.emit(NO_MORE_TASKS);
       await fireSessionHook("post_session", statsContext(0, 0, 0));
-      return { ...empty, boot, total: 0, drained: true };
+      return { ...empty, boot, total: 0, drained: true, stopReason: "drain-empty" };
     }
 
     // ---- 5. drain under the -n cap ----
@@ -479,15 +524,36 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
     let failed = 0;
     let exhaustedStop = false;
     let runnerTransientStop = false;
+    let stopReason: SessionStopReason | undefined;
     // --alternate: the runner rotates per issue. The first issue uses ctx.runner.
     let activeRunner: Runner = ctx.runner;
 
     for (let i = 0; i < queue.length; i++) {
-      if (i >= cap) break; // -n N reached → stop the drain (Stop Conditions).
+      if (ctx.policy?.supervisorKilled?.()) {
+        stopReason = "supervisor-kill";
+        break;
+      }
+      if (budgetSpent(ctx.policy?.budget?.())) {
+        stopReason = "budget-cap";
+        break;
+      }
+      if (ctx.policy?.maxRuntimeMs !== undefined && nowMs() - startedMs >= ctx.policy.maxRuntimeMs) {
+        stopReason = "lifetime-cap";
+        break;
+      }
+      if (ctx.policy?.maxIssues !== undefined && processed.length >= ctx.policy.maxIssues) {
+        stopReason = "lifetime-cap";
+        break;
+      }
+      if (i >= cap) {
+        stopReason = "iter-cap";
+        break; // -n N reached → stop the drain (Stop Conditions).
+      }
       const candidate = queue[i]!;
       const issueRunner = ctx.alternate ? activeRunner : ctx.runner;
       if (deps.runnerCircuit && (await deps.runnerCircuit.isOpen(issueRunner))) {
         runnerTransientStop = true;
+        stopReason = "runner-unavailable";
         deps.emit(`runner ${issueRunner} circuit open — stopping before claiming more issues`);
         break;
       }
@@ -514,10 +580,12 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
       // claiming more issues just spreads blocked:runner-transient labels.
       if (result.outcome === "exhausted") {
         exhaustedStop = true;
+        stopReason = "exhausted";
         break;
       }
       if (result.outcome === "runner-transient") {
         runnerTransientStop = true;
+        stopReason = "runner-unavailable";
         break;
       }
 
@@ -527,12 +595,20 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
       // iteration: under the fleet supervisor every worker IS --once, so
       // exiting here respawns a fresh worker that re-races the same head issue
       // forever — the #644 churn that starved 2 of 3 slots.
-      if (ctx.once && result.outcome !== "claim-lost") break;
+      if (ctx.once && result.outcome !== "claim-lost") {
+        stopReason = "once";
+        break;
+      }
+      if (ctx.policy?.shouldRetire?.()) {
+        stopReason = "graceful-retirement";
+        break;
+      }
       if (ctx.alternate) activeRunner = otherRunner(activeRunner, ctx.runner);
     }
 
     // ---- 6. post_session (normal end) ----
     await fireSessionHook("post_session", statsContext(done, blocked, total));
+    if (stopReason) emitStop(deps, stopReason);
 
     return {
       runner: ctx.runner,
@@ -547,6 +623,7 @@ export async function runSession(deps: SessionDeps, ctx: SessionContext): Promis
       exhausted: exhaustedStop,
       runnerTransient: runnerTransientStop,
       sessionHooksFired,
+      stopReason,
     };
   } catch (error) {
     // on_session_error death-notification path: fire the crash hook (log-and-

--- a/apps/dev/src/core/worker-paths.ts
+++ b/apps/dev/src/core/worker-paths.ts
@@ -64,13 +64,13 @@ export function buildWorkerAttemptPath(
   root: string,
   worker: string,
   issueValue: string | number,
-  attemptValue: string | number,
+  _attemptValue: string | number,
 ): string {
   if (!root) throw new Error("root is required");
   if (!isValidWorkerId(worker)) throw new Error(`invalid worker id: ${worker}`);
   const issue = asPositiveInteger(issueValue, "issue");
-  const attempt = asPositiveInteger(attemptValue, "attempt");
-  return `${normalizeRoot(root)}/${workersSegment()}/${worker}/${issue}-a${attempt}`;
+  asPositiveInteger(_attemptValue, "attempt");
+  return `${normalizeRoot(root)}/${workersSegment()}/${worker}/${issue}`;
 }
 
 export function parseWorkerAttemptPath(path: string): WorkerAttemptIdentity | null {
@@ -78,17 +78,17 @@ export function parseWorkerAttemptPath(path: string): WorkerAttemptIdentity | nu
   const normalized = path.replace(/\/$/, "");
   // Accept every worker-lane segment so a parked-attempt path reverses
   // regardless of which lane minted it.
-  const match = normalized.match(/(?:^|\/)(?:workers|go-workers|scout-workers)\/([^/]+)\/([1-9][0-9]*)-a([1-9][0-9]*)$/);
+  const match = normalized.match(/(?:^|\/)(?:workers|go-workers|scout-workers)\/([^/]+)\/([1-9][0-9]*)(?:-a([1-9][0-9]*))?$/);
   if (!match) return null;
   const [, worker, issue, attempt] = match;
   if (!isValidWorkerId(worker)) return null;
-  return { worker, issue: Number(issue), attempt: Number(attempt) };
+  return { worker, issue: Number(issue), attempt: attempt ? Number(attempt) : 1 };
 }
 
 export function issueAttemptsGlob(root: string, issueValue: string | number): string {
   if (!root) throw new Error("root is required");
   const issue = asPositiveInteger(issueValue, "issue");
-  return `${normalizeRoot(root)}/${workersSegment()}/*/${issue}-a*`;
+  return `${normalizeRoot(root)}/${workersSegment()}/*/${issue}*`;
 }
 
 export function workersGlob(root: string): string {

--- a/apps/dev/tests/adopt-presence-io.test.ts
+++ b/apps/dev/tests/adopt-presence-io.test.ts
@@ -22,7 +22,7 @@ afterEach(() => {
 });
 
 const attemptDir = (tmpDir: string, issue: number): string =>
-  join(tmpDir, "workers", "requeue-adopt", `${issue}-a1`);
+  join(tmpDir, "workers", "requeue-adopt", String(issue));
 
 describe("makeAdoptPresenceIo — real state file, read through the shipped reader", () => {
   it("renders a live requeue-origin row mid-run, advances stage, then tears down on the landed path", async () => {

--- a/apps/dev/tests/adopt-presence.test.ts
+++ b/apps/dev/tests/adopt-presence.test.ts
@@ -58,9 +58,9 @@ describe("withAdoptPresence — seed", () => {
     expect(seed.title).toBe("Fix the thing");
     expect(seed.runner).toBe("claude");
     expect(seed.stage).toBe("validating");
-    // Canonical `workers/` root (never go-workers/scout-workers) + a1 attempt.
-    expect(seed.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1");
-    expect(seed.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1/afk.state.json");
+    // Canonical `workers/` root (never go-workers/scout-workers) + stable issue id.
+    expect(seed.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42");
+    expect(seed.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42/afk.state.json");
   });
 
   it("uses a distinct requeue provenance constant", () => {
@@ -77,7 +77,7 @@ describe("withAdoptPresence — teardown on every exit path", () => {
 
     expect(outcome).toBe("landed");
     expect(r.teardowns).toHaveLength(1);
-    expect(r.teardowns[0]!.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1");
+    expect(r.teardowns[0]!.attemptDir).toBe("/tmp/.red/tmp/workers/requeue-adopt/42");
     // Seed happens before teardown.
     expect(r.events).toEqual(["seed", "teardown"]);
   });
@@ -120,7 +120,7 @@ describe("withAdoptPresence — stage progression", () => {
     expect(r.stages.map((s) => s.stage)).toEqual(["validating", "landing"]);
     // Stage updates target the seeded presence state file.
     for (const s of r.stages) {
-      expect(s.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42-a1/afk.state.json");
+      expect(s.statePath).toBe("/tmp/.red/tmp/workers/requeue-adopt/42/afk.state.json");
     }
     // Order: seed → stages → teardown last.
     expect(r.events).toEqual(["seed", "stage:validating", "stage:landing", "teardown"]);

--- a/apps/dev/tests/attempt-ledger.test.ts
+++ b/apps/dev/tests/attempt-ledger.test.ts
@@ -70,6 +70,18 @@ describe("attempt-ledger next number (FS-backed)", () => {
     expect(await attemptLedgerNextNumber(root, 249)).toBe(1);
   });
 
+  it("reads the workerId-issueId directory as the first retained run", async () => {
+    const root = await tmpRoot();
+    const dir = join(root, "workers", "wC7D2", "249");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "failure.reason"), "runner-transient\n", "utf8");
+
+    expect(await attemptLedgerNextNumber(root, 249)).toBe(2);
+    const context = await attemptLedgerContext(root, 249);
+    expect(context?.prevAttempt).toBe(1);
+    expect(context?.prevFailureReason).toBe("runner-transient\n");
+  });
+
   it("derives max+1 across workers, numeric not lexical, independent per issue", async () => {
     const root = await tmpRoot();
     await mkAttempt(root, { worker: "wA1B9", issue: 249, attempt: 1, branch: "afk-attempts/wA1B9/249-foo", reason: "BLOCKED: typecheck failed" });

--- a/apps/dev/tests/session.test.ts
+++ b/apps/dev/tests/session.test.ts
@@ -233,6 +233,11 @@ interface RunHarnessOptions {
   sweepsSkipped?: boolean;
   /** Runners whose shared circuit is already open before the next claim. */
   circuitOpenFor?: Runner[];
+  maxIssues?: number;
+  maxRuntimeMs?: number;
+  budget?: { used: number; cap: number };
+  supervisorKilled?: boolean;
+  shouldRetire?: boolean;
 }
 
 function makeSession(opts: RunHarnessOptions = {}): {
@@ -354,6 +359,14 @@ function makeSession(opts: RunHarnessOptions = {}): {
       repoDir: "/repo",
       remote: "origin",
     },
+    policy: {
+      nowMs: () => 1_000,
+      ...(opts.maxIssues !== undefined ? { maxIssues: opts.maxIssues } : {}),
+      ...(opts.maxRuntimeMs !== undefined ? { maxRuntimeMs: opts.maxRuntimeMs } : {}),
+      ...(opts.budget ? { budget: () => opts.budget! } : {}),
+      ...(opts.supervisorKilled !== undefined ? { supervisorKilled: () => opts.supervisorKilled! } : {}),
+      ...(opts.shouldRetire !== undefined ? { shouldRetire: () => opts.shouldRetire! } : {}),
+    },
   };
 
   return { deps, ctx, trace };
@@ -419,12 +432,47 @@ describe("runSession", () => {
     expect(trace.emitted).toEqual([
       "progress: 1/4 (25%) — 3 remaining",
       "progress: 2/4 (50%) — 2 remaining",
+      "worker stop: iter-cap",
     ]);
   });
 
   it("--once stops after the first processed issue", async () => {
     const { deps, ctx, trace } = makeSession({ candidates: [cand(1), cand(2), cand(3)], once: true });
     await runSession(deps, ctx);
+    expect(trace.processedOrder).toEqual([1]);
+  });
+
+  it("stops on the config-tunable long-running worker lifetime cap", async () => {
+    const { deps, ctx, trace } = makeSession({ maxIssues: 2 });
+    const summary = await runSession(deps, ctx);
+
+    expect(summary.stopReason).toBe("lifetime-cap");
+    expect(trace.processedOrder).toEqual([1, 2]);
+    expect(trace.emitted.at(-1)).toBe("worker stop: lifetime-cap");
+  });
+
+  it("stops before claiming when the session budget cap is already spent", async () => {
+    const { deps, ctx, trace } = makeSession({ budget: { used: 11, cap: 10 } });
+    const summary = await runSession(deps, ctx);
+
+    expect(summary.stopReason).toBe("budget-cap");
+    expect(trace.processedOrder).toEqual([]);
+    expect(trace.emitted).toContain("worker stop: budget-cap");
+  });
+
+  it("stops before claiming when the supervisor kill flag is set", async () => {
+    const { deps, ctx, trace } = makeSession({ supervisorKilled: true });
+    const summary = await runSession(deps, ctx);
+
+    expect(summary.stopReason).toBe("supervisor-kill");
+    expect(trace.processedOrder).toEqual([]);
+  });
+
+  it("supports graceful retirement after the current issue completes", async () => {
+    const { deps, ctx, trace } = makeSession({ shouldRetire: true });
+    const summary = await runSession(deps, ctx);
+
+    expect(summary.stopReason).toBe("graceful-retirement");
     expect(trace.processedOrder).toEqual([1]);
   });
 
@@ -581,6 +629,7 @@ describe("runSession — exhaustion stops the drain (exit-75 signal)", () => {
     expect(summary.blocked).toBe(0);
     expect(trace.emitted).toEqual([
       "runner claude circuit open — stopping before claiming more issues",
+      "worker stop: runner-unavailable",
     ]);
   });
 

--- a/apps/dev/tests/worker-paths.test.ts
+++ b/apps/dev/tests/worker-paths.test.ts
@@ -21,20 +21,24 @@ describe("worker paths", () => {
     delete process.env.RED_AFK_WORKERS_NAMESPACE;
   });
 
-  it("round-trips the nested worker/issue/attempt layout", () => {
+  it("builds the worker/issue layout without attempt suffixes for new runs", () => {
     const path = buildWorkerAttemptPath(".red/tmp/", "wZ2R4", 142, 3);
-    expect(path).toBe(".red/tmp/workers/wZ2R4/142-a3");
-    expect(parseWorkerAttemptPath(`${path}/`)).toEqual({ worker: "wZ2R4", issue: 142, attempt: 3 });
+    expect(path).toBe(".red/tmp/workers/wZ2R4/142");
+    expect(parseWorkerAttemptPath(`${path}/`)).toEqual({ worker: "wZ2R4", issue: 142, attempt: 1 });
+  });
+
+  it("still reads retained legacy attempt-suffixed directories", () => {
+    expect(parseWorkerAttemptPath(".red/tmp/workers/wZ2R4/142-a3")).toEqual({ worker: "wZ2R4", issue: 142, attempt: 3 });
   });
 
   it("rejects malformed identities instead of constructing ambiguous paths", () => {
     expect(() => buildWorkerAttemptPath(".red/tmp", "../bad", 1, 1)).toThrow(/invalid worker/);
     expect(() => buildWorkerAttemptPath(".red/tmp", "wOK", "01", 1)).toThrow(/invalid issue/);
-    expect(parseWorkerAttemptPath(".red/tmp/workers/wOK/01-a1")).toBeNull();
+    expect(parseWorkerAttemptPath(".red/tmp/workers/wOK/01")).toBeNull();
   });
 
   it("returns canonical globs and pid paths", () => {
-    expect(issueAttemptsGlob(".red/tmp/", 42)).toBe(".red/tmp/workers/*/42-a*");
+    expect(issueAttemptsGlob(".red/tmp/", 42)).toBe(".red/tmp/workers/*/42*");
     expect(workersGlob(".red/tmp/")).toBe(".red/tmp/workers/*");
     expect(workerDir(".red/tmp/", "wAAAA")).toBe(".red/tmp/workers/wAAAA");
     expect(workerPidFile(".red/tmp/", "wAAAA")).toBe(".red/tmp/workers/wAAAA/worker.pid");
@@ -59,10 +63,10 @@ describe("worker paths — /go namespace", () => {
     process.env.RED_AFK_WORKERS_NAMESPACE = "go-workers";
     expect(workersSegment()).toBe("go-workers");
     const path = buildWorkerAttemptPath(".red/tmp/", "wGO12", 938, 1);
-    expect(path).toBe(".red/tmp/go-workers/wGO12/938-a1");
+    expect(path).toBe(".red/tmp/go-workers/wGO12/938");
     expect(parseWorkerAttemptPath(path)).toEqual({ worker: "wGO12", issue: 938, attempt: 1 });
     expect(workersGlob(".red/tmp/")).toBe(".red/tmp/go-workers/*");
-    expect(issueAttemptsGlob(".red/tmp/", 938)).toBe(".red/tmp/go-workers/*/938-a*");
+    expect(issueAttemptsGlob(".red/tmp/", 938)).toBe(".red/tmp/go-workers/*/938*");
     expect(workerDir(".red/tmp/", "wGO12")).toBe(".red/tmp/go-workers/wGO12");
     expect(livePidsGlob(".red/tmp/")).toBe(".red/tmp/go-workers/*/worker.pid");
   });
@@ -79,10 +83,10 @@ describe("worker paths — /go namespace", () => {
       "/repo/.red/tmp/go-workers",
       "/repo/.red/tmp/scout-workers",
     ]);
-    expect(parseWorkerAttemptPath("/repo/.red/tmp/scout-workers/wSCOUT/15-a2")).toEqual({
+    expect(parseWorkerAttemptPath("/repo/.red/tmp/scout-workers/wSCOUT/15")).toEqual({
       worker: "wSCOUT",
       issue: 15,
-      attempt: 2,
+      attempt: 1,
     });
   });
 


### PR DESCRIPTION
Automated AFK landing for #1912. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1912

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786838602&installation_id=129708444&pr_number=1939&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1939&signature=fd1d1455fd825ed480aa49c9c0b81738c298a1468600afe1252fc3da4283e8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->