### PR TITLE
fix: #1913 Castle supervisor with elastic fleet

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,11 +1,11 @@
 import { constants } from "node:fs";
-import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { afkPaths, preferExistingPath } from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
-import { classifySupervisor, resolveSupervisorConfig } from "../core/supervisor.js";
+import { classifySupervisor, resolveSupervisorConfig, type ElasticShrinkMode } from "../core/supervisor.js";
 import { teardownWedgedSupervisor } from "../core/watchdog.js";
 import { buildWatchdogIO } from "../runtime/watchdog-io.js";
 import { spawnSupervisor } from "../runtime/supervisor-spawn.js";
@@ -13,7 +13,7 @@ import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
 import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 
 export interface FleetLaunchResult {
-  status: "launched";
+  status: "launched" | "resized";
   pid: number;
   target: number;
   log: string;
@@ -42,13 +42,20 @@ function parsePositiveNumber(raw: string | undefined, flag: string): number {
   return n;
 }
 
-function parseFleetArgs(args: readonly string[]): { stop: boolean; target: number; request?: string; runnerFlag?: string; drainBudgetUsd?: number; passthrough: string[] } {
+function parseShrinkMode(raw: string | undefined, flag: string): ElasticShrinkMode {
+  if (raw === undefined) throw new Error(`${flag} requires a value`);
+  if (raw === "hard-kill" || raw === "drain-then-retire") return raw;
+  throw new Error(`${flag} must be hard-kill or drain-then-retire`);
+}
+
+function parseFleetArgs(args: readonly string[]): { stop: boolean; target: number; request?: string; runnerFlag?: string; drainBudgetUsd?: number; shrinkMode?: ElasticShrinkMode; passthrough: string[] } {
   const passthrough: string[] = [];
   let stop = false;
   let target: number | undefined;
   let request: string | undefined;
   let runnerFlag: string | undefined;
   let drainBudgetUsd: number | undefined;
+  let shrinkMode: ElasticShrinkMode | undefined;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]!;
@@ -86,13 +93,31 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; target: numbe
       drainBudgetUsd = parsePositiveNumber(arg.slice("--drain-budget-usd=".length), "--drain-budget-usd");
       continue;
     }
+    if (arg === "--shrink-mode") {
+      shrinkMode = parseShrinkMode(args[++i], arg);
+      continue;
+    }
+    if (arg.startsWith("--shrink-mode=")) {
+      shrinkMode = parseShrinkMode(arg.slice("--shrink-mode=".length), "--shrink-mode");
+      continue;
+    }
     if (/^[0-9]+$/.test(arg) && target === undefined) {
       target = Number(arg);
       continue;
     }
     passthrough.push(arg);
   }
-  return { stop, target: target ?? 2, request, runnerFlag, drainBudgetUsd, passthrough };
+  return { stop, target: target ?? 2, request, runnerFlag, drainBudgetUsd, shrinkMode, passthrough };
+}
+
+async function writeResizeRequest(path: string, target: number, shrinkMode: ElasticShrinkMode): Promise<void> {
+  const tmp = `${path}.tmp`;
+  await writeFile(
+    tmp,
+    `${JSON.stringify({ target, shrink_mode: shrinkMode }, null, 2)}\n`,
+    "utf8",
+  );
+  await rename(tmp, path);
 }
 
 export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetStopResult> {
@@ -175,7 +200,12 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     const liveness = await io.liveness();
     const health = classifySupervisor(liveness, io.now(), cfg.supervisorStaleS, cfg.progressStaleS);
     if (health !== "quiescent") {
-      throw new Error(`fleet already running (supervisor pid=${existing}, log .red/tmp/afk-supervisor.log).\n  to stop it: /dev:afk fleet stop`);
+      const shrinkMode = parsed.shrinkMode ?? cfg.shrinkMode;
+      await writeResizeRequest(paths.supervisorResizePath, parsed.target, shrinkMode);
+      stdout.write(
+        `fleet resize requested (supervisor pid=${existing}, target=${parsed.target}, shrink-mode=${shrinkMode})\n`,
+      );
+      return { status: "resized", pid: existing, target: parsed.target, log: logFile };
     }
     const staleForS = liveness.lastHeartbeatEpoch !== null ? io.now() - liveness.lastHeartbeatEpoch : null;
     io.log(
@@ -198,6 +228,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     passthrough: parsed.passthrough,
     request: parsed.request,
     drainBudgetUsd: parsed.drainBudgetUsd,
+    shrinkMode: parsed.shrinkMode,
   });
   if (!supervisorPid) {
     let tail = "";

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -7,10 +7,11 @@
 // native — no bash anywhere in the loop.
 
 import { spawn } from "node:child_process";
-import { existsSync, openSync, closeSync, writeFileSync, writeSync, rmSync, renameSync } from "node:fs";
+import { existsSync, openSync, closeSync, readFileSync, writeFileSync, writeSync, rmSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   type FleetHeartbeat,
+  type ElasticResizeRequest,
   initSupervisorState,
   resolveSupervisorConfig,
   runSupervisor,
@@ -127,6 +128,8 @@ export const PASSTHROUGH_DENYLIST: readonly string[] = [
   "RED_AFK_EXIT_CODE",
   "RED_AFK_DURATION_S",
   "RED_AFK_TASK_TIER_DOWNGRADE",
+  "RED_AFK_SHRINK_MODE",
+  "RED_AFK_RETIRE_FILE",
 ];
 
 /**
@@ -182,11 +185,40 @@ export function buildSlotEnv(
   workerEnv: Record<string, string>,
   slot: number,
   policy: SpawnPolicy = {},
+  retireFile?: string,
 ): Record<string, string> {
   const out: Record<string, string> = { ...workerEnv, RED_AFK_SLOT: String(slot) };
   if (policy.taskTierDowngrade) out.RED_AFK_TASK_TIER_DOWNGRADE = "1";
   else delete out.RED_AFK_TASK_TIER_DOWNGRADE;
+  if (retireFile !== undefined) out.RED_AFK_RETIRE_FILE = retireFile;
+  else delete out.RED_AFK_RETIRE_FILE;
   return out;
+}
+
+function slotRetirePath(statePath: string, slot: number): string {
+  return join(dirname(statePath), `afk-supervisor-slot-${slot}.retire`);
+}
+
+function readResizeRequest(path: string): ElasticResizeRequest | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as {
+      target?: unknown;
+      shrink_mode?: unknown;
+      shrinkMode?: unknown;
+    };
+    if (!Number.isInteger(parsed.target) || (parsed.target as number) < 0) return null;
+    const rawMode = parsed.shrink_mode ?? parsed.shrinkMode;
+    const shrinkMode =
+      rawMode === "hard-kill" || rawMode === "drain-then-retire"
+        ? rawMode
+        : undefined;
+    return {
+      target: parsed.target as number,
+      ...(shrinkMode !== undefined ? { shrinkMode } : {}),
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -365,9 +397,11 @@ function buildSupervisorDeps(
         // (mirrors spawn_slot's per-slot slot_log in supervisor.sh).
         const slotLogFile = join(tmpDir, `afk-supervisor-slot-${slot}.log`);
         const slotFd = openSync(slotLogFile, "a");
+        const retireFile = slotRetirePath(statePath, slot);
+        rmSync(retireFile, { force: true });
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
-          env: buildSlotEnv(workerEnv, slot, policy),
+          env: buildSlotEnv(workerEnv, slot, policy, retireFile),
           detached: true,
           stdio: ["ignore", slotFd, slotFd],
         });
@@ -390,7 +424,7 @@ function buildSupervisorDeps(
         ];
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
-          env: buildSlotEnv(workerEnv, slot),
+          env: buildSlotEnv(workerEnv, slot, undefined, slotRetirePath(statePath, slot)),
           detached: true,
           stdio: ["ignore", logFd, logFd],
         });
@@ -405,6 +439,9 @@ function buildSupervisorDeps(
       },
       lastExitCode: (slot) => slotExitCodes.get(slot) ?? null,
       isAlive,
+      requestSlotRetire: async (slot) => {
+        writeFileSync(slotRetirePath(statePath, slot), "", "utf8");
+      },
       // Wait-and-escalate killer (#580): SIGTERM → grace → SIGKILL → CONFIRM the
       // tree is gone, then return whether it actually died. The reaper gates its
       // `rm -rf` worktree teardown on this, so a SIGTERM-ignoring worker can
@@ -538,6 +575,7 @@ function buildSupervisorDeps(
       }
     },
     attemptBranchHead: (branch) => gitx.branchHead({ cwd: root }, branch),
+    resizeRequest: async () => readResizeRequest(afkPaths(root).supervisorResizePath),
     // Fleet-scoped lifecycle hooks (#833). Commands are resolved from the same
     // .red/hooks/<point>/ + library layering as worker hooks. Best-effort:
     // a dispatch failure is returned to the caller; the caller catches and logs.
@@ -622,6 +660,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   writeFileSync(pidFile, String(process.pid), "utf8");
   // clear any stale stop file
   if (existsSync(stopFile)) rmSync(stopFile, { force: true });
+  rmSync(paths.supervisorResizePath, { force: true });
 
   const logFd = openSync(logFile, "a");
   const values = loadConfig(paths.configPath, { warn: () => undefined });

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -173,6 +173,8 @@ export interface SupervisorConfig {
    * original attempt branch to advance before rotating the issue back to
    * ready-for-agent. */
   reapContestWindowS: number;
+  /** RED_AFK_SHRINK_MODE — runtime fleet shrink behavior. */
+  shrinkMode: ElasticShrinkMode;
 }
 
 export const SUPERVISOR_DEFAULTS = {
@@ -194,7 +196,15 @@ export const SUPERVISOR_DEFAULTS = {
   supervisorMaxRestarts: 5,
   supervisorRestartWindowS: 300,
   reapContestWindowS: 30,
+  shrinkMode: "drain-then-retire",
 } as const satisfies SupervisorConfig;
+
+export type ElasticShrinkMode = "hard-kill" | "drain-then-retire";
+
+export interface ElasticResizeRequest {
+  target: number;
+  shrinkMode?: ElasticShrinkMode;
+}
 
 export type DrainBudgetTier = "OK" | "WARNING" | "CRITICAL" | "HARD_STOP";
 
@@ -221,6 +231,11 @@ function parsePositiveNumber(raw: string | undefined): number | undefined {
   if (raw === undefined || raw.trim() === "") return undefined;
   const n = Number(raw);
   return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function parseShrinkMode(raw: string | undefined): ElasticShrinkMode | undefined {
+  if (raw === "hard-kill" || raw === "drain-then-retire") return raw;
+  return undefined;
 }
 
 export type SupervisorConfigReader = (key: string) => string;
@@ -325,6 +340,10 @@ export function resolveSupervisorConfig(
       parsePositiveNumber(env.RED_AFK_DRAIN_MAX_COST_USD) ??
       parsePositiveNumber(getCfg("afk.drain.max_cost_usd")),
     reapContestWindowS: num("RED_AFK_REAP_CONTEST_WINDOW_S", SUPERVISOR_DEFAULTS.reapContestWindowS),
+    shrinkMode:
+      parseShrinkMode(env.RED_AFK_SHRINK_MODE) ??
+      parseShrinkMode(getCfg("afk.shrink_mode")) ??
+      SUPERVISOR_DEFAULTS.shrinkMode,
   };
 }
 
@@ -542,6 +561,10 @@ export interface SupervisorProc {
    * The reaper gates its worktree teardown on this so `rm -rf` never races a
    * still-live worker (#580). */
   killTree(pid: number): Promise<boolean | void>;
+  /** Ask a live slot worker to finish its current claim and exit before the next
+   * claim. Optional: older runtimes simply leave the supervisor-side retiring
+   * flag active until the worker exits. */
+  requestSlotRetire?(slot: number, pid: number): Promise<void>;
   /** Sample the worker tree into the per-process snapshot the reaper-signal
    * reduction consumes (deriveSnapshot). Mirrors sup_descendant_pids feeding
    * sup_active_descendant + sup_tree_cpu. */
@@ -796,6 +819,9 @@ export interface SupervisorDeps {
   /** Resolve the current local HEAD of an attempt branch. Best-effort: undefined
    * means the contest window cannot observe advancement yet. */
   attemptBranchHead?(branch: string): Promise<string | undefined>;
+  /** Runtime elastic fleet request, typically read from the state/afk control
+   * file written by `fleet N`. Null means keep the launched config target. */
+  resizeRequest?(): Promise<ElasticResizeRequest | null>;
 }
 
 // ---------- per-slot runtime state ----------
@@ -844,6 +870,8 @@ export interface SlotState {
    * `running` + `contested`; a late commit on `branch` reclaims the issue,
    * otherwise the normal clean retry label flip runs when `deadlineEpoch` passes. */
   contest: ReapContestState | null;
+  /** Slot is above the current target and should not claim another issue. */
+  retiring: boolean;
 }
 
 export function freshSlot(): SlotState {
@@ -862,6 +890,7 @@ export function freshSlot(): SlotState {
     backoffStep: 0,
     halfOpen: false,
     contest: null,
+    retiring: false,
   };
 }
 
@@ -1077,6 +1106,8 @@ export interface TickResult {
    * this tick (#844). Empty when the sweep was throttled, unwired, found nothing
    * to promote, or failed (best-effort). */
   unblocked: number[];
+  /** Slots removed from the runtime fleet by elastic shrink this tick. */
+  retiredSlots: number[];
   /** True when the stop-file was honoured and all workers terminated. */
   stopped: boolean;
   /** Ready-queue depth sampled at the start of this tick (0 on an abandoned
@@ -1600,6 +1631,128 @@ async function spawnSlotForBudget(
   return policy ? deps.proc.spawnSlot(slot, policy) : deps.proc.spawnSlot(slot);
 }
 
+async function resolveElasticResize(
+  deps: SupervisorDeps,
+  config: SupervisorConfig,
+): Promise<Required<ElasticResizeRequest>> {
+  let request: ElasticResizeRequest | null = null;
+  try {
+    request = (await deps.resizeRequest?.()) ?? null;
+  } catch {
+    request = null;
+  }
+  const target =
+    request && Number.isInteger(request.target) && request.target >= 0
+      ? request.target
+      : config.target;
+  return {
+    target,
+    shrinkMode: request?.shrinkMode ?? config.shrinkMode,
+  };
+}
+
+async function growFleetToTarget(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  config: SupervisorConfig,
+  target: number,
+  drainBudget: DrainBudgetStatus | undefined,
+  result: TickResult,
+): Promise<void> {
+  for (const slot of state.slots) {
+    slot.retiring = false;
+  }
+  while (state.slots.length < target) {
+    const slotIndex = state.slots.length;
+    const slot = freshSlot();
+    state.slots.push(slot);
+    const spawned = await spawnSlotForBudget(slotIndex, deps, state, drainBudget);
+    if (spawned === null) continue;
+    slot.pid = spawned.pid;
+    slot.spawnEpoch = spawned.spawnEpoch;
+    result.respawned.push(slotIndex);
+    if (deps.dispatchFleetHook) {
+      try {
+        await deps.dispatchFleetHook("on_slot_spawn", {
+          event: "on_slot_spawn",
+          runner: config.runner,
+          slot: slotIndex,
+          pid: slot.pid,
+        });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}
+
+async function retireSlotAt(
+  state: SupervisorState,
+  index: number,
+  result: TickResult,
+): Promise<void> {
+  state.slots.splice(index, 1);
+  result.retiredSlots.push(index);
+}
+
+async function shrinkFleetToTarget(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  target: number,
+  mode: ElasticShrinkMode,
+  result: TickResult,
+): Promise<void> {
+  if (target >= state.slots.length) return;
+  for (let i = state.slots.length - 1; i >= target; i -= 1) {
+    const slot = state.slots[i]!;
+    if (mode === "hard-kill") {
+      const pid = slot.pid;
+      const info = deps.fs.resolveIterDir(i);
+      if (pid !== null && deps.proc.isAlive(pid)) {
+        await deps.proc.killTree(pid);
+      }
+      slot.pid = null;
+      slot.stalled = false;
+      slot.stallSinceEpoch = 0;
+      slot.reaped = false;
+      try {
+        const reconciled = await reconcileDeadWorkerClaim(info, deps);
+        if (reconciled !== null) result.crashReconciled.push(reconciled);
+      } catch {
+        // best-effort
+      }
+      await retireSlotAt(state, i, result);
+      continue;
+    }
+
+    slot.retiring = true;
+    const pid = slot.pid;
+    if (pid !== null && deps.proc.isAlive(pid)) {
+      try {
+        await deps.proc.requestSlotRetire?.(i, pid);
+      } catch {
+        // best-effort
+      }
+      continue;
+    }
+    await retireSlotAt(state, i, result);
+  }
+}
+
+async function retireDrainedSlots(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  result: TickResult,
+): Promise<void> {
+  for (let i = state.slots.length - 1; i >= 0; i -= 1) {
+    const slot = state.slots[i]!;
+    if (!slot.retiring) continue;
+    const pid = slot.pid;
+    if (pid !== null && deps.proc.isAlive(pid)) continue;
+    await retireSlotAt(state, i, result);
+  }
+}
+
 /**
  * handle_dead_slot (supervisor.sh ~994): a slot whose worker exited. Record the
  * death against the circuit breaker; on a trip park the slot and run the trip
@@ -1856,6 +2009,7 @@ export async function superviseTick(
     crashReconciled: [],
     reconciledSlots: [],
     unblocked: [],
+    retiredSlots: [],
     stopped: false,
     queueDepth: 0,
     abandoned: false,
@@ -1880,6 +2034,17 @@ export async function superviseTick(
   result.drainBudget = drainBudget;
   logDrainBudgetTransition(state, deps, drainBudget, queueDepth);
   const spawnPolicy = spawnPolicyForBudget(state, drainBudget);
+
+  const resize = await resolveElasticResize(deps, config);
+  if (resize.target >= state.slots.length) {
+    for (const slot of state.slots) slot.retiring = false;
+  }
+  if (resize.target > state.slots.length && spawnPolicy !== "hard-stop") {
+    await growFleetToTarget(state, deps, config, resize.target, drainBudget, result);
+  } else if (resize.target < state.slots.length) {
+    await shrinkFleetToTarget(state, deps, resize.target, resize.shrinkMode, result);
+  }
+  await retireDrainedSlots(state, deps, result);
 
   for (let i = 0; i < state.slots.length; i += 1) {
     await resolveReapContest(i, state.slots[i]!, deps, config);
@@ -2240,7 +2405,7 @@ export async function runSupervisor(
 /** A non-stop tick result (the abandon/error fallback). The `abandoned` flag
  * tells runSupervisor not to advance lastProgressEpoch for this pass. */
 function continueResult(): TickResult {
-  return { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], stopped: false, queueDepth: 0, abandoned: true };
+  return { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], stopped: false, queueDepth: 0, abandoned: true };
 }
 
 /**

--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -9,6 +9,7 @@ import { mkdirSync, openSync, renameSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afkStateDir } from "@reddb-io/shared/red-paths.js";
+import type { ElasticShrinkMode } from "../core/supervisor.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -52,6 +53,8 @@ export interface SpawnSupervisorOptions {
   request?: string;
   /** Optional per-drain USD budget, forwarded as RED_AFK_DRAIN_MAX_COST_USD. */
   drainBudgetUsd?: number;
+  /** Initial shrink mode for runtime target decreases. */
+  shrinkMode?: ElasticShrinkMode;
 }
 
 /**
@@ -76,6 +79,7 @@ export async function spawnSupervisor(opts: SpawnSupervisorOptions): Promise<num
   };
   if (opts.request) env.RED_AFK_REQUEST = opts.request;
   if (opts.drainBudgetUsd !== undefined) env.RED_AFK_DRAIN_MAX_COST_USD = String(opts.drainBudgetUsd);
+  if (opts.shrinkMode !== undefined) env.RED_AFK_SHRINK_MODE = opts.shrinkMode;
 
   const out = openSync(logFile, "a");
   const child = spawn(process.execPath, [process.argv[1]!, "__supervise", ...childArgs], {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -88,6 +88,8 @@ export interface AfkPaths {
   supervisorStopPath: string;
   /** Supervisor launch log (state tier). */
   supervisorLogPath: string;
+  /** Runtime elastic resize request (state tier). */
+  supervisorResizePath: string;
   /** Watchdog restart ledger (state tier). */
   supervisorRestartsPath: string;
   /** Runner circuit-breaker directory (state tier). */
@@ -133,6 +135,7 @@ export function afkPaths(root: string): AfkPaths {
     supervisorPidPath: join(afkState, "afk-supervisor.pid"),
     supervisorStopPath: join(afkState, "afk-supervisor.stop"),
     supervisorLogPath: join(afkState, "afk-supervisor.log"),
+    supervisorResizePath: join(afkState, "afk-supervisor.resize.json"),
     supervisorRestartsPath: join(afkState, "afk-supervisor.restarts.json"),
     runnerCircuitDir: join(afkState, "runner-circuit"),
     statuslineCachePath: join(statusline, "statusline-cache.json"),

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -102,6 +102,39 @@ describe("fleet command stale supervisor state", () => {
       expect(existsSync(paths.state)).toBe(true);
       expect(existsSync(paths.log)).toBe(true);
       expect(existsSync(paths.firehose)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("launchFleet writes a resize request when a healthy supervisor is already running", async () => {
+    const root = scratch();
+    try {
+      const stateAfk = join(root, ".red", "state", "afk");
+      mkdirSync(stateAfk, { recursive: true });
+      writeFileSync(join(stateAfk, "afk-supervisor.pid"), "12345", "utf8");
+      const epoch = Math.floor(Date.now() / 1000);
+      writeFileSync(
+        join(stateAfk, "afk-supervisor.state.json"),
+        JSON.stringify({
+          epoch,
+          last_progress_epoch: epoch,
+          runner: "codex",
+          slots: { busy: 1, free: 1, total: 2, parked: 0 },
+        }),
+        "utf8",
+      );
+      vi.mocked(isLivePid).mockReturnValue(true);
+      const out = stream();
+
+      const result = await launchFleet(["4", "--shrink-mode", "hard-kill"], root, out);
+
+      expect(result).toMatchObject({ status: "resized", pid: 12345, target: 4 });
+      expect(spawnSupervisor).not.toHaveBeenCalled();
+      expect(JSON.parse(readFileSync(join(stateAfk, "afk-supervisor.resize.json"), "utf8"))).toEqual({
+        target: 4,
+        shrink_mode: "hard-kill",
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/fleet-hooks.test.ts
+++ b/apps/dev/tests/fleet-hooks.test.ts
@@ -54,6 +54,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     supervisorMaxRestarts: 5,
     supervisorRestartWindowS: 300,
     reapContestWindowS: 30,
+    shrinkMode: "drain-then-retire",
     ...over,
   };
 }

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -83,6 +83,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     supervisorMaxRestarts: 5,
     supervisorRestartWindowS: 300,
     reapContestWindowS: 30,
+    shrinkMode: "drain-then-retire",
     ...over,
   };
 }
@@ -103,6 +104,7 @@ interface FakeIo {
   spawnReconcileWorker: ReturnType<typeof vi.fn>;
   isAlive: ReturnType<typeof vi.fn>;
   killTree: ReturnType<typeof vi.fn>;
+  requestSlotRetire: ReturnType<typeof vi.fn>;
   inspectTree: ReturnType<typeof vi.fn>;
   sleep: ReturnType<typeof vi.fn>;
   lastExitCode: ReturnType<typeof vi.fn>;
@@ -121,6 +123,7 @@ interface FakeIo {
   emitFleetHeartbeat: ReturnType<typeof vi.fn>;
   unblockSweep: ReturnType<typeof vi.fn>;
   fleetCostUsd: ReturnType<typeof vi.fn>;
+  resizeRequest: ReturnType<typeof vi.fn>;
   attemptBranchHead: ReturnType<typeof vi.fn>;
   logLines: string[];
   now: ReturnType<typeof vi.fn>;
@@ -136,6 +139,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     spawnReconcileWorker: vi.fn(async () => ({ pid: ++nextPid, spawnEpoch: NOW })),
     isAlive: vi.fn(() => true),
     killTree: vi.fn(async () => {}),
+    requestSlotRetire: vi.fn(async () => {}),
     inspectTree: vi.fn((): readonly ProcessSnapshotEntry[] => []),
     // Resolve on a macrotask (not immediately): runSupervisor wraps each tick in
     // guardedTick, which RACES the tick against `sleep(ceiling)`. An
@@ -165,6 +169,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     emitFleetHeartbeat: vi.fn(async () => {}),
     unblockSweep: vi.fn(async (): Promise<number[]> => []),
     fleetCostUsd: vi.fn(() => 0),
+    resizeRequest: vi.fn(async () => null),
     attemptBranchHead: vi.fn(async () => undefined as string | undefined),
     logLines: [],
     now: vi.fn(() => NOW),
@@ -177,6 +182,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       isAlive: io.isAlive,
       lastExitCode: io.lastExitCode,
       killTree: io.killTree,
+      requestSlotRetire: io.requestSlotRetire,
       inspectTree: io.inspectTree,
       sleep: io.sleep,
     },
@@ -204,6 +210,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     emitFleetHeartbeat: io.emitFleetHeartbeat,
     unblockSweep: io.unblockSweep,
     attemptBranchHead: io.attemptBranchHead,
+    resizeRequest: io.resizeRequest,
   };
   return { deps, io };
 }
@@ -560,6 +567,7 @@ describe("guardedTick — abandoned flag", () => {
       crashReconciled: [],
       reconciledSlots: [],
       unblocked: [],
+      retiredSlots: [],
       stopped: false,
       queueDepth: 0,
       abandoned: false,
@@ -1244,6 +1252,78 @@ describe("superviseTick", () => {
   });
 });
 
+describe("superviseTick — elastic fleet resize (#1913)", () => {
+  it("grows at runtime by adding slots and spawning them immediately", async () => {
+    const { deps, io } = makeDeps({
+      spawnSlot: vi.fn(async (slot: number) => ({ pid: 9000 + slot, spawnEpoch: NOW })),
+      resizeRequest: vi.fn(async () => ({ target: 3, shrinkMode: "drain-then-retire" })),
+    });
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 5000;
+    state.slots[0]!.spawnEpoch = NOW - 30;
+
+    const result = await superviseTick(state, deps, config({ target: 1 }), () => false);
+
+    expect(state.slots).toHaveLength(3);
+    expect(io.spawnSlot).toHaveBeenCalledWith(1);
+    expect(io.spawnSlot).toHaveBeenCalledWith(2);
+    expect(state.slots[1]!.pid).toBe(9001);
+    expect(state.slots[2]!.pid).toBe(9002);
+    expect(result.respawned).toEqual([1, 2]);
+  });
+
+  it("shrinks with hard-kill by killing trailing slots, reconciling claims, and removing them immediately", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      resizeRequest: vi.fn(async () => ({ target: 1, shrinkMode: "hard-kill" })),
+      resolveIterDir: vi.fn((slot: number): IterDirInfo | null =>
+        slot === 2 ? crashInfo({ issue: 902, workerId: "wSHRINK" }) : null,
+      ),
+      crashedClaimState: vi.fn(async () => ({ ghOk: true, stillRunning: true, envelopePosted: true })),
+    });
+    deps.recoveryEnv = { RED_AFK_RETRY_CRASH: "2" };
+    const state = initSupervisorState(3);
+    state.slots[0]!.pid = 5000;
+    state.slots[1]!.pid = 5001;
+    state.slots[2]!.pid = 5002;
+
+    const result = await superviseTick(state, deps, config({ target: 3 }), () => false);
+
+    expect(io.killTree).toHaveBeenCalledWith(5002);
+    expect(io.killTree).toHaveBeenCalledWith(5001);
+    expect(io.editLabels).toHaveBeenCalledWith(902, ["ready-for-agent"], ["running"]);
+    expect(state.slots).toHaveLength(1);
+    expect(result.retiredSlots).toEqual([2, 1]);
+  });
+
+  it("shrinks with drain-then-retire by marking live trailing slots and removing them only after exit", async () => {
+    const live = new Set([5000, 5001]);
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn((pid: number) => live.has(pid)),
+      resizeRequest: vi.fn(async () => ({ target: 1, shrinkMode: "drain-then-retire" })),
+    });
+    const state = initSupervisorState(2);
+    state.slots[0]!.pid = 5000;
+    state.slots[1]!.pid = 5001;
+
+    let result = await superviseTick(state, deps, config({ target: 2 }), () => false);
+
+    expect(state.slots).toHaveLength(2);
+    expect(state.slots[1]!.retiring).toBe(true);
+    expect(io.requestSlotRetire).toHaveBeenCalledWith(1, 5001);
+    expect(io.killTree).not.toHaveBeenCalled();
+    expect(result.retiredSlots).toEqual([]);
+
+    live.delete(5001);
+    io.lastExitCode.mockReturnValue(0);
+    result = await superviseTick(state, deps, config({ target: 2 }), () => false);
+
+    expect(state.slots).toHaveLength(1);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(result.retiredSlots).toEqual([1]);
+  });
+});
+
 // ---------- crash reconcile (#815, ADR 0071 Pattern 5) ----------
 
 function crashInfo(over: Partial<IterDirInfo> = {}): IterDirInfo {
@@ -1597,8 +1677,8 @@ describe("envelope builders", () => {
 describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () => {
   const never = (): Promise<void> => new Promise<void>(() => {});
   const immediate = (): Promise<void> => Promise.resolve();
-  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], stopped: false, queueDepth: 0, abandoned: false };
-  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], stopped: false, queueDepth: 0, abandoned: true };
+  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], stopped: false, queueDepth: 0, abandoned: false };
+  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], stopped: false, queueDepth: 0, abandoned: true };
 
   it("returns the tick result when it completes before the ceiling", async () => {
     const logs: string[] = [];


### PR DESCRIPTION
Automated AFK landing for #1913. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1913

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786839494&installation_id=129708444&pr_number=1940&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1940&signature=5f8a045bf6bfa6c2f43161591396646845bf0d26a8bb78b93548fe64113b5f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->