### PR TITLE
merge: #1916 Flip go --once to the castle engine (with --kind)

### DIFF
--- a/apps/dev/src/commands/go.ts
+++ b/apps/dev/src/commands/go.ts
@@ -3,21 +3,18 @@
 // `/go "<demand>"` is the semi-structured front door between `/goal` and
 // `/afk`. It mints a DISPOSABLE tracking issue in the isolated `lane:go` lane
 // (out of `ready-for-agent`, so the running fleet can never claim it), spins a
-// DEDICATED namespaced worker under `.red/tmp/go-workers/` (separate from the
-// fleet's `.red/tmp/workers/`), and reuses the ENTIRE AFK engine end-to-end
-// with `origin=go` and the interactive gate sink. The disposable issue
+// DEDICATED castle worker with `--kind go`, and reuses the ENTIRE AFK engine
+// end-to-end with `origin=go` and the interactive gate sink. The disposable issue
 // auto-closes on merge (the engine's PR body carries `Closes #N`). Works with
 // or without a fleet running — it is a self-sufficient front door.
 //
 // The classification + escalation logic lives in core/go.ts (pure, injected
-// IO); this command supplies the real gh + engine effects and the namespaced
-// worker root.
+// IO); this command supplies the real gh + engine effects.
 
 import {
   dispatchGo,
   parseGoMode,
   DEFAULT_GO_MODE,
-  GO_WORKERS_SEGMENT,
   type GoDodSpec,
   type DisposableIssueSpec,
   type GoMode,
@@ -28,6 +25,8 @@ import { afkPaths, resolveRepoContext } from "../runtime/wire.js";
 import { runCommand } from "./run.js";
 import * as ghx from "../runtime/gh.js";
 import type { GhContext } from "../runtime/gh.js";
+import { execTool } from "../runtime/exec.js";
+import { createGitHubTrackerAdapter } from "@reddb-io/red-castle/engine";
 
 interface ParsedGoArgs {
   demand: string;
@@ -172,16 +171,21 @@ export async function goCommand(args: string[], cwd = process.cwd()): Promise<nu
     }
   }
 
-  // Standard /go: namespace under go-workers/ so the single-shot worker never
-  // collides with the fleet's workers/. Read per-call by
-  // worker-paths.workersSegment(); scoped to this process.
-  process.env.RED_AFK_WORKERS_NAMESPACE = GO_WORKERS_SEGMENT;
-
   try {
+    const tracker = createGitHubTrackerAdapter({
+      repo: ctx.repo,
+      gh: async (args: readonly string[]) => {
+        const result = await execTool("gh", args, { cwd: ctx.root });
+        if (result.code !== 0) {
+          throw new Error((result.stderr || result.stdout || `gh exited ${result.code}`).trim());
+        }
+        return result.stdout;
+      },
+    });
     const result = await dispatchGo(
       {
         ensureLabel: (name) => ghx.ensureLabel(ghCtx, name),
-        createIssue: (spec: DisposableIssueSpec) => ghx.createIssue(ghCtx, spec),
+        createIssue: (spec: DisposableIssueSpec) => tracker.createIssue!(spec),
         // Reuse the full AFK engine in-process for exactly the minted issue.
         runEngine: (engineArgs) => runCommand({ args: engineArgs, cwd }),
       },
@@ -199,7 +203,7 @@ export async function goCommand(args: string[], cwd = process.cwd()): Promise<nu
     );
     process.stdout.write(
       `🚀 /go dispatched disposable issue #${result.issue} ` +
-        `(origin=go, lane:go, go-workers/, mode=${parsed.mode}${parsed.yolo ? ", +yolo" : ""}). ` +
+        `(origin=go, kind=go, lane:go, mode=${parsed.mode}${parsed.yolo ? ", +yolo" : ""}). ` +
         `engine exit ${result.engineExit}.\n`,
     );
     return result.engineExit;

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -64,7 +64,7 @@ import {
   type IssueClassificationMetadata,
 } from "../core/issue-classifier.js";
 import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE, LABEL_MERGE_CONFLICT } from "../core/triage-labels.js";
-import { GO_ORIGIN, GO_WORKERS_SEGMENT } from "../core/go.js";
+import { GO_KIND, GO_ORIGIN } from "../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../core/scout.js";
 import { resolveHooks } from "../core/hook-config.js";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
@@ -127,6 +127,9 @@ interface ParsedRunFlags {
    * (`"afk"` | `"go"` | …). Set by each entry point so the
    * monitor/statusline can render per-source counts. */
   origin?: string;
+  /** --kind <kind>: castle worker kind recorded in state.toon (`afk`, `go`, or
+   * `scout`). */
+  kind?: string;
   /** --lane <label>: the candidate-listing label the session drains. Defaults
    * to `ready-for-agent` (the fleet). `/go` passes its isolated `lane:go` so
    * its dedicated worker sees only the minted disposable issue and the running
@@ -185,24 +188,24 @@ export async function probeFleetSupervisor(
 }
 
 /**
- * Detect a `/go` or `--scout` dispatch (#1087). These runs live in their OWN
- * worker namespace (`go-workers/` / `scout-workers/`), their own lane
- * (`lane:go` / `lane:scout`, never `ready-for-agent`), and carry `--origin
- * go`/`--origin scout` — so they can NEVER collide with a fleet's `workers/`
- * namespace, claims, or lane. The fleet-supervisor boot guard exists ONLY to
- * stop a second fleet from stomping the first on the shared `workers/`
- * namespace; it must not apply to these isolated dispatches, which the SKILL.md
- * contract requires to boot "whether or not a fleet is up". Detected via any of
- * the three redundant signals threaded through the boot context.
+ * Detect a `/go` or `--scout` dispatch (#1087). These runs carry their own
+ * castle worker kind and lane (`lane:go` / `lane:scout`, never
+ * `ready-for-agent`) so they do not collide with a fleet drain. The
+ * fleet-supervisor boot guard exists ONLY to stop a second fleet from stomping
+ * the first; it must not apply to these isolated dispatches, which the SKILL.md
+ * contract requires to boot "whether or not a fleet is up". Detected via the
+ * flags threaded through the boot context, plus the legacy namespace env while
+ * scout still migrates.
  */
 export function isNamespacedDispatch(
-  args: { origin?: string; lane?: string },
+  args: { origin?: string; kind?: string; lane?: string },
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
+  if (args.kind === GO_KIND || args.kind === SCOUT_ORIGIN) return true;
   if (args.origin === GO_ORIGIN || args.origin === SCOUT_ORIGIN) return true;
   if (args.lane === LABEL_GO_LANE || args.lane === LABEL_SCOUT_LANE) return true;
   const ns = env.RED_AFK_WORKERS_NAMESPACE;
-  if (ns === GO_WORKERS_SEGMENT || ns === SCOUT_WORKERS_SEGMENT) return true;
+  if (ns === SCOUT_WORKERS_SEGMENT) return true;
   return false;
 }
 
@@ -281,6 +284,7 @@ const RUN_FLAG_SCHEMA = {
   "boot-only": { kind: "boolean" },
   "reconcile-issue": { kind: "value", coerce: (raw: string): number => Number(raw) },
   origin: { kind: "value", coerce: (raw: string): string => raw },
+  kind: { kind: "value", coerce: (raw: string): string => raw },
   lane: { kind: "value", coerce: (raw: string): string => raw },
   "pre-pr": { kind: "boolean" },
   "local-merge": { kind: "boolean" },
@@ -338,6 +342,7 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     bootOnly: values["boot-only"] === true,
     reconcileIssue,
     origin: values.origin as string | undefined,
+    kind: values.kind as string | undefined,
     lane: values.lane as string | undefined,
     prePr: values["pre-pr"] === true,
     localMerge: values["local-merge"] === true,
@@ -1824,7 +1829,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // never collide with the fleet, so it must boot whether or not a fleet is up.
   if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
     const pidFile = preferExistingPath(paths.supervisorPidPath, join(paths.tmpDir, "afk-supervisor.pid"));
-    const exempt = isNamespacedDispatch({ origin: flags.origin, lane: flags.lane });
+    const exempt = isNamespacedDispatch({
+      origin: flags.origin,
+      kind: flags.kind,
+      lane: flags.lane,
+    });
     const guard = await checkBootGuard(pidFile, flags.force, process.stdout, isLivePid, exempt);
     if (guard === "refused") return 1;
   }
@@ -2054,6 +2063,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
           origin: flags.origin ?? "",
           log: join(attemptDir, "afk.log"),
           started_at: startedAt,
+          "current.kind": flags.kind ?? flags.origin ?? "afk",
           "current.number": candidate.number,
           "current.title": candidate.title,
           "current.worktree": join(attemptDir, "worktree"),

--- a/apps/dev/src/core/go.ts
+++ b/apps/dev/src/core/go.ts
@@ -3,8 +3,8 @@
 // `/go` is the semi-structured front door between `/goal` and `/afk`. It mints a
 // DISPOSABLE tracking issue in an ISOLATED LANE (`lane:go`, out of
 // `ready-for-agent` so the running fleet can never claim it), spins a DEDICATED
-// namespaced worker (`go-workers/`, separate from `/afk`'s `workers/`), and
-// reuses the ENTIRE AFK engine end-to-end with `origin=go` and the INTERACTIVE
+// castle worker of kind `go`, and reuses the ENTIRE AFK engine end-to-end with
+// `origin=go`, `--kind go`, and the INTERACTIVE
 // (pause/ask) gate sink. The disposable issue auto-closes on merge because the
 // engine's PR body already carries `Closes #N` (core/merge.ts).
 //
@@ -21,10 +21,8 @@ export { LABEL_GO_LANE };
  * `/afk` (issue #930). */
 export const GO_ORIGIN = "go";
 
-/** The worker/worktree root segment for `/go`, kept separate from `/afk`'s
- * `workers/` so the two never collide under `.red/tmp`. Honoured by
- * `worker-paths.workersSegment()` via `RED_AFK_WORKERS_NAMESPACE`. */
-export const GO_WORKERS_SEGMENT = "go-workers";
+/** Castle worker kind for `/go`, recorded in the castle worker `state.toon`. */
+export const GO_KIND = "go";
 
 /** `/go` runs with a human present → the interactive (pause/ask) gate sink,
  * never the headless park-to-`ready-for-human` sink `/afk` uses. */
@@ -163,17 +161,11 @@ export function buildDisposableIssue(demand: string, dodSpec: GoDodSpec = {}): D
   return { title, body, labels: [LABEL_GO_LANE] };
 }
 
-/** The `/go` worker/worktree root: `<tmpDir>/go-workers`, separate from
- * `/afk`'s `<tmpDir>/workers`. */
-export function goWorkersRoot(tmpDir: string): string {
-  return `${tmpDir.replace(/\/+$/, "")}/${GO_WORKERS_SEGMENT}`;
-}
-
 /**
  * Build the run-engine argv that reuses the FULL AFK engine for exactly ONE
  * minted disposable issue: single-issue (`--issues N`), single-shot (`--once`),
- * `origin=go`, and listing the isolated `lane:go` pool (`--lane`) instead of
- * `ready-for-agent`. The dispatch `mode` (default `direct-PR`) appends its
+ * `origin=go`, `kind=go`, and listing the isolated `lane:go` pool (`--lane`)
+ * instead of `ready-for-agent`. The dispatch `mode` (default `direct-PR`) appends its
  * routing flag and the opt-in `yolo` autonomy bump appends `--yolo`. An optional
  * runner pins the backend. Throws on a non-positive issue so a failed mint can
  * never spawn a worker at issue 0.
@@ -197,6 +189,8 @@ export function buildGoEngineArgs(opts: {
     String(opts.issue),
     "--origin",
     GO_ORIGIN,
+    "--kind",
+    GO_KIND,
     "--lane",
     LABEL_GO_LANE,
   ];

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -179,6 +179,7 @@ const IMMUTABLE_STATE_FIELDS = [
   "started_at",
   "origin",
   "runner",
+  "current.kind",
   "current.number",
   "current.started_at",
   "current.runner",

--- a/apps/dev/src/core/worker-paths.ts
+++ b/apps/dev/src/core/worker-paths.ts
@@ -19,12 +19,11 @@ function normalizeRoot(root: string): string {
 }
 
 /**
- * The canonical worker-lane namespaces under `.red/tmp/`. The `/afk` fleet lives
- * in `workers`, a `/go` dispatch in `go-workers`, a `--scout` run in
- * `scout-workers`. Each RUN-TIME write path stays scoped to its single
- * {@link workersSegment} lane (via `RED_AFK_WORKERS_NAMESPACE`), but the
- * read-only observability surfaces (statusline/monitor/dashboard) must UNION
- * over all of these — a live `/go` or `--scout` worker is one more live worker.
+ * Worker-lane namespaces readers still understand under `.red/tmp/`. New castle
+ * workers write to the shared `workers` root with `current.kind` carrying
+ * `afk`/`go`/`scout`; the `go-workers` and `scout-workers` lanes remain here so
+ * read-only observability surfaces can UNION legacy live workers until their
+ * lanes age out.
  */
 export const WORKER_NAMESPACES = ["workers", "go-workers", "scout-workers"] as const;
 
@@ -42,13 +41,11 @@ export function allWorkersRoots(tmpDir: string): string[] {
 }
 
 /**
- * The worker-tree segment under the tmp root. Defaults to `workers` (the `/afk`
- * fleet). A `/go` dispatch sets `RED_AFK_WORKERS_NAMESPACE=go-workers` in its
- * own process so its worker dir + worktree land under `.red/tmp/go-workers/`,
- * never colliding with the fleet's `.red/tmp/workers/`. The override is read
- * per-call so it is process-scoped: the fleet supervisor (no env) keeps seeing
- * `workers/` and never manages a `/go` worker, preserving lane isolation. Only
- * a `[A-Za-z0-9_-]+` value is honoured; anything else falls back to `workers`.
+ * The worker-tree segment under the tmp root. Defaults to `workers` (the castle
+ * worker root). `RED_AFK_WORKERS_NAMESPACE` remains as a legacy compatibility
+ * override for still-migrating lanes such as scout; `/go` no longer sets it.
+ * Only a `[A-Za-z0-9_-]+` value is honoured; anything else falls back to
+ * `workers`.
  */
 export function workersSegment(): string {
   const ns = process.env.RED_AFK_WORKERS_NAMESPACE;

--- a/apps/dev/src/types/state.ts
+++ b/apps/dev/src/types/state.ts
@@ -6,6 +6,10 @@ export const AfkFilterSchema = z.object({
 });
 
 export const AfkCurrentSchema = z.object({
+  /** Castle worker kind for this dispatch (`afk`, `go`, or `scout`). Kept under
+   * `current` so it does not collide with castle's top-level state entity kind
+   * (`worker` / `supervisor`). */
+  kind: z.string().default(""),
   number: z.union([z.number(), z.string()]).optional().default(""),
   title: z.string().default(""),
   slug: z.string().default(""),

--- a/apps/dev/tests/boot-guard.test.ts
+++ b/apps/dev/tests/boot-guard.test.ts
@@ -134,7 +134,8 @@ describe("checkBootGuard (#1027)", () => {
 });
 
 describe("isNamespacedDispatch (#1087)", () => {
-  it("is true for a /go dispatch (origin=go)", () => {
+  it("is true for a /go dispatch (kind=go or origin=go)", () => {
+    expect(isNamespacedDispatch({ kind: "go" }, {})).toBe(true);
     expect(isNamespacedDispatch({ origin: "go" }, {})).toBe(true);
   });
 
@@ -147,8 +148,8 @@ describe("isNamespacedDispatch (#1087)", () => {
     expect(isNamespacedDispatch({ lane: "lane:scout" }, {})).toBe(true);
   });
 
-  it("is true when RED_AFK_WORKERS_NAMESPACE is go-workers or scout-workers", () => {
-    expect(isNamespacedDispatch({}, { RED_AFK_WORKERS_NAMESPACE: "go-workers" })).toBe(true);
+  it("keeps only scout on the legacy RED_AFK_WORKERS_NAMESPACE dispatch signal", () => {
+    expect(isNamespacedDispatch({}, { RED_AFK_WORKERS_NAMESPACE: "go-workers" })).toBe(false);
     expect(isNamespacedDispatch({}, { RED_AFK_WORKERS_NAMESPACE: "scout-workers" })).toBe(true);
   });
 

--- a/apps/dev/tests/go.test.ts
+++ b/apps/dev/tests/go.test.ts
@@ -4,14 +4,13 @@ import {
   DEFAULT_GO_VERIFY_RETRIES,
   GO_NO_HARNESS_ITER_CAP,
   GO_GATE_CONTEXT,
+  GO_KIND,
   GO_MODES,
   GO_ORIGIN,
-  GO_WORKERS_SEGMENT,
   LABEL_GO_LANE,
   buildDisposableIssue,
   buildGoEngineArgs,
   dispatchGo,
-  goWorkersRoot,
   parseGoMode,
   type DisposableIssueSpec,
 } from "../src/core/go.js";
@@ -56,26 +55,21 @@ describe("buildDisposableIssue", () => {
   });
 });
 
-describe("goWorkersRoot", () => {
-  it("namespaces under go-workers, separate from the fleet's workers", () => {
-    expect(goWorkersRoot("/repo/.red/tmp")).toBe("/repo/.red/tmp/go-workers");
-    expect(goWorkersRoot("/repo/.red/tmp/")).toBe("/repo/.red/tmp/go-workers");
-    expect(GO_WORKERS_SEGMENT).toBe("go-workers");
-  });
-});
-
 describe("buildGoEngineArgs", () => {
-  it("reuses the engine single-shot, single-issue, origin=go, lane:go", () => {
+  it("reuses the castle engine single-shot, single-issue, origin=go, kind=go, lane:go", () => {
     expect(buildGoEngineArgs({ issue: 938 })).toEqual([
       "--once",
       "--issues",
       "938",
       "--origin",
       "go",
+      "--kind",
+      "go",
       "--lane",
       "lane:go",
     ]);
     expect(GO_ORIGIN).toBe("go");
+    expect(GO_KIND).toBe("go");
     expect(GO_GATE_CONTEXT).toBe("interactive");
   });
 

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -164,11 +164,13 @@ describe("parseRunFlags", () => {
     expect(parseRunFlags(["--spec=7"]).filter).toEqual({ kind: "spec", spec: 7 });
   });
 
-  it("parses --origin and --lane (the /go provenance + isolated lane), undefined by default", () => {
+  it("parses --origin, --kind, and --lane (the /go provenance + castle kind + isolated lane), undefined by default", () => {
     expect(parseRunFlags([]).origin).toBeUndefined();
+    expect(parseRunFlags([]).kind).toBeUndefined();
     expect(parseRunFlags([]).lane).toBeUndefined();
-    const f = parseRunFlags(["--origin", "go", "--lane", "lane:go"]);
+    const f = parseRunFlags(["--origin", "go", "--kind", "go", "--lane", "lane:go"]);
     expect(f.origin).toBe("go");
+    expect(f.kind).toBe("go");
     expect(f.lane).toBe("lane:go");
   });
 

--- a/apps/dev/tests/state.test.ts
+++ b/apps/dev/tests/state.test.ts
@@ -96,6 +96,30 @@ describe("state", () => {
     expect(after.current.activity).toBe("tests");
   });
 
+  it("records and preserves the castle worker kind under current.kind", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
+    const path = join(dir, "afk.state.json");
+
+    initStateSync(path, {
+      worker_id: "wGO12",
+      pid: 4242,
+      origin: "go",
+      "current.kind": "go",
+      "current.number": 1916,
+      "current.activity": "setup",
+    });
+
+    const seeded = await readState(path);
+    expect(seeded.current.kind).toBe("go");
+    const after = await updateState(path, {
+      origin: "",
+      current: { kind: "", activity: "tests" },
+    });
+    expect(after.origin).toBe("go");
+    expect(after.current.kind).toBe("go");
+    expect(after.current.activity).toBe("tests");
+  });
+
   it("preserves stamped identity, vitals, and loc when a stage writer carries default identity fields", async () => {
     const dir = await mkdtemp(join(tmpdir(), "afk-state-"));
     const path = join(dir, "afk.state.json");

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -50,3 +50,4 @@ export type {
   AcquireIssueLeaseOptions,
 } from "./tracker/claim.js";
 export * from "./tracker/port.js";
+export * from "./tracker/github/adapter.js";

--- a/packages/red-castle/src/engine/tracker/github/adapter.test.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.test.ts
@@ -44,6 +44,9 @@ describe("GitHub tracker adapter", () => {
         });
         return `${id}\n`;
       }
+      if (args[0] === "issue" && args[1] === "create") {
+        return "https://github.com/owner/repo/issues/77\n";
+      }
       return "";
     };
 
@@ -57,6 +60,13 @@ describe("GitHub tracker adapter", () => {
     });
 
     try {
+      await expect(
+        tracker.createIssue?.({
+          title: "/go: x",
+          body: "demand",
+          labels: ["lane:go", "kind,with-comma"],
+        }),
+      ).resolves.toBe(77);
       await expect(
         tracker.listOpenIssuesByLabel("wait:dependency"),
       ).resolves.toEqual([
@@ -99,6 +109,20 @@ describe("GitHub tracker adapter", () => {
     ]);
 
     expect(calls).toEqual([
+      [
+        "issue",
+        "create",
+        "--title",
+        "/go: x",
+        "--body",
+        "demand",
+        "--label",
+        "lane:go",
+        "--label",
+        "kind,with-comma",
+        "--repo",
+        "owner/repo",
+      ],
       [
         "issue",
         "list",

--- a/packages/red-castle/src/engine/tracker/github/adapter.ts
+++ b/packages/red-castle/src/engine/tracker/github/adapter.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import type {
   TrackerIssue,
   TrackerPort,
+  TrackerIssueCreateSpec,
   TrackerLabelMutation,
   TrackerIssueReference,
 } from "../port.js";
@@ -57,6 +58,27 @@ export function createGitHubTrackerAdapter(
   };
 
   return {
+    async createIssue(spec: TrackerIssueCreateSpec) {
+      const stdout = await gh(
+        withRepo([
+          "issue",
+          "create",
+          "--title",
+          spec.title,
+          "--body",
+          spec.body,
+          ...labelArgs(spec.labels ?? []),
+        ]),
+      );
+      const match = stdout.match(/\/issues\/(\d+)\b/);
+      const issue = match ? Number(match[1]) : NaN;
+      if (!Number.isInteger(issue) || issue <= 0) {
+        throw new Error(
+          `tracker failed to create issue: unparseable gh output ${JSON.stringify(stdout.trim())}`,
+        );
+      }
+      return issue;
+    },
     async listOpenIssuesByLabel(label) {
       const stdout = await gh(
         withRepo([
@@ -129,6 +151,10 @@ export function createGitHubTrackerAdapter(
       });
     },
   };
+}
+
+function labelArgs(labels: readonly string[]): string[] {
+  return labels.flatMap((label) => ["--label", label]);
 }
 
 async function defaultGhExec(args: readonly string[]): Promise<string> {

--- a/packages/red-castle/src/engine/tracker/port.ts
+++ b/packages/red-castle/src/engine/tracker/port.ts
@@ -10,6 +10,12 @@ export interface TrackerIssueReference {
   readonly url?: string;
 }
 
+export interface TrackerIssueCreateSpec {
+  readonly title: string;
+  readonly body: string;
+  readonly labels?: readonly string[];
+}
+
 export interface TrackerLabelMutation {
   readonly remove: readonly string[];
   readonly add: readonly string[];
@@ -39,6 +45,7 @@ export interface TrackerClaimDecision {
 }
 
 export interface TrackerPort {
+  createIssue?(spec: TrackerIssueCreateSpec): Promise<number>;
   listOpenIssuesByLabel(label: string): Promise<TrackerIssue[]>;
   isIssueClosed(issue: number): Promise<boolean>;
   editIssueLabels(issue: number, mutation: TrackerLabelMutation): Promise<void>;


### PR DESCRIPTION
Automated AFK landing for #1916. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1916

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786840367&installation_id=129708444&pr_number=1942&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1942&signature=437c30bb692322990f8d9fac8d0c1b14132d9138a89d312dd123cb79f7208bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->