### PR TITLE
fix: #1943 /go: Change the RedSkills statusline refresh recommendation from 5s to 60s ac

### DIFF
--- a/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
+++ b/apps/dev/tests/skill-progressive-disclosure-docs.test.ts
@@ -74,6 +74,9 @@ describe("skill progressive-disclosure docs", () => {
     expect(hostNotes).toContain("Claude Code's `statusLine` renders multiple rows");
     expect(hostNotes).toContain("red-skills-dev codex-statusline --fix");
     expect(hostNotes).toContain("Every `k=v` key on this line is **exactly 3 letters**");
+    expect(hostNotes).toContain('"refreshInterval": 60');
+    expect(hostNotes).not.toContain('"refreshInterval": 5');
+    expect(hostNotes).toContain("60s matches the real rate of change of fleet/PR state");
     expect(hostNotes).toContain("OpenCode is an AFK API-auth runner lane");
   });
 

--- a/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
+++ b/plugins/dev/skills/engineering/red-statusline/HOST-NOTES.md
@@ -46,12 +46,14 @@ This mirrors how Codex itself organizes customization: skills define reusable wo
   "statusLine": {
     "type": "command",
     "command": "sh -c 'b=$(ls -1 \"$HOME\"/.cache/red-skills/bundles/dev-*.bundle.min.mjs 2>/dev/null | sort -V | tail -1); [ -z \"$b\" ] && b=$(ls -1 \"$HOME\"/.claude/plugins/cache/red-skills/dev/*/skills/engineering/afk/bin/afk.mjs 2>/dev/null | sort -V | tail -1); [ -n \"$b\" ] && exec node \"$b\" statusline'",
-    "refreshInterval": 5
+    "refreshInterval": 60
   }
 }
 ```
 
 **Why this shape (cached-bundle-first, not `$CLAUDE_PLUGIN_ROOT`, not `afk.mjs` directly):** the command above is cached-bundle-first by design (ADR 0084) — never alter it to fetch synchronously in the render path.
+
+Use a 60s refresh interval because the producer reads cached state: 5s ticks burn CPU and repeat calls without new information at that cadence, while 60s matches the real rate of change of fleet/PR state.
 
 Use `jq` to merge when `.claude/settings.json` already exists; create `.claude/`
 and a fresh file when it is missing. Keep unrelated settings intact.


### PR DESCRIPTION
Automated AFK landing for #1943. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1943

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786844777&installation_id=129708444&pr_number=1944&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1944&signature=10f2c62772d3940ee6ebec5f707c9dd905eac3096e3539b1b1908fc0b8d8ef74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->