### PR TITLE
merge: #1917 Flip afk run to the castle engine

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -357,6 +357,25 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
   };
 }
 
+export interface RunDispatchIdentity {
+  origin: string;
+  kind: string;
+  lane?: string;
+}
+
+/**
+ * Resolve the castle dispatch identity stamped onto every run. `/go` and scout
+ * pass explicit provenance; bare `/afk run` is the default castle `afk` worker.
+ */
+export function resolveRunDispatchIdentity(flags: Pick<ParsedRunFlags, "origin" | "kind" | "lane">): RunDispatchIdentity {
+  const origin = flags.origin ?? "afk";
+  return {
+    origin,
+    kind: flags.kind ?? origin,
+    lane: flags.lane,
+  };
+}
+
 /**
  * Real mechanical-conflict resolver for the #1095 merge-conflict reland. Bound
  * to `gitCtx`, returns the port `preMergeRebase` invokes when a rebase onto
@@ -1799,6 +1818,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
 
   const flags = parseRunFlags(options.args);
+  const dispatchIdentity = resolveRunDispatchIdentity(flags);
   // --model / --effort pre-set the env override (flag > env). Setting them on the
   // process env makes the override flow through both the in-process `--once` path
   // (resolveTier reads process.env) and the fleet path (buildWorkerEnv passes
@@ -1830,9 +1850,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
   if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
     const pidFile = preferExistingPath(paths.supervisorPidPath, join(paths.tmpDir, "afk-supervisor.pid"));
     const exempt = isNamespacedDispatch({
-      origin: flags.origin,
-      kind: flags.kind,
-      lane: flags.lane,
+      origin: dispatchIdentity.origin,
+      kind: dispatchIdentity.kind,
+      lane: dispatchIdentity.lane,
     });
     const guard = await checkBootGuard(pidFile, flags.force, process.stdout, isLivePid, exempt);
     if (guard === "refused") return 1;
@@ -2060,10 +2080,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
           runner: c.runner,
           // Spawn-time provenance (issue #930): stamped once here, never mutated.
           // The entry point (`/afk`, `/go`) passes `--origin <label>`.
-          origin: flags.origin ?? "",
+          origin: dispatchIdentity.origin,
           log: join(attemptDir, "afk.log"),
           started_at: startedAt,
-          "current.kind": flags.kind ?? flags.origin ?? "afk",
+          "current.kind": dispatchIdentity.kind,
           "current.number": candidate.number,
           "current.title": candidate.title,
           "current.worktree": join(attemptDir, "worktree"),
@@ -2087,7 +2107,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         writeIdentitySync(attemptDir, {
           worker_id: c.workerId,
           runner: c.runner,
-          origin: flags.origin ?? "",
+          origin: dispatchIdentity.origin,
           number: candidate.number,
           started_at: startedAt,
         });

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseRunFlags, RunFlagError, deriveActivity } from "../src/commands/run.js";
+import { parseRunFlags, RunFlagError, deriveActivity, resolveRunDispatchIdentity } from "../src/commands/run.js";
 import type { AgentStreamEvent } from "../src/core/execution.js";
 
 describe("deriveActivity (native-path monitor stage detection)", () => {
@@ -207,5 +207,30 @@ describe("parseRunFlags", () => {
   it("parses --force as a boolean, defaulting to false (#1027)", () => {
     expect(parseRunFlags(["--force"]).force).toBe(true);
     expect(parseRunFlags([]).force).toBe(false);
+  });
+});
+
+describe("resolveRunDispatchIdentity", () => {
+  it("stamps bare /afk run as the castle afk worker kind and origin", () => {
+    expect(resolveRunDispatchIdentity(parseRunFlags([]))).toEqual({
+      origin: "afk",
+      kind: "afk",
+      lane: undefined,
+    });
+  });
+
+  it("preserves namespaced dispatch identity for /go and scout", () => {
+    expect(
+      resolveRunDispatchIdentity(parseRunFlags(["--origin", "go", "--kind", "go", "--lane", "lane:go"])),
+    ).toEqual({
+      origin: "go",
+      kind: "go",
+      lane: "lane:go",
+    });
+    expect(resolveRunDispatchIdentity(parseRunFlags(["--origin", "scout", "--lane", "lane:scout"]))).toEqual({
+      origin: "scout",
+      kind: "scout",
+      lane: "lane:scout",
+    });
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1917. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1917

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786845526&installation_id=129708444&pr_number=1945&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1945&signature=fb2ebeb90ae070f94f4d3d4d36fceb298b3eb7f45f87ccf875c839cdc29ce3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->