### PR TITLE
fix: #1946 AFK invocation contract has no binary provenance: red-skills-dev is undocumented and unreachable on a fresh machine

### DIFF
--- a/apps/dev/tests/afk-invocation-contract-docs.test.ts
+++ b/apps/dev/tests/afk-invocation-contract-docs.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const SKILLS = join(ROOT, "plugins", "dev", "skills", "engineering");
+
+async function readSkill(relativePath: string): Promise<string> {
+  return readFile(join(SKILLS, relativePath), "utf8");
+}
+
+describe("AFK invocation contract docs (#1946)", () => {
+  it("AFK documents runtime resolution, npm direct-run fallback, and valid subcommands", async () => {
+    const skill = await readSkill("afk/SKILL.md");
+
+    expect(skill).toContain("installed `red-skills-dev` shim on `PATH` first");
+    expect(skill).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev");
+    expect(skill).toContain("The AFK queue-drain subcommand is `run`");
+    expect(skill).toContain("There is no\n`red-skills-dev afk` subcommand");
+  });
+
+  it("shared report-runtime wrapper owns the binary precedence and missing-shim action", async () => {
+    const wrapper = await readSkill("_report-runtime/WRAPPER.md");
+
+    expect(wrapper).toContain("Prefer an installed `red-skills-dev` shim on `PATH`");
+    expect(wrapper).toContain("Otherwise use the ADR 0091 npm direct-run transport");
+    expect(wrapper).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [args]");
+    expect(wrapper).toContain("do not report a bare command-not-found");
+    expect(wrapper).toContain("There is no `red-skills-dev afk` subcommand");
+  });
+
+  it("sibling skills route through the same shared runtime contract", async () => {
+    const go = await readSkill("go/SKILL.md");
+    const retake = await readSkill("retake/SKILL.md");
+    const dailyReview = await readSkill("daily-review/SKILL.md");
+    const dashboard = await readSkill("dashboard/SKILL.md");
+
+    for (const text of [go, retake, dailyReview, dashboard]) {
+      expect(text).toContain("_report-runtime/WRAPPER.md");
+    }
+    expect(go).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev go");
+    expect(retake).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev retake");
+  });
+
+  it("installed shim failure message names the npm fallback", async () => {
+    const script = await readSkill("red-setup/scripts/install-runtime-shim.sh");
+
+    expect(script).toContain("Fallback:");
+    expect(script).toContain("npx -y -p @reddb-io/red-skills@<version> red-skills-dev");
+    expect(script).toContain("npm direct-run fallback");
+  });
+});

--- a/plugins/dev/skills/engineering/_report-runtime/WRAPPER.md
+++ b/plugins/dev/skills/engineering/_report-runtime/WRAPPER.md
@@ -5,7 +5,28 @@ hand-calculate metrics.
 
 ## Run shim
 
-Run the host-level RedSkills dev runtime shim with the skill-specific subcommand:
+Resolve the RedSkills dev runtime the same way for every operational skill:
+
+1. Prefer an installed `red-skills-dev` shim on `PATH` when `command -v
+   red-skills-dev` succeeds. This is the short form used by prepared hosts.
+2. Otherwise use the ADR 0091 npm direct-run transport. Pin a known version when
+   the caller or repo provides one; use the current dist-tag only when no pin is
+   available:
+
+```bash
+npx -y -p @reddb-io/red-skills@<version> red-skills-dev <subcommand> [args]
+```
+
+If `red-skills-dev` is missing, do not report a bare command-not-found. Say that
+the host lacks the shim and run, or ask the operator to run, the `npx -y -p
+@reddb-io/red-skills@<version> red-skills-dev ...` fallback.
+
+The valid dev CLI subcommands for these skills are explicit: `run`, `fleet`,
+`monitor`, `dashboard`, `daily-review`, `weekly-review`, `retake`, and
+`requeue`. There is no `red-skills-dev afk` subcommand; `/afk` maps to
+`red-skills-dev run` or to the bare run flags documented by the AFK skill.
+
+When the shim is available, run it with the skill-specific subcommand:
 
 ```bash
 red-skills-dev <subcommand> [--json]

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -12,17 +12,27 @@ letting the runtime select issues, create isolated worktrees, run the inner
 agent, validate, land, close, and clean up.
 
 The invoking LLM is responsible for setting `RED_AFK_RUNNER` to its own host
-runner (`codex` from Codex, `claude` from Claude Code). Run the bundle, not the
-source:
+runner (`codex` from Codex, `claude` from Claude Code). Resolve the
+`red-skills-dev` runtime through the shared contract in
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
+installed `red-skills-dev` shim on `PATH` first, otherwise use the ADR 0091 npm
+direct-run fallback
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev ...`. If the shim is
+missing, name that fallback instead of surfacing a bare command-not-found.
+
+Run the bundle, not the source:
 
 ```bash
 RED_AFK_RUNNER=<claude|codex|opencode> red-skills-dev <command> [params]
 ```
 
 `afk.mjs` is a dedicated forwarder to the `dev` bundle. Every argument reaches
-the orchestrator unchanged, so `run`, `monitor`, `fleet`, and a bare
-`--issues 42` all use the same command surface. Runtime details and the full
-operations contract live in [`docs/OPERATIONS.md`](./docs/OPERATIONS.md).
+the orchestrator unchanged. The AFK queue-drain subcommand is `run`; valid
+top-level dev CLI subcommands include `run`, `monitor`, `fleet`, `dashboard`,
+`daily-review`, `weekly-review`, `retake`, `requeue`, and `reap`. A bare
+`--issues 42` is forwarded to the same run surface. There is no
+`red-skills-dev afk` subcommand. Runtime details and the full operations
+contract live in [`docs/OPERATIONS.md`](./docs/OPERATIONS.md).
 
 ## When To Use
 

--- a/plugins/dev/skills/engineering/go/SKILL.md
+++ b/plugins/dev/skills/engineering/go/SKILL.md
@@ -33,6 +33,12 @@ Scout mode is read-only and report-producing, so this Task+DoD gate does not app
 
 **Run the bundle — do not read its source.** This SKILL.md is the contract; the `dev` bundle's `go` command is a build artifact.
 
+Resolve the `red-skills-dev` runtime through the shared contract in
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
+installed shim on `PATH` first, otherwise use the ADR 0091 npm direct-run form
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev go ...`. If the shim
+is missing, name that fallback instead of surfacing a bare command-not-found.
+
 Invoke the dev CLI's `go` command with the demand as a single quoted argument:
 
 ```

--- a/plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh
+++ b/plugins/dev/skills/engineering/red-setup/scripts/install-runtime-shim.sh
@@ -70,8 +70,12 @@ Expected one of:
 - an installed dev plugin under ~/.claude/plugins/cache/red-skills/dev/*
 - a warmed bundle under ~/.cache/red-skills/bundles/dev-*.bundle.min.mjs
 
+Fallback:
+  npx -y -p @reddb-io/red-skills@<version> red-skills-dev "$@"
+
 Run /red-setup in a repo with plugins.dev.enabled: true, then restart the
-agent session so the plugin SessionStart hook can warm the runtime cache.
+agent session so the plugin SessionStart hook can warm the runtime cache, or use
+the npm direct-run fallback above for a fresh machine.
 EOF
 exit 127
 SH

--- a/plugins/dev/skills/engineering/retake/SKILL.md
+++ b/plugins/dev/skills/engineering/retake/SKILL.md
@@ -17,6 +17,13 @@ the label claims `ready-for-human`, but the truth is in the worktree.
 
 ## 1. Diagnose — Reconstruct The State
 
+Resolve the `red-skills-dev` runtime through the shared contract in
+[`../_report-runtime/WRAPPER.md`](../_report-runtime/WRAPPER.md): use an
+installed shim on `PATH` first, otherwise use the ADR 0091 npm direct-run form
+`npx -y -p @reddb-io/red-skills@<version> red-skills-dev retake ...`. If the
+shim is missing, name that fallback instead of surfacing a bare
+command-not-found.
+
 ```bash
 red-skills-dev retake 123
 ```


### PR DESCRIPTION
Automated AFK landing for #1946. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1946

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786847130&installation_id=129708444&pr_number=1947&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1947&signature=abe64568cbb6a122196ce1ae96f4a1bfa8027d404bd4588d4eb581a849571682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->