### PR TITLE
merge: #1917 Flip afk run to the castle engine

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1,15 +1,14 @@
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
 import {
-  runSession,
   runModeForCandidate,
   type SessionContext,
-  type SessionDeps,
+  type SessionIssueTemplate,
   type SelectionFilter,
   type IssueCandidate,
 } from "../core/session.js";
 import { genWorkerId } from "../core/session.js";
-import { runBoot, type BootDeps, type BootOptions, type BootstrapInput, type ReconcileBootRunner } from "../core/boot.js";
+import { runBoot, type BootDeps, type BootOptions, type BootResult, type BootstrapInput, type ReconcileBootRunner } from "../core/boot.js";
 import { reconcile, type ReconcileDeps, type ReconcileInput } from "../core/reconcile.js";
 import { resolveBase } from "../core/base-resolver.js";
 import { findOwnedBranch, type ReconcileSweepPlan } from "../core/boot-sweep.js";
@@ -18,7 +17,7 @@ import {
   partitionConflicts,
   type ConflictFinding,
 } from "../core/merge-conflict-reconcile.js";
-import { processIssue, type ProcessIssueDeps, type ProcessIssueInput } from "../core/process-issue.js";
+import { processIssue, type ProcessIssueDeps, type ProcessIssueInput, type ProcessIssueResult } from "../core/process-issue.js";
 import { passExitBarrier, passTerminalBarrier } from "../core/exit-barrier.js";
 import {
   toMemoryPayload,
@@ -66,7 +65,9 @@ import {
 import { LABEL_READY_FOR_REVIEW, LABEL_GO_LANE, LABEL_SCOUT_LANE, LABEL_MERGE_CONFLICT } from "../core/triage-labels.js";
 import { GO_KIND, GO_ORIGIN } from "../core/go.js";
 import { SCOUT_ORIGIN, SCOUT_WORKERS_SEGMENT } from "../core/scout.js";
-import { resolveHooks } from "../core/hook-config.js";
+import { resolveHooks, type HookName } from "../core/hook-config.js";
+import { dispatchHooks } from "../core/hook-dispatcher.js";
+import { runCastleWorkerDrain, type CastleSessionHookName, type CastleWorkerDrainDeps } from "@reddb-io/red-castle/engine";
 import { attemptLedgerContext, formatAttemptContext, highestAttempt, type AttemptDirEntry } from "../core/attempt-ledger.js";
 import { isValidWorkerId, WORKER_NAMESPACES } from "../core/worker-paths.js";
 import { readdirSync, existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -156,6 +157,12 @@ interface ParsedRunFlags {
   /** --force: bypass the live-supervisor boot guard (#1027). Operator accepts
    * the collision risk; a warning is printed but the run proceeds. */
   force: boolean;
+}
+
+export interface RunDispatchIdentity {
+  origin: string;
+  kind: string;
+  lane?: string;
 }
 
 /** Raised when --alternate is combined with --runner (mutually exclusive). */
@@ -355,6 +362,12 @@ export function parseRunFlags(args: readonly string[]): ParsedRunFlags {
     runMode: values["run-mode"] as string | undefined,
     force: values.force === true,
   };
+}
+
+export function resolveRunDispatchIdentity(flags: Pick<ParsedRunFlags, "origin" | "kind" | "lane">): RunDispatchIdentity {
+  const origin = flags.origin?.trim() || "afk";
+  const kind = flags.kind?.trim() || origin;
+  return flags.lane === undefined ? { origin, kind } : { origin, kind, lane: flags.lane };
 }
 
 /**
@@ -1799,6 +1812,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const cwd = options.cwd ?? process.cwd();
 
   const flags = parseRunFlags(options.args);
+  const dispatchIdentity = resolveRunDispatchIdentity(flags);
   // --model / --effort pre-set the env override (flag > env). Setting them on the
   // process env makes the override flow through both the in-process `--once` path
   // (resolveTier reads process.env) and the fleet path (buildWorkerEnv passes
@@ -1830,9 +1844,9 @@ export async function runCommand(options: RunOptions): Promise<number> {
   if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
     const pidFile = preferExistingPath(paths.supervisorPidPath, join(paths.tmpDir, "afk-supervisor.pid"));
     const exempt = isNamespacedDispatch({
-      origin: flags.origin,
-      kind: flags.kind,
-      lane: flags.lane,
+      origin: dispatchIdentity.origin,
+      kind: dispatchIdentity.kind,
+      lane: dispatchIdentity.lane,
     });
     const guard = await checkBootGuard(pidFile, flags.force, process.stdout, isLivePid, exempt);
     if (guard === "refused") return 1;
@@ -1966,9 +1980,24 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   // --request/-r special block, threaded into the handoff the agent reads.
   const requestBlock = specialUserRequestBlock(flags.request);
+  const sessionHooks = {
+    config: loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined }),
+    resolveOptions: makeHookResolveOptions(ctx.root),
+    exec: makeHookExec(ctx.root),
+    env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
+  };
+  const resolvedSessionHooks = resolveHooks(sessionHooks.config, sessionHooks.resolveOptions);
 
-  const deps: SessionDeps = {
-    gh: { listCandidates: () => ghx.listCandidates(ghCtx, flags.lane) },
+  const deps: CastleWorkerDrainDeps<
+    BootDeps,
+    BootOptions,
+    BootResult,
+    ProcessIssueDeps,
+    ProcessIssueInput,
+    ProcessIssueResult,
+    SessionIssueTemplate
+  > = {
+    gh: { listCandidates: () => ghx.listCandidates(ghCtx, dispatchIdentity.lane) },
     runBoot,
     bootDeps,
     bootOptions,
@@ -2012,14 +2041,21 @@ export async function runCommand(options: RunOptions): Promise<number> {
       flags.verifyCommand,
       flags.goVerifyRetries,
     ),
-    // Session-scoped lifecycle hooks (PRD #207): compose the same config /
-    // resolver / exec / env the process deps use, so session + per-issue points
-    // share one dispatcher rather than duplicating the wiring.
-    hooks: {
-      config: loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined }),
-      resolveOptions: makeHookResolveOptions(ctx.root),
-      exec: makeHookExec(ctx.root),
-      env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),
+    // Session-scoped lifecycle hooks (PRD #207): the castle drain owns the
+    // session state machine, while dev supplies the existing hook dispatcher so
+    // the configured hook surface and output stay unchanged.
+    dispatchSessionHook: async (name: CastleSessionHookName, context: string) => {
+      const result = await dispatchHooks(
+        name as HookName,
+        resolvedSessionHooks[name as HookName],
+        context,
+        sessionHooks.exec,
+        {
+          env: sessionHooks.env,
+          log: (line) => process.stdout.write(`${line}\n`),
+        },
+      );
+      return { aborted: result.aborted };
     },
     runnerCircuit: {
       isOpen: (r) => runnerCircuitOpen(paths.runnerCircuitDir, r, Math.floor(Date.now() / 1000)),
@@ -2060,10 +2096,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
           runner: c.runner,
           // Spawn-time provenance (issue #930): stamped once here, never mutated.
           // The entry point (`/afk`, `/go`) passes `--origin <label>`.
-          origin: flags.origin ?? "",
+          origin: dispatchIdentity.origin,
           log: join(attemptDir, "afk.log"),
           started_at: startedAt,
-          "current.kind": flags.kind ?? flags.origin ?? "afk",
+          "current.kind": dispatchIdentity.kind,
           "current.number": candidate.number,
           "current.title": candidate.title,
           "current.worktree": join(attemptDir, "worktree"),
@@ -2087,7 +2123,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         writeIdentitySync(attemptDir, {
           worker_id: c.workerId,
           runner: c.runner,
-          origin: flags.origin ?? "",
+          origin: dispatchIdentity.origin,
           number: candidate.number,
           started_at: startedAt,
         });
@@ -2122,7 +2158,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
         // `--lane` value), not a hardcoded `ready-for-agent`. `flags.lane` is
         // undefined for `/afk` (→ defaults to `ready-for-agent` in processIssue)
         // and `lane:go`/`lane:scout` for the isolated `/go`/scout lanes.
-        laneLabel: flags.lane,
+        laneLabel: dispatchIdentity.lane,
       };
     },
     emit: (line: string) => process.stdout.write(`${line}\n`),
@@ -2130,7 +2166,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   let summary;
   try {
-    summary = await runSession(deps, sessionCtx);
+    summary = await runCastleWorkerDrain(deps, sessionCtx);
   } catch (err) {
     await recordBootError(bootstrap.workerDir, "session-error", err).catch(() => {
       process.stderr.write(`[afk] session-error: ${err instanceof Error ? err.message : String(err)}\n`);

--- a/apps/dev/tests/afk-castle-run-wiring.test.ts
+++ b/apps/dev/tests/afk-castle-run-wiring.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const runTs = resolve(here, "../src/commands/run.ts");
+
+describe("afk run castle engine flip", () => {
+  it("routes the drain through the red-castle worker engine instead of the dev session loop", () => {
+    const source = readFileSync(runTs, "utf8");
+
+    expect(source).toContain('from "@reddb-io/red-castle/engine"');
+    expect(source).toContain("runCastleWorkerDrain");
+    expect(source).toContain("summary = await runCastleWorkerDrain(deps, sessionCtx)");
+    expect(source).not.toContain("summary = await runSession(deps, sessionCtx)");
+  });
+});

--- a/apps/dev/tests/run-flags.test.ts
+++ b/apps/dev/tests/run-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseRunFlags, RunFlagError, deriveActivity } from "../src/commands/run.js";
+import { parseRunFlags, RunFlagError, deriveActivity, resolveRunDispatchIdentity } from "../src/commands/run.js";
 import type { AgentStreamEvent } from "../src/core/execution.js";
 
 describe("deriveActivity (native-path monitor stage detection)", () => {
@@ -172,6 +172,15 @@ describe("parseRunFlags", () => {
     expect(f.origin).toBe("go");
     expect(f.kind).toBe("go");
     expect(f.lane).toBe("lane:go");
+  });
+
+  it("resolves plain afk run as explicit castle afk identity", () => {
+    expect(resolveRunDispatchIdentity(parseRunFlags([]))).toEqual({ origin: "afk", kind: "afk" });
+    expect(resolveRunDispatchIdentity(parseRunFlags(["--origin", "go", "--kind", "go", "--lane", "lane:go"]))).toEqual({
+      origin: "go",
+      kind: "go",
+      lane: "lane:go",
+    });
   });
 
   it("parses --run-mode (the scout read-only enforcement flag), undefined by default", () => {

--- a/packages/red-castle/src/engine/index.ts
+++ b/packages/red-castle/src/engine/index.ts
@@ -21,6 +21,7 @@ export * from "./landing.js";
 export * from "./lifecycle-hooks.js";
 export * from "./terminal-events.js";
 export * from "./validation-cone.js";
+export * from "./worker-drain.js";
 export * from "./config.js";
 export * from "./contracts/index.js";
 export * from "./minimax-env.js";

--- a/packages/red-castle/src/engine/worker-drain.test.ts
+++ b/packages/red-castle/src/engine/worker-drain.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CASTLE_NO_MORE_TASKS,
+  runCastleWorkerDrain,
+  selectCastleIssues,
+  type CastleIssueCandidate,
+} from "./worker-drain.js";
+
+const boot = { precheck: { ok: true } };
+const processDeps = {};
+
+function candidate(number: number, labels: string[] = ["ready-for-agent"]): CastleIssueCandidate {
+  return {
+    number,
+    title: `Issue ${number}`,
+    body: "",
+    labels,
+  };
+}
+
+describe("castle worker drain", () => {
+  it("selects urgent first, drops specs, and keeps issue filters ordered", () => {
+    const candidates = [
+      candidate(30),
+      candidate(10, ["ready-for-agent", "priority:urgent"]),
+      candidate(20, ["ready-for-agent", "priority:high"]),
+      candidate(7, ["ready-for-agent", "type:spec"]),
+    ];
+
+    expect(selectCastleIssues(candidates, { kind: "all" }).map((row) => row.number)).toEqual([10, 20, 30]);
+    expect(selectCastleIssues(candidates, { kind: "issues", numbers: [30, 10] }).map((row) => row.number)).toEqual([10, 30]);
+  });
+
+  it("runs the castle-owned drain loop through claim/work and preserves progress output", async () => {
+    const emitted: string[] = [];
+    const processIssue = vi
+      .fn()
+      .mockResolvedValueOnce({ outcome: "claim-lost" })
+      .mockResolvedValueOnce({ outcome: "done" });
+
+    const result = await runCastleWorkerDrain({
+      gh: { listCandidates: async () => [candidate(1), candidate(2)] },
+      runBoot: async () => boot,
+      bootDeps: {},
+      bootOptions: {},
+      processIssue,
+      processDeps,
+      buildProcessInput: (row, ctx) => ({ issue: row.number, runner: ctx.runner }),
+      emit: (line) => emitted.push(line),
+    }, {
+      runner: "codex",
+      workerId: "wAB12",
+      filter: { kind: "all" },
+      once: true,
+      issueTemplate: {},
+    });
+
+    expect(processIssue).toHaveBeenCalledTimes(2);
+    expect(processIssue.mock.calls.map((call) => call[1])).toEqual([
+      { issue: 1, runner: "codex" },
+      { issue: 2, runner: "codex" },
+    ]);
+    expect(result).toMatchObject({
+      done: 1,
+      blocked: 0,
+      failed: 1,
+      total: 2,
+      stopReason: "once",
+    });
+    expect(emitted).toEqual([
+      "progress: 1/2 (50%) — 1 remaining",
+      "progress: 2/2 (100%) — 0 remaining",
+      "worker stop: once",
+    ]);
+  });
+
+  it("emits the frozen no-more-tasks sentinel on an empty queue", async () => {
+    const emitted: string[] = [];
+    const result = await runCastleWorkerDrain({
+      gh: { listCandidates: async () => [] },
+      runBoot: async () => boot,
+      bootDeps: {},
+      bootOptions: {},
+      processIssue: async () => ({ outcome: "done" }),
+      processDeps,
+      buildProcessInput: (row, ctx) => ({ issue: row.number, runner: ctx.runner }),
+      emit: (line) => emitted.push(line),
+    }, {
+      runner: "claude",
+      workerId: "wZZ99",
+      filter: { kind: "all" },
+      issueTemplate: {},
+    });
+
+    expect(result.drained).toBe(true);
+    expect(result.stopReason).toBe("drain-empty");
+    expect(emitted).toEqual([CASTLE_NO_MORE_TASKS]);
+  });
+});

--- a/packages/red-castle/src/engine/worker-drain.ts
+++ b/packages/red-castle/src/engine/worker-drain.ts
@@ -1,0 +1,427 @@
+import type { Runner } from "./runner-types.js";
+
+export interface CastleIssueCandidate {
+  number: number;
+  title: string;
+  body: string;
+  labels: readonly string[];
+}
+
+export type CastleSelectionFilter =
+  | { kind: "all" }
+  | { kind: "issues"; numbers: number[] }
+  | { kind: "spec"; spec: number };
+
+export interface CastleSelectionLabels {
+  ready: string;
+  typeSpec: string;
+  urgent: string;
+  high: string;
+}
+
+export const DEFAULT_CASTLE_SELECTION_LABELS: CastleSelectionLabels = {
+  ready: "ready-for-agent",
+  typeSpec: "type:spec",
+  urgent: "priority:urgent",
+  high: "priority:high",
+};
+
+export class CastleIssueSelectionError extends Error {
+  constructor(
+    message: string,
+    readonly numbers: number[],
+  ) {
+    super(message);
+    this.name = "CastleIssueSelectionError";
+  }
+}
+
+function hasLabel(candidate: CastleIssueCandidate, label: string): boolean {
+  return candidate.labels.includes(label);
+}
+
+function matchesSpec(candidate: CastleIssueCandidate, spec: number): boolean {
+  if (hasLabel(candidate, `spec:${spec}`)) return true;
+  return new RegExp(`spec:\\s*#?${spec}\\b`).test(candidate.body ?? "");
+}
+
+function sortByPriority(
+  candidates: readonly CastleIssueCandidate[],
+  labels: CastleSelectionLabels,
+): CastleIssueCandidate[] {
+  return [...candidates].sort((a, b) => {
+    const ar = hasLabel(a, labels.high) ? 0 : 1;
+    const br = hasLabel(b, labels.high) ? 0 : 1;
+    if (ar !== br) return ar - br;
+    return a.number - b.number;
+  });
+}
+
+export function selectCastleIssues(
+  candidates: readonly CastleIssueCandidate[],
+  filter: CastleSelectionFilter,
+  labels: CastleSelectionLabels = DEFAULT_CASTLE_SELECTION_LABELS,
+): CastleIssueCandidate[] {
+  const pool = candidates.filter((candidate) => !hasLabel(candidate, labels.typeSpec));
+  const urgent = pool
+    .filter((candidate) => hasLabel(candidate, labels.urgent))
+    .sort((a, b) => a.number - b.number);
+  const rest = pool.filter((candidate) => !hasLabel(candidate, labels.urgent));
+
+  let filtered: CastleIssueCandidate[];
+  switch (filter.kind) {
+    case "issues": {
+      const byNumber = new Map(pool.map((candidate) => [candidate.number, candidate] as const));
+      const ordered: CastleIssueCandidate[] = [];
+      const missing: number[] = [];
+      for (const number of filter.numbers) {
+        const candidate = byNumber.get(number);
+        if (candidate) ordered.push(candidate);
+        else missing.push(number);
+      }
+      if (missing.length > 0) {
+        throw new CastleIssueSelectionError(
+          `requested issue(s) missing from the ${labels.ready} queue: ${missing.map((number) => `#${number}`).join(", ")}`,
+          missing,
+        );
+      }
+      filtered = ordered;
+      break;
+    }
+    case "spec":
+      filtered = sortByPriority(
+        rest.filter((candidate) => matchesSpec(candidate, filter.spec)),
+        labels,
+      );
+      break;
+    case "all":
+    default:
+      filtered = sortByPriority(rest, labels);
+      break;
+  }
+
+  const urgentNumbers = new Set(urgent.map((candidate) => candidate.number));
+  return [...urgent, ...filtered.filter((candidate) => !urgentNumbers.has(candidate.number))];
+}
+
+export type CastleWorkerOutcome =
+  | "done"
+  | "claim-lost"
+  | "hook-aborted"
+  | "exhausted"
+  | "runner-transient"
+  | (string & {});
+
+export interface CastleWorkerProcessResult {
+  outcome: CastleWorkerOutcome;
+}
+
+export interface CastleWorkerDrainBudgetSnapshot {
+  used: number;
+  cap: number;
+}
+
+export interface CastleWorkerDrainPolicy {
+  maxIssues?: number;
+  maxRuntimeMs?: number;
+  nowMs?: () => number;
+  budget?: () => CastleWorkerDrainBudgetSnapshot;
+  supervisorKilled?: () => boolean;
+  shouldRetire?: () => boolean;
+}
+
+export type CastleWorkerStopReason =
+  | "drain-empty"
+  | "lifetime-cap"
+  | "budget-cap"
+  | "supervisor-kill"
+  | "graceful-retirement"
+  | "iter-cap"
+  | "once"
+  | "runner-unavailable"
+  | "exhausted";
+
+export type CastleSessionHookName =
+  | "pre_session"
+  | "pre_pick"
+  | "post_pick"
+  | "on_idle"
+  | "post_session"
+  | "on_session_error";
+
+export interface CastleWorkerDrainContext<TIssueTemplate = unknown> {
+  runner: Runner;
+  workerId: string;
+  iterCap?: number;
+  once?: boolean;
+  filter: CastleSelectionFilter;
+  alternate?: boolean;
+  bootOnly?: boolean;
+  sweepsSkipped?: boolean;
+  issueTemplate: TIssueTemplate;
+  policy?: CastleWorkerDrainPolicy;
+}
+
+export interface CastleWorkerDrainProcessed {
+  issue: number;
+  outcome: CastleWorkerOutcome;
+}
+
+export interface CastleWorkerDrainSummary<TBootResult = unknown> {
+  runner: Runner;
+  workerId: string;
+  done: number;
+  blocked: number;
+  failed: number;
+  total: number;
+  boot: TBootResult;
+  processed: CastleWorkerDrainProcessed[];
+  drained: boolean;
+  exhausted: boolean;
+  runnerTransient: boolean;
+  sessionHooksFired: CastleSessionHookName[];
+  stopReason?: CastleWorkerStopReason;
+}
+
+export interface CastleWorkerDrainDeps<
+  TBootDeps,
+  TBootOptions,
+  TBootResult extends { precheck: { ok: boolean } },
+  TProcessDeps,
+  TProcessInput,
+  TProcessResult extends CastleWorkerProcessResult,
+  TIssueTemplate = unknown,
+> {
+  gh: {
+    listCandidates(): Promise<CastleIssueCandidate[]>;
+  };
+  runBoot(deps: TBootDeps, options: TBootOptions): Promise<TBootResult>;
+  bootDeps: TBootDeps;
+  bootOptions: TBootOptions;
+  processIssue(deps: TProcessDeps, input: TProcessInput): Promise<TProcessResult>;
+  processDeps: TProcessDeps;
+  buildProcessInput(
+    candidate: CastleIssueCandidate,
+    ctx: CastleWorkerDrainContext<TIssueTemplate>,
+  ): TProcessInput;
+  runnerCircuit?: {
+    isOpen(runner: Runner): Promise<boolean>;
+  };
+  emit(line: string): void;
+  dispatchSessionHook?(
+    name: CastleSessionHookName,
+    context: string,
+  ): Promise<{ aborted: boolean }>;
+  labels?: CastleSelectionLabels;
+}
+
+export const CASTLE_NO_MORE_TASKS = "<promise>NO MORE TASKS</promise>";
+
+function otherRunner(runner: Runner, initial: Runner): Runner {
+  if (runner !== initial) return initial;
+  if (initial === "claude-minimax") return "claude";
+  if (initial === "claude") return "codex";
+  return "claude";
+}
+
+function classify(outcome: CastleWorkerOutcome): "done" | "blocked" | "failed" {
+  switch (outcome) {
+    case "done":
+      return "done";
+    case "claim-lost":
+    case "hook-aborted":
+      return "failed";
+    default:
+      return "blocked";
+  }
+}
+
+function budgetSpent(snapshot: CastleWorkerDrainBudgetSnapshot | undefined): boolean {
+  return snapshot !== undefined && snapshot.cap > 0 && snapshot.used >= snapshot.cap;
+}
+
+export async function runCastleWorkerDrain<
+  TBootDeps,
+  TBootOptions,
+  TBootResult extends { precheck: { ok: boolean } },
+  TProcessDeps,
+  TProcessInput extends { runner: Runner },
+  TProcessResult extends CastleWorkerProcessResult,
+  TIssueTemplate = unknown,
+>(
+  deps: CastleWorkerDrainDeps<
+    TBootDeps,
+    TBootOptions,
+    TBootResult,
+    TProcessDeps,
+    TProcessInput,
+    TProcessResult,
+    TIssueTemplate
+  >,
+  ctx: CastleWorkerDrainContext<TIssueTemplate>,
+): Promise<CastleWorkerDrainSummary<TBootResult>> {
+  const sessionHooksFired: CastleSessionHookName[] = [];
+  const fireSessionHook = async (name: CastleSessionHookName, context: string): Promise<boolean> => {
+    if (!deps.dispatchSessionHook) return true;
+    sessionHooksFired.push(name);
+    const result = await deps.dispatchSessionHook(name, context);
+    return !result.aborted;
+  };
+  const statsContext = (done: number, blocked: number, total: number): string =>
+    JSON.stringify({
+      runner: ctx.runner,
+      worker_id: ctx.workerId,
+      stats: { done, blocked, total },
+    });
+
+  const nowMs = ctx.policy?.nowMs ?? (() => Date.now());
+  const startedMs = nowMs();
+  const boot = await deps.runBoot(deps.bootDeps, deps.bootOptions);
+  const empty: CastleWorkerDrainSummary<TBootResult> = {
+    runner: ctx.runner,
+    workerId: ctx.workerId,
+    done: 0,
+    blocked: 0,
+    failed: 0,
+    total: 0,
+    boot,
+    processed: [],
+    drained: false,
+    exhausted: false,
+    runnerTransient: false,
+    sessionHooksFired,
+  };
+
+  if (!boot.precheck.ok) return empty;
+
+  if (ctx.bootOnly) {
+    deps.emit(
+      ctx.sweepsSkipped
+        ? "boot complete (--boot-only): sweeps skipped (supervisor-owned), no issues processed"
+        : "boot complete (--boot-only): sweeps ran, no issues processed",
+    );
+    return empty;
+  }
+
+  try {
+    if (!(await fireSessionHook("pre_session", statsContext(0, 0, 0)))) return empty;
+
+    await fireSessionHook("pre_pick", JSON.stringify({ filter: ctx.filter }));
+    const candidates = await deps.gh.listCandidates();
+    const queue = selectCastleIssues(candidates, ctx.filter, deps.labels);
+    const total = queue.length;
+    await fireSessionHook("post_pick", JSON.stringify({ issues: queue.map((candidate) => candidate.number) }));
+
+    if (total === 0) {
+      await fireSessionHook("on_idle", statsContext(0, 0, 0));
+      deps.emit(CASTLE_NO_MORE_TASKS);
+      await fireSessionHook("post_session", statsContext(0, 0, 0));
+      return { ...empty, total: 0, drained: true, stopReason: "drain-empty" };
+    }
+
+    const cap = ctx.iterCap && ctx.iterCap > 0 ? ctx.iterCap : total;
+    const processed: CastleWorkerDrainProcessed[] = [];
+    let done = 0;
+    let blocked = 0;
+    let failed = 0;
+    let exhaustedStop = false;
+    let runnerTransientStop = false;
+    let stopReason: CastleWorkerStopReason | undefined;
+    let activeRunner: Runner = ctx.runner;
+
+    for (let i = 0; i < queue.length; i++) {
+      if (ctx.policy?.supervisorKilled?.()) {
+        stopReason = "supervisor-kill";
+        break;
+      }
+      if (budgetSpent(ctx.policy?.budget?.())) {
+        stopReason = "budget-cap";
+        break;
+      }
+      if (ctx.policy?.maxRuntimeMs !== undefined && nowMs() - startedMs >= ctx.policy.maxRuntimeMs) {
+        stopReason = "lifetime-cap";
+        break;
+      }
+      if (ctx.policy?.maxIssues !== undefined && processed.length >= ctx.policy.maxIssues) {
+        stopReason = "lifetime-cap";
+        break;
+      }
+      if (i >= cap) {
+        stopReason = "iter-cap";
+        break;
+      }
+
+      const candidate = queue[i]!;
+      const issueRunner = ctx.alternate ? activeRunner : ctx.runner;
+      if (deps.runnerCircuit && (await deps.runnerCircuit.isOpen(issueRunner))) {
+        runnerTransientStop = true;
+        stopReason = "runner-unavailable";
+        deps.emit(`runner ${issueRunner} circuit open — stopping before claiming more issues`);
+        break;
+      }
+
+      const input = deps.buildProcessInput(candidate, ctx);
+      const perIssueInput = ctx.alternate ? { ...input, runner: issueRunner } : input;
+      const result = await deps.processIssue(deps.processDeps, perIssueInput);
+      const bucket = classify(result.outcome);
+      if (bucket === "done") done++;
+      else if (bucket === "blocked") blocked++;
+      else failed++;
+      processed.push({ issue: candidate.number, outcome: result.outcome });
+
+      const idx = i + 1;
+      const pct = Math.floor((idx * 100) / total);
+      const remaining = total - idx;
+      deps.emit(`progress: ${idx}/${total} (${pct}%) — ${remaining} remaining`);
+
+      if (result.outcome === "exhausted") {
+        exhaustedStop = true;
+        stopReason = "exhausted";
+        break;
+      }
+      if (result.outcome === "runner-transient") {
+        runnerTransientStop = true;
+        stopReason = "runner-unavailable";
+        break;
+      }
+      if (ctx.once && result.outcome !== "claim-lost") {
+        stopReason = "once";
+        break;
+      }
+      if (ctx.policy?.shouldRetire?.()) {
+        stopReason = "graceful-retirement";
+        break;
+      }
+      if (ctx.alternate) activeRunner = otherRunner(activeRunner, ctx.runner);
+    }
+
+    await fireSessionHook("post_session", statsContext(done, blocked, total));
+    if (stopReason) deps.emit(`worker stop: ${stopReason}`);
+
+    return {
+      runner: ctx.runner,
+      workerId: ctx.workerId,
+      done,
+      blocked,
+      failed,
+      total,
+      boot,
+      processed,
+      drained: false,
+      exhausted: exhaustedStop,
+      runnerTransient: runnerTransientStop,
+      sessionHooksFired,
+      stopReason,
+    };
+  } catch (error) {
+    await fireSessionHook(
+      "on_session_error",
+      JSON.stringify({
+        runner: ctx.runner,
+        worker_id: ctx.workerId,
+        error: { message: error instanceof Error ? error.message : String(error) },
+      }),
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
Automated AFK landing for #1917. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1917

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786847389&installation_id=129708444&pr_number=1949&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1949&signature=15ac09fe4bd4c1feeb3d5ebeafa39670d158cc8dbece8f4a4696d54445738666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->