### PR TITLE
fix: #1948 /go: Make the AFK branch precondition error tell the truth, in apps/dev/src/c

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -27,7 +27,7 @@ import {
   buildBootDeps,
   type RepoContext,
 } from "../runtime/wire.js";
-import { runBoot, type BootResult, type BootstrapInput } from "../core/boot.js";
+import { formatPreconditionFailure, runBoot, type BootResult, type BootstrapInput } from "../core/boot.js";
 import { inspectProcessTreeNative } from "../runtime/proc-tree.js";
 import {
   workerLivenessFor,
@@ -276,7 +276,7 @@ export function slotFilterArgs(args: readonly string[]): string[] {
  */
 export function formatBootSweepResult(result: BootResult): string {
   if (!result.precheck.ok) {
-    return `boot sweeps: precheck FAILED (${result.precheck.failed}) — workers will run their own precheck`;
+    return `boot sweeps: precheck FAILED (${formatPreconditionFailure(result.precheck)}) — workers will run their own precheck`;
   }
   const oc = result.orphanCleanup;
   const ac = result.attemptCap;

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -73,8 +73,16 @@ export type Precondition =
   | "not-a-git-repo"
   | "https-remote-forbidden"
   | "no-main-branch"
-  | "not-on-main"
+  | "not-on-trunk"
   | "pnpm-missing";
+
+export type FocalBranchSource = "lock" | "pin" | "trunk";
+
+export interface BranchPreconditionDetail {
+  current: string;
+  expected: string;
+  source: FocalBranchSource;
+}
 
 /** Facts the precheck consumes. The caller resolves each via real IO (command
  * lookups, `gh auth status`, `git remote -v`, `git branch --show-current`) and
@@ -96,11 +104,13 @@ export interface PrecheckFacts {
    */
   lockedBranch?: string;
   /**
-   * The configured AFK boot branch resolved by the caller from repo config
-   * (config lock/trunk, falling back to main). Kept injected so precheck stays
-   * a pure rule over facts.
+   * The configured AFK boot branch resolved by the caller from repo config:
+   * static branch pin first, then trunk/default. Kept injected so precheck
+   * stays a pure rule over facts.
    */
   configuredTrunk?: string;
+  /** Where `configuredTrunk` came from when no runtime lock overrides it. */
+  configuredTrunkSource?: Exclude<FocalBranchSource, "lock">;
   pnpmInstalled: boolean;
   /**
    * Relax the SSH-only remote rule. "Reject https remote" is a LOCAL-dev safety
@@ -115,17 +125,19 @@ export interface PrecheckFacts {
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and
  * `detail` carries the offending value (e.g. the https URL) or, for a branch
- * mismatch, the branch the checkout was expected to be on. pnpm-missing is a
- * WARNING in afk.sh (`log "warn: …"`), not a `die`; it is surfaced via
- * `warnings` while the verdict still passes. */
+ * mismatch, the current branch, expected branch, and expectation source.
+ * pnpm-missing is a WARNING in afk.sh (`log "warn: …"`), not a `die`; it is
+ * surfaced via `warnings` while the verdict still passes. */
 export type PrecheckResult =
   | { ok: true; warnings: string[] }
-  | { ok: false; failed: Precondition; detail?: string };
+  | { ok: false; failed: Exclude<Precondition, "not-on-trunk">; detail?: string }
+  | { ok: false; failed: "not-on-trunk"; detail: BranchPreconditionDetail };
 
 /** Evaluate the hard preconditions in afk.sh order. The `die` ladder is:
  *   gh installed → gh authenticated → is-git-repo → no https remote →
- *   local main exists → on main. pnpm is the lone soft check (warn, not die),
- *   evaluated last so a clean pass still reports the warning. */
+ *   local main exists → on the resolved focal branch. pnpm is the lone soft
+ *   check (warn, not die), evaluated last so a clean pass still reports the
+ *   warning. */
 export function precheck(facts: PrecheckFacts): PrecheckResult {
   if (!facts.ghInstalled) return { ok: false, failed: "gh-missing" };
   if (!facts.ghAuthenticated) return { ok: false, failed: "gh-unauthenticated" };
@@ -140,13 +152,28 @@ export function precheck(facts: PrecheckFacts): PrecheckResult {
   if (!facts.hasMainBranch) return { ok: false, failed: "no-main-branch" };
   const expectedBranch = facts.lockedBranch ?? facts.configuredTrunk ?? "main";
   if (facts.currentBranch !== expectedBranch) {
-    return { ok: false, failed: "not-on-main", detail: expectedBranch };
+    const source: FocalBranchSource = facts.lockedBranch !== undefined
+      ? "lock"
+      : facts.configuredTrunkSource ?? "trunk";
+    return {
+      ok: false,
+      failed: "not-on-trunk",
+      detail: { current: facts.currentBranch, expected: expectedBranch, source },
+    };
   }
   const warnings: string[] = [];
   if (!facts.pnpmInstalled) {
     warnings.push("pnpm not on PATH; feedback loops will be skipped");
   }
   return { ok: true, warnings };
+}
+
+export function formatPreconditionFailure(result: Extract<PrecheckResult, { ok: false }>): string {
+  if (result.failed === "not-on-trunk") {
+    const d = result.detail;
+    return `${result.failed}: current=${d.current} expected=${d.expected} source=${d.source}`;
+  }
+  return result.failed;
 }
 
 // ---------- injected IO ----------

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1698,6 +1698,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
   const config = loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined });
   const configLockedBranch = getConfig(config, "dev.lock.branch") || undefined;
   const configTrunk = getConfig(config, "dev.trunk") || undefined;
+  const configuredTrunkSource = configLockedBranch?.trim() ? "pin" : "trunk";
   const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch, pnpmProbe, lockedBranch] =
     await Promise.all([
       ghx.ghInstalled(ghCtx),
@@ -1728,6 +1729,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     currentBranch,
     lockedBranch,
     configuredTrunk,
+    configuredTrunkSource,
     pnpmInstalled,
     // CI lanes (the GHA Actions lane) check out an https remote token-authed by
     // GITHUB_TOKEN — the intended setup — so the SSH-only rule must not fire there.

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -87,11 +87,11 @@ describe("precheck", () => {
     });
   });
 
-  it("fails not-on-main, naming the expected default branch", () => {
+  it("fails not-on-trunk, naming the current branch, expected default branch, and trunk source", () => {
     expect(precheck(facts({ currentBranch: "feature/x" }))).toEqual({
       ok: false,
-      failed: "not-on-main",
-      detail: "main",
+      failed: "not-on-trunk",
+      detail: { current: "feature/x", expected: "main", source: "trunk" },
     });
   });
 
@@ -102,11 +102,21 @@ describe("precheck", () => {
     });
   });
 
-  it("fails not-on-main, naming the configured trunk when the checkout is on main", () => {
+  it("fails not-on-trunk, naming the configured trunk when the checkout is on main", () => {
     expect(precheck(facts({ currentBranch: "main", configuredTrunk: "develop" }))).toEqual({
       ok: false,
-      failed: "not-on-main",
-      detail: "develop",
+      failed: "not-on-trunk",
+      detail: { current: "main", expected: "develop", source: "trunk" },
+    });
+  });
+
+  it("fails not-on-trunk, naming the configured branch pin as the expectation source", () => {
+    expect(
+      precheck(facts({ currentBranch: "main", configuredTrunk: "release/x", configuredTrunkSource: "pin" })),
+    ).toEqual({
+      ok: false,
+      failed: "not-on-trunk",
+      detail: { current: "main", expected: "release/x", source: "pin" },
     });
   });
 
@@ -132,19 +142,19 @@ describe("precheck", () => {
     });
   });
 
-  it("locked: fails not-on-main when currentBranch is main instead of the lock value", () => {
+  it("locked: fails not-on-trunk when currentBranch is main instead of the lock value", () => {
     expect(precheck(facts({ currentBranch: "main", lockedBranch: "feature-locked" }))).toEqual({
       ok: false,
-      failed: "not-on-main",
-      detail: "feature-locked",
+      failed: "not-on-trunk",
+      detail: { current: "main", expected: "feature-locked", source: "lock" },
     });
   });
 
-  it("locked: fails not-on-main when currentBranch is a different branch than the lock value", () => {
+  it("locked: fails not-on-trunk when currentBranch is a different branch than the lock value", () => {
     expect(precheck(facts({ currentBranch: "other-branch", lockedBranch: "feature-locked" }))).toEqual({
       ok: false,
-      failed: "not-on-main",
-      detail: "feature-locked",
+      failed: "not-on-trunk",
+      detail: { current: "other-branch", expected: "feature-locked", source: "lock" },
     });
   });
 

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -166,9 +166,15 @@ describe("formatBootSweepResult — supervisor boot log shape (#623)", () => {
   });
 
   it("reports a precheck failure (workers fall back to their own precheck)", () => {
-    const result: BootResult = { precheck: { ok: false, failed: "not-on-main", detail: "feat/x" } };
+    const result: BootResult = {
+      precheck: {
+        ok: false,
+        failed: "not-on-trunk",
+        detail: { current: "main", expected: "feat/x", source: "pin" },
+      },
+    };
     expect(formatBootSweepResult(result)).toBe(
-      "boot sweeps: precheck FAILED (not-on-main) — workers will run their own precheck",
+      "boot sweeps: precheck FAILED (not-on-trunk: current=main expected=feat/x source=pin) — workers will run their own precheck",
     );
   });
 });


### PR DESCRIPTION
Automated AFK landing for #1948. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1948

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786848066&installation_id=129708444&pr_number=1950&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1950&signature=ac227e90cf85c9384dc8be73cd29beb3edf09baa21a82fd720332da9886f6690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->