### PR TITLE
fix: #1951 /go: Fix the published bundle breakage caused by an unbundled require("js-yam

### DIFF
--- a/apps/dev/src/core/toon-version.ts
+++ b/apps/dev/src/core/toon-version.ts
@@ -1,10 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import { dirname, join, parse } from "node:path";
-
-const require = createRequire(import.meta.url);
-const yaml = require("js-yaml") as { load(input: string): unknown };
+import yaml from "js-yaml";
 
 const TOON_PACKAGE_NAME = "@reddb-io/toon";
 const SEMVER = /^\d+\.\d+\.\d+$/;

--- a/apps/dev/src/types/js-yaml.d.ts
+++ b/apps/dev/src/types/js-yaml.d.ts
@@ -1,0 +1,7 @@
+declare module "js-yaml" {
+  const yaml: {
+    load(input: string): unknown;
+  };
+
+  export default yaml;
+}

--- a/apps/dev/tests/dev-bundle-contract.test.ts
+++ b/apps/dev/tests/dev-bundle-contract.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const DEV_APP = join(ROOT, "apps", "dev");
+const DEV_BUNDLE = join(ROOT, "dist", "dev.bundle.min.mjs");
+const REQUIRE_LITERAL = /\brequire\(\s*(["'])([^"']+)\1\s*\)/g;
+const builtinSpecifiers = new Set(
+  builtinModules.flatMap((name) => {
+    const bare = name.replace(/^node:/, "");
+    return [bare, `node:${bare}`];
+  }),
+);
+
+describe("dev bundle contract", () => {
+  it(
+    "does not leave third-party package requires in the generated bundle",
+    () => {
+      execFileSync("pnpm", ["run", "bundle"], {
+        cwd: DEV_APP,
+        env: {
+          ...process.env,
+          RED_BUILD_VERSION: "0.0.0-test",
+          RED_BUILD_GIT_SHA: "test",
+          RED_BUILD_TIME: "2026-01-01T00:00:00.000Z",
+        },
+        stdio: "pipe",
+      });
+
+      const bundle = readFileSync(DEV_BUNDLE, "utf8");
+      const thirdPartyRequires = [...bundle.matchAll(REQUIRE_LITERAL)]
+        .map((match) => match[2])
+        .filter(isBarePackageSpecifier)
+        .filter((specifier) => !builtinSpecifiers.has(specifier));
+
+      expect(thirdPartyRequires).toEqual([]);
+    },
+    120_000,
+  );
+});
+
+function isBarePackageSpecifier(specifier: string): boolean {
+  return !specifier.startsWith(".") && !specifier.startsWith("/") && !specifier.startsWith("file:");
+}


### PR DESCRIPTION
Automated AFK landing for #1951. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1951

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786850391&installation_id=129708444&pr_number=1953&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1953&signature=db60189fe1381f1a21261701503ed38b3dd66ddac1cad8a33b1b3f4515e2995e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->