### PR TITLE
merge: #1919 Flip fleet to the castle engine

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -47,6 +47,11 @@ import { dispatchFleetHook } from "../core/fleet-hook-dispatcher.js";
 import { makeHookExec, makeHookResolveOptions } from "../runtime/hooks.js";
 import { getConfig, loadConfig } from "../core/config.js";
 import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
+import {
+  castleStateSnapshotPath,
+  createEnginePaths,
+  writeCastleStateSnapshot,
+} from "@reddb-io/red-castle/engine";
 
 function isAlive(pid: number): boolean {
   try {
@@ -96,6 +101,50 @@ function writeFleetStateAtomic(path: string, hb: FleetHeartbeat): void {
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, fleetHeartbeatState(hb), "utf8");
   renameSync(tmp, path);
+}
+
+async function writeCastleSupervisorSnapshot(
+  root: string,
+  supervisorId: string,
+  hb: FleetHeartbeat,
+): Promise<void> {
+  const paths = createEnginePaths(join(root, ".red"));
+  await writeCastleStateSnapshot(
+    castleStateSnapshotPath(paths, "supervisor", supervisorId),
+    {
+      kind: "supervisor",
+      id: supervisorId,
+      supervisor_id: supervisorId,
+      version: 1,
+      updated_at: hb.ts,
+      runner: hb.runner,
+      pid: process.pid,
+      current: {
+        epoch: hb.epoch,
+        last_progress_epoch: hb.lastProgressEpoch,
+        ready_for_agent: hb.readyForAgent,
+        slots: {
+          busy: hb.slotsBusy,
+          free: hb.slotsFree,
+          total: hb.slotsTotal,
+          parked: hb.slotsParked,
+        },
+        spawns_this_tick: hb.spawnsThisTick,
+        ...(hb.drainBudget
+          ? {
+              drain_budget: {
+                tier: hb.drainBudget.tier,
+                spent_usd: Number(hb.drainBudget.spentUsd.toFixed(4)),
+                limit_usd: Number(hb.drainBudget.limitUsd.toFixed(4)),
+                percent: Number((hb.drainBudget.percent * 100).toFixed(2)),
+              },
+            }
+          : {}),
+      },
+      queue: [],
+      completed: [],
+    },
+  );
 }
 
 /**
@@ -591,6 +640,11 @@ function buildSupervisorDeps(
         writeFleetStateAtomic(statePath, hb);
       } catch {
         // best-effort: state-file failure must not affect the supervisor.
+      }
+      try {
+        await writeCastleSupervisorSnapshot(root, `s${process.pid}`, hb);
+      } catch {
+        // best-effort: castle state mirroring must not affect the supervisor.
       }
       try {
         await appendRecordToonlRow(firehosePath, "heartbeat", fleetHeartbeatMessage(hb), {

--- a/apps/dev/src/core/history.ts
+++ b/apps/dev/src/core/history.ts
@@ -1,8 +1,9 @@
 import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
-import { dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { decode, encode, type JsonValue } from "@reddb-io/toon";
+import { appendCastleHistoryRecord } from "@reddb-io/red-castle/engine";
 
 // Port of lib/history.sh — the afk-history.jsonl ledger. The pure parts (the
 // JSONL record shape, the 48h `done`-event bucketing, and the sparkline glyph
@@ -280,6 +281,21 @@ export const defaultHistoryIO: HistoryIO = {
   },
 };
 
+function castleHistoryMirrorPath(path: string, io: HistoryIO): string | null {
+  if (io !== defaultHistoryIO) return null;
+  const file = basename(path);
+  if (file !== "afk-history.toonl" && file !== "afk-history.jsonl") return null;
+  const stateDir = dirname(path);
+  if (basename(stateDir) !== "state") return null;
+  return join(stateDir, "castle", "history.toonl");
+}
+
+async function mirrorCastleHistory(path: string, record: HistoryRecord, io: HistoryIO): Promise<void> {
+  const castlePath = castleHistoryMirrorPath(path, io);
+  if (castlePath === null) return;
+  await appendCastleHistoryRecord(castlePath, record).catch(() => undefined);
+}
+
 export interface HistoryTrimTool {
   trimKeepLast(path: string, keepLast: number): Promise<boolean>;
 }
@@ -315,9 +331,11 @@ export async function historyAppend(
   if (path.endsWith(".toonl")) {
     const existing = parseHistoryLines((await io.read(path)) ?? "");
     await io.write(path, renderHistoryToonl([...existing, record]));
+    await mirrorCastleHistory(path, record, io);
     return record;
   }
   await io.append(path, `${serializeHistoryRecord(record)}\n`);
+  await mirrorCastleHistory(path, record, io);
   return record;
 }
 

--- a/apps/dev/tests/castle-acceptance-harness.test.ts
+++ b/apps/dev/tests/castle-acceptance-harness.test.ts
@@ -239,6 +239,7 @@ describe("castle acceptance harness", () => {
     ) as {
       workers: Array<{ id: string; issue: number }>;
       fleet: { slots_busy: number; slots_free: number };
+      proving_drain: { drained: number; required: number; remaining: number; passed: number };
       summary: string;
     };
     expect(monitor.workers.map((worker) => worker.issue).sort()).toEqual([
@@ -246,8 +247,15 @@ describe("castle acceptance harness", () => {
       1918,
     ]);
     expect(monitor.fleet).toMatchObject({ slots_busy: 2, slots_free: 0 });
+    expect(monitor.proving_drain).toMatchObject({
+      drained: 1,
+      required: 20,
+      remaining: 19,
+      passed: 0,
+    });
     expect(monitor.summary).toContain("2 workers");
     expect(monitor.summary).toContain("1 closed");
+    expect(monitor.summary).toContain("proving 1/20");
 
     const statusline = renderStatusline({
       project: { basename: "red-skills", branch: "main" },

--- a/apps/dev/tests/history.test.ts
+++ b/apps/dev/tests/history.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import { readCastleHistoryRecords } from "@reddb-io/red-castle/engine";
 import {
   buildSparkline,
   historyAppend,
@@ -138,6 +139,31 @@ describe("history append", () => {
     const records = parseHistoryLines(await readFile(path, "utf8"));
     const { total } = buildSparkline(records, nowEpoch, 48);
     expect(total).toBe(1);
+  });
+
+  it("mirrors the default AFK history ledger into castle history", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "afk-history-"));
+    const path = join(dir, ".red", "state", "afk-history.toonl");
+
+    await historyAppend(
+      path,
+      { ts: "2026-07-17T03:30:00.000Z", epoch: 1784259000 },
+      "done",
+      { worker: "wCASTLE", issue: 1919, runner: "codex", duration_s: 180, merge_sha: "abc1234" },
+    );
+
+    const castle = await readCastleHistoryRecords(
+      join(dir, ".red", "state", "castle", "history.toonl"),
+    );
+    expect(castle).toEqual([
+      expect.objectContaining({
+        event: "done",
+        issue: 1919,
+        worker: "wCASTLE",
+        runner: "codex",
+        merge_sha: "abc1234",
+      }),
+    ]);
   });
 
   it("skips malformed legacy JSONL lines while keeping valid monitor history", () => {

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -43,6 +43,28 @@ export interface SparklineResult {
   line: string;
 }
 
+export interface ProvingDrainCounter {
+  drained: number;
+  required: number;
+  remaining: number;
+  passed: boolean;
+}
+
+export const PROVING_DRAIN_REQUIRED = 20;
+
+export function computeProvingDrainCounter(
+  events: ReadonlyArray<Pick<HistoryRecord, "event">>,
+  required: number = PROVING_DRAIN_REQUIRED,
+): ProvingDrainCounter {
+  const drained = events.filter((event) => event.event === "done").length;
+  return {
+    drained,
+    required,
+    remaining: Math.max(0, required - drained),
+    passed: drained >= required,
+  };
+}
+
 export function readDoneBuckets(
   events: ReadonlyArray<Pick<HistoryRecord, "event" | "epoch">>,
   fromHour: number,
@@ -590,12 +612,19 @@ export function renderCompactDashboardToon(
     if (compactWorkerTag(w) === "live") active += 1;
   }
   const sparkline = buildSparkline(events, now);
+  const provingDrain = computeProvingDrainCounter(events);
 
   const root: JsonObject = {
     sparkline: sparkline.line,
     diff_added: added,
     diff_removed: removed,
     sources: sourceCountRows(workers),
+    proving_drain: {
+      drained: provingDrain.drained,
+      required: provingDrain.required,
+      remaining: provingDrain.remaining,
+      passed: provingDrain.passed ? 1 : 0,
+    },
   };
 
   if (fleet) {
@@ -647,6 +676,6 @@ export function renderCompactDashboardToon(
 
   return appendSummaryField(
     root,
-    `${workers.length} workers · ${active} active · ${sparkline.total} closed · ${formatDiff(added, removed)}`,
+    `${workers.length} workers · ${active} active · ${sparkline.total} closed · proving ${provingDrain.drained}/${provingDrain.required} · ${formatDiff(added, removed)}`,
   );
 }


### PR DESCRIPTION
ADR 0107 flip 4 (final): the fleet supervisor runs on the castle engine.

The local gate parked this branch on `blocked:validation` reporting 1 test file / 2 tests failing out of 3752, with typecheck and build green. The gate's summary tail truncated the failing file name and its feedback worktree has been reclaimed, so the failing identity is not recoverable locally. Both test files this branch touches pass on the branch with dependencies installed (`history.test.ts` 21/21, `castle-acceptance-harness.test.ts` 1/1), which points at load contention during a concurrent fleet run rather than a defect — the same pattern as #1904 / #1927.

This PR exists to let clean CI adjudicate that question on an idle runner. If CI is green, the park was a mirage and the branch lands. If CI is red, it names the failing test and the finding is real.

`landing:manual`: the merge is held for a human.

Closes #1919

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786850563&installation_id=129708444&pr_number=1954&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1954&signature=4fd9f406b200246a58bf32dfd8379889fec4b3c0c437c86e36bd9b6634f13061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->