### PR TITLE
fix(dev): make a validation park name the check that failed

### DIFF
--- a/apps/dev/src/core/feedback.ts
+++ b/apps/dev/src/core/feedback.ts
@@ -373,11 +373,57 @@ export function isInfraFeedbackFailure(feedback: RunFeedbackResult): boolean {
   return false;
 }
 
+/** Strip ANSI SGR sequences so identity matching survives coloured runner output.
+ * Test runners colour their FAIL markers; the raw captured bytes keep the escape
+ * codes, and an un-stripped `^\s*FAIL\b` never matches `\x1b[31m FAIL \x1b[0m`. */
+function stripAnsi(line: string): string {
+  // eslint-disable-next-line no-control-regex
+  return line.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+/** Patterns that name WHICH check failed, as opposed to how many did.
+ * Vitest emits `FAIL  <file> > <suite> > <test>`; cargo emits `<name> ... FAILED`
+ * and `---- <name> stdout ----`. Every one of them prints ABOVE the run's
+ * trailing counters, which is precisely why a tail slice loses them. */
+const FAILURE_IDENTITY_PATTERNS: readonly RegExp[] = [
+  /^\s*FAIL\s+\S.*$/,
+  /^\s*\S.*\.{3}\s+FAILED\s*$/,
+  /^\s*----\s+\S.*\s+stdout\s+----\s*$/,
+];
+
+/** How many distinct failing identities to name before eliding the rest. A run
+ * with dozens of failures is a systemic break, not a list to read line by line. */
+const MAX_NAMED_FAILURES = 5;
+
+/** Scan the WHOLE output for lines that name a failing check, deduped and in
+ * first-seen order. Returns [] when the runner names nothing recognisable, which
+ * keeps the tail-only summary as the honest fallback rather than inventing one. */
+export function namedFailures(output: string): string[] {
+  const seen = new Set<string>();
+  for (const raw of output.split("\n")) {
+    const line = stripAnsi(raw).replace(/\s+/g, " ").trim();
+    if (line === "") continue;
+    if (!FAILURE_IDENTITY_PATTERNS.some((re) => re.test(line))) continue;
+    seen.add(line);
+    if (seen.size >= MAX_NAMED_FAILURES) break;
+  }
+  return [...seen];
+}
+
 /**
  * Short summary for a finished check — the port of afk_validation_output_summary.
- * A passing check is always `command exited 0`; a failing check surfaces a
- * trailing slice of its captured output (joined to one line, capped at 1000
- * chars), or `command exited non-zero` when there is nothing to show.
+ * A passing check is always `command exited 0`; a failing check surfaces the
+ * identities of the checks that failed followed by a trailing slice of its
+ * captured output (joined to one line, capped at 1000 chars), or `command exited
+ * non-zero` when there is nothing to show.
+ *
+ * The identity prefix exists because the tail alone is NOT actionable: a runner
+ * prints `Tests 2 failed | 3750 passed` at the very end but names the two
+ * failures higher up, so a park built from the tail says how many broke while
+ * dropping which — forcing a human (or a whole CI round-trip) to re-derive what
+ * the gate already had in hand. The identities lead because they are the part a
+ * reader acts on, and the 1000-char cap is applied last so a verbose tail can
+ * never crowd them out.
  */
 export function outputSummary(status: ValidationStatus, output: string): string {
   if (status === "passed") return "command exited 0";
@@ -385,7 +431,9 @@ export function outputSummary(status: ValidationStatus, output: string): string 
   if (trimmed === "") return "command exited non-zero";
   const lines = trimmed.split("\n");
   const tail = lines.slice(-20).join(" ");
-  return tail.slice(0, 1000);
+  const named = namedFailures(trimmed);
+  if (named.length === 0) return tail.slice(0, 1000);
+  return `failing: ${named.join(" | ")} — ${tail}`.slice(0, 1000);
 }
 
 // ---------- orchestration ----------

--- a/apps/dev/tests/feedback.test.ts
+++ b/apps/dev/tests/feedback.test.ts
@@ -5,6 +5,7 @@ import {
   decideBaselineDiffGate,
   isInfraFeedbackFailure,
   nearestPackageScope,
+  namedFailures,
   outputSummary,
   relevantScopes,
   runFeedback,
@@ -365,6 +366,47 @@ describe("pure shaping helpers", () => {
     expect(outputSummary("failed", "line a\nline b\n")).toBe("line a line b");
     const long = `${"x".repeat(2000)}\n`;
     expect(outputSummary("failed", long).length).toBe(1000);
+  });
+
+  it("names the failing test instead of only reporting how many failed", () => {
+    // Verbatim shape of the vitest output that parked #1919: the identities sit
+    // far above the counters, so the pre-#1929 tail-only summary reported
+    // "2 failed" and dropped both names. The gate had this in hand all along.
+    const vitest = [
+      " FAIL  tests/monitor.test.ts > monitor — compact dashboard > renders one worker",
+      "AssertionError: expected '1 workers · proving…' to be '1 workers · +10…'",
+      ...Array.from({ length: 30 }, (_, i) => `noise line ${i}`),
+      " Test Files  1 failed | 215 passed (216)",
+      "      Tests  2 failed | 3750 passed (3752)",
+    ].join("\n");
+    const summary = outputSummary("failed", vitest);
+    expect(summary).toContain("tests/monitor.test.ts");
+    expect(summary).toContain("renders one worker");
+    expect(summary.startsWith("failing: ")).toBe(true);
+  });
+
+  it("matches failure identities through ANSI colour codes", () => {
+    const coloured = "[31m FAIL [39m tests/a.test.ts > boom\nTests 1 failed";
+    expect(namedFailures(coloured)).toEqual(["FAIL tests/a.test.ts > boom"]);
+  });
+
+  it("names cargo failures too, deduped and capped", () => {
+    const cargo = [
+      "test net::sends ... FAILED",
+      "test net::sends ... FAILED",
+      ...Array.from({ length: 8 }, (_, i) => `test x::case_${i} ... FAILED`),
+      "test result: FAILED. 9 passed; 9 failed",
+    ].join("\n");
+    const named = namedFailures(cargo);
+    expect(named[0]).toBe("test net::sends ... FAILED");
+    expect(named.length).toBe(5);
+    expect(new Set(named).size).toBe(named.length);
+  });
+
+  it("falls back to the tail when the runner names nothing recognisable", () => {
+    // No invented identity: an unrecognised runner keeps the old honest behaviour.
+    expect(outputSummary("failed", "segfault\ncore dumped")).toBe("segfault core dumped");
+    expect(namedFailures("segfault\ncore dumped")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What was wrong

The AFK gate's validation park summary was built from the last 20 lines of the runner's captured output (`outputSummary` in `apps/dev/src/core/feedback.ts`). Test runners print their trailing counters last and the failing identities higher up, so the tail reliably captured `Tests 2 failed | 3750 passed` and reliably dropped the names.

Every validation park therefore told a reader **how many** checks broke and never **which** — the one fact they act on.

## What it cost, concretely

#1919 parked on `blocked:validation` with `scope: whole-workspace (trigger: apps/dev/src/core/history.ts)` and a summary that ended in the counters. Recovering the two identities took: two wrong guesses at the failing file, a throwaway PR (#1954), and a full CI round-trip — to ask GitHub for information the gate already had in hand and threw away. CI then named it immediately: two `apps/dev/tests/monitor.test.ts` assertions.

## The fix

Scan the whole output for lines that name a failing check, and lead the summary with them:

- Vitest `FAIL <file> > <suite> > <test>` rows, cargo `<name> ... FAILED` rows and `---- <name> stdout ----` banners.
- ANSI-stripped first, since runners colour their FAIL markers and `^\s*FAIL\b` never matches `\x1b[31m FAIL \x1b[0m`.
- Deduped, first-seen order, capped at 5 — dozens of failures is a systemic break, not a list to read line by line.
- The 1000-char cap applies **last**, so a verbose tail cannot crowd the identities out.
- When a runner names nothing recognisable, the tail-only summary stays as the fallback. No invented identities.

## Verification

`feedback.test.ts` 47/47, and the 6 test files that assert validation summaries (envelope-emit, quarantine, dashboard, monitor, afk-resilience, review) pass 160/160. `apps/dev` typecheck clean. The new regression test replays the verbatim vitest output shape that parked #1919 and asserts the summary names `tests/monitor.test.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786865095&installation_id=129708444&pr_number=1956&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1956&signature=7340b1672b75730a97e2dfbc99fbac078b1f2a19904b9ee6be47e49024740e15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->