### PR TITLE
fix: #1957 /go: Make two RedSkills statusline segments more compact in apps/dev/src/core

### DIFF
--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -489,11 +489,11 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   const busy = Math.max(0, Math.floor(fleet.busy));
   const total = Math.max(0, Math.floor(fleet.total));
   const queue = Math.max(0, Math.floor(fleet.queue));
-  const parts = [`flt=${runner} ${busy}/${total} busy`, `q=${queue}`];
+  const parts = [`flt=${runner} ${busy}/${total}`, `q=${queue}`];
   if (fleet.parked !== undefined && fleet.parked > 0) {
-    parts.push(`park=${Math.floor(fleet.parked)}`);
+    parts.push(`prk=${Math.floor(fleet.parked)}`);
   }
-  return parts.join(" · ");
+  return parts.join(" ");
 }
 
 export function renderUnlandedDocsBlock(docs: DocsInput | undefined): string | null {
@@ -504,12 +504,7 @@ export function renderUnlandedDocsBlock(docs: DocsInput | undefined): string | n
 export function renderRspBlock(rsp: RspStatusInput | undefined): string | null {
   if (!rsp) return null;
   if (rsp.state === "ready") {
-    const decisions =
-      rsp.decisions && Number.isFinite(rsp.decisions.seen) && rsp.decisions.seen > 0
-        ? ` int=${Math.max(0, Math.floor(rsp.decisions.contributed))}/${Math.floor(rsp.decisions.seen)}`
-        : "";
-    const hitRate = typeof rsp.showHitRate === "number" ? ` hit=${Math.round(rsp.showHitRate * 100)}%` : "";
-    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}${decisions}${hitRate}`;
+    return `rsp=↓${formatRspTickerValue(rsp.tokensSavedToday)}`;
   }
   if (rsp.state === "warming") return "rsp=…";
   return "rsp=!";

--- a/apps/dev/tests/castle-acceptance-harness.test.ts
+++ b/apps/dev/tests/castle-acceptance-harness.test.ts
@@ -268,7 +268,7 @@ describe("castle acceptance harness", () => {
         sourceCounts: [{ origin: "afk", count: 2 }],
       },
     });
-    expect(statusline).toContain("flt=codex 2/2 busy");
+    expect(statusline).toContain("flt=codex 2/2");
     expect(statusline).toContain("wrk=2");
     expect(statusline).toContain("#1917·validating");
 

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -651,7 +651,7 @@ describe("statusline command — rendered line", () => {
 
     const rows = stripAnsi(out.text()).trimEnd().split("\n");
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toContain("flt=codex 1/1 busy");
+    expect(rows[0]).toContain("flt=codex 1/1");
     expect(rows[0]).toContain("q=2");
     expect(rows[0]).not.toContain("wrk=");
   });
@@ -690,7 +690,7 @@ describe("statusline command — rendered line", () => {
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("park=1");
+    expect(stripAnsi(out.text())).toContain("prk=1");
   });
 
   it("renders only the project block outside Claude Code (empty stdin)", async () => {
@@ -788,7 +788,7 @@ describe("statusline command — rendered line", () => {
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
-    expect(stripAnsi(out.text())).toContain("rsp=↓1.32M int=0/12");
+    expect(stripAnsi(out.text())).toContain("rsp=↓1.32M");
   });
 
   it("reads a TOON rsp resident summary for statusline rendering", async () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -343,7 +343,13 @@ describe("statusline — repo block", () => {
 describe("statusline — fleet block", () => {
   it("renders runner, busy/total occupancy, queue depth, and parked slots", () => {
     expect(renderFleetBlock({ runner: "codex", busy: 1, total: 2, queue: 7, parked: 1 })).toBe(
-      "flt=codex 1/2 busy · q=7 · park=1",
+      "flt=codex 1/2 q=7 prk=1",
+    );
+  });
+
+  it("omits the parked part when fleet.parked is zero", () => {
+    expect(renderFleetBlock({ runner: "codex", busy: 0, total: 3, queue: 0 })).toBe(
+      "flt=codex 0/3 q=0",
     );
   });
 });
@@ -561,7 +567,7 @@ describe("statusline — full assembly", () => {
     })).toBe("red-skills (main) · rsp=↓2.0k");
   });
 
-  it("renders rsp decisions contribution as contributed/seen when cached lane data exists", () => {
+  it("omits the decisions suffix regardless of cached lane data", () => {
     const input: StatuslineInput = {
       project: { basename: "red-skills", branch: "main" },
       rsp: {
@@ -570,19 +576,8 @@ describe("statusline — full assembly", () => {
         decisions: { contributed: 8, seen: 10 },
       },
     };
-    expect(renderStatusline(input)).toBe("red-skills (main) · rsp=↓1.2k int=8/10");
-    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp=↓1.2k int=8/10");
-  });
-
-  it("renders zero rsp decisions contribution as a visible zero-over-seen signal", () => {
-    expect(renderStatusline({
-      project: { basename: "red-skills", branch: "main" },
-      rsp: {
-        state: "ready",
-        tokensSavedToday: 1200,
-        decisions: { contributed: 0, seen: 12 },
-      },
-    })).toBe("red-skills (main) · rsp=↓1.2k int=0/12");
+    expect(renderStatusline(input)).toBe("red-skills (main) · rsp=↓1.2k");
+    expect(renderStatuslineWithPreset(input, "short")).toBe("red-skills (main) · rsp=↓1.2k");
   });
 
   it("omits rsp decisions contribution when the cached decisions lane is missing", () => {


### PR DESCRIPTION
Automated AFK landing for #1957. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1957

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786880550&installation_id=129708444&pr_number=1958&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1958&signature=3e82be8e73d2362310ad24d760d3a5a15c02b9a3990e33aa51ad02d96fb61583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->