### PR TITLE
fix: #1960 Fleet bundle version is invisible: a supervisor can silently drain on a stale engine across releases

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -16,13 +16,13 @@
 // `.workspace.project_dir` (the fixed session root — survives `cd` into subdirs),
 // else `.workspace.current_dir // .cwd`, else `process.cwd()`.
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
-import { homedir } from "node:os";
 import { configFile } from "@reddb-io/shared/red-paths.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { decode } from "@reddb-io/toon";
 import { resolveBase } from "../core/base-resolver.js";
+import { newestCachedDevBundleVersion } from "../core/bundle-version.js";
 import { type ClaudeInput, type ProjectInput, type RspStatusInput, type StatuslinePreset } from "../core/statusline.js";
 import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
@@ -209,48 +209,6 @@ function dollarsSavedForCurrentDay(summary: RspSummaryFile, nowMs: number): numb
   return Math.max(0, summary.dollars_saved_today_usd);
 }
 
-function semverParts(version: string): [number, number, number] | null {
-  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(version.trim());
-  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
-}
-
-function compareSemver(a: string, b: string): number {
-  const pa = semverParts(a);
-  const pb = semverParts(b);
-  if (!pa || !pb) return 0;
-  return pa[0] - pb[0] || pa[1] - pb[1] || pa[2] - pb[2];
-}
-
-function redSkillsCacheDir(env: NodeJS.ProcessEnv = process.env): string {
-  if (env.RED_SKILLS_CACHE_DIR) return env.RED_SKILLS_CACHE_DIR;
-  if (env.XDG_CACHE_HOME) return join(env.XDG_CACHE_HOME, "red-skills", "bundles");
-  return join(homedir(), ".cache", "red-skills", "bundles");
-}
-
-function newestCachedDevBundleVersion(
-  installedVersion: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
-  const current = semverParts(installedVersion);
-  if (!current) return undefined;
-  const cacheDir = redSkillsCacheDir(env);
-  let best: string | undefined;
-  try {
-    for (const entry of readdirSync(cacheDir, { withFileTypes: true })) {
-      if (!entry.isFile()) continue;
-      const m = /^dev-(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?)\.bundle\.min\.mjs$/.exec(entry.name);
-      if (!m) continue;
-      const version = m[1];
-      if (semverParts(version) === null) continue;
-      if (compareSemver(version, installedVersion) <= 0) continue;
-      if (best === undefined || compareSemver(version, best) > 0) best = version;
-    }
-  } catch {
-    return undefined;
-  }
-  return best;
-}
-
 function decisionsFromSummary(summary: RspSummaryFile): Extract<RspStatusInput, { state: "ready" }>["decisions"] {
   const seen = summary.decisions?.seen;
   const contributed = summary.decisions?.contributed;
@@ -380,7 +338,7 @@ export async function statuslineCommand(
   // the per-worker records feed the themed multi-line form (Claude Code). Both
   // read the same worker states — cheap file reads — so the two forms stay in
   // sync while each renders its own layout.
-  const [repo, docs, afk, fleet, workers, rsp] = await Promise.all([
+  const [repo, docs, afk, rawFleet, workers, rsp] = await Promise.all([
     collectStatuslineRepo(repoCtx, cacheTtlS, repoLocBaseRef),
     collectStatuslineDocs(repoCtx, base),
     collectStatuslineAfk(repoCtx, cacheTtlS).then((a) => a ?? undefined),
@@ -388,6 +346,10 @@ export async function statuslineCommand(
     collectStatuslineWorkers(repoCtx),
     resolveStatuslineRsp(root),
   ]);
+  const fleet =
+    rawFleet && project.latestCachedVersion !== undefined && rawFleet.bundleVersion !== undefined
+      ? { ...rawFleet, latestBundleVersion: project.latestCachedVersion }
+      : rawFleet;
 
   // Theme on by default (the multi-line wine layout: a repo-global header line
   // then one line per live worker); honour NO_COLOR for plain consumers (the

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -9,6 +9,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, openSync, closeSync, readFileSync, writeFileSync, writeSync, rmSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { readBuildInfo } from "@reddb-io/build-info";
 import {
   type FleetHeartbeat,
   type ElasticResizeRequest,
@@ -68,6 +69,7 @@ function fleetHeartbeatState(hb: FleetHeartbeat): string {
       epoch: hb.epoch,
       last_progress_epoch: hb.lastProgressEpoch > 0 ? hb.lastProgressEpoch : undefined,
       runner: hb.runner,
+      bundle_version: hb.bundleVersion,
       ready_for_agent: hb.readyForAgent,
       slots: {
         busy: hb.slotsBusy,
@@ -356,6 +358,7 @@ function buildSupervisorDeps(
   hookEnvBase: Record<string, string>,
 ): SupervisorDeps {
   const bundle = process.argv[1];
+  const bundleVersion = readBuildInfo("dev").version;
   const now = () => Math.floor(Date.now() / 1000);
   // Per-tick / boot liveness line into afk-supervisor.log (best-effort). Shared
   // by `log` and the pre-spawn boot sweeps so both land in the supervisor log.
@@ -587,29 +590,31 @@ function buildSupervisorDeps(
       });
     },
     emitFleetHeartbeat: async (hb) => {
+      const stamped = { ...hb, bundleVersion };
       try {
-        writeFleetStateAtomic(statePath, hb);
+        writeFleetStateAtomic(statePath, stamped);
       } catch {
         // best-effort: state-file failure must not affect the supervisor.
       }
       try {
-        await appendRecordToonlRow(firehosePath, "heartbeat", fleetHeartbeatMessage(hb), {
-          ts: hb.ts,
+        await appendRecordToonlRow(firehosePath, "heartbeat", fleetHeartbeatMessage(stamped), {
+          ts: stamped.ts,
           fields: {
             worker: "fleet",
             extra: {
               scope: "fleet",
-              runner: hb.runner,
-              ready_for_agent: String(hb.readyForAgent),
-              slots_busy: String(hb.slotsBusy),
-              slots_free: String(hb.slotsFree),
-              slots_total: String(hb.slotsTotal),
-              slots_parked: String(hb.slotsParked),
-              spawns_this_tick: String(hb.spawnsThisTick),
-              drain_budget_tier: hb.drainBudget?.tier ?? null,
-              drain_budget_spent_usd: hb.drainBudget?.spentUsd.toFixed(4) ?? null,
-              drain_budget_limit_usd: hb.drainBudget?.limitUsd.toFixed(4) ?? null,
-              drain_budget_percent: hb.drainBudget ? (hb.drainBudget.percent * 100).toFixed(2) : null,
+              runner: stamped.runner,
+              bundle_version: stamped.bundleVersion ?? null,
+              ready_for_agent: String(stamped.readyForAgent),
+              slots_busy: String(stamped.slotsBusy),
+              slots_free: String(stamped.slotsFree),
+              slots_total: String(stamped.slotsTotal),
+              slots_parked: String(stamped.slotsParked),
+              spawns_this_tick: String(stamped.spawnsThisTick),
+              drain_budget_tier: stamped.drainBudget?.tier ?? null,
+              drain_budget_spent_usd: stamped.drainBudget?.spentUsd.toFixed(4) ?? null,
+              drain_budget_limit_usd: stamped.drainBudget?.limitUsd.toFixed(4) ?? null,
+              drain_budget_percent: stamped.drainBudget ? (stamped.drainBudget.percent * 100).toFixed(2) : null,
             },
           },
         });

--- a/apps/dev/src/core/bundle-version.ts
+++ b/apps/dev/src/core/bundle-version.ts
@@ -1,0 +1,45 @@
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function semverParts(version: string | undefined): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(version ?? "").trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+export function compareSemver(a: string | undefined, b: string | undefined): number {
+  const pa = semverParts(a);
+  const pb = semverParts(b);
+  if (!pa || !pb) return 0;
+  return pa[0] - pb[0] || pa[1] - pb[1] || pa[2] - pb[2];
+}
+
+export function redSkillsCacheDir(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.RED_SKILLS_CACHE_DIR) return env.RED_SKILLS_CACHE_DIR;
+  if (env.XDG_CACHE_HOME) return join(env.XDG_CACHE_HOME, "red-skills", "bundles");
+  return join(homedir(), ".cache", "red-skills", "bundles");
+}
+
+export function newestCachedDevBundleVersion(
+  installedVersion: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (!semverParts(installedVersion)) return undefined;
+  const cacheDir = redSkillsCacheDir(env);
+  let best: string | undefined;
+  try {
+    for (const entry of readdirSync(cacheDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const m = /^dev-(\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?)\.bundle\.min\.mjs$/.exec(entry.name);
+      if (!m) continue;
+      const version = m[1];
+      if (semverParts(version) === null) continue;
+      if (compareSemver(version, installedVersion) <= 0) continue;
+      if (best === undefined || compareSemver(version, best) > 0) best = version;
+    }
+  } catch {
+    return undefined;
+  }
+  return best;
+}
+

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -25,6 +25,8 @@
 // out of scope — the test asserts the plain/structural content exactly as
 // statusline.test.sh does after stripping escapes.
 
+import { compareSemver } from "./bundle-version.js";
+
 /** The block-1 project inputs: basename plus optional git ref. */
 export interface ProjectInput {
   /** `basename "$cwd"` — always present. */
@@ -170,6 +172,10 @@ export interface FleetInput {
   queue: number;
   /** Parked slots from the supervisor snapshot. */
   parked?: number;
+  /** Dev bundle version the running supervisor was launched from. */
+  bundleVersion?: string;
+  /** Newest compatible dev bundle seen in the local cache. */
+  latestBundleVersion?: string;
 }
 
 export type RspStatusInput =
@@ -300,18 +306,6 @@ export function formatCacheAge(ageS: number): string {
   const h = Math.floor(m / 60);
   const rm = m % 60;
   return rm > 0 ? `${h}h${rm}m` : `${h}h`;
-}
-
-function semverParts(version: string | undefined): [number, number, number] | null {
-  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(version ?? "").trim());
-  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
-}
-
-function compareSemver(a: string | undefined, b: string | undefined): number {
-  const pa = semverParts(a);
-  const pb = semverParts(b);
-  if (!pa || !pb) return 0;
-  return pa[0] - pb[0] || pa[1] - pb[1] || pa[2] - pb[2];
 }
 
 function hasCachedUpdate(project: ProjectInput): boolean {
@@ -489,7 +483,12 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   const busy = Math.max(0, Math.floor(fleet.busy));
   const total = Math.max(0, Math.floor(fleet.total));
   const queue = Math.max(0, Math.floor(fleet.queue));
-  const parts = [`flt=${runner} ${busy}/${total}`, `q=${queue}`];
+  const parts = [`flt=${runner} ${busy}/${total}`];
+  if (fleet.bundleVersion) {
+    const skew = compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0;
+    parts.push(`@${fleet.bundleVersion}${skew ? `<${fleet.latestBundleVersion}` : ""}`);
+  }
+  parts.push(`q=${queue}`);
   if (fleet.parked !== undefined && fleet.parked > 0) {
     parts.push(`prk=${Math.floor(fleet.parked)}`);
   }

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -71,6 +71,8 @@ export interface SupervisorConfig {
   /** Runner name carried in the discard / no-sentinel envelopes
    * (RED_AFK_RUNNER, default "claude"). */
   runner: string;
+  /** Dev bundle version the running supervisor was launched from. */
+  bundleVersion?: string;
   /** RED_AFK_POLL_S — seconds the health-check loop sleeps between ticks
    * (default 15, matching supervisor.sh). Prevents the loop from busy-spinning.
    * This is the interval used when NO event lane is wired (`deps.wake` absent) —
@@ -699,6 +701,8 @@ export interface FleetHeartbeat {
   /** Runner this fleet was launched with — lets the watchdog relaunch a recovered
    * supervisor with the same runner instead of re-detecting from its own tree. */
   runner: string;
+  /** Dev bundle version the running supervisor was launched from. */
+  bundleVersion?: string;
   readyForAgent: number;
   slotsBusy: number;
   slotsFree: number;

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -17,6 +17,7 @@ import { hostFingerprintPrefix } from "../core/host-identity.js";
 import * as rp from "@reddb-io/shared/red-paths.js";
 import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
+import { newestCachedDevBundleVersion } from "../core/bundle-version.js";
 import { resolveBase } from "../core/base-resolver.js";
 import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
@@ -581,6 +582,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     epoch?: unknown;
     last_progress_epoch?: unknown;
     runner?: unknown;
+    bundle_version?: unknown;
     ready_for_agent?: unknown;
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
     spawns_this_tick?: unknown;
@@ -611,6 +613,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     epoch,
     lastProgressEpoch: Number.isFinite(rawProgress) && rawProgress > 0 ? rawProgress : undefined,
     runner: typeof rec.runner === "string" ? rec.runner : "",
+    bundleVersion: typeof rec.bundle_version === "string" ? rec.bundle_version : undefined,
     readyForAgent: Number(rec.ready_for_agent ?? 0) || 0,
     slotsBusy: Number(rec.slots?.busy ?? 0) || 0,
     slotsFree: Number(rec.slots?.free ?? 0) || 0,
@@ -829,6 +832,9 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
     (await readFleetState(
       preferExistingPath(paths.fleetStatePath, legacyTmpPath(root, "afk-supervisor.state.json")),
     ));
+  if (fleet?.bundleVersion) {
+    fleet.latestBundleVersion = newestCachedDevBundleVersion(fleet.bundleVersion) ?? undefined;
+  }
 
   // Remote facts: read the statusline TTL cache passively (no refresh — the monitor
   // is read-only; the statusline owns the cache lifecycle). Include queue/human counts
@@ -1308,6 +1314,7 @@ export async function collectStatuslineFleet(
     total: state.slotsTotal,
     queue: state.readyForAgent,
     parked: state.slotsParked,
+    bundleVersion: state.bundleVersion,
   };
 }
 

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -369,6 +369,20 @@ describe("monitor — compact dashboard", () => {
       expect(decoded.fleet.ready).toBe(0);
     });
 
+    it("includes fleet bundle version and skew in the fleet status block", () => {
+      const out = renderCompactDashboardToon([], fixtureEvents, 1780138815, {
+        ...baseFleet(),
+        bundleVersion: "2.60.2",
+        latestBundleVersion: "2.61.0",
+      });
+      const decoded = decode(out) as {
+        fleet: { bundle_version: string; latest_bundle_version: string; version_skew: number };
+      };
+      expect(decoded.fleet.bundle_version).toBe("2.60.2");
+      expect(decoded.fleet.latest_bundle_version).toBe("2.61.0");
+      expect(decoded.fleet.version_skew).toBe(1);
+    });
+
     it("is materially cheaper than JSON for a typical multi-worker board (#995)", () => {
       // The token win is the whole point of TOON as the default agent-facing
       // render (#995): the worker table names its 20 columns ONCE, where JSON
@@ -387,6 +401,17 @@ describe("monitor — compact dashboard", () => {
     const out = renderCompactDashboard([], fixtureEvents, 1780138815, baseFleet());
     expect(out.split("\n")[1]).toBe(
       "fleet [idle] last ticked 00:00:15 ago  ready:0  slots busy:0 free:2 parked:0  spawns:0",
+    );
+  });
+
+  it("surfaces fleet bundle version skew on the plain fleet line", () => {
+    const out = renderCompactDashboard([], fixtureEvents, 1780138815, {
+      ...baseFleet(),
+      bundleVersion: "2.60.2",
+      latestBundleVersion: "2.61.0",
+    });
+    expect(out.split("\n")[1]).toBe(
+      "fleet [idle] last ticked 00:00:15 ago  ready:0  slots busy:0 free:2 parked:0  spawns:0  bundle:2.60.2<2.61.0",
     );
   });
 

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -54,6 +54,29 @@ describe("statusline — formatCacheAge", () => {
   });
 });
 
+describe("statusline — fleet block", () => {
+  it("renders the supervisor bundle version when present", () => {
+    expect(renderFleetBlock({
+      runner: "codex",
+      busy: 0,
+      total: 2,
+      queue: 4,
+      bundleVersion: "2.61.0",
+    })).toBe("flt=codex 0/2 @2.61.0 q=4");
+  });
+
+  it("marks fleet bundle skew against the latest cached bundle", () => {
+    expect(renderFleetBlock({
+      runner: "codex",
+      busy: 0,
+      total: 2,
+      queue: 4,
+      bundleVersion: "2.60.2",
+      latestBundleVersion: "2.61.0",
+    })).toBe("flt=codex 0/2 @2.60.2<2.61.0 q=4");
+  });
+});
+
 describe("statusline — humanizeAlive", () => {
   it("renders seconds when under one minute", () => {
     expect(humanizeAlive(30 * 1000)).toBe("30s");

--- a/packages/red-castle/src/engine/contracts/index.ts
+++ b/packages/red-castle/src/engine/contracts/index.ts
@@ -56,6 +56,7 @@ export interface CastleStateSnapshot {
   worker_id?: string;
   supervisor_id?: string;
   runner?: string;
+  bundle_version?: string;
   pid?: number;
   started_at?: string;
   current?: Record<string, unknown>;
@@ -159,6 +160,7 @@ export const CASTLE_PUBLISHED_CONTRACTS = [
       worker_id: true,
       supervisor_id: true,
       runner: true,
+      bundle_version: true,
       pid: true,
       started_at: true,
       current: true,

--- a/packages/red-castle/src/engine/monitor-readers.ts
+++ b/packages/red-castle/src/engine/monitor-readers.ts
@@ -245,6 +245,7 @@ function fleetFromSupervisorSnapshot(
     epoch,
     lastProgressEpoch: numberField(current, "last_progress_epoch") || undefined,
     runner: snapshot.runner ?? stringField(current, "runner"),
+    bundleVersion: snapshot.bundle_version ?? stringField(current, "bundle_version"),
     readyForAgent: numberField(
       current,
       "ready_for_agent",

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -15,6 +15,18 @@
 import { appendSummaryField, type JsonObject, type JsonValue as ToonValue } from "@reddb-io/toon";
 import type { LivenessVerdict } from "../LivenessEvaluator.js";
 
+function semverParts(version: string | undefined): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(String(version ?? "").trim());
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+function compareSemver(a: string | undefined, b: string | undefined): number {
+  const pa = semverParts(a);
+  const pb = semverParts(b);
+  if (!pa || !pb) return 0;
+  return pa[0] - pb[0] || pa[1] - pb[1] || pa[2] - pb[2];
+}
+
 export type HistoryEvent = "done" | "blocked" | "exhausted" | (string & {});
 
 export interface HistoryRecord {
@@ -205,6 +217,10 @@ export interface FleetState {
   lastProgressEpoch?: number;
   /** Runner the fleet was launched with (default "" for pre-#407 state files). */
   runner: string;
+  /** Dev bundle version the running supervisor was launched from. */
+  bundleVersion?: string;
+  /** Newest compatible dev bundle seen in the local cache. */
+  latestBundleVersion?: string;
   readyForAgent: number;
   slotsBusy: number;
   slotsFree: number;
@@ -247,11 +263,15 @@ export function renderFleetLine(fleet: FleetState, now: number): string {
     : fleet.readyForAgent === 0 && fleet.slotsBusy === 0
       ? "idle"
       : "draining";
+  const bundle = fleet.bundleVersion
+    ? `  bundle:${fleet.bundleVersion}${compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0 ? `<${fleet.latestBundleVersion}` : ""}`
+    : "";
   return (
     `fleet [${status}] last ticked ${formatElapsed(age)} ago` +
     `  ready:${fleet.readyForAgent}` +
     `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}` +
-    `  spawns:${fleet.spawnsThisTick}`
+    `  spawns:${fleet.spawnsThisTick}` +
+    bundle
   );
 }
 
@@ -614,6 +634,9 @@ export function renderCompactDashboardToon(
       slots_free: fleet.slotsFree,
       slots_parked: fleet.slotsParked,
       spawns: fleet.spawnsThisTick,
+      bundle_version: fleet.bundleVersion ?? "",
+      latest_bundle_version: fleet.latestBundleVersion ?? "",
+      version_skew: compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0 ? 1 : 0,
       slot_details: (fleet.slotDetails ?? []).map((d) => ({
         index: d.index,
         status: d.status,

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -22,6 +22,15 @@ Fleet mode is **runner-portable**: the supervisor is plain process orchestration
 - Codex: launch fleet with `RED_AFK_RUNNER=codex` and spawn one read-only Codex monitor agent from the bundle's `codex-monitor-agent --mode fleet` prompt when a sub-agent primitive is available. If no sub-agent primitive is available, launch fleet anyway and print `monitor loop unavailable in this runner; run /dev:afk monitor or tail .red/tmp/afk-supervisor.log manually.`
 - Bare terminal / unknown runner: launch fleet and print the manual-monitor guidance.
 
+**Release recycle rule.** A fleet supervisor keeps running the exact dev bundle
+version it was launched from. After any RedSkills release that changes AFK or
+castle engine behavior, stop and relaunch the fleet before starting or counting
+a proving drain; otherwise the drain may still be executing on the pre-release
+engine. `monitor` and the statusline fleet cell show the running bundle version
+and mark skew against a newer locally cached bundle so stale supervisors are
+visible. Automatic drain-and-respawn on version change is a future enhancement,
+not part of the current fleet contract.
+
 ### `/dev:afk fleet [N]` — launch
 
 `N` is optional and defaults to `2`. Parse it as a non-negative integer; reject anything else (including `stop`, which is the other subcommand and routes below). Steps the agent must perform, in order:


### PR DESCRIPTION
Automated AFK landing for #1960. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1960

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786882207&installation_id=129708444&pr_number=1962&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1962&signature=47064c6bf6aa6986fdbb2f9cdac5571a1c198e75df0354af532e3cc519790c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->