### PR TITLE
fix: #1959 Supervisor heartbeat writes can die silently while the tick loop survives, making a live fleet invisible

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
 import {
   type FleetHeartbeat,
+  type FleetHeartbeatEmitResult,
   type ElasticResizeRequest,
   initSupervisorState,
   resolveSupervisorConfig,
@@ -98,6 +99,10 @@ function writeFleetStateAtomic(path: string, hb: FleetHeartbeat): void {
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, fleetHeartbeatState(hb), "utf8");
   renameSync(tmp, path);
+}
+
+function heartbeatWriteError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 /**
@@ -589,12 +594,17 @@ function buildSupervisorDeps(
         log: logLine,
       });
     },
-    emitFleetHeartbeat: async (hb) => {
+    emitFleetHeartbeat: async (hb): Promise<FleetHeartbeatEmitResult> => {
       const stamped = { ...hb, bundleVersion };
+      let stateWritten = false;
+      let firehoseWritten = false;
+      let stateError: string | undefined;
+      let firehoseError: string | undefined;
       try {
         writeFleetStateAtomic(statePath, stamped);
-      } catch {
-        // best-effort: state-file failure must not affect the supervisor.
+        stateWritten = true;
+      } catch (err) {
+        stateError = heartbeatWriteError(err);
       }
       try {
         await appendRecordToonlRow(firehosePath, "heartbeat", fleetHeartbeatMessage(stamped), {
@@ -618,8 +628,24 @@ function buildSupervisorDeps(
             },
           },
         });
-      } catch {
-        // best-effort: firehose failure must not affect the supervisor.
+        firehoseWritten = true;
+      } catch (err) {
+        firehoseError = heartbeatWriteError(err);
+      }
+      return {
+        stateWritten,
+        firehoseWritten,
+        ...(stateError !== undefined ? { stateError } : {}),
+        ...(firehoseError !== undefined ? { firehoseError } : {}),
+      };
+    },
+    repairFleetHeartbeat: async (hb): Promise<FleetHeartbeatEmitResult> => {
+      const stamped = { ...hb, bundleVersion };
+      try {
+        writeFleetStateAtomic(statePath, stamped);
+        return { stateWritten: true };
+      } catch (err) {
+        return { stateWritten: false, stateError: heartbeatWriteError(err) };
       }
     },
   };

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -715,6 +715,17 @@ export interface FleetHeartbeat {
   slotDetails: HeartbeatSlotDetail[];
 }
 
+export interface FleetHeartbeatEmitResult {
+  /** The freshness-critical state file was written successfully. */
+  stateWritten: boolean;
+  /** The human/debug firehose record was appended successfully. */
+  firehoseWritten?: boolean;
+  /** Short diagnostic for the most recent state write failure. */
+  stateError?: string;
+  /** Short diagnostic for the most recent firehose write failure. */
+  firehoseError?: string;
+}
+
 /** The slot's current iteration, resolved from the filesystem. Mirrors the
  * fields reap_stalled_slot pulls out of afk.state.json. */
 export interface IterDirInfo {
@@ -786,7 +797,15 @@ export interface SupervisorDeps {
    * writes it to the supervisor firehose and state file. Best-effort; never
    * throws out of the loop.
    */
-  emitFleetHeartbeat?(heartbeat: FleetHeartbeat): void | Promise<void>;
+  emitFleetHeartbeat?(heartbeat: FleetHeartbeat): FleetHeartbeatEmitResult | void | Promise<FleetHeartbeatEmitResult | void>;
+  /**
+   * Synchronous-with-the-tick repair path for a stale supervisor state writer.
+   * Called only after multiple consecutive state-write failures have made the
+   * last successful state snapshot older than the live tick loop. The CLI writes
+   * the current tick snapshot directly to the state file again and reports
+   * whether that repair landed.
+   */
+  repairFleetHeartbeat?(heartbeat: FleetHeartbeat): FleetHeartbeatEmitResult | void | Promise<FleetHeartbeatEmitResult | void>;
   /**
    * Run the shared boot sweeps ONCE before the initial fleet spawn (#623). The
    * fleet supervisor owns the boot: it runs orphan cleanup / attempt cap /
@@ -926,6 +945,10 @@ export interface SupervisorState {
   drainBudgetHardStopped: boolean;
   /** Last budget tier logged, to avoid repeating unchanged OK/WARNING/CRITICAL. */
   lastDrainBudgetTier?: DrainBudgetTier;
+  /** Epoch seconds of the last successful supervisor state heartbeat write. */
+  lastHeartbeatStateWriteEpoch: number;
+  /** Consecutive ticks whose state heartbeat write did not land. */
+  heartbeatStateWriteMisses: number;
 }
 
 /** Build the initial runtime for `target` slots. */
@@ -936,6 +959,8 @@ export function initSupervisorState(target: number): SupervisorState {
     lastUnblockSweepEpoch: 0,
     wakeStats: freshWakeStats(),
     drainBudgetHardStopped: false,
+    lastHeartbeatStateWriteEpoch: 0,
+    heartbeatStateWriteMisses: 0,
   };
 }
 
@@ -1152,6 +1177,8 @@ function isoFromEpoch(epoch: number): string {
   return new Date(epoch * 1000).toISOString();
 }
 
+export const HEARTBEAT_STATE_REPAIR_AFTER_TICKS = 2;
+
 function buildSlotDetails(
   state: SupervisorState,
   config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS">,
@@ -1180,7 +1207,7 @@ async function emitFleetHeartbeat(
   result: TickResult,
   runner: string,
   config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS">,
-): Promise<FleetHeartbeat> {
+): Promise<{ heartbeat: FleetHeartbeat; write: FleetHeartbeatEmitResult }> {
   // Queue depth was fetched once by superviseTick at the start of this tick
   // and stored in result.queueDepth — reuse it here so there is exactly one
   // readyQueueDepth call per tick (0 on a stop tick or abandoned tick).
@@ -1197,12 +1224,64 @@ async function emitFleetHeartbeat(
     ...(result.drainBudget ? { drainBudget: result.drainBudget } : {}),
     slotDetails: buildSlotDetails(state, config),
   };
+  let rawWrite: FleetHeartbeatEmitResult | void = undefined;
   try {
-    await deps.emitFleetHeartbeat?.(heartbeat);
+    rawWrite = await deps.emitFleetHeartbeat?.(heartbeat);
   } catch {
     // best-effort: heartbeat IO must never affect supervisor scheduling.
   }
-  return heartbeat;
+  return {
+    heartbeat,
+    write: rawWrite ?? { stateWritten: true, firehoseWritten: true },
+  };
+}
+
+function shortError(message: string | undefined): string {
+  return message && message.length > 0 ? ` error=${message}` : "";
+}
+
+async function superviseHeartbeatStateWrite(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  heartbeat: FleetHeartbeat,
+  write: FleetHeartbeatEmitResult,
+): Promise<void> {
+  if (write.stateWritten) {
+    state.lastHeartbeatStateWriteEpoch = heartbeat.epoch;
+    state.heartbeatStateWriteMisses = 0;
+    return;
+  }
+
+  state.heartbeatStateWriteMisses += 1;
+  if (state.heartbeatStateWriteMisses < HEARTBEAT_STATE_REPAIR_AFTER_TICKS) return;
+
+  const staleForS =
+    state.lastHeartbeatStateWriteEpoch > 0
+      ? heartbeat.epoch - state.lastHeartbeatStateWriteEpoch
+      : heartbeat.epoch;
+  deps.log?.(
+    `heartbeat state writer stale: misses=${state.heartbeatStateWriteMisses} ` +
+      `stale_for_s=${staleForS}${shortError(write.stateError)}; rewriting current tick snapshot`,
+  );
+
+  let repair: FleetHeartbeatEmitResult | void;
+  try {
+    repair = await deps.repairFleetHeartbeat?.(heartbeat);
+  } catch (err) {
+    deps.log?.(`heartbeat state repair threw: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  if (repair?.stateWritten) {
+    state.lastHeartbeatStateWriteEpoch = heartbeat.epoch;
+    state.heartbeatStateWriteMisses = 0;
+    deps.log?.(`heartbeat state repair wrote epoch=${heartbeat.epoch}`);
+  } else {
+    deps.log?.(
+      `heartbeat state repair failed: misses=${state.heartbeatStateWriteMisses}` +
+        shortError(repair?.stateError),
+    );
+  }
 }
 
 /**
@@ -2359,7 +2438,8 @@ export async function runSupervisor(
     if (!result.abandoned) {
       state.lastProgressEpoch = deps.now();
     }
-    const heartbeat = await emitFleetHeartbeat(state, deps, result, config.runner, config);
+    const { heartbeat, write } = await emitFleetHeartbeat(state, deps, result, config.runner, config);
+    await superviseHeartbeatStateWrite(state, deps, heartbeat, write);
     deps.log?.(
       `tick: slots=${state.slots.length} respawned=${result.respawned.length} ` +
         `deaths=${result.deaths.length} parked=${result.parked.length} idle-parked=${result.idleParked.length} ` +

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -121,6 +121,7 @@ interface FakeIo {
   findReconcileCandidate: ReturnType<typeof vi.fn>;
   crashedClaimState: ReturnType<typeof vi.fn>;
   emitFleetHeartbeat: ReturnType<typeof vi.fn>;
+  repairFleetHeartbeat: ReturnType<typeof vi.fn>;
   unblockSweep: ReturnType<typeof vi.fn>;
   fleetCostUsd: ReturnType<typeof vi.fn>;
   resizeRequest: ReturnType<typeof vi.fn>;
@@ -167,6 +168,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     // Default: no stranded claim → reconcile is a no-op (existing tests unaffected).
     crashedClaimState: vi.fn(async () => ({ ghOk: true, stillRunning: false, envelopePosted: false })),
     emitFleetHeartbeat: vi.fn(async () => {}),
+    repairFleetHeartbeat: vi.fn(async () => ({ stateWritten: true })),
     unblockSweep: vi.fn(async (): Promise<number[]> => []),
     fleetCostUsd: vi.fn(() => 0),
     resizeRequest: vi.fn(async () => null),
@@ -208,6 +210,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
       io.logLines.push(line);
     },
     emitFleetHeartbeat: io.emitFleetHeartbeat,
+    repairFleetHeartbeat: io.repairFleetHeartbeat,
     unblockSweep: io.unblockSweep,
     attemptBranchHead: io.attemptBranchHead,
     resizeRequest: io.resizeRequest,
@@ -1612,6 +1615,36 @@ describe("runSupervisor", () => {
       readyForAgent: 0,
       spawnsThisTick: 0,
     });
+  });
+
+  it("repairs a stale state heartbeat writer from the current tick snapshot", async () => {
+    let clock = NOW;
+    let probes = 0;
+    const stop = () => {
+      probes += 1;
+      clock = NOW + probes * 15;
+      return probes >= 3;
+    };
+    const { deps, io } = makeDeps({
+      now: vi.fn(() => clock),
+      emitFleetHeartbeat: vi.fn(async () => ({
+        stateWritten: false,
+        firehoseWritten: true,
+        stateError: "simulated state write failure",
+      })),
+      repairFleetHeartbeat: vi.fn(async () => ({ stateWritten: true })),
+    });
+    const state = initSupervisorState(1);
+
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15 }), stop);
+
+    expect(io.repairFleetHeartbeat).toHaveBeenCalledTimes(1);
+    expect(io.repairFleetHeartbeat.mock.calls[0]![0]).toMatchObject({
+      epoch: NOW + 30,
+      readyForAgent: 0,
+      slotsBusy: 1,
+    });
+    expect(io.logLines.some((line) => line.includes("heartbeat state writer stale"))).toBe(true);
   });
 
   it("does not report a cleanly exited worker pid as busy in the heartbeat", async () => {


### PR DESCRIPTION
Automated AFK landing for #1959. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1959

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786882980&installation_id=129708444&pr_number=1964&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1964&signature=f749704dc03eadb281ebb17f734d264267c0dcfc129e28c803c116529a4bed92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->