### PR TITLE
feat: #1975 Quota-free polling: ETag conditional requests across the rsp gh surface and rsp wait

### DIFF
--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -58,6 +58,10 @@ function runGh(ctx: GhContext, args: readonly string[]): Promise<ExecOutput> {
   return (ctx.exec ?? execTool)("gh", args, opts(ctx));
 }
 
+function runRsp(ctx: GhContext, args: readonly string[]): Promise<ExecOutput> {
+  return (ctx.exec ?? execTool)("rsp", args, opts(ctx));
+}
+
 function repoArgs(ctx: GhContext): string[] {
   return ctx.repo ? ["--repo", ctx.repo] : [];
 }
@@ -119,6 +123,13 @@ export async function ghAuthenticated(ctx: GhContext): Promise<boolean> {
  * `lane:go` label so its dedicated worker sees only the minted disposable issue
  * and the fleet never does. */
 export async function listCandidates(ctx: GhContext, label: string = LABEL_READY): Promise<IssueCandidate[]> {
+  const cached = await listIssuesViaRsp(ctx, label, "200");
+  if (cached) return cached.map((item): IssueCandidate => ({
+    number: item.number,
+    title: item.title,
+    body: item.body,
+    labels: item.labels,
+  }));
   const r = await runGh(ctx,
     [
       "issue",
@@ -975,9 +986,68 @@ function statuslineSearchQuery(repo: string, label: string): string {
   return `repo:${repo} is:issue is:open label:"${label}"`;
 }
 
+interface RspIssueListItem {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+async function listIssuesViaRsp(ctx: GhContext, label: string, limit: string): Promise<RspIssueListItem[] | null> {
+  const r = await runRsp(ctx, [
+    "gh-api-json",
+    "repos/{owner}/{repo}/issues",
+    "-f",
+    "state=open",
+    "-f",
+    `labels=${label}`,
+    "-f",
+    `per_page=${limit}`,
+  ]);
+  if (r.code !== 0) return null;
+  try {
+    const raw = JSON.parse(r.stdout || "[]") as unknown;
+    if (!Array.isArray(raw)) return null;
+    return raw.filter((row) => isRecord(row) && !isRecord(row.pull_request)).map((row) => ({
+      number: Number(row.number ?? 0),
+      title: String(row.title ?? ""),
+      body: String(row.body ?? ""),
+      labels: Array.isArray(row.labels)
+        ? row.labels.map((item: unknown) => isRecord(item) ? String(item.name ?? "") : "").filter(Boolean)
+        : [],
+    }));
+  } catch {
+    return null;
+  }
+}
+
+async function countSearchViaRsp(ctx: GhContext, query: string): Promise<number | null> {
+  const r = await runRsp(ctx, [
+    "gh-api-json",
+    "search/issues",
+    "-f",
+    `q=${query}`,
+    "-f",
+    "per_page=1",
+  ]);
+  if (r.code !== 0) return null;
+  try {
+    const parsed = JSON.parse(r.stdout || "{}") as unknown;
+    if (!isRecord(parsed)) return null;
+    return typeof parsed.total_count === "number" ? parsed.total_count : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Count both statusline queue buckets with one GraphQL search request. */
 export async function countStatuslineQueueCounts(ctx: GhContext): Promise<StatuslineQueueCounts> {
   if (!ctx.repo) return { queue: 0, human: 0 };
+  const [queue, human] = await Promise.all([
+    countSearchViaRsp(ctx, statuslineSearchQuery(ctx.repo, LABEL_READY)),
+    countSearchViaRsp(ctx, statuslineSearchQuery(ctx.repo, LABEL_HUMAN)),
+  ]);
+  if (queue != null && human != null) return { queue, human };
   const query = `
     query($ready: String!, $human: String!) {
       ready: search(type: ISSUE, query: $ready) { issueCount }
@@ -1250,6 +1320,10 @@ async function listIssuesByLabel(ctx: GhContext, label: string): Promise<Reconci
   } catch {
     return [];
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/apps/dev/tests/gh-go.test.ts
+++ b/apps/dev/tests/gh-go.test.ts
@@ -50,7 +50,8 @@ describe("listCandidates lane", () => {
     const rec = recording("[]");
     const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec: rec.exec };
     await listCandidates(ctx);
-    expect(rec.calls[0]!.args).toContain("ready-for-agent");
+    expect(rec.calls[0]!.cmd).toBe("rsp");
+    expect(rec.calls[0]!.args).toContain("labels=ready-for-agent");
   });
 
   it("lists the given lane label when /go passes one", async () => {
@@ -58,7 +59,8 @@ describe("listCandidates lane", () => {
     const ctx: GhContext = { cwd: "/r", repo: "acme/widgets", exec: rec.exec };
     await listCandidates(ctx, "lane:go");
     const args = rec.calls[0]!.args;
-    expect(args).toContain("lane:go");
-    expect(args).not.toContain("ready-for-agent");
+    expect(rec.calls[0]!.cmd).toBe("rsp");
+    expect(args).toContain("labels=lane:go");
+    expect(args).not.toContain("labels=ready-for-agent");
   });
 });

--- a/apps/dev/tests/gh-statusline-counts.test.ts
+++ b/apps/dev/tests/gh-statusline-counts.test.ts
@@ -3,6 +3,28 @@ import { countStatuslineQueueCounts, countPrsCreatedToday } from "../src/runtime
 import type { ExecFn } from "../src/runtime/exec.js";
 
 describe("gh statusline counts", () => {
+  it("prefers rsp conditional REST search counts when available", async () => {
+    const calls: Array<{ tool: string; args: readonly string[] }> = [];
+    const exec: ExecFn = async (tool, args) => {
+      calls.push({ tool, args });
+      const query = args.find((arg) => String(arg).startsWith("q="));
+      return {
+        code: 0,
+        stdout: JSON.stringify({ total_count: String(query).includes("ready-for-human") ? 2 : 7 }),
+        stderr: "",
+      };
+    };
+
+    const counts = await countStatuslineQueueCounts({ cwd: "/repo", repo: "o/r", exec });
+
+    expect(counts).toEqual({ queue: 7, human: 2 });
+    expect(calls).toHaveLength(2);
+    expect(calls.every((call) => call.tool === "rsp")).toBe(true);
+    expect(calls[0]!.args.slice(0, 2)).toEqual(["gh-api-json", "search/issues"]);
+    expect(calls[0]!.args).toContain('q=repo:o/r is:issue is:open label:"ready-for-agent"');
+    expect(calls[1]!.args).toContain('q=repo:o/r is:issue is:open label:"ready-for-human"');
+  });
+
   it("fetches ready and human counts with one GraphQL request", async () => {
     const calls: Array<{ tool: string; args: readonly string[] }> = [];
     const exec: ExecFn = async (tool, args) => {
@@ -17,13 +39,15 @@ describe("gh statusline counts", () => {
     const counts = await countStatuslineQueueCounts({ cwd: "/repo", repo: "o/r", exec });
 
     expect(counts).toEqual({ queue: 7, human: 2 });
-    expect(calls).toHaveLength(1);
-    expect(calls[0]!.tool).toBe("gh");
-    expect(calls[0]!.args.slice(0, 2)).toEqual(["api", "graphql"]);
-    expect(calls[0]!.args.join(" ")).toContain("ready: search");
-    expect(calls[0]!.args.join(" ")).toContain("human: search");
-    expect(calls[0]!.args).toContain('ready=repo:o/r is:issue is:open label:"ready-for-agent"');
-    expect(calls[0]!.args).toContain('human=repo:o/r is:issue is:open label:"ready-for-human"');
+    expect(calls).toHaveLength(3);
+    expect(calls[0]!.tool).toBe("rsp");
+    expect(calls[1]!.tool).toBe("rsp");
+    expect(calls[2]!.tool).toBe("gh");
+    expect(calls[2]!.args.slice(0, 2)).toEqual(["api", "graphql"]);
+    expect(calls[2]!.args.join(" ")).toContain("ready: search");
+    expect(calls[2]!.args.join(" ")).toContain("human: search");
+    expect(calls[2]!.args).toContain('ready=repo:o/r is:issue is:open label:"ready-for-agent"');
+    expect(calls[2]!.args).toContain('human=repo:o/r is:issue is:open label:"ready-for-human"');
   });
 });
 

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -158,6 +158,24 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     process.stdout.write(`${encodeSnapshotToon(status as unknown as JsonObject)}\n`);
     return 0;
   }
+  if (args.command === "gh-api-json") {
+    const { readGhConditionalJson } = await import("./gh-conditional.js");
+    const request = parseGhApiJsonArgs(args.positional);
+    if (!request) {
+      process.stderr.write("usage: rsp gh-api-json <path> [-f name=value ...]\n");
+      return 2;
+    }
+    const response = await readGhConditionalJson({
+      path: request.path,
+      params: request.params,
+      cwd: process.cwd(),
+      telemetryRoot: residentPaths.rootDir,
+      command: `rsp ${args.positional.join(" ")}`,
+    });
+    process.stdout.write(response.stdout);
+    if (response.stderr) process.stderr.write(`${response.stderr}\n`);
+    return response.status;
+  }
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
     if (wrapperCommand) return await runColdWrappedCommand(args, config, residentPaths.rootDir);
     process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
@@ -872,7 +890,7 @@ function rspDisabledReason(): string {
 
 function isWrapperCommand(command: string | undefined): boolean {
   return command === "git" || command === "gh" || command === "vitest" || command === "cargo" || command === "cat" ||
-    command === "exec" || command === "proxy";
+    command === "exec" || command === "proxy" || command === "gh-api-json";
 }
 
 async function passthrough(argv: readonly string[]): Promise<number> {
@@ -965,6 +983,21 @@ function parseArgs(argv: string[]): ParsedArgs {
   return out;
 }
 
+function parseGhApiJsonArgs(argv: readonly string[]): { path: string; params: Record<string, string> } | null {
+  const path = argv[1];
+  if (!path) return null;
+  const params: Record<string, string> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg !== "-f" && arg !== "-F") continue;
+    const assignment = argv[++i] ?? "";
+    const separator = assignment.indexOf("=");
+    if (separator <= 0) continue;
+    params[assignment.slice(0, separator)] = assignment.slice(separator + 1);
+  }
+  return { path, params };
+}
+
 function sinceDays(args: readonly string[], fallback: number): number {
   const raw = valueAfter(args, "--since") ?? args.find((arg) => arg.startsWith("--since="))?.slice("--since=".length);
   if (!raw) return fallback;
@@ -1029,6 +1062,7 @@ function renderStats(
     `  contributed: ${telemetry.decisions.contributed}`,
     `  passed: ${telemetry.decisions.passed}`,
     `  failed_open: ${telemetry.decisions.failed_open}`,
+    `  quota_free_saved_units: ${telemetry.decisions.quota_free_saved_units}`,
     `  contribution_rate: ${formatRate(telemetry.decisions.contribution_rate)}`,
     "  top_pass_reasons:",
     ...renderReasons(telemetry.decisions.top_pass_reasons.slice(0, full ? 10 : 3)),
@@ -1135,6 +1169,7 @@ function emptyTelemetryStats(windowDays: number): RspTelemetryStats {
       contributed: 0,
       passed: 0,
       failed_open: 0,
+      quota_free_saved_units: 0,
       contribution_rate: 0,
       top_pass_reasons: [],
     },

--- a/apps/rsp/src/gh-conditional.ts
+++ b/apps/rsp/src/gh-conditional.ts
@@ -1,0 +1,208 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { rspStateDir } from "@reddb-io/shared/red-paths.js";
+import { appendTelemetryEvent, RSP_DECISIONS_COLLECTION } from "./telemetry.js";
+
+export interface GhConditionalRequest {
+  path: string;
+  params?: Record<string, string | number | boolean | undefined>;
+  cwd?: string;
+  telemetryRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  command?: string;
+}
+
+export interface GhConditionalResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  etag?: string;
+  quotaFree: boolean;
+}
+
+interface GhEtagCacheDocument {
+  version: 1;
+  entries: Record<string, GhEtagCacheEntry>;
+}
+
+interface GhEtagCacheEntry {
+  key: string;
+  request: string;
+  etag: string;
+  body: string;
+  updated_at: string;
+}
+
+const CACHE_FILE = "gh-etag-cache.json";
+
+export async function readGhConditionalJson(request: GhConditionalRequest): Promise<GhConditionalResult> {
+  const cwd = request.cwd ?? process.cwd();
+  const telemetryRoot = request.telemetryRoot ?? cwd;
+  const identity = requestIdentity(request.path, request.params);
+  const key = cacheKey(identity);
+  const cache = await readCache(telemetryRoot);
+  const cached = cache.entries[key];
+  const args = ["api", "--include", "--method", "GET", request.path];
+  for (const [name, value] of sortedParams(request.params)) {
+    args.push("-f", `${name}=${String(value)}`);
+  }
+  if (cached?.etag) args.push("-H", `If-None-Match: ${cached.etag}`);
+
+  const result = await runGh(args, cwd, request.env);
+  const parsed = parseIncludedResponse(result.stdout);
+  const quotaFree = parsed.statusCode === 304 && !!cached;
+  if (quotaFree) {
+    await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, true);
+    return {
+      status: 0,
+      stdout: cached.body,
+      stderr: result.stderr,
+      etag: cached.etag,
+      quotaFree: true,
+    };
+  }
+
+  if (parsed.statusCode >= 200 && parsed.statusCode < 300) {
+    const etag = parsed.headers.get("etag");
+    if (etag) {
+      cache.entries[key] = {
+        key,
+        request: identity,
+        etag,
+        body: parsed.body,
+        updated_at: new Date().toISOString(),
+      };
+      await writeCache(telemetryRoot, cache);
+    }
+    await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, false);
+    return {
+      status: result.status,
+      stdout: parsed.body,
+      stderr: result.stderr,
+      etag: etag ?? undefined,
+      quotaFree: false,
+    };
+  }
+
+  await recordConditionalTelemetry(telemetryRoot, request.command ?? `gh api ${request.path}`, false);
+  return {
+    status: result.status,
+    stdout: parsed.body || result.stdout,
+    stderr: result.stderr,
+    quotaFree: false,
+  };
+}
+
+function sortedParams(params: GhConditionalRequest["params"]): Array<[string, string | number | boolean]> {
+  return Object.entries(params ?? {})
+    .filter((entry): entry is [string, string | number | boolean] => entry[1] !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+}
+
+function requestIdentity(path: string, params: GhConditionalRequest["params"]): string {
+  return JSON.stringify({ method: "GET", path, params: sortedParams(params) });
+}
+
+function cacheKey(identity: string): string {
+  return createHash("sha256").update(`rsp-gh-etag-v1\0${identity}`).digest("hex");
+}
+
+async function runGh(args: readonly string[], cwd: string, env?: NodeJS.ProcessEnv): Promise<{ status: number; stdout: string; stderr: string }> {
+  return await new Promise((resolveResult) => {
+    const child = spawn("gh", args, {
+      cwd,
+      env: env ? { ...process.env, ...env } : process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+    child.once("error", (err) => resolveResult({ status: 1, stdout: "", stderr: err.message }));
+    child.once("close", (status) => {
+      resolveResult({
+        status: status ?? 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8").trim(),
+      });
+    });
+  });
+}
+
+function parseIncludedResponse(raw: string): { statusCode: number; headers: Map<string, string>; body: string } {
+  const normalized = raw.replace(/\r\n/g, "\n");
+  const matches = [...normalized.matchAll(/^HTTP\/\S+\s+(\d{3})[^\n]*\n/gm)];
+  if (matches.length === 0) return { statusCode: 0, headers: new Map(), body: raw };
+  const last = matches[matches.length - 1]!;
+  const statusCode = Number(last[1]);
+  const headerStart = last.index! + last[0].length;
+  const bodyStart = normalized.indexOf("\n\n", headerStart);
+  const headerText = bodyStart >= 0 ? normalized.slice(headerStart, bodyStart) : normalized.slice(headerStart);
+  const headers = new Map<string, string>();
+  for (const line of headerText.split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) continue;
+    headers.set(line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim());
+  }
+  return {
+    statusCode,
+    headers,
+    body: bodyStart >= 0 ? normalized.slice(bodyStart + 2) : "",
+  };
+}
+
+async function readCache(root: string): Promise<GhEtagCacheDocument> {
+  try {
+    const parsed = JSON.parse(await readFile(cachePath(root), "utf8")) as unknown;
+    if (isCacheDocument(parsed)) return parsed;
+  } catch {}
+  return { version: 1, entries: {} };
+}
+
+async function writeCache(root: string, cache: GhEtagCacheDocument): Promise<void> {
+  const path = cachePath(root);
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(cache)}\n`, { encoding: "utf8", mode: 0o600 });
+  await rename(tmp, path);
+}
+
+function cachePath(root: string): string {
+  return join(rspStateDir(root), CACHE_FILE);
+}
+
+async function recordConditionalTelemetry(root: string, command: string, quotaFree: boolean): Promise<void> {
+  await appendTelemetryEvent(root, {
+    collection: RSP_DECISIONS_COLLECTION,
+    id: randomUUID(),
+    created_at: new Date().toISOString(),
+    command,
+    command_family: "gh api",
+    decision: "contributed",
+    reason: quotaFree ? "gh-conditional-304" : "gh-conditional-fetch",
+    quota_free: quotaFree,
+    saved_units: quotaFree ? 1 : 0,
+  });
+}
+
+function isCacheDocument(value: unknown): value is GhEtagCacheDocument {
+  return isRecord(value) &&
+    value.version === 1 &&
+    isRecord(value.entries) &&
+    Object.values(value.entries).every(isCacheEntry);
+}
+
+function isCacheEntry(value: unknown): value is GhEtagCacheEntry {
+  return isRecord(value) &&
+    typeof value.key === "string" &&
+    typeof value.request === "string" &&
+    typeof value.etag === "string" &&
+    typeof value.body === "string" &&
+    typeof value.updated_at === "string";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
+import { readGhConditionalJson } from "./gh-conditional.js";
 import { recoveryInstruction, type RecordedGitContract } from "./git-wrapper.js";
 import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
 
@@ -182,41 +183,190 @@ function machineArgs(command: GhCommand): string[] {
 
 async function collectGhContract(command: GhCommand): Promise<RecordedGitContract> {
   if (command.action === "combined") return await collectCombinedPrContract(command);
-  const child = spawn("gh", machineArgs(command), { stdio: ["ignore", "pipe", "pipe"] });
-  const stdout: Buffer[] = [];
-  const stderr: Buffer[] = [];
-  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-  return await new Promise((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", (status, signal) => {
-      resolve({
-        stdout: Buffer.concat(stdout).toString("utf8"),
-        stderr: Buffer.concat(stderr).toString("utf8"),
-        status,
-        signal,
-      });
-    });
+  const request = ghApiRequest(command);
+  if (!request) return await collectRawGh(machineArgs(command));
+  const response = await readGhConditionalJson({
+    ...request,
+    command: ["gh", ...machineArgs(command)].join(" "),
   });
+  if (response.status !== 0) {
+    return { stdout: response.stdout, stderr: response.stderr, status: response.status, signal: null };
+  }
+  return {
+    stdout: JSON.stringify(await normalizeGhApiPayload(command, response.stdout)),
+    stderr: response.stderr,
+    status: 0,
+    signal: null,
+  };
 }
 
 async function collectCombinedPrContract(command: GhCommand): Promise<RecordedGitContract> {
   const target = command.target ?? "";
-  const viewFields = ["number", "title", "state", "body", "author", "labels", "url", "baseRefName", "headRefName"];
-  const commentsFields = ["comments"];
   const [view, checks, comments] = await Promise.all([
-    collectRawGh(["pr", "view", target, "--json", viewFields.join(",")]),
-    collectRawGh(["pr", "checks", target, "--json", "name,state,bucket,conclusion,link,startedAt,completedAt,workflow"]),
-    collectRawGh(["pr", "view", target, "--comments", "--json", commentsFields.join(",")]),
+    readGhConditionalJson({ path: `repos/{owner}/{repo}/pulls/${target}`, command: `gh pr view ${target}` }),
+    readGhConditionalJson({ path: `repos/{owner}/{repo}/pulls/${target}/commits`, command: `gh pr checks ${target}` }),
+    readGhConditionalJson({ path: `repos/{owner}/{repo}/issues/${target}/comments`, command: `gh pr view ${target} --comments` }),
   ]);
-  const failed = [view, checks, comments].find((result) => (result.status ?? 0) !== 0 || result.signal);
-  if (failed) return failed;
+  const failed = [view, checks, comments].find((result) => (result.status ?? 0) !== 0);
+  if (failed) return { stdout: failed.stdout, stderr: failed.stderr, status: failed.status, signal: null };
+  const viewRow = normalizePrView(parseJson(view.stdout));
   return {
-    stdout: JSON.stringify({ view: parseJson(view.stdout), checks: parseJson(checks.stdout), comments: parseJson(comments.stdout) }),
+    stdout: JSON.stringify({
+      view: viewRow,
+      checks: [],
+      comments: { comments: arrayOfRecords(parseJson(comments.stdout)).map(normalizeComment) },
+    }),
     stderr: [view.stderr, checks.stderr, comments.stderr].filter(Boolean).join(""),
     status: 0,
     signal: null,
   };
+}
+
+function ghApiRequest(command: GhCommand): { path: string; params?: Record<string, string | number | boolean | undefined> } | null {
+  const target = firstPositional(command.passthrough);
+  const limit = numberOption(command.passthrough, "--limit") ?? 30;
+  const state = stringOption(command.passthrough, "--state") ?? "open";
+  switch (`${command.kind}:${command.action}`) {
+    case "pr:list":
+      return { path: "repos/{owner}/{repo}/pulls", params: { state, per_page: limit } };
+    case "pr:view":
+      return target ? { path: `repos/{owner}/{repo}/pulls/${target}` } : null;
+    case "issue:list":
+      return {
+        path: "repos/{owner}/{repo}/issues",
+        params: { state, labels: stringOption(command.passthrough, "--label"), per_page: limit },
+      };
+    case "issue:view":
+      return target ? { path: `repos/{owner}/{repo}/issues/${target}` } : null;
+    case "run:list":
+      return { path: "repos/{owner}/{repo}/actions/runs", params: { per_page: limit } };
+    case "run:view":
+      return target ? { path: `repos/{owner}/{repo}/actions/runs/${target}` } : null;
+    default:
+      return null;
+  }
+}
+
+async function normalizeGhApiPayload(command: GhCommand, raw: string): Promise<unknown> {
+  const parsed = parseJson(raw);
+  switch (`${command.kind}:${command.action}`) {
+    case "pr:list":
+      return arrayOfRecords(parsed).map(normalizePrListItem);
+    case "pr:view":
+      return normalizePrView(parsed);
+    case "issue:list":
+      return arrayOfRecords(parsed).filter((row) => !isRecord(row.pull_request)).map(normalizeIssue);
+    case "issue:view":
+      return normalizeIssue(parsed);
+    case "run:list":
+      return arrayOfRecords(recordOf(parsed).workflow_runs).map(normalizeRun);
+    case "run:view": {
+      const run = normalizeRun(parsed);
+      const target = firstPositional(command.passthrough);
+      if (!target) return run;
+      const jobs = await readGhConditionalJson({
+        path: `repos/{owner}/{repo}/actions/runs/${target}/jobs`,
+        command: `gh run view ${target} jobs`,
+      });
+      return {
+        ...run,
+        jobs: jobs.status === 0 ? arrayOfRecords(recordOf(parseJson(jobs.stdout)).jobs).map(normalizeJob) : [],
+      };
+    }
+    default:
+      return parsed;
+  }
+}
+
+function normalizePrListItem(value: unknown): JsonObject {
+  const row = recordOf(value);
+  return {
+    number: numberField(row, "number"),
+    title: stringField(row, "title"),
+    state: stringField(row, "state").toUpperCase(),
+    isDraft: Boolean(row.draft),
+    author: normalizeUser(row.user),
+    labels: arrayOfRecords(row.labels).map((label) => ({ name: stringField(label, "name") })),
+    url: stringField(row, "html_url"),
+    updatedAt: stringField(row, "updated_at"),
+    body: stringField(row, "body"),
+    baseRefName: stringField(recordOf(row.base), "ref"),
+    headRefName: stringField(recordOf(row.head), "ref"),
+  };
+}
+
+function normalizePrView(value: unknown): JsonObject {
+  return normalizePrListItem(value);
+}
+
+function normalizeIssue(value: unknown): JsonObject {
+  const row = recordOf(value);
+  return {
+    number: numberField(row, "number"),
+    title: stringField(row, "title"),
+    state: stringField(row, "state").toUpperCase(),
+    labels: arrayOfRecords(row.labels).map((label) => ({ name: stringField(label, "name") })),
+    author: normalizeUser(row.user),
+    url: stringField(row, "html_url"),
+    updatedAt: stringField(row, "updated_at"),
+    body: stringField(row, "body"),
+  };
+}
+
+function normalizeRun(value: unknown): JsonObject {
+  const row = recordOf(value);
+  return {
+    databaseId: numberField(row, "database_id") || numberField(row, "id"),
+    name: stringField(row, "name") || stringField(row, "display_title"),
+    status: stringField(row, "status").toUpperCase(),
+    conclusion: stringField(row, "conclusion").toUpperCase(),
+    event: stringField(row, "event"),
+    headBranch: stringField(row, "head_branch"),
+    workflowName: stringField(row, "workflow_name"),
+    createdAt: stringField(row, "created_at"),
+    url: stringField(row, "html_url"),
+    jobs: [],
+  };
+}
+
+function normalizeJob(value: unknown): JsonObject {
+  const row = recordOf(value);
+  return {
+    name: stringField(row, "name"),
+    status: stringField(row, "status").toUpperCase(),
+    conclusion: stringField(row, "conclusion").toUpperCase(),
+    log: "",
+  };
+}
+
+function normalizeComment(value: unknown): JsonObject {
+  const row = recordOf(value);
+  return {
+    author: normalizeUser(row.user),
+    body: stringField(row, "body"),
+    createdAt: stringField(row, "created_at"),
+  };
+}
+
+function normalizeUser(value: unknown): JsonObject {
+  const row = recordOf(value);
+  return { login: stringField(row, "login") };
+}
+
+function firstPositional(args: readonly string[]): string | undefined {
+  return args.find((arg) => !arg.startsWith("-"));
+}
+
+function stringOption(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function numberOption(args: readonly string[], name: string): number | undefined {
+  const value = stringOption(args, name);
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 async function collectRawGh(args: readonly string[]): Promise<RecordedGitContract> {

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -90,6 +90,7 @@ export interface RspTelemetryStats {
     contributed: number;
     passed: number;
     failed_open: number;
+    quota_free_saved_units: number;
     contribution_rate: number;
     top_pass_reasons: Array<{ reason: string; count: number }>;
   };
@@ -690,12 +691,14 @@ function countDecisions(records: Array<Record<string, unknown>>): RspTelemetrySt
   let contributed = 0;
   let passed = 0;
   let failedOpen = 0;
+  let quotaFreeSavedUnits = 0;
   const passReasons = new Map<string, number>();
   for (const record of records) {
     const decision = stringField(record.decision);
     if (decision === "contributed") contributed++;
     else if (decision === "failed-open") failedOpen++;
     else passed++;
+    if (record.quota_free === true) quotaFreeSavedUnits += Math.max(1, numeric(record.saved_units));
     if (decision !== "contributed") {
       const reason = stringField(record.reason) || "unknown";
       passReasons.set(reason, (passReasons.get(reason) ?? 0) + 1);
@@ -706,6 +709,7 @@ function countDecisions(records: Array<Record<string, unknown>>): RspTelemetrySt
     contributed,
     passed,
     failed_open: failedOpen,
+    quota_free_saved_units: quotaFreeSavedUnits,
     contribution_rate: records.length === 0 ? 0 : round(contributed / records.length),
     top_pass_reasons: [...passReasons.entries()]
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))

--- a/apps/rsp/src/wait.ts
+++ b/apps/rsp/src/wait.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { decode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { encodeSnapshotToon } from "@reddb-io/shared/toon-migration.js";
+import { readGhConditionalJson } from "./gh-conditional.js";
 
 type WaitKind = "cmd" | "pr" | "run" | "release";
 type WaitStatus = "running" | "success" | "failure" | "timeout" | "indeterminate";
@@ -329,6 +330,8 @@ async function probeRelease(tagGlob: string | undefined, startedAt: Date, cwd: s
 }
 
 async function ghJson(args: readonly string[], cwd: string): Promise<{ status: number; stdout: string; stderr: string }> {
+  const conditional = await conditionalGhJson(args, cwd);
+  if (conditional) return conditional;
   return await new Promise((resolveResult) => {
     const child = spawn("gh", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
     const stdout: Buffer[] = [];
@@ -344,6 +347,118 @@ async function ghJson(args: readonly string[], cwd: string): Promise<{ status: n
       });
     });
   });
+}
+
+async function conditionalGhJson(args: readonly string[], cwd: string): Promise<{ status: number; stdout: string; stderr: string } | null> {
+  if (args[0] === "pr" && args[1] === "view" && args[2]) {
+    return await conditionalPrView(args[2], cwd);
+  }
+  if (args[0] === "run" && args[1] === "view" && args[2]) {
+    const response = await readGhConditionalJson({
+      path: `repos/{owner}/{repo}/actions/runs/${args[2]}`,
+      cwd,
+      command: `gh ${args.join(" ")}`,
+    });
+    if (response.status !== 0) return response;
+    const row = recordOf(JSON.parse(response.stdout));
+    return {
+      status: 0,
+      stderr: response.stderr,
+      stdout: JSON.stringify({
+        databaseId: numberField(row, "database_id") || numberField(row, "id"),
+        status: stringField(row, "status").toUpperCase(),
+        conclusion: stringField(row, "conclusion").toUpperCase(),
+        workflowName: stringField(row, "workflow_name") || stringField(row, "name"),
+        headBranch: stringField(row, "head_branch"),
+        url: stringField(row, "html_url"),
+      }),
+    };
+  }
+  if (args[0] === "run" && args[1] === "list") {
+    const branch = optionAfter(args, "--branch");
+    const limit = optionAfter(args, "--limit") ?? "20";
+    const response = await readGhConditionalJson({
+      path: "repos/{owner}/{repo}/actions/runs",
+      params: { branch, per_page: limit },
+      cwd,
+      command: `gh ${args.join(" ")}`,
+    });
+    if (response.status !== 0) return response;
+    const rows = arrayOfRecords(recordOf(JSON.parse(response.stdout)).workflow_runs).map((row) => ({
+      databaseId: numberField(row, "database_id") || numberField(row, "id"),
+    }));
+    return { status: 0, stdout: JSON.stringify(rows), stderr: response.stderr };
+  }
+  if (args[0] === "release" && args[1] === "list") {
+    const limit = optionAfter(args, "--limit") ?? "20";
+    const response = await readGhConditionalJson({
+      path: "repos/{owner}/{repo}/releases",
+      params: { per_page: limit },
+      cwd,
+      command: `gh ${args.join(" ")}`,
+    });
+    if (response.status !== 0) return response;
+    const rows = arrayOfRecords(JSON.parse(response.stdout)).map((row) => ({
+      tagName: stringField(row, "tag_name"),
+      publishedAt: stringField(row, "published_at"),
+      isDraft: row.draft === true,
+    }));
+    return { status: 0, stdout: JSON.stringify(rows), stderr: response.stderr };
+  }
+  return null;
+}
+
+async function conditionalPrView(number: string, cwd: string): Promise<{ status: number; stdout: string; stderr: string }> {
+  const pr = await readGhConditionalJson({
+    path: `repos/{owner}/{repo}/pulls/${number}`,
+    cwd,
+    command: `gh pr view ${number}`,
+  });
+  if (pr.status !== 0) return pr;
+  const row = recordOf(JSON.parse(pr.stdout));
+  if (Array.isArray(row.statusCheckRollup)) return { status: 0, stdout: pr.stdout, stderr: pr.stderr };
+  const sha = stringField(recordOf(row.head), "sha");
+  const [combinedStatus, checkRuns] = sha
+    ? await Promise.all([
+      readGhConditionalJson({
+        path: `repos/{owner}/{repo}/commits/${sha}/status`,
+        cwd,
+        command: `gh pr view ${number} status`,
+      }),
+      readGhConditionalJson({
+        path: `repos/{owner}/{repo}/commits/${sha}/check-runs`,
+        cwd,
+        command: `gh pr view ${number} check-runs`,
+      }),
+    ])
+    : [{ status: 0, stdout: "{}", stderr: "", quotaFree: false }, { status: 0, stdout: "{}", stderr: "", quotaFree: false }];
+  const statuses = combinedStatus.status === 0 ? arrayOfRecords(recordOf(JSON.parse(combinedStatus.stdout)).statuses) : [];
+  const runs = checkRuns.status === 0 ? arrayOfRecords(recordOf(JSON.parse(checkRuns.stdout)).check_runs) : [];
+  return {
+    status: 0,
+    stderr: [pr.stderr, combinedStatus.stderr, checkRuns.stderr].filter(Boolean).join("\n"),
+    stdout: JSON.stringify({
+      number: numberField(row, "number"),
+      state: stringField(row, "state").toUpperCase(),
+      mergeable: mergeableState(row),
+      statusCheckRollup: [
+        ...statuses.map((status) => ({ conclusion: stringField(status, "state").toUpperCase() })),
+        ...runs.map((run) => ({
+          status: stringField(run, "status").toUpperCase(),
+          conclusion: stringField(run, "conclusion").toUpperCase(),
+        })),
+      ],
+      url: stringField(row, "html_url"),
+    }),
+  };
+}
+
+function mergeableState(row: Record<string, unknown>): string {
+  const state = stringField(row, "mergeable_state").toUpperCase();
+  if (state && state !== "UNKNOWN") return state === "CLEAN" ? "MERGEABLE" : state;
+  if (row.mergeable === true) return "MERGEABLE";
+  if (row.mergeable === false) return "CONFLICTING";
+  return "UNKNOWN";
 }
 
 async function listWaits(cwd: string): Promise<JsonObject[]> {
@@ -470,6 +585,29 @@ function parseStructuredRecord(raw: string): Record<string, unknown> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordOf(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function arrayOfRecords(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function stringField(row: Record<string, unknown>, field: string): string {
+  const value = row[field];
+  return typeof value === "string" ? value : "";
+}
+
+function numberField(row: Record<string, unknown>, field: string): number {
+  const value = row[field];
+  return typeof value === "number" ? value : 0;
+}
+
+function optionAfter(args: readonly string[], option: string): string | undefined {
+  const index = args.indexOf(option);
+  return index >= 0 ? args[index + 1] : undefined;
 }
 
 function parseDuration(value: string): number {

--- a/apps/rsp/tests/gh-conditional.test.ts
+++ b/apps/rsp/tests/gh-conditional.test.ts
@@ -1,0 +1,58 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readGhConditionalJson } from "../src/gh-conditional.js";
+import { telemetrySpoolPath } from "../src/telemetry.js";
+
+const roots: string[] = [];
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "rsp-gh-conditional-"));
+  roots.push(root);
+  await mkdir(join(root, ".red", "state", "rsp"), { recursive: true });
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("gh conditional requests", () => {
+  it("serves repeated unchanged GETs from a 304-backed cached body and records quota-free telemetry", async () => {
+    const root = await tempRoot();
+    const bin = join(root, "bin");
+    const countFile = join(root, "count");
+    await mkdir(bin, { recursive: true });
+    await writeFile(join(bin, "gh"), [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `count_file=${shellQuote(countFile)}`,
+      "count=0",
+      "[ -f \"$count_file\" ] && count=\"$(cat \"$count_file\")\"",
+      "next=$((count + 1))",
+      "printf '%s' \"$next\" > \"$count_file\"",
+      "if printf '%s\\n' \"$@\" | grep -q 'If-None-Match: rsp-test-etag'; then",
+      "  printf 'HTTP/2 304 Not Modified\\r\\netag: rsp-test-etag\\r\\n\\r\\n'",
+      "else",
+      "  printf 'HTTP/2 200 OK\\r\\netag: rsp-test-etag\\r\\n\\r\\n{\"number\":1975,\"state\":\"OPEN\"}\\n'",
+      "fi",
+      "",
+    ].join("\n"), "utf8");
+    await chmod(join(bin, "gh"), 0o755);
+
+    const env = { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` };
+    const first = await readGhConditionalJson({ path: "repos/owner/repo/issues/1975", cwd: root, telemetryRoot: root, env });
+    const second = await readGhConditionalJson({ path: "repos/owner/repo/issues/1975", cwd: root, telemetryRoot: root, env });
+
+    expect(first).toMatchObject({ status: 0, quotaFree: false });
+    expect(second).toMatchObject({ status: 0, quotaFree: true });
+    expect(second.stdout).toBe("{\"number\":1975,\"state\":\"OPEN\"}\n");
+    expect(await readFile(countFile, "utf8")).toBe("2");
+    await expect(readFile(telemetrySpoolPath(root), "utf8")).resolves.toContain("quota_free");
+  });
+});
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -601,15 +601,25 @@ describe("rsp telemetry spool", () => {
         decision: "failed-open",
         reason: "hook-exception",
       });
+      await db.kv(RSP_DECISIONS_COLLECTION).put("quota-free", {
+        created_at: "2026-07-10T10:03:00.000Z",
+        command: "gh api repos/o/r/issues/1",
+        command_family: "gh api",
+        decision: "contributed",
+        reason: "gh-conditional-304",
+        quota_free: true,
+        saved_units: 1,
+      });
 
       const stats = await readTelemetryStats(db, 7, new Date("2026-07-11T00:00:00.000Z"));
 
       expect(stats.decisions).toEqual({
-        seen: 4,
-        contributed: 0,
+        seen: 5,
+        contributed: 1,
         passed: 3,
         failed_open: 1,
-        contribution_rate: 0,
+        quota_free_saved_units: 1,
+        contribution_rate: 0.2,
         top_pass_reasons: [
           { reason: "disabled", count: 1 },
           { reason: "hook-exception", count: 1 },


### PR DESCRIPTION
Automated AFK landing for #1975. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1975

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786885088&installation_id=129708444&pr_number=1978&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1978&signature=63771e45f903e8c5344339964a4f74c64e519b8f0dc0e137dfa650ce6880df44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->