### PR TITLE
fix: #1977 rsp: 140 silent 'wrapper failed' fail-open degradations — capture failure identity, surface in stats, fix root cause

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -825,6 +825,7 @@ async function degradeToPassthrough(reason: string, argv: readonly string[], err
   process.stderr.write(`rsp: ${reason}, passing through\n`);
   const status = await passthrough(argv);
   if (telemetryRoot) {
+    const failure = wrapperFailureIdentity(reason, argv, err);
     const {
       appendTelemetryEvent,
       RSP_ACCOUNTING_EVENTS_COLLECTION,
@@ -839,17 +840,71 @@ async function degradeToPassthrough(reason: string, argv: readonly string[], err
       loss: "lossless",
       raw_bytes: 0,
       emitted_bytes: 0,
-      degradation_reason: reason,
+      degradation_reason: failure.reason,
+      wrapper_family: failure.family,
+      wrapper_exit_code: failure.exitCode,
+      stderr_head: failure.stderrHead,
     }));
     fireAndForget(appendTelemetryEvent(telemetryRoot, {
       collection: RSP_TELEMETRY_DEGRADATIONS_COLLECTION,
       ts: new Date().toISOString(),
       command: passthroughTelemetryCommand(argv),
-      reason,
+      reason: failure.reason,
+      wrapper_family: failure.family,
+      wrapper_exit_code: failure.exitCode,
+      stderr_head: failure.stderrHead,
       accounting_recorded: true,
     }));
   }
   return status;
+}
+
+function wrapperFailureIdentity(
+  fallbackReason: string,
+  argv: readonly string[],
+  err: unknown,
+): { reason: string; family: string; exitCode: number; stderrHead: string } {
+  const family = argv[0] ?? "unknown";
+  const stderrHead = firstDiagnosticLine(err) || fallbackReason;
+  const unavailable = errorCode(err) === "ENOENT" ||
+    errorCode(err) === "MODULE_NOT_FOUND" ||
+    /(?:command not found|cannot find package|cannot find module|module not found|not provisioned)/i.test(stderrHead);
+  return {
+    reason: unavailable ? "wrapper-unavailable" : "wrapper-crash",
+    family,
+    exitCode: numericErrorStatus(err) ?? 1,
+    stderrHead: truncateOneLine(stderrHead, 240),
+  };
+}
+
+function firstDiagnosticLine(err: unknown): string {
+  if (err instanceof Error) return firstLine(err.message);
+  return firstLine(String(err ?? ""));
+}
+
+function firstLine(text: string): string {
+  return text.split(/\r?\n/, 1)[0]?.trim() ?? "";
+}
+
+function truncateOneLine(text: string, maxChars: number): string {
+  const line = firstLine(text).replace(/\s+/g, " ").trim();
+  if (line.length <= maxChars) return line;
+  return `${line.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function errorCode(err: unknown): string {
+  if (typeof err !== "object" || err === null || !("code" in err)) return "";
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : "";
+}
+
+function numericErrorStatus(err: unknown): number | null {
+  if (typeof err !== "object" || err === null) return null;
+  for (const key of ["status", "exitCode", "exit_code"]) {
+    const value = (err as Record<string, unknown>)[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
 }
 
 function fireAndForget(promise: Promise<unknown>): void {
@@ -1057,6 +1112,13 @@ function renderStats(
     `  most_recent_degradation_reason: ${telemetry.health.most_recent?.reason ?? "none"}`,
     "  degradations_by_reason:",
     ...renderReasons(telemetry.health.by_reason),
+    "  wrapper_failures_by_family:",
+    ...renderFamilyCounts(telemetry.health.by_family),
+    "  recent_wrapper_failures:",
+    ...renderRecentFailures(telemetry.health.recent_failures.slice(0, full ? 20 : 5)),
+    ...(!full && telemetry.health.recent_failures.length > 5
+      ? [`    elided_failures: ${telemetry.health.recent_failures.length - 5}`, "    hint: --full"]
+      : []),
     "decisions:",
     `  seen: ${telemetry.decisions.seen}`,
     `  contributed: ${telemetry.decisions.contributed}`,
@@ -1109,6 +1171,20 @@ function renderReasons(reasons: Array<{ reason: string; count: number }>): strin
   return reasons.map((entry) => `    ${entry.reason}: ${entry.count}`);
 }
 
+function renderFamilyCounts(families: Array<{ family: string; count: number }>): string[] {
+  if (families.length === 0) return ["    empty: true"];
+  return families.map((entry) => `    ${entry.family}: ${entry.count}`);
+}
+
+function renderRecentFailures(failures: RspTelemetryStats["health"]["recent_failures"]): string[] {
+  if (failures.length === 0) return ["    empty: true"];
+  return failures.map((entry) =>
+    `    - at: ${entry.timestamp || "unknown"} family: ${entry.family} command: ${entry.command} reason: ${entry.reason} exit_code: ${
+      entry.exit_code ?? "none"
+    } stderr_head: ${entry.stderr_head ?? "none"}`
+  );
+}
+
 function renderStorageClasses(stats: RspStorageClassStats): string[] {
   return (["derivable", "re-executable", "ephemeral"] as const).map((storageClass) =>
     `  ${storageClass}: records: ${stats[storageClass].records} bytes: ${stats[storageClass].bytes} raw_bytes: ${stats[storageClass].raw_bytes}`
@@ -1155,6 +1231,8 @@ function emptyTelemetryStats(windowDays: number): RspTelemetryStats {
       show_misses: 0,
       show_hit_rate: 0,
       by_reason: [],
+      by_family: [],
+      recent_failures: [],
       most_recent: null,
     },
     latency: {

--- a/apps/rsp/src/proxy.ts
+++ b/apps/rsp/src/proxy.ts
@@ -190,6 +190,9 @@ function matchProxyCapability(words: readonly ShellWord[]): { capabilityId: stri
   if (values[0] === "git" && ["status", "log", "diff", "show", "blame"].includes(values[1] ?? "")) {
     return { capabilityId: `git:${values[1]}`, wrapperWords: raw };
   }
+  if (values[0] === "git" && values[1] === "branch" && values[2] === "-av") {
+    return { capabilityId: "git:branch:av", wrapperWords: raw };
+  }
   if (values[0] === "gh" && ["pr", "issue", "run"].includes(values[1] ?? "") && ["list", "view"].includes(values[2] ?? "")) {
     return { capabilityId: `gh:${values[1]}:${values[2]}`, wrapperWords: raw };
   }

--- a/apps/rsp/src/resident-server.ts
+++ b/apps/rsp/src/resident-server.ts
@@ -381,6 +381,9 @@ class ResidentTelemetryDrain {
         raw_bytes: 0,
         emitted_bytes: 0,
         degradation_reason: stringField(event.reason) || "unknown",
+        wrapper_family: stringField(event.wrapper_family),
+        wrapper_exit_code: event.wrapper_exit_code,
+        stderr_head: stringField(event.stderr_head),
       });
     }
     return null;

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -76,6 +76,15 @@ export interface RspTelemetryStats {
     show_misses: number;
     show_hit_rate: number;
     by_reason: Array<{ reason: string; count: number }>;
+    by_family: Array<{ family: string; count: number }>;
+    recent_failures: Array<{
+      timestamp: string;
+      family: string;
+      command: string;
+      reason: string;
+      exit_code: number | null;
+      stderr_head: string | null;
+    }>;
     most_recent: { timestamp: string; reason: string; command: string } | null;
   };
   latency: {
@@ -620,11 +629,23 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
   }
 
   const byReason = new Map<string, number>();
+  const byFamily = new Map<string, number>();
+  const recentFailures: RspTelemetryStats["health"]["recent_failures"] = [];
   let mostRecent: RspTelemetryStats["health"]["most_recent"] = null;
   for (const record of degradations) {
     const reason = stringField(record.degradation_reason) || stringField(record.reason) || "unknown";
+    const family = stringField(record.wrapper_family) || commandFamily(stringField(record.command));
     byReason.set(reason, (byReason.get(reason) ?? 0) + 1);
+    byFamily.set(family, (byFamily.get(family) ?? 0) + 1);
     const timestamp = timestampString(record);
+    recentFailures.push({
+      timestamp,
+      family,
+      command: stringField(record.command) || "unknown",
+      reason,
+      exit_code: optionalNumeric(record.wrapper_exit_code),
+      stderr_head: stringField(record.stderr_head) || null,
+    });
     if (!mostRecent || timestamp > mostRecent.timestamp) {
       mostRecent = {
         timestamp,
@@ -674,6 +695,12 @@ export async function readTelemetryStats(db: RedDB, sinceDays: number, now = new
       by_reason: [...byReason.entries()]
         .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
         .map(([reason, count]) => ({ reason, count })),
+      by_family: [...byFamily.entries()]
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .map(([family, count]) => ({ family, count })),
+      recent_failures: recentFailures
+        .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+        .slice(0, 20),
       most_recent: mostRecent,
     },
     latency: {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -1921,7 +1921,10 @@ describe("rsp cli", () => {
     const degradations = await readTelemetryRecords(storeUri, RSP_TELEMETRY_DEGRADATIONS_COLLECTION);
     expect(degradations).toContainEqual(expect.objectContaining({
       command: "git",
-      reason: "wrapper failed",
+      reason: "wrapper-crash",
+      wrapper_family: "git",
+      wrapper_exit_code: 1,
+      stderr_head: "unsupported git subcommand:",
     }));
 
     const stats = runBundleFromCwd(root, ["stats", "--since", "7d", "--full"], { RED_SKILLS_CACHE_DIR: cacheDir });
@@ -1942,7 +1945,11 @@ describe("rsp cli", () => {
     expect(statsText).toContain("health:\n");
     expect(statsText).toContain("  degradations: 1\n");
     expect(statsText).toContain("  degradation_rate: 0.3333\n");
-    expect(statsText).toContain("  most_recent_degradation_reason: wrapper failed\n");
+    expect(statsText).toContain("  most_recent_degradation_reason: wrapper-crash\n");
+    expect(statsText).toContain("  degradations_by_reason:\n    wrapper-crash: 1\n");
+    expect(statsText).toContain("  wrapper_failures_by_family:\n    git: 1\n");
+    expect(statsText).toContain("  recent_wrapper_failures:\n");
+    expect(statsText).toContain("family: git command: git reason: wrapper-crash exit_code: 1 stderr_head: unsupported git subcommand:");
     expect(statsText).toContain("latency:\n");
     expect(statsText).toMatch(/  wrapper_ms_p50: [0-9.]+\n/);
     expect(statsText).toMatch(/  wrapper_ms_p95: [0-9.]+\n/);

--- a/apps/rsp/tests/proxy.test.ts
+++ b/apps/rsp/tests/proxy.test.ts
@@ -37,6 +37,10 @@ describe("rsp proxy segment recognition", () => {
       commandLine: "cd apps && rsp --terse git log",
       matches: [expect.objectContaining({ capabilityId: "git:log", command: "git log" })],
     });
+    expect(rewriteProxyCommandLine("git branch -av", "brief")).toMatchObject({
+      commandLine: "rsp --brief git branch -av",
+      matches: [expect.objectContaining({ capabilityId: "git:branch:av", command: "git branch -av" })],
+    });
     expect(rewriteProxyCommandLine("printf 'x\\n' | grep x", "brief")).toMatchObject({
       commandLine: "printf 'x\\n' | grep x",
       matches: [],

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -387,7 +387,10 @@ describe("rsp telemetry spool", () => {
       id: "degraded",
       created_at: new Date().toISOString(),
       command: "git --version",
-      reason: "wrapper failed",
+      reason: "wrapper-crash",
+      wrapper_family: "git",
+      wrapper_exit_code: 1,
+      stderr_head: "unsupported git subcommand:",
       bytes: 100,
     });
 
@@ -428,8 +431,18 @@ describe("rsp telemetry spool", () => {
       health: {
         degradations: 1,
         degradation_rate: 0.5,
-        by_reason: [{ reason: "wrapper failed", count: 1 }],
-        most_recent: expect.objectContaining({ reason: "wrapper failed", command: "git --version" }),
+        by_reason: [{ reason: "wrapper-crash", count: 1 }],
+        by_family: [{ family: "git", count: 1 }],
+        recent_failures: [
+          expect.objectContaining({
+            family: "git",
+            command: "git --version",
+            reason: "wrapper-crash",
+            exit_code: 1,
+            stderr_head: "unsupported git subcommand:",
+          }),
+        ],
+        most_recent: expect.objectContaining({ reason: "wrapper-crash", command: "git --version" }),
       },
       latency: {
         wrapper_ms_p50: 12,


### PR DESCRIPTION
Automated AFK landing for #1977. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1977

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786885552&installation_id=129708444&pr_number=1980&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1980&signature=425247685a576b6b13d6c88930da91e6d6358d7f8b422484eb4c3f6c617422c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->