### PR TITLE
fix: #1928 command-guard refuses deleting .red/tmp root and live supervisor/worker artifacts

### DIFF
--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -18,7 +18,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, normalize, sep } from "node:path";
 import type { FailureMarkers } from "../core/envelope-emit.js";
 import type { OrphanDir, StaleClaimDir } from "../core/boot.js";
 import { readState, updateState } from "../core/state.js";
@@ -126,7 +126,80 @@ export async function claimPathHeldByLivePid(dir: string): Promise<boolean> {
 }
 
 export async function removeDir(path: string): Promise<void> {
+  await assertSweepRemovalSafe(path);
   await rm(path, { recursive: true, force: true });
+}
+
+function normalizedParts(path: string): string[] {
+  return normalize(path).split(sep).filter(Boolean);
+}
+
+function isLivePid(raw: string | null): boolean {
+  if (raw === null) return false;
+  const trimmed = raw.trim();
+  if (!/^[1-9][0-9]*$/.test(trimmed)) return false;
+  try {
+    process.kill(Number(trimmed), 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function pidFileNamesLiveProcess(path: string): Promise<boolean> {
+  try {
+    return isLivePid(await readFile(path, "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+function isRedTmpRoot(path: string): boolean {
+  const parts = normalizedParts(path);
+  return parts.length >= 2 && parts.at(-2) === ".red" && parts.at(-1) === "tmp";
+}
+
+function supervisorArtifactDir(path: string): string | null {
+  const parts = normalizedParts(path);
+  const name = parts.at(-1) ?? "";
+  const parent = parts.at(-2) ?? "";
+  const grandparent = parts.at(-3) ?? "";
+  if (name.startsWith("afk-supervisor.") && parent === "afk" && grandparent === "state") return dirname(path);
+  if (name.startsWith("afk-supervisor.") && parent === "tmp" && grandparent === ".red") return dirname(path);
+  if (name === "afk" && parent === "state") return path;
+  return null;
+}
+
+function liveWorkerDirFor(path: string): string | null {
+  const parts = normalizedParts(path);
+  const tmpIndex = parts.findIndex((part, idx) => part === "tmp" && parts[idx - 1] === ".red");
+  if (tmpIndex < 0) return null;
+  const namespace = parts[tmpIndex + 1];
+  if (!["workers", "go-workers", "scout-workers"].includes(namespace ?? "")) return null;
+  const worker = parts[tmpIndex + 2];
+  if (!worker) return null;
+  const prefixParts = parts.slice(0, tmpIndex + 3);
+  return `${path.startsWith(sep) ? sep : ""}${prefixParts.join(sep)}`;
+}
+
+async function assertSweepRemovalSafe(path: string): Promise<void> {
+  if (isRedTmpRoot(path)) {
+    throw new Error(`refusing to remove .red/tmp root: ${path}`);
+  }
+
+  const supervisorDir = supervisorArtifactDir(path);
+  if (supervisorDir && await pidFileNamesLiveProcess(join(supervisorDir, "afk-supervisor.pid"))) {
+    throw new Error(`refusing to remove live supervisor artifact: ${path}`);
+  }
+
+  const workerDir = liveWorkerDirFor(path);
+  if (workerDir && await pidFileNamesLiveProcess(join(workerDir, "worker.pid"))) {
+    const target = normalize(path);
+    const workerRoot = normalize(workerDir);
+    if (target === workerRoot || target === join(workerRoot, "worker.pid")) {
+      throw new Error(`refusing to remove live worker artifact: ${path}`);
+    }
+  }
 }
 
 export async function writeHandoff(path: string, content: string): Promise<void> {

--- a/apps/dev/tests/fs-sweep.test.ts
+++ b/apps/dev/tests/fs-sweep.test.ts
@@ -8,6 +8,7 @@ import {
   listLegacyWorkDirs,
   tryAcquireClaimDir,
   listOrphanDirs,
+  removeDir,
   reapDeadEmptyWorkerShells,
 } from "../src/runtime/fs.js";
 
@@ -65,6 +66,52 @@ describe("listStaleClaimDirs", () => {
       writeFileSync(join(blank, "pid"), "   ");
       const stale = (await listStaleClaimDirs(root)).map((s) => s.path).sort();
       expect(stale).toEqual([noPid, blank].sort());
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("removeDir sweep guard (#1928)", () => {
+  it("refuses to remove the .red/tmp root", async () => {
+    const root = scratch();
+    try {
+      const tmpRoot = join(root, ".red", "tmp");
+      mkdirSync(tmpRoot, { recursive: true });
+
+      await expect(removeDir(tmpRoot)).rejects.toThrow("refusing to remove .red/tmp root");
+      expect(existsSync(tmpRoot)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to remove a live supervisor anchor", async () => {
+    const root = scratch();
+    try {
+      const stateAfk = join(root, ".red", "state", "afk");
+      mkdirSync(stateAfk, { recursive: true });
+      writeFileSync(join(stateAfk, "afk-supervisor.pid"), ALIVE_PID);
+      const log = join(stateAfk, "afk-supervisor.log");
+      writeFileSync(log, "live\n");
+
+      await expect(removeDir(log)).rejects.toThrow("refusing to remove live supervisor artifact");
+      expect(readFileSync(log, "utf8")).toBe("live\n");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to remove a live worker anchor", async () => {
+    const root = scratch();
+    try {
+      const worker = join(root, ".red", "tmp", "workers", "wLIVE");
+      mkdirSync(worker, { recursive: true });
+      const pidFile = join(worker, "worker.pid");
+      writeFileSync(pidFile, ALIVE_PID);
+
+      await expect(removeDir(pidFile)).rejects.toThrow("refusing to remove live worker artifact");
+      expect(readFileSync(pidFile, "utf8")).toBe(ALIVE_PID);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/plugins/dev/hooks/command-guard.sh
+++ b/plugins/dev/hooks/command-guard.sh
@@ -584,6 +584,136 @@ enforce_tmp_root_write_policy() {
 
 enforce_tmp_root_write_policy
 
+strip_path_token() {
+  local s="$1"
+  [[ "$s" == \'* ]] && s="${s:1}" && s="${s%\'}"
+  [[ "$s" == \"* ]] && s="${s:1}" && s="${s%\"}"
+  printf '%s' "$s"
+}
+
+pid_file_live() {
+  local pid_file="$1" raw
+  [[ -f "$pid_file" ]] || return 1
+  raw="$(tr -d '[:space:]' <"$pid_file" 2>/dev/null || true)"
+  [[ "$raw" =~ ^[1-9][0-9]*$ ]] || return 1
+  kill -0 "$raw" 2>/dev/null
+}
+
+supervisor_delete_reason() {
+  local abs="$1" dir
+  for dir in \
+    "$(canonical_path "$REPO_ROOT" ".red/state/afk")" \
+    "$(canonical_path "$REPO_ROOT" ".red/tmp")"
+  do
+    case "$abs" in
+      "$dir"/afk-supervisor.*|"$dir")
+        if pid_file_live "$dir/afk-supervisor.pid"; then
+          printf 'refusing to delete live supervisor artifacts under %s' "$dir"
+          return 0
+        fi
+        ;;
+    esac
+  done
+  return 1
+}
+
+worker_delete_reason() {
+  local abs="$1" tmp_root ns prefix rel worker worker_dir
+  tmp_root="$(canonical_path "$REPO_ROOT" ".red/tmp")"
+  for ns in workers go-workers scout-workers; do
+    prefix="$tmp_root/$ns/"
+    case "$abs" in
+      "$prefix"*)
+        rel="${abs#$prefix}"
+        worker="${rel%%/*}"
+        [[ -n "$worker" ]] || continue
+        worker_dir="$prefix$worker"
+        if pid_file_live "$worker_dir/worker.pid"; then
+          printf 'refusing to delete live worker artifacts under %s' "$worker_dir"
+          return 0
+        fi
+        ;;
+    esac
+  done
+  return 1
+}
+
+delete_target_reason() {
+  local raw="$1" s abs tmp_root rel reason
+  s="$(strip_path_token "$raw")"
+  [[ -n "$s" ]] || return 1
+  abs="$(canonical_path "$ROOT" "$s")"
+  tmp_root="$(canonical_path "$REPO_ROOT" ".red/tmp")"
+
+  if [[ "$abs" == "$tmp_root" ]]; then
+    printf 'refusing to delete the .red/tmp root'
+    return 0
+  fi
+
+  case "$abs" in
+    "$tmp_root"/*)
+      rel="${abs#$tmp_root/}"
+      if [[ "$rel" == "*" ]]; then
+        printf 'refusing to delete every entry under .red/tmp'
+        return 0
+      fi
+      ;;
+  esac
+
+  reason="$(supervisor_delete_reason "$abs" || true)"
+  if [[ -n "$reason" ]]; then
+    printf '%s' "$reason"
+    return 0
+  fi
+
+  reason="$(worker_delete_reason "$abs" || true)"
+  if [[ -n "$reason" ]]; then
+    printf '%s' "$reason"
+    return 0
+  fi
+
+  return 1
+}
+
+deny_tmp_delete() {
+  local path="$1" reason="$2"
+  deny "$(cat <<EOF
+BLOCKED by RedSkills tmp deletion guard.
+plugins.dev.enabled is true, so cleanup commands must delete a named lane under .red/tmp/, not the tmp root or live liveness anchors.
+
+Requested path: $path
+Reason: $reason
+
+Target a specific owned lane or stop the live supervisor/worker before removing its anchors.
+EOF
+  )"
+}
+
+enforce_tmp_delete_policy() {
+  local -a tokens
+  read -ra tokens <<<"$COMMAND"
+  local n=${#tokens[@]}
+  ((n > 0)) || return 0
+
+  local i j arg reason
+  for ((i = 0; i < n; i++)); do
+    case "${tokens[i]}" in
+      rm|/bin/rm|/usr/bin/rm)
+        for ((j = i + 1; j < n; j++)); do
+          arg="${tokens[j]}"
+          case "$arg" in '>'|'>>'|'|'|'&&'|'||'|';') break ;; esac
+          [[ "$arg" == -- ]] && continue
+          [[ "${arg:0:1}" == "-" ]] && continue
+          reason="$(delete_target_reason "$arg" || true)"
+          [[ -n "$reason" ]] && deny_tmp_delete "$arg" "$reason"
+        done
+        ;;
+    esac
+  done
+}
+
+enforce_tmp_delete_policy
+
 guard_scope_for_path() {
   local path="$1"
   case "$path" in

--- a/plugins/dev/hooks/tests/command-guard.test.sh
+++ b/plugins/dev/hooks/tests/command-guard.test.sh
@@ -344,6 +344,27 @@ expect_eq "tmp-root guard: allows write inside workers lane" "0" "$(sed -n '1p' 
 result="$(run_hook "$repo" "$(payload "$repo" "tee -a .red/tmp/scratch/trace.log")")"
 expect_eq "tmp-root guard: allows tee inside scratch lane" "0" "$(sed -n '1p' <<<"$result")"
 
+result="$(run_hook "$repo" "$(payload "$repo" "rm -rf .red/tmp")")"
+stderr="$(sed -n '/---stderr---/,$p' <<<"$result")"
+expect_eq "tmp delete guard: blocks tmp root removal" "0" "$(sed -n '1p' <<<"$result")"
+expect_contains "tmp delete guard: explains named lanes" "delete a named lane under .red/tmp/" "$stderr"
+
+result="$(run_hook "$repo" "$(payload "$repo" "rm -rf .red/tmp/*")")"
+expect_eq "tmp delete guard: blocks tmp root wildcard removal" "0" "$(sed -n '1p' <<<"$result")"
+
+mkdir -p "$repo/.red/tmp" "$repo/.red/state/afk"
+printf '%s\n' "$$" >"$repo/.red/tmp/afk-supervisor.pid"
+printf 'log\n' >"$repo/.red/tmp/afk-supervisor.log"
+result="$(run_hook "$repo" "$(payload "$repo" "rm -f .red/tmp/afk-supervisor.log")")"
+stderr="$(sed -n '/---stderr---/,$p' <<<"$result")"
+expect_eq "tmp delete guard: blocks live legacy supervisor log removal" "0" "$(sed -n '1p' <<<"$result")"
+expect_contains "tmp delete guard: names live supervisor" "live supervisor" "$stderr"
+
+printf '%s\n' "$$" >"$repo/.red/state/afk/afk-supervisor.pid"
+printf 'state log\n' >"$repo/.red/state/afk/afk-supervisor.log"
+result="$(run_hook "$repo" "$(payload "$repo" "rm -f .red/state/afk/afk-supervisor.log")")"
+expect_eq "tmp delete guard: blocks live state supervisor log removal" "0" "$(sed -n '1p' <<<"$result")"
+
 cat >"$repo/.red/config.yaml" <<'YAML'
 plugins:
   dev:


### PR DESCRIPTION
Closes #1928

Adopts the parked AFK worker branch (sensitive-path park reviewed by maintainer + session review). The command-guard hook gains three refusals: deleting the `.red/tmp` root (or every entry under it), deleting supervisor artifacts while the supervisor pid is live, and deleting a worker directory while its `worker.pid` is live. Companion fs sweep hardening + tests for both layers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786886118&installation_id=129708444&pr_number=1992&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1992&signature=6f418418b13c59eb41dc560c306a5d3a0c1e868fafc10c0dee1b502cd73e7e7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->