### PR TITLE
fix: #1985 rsp: shared structured-error contract (TOON errors with fix commands, exit codes, loud unknown flags, idempotent no-ops)

### DIFF
--- a/apps/rsp/src/cat-wrapper.ts
+++ b/apps/rsp/src/cat-wrapper.ts
@@ -4,6 +4,7 @@ import { extname } from "node:path";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { type RspLossLevel, type RspMintMeta } from "./elision-store.js";
 import { recoveryInstruction, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
+import { classifyWrappedFailure, renderStructuredError } from "./structured-error.js";
 
 export interface CatRenderOptions {
   level: RspLossLevel;
@@ -51,7 +52,19 @@ const CODE_EXTENSIONS = new Set([
 
 export async function runCatWrapper(argv: readonly string[], options: CatRenderOptions): Promise<GitRenderResult> {
   const parsed = parseCatCommand(argv);
-  const bytes = await readFile(parsed.file);
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(parsed.file);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const error = classifyWrappedFailure(argv.join(" "), "", message);
+    return {
+      stdout: renderStructuredError({ ...error, help: `ls ${parsed.file}` }),
+      stderr: Buffer.from(`${message}\n`),
+      status: 1,
+      signal: null,
+    };
+  }
   if (isBinary(bytes)) {
     return {
       stdout: bytes,
@@ -70,10 +83,11 @@ export async function renderCatContract(
   options: CatRenderOptions,
 ): Promise<GitRenderResult> {
   if ((contract.status ?? 0) !== 0 || contract.signal) {
+    const error = classifyWrappedFailure(command.join(" "), contract.stdout, contract.stderr);
     return {
-      stdout: Buffer.from(contract.stdout),
+      stdout: renderStructuredError(error),
       stderr: Buffer.from(contract.stderr),
-      status: contract.status,
+      status: error.exitCode ?? 1,
       signal: contract.signal,
     };
   }

--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -14,6 +14,7 @@ import type { RspRuntimeConfig } from "./config.js";
 import type { RspElisionStore, RspMintMeta, RspStorageClassStats } from "./elision-store.js";
 import { formatUsd } from "./pricing.js";
 import type { ResidentResponseMetrics } from "./resident-client.js";
+import { renderStructuredError, renderUnknownFlag } from "./structured-error.js";
 import {
   appendTelemetryEventSync,
   telemetrySpoolPath,
@@ -68,7 +69,12 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   if (args.command === "shell-init") {
     const shell = args.positional[1];
     if (shell !== "fish" && shell !== "bash" && shell !== "zsh") {
-      process.stdout.write("error: usage rsp shell-init fish|bash|zsh\n");
+      process.stdout.write(renderStructuredError({
+        command: args.positional.join(" ") || "shell-init",
+        category: "usage",
+        error: "usage rsp shell-init fish|bash|zsh",
+        help: "rsp shell-init bash",
+      }));
       return 2;
     }
     const { renderShellInit } = await import("./shell-init.js");
@@ -162,7 +168,13 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     const { readGhConditionalJson } = await import("./gh-conditional.js");
     const request = parseGhApiJsonArgs(args.positional);
     if (!request) {
-      process.stderr.write("usage: rsp gh-api-json <path> [-f name=value ...]\n");
+      process.stdout.write(renderStructuredError({
+        command: args.positional.join(" "),
+        category: "usage",
+        error: "usage rsp gh-api-json <path> [-f name=value ...]",
+        help: "rsp gh-api-json repos/{owner}/{repo}",
+        validFlags: ["-f", "-F"],
+      }));
       return 2;
     }
     const response = await readGhConditionalJson({
@@ -178,7 +190,12 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   }
   if (!args.storeUri && config.storeUri.startsWith("file://") && !existsSync(fileURLToPath(config.storeUri))) {
     if (wrapperCommand) return await runColdWrappedCommand(args, config, residentPaths.rootDir);
-    process.stdout.write("error: rsp repo store is not provisioned - run /red-setup\n");
+    process.stdout.write(renderStructuredError({
+      command: telemetryCommand(args) || "rsp",
+      category: "real-error",
+      error: "rsp repo store is not provisioned",
+      help: "/red-setup",
+    }));
     return 1;
   }
   const openResidentStore = (ensureResident = true) => Promise.resolve(new ResidentRspElisionStore(residentPaths, {
@@ -313,20 +330,39 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
         return 0;
       }
       if (record?.status === "expired") {
-        const text = `expired ${record.expired_at} — re-run: ${record.command}\n`;
+        const text = renderStructuredError({
+          command: `rsp show ${args.handle}`,
+          category: "real-error",
+          error: `expired ${record.expired_at}`,
+          help: record.command,
+        });
         process.stdout.write(text);
-        await appendShowAccountingEvent(residentPaths.rootDir, args.handle, false, Buffer.byteLength(text, "utf8"));
+        await appendShowAccountingEvent(residentPaths.rootDir, args.handle, false, text.length);
         return 1;
       }
-      const text = `expired unknown — re-run: ${args.handle}\n`;
+      const text = renderStructuredError({
+        command: `rsp show ${args.handle}`,
+        category: "real-error",
+        error: "expired unknown",
+        help: args.handle,
+      });
       process.stdout.write(text);
-      await appendShowAccountingEvent(residentPaths.rootDir, args.handle, false, Buffer.byteLength(text, "utf8"));
+      await appendShowAccountingEvent(residentPaths.rootDir, args.handle, false, text.length);
       return 1;
     }
 
-    process.stdout.write("error: usage rsp show el:<id>\n");
+    process.stdout.write(renderStructuredError({
+      command: args.positional.join(" ") || "rsp",
+      category: "usage",
+      error: "usage rsp show el:<id>",
+      help: "rsp show el:<id>",
+    }));
     return 2;
   } catch (err) {
+    if (isStructuredUsageRenderable(err)) {
+      process.stdout.write(err.render());
+      return 2;
+    }
     if (wrapperCommand) return await degradeToPassthrough("wrapper failed", args.positional, err, residentPaths.rootDir);
     throw err;
   } finally {
@@ -573,6 +609,10 @@ async function runColdWrappedCommand(
       return await emitWrappedResult(args, result, started, store);
     }
   } catch (coldErr) {
+    if (isStructuredUsageRenderable(coldErr)) {
+      process.stdout.write(coldErr.render());
+      return 2;
+    }
     return await degradeToPassthrough("wrapper failed", args.positional, coldErr, telemetryRoot);
   } finally {
     await store.close();
@@ -1058,6 +1098,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     else if (arg === "--terse") out.level = "terse";
     else if (arg === "--query") out.query = argv[++i];
     else if (arg.startsWith("--query=")) out.query = arg.slice("--query=".length);
+    else if (positional.length === 0 && arg.startsWith("--")) throw new CliUsageError(arg);
     else positional.push(arg);
   }
   if (out.query && positional[0] !== "show" && !positional.some((arg) => arg === "--query" || arg.startsWith("--query="))) {
@@ -1067,6 +1108,21 @@ function parseArgs(argv: string[]): ParsedArgs {
   out.handle = positional[1];
   out.positional = positional;
   return out;
+}
+
+class CliUsageError extends Error {
+  constructor(readonly flag: string) {
+    super(`unknown flag: ${flag}`);
+  }
+
+  render(): Buffer {
+    return renderUnknownFlag("rsp", this.flag, ["--store-uri", "--brief", "--terse", "--query"], "rsp --help");
+  }
+}
+
+function isStructuredUsageRenderable(err: unknown): err is { render: () => Buffer } {
+  return typeof err === "object" && err !== null && "render" in err &&
+    typeof (err as { render?: unknown }).render === "function";
 }
 
 function parseGhApiJsonArgs(argv: readonly string[]): { path: string; params: Record<string, string> } | null {
@@ -1318,7 +1374,16 @@ function renderSetupResult(result: {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().then((code) => process.exit(code), (err) => {
-    process.stdout.write(`error: ${err instanceof Error ? err.message : String(err)}\n`);
+    if (isStructuredUsageRenderable(err)) {
+      process.stdout.write(err.render());
+      process.exit(2);
+    }
+    process.stdout.write(renderStructuredError({
+      command: "rsp",
+      category: "real-error",
+      error: err instanceof Error ? err.message : String(err),
+      help: "rsp --help",
+    }));
     process.exit(1);
   });
 }

--- a/apps/rsp/src/exec-wrapper.ts
+++ b/apps/rsp/src/exec-wrapper.ts
@@ -4,6 +4,7 @@ import { scoreStructuralOutliers, type PreservedOutlierLine } from "./anomaly-sc
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
 import { recoveryInstruction, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
 import { normalizeOutput, renderGenericJsonLane } from "./normalize.js";
+import { classifyWrappedFailure, renderStructuredError } from "./structured-error.js";
 
 export interface ExecRenderOptions {
   level: RspLossLevel;
@@ -33,6 +34,16 @@ export async function renderExecContract(
 ): Promise<GitRenderResult> {
   const rawStdout = Buffer.from(contract.stdout, "binary");
   const stderr = Buffer.from(contract.stderr, "binary");
+  if ((contract.status ?? 0) !== 0 || contract.signal) {
+    const error = classifyWrappedFailure(commandLine, contract.stdout, contract.stderr);
+    return {
+      stdout: renderStructuredError(error),
+      stderr,
+      status: error.exitCode ?? 1,
+      signal: contract.signal,
+      rawOutput: rawStdout,
+    };
+  }
   if (rawStdout.length === 0) {
     return {
       stdout: rawStdout,

--- a/apps/rsp/src/gh-wrapper.ts
+++ b/apps/rsp/src/gh-wrapper.ts
@@ -3,7 +3,8 @@ import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
 import { readGhConditionalJson } from "./gh-conditional.js";
 import { recoveryInstruction, type RecordedGitContract } from "./git-wrapper.js";
-import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
+import { extractQueryArg, filterRows, withHelp } from "./output-levers.js";
+import { classifyWrappedFailure, renderStructuredError } from "./structured-error.js";
 
 export type GhKind = "pr" | "issue" | "run";
 export type GhAction = "list" | "view" | "combined";
@@ -73,12 +74,12 @@ export async function renderGhContract(
   contract: RecordedGitContract,
   options: GhRenderOptions,
 ): Promise<GhRenderResult> {
-  const parsedCommand = extractQueryArg(commandArgv);
   if ((contract.status ?? 0) !== 0 || contract.signal) {
+    const error = classifyWrappedFailure(commandArgv.join(" "), contract.stdout, contract.stderr);
     return {
-      stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
+      stdout: renderStructuredError(error),
       stderr: Buffer.from(contract.stderr),
-      status: contract.status,
+      status: error.exitCode ?? 1,
       signal: contract.signal,
     };
   }

--- a/apps/rsp/src/git-wrapper.ts
+++ b/apps/rsp/src/git-wrapper.ts
@@ -2,7 +2,8 @@ import { spawn } from "node:child_process";
 import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
-import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
+import { extractQueryArg, filterRows, withHelp } from "./output-levers.js";
+import { classifyWrappedFailure, renderStructuredError, renderUnknownFlag } from "./structured-error.js";
 
 export { DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD } from "./config.js";
 
@@ -59,10 +60,11 @@ export async function renderGitContract(
 ): Promise<GitRenderResult> {
   const parsedCommand = parseGitRenderCommand(command);
   if ((contract.status ?? 0) !== 0 || contract.signal) {
+    const error = classifyWrappedFailure(command.join(" "), contract.stdout, contract.stderr);
     return {
-      stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
+      stdout: renderStructuredError(error),
       stderr: Buffer.from(contract.stderr),
-      status: contract.status,
+      status: error.exitCode ?? 1,
       signal: contract.signal,
     };
   }
@@ -142,6 +144,8 @@ function parseGitRenderCommand(command: readonly string[]): ParsedGitRenderComma
     }
     argv.push(arg);
   }
+  const unknown = argv.slice(2).find((arg) => arg.startsWith("--rsp-"));
+  if (unknown) throw new StructuredUsageError(command.join(" "), unknown, ["--full", "--brief", "--terse", "--query"]);
   return { argv, query: parsed.query, full };
 }
 
@@ -354,12 +358,38 @@ function parsePush(command: readonly string[], stdout: string): JsonObject {
   const pushed = refs.find((ref) => ref.flag !== "=") ?? refs[0];
   const branch = pushed?.to.startsWith("refs/heads/") ? pushed.to.slice("refs/heads/".length) : (pushed?.to ?? "");
   const commitCount = pushed?.summary.includes("..") ? 1 : 0;
+  if (refs.length > 0 && refs.every((ref) => ref.flag === "=")) {
+    return {
+      command: command.join(" "),
+      category: "no-op",
+      exit_code: 0,
+      noop: true,
+      remote,
+      refs,
+      summary: `push already satisfied for ${branch} -> ${remote}`,
+      help: ["rsp gh pr list --query <branch>"] as JsonValue,
+    };
+  }
   return {
     command: command.join(" "),
     remote,
     refs,
     summary: `pushed ${branch} -> ${remote} +${commitCount} commits`,
   };
+}
+
+export class StructuredUsageError extends Error {
+  constructor(
+    readonly command: string,
+    readonly flag: string,
+    readonly validFlags: readonly string[],
+  ) {
+    super(`unknown flag: ${flag}`);
+  }
+
+  render(): Buffer {
+    return renderUnknownFlag(this.command, this.flag, this.validFlags, `${this.command} --help`);
+  }
 }
 
 function parseBlame(command: readonly string[], stdout: string, query?: string): JsonObject {

--- a/apps/rsp/src/structured-error.ts
+++ b/apps/rsp/src/structured-error.ts
@@ -1,0 +1,111 @@
+import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+
+export type RspErrorCategory = "usage" | "real-error" | "no-op";
+
+export interface RspStructuredErrorOptions {
+  command: string;
+  category: RspErrorCategory;
+  error: string;
+  help: string;
+  exitCode?: 0 | 1 | 2;
+  validFlags?: readonly string[];
+  diagnostics?: string;
+}
+
+export function structuredExitCode(category: RspErrorCategory): 0 | 1 | 2 {
+  if (category === "no-op") return 0;
+  if (category === "usage") return 2;
+  return 1;
+}
+
+export function renderStructuredError(options: RspStructuredErrorOptions): Buffer {
+  const payload: JsonObject = {
+    command: options.command,
+    category: options.category,
+    exit_code: options.exitCode ?? structuredExitCode(options.category),
+    error: options.error,
+    help: [options.help] as JsonValue,
+  };
+  if (options.validFlags && options.validFlags.length > 0) payload.valid_flags = [...options.validFlags] as JsonValue;
+  if (options.diagnostics) payload.diagnostics = firstLines(options.diagnostics, 3);
+  return Buffer.from(`${encode(payload)}\n`);
+}
+
+export function renderNoop(command: string, summary: string, help: string): Buffer {
+  const payload: JsonObject = {
+    command,
+    category: "no-op",
+    exit_code: 0,
+    noop: true,
+    summary,
+    help: [help] as JsonValue,
+  };
+  return Buffer.from(`${encode(payload)}\n`);
+}
+
+export function classifyWrappedFailure(command: string, stdout: string, stderr: string): RspStructuredErrorOptions {
+  const diagnostics = [stderr, stdout].find((text) => text.trim()) ?? "";
+  const normalized = diagnostics.trim();
+  const lower = normalized.toLowerCase();
+  if (/\bgh\b/.test(command) && (lower.includes("gh_token") || lower.includes("not logged in") || lower.includes("authentication"))) {
+    return {
+      command,
+      category: "real-error",
+      error: firstLine(normalized) || "GitHub authentication failed",
+      help: "gh auth login",
+      diagnostics: normalized,
+    };
+  }
+  if (/\bgh\b/.test(command) && lower.includes("rate limit")) {
+    return {
+      command,
+      category: "real-error",
+      error: firstLine(normalized) || "GitHub API rate limit exceeded",
+      help: "gh auth status",
+      diagnostics: normalized,
+    };
+  }
+  if (lower.includes("not a git repository")) {
+    return {
+      command,
+      category: "real-error",
+      error: firstLine(normalized) || "not a git repository",
+      help: "git status",
+      diagnostics: normalized,
+    };
+  }
+  if (lower.includes("repository not found") || lower.includes("could not resolve host")) {
+    return {
+      command,
+      category: "real-error",
+      error: firstLine(normalized) || "repository is unavailable",
+      help: command.startsWith("gh ") ? "gh repo view" : "git remote -v",
+      diagnostics: normalized,
+    };
+  }
+  return {
+    command,
+    category: "real-error",
+    error: firstLine(normalized) || "command failed",
+    help: `${command} --help`,
+    diagnostics: normalized,
+  };
+}
+
+export function renderUnknownFlag(command: string, flag: string, validFlags: readonly string[], help: string): Buffer {
+  return renderStructuredError({
+    command,
+    category: "usage",
+    error: `unknown flag: ${flag}`,
+    help,
+    validFlags,
+  });
+}
+
+function firstLine(text: string): string {
+  return text.split(/\r?\n/, 1)[0]?.trim() ?? "";
+}
+
+function firstLines(text: string, maxLines: number): string {
+  return text.split(/\r?\n/).slice(0, maxLines).join("\n").trim();
+}

--- a/apps/rsp/src/test-wrapper.ts
+++ b/apps/rsp/src/test-wrapper.ts
@@ -2,7 +2,8 @@ import { spawn } from "node:child_process";
 import { encode, type JsonObject } from "@reddb-io/toon";
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
 import { recoveryInstruction, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
-import { extractQueryArg, filterRows, filterTextLines, withHelp } from "./output-levers.js";
+import { extractQueryArg, filterRows, withHelp } from "./output-levers.js";
+import { classifyWrappedFailure, renderStructuredError } from "./structured-error.js";
 
 export interface TestRenderOptions {
   level: RspLossLevel;
@@ -62,10 +63,11 @@ export async function renderTestContract(
   const status = contract.status;
 
   if (!parsed || ((status ?? 0) !== 0 && parsed.failed === 0)) {
+    const error = classifyWrappedFailure(command.join(" "), contract.stdout, contract.stderr);
     return {
-      stdout: Buffer.from(filterTextLines(contract.stdout, parsedCommand.query)),
+      stdout: renderStructuredError(error),
       stderr: Buffer.from(contract.stderr),
-      status: contract.status,
+      status: error.exitCode ?? 1,
       signal: contract.signal,
     };
   }
@@ -100,7 +102,7 @@ export async function renderTestContract(
   return {
     stdout: Buffer.from(encode(renderedPayload as unknown as JsonObject)),
     stderr: Buffer.from(contract.stderr),
-    status: contract.status,
+    status: normalizeWrapperStatus(contract.status),
     signal: contract.signal,
     payload: renderedPayload as unknown as JsonObject,
     mintedHandle,
@@ -135,7 +137,7 @@ async function renderTerse(
     return {
       stdout: Buffer.from(terseToon),
       stderr: Buffer.from(contract.stderr),
-      status: contract.status,
+      status: normalizeWrapperStatus(contract.status),
       signal: contract.signal,
       payload: renderedTersePayload as unknown as JsonObject,
     };
@@ -163,7 +165,7 @@ async function renderTerse(
   return {
     stdout: Buffer.from(`${terseToon}\n${marker}`),
     stderr: Buffer.from(contract.stderr),
-    status: contract.status,
+    status: normalizeWrapperStatus(contract.status),
     signal: contract.signal,
     payload: renderedTersePayload as unknown as JsonObject,
     mintedHandle: handle,
@@ -171,6 +173,10 @@ async function renderTerse(
     rowsElided: elidedFailures,
     rawOutput: Buffer.from(fullToon),
   };
+}
+
+function normalizeWrapperStatus(status: number | null): number {
+  return status === 0 || status === null ? 0 : 1;
 }
 
 function renderTerseInlineFailures(failures: readonly TestFailureSource[]): TestFailure[] {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -679,6 +679,19 @@ async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
 }
 
 describe("rsp cli", () => {
+  it("prints unknown rsp flags as structured usage errors", async () => {
+    const root = await tempRoot();
+
+    const res = runRsp(root, ["--bogus"], {});
+    const decoded = decode(res.stdout.toString("utf8")) as { category: string; exit_code: number; valid_flags: string[] };
+
+    expect(res.status).toBe(2);
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+    expect(decoded.category).toBe("usage");
+    expect(decoded.exit_code).toBe(2);
+    expect(decoded.valid_flags).toContain("--brief");
+  });
+
   it.each([
     ["compound-stdout-stderr", "printf 'out\\n'; printf 'err\\n' >&2"],
     ["pipeline", "printf 'one\\ntwo\\n' | sed -n '2p'"],
@@ -1830,7 +1843,7 @@ describe("rsp cli", () => {
     expect(shown.stderr).toEqual(Buffer.alloc(0));
   }, 120_000);
 
-  it("built bundle preserves rsp exec redirects, stderr, and exit code", async () => {
+  it("built bundle preserves rsp exec redirects and structures failing command errors", async () => {
     buildBundleOnce();
     const root = await initGitRepo();
     const cacheDir = await seedWarmRedCache();
@@ -1850,10 +1863,12 @@ describe("rsp cli", () => {
     const failingCommand = `${shellQuote(process.execPath)} -e "process.stderr.write('bad\\\\n'); process.exit(7)"`;
     const direct = runShellFromCwd(root, failingCommand);
     const failing = runBundleFromCwd(root, ["exec", "--", failingCommand], { RED_SKILLS_CACHE_DIR: cacheDir });
+    const decoded = decode(failing.stdout.toString("utf8")) as { category: string; error: string; help: string[] };
 
-    expect(failing.status).toBe(direct.status);
+    expect(failing.status).toBe(1);
+    expect(direct.status).toBe(7);
     expect(failing.stderr).toEqual(direct.stderr);
-    expect(failing.stdout).toEqual(direct.stdout);
+    expect(decoded).toMatchObject({ category: "real-error", error: "bad", help: [`${failingCommand} --help`] });
   }, 120_000);
 
   it("built bundle records invocation and degradation telemetry through the resident", async () => {
@@ -2211,14 +2226,19 @@ describe("rsp cli", () => {
     );
   }, 120_000);
 
-  it("fails closed instead of creating the default Repo store when setup has not provisioned it", async () => {
+  it("fails closed with a structured error instead of creating the default Repo store when setup has not provisioned it", async () => {
     const root = await tempRoot();
     await enableRsp(root);
 
     const res = runRspFromCwd(root, [], {});
+    const decoded = decode(res.stdout.toString("utf8")) as { category: string; help: string[]; error: string };
 
     expect(res.status).toBe(1);
-    expect(res.stdout).toEqual(Buffer.from("error: rsp repo store is not provisioned - run /red-setup\n"));
+    expect(decoded).toMatchObject({
+      category: "real-error",
+      error: "rsp repo store is not provisioned",
+      help: ["/red-setup"],
+    });
     await expect(stat(join(root, ".red", "red.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(root, ".red", "state", "red-skills.rdb"))).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/apps/rsp/tests/gh-wrapper.test.ts
+++ b/apps/rsp/tests/gh-wrapper.test.ts
@@ -117,7 +117,7 @@ describe("rsp gh fidelity fixtures", () => {
     }
   });
 
-  it("forwards gh auth failures and rate limits byte-intact", async () => {
+  it("renders gh auth failures and rate limits as structured errors", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
     try {
@@ -125,16 +125,20 @@ describe("rsp gh fidelity fixtures", () => {
       const auth = fixtures.find((candidate) => candidate.name === "issue-list-auth-failure")!;
       const rate = fixtures.find((candidate) => candidate.name === "run-list-rate-limit")!;
 
-      await expect(runFidelityFixture(auth, { level: "lossless", store })).resolves.toMatchObject({
-        status: 4,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from("gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.\n"),
-      });
-      await expect(runFidelityFixture(rate, { level: "lossless", store })).resolves.toMatchObject({
+      const authResult = await runFidelityFixture(auth, { level: "lossless", store });
+      const authError = decode(authResult.stdout.toString("utf8")) as { category: string; help: string[]; error: string };
+      expect(authResult.status).toBe(1);
+      expect(authResult.stderr).toEqual(Buffer.from("gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.\n"));
+      expect(authError).toMatchObject({ category: "real-error", help: ["gh auth login"] });
+      expect(authError.error).toContain("GH_TOKEN");
+
+      const rateResult = await runFidelityFixture(rate, { level: "lossless", store });
+      const rateError = decode(rateResult.stdout.toString("utf8")) as { category: string; help: string[]; error: string };
+      expect(rateResult).toMatchObject({
         status: 1,
-        stdout: Buffer.from(""),
         stderr: Buffer.from("API rate limit exceeded for installation ID 12345.\n"),
       });
+      expect(rateError).toMatchObject({ category: "real-error", help: ["gh auth status"] });
     } finally {
       await store.close();
     }

--- a/apps/rsp/tests/git-wrapper.test.ts
+++ b/apps/rsp/tests/git-wrapper.test.ts
@@ -178,19 +178,41 @@ describe("rsp git fidelity fixtures", () => {
     }
   });
 
-  it("forwards non-zero git status and stderr byte-intact from fault fixtures", async () => {
+  it("renders non-zero git status as a structured error with diagnostic stderr", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
     try {
       const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "push-rejected")!;
       const result = await runFidelityFixture(fixture, { level: "lossless", store });
+      const decoded = decode(result.stdout.toString("utf8")) as { category: string; error: string; help: string[] };
 
       expect(result.status).toBe(1);
       expect(result.stderr).toEqual(Buffer.from("fatal: unable to access 'https://example.invalid/repo.git/': denied\n"));
-      expect(result.stdout).toEqual(Buffer.from(""));
+      expect(decoded.category).toBe("real-error");
+      expect(decoded.error).toContain("fatal: unable to access");
+      expect(decoded.help).toEqual(["git push --help"]);
     } finally {
       await store.close();
     }
+  });
+
+  it("reports already-satisfied git push as an explicit no-op", async () => {
+    const result = await renderGitContract(["git", "push"], {
+      stdout: [
+        "To github.com:reddb-io/red-skills.git",
+        "=\trefs/heads/main:refs/heads/main\t[up to date]",
+        "Done",
+        "",
+      ].join("\n"),
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, { level: "lossless" });
+    const decoded = decode(result.stdout.toString("utf8")) as { category: string; noop: boolean; summary: string };
+
+    expect(result.status).toBe(0);
+    expect(decoded).toMatchObject({ category: "no-op", noop: true });
+    expect(decoded.summary).toContain("already satisfied");
   });
 
   it("keeps commit-created and push-ref-update fixtures as compact TOON instead of scalar verdicts", async () => {
@@ -211,15 +233,17 @@ describe("rsp git fidelity fixtures", () => {
     }
   });
 
-  it("keeps rejected push fixtures at full fidelity while bypassing the scalar fast-path", async () => {
+  it("keeps rejected push fixtures structured while bypassing the scalar fast-path", async () => {
     const root = await tempRoot();
     const store = await RspElisionStore.open({ uri: `file://${join(root, "red.rdb")}` });
     try {
       const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "push-rejected")!;
       const result = await runFidelityFixture(fixture, { level: "lossless", store });
+      const decoded = decode(result.stdout.toString("utf8")) as { category: string; error: string };
 
       expect(result.oneLine).toBeUndefined();
-      expect(result.stdout.toString("utf8")).toBe(fixture.expected);
+      expect(decoded.category).toBe("real-error");
+      expect(decoded.error).toContain("fatal: unable to access");
       expect(result.assertionFailures).toEqual([]);
     } finally {
       await store.close();

--- a/apps/rsp/tests/test-wrapper.test.ts
+++ b/apps/rsp/tests/test-wrapper.test.ts
@@ -63,7 +63,7 @@ describe("rsp test runner fidelity fixtures", () => {
         const result = await runFidelityFixture(fixture, { level: "lossless", store });
         const decoded = decode(result.stdout.toString("utf8"));
 
-        expect(result.status).toBe(fixture.recorded.status);
+        expect(result.status).toBe(fixture.recorded.status === 0 ? 0 : 1);
         expect(result.assertionFailures).toEqual([]);
         expect(decoded).toEqual(fixture.expected);
       }
@@ -78,9 +78,11 @@ describe("rsp test runner fidelity fixtures", () => {
     try {
       const fixture = (await discoverFidelityFixtures(fixtureRoot)).find((candidate) => candidate.name === "vitest-fault-green-nonzero")!;
       const result = await runFidelityFixture(fixture, { level: "lossless", store });
+      const decoded = decode(result.stdout.toString("utf8")) as { category: string; error: string };
 
       expect(result.status).toBe(1);
-      expect(result.stdout).toEqual(Buffer.from(fixture.recorded.stdout, "utf8"));
+      expect(decoded.category).toBe("real-error");
+      expect(decoded.error).toBe("worker crashed after reporting JSON");
       expect(result.stdout.toString("utf8")).not.toContain("0/2 failed");
     } finally {
       await store.close();


### PR DESCRIPTION
Automated AFK landing for #1985. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1985

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/1994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786886385&installation_id=129708444&pr_number=1994&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F1994&signature=be5aa50fdaff3af36a64dab03cac54cebe982ba97cc8e7529b6e66cd89989757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->