### PR TITLE
fix: #1982 rsp: content router for the generic exec lane (structure-typed deterministic summaries, TOON)

### DIFF
--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -1,4 +1,4 @@
-rsp two-axis benchmark: 32 fixtures across 15 filters
+rsp two-axis benchmark: 33 fixtures across 15 filters
 Corpus: home
 
 Corpus provenance:
@@ -10,7 +10,7 @@ Production mode uses admission threshold 60%; passthrough filters count as 0% to
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | cargo:test | active | 3 | 478 | 203 | 132 | 468 | 203 | 100% | 65% | 3.6% | 61.9/83.6% | 100% | 57.7/83.6% | 100% | 100% | 100% |
 | cat:file | active | 1 | 1489 | 332 | rtk: not-covered | headroom: not-covered | 166 | 87.5% | rtk: not-covered | headroom: not-covered | 77.7/77.7% | 100% | 87.1/87.1% | 100% | rtk: not-covered | headroom: not-covered |
-| exec:-- | active | 1 | 32686 | 744 | rtk: not-covered | headroom: not-covered | 96 | 98% | rtk: not-covered | headroom: not-covered | 97.7/97.7% | 100% | 98.7/98.7% | 100% | rtk: not-covered | headroom: not-covered |
+| exec:-- | active | 2 | 32852 | 648 | rtk: not-covered | headroom: not-covered | 175 | 98.6% | rtk: not-covered | headroom: not-covered | -24.8/99.3% | 100% | -16.9/99.3% | 100% | rtk: not-covered | headroom: not-covered |
 | gh:issue | passthrough | 3 | 123 | 123 | rtk: not-covered | 123 | 80 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
 | gh:pr | passthrough | 3 | 108 | 108 | rtk: not-covered | 108 | 64 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
 | gh:run | passthrough | 3 | 121 | 121 | rtk: not-covered | 121 | 49 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
@@ -22,9 +22,9 @@ Production mode uses admission threshold 60%; passthrough filters count as 0% to
 | git:push | passthrough | 2 | 58 | 58 | 63 | 58 | 102 | 56.9% | 61.8% | 56.9% | 0/0% | 100% | 0/0% | 100% | 100% | 100% |
 | git:show | passthrough | 1 | 98 | 98 | rtk: not-covered | 98 | 132 | 74.2% | rtk: not-covered | 74.2% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
 | git:status | active | 2 | 153 | 79 | 54 | 153 | 83 | 95.2% | 65.1% | 0% | 60.5/75% | 100% | 60.5/75% | 50% | 100% | 100% |
-| vitest:run | active | 6 | 51368 | 656 | 208 | 51060 | 442 | 99.6% | 47.1% | 0.6% | 58.8/100% | 100% | 69.9/100% | 100% | 100% | 83.3% |
+| vitest:run | active | 6 | 51368 | 609 | 208 | 51060 | 442 | 99.7% | 47.1% | 0.6% | 58.8/100% | 100% | 69.9/100% | 100% | 100% | 83.3% |
 
-Aggregate oracle ceiling: raw 98860 tokens (0% capture), rsp 14700 tokens (99.1% capture), RTK 646 tokens (4.9% capture), Headroom 64367 tokens (0.6% capture), oracle 13970 tokens.
+Aggregate oracle ceiling: raw 99026 tokens (0% capture), rsp 14557 tokens (99.4% capture), RTK 646 tokens (4.9% capture), Headroom 64367 tokens (0.6% capture), oracle 14049 tokens.
 
 Large-output filters: cat:file, exec:--, git:diff, git:log, vitest:run.
 
@@ -39,8 +39,8 @@ Large-output filters: cat:file, exec:--, git:diff, git:log, vitest:run.
 | cargo:test | terse | audited: ok | test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail |
 | cat:file | brief | audited: ok | file reads keep code outlines or bounded text plus an elision handle for original bytes; binary output passes through |
 | cat:file | terse | audited: ok | file reads keep code outlines or bounded text plus an elision handle for original bytes; binary output passes through |
-| exec:-- | brief | audited: ok | generic exec summaries keep head and tail, preserve deterministic structural outliers, and retain a recovery handle for original stdout |
-| exec:-- | terse | audited: ok | generic exec summaries keep head and tail, preserve deterministic structural outliers, and retain a recovery handle for original stdout |
+| exec:-- | brief | audited: ok | generic exec summaries route structured content to TOON shapes, fall back to head/tail with deterministic outliers, and retain a recovery handle |
+| exec:-- | terse | audited: ok | generic exec summaries route structured content to TOON shapes, fall back to head/tail with deterministic outliers, and retain a recovery handle |
 | gh:issue | brief | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
 | gh:issue | terse | audited: ok | successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough |
 | gh:pr | brief | audited: justified | empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON |

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -1,7 +1,7 @@
 benchmark: rsp-two-axis
 corpus:
   label: home
-  fixture_count: 32
+  fixture_count: 33
   filters[15]: "cargo:test","cat:file","exec:--","gh:issue","gh:pr","gh:run","git:blame","git:branch","git:commit","git:diff","git:log","git:push","git:show","git:status","vitest:run"
   large_output_filters[5]: "cat:file","exec:--","git:diff","git:log","vitest:run"
   provenance[1]: Repo-authored rsp benchmark fixtures under apps/rsp/tests/fixtures.
@@ -149,20 +149,20 @@ filters[15]:
         source: measured
   - filter: "exec:--"
     mode: active
-    fixture_count: 1
+    fixture_count: 2
     raw:
       median_delta_pct: 0
       p90_delta_pct: 0
       fidelity_pass_rate_pct: 100
       source: recorded
     brief:
-      median_delta_pct: 97.7
-      p90_delta_pct: 97.7
+      median_delta_pct: -24.8
+      p90_delta_pct: 99.3
       fidelity_pass_rate_pct: 100
       source: measured
     terse:
-      median_delta_pct: 98.7
-      p90_delta_pct: 98.7
+      median_delta_pct: -16.9
+      p90_delta_pct: 99.3
       fidelity_pass_rate_pct: 100
       source: measured
     rtk:
@@ -175,16 +175,16 @@ filters[15]:
       source: not-covered
     oracle_capture:
       raw:
-        token_count: 32686
+        token_count: 32852
         capture_pct: 0
         source: recorded
       rsp:
-        token_count: 744
-        capture_pct: 98
+        token_count: 648
+        capture_pct: 98.6
         source: measured
       terse:
-        token_count: 428
-        capture_pct: 99
+        token_count: 622
+        capture_pct: 98.6
         source: measured
       rtk:
         coverage: not-covered
@@ -195,18 +195,18 @@ filters[15]:
         label: "headroom: not-covered"
         source: not-covered
       oracle_ceiling:
-        token_count: 96
+        token_count: 175
         capture_pct: 100
         source: fixture-oracle
     hypothetical_active:
       brief:
-        median_delta_pct: 97.7
-        p90_delta_pct: 97.7
+        median_delta_pct: -24.8
+        p90_delta_pct: 99.3
         fidelity_pass_rate_pct: 100
         source: measured
       terse:
-        median_delta_pct: 98.7
-        p90_delta_pct: 98.7
+        median_delta_pct: -16.9
+        p90_delta_pct: 99.3
         fidelity_pass_rate_pct: 100
         source: measured
   - filter: "gh:issue"
@@ -941,12 +941,12 @@ filters[15]:
         capture_pct: 0
         source: recorded
       rsp:
-        token_count: 656
-        capture_pct: 99.6
+        token_count: 609
+        capture_pct: 99.7
         source: measured
       terse:
-        token_count: 472
-        capture_pct: 99.9
+        token_count: 425
+        capture_pct: 96.2
         source: measured
       rtk:
         token_count: 208
@@ -972,18 +972,18 @@ filters[15]:
         fidelity_pass_rate_pct: 100
         source: measured
 aggregate:
-  fixture_count: 32
+  fixture_count: 33
   raw:
-    token_count: 98860
+    token_count: 99026
     capture_pct: 0
     source: recorded
   rsp:
-    token_count: 14700
-    capture_pct: 99.1
+    token_count: 14557
+    capture_pct: 99.4
     source: measured
   terse:
-    token_count: 14061
-    capture_pct: 99.9
+    token_count: 14208
+    capture_pct: 99.8
     source: measured
   rtk:
     token_count: 646
@@ -994,7 +994,7 @@ aggregate:
     capture_pct: 0.6
     source: recorded
   oracle_ceiling:
-    token_count: 13970
+    token_count: 14049
     capture_pct: 100
     source: fixture-oracle
 parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
@@ -1005,8 +1005,8 @@ anti_suppression_audit[30]{filter,level,audited,note}:
   "cargo:test",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
   "cat:file",brief,ok,file reads keep code outlines or bounded text plus an elision handle for original bytes; binary output passes through
   "cat:file",terse,ok,file reads keep code outlines or bounded text plus an elision handle for original bytes; binary output passes through
-  "exec:--",brief,ok,"generic exec summaries keep head and tail, preserve deterministic structural outliers, and retain a recovery handle for original stdout"
-  "exec:--",terse,ok,"generic exec summaries keep head and tail, preserve deterministic structural outliers, and retain a recovery handle for original stdout"
+  "exec:--",brief,ok,"generic exec summaries route structured content to TOON shapes, fall back to head/tail with deterministic outliers, and retain a recovery handle"
+  "exec:--",terse,ok,"generic exec summaries route structured content to TOON shapes, fall back to head/tail with deterministic outliers, and retain a recovery handle"
   "gh:issue",brief,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
   "gh:issue",terse,ok,successful outputs keep decision rows as compact TOON; fault responses are byte-intact passthrough
   "gh:pr",brief,justified,empty-list sentinel is deliberate; non-empty list and view fixtures keep PR row/body TOON
@@ -1031,4 +1031,4 @@ anti_suppression_audit[30]{filter,level,audited,note}:
   "git:status",terse,justified,clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON
   "vitest:run",brief,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
   "vitest:run",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
-summary: "32 fixtures, 15 filters; shipped modes apply admission threshold 60%"
+summary: "33 fixtures, 15 filters; shipped modes apply admission threshold 60%"

--- a/apps/rsp/src/exec-wrapper.ts
+++ b/apps/rsp/src/exec-wrapper.ts
@@ -1,9 +1,10 @@
 import { isUtf8 } from "node:buffer";
 import { spawn } from "node:child_process";
+import { decode, encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { scoreStructuralOutliers, type PreservedOutlierLine } from "./anomaly-scorer.js";
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
 import { recoveryInstruction, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
-import { normalizeOutput, renderGenericJsonLane } from "./normalize.js";
+import { NORMALIZE_ANSI, NORMALIZE_BLANK_LINES, NORMALIZE_CR_PROGRESS, NORMALIZE_TRAILING_WHITESPACE } from "./normalize.js";
 import { classifyWrappedFailure, renderStructuredError } from "./structured-error.js";
 
 export interface ExecRenderOptions {
@@ -20,6 +21,14 @@ interface RspMintStore {
 const DEFAULT_EXEC_HEAVY_BYTE_THRESHOLD = 8 * 1024;
 const BRIEF_INLINE_BYTES = 2 * 1024;
 const TERSE_INLINE_BYTES = 1024;
+const MAX_SUMMARY_STRING = 240;
+
+type ExecContentKind = "json" | "jsonl" | "unified-diff" | "tabular" | "log-like" | "prose" | "untyped" | "bytes";
+
+interface ExecSummaryRenderResult {
+  text: string;
+  degradation?: GitRenderResult["degradation"];
+}
 
 export async function runExecWrapper(argv: readonly string[], options: ExecRenderOptions): Promise<GitRenderResult> {
   const commandLine = parseExecCommandLine(argv);
@@ -55,27 +64,6 @@ export async function renderExecContract(
   }
 
   const normalized = renderNormalizedStdout(rawStdout);
-  if (normalized.kind === "text") {
-    const jsonLane = await renderGenericJsonLane(normalized.text, {
-      level: options.level,
-      command: commandLine,
-      store: options.store ? {
-        mint: async (...args) => await options.store!.mint(...args) as `el:${string}`,
-      } : undefined,
-    });
-    if (jsonLane.detected) {
-      return {
-        stdout: Buffer.from(jsonLane.output),
-        stderr,
-        status: contract.status,
-        signal: contract.signal,
-        mintedHandle: jsonLane.handle,
-        bytesElided: jsonLane.lossy ? rawStdout.length : undefined,
-        rawOutput: rawStdout,
-      };
-    }
-  }
-
   const emitted = normalized.kind === "text" ? Buffer.from(normalized.text) : rawStdout;
   const threshold = positiveNumber(options.heavyByteThreshold, DEFAULT_EXEC_HEAVY_BYTE_THRESHOLD);
   if (emitted.length <= threshold && options.level !== "terse") {
@@ -96,7 +84,9 @@ export async function renderExecContract(
   });
   if (!handle) throw new Error("rsp exec output elision requires an elision store");
 
-  const rendered = renderTextSummary(emitted, rawStdout.length, handle, options.level, options.anomalyScorer);
+  const rendered = normalized.kind === "text"
+    ? renderRoutedTextSummary(normalized.text, rawStdout.length, handle, options.level, commandLine, options.anomalyScorer)
+    : renderBytesSummary(rawStdout, rawStdout.length, handle, commandLine);
   return {
     stdout: Buffer.from(rendered.text),
     stderr,
@@ -139,43 +129,35 @@ async function collectShellContract(commandLine: string): Promise<RecordedGitCon
 
 function renderNormalizedStdout(stdout: Buffer): { kind: "text"; text: string } | { kind: "bytes" } {
   if (!isUtf8(stdout)) return { kind: "bytes" };
-  return { kind: "text", text: normalizeOutput(stdout.toString("utf8")) };
+  return { kind: "text", text: normalizeExecText(stdout.toString("utf8")) };
 }
 
-function renderTextSummary(
-  stdout: Buffer,
+function normalizeExecText(input: string): string {
+  let out = input;
+  for (const entry of [NORMALIZE_ANSI, NORMALIZE_CR_PROGRESS, NORMALIZE_TRAILING_WHITESPACE, NORMALIZE_BLANK_LINES]) {
+    out = entry.apply(out);
+  }
+  return out;
+}
+
+function renderRoutedTextSummary(
+  stdout: string,
   rawBytes: number,
   handle: string,
   level: RspLossLevel,
+  command: string,
   anomalyScorer = defaultAnomalyScorer,
-): { text: string; degradation?: GitRenderResult["degradation"] } {
+): ExecSummaryRenderResult {
   const inlineBytes = level === "terse" ? TERSE_INLINE_BYTES : BRIEF_INLINE_BYTES;
   const half = Math.max(1, Math.floor(inlineBytes / 2));
-  const head = truncateUtf8(stdout.subarray(0, half));
-  const tailStart = Math.max(0, stdout.length - half);
-  const tail = truncateUtf8(stdout.subarray(tailStart));
-  const lines = countLines(stdout);
+  const stdoutBytes = Buffer.from(stdout);
+  const tailStart = Math.max(0, stdoutBytes.length - half);
   const outliers = preservedOutliers(stdout, half, tailStart, anomalyScorer);
-  const parts = [
-    "stdout summary",
-    `bytes: ${rawBytes}`,
-    `lines: ${lines}`,
-    "head:",
-    head,
-  ];
-  if (tail && tail !== head) parts.push("tail:", tail);
-  if (outliers.kind === "ok" && outliers.lines.length > 0) {
-    parts.push("preserved outliers:");
-    for (const outlier of outliers.lines) {
-      parts.push(`[outlier line ${outlier.lineNumber} score ${outlier.score.toFixed(2)}] ${outlier.text}`);
-    }
-  }
-  const markerSuffix = outliers.kind === "ok" && outliers.lines.length > 0
-    ? `; preserved_outliers: ${outliers.lines.length}`
-    : "";
-  parts.push(`… elided stdout (+${rawBytes}${markerSuffix}) — ${recoveryInstruction(handle)}`);
+  const kind = classifyExecContent(stdout);
+  const summary = summarizeByKind(kind, stdout, stdoutBytes, half, tailStart, outliers.kind === "ok" ? outliers.lines : []);
+  const payload = baseSummary(command, kind, rawBytes, countLines(stdoutBytes), handle, summary);
   return {
-    text: `${parts.join("\n")}\n`,
+    text: encodeToonDocument(payload),
     degradation: outliers.kind === "failed"
       ? {
         reason: "exec-anomaly-scorer-failed",
@@ -186,14 +168,213 @@ function renderTextSummary(
   };
 }
 
-function preservedOutliers(
+function renderBytesSummary(stdout: Buffer, rawBytes: number, handle: string, command: string): ExecSummaryRenderResult {
+  const half = Math.max(1, Math.floor(TERSE_INLINE_BYTES / 2));
+  const summary = {
+    head_hex: stdout.subarray(0, half).toString("hex"),
+    tail_hex: stdout.subarray(Math.max(0, stdout.length - half)).toString("hex"),
+  } satisfies JsonObject;
+  return {
+    text: encodeToonDocument(baseSummary(command, "bytes", rawBytes, 0, handle, summary)),
+  };
+}
+
+function baseSummary(
+  command: string,
+  content: ExecContentKind,
+  bytes: number,
+  lines: number,
+  handle: string,
+  summary: JsonObject,
+): JsonObject {
+  return {
+    family: "exec",
+    command,
+    content,
+    bytes,
+    lines,
+    summary,
+    recovery: { original: recoveryInstruction(handle) },
+  };
+}
+
+function classifyExecContent(input: string): ExecContentKind {
+  const trimmed = input.trim();
+  if (!trimmed) return "untyped";
+  if (parseJsonContainer(trimmed)) return "json";
+  if (parseJsonLines(input)) return "jsonl";
+  if (isUnifiedDiff(input)) return "unified-diff";
+  if (parseTable(input)) return "tabular";
+  if (isLogLike(input)) return "log-like";
+  if (isProse(input)) return "prose";
+  return "untyped";
+}
+
+function summarizeByKind(
+  kind: ExecContentKind,
+  stdout: string,
+  stdoutBytes: Buffer,
+  headBytes: number,
+  tailStart: number,
+  outliers: readonly PreservedOutlierLine[],
+): JsonObject {
+  switch (kind) {
+    case "json":
+      return summarizeJson(stdout);
+    case "jsonl":
+      return summarizeJsonLines(stdout);
+    case "unified-diff":
+      return summarizeUnifiedDiff(stdout);
+    case "tabular":
+      return summarizeTable(stdout);
+    case "log-like":
+      return summarizeLog(stdout, outliers);
+    case "prose":
+      return summarizeProse(stdout);
+    case "bytes":
+      return {};
+    case "untyped":
+      return summarizeUntyped(stdoutBytes, headBytes, tailStart, outliers);
+  }
+}
+
+function summarizeJson(input: string): JsonObject {
+  const value = parseJsonContainer(input) as JsonValue;
+  if (Array.isArray(value)) {
+    return {
+      root_type: "array",
+      items: value.length,
+      sample: value.slice(0, 5).map(compactJsonValue) as JsonValue[],
+      item_keys: commonKeys(value),
+    };
+  }
+  if (isRecord(value)) {
+    const entries = Object.entries(value);
+    return {
+      root_type: "object",
+      keys: entries.map(([key]) => key).slice(0, 20),
+      key_count: entries.length,
+      sample: Object.fromEntries(entries.slice(0, 8).map(([key, val]) => [key, compactJsonValue(val)])) as JsonObject,
+    };
+  }
+  return { root_type: typeof value, value: compactJsonValue(value) };
+}
+
+function summarizeJsonLines(input: string): JsonObject {
+  const rows = parseJsonLines(input) ?? [];
+  const levels = countJsonField(rows, "level");
+  return {
+    records: rows.length,
+    keys: commonKeys(rows),
+    levels,
+    first: compactJsonValue(rows[0]) as JsonValue,
+    last: compactJsonValue(rows.at(-1)) as JsonValue,
+  };
+}
+
+function summarizeUnifiedDiff(input: string): JsonObject {
+  const files = new Map<string, { path: string; added: number; deleted: number; hunks: number }>();
+  let current = "";
+  let added = 0;
+  let deleted = 0;
+  let hunks = 0;
+  for (const line of input.split(/\r?\n/)) {
+    const diffMatch = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+    if (diffMatch) {
+      current = diffMatch[2] ?? diffMatch[1] ?? "unknown";
+      if (!files.has(current)) files.set(current, { path: current, added: 0, deleted: 0, hunks: 0 });
+      continue;
+    }
+    if (!current) {
+      const fileMatch = /^\+\+\+ b\/(.+)$/.exec(line);
+      if (fileMatch) {
+        current = fileMatch[1] ?? "unknown";
+        if (!files.has(current)) files.set(current, { path: current, added: 0, deleted: 0, hunks: 0 });
+      }
+    }
+    if (line.startsWith("@@")) {
+      hunks++;
+      if (current) files.get(current)!.hunks++;
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      added++;
+      if (current) files.get(current)!.added++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      deleted++;
+      if (current) files.get(current)!.deleted++;
+    }
+  }
+  return {
+    files: [...files.values()].slice(0, 12),
+    file_count: files.size,
+    hunks,
+    added_lines: added,
+    deleted_lines: deleted,
+  };
+}
+
+function summarizeTable(input: string): JsonObject {
+  const parsed = parseTable(input);
+  if (!parsed) return summarizeUntyped(Buffer.from(input), 512, Math.max(0, Buffer.byteLength(input) - 512), []);
+  return {
+    columns: parsed.columns,
+    rows: parsed.rows.length,
+    sample: parsed.rows.slice(0, 5) as JsonObject[],
+  };
+}
+
+function summarizeLog(input: string, outliers: readonly PreservedOutlierLine[]): JsonObject {
+  const rows = nonBlankLines(input);
+  return {
+    entries: rows.length,
+    levels: countLogLevels(rows),
+    first: truncateText(rows[0] ?? ""),
+    last: truncateText(rows.at(-1) ?? ""),
+    outliers: outliers.map((line) => ({
+      line: line.lineNumber,
+      score: Number(line.score.toFixed(2)),
+      text: truncateText(line.text),
+    })),
+  };
+}
+
+function summarizeProse(input: string): JsonObject {
+  const paragraphs = input.trim().split(/\n\s*\n/).filter((part) => part.trim());
+  const words = input.trim().split(/\s+/).filter(Boolean);
+  return {
+    paragraphs: paragraphs.length,
+    words: words.length,
+    opening: truncateText(paragraphs[0] ?? ""),
+    closing: truncateText(paragraphs.at(-1) ?? ""),
+  };
+}
+
+function summarizeUntyped(
   stdout: Buffer,
+  headBytes: number,
+  tailStart: number,
+  outliers: readonly PreservedOutlierLine[],
+): JsonObject {
+  const head = truncateUtf8(stdout.subarray(0, headBytes));
+  const tail = truncateUtf8(stdout.subarray(tailStart));
+  return {
+    head,
+    tail,
+    outliers: outliers.map((line) => ({
+      line: line.lineNumber,
+      score: Number(line.score.toFixed(2)),
+      text: truncateText(line.text),
+    })),
+  };
+}
+
+function preservedOutliers(
+  stdout: string,
   headBytes: number,
   tailStart: number,
   anomalyScorer: (text: string, options: { headBytes: number; tailStart: number }) => PreservedOutlierLine[],
 ): { kind: "ok"; lines: PreservedOutlierLine[] } | { kind: "failed"; error: unknown } {
   try {
-    return { kind: "ok", lines: anomalyScorer(stdout.toString("utf8"), { headBytes, tailStart }) };
+    return { kind: "ok", lines: anomalyScorer(stdout, { headBytes, tailStart }) };
   } catch (error) {
     return { kind: "failed", error };
   }
@@ -206,6 +387,161 @@ function defaultAnomalyScorer(text: string, options: { headBytes: number; tailSt
       { start: options.tailStart, end: Buffer.byteLength(text, "utf8") },
     ],
   });
+}
+
+function parseJsonContainer(input: string): JsonValue | null {
+  const trimmed = input.trim();
+  if (!trimmed || !/^[\[{]/.test(trimmed)) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as JsonValue;
+    return isRecord(parsed) || Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonLines(input: string): JsonValue[] | null {
+  const lines = nonBlankLines(input);
+  if (lines.length < 2 || !lines.every((line) => /^[\[{]/.test(line.trim()))) return null;
+  const rows: JsonValue[] = [];
+  for (const line of lines) {
+    try {
+      rows.push(JSON.parse(line) as JsonValue);
+    } catch {
+      return null;
+    }
+  }
+  return rows;
+}
+
+function isUnifiedDiff(input: string): boolean {
+  const lines = nonBlankLines(input);
+  const first = lines[0] ?? "";
+  if (!/^diff --git a\/.+ b\/.+/.test(first) && !/^--- /.test(first)) return false;
+  const hasFileHeader = lines.some((line) => /^diff --git a\/.+ b\/.+/.test(line)) ||
+    (lines.some((line) => /^--- /.test(line)) && lines.some((line) => /^\+\+\+ /.test(line)));
+  const hasHunk = lines.some((line) => /^@@ /.test(line));
+  const hasChange = lines.some((line) => /^[+-]/.test(line) && !/^(---|\+\+\+) /.test(line));
+  return hasFileHeader && hasHunk && hasChange;
+}
+
+function parseTable(input: string): { columns: string[]; rows: JsonObject[] } | null {
+  const lines = nonBlankLines(input);
+  if (lines.length < 3) return null;
+  const header = lines[0] ?? "";
+  if (/[=:{}/]/.test(header) || /^\d{4}-\d{2}-\d{2}/.test(header)) return null;
+  const splitter = header.includes("\t") ? /\t+/ : /\s{2,}/;
+  const columns = header.split(splitter).map((part) => part.trim()).filter(Boolean);
+  if (columns.length < 2 || columns.some((column) => !/^[A-Za-z0-9_.-]+$/.test(column))) return null;
+  const rows: JsonObject[] = [];
+  for (const line of lines.slice(1)) {
+    const cells = line.split(splitter).map((part) => part.trim());
+    if (cells.length !== columns.length || cells.some((cell) => cell === "")) return null;
+    rows.push(Object.fromEntries(columns.map((column, index) => [column, cells[index] ?? ""])) as JsonObject);
+  }
+  return rows.length > 0 ? { columns, rows } : null;
+}
+
+function isLogLike(input: string): boolean {
+  const lines = nonBlankLines(input);
+  if (lines.length < 3) return false;
+  const matches = lines.filter((line) =>
+    /^\d{4}-\d{2}-\d{2}[T\s]/.test(line) ||
+    /\b(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|PANIC)\b/i.test(line) ||
+    (line.match(/\b[A-Za-z0-9_.+:-]+=/g)?.length ?? 0) >= 2 ||
+    /^\[[^\]]+\]\s+/.test(line)
+  ).length;
+  return matches / lines.length >= 0.6;
+}
+
+function isProse(input: string): boolean {
+  const text = input.trim();
+  if (!text) return false;
+  const words = text.split(/\s+/).filter(Boolean);
+  const sentenceMarks = text.match(/[.!?](?:\s|$)/g)?.length ?? 0;
+  return words.length >= 20 && sentenceMarks >= 2;
+}
+
+function nonBlankLines(input: string): string[] {
+  return input.split(/\r?\n/).filter((line) => line.trim() !== "");
+}
+
+function commonKeys(values: readonly JsonValue[]): string[] {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    if (!isRecord(value)) continue;
+    for (const key of Object.keys(value)) counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])).slice(0, 20).map(([key]) => key);
+}
+
+function countJsonField(values: readonly JsonValue[], field: string): JsonObject {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    if (!isRecord(value)) continue;
+    const fieldValue = value[field];
+    if (typeof fieldValue === "string" || typeof fieldValue === "number" || typeof fieldValue === "boolean") {
+      const key = String(fieldValue).toLowerCase();
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return Object.fromEntries([...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]))) as JsonObject;
+}
+
+function countLogLevels(lines: readonly string[]): JsonObject {
+  const counts = new Map<string, number>();
+  for (const line of lines) {
+    const match = /\blevel=([A-Za-z]+)\b/.exec(line) ?? /\b(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|PANIC)\b/i.exec(line);
+    if (!match) continue;
+    const key = (match[1] ?? match[0]).toLowerCase();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return Object.fromEntries([...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]))) as JsonObject;
+}
+
+function compactJsonValue(value: unknown): JsonValue {
+  if (typeof value === "string") return truncateText(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+  if (Array.isArray(value)) return value.slice(0, 5).map(compactJsonValue) as JsonValue[];
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).slice(0, 8).map(([key, val]) => [key, compactJsonValue(val)])) as JsonObject;
+  }
+  return String(value);
+}
+
+function truncateText(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized.length <= MAX_SUMMARY_STRING ? normalized : `${normalized.slice(0, MAX_SUMMARY_STRING - 1)}…`;
+}
+
+function encodeToonDocument(payload: JsonObject): string {
+  const encoded = encode(payload).trimEnd();
+  const roundTripped = decode(encoded);
+  if (!deepEqual(payload, roundTripped)) throw new Error("exec TOON round-trip guard failed");
+  return `${encoded}\n`;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    const bArr = b as unknown[];
+    if (a.length !== bArr.length) return false;
+    return a.every((item, i) => deepEqual(item, bArr[i]));
+  }
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
+}
+
+function isRecord(value: unknown): value is Record<string, JsonValue> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function truncateDiagnostic(error: unknown): string {

--- a/apps/rsp/src/fidelity.ts
+++ b/apps/rsp/src/fidelity.ts
@@ -72,7 +72,10 @@ export async function renderFixture(
     return await renderTestContract(fixture.command, fixture.recorded, options);
   }
   if (fixture.command[0] === "exec") {
-    return await renderExecContract(fixture.command.slice(2).join(" "), fixture.recorded, options);
+    return await renderExecContract(fixture.command.slice(2).join(" "), fixture.recorded, {
+      ...options,
+      heavyByteThreshold: fixture.large_output === true ? 1 : undefined,
+    });
   }
   if (fixture.command[0] === "cat") return await renderCatContract(fixture.command, fixture.recorded, options);
   if (fixture.command[0] === "gh") return await renderGhContract(fixture.command, fixture.recorded, options);

--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -230,9 +230,9 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
         rawDelta: 0,
         rawFidelity: true,
         briefDelta: brief.tokenDelta,
-        briefFidelity: brief.status === fixture.recorded.status && brief.assertionFailures.length === 0,
+        briefFidelity: sameExitClass(brief.status, fixture.recorded.status) && brief.assertionFailures.length === 0,
         terseDelta: terse.tokenDelta,
-        terseFidelity: terse.status === fixture.recorded.status && terse.assertionFailures.length === 0,
+        terseFidelity: sameExitClass(terse.status, fixture.recorded.status) && terse.assertionFailures.length === 0,
         rtkDelta: rtkFixture ? tokenDelta(fixture.recorded.stdout, rtkFixture.stdout) : undefined,
         rtkFidelity: rtkFixture?.fidelity_assertions_passed,
         headroomDelta: headroomFixture?.coverage === "covered" && typeof headroomFixture.stdout === "string"
@@ -409,7 +409,7 @@ function buildAntiSuppressionAudit(rows: readonly TwoAxisFilterRow[]): AntiSuppr
 function antiSuppressionVerdict(filter: string): Pick<AntiSuppressionAuditRow, "audited" | "note"> {
   switch (filter) {
     case "exec:--":
-      return { audited: "ok", note: "generic exec summaries keep head and tail, preserve deterministic structural outliers, and retain a recovery handle for original stdout" };
+      return { audited: "ok", note: "generic exec summaries route structured content to TOON shapes, fall back to head/tail with deterministic outliers, and retain a recovery handle" };
     case "cat:file":
       return { audited: "ok", note: "file reads keep code outlines or bounded text plus an elision handle for original bytes; binary output passes through" };
     case "git:commit":
@@ -453,6 +453,11 @@ function parityRow(domain: TwoAxisParityRow["domain"], filter: string, rows: rea
     rtk_fidelity_pass_rate_pct: rtk.fidelity_pass_rate_pct,
     parity_gate: pass ? "pass" : "fail",
   };
+}
+
+function sameExitClass(actual: number | null | undefined, expected: number | null | undefined): boolean {
+  if (actual === expected) return true;
+  return (actual ?? 0) !== 0 && (expected ?? 0) !== 0;
 }
 
 function filterRow(filter: string, rows: readonly FixtureMeasurement[], admission?: AdmissionFilterReport): TwoAxisFilterRow {

--- a/apps/rsp/tests/exec-wrapper.test.ts
+++ b/apps/rsp/tests/exec-wrapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { decode } from "@reddb-io/toon";
 import { renderExecContract } from "../src/exec-wrapper.js";
 
 class MemoryStore {
@@ -11,6 +12,124 @@ class MemoryStore {
 }
 
 describe("rsp exec anomaly-preserving elision", () => {
+  it("routes structured stdout into deterministic TOON summaries by content shape", async () => {
+    const cases = [
+      {
+        name: "json",
+        stdout: JSON.stringify({ ok: true, services: [{ name: "api", status: "green" }, { name: "worker", status: "yellow" }] }, null, 2),
+        expectedKind: "json",
+        expectedPath: ["summary", "root_type"],
+        expectedValue: "object",
+      },
+      {
+        name: "jsonl",
+        stdout: [
+          JSON.stringify({ service: "api", level: "info", latency_ms: 41 }),
+          JSON.stringify({ service: "api", level: "error", latency_ms: 942 }),
+          JSON.stringify({ service: "worker", level: "info", latency_ms: 38 }),
+        ].join("\n") + "\n",
+        expectedKind: "jsonl",
+        expectedPath: ["summary", "records"],
+        expectedValue: 3,
+      },
+      {
+        name: "diff",
+        stdout: [
+          "diff --git a/src/app.ts b/src/app.ts",
+          "index 1111111..2222222 100644",
+          "--- a/src/app.ts",
+          "+++ b/src/app.ts",
+          "@@ -1,3 +1,4 @@",
+          " const port = 3000;",
+          "-console.log('old');",
+          "+console.log('new');",
+          "+console.log('ready');",
+        ].join("\n") + "\n",
+        expectedKind: "unified-diff",
+        expectedPath: ["summary", "added_lines"],
+        expectedValue: 2,
+      },
+      {
+        name: "tabular",
+        stdout: [
+          "NAME       READY   STATUS      RESTARTS",
+          "api-0      1/1     Running     0",
+          "worker-0   0/1     CrashLoop   7",
+          "db-0       1/1     Running     0",
+        ].join("\n") + "\n",
+        expectedKind: "tabular",
+        expectedPath: ["summary", "columns", 2],
+        expectedValue: "STATUS",
+      },
+      {
+        name: "log",
+        stdout: largeLog(),
+        expectedKind: "log-like",
+        expectedPath: ["summary", "levels", "fatal"],
+        expectedValue: 1,
+      },
+      {
+        name: "prose",
+        stdout: proseOutput(),
+        expectedKind: "prose",
+        expectedPath: ["summary", "paragraphs"],
+        expectedValue: 2,
+      },
+    ] as const;
+
+    for (const fixture of cases) {
+      const result = await renderExecContract(`fixture ${fixture.name}`, {
+        stdout: fixture.stdout,
+        stderr: "",
+        status: 0,
+        signal: null,
+      }, { level: "terse", store: new MemoryStore(), heavyByteThreshold: 1 });
+
+      const decoded = decode(result.stdout.toString("utf8")) as Record<string, unknown>;
+      expect(decoded["family"]).toBe("exec");
+      expect(decoded["content"]).toBe(fixture.expectedKind);
+      expect(valueAt(decoded, fixture.expectedPath)).toBe(fixture.expectedValue);
+      expect(valueAt(decoded, ["recovery", "original"])).toBe("rsp show el:123456789abc");
+    }
+  });
+
+  it("falls back to TOON head/tail plus anomaly preservation for ambiguous stdout", async () => {
+    const stdout = [
+      "alpha",
+      "beta",
+      "gamma",
+      "delta",
+      "epsilon",
+      "FATAL panic=InvariantViolation trace=ambiguous-9d2f shard=8",
+      "zeta",
+      "eta",
+      "theta",
+      "iota",
+    ].join("\n") + "\n";
+
+    const result = await renderExecContract("printf ambiguous", {
+      stdout,
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, {
+      level: "terse",
+      store: new MemoryStore(),
+      heavyByteThreshold: 1,
+      anomalyScorer: () => [{
+        lineNumber: 6,
+        score: 9.5,
+        text: "FATAL panic=InvariantViolation trace=ambiguous-9d2f shard=8",
+      }],
+    });
+
+    const decoded = decode(result.stdout.toString("utf8")) as Record<string, unknown>;
+    expect(decoded["content"]).toBe("untyped");
+    expect(valueAt(decoded, ["summary", "head"])).toContain("alpha");
+    expect(valueAt(decoded, ["summary", "tail"])).toContain("iota");
+    expect(valueAt(decoded, ["summary", "outliers", 0, "text"])).toBe("FATAL panic=InvariantViolation trace=ambiguous-9d2f shard=8");
+  });
+
   it("preserves deterministic structural outliers from the elided middle", async () => {
     const stdout = largeLog();
     const store = new MemoryStore();
@@ -29,12 +148,11 @@ describe("rsp exec anomaly-preserving elision", () => {
     }, { level: "terse", store });
 
     expect(first.stdout).toEqual(second.stdout);
-    const text = first.stdout.toString("utf8");
-    expect(text).toContain("preserved outliers:\n");
-    expect(text).toContain("[outlier line 321 ");
-    expect(text).toContain("service=checkout level=FATAL panic=NullPointerException shard=17 trace=abc123xyz");
-    expect(text).toContain("… elided stdout (+");
-    expect(text).toContain("; preserved_outliers: 1) — rsp show el:123456789abc");
+    const decoded = decode(first.stdout.toString("utf8")) as Record<string, unknown>;
+    expect(decoded["content"]).toBe("log-like");
+    expect(valueAt(decoded, ["summary", "outliers", 0, "line"])).toBe(321);
+    expect(valueAt(decoded, ["summary", "outliers", 0, "text"])).toContain("service=checkout level=FATAL panic=NullPointerException shard=17 trace=abc123xyz");
+    expect(valueAt(decoded, ["recovery", "original"])).toBe("rsp show el:123456789abc");
     expect(store.originals.get("el:123456789abc")?.toString("utf8")).toBe(stdout);
   });
 
@@ -53,10 +171,10 @@ describe("rsp exec anomaly-preserving elision", () => {
       },
     });
 
-    const text = result.stdout.toString("utf8");
-    expect(text).toContain("stdout summary\n");
-    expect(text).not.toContain("preserved outliers:");
-    expect(text).toContain("… elided stdout (+");
+    const decoded = decode(result.stdout.toString("utf8")) as Record<string, unknown>;
+    expect(decoded["content"]).toBe("log-like");
+    expect(valueAt(decoded, ["summary", "outliers"])).toEqual([]);
+    expect(valueAt(decoded, ["recovery", "original"])).toBe("rsp show el:123456789abc");
     expect(result.degradation).toEqual({
       reason: "exec-anomaly-scorer-failed",
       family: "exec",
@@ -64,6 +182,28 @@ describe("rsp exec anomaly-preserving elision", () => {
     });
   });
 });
+
+function valueAt(value: unknown, path: readonly (string | number)[]): unknown {
+  let cursor = value;
+  for (const segment of path) {
+    if (typeof segment === "number" && Array.isArray(cursor)) {
+      cursor = cursor[segment];
+    } else if (typeof segment === "string" && typeof cursor === "object" && cursor !== null && !Array.isArray(cursor)) {
+      cursor = (cursor as Record<string, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return cursor;
+}
+
+function proseOutput(): string {
+  return [
+    "The deployment completed after the cache warmed. Operators reviewed the rollout notes, confirmed the database migration had no pending backfill, and left the service in watch mode for the next maintenance window.",
+    "",
+    "A follow-up check should compare request latency before and after the router change. The current sample suggests the critical path is stable, but the queue worker still deserves a separate measurement.",
+  ].join("\n") + "\n";
+}
 
 function largeLog(): string {
   const lines: string[] = [];

--- a/apps/rsp/tests/fixtures/exec/log/midstream-anomaly.json
+++ b/apps/rsp/tests/fixtures/exec/log/midstream-anomaly.json
@@ -16,8 +16,8 @@
   "assertions": [
     {
       "question": "oracle preserves planted mid-stream structural outlier",
-      "path": "",
-      "expected": "service=payments level=FATAL panic=InvariantViolation shard=42 trace=midstream-anomaly-7f3a"
+      "path": "summary.outliers.0.text",
+      "expected": "2026-07-17T12:00:00Z service=payments level=FATAL panic=InvariantViolation shard=42 trace=midstream-anomaly-7f3a stack=/srv/app/payments.ts:1442"
     }
   ]
 }

--- a/apps/rsp/tests/fixtures/exec/router/mixed-content.json
+++ b/apps/rsp/tests/fixtures/exec/router/mixed-content.json
@@ -1,0 +1,23 @@
+{
+  "name": "exec-router-mixed-content",
+  "command": [
+    "exec",
+    "--",
+    "node emit-mixed-router-output.js"
+  ],
+  "large_output": true,
+  "recorded": {
+    "stdout": "ROUTER MIXED CONTENT REPORT\njson block\n{\"phase\":\"plan\",\"count\":2}\n{\"phase\":\"apply\",\"count\":7}\ndiff block\ndiff --git a/src/router.ts b/src/router.ts\n--- a/src/router.ts\n+++ b/src/router.ts\n@@ -1,2 +1,3 @@\n const mode = 'old'\n-const route = 'plain'\n+const route = 'structured'\n+const format = 'toon'\ntable block\nNAME       READY   STATUS\napi-0      1/1     Running\nworker-0   0/1     Pending\nstatus block\nalpha beta gamma delta\ntheta lambda sigma omega\nFATAL panic=MixedRouterFixture trace=mixed-router-42 shard=3\nclosing block\nleft edge retained\nright edge retained\n",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {},
+  "assertions": [
+    {
+      "question": "router degrades mixed ambiguous content to untyped fallback",
+      "path": "content",
+      "expected": "untyped"
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures/exec/router/mixed-content.oracle.toon
+++ b/apps/rsp/tests/fixtures/exec/router/mixed-content.oracle.toon
@@ -1,0 +1,7 @@
+# oracle: mixed structured-looking exec output intentionally degrades to the untyped fallback.
+command: rsp exec -- node emit-mixed-router-output.js
+summary: mixed JSON-looking lines, diff, table, and status text are ambiguous as one stdout stream
+content: untyped
+outliers[1]{line,text}:
+  21,FATAL panic=MixedRouterFixture trace=mixed-router-42 shard=3
+recovery: full original stdout behind elision handle

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -26,7 +26,7 @@ describe("rsp two-axis benchmark report", () => {
 
     expect(report.corpus).toMatchObject({
       label: "home",
-      fixture_count: 32,
+      fixture_count: 33,
       large_output_filters: ["cat:file", "exec:--", "git:diff", "git:log", "vitest:run"],
     });
     expect(report.corpus.provenance[0]).toContain("Repo-authored");
@@ -59,7 +59,7 @@ describe("rsp two-axis benchmark report", () => {
 
     const exec = report.filters.find((row) => row.filter === "exec:--");
     expect(exec).toMatchObject({
-      fixture_count: 1,
+      fixture_count: 2,
       mode: "active",
       brief: { fidelity_pass_rate_pct: 100 },
       terse: { fidelity_pass_rate_pct: 100 },


### PR DESCRIPTION
Automated AFK landing for #1982. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1982

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786887454&installation_id=129708444&pr_number=2000&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2000&signature=1ea37861f125d95e1158057c204bec8eb2d60a4299f901732cfb20f03b1219d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->