### PR TITLE
fix: #1983 rsp: deterministic JSON-array crusher (statistical keep rules, kept/dropped counts, handle recovery)

### DIFF
--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -1,4 +1,4 @@
-rsp two-axis benchmark: 33 fixtures across 15 filters
+rsp two-axis benchmark: 34 fixtures across 15 filters
 Corpus: home
 
 Corpus provenance:
@@ -10,7 +10,7 @@ Production mode uses admission threshold 60%; passthrough filters count as 0% to
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | cargo:test | active | 3 | 478 | 203 | 132 | 468 | 203 | 100% | 65% | 3.6% | 61.9/83.6% | 100% | 57.7/83.6% | 100% | 100% | 100% |
 | cat:file | active | 1 | 1489 | 332 | rtk: not-covered | headroom: not-covered | 166 | 87.5% | rtk: not-covered | headroom: not-covered | 77.7/77.7% | 100% | 87.1/87.1% | 100% | rtk: not-covered | headroom: not-covered |
-| exec:-- | active | 2 | 32852 | 648 | rtk: not-covered | headroom: not-covered | 175 | 98.6% | rtk: not-covered | headroom: not-covered | -24.8/99.3% | 100% | -16.9/99.3% | 100% | rtk: not-covered | headroom: not-covered |
+| exec:-- | active | 3 | 33149 | 851 | rtk: not-covered | headroom: not-covered | 345 | 98.5% | rtk: not-covered | headroom: not-covered | 31.6/99.3% | 100% | 31.6/99.3% | 100% | rtk: not-covered | headroom: not-covered |
 | gh:issue | passthrough | 3 | 123 | 123 | rtk: not-covered | 123 | 80 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
 | gh:pr | passthrough | 3 | 108 | 108 | rtk: not-covered | 108 | 64 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
 | gh:run | passthrough | 3 | 121 | 121 | rtk: not-covered | 121 | 49 | 0% | rtk: not-covered | 0% | 0/0% | 100% | 0/0% | 100% | rtk: not-covered | 100% |
@@ -24,7 +24,7 @@ Production mode uses admission threshold 60%; passthrough filters count as 0% to
 | git:status | active | 2 | 153 | 79 | 54 | 153 | 83 | 95.2% | 65.1% | 0% | 60.5/75% | 100% | 60.5/75% | 50% | 100% | 100% |
 | vitest:run | active | 6 | 51368 | 609 | 208 | 51060 | 442 | 99.7% | 47.1% | 0.6% | 58.8/100% | 100% | 69.9/100% | 100% | 100% | 83.3% |
 
-Aggregate oracle ceiling: raw 99026 tokens (0% capture), rsp 14557 tokens (99.4% capture), RTK 646 tokens (4.9% capture), Headroom 64367 tokens (0.6% capture), oracle 14049 tokens.
+Aggregate oracle ceiling: raw 99323 tokens (0% capture), rsp 14760 tokens (99.4% capture), RTK 646 tokens (4.9% capture), Headroom 64367 tokens (0.6% capture), oracle 14219 tokens.
 
 Large-output filters: cat:file, exec:--, git:diff, git:log, vitest:run.
 

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -1,7 +1,7 @@
 benchmark: rsp-two-axis
 corpus:
   label: home
-  fixture_count: 33
+  fixture_count: 34
   filters[15]: "cargo:test","cat:file","exec:--","gh:issue","gh:pr","gh:run","git:blame","git:branch","git:commit","git:diff","git:log","git:push","git:show","git:status","vitest:run"
   large_output_filters[5]: "cat:file","exec:--","git:diff","git:log","vitest:run"
   provenance[1]: Repo-authored rsp benchmark fixtures under apps/rsp/tests/fixtures.
@@ -149,19 +149,19 @@ filters[15]:
         source: measured
   - filter: "exec:--"
     mode: active
-    fixture_count: 2
+    fixture_count: 3
     raw:
       median_delta_pct: 0
       p90_delta_pct: 0
       fidelity_pass_rate_pct: 100
       source: recorded
     brief:
-      median_delta_pct: -24.8
+      median_delta_pct: 31.6
       p90_delta_pct: 99.3
       fidelity_pass_rate_pct: 100
       source: measured
     terse:
-      median_delta_pct: -16.9
+      median_delta_pct: 31.6
       p90_delta_pct: 99.3
       fidelity_pass_rate_pct: 100
       source: measured
@@ -175,16 +175,16 @@ filters[15]:
       source: not-covered
     oracle_capture:
       raw:
-        token_count: 32852
+        token_count: 33149
         capture_pct: 0
         source: recorded
       rsp:
-        token_count: 648
-        capture_pct: 98.6
+        token_count: 851
+        capture_pct: 98.5
         source: measured
       terse:
-        token_count: 622
-        capture_pct: 98.6
+        token_count: 825
+        capture_pct: 98.5
         source: measured
       rtk:
         coverage: not-covered
@@ -195,17 +195,17 @@ filters[15]:
         label: "headroom: not-covered"
         source: not-covered
       oracle_ceiling:
-        token_count: 175
+        token_count: 345
         capture_pct: 100
         source: fixture-oracle
     hypothetical_active:
       brief:
-        median_delta_pct: -24.8
+        median_delta_pct: 31.6
         p90_delta_pct: 99.3
         fidelity_pass_rate_pct: 100
         source: measured
       terse:
-        median_delta_pct: -16.9
+        median_delta_pct: 31.6
         p90_delta_pct: 99.3
         fidelity_pass_rate_pct: 100
         source: measured
@@ -972,17 +972,17 @@ filters[15]:
         fidelity_pass_rate_pct: 100
         source: measured
 aggregate:
-  fixture_count: 33
+  fixture_count: 34
   raw:
-    token_count: 99026
+    token_count: 99323
     capture_pct: 0
     source: recorded
   rsp:
-    token_count: 14557
+    token_count: 14760
     capture_pct: 99.4
     source: measured
   terse:
-    token_count: 14208
+    token_count: 14411
     capture_pct: 99.8
     source: measured
   rtk:
@@ -994,7 +994,7 @@ aggregate:
     capture_pct: 0.6
     source: recorded
   oracle_ceiling:
-    token_count: 14049
+    token_count: 14219
     capture_pct: 100
     source: fixture-oracle
 parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
@@ -1031,4 +1031,4 @@ anti_suppression_audit[30]{filter,level,audited,note}:
   "git:status",terse,justified,clean-tree sentinel is a deliberate definitive empty state; changed-tree output keeps row TOON
   "vitest:run",brief,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
   "vitest:run",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
-summary: "33 fixtures, 15 filters; shipped modes apply admission threshold 60%"
+summary: "34 fixtures, 15 filters; shipped modes apply admission threshold 60%"

--- a/apps/rsp/src/exec-wrapper.ts
+++ b/apps/rsp/src/exec-wrapper.ts
@@ -4,7 +4,14 @@ import { decode, encode, type JsonObject, type JsonValue } from "@reddb-io/toon"
 import { scoreStructuralOutliers, type PreservedOutlierLine } from "./anomaly-scorer.js";
 import { type RspMintMeta, type RspLossLevel } from "./elision-store.js";
 import { recoveryInstruction, type GitRenderResult, type RecordedGitContract } from "./git-wrapper.js";
-import { NORMALIZE_ANSI, NORMALIZE_BLANK_LINES, NORMALIZE_CR_PROGRESS, NORMALIZE_TRAILING_WHITESPACE } from "./normalize.js";
+import {
+  crushJsonArrayItems,
+  NORMALIZE_ANSI,
+  NORMALIZE_BLANK_LINES,
+  NORMALIZE_CR_PROGRESS,
+  NORMALIZE_TRAILING_WHITESPACE,
+  type JsonArrayCrusher,
+} from "./normalize.js";
 import { classifyWrappedFailure, renderStructuredError } from "./structured-error.js";
 
 export interface ExecRenderOptions {
@@ -12,6 +19,7 @@ export interface ExecRenderOptions {
   store?: RspMintStore;
   heavyByteThreshold?: number;
   anomalyScorer?: (text: string, options: { headBytes: number; tailStart: number }) => PreservedOutlierLine[];
+  jsonArrayCrusher?: JsonArrayCrusher;
 }
 
 interface RspMintStore {
@@ -85,7 +93,7 @@ export async function renderExecContract(
   if (!handle) throw new Error("rsp exec output elision requires an elision store");
 
   const rendered = normalized.kind === "text"
-    ? renderRoutedTextSummary(normalized.text, rawStdout.length, handle, options.level, commandLine, options.anomalyScorer)
+    ? renderRoutedTextSummary(normalized.text, rawStdout.length, handle, options.level, commandLine, options.anomalyScorer, options.jsonArrayCrusher)
     : renderBytesSummary(rawStdout, rawStdout.length, handle, commandLine);
   return {
     stdout: Buffer.from(rendered.text),
@@ -147,6 +155,7 @@ function renderRoutedTextSummary(
   level: RspLossLevel,
   command: string,
   anomalyScorer = defaultAnomalyScorer,
+  jsonArrayCrusher = crushJsonArrayItems,
 ): ExecSummaryRenderResult {
   const inlineBytes = level === "terse" ? TERSE_INLINE_BYTES : BRIEF_INLINE_BYTES;
   const half = Math.max(1, Math.floor(inlineBytes / 2));
@@ -154,17 +163,18 @@ function renderRoutedTextSummary(
   const tailStart = Math.max(0, stdoutBytes.length - half);
   const outliers = preservedOutliers(stdout, half, tailStart, anomalyScorer);
   const kind = classifyExecContent(stdout);
-  const summary = summarizeByKind(kind, stdout, stdoutBytes, half, tailStart, outliers.kind === "ok" ? outliers.lines : []);
-  const payload = baseSummary(command, kind, rawBytes, countLines(stdoutBytes), handle, summary);
+  const routed = summarizeByKind(kind, stdout, stdoutBytes, half, tailStart, outliers.kind === "ok" ? outliers.lines : [], jsonArrayCrusher);
+  const payload = baseSummary(command, kind, rawBytes, countLines(stdoutBytes), handle, routed.summary);
+  const degradation = outliers.kind === "failed"
+    ? {
+      reason: "exec-anomaly-scorer-failed",
+      family: "exec",
+      stderrHead: truncateDiagnostic(outliers.error),
+    }
+    : routed.degradation;
   return {
     text: encodeToonDocument(payload),
-    degradation: outliers.kind === "failed"
-      ? {
-        reason: "exec-anomaly-scorer-failed",
-        family: "exec",
-        stderrHead: truncateDiagnostic(outliers.error),
-      }
-      : undefined,
+    degradation,
   };
 }
 
@@ -217,47 +227,80 @@ function summarizeByKind(
   headBytes: number,
   tailStart: number,
   outliers: readonly PreservedOutlierLine[],
-): JsonObject {
+  jsonArrayCrusher = crushJsonArrayItems,
+): { summary: JsonObject; degradation?: GitRenderResult["degradation"] } {
   switch (kind) {
     case "json":
-      return summarizeJson(stdout);
+      return summarizeJson(stdout, jsonArrayCrusher);
     case "jsonl":
-      return summarizeJsonLines(stdout);
+      return { summary: summarizeJsonLines(stdout) };
     case "unified-diff":
-      return summarizeUnifiedDiff(stdout);
+      return { summary: summarizeUnifiedDiff(stdout) };
     case "tabular":
-      return summarizeTable(stdout);
+      return { summary: summarizeTable(stdout) };
     case "log-like":
-      return summarizeLog(stdout, outliers);
+      return { summary: summarizeLog(stdout, outliers) };
     case "prose":
-      return summarizeProse(stdout);
+      return { summary: summarizeProse(stdout) };
     case "bytes":
-      return {};
+      return { summary: {} };
     case "untyped":
-      return summarizeUntyped(stdoutBytes, headBytes, tailStart, outliers);
+      return { summary: summarizeUntyped(stdoutBytes, headBytes, tailStart, outliers) };
   }
 }
 
-function summarizeJson(input: string): JsonObject {
+function summarizeJson(input: string, jsonArrayCrusher: JsonArrayCrusher): { summary: JsonObject; degradation?: GitRenderResult["degradation"] } {
   const value = parseJsonContainer(input) as JsonValue;
   if (Array.isArray(value)) {
-    return {
-      root_type: "array",
-      items: value.length,
-      sample: value.slice(0, 5).map(compactJsonValue) as JsonValue[],
-      item_keys: commonKeys(value),
-    };
+    if (value.length > 15) {
+      try {
+        const crushed = jsonArrayCrusher(value, 15);
+        return {
+          summary: {
+            root_type: "array",
+            total: crushed.total,
+            kept: crushed.kept,
+            dropped: crushed.dropped,
+            shape_outliers: crushed.shapeOutliers,
+            value_outliers: crushed.valueOutliers,
+            items: crushed.items.map(compactJsonValue) as JsonValue[],
+            item_keys: commonKeys(value),
+          },
+        };
+      } catch (error) {
+        return {
+          summary: summarizeJsonArraySample(value),
+          degradation: {
+            reason: "exec-json-array-crusher-failed",
+            family: "exec",
+            stderrHead: truncateDiagnostic(error),
+          },
+        };
+      }
+    }
+    return { summary: summarizeJsonArraySample(value) };
   }
   if (isRecord(value)) {
     const entries = Object.entries(value);
     return {
-      root_type: "object",
-      keys: entries.map(([key]) => key).slice(0, 20),
-      key_count: entries.length,
-      sample: Object.fromEntries(entries.slice(0, 8).map(([key, val]) => [key, compactJsonValue(val)])) as JsonObject,
+      summary: {
+        root_type: "object",
+        keys: entries.map(([key]) => key).slice(0, 20),
+        key_count: entries.length,
+        sample: Object.fromEntries(entries.slice(0, 8).map(([key, val]) => [key, compactJsonValue(val)])) as JsonObject,
+      },
     };
   }
-  return { root_type: typeof value, value: compactJsonValue(value) };
+  return { summary: { root_type: typeof value, value: compactJsonValue(value) } };
+}
+
+function summarizeJsonArraySample(value: readonly JsonValue[]): JsonObject {
+  return {
+    root_type: "array",
+    items: value.length,
+    sample: value.slice(0, 5).map(compactJsonValue) as JsonValue[],
+    item_keys: commonKeys(value),
+  };
 }
 
 function summarizeJsonLines(input: string): JsonObject {

--- a/apps/rsp/src/normalize.ts
+++ b/apps/rsp/src/normalize.ts
@@ -91,6 +91,7 @@ export interface GenericJsonLaneOptions {
   maxItems?: number;
   command?: string;
   store?: Pick<RspElisionStore, "mint">;
+  crusher?: JsonArrayCrusher;
 }
 
 export interface GenericJsonLaneResult {
@@ -100,10 +101,26 @@ export interface GenericJsonLaneResult {
   totalItems?: number;
   keptItems?: number;
   handle?: `el:${string}`;
+  degradation?: {
+    reason: string;
+    family: string;
+    stderrHead: string;
+  };
 }
 
 const DEFAULT_JSON_MIN_TOKENS = 200;
 const DEFAULT_JSON_MAX_ITEMS = 15;
+
+export interface JsonArrayCrushResult {
+  items: JsonValue[];
+  total: number;
+  kept: number;
+  dropped: number;
+  shapeOutliers: number;
+  valueOutliers: number;
+}
+
+export type JsonArrayCrusher = (items: readonly JsonValue[], maxItems: number) => JsonArrayCrushResult;
 
 export async function renderGenericJsonLane(
   input: string,
@@ -125,11 +142,28 @@ export async function renderGenericJsonLane(
     return { output: encode(value as JsonValue).trimEnd(), detected: true, lossy: false, totalItems: total, keptItems: total };
   }
 
-  const kept = selectJsonItems(value, maxItems);
+  let crushed: JsonArrayCrushResult;
+  try {
+    crushed = (options.crusher ?? crushJsonArrayItems)(value, maxItems);
+  } catch (error) {
+    return {
+      output: encode(value as JsonValue).trimEnd(),
+      detected: true,
+      lossy: false,
+      totalItems: total,
+      keptItems: total,
+      degradation: {
+        reason: "json-array-crusher-failed",
+        family: "json",
+        stderrHead: truncateDiagnostic(error),
+      },
+    };
+  }
+  const kept = crushed.items;
   const payload = {
     items: kept as JsonValue,
   } satisfies JsonObject;
-  const marker = `items: ${kept.length} of ${total} kept`;
+  const marker = `items: ${crushed.kept} kept, ${crushed.dropped} dropped (shape outliers: ${crushed.shapeOutliers}, value outliers: ${crushed.valueOutliers})`;
   let handle: `el:${string}` | undefined;
   if (options.level && options.level !== "lossless") {
     handle = await options.store?.mint(Buffer.from(input), {
@@ -148,6 +182,42 @@ export async function renderGenericJsonLane(
     totalItems: total,
     keptItems: kept.length,
     handle,
+  };
+}
+
+export function crushJsonArrayItems(items: readonly JsonValue[], maxItems: number): JsonArrayCrushResult {
+  if (items.length <= maxItems) {
+    return {
+      items: [...items],
+      total: items.length,
+      kept: items.length,
+      dropped: 0,
+      shapeOutliers: 0,
+      valueOutliers: 0,
+    };
+  }
+
+  const keep = new Set<number>([0, items.length - 1]);
+  const commonShape = majorityShape(items);
+  const shapeIndexes = new Set<number>();
+  if (commonShape) {
+    items.forEach((item, index) => {
+      if (shapeSignature(item) !== commonShape) shapeIndexes.add(index);
+    });
+  }
+
+  const valueIndexes = valueOutlierIndexes(items, commonShape);
+  for (const index of shapeIndexes) keep.add(index);
+  for (const index of valueIndexes) keep.add(index);
+
+  const sorted = [...keep].sort((a, b) => a - b).slice(0, Math.max(2, maxItems));
+  return {
+    items: sorted.map((index) => items[index] as JsonValue),
+    total: items.length,
+    kept: sorted.length,
+    dropped: items.length - sorted.length,
+    shapeOutliers: [...shapeIndexes].filter((index) => sorted.includes(index)).length,
+    valueOutliers: [...valueIndexes].filter((index) => sorted.includes(index)).length,
   };
 }
 
@@ -322,79 +392,89 @@ function parseJsonOrNdjson(input: string): { value: JsonObject | JsonValue[] } |
   return rows.length > 0 ? { value: rows } : null;
 }
 
-function selectJsonItems(items: readonly JsonValue[], maxItems: number): JsonValue[] {
-  if (items.length <= maxItems) return [...items];
-  const keep = new Set<number>();
-  const edge = Math.max(1, Math.floor(maxItems * 0.2));
-  for (let i = 0; i < edge; i++) {
-    keep.add(i);
-    keep.add(items.length - 1 - i);
+function majorityShape(items: readonly JsonValue[]): string | null {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const signature = shapeSignature(item);
+    counts.set(signature, (counts.get(signature) ?? 0) + 1);
   }
-
-  for (let i = 0; i < items.length; i++) {
-    if (isErrorShaped(items[i])) keep.add(i);
-  }
-
-  for (const i of numericAnomalyIndexes(items)) keep.add(i);
-  for (const i of changePointIndexes(items)) keep.add(i);
-
-  const stride = Math.max(1, Math.floor(items.length / Math.max(1, maxItems - keep.size)));
-  for (let offset = 0; keep.size < maxItems && offset < stride; offset++) {
-    for (let i = offset; keep.size < maxItems && i < items.length; i += stride) keep.add(i);
-  }
-
-  return [...keep].sort((a, b) => a - b).slice(0, maxItems).map((i) => items[i] as JsonValue);
+  const [shape, count] = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0] ?? [];
+  return typeof shape === "string" && typeof count === "number" && count > items.length / 2 ? shape : null;
 }
 
-function isErrorShaped(value: unknown): boolean {
-  if (!isRecord(value)) return false;
-  const level = value.level;
-  if (typeof level === "string" && level.toLowerCase() === "error") return true;
-  if (Object.prototype.hasOwnProperty.call(value, "error") && value.error) return true;
-  const status = value.status;
-  return typeof status === "number" && status >= 400;
+function shapeSignature(value: unknown): string {
+  if (Array.isArray(value)) return "array";
+  if (!isRecord(value)) return scalarKind(value);
+  return Object.keys(value).sort().map((key) => `${key}:${scalarKind(value[key])}`).join("|");
 }
 
-function numericAnomalyIndexes(items: readonly JsonValue[]): number[] {
-  const numbersByField = new Map<string, Array<{ index: number; value: number }>>();
+function valueOutlierIndexes(items: readonly JsonValue[], commonShape: string | null): Set<number> {
+  const indexes = new Set<number>();
+  const scalars = new Map<string, Array<{ index: number; value: string | number | boolean | null }>>();
   items.forEach((item, index) => {
-    if (!isRecord(item)) return;
-    for (const [key, value] of Object.entries(item)) {
-      if (typeof value !== "number" || !Number.isFinite(value)) continue;
-      const rows = numbersByField.get(key) ?? [];
+    if (commonShape && shapeSignature(item) !== commonShape) return;
+    for (const [path, value] of scalarEntries(item)) {
+      const rows = scalars.get(path) ?? [];
       rows.push({ index, value });
-      numbersByField.set(key, rows);
+      scalars.set(path, rows);
     }
   });
 
-  const indexes = new Set<number>();
-  for (const rows of numbersByField.values()) {
-    if (rows.length < 3) continue;
-    const mean = rows.reduce((sum, row) => sum + row.value, 0) / rows.length;
-    const variance = rows.reduce((sum, row) => sum + Math.pow(row.value - mean, 2), 0) / rows.length;
-    const stddev = Math.sqrt(variance);
-    if (stddev === 0) continue;
-    for (const row of rows) {
-      if (Math.abs(row.value - mean) > stddev * 2) indexes.add(row.index);
-    }
+  for (const rows of scalars.values()) {
+    for (const index of numericValueOutliers(rows)) indexes.add(index);
+    for (const index of categoricalValueOutliers(rows)) indexes.add(index);
   }
-  return [...indexes];
+  return indexes;
 }
 
-function changePointIndexes(items: readonly JsonValue[]): number[] {
-  const indexes = new Set<number>();
-  for (let i = 1; i < items.length; i++) {
-    const before = items[i - 1];
-    const after = items[i];
-    if (!isRecord(before) || !isRecord(after)) continue;
-    for (const [key, value] of Object.entries(after)) {
-      if (typeof value !== "number" || !Number.isFinite(value)) continue;
-      const previous = before[key];
-      if (typeof previous !== "number" || !Number.isFinite(previous)) continue;
-      if (previous === 0 ? Math.abs(value) > 10 : Math.abs((value - previous) / previous) >= 2) indexes.add(i);
-    }
+function numericValueOutliers(rows: readonly { index: number; value: string | number | boolean | null }[]): number[] {
+  const numeric = rows.filter((row): row is { index: number; value: number } =>
+    typeof row.value === "number" && Number.isFinite(row.value)
+  );
+  if (numeric.length < 5 || numeric.length !== rows.length) return [];
+  const values = numeric.map((row) => row.value).sort((a, b) => a - b);
+  const medianValue = median(values);
+  const deviations = values.map((value) => Math.abs(value - medianValue)).sort((a, b) => a - b);
+  const mad = median(deviations);
+  if (mad === 0) {
+    const commonCount = numeric.filter((row) => row.value === medianValue).length;
+    if (commonCount / numeric.length < 0.8) return [];
+    return numeric.filter((row) => row.value !== medianValue).map((row) => row.index);
   }
-  return [...indexes];
+  const cutoff = mad * 8;
+  return numeric.filter((row) => Math.abs(row.value - medianValue) > cutoff).map((row) => row.index);
+}
+
+function categoricalValueOutliers(rows: readonly { index: number; value: string | number | boolean | null }[]): number[] {
+  if (rows.length < 5) return [];
+  if (!rows.every((row) => typeof row.value === "string" || typeof row.value === "boolean" || row.value === null)) return [];
+  const counts = new Map<string, number>();
+  for (const row of rows) counts.set(String(row.value), (counts.get(String(row.value)) ?? 0) + 1);
+  const majority = Math.max(...counts.values());
+  if (majority / rows.length < 0.8) return [];
+  const rareLimit = Math.max(2, Math.floor(rows.length * 0.05));
+  return rows.filter((row) => (counts.get(String(row.value)) ?? 0) <= rareLimit).map((row) => row.index);
+}
+
+function scalarEntries(value: unknown, prefix = ""): Array<[string, string | number | boolean | null]> {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return [[prefix || "$", value]];
+  }
+  if (Array.isArray(value)) return [];
+  if (!isRecord(value)) return [];
+  return Object.entries(value).flatMap(([key, child]) => scalarEntries(child, prefix ? `${prefix}.${key}` : key));
+}
+
+function scalarKind(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function median(values: readonly number[]): number {
+  const mid = Math.floor(values.length / 2);
+  if (values.length % 2 === 1) return values[mid] ?? 0;
+  return ((values[mid - 1] ?? 0) + (values[mid] ?? 0)) / 2;
 }
 
 function estimateTokens(input: string): number {
@@ -404,6 +484,12 @@ function estimateTokens(input: string): number {
 function positiveInteger(value: number | undefined, fallback: number): number {
   if (value == null) return fallback;
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function truncateDiagnostic(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error ?? "unknown crusher failure");
+  const line = text.split(/\r?\n/, 1)[0]?.replace(/\s+/g, " ").trim() || "unknown crusher failure";
+  return line.length <= 240 ? line : `${line.slice(0, 239)}…`;
 }
 
 function stringAt(record: Record<string, unknown>, path: readonly string[]): string {

--- a/apps/rsp/tests/exec-wrapper.test.ts
+++ b/apps/rsp/tests/exec-wrapper.test.ts
@@ -156,6 +156,66 @@ describe("rsp exec anomaly-preserving elision", () => {
     expect(store.originals.get("el:123456789abc")?.toString("utf8")).toBe(stdout);
   });
 
+  it("uses the deterministic JSON-array crusher for JSON-classified exec output", async () => {
+    const rows: Array<Record<string, unknown>> = Array.from({ length: 220 }, (_, i) => ({
+      seq: i,
+      metric: i === 80 ? 9000 : 50,
+      class: i === 160 ? "rare" : "normal",
+    }));
+    rows[120] = { ...rows[120]!, variant: "shape-break" };
+    const stdout = JSON.stringify(rows);
+    const store = new MemoryStore();
+
+    const result = await renderExecContract("node emit-json-array.js", {
+      stdout,
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, { level: "terse", store, heavyByteThreshold: 1 });
+
+    const decoded = decode(result.stdout.toString("utf8")) as Record<string, unknown>;
+    expect(decoded["content"]).toBe("json");
+    expect(valueAt(decoded, ["summary", "root_type"])).toBe("array");
+    expect(valueAt(decoded, ["summary", "kept"])).toBe(5);
+    expect(valueAt(decoded, ["summary", "dropped"])).toBe(215);
+    expect(valueAt(decoded, ["summary", "shape_outliers"])).toBe(1);
+    expect(valueAt(decoded, ["summary", "value_outliers"])).toBe(2);
+    expect(valueAt(decoded, ["summary", "items", 1, "seq"])).toBe(80);
+    expect(valueAt(decoded, ["summary", "items", 2, "variant"])).toBe("shape-break");
+    expect(valueAt(decoded, ["summary", "items", 3, "class"])).toBe("rare");
+    expect(valueAt(decoded, ["recovery", "original"])).toBe("rsp show el:123456789abc");
+    expect(store.originals.get("el:123456789abc")?.toString("utf8")).toBe(stdout);
+  });
+
+  it("falls open to the prior JSON sample summary and reports degradation when array crushing fails", async () => {
+    const stdout = JSON.stringify(Array.from({ length: 40 }, (_, i) => ({ seq: i, metric: 50 })));
+
+    const result = await renderExecContract("node emit-json-array.js", {
+      stdout,
+      stderr: "",
+      status: 0,
+      signal: null,
+    }, {
+      level: "terse",
+      store: new MemoryStore(),
+      heavyByteThreshold: 1,
+      jsonArrayCrusher: () => {
+        throw new Error("fixture crusher failure");
+      },
+    });
+
+    const decoded = decode(result.stdout.toString("utf8")) as Record<string, unknown>;
+    expect(decoded["content"]).toBe("json");
+    expect(valueAt(decoded, ["summary", "items"])).toBe(40);
+    expect(valueAt(decoded, ["summary", "sample", 4, "seq"])).toBe(4);
+    expect(valueAt(decoded, ["summary", "kept"])).toBeUndefined();
+    expect(result.degradation).toEqual({
+      reason: "exec-json-array-crusher-failed",
+      family: "exec",
+      stderrHead: "fixture crusher failure",
+    });
+  });
+
   it("falls open to head and tail when scoring fails and reports degradation identity", async () => {
     const stdout = largeLog();
     const result = await renderExecContract("node emit-log.js", {

--- a/apps/rsp/tests/fixtures/exec/json-array-crusher.json
+++ b/apps/rsp/tests/fixtures/exec/json-array-crusher.json
@@ -1,0 +1,43 @@
+{
+  "name": "exec-json-array-crusher",
+  "command": [
+    "exec",
+    "--",
+    "node emit-json-array.js"
+  ],
+  "large_output": true,
+  "recorded": {
+    "stdout": "[{\"seq\":0,\"metric\":50,\"class\":\"normal\"},{\"seq\":1,\"metric\":50,\"class\":\"normal\"},{\"seq\":2,\"metric\":50,\"class\":\"normal\"},{\"seq\":3,\"metric\":50,\"class\":\"normal\"},{\"seq\":4,\"metric\":50,\"class\":\"normal\"},{\"seq\":5,\"metric\":50,\"class\":\"normal\"},{\"seq\":6,\"metric\":50,\"class\":\"normal\"},{\"seq\":7,\"metric\":9000,\"class\":\"normal\"},{\"seq\":8,\"metric\":50,\"class\":\"normal\"},{\"seq\":9,\"metric\":50,\"class\":\"normal\"},{\"seq\":10,\"metric\":50,\"class\":\"normal\"},{\"seq\":11,\"metric\":50,\"class\":\"normal\"},{\"seq\":12,\"metric\":50,\"class\":\"normal\",\"variant\":\"shape-break\"},{\"seq\":13,\"metric\":50,\"class\":\"normal\"},{\"seq\":14,\"metric\":50,\"class\":\"normal\"},{\"seq\":15,\"metric\":50,\"class\":\"normal\"},{\"seq\":16,\"metric\":50,\"class\":\"normal\"},{\"seq\":17,\"metric\":50,\"class\":\"normal\"},{\"seq\":18,\"metric\":50,\"class\":\"rare\"},{\"seq\":19,\"metric\":50,\"class\":\"normal\"},{\"seq\":20,\"metric\":50,\"class\":\"normal\"},{\"seq\":21,\"metric\":50,\"class\":\"normal\"},{\"seq\":22,\"metric\":50,\"class\":\"normal\"},{\"seq\":23,\"metric\":50,\"class\":\"normal\"}]",
+    "stderr": "",
+    "status": 0,
+    "signal": null
+  },
+  "expected": {},
+  "assertions": [
+    {
+      "question": "crusher keeps first row",
+      "path": "summary.items.0.seq",
+      "expected": 0
+    },
+    {
+      "question": "crusher keeps numeric value outlier",
+      "path": "summary.items.1.seq",
+      "expected": 7
+    },
+    {
+      "question": "crusher keeps shape outlier",
+      "path": "summary.items.2.variant",
+      "expected": "shape-break"
+    },
+    {
+      "question": "crusher keeps rare scalar value outlier",
+      "path": "summary.items.3.class",
+      "expected": "rare"
+    },
+    {
+      "question": "crusher reports dropped count",
+      "path": "summary.dropped",
+      "expected": 19
+    }
+  ]
+}

--- a/apps/rsp/tests/fixtures/exec/json-array-crusher.oracle.toon
+++ b/apps/rsp/tests/fixtures/exec/json-array-crusher.oracle.toon
@@ -1,0 +1,28 @@
+# oracle: preserves first and last rows plus planted shape and value outliers from an exec JSON array.
+command: rsp exec -- node emit-json-array.js
+content: json
+summary:
+  root_type: array
+  total: 24
+  kept: 5
+  dropped: 19
+  shape_outliers: 1
+  value_outliers: 2
+  items[5]:
+    - seq: 0
+      metric: 50
+      class: normal
+    - seq: 7
+      metric: 9000
+      class: normal
+    - seq: 12
+      metric: 50
+      class: normal
+      variant: shape-break
+    - seq: 18
+      metric: 50
+      class: rare
+    - seq: 23
+      metric: 50
+      class: normal
+recovery: full original stdout behind elision handle

--- a/apps/rsp/tests/normalize.test.ts
+++ b/apps/rsp/tests/normalize.test.ts
@@ -241,21 +241,36 @@ describe("generic JSON lane — detection, selection, encoding, reversibility", 
     expect(result.output).toBe("outer:\n  inner:\n    value: 3");
   });
 
-  it("keeps boundary rows, error-shaped rows, anomalies, and emits an explicit marker", async () => {
-    const rows = Array.from({ length: 40 }, (_, i) => ({
+  it("crushes homogeneous JSON arrays to boundary rows plus statistical shape and value outliers", async () => {
+    const rows: Array<Record<string, unknown>> = Array.from({ length: 240 }, (_, i) => ({
       id: i,
-      status: i === 12 ? 500 : 200,
-      latency: i === 21 ? 1000 : i,
-      phase: i < 25 ? "steady" : "changed",
+      value: i === 42 ? 10_000 : 100,
+      bucket: i === 177 ? "rare" : "steady",
     }));
-    const result = await renderGenericJsonLane(JSON.stringify(rows), { level: "terse", minTokens: 1, maxItems: 8 });
+    rows[111] = { ...rows[111]!, extra: "shape-break" };
+    const result = await renderGenericJsonLane(JSON.stringify(rows), { level: "terse", minTokens: 1, maxItems: 12 });
     expect(result.lossy).toBe(true);
-    expect(result.output).toContain("items: 8 of 40 kept");
-    expect(result.output).toContain("items[8]{id,status,latency,phase}");
-    expect(result.output).toContain("original: unavailable - re-run: command");
-    expect(result.output).toContain("12,500,12,steady");
-    expect(result.output).toContain("21,200,1000,steady");
-    expect(result.output).toContain("39,200,39,changed");
+    expect(result.output).toBe([
+      "items: 5 kept, 235 dropped (shape outliers: 1, value outliers: 2)",
+      "original: unavailable - re-run: command",
+      "items[5]:",
+      "  - id: 0",
+      "    value: 100",
+      "    bucket: steady",
+      "  - id: 42",
+      "    value: 10000",
+      "    bucket: steady",
+      "  - id: 111",
+      "    value: 100",
+      "    bucket: steady",
+      "    extra: shape-break",
+      "  - id: 177",
+      "    value: 100",
+      "    bucket: rare",
+      "  - id: 239",
+      "    value: 100",
+      "    bucket: steady",
+    ].join("\n"));
   });
 
   it("mints a handle to original bytes for lossy output", async () => {
@@ -277,6 +292,30 @@ describe("generic JSON lane — detection, selection, encoding, reversibility", 
     expect(result.output).toContain("original: rsp show el:test");
     expect(minted.get("el:test")?.toString("utf8")).toBe(original);
   });
+
+  it("falls open to uncrushed JSON and records degradation when the array crusher fails", async () => {
+    const original = JSON.stringify(Array.from({ length: 25 }, (_, i) => ({ id: i, value: 100 })));
+    const result = await renderGenericJsonLane(original, {
+      level: "terse",
+      minTokens: 1,
+      maxItems: 6,
+      crusher: () => {
+        throw new Error("fixture crusher failure");
+      },
+    });
+    expect(result).toMatchObject({
+      detected: true,
+      lossy: false,
+      totalItems: 25,
+      keptItems: 25,
+      degradation: {
+        reason: "json-array-crusher-failed",
+        family: "json",
+        stderrHead: "fixture crusher failure",
+      },
+    });
+    expect(result.output).toBe(transcodeJsonToToon(original));
+  });
 });
 
 // ─── Structural invariant ─────────────────────────────────────────────────────
@@ -295,6 +334,13 @@ describe("structural invariant: no mint API access", () => {
       "blank-lines",
       "json-to-toon",
     ]);
+  });
+
+  it("JSON array crusher has no legacy field-name shortcut allowlist", () => {
+    const src = readFileSync(join(import.meta.dirname, "..", "src", "normalize.ts"), "utf8");
+    expect(src).not.toContain("isErrorShaped");
+    expect(src).not.toMatch(/toLowerCase\(\)\s*===\s*["']error["']/);
+    expect(src).not.toMatch(/status\s*>?=\s*400/);
   });
 });
 

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -26,7 +26,7 @@ describe("rsp two-axis benchmark report", () => {
 
     expect(report.corpus).toMatchObject({
       label: "home",
-      fixture_count: 33,
+      fixture_count: 34,
       large_output_filters: ["cat:file", "exec:--", "git:diff", "git:log", "vitest:run"],
     });
     expect(report.corpus.provenance[0]).toContain("Repo-authored");
@@ -59,7 +59,7 @@ describe("rsp two-axis benchmark report", () => {
 
     const exec = report.filters.find((row) => row.filter === "exec:--");
     expect(exec).toMatchObject({
-      fixture_count: 2,
+      fixture_count: 3,
       mode: "active",
       brief: { fidelity_pass_rate_pct: 100 },
       terse: { fidelity_pass_rate_pct: 100 },


### PR DESCRIPTION
Automated AFK landing for #1983. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1983

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786888201&installation_id=129708444&pr_number=2002&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2002&signature=5759ed777690bac00908a99889992beb831f7dddcef158b951e9a59b4b35eb8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->