### PR TITLE
fix: #1967 Queue-visibility probe: the engine's own listing path, transport-failure classification

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -147,7 +147,7 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
     const ctx = await resolveRepoContext(flags.root);
     const paths = afkPaths(ctx.root);
     const precheckFacts = await collectPrecheckFacts(ctx);
-    const probeReport = runOperationalProbes(precheckFacts);
+    const probeReport = await runOperationalProbes(precheckFacts);
     const issueStates = ctx.repo
       ? await listIssueStates({ cwd: ctx.root, repo: ctx.repo } satisfies GhContext)
       : new Map();

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -128,6 +128,8 @@ export interface PrecheckFacts {
    * Set by the runtime facts-builder from the environment.
    */
   allowHttpsRemote?: boolean;
+  /** Optional boot-time queue probe; injected by runtime facts so boot refuses on an unlistable AFK queue. */
+  queueVisibility?: OperationalProbeContext["queueVisibility"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and
@@ -541,7 +543,7 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   if (!pre.ok) return { precheck: pre };
 
   // ---- 1a. operational probes ----
-  const operationalProbes = runOperationalProbes(options.operationalProbes ?? options.precheck);
+  const operationalProbes = await runOperationalProbes(options.operationalProbes ?? options.precheck);
   const redProbe = operationalProbes.findings[0];
   if (redProbe) throw new BootHaltError("operational-probe", redProbe);
 

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -1,3 +1,4 @@
 export * from "./operational-probes/types.js";
 export * from "./operational-probes/https-remote.js";
+export * from "./operational-probes/queue-visibility.js";
 export * from "./operational-probes/registry.js";

--- a/apps/dev/src/core/operational-probes/queue-visibility.ts
+++ b/apps/dev/src/core/operational-probes/queue-visibility.ts
@@ -1,0 +1,165 @@
+import type {
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeResult,
+  QueueVisibilityTransportFailure,
+  QueueVisibilityTransportSurface,
+} from "./types.js";
+
+export const QUEUE_VISIBILITY_PROBE_ID = "afk.queue-visibility";
+export const QUEUE_VISIBILITY_PROBE_NAME = "AFK queue visibility";
+export const QUEUE_VISIBILITY_CANONICAL_FIX =
+  "Restore GitHub queue visibility for the AFK engine; if SSO is reported, run `gh auth refresh -h github.com -s repo,read:org,workflow` and authorize the token for the GitHub organization SSO prompt.";
+
+export type QueueVisibilityFailureClass =
+  | "sso-or-scope"
+  | "rate-limit"
+  | "graphql-transport"
+  | "rest-transport"
+  | "generic-transport";
+
+export interface QueueVisibilityProbeData {
+  readonly label: string;
+  readonly engineCount?: number;
+  readonly restCount?: number;
+  readonly classification?: QueueVisibilityFailureClass;
+  readonly surface?: QueueVisibilityTransportSurface;
+}
+
+const SSO_FIX =
+  "Run `gh auth refresh -h github.com -s repo,read:org,workflow`, then open the GitHub organization SSO authorization prompt for the affected org and authorize the gh token.";
+const RATE_LIMIT_FIX =
+  "Wait for the GitHub primary/secondary rate limit window to reset, then rerun `/afk`; if this repeats, reduce fleet concurrency before retrying.";
+const GRAPHQL_FIX =
+  "Repair GitHub GraphQL access for `gh issue list --json`: refresh the gh token scopes and verify org authorization before restarting `/afk`.";
+const REST_FIX =
+  "Repair GitHub REST access for `gh api` queue reads: refresh the gh token scopes and verify org authorization before restarting `/afk`.";
+const GENERIC_FIX =
+  "Inspect `gh auth status` and network reachability, then rerun `/afk` once GitHub issue listing succeeds.";
+
+function transportText(failure: unknown): string {
+  if (failure instanceof Error) {
+    const rec = failure as Error & Partial<QueueVisibilityTransportFailure>;
+    return [failure.message, rec.stdout, rec.stderr].filter(Boolean).join("\n");
+  }
+  if (failure && typeof failure === "object") {
+    const rec = failure as Partial<QueueVisibilityTransportFailure>;
+    return [rec.message, rec.stdout, rec.stderr].filter(Boolean).join("\n");
+  }
+  return String(failure ?? "");
+}
+
+function transportSurface(failure: unknown): QueueVisibilityTransportSurface {
+  if (failure && typeof failure === "object") {
+    const surface = (failure as Partial<QueueVisibilityTransportFailure>).surface;
+    if (surface === "graphql" || surface === "rest" || surface === "rest-cache" || surface === "unknown") return surface;
+  }
+  return "unknown";
+}
+
+export function classifyQueueVisibilityTransportFailure(failure: unknown): QueueVisibilityFailureClass {
+  const text = transportText(failure);
+  if (
+    /saml|single sign-on|sso|x-github-sso|resource protected by organization saml enforcement|authorize.*oauth/i.test(text) ||
+    /requires one of the following oauth scopes|insufficient(_|\s)?scope|missing.*scope|must have.*scope/i.test(text)
+  ) {
+    return "sso-or-scope";
+  }
+  if (/rate limit|secondary rate|abuse detection|too many requests|\b429\b/i.test(text)) return "rate-limit";
+  const surface = transportSurface(failure);
+  if (surface === "graphql") return "graphql-transport";
+  if (surface === "rest" || surface === "rest-cache") return "rest-transport";
+  return "generic-transport";
+}
+
+function fixForClassification(classification: QueueVisibilityFailureClass): string {
+  switch (classification) {
+    case "sso-or-scope":
+      return SSO_FIX;
+    case "rate-limit":
+      return RATE_LIMIT_FIX;
+    case "graphql-transport":
+      return GRAPHQL_FIX;
+    case "rest-transport":
+      return REST_FIX;
+    case "generic-transport":
+      return GENERIC_FIX;
+  }
+}
+
+function failureEvidence(classification: QueueVisibilityFailureClass, surface: QueueVisibilityTransportSurface): string {
+  return `queue listing failed (${classification}, surface=${surface})`;
+}
+
+export async function runQueueVisibilityProbe(context: OperationalProbeContext): Promise<OperationalProbeResult> {
+  const input = context.queueVisibility;
+  const label = input?.label ?? "ready-for-agent";
+  if (!input) {
+    return {
+      id: QUEUE_VISIBILITY_PROBE_ID,
+      name: QUEUE_VISIBILITY_PROBE_NAME,
+      verdict: "ok",
+      evidence: "queue visibility check not configured",
+      canonicalFix: QUEUE_VISIBILITY_CANONICAL_FIX,
+    };
+  }
+
+  let engineCount: number;
+  try {
+    engineCount = await input.listEngineCandidates();
+  } catch (error) {
+    const classification = classifyQueueVisibilityTransportFailure(error);
+    const surface = transportSurface(error);
+    return {
+      id: QUEUE_VISIBILITY_PROBE_ID,
+      name: QUEUE_VISIBILITY_PROBE_NAME,
+      verdict: "red",
+      evidence: failureEvidence(classification, surface),
+      canonicalFix: fixForClassification(classification),
+      data: { label, classification, surface } satisfies QueueVisibilityProbeData,
+    };
+  }
+
+  let restCount: number;
+  try {
+    restCount = await input.countRestQueue();
+  } catch (error) {
+    const classification = classifyQueueVisibilityTransportFailure(error);
+    const surface = transportSurface(error);
+    return {
+      id: QUEUE_VISIBILITY_PROBE_ID,
+      name: QUEUE_VISIBILITY_PROBE_NAME,
+      verdict: "red",
+      evidence: failureEvidence(classification, surface),
+      canonicalFix: fixForClassification(classification),
+      data: { label, engineCount, classification, surface } satisfies QueueVisibilityProbeData,
+    };
+  }
+
+  if (engineCount !== restCount) {
+    return {
+      id: QUEUE_VISIBILITY_PROBE_ID,
+      name: QUEUE_VISIBILITY_PROBE_NAME,
+      verdict: "red",
+      evidence: `engine sees ${engineCount} open ${label}; REST sees ${restCount}`,
+      canonicalFix: QUEUE_VISIBILITY_CANONICAL_FIX,
+      data: { label, engineCount, restCount } satisfies QueueVisibilityProbeData,
+    };
+  }
+
+  return {
+    id: QUEUE_VISIBILITY_PROBE_ID,
+    name: QUEUE_VISIBILITY_PROBE_NAME,
+    verdict: "ok",
+    evidence: `engine and REST both see ${engineCount} open ${label}`,
+    canonicalFix: QUEUE_VISIBILITY_CANONICAL_FIX,
+    data: { label, engineCount, restCount } satisfies QueueVisibilityProbeData,
+  };
+}
+
+export const queueVisibilityProbe: OperationalProbe = {
+  id: QUEUE_VISIBILITY_PROBE_ID,
+  name: QUEUE_VISIBILITY_PROBE_NAME,
+  canonicalFix: QUEUE_VISIBILITY_CANONICAL_FIX,
+  run: runQueueVisibilityProbe,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -1,5 +1,6 @@
 import { encode as encodeToon } from "@reddb-io/toon";
 import { httpsRemoteProbe } from "./https-remote.js";
+import { queueVisibilityProbe } from "./queue-visibility.js";
 import type {
   OperationalProbe,
   OperationalProbeContext,
@@ -10,13 +11,14 @@ import type {
 
 export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   httpsRemoteProbe,
+  queueVisibilityProbe,
 ];
 
-export function runOperationalProbes(
+export async function runOperationalProbes(
   context: OperationalProbeContext,
   probes: readonly OperationalProbe[] = OPERATIONAL_PROBES,
-): OperationalProbeReport {
-  const rows = probes.map((probe) => probe.run(context));
+): Promise<OperationalProbeReport> {
+  const rows = await Promise.all(probes.map((probe) => probe.run(context)));
   return {
     probes: rows,
     findings: rows.filter((row) => row.verdict === "red"),

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -8,6 +8,23 @@ export interface RemoteUrlFact {
 export interface OperationalProbeContext {
   readonly remoteUrls: readonly (string | RemoteUrlFact)[];
   readonly allowHttpsRemote?: boolean;
+  readonly queueVisibility?: QueueVisibilityProbeInput;
+}
+
+export type QueueVisibilityTransportSurface = "graphql" | "rest" | "rest-cache" | "unknown";
+
+export interface QueueVisibilityTransportFailure {
+  readonly surface?: QueueVisibilityTransportSurface;
+  readonly code?: number;
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly message?: string;
+}
+
+export interface QueueVisibilityProbeInput {
+  readonly label?: string;
+  readonly listEngineCandidates: () => Promise<number>;
+  readonly countRestQueue: () => Promise<number>;
 }
 
 export interface OperationalProbeFix {
@@ -42,7 +59,7 @@ export interface OperationalProbe {
   readonly id: string;
   readonly name: string;
   readonly canonicalFix: string;
-  run(context: OperationalProbeContext): OperationalProbeResult;
+  run(context: OperationalProbeContext): OperationalProbeResult | Promise<OperationalProbeResult>;
   applyFix?(finding: OperationalProbeResult, deps: OperationalProbeFixDeps): Promise<OperationalProbeFixResult>;
 }
 

--- a/apps/dev/src/runtime/gh.ts
+++ b/apps/dev/src/runtime/gh.ts
@@ -26,6 +26,11 @@ import type { ActorTrustVerdict, RepoVisibility } from "../core/trust-gate.js";
 import type { IssueOpenState } from "../core/reclaim.js";
 import type { UnblockCandidate, ReconcileSweepCandidate } from "../core/boot-sweep.js";
 import type { SpecSubIssueCandidate } from "../core/spec-subissue-reconciler.js";
+import type {
+  QueueVisibilityProbeInput,
+  QueueVisibilityTransportFailure,
+  QueueVisibilityTransportSurface,
+} from "../core/operational-probes.js";
 import {
   MAIN_RED_REPAIR_TITLE,
   type MainRedRepairIssue,
@@ -122,7 +127,30 @@ export async function ghAuthenticated(ctx: GhContext): Promise<boolean> {
  * `ready-for-agent` lane the `/afk` fleet drains; `/go` passes its isolated
  * `lane:go` label so its dedicated worker sees only the minted disposable issue
  * and the fleet never does. */
-export async function listCandidates(ctx: GhContext, label: string = LABEL_READY): Promise<IssueCandidate[]> {
+export interface CandidateListDiagnostics {
+  onTransportFailure?(failure: QueueVisibilityTransportFailure): void;
+}
+
+function emitTransportFailure(
+  diagnostics: CandidateListDiagnostics | undefined,
+  surface: QueueVisibilityTransportSurface,
+  r: ExecOutput,
+  message: string,
+): void {
+  diagnostics?.onTransportFailure?.({
+    surface,
+    code: r.code,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    message,
+  });
+}
+
+export async function listCandidates(
+  ctx: GhContext,
+  label: string = LABEL_READY,
+  diagnostics?: CandidateListDiagnostics,
+): Promise<IssueCandidate[]> {
   const cached = await listIssuesViaRsp(ctx, label, "200");
   if (cached) return cached.map((item): IssueCandidate => ({
     number: item.number,
@@ -145,14 +173,21 @@ export async function listCandidates(ctx: GhContext, label: string = LABEL_READY
       "number,title,labels,body",
     ],
   );
-  if (r.code !== 0) return [];
+  if (r.code !== 0) {
+    emitTransportFailure(diagnostics, "graphql", r, "gh issue list failed");
+    return [];
+  }
   let raw: unknown;
   try {
     raw = JSON.parse(r.stdout || "[]");
   } catch {
+    emitTransportFailure(diagnostics, "graphql", r, "gh issue list returned malformed JSON");
     return [];
   }
-  if (!Array.isArray(raw)) return [];
+  if (!Array.isArray(raw)) {
+    emitTransportFailure(diagnostics, "graphql", r, "gh issue list returned a non-array payload");
+    return [];
+  }
   return raw.map((row): IssueCandidate => {
     const item = row as { number?: number; title?: string; body?: string; labels?: Array<{ name?: string }> };
     return {
@@ -1019,6 +1054,60 @@ async function listIssuesViaRsp(ctx: GhContext, label: string, limit: string): P
   } catch {
     return null;
   }
+}
+
+function queueVisibilityError(
+  surface: QueueVisibilityTransportSurface,
+  r: ExecOutput,
+  message: string,
+): Error & QueueVisibilityTransportFailure {
+  return Object.assign(new Error(message), {
+    surface,
+    code: r.code,
+    stdout: r.stdout,
+    stderr: r.stderr,
+  });
+}
+
+async function countOpenIssuesByLabelViaRest(ctx: GhContext, label: string): Promise<number> {
+  if (!ctx.repo) return 0;
+  const r = await runGh(ctx, [
+    "api",
+    "--method",
+    "GET",
+    "search/issues",
+    "-f",
+    `q=repo:${ctx.repo} is:issue is:open label:"${label}"`,
+    "--jq",
+    ".total_count",
+  ]);
+  if (r.code !== 0) throw queueVisibilityError("rest", r, "gh api REST issue search failed");
+  const count = Number(r.stdout.trim());
+  if (!Number.isFinite(count)) throw queueVisibilityError("rest", r, "gh api REST issue search returned a non-numeric count");
+  return count;
+}
+
+export function queueVisibilityProbeInput(ctx: GhContext, label: string = LABEL_READY): QueueVisibilityProbeInput {
+  return {
+    label,
+    listEngineCandidates: async () => {
+      const failures: QueueVisibilityTransportFailure[] = [];
+      const candidates = await listCandidates(ctx, label, {
+        onTransportFailure: (failure) => failures.push(failure),
+      });
+      if (failures.length > 0 && candidates.length === 0) {
+        const failure = failures[failures.length - 1];
+        throw Object.assign(new Error(failure.message ?? "AFK engine candidate listing failed"), {
+          surface: failure.surface,
+          code: failure.code,
+          stdout: failure.stdout,
+          stderr: failure.stderr,
+        });
+      }
+      return candidates.length;
+    },
+    countRestQueue: () => countOpenIssuesByLabelViaRest(ctx, label),
+  };
 }
 
 async function countSearchViaRsp(ctx: GhContext, query: string): Promise<number | null> {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1750,6 +1750,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     // GITHUB_TOKEN — the intended setup — so the SSH-only rule must not fire there.
     allowHttpsRemote:
       process.env.RED_AFK_LANE === "actions" || process.env.GITHUB_ACTIONS === "true",
+    queueVisibility: ghx.queueVisibilityProbeInput(ghCtx),
   };
 }
 

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -341,6 +341,35 @@ describe("runBoot precheck short-circuit", () => {
     ).rejects.toThrow(/SSH-only git remotes.*Use SSH git remotes/);
     expect(calls).toEqual([]);
   });
+
+  it("refuses on an unlistable queue, naming the queue visibility probe", async () => {
+    const { deps, calls } = makeDeps();
+    await expect(
+      runBoot(
+        deps,
+        options({
+          precheck: facts({
+            remoteUrls: [],
+            queueVisibility: {
+              listEngineCandidates: async () => {
+                throw Object.assign(new Error("Resource protected by organization SAML enforcement"), {
+                  surface: "graphql",
+                });
+              },
+              countRestQueue: async () => 3,
+            },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      phase: "operational-probe",
+      probe: {
+        name: "AFK queue visibility",
+        canonicalFix: expect.stringContaining("gh auth refresh"),
+      },
+    });
+    expect(calls).toEqual([]);
+  });
 });
 
 describe("runBoot Docs Sweep", () => {

--- a/apps/dev/tests/fixtures/github-transport/rate-limit.txt
+++ b/apps/dev/tests/fixtures/github-transport/rate-limit.txt
@@ -1,0 +1,1 @@
+API rate limit exceeded for user ID 12345. Please wait before retrying.

--- a/apps/dev/tests/fixtures/github-transport/saml-enforcement.txt
+++ b/apps/dev/tests/fixtures/github-transport/saml-enforcement.txt
@@ -1,0 +1,1 @@
+GraphQL: Resource protected by organization SAML enforcement. You must grant your OAuth token access to this organization.

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -1,14 +1,17 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { decode } from "@reddb-io/toon";
 import {
   applyOperationalProbeFixes,
+  classifyQueueVisibilityTransportFailure,
   renderOperationalProbeReportToon,
   runOperationalProbes,
 } from "../src/core/operational-probes.js";
 
 describe("operational probe registry", () => {
-  it("reports the HTTPS remote proof probe as red with a canonical fix", () => {
-    const report = runOperationalProbes({
+  it("reports the HTTPS remote proof probe as red with a canonical fix", async () => {
+    const report = await runOperationalProbes({
       remoteUrls: [{ name: "origin", url: "https://example.invalid/acme/widgets.git" }],
     });
 
@@ -21,8 +24,8 @@ describe("operational probe registry", () => {
     expect(report.findings[0]?.canonicalFix).toContain("Use SSH git remotes");
   });
 
-  it("leaves the proof probe green when the Actions lane allows HTTPS remotes", () => {
-    const report = runOperationalProbes({
+  it("leaves the proof probe green when the Actions lane allows HTTPS remotes", async () => {
+    const report = await runOperationalProbes({
       remoteUrls: [{ name: "origin", url: "https://example.invalid/acme/widgets.git" }],
       allowHttpsRemote: true,
     });
@@ -31,20 +34,23 @@ describe("operational probe registry", () => {
     expect(report.probes[0]?.verdict).toBe("ok");
   });
 
-  it("renders AI-facing output as TOON", () => {
+  it("renders AI-facing output as TOON", async () => {
     const toon = renderOperationalProbeReportToon(
-      runOperationalProbes({ remoteUrls: ["https://example.invalid/acme/widgets.git"] }),
+      await runOperationalProbes({ remoteUrls: ["https://example.invalid/acme/widgets.git"] }),
     );
     const decoded = decode(toon) as { probes: Array<{ id: string; verdict: string }>; findings: unknown[] };
 
-    expect(decoded.probes).toEqual([{ id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" }]);
+    expect(decoded.probes).toEqual([
+      { id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" },
+      { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
+    ]);
     expect(decoded.findings).toHaveLength(1);
     expect(toon).not.toContain("{\n");
     expect(toon).not.toContain('": "');
   });
 
   it("refuses a gated fix without applying any remote changes", async () => {
-    const report = runOperationalProbes({
+    const report = await runOperationalProbes({
       remoteUrls: [{ name: "origin", url: "https://example.invalid/acme/widgets.git" }],
     });
     const setRemoteUrl = vi.fn(async () => {});
@@ -61,7 +67,7 @@ describe("operational probe registry", () => {
   });
 
   it("applies a confirmed gated fix as an observable remote rewrite", async () => {
-    const report = runOperationalProbes({
+    const report = await runOperationalProbes({
       remoteUrls: [{ name: "origin", url: "https://example.invalid/acme/widgets.git" }],
     });
     const setRemoteUrl = vi.fn(async () => {});
@@ -76,4 +82,89 @@ describe("operational probe registry", () => {
     ]);
     expect(setRemoteUrl).toHaveBeenCalledWith("origin", "git@example.invalid:acme/widgets.git");
   });
+
+  it("runs the engine listing seam and flags an engine-vs-REST queue mismatch", async () => {
+    const listEngineCandidates = vi.fn(async () => 0);
+    const countRestQueue = vi.fn(async () => 11);
+
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      queueVisibility: {
+        listEngineCandidates,
+        countRestQueue,
+      },
+    });
+
+    expect(listEngineCandidates).toHaveBeenCalledOnce();
+    expect(countRestQueue).toHaveBeenCalledOnce();
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        id: "afk.queue-visibility",
+        verdict: "red",
+        evidence: "engine sees 0 open ready-for-agent; REST sees 11",
+      }),
+    ]);
+  });
+
+  it("classifies SSO/scope failures from captured GitHub payloads with the exact human fix", async () => {
+    const payload = await readFixture("saml-enforcement.txt");
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      queueVisibility: {
+        listEngineCandidates: async () => {
+          throw Object.assign(new Error("gh issue list failed"), {
+            surface: "graphql",
+            stderr: payload,
+          });
+        },
+        countRestQueue: async () => 1,
+      },
+    });
+
+    expect(classifyQueueVisibilityTransportFailure({ surface: "graphql", stderr: payload })).toBe("sso-or-scope");
+    expect(report.findings[0]).toMatchObject({
+      id: "afk.queue-visibility",
+      evidence: "queue listing failed (sso-or-scope, surface=graphql)",
+      canonicalFix: expect.stringContaining("gh auth refresh -h github.com -s repo,read:org,workflow"),
+    });
+    expect(report.findings[0]?.canonicalFix).toContain("SSO authorization prompt");
+  });
+
+  it("classifies rate-limit failures distinctly from generic transport failures", async () => {
+    const payload = await readFixture("rate-limit.txt");
+    const rateLimited = await runOperationalProbes({
+      remoteUrls: [],
+      queueVisibility: {
+        listEngineCandidates: async () => 1,
+        countRestQueue: async () => {
+          throw Object.assign(new Error("gh api failed"), {
+            surface: "rest",
+            stderr: payload,
+          });
+        },
+      },
+    });
+    const generic = await runOperationalProbes({
+      remoteUrls: [],
+      queueVisibility: {
+        listEngineCandidates: async () => {
+          throw Object.assign(new Error("socket hang up"), { surface: "unknown" });
+        },
+        countRestQueue: async () => 0,
+      },
+    });
+
+    expect(rateLimited.findings[0]).toMatchObject({
+      evidence: "queue listing failed (rate-limit, surface=rest)",
+      canonicalFix: expect.stringContaining("rate limit window"),
+    });
+    expect(generic.findings[0]).toMatchObject({
+      evidence: "queue listing failed (generic-transport, surface=unknown)",
+      canonicalFix: expect.stringContaining("gh auth status"),
+    });
+  });
 });
+
+function readFixture(name: string): Promise<string> {
+  return readFile(join(process.cwd(), "tests", "fixtures", "github-transport", name), "utf8");
+}


### PR DESCRIPTION
Automated AFK landing for #1967. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1967

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786888553&installation_id=129708444&pr_number=2003&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2003&signature=7a462296d4aed6616957c1045606dd248a5dc80988846a90fd39422817ec70d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->