### PR TITLE
fix: #1984 rsp: bench arbiter — anomaly corpora, end-task parity probe, refreshed two-axis results vs headroom

### DIFF
--- a/apps/rsp/bench/README.md
+++ b/apps/rsp/bench/README.md
@@ -67,6 +67,7 @@ in `src/two-axis-thresholds.ts`.
 
 The benchmark discovers fidelity fixtures under `apps/rsp/tests/fixtures`:
 
+- `exec`
 - `file-read`
 - `gh`
 - `git`
@@ -77,6 +78,11 @@ fixtures have an adjacent `.oracle.toon` file that represents the hand-reviewed
 compact oracle. The benchmark requires large-output fixtures for git diff,
 git log, vitest green output, and vitest failure output so the result continues
 to cover the cases where reduction matters most.
+
+The default invocation is the standing quality arbiter: it runs the pre-existing
+quality corpus and the anomaly, mixed-content, and JSON-outlier families in one
+report. The generated summary emits oracle-capture and token counts for each
+family as well as for the full aggregate.
 
 The RTK and Headroom comparators are recorded baselines:
 
@@ -118,6 +124,11 @@ The main table has one row per filter:
 The aggregate line combines all fixtures. It is the fastest way to compare rsp,
 RTK, Headroom, raw output, and the oracle ceiling.
 
+The corpus table breaks the same token and oracle-capture numbers down by
+quality family. The end-task parity table then checks representative agent
+questions against both raw-output answers and rsp-summary answers; every row
+must report the same answer.
+
 ## Read the TOON Artifact
 
 `bench/results/rsp-two-axis.toon` is the machine-readable report. It includes:
@@ -128,7 +139,11 @@ RTK, Headroom, raw output, and the oracle ceiling.
   oracle-capture axes, and hypothetical active-mode results for passthrough
   filters.
 - `aggregate`: corpus-wide oracle-capture counts and percentages.
+- `quality_corpora`: pre-existing, anomaly, mixed-content, and JSON-outlier
+  corpus rows with token counts and oracle-capture percentages.
 - `parity`: direct fidelity gates for selected parity domains.
+- `end_task_parity`: representative same-answer probes comparing raw-output
+  answers with rsp-summary answers.
 - `anti_suppression_audit`: notes explaining why each filter does not hide the
   decision signal.
 

--- a/apps/rsp/bench/results/rsp-two-axis.md
+++ b/apps/rsp/bench/results/rsp-two-axis.md
@@ -26,12 +26,28 @@ Production mode uses admission threshold 60%; passthrough filters count as 0% to
 
 Aggregate oracle ceiling: raw 99323 tokens (0% capture), rsp 14760 tokens (99.4% capture), RTK 646 tokens (4.9% capture), Headroom 64367 tokens (0.6% capture), oracle 14219 tokens.
 
+| Corpus | Fixtures | Filters | raw tokens | rsp tokens | Headroom tokens | oracle tokens | rsp capture | Headroom capture |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| pre-existing-quality | 31 | cargo:test, cat:file, gh:issue, gh:pr, gh:run, git:blame, git:branch, git:commit, git:diff, git:log, git:push, git:show, git:status, vitest:run | 66174 | 13909 | 64367 | 13874 | 99.9% | 0.6% |
+| anomaly | 1 | exec:-- | 32686 | 235 | headroom: not-covered | 96 | 99.6% | headroom: not-covered |
+| mixed-content | 1 | exec:-- | 166 | 413 | headroom: not-covered | 79 | 0% | headroom: not-covered |
+| json-outlier | 1 | exec:-- | 297 | 203 | headroom: not-covered | 170 | 74% | headroom: not-covered |
+
 Large-output filters: cat:file, exec:--, git:diff, git:log, vitest:run.
 
 | Parity domain | Filter | Gate | rsp fidelity | RTK fidelity |
 | --- | --- | --- | ---: | ---: |
 | cargo-test | cargo:test | fail | 100% | 100% |
 | git-commit | git:commit | pass | 100% | 100% |
+
+| End-task parity probe | Fixture | Raw answer | rsp summary answer | Same answer |
+| --- | --- | --- | --- | --- |
+| crusher keeps numeric value outlier | exec-json-array-crusher | 7 | 7 | yes |
+| crusher keeps shape outlier | exec-json-array-crusher | shape-break | shape-break | yes |
+| oracle preserves planted mid-stream structural outlier | exec-midstream-anomaly | 2026-07-17T12:00:00Z service=payments level=FATAL panic=InvariantViolation shard=42 trace=midstream-anomaly-7f3a stack=/srv/app/payments.ts:1442 | 2026-07-17T12:00:00Z service=payments level=FATAL panic=InvariantViolation shard=42 trace=midstream-anomaly-7f3a stack=/srv/app/payments.ts:1442 | yes |
+| router degrades mixed ambiguous content to untyped fallback | exec-router-mixed-content | untyped | untyped | yes |
+| which PR is first? | pr-list-default | 42 | 42 | yes |
+| how many failed? | vitest-many-failures | 5/8 failed · 2 suites · 3.2s | 5/8 failed · 2 suites · 3.2s | yes |
 
 | Anti-suppression audit | Level | Verdict | Note |
 | --- | --- | --- | --- |

--- a/apps/rsp/bench/results/rsp-two-axis.toon
+++ b/apps/rsp/bench/results/rsp-two-axis.toon
@@ -997,9 +997,129 @@ aggregate:
     token_count: 14219
     capture_pct: 100
     source: fixture-oracle
+quality_corpora[4]:
+  - corpus: pre-existing-quality
+    fixture_count: 31
+    filters[14]: "cargo:test","cat:file","gh:issue","gh:pr","gh:run","git:blame","git:branch","git:commit","git:diff","git:log","git:push","git:show","git:status","vitest:run"
+    oracle_capture:
+      raw:
+        token_count: 66174
+        capture_pct: 0
+        source: recorded
+      rsp:
+        token_count: 13909
+        capture_pct: 99.9
+        source: measured
+      terse:
+        token_count: 13586
+        capture_pct: 97.9
+        source: measured
+      rtk:
+        token_count: 646
+        capture_pct: 4.9
+        source: recorded
+      headroom:
+        token_count: 64367
+        capture_pct: 0.6
+        source: recorded
+      oracle_ceiling:
+        token_count: 13874
+        capture_pct: 100
+        source: fixture-oracle
+  - corpus: anomaly
+    fixture_count: 1
+    filters[1]: "exec:--"
+    oracle_capture:
+      raw:
+        token_count: 32686
+        capture_pct: 0
+        source: recorded
+      rsp:
+        token_count: 235
+        capture_pct: 99.6
+        source: measured
+      terse:
+        token_count: 235
+        capture_pct: 99.6
+        source: measured
+      rtk:
+        coverage: not-covered
+        label: "rtk: not-covered"
+        source: not-covered
+      headroom:
+        coverage: not-covered
+        label: "headroom: not-covered"
+        source: not-covered
+      oracle_ceiling:
+        token_count: 96
+        capture_pct: 100
+        source: fixture-oracle
+  - corpus: mixed-content
+    fixture_count: 1
+    filters[1]: "exec:--"
+    oracle_capture:
+      raw:
+        token_count: 166
+        capture_pct: 0
+        source: recorded
+      rsp:
+        token_count: 413
+        capture_pct: 0
+        source: measured
+      terse:
+        token_count: 387
+        capture_pct: 0
+        source: measured
+      rtk:
+        coverage: not-covered
+        label: "rtk: not-covered"
+        source: not-covered
+      headroom:
+        coverage: not-covered
+        label: "headroom: not-covered"
+        source: not-covered
+      oracle_ceiling:
+        token_count: 79
+        capture_pct: 100
+        source: fixture-oracle
+  - corpus: json-outlier
+    fixture_count: 1
+    filters[1]: "exec:--"
+    oracle_capture:
+      raw:
+        token_count: 297
+        capture_pct: 0
+        source: recorded
+      rsp:
+        token_count: 203
+        capture_pct: 74
+        source: measured
+      terse:
+        token_count: 203
+        capture_pct: 74
+        source: measured
+      rtk:
+        coverage: not-covered
+        label: "rtk: not-covered"
+        source: not-covered
+      headroom:
+        coverage: not-covered
+        label: "headroom: not-covered"
+        source: not-covered
+      oracle_ceiling:
+        token_count: 170
+        capture_pct: 100
+        source: fixture-oracle
 parity[2]{domain,filter,rsp_median_delta_pct,rtk_median_delta_pct,rsp_fidelity_pass_rate_pct,rtk_fidelity_pass_rate_pct,parity_gate}:
   cargo-test,"cargo:test",61.9,67.8,100,100,fail
   git-commit,"git:commit",0,-78.8,100,100,pass
+end_task_parity[6]{task,fixture,raw_answer,rsp_answer,same_answer}:
+  crusher keeps numeric value outlier,exec-json-array-crusher,7,7,true
+  crusher keeps shape outlier,exec-json-array-crusher,shape-break,shape-break,true
+  oracle preserves planted mid-stream structural outlier,exec-midstream-anomaly,"2026-07-17T12:00:00Z service=payments level=FATAL panic=InvariantViolation shard=42 trace=midstream-anomaly-7f3a stack=/srv/app/payments.ts:1442","2026-07-17T12:00:00Z service=payments level=FATAL panic=InvariantViolation shard=42 trace=midstream-anomaly-7f3a stack=/srv/app/payments.ts:1442",true
+  router degrades mixed ambiguous content to untyped fallback,exec-router-mixed-content,untyped,untyped,true
+  which PR is first?,pr-list-default,42,42,true
+  how many failed?,vitest-many-failures,5/8 failed · 2 suites · 3.2s,5/8 failed · 2 suites · 3.2s,true
 anti_suppression_audit[30]{filter,level,audited,note}:
   "cargo:test",brief,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"
   "cargo:test",terse,ok,"test outputs keep exit code, summary, and failure rows in compact TOON with handles for elided detail"

--- a/apps/rsp/src/two-axis-benchmark.ts
+++ b/apps/rsp/src/two-axis-benchmark.ts
@@ -2,7 +2,7 @@ import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promise
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
+import { decode, encode, type JsonObject, type JsonValue } from "@reddb-io/toon";
 import { encodingForModel } from "js-tiktoken";
 import { discoverFidelityFixtures, runFidelityFixture, type FidelityFixture } from "./fidelity.js";
 import { RspElisionStore } from "./elision-store.js";
@@ -87,6 +87,21 @@ export interface TwoAxisParityRow {
   parity_gate: "pass" | "fail";
 }
 
+export interface QualityCorpusRow {
+  corpus: "pre-existing-quality" | "anomaly" | "mixed-content" | "json-outlier";
+  fixture_count: number;
+  filters: string[];
+  oracle_capture: OracleCaptureRow;
+}
+
+export interface EndTaskParityRow {
+  task: string;
+  fixture: string;
+  raw_answer: JsonValue;
+  rsp_answer: JsonValue;
+  same_answer: boolean;
+}
+
 export interface AntiSuppressionAuditRow {
   filter: string;
   level: "brief" | "terse";
@@ -122,7 +137,9 @@ export interface TwoAxisBenchmarkReport {
   };
   filters: TwoAxisFilterRow[];
   aggregate: OracleCaptureRow & { fixture_count: number };
+  quality_corpora: QualityCorpusRow[];
   parity: TwoAxisParityRow[];
+  end_task_parity: EndTaskParityRow[];
   anti_suppression_audit: AntiSuppressionAuditRow[];
   summary: string;
   toon: string;
@@ -186,6 +203,14 @@ interface FixtureMeasurement {
   oracleTokens: number;
 }
 
+interface EndTaskCandidate {
+  fixture: string;
+  task: string;
+  rawAnswer: JsonValue;
+  rspAnswer: JsonValue;
+  sameAnswer: boolean;
+}
+
 const tokenizer = encodingForModel("gpt-4o");
 const ADMISSION_THRESHOLD_PCT = 60;
 const DEFAULT_FIXTURE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "tests", "fixtures");
@@ -212,6 +237,7 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
   const headroom = await readHeadroomBaselines(join(fixtureRoot, "headroom", "baselines.json"));
   const headroomByName = new Map(headroom.fixtures.map((fixture) => [fixture.name, fixture]));
   const measurements: FixtureMeasurement[] = [];
+  const endTaskCandidates: EndTaskCandidate[] = [];
   const tempRoot = await mkdtemp(join(tmpdir(), "rsp-two-axis-store-"));
   const store = await RspElisionStore.open({ uri: `file://${join(tempRoot, "red.rdb")}` });
   try {
@@ -220,6 +246,7 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
       const headroomFixture = headroomByName.get(fixture.name);
       const brief = await runFidelityFixture(fixture, { level: "lossless", store });
       const terse = await runFidelityFixture(fixture, { level: "terse", store });
+      endTaskCandidates.push(...buildEndTaskCandidates(fixture, brief.stdout.toString("utf8"), brief.oneLine === true));
       const active = admissionByFilter.get(filterName(fixture))?.mode === "active";
       const rawTokens = tokenCount(fixture.recorded.stdout);
       const briefTokens = tokenCount(brief.stdout.toString("utf8"));
@@ -259,6 +286,8 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
     filterRow(filter, rows, admissionByFilter.get(filter))
   );
   const parity = buildParity(rows);
+  const qualityCorpora = buildQualityCorpora(measurements);
+  const endTaskParity = selectEndTaskParity(endTaskCandidates);
   const antiSuppressionAudit = buildAntiSuppressionAudit(rows);
   const payload = {
     benchmark: "rsp-two-axis",
@@ -288,7 +317,9 @@ export async function buildTwoAxisBenchmarkReport(options: TwoAxisBenchmarkOptio
     },
     filters: rows,
     aggregate: aggregateOracleCapture(measurements),
+    quality_corpora: qualityCorpora,
     parity,
+    end_task_parity: endTaskParity,
     anti_suppression_audit: antiSuppressionAudit,
     summary: `${measurements.length} fixtures, ${rows.length} filters; shipped modes apply admission threshold ${ADMISSION_THRESHOLD_PCT}%`,
   } satisfies Omit<TwoAxisBenchmarkReport, "toon">;
@@ -325,12 +356,24 @@ export function renderTwoAxisSummary(report: TwoAxisBenchmarkReport): string {
     "",
     `Aggregate oracle ceiling: raw ${report.aggregate.raw.token_count} tokens (${fmt(report.aggregate.raw.capture_pct)}% capture), rsp ${report.aggregate.rsp.token_count} tokens (${fmt(report.aggregate.rsp.capture_pct)}% capture), RTK ${fmtComparatorTokenCount(report.aggregate.rtk)} tokens (${fmtComparatorCapture(report.aggregate.rtk)} capture), Headroom ${fmtComparatorTokenCount(report.aggregate.headroom)} tokens (${fmtComparatorCapture(report.aggregate.headroom)} capture), oracle ${report.aggregate.oracle_ceiling.token_count} tokens.`,
     "",
+    "| Corpus | Fixtures | Filters | raw tokens | rsp tokens | Headroom tokens | oracle tokens | rsp capture | Headroom capture |",
+    "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ...report.quality_corpora.map((row) =>
+      `| ${row.corpus} | ${row.fixture_count} | ${row.filters.join(", ")} | ${row.oracle_capture.raw.token_count} | ${row.oracle_capture.rsp.token_count} | ${fmtComparatorTokenCount(row.oracle_capture.headroom)} | ${row.oracle_capture.oracle_ceiling.token_count} | ${fmt(row.oracle_capture.rsp.capture_pct)}% | ${fmtComparatorCapture(row.oracle_capture.headroom)} |`
+    ),
+    "",
     `Large-output filters: ${report.corpus.large_output_filters.join(", ") || "none"}.`,
     "",
     "| Parity domain | Filter | Gate | rsp fidelity | RTK fidelity |",
     "| --- | --- | --- | ---: | ---: |",
     ...report.parity.map((row) =>
       `| ${row.domain} | ${row.filter} | ${row.parity_gate} | ${fmt(row.rsp_fidelity_pass_rate_pct)}% | ${fmt(row.rtk_fidelity_pass_rate_pct)}% |`
+    ),
+    "",
+    "| End-task parity probe | Fixture | Raw answer | rsp summary answer | Same answer |",
+    "| --- | --- | --- | --- | --- |",
+    ...report.end_task_parity.map((row) =>
+      `| ${row.task} | ${row.fixture} | ${fmtJsonValue(row.raw_answer)} | ${fmtJsonValue(row.rsp_answer)} | ${row.same_answer ? "yes" : "no"} |`
     ),
     "",
     "| Anti-suppression audit | Level | Verdict | Note |",
@@ -392,6 +435,102 @@ function buildParity(rows: readonly TwoAxisFilterRow[]): TwoAxisParityRow[] {
     parityRow("cargo-test", "cargo:test", rows),
     parityRow("git-commit", "git:commit", rows),
   ];
+}
+
+function buildQualityCorpora(measurements: readonly FixtureMeasurement[]): QualityCorpusRow[] {
+  return [...groupByCorpus(measurements).entries()]
+    .sort(([a], [b]) => corpusSortKey(a) - corpusSortKey(b))
+    .map(([corpus, rows]) => ({
+      corpus,
+      fixture_count: rows.length,
+      filters: [...new Set(rows.map((row) => row.filter))].sort((a, b) => a.localeCompare(b)),
+      oracle_capture: oracleCapture(rows),
+    }));
+}
+
+function groupByCorpus(measurements: readonly FixtureMeasurement[]): Map<QualityCorpusRow["corpus"], FixtureMeasurement[]> {
+  const out = new Map<QualityCorpusRow["corpus"], FixtureMeasurement[]>();
+  for (const measurement of measurements) {
+    const corpus = qualityCorpus(measurement.fixture);
+    out.set(corpus, [...(out.get(corpus) ?? []), measurement]);
+  }
+  return out;
+}
+
+function qualityCorpus(fixture: FidelityFixture): QualityCorpusRow["corpus"] {
+  if (fixture.name === "exec-midstream-anomaly") return "anomaly";
+  if (fixture.name === "exec-router-mixed-content") return "mixed-content";
+  if (fixture.name === "exec-json-array-crusher") return "json-outlier";
+  return "pre-existing-quality";
+}
+
+function corpusSortKey(corpus: QualityCorpusRow["corpus"]): number {
+  return ["pre-existing-quality", "anomaly", "mixed-content", "json-outlier"].indexOf(corpus);
+}
+
+function buildEndTaskCandidates(fixture: FidelityFixture, rspStdout: string, oneLine: boolean): EndTaskCandidate[] {
+  const probes = fixture.assertions.filter((assertion) => isEndTaskProbe(fixture.name, assertion.question));
+  if (probes.length === 0) return [];
+  const decoded = decodeBenchmarkRenderOutput(rspStdout, oneLine);
+  return probes.map((assertion) => {
+    const rspAnswer = toJsonValue(getPath(decoded, assertion.path));
+    const rawAnswer = toJsonValue(assertion.expected);
+    return {
+      fixture: fixture.name,
+      task: assertion.question,
+      rawAnswer,
+      rspAnswer,
+      sameAnswer: Object.is(rspAnswer, rawAnswer),
+    };
+  });
+}
+
+function isEndTaskProbe(fixtureName: string, question: string): boolean {
+  return new Set([
+    "exec-midstream-anomaly::oracle preserves planted mid-stream structural outlier",
+    "exec-json-array-crusher::crusher keeps numeric value outlier",
+    "exec-json-array-crusher::crusher keeps shape outlier",
+    "exec-router-mixed-content::router degrades mixed ambiguous content to untyped fallback",
+    "pr-list-default::which PR is first?",
+    "vitest-many-failures::how many failed?",
+  ]).has(`${fixtureName}::${question}`);
+}
+
+function selectEndTaskParity(candidates: readonly EndTaskCandidate[]): EndTaskParityRow[] {
+  return candidates.map((candidate) => ({
+    task: candidate.task,
+    fixture: candidate.fixture,
+    raw_answer: candidate.rawAnswer,
+    rsp_answer: candidate.rspAnswer,
+    same_answer: candidate.sameAnswer,
+  }));
+}
+
+function decodeBenchmarkRenderOutput(stdout: string, oneLine: boolean): unknown {
+  if (oneLine) return stdout.replace(/\n$/, "");
+  if (stdout === "git empty\n") return "git empty\n";
+  if (stdout.startsWith("stdout summary\n")) return stdout;
+  if (stdout.startsWith("0 ")) return stdout;
+  const toon = stdout.split("\n").filter((line) => !line.startsWith("… elided ")).join("\n");
+  return decode(toon);
+}
+
+function getPath(value: unknown, path: string): unknown {
+  let cursor = value;
+  for (const segment of path.split(".")) {
+    if (segment === "length" && Array.isArray(cursor)) {
+      cursor = cursor.length;
+    } else if (segment === "length" && isRecord(cursor)) {
+      cursor = Object.keys(cursor).length;
+    } else if (/^\d+$/.test(segment) && Array.isArray(cursor)) {
+      cursor = cursor[Number(segment)];
+    } else if (isRecord(cursor)) {
+      cursor = cursor[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return cursor;
 }
 
 function buildAntiSuppressionAudit(rows: readonly TwoAxisFilterRow[]): AntiSuppressionAuditRow[] {
@@ -672,6 +811,25 @@ function fmtComparatorTokenCount(value: ComparatorTokenCaptureAxis): string {
 function fmtComparatorCapture(value: ComparatorTokenCaptureAxis): string {
   if (value.source === "not-covered") return value.label;
   return `${fmt(value.capture_pct)}%`;
+}
+
+function fmtJsonValue(value: JsonValue): string {
+  if (typeof value === "string") return value.replace(/\|/g, "\\|");
+  return JSON.stringify(value);
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    Array.isArray(value) ||
+    isRecord(value)
+  ) {
+    return value as JsonValue;
+  }
+  return null;
 }
 
 function externalClaims(): ExternalClaim[] {

--- a/apps/rsp/tests/two-axis-benchmark.test.ts
+++ b/apps/rsp/tests/two-axis-benchmark.test.ts
@@ -148,6 +148,52 @@ describe("rsp two-axis benchmark report", () => {
     expect(report.aggregate.oracle_ceiling.capture_pct).toBe(100);
     expect(report.aggregate.raw.token_count).toBeGreaterThan(report.aggregate.oracle_ceiling.token_count);
     expect(report.aggregate.headroom.source).toBe("recorded");
+    expect(report.quality_corpora.map((row) => row.corpus)).toEqual([
+      "pre-existing-quality",
+      "anomaly",
+      "mixed-content",
+      "json-outlier",
+    ]);
+    expect(report.quality_corpora.find((row) => row.corpus === "anomaly")).toMatchObject({
+      fixture_count: 1,
+      filters: ["exec:--"],
+      oracle_capture: {
+        raw: { token_count: expect.any(Number) },
+        rsp: { token_count: expect.any(Number), source: "measured" },
+        oracle_ceiling: { source: "fixture-oracle" },
+      },
+    });
+    expect(report.end_task_parity).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        fixture: "exec-midstream-anomaly",
+        task: "oracle preserves planted mid-stream structural outlier",
+        same_answer: true,
+      }),
+      expect.objectContaining({
+        fixture: "exec-json-array-crusher",
+        task: "crusher keeps numeric value outlier",
+        raw_answer: 7,
+        rsp_answer: 7,
+        same_answer: true,
+      }),
+      expect.objectContaining({
+        fixture: "exec-router-mixed-content",
+        task: "router degrades mixed ambiguous content to untyped fallback",
+        raw_answer: "untyped",
+        rsp_answer: "untyped",
+        same_answer: true,
+      }),
+      expect.objectContaining({
+        fixture: "pr-list-default",
+        task: "which PR is first?",
+        same_answer: true,
+      }),
+      expect.objectContaining({
+        fixture: "vitest-many-failures",
+        task: "how many failed?",
+        same_answer: true,
+      }),
+    ]));
   });
 
   it("writes a reproducible TOON artifact and matching human summary", async () => {
@@ -166,6 +212,10 @@ describe("rsp two-axis benchmark report", () => {
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("rtk: not-covered");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("Headroom baseline is replayed from checked-in recorded fixtures only");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("Aggregate oracle ceiling:");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Corpus | Fixtures | Filters | raw tokens | rsp tokens | Headroom tokens | oracle tokens | rsp capture | Headroom capture |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| anomaly | 1 | exec:-- |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| End-task parity probe | Fixture | Raw answer | rsp summary answer | Same answer |");
+    await expect(readFile(summaryPath, "utf8")).resolves.toContain("| crusher keeps numeric value outlier | exec-json-array-crusher | 7 | 7 | yes |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| Anti-suppression audit | Level | Verdict | Note |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| git:commit | brief | audited: fixed |");
     await expect(readFile(summaryPath, "utf8")).resolves.toContain("| git:push | terse | audited: fixed |");


### PR DESCRIPTION
Automated AFK landing for #1984. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786888750&installation_id=129708444&pr_number=2004&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2004&signature=3e8b62e04d55bdb19971e9089af8b5ff4aadb385d5248e4e0310ba90f4818930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->