### PR TITLE
fix: #1968 Focal-branch resolution probe: lock > pin > trunk provenance + stale branch-lock repair

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -3,6 +3,7 @@ import { encode as encodeToon } from "@reddb-io/toon";
 import { afkPaths, collectPrecheckFacts, resolveRepoContext } from "../runtime/wire.js";
 import { listIssueStates, type GhContext } from "../runtime/gh.js";
 import { applyTmpJanitorReport, collectTmpJanitorReport, type TmpJanitorApplyResult, type TmpJanitorReport } from "../runtime/tmp-janitor.js";
+import { branchLockPath, clearBranchLock, writeBranchLock } from "../runtime/lock.js";
 import {
   applyOperationalProbeFixes,
   runOperationalProbes,
@@ -156,10 +157,13 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
       return state === "CLOSED" ? "CLOSED" : state === "OPEN" ? "OPEN" : "UNKNOWN";
     });
     const gitCtx: gitx.GitContext = { cwd: ctx.root };
+    const lockPath = branchLockPath(ctx.root);
     const probeFixes = flags.fix
       ? await applyOperationalProbeFixes(probeReport, {
           confirm: async () => flags.yes,
           setRemoteUrl: async (name, url) => gitx.setRemoteUrl(gitCtx, name, url),
+          removeBranchLock: async () => clearBranchLock(lockPath),
+          writeBranchLock: async (branch) => writeBranchLock(lockPath, branch),
         })
       : [];
     const applied = flags.fix ? await applyTmpJanitorReport(paths.tmpDir, report) : undefined;

--- a/apps/dev/src/core/base-resolver.ts
+++ b/apps/dev/src/core/base-resolver.ts
@@ -23,7 +23,7 @@
 // filesystem directly. All real IO (the lock file read, the gh body fetch) is
 // injected, so the precedence stays unit-testable against fixed inputs.
 
-import { DEFAULT_BRANCH, resolvePin, type ResolvePinInput } from "./pin-reader.js";
+import { DEFAULT_BRANCH, resolvePinWithSource, type ResolvePinInput } from "./pin-reader.js";
 
 /** True when `value` has at least one non-whitespace char (mirrors `_base_is_set`). */
 function isSet(value: string | undefined): value is string {
@@ -55,6 +55,12 @@ export interface ResolveBaseDeps {
 }
 
 export type ResolveBaseInput = ResolvePinInput;
+export type ResolveBaseSource = "lock" | "pin" | "trunk";
+
+export interface ResolvedBase {
+  branch: string;
+  source: ResolveBaseSource;
+}
 
 /**
  * Resolve the effective base branch by the fixed precedence
@@ -68,17 +74,21 @@ export type ResolveBaseInput = ResolvePinInput;
  * `resolvePin` (whose pinless collapse also lands on the Trunk). A
  * whitespace-only value counts as "not set".
  */
-export async function resolveBase(input: ResolveBaseInput, deps: ResolveBaseDeps): Promise<string> {
+export async function resolveBaseWithSource(input: ResolveBaseInput, deps: ResolveBaseDeps): Promise<ResolvedBase> {
   const locked = await deps.readLockedBranch();
-  if (isSet(locked)) return locked.trim();
+  if (isSet(locked)) return { branch: locked.trim(), source: "lock" };
 
-  if (isSet(deps.configLockedBranch)) return deps.configLockedBranch.trim();
+  if (isSet(deps.configLockedBranch)) return { branch: deps.configLockedBranch.trim(), source: "pin" };
 
-  const pinned = await resolvePin(input, {
+  const pinned = await resolvePinWithSource(input, {
     fetchIssueBody: deps.fetchIssueBody,
     defaultBranch: deps.configTrunk,
   });
-  if (isSet(pinned)) return pinned;
+  if (isSet(pinned.branch)) return pinned;
 
-  return isSet(deps.configTrunk) ? deps.configTrunk.trim() : DEFAULT_BRANCH;
+  return { branch: isSet(deps.configTrunk) ? deps.configTrunk.trim() : DEFAULT_BRANCH, source: "trunk" };
+}
+
+export async function resolveBase(input: ResolveBaseInput, deps: ResolveBaseDeps): Promise<string> {
+  return (await resolveBaseWithSource(input, deps)).branch;
 }

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -130,6 +130,8 @@ export interface PrecheckFacts {
   allowHttpsRemote?: boolean;
   /** Optional boot-time queue probe; injected by runtime facts so boot refuses on an unlistable AFK queue. */
   queueVisibility?: OperationalProbeContext["queueVisibility"];
+  /** Optional boot-time focal-branch probe, sharing the same lock/pin/trunk resolver as the precheck. */
+  focalBranch?: OperationalProbeContext["focalBranch"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -1,4 +1,5 @@
 export * from "./operational-probes/types.js";
+export * from "./operational-probes/focal-branch.js";
 export * from "./operational-probes/https-remote.js";
 export * from "./operational-probes/queue-visibility.js";
 export * from "./operational-probes/registry.js";

--- a/apps/dev/src/core/operational-probes/focal-branch.ts
+++ b/apps/dev/src/core/operational-probes/focal-branch.ts
@@ -1,0 +1,114 @@
+import type {
+  FocalBranchProbeInput,
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeFixDeps,
+  OperationalProbeFixResult,
+  OperationalProbeResult,
+} from "./types.js";
+
+export const FOCAL_BRANCH_PROBE_ID = "afk.focal-branch-resolution";
+export const FOCAL_BRANCH_PROBE_NAME = "AFK focal branch resolution";
+export const FOCAL_BRANCH_CANONICAL_FIX =
+  "Repair stale branch-lock state by clearing a dead lock, or keep a live intentional lock and switch the primary checkout to the resolved focal branch.";
+
+export type FocalBranchFindingKind = "stale-lock-target-missing" | "contradictory-lock-without-live-session";
+
+export interface FocalBranchProbeData {
+  readonly resolved: FocalBranchProbeInput["resolved"];
+  readonly configuredTrunk: string;
+  readonly lock?: FocalBranchProbeInput["lock"];
+  readonly finding?: FocalBranchFindingKind;
+}
+
+function evidence(input: FocalBranchProbeInput, finding?: FocalBranchFindingKind): string {
+  const lock = input.lock;
+  const lockEvidence = lock
+    ? `; lock=${JSON.stringify(lock.raw)} targetExists=${String(lock.targetExists)}`
+    : "";
+  const suffix = `; configuredTrunk=${input.configuredTrunk}${lockEvidence}`;
+  if (finding === "stale-lock-target-missing") {
+    return `resolved ${input.resolved.branch} from ${input.resolved.source}; stale lock target is missing${suffix}`;
+  }
+  if (finding === "contradictory-lock-without-live-session") {
+    return `resolved ${input.resolved.branch} from ${input.resolved.source}; lock diverges from configured trunk without a live holder${suffix}`;
+  }
+  return `resolved ${input.resolved.branch} from ${input.resolved.source}${suffix}`;
+}
+
+function findingKind(input: FocalBranchProbeInput): FocalBranchFindingKind | undefined {
+  const lock = input.lock;
+  if (!lock?.branch) return undefined;
+  if (lock.targetExists === false) return "stale-lock-target-missing";
+  if (
+    lock.branch !== input.configuredTrunk &&
+    lock.heldByLiveSession === false
+  ) {
+    return "contradictory-lock-without-live-session";
+  }
+  return undefined;
+}
+
+export function runFocalBranchProbe(context: OperationalProbeContext): OperationalProbeResult {
+  const input = context.focalBranch;
+  if (!input) {
+    return {
+      id: FOCAL_BRANCH_PROBE_ID,
+      name: FOCAL_BRANCH_PROBE_NAME,
+      verdict: "ok",
+      evidence: "focal branch resolution check not configured",
+      canonicalFix: FOCAL_BRANCH_CANONICAL_FIX,
+    };
+  }
+
+  const finding = findingKind(input);
+  return {
+    id: FOCAL_BRANCH_PROBE_ID,
+    name: FOCAL_BRANCH_PROBE_NAME,
+    verdict: finding ? "red" : "ok",
+    evidence: evidence(input, finding),
+    canonicalFix: FOCAL_BRANCH_CANONICAL_FIX,
+    fix: finding
+      ? {
+          gate: "confirm",
+          description: "clear the stale branch-lock so boot falls back to the configured focal branch",
+        }
+      : undefined,
+    data: {
+      resolved: input.resolved,
+      configuredTrunk: input.configuredTrunk,
+      lock: input.lock,
+      finding,
+    } satisfies FocalBranchProbeData,
+  };
+}
+
+export async function applyFocalBranchFix(
+  finding: OperationalProbeResult,
+  deps: OperationalProbeFixDeps,
+): Promise<OperationalProbeFixResult> {
+  const data = finding.data as Partial<FocalBranchProbeData> | undefined;
+  if (!data?.finding) {
+    return { probeId: finding.id, status: "noop", evidence: "no focal branch repair is needed" };
+  }
+
+  const confirmed = await deps.confirm(finding);
+  if (!confirmed) {
+    return { probeId: finding.id, status: "declined", evidence: "operator declined fix" };
+  }
+
+  if (!deps.removeBranchLock) {
+    return { probeId: finding.id, status: "noop", evidence: "branch-lock repair is not wired" };
+  }
+
+  await deps.removeBranchLock();
+  return { probeId: finding.id, status: "applied", evidence: "cleared branch-lock" };
+}
+
+export const focalBranchProbe: OperationalProbe = {
+  id: FOCAL_BRANCH_PROBE_ID,
+  name: FOCAL_BRANCH_PROBE_NAME,
+  canonicalFix: FOCAL_BRANCH_CANONICAL_FIX,
+  run: runFocalBranchProbe,
+  applyFix: applyFocalBranchFix,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -1,4 +1,5 @@
 import { encode as encodeToon } from "@reddb-io/toon";
+import { focalBranchProbe } from "./focal-branch.js";
 import { httpsRemoteProbe } from "./https-remote.js";
 import { queueVisibilityProbe } from "./queue-visibility.js";
 import type {
@@ -12,6 +13,7 @@ import type {
 export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   httpsRemoteProbe,
   queueVisibilityProbe,
+  focalBranchProbe,
 ];
 
 export async function runOperationalProbes(

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -9,6 +9,23 @@ export interface OperationalProbeContext {
   readonly remoteUrls: readonly (string | RemoteUrlFact)[];
   readonly allowHttpsRemote?: boolean;
   readonly queueVisibility?: QueueVisibilityProbeInput;
+  readonly focalBranch?: FocalBranchProbeInput;
+}
+
+export type FocalBranchSource = "lock" | "pin" | "trunk";
+
+export interface FocalBranchProbeInput {
+  readonly resolved: {
+    readonly branch: string;
+    readonly source: FocalBranchSource;
+  };
+  readonly configuredTrunk: string;
+  readonly lock?: {
+    readonly raw: string;
+    readonly branch?: string;
+    readonly targetExists?: boolean;
+    readonly heldByLiveSession?: boolean;
+  };
 }
 
 export type QueueVisibilityTransportSurface = "graphql" | "rest" | "rest-cache" | "unknown";
@@ -45,6 +62,8 @@ export interface OperationalProbeResult {
 export interface OperationalProbeFixDeps {
   confirm(finding: OperationalProbeResult): Promise<boolean>;
   setRemoteUrl?(name: string, url: string): Promise<void>;
+  removeBranchLock?(): Promise<void>;
+  writeBranchLock?(branch: string): Promise<void>;
 }
 
 export type OperationalProbeFixStatus = "applied" | "declined" | "noop";

--- a/apps/dev/src/core/pin-reader.ts
+++ b/apps/dev/src/core/pin-reader.ts
@@ -76,6 +76,13 @@ export interface ResolvePinInput {
   issueBody: string;
 }
 
+export type ResolvePinSource = "pin" | "trunk";
+
+export interface ResolvedPin {
+  branch: string;
+  source: ResolvePinSource;
+}
+
 /**
  * Apply the inheritance chain and always resolve to a branch:
  *   the Ticket's own pin, else its parent Spec's pin, else the Trunk
@@ -84,19 +91,23 @@ export interface ResolvePinInput {
  * The parent Spec body is fetched lazily via the injected `fetchIssueBody`,
  * keyed off the Ticket body's `Spec #<n>` reference.
  */
-export async function resolvePin(input: ResolvePinInput, deps: ResolvePinDeps): Promise<string> {
+export async function resolvePinWithSource(input: ResolvePinInput, deps: ResolvePinDeps): Promise<ResolvedPin> {
   const own = parseBranchPin(input.issueBody);
-  if (own) return own;
+  if (own) return { branch: own, source: "pin" };
 
   const parent = parseParentSpec(input.issueBody);
   if (parent !== undefined) {
     const specBody = await deps.fetchIssueBody(parent);
     if (specBody !== undefined) {
       const inherited = parseBranchPin(specBody);
-      if (inherited) return inherited;
+      if (inherited) return { branch: inherited, source: "pin" };
     }
   }
 
   const trunk = deps.defaultBranch?.trim();
-  return trunk !== undefined && trunk.length > 0 ? trunk : DEFAULT_BRANCH;
+  return { branch: trunk !== undefined && trunk.length > 0 ? trunk : DEFAULT_BRANCH, source: "trunk" };
+}
+
+export async function resolvePin(input: ResolvePinInput, deps: ResolvePinDeps): Promise<string> {
+  return (await resolvePinWithSource(input, deps)).branch;
 }

--- a/apps/dev/src/runtime/lock.ts
+++ b/apps/dev/src/runtime/lock.ts
@@ -9,7 +9,9 @@
 // toggles landMerge vs landPr).
 
 import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { dirname } from "node:path";
 import { branchLockFile, tmpDir } from "@reddb-io/shared/red-paths.js";
 import { readText } from "./fs.js";
 
@@ -46,4 +48,13 @@ export async function readLockedBranch(lockPath: string): Promise<string | undef
 /** True when a non-empty lock file is present. Mirrors `lock_store_is_locked`. */
 export async function isLocked(lockPath: string): Promise<boolean> {
   return (await readLockedBranch(lockPath)) !== undefined;
+}
+
+export async function clearBranchLock(lockPath: string): Promise<void> {
+  await rm(lockPath, { force: true });
+}
+
+export async function writeBranchLock(lockPath: string, branch: string): Promise<void> {
+  await mkdir(dirname(lockPath), { recursive: true });
+  await writeFile(lockPath, `${branch}\n`, "utf8");
 }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -18,7 +18,8 @@ import * as rp from "@reddb-io/shared/red-paths.js";
 import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { loadConfig, getConfig, resolveTier } from "../core/config.js";
 import { newestCachedDevBundleVersion } from "../core/bundle-version.js";
-import { resolveBase } from "../core/base-resolver.js";
+import { resolveBase, resolveBaseWithSource } from "../core/base-resolver.js";
+import { DEFAULT_BRANCH } from "../core/pin-reader.js";
 import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { SandboxMode } from "../core/execution.js";
@@ -1714,7 +1715,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
   const configLockedBranch = getConfig(config, "dev.lock.branch") || undefined;
   const configTrunk = getConfig(config, "dev.trunk") || undefined;
   const configuredTrunkSource = configLockedBranch?.trim() ? "pin" : "trunk";
-  const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch, pnpmProbe, lockedBranch] =
+  const [ghInstalled, ghAuthenticated, isRepo, remoteUrls, hasMain, currentBranch, pnpmProbe, lockedBranch, lockRaw] =
     await Promise.all([
       ghx.ghInstalled(ghCtx),
       ghx.ghAuthenticated(ghCtx),
@@ -1724,8 +1725,9 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
       gitx.currentBranch(gitCtx),
       import("./exec.js").then((m) => m.pnpm(["--version"], { cwd: ctx.root })),
       readLockedBranch(lockPath),
+      fsx.readText(lockPath),
     ]);
-  const configuredTrunk = await resolveBase(
+  const resolvedFocalBranch = await resolveBaseWithSource(
     { issueBody: "" },
     {
       readLockedBranch: async () => lockedBranch,
@@ -1734,6 +1736,8 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
       fetchIssueBody: async () => undefined,
     },
   );
+  const configuredTrunk = resolvedFocalBranch.branch;
+  const lockTargetExists = lockedBranch ? await gitx.branchExists(gitCtx, lockedBranch) : undefined;
   const pnpmInstalled = pnpmProbe.code !== 127;
   return {
     ghInstalled,
@@ -1750,8 +1754,25 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     // GITHUB_TOKEN — the intended setup — so the SSH-only rule must not fire there.
     allowHttpsRemote:
       process.env.RED_AFK_LANE === "actions" || process.env.GITHUB_ACTIONS === "true",
-    queueVisibility: ghx.queueVisibilityProbeInput(ghCtx),
+    queueVisibility: ctx.repo ? ghx.queueVisibilityProbeInput(ghCtx) : undefined,
+    focalBranch: {
+      resolved: resolvedFocalBranch,
+      configuredTrunk: normalizeConfiguredTrunk(configTrunk),
+      lock: lockRaw === null
+        ? undefined
+        : {
+            raw: lockRaw,
+            branch: lockedBranch,
+            targetExists: lockTargetExists,
+            heldByLiveSession: lockedBranch ? currentBranch === lockedBranch : false,
+          },
+    },
   };
+}
+
+function normalizeConfiguredTrunk(value: string | undefined): string {
+  const trunk = value?.trim();
+  return trunk && trunk.length > 0 ? trunk : DEFAULT_BRANCH;
 }
 
 const DOC_SWEEP_PATHS = [".red/CONTEXT.md", ".red/CONTEXT-MAP.md", ".red/contexts", ".red/adr"] as const;

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -1,4 +1,7 @@
-import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { decode } from "@reddb-io/toon";
@@ -8,6 +11,7 @@ import {
   renderOperationalProbeReportToon,
   runOperationalProbes,
 } from "../src/core/operational-probes.js";
+import { collectPrecheckFacts } from "../src/runtime/wire.js";
 
 describe("operational probe registry", () => {
   it("reports the HTTPS remote proof probe as red with a canonical fix", async () => {
@@ -43,6 +47,7 @@ describe("operational probe registry", () => {
     expect(decoded.probes).toEqual([
       { id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" },
       { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
+      { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },
     ]);
     expect(decoded.findings).toHaveLength(1);
     expect(toon).not.toContain("{\n");
@@ -163,8 +168,167 @@ describe("operational probe registry", () => {
       canonicalFix: expect.stringContaining("gh auth status"),
     });
   });
+
+  it("reports resolved focal branch provenance when the runtime supplies the boot resolver triple", async () => {
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      focalBranch: {
+        resolved: { branch: "develop", source: "trunk" },
+        configuredTrunk: "develop",
+      },
+    });
+
+    expect(report.findings).toEqual([]);
+    expect(report.probes.at(-1)).toMatchObject({
+      id: "afk.focal-branch-resolution",
+      verdict: "ok",
+      evidence: "resolved develop from trunk; configuredTrunk=develop",
+    });
+  });
+
+  it("flags stale and contradictory branch locks as distinct focal-branch findings", async () => {
+    const stale = await runOperationalProbes({
+      remoteUrls: [],
+      focalBranch: {
+        resolved: { branch: "missing/branch", source: "lock" },
+        configuredTrunk: "develop",
+        lock: {
+          raw: "missing/branch\n",
+          branch: "missing/branch",
+          targetExists: false,
+          heldByLiveSession: false,
+        },
+      },
+    });
+    const contradictory = await runOperationalProbes({
+      remoteUrls: [],
+      focalBranch: {
+        resolved: { branch: "release/old", source: "lock" },
+        configuredTrunk: "develop",
+        lock: {
+          raw: "release/old\n",
+          branch: "release/old",
+          targetExists: true,
+          heldByLiveSession: false,
+        },
+      },
+    });
+
+    expect(stale.findings[0]).toMatchObject({
+      id: "afk.focal-branch-resolution",
+      verdict: "red",
+      data: expect.objectContaining({ finding: "stale-lock-target-missing" }),
+    });
+    expect(stale.findings[0]?.evidence).toContain("stale lock target is missing");
+    expect(contradictory.findings[0]).toMatchObject({
+      id: "afk.focal-branch-resolution",
+      verdict: "red",
+      data: expect.objectContaining({ finding: "contradictory-lock-without-live-session" }),
+    });
+    expect(contradictory.findings[0]?.evidence).toContain("without a live holder");
+  });
+
+  it("keeps a divergent lock green when the current live session holds it", async () => {
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      focalBranch: {
+        resolved: { branch: "release/held", source: "lock" },
+        configuredTrunk: "develop",
+        lock: {
+          raw: "release/held\n",
+          branch: "release/held",
+          targetExists: true,
+          heldByLiveSession: true,
+        },
+      },
+    });
+
+    expect(report.findings).toEqual([]);
+    expect(report.probes.at(-1)?.evidence).toContain("resolved release/held from lock");
+  });
+
+  it("leaves a real stale branch-lock file byte-identical when the gated repair is refused", async () => {
+    const { root, lockPath } = await makeGitRepo();
+    try {
+      await writeFile(lockPath, "missing/branch\n", "utf8");
+      const before = await readFile(lockPath, "utf8");
+      const facts = await collectPrecheckFacts({ root, repo: "", remote: "origin" });
+      const report = await runOperationalProbes(facts);
+      const removeBranchLock = vi.fn(async () => {
+        await rm(lockPath, { force: true });
+      });
+
+      const fixes = await applyOperationalProbeFixes(report, {
+        confirm: async () => false,
+        removeBranchLock,
+      });
+
+      expect(report.findings[0]).toMatchObject({
+        id: "afk.focal-branch-resolution",
+        data: expect.objectContaining({ finding: "stale-lock-target-missing" }),
+      });
+      expect(fixes).toContainEqual({
+        probeId: "afk.focal-branch-resolution",
+        status: "declined",
+        evidence: "operator declined fix",
+      });
+      expect(removeBranchLock).not.toHaveBeenCalled();
+      expect(await readFile(lockPath, "utf8")).toBe(before);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("applies the confirmed gated repair to a real contradictory branch-lock file", async () => {
+    const { root, lockPath } = await makeGitRepo();
+    try {
+      git(root, "checkout", "develop");
+      await writeFile(lockPath, "main\n", "utf8");
+      const facts = await collectPrecheckFacts({ root, repo: "", remote: "origin" });
+      const report = await runOperationalProbes(facts);
+
+      const fixes = await applyOperationalProbeFixes(report, {
+        confirm: async () => true,
+        removeBranchLock: async () => {
+          await rm(lockPath, { force: true });
+        },
+      });
+
+      expect(report.findings[0]).toMatchObject({
+        id: "afk.focal-branch-resolution",
+        data: expect.objectContaining({ finding: "contradictory-lock-without-live-session" }),
+      });
+      expect(fixes).toContainEqual({
+        probeId: "afk.focal-branch-resolution",
+        status: "applied",
+        evidence: "cleared branch-lock",
+      });
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 function readFixture(name: string): Promise<string> {
   return readFile(join(process.cwd(), "tests", "fixtures", "github-transport", name), "utf8");
+}
+
+async function makeGitRepo(): Promise<{ root: string; lockPath: string }> {
+  const root = await mkdtemp(join(tmpdir(), "red-skills-focal-"));
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "red@example.invalid");
+  git(root, "config", "user.name", "Red Test");
+  await writeFile(join(root, "README.md"), "fixture\n", "utf8");
+  git(root, "add", "README.md");
+  git(root, "commit", "-m", "initial");
+  git(root, "branch", "develop");
+  await mkdir(join(root, ".red", "state"), { recursive: true });
+  await mkdir(join(root, ".red"), { recursive: true });
+  await writeFile(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    trunk: develop\n", "utf8");
+  return { root, lockPath: join(root, ".red", "state", "branch-lock.yaml") };
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" });
 }


### PR DESCRIPTION
Automated AFK landing for #1968. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1968

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786889640&installation_id=129708444&pr_number=2005&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2005&signature=81a20dd2089c76e6c2f7767f6d4cbccbf38bde2e38ac5b72ba6bef5f2578b3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->