### PR TITLE
fix: #1997 config parser silently discards the whole file on quoted comment lines — the shipped template itself triggers it (trunk→main, gate off)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -428,7 +428,7 @@ function makeBootReconcileRunner(
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: GitContext = { cwd: ctx.root };
   const lockPath = branchLockPath(ctx.root);
-  const reconcileConfig = loadConfig(paths.configPath, { warn: () => undefined });
+  const reconcileConfig = loadConfig(paths.configPath);
   const configLockedBranch = getConfig(reconcileConfig, "dev.lock.branch") || undefined;
   const configTrunk = getConfig(reconcileConfig, "dev.trunk") || undefined;
 
@@ -610,7 +610,7 @@ async function runReconcileWorker(
   };
 
   const reconcileSettings = resolveRunSettings(ctx.root, process.env, runner);
-  const config = loadConfig(paths.configPath, { warn: () => undefined });
+  const config = loadConfig(paths.configPath);
   const feedback = makeFeedbackWorktree(ctx.root, paths.feedbackWorktreesDir, undefined, {
     rebaseOnto: reconcileSettings.feedbackRebaseBase,
     resourceBudget: readValidationResourceBudget(config),
@@ -1981,7 +1981,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // --request/-r special block, threaded into the handoff the agent reads.
   const requestBlock = specialUserRequestBlock(flags.request);
   const sessionHooks = {
-    config: loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined }),
+    config: loadConfig(afkPaths(ctx.root).configPath),
     resolveOptions: makeHookResolveOptions(ctx.root),
     exec: makeHookExec(ctx.root),
     env: hookEnv(ctx.repo, ctx.root, parseSlot(process.env.RED_AFK_SLOT), runner),

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -268,6 +268,30 @@ export class MalformedConfigError extends Error {
   }
 }
 
+function malformedConfigLine(line: number, reason: string): MalformedConfigError {
+  return new MalformedConfigError(`malformed YAML at line ${line}: ${reason}`);
+}
+
+function stripYamlComment(raw: string): string {
+  const content = raw.trimStart();
+  if (content === "" || content.startsWith("#")) return "";
+
+  let quote: '"' | "'" | undefined;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (quote !== undefined) {
+      if (ch === quote) quote = undefined;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "#") return raw.slice(0, i);
+  }
+  return raw;
+}
+
 function configDefaults(): ConfigValues {
   return { ...CONFIG_DEFAULTS };
 }
@@ -289,23 +313,23 @@ export function parseConfigYaml(text: string): ConfigValues {
   // flat config map keeps its `dotted.key -> value` shape (see readBackpressure).
   const seqCounters: Record<string, number> = {};
 
+  let lineNumber = 0;
   for (let raw of text.split("\n")) {
+    lineNumber += 1;
     // strip a trailing CR (CRLF tolerance)
     raw = raw.replace(/\r$/, "");
 
-    // strip inline comments unless the line contains a quoted string
-    let stripped = raw;
-    if (!/".*"/.test(stripped) && !/'.*'/.test(stripped)) {
-      const hash = stripped.indexOf("#");
-      if (hash >= 0) stripped = stripped.slice(0, hash);
-    }
+    // Strip comments only when `#` is outside a quoted scalar. Full-line
+    // comments are always skipped before the grammar sees them, even if their
+    // example payload contains quotes.
+    const stripped = stripYamlComment(raw);
 
     // skip blank / whitespace-only lines
     if (stripped.replace(/\s/g, "") === "") continue;
 
     const indentStr = stripped.match(/^\s*/)?.[0] ?? "";
     const indent = indentStr.length;
-    if (indent % 2 !== 0) throw new MalformedConfigError();
+    if (indent % 2 !== 0) throw malformedConfigLine(lineNumber, "odd indentation");
 
     let rest = stripped.slice(indent).replace(/\s+$/, "");
 
@@ -318,10 +342,10 @@ export function parseConfigYaml(text: string): ConfigValues {
         stack.pop();
         indents.pop();
       }
-      if (stack.length === 0) throw new MalformedConfigError();
+      if (stack.length === 0) throw malformedConfigLine(lineNumber, "sequence item without a parent mapping");
 
       let item = rest.slice(1).replace(/^\s+/, "");
-      if (item === "") throw new MalformedConfigError();
+      if (item === "") throw malformedConfigLine(lineNumber, "empty sequence item");
       // Strip an inline comment that follows the closing quote (e.g. `- "cmd" # note`).
       if (item[0] === '"' || item[0] === "'") {
         const q = item[0];
@@ -332,10 +356,14 @@ export function parseConfigYaml(text: string): ConfigValues {
         }
       }
       if (item.startsWith('"')) {
-        if (!item.endsWith('"') || item.length < 2) throw new MalformedConfigError();
+        if (!item.endsWith('"') || item.length < 2) {
+          throw malformedConfigLine(lineNumber, "unclosed double-quoted sequence item");
+        }
         item = item.slice(1, -1);
       } else if (item.startsWith("'")) {
-        if (!item.endsWith("'") || item.length < 2) throw new MalformedConfigError();
+        if (!item.endsWith("'") || item.length < 2) {
+          throw malformedConfigLine(lineNumber, "unclosed single-quoted sequence item");
+        }
         item = item.slice(1, -1);
       }
 
@@ -346,7 +374,9 @@ export function parseConfigYaml(text: string): ConfigValues {
       continue;
     }
 
-    if (!/^[a-zA-Z_][a-zA-Z0-9_-]*:/.test(rest)) throw new MalformedConfigError();
+    if (!/^[a-zA-Z_][a-zA-Z0-9_-]*:/.test(rest)) {
+      throw malformedConfigLine(lineNumber, "expected a mapping key");
+    }
 
     const colon = rest.indexOf(":");
     const key = rest.slice(0, colon);
@@ -363,10 +393,14 @@ export function parseConfigYaml(text: string): ConfigValues {
     }
     // unclosed-quote detection / strip matching quotes
     if (value.startsWith('"')) {
-      if (!value.endsWith('"') || value.length < 2) throw new MalformedConfigError();
+      if (!value.endsWith('"') || value.length < 2) {
+        throw malformedConfigLine(lineNumber, "unclosed double-quoted scalar");
+      }
       value = value.slice(1, -1);
     } else if (value.startsWith("'")) {
-      if (!value.endsWith("'") || value.length < 2) throw new MalformedConfigError();
+      if (!value.endsWith("'") || value.length < 2) {
+        throw malformedConfigLine(lineNumber, "unclosed single-quoted scalar");
+      }
       value = value.slice(1, -1);
     }
 
@@ -432,8 +466,9 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
   let parsed: ConfigValues;
   try {
     parsed = parseConfigYaml(text);
-  } catch {
-    warn(`[afk:config] warn: malformed YAML in ${path} — using defaults`);
+  } catch (err) {
+    const detail = err instanceof MalformedConfigError ? ` (${err.message})` : "";
+    warn(`[afk:config] warn: malformed YAML in ${path}${detail} — using defaults`);
     return configDefaults();
   }
 

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -280,7 +280,7 @@ export function resolveRunSettings(
   runner?: Runner,
 ): RunSettings {
   const paths = afkPaths(root);
-  const cfg = loadConfig(paths.configPath, { warn: () => undefined });
+  const cfg = loadConfig(paths.configPath);
   // Precedence: RED_AFK_SANDBOX env override > afk.sandbox config > "none".
   // The env knob lets an E2E/CI run pick the isolation backend without mutating
   // the target repo's .red/config.yaml, consistent with the other RED_AFK_* knobs.
@@ -1711,7 +1711,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const { branchLockPath, readLockedBranch } = await import("./lock.js");
   const lockPath = branchLockPath(ctx.root);
-  const config = loadConfig(afkPaths(ctx.root).configPath, { warn: () => undefined });
+  const config = loadConfig(afkPaths(ctx.root).configPath);
   const configLockedBranch = getConfig(config, "dev.lock.branch") || undefined;
   const configTrunk = getConfig(config, "dev.trunk") || undefined;
   const configuredTrunkSource = configLockedBranch?.trim() ? "pin" : "trunk";
@@ -1947,7 +1947,7 @@ export async function buildBootDeps(ctx: RepoContext, options: BootOptions, nowS
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const gitCtx: gitx.GitContext = { cwd: ctx.root };
   const paths = afkPaths(ctx.root);
-  const cfg = loadConfig(paths.configPath, { warn: () => undefined });
+  const cfg = loadConfig(paths.configPath);
   const countCachePath = statuslineCountCachePath(ctx.root);
   // ONE batched issue-state fetch backs every per-issue boot lookup below.
   const issueStates = await ghx.listIssueStates(ghCtx);

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -175,6 +176,69 @@ describe("config", () => {
     expect(getConfig(values, "afk.default_runner")).toBe("codex");
     expect(getConfig(values, "afk.fleet.target")).toBe("3");
     expect(warnings).toHaveLength(0);
+  });
+
+  it("skips full-line comments even when they contain quoted strings", () => {
+    const text = [
+      "plugins:",
+      "  dev:",
+      "    enabled: true",
+      "    trunk: develop",
+      "    lock:",
+      "      primary-branch: true",
+      "      branch: release/train",
+      "# command guard examples:",
+      "#     - \"rm -Rf /*\"",
+      "#     - 'git stash'",
+      "",
+    ].join("\n");
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "plugins.dev.enabled")).toBe("true");
+    expect(getConfig(values, "dev.trunk")).toBe("develop");
+    expect(getConfig(values, "dev.lock.primary-branch")).toBe("true");
+    expect(getConfig(values, "dev.lock.branch")).toBe("release/train");
+  });
+
+  it("strips inline comments outside quotes while preserving # inside quoted values", () => {
+    expect(parseConfigYaml([
+      "afk:",
+      "  default_runner: codex # unquoted comment",
+      "  model: \"model#tag\" # quoted scalar comment",
+      "  backpressure:",
+      "    - \"npm run test # focused\" # sequence comment",
+      "",
+    ].join("\n"))).toEqual({
+      "afk.default_runner": "codex",
+      "afk.model": "model#tag",
+      "afk.backpressure.0": "npm run test # focused",
+    });
+  });
+
+  it("malformed fallback warning names the first offending line", async () => {
+    const warnings: string[] = [];
+    const path = await writeConfig("afk:\n  default_runner: codex\n   fleet:\n    target: 3\n");
+    loadConfig(path, { warn: (m) => warnings.push(m) });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("line 3");
+  });
+
+  it("loads the shipped setup config template after activation lines are uncommented", () => {
+    const template = readFileSync(
+      new URL("../../../plugins/dev/skills/engineering/red-setup/config-template.yaml", import.meta.url),
+      "utf8",
+    );
+    const activated = template
+      .replace("  #   trunk: main", "    trunk: develop")
+      .replace("  #   lock:", "    lock:")
+      .replace("  #     primary-branch: true", "      primary-branch: true")
+      .replace("  #     branch: my-branch", "      branch: release/train");
+    const values = loadConfig("/x/.red/config.yaml", { read: () => activated });
+
+    expect(getConfig(values, "plugins.dev.enabled")).toBe("true");
+    expect(getConfig(values, "dev.trunk")).toBe("develop");
+    expect(getConfig(values, "dev.lock.primary-branch")).toBe("true");
+    expect(getConfig(values, "dev.lock.branch")).toBe("release/train");
+    expect(getConfig(values, "rsp.enabled")).toBe("true");
   });
 
   it("getConfig returns empty string for unset keys", () => {


### PR DESCRIPTION
Automated AFK landing for #1997. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1997

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786890996&installation_id=129708444&pr_number=2010&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2010&signature=e746e8d3716f49408b59135ad852ca27cc16e5513be6f25f98f789f4a0a162cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->