### PR TITLE
fix: #1995 config: root-level dev.* spellings accepted by accident in folding readers only — warn, pin canonical precedence, doctor finding

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -132,6 +132,8 @@ export interface PrecheckFacts {
   queueVisibility?: OperationalProbeContext["queueVisibility"];
   /** Optional boot-time focal-branch probe, sharing the same lock/pin/trunk resolver as the precheck. */
   focalBranch?: OperationalProbeContext["focalBranch"];
+  /** Optional config namespacing probe facts for red-doctor and boot visibility. */
+  configNamespacing?: OperationalProbeContext["configNamespacing"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and

--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -434,6 +434,11 @@ export interface LoadConfigOptions {
   warn?: ConfigWarn;
 }
 
+export interface RootDevConfigCollision {
+  readonly key: string;
+  readonly canonicalKey: string;
+}
+
 const defaultReader: ConfigReader = (path) => {
   try {
     return readFileSync(path, "utf8");
@@ -445,6 +450,20 @@ const defaultReader: ConfigReader = (path) => {
 const defaultWarn: ConfigWarn = (message) => {
   process.stderr.write(`${message}\n`);
 };
+
+export function rootDevConfigCollisions(values: ConfigValues): RootDevConfigCollision[] {
+  return Object.keys(values)
+    .filter((key) => key.startsWith("dev."))
+    .sort()
+    .map((key) => ({
+      key,
+      canonicalKey: `plugins.${key}`,
+    }));
+}
+
+export function rootDevConfigCollisionsFromText(text: string): RootDevConfigCollision[] {
+  return rootDevConfigCollisions(parseConfigYaml(text));
+}
 
 /**
  * Load config from `path`, merging file overrides onto the v1 defaults.
@@ -484,6 +503,12 @@ export function loadConfig(path: string, options: LoadConfigOptions = {}): Confi
   for (const [key, value] of Object.entries(parsed)) {
     values[key] = value;
     explicitAccessorKeys.add(key);
+  }
+  for (const collision of rootDevConfigCollisions(parsed)) {
+    warn(
+      `[afk:config] warn: root-level \`${collision.key}\` is off-contract; ` +
+        `use \`${collision.canonicalKey}\` in .red/config.yaml`,
+    );
   }
   for (const [key, value] of Object.entries(parsed)) {
     const m = /^plugins\.dev\.(.+)$/.exec(key);

--- a/apps/dev/src/core/operational-probes/config-namespacing.ts
+++ b/apps/dev/src/core/operational-probes/config-namespacing.ts
@@ -1,0 +1,31 @@
+import type { OperationalProbe, OperationalProbeResult } from "./types.js";
+
+const CANONICAL_FIX = "Move root-level dev-plugin settings under plugins.dev.* in .red/config.yaml.";
+
+export const configNamespacingProbe: OperationalProbe = {
+  id: "config.dev-root-spelling",
+  name: "Config dev-plugin namespacing",
+  canonicalFix: CANONICAL_FIX,
+  run(context): OperationalProbeResult {
+    const rootDevKeys = [...(context.configNamespacing?.rootDevKeys ?? [])].sort();
+    if (rootDevKeys.length === 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        verdict: "ok",
+        evidence: "no root-level dev.* settings",
+        canonicalFix: this.canonicalFix,
+      };
+    }
+
+    const canonicalKeys = rootDevKeys.map((key) => `plugins.${key}`);
+    return {
+      id: this.id,
+      name: this.name,
+      verdict: "red",
+      evidence: `root-level ${rootDevKeys.join(", ")} is off-contract; canonical ${canonicalKeys.join(", ")}`,
+      canonicalFix: `${this.canonicalFix} For example, use ${canonicalKeys[0]}.`,
+      data: { rootDevKeys, canonicalKeys },
+    };
+  },
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -1,4 +1,5 @@
 import { encode as encodeToon } from "@reddb-io/toon";
+import { configNamespacingProbe } from "./config-namespacing.js";
 import { focalBranchProbe } from "./focal-branch.js";
 import { httpsRemoteProbe } from "./https-remote.js";
 import { queueVisibilityProbe } from "./queue-visibility.js";
@@ -14,6 +15,7 @@ export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   httpsRemoteProbe,
   queueVisibilityProbe,
   focalBranchProbe,
+  configNamespacingProbe,
 ];
 
 export async function runOperationalProbes(

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -10,6 +10,11 @@ export interface OperationalProbeContext {
   readonly allowHttpsRemote?: boolean;
   readonly queueVisibility?: QueueVisibilityProbeInput;
   readonly focalBranch?: FocalBranchProbeInput;
+  readonly configNamespacing?: ConfigNamespacingProbeInput;
+}
+
+export interface ConfigNamespacingProbeInput {
+  readonly rootDevKeys: readonly string[];
 }
 
 export type FocalBranchSource = "lock" | "pin" | "trunk";

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -16,7 +16,7 @@ import { dirname, join } from "node:path";
 import { hostFingerprintPrefix } from "../core/host-identity.js";
 import * as rp from "@reddb-io/shared/red-paths.js";
 import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
-import { loadConfig, getConfig, resolveTier } from "../core/config.js";
+import { loadConfig, getConfig, resolveTier, rootDevConfigCollisionsFromText } from "../core/config.js";
 import { newestCachedDevBundleVersion } from "../core/bundle-version.js";
 import { resolveBase, resolveBaseWithSource } from "../core/base-resolver.js";
 import { DEFAULT_BRANCH } from "../core/pin-reader.js";
@@ -1711,7 +1711,18 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo };
   const { branchLockPath, readLockedBranch } = await import("./lock.js");
   const lockPath = branchLockPath(ctx.root);
-  const config = loadConfig(afkPaths(ctx.root).configPath);
+  const paths = afkPaths(ctx.root);
+  const configPath = paths.configPath;
+  const configText = await fsx.readText(configPath);
+  const config = loadConfig(configPath);
+  let rootDevKeys: string[] = [];
+  if (configText !== null) {
+    try {
+      rootDevKeys = rootDevConfigCollisionsFromText(configText).map((collision) => collision.key);
+    } catch {
+      rootDevKeys = [];
+    }
+  }
   const configLockedBranch = getConfig(config, "dev.lock.branch") || undefined;
   const configTrunk = getConfig(config, "dev.trunk") || undefined;
   const configuredTrunkSource = configLockedBranch?.trim() ? "pin" : "trunk";
@@ -1767,6 +1778,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
             heldByLiveSession: lockedBranch ? currentBranch === lockedBranch : false,
           },
     },
+    configNamespacing: { rootDevKeys },
   };
 }
 

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -15,6 +15,7 @@ import {
   resolveTier,
   resolveCiTimeoutSeconds,
   DEFAULT_MERGE_CI_TIMEOUT_S,
+  rootDevConfigCollisionsFromText,
 } from "../src/core/config.js";
 
 async function writeConfig(yaml: string): Promise<string> {
@@ -354,6 +355,46 @@ describe("config — the Trunk (`plugins.dev.trunk`, ADR 0083)", () => {
     const text = "plugins:\n  dev:\n    trunk: develop\n";
     const values = loadConfig("/x/.red/config.yaml", { read: () => text });
     expect(getConfig(values, "dev.trunk")).toBe("develop");
+  });
+
+  it("warns when root-level dev.trunk is used, while preserving the current folded accessor behavior", () => {
+    const warnings: string[] = [];
+    const text = "dev:\n  trunk: develop\n";
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => text,
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(getConfig(values, "dev.trunk")).toBe("develop");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("dev.trunk");
+    expect(warnings[0]).toContain("plugins.dev.trunk");
+  });
+
+  it("keeps canonical plugins.dev.trunk ahead of accidental root-level dev.trunk", () => {
+    const warnings: string[] = [];
+    const text = "dev:\n  trunk: wrong\nplugins:\n  dev:\n    trunk: develop\n";
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => text,
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(getConfig(values, "dev.trunk")).toBe("develop");
+    expect(warnings).toHaveLength(1);
+    expect(rootDevConfigCollisionsFromText(text)).toEqual([
+      { key: "dev.trunk", canonicalKey: "plugins.dev.trunk" },
+    ]);
+  });
+
+  it("does not warn for the legacy-supported top-level afk.* block", () => {
+    const warnings: string[] = [];
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => "afk:\n  default_runner: codex\n",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(getConfig(values, "afk.default_runner")).toBe("codex");
+    expect(warnings).toEqual([]);
   });
 
   it("accepts a namespaced branch value (e.g. workspace/<user>)", () => {

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -48,10 +48,29 @@ describe("operational probe registry", () => {
       { id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" },
       { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
       { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },
+      { id: "config.dev-root-spelling", name: "Config dev-plugin namespacing", verdict: "ok" },
     ]);
     expect(decoded.findings).toHaveLength(1);
     expect(toon).not.toContain("{\n");
     expect(toon).not.toContain('": "');
+  });
+
+  it("surfaces root-level dev.* config spellings with the canonical plugins.dev.* fix", async () => {
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      configNamespacing: { rootDevKeys: ["dev.trunk"] },
+    });
+
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        id: "config.dev-root-spelling",
+        name: "Config dev-plugin namespacing",
+        verdict: "red",
+        evidence: expect.stringContaining("dev.trunk"),
+        canonicalFix: expect.stringContaining("plugins.dev.trunk"),
+      }),
+    ]);
+    expect(report.findings[0]?.canonicalFix).toContain("plugins.dev.*");
   });
 
   it("refuses a gated fix without applying any remote changes", async () => {
@@ -179,7 +198,7 @@ describe("operational probe registry", () => {
     });
 
     expect(report.findings).toEqual([]);
-    expect(report.probes.at(-1)).toMatchObject({
+    expect(report.probes.find((probe) => probe.id === "afk.focal-branch-resolution")).toMatchObject({
       id: "afk.focal-branch-resolution",
       verdict: "ok",
       evidence: "resolved develop from trunk; configuredTrunk=develop",
@@ -244,7 +263,9 @@ describe("operational probe registry", () => {
     });
 
     expect(report.findings).toEqual([]);
-    expect(report.probes.at(-1)?.evidence).toContain("resolved release/held from lock");
+    expect(report.probes.find((probe) => probe.id === "afk.focal-branch-resolution")?.evidence).toContain(
+      "resolved release/held from lock",
+    );
   });
 
   it("leaves a real stale branch-lock file byte-identical when the gated repair is refused", async () => {

--- a/plugins/dev/skills/engineering/red-setup/config-template.yaml
+++ b/plugins/dev/skills/engineering/red-setup/config-template.yaml
@@ -9,7 +9,8 @@
 plugins:
   dev:
     enabled: true                 # the engineering stack (/afk, /triage, /retake, …)
-  #   trunk: main                 # the Trunk (ADR 0083): the focal branch agent work
+  #   trunk: main                 # canonical location: plugins.dev.trunk.
+  #                               # The Trunk (ADR 0083): the focal branch agent work
   #                               # bases on and lands to when no lock/pin names one
   #                               # (precedence lock > pin > trunk). Always consumed
   #                               # as fresh-fetched origin/<trunk>, never the local


### PR DESCRIPTION
Automated AFK landing for #1995. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1995

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891687&installation_id=129708444&pr_number=2011&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2011&signature=76df4f21296c385f0684f2b74dd26ab4dd4c45455ee7f158b07e3a90b0a06050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->