### PR TITLE
feat: #1998 config parser: support YAML literal block scalars (| / |-) — multi-line script blocks currently nuke the whole config

### DIFF
--- a/apps/dev/src/core/config.ts
+++ b/apps/dev/src/core/config.ts
@@ -272,6 +272,10 @@ function malformedConfigLine(line: number, reason: string): MalformedConfigError
   return new MalformedConfigError(`malformed YAML at line ${line}: ${reason}`);
 }
 
+function indentOf(raw: string): number {
+  return raw.match(/^\s*/)?.[0].length ?? 0;
+}
+
 function stripYamlComment(raw: string): string {
   const content = raw.trimStart();
   if (content === "" || content.startsWith("#")) return "";
@@ -290,6 +294,55 @@ function stripYamlComment(raw: string): string {
     if (ch === "#") return raw.slice(0, i);
   }
   return raw;
+}
+
+function isLiteralBlockScalar(value: string): value is "|" | "|-" {
+  return value === "|" || value === "|-";
+}
+
+function assertSupportedBlockScalar(line: number, value: string): void {
+  if (value === ">" || value === ">-") {
+    throw malformedConfigLine(line, "unsupported folded block scalar");
+  }
+  if (value.startsWith("|") && !isLiteralBlockScalar(value)) {
+    throw malformedConfigLine(line, `unsupported literal block scalar indicator ${value}`);
+  }
+}
+
+function readLiteralBlockScalar(
+  lines: readonly string[],
+  startIndex: number,
+  headerIndent: number,
+  indicator: "|" | "|-",
+): { value: string; nextIndex: number } {
+  const contentIndent = headerIndent + 2;
+  const blockLines: string[] = [];
+  let i = startIndex;
+
+  for (; i < lines.length; i++) {
+    const raw = lines[i]!.replace(/\r$/, "");
+    const isFinalSplitBlank = raw === "" && i === lines.length - 1;
+    if (isFinalSplitBlank) break;
+
+    const blank = raw.replace(/\s/g, "") === "";
+    if (blank) {
+      blockLines.push("");
+      continue;
+    }
+
+    const indent = indentOf(raw);
+    if (indent <= headerIndent) break;
+    if (indent < contentIndent) {
+      throw malformedConfigLine(i + 1, "literal block scalar continuation is under-indented");
+    }
+    blockLines.push(raw.slice(contentIndent));
+  }
+
+  const value = blockLines.join("\n");
+  return {
+    value: indicator === "|-" ? value : `${value}\n`,
+    nextIndex: i,
+  };
 }
 
 function configDefaults(): ConfigValues {
@@ -313,9 +366,12 @@ export function parseConfigYaml(text: string): ConfigValues {
   // flat config map keeps its `dotted.key -> value` shape (see readBackpressure).
   const seqCounters: Record<string, number> = {};
 
-  let lineNumber = 0;
-  for (let raw of text.split("\n")) {
-    lineNumber += 1;
+  const lines = text.split("\n");
+  let lineIndex = 0;
+  while (lineIndex < lines.length) {
+    const lineNumber = lineIndex + 1;
+    let raw = lines[lineIndex]!;
+    lineIndex += 1;
     // strip a trailing CR (CRLF tolerance)
     raw = raw.replace(/\r$/, "");
 
@@ -346,6 +402,7 @@ export function parseConfigYaml(text: string): ConfigValues {
 
       let item = rest.slice(1).replace(/^\s+/, "");
       if (item === "") throw malformedConfigLine(lineNumber, "empty sequence item");
+      assertSupportedBlockScalar(lineNumber, item);
       // Strip an inline comment that follows the closing quote (e.g. `- "cmd" # note`).
       if (item[0] === '"' || item[0] === "'") {
         const q = item[0];
@@ -370,7 +427,13 @@ export function parseConfigYaml(text: string): ConfigValues {
       const parent = stack.join(".");
       const idx = seqCounters[parent] ?? 0;
       seqCounters[parent] = idx + 1;
-      out[`${parent}.${idx}`] = item;
+      if (isLiteralBlockScalar(item)) {
+        const block = readLiteralBlockScalar(lines, lineIndex, indent, item);
+        lineIndex = block.nextIndex;
+        out[`${parent}.${idx}`] = block.value;
+      } else {
+        out[`${parent}.${idx}`] = item;
+      }
       continue;
     }
 
@@ -381,6 +444,7 @@ export function parseConfigYaml(text: string): ConfigValues {
     const colon = rest.indexOf(":");
     const key = rest.slice(0, colon);
     let value = rest.slice(colon + 1).replace(/^\s+/, "");
+    assertSupportedBlockScalar(lineNumber, value);
 
     // Strip an inline comment that follows the closing quote (e.g. `key: "v" # note`).
     if (value[0] === '"' || value[0] === "'") {
@@ -412,7 +476,11 @@ export function parseConfigYaml(text: string): ConfigValues {
 
     const full = stack.length > 0 ? `${stack.join(".")}.${key}` : key;
 
-    if (value === "") {
+    if (isLiteralBlockScalar(value)) {
+      const block = readLiteralBlockScalar(lines, lineIndex, indent, value);
+      lineIndex = block.nextIndex;
+      out[full] = block.value;
+    } else if (value === "") {
       stack.push(key);
       indents.push(indent);
     } else {

--- a/apps/dev/tests/config.test.ts
+++ b/apps/dev/tests/config.test.ts
@@ -460,6 +460,89 @@ describe("config — block sequences (afk.backpressure, #430)", () => {
   });
 });
 
+describe("config — literal block scalars (#1998)", () => {
+  it("honors `|` and `|-` newline semantics on mapping values", () => {
+    const text = [
+      "afk:",
+      "  keep: |",
+      "    first",
+      "    second",
+      "  strip: |-",
+      "    third",
+      "    fourth",
+      "",
+    ].join("\n");
+    expect(parseConfigYaml(text)).toEqual({
+      "afk.keep": "first\nsecond\n",
+      "afk.strip": "third\nfourth",
+    });
+  });
+
+  it("parses literal block sequence items without dropping siblings or following keys", () => {
+    const text = [
+      "dev:",
+      "  trunk: develop",
+      "plugins:",
+      "  dev:",
+      "    enabled: true",
+      "    afk:",
+      "      backpressure:",
+      "        - |",
+      "          set -euo pipefail",
+      "          pnpm --filter @reddb-io/dev test -- config.test.ts",
+      "",
+      "          if [ -f package.json ]; then",
+      "            pnpm --filter @reddb-io/dev typecheck",
+      "          fi",
+      "        - |-",
+      "          pnpm --filter @reddb-io/dev build",
+      "      merge:",
+      "        wait_for_review: true",
+      "rsp:",
+      "  enabled: true",
+      "",
+    ].join("\n");
+    const values = loadConfig("/x/.red/config.yaml", { read: () => text });
+    expect(getConfig(values, "dev.trunk")).toBe("develop");
+    expect(getConfig(values, "plugins.dev.enabled")).toBe("true");
+    expect(readBackpressure(values)).toEqual([
+      [
+        "set -euo pipefail",
+        "pnpm --filter @reddb-io/dev test -- config.test.ts",
+        "",
+        "if [ -f package.json ]; then",
+        "  pnpm --filter @reddb-io/dev typecheck",
+        "fi",
+        "",
+      ].join("\n"),
+      "pnpm --filter @reddb-io/dev build",
+    ]);
+    expect(getConfig(values, "afk.merge.wait_for_review")).toBe("true");
+    expect(getConfig(values, "rsp.enabled")).toBe("true");
+  });
+
+  it("fails loudly on unsupported folded block scalars", () => {
+    expect(() => parseConfigYaml("afk:\n  script: >\n    echo nope\n")).toThrow(
+      /line 2: unsupported folded block scalar/,
+    );
+    expect(() => parseConfigYaml("afk:\n  backpressure:\n    - >\n      echo nope\n")).toThrow(
+      /line 3: unsupported folded block scalar/,
+    );
+  });
+
+  it("loader warning names the unsupported folded block scalar construct", () => {
+    const warnings: string[] = [];
+    const values = loadConfig("/x/.red/config.yaml", {
+      read: () => "afk:\n  script: >\n    echo nope\n",
+      warn: (m) => warnings.push(m),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("line 2");
+    expect(warnings[0]).toContain("unsupported folded block scalar");
+    expect(getConfig(values, "afk.default_runner")).toBe("claude");
+  });
+});
+
 describe("config — afk.merge.wait_for_review (ADR 0048)", () => {
   it("defaults to false (merge-without-advice) with CodeRabbit as the review check", () => {
     const values = loadConfig("/nonexistent/.red/config.yaml", { warn: () => {} });


### PR DESCRIPTION
Automated AFK landing for #1998. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1998

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891765&installation_id=129708444&pr_number=2012&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2012&signature=3a2925f009407324b237f1b6fdfcfc8854aa312cbab13663d30cff951e190032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->