### PR TITLE
fix: #2009 /go: Migrate every castle-engine write surface to TOON/TOONL, closing the wav

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -56,6 +56,7 @@ import {
   createEnginePaths,
   writeCastleStateSnapshot,
 } from "@reddb-io/red-castle/engine";
+import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 
 function isAlive(pid: number): boolean {
   try {
@@ -70,36 +71,39 @@ function fleetHeartbeatMessage(hb: FleetHeartbeat): string {
   return `fleet tick ready=${hb.readyForAgent} busy=${hb.slotsBusy} free=${hb.slotsFree} spawns=${hb.spawnsThisTick}`;
 }
 
-function fleetHeartbeatState(hb: FleetHeartbeat): string {
-  return JSON.stringify(
-    {
-      ts: hb.ts,
-      epoch: hb.epoch,
-      last_progress_epoch: hb.lastProgressEpoch > 0 ? hb.lastProgressEpoch : undefined,
-      runner: hb.runner,
-      bundle_version: hb.bundleVersion,
-      ready_for_agent: hb.readyForAgent,
-      slots: {
-        busy: hb.slotsBusy,
-        free: hb.slotsFree,
-        total: hb.slotsTotal,
-        parked: hb.slotsParked,
-      },
-      spawns_this_tick: hb.spawnsThisTick,
-      ...(hb.drainBudget
-        ? {
-            drain_budget: {
-              tier: hb.drainBudget.tier,
-              spent_usd: Number(hb.drainBudget.spentUsd.toFixed(4)),
-              limit_usd: Number(hb.drainBudget.limitUsd.toFixed(4)),
-              percent: Number((hb.drainBudget.percent * 100).toFixed(2)),
-            },
-          }
-        : {}),
+/**
+ * Serialize the fleet supervisor state snapshot as TOON (castle-engine write
+ * surface — never raw JSON, ADR 0097). Exported so the castle-engine uniformity
+ * test can enumerate this writer and assert it never emits JSON. Undefined-valued
+ * keys are dropped before encoding (TOON `encode` rejects `undefined`), matching
+ * the old `JSON.stringify` behaviour that omitted them.
+ */
+export function fleetHeartbeatState(hb: FleetHeartbeat): string {
+  return encodeDevSnapshotToon({
+    ts: hb.ts,
+    epoch: hb.epoch,
+    ...(hb.lastProgressEpoch > 0 ? { last_progress_epoch: hb.lastProgressEpoch } : {}),
+    runner: hb.runner,
+    ...(hb.bundleVersion ? { bundle_version: hb.bundleVersion } : {}),
+    ready_for_agent: hb.readyForAgent,
+    slots: {
+      busy: hb.slotsBusy,
+      free: hb.slotsFree,
+      total: hb.slotsTotal,
+      parked: hb.slotsParked,
     },
-    null,
-    2,
-  );
+    spawns_this_tick: hb.spawnsThisTick,
+    ...(hb.drainBudget
+      ? {
+          drain_budget: {
+            tier: hb.drainBudget.tier,
+            spent_usd: Number(hb.drainBudget.spentUsd.toFixed(4)),
+            limit_usd: Number(hb.drainBudget.limitUsd.toFixed(4)),
+            percent: Number((hb.drainBudget.percent * 100).toFixed(2)),
+          },
+        }
+      : {}),
+  });
 }
 
 function writeFleetStateAtomic(path: string, hb: FleetHeartbeat): void {

--- a/apps/dev/src/core/state.ts
+++ b/apps/dev/src/core/state.ts
@@ -1,15 +1,21 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
-import { encodeDevSnapshotToon } from "./toon-snapshot.js";
+import { type JsonValue as ToonValue } from "@reddb-io/toon";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "./toon-snapshot.js";
 import { AfkStateSchema, type AfkState } from "../types/state.js";
 
 export function defaultState(): AfkState {
   return AfkStateSchema.parse({});
 }
 
-/** The write-once identity sidecar filename in an attempt dir (issue #1219). */
+/**
+ * The write-once identity sidecar filename in an attempt dir (issue #1219). The
+ * filename is retained across the TOON migration (wave-1 in-place convention):
+ * the content flips from raw JSON to TOON but the `.json` name stays, and the
+ * reader sniffs JSON-then-TOON so a sidecar written by an older bundle still
+ * reads.
+ */
 export const IDENTITY_FILENAME = "identity.json";
 
 /**
@@ -40,17 +46,18 @@ export function writeIdentitySync(attemptDir: string, identity: WorkerIdentity):
   if (existsSync(path)) return;
   mkdirSync(attemptDir, { recursive: true });
   const tmp = `${path}.tmp.${process.pid}.sync`;
-  writeFileSync(tmp, `${JSON.stringify(identity)}\n`, "utf8");
+  writeFileSync(tmp, encodeDevSnapshotToon(identity as unknown as ToonValue), "utf8");
   renameSync(tmp, path);
 }
 
-/** Parse a {@link WorkerIdentity} from raw JSON text, or `null` when absent /
- * malformed. Only string/number fields are honoured; anything else is dropped to
- * the empty default so a partial file never throws. */
+/** Parse a {@link WorkerIdentity} from a sidecar's text (TOON, with a raw-JSON
+ * sniff fallback for pre-migration sidecars), or `null` when absent / malformed.
+ * Only string/number fields are honoured; anything else is dropped to the empty
+ * default so a partial file never throws. */
 export function parseIdentity(raw: string | null | undefined): WorkerIdentity | null {
   if (!raw) return null;
   try {
-    const p = JSON.parse(raw) as Partial<WorkerIdentity>;
+    const p = decodeDevSnapshotSniff(raw) as Partial<WorkerIdentity>;
     if (typeof p !== "object" || p === null) return null;
     return {
       worker_id: typeof p.worker_id === "string" ? p.worker_id : "",
@@ -103,11 +110,7 @@ export function parseState(data: unknown): AfkState {
 }
 
 export function parseStateDocument(text: string): AfkState {
-  try {
-    return parseState(JSON.parse(text));
-  } catch {
-    return parseState(decodeToon(text));
-  }
+  return parseState(decodeDevSnapshotSniff(text));
 }
 
 export async function readState(path: string): Promise<AfkState> {

--- a/apps/dev/src/core/toon-snapshot.ts
+++ b/apps/dev/src/core/toon-snapshot.ts
@@ -4,6 +4,22 @@ export function encodeDevSnapshotToon(value: JsonValue): string {
   return encode(value, { keyedMapCollapse: true });
 }
 
+/**
+ * Sniff-decode a converted snapshot document: legacy raw JSON first, TOON
+ * fallback. This is the in-place migration reader every castle-engine snapshot
+ * surface uses (wave-1 convention — the filename is retained and only the
+ * content flips to TOON, so a bundle written before the flip still reads). TOON
+ * `decode` throws on the JSON `{`/`[` header shapes, so the JSON-first order
+ * never mis-parses a TOON document as JSON.
+ */
+export function decodeDevSnapshotSniff(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return decode(text);
+  }
+}
+
 export function assertDevSnapshotToonLossless(value: JsonValue): string {
   const toon = encodeDevSnapshotToon(value);
   const decoded = decode(toon);

--- a/apps/dev/src/runtime/log-cursor.ts
+++ b/apps/dev/src/runtime/log-cursor.ts
@@ -6,6 +6,7 @@ import {
   ToonlCursorInvalidationError,
   type ToonlLaneCursor,
 } from "../core/jsonl-log.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 
 export interface LogLineCursor {
   size: number;
@@ -52,7 +53,8 @@ function validCursor(value: unknown): LogLineCursor | null {
 
 export async function readLogLineCursors(path: string): Promise<LogLineCursorStore> {
   try {
-    const parsed = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    // Sniff JSON-then-TOON so a cursor cache written by an older bundle still reads.
+    const parsed = decodeDevSnapshotSniff(await readFile(path, "utf8")) as Record<string, unknown>;
     if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return {};
     const out: LogLineCursorStore = {};
     for (const [logPath, value] of Object.entries(parsed)) {
@@ -68,7 +70,8 @@ export async function readLogLineCursors(path: string): Promise<LogLineCursorSto
 export async function writeLogLineCursors(path: string, cursors: LogLineCursorStore): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
-  await writeFile(tmp, `${JSON.stringify(cursors)}\n`, "utf8");
+  // TOON, never raw JSON — the monitor log-cursor snapshot surface (ADR 0097).
+  await writeFile(tmp, encodeDevSnapshotToon(cursors as unknown as Parameters<typeof encodeDevSnapshotToon>[0]), "utf8");
   await rename(tmp, path);
 }
 

--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -9,6 +9,7 @@ import { mkdirSync, openSync, renameSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afkStateDir } from "@reddb-io/shared/red-paths.js";
+import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { ElasticShrinkMode } from "../core/supervisor.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -106,21 +107,19 @@ export function stampFreshFleetHeartbeat(
   runner: string,
   target: number,
 ): void {
-  const body = JSON.stringify(
-    {
-      ts: new Date(epoch * 1000).toISOString(),
-      epoch,
-      // A fresh relaunch stamp counts as progress: the new supervisor is
-      // healthy until proven otherwise, so seed both epochs to `epoch`.
-      last_progress_epoch: epoch,
-      runner,
-      ready_for_agent: 0,
-      slots: { busy: 0, free: target, total: target, parked: 0 },
-      spawns_this_tick: 0,
-    },
-    null,
-    2,
-  );
+  // TOON, never raw JSON — this is the fleet supervisor state snapshot surface
+  // (ADR 0097); `readFleetState` sniffs so a stamp from an older bundle still reads.
+  const body = encodeDevSnapshotToon({
+    ts: new Date(epoch * 1000).toISOString(),
+    epoch,
+    // A fresh relaunch stamp counts as progress: the new supervisor is
+    // healthy until proven otherwise, so seed both epochs to `epoch`.
+    last_progress_epoch: epoch,
+    runner,
+    ready_for_agent: 0,
+    slots: { busy: 0, free: target, total: target, parked: 0 },
+    spawns_this_tick: 0,
+  });
   const tmp = `${statePath}.tmp`;
   writeFileSync(tmp, body, "utf8");
   renameSync(tmp, statePath);

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -16,6 +16,7 @@ import { countReadyForAgent } from "./gh.js";
 import { detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "./caller-process.js";
 import { spawnSupervisor, stampFreshFleetHeartbeat } from "./supervisor-spawn.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 // The wait-and-escalate killer (SIGTERM → grace → SIGKILL → confirm) is shared
 // with the fleet reaper and `fleet stop` (#580). It matters for recovery
 // correctness here too: the supervisor's own `finally` removes the pid/stop
@@ -194,7 +195,8 @@ export function buildWatchdogIO(
     readRestartLedger: async (): Promise<number[]> => {
       try {
         const raw = await readFile(restartLedgerFile, "utf8");
-        const parsed = JSON.parse(raw) as unknown;
+        // Sniff JSON-then-TOON so a ledger written by an older bundle still reads.
+        const parsed = decodeDevSnapshotSniff(raw) as unknown;
         if (!Array.isArray(parsed)) return [];
         return parsed.filter((n): n is number => typeof n === "number" && Number.isFinite(n));
       } catch {
@@ -204,7 +206,8 @@ export function buildWatchdogIO(
 
     writeRestartLedger: async (epochs: number[]): Promise<void> => {
       try {
-        await writeFile(restartLedgerFile, JSON.stringify(epochs), "utf8");
+        // TOON, never raw JSON — the supervisor restart-ledger snapshot (ADR 0097).
+        await writeFile(restartLedgerFile, encodeDevSnapshotToon(epochs), "utf8");
       } catch {
         // best-effort: a failed ledger write only weakens the crash-loop bound.
       }

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -21,7 +21,7 @@ import { newestCachedDevBundleVersion } from "../core/bundle-version.js";
 import { resolveBase, resolveBaseWithSource } from "../core/base-resolver.js";
 import { DEFAULT_BRANCH } from "../core/pin-reader.js";
 import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
-import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { SandboxMode } from "../core/execution.js";
 import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
 // Value import (pure, no sandcastle pull — the providers load lazily via
@@ -630,7 +630,7 @@ export async function readFleetState(path: string): Promise<FleetState | null> {
   const text = await fsx.readText(path);
   if (text === null) return null;
   try {
-    return parseFleetState(JSON.parse(text));
+    return parseFleetState(decodeDevSnapshotSniff(text));
   } catch {
     return null;
   }

--- a/apps/dev/tests/castle-engine-toon-uniformity.test.ts
+++ b/apps/dev/tests/castle-engine-toon-uniformity.test.ts
@@ -1,0 +1,148 @@
+// Uniformity sweep for the castle-engine write surfaces (issue #2008 / #2009).
+//
+// The maintainer's standing rule is total: every file the fleet runtime writes
+// is TOON (TOONL for line-oriented lanes). The single sanctioned non-TOON file
+// is the repo config YAML `.red/config.yaml` — the protocol owner (the human +
+// the loader) sets that format, so it is exempt by contract (ADR 0097). This
+// test enumerates the castle-engine snapshot/state writers and FAILS on any raw
+// JSON emission, so a future engine relocation cannot silently regress the
+// uniformity the TOON waves established.
+
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { decode } from "@reddb-io/toon";
+import { describe, expect, it } from "vitest";
+import {
+  CASTLE_LANE_FILENAMES,
+  castleStateSnapshotPath,
+  createEnginePaths,
+} from "@reddb-io/red-castle/engine";
+import {
+  IDENTITY_FILENAME,
+  writeIdentitySync,
+  writeStateAtomic,
+  defaultState,
+} from "../src/core/state.js";
+import { fleetHeartbeatState } from "../src/commands/supervise.js";
+import { stampFreshFleetHeartbeat } from "../src/runtime/supervisor-spawn.js";
+import { writeLogLineCursors } from "../src/runtime/log-cursor.js";
+import { buildWatchdogIO } from "../src/runtime/watchdog-io.js";
+import { afkPaths } from "../src/runtime/wire.js";
+import type { FleetHeartbeat } from "../src/core/supervisor.js";
+
+/** The single sanctioned non-TOON file the stack writes (ADR 0097). */
+const SOLE_NON_TOON_FILE = ".red/config.yaml";
+
+/** Assert a snapshot document's bytes are TOON, never raw JSON. Raw JSON of an
+ * object/non-empty array starts with `{`/`[` and round-trips through
+ * `JSON.parse`; TOON `decode` throws on those header shapes, so a document that
+ * `decode`s AND fails `JSON.parse` is provably not raw JSON. */
+function expectToonNotJson(bytes: string, expected: unknown): void {
+  expect(() => JSON.parse(bytes)).toThrow();
+  expect(decode(bytes)).toEqual(expected);
+}
+
+function sampleHeartbeat(): FleetHeartbeat {
+  return {
+    ts: "2026-07-17T00:00:00.000Z",
+    epoch: 42,
+    lastProgressEpoch: 41,
+    runner: "claude",
+    bundleVersion: "9.9.9",
+    readyForAgent: 3,
+    slotsBusy: 1,
+    slotsFree: 1,
+    slotsTotal: 2,
+    slotsParked: 0,
+    spawnsThisTick: 0,
+  } as FleetHeartbeat;
+}
+
+describe("castle-engine write-surface TOON uniformity", () => {
+  it("the worker identity stamp is TOON, never raw JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "castle-toon-identity-"));
+    const identity = {
+      worker_id: "wAB12",
+      runner: "claude",
+      origin: "afk",
+      number: 2009,
+      started_at: "2026-07-17T00:00:00.000Z",
+    };
+    writeIdentitySync(dir, identity);
+    const bytes = await readFile(join(dir, IDENTITY_FILENAME), "utf8");
+    expectToonNotJson(bytes, identity);
+  });
+
+  it("the per-attempt worker state snapshot is TOON, never raw JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "castle-toon-state-"));
+    const path = join(dir, "afk.state.json");
+    const state = defaultState();
+    await writeStateAtomic(path, state);
+    const bytes = await readFile(path, "utf8");
+    // A populated AfkState never encodes to raw JSON under the TOON encoder.
+    expect(() => JSON.parse(bytes)).toThrow();
+    expect(decode(bytes)).toBeTruthy();
+  });
+
+  it("the supervisor state snapshot serializer emits TOON, never raw JSON", () => {
+    const bytes = fleetHeartbeatState(sampleHeartbeat());
+    expect(() => JSON.parse(bytes)).toThrow();
+    const decoded = decode(bytes) as Record<string, unknown>;
+    expect(decoded.epoch).toBe(42);
+    expect(decoded.slots).toEqual({ busy: 1, free: 1, total: 2, parked: 0 });
+  });
+
+  it("the fresh-relaunch supervisor heartbeat stamp is TOON, never raw JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "castle-toon-stamp-"));
+    const path = join(dir, "afk-supervisor.state.json");
+    stampFreshFleetHeartbeat(path, 7, "claude", 2);
+    const bytes = await readFile(path, "utf8");
+    expect(() => JSON.parse(bytes)).toThrow();
+    const decoded = decode(bytes) as Record<string, unknown>;
+    expect(decoded.epoch).toBe(7);
+    expect(decoded.slots).toEqual({ busy: 0, free: 2, total: 2, parked: 0 });
+  });
+
+  it("the supervisor restart ledger is TOON, never raw JSON", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-toon-restarts-"));
+    const io = buildWatchdogIO(root);
+    // The supervisor ensures the state-tier dir before writing; mirror that here.
+    await mkdir(dirname(afkPaths(root).supervisorRestartsPath), { recursive: true });
+    await io.writeRestartLedger!([100, 200, 300]);
+    const roundTripped = await io.readRestartLedger!();
+    expect(roundTripped).toEqual([100, 200, 300]);
+    const bytes = await readFile(afkPaths(root).supervisorRestartsPath, "utf8");
+    expectToonNotJson(bytes, [100, 200, 300]);
+  });
+
+  it("the monitor log-cursor snapshot is TOON, never raw JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "castle-toon-cursors-"));
+    const path = join(dir, "monitor-log-cursors.json");
+    const cursors = { "/x/afk.log": { size: 5, lines: 1 } };
+    await writeLogLineCursors(path, cursors);
+    const bytes = await readFile(path, "utf8");
+    expectToonNotJson(bytes, cursors);
+  });
+
+  it("every castle-engine lane and state snapshot filename is born TOON/TOONL", () => {
+    const paths = createEnginePaths(join(tmpdir(), ".red"));
+    const suffixes = [
+      ...Object.values(CASTLE_LANE_FILENAMES),
+      castleStateSnapshotPath(paths, "supervisor", "s"),
+      castleStateSnapshotPath(paths, "worker", "w"),
+    ];
+    for (const name of suffixes) {
+      expect(name.endsWith(".toon") || name.endsWith(".toonl")).toBe(true);
+      expect(name.endsWith(".json") || name.endsWith(".jsonl")).toBe(false);
+    }
+  });
+
+  it("documents .red/config.yaml as the single sanctioned non-TOON file", () => {
+    // Contract statement (ADR 0097): the config YAML is the ONLY file the stack
+    // writes that is not TOON. No castle-engine snapshot surface above is a YAML
+    // or config file — they are all TOON documents.
+    expect(SOLE_NON_TOON_FILE).toBe(".red/config.yaml");
+    expect(SOLE_NON_TOON_FILE.endsWith(".yaml")).toBe(true);
+  });
+});

--- a/apps/dev/tests/log-cursor.test.ts
+++ b/apps/dev/tests/log-cursor.test.ts
@@ -46,9 +46,11 @@ describe("monitor log cursor", () => {
     await writeFile(log, "line\n", "utf8");
     await collectLogLineCounts(cache, [log]);
 
+    // The cursor cache is a TOON snapshot surface now — never raw JSON.
     const raw = await readFile(cache, "utf8");
-    expect(JSON.parse(raw)).toHaveProperty(log);
+    expect(() => JSON.parse(raw)).toThrow();
     const parsed = await readLogLineCursors(cache);
+    expect(parsed).toHaveProperty(log);
     expect(parsed[log]).toEqual({ size: 5, lines: 1 });
   });
 

--- a/packages/red-castle/CLAUDE.md
+++ b/packages/red-castle/CLAUDE.md
@@ -35,9 +35,20 @@ fallback) so files written before a conversion still read.
 Exempt by contract, do not "fix" them: the raw agent-output firehose sink
 (agent-owned bytes passed through verbatim — re-encoding would corrupt them),
 prose session logs (human-readable text, not records), and agent-owned session
-transcript formats. Whole-document snapshot state files are currently still
-JSON; converting one is a deliberate change with its own reader plan, not a
-drive-by.
+transcript formats. The single sanctioned non-TOON file the stack writes is the
+repo config YAML `.red/config.yaml` (its protocol owner sets the format).
+
+Whole-document snapshot state files are TOON too (issue #2008): the castle
+`state.toon` snapshots plus the fleet-runtime snapshot surfaces in the consuming
+`apps/dev` workspace — the worker identity stamp (`identity.json`), the
+per-attempt worker state (`afk.state.json`), the supervisor state snapshot and
+its restart ledger (`afk-supervisor.state.json` / `.restarts.json`), and the
+monitor log-cursor snapshot (`monitor-log-cursors.json`). Each keeps its
+filename (wave-1 in-place convention) but writes TOON content, and its reader
+sniffs JSON-then-TOON so a file written by an older bundle still reads.
+Converting a NEW snapshot is a deliberate change with its own reader plan, not a
+drive-by. The `apps/dev` uniformity test (`castle-engine-toon-uniformity.test.ts`)
+enumerates these writers and fails on any raw-JSON emission.
 
 ## `.red-castle` is the on-disk directory identity
 


### PR DESCRIPTION
Automated AFK landing for #2009. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2009

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893164&installation_id=129708444&pr_number=2016&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2016&signature=78c8f7e6d8fb74489937b765b8386a512177951bf2f38f85c28a8b5f0e12cea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->