### PR TITLE
fix: #1969 Fleet-truth probe: pid liveness vs heartbeat freshness vs bundle version skew

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -1,4 +1,5 @@
 import { relative } from "node:path";
+import { Writable } from "node:stream";
 import { encode as encodeToon } from "@reddb-io/toon";
 import { afkPaths, collectPrecheckFacts, resolveRepoContext } from "../runtime/wire.js";
 import { listIssueStates, type GhContext } from "../runtime/gh.js";
@@ -7,10 +8,12 @@ import { branchLockPath, clearBranchLock, writeBranchLock } from "../runtime/loc
 import {
   applyOperationalProbeFixes,
   runOperationalProbes,
+  terminateSupervisorPid,
   type OperationalProbeFixResult,
   type OperationalProbeReport,
 } from "../core/operational-probes.js";
 import * as gitx from "../runtime/git.js";
+import { launchFleet } from "./fleet.js";
 
 interface RedDoctorFlags {
   fix: boolean;
@@ -143,6 +146,8 @@ function renderToon(
   });
 }
 
+const discardStream = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+
 export async function redDoctorCommand(args: readonly string[], cwd = process.cwd()): Promise<number> {
   try {
     const flags = parseFlags(args, cwd);
@@ -165,6 +170,17 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
           setRemoteUrl: async (name, url) => gitx.setRemoteUrl(gitCtx, name, url),
           removeBranchLock: async () => clearBranchLock(lockPath),
           writeBranchLock: async (branch) => writeBranchLock(lockPath, branch),
+          terminateSupervisor: terminateSupervisorPid,
+          confirmRelaunch: async () => flags.yes,
+          relaunchFleet: async (request) => {
+            const args = [
+              String(request.target ?? 2),
+              ...(request.runner ? ["--runner", request.runner] : []),
+              ...(request.args ?? []),
+            ];
+            const launched = await launchFleet(args, ctx.root, discardStream);
+            return { status: launched.status, pid: launched.pid };
+          },
         })
       : [];
     const applied = flags.fix ? await applyTmpJanitorReport(paths.tmpDir, report) : undefined;

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -134,6 +134,8 @@ export interface PrecheckFacts {
   focalBranch?: OperationalProbeContext["focalBranch"];
   /** Optional config namespacing probe facts for red-doctor and boot visibility. */
   configNamespacing?: OperationalProbeContext["configNamespacing"];
+  /** Optional fleet truth probe facts for red-doctor and boot visibility. */
+  fleetTruth?: OperationalProbeContext["fleetTruth"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -1,4 +1,5 @@
 export * from "./operational-probes/types.js";
+export * from "./operational-probes/fleet-truth.js";
 export * from "./operational-probes/focal-branch.js";
 export * from "./operational-probes/https-remote.js";
 export * from "./operational-probes/queue-visibility.js";

--- a/apps/dev/src/core/operational-probes/fleet-truth.ts
+++ b/apps/dev/src/core/operational-probes/fleet-truth.ts
@@ -1,0 +1,265 @@
+import { readFile, stat } from "node:fs/promises";
+import { compareSemver } from "../bundle-version.js";
+import type {
+  FleetTruthProbeInput,
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeFixDeps,
+  OperationalProbeFixResult,
+  OperationalProbeResult,
+} from "./types.js";
+
+export const FLEET_TRUTH_PROBE_ID = "afk.fleet-truth";
+export const FLEET_TRUTH_PROBE_NAME = "AFK fleet truth";
+export const FLEET_TRUTH_CANONICAL_FIX =
+  "For zombie supervisors, confirm SIGTERM, verify the supervisor exits, then relaunch the fleet if requested. For version findings, restart the fleet from the current bundle.";
+
+export type FleetTruthFindingKind = "zombie" | "version-skew" | "version-unknown";
+
+export interface FleetTruthProbeData {
+  readonly findings: readonly FleetTruthFindingKind[];
+  readonly pid?: number;
+  readonly target?: number;
+  readonly runner?: string;
+  readonly relaunchArgs?: readonly string[];
+}
+
+export interface FleetTruthProbePaths {
+  readonly supervisorPidPath: string;
+  readonly fleetStatePath: string;
+}
+
+export interface CollectFleetTruthProbeOptions {
+  readonly nowMs?: number;
+  readonly heartbeatStaleMs: number;
+  readonly latestBundleVersion?: string;
+  readonly pidLive?: (pid: number) => boolean;
+}
+
+const seconds = (ms: number): number => Math.floor(Math.max(0, ms) / 1000);
+
+function ageMs(nowMs: number, thenMs: number | undefined): number | undefined {
+  return thenMs === undefined ? undefined : Math.max(0, nowMs - thenMs);
+}
+
+function formatAge(label: string, ms: number | undefined): string | undefined {
+  return ms === undefined ? undefined : `${label}=${seconds(ms)}s`;
+}
+
+function parsePid(raw: string): number | null {
+  const pid = Number.parseInt(raw.trim(), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function readNumberField(value: unknown): number | undefined {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function defaultPidLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function collectFleetTruthProbeInput(
+  paths: FleetTruthProbePaths,
+  options: CollectFleetTruthProbeOptions,
+): Promise<FleetTruthProbeInput> {
+  const nowMs = options.nowMs ?? Date.now();
+  const pidLive = options.pidLive ?? defaultPidLive;
+  let supervisorPid: number | null = null;
+  let supervisorPidMtimeMs: number | undefined;
+  let stateMtimeMs: number | undefined;
+  let heartbeatEpochMs: number | undefined;
+  let bundleVersion: string | undefined;
+  let runner: string | undefined;
+  let target: number | undefined;
+
+  try {
+    const [raw, info] = await Promise.all([readFile(paths.supervisorPidPath, "utf8"), stat(paths.supervisorPidPath)]);
+    supervisorPid = parsePid(raw);
+    supervisorPidMtimeMs = info.mtimeMs;
+  } catch {
+    supervisorPid = null;
+  }
+
+  try {
+    const [raw, info] = await Promise.all([readFile(paths.fleetStatePath, "utf8"), stat(paths.fleetStatePath)]);
+    stateMtimeMs = info.mtimeMs;
+    const rec = JSON.parse(raw) as Record<string, unknown>;
+    const epoch = readNumberField(rec.epoch);
+    heartbeatEpochMs = epoch === undefined ? undefined : epoch * 1000;
+    bundleVersion = typeof rec.bundle_version === "string" && rec.bundle_version.trim() ? rec.bundle_version : undefined;
+    runner = typeof rec.runner === "string" && rec.runner.trim() ? rec.runner : undefined;
+    const slots = rec.slots && typeof rec.slots === "object" ? rec.slots as Record<string, unknown> : undefined;
+    target = readNumberField(slots?.total);
+  } catch {
+    // State absence is rendered as missing heartbeat/bundle evidence, not a crash.
+  }
+
+  return {
+    supervisorPid,
+    supervisorPidLive: supervisorPid !== null ? pidLive(supervisorPid) : false,
+    supervisorPidMtimeMs,
+    stateMtimeMs,
+    heartbeatEpochMs,
+    nowMs,
+    heartbeatStaleMs: options.heartbeatStaleMs,
+    bundleVersion,
+    latestBundleVersion: options.latestBundleVersion,
+    runner,
+    target,
+  };
+}
+
+function fleetTruthFindings(input: FleetTruthProbeInput): FleetTruthFindingKind[] {
+  const findings: FleetTruthFindingKind[] = [];
+  const heartbeatAge = ageMs(input.nowMs, input.heartbeatEpochMs ?? input.stateMtimeMs);
+  if (input.supervisorPidLive && heartbeatAge !== undefined && heartbeatAge > input.heartbeatStaleMs) {
+    findings.push("zombie");
+  }
+  if (input.supervisorPidLive) {
+    if (!input.bundleVersion) {
+      findings.push("version-unknown");
+    } else if (input.latestBundleVersion && compareSemver(input.bundleVersion, input.latestBundleVersion) !== 0) {
+      findings.push("version-skew");
+    }
+  }
+  return findings;
+}
+
+function evidence(input: FleetTruthProbeInput, findings: readonly FleetTruthFindingKind[]): string {
+  if (!input.supervisorPid) return "no supervisor pid file";
+  if (!input.supervisorPidLive) return `pid=${input.supervisorPid} is not live`;
+
+  const parts = [
+    `pid=${input.supervisorPid}`,
+    `live=${String(input.supervisorPidLive)}`,
+    formatAge("heartbeat_age", ageMs(input.nowMs, input.heartbeatEpochMs ?? input.stateMtimeMs)),
+    formatAge("pid_mtime_age", ageMs(input.nowMs, input.supervisorPidMtimeMs)),
+    formatAge("state_mtime_age", ageMs(input.nowMs, input.stateMtimeMs)),
+    `threshold=${seconds(input.heartbeatStaleMs)}s`,
+  ].filter((p): p is string => Boolean(p));
+
+  if (findings.includes("version-skew")) {
+    parts.push(`version_skew bundle=${input.bundleVersion} latest=${input.latestBundleVersion}`);
+  } else if (findings.includes("version-unknown")) {
+    parts.push(`version_unknown latest=${input.latestBundleVersion ?? "unknown"}`);
+  } else if (input.bundleVersion) {
+    parts.push(`bundle=${input.bundleVersion}${input.latestBundleVersion ? ` latest=${input.latestBundleVersion}` : ""}`);
+  }
+  return parts.join(" ");
+}
+
+export function runFleetTruthProbe(context: OperationalProbeContext): OperationalProbeResult {
+  const input = context.fleetTruth;
+  if (!input) {
+    return {
+      id: FLEET_TRUTH_PROBE_ID,
+      name: FLEET_TRUTH_PROBE_NAME,
+      verdict: "ok",
+      evidence: "fleet truth check not configured",
+      canonicalFix: FLEET_TRUTH_CANONICAL_FIX,
+    };
+  }
+
+  const findings = fleetTruthFindings(input);
+  const data: FleetTruthProbeData = {
+    findings,
+    ...(input.supervisorPid ? { pid: input.supervisorPid } : {}),
+    ...(input.target !== undefined ? { target: input.target } : {}),
+    ...(input.runner ? { runner: input.runner } : {}),
+    ...(input.relaunchArgs ? { relaunchArgs: input.relaunchArgs } : {}),
+  };
+  return {
+    id: FLEET_TRUTH_PROBE_ID,
+    name: FLEET_TRUTH_PROBE_NAME,
+    verdict: findings.length > 0 ? "red" : "ok",
+    evidence: evidence(input, findings),
+    canonicalFix: FLEET_TRUTH_CANONICAL_FIX,
+    fix: findings.includes("zombie")
+      ? {
+          gate: "confirm",
+          description: "SIGTERM the stale-but-live fleet supervisor and verify it exits",
+        }
+      : undefined,
+    data,
+  };
+}
+
+function fleetTruthData(finding: OperationalProbeResult): FleetTruthProbeData | undefined {
+  const data = finding.data;
+  if (!data || typeof data !== "object") return undefined;
+  const rec = data as Partial<FleetTruthProbeData>;
+  return Array.isArray(rec.findings) ? rec as FleetTruthProbeData : undefined;
+}
+
+export async function applyFleetTruthFix(
+  finding: OperationalProbeResult,
+  deps: OperationalProbeFixDeps,
+): Promise<OperationalProbeFixResult> {
+  const data = fleetTruthData(finding);
+  if (!data?.findings.includes("zombie") || !data.pid) {
+    return { probeId: finding.id, status: "noop", evidence: "no zombie supervisor repair is needed" };
+  }
+
+  const confirmed = await deps.confirm(finding);
+  if (!confirmed) return { probeId: finding.id, status: "declined", evidence: "operator declined fix" };
+  if (!deps.terminateSupervisor) {
+    return { probeId: finding.id, status: "noop", evidence: "supervisor SIGTERM repair is not wired" };
+  }
+
+  const exited = await deps.terminateSupervisor(data.pid);
+  if (!exited) {
+    return { probeId: finding.id, status: "noop", evidence: `supervisor pid=${data.pid} still live after SIGTERM` };
+  }
+
+  const relaunch = deps.confirmRelaunch ? await deps.confirmRelaunch(finding) : false;
+  if (!relaunch) {
+    return { probeId: finding.id, status: "applied", evidence: "supervisor pid exited; relaunch declined" };
+  }
+  if (!deps.relaunchFleet) {
+    return { probeId: finding.id, status: "applied", evidence: "supervisor pid exited; relaunch not wired" };
+  }
+
+  const launched = await deps.relaunchFleet({
+    target: data.target,
+    runner: data.runner,
+    args: data.relaunchArgs,
+  });
+  return {
+    probeId: finding.id,
+    status: "applied",
+    evidence: `supervisor pid exited; relaunch ${launched.status}${launched.pid ? ` pid=${launched.pid}` : ""}`,
+  };
+}
+
+export async function terminateSupervisorPid(
+  pid: number,
+  options: { readonly pollMs?: number; readonly timeoutMs?: number } = {},
+): Promise<boolean> {
+  const pollMs = options.pollMs ?? 50;
+  const deadline = Date.now() + (options.timeoutMs ?? 5_000);
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return true;
+  }
+  while (Date.now() < deadline) {
+    if (!defaultPidLive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return !defaultPidLive(pid);
+}
+
+export const fleetTruthProbe: OperationalProbe = {
+  id: FLEET_TRUTH_PROBE_ID,
+  name: FLEET_TRUTH_PROBE_NAME,
+  canonicalFix: FLEET_TRUTH_CANONICAL_FIX,
+  run: runFleetTruthProbe,
+  applyFix: applyFleetTruthFix,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -1,5 +1,6 @@
 import { encode as encodeToon } from "@reddb-io/toon";
 import { configNamespacingProbe } from "./config-namespacing.js";
+import { fleetTruthProbe } from "./fleet-truth.js";
 import { focalBranchProbe } from "./focal-branch.js";
 import { httpsRemoteProbe } from "./https-remote.js";
 import { queueVisibilityProbe } from "./queue-visibility.js";
@@ -15,6 +16,7 @@ export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   httpsRemoteProbe,
   queueVisibilityProbe,
   focalBranchProbe,
+  fleetTruthProbe,
   configNamespacingProbe,
 ];
 

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -11,6 +11,7 @@ export interface OperationalProbeContext {
   readonly queueVisibility?: QueueVisibilityProbeInput;
   readonly focalBranch?: FocalBranchProbeInput;
   readonly configNamespacing?: ConfigNamespacingProbeInput;
+  readonly fleetTruth?: FleetTruthProbeInput;
 }
 
 export interface ConfigNamespacingProbeInput {
@@ -49,6 +50,21 @@ export interface QueueVisibilityProbeInput {
   readonly countRestQueue: () => Promise<number>;
 }
 
+export interface FleetTruthProbeInput {
+  readonly supervisorPid?: number | null;
+  readonly supervisorPidLive: boolean;
+  readonly supervisorPidMtimeMs?: number;
+  readonly stateMtimeMs?: number;
+  readonly heartbeatEpochMs?: number;
+  readonly nowMs: number;
+  readonly heartbeatStaleMs: number;
+  readonly bundleVersion?: string;
+  readonly latestBundleVersion?: string;
+  readonly runner?: string;
+  readonly target?: number;
+  readonly relaunchArgs?: readonly string[];
+}
+
 export interface OperationalProbeFix {
   readonly gate: "confirm";
   readonly description: string;
@@ -66,9 +82,16 @@ export interface OperationalProbeResult {
 
 export interface OperationalProbeFixDeps {
   confirm(finding: OperationalProbeResult): Promise<boolean>;
+  confirmRelaunch?(finding: OperationalProbeResult): Promise<boolean>;
   setRemoteUrl?(name: string, url: string): Promise<void>;
   removeBranchLock?(): Promise<void>;
   writeBranchLock?(branch: string): Promise<void>;
+  terminateSupervisor?(pid: number): Promise<boolean>;
+  relaunchFleet?(request: {
+    readonly target?: number;
+    readonly runner?: string;
+    readonly args?: readonly string[];
+  }): Promise<{ readonly status: string; readonly pid?: number | null }>;
 }
 
 export type OperationalProbeFixStatus = "applied" | "declined" | "noop";

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -13,11 +13,12 @@ import { spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { copyFileSync, readFileSync, writeFileSync, renameSync, existsSync, mkdirSync, rmSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { readBuildInfo } from "@reddb-io/build-info";
 import { hostFingerprintPrefix } from "../core/host-identity.js";
 import * as rp from "@reddb-io/shared/red-paths.js";
 import { decode as decodeToon, type JsonValue as ToonValue } from "@reddb-io/toon";
 import { loadConfig, getConfig, resolveTier, rootDevConfigCollisionsFromText } from "../core/config.js";
-import { newestCachedDevBundleVersion } from "../core/bundle-version.js";
+import { compareSemver, newestCachedDevBundleVersion } from "../core/bundle-version.js";
 import { resolveBase, resolveBaseWithSource } from "../core/base-resolver.js";
 import { DEFAULT_BRANCH } from "../core/pin-reader.js";
 import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
@@ -54,6 +55,8 @@ import { collectLogLineCounts } from "./log-cursor.js";
 import { isLivePid } from "./kill-tree.js";
 import { execTool } from "./exec.js";
 import { collectTmpJanitorReport } from "./tmp-janitor.js";
+import { collectFleetTruthProbeInput } from "../core/operational-probes.js";
+import { resolveSupervisorConfig } from "../core/supervisor.js";
 
 // ---------- repo resolution ----------
 
@@ -1750,6 +1753,23 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
   const configuredTrunk = resolvedFocalBranch.branch;
   const lockTargetExists = lockedBranch ? await gitx.branchExists(gitCtx, lockedBranch) : undefined;
   const pnpmInstalled = pnpmProbe.code !== 127;
+  const installedBundleVersion = readBuildInfo("dev").version;
+  const cachedBundleVersion = newestCachedDevBundleVersion(installedBundleVersion);
+  const latestBundleVersion =
+    cachedBundleVersion && compareSemver(cachedBundleVersion, installedBundleVersion) > 0
+      ? cachedBundleVersion
+      : installedBundleVersion;
+  const supervisorCfg = resolveSupervisorConfig();
+  const fleetTruth = await collectFleetTruthProbeInput(
+    {
+      supervisorPidPath: preferExistingPath(paths.supervisorPidPath, legacyTmpPath(ctx.root, "afk-supervisor.pid")),
+      fleetStatePath: preferExistingPath(paths.fleetStatePath, legacyTmpPath(ctx.root, "afk-supervisor.state.json")),
+    },
+    {
+      heartbeatStaleMs: supervisorCfg.supervisorStaleS * 1000,
+      latestBundleVersion,
+    },
+  );
   return {
     ghInstalled,
     ghAuthenticated,
@@ -1779,6 +1799,7 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
           },
     },
     configNamespacing: { rootDevKeys },
+    fleetTruth,
   };
 }
 

--- a/apps/dev/tests/fleet-truth.test.ts
+++ b/apps/dev/tests/fleet-truth.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyFleetTruthFix,
+  collectFleetTruthProbeInput,
+  runFleetTruthProbe,
+  terminateSupervisorPid,
+} from "../src/core/operational-probes/fleet-truth.js";
+
+const children: number[] = [];
+
+afterEach(async () => {
+  for (const pid of children.splice(0)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // already exited
+    }
+  }
+});
+
+describe("fleet truth operational probe", () => {
+  it("finds pid-live stale-heartbeat zombies with mtimes and ages", async () => {
+    const result = runFleetTruthProbe({
+      remoteUrls: [],
+      fleetTruth: {
+        supervisorPid: 1234,
+        supervisorPidLive: true,
+        supervisorPidMtimeMs: 1_000,
+        stateMtimeMs: 2_000,
+        heartbeatEpochMs: 1_500,
+        nowMs: 601_500,
+        heartbeatStaleMs: 300_000,
+        bundleVersion: "2.62.0",
+        latestBundleVersion: "2.62.0",
+      },
+    });
+
+    expect(result.verdict).toBe("red");
+    expect(result.evidence).toContain("pid=1234");
+    expect(result.evidence).toContain("heartbeat_age=600s");
+    expect(result.evidence).toContain("pid_mtime_age=600s");
+    expect(result.evidence).toContain("state_mtime_age=599s");
+    expect(result.fix?.gate).toBe("confirm");
+  });
+
+  it("reports version skew and absent stamps distinctly", () => {
+    const skew = runFleetTruthProbe({
+      remoteUrls: [],
+      fleetTruth: {
+        supervisorPid: 42,
+        supervisorPidLive: true,
+        nowMs: 10_000,
+        heartbeatStaleMs: 300_000,
+        heartbeatEpochMs: 9_000,
+        bundleVersion: "2.62.0",
+        latestBundleVersion: "2.63.0",
+      },
+    });
+    expect(skew.verdict).toBe("red");
+    expect(skew.evidence).toContain("version_skew");
+    expect(skew.evidence).toContain("bundle=2.62.0 latest=2.63.0");
+
+    const unknown = runFleetTruthProbe({
+      remoteUrls: [],
+      fleetTruth: {
+        supervisorPid: 42,
+        supervisorPidLive: true,
+        nowMs: 10_000,
+        heartbeatStaleMs: 300_000,
+        heartbeatEpochMs: 9_000,
+        latestBundleVersion: "2.63.0",
+      },
+    });
+    expect(unknown.verdict).toBe("red");
+    expect(unknown.evidence).toContain("version_unknown");
+  });
+
+  it("gates SIGTERM, verifies live process exit, and leaves refusal untouched", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "red-skills-fleet-truth-"));
+    const pidPath = join(dir, "afk-supervisor.pid");
+    const statePath = join(dir, "afk-supervisor.state.json");
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    if (!child.pid) throw new Error("child process did not expose pid");
+    children.push(child.pid);
+
+    await writeFile(pidPath, `${child.pid}\n`, "utf8");
+    await writeFile(
+      statePath,
+      JSON.stringify({ epoch: 1, bundle_version: "2.62.0", runner: "codex", slots: { total: 2 } }),
+      "utf8",
+    );
+    const stateStat = await stat(statePath);
+    const facts = await collectFleetTruthProbeInput(
+      { supervisorPidPath: pidPath, fleetStatePath: statePath },
+      {
+        nowMs: stateStat.mtimeMs + 601_000,
+        heartbeatStaleMs: 300_000,
+        latestBundleVersion: "2.62.0",
+      },
+    );
+    const finding = runFleetTruthProbe({ remoteUrls: [], fleetTruth: facts });
+
+    const declined = await applyFleetTruthFix(finding, {
+      confirm: async () => false,
+      terminateSupervisor: terminateSupervisorPid,
+    });
+    expect(declined.status).toBe("declined");
+    expect(process.kill(child.pid, 0)).toBe(true);
+
+    const applied = await applyFleetTruthFix(finding, {
+      confirm: async () => true,
+      confirmRelaunch: async () => false,
+      terminateSupervisor: terminateSupervisorPid,
+    });
+    expect(applied.status).toBe("applied");
+    expect(applied.evidence).toContain("supervisor pid exited");
+    await expect(async () => process.kill(child.pid!, 0)).rejects.toThrow();
+    children.splice(children.indexOf(child.pid), 1);
+  });
+});

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -48,6 +48,7 @@ describe("operational probe registry", () => {
       { id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" },
       { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
       { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },
+      { id: "afk.fleet-truth", name: "AFK fleet truth", verdict: "ok" },
       { id: "config.dev-root-spelling", name: "Config dev-plugin namespacing", verdict: "ok" },
     ]);
     expect(decoded.findings).toHaveLength(1);


### PR DESCRIPTION
Automated AFK landing for #1969. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1969

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893936&installation_id=129708444&pr_number=2018&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2018&signature=16917eae595f4693be28b34b9dd1fc90862b442263dc4ab020fa6b5ef24a6965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->