### PR TITLE
fix: #1988 rsp: honest measurement — Anthropic pricing, labeled estimates, control holdout with confidence interval, telemetry mining report

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -94,6 +94,10 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     return await emitWrappedResult(args, await runFastGitStatus(), started, undefined, await fastTelemetryRoot(process.cwd()));
   }
   const { resolveResidentPaths, ResidentRspElisionStore, ensureResidentServer } = await import("./resident-client.js");
+  const residentPaths = resolveResidentPaths(process.cwd());
+  if (wrapperCommand && shouldUseControlHoldout(config.measurementHoldoutShare)) {
+    return await runControlHoldout(args, residentPaths.rootDir, config.measurementHoldoutShare);
+  }
   if (args.command === "server") {
     const { runResidentServer } = await import("./resident-server.js");
     const serverPaths = resolveResidentPaths(process.cwd());
@@ -150,8 +154,6 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
     });
     return 0;
   }
-
-  const residentPaths = resolveResidentPaths(process.cwd());
   if (args.command === "proxy") {
     const { runProxy } = await import("./proxy.js");
     return await runProxy(args.positional, { telemetryRoot: residentPaths.rootDir, level: args.level });
@@ -368,6 +370,88 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   } finally {
     await closeStore?.();
   }
+}
+
+async function runControlHoldout(args: ParsedArgs, telemetryRoot: string, holdoutShare: number): Promise<number> {
+  const started = process.hrtime.bigint();
+  const result = await passthroughCaptured(args.positional);
+  const wrapperMs = Number(process.hrtime.bigint() - started) / 1_000_000;
+  appendControlHoldoutTelemetry(telemetryRoot, args, result, wrapperMs, holdoutShare);
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return 128;
+  }
+  return result.status ?? 0;
+}
+
+async function passthroughCaptured(argv: readonly string[]): Promise<{ stdoutBytes: number; stderrBytes: number; status: number | null; signal: NodeJS.Signals | null }> {
+  const command = argv[0];
+  if (!command) return { stdoutBytes: 0, stderrBytes: 0, status: 2, signal: null };
+  let child;
+  if (command === "exec" || command === "proxy") {
+    const commandLine = command === "proxy"
+      ? await import("./proxy.js").then((module) => module.parseProxyCommandLine(argv))
+      : await import("./exec-wrapper.js").then((module) => module.parseExecCommandLine(argv));
+    child = spawn(commandLine, { shell: true, stdio: ["inherit", "pipe", "pipe"] });
+  } else {
+    child = spawn(command, argv.slice(1), { stdio: ["inherit", "pipe", "pipe"] });
+  }
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdoutBytes += chunk.length;
+    process.stdout.write(chunk);
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderrBytes += chunk.length;
+    process.stderr.write(chunk);
+  });
+  return await new Promise((resolve) => {
+    child.on("error", (err) => {
+      const text = `${err instanceof Error ? err.message : String(err)}\n`;
+      stderrBytes += Buffer.byteLength(text);
+      process.stderr.write(text);
+      resolve({ stdoutBytes, stderrBytes, status: 127, signal: null });
+    });
+    child.on("close", (status, signal) => resolve({ stdoutBytes, stderrBytes, status, signal }));
+  });
+}
+
+function shouldUseControlHoldout(share: number): boolean {
+  return share > 0 && Math.random() < share;
+}
+
+function appendControlHoldoutTelemetry(
+  telemetryRoot: string,
+  args: ParsedArgs,
+  result: { stdoutBytes: number; stderrBytes: number },
+  wrapperMs: number,
+  holdoutShare: number,
+): void {
+  const bytes = result.stdoutBytes + result.stderrBytes;
+  const event = {
+    event_type: "control_holdout",
+    control_holdout: true,
+    holdout_share: holdoutShare,
+    ts: new Date().toISOString(),
+    command: telemetryCommand(args),
+    command_class: args.command ?? "unknown",
+    wrapper: args.command,
+    loss: "lossless",
+    elided: false,
+    raw_bytes: bytes,
+    emitted_bytes: bytes,
+    wrapper_ms: wrapperMs,
+  };
+  appendTelemetryEventSync(telemetryRoot, {
+    collection: "rsp_accounting_events_v1",
+    ...event,
+  });
+  appendTelemetryEventSync(telemetryRoot, {
+    collection: "rsp_telemetry_invocations_v1",
+    ...event,
+    accounting_recorded: true,
+  });
 }
 
 function valueAfter(args: readonly string[], flag: string): string | undefined {

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -16,6 +16,7 @@ export const DEFAULT_RSP_TELEMETRY_DRAIN_INTERVAL_MS = 30_000;
 export const DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS = 2_000;
 export const DEFAULT_RSP_IDLE_MS = 5 * 60_000;
 export const MIN_RSP_IDLE_MS = 5_000;
+export const DEFAULT_RSP_MEASUREMENT_HOLDOUT_SHARE = 0;
 
 export interface RspRuntimeConfig {
   enabled: boolean;
@@ -30,6 +31,7 @@ export interface RspRuntimeConfig {
   telemetryDrainTimeoutMs: number;
   idleMs: number;
   heavyGitByteThreshold: number;
+  measurementHoldoutShare: number;
 }
 
 export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitStoreUri?: string): RspRuntimeConfig {
@@ -71,6 +73,10 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     numericEnv(env.RSP_HEAVY_GIT_BYTE_THRESHOLD) ?? readNumericYamlPath(yaml, "rsp.heavyGitByteThreshold"),
     DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
   );
+  const measurementHoldoutShare = shareNumber(
+    numericEnv(env.RSP_MEASUREMENT_HOLDOUT_SHARE) ?? readNumericYamlPath(yaml, "rsp.measurement.holdoutShare"),
+    DEFAULT_RSP_MEASUREMENT_HOLDOUT_SHARE,
+  );
   const storeRoot = resolveResidentPaths(cwd).rootDir;
   // Honor the transition window: open the legacy tmp-tier store if it still
   // exists and setup has not yet migrated it to the state tier.
@@ -90,6 +96,7 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     telemetryDrainTimeoutMs,
     idleMs,
     heavyGitByteThreshold,
+    measurementHoldoutShare,
   };
 }
 
@@ -107,6 +114,13 @@ function positiveNumber(value: number | undefined, fallback: number): number {
 function minNumber(value: number | undefined, fallback: number, min: number): number {
   const n = positiveNumber(value, fallback);
   return Math.max(n, min);
+}
+
+function shareNumber(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
 }
 
 function numericEnv(value: string | undefined): number | undefined {

--- a/apps/rsp/src/pricing.ts
+++ b/apps/rsp/src/pricing.ts
@@ -24,6 +24,12 @@ export const RSP_INPUT_TOKEN_PRICE_USD_PER_MILLION: Record<string, number> = {
   "gpt-4.1-mini": 0.4,
   "gpt-4o": 2.5,
   "gpt-4o-mini": 0.15,
+  "claude-opus-4.1": 15,
+  "claude-opus-4": 15,
+  "claude-sonnet-4.5": 3,
+  "claude-sonnet-4": 3,
+  "claude-haiku-4.5": 1,
+  "claude-haiku-3.5": 0.8,
 };
 
 const PRICING_NOTE = "estimate derived from byte-based token estimate when token counts are estimated";

--- a/apps/rsp/src/telemetry.ts
+++ b/apps/rsp/src/telemetry.ts
@@ -146,6 +146,15 @@ export interface RspTelemetryGainsReport {
   };
   savings: {
     tokens: TokenSavingsEstimate;
+    measured_control_holdout: {
+      enabled: boolean;
+      holdout_share: number;
+      holdout_invocations: number;
+      compressed_invocations: number;
+      savings_rate: number | null;
+      confidence_interval_95: { low: number; high: number } | null;
+      note: string;
+    };
     weekly_tokens_saved: Array<{ week_start: string; tokens_saved: number; wow_delta_pct: number | null }>;
     elision_rate: number;
     top_commands_by_tokens_saved: Array<{ command_family: string; invocations: number; tokens_saved: number; bytes_saved: number }>;
@@ -162,6 +171,11 @@ export interface RspTelemetryGainsReport {
     degradations_by_reason: Array<{ reason: string; count: number }>;
     cold_boots: number | null;
     warm_hits: number | null;
+  };
+  mining: {
+    recovery_usage_by_family: Array<{ command_family: string; show_total: number; show_hits: number; show_misses: number; show_hit_rate: number }>;
+    degradation_clusters: Array<{ command_family: string; reason: string; count: number; suggestion: string }>;
+    threshold_tuning_suggestions: Array<{ command_family: string; signal: string; suggestion: string }>;
   };
 }
 
@@ -772,8 +786,13 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
   const sinceMs = Date.parse(since);
   const accounting = await readAccountingRecords(db, sinceMs);
   const invocations = accounting.filter((record) =>
-    stringField(record.event_type) !== "show" && stringField(record.degradation_reason) === ""
+    stringField(record.event_type) !== "show" &&
+    stringField(record.event_type) !== "control_holdout" &&
+    record.control_holdout !== true &&
+    stringField(record.degradation_reason) === ""
   );
+  const holdouts = accounting.filter((record) => stringField(record.event_type) === "control_holdout" || record.control_holdout === true);
+  const showEvents = accounting.filter((record) => stringField(record.event_type) === "show");
   const degradations = accounting.filter((record) => stringField(record.degradation_reason) !== "");
   const allTimestamps = [...invocations, ...degradations]
     .map(timestampMs)
@@ -846,6 +865,9 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
   for (const entry of degradationTimeline) {
     byReason.set(entry.reason, (byReason.get(entry.reason) ?? 0) + 1);
   }
+  const degradationClusters = degradationClusterRows(degradationTimeline);
+  const recoveryUsage = recoveryUsageRows(showEvents);
+  const thresholdSuggestions = thresholdTuningSuggestions([...commandTotals.values()], recoveryUsage, degradationClusters);
   const peakMinute = [...requestsByMinute.entries()]
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0];
 
@@ -879,6 +901,7 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
     },
     savings: {
       tokens: tokenSavingsEstimate(totalTokensSaved, tokensEstimated),
+      measured_control_holdout: measuredControlHoldout(invocations, holdouts),
       weekly_tokens_saved: weeklySeries(weeklyTokens),
       elision_rate: invocations.length === 0 ? 0 : round(elided / invocations.length),
       top_commands_by_tokens_saved: [...commandTotals.values()]
@@ -897,25 +920,33 @@ export async function readTelemetryGainsReport(db: RedDB, sinceDays: number, now
       cold_boots: recordsWithStoreMetric === 0 ? null : coldBoots,
       warm_hits: recordsWithStoreMetric === 0 ? null : Math.max(0, recordsWithStoreMetric - coldBoots),
     },
+    mining: {
+      recovery_usage_by_family: recoveryUsage,
+      degradation_clusters: degradationClusters,
+      threshold_tuning_suggestions: thresholdSuggestions,
+    },
   };
 }
 
 async function readAccountingRecords(db: RedDB, sinceMs: number): Promise<Array<Record<string, unknown>>> {
   const accounting = (await readCollection(db, RSP_ACCOUNTING_EVENTS_COLLECTION))
     .filter((record) => timestampMs(record) >= sinceMs);
-  if (accounting.length > 0) return accounting;
-
+  const accountingHasInvocationLike = accounting.some((record) =>
+    stringField(record.event_type) !== "show" || stringField(record.degradation_reason) !== ""
+  );
   const legacyInvocations = (await readCollection(db, RSP_TELEMETRY_INVOCATIONS_COLLECTION))
     .filter((record) => timestampMs(record) >= sinceMs)
-    .map((record) => ({ ...record, event_type: "invocation" }));
+    .filter((record) => !accountingHasInvocationLike && record.accounting_recorded !== true)
+    .map((record) => ({ ...record, event_type: stringField(record.event_type) || "invocation" }));
   const legacyDegradations = (await readCollection(db, RSP_TELEMETRY_DEGRADATIONS_COLLECTION))
     .filter((record) => timestampMs(record) >= sinceMs)
+    .filter((record) => !accountingHasInvocationLike && record.accounting_recorded !== true)
     .map((record) => ({
       ...record,
       event_type: "invocation",
       degradation_reason: stringField(record.reason) || "unknown",
     }));
-  return [...legacyInvocations, ...legacyDegradations];
+  return [...accounting, ...legacyInvocations, ...legacyDegradations];
 }
 
 function tokenCountFromCounters(record: Record<string, unknown>, field: "raw" | "emitted"): { tokens: number; estimated: boolean } {
@@ -923,6 +954,135 @@ function tokenCountFromCounters(record: Record<string, unknown>, field: "raw" | 
   if (exact != null) return { tokens: exact, estimated: false };
   const bytes = numeric(record[field === "raw" ? "raw_bytes" : "emitted_bytes"]);
   return { tokens: Math.ceil(bytes / 4), estimated: bytes > 0 };
+}
+
+function measuredControlHoldout(
+  invocations: readonly Record<string, unknown>[],
+  holdouts: readonly Record<string, unknown>[],
+): RspTelemetryGainsReport["savings"]["measured_control_holdout"] {
+  const holdoutShare = maxNumeric(holdouts.map((record) => optionalNumeric(record.holdout_share))) ?? 0;
+  if (holdouts.length === 0) {
+    return {
+      enabled: false,
+      holdout_share: holdoutShare,
+      holdout_invocations: 0,
+      compressed_invocations: invocations.length,
+      savings_rate: null,
+      confidence_interval_95: null,
+      note: "control holdout disabled or no holdout samples in window",
+    };
+  }
+  const compressedRates = invocations.map(tokenSavingsRate).filter((value): value is number => value != null);
+  const holdoutRates = holdouts.map(tokenSavingsRate).filter((value): value is number => value != null);
+  const rates = compressedRates.length > 0 ? compressedRates : holdoutRates;
+  const mean = rates.length === 0 ? null : round(meanOf(rates));
+  return {
+    enabled: true,
+    holdout_share: round(holdoutShare),
+    holdout_invocations: holdouts.length,
+    compressed_invocations: invocations.length,
+    savings_rate: mean,
+    confidence_interval_95: mean == null ? null : confidenceInterval95(rates, mean),
+    note: "measured from opt-in uncompressed control holdout; report proposes, it does not tune automatically",
+  };
+}
+
+function tokenSavingsRate(record: Record<string, unknown>): number | null {
+  const raw = tokenCountFromCounters(record, "raw").tokens;
+  if (raw <= 0) return null;
+  const emitted = tokenCountFromCounters(record, "emitted").tokens;
+  return Math.max(0, raw - emitted) / raw;
+}
+
+function confidenceInterval95(values: readonly number[], mean: number): { low: number; high: number } {
+  if (values.length <= 1) return { low: round(Math.max(0, mean)), high: round(Math.min(1, mean)) };
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1);
+  const margin = 1.96 * Math.sqrt(variance / values.length);
+  return {
+    low: round(Math.max(0, mean - margin)),
+    high: round(Math.min(1, mean + margin)),
+  };
+}
+
+function recoveryUsageRows(records: readonly Record<string, unknown>[]): RspTelemetryGainsReport["mining"]["recovery_usage_by_family"] {
+  const byFamily = new Map<string, { command_family: string; show_total: number; show_hits: number; show_misses: number }>();
+  for (const record of records) {
+    const family = commandFamily(stringField(record.recovered_command) || stringField(record.command));
+    const row = byFamily.get(family) ?? { command_family: family, show_total: 0, show_hits: 0, show_misses: 0 };
+    row.show_total++;
+    if (record.hit === true) row.show_hits++;
+    else row.show_misses++;
+    byFamily.set(family, row);
+  }
+  return [...byFamily.values()]
+    .sort((a, b) => b.show_total - a.show_total || a.command_family.localeCompare(b.command_family))
+    .map((row) => ({ ...row, show_hit_rate: row.show_total === 0 ? 0 : round(row.show_hits / row.show_total) }));
+}
+
+function degradationClusterRows(
+  timeline: readonly { timestamp: string; command_family: string; reason: string }[],
+): RspTelemetryGainsReport["mining"]["degradation_clusters"] {
+  const counts = new Map<string, { command_family: string; reason: string; count: number }>();
+  for (const entry of timeline) {
+    const key = `${entry.command_family}\0${entry.reason}`;
+    const row = counts.get(key) ?? { command_family: entry.command_family, reason: entry.reason, count: 0 };
+    row.count++;
+    counts.set(key, row);
+  }
+  return [...counts.values()]
+    .sort((a, b) => b.count - a.count || a.command_family.localeCompare(b.command_family) || a.reason.localeCompare(b.reason))
+    .map((row) => ({ ...row, suggestion: degradationSuggestion(row) }));
+}
+
+function degradationSuggestion(row: { command_family: string; reason: string; count: number }): string {
+  if (/unavailable|not provisioned|missing/i.test(row.reason)) {
+    return `Investigate ${row.command_family} wrapper availability before changing thresholds`;
+  }
+  if (/timeout|large|limit/i.test(row.reason)) {
+    return `Review ${row.command_family} byte thresholds and timeout caps for ${row.count} matching degradations`;
+  }
+  return `Investigate ${row.command_family} ${row.reason} cluster before tuning compression thresholds`;
+}
+
+function thresholdTuningSuggestions(
+  commandTotals: readonly { command_family: string; invocations: number; tokens_saved: number; bytes_saved: number }[],
+  recoveryUsage: readonly { command_family: string; show_total: number; show_hits: number; show_misses: number; show_hit_rate: number }[],
+  degradationClusters: readonly { command_family: string; reason: string; count: number }[],
+): RspTelemetryGainsReport["mining"]["threshold_tuning_suggestions"] {
+  const suggestions: RspTelemetryGainsReport["mining"]["threshold_tuning_suggestions"] = [];
+  for (const row of recoveryUsage.filter((entry) => entry.show_total > 0)) {
+    suggestions.push({
+      command_family: row.command_family,
+      signal: `recovery_show_rate=${row.show_total}`,
+      suggestion: row.show_hit_rate >= 0.5
+        ? "Consider preserving more context or raising terse thresholds for frequently recovered outputs"
+        : "Recovery misses dominate; inspect handle lifetime before threshold changes",
+    });
+  }
+  for (const row of degradationClusters.filter((entry) => entry.count > 1)) {
+    suggestions.push({
+      command_family: row.command_family,
+      signal: `degradation_cluster=${row.reason}:${row.count}`,
+      suggestion: "Fix the repeated degradation before tightening compression",
+    });
+  }
+  for (const row of commandTotals.filter((entry) => entry.invocations > 0 && entry.tokens_saved === 0)) {
+    suggestions.push({
+      command_family: row.command_family,
+      signal: "zero_token_savings",
+      suggestion: "Consider bypassing or raising admission thresholds for this family",
+    });
+  }
+  return suggestions.slice(0, 10);
+}
+
+function meanOf(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function maxNumeric(values: readonly (number | null)[]): number | null {
+  const present = values.filter((value): value is number => value != null);
+  return present.length === 0 ? null : Math.max(...present);
 }
 
 function accountingStorageClassStats(records: readonly Record<string, unknown>[]): RspStorageClassStats {

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -50,6 +50,7 @@ describe("resolveRspConfig", () => {
       telemetryDrainTimeoutMs: 456,
       idleMs: 10_000,
       heavyGitByteThreshold: 99,
+      measurementHoldoutShare: 0,
     });
   });
 
@@ -72,7 +73,20 @@ describe("resolveRspConfig", () => {
       telemetryDrainTimeoutMs: DEFAULT_RSP_TELEMETRY_DRAIN_TIMEOUT_MS,
       idleMs: DEFAULT_RSP_IDLE_MS,
       heavyGitByteThreshold: DEFAULT_RSP_HEAVY_GIT_BYTE_THRESHOLD,
+      measurementHoldoutShare: 0,
     });
+  });
+
+  it("keeps measurement holdout off by default and reads it additively", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red"), { recursive: true });
+    await writeFile(join(root, ".red", "config.yaml"), "rsp:\n  enabled: true\n  measurement:\n    holdoutShare: 0.05\n", "utf8");
+
+    const config = resolveRspConfig(root, {}, undefined);
+
+    expect(config.proxyEnabled).toBe(true);
+    expect(config.measurementHoldoutShare).toBe(0.05);
+    expect(resolveRspConfig(root, { RSP_MEASUREMENT_HOLDOUT_SHARE: "0" }, undefined).measurementHoldoutShare).toBe(0);
   });
 
   it("exposes the universal proxy flag separately from rsp enablement", async () => {

--- a/apps/rsp/tests/telemetry.test.ts
+++ b/apps/rsp/tests/telemetry.test.ts
@@ -69,6 +69,12 @@ describe("rsp telemetry spool", () => {
       tokens_saved_high: null,
       dollars_saved_estimate_usd: 0.00125,
     });
+    expect(tokenSavingsEstimate(1_000_000, false, "claude-sonnet-4")).toMatchObject({
+      tokens_saved: 1_000_000,
+      dollars_saved_estimate_usd: 3,
+      pricing_model_family: "claude-sonnet-4",
+      pricing_input_usd_per_million_tokens: 3,
+    });
   });
 
   it("appends TOONL rows without throwing when the target is unavailable", async () => {
@@ -1045,8 +1051,33 @@ describe("rsp telemetry spool", () => {
         wrapper_ms: 100,
         store_open_count: 0,
       });
+      await db.kv(RSP_TELEMETRY_INVOCATIONS_COLLECTION).put("holdout-one", {
+        created_at: "2026-07-08T12:17:00.000Z",
+        command: "git log --brief",
+        event_type: "control_holdout",
+        control_holdout: true,
+        holdout_share: 0.1,
+        raw_bytes: 2400,
+        emitted_bytes: 2400,
+        tokens_raw: 600,
+        tokens_emitted: 600,
+      });
+      await db.kv(RSP_ACCOUNTING_EVENTS_COLLECTION).put("show-git-log", {
+        created_at: "2026-07-08T12:18:00.000Z",
+        event_type: "show",
+        command: "rsp show",
+        recovered_command: "git log --brief",
+        hit: true,
+        raw_bytes: 1000,
+        emitted_bytes: 1000,
+      });
       await db.kv(RSP_TELEMETRY_DEGRADATIONS_COLLECTION).put("degraded", {
         created_at: "2026-07-08T12:16:00.000Z",
+        command: "git --version",
+        reason: "wrapper failed",
+      });
+      await db.kv(RSP_TELEMETRY_DEGRADATIONS_COLLECTION).put("degraded-two", {
+        created_at: "2026-07-08T12:19:00.000Z",
         command: "git --version",
         reason: "wrapper failed",
       });
@@ -1059,7 +1090,7 @@ describe("rsp telemetry spool", () => {
         label: "window: 28d, data: 9d",
         empty: false,
         invocations: 3,
-        degradations: 1,
+        degradations: 2,
       });
       expect(report.latency.global).toEqual({
         wrapper_ms_p50: 20,
@@ -1095,10 +1126,31 @@ describe("rsp telemetry spool", () => {
       expect(report.savings.top_commands_by_tokens_saved[0]).toMatchObject({ command_family: "git log", invocations: 2, tokens_saved: 1150 });
       expect(report.savings.top_commands_by_invocation_count[0]).toMatchObject({ command_family: "git log", invocations: 2 });
       expect(report.savings.single_biggest_elision).toMatchObject({ command_family: "git log", tokens_saved: 900 });
+      expect(report.savings.measured_control_holdout).toMatchObject({
+        enabled: true,
+        holdout_share: 0.1,
+        holdout_invocations: 1,
+        compressed_invocations: 3,
+        savings_rate: expect.any(Number),
+        confidence_interval_95: { low: expect.any(Number), high: expect.any(Number) },
+      });
+      expect(report.mining.recovery_usage_by_family).toEqual([
+        { command_family: "git log", show_total: 1, show_hits: 1, show_misses: 0, show_hit_rate: 1 },
+      ]);
+      expect(report.mining.degradation_clusters).toEqual([
+        expect.objectContaining({
+          command_family: "git --version",
+          reason: "wrapper failed",
+          count: 2,
+          suggestion: expect.stringContaining("Investigate"),
+        }),
+      ]);
+      expect(report.mining.threshold_tuning_suggestions.length).toBeGreaterThan(0);
       expect(report.health.degradation_timeline).toEqual([
         { timestamp: "2026-07-08T12:16:00.000Z", command_family: "git --version", reason: "wrapper failed" },
+        { timestamp: "2026-07-08T12:19:00.000Z", command_family: "git --version", reason: "wrapper failed" },
       ]);
-      expect(report.health.degradations_by_reason).toEqual([{ reason: "wrapper failed", count: 1 }]);
+      expect(report.health.degradations_by_reason).toEqual([{ reason: "wrapper failed", count: 2 }]);
       expect(report.health).toMatchObject({ cold_boots: 1, warm_hits: 2 });
     } finally {
       await db.close();


### PR DESCRIPTION
Automated AFK landing for #1988. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1988

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786894117&installation_id=129708444&pr_number=2019&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2019&signature=75ebc5512e7f49bb43a926afbd1fdf9b679431533d5819f9f82d54255d46c914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->