### PR TITLE
fix: #1970 Claim-hygiene probe: dangling claim markers, gated concede for dead own workers

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -2,7 +2,7 @@ import { relative } from "node:path";
 import { Writable } from "node:stream";
 import { encode as encodeToon } from "@reddb-io/toon";
 import { afkPaths, collectPrecheckFacts, resolveRepoContext } from "../runtime/wire.js";
-import { listIssueStates, type GhContext } from "../runtime/gh.js";
+import { listIssueStates, postClaimComment, type GhContext } from "../runtime/gh.js";
 import { applyTmpJanitorReport, collectTmpJanitorReport, type TmpJanitorApplyResult, type TmpJanitorReport } from "../runtime/tmp-janitor.js";
 import { branchLockPath, clearBranchLock, writeBranchLock } from "../runtime/lock.js";
 import {
@@ -171,6 +171,9 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
           removeBranchLock: async () => clearBranchLock(lockPath),
           writeBranchLock: async (branch) => writeBranchLock(lockPath, branch),
           terminateSupervisor: terminateSupervisorPid,
+          concedeClaim: async (issue, body) => {
+            await postClaimComment({ cwd: ctx.root, repo: ctx.repo } satisfies GhContext, issue, body);
+          },
           confirmRelaunch: async () => flags.yes,
           relaunchFleet: async (request) => {
             const args = [

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -136,6 +136,8 @@ export interface PrecheckFacts {
   configNamespacing?: OperationalProbeContext["configNamespacing"];
   /** Optional fleet truth probe facts for red-doctor and boot visibility. */
   fleetTruth?: OperationalProbeContext["fleetTruth"];
+  /** Optional claim hygiene probe facts for red-doctor and boot visibility. */
+  claimHygiene?: OperationalProbeContext["claimHygiene"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -1,4 +1,5 @@
 export * from "./operational-probes/types.js";
+export * from "./operational-probes/claim-hygiene.js";
 export * from "./operational-probes/fleet-truth.js";
 export * from "./operational-probes/focal-branch.js";
 export * from "./operational-probes/https-remote.js";

--- a/apps/dev/src/core/operational-probes/claim-hygiene.ts
+++ b/apps/dev/src/core/operational-probes/claim-hygiene.ts
@@ -1,0 +1,274 @@
+import { renderClaimComment } from "../claim.js";
+import type {
+  ClaimHygieneIssueInput,
+  ClaimHygieneProbeInput,
+  ClaimHygieneWorkerPidState,
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeFixDeps,
+  OperationalProbeFixResult,
+  OperationalProbeResult,
+} from "./types.js";
+
+export const CLAIM_HYGIENE_PROBE_ID = "afk.claim-hygiene";
+export const CLAIM_HYGIENE_PROBE_NAME = "AFK claim hygiene";
+export const CLAIM_HYGIENE_CANONICAL_FIX =
+  "For dangling afk claim markers owned by this machine with a dead worker pid, confirm per issue and post a matching concede marker. Report foreign claim namespaces without mutation.";
+
+type ClaimMarkerKind = "claim" | "concede";
+
+interface GenericClaimMarker {
+  readonly namespace: string;
+  readonly commentId: number;
+  readonly worker: string;
+  readonly kind: ClaimMarkerKind;
+  readonly runner?: string;
+  readonly createdAt?: string;
+}
+
+interface DanglingClaim {
+  readonly issue: number;
+  readonly marker: GenericClaimMarker;
+}
+
+interface ClaimHygieneConcedeAction {
+  readonly issue: number;
+  readonly markerComment: number;
+  readonly namespace: string;
+  readonly worker: string;
+  readonly runner?: string;
+  readonly pidState: ClaimHygieneWorkerPidState;
+}
+
+interface ClaimHygieneReportEntry {
+  readonly issue: number;
+  readonly markerComment: number;
+  readonly namespace: string;
+  readonly worker: string;
+}
+
+interface ClaimHygieneProbeData {
+  readonly actions: readonly ClaimHygieneConcedeAction[];
+  readonly foreign: readonly ClaimHygieneReportEntry[];
+  readonly liveOwn: number;
+  readonly unknownOwn: number;
+}
+
+const CLAIM_MARKER_RE = /<!--\s*([a-z][a-z0-9_-]*):claim\s+([^>]*?)\s*-->/gi;
+
+function parseFields(raw: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const tok of raw.split(/\s+/)) {
+    const eq = tok.indexOf("=");
+    if (eq <= 0) continue;
+    out.set(tok.slice(0, eq), tok.slice(eq + 1));
+  }
+  return out;
+}
+
+function parseGenericClaimMarkers(issue: ClaimHygieneIssueInput): GenericClaimMarker[] {
+  const out: GenericClaimMarker[] = [];
+  for (const comment of issue.comments) {
+    if (!Number.isFinite(comment.id) || typeof comment.body !== "string") continue;
+    CLAIM_MARKER_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = CLAIM_MARKER_RE.exec(comment.body)) !== null) {
+      const namespace = match[1].toLowerCase();
+      const fields = parseFields(match[2]);
+      const worker = fields.get("worker");
+      if (!worker) continue;
+      out.push({
+        namespace,
+        commentId: comment.id,
+        worker,
+        kind: fields.get("kind") === "concede" ? "concede" : "claim",
+        runner: fields.get("runner"),
+        createdAt: fields.get("ts") ?? comment.createdAt,
+      });
+    }
+  }
+  return out;
+}
+
+function danglingClaims(issue: ClaimHygieneIssueInput): DanglingClaim[] {
+  const latestByOwner = new Map<string, GenericClaimMarker>();
+  for (const marker of parseGenericClaimMarkers(issue)) {
+    const key = `${marker.namespace}\0${marker.worker}`;
+    const prev = latestByOwner.get(key);
+    if (!prev || marker.commentId >= prev.commentId) latestByOwner.set(key, marker);
+  }
+  return [...latestByOwner.values()]
+    .filter((marker) => marker.kind === "claim")
+    .map((marker) => ({ issue: issue.number, marker }));
+}
+
+function classifyClaimHygiene(input: ClaimHygieneProbeInput, issues: readonly ClaimHygieneIssueInput[]): ClaimHygieneProbeData {
+  const ownNamespace = (input.ownNamespace ?? "afk").toLowerCase();
+  const actions: ClaimHygieneConcedeAction[] = [];
+  const foreign: ClaimHygieneReportEntry[] = [];
+  let liveOwn = 0;
+  let unknownOwn = 0;
+
+  for (const issue of issues) {
+    for (const claim of danglingClaims(issue)) {
+      const marker = claim.marker;
+      if (marker.namespace !== ownNamespace) {
+        foreign.push({
+          issue: claim.issue,
+          markerComment: marker.commentId,
+          namespace: marker.namespace,
+          worker: marker.worker,
+        });
+        continue;
+      }
+      const pidState = input.workerPidState(marker.worker);
+      if (pidState === "dead") {
+        actions.push({
+          issue: claim.issue,
+          markerComment: marker.commentId,
+          namespace: marker.namespace,
+          worker: marker.worker,
+          runner: marker.runner,
+          pidState,
+        });
+      } else if (pidState === "live") {
+        liveOwn += 1;
+      } else {
+        unknownOwn += 1;
+      }
+    }
+  }
+
+  return { actions, foreign, liveOwn, unknownOwn };
+}
+
+function actionEvidence(actions: readonly ClaimHygieneConcedeAction[]): string {
+  return actions
+    .map(
+      (action) =>
+        `issue=#${action.issue} marker_comment=${action.markerComment} namespace=${action.namespace} worker=${action.worker} pid=${action.pidState}`,
+    )
+    .join("; ");
+}
+
+function evidence(data: ClaimHygieneProbeData): string {
+  const parts: string[] = [];
+  if (data.actions.length > 0) parts.push(actionEvidence(data.actions));
+  if (data.foreign.length > 0) {
+    parts.push(
+      data.foreign
+        .map(
+          (entry) =>
+            `issue=#${entry.issue} marker_comment=${entry.markerComment} foreign_namespace=${entry.namespace} worker=${entry.worker}`,
+        )
+        .join("; "),
+    );
+  }
+  if (data.liveOwn > 0) parts.push(`live_own=${data.liveOwn}`);
+  if (data.unknownOwn > 0) parts.push(`unknown_own=${data.unknownOwn}`);
+  return parts.length > 0 ? parts.join("; ") : "no dangling claim markers found";
+}
+
+export async function runClaimHygieneProbe(context: OperationalProbeContext): Promise<OperationalProbeResult> {
+  const input = context.claimHygiene;
+  if (!input) {
+    return {
+      id: CLAIM_HYGIENE_PROBE_ID,
+      name: CLAIM_HYGIENE_PROBE_NAME,
+      verdict: "ok",
+      evidence: "claim hygiene check not configured",
+      canonicalFix: CLAIM_HYGIENE_CANONICAL_FIX,
+    };
+  }
+
+  const issues = await input.listOpenQueueIssues();
+  const data = classifyClaimHygiene(input, issues);
+  const hasFinding = data.actions.length > 0 || data.foreign.length > 0 || data.unknownOwn > 0;
+  return {
+    id: CLAIM_HYGIENE_PROBE_ID,
+    name: CLAIM_HYGIENE_PROBE_NAME,
+    verdict: hasFinding ? "red" : "ok",
+    evidence: evidence(data),
+    canonicalFix: CLAIM_HYGIENE_CANONICAL_FIX,
+    fix: data.actions.length > 0
+      ? {
+          gate: "confirm",
+          description: "post matching concede markers for dead own-namespace workers",
+        }
+      : undefined,
+    data,
+  };
+}
+
+function claimHygieneData(finding: OperationalProbeResult): ClaimHygieneProbeData | undefined {
+  const data = finding.data;
+  if (!data || typeof data !== "object") return undefined;
+  const rec = data as Partial<ClaimHygieneProbeData>;
+  if (!Array.isArray(rec.actions) || !Array.isArray(rec.foreign)) return undefined;
+  return rec as ClaimHygieneProbeData;
+}
+
+function groupActionsByIssue(actions: readonly ClaimHygieneConcedeAction[]): ClaimHygieneConcedeAction[][] {
+  const byIssue = new Map<number, ClaimHygieneConcedeAction[]>();
+  for (const action of actions) {
+    const list = byIssue.get(action.issue) ?? [];
+    list.push(action);
+    byIssue.set(action.issue, list);
+  }
+  return [...byIssue.values()];
+}
+
+export async function applyClaimHygieneFix(
+  finding: OperationalProbeResult,
+  deps: OperationalProbeFixDeps,
+): Promise<OperationalProbeFixResult> {
+  const data = claimHygieneData(finding);
+  if (!data || data.actions.length === 0) {
+    return {
+      probeId: finding.id,
+      status: "noop",
+      evidence: "no dead own-namespace dangling claims need repair",
+    };
+  }
+  if (!deps.concedeClaim) {
+    return { probeId: finding.id, status: "noop", evidence: "claim concede repair is not wired" };
+  }
+
+  let posted = 0;
+  let declined = 0;
+  for (const actions of groupActionsByIssue(data.actions)) {
+    const issueFinding: OperationalProbeResult = {
+      ...finding,
+      evidence: actionEvidence(actions),
+      data: { actions, foreign: [], liveOwn: 0, unknownOwn: 0 } satisfies ClaimHygieneProbeData,
+    };
+    if (!(await deps.confirm(issueFinding))) {
+      declined += 1;
+      continue;
+    }
+    for (const action of actions) {
+      await deps.concedeClaim(
+        action.issue,
+        renderClaimComment({ worker: action.worker, runner: action.runner }, "concede"),
+      );
+      posted += 1;
+    }
+  }
+
+  if (posted === 0 && declined > 0) {
+    return { probeId: finding.id, status: "declined", evidence: `operator declined ${declined} issue repair` };
+  }
+  return {
+    probeId: finding.id,
+    status: posted > 0 ? "applied" : "noop",
+    evidence: posted === 1 ? "posted 1 concede marker" : `posted ${posted} concede markers`,
+  };
+}
+
+export const claimHygieneProbe: OperationalProbe = {
+  id: CLAIM_HYGIENE_PROBE_ID,
+  name: CLAIM_HYGIENE_PROBE_NAME,
+  canonicalFix: CLAIM_HYGIENE_CANONICAL_FIX,
+  run: runClaimHygieneProbe,
+  applyFix: applyClaimHygieneFix,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -1,4 +1,5 @@
 import { encode as encodeToon } from "@reddb-io/toon";
+import { claimHygieneProbe } from "./claim-hygiene.js";
 import { configNamespacingProbe } from "./config-namespacing.js";
 import { fleetTruthProbe } from "./fleet-truth.js";
 import { focalBranchProbe } from "./focal-branch.js";
@@ -17,6 +18,7 @@ export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   queueVisibilityProbe,
   focalBranchProbe,
   fleetTruthProbe,
+  claimHygieneProbe,
   configNamespacingProbe,
 ];
 

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -12,6 +12,7 @@ export interface OperationalProbeContext {
   readonly focalBranch?: FocalBranchProbeInput;
   readonly configNamespacing?: ConfigNamespacingProbeInput;
   readonly fleetTruth?: FleetTruthProbeInput;
+  readonly claimHygiene?: ClaimHygieneProbeInput;
 }
 
 export interface ConfigNamespacingProbeInput {
@@ -65,6 +66,26 @@ export interface FleetTruthProbeInput {
   readonly relaunchArgs?: readonly string[];
 }
 
+export type ClaimHygieneWorkerPidState = "live" | "dead" | "foreign" | "unknown";
+
+export interface ClaimHygieneCommentInput {
+  readonly id: number;
+  readonly body: string;
+  readonly createdAt?: string;
+}
+
+export interface ClaimHygieneIssueInput {
+  readonly number: number;
+  readonly comments: readonly ClaimHygieneCommentInput[];
+}
+
+export interface ClaimHygieneProbeInput {
+  readonly ownNamespace?: string;
+  readonly ownWorkerPrefix: string;
+  readonly listOpenQueueIssues: () => Promise<readonly ClaimHygieneIssueInput[]>;
+  readonly workerPidState: (worker: string) => ClaimHygieneWorkerPidState;
+}
+
 export interface OperationalProbeFix {
   readonly gate: "confirm";
   readonly description: string;
@@ -87,6 +108,7 @@ export interface OperationalProbeFixDeps {
   removeBranchLock?(): Promise<void>;
   writeBranchLock?(branch: string): Promise<void>;
   terminateSupervisor?(pid: number): Promise<boolean>;
+  concedeClaim?(issue: number, body: string): Promise<void>;
   relaunchFleet?(request: {
     readonly target?: number;
     readonly runner?: string;

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1770,6 +1770,21 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
       latestBundleVersion,
     },
   );
+  const workerPidState = (worker: string) => {
+    const hostPrefix = hostFingerprintPrefix();
+    if (!worker.startsWith(hostPrefix)) return "foreign" as const;
+    const workerId = worker.slice(hostPrefix.length);
+    if (!workerId) return "unknown" as const;
+    const pidPath = join(paths.workersRoot, workerId, "worker.pid");
+    if (!existsSync(pidPath)) return "dead" as const;
+    try {
+      const pid = Number(readFileSync(pidPath, "utf8").trim());
+      if (!Number.isInteger(pid) || pid <= 0) return "dead" as const;
+      return isLivePid(pid) ? "live" as const : "dead" as const;
+    } catch {
+      return "unknown" as const;
+    }
+  };
   return {
     ghInstalled,
     ghAuthenticated,
@@ -1786,6 +1801,21 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     allowHttpsRemote:
       process.env.RED_AFK_LANE === "actions" || process.env.GITHUB_ACTIONS === "true",
     queueVisibility: ctx.repo ? ghx.queueVisibilityProbeInput(ghCtx) : undefined,
+    claimHygiene: ctx.repo
+      ? {
+          ownWorkerPrefix: hostFingerprintPrefix(),
+          listOpenQueueIssues: async () => {
+            const candidates = await ghx.listCandidates(ghCtx, LABEL_READY);
+            return Promise.all(
+              candidates.map(async (candidate) => ({
+                number: candidate.number,
+                comments: await ghx.listClaimComments(ghCtx, candidate.number),
+              })),
+            );
+          },
+          workerPidState,
+        }
+      : undefined,
     focalBranch: {
       resolved: resolvedFocalBranch,
       configuredTrunk: normalizeConfiguredTrunk(configTrunk),

--- a/apps/dev/tests/claim-hygiene.test.ts
+++ b/apps/dev/tests/claim-hygiene.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyClaimHygieneFix,
+  runClaimHygieneProbe,
+} from "../src/core/operational-probes/claim-hygiene.js";
+import type { OperationalProbeResult } from "../src/core/operational-probes.js";
+
+describe("claim hygiene operational probe", () => {
+  it("gates concede for dead own workers, preserves live claims, and reports foreign namespaces", async () => {
+    const deadClaim = "<!-- afk:claim v1 worker=8cb3eafdcbd2:wDead kind=claim runner=codex -->";
+    const liveClaim = "<!-- afk:claim v1 worker=8cb3eafdcbd2:wLive kind=claim runner=codex -->";
+    const foreignClaim = "<!-- stn:claim v1 worker=stone:wOther kind=claim runner=codex -->";
+    const concededClaim = "<!-- afk:claim v1 worker=8cb3eafdcbd2:wGone kind=claim runner=codex -->";
+    const concede = "<!-- afk:claim v1 worker=8cb3eafdcbd2:wGone kind=concede runner=codex -->";
+    const result = await runClaimHygieneProbe({
+      remoteUrls: [],
+      claimHygiene: {
+        ownWorkerPrefix: "8cb3eafdcbd2:",
+        listOpenQueueIssues: async () => [
+          {
+            number: 1970,
+            comments: [
+              { id: 10, body: deadClaim, createdAt: "2026-07-17T10:00:00Z" },
+              { id: 11, body: liveClaim, createdAt: "2026-07-17T10:01:00Z" },
+              { id: 12, body: foreignClaim, createdAt: "2026-07-17T10:02:00Z" },
+              { id: 13, body: concededClaim, createdAt: "2026-07-17T10:03:00Z" },
+              { id: 14, body: concede, createdAt: "2026-07-17T10:04:00Z" },
+            ],
+          },
+        ],
+        workerPidState: (worker) => {
+          if (worker.endsWith(":wDead")) return "dead";
+          if (worker.endsWith(":wLive")) return "live";
+          return "foreign";
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      id: "afk.claim-hygiene",
+      verdict: "red",
+      fix: { gate: "confirm" },
+    });
+    expect(result.evidence).toContain("issue=#1970");
+    expect(result.evidence).toContain("worker=8cb3eafdcbd2:wDead");
+    expect(result.evidence).toContain("pid=dead");
+    expect(result.evidence).toContain("foreign_namespace=stn");
+    expect(result.evidence).toContain("live_own=1");
+    expect(result.evidence).not.toContain("wGone");
+
+    const confirm = vi.fn(async (_finding: OperationalProbeResult) => true);
+    const concedeClaim = vi.fn(async (_issue: number, _body: string) => {});
+    const fix = await applyClaimHygieneFix(result, { confirm, concedeClaim });
+
+    expect(fix).toEqual({
+      probeId: "afk.claim-hygiene",
+      status: "applied",
+      evidence: "posted 1 concede marker",
+    });
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(confirm.mock.calls[0]?.[0].evidence).toContain("marker_comment=10");
+    expect(concedeClaim).toHaveBeenCalledOnce();
+    expect(concedeClaim.mock.calls[0]?.[0]).toBe(1970);
+    expect(concedeClaim.mock.calls[0]?.[1]).toContain(
+      "<!-- afk:claim v1 worker=8cb3eafdcbd2:wDead kind=concede runner=codex -->",
+    );
+  });
+
+  it("does not mutate foreign namespace-only findings", async () => {
+    const result = await runClaimHygieneProbe({
+      remoteUrls: [],
+      claimHygiene: {
+        ownWorkerPrefix: "8cb3eafdcbd2:",
+        listOpenQueueIssues: async () => [
+          {
+            number: 2000,
+            comments: [
+              {
+                id: 20,
+                body: "<!-- stn:claim v1 worker=stone:wOther kind=claim runner=codex -->",
+                createdAt: "2026-07-17T10:00:00Z",
+              },
+            ],
+          },
+        ],
+        workerPidState: () => "foreign",
+      },
+    });
+    const concedeClaim = vi.fn(async (_issue: number, _body: string) => {});
+    const fix = await applyClaimHygieneFix(result, {
+      confirm: async () => true,
+      concedeClaim,
+    });
+
+    expect(result.verdict).toBe("red");
+    expect(result.fix).toBeUndefined();
+    expect(result.evidence).toContain("foreign_namespace=stn");
+    expect(fix).toEqual({
+      probeId: "afk.claim-hygiene",
+      status: "noop",
+      evidence: "no dead own-namespace dangling claims need repair",
+    });
+    expect(concedeClaim).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -49,6 +49,7 @@ describe("operational probe registry", () => {
       { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
       { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },
       { id: "afk.fleet-truth", name: "AFK fleet truth", verdict: "ok" },
+      { id: "afk.claim-hygiene", name: "AFK claim hygiene", verdict: "ok" },
       { id: "config.dev-root-spelling", name: "Config dev-plugin namespacing", verdict: "ok" },
     ]);
     expect(decoded.findings).toHaveLength(1);


### PR DESCRIPTION
Automated AFK landing for #1970. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1970

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786895151&installation_id=129708444&pr_number=2020&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2020&signature=051bbb46771c36fe014a9b6f75d133197e0acde22d7473088ad21335eafdcc60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->