### PR TITLE
fix: #1990 rsp: doctor verb — named plumbing probes with fix commands per red probe

### DIFF
--- a/apps/rsp/src/cli.ts
+++ b/apps/rsp/src/cli.ts
@@ -14,8 +14,8 @@ import type { RspRuntimeConfig } from "./config.js";
 import type { RspElisionStore, RspMintMeta, RspRecoveryHandle, RspStorageClassStats } from "./elision-store.js";
 import { withNextSteps } from "./output-levers.js";
 import { formatUsd } from "./pricing.js";
-import type { ResidentResponseMetrics } from "./resident-client.js";
-import { renderStructuredError, renderUnknownFlag } from "./structured-error.js";
+import type { ResidentResponseMetrics, RspResidentPaths } from "./resident-client.js";
+import { renderStructuredError, renderUnknownFlag, structuredErrorPayload } from "./structured-error.js";
 import {
   appendTelemetryEventSync,
   telemetrySpoolPath,
@@ -88,6 +88,13 @@ async function main(argv = process.argv.slice(2)): Promise<number> {
   }
   const { resolveRspConfig } = await import("./config.js");
   const config = resolveRspConfig(process.cwd(), process.env, args.storeUri);
+  if (args.command === "doctor") {
+    const { resolveResidentPaths } = await import("./resident-client.js");
+    const residentPaths = resolveResidentPaths(process.cwd());
+    const status = await runDoctor(config, residentPaths, sinceDays(args.positional, 1));
+    process.stdout.write(renderDoctor(status));
+    return status.exitCode;
+  }
   const wrapperCommand = isWrapperCommand(args.command);
   if (!config.enabled) {
     if (wrapperCommand) return await passthroughDisabledDirectory(args.positional);
@@ -779,6 +786,179 @@ interface DashboardSnapshot {
   waits: JsonObject[];
 }
 
+type DoctorProbeName =
+  | "config_gate_resolution"
+  | "hook_wiring"
+  | "proxy_mode"
+  | "resident_liveness"
+  | "store_provisioning"
+  | "recent_degradation_rate";
+
+type DoctorError = JsonObject;
+
+interface DoctorProbe {
+  name: DoctorProbeName;
+  pass: boolean;
+  finding: string;
+  fix_command?: string;
+  error?: DoctorError;
+}
+
+interface DoctorStatus {
+  schema_version: "red.rsp.doctor.v1";
+  status: "pass" | "fail" | "disabled";
+  exitCode: 0 | 1;
+  window_days: number;
+  probes: DoctorProbe[];
+  errors: DoctorError[];
+}
+
+interface ResidentRegistryStateLike {
+  state: string;
+}
+
+async function runDoctor(
+  config: RspRuntimeConfig,
+  residentPaths: RspResidentPaths,
+  windowDays: number,
+): Promise<DoctorStatus> {
+  const probes: DoctorProbe[] = [];
+  const disabled = !config.enabled;
+  probes.push(disabled
+    ? passProbe("config_gate_resolution", "rsp disabled in this directory; run /red-setup to opt in")
+    : passProbe("config_gate_resolution", "rsp.enabled resolved true for this directory"));
+
+  if (disabled) {
+    probes.push(
+      passProbe("hook_wiring", "skipped because rsp is disabled"),
+      passProbe("proxy_mode", "skipped because rsp is disabled"),
+      passProbe("resident_liveness", "skipped because rsp is disabled"),
+      passProbe("store_provisioning", "skipped because rsp is disabled"),
+      passProbe("recent_degradation_rate", "skipped because rsp is disabled"),
+    );
+    return doctorStatus("disabled", probes, windowDays);
+  }
+
+  probes.push(await doctorHookProbe(config));
+  probes.push(config.proxyEnabled
+    ? passProbe("proxy_mode", "proxy routing enabled for pre-exec rewrites")
+    : failProbe(
+      "proxy_mode",
+      "proxy routing is explicitly disabled; hook falls back to fixed wrapper capabilities",
+      "rsp setup",
+    ));
+
+  const { residentRegistryStatus } = await import("./resident-client.js");
+  probes.push(residentProbe(await residentRegistryStatus(residentPaths)));
+  probes.push(storeProbe(config));
+
+  if (storeExists(config)) {
+    const { telemetry } = await readStatsSnapshot(config, windowDays);
+    probes.push(degradationProbe(telemetry, windowDays));
+  } else {
+    probes.push(passProbe("recent_degradation_rate", "no telemetry store available yet; no recent degradation spike detected"));
+  }
+
+  return doctorStatus(probes.some((probe) => !probe.pass) ? "fail" : "pass", probes, windowDays);
+}
+
+async function doctorHookProbe(config: RspRuntimeConfig): Promise<DoctorProbe> {
+  try {
+    if (config.proxyEnabled) return passProbe("hook_wiring", "pre-exec hook would rewrite git status through rsp proxy");
+    const { rewriteCommand } = await import("./intercept.js");
+    const decision = rewriteCommand("git status");
+    if (decision.kind === "rewrite") return passProbe("hook_wiring", `pre-exec hook would rewrite git status through ${decision.capabilityId}`);
+    return failProbe("hook_wiring", `pre-exec hook passed git status through: ${decision.reason ?? "unsupported-command"}`, "rsp setup");
+  } catch (err) {
+    return failProbe("hook_wiring", `pre-exec hook probe failed: ${err instanceof Error ? firstLine(err.message) : "unknown error"}`, "rsp setup");
+  }
+}
+
+function residentProbe(status: ResidentRegistryStateLike): DoctorProbe {
+  if (status.state === "registered-alive-socket-healthy") {
+    return passProbe("resident_liveness", "resident registry points at a healthy socket");
+  }
+  return failProbe("resident_liveness", `resident registry state is ${status.state}`, "rsp warm-resident");
+}
+
+function storeProbe(config: RspRuntimeConfig): DoctorProbe {
+  if (!config.storeUri.startsWith("file://")) {
+    return passProbe("store_provisioning", "non-file store URI configured; provisioning is delegated to that backend");
+  }
+  if (storeExists(config)) return passProbe("store_provisioning", "rsp store exists for this directory");
+  return failProbe("store_provisioning", "rsp store is not provisioned", "rsp setup");
+}
+
+function degradationProbe(telemetry: RspTelemetryStats, windowDays: number): DoctorProbe {
+  const dominant = telemetry.health.by_reason[0];
+  if (telemetry.health.degradations === 0) {
+    return passProbe("recent_degradation_rate", `0 degradations in the recent ${windowDays}d window`);
+  }
+  const count = telemetry.health.degradations;
+  const reason = dominant?.reason ?? telemetry.health.most_recent?.reason ?? "unknown";
+  const reasonCount = dominant?.count ?? count;
+  return failProbe(
+    "recent_degradation_rate",
+    `${count} degradation(s) in the recent ${windowDays}d window; dominant reason ${reason} (${reasonCount})`,
+    degradationFixCommand(reason, windowDays),
+  );
+}
+
+function degradationFixCommand(reason: string, windowDays: number): string {
+  if (/unavailable|not provisioned|missing/i.test(reason)) return "rsp setup";
+  if (/resident|socket|registry/i.test(reason)) return "rsp warm-resident";
+  return `rsp stats --since ${windowDays}d --full`;
+}
+
+function storeExists(config: RspRuntimeConfig): boolean {
+  if (!config.storeUri.startsWith("file://")) return true;
+  try {
+    return existsSync(fileURLToPath(config.storeUri));
+  } catch {
+    return false;
+  }
+}
+
+function passProbe(name: DoctorProbeName, finding: string): DoctorProbe {
+  return { name, pass: true, finding };
+}
+
+function failProbe(name: DoctorProbeName, finding: string, fixCommand: string): DoctorProbe {
+  return {
+    name,
+    pass: false,
+    finding,
+    fix_command: fixCommand,
+    error: structuredErrorPayload({
+      command: `rsp doctor:${name}`,
+      category: "real-error",
+      error: finding,
+      help: fixCommand,
+    }),
+  };
+}
+
+function doctorStatus(status: DoctorStatus["status"], probes: DoctorProbe[], windowDays: number): DoctorStatus {
+  return {
+    schema_version: "red.rsp.doctor.v1",
+    status,
+    exitCode: status === "fail" ? 1 : 0,
+    window_days: windowDays,
+    probes,
+    errors: probes.map((probe) => probe.error).filter((error): error is DoctorError => Boolean(error)),
+  };
+}
+
+function renderDoctor(status: DoctorStatus): string {
+  const { exitCode: _exitCode, ...payload } = status;
+  return `${encodeSnapshotToon({
+    ...payload,
+    exit_code: status.exitCode,
+    probes: status.probes as unknown as JsonObject[],
+    errors: status.errors,
+  })}\n`;
+}
+
 async function readDashboardSnapshot(config: RspRuntimeConfig): Promise<DashboardSnapshot> {
   const { stats, telemetry } = await readStatsSnapshot(config, 30);
   const [recoveryHandles, waits] = await Promise.all([
@@ -1361,6 +1541,10 @@ function commandHelpLines(command: string | undefined): string[] {
         "",
         "Exit codes: 0 = success verdict, 1 = failure verdict, 2 = timeout/indeterminate.",
       ];
+    case "doctor":
+      return scopedHelp("rsp doctor [--since <days>d]", [
+        "--since <days>d  recent degradation window, default 1d",
+      ], ["rsp doctor", "rsp doctor --since 7d"]);
     case "status":
       return scopedHelp("rsp status", [
         "No flags. Prints resident registry status as TOON.",
@@ -1417,7 +1601,7 @@ function commandHelpLines(command: string | undefined): string[] {
         "",
         "Subcommands:",
         "  stats, gains, show, git, gh, vitest, cargo, cat, exec, proxy, wait",
-        "  status, sweep, setup, mcp, shell-init, server, warm-resident, gh-api-json, hook",
+        "  doctor, status, sweep, setup, mcp, shell-init, server, warm-resident, gh-api-json, hook",
         "",
         "Global flags:",
         "  --store-uri <uri>  default repo store",

--- a/apps/rsp/src/structured-error.ts
+++ b/apps/rsp/src/structured-error.ts
@@ -19,6 +19,10 @@ export function structuredExitCode(category: RspErrorCategory): 0 | 1 | 2 {
 }
 
 export function renderStructuredError(options: RspStructuredErrorOptions): Buffer {
+  return Buffer.from(`${encode(structuredErrorPayload(options))}\n`);
+}
+
+export function structuredErrorPayload(options: RspStructuredErrorOptions): JsonObject {
   const payload: JsonObject = {
     command: options.command,
     category: options.category,
@@ -28,7 +32,7 @@ export function renderStructuredError(options: RspStructuredErrorOptions): Buffe
   };
   if (options.validFlags && options.validFlags.length > 0) payload.valid_flags = [...options.validFlags] as JsonValue;
   if (options.diagnostics) payload.diagnostics = firstLines(options.diagnostics, 3);
-  return Buffer.from(`${encode(payload)}\n`);
+  return payload;
 }
 
 export function renderNoop(command: string, summary: string, help: string): Buffer {

--- a/apps/rsp/tests/cli.test.ts
+++ b/apps/rsp/tests/cli.test.ts
@@ -773,6 +773,139 @@ describe("rsp cli", () => {
     await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("doctor reports rsp disabled as a definitive finding, not an error", async () => {
+    const root = await initGitRepo();
+
+    const res = runRspFromCwd(root, ["doctor"], {});
+    const decoded = decode(res.stdout.toString("utf8")) as {
+      status: string;
+      exit_code: number;
+      probes: Array<{ name: string; pass: boolean; finding: string }>;
+      errors: unknown[];
+    };
+
+    expect(res.status).toBe(0);
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+    expect(decoded.status).toBe("disabled");
+    expect(decoded.exit_code).toBe(0);
+    expect(decoded.errors).toEqual([]);
+    expect(decoded.probes.map((probe) => probe.name)).toEqual([
+      "config_gate_resolution",
+      "hook_wiring",
+      "proxy_mode",
+      "resident_liveness",
+      "store_provisioning",
+      "recent_degradation_rate",
+    ]);
+    expect(decoded.probes.find((probe) => probe.name === "config_gate_resolution")).toMatchObject({
+      pass: true,
+      finding: "rsp disabled in this directory; run /red-setup to opt in",
+    });
+    await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("doctor reports named red plumbing probes with shared structured fix commands", async () => {
+    const root = await initGitRepo();
+    await enableRsp(root);
+
+    const res = runRspFromCwd(root, ["doctor"], {});
+    const decoded = decode(res.stdout.toString("utf8")) as {
+      status: string;
+      exit_code: number;
+      probes: Array<{
+        name: string;
+        pass: boolean;
+        finding: string;
+        fix_command?: string;
+        error?: { command: string; category: string; exit_code: number; error: string; help: string[] };
+      }>;
+      errors: Array<{ command: string; category: string; exit_code: number; error: string; help: string[] }>;
+    };
+
+    expect(res.status).toBe(1);
+    expect(res.stderr).toEqual(Buffer.alloc(0));
+    expect(decoded.status).toBe("fail");
+    expect(decoded.exit_code).toBe(1);
+    expect(decoded.probes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "config_gate_resolution", pass: true, finding: "rsp.enabled resolved true for this directory" }),
+      expect.objectContaining({ name: "hook_wiring", pass: true }),
+      expect.objectContaining({ name: "proxy_mode", pass: true }),
+      expect.objectContaining({ name: "resident_liveness", pass: false, fix_command: "rsp warm-resident" }),
+      expect.objectContaining({ name: "store_provisioning", pass: false, fix_command: "rsp setup" }),
+      expect.objectContaining({ name: "recent_degradation_rate", pass: true }),
+    ]));
+    for (const probe of decoded.probes.filter((entry) => !entry.pass)) {
+      expect(probe.error).toMatchObject({
+        command: `rsp doctor:${probe.name}`,
+        category: "real-error",
+        exit_code: 1,
+        error: probe.finding,
+        help: [probe.fix_command],
+      });
+    }
+    expect(decoded.errors).toEqual(decoded.probes.filter((entry) => !entry.pass).map((entry) => entry.error));
+  });
+
+  it("doctor turns recent degradation spikes red with count and dominant reason", async () => {
+    const root = await initGitRepo();
+    await enableRsp(root);
+    const storeUri = `file://${join(root, ".red", "state", "red-skills.rdb")}`;
+    const store = await RspElisionStore.open({ uri: storeUri, allowResidentOpen: true });
+    await store.close();
+    const db = await connect(storeUri);
+    try {
+      await db.kv(RSP_ACCOUNTING_EVENTS_COLLECTION).put("ok", {
+        created_at: new Date().toISOString(),
+        event_type: "invocation",
+        command: "git status",
+        raw_bytes: 20,
+        emitted_bytes: 20,
+      });
+      await db.kv(RSP_ACCOUNTING_EVENTS_COLLECTION).put("degraded-one", {
+        created_at: new Date().toISOString(),
+        event_type: "invocation",
+        command: "git log",
+        degradation_reason: "wrapper-crash",
+        wrapper_family: "git",
+        wrapper_exit_code: 1,
+        stderr_head: "boom",
+      });
+      await db.kv(RSP_ACCOUNTING_EVENTS_COLLECTION).put("degraded-two", {
+        created_at: new Date().toISOString(),
+        event_type: "invocation",
+        command: "git diff",
+        degradation_reason: "wrapper-crash",
+        wrapper_family: "git",
+        wrapper_exit_code: 1,
+        stderr_head: "boom",
+      });
+    } finally {
+      await db.close();
+    }
+
+    const res = runRspFromCwd(root, ["doctor", "--since", "1d"], {});
+    const decoded = decode(res.stdout.toString("utf8")) as {
+      status: string;
+      probes: Array<{
+        name: string;
+        pass: boolean;
+        finding: string;
+        fix_command?: string;
+        error?: { category: string; help: string[] };
+      }>;
+    };
+    const degradation = decoded.probes.find((probe) => probe.name === "recent_degradation_rate");
+
+    expect(res.status).toBe(1);
+    expect(decoded.status).toBe("fail");
+    expect(degradation).toMatchObject({
+      pass: false,
+      finding: "2 degradation(s) in the recent 1d window; dominant reason wrapper-crash (2)",
+      fix_command: "rsp stats --since 1d --full",
+      error: { category: "real-error", help: ["rsp stats --since 1d --full"] },
+    });
+  });
+
   it("built bundle keeps disabled passthrough silent, debuggable, and distinct from enabled degradation", async () => {
     buildBundleOnce();
     const disabledRoot = await initGitRepo();


### PR DESCRIPTION
Automated AFK landing for #1990. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1990

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786895906&installation_id=129708444&pr_number=2022&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2022&signature=26967af2d2a90116bbf4a084a1f46d63565055a1c80f5ac69cc3dadece88631c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->