### PR TITLE
fix: #1971 Label-body coherence probe: ready-for-agent issues carrying an active body blocker

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -2,7 +2,7 @@ import { relative } from "node:path";
 import { Writable } from "node:stream";
 import { encode as encodeToon } from "@reddb-io/toon";
 import { afkPaths, collectPrecheckFacts, resolveRepoContext } from "../runtime/wire.js";
-import { listIssueStates, postClaimComment, type GhContext } from "../runtime/gh.js";
+import { editBody, listIssueStates, postClaimComment, type GhContext } from "../runtime/gh.js";
 import { applyTmpJanitorReport, collectTmpJanitorReport, type TmpJanitorApplyResult, type TmpJanitorReport } from "../runtime/tmp-janitor.js";
 import { branchLockPath, clearBranchLock, writeBranchLock } from "../runtime/lock.js";
 import {
@@ -173,6 +173,9 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
           terminateSupervisor: terminateSupervisorPid,
           concedeClaim: async (issue, body) => {
             await postClaimComment({ cwd: ctx.root, repo: ctx.repo } satisfies GhContext, issue, body);
+          },
+          updateIssueBody: async (issue, body) => {
+            await editBody({ cwd: ctx.root, repo: ctx.repo } satisfies GhContext, issue, body);
           },
           confirmRelaunch: async () => flags.yes,
           relaunchFleet: async (request) => {

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -138,6 +138,8 @@ export interface PrecheckFacts {
   fleetTruth?: OperationalProbeContext["fleetTruth"];
   /** Optional claim hygiene probe facts for red-doctor and boot visibility. */
   claimHygiene?: OperationalProbeContext["claimHygiene"];
+  /** Optional ready-label/body-blocker coherence probe facts for red-doctor and boot visibility. */
+  labelBodyCoherence?: OperationalProbeContext["labelBodyCoherence"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -3,5 +3,6 @@ export * from "./operational-probes/claim-hygiene.js";
 export * from "./operational-probes/fleet-truth.js";
 export * from "./operational-probes/focal-branch.js";
 export * from "./operational-probes/https-remote.js";
+export * from "./operational-probes/label-body-coherence.js";
 export * from "./operational-probes/queue-visibility.js";
 export * from "./operational-probes/registry.js";

--- a/apps/dev/src/core/operational-probes/label-body-coherence.ts
+++ b/apps/dev/src/core/operational-probes/label-body-coherence.ts
@@ -1,0 +1,157 @@
+import { clearCurrentBlocker, parseCurrentBlocker, type CurrentBlocker } from "../blocker-state.js";
+import { LABEL_READY } from "../triage-labels.js";
+import type {
+  LabelBodyCoherenceIssueInput,
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeFixDeps,
+  OperationalProbeFixResult,
+  OperationalProbeResult,
+} from "./types.js";
+
+export const LABEL_BODY_COHERENCE_PROBE_ID = "afk.label-body-coherence";
+export const LABEL_BODY_COHERENCE_PROBE_NAME = "AFK label/body coherence";
+export const LABEL_BODY_COHERENCE_CANONICAL_FIX =
+  "For ready-for-agent issues whose body still carries an active Current blocker, confirm per issue and archive the blocker into Resolved blockers while clearing Current blocker to None.";
+
+interface LabelBodyCoherenceAction {
+  readonly issue: number;
+  readonly labels: readonly string[];
+  readonly blocker: CurrentBlocker;
+  readonly body: string;
+}
+
+interface LabelBodyCoherenceProbeData {
+  readonly actions: readonly LabelBodyCoherenceAction[];
+}
+
+function classifyIssues(issues: readonly LabelBodyCoherenceIssueInput[]): LabelBodyCoherenceProbeData {
+  const actions: LabelBodyCoherenceAction[] = [];
+  for (const issue of issues) {
+    if (!issue.labels.includes(LABEL_READY)) continue;
+    const blocker = parseCurrentBlocker(issue.body);
+    if (!blocker) continue;
+    actions.push({
+      issue: issue.number,
+      labels: issue.labels,
+      blocker,
+      body: issue.body,
+    });
+  }
+  return { actions };
+}
+
+function labelText(labels: readonly string[]): string {
+  return labels.length > 0 ? labels.join(",") : "(none)";
+}
+
+function blockerEvidence(action: LabelBodyCoherenceAction): string {
+  const ref = action.blocker.ref ? ` ref=${action.blocker.ref}` : "";
+  return [
+    `issue=#${action.issue}`,
+    `labels=[${labelText(action.labels)}]`,
+    `blocker={status=blocked kind=${action.blocker.kind}${ref} summary=${JSON.stringify(action.blocker.summary)} next=${JSON.stringify(action.blocker.next)}}`,
+  ].join(" ");
+}
+
+function evidence(data: LabelBodyCoherenceProbeData): string {
+  if (data.actions.length === 0) return "no ready-for-agent issues carry an active Current blocker";
+  return data.actions.map(blockerEvidence).join("; ");
+}
+
+export async function runLabelBodyCoherenceProbe(context: OperationalProbeContext): Promise<OperationalProbeResult> {
+  const input = context.labelBodyCoherence;
+  if (!input) {
+    return {
+      id: LABEL_BODY_COHERENCE_PROBE_ID,
+      name: LABEL_BODY_COHERENCE_PROBE_NAME,
+      verdict: "ok",
+      evidence: "label/body coherence check not configured",
+      canonicalFix: LABEL_BODY_COHERENCE_CANONICAL_FIX,
+    };
+  }
+
+  const data = classifyIssues(await input.listOpenReadyIssues());
+  return {
+    id: LABEL_BODY_COHERENCE_PROBE_ID,
+    name: LABEL_BODY_COHERENCE_PROBE_NAME,
+    verdict: data.actions.length > 0 ? "red" : "ok",
+    evidence: evidence(data),
+    canonicalFix: LABEL_BODY_COHERENCE_CANONICAL_FIX,
+    fix: data.actions.length > 0
+      ? {
+          gate: "confirm",
+          description: "archive active Current blockers on ready-for-agent issues",
+        }
+      : undefined,
+    data,
+  };
+}
+
+function labelBodyCoherenceData(finding: OperationalProbeResult): LabelBodyCoherenceProbeData | undefined {
+  const data = finding.data;
+  if (!data || typeof data !== "object") return undefined;
+  const rec = data as Partial<LabelBodyCoherenceProbeData>;
+  if (!Array.isArray(rec.actions)) return undefined;
+  return rec as LabelBodyCoherenceProbeData;
+}
+
+function archiveBody(action: LabelBodyCoherenceAction): string {
+  return clearCurrentBlocker(action.body, {
+    summary: action.blocker.summary,
+    resolution: "ready-for-agent label confirmed; active blocker archived by gated repair.",
+  });
+}
+
+export async function applyLabelBodyCoherenceFix(
+  finding: OperationalProbeResult,
+  deps: OperationalProbeFixDeps,
+): Promise<OperationalProbeFixResult> {
+  const data = labelBodyCoherenceData(finding);
+  if (!data || data.actions.length === 0) {
+    return {
+      probeId: finding.id,
+      status: "noop",
+      evidence: "no active ready-labelled blockers need repair",
+    };
+  }
+  if (!deps.updateIssueBody) {
+    return { probeId: finding.id, status: "noop", evidence: "issue body repair is not wired" };
+  }
+
+  let applied = 0;
+  let declined = 0;
+  for (const action of data.actions) {
+    const issueFinding: OperationalProbeResult = {
+      ...finding,
+      evidence: blockerEvidence(action),
+      data: { actions: [action] } satisfies LabelBodyCoherenceProbeData,
+    };
+    if (!(await deps.confirm(issueFinding))) {
+      declined += 1;
+      continue;
+    }
+    const nextBody = archiveBody(action);
+    if (nextBody !== action.body) {
+      await deps.updateIssueBody(action.issue, nextBody);
+      applied += 1;
+    }
+  }
+
+  if (applied === 0 && declined > 0) {
+    return { probeId: finding.id, status: "declined", evidence: `operator declined ${declined} issue repair` };
+  }
+  return {
+    probeId: finding.id,
+    status: applied > 0 ? "applied" : "noop",
+    evidence: applied === 1 ? "archived 1 active blocker" : `archived ${applied} active blockers`,
+  };
+}
+
+export const labelBodyCoherenceProbe: OperationalProbe = {
+  id: LABEL_BODY_COHERENCE_PROBE_ID,
+  name: LABEL_BODY_COHERENCE_PROBE_NAME,
+  canonicalFix: LABEL_BODY_COHERENCE_CANONICAL_FIX,
+  run: runLabelBodyCoherenceProbe,
+  applyFix: applyLabelBodyCoherenceFix,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -4,6 +4,7 @@ import { configNamespacingProbe } from "./config-namespacing.js";
 import { fleetTruthProbe } from "./fleet-truth.js";
 import { focalBranchProbe } from "./focal-branch.js";
 import { httpsRemoteProbe } from "./https-remote.js";
+import { labelBodyCoherenceProbe } from "./label-body-coherence.js";
 import { queueVisibilityProbe } from "./queue-visibility.js";
 import type {
   OperationalProbe,
@@ -19,6 +20,7 @@ export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   focalBranchProbe,
   fleetTruthProbe,
   claimHygieneProbe,
+  labelBodyCoherenceProbe,
   configNamespacingProbe,
 ];
 

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -13,6 +13,7 @@ export interface OperationalProbeContext {
   readonly configNamespacing?: ConfigNamespacingProbeInput;
   readonly fleetTruth?: FleetTruthProbeInput;
   readonly claimHygiene?: ClaimHygieneProbeInput;
+  readonly labelBodyCoherence?: LabelBodyCoherenceProbeInput;
 }
 
 export interface ConfigNamespacingProbeInput {
@@ -86,6 +87,17 @@ export interface ClaimHygieneProbeInput {
   readonly workerPidState: (worker: string) => ClaimHygieneWorkerPidState;
 }
 
+export interface LabelBodyCoherenceIssueInput {
+  readonly number: number;
+  readonly title?: string;
+  readonly labels: readonly string[];
+  readonly body: string;
+}
+
+export interface LabelBodyCoherenceProbeInput {
+  readonly listOpenReadyIssues: () => Promise<readonly LabelBodyCoherenceIssueInput[]>;
+}
+
 export interface OperationalProbeFix {
   readonly gate: "confirm";
   readonly description: string;
@@ -109,6 +121,7 @@ export interface OperationalProbeFixDeps {
   writeBranchLock?(branch: string): Promise<void>;
   terminateSupervisor?(pid: number): Promise<boolean>;
   concedeClaim?(issue: number, body: string): Promise<void>;
+  updateIssueBody?(issue: number, body: string): Promise<void>;
   relaunchFleet?(request: {
     readonly target?: number;
     readonly runner?: string;

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -1816,6 +1816,11 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
           workerPidState,
         }
       : undefined,
+    labelBodyCoherence: ctx.repo
+      ? {
+          listOpenReadyIssues: async () => ghx.listCandidates(ghCtx, LABEL_READY),
+        }
+      : undefined,
     focalBranch: {
       resolved: resolvedFocalBranch,
       configuredTrunk: normalizeConfiguredTrunk(configTrunk),

--- a/apps/dev/tests/fixtures/github-transport/ready-body-blocker.json
+++ b/apps/dev/tests/fixtures/github-transport/ready-body-blocker.json
@@ -1,0 +1,8 @@
+[
+  {
+    "number": 1971,
+    "title": "Label-body coherence probe",
+    "labels": ["ready-for-agent", "priority:normal"],
+    "body": "## Summary\nReady label was restored by hand.\n\n## Current blocker\n\n<!-- red:blocker-state v1 -->\nstatus: blocked\nkind: validation\nref: #1965\nsummary: Gate failed before the manual requeue.\nnext: Confirm the issue is safe to delegate again.\n<!-- /red:blocker-state -->\n\n## Acceptance\n- [ ] Gate green\n"
+  }
+]

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { decode } from "@reddb-io/toon";
+import { parseCurrentBlocker } from "../src/core/blocker-state.js";
 import {
   applyOperationalProbeFixes,
   classifyQueueVisibilityTransportFailure,
@@ -50,6 +51,7 @@ describe("operational probe registry", () => {
       { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },
       { id: "afk.fleet-truth", name: "AFK fleet truth", verdict: "ok" },
       { id: "afk.claim-hygiene", name: "AFK claim hygiene", verdict: "ok" },
+      { id: "afk.label-body-coherence", name: "AFK label/body coherence", verdict: "ok" },
       { id: "config.dev-root-spelling", name: "Config dev-plugin namespacing", verdict: "ok" },
     ]);
     expect(decoded.findings).toHaveLength(1);
@@ -188,6 +190,84 @@ describe("operational probe registry", () => {
       evidence: "queue listing failed (generic-transport, surface=unknown)",
       canonicalFix: expect.stringContaining("gh auth status"),
     });
+  });
+
+  it("flags ready-labelled issues with an active body blocker and archives the blocker on confirmed repair", async () => {
+    const fixture = JSON.parse(await readFixture("ready-body-blocker.json")) as Array<{
+      number: number;
+      title: string;
+      labels: string[];
+      body: string;
+    }>;
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      labelBodyCoherence: {
+        listOpenReadyIssues: async () => fixture,
+      },
+    });
+
+    const finding = report.findings.find((row) => row.id === "afk.label-body-coherence");
+    expect(finding).toMatchObject({
+      id: "afk.label-body-coherence",
+      verdict: "red",
+      fix: { gate: "confirm" },
+    });
+    expect(finding?.evidence).toContain("issue=#1971");
+    expect(finding?.evidence).toContain("labels=[ready-for-agent,priority:normal]");
+    expect(finding?.evidence).toContain("blocker={status=blocked kind=validation ref=#1965");
+    expect(finding?.evidence).toContain("summary=\"Gate failed before the manual requeue.\"");
+    expect(finding?.evidence).toContain("next=\"Confirm the issue is safe to delegate again.\"");
+
+    const updateIssueBody = vi.fn(async (_issue: number, _body: string) => {});
+    const fixes = await applyOperationalProbeFixes(report, {
+      confirm: async () => true,
+      updateIssueBody,
+    });
+
+    expect(fixes).toContainEqual({
+      probeId: "afk.label-body-coherence",
+      status: "applied",
+      evidence: "archived 1 active blocker",
+    });
+    expect(updateIssueBody).toHaveBeenCalledOnce();
+    expect(updateIssueBody.mock.calls[0]?.[0]).toBe(1971);
+    const nextBody = String(updateIssueBody.mock.calls[0]?.[1] ?? "");
+    expect(parseCurrentBlocker(nextBody)).toBeNull();
+    expect(nextBody).toContain("## Current blocker\n\nNone");
+    expect(nextBody).toContain("## Resolved blockers");
+    expect(nextBody).toContain(
+      "- [x] Gate failed before the manual requeue. - ready-for-agent label confirmed; active blocker archived by gated repair.",
+    );
+  });
+
+  it("leaves the ready issue body byte-identical when the coherence repair is refused", async () => {
+    const fixture = JSON.parse(await readFixture("ready-body-blocker.json")) as Array<{
+      number: number;
+      title: string;
+      labels: string[];
+      body: string;
+    }>;
+    const before = fixture[0]!.body;
+    const report = await runOperationalProbes({
+      remoteUrls: [],
+      labelBodyCoherence: {
+        listOpenReadyIssues: async () => fixture,
+      },
+    });
+    const updateIssueBody = vi.fn(async (_issue: number, _body: string) => {});
+
+    const fixes = await applyOperationalProbeFixes(report, {
+      confirm: async () => false,
+      updateIssueBody,
+    });
+
+    expect(fixes).toContainEqual({
+      probeId: "afk.label-body-coherence",
+      status: "declined",
+      evidence: "operator declined 1 issue repair",
+    });
+    expect(updateIssueBody).not.toHaveBeenCalled();
+    expect(fixture[0]!.body).toBe(before);
   });
 
   it("reports resolved focal branch provenance when the runtime supplies the boot resolver triple", async () => {


### PR DESCRIPTION
Automated AFK landing for #1971. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786896103&installation_id=129708444&pr_number=2023&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2023&signature=c6034d0ee0fd2e1a089428302e44029ffc16f2e9e80575debab7767e6286da79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->