### PR TITLE
fix: #2015 fleet stop concedes claims but strands the running label — killed workers' issues vanish from the queue

### DIFF
--- a/apps/dev/src/commands/stop.ts
+++ b/apps/dev/src/commands/stop.ts
@@ -4,8 +4,10 @@ import { encode as encodeToon } from "@reddb-io/toon";
 import { isValidWorkerId, workerPidFile } from "../core/worker-paths.js";
 import { isLivePid, killTreeAndWait } from "../runtime/kill-tree.js";
 import { listStaleClaimDirs, removeDir } from "../runtime/fs.js";
-import { afkPaths } from "../runtime/wire.js";
+import { afkPaths, resolveRepoContext } from "../runtime/wire.js";
+import * as ghx from "../runtime/gh.js";
 import { stopFleet, type FleetStopResult } from "./fleet.js";
+import { LABEL_HUMAN, LABEL_READY, LABEL_RUNNING } from "../core/triage-labels.js";
 
 async function readWorkerPid(pidFile: string): Promise<number | null> {
   try {
@@ -20,7 +22,8 @@ async function readWorkerPid(pidFile: string): Promise<number | null> {
 /** Injectable IO for deterministic testing. */
 export interface StopIO {
   stopFleet(root: string, out: NodeJS.WritableStream): Promise<FleetStopResult>;
-  listStaleClaimDirs(tmpDir: string): Promise<Array<{ path: string }>>;
+  listStaleClaimDirs(tmpDir: string): Promise<Array<{ path: string; issue?: number }>>;
+  restoreClaimLabels(root: string, issue: number): Promise<boolean>;
   removeDir(path: string): Promise<void>;
   readWorkerPid(pidFile: string): Promise<number | null>;
   isLivePid(pid: number): boolean;
@@ -30,6 +33,7 @@ export interface StopIO {
 const defaultIO: StopIO = {
   stopFleet,
   listStaleClaimDirs,
+  restoreClaimLabels,
   removeDir,
   readWorkerPid,
   isLivePid,
@@ -101,7 +105,12 @@ async function stopFleetWithReconcile(
 
   const stale = await io.listStaleClaimDirs(tmpDir).catch(() => []);
   let claimsReleased = 0;
+  let labelsRestored = 0;
   for (const dir of stale) {
+    const issue = dir.issue ?? issueFromClaimDirPath(dir.path);
+    if (issue !== null && await io.restoreClaimLabels(cwd, issue).catch(() => false)) {
+      labelsRestored += 1;
+    }
     await io.removeDir(dir.path).catch(() => {});
     claimsReleased += 1;
   }
@@ -112,10 +121,26 @@ async function stopFleetWithReconcile(
       supervisor_pid: fleetResult.pid ?? null,
       supervisor_status: fleetResult.status,
       claims_released: claimsReleased,
+      labels_restored: labelsRestored,
     }) + "\n",
   );
 
   return fleetResult.status === "timeout" ? 1 : 0;
+}
+
+function issueFromClaimDirPath(path: string): number | null {
+  const name = path.split(/[\\/]/).filter(Boolean).at(-1) ?? "";
+  return /^[1-9][0-9]*$/.test(name) ? Number(name) : null;
+}
+
+async function restoreClaimLabels(root: string, issue: number): Promise<boolean> {
+  const ctx = await resolveRepoContext(root);
+  const ghCtx = { cwd: root, repo: ctx.repo };
+  const labels = await ghx.viewLabels(ghCtx, issue);
+  const parked = labels.includes(LABEL_HUMAN) || labels.some((l) => l.startsWith("blocked:"));
+  if (!labels.includes(LABEL_RUNNING) || parked) return false;
+  await ghx.editLabels(ghCtx, issue, [LABEL_RUNNING], [LABEL_READY]);
+  return true;
 }
 
 async function stopWorker(

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -46,6 +46,7 @@ import {
 } from "./boot-sweep.js";
 import {
   planStaleClaimSweep,
+  renderConcededClaimSweepAudit,
   renderDeadClaimSweepAudit,
   renderStaleClaimSweepAudit,
   resolveClaimReaperConfig,
@@ -369,6 +370,8 @@ export interface BranchCleanupInput {
 export interface StaleClaimDir {
   /** Absolute path to the claim lock dir (`.red/tmp/claims/<N>`). */
   path: string;
+  /** Issue number from the claim dir basename, when parseable. */
+  issue?: number;
 }
 
 /** The full set of per-step inputs the caller resolves before `runBoot`. */
@@ -467,6 +470,8 @@ export interface StaleClaimSweepResult {
   /** Issues released back to the executable pool because their cross-host owner
    * stopped refreshing past the staleness window. */
   released: number[];
+  /** Released issues whose active claim markers had already ended in concede. */
+  repairedConceded?: number[];
 }
 
 export interface ReconcileSweepResult {
@@ -711,6 +716,7 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
   const config = resolveClaimReaperConfig(deps.env ?? process.env, (key) => deps.config?.[key] ?? "");
   const plans = planStaleClaimSweep(claimed, deps.nowS, config);
   const released: number[] = [];
+  const repairedConceded: number[] = [];
   for (const p of plans) {
     try {
       // Re-fetch current labels: the batched issueStates snapshot used by
@@ -729,20 +735,25 @@ async function runStaleClaimSweep(deps: BootDeps): Promise<StaleClaimSweepResult
         released.push(p.issue);
         continue;
       }
-      const addLabels = currentLabels.includes(LABEL_HUMAN) ? [] : [LABEL_READY];
+      const parked = currentLabels.includes(LABEL_HUMAN) || currentLabels.some((l) => l.startsWith("blocked:"));
+      const addLabels = parked ? [] : [LABEL_READY];
       await deps.gh.editLabels(p.issue, [LABEL_RUNNING], addLabels);
       const claimedIssue = claimed.find((c) => c.issue === p.issue);
       const deadOwners = new Set(claimedIssue?.deadOwners ?? []);
-      const body = p.staleOwners.some((owner) => deadOwners.has(owner))
-        ? renderDeadClaimSweepAudit(p.staleOwners)
-        : renderStaleClaimSweepAudit(p.staleOwners);
+      const concededOwners = p.concededOwners ?? [];
+      const body = concededOwners.length > 0
+        ? renderConcededClaimSweepAudit(concededOwners)
+        : p.staleOwners.some((owner) => deadOwners.has(owner))
+          ? renderDeadClaimSweepAudit(p.staleOwners)
+          : renderStaleClaimSweepAudit(p.staleOwners);
       await deps.gh.comment(p.issue, body);
       released.push(p.issue);
+      if (concededOwners.length > 0) repairedConceded.push(p.issue);
     } catch {
       // Best-effort: a failed release leaves the issue for the next boot's sweep.
     }
   }
-  return { released };
+  return repairedConceded.length > 0 ? { released, repairedConceded } : { released };
 }
 
 /** Step 3: decideOrphanFate per dir, then apply the fate via gh + fs. Mirrors
@@ -834,6 +845,17 @@ async function runOrphanCleanup(
   // `for c in "$TMP_DIR"/claims/*/` loop in prune_orphans. Runs last, after the
   // attempt-dir sweep, so a freshly-released claim is never re-examined.
   for (const claim of options.staleClaimDirs ?? []) {
+    if (claim.issue !== undefined) {
+      try {
+        const currentLabels = await deps.gh.viewLabels(claim.issue);
+        const parked = currentLabels.includes(LABEL_HUMAN) || currentLabels.some((l) => l.startsWith("blocked:"));
+        if (currentLabels.includes(LABEL_RUNNING) && !parked) {
+          await deps.gh.editLabels(claim.issue, [LABEL_RUNNING], [LABEL_READY]);
+        }
+      } catch {
+        // Best-effort: stale local claim dirs are still safe to remove.
+      }
+    }
     await deps.fs.removeDir(claim.path);
     claimsReleased.push(claim.path);
   }

--- a/apps/dev/src/core/claim-staleness.ts
+++ b/apps/dev/src/core/claim-staleness.ts
@@ -149,6 +149,10 @@ export interface IssueClaimState {
   liveOwner: string | null;
   /** Active (non-conceded) claimants whose LATEST marker classified stale. */
   staleOwners: string[];
+  /** Workers whose latest marker withdrew from the issue. If every claim has
+   * ended in concede while the issue still carries `running`, the label
+   * projection is stranded and the boot sweep must repair it. */
+  concededOwners: string[];
 }
 
 /**
@@ -194,8 +198,12 @@ export function classifyIssueClaims(
   let liveOwner: string | null = null;
   let liveOwnerId = Infinity;
   const staleOwners: string[] = [];
+  const concededOwners: string[] = [];
   for (const [worker, f] of folds) {
-    if (f.latestKind === "concede") continue; // withdrew
+    if (f.latestKind === "concede") {
+      concededOwners.push(worker);
+      continue; // withdrew
+    }
     if (f.earliestClaimId === null) continue; // only ever conceded — not a claim
     if (isStale(f.latestRecord)) {
       staleOwners.push(worker);
@@ -207,7 +215,8 @@ export function classifyIssueClaims(
     }
   }
   staleOwners.sort();
-  return { liveOwner, staleOwners };
+  concededOwners.sort();
+  return { liveOwner, staleOwners, concededOwners };
 }
 
 /** One claimed issue handed to the sweep: the issue number + its parsed claim
@@ -227,6 +236,7 @@ export interface ClaimedIssue {
 export interface StaleClaimRelease {
   issue: number;
   staleOwners: string[];
+  concededOwners?: string[];
 }
 
 /** Render the single audit comment the boot sweep posts when it releases an
@@ -247,6 +257,18 @@ export function renderDeadClaimSweepAudit(staleOwners: readonly string[]): strin
   return (
     `🤖 AFK same-host ghost-claim sweep: released this issue back to \`ready-for-agent\` — ` +
     `${staleOwners.length === 1 ? "the claim" : "the claims"} held by ${who} had a dead \`worker.pid\`.`
+  );
+}
+
+/** Render the audit comment for a stranded label projection: all claim markers
+ * ended in concede but the issue still carried `running`, so the sweep returned
+ * it to the executable pool. */
+export function renderConcededClaimSweepAudit(concededOwners: readonly string[]): string {
+  const who = concededOwners.map((w) => `\`${w}\``).join(", ");
+  return (
+    `🤖 AFK claim-label sweep: released this issue back to \`ready-for-agent\` — ` +
+    `${concededOwners.length === 1 ? "the latest claim marker" : "the latest claim markers"} for ${who} ` +
+    `ended in concede while the issue was still labeled \`running\`.`
   );
 }
 
@@ -272,6 +294,10 @@ export function planStaleClaimSweep(
       const hasDeadOwner = state.staleOwners.some((owner) => deadOwners.has(owner));
       if (!hasDeadOwner && isRecentAttemptCommit(c.attemptBranchCommitS, nowS, config.recentCommitProtectionS)) continue;
       releases.push({ issue: c.issue, staleOwners: state.staleOwners });
+      continue;
+    }
+    if (state.liveOwner === null && state.staleOwners.length === 0 && state.concededOwners.length > 0) {
+      releases.push({ issue: c.issue, staleOwners: [], concededOwners: state.concededOwners });
     }
   }
   return releases;

--- a/apps/dev/src/runtime/fs.ts
+++ b/apps/dev/src/runtime/fs.ts
@@ -506,7 +506,10 @@ export async function listStaleClaimDirs(tmpDir: string): Promise<StaleClaimDir[
       continue;
     }
     const raw = await readText(join(dir, "pid"));
-    if (!pidAlive(raw)) out.push({ path: dir });
+    if (!pidAlive(raw)) {
+      const issue = /^[1-9][0-9]*$/.test(entry) ? Number(entry) : undefined;
+      out.push(issue === undefined ? { path: dir } : { path: dir, issue });
+    }
   }
   return out;
 }

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -968,6 +968,27 @@ describe("runBoot cross-host stale-claim sweep (#627)", () => {
     expect(ghCalls.comment[0].body).toContain("cross-host stale-claim sweep");
   });
 
+  it("repairs an open running issue whose latest claim marker is a concede", async () => {
+    const claimedIssues = async () => [
+      {
+        issue: 43,
+        records: [
+          claim(10, "host1:wGone", 120),
+          { commentId: 20, worker: "host1:wGone", kind: "concede" as const },
+        ],
+      },
+    ];
+    const { deps, ghCalls } = makeDeps({ claimedIssues });
+    const r = await runBoot(deps, options());
+    expect(r.staleClaimSweep).toEqual({ released: [43], repairedConceded: [43] });
+    expect(ghCalls.editLabels).toEqual([
+      { issue: 43, remove: ["running"], add: ["ready-for-agent"] },
+    ]);
+    expect(ghCalls.comment).toHaveLength(1);
+    expect(ghCalls.comment[0].body).toContain("claim-label sweep");
+    expect(ghCalls.comment[0].body).toContain("ended in concede");
+  });
+
   it("never releases an issue still held by a live worker", async () => {
     const claimedIssues = async () => [{ issue: 42, records: [claim(10, "host1:wXY", 120)] }];
     const { deps, ghCalls } = makeDeps({ claimedIssues });

--- a/apps/dev/tests/claim-staleness.test.ts
+++ b/apps/dev/tests/claim-staleness.test.ts
@@ -166,12 +166,12 @@ describe("classifyIssueClaims", () => {
 
   it("a single fresh claim is the live owner, no stale owners", () => {
     const st = classifyIssueClaims([claimAt(10, "live:host", 60)], isStale);
-    expect(st).toEqual({ liveOwner: "live:host", staleOwners: [] });
+    expect(st).toEqual({ liveOwner: "live:host", staleOwners: [], concededOwners: [] });
   });
 
   it("a single aged-out claim has no live owner and one stale owner", () => {
     const st = classifyIssueClaims([claimAt(10, "dead:host", 9999)], isStale);
-    expect(st).toEqual({ liveOwner: null, staleOwners: ["dead:host"] });
+    expect(st).toEqual({ liveOwner: null, staleOwners: ["dead:host"], concededOwners: [] });
   });
 
   it("a live contender holds the issue even when an older claim went stale", () => {
@@ -197,7 +197,7 @@ describe("classifyIssueClaims", () => {
       { commentId: 40, worker: "gone:host", kind: "concede" },
     ];
     const st = classifyIssueClaims(records, isStale);
-    expect(st).toEqual({ liveOwner: null, staleOwners: [] });
+    expect(st).toEqual({ liveOwner: null, staleOwners: [], concededOwners: ["gone:host"] });
   });
 });
 
@@ -315,5 +315,23 @@ describe("planStaleClaimSweep", () => {
       cfg,
     );
     expect(releases).toEqual([{ issue: 7, staleOwners: ["dead:host"] }]);
+  });
+
+  it("repairs a running-label contradiction when every latest claim marker conceded", () => {
+    const releases = planStaleClaimSweep(
+      [
+        {
+          issue: 9,
+          records: [
+            claimAt(10, "gone:host", 30),
+            { commentId: 20, worker: "gone:host", kind: "concede" },
+          ],
+          attemptBranchCommitS: T0 - 10,
+        },
+      ],
+      T0,
+      cfg,
+    );
+    expect(releases).toEqual([{ issue: 9, staleOwners: [], concededOwners: ["gone:host"] }]);
   });
 });

--- a/apps/dev/tests/fs-sweep.test.ts
+++ b/apps/dev/tests/fs-sweep.test.ts
@@ -38,7 +38,7 @@ describe("listStaleClaimDirs", () => {
       mkdirSync(dir, { recursive: true });
       writeFileSync(join(dir, "pid"), DEAD_PID);
       const stale = await listStaleClaimDirs(root);
-      expect(stale).toEqual([{ path: dir }]);
+      expect(stale).toEqual([{ path: dir, issue: 7 }]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -64,8 +64,11 @@ describe("listStaleClaimDirs", () => {
       mkdirSync(noPid, { recursive: true });
       mkdirSync(blank, { recursive: true });
       writeFileSync(join(blank, "pid"), "   ");
-      const stale = (await listStaleClaimDirs(root)).map((s) => s.path).sort();
-      expect(stale).toEqual([noPid, blank].sort());
+      const stale = (await listStaleClaimDirs(root)).sort((a, b) => a.path.localeCompare(b.path));
+      expect(stale).toEqual([
+        { path: noPid, issue: 11 },
+        { path: blank, issue: 12 },
+      ].sort((a, b) => a.path.localeCompare(b.path)));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/dev/tests/stop-command.test.ts
+++ b/apps/dev/tests/stop-command.test.ts
@@ -36,17 +36,30 @@ function fakeIO(opts: {
   fleetStatus?: FleetStatus;
   fleetPid?: number;
   staleClaims?: string[];
+  claimLabels?: Record<number, string[]>;
   workerPid?: number | null;
   workerLive?: boolean;
   workerKillResult?: boolean;
-} = {}): StopIO & { stopFleetCalled: boolean; removedDirs: string[]; workerKillCalled: boolean } {
+} = {}): StopIO & {
+  stopFleetCalled: boolean;
+  removedDirs: string[];
+  labelRestores: Array<{ issue: number; labels: string[] }>;
+  workerKillCalled: boolean;
+} {
   let stopFleetCalled = false;
   const removedDirs: string[] = [];
+  const labelRestores: Array<{ issue: number; labels: string[] }> = [];
   let workerKillCalled = false;
 
-  const io: StopIO & { stopFleetCalled: boolean; removedDirs: string[]; workerKillCalled: boolean } = {
+  const io: StopIO & {
+    stopFleetCalled: boolean;
+    removedDirs: string[];
+    labelRestores: Array<{ issue: number; labels: string[] }>;
+    workerKillCalled: boolean;
+  } = {
     get stopFleetCalled() { return stopFleetCalled; },
     get removedDirs() { return removedDirs; },
+    get labelRestores() { return labelRestores; },
     get workerKillCalled() { return workerKillCalled; },
 
     async stopFleet(_root, _out) {
@@ -54,7 +67,18 @@ function fakeIO(opts: {
       return { status: opts.fleetStatus ?? "none", pid: opts.fleetPid };
     },
     async listStaleClaimDirs(_tmpDir) {
-      return (opts.staleClaims ?? []).map((p) => ({ path: p }));
+      return (opts.staleClaims ?? []).map((p) => {
+        const name = p.split("/").filter(Boolean).at(-1) ?? "";
+        const issue = /^[1-9][0-9]*$/.test(name) ? Number(name) : undefined;
+        return issue === undefined ? { path: p } : { path: p, issue };
+      });
+    },
+    async restoreClaimLabels(_root, issue) {
+      const labels = opts.claimLabels?.[issue] ?? [];
+      if (!labels.includes("running")) return false;
+      if (labels.includes("ready-for-human") || labels.some((l) => l.startsWith("blocked:"))) return false;
+      labelRestores.push({ issue, labels: ["ready-for-agent"] });
+      return true;
     },
     async removeDir(path) {
       removedDirs.push(path);
@@ -148,13 +172,20 @@ describe("stopCommand — fleet stop", () => {
 
   it("reconciles stale claim dirs after stop and reports the count", async () => {
     const staleDirs = ["/repo/.red/tmp/claims/42", "/repo/.red/tmp/claims/77"];
-    const io = fakeIO({ fleetStatus: "stopped", fleetPid: 5678, staleClaims: staleDirs });
+    const io = fakeIO({
+      fleetStatus: "stopped",
+      fleetPid: 5678,
+      staleClaims: staleDirs,
+      claimLabels: { 42: ["running"], 77: ["running", "blocked:validation"] },
+    });
     const { stream, text } = capture();
     await stopCommand([], "/repo", stream, io);
 
     // All stale dirs removed.
     expect(io.removedDirs).toEqual(staleDirs);
+    expect(io.labelRestores).toEqual([{ issue: 42, labels: ["ready-for-agent"] }]);
     expect(text()).toContain("claims_released: 2");
+    expect(text()).toContain("labels_restored: 1");
   });
 
   it("reconciles zero claims when none are stale", async () => {


### PR DESCRIPTION
Automated AFK landing for #2015. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2015

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786896969&installation_id=129708444&pr_number=2026&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2026&signature=7d9b23dbc4d310d045e8f23873d1b8df75589355860e14da45f0d1fd3f4bcf8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->