### PR TITLE
fix: #1972 Base-freshness probe: local trunk behind origin, guarded fast-forward fix

### DIFF
--- a/apps/dev/src/commands/red-doctor.ts
+++ b/apps/dev/src/commands/red-doctor.ts
@@ -12,6 +12,7 @@ import {
   type OperationalProbeFixResult,
   type OperationalProbeReport,
 } from "../core/operational-probes.js";
+import { fastForwardLocalTarget } from "../core/merge.js";
 import * as gitx from "../runtime/git.js";
 import { launchFleet } from "./fleet.js";
 
@@ -170,6 +171,8 @@ export async function redDoctorCommand(args: readonly string[], cwd = process.cw
           setRemoteUrl: async (name, url) => gitx.setRemoteUrl(gitCtx, name, url),
           removeBranchLock: async () => clearBranchLock(lockPath),
           writeBranchLock: async (branch) => writeBranchLock(lockPath, branch),
+          fastForwardLocalBase: async ({ remote, target }) =>
+            fastForwardLocalTarget(gitx.mergeExec(gitCtx), { gitRepo: ctx.root, remote, target }),
           terminateSupervisor: terminateSupervisorPid,
           concedeClaim: async (issue, body) => {
             await postClaimComment({ cwd: ctx.root, repo: ctx.repo } satisfies GhContext, issue, body);

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -141,6 +141,8 @@ export interface PrecheckFacts {
   claimHygiene?: OperationalProbeContext["claimHygiene"];
   /** Optional ready-label/body-blocker coherence probe facts for red-doctor and boot visibility. */
   labelBodyCoherence?: OperationalProbeContext["labelBodyCoherence"];
+  /** Optional local trunk freshness probe facts for red-doctor and boot visibility. */
+  baseFreshness?: OperationalProbeContext["baseFreshness"];
 }
 
 /** A pass/fail precheck verdict. On failure, `failed` names the precondition and

--- a/apps/dev/src/core/merge.ts
+++ b/apps/dev/src/core/merge.ts
@@ -610,27 +610,145 @@ const PR_BODY_PREFIX = "Automated AFK landing for #";
  *   4. `merge --ff-only` only — never `reset`, never `--no-ff`.
  * Every git call is best-effort; any non-zero exit leaves the primary untouched.
  */
-export async function fastForwardLocalTarget(
+export type FastForwardLocalTargetRefusal =
+  | "head-unresolved"
+  | "not-on-trunk"
+  | "status-unreadable"
+  | "dirty-tree"
+  | "fetch-failed"
+  | "not-ancestor"
+  | "merge-failed";
+
+export interface FastForwardLocalTargetGuardResult {
+  readonly guard: "passed" | "refused";
+  readonly target: string;
+  readonly remote: string;
+  readonly currentBranch?: string;
+  readonly failed?: FastForwardLocalTargetRefusal;
+  readonly failedCondition?: "on-trunk" | "clean-tree" | "fetch" | "ancestor" | "merge";
+  readonly evidence: string;
+}
+
+export interface FastForwardLocalTargetResult extends FastForwardLocalTargetGuardResult {
+  readonly action: "fast-forward" | "noop";
+}
+
+/**
+ * Observable half of {@link fastForwardLocalTarget}. The mutating finalizer and
+ * operational probes share this exact guard so findings report the same refusal
+ * reasons the real fast-forward will enforce.
+ */
+export async function evaluateFastForwardLocalTarget(
   exec: Exec,
   input: { gitRepo: string; remote: string; target: string },
-): Promise<void> {
+): Promise<FastForwardLocalTargetGuardResult> {
   const { gitRepo, remote, target } = input;
   // 1. Only advance the branch the operator is actually on.
   const head = await exec(["git", "-C", gitRepo, "symbolic-ref", "--short", "HEAD"]);
-  if (head.code !== 0 || head.stdout.trim() !== target) return;
+  const currentBranch = head.stdout.trim();
+  if (head.code !== 0) {
+    return {
+      guard: "refused",
+      target,
+      remote,
+      failed: "head-unresolved",
+      failedCondition: "on-trunk",
+      evidence: `condition failed: on-trunk (could not resolve current branch; expected=${target})`,
+    };
+  }
+  if (currentBranch !== target) {
+    return {
+      guard: "refused",
+      target,
+      remote,
+      currentBranch,
+      failed: "not-on-trunk",
+      failedCondition: "on-trunk",
+      evidence: `condition failed: on-trunk (current=${currentBranch || "unknown"} expected=${target})`,
+    };
+  }
   // 2. A dirty primary keeps pending WIP — never write over it (#1019).
   const status = await exec(["git", "-C", gitRepo, "status", "--porcelain"]);
-  if (status.code !== 0 || status.stdout.trim() !== "") return;
+  if (status.code !== 0) {
+    return {
+      guard: "refused",
+      target,
+      remote,
+      currentBranch,
+      failed: "status-unreadable",
+      failedCondition: "clean-tree",
+      evidence: "condition failed: clean-tree (could not read git status)",
+    };
+  }
+  const dirty = status.stdout.trim();
+  if (dirty !== "") {
+    return {
+      guard: "refused",
+      target,
+      remote,
+      currentBranch,
+      failed: "dirty-tree",
+      failedCondition: "clean-tree",
+      evidence: `condition failed: clean-tree (${dirty.split("\n").length} dirty path(s))`,
+    };
+  }
   // Refresh the remote ref so the ancestry test and the FF see the merge.
-  await exec(["git", "-C", gitRepo, "fetch", remote, target, "--quiet"]);
+  const fetch = await exec(["git", "-C", gitRepo, "fetch", "--quiet", remote, target]);
+  if (fetch.code !== 0) {
+    return {
+      guard: "refused",
+      target,
+      remote,
+      currentBranch,
+      failed: "fetch-failed",
+      failedCondition: "fetch",
+      evidence: `condition failed: fetch (${remote}/${target} unavailable)`,
+    };
+  }
   // 3. Pure fast-forward only: local <target> must be an ancestor of the tip.
   const ancestor = await exec([
     "git", "-C", gitRepo,
     "merge-base", "--is-ancestor", target, `${remote}/${target}`,
   ]);
-  if (ancestor.code !== 0) return;
+  if (ancestor.code !== 0) {
+    return {
+      guard: "refused",
+      target,
+      remote,
+      currentBranch,
+      failed: "not-ancestor",
+      failedCondition: "ancestor",
+      evidence: `condition failed: ancestor (${target} is not an ancestor of ${remote}/${target})`,
+    };
+  }
+  return {
+    guard: "passed",
+    target,
+    remote,
+    currentBranch,
+    evidence: `guard passed: on-trunk clean-tree ancestor (${target} -> ${remote}/${target})`,
+  };
+}
+
+export async function fastForwardLocalTarget(
+  exec: Exec,
+  input: { gitRepo: string; remote: string; target: string },
+): Promise<FastForwardLocalTargetResult> {
+  const guard = await evaluateFastForwardLocalTarget(exec, input);
+  if (guard.guard !== "passed") return { ...guard, action: "noop" };
   // 4. Advance the pointer. ff-only can only succeed as a pure fast-forward.
-  await exec(["git", "-C", gitRepo, "merge", "--ff-only", `${remote}/${target}`]);
+  const ff = await exec(["git", "-C", input.gitRepo, "merge", "--ff-only", `${input.remote}/${input.target}`]);
+  if (ff.code !== 0) {
+    return {
+      ...guard,
+      guard: "refused",
+      action: "noop",
+      failed: "merge-failed",
+      failedCondition: "merge",
+      evidence: `condition failed: merge (ff-only merge of ${input.remote}/${input.target} failed)`,
+    };
+  }
+  return { ...guard, action: "fast-forward", evidence: `fast-forwarded ${input.target} to ${input.remote}/${input.target}` };
 }
 
 /**

--- a/apps/dev/src/core/operational-probes.ts
+++ b/apps/dev/src/core/operational-probes.ts
@@ -1,4 +1,5 @@
 export * from "./operational-probes/types.js";
+export * from "./operational-probes/base-freshness.js";
 export * from "./operational-probes/claim-hygiene.js";
 export * from "./operational-probes/fleet-truth.js";
 export * from "./operational-probes/focal-branch.js";

--- a/apps/dev/src/core/operational-probes/base-freshness.ts
+++ b/apps/dev/src/core/operational-probes/base-freshness.ts
@@ -1,0 +1,98 @@
+import type {
+  BaseFreshnessProbeInput,
+  OperationalProbe,
+  OperationalProbeContext,
+  OperationalProbeFixDeps,
+  OperationalProbeFixResult,
+  OperationalProbeResult,
+} from "./types.js";
+
+export const BASE_FRESHNESS_PROBE_ID = "afk.base-freshness";
+export const BASE_FRESHNESS_PROBE_NAME = "AFK local trunk freshness";
+export const BASE_FRESHNESS_CANONICAL_FIX =
+  "Fast-forward the local trunk from origin under the shared finalizer guard: on-trunk, clean tree, and local ancestor only.";
+
+export interface BaseFreshnessProbeData extends BaseFreshnessProbeInput {
+  readonly finding?: "local-trunk-behind-origin";
+}
+
+function guardVerdict(input: BaseFreshnessProbeInput): string {
+  if (input.guard.guard === "passed") return `guard=passed (${input.guard.evidence})`;
+  return `guard=refused (${input.guard.evidence})`;
+}
+
+function evidence(input: BaseFreshnessProbeInput, finding?: BaseFreshnessProbeData["finding"]): string {
+  const ahead = input.ahead ?? 0;
+  const behind = input.behind ?? 0;
+  const ref = `${input.remote}/${input.trunk}`;
+  if (!input.localSha || !input.remoteSha) {
+    return `local ${input.trunk} or ${ref} is unresolved; ${guardVerdict(input)}`;
+  }
+  if (finding === "local-trunk-behind-origin") {
+    return `local ${input.trunk} is ${behind} commit(s) behind ${ref}; ahead=${ahead}; ${guardVerdict(input)}`;
+  }
+  return `local ${input.trunk} is not behind ${ref}; ahead=${ahead} behind=${behind}; ${guardVerdict(input)}`;
+}
+
+export function runBaseFreshnessProbe(context: OperationalProbeContext): OperationalProbeResult {
+  const input = context.baseFreshness;
+  if (!input) {
+    return {
+      id: BASE_FRESHNESS_PROBE_ID,
+      name: BASE_FRESHNESS_PROBE_NAME,
+      verdict: "ok",
+      evidence: "base freshness check not configured",
+      canonicalFix: BASE_FRESHNESS_CANONICAL_FIX,
+    };
+  }
+
+  const behind = input.behind ?? 0;
+  const finding = behind > 0 ? "local-trunk-behind-origin" : undefined;
+  return {
+    id: BASE_FRESHNESS_PROBE_ID,
+    name: BASE_FRESHNESS_PROBE_NAME,
+    verdict: finding ? "red" : "ok",
+    evidence: evidence(input, finding),
+    canonicalFix: BASE_FRESHNESS_CANONICAL_FIX,
+    fix: finding
+      ? {
+          gate: "confirm",
+          description: "fast-forward local trunk from origin under the finalizer guard",
+        }
+      : undefined,
+    data: { ...input, finding } satisfies BaseFreshnessProbeData,
+  };
+}
+
+export async function applyBaseFreshnessFix(
+  finding: OperationalProbeResult,
+  deps: OperationalProbeFixDeps,
+): Promise<OperationalProbeFixResult> {
+  const data = finding.data as Partial<BaseFreshnessProbeData> | undefined;
+  if (data?.finding !== "local-trunk-behind-origin" || !data.remote || !data.trunk) {
+    return { probeId: finding.id, status: "noop", evidence: "no base freshness repair is needed" };
+  }
+
+  const confirmed = await deps.confirm(finding);
+  if (!confirmed) {
+    return { probeId: finding.id, status: "declined", evidence: "operator declined fix" };
+  }
+
+  if (!deps.fastForwardLocalBase) {
+    return { probeId: finding.id, status: "noop", evidence: "base fast-forward repair is not wired" };
+  }
+
+  const result = await deps.fastForwardLocalBase({ remote: data.remote, target: data.trunk });
+  if (result.action === "fast-forward") {
+    return { probeId: finding.id, status: "applied", evidence: result.evidence };
+  }
+  return { probeId: finding.id, status: "noop", evidence: `guard refused: ${result.evidence}` };
+}
+
+export const baseFreshnessProbe: OperationalProbe = {
+  id: BASE_FRESHNESS_PROBE_ID,
+  name: BASE_FRESHNESS_PROBE_NAME,
+  canonicalFix: BASE_FRESHNESS_CANONICAL_FIX,
+  run: runBaseFreshnessProbe,
+  applyFix: applyBaseFreshnessFix,
+};

--- a/apps/dev/src/core/operational-probes/registry.ts
+++ b/apps/dev/src/core/operational-probes/registry.ts
@@ -1,4 +1,5 @@
 import { encode as encodeToon } from "@reddb-io/toon";
+import { baseFreshnessProbe } from "./base-freshness.js";
 import { claimHygieneProbe } from "./claim-hygiene.js";
 import { configNamespacingProbe } from "./config-namespacing.js";
 import { fleetTruthProbe } from "./fleet-truth.js";
@@ -18,6 +19,7 @@ export const OPERATIONAL_PROBES: readonly OperationalProbe[] = [
   httpsRemoteProbe,
   queueVisibilityProbe,
   focalBranchProbe,
+  baseFreshnessProbe,
   fleetTruthProbe,
   claimHygieneProbe,
   labelBodyCoherenceProbe,

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -1,3 +1,5 @@
+import type { FastForwardLocalTargetGuardResult, FastForwardLocalTargetResult } from "../merge.js";
+
 export type OperationalProbeVerdict = "ok" | "red";
 
 export interface RemoteUrlFact {
@@ -14,6 +16,7 @@ export interface OperationalProbeContext {
   readonly fleetTruth?: FleetTruthProbeInput;
   readonly claimHygiene?: ClaimHygieneProbeInput;
   readonly labelBodyCoherence?: LabelBodyCoherenceProbeInput;
+  readonly baseFreshness?: BaseFreshnessProbeInput;
 }
 
 export interface ConfigNamespacingProbeInput {
@@ -98,6 +101,17 @@ export interface LabelBodyCoherenceProbeInput {
   readonly listOpenReadyIssues: () => Promise<readonly LabelBodyCoherenceIssueInput[]>;
 }
 
+export interface BaseFreshnessProbeInput {
+  readonly trunk: string;
+  readonly remote: string;
+  readonly localSha?: string;
+  readonly remoteSha?: string;
+  readonly ahead?: number;
+  readonly behind?: number;
+  readonly remoteReachable: boolean;
+  readonly guard: FastForwardLocalTargetGuardResult;
+}
+
 export interface OperationalProbeFix {
   readonly gate: "confirm";
   readonly description: string;
@@ -120,6 +134,10 @@ export interface OperationalProbeFixDeps {
   removeBranchLock?(): Promise<void>;
   writeBranchLock?(branch: string): Promise<void>;
   terminateSupervisor?(pid: number): Promise<boolean>;
+  fastForwardLocalBase?(request: {
+    readonly remote: string;
+    readonly target: string;
+  }): Promise<FastForwardLocalTargetResult>;
   concedeClaim?(issue: number, body: string): Promise<void>;
   updateIssueBody?(issue: number, body: string): Promise<void>;
   relaunchFleet?(request: {

--- a/apps/dev/src/runtime/git.ts
+++ b/apps/dev/src/runtime/git.ts
@@ -139,6 +139,36 @@ export async function branchHead(ctx: GitContext, branch: string): Promise<strin
   return r.code === 0 && sha !== "" ? sha : undefined;
 }
 
+export interface LocalRemoteDivergence {
+  readonly localSha?: string;
+  readonly remoteSha?: string;
+  readonly ahead?: number;
+  readonly behind?: number;
+  readonly remoteReachable: boolean;
+}
+
+export async function localRemoteDivergence(
+  ctx: GitContext,
+  input: { remote: string; branch: string },
+): Promise<LocalRemoteDivergence> {
+  const remote = input.remote.trim() || "origin";
+  const branch = input.branch.trim();
+  if (!branch) return { remoteReachable: false };
+  const fetch = await runGit(ctx, ["fetch", "--quiet", remote, branch]);
+  const localSha = await revParse(ctx, `refs/heads/${branch}`);
+  const remoteSha = await revParse(ctx, `${remote}/${branch}`);
+  const counts = localSha && remoteSha
+    ? await localAheadBehind(ctx, `refs/heads/${branch}`, `${remote}/${branch}`)
+    : undefined;
+  return {
+    localSha,
+    remoteSha,
+    ahead: counts?.ahead,
+    behind: counts?.behind,
+    remoteReachable: fetch.code === 0,
+  };
+}
+
 /** Best-effort `git fetch origin <branch>` (FIX E recovery: try once to pull a
  * sandcastle-pushed worker branch onto the host before declaring it absent). */
 export async function fetchBranch(ctx: GitContext, branch: string): Promise<void> {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -57,6 +57,7 @@ import { execTool } from "./exec.js";
 import { collectTmpJanitorReport } from "./tmp-janitor.js";
 import { collectFleetTruthProbeInput } from "../core/operational-probes.js";
 import { resolveSupervisorConfig } from "../core/supervisor.js";
+import { evaluateFastForwardLocalTarget } from "../core/merge.js";
 
 // ---------- repo resolution ----------
 
@@ -1751,6 +1752,15 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
     },
   );
   const configuredTrunk = resolvedFocalBranch.branch;
+  const baseFreshnessDivergence = await gitx.localRemoteDivergence(gitCtx, {
+    remote: ctx.remote,
+    branch: configuredTrunk,
+  });
+  const baseFreshnessGuard = await evaluateFastForwardLocalTarget(gitx.mergeExec(gitCtx), {
+    gitRepo: ctx.root,
+    remote: ctx.remote,
+    target: configuredTrunk,
+  });
   const lockTargetExists = lockedBranch ? await gitx.branchExists(gitCtx, lockedBranch) : undefined;
   const pnpmInstalled = pnpmProbe.code !== 127;
   const installedBundleVersion = readBuildInfo("dev").version;
@@ -1832,6 +1842,12 @@ export async function collectPrecheckFacts(ctx: RepoContext): Promise<PrecheckFa
             targetExists: lockTargetExists,
             heldByLiveSession: lockedBranch ? currentBranch === lockedBranch : false,
           },
+    },
+    baseFreshness: {
+      trunk: configuredTrunk,
+      remote: ctx.remote,
+      ...baseFreshnessDivergence,
+      guard: baseFreshnessGuard,
     },
     configNamespacing: { rootDevKeys },
     fleetTruth,

--- a/apps/dev/tests/merge.test.ts
+++ b/apps/dev/tests/merge.test.ts
@@ -313,7 +313,7 @@ describe("fastForwardLocalTarget (post-merge primary promotion, ADR 0083 §2 ame
     const { exec, calls } = fakeExec([onTarget]);
     await fastForwardLocalTarget(exec, base);
     const c = joined(calls);
-    expect(c).toContain("git -C /repo fetch origin main --quiet");
+    expect(c).toContain("git -C /repo fetch --quiet origin main");
     expect(c).toContain("git -C /repo merge --ff-only origin/main");
   });
 

--- a/apps/dev/tests/operational-probes.test.ts
+++ b/apps/dev/tests/operational-probes.test.ts
@@ -12,6 +12,7 @@ import {
   renderOperationalProbeReportToon,
   runOperationalProbes,
 } from "../src/core/operational-probes.js";
+import { fastForwardLocalTarget, type Exec, type ExecResult } from "../src/core/merge.js";
 import { collectPrecheckFacts } from "../src/runtime/wire.js";
 
 describe("operational probe registry", () => {
@@ -49,6 +50,7 @@ describe("operational probe registry", () => {
       { id: "git.remote.https-forbidden", name: "SSH-only git remotes", verdict: "red" },
       { id: "afk.queue-visibility", name: "AFK queue visibility", verdict: "ok" },
       { id: "afk.focal-branch-resolution", name: "AFK focal branch resolution", verdict: "ok" },
+      { id: "afk.base-freshness", name: "AFK local trunk freshness", verdict: "ok" },
       { id: "afk.fleet-truth", name: "AFK fleet truth", verdict: "ok" },
       { id: "afk.claim-hygiene", name: "AFK claim hygiene", verdict: "ok" },
       { id: "afk.label-body-coherence", name: "AFK label/body coherence", verdict: "ok" },
@@ -411,6 +413,116 @@ describe("operational probe registry", () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it("reports a behind-origin local trunk with distance and the shared guard verdict", async () => {
+    const { root, repo } = await makeBaseFreshnessRepo();
+    try {
+      const facts = await collectPrecheckFacts({ root: repo, repo: "", remote: "origin" });
+      const report = await runOperationalProbes(facts);
+
+      const finding = report.findings.find((row) => row.id === "afk.base-freshness");
+      expect(finding).toMatchObject({
+        id: "afk.base-freshness",
+        verdict: "red",
+        fix: { gate: "confirm" },
+      });
+      expect(finding?.evidence).toContain("local main is 2 commit(s) behind origin/main");
+      expect(finding?.evidence).toContain("guard=passed");
+      expect(finding?.canonicalFix).toContain("on-trunk, clean tree, and local ancestor");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("gated-fixes a real behind-origin local trunk by reusing the finalizer fast-forward guard", async () => {
+    const { root, repo } = await makeBaseFreshnessRepo();
+    try {
+      const report = await runOperationalProbes(await collectPrecheckFacts({ root: repo, repo: "", remote: "origin" }));
+
+      const fixes = await applyOperationalProbeFixes(report, {
+        confirm: async () => true,
+        fastForwardLocalBase: async ({ remote, target }) =>
+          fastForwardLocalTarget(realExec(), { gitRepo: repo, remote, target }),
+      });
+
+      expect(fixes).toContainEqual({
+        probeId: "afk.base-freshness",
+        status: "applied",
+        evidence: "fast-forwarded main to origin/main",
+      });
+      expect(git(repo, "rev-parse", "main").trim()).toBe(git(repo, "rev-parse", "origin/main").trim());
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses the gated base-freshness fix when the primary is not on trunk", async () => {
+    const { root, repo } = await makeBaseFreshnessRepo();
+    try {
+      git(repo, "checkout", "-b", "feature/work");
+      const report = await runOperationalProbes(await collectPrecheckFacts({ root: repo, repo: "", remote: "origin" }));
+
+      const fixes = await applyOperationalProbeFixes(report, {
+        confirm: async () => true,
+        fastForwardLocalBase: async ({ remote, target }) =>
+          fastForwardLocalTarget(realExec(), { gitRepo: repo, remote, target }),
+      });
+
+      expect(fixes).toContainEqual({
+        probeId: "afk.base-freshness",
+        status: "noop",
+        evidence: "guard refused: condition failed: on-trunk (current=feature/work expected=main)",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses the gated base-freshness fix when the primary trunk is dirty", async () => {
+    const { root, repo } = await makeBaseFreshnessRepo();
+    try {
+      await writeFile(join(repo, "scratch.txt"), "dirty\n", "utf8");
+      const report = await runOperationalProbes(await collectPrecheckFacts({ root: repo, repo: "", remote: "origin" }));
+
+      const fixes = await applyOperationalProbeFixes(report, {
+        confirm: async () => true,
+        fastForwardLocalBase: async ({ remote, target }) =>
+          fastForwardLocalTarget(realExec(), { gitRepo: repo, remote, target }),
+      });
+
+      expect(fixes).toContainEqual({
+        probeId: "afk.base-freshness",
+        status: "noop",
+        evidence: "guard refused: condition failed: clean-tree (1 dirty path(s))",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses the gated base-freshness fix when local trunk is not an ancestor of origin", async () => {
+    const { root, repo } = await makeBaseFreshnessRepo();
+    try {
+      await writeFile(join(repo, "local.txt"), "local\n", "utf8");
+      git(repo, "add", "local.txt");
+      git(repo, "commit", "-m", "local only");
+      const report = await runOperationalProbes(await collectPrecheckFacts({ root: repo, repo: "", remote: "origin" }));
+
+      const fixes = await applyOperationalProbeFixes(report, {
+        confirm: async () => true,
+        fastForwardLocalBase: async ({ remote, target }) =>
+          fastForwardLocalTarget(realExec(), { gitRepo: repo, remote, target }),
+      });
+
+      expect(fixes).toContainEqual({
+        probeId: "afk.base-freshness",
+        status: "noop",
+        evidence: "guard refused: condition failed: ancestor (main is not an ancestor of origin/main)",
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 function readFixture(name: string): Promise<string> {
@@ -430,6 +542,59 @@ async function makeGitRepo(): Promise<{ root: string; lockPath: string }> {
   await mkdir(join(root, ".red"), { recursive: true });
   await writeFile(join(root, ".red", "config.yaml"), "plugins:\n  dev:\n    trunk: develop\n", "utf8");
   return { root, lockPath: join(root, ".red", "state", "branch-lock.yaml") };
+}
+
+async function makeBaseFreshnessRepo(): Promise<{ root: string; repo: string; origin: string }> {
+  const root = await mkdtemp(join(tmpdir(), "red-skills-base-freshness-"));
+  const repo = join(root, "repo");
+  const origin = join(root, "origin.git");
+  const peer = join(root, "peer");
+  await mkdir(repo, { recursive: true });
+  git(root, "init", "--bare", "-b", "main", "origin.git");
+  git(repo, "init", "-b", "main");
+  configureGit(repo);
+  await mkdir(join(repo, ".red"), { recursive: true });
+  await writeFile(join(repo, ".red", "config.yaml"), "plugins:\n  dev:\n    trunk: main\n", "utf8");
+  await writeFile(join(repo, "README.md"), "fixture\n", "utf8");
+  git(repo, "add", ".red/config.yaml", "README.md");
+  git(repo, "commit", "-m", "initial");
+  git(repo, "remote", "add", "origin", origin);
+  git(repo, "push", "-u", "origin", "main");
+
+  git(root, "clone", origin, peer);
+  configureGit(peer);
+  await writeFile(join(peer, "remote-one.txt"), "one\n", "utf8");
+  git(peer, "add", "remote-one.txt");
+  git(peer, "commit", "-m", "remote one");
+  await writeFile(join(peer, "remote-two.txt"), "two\n", "utf8");
+  git(peer, "add", "remote-two.txt");
+  git(peer, "commit", "-m", "remote two");
+  git(peer, "push", "origin", "main");
+  return { root, repo, origin };
+}
+
+function configureGit(cwd: string): void {
+  git(cwd, "config", "user.email", "red@example.invalid");
+  git(cwd, "config", "user.name", "Red Test");
+}
+
+function realExec(): Exec {
+  return async (argv: string[]): Promise<ExecResult> => {
+    try {
+      const stdout = execFileSync(argv[0] ?? "git", argv.slice(1), {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      return { code: 0, stdout, stderr: "" };
+    } catch (error) {
+      const err = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+      return {
+        code: err.status ?? 1,
+        stdout: String(err.stdout ?? ""),
+        stderr: String(err.stderr ?? ""),
+      };
+    }
+  };
 }
 
 function git(cwd: string, ...args: string[]): string {


### PR DESCRIPTION
Automated AFK landing for #1972. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1972

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786897134&installation_id=129708444&pr_number=2027&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2027&signature=3cdc0cf3a445f920fc2c11adc85ea2160c9b9a2f43b59b15ea0ee3bd1675ea8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->