### PR TITLE
fix: #2030 Fleet-truth boot probe self-detects the booting supervisor and halts every fleet launch (2.64.0 bootstrap deadlock)

### DIFF
--- a/apps/dev/src/core/operational-probes/fleet-truth.ts
+++ b/apps/dev/src/core/operational-probes/fleet-truth.ts
@@ -33,6 +33,7 @@ export interface CollectFleetTruthProbeOptions {
   readonly nowMs?: number;
   readonly heartbeatStaleMs: number;
   readonly latestBundleVersion?: string;
+  readonly ownSupervisorPid?: number;
   readonly pidLive?: (pid: number) => boolean;
 }
 
@@ -103,6 +104,7 @@ export async function collectFleetTruthProbeInput(
 
   return {
     supervisorPid,
+    ownSupervisorPid: options.ownSupervisorPid ?? process.pid,
     supervisorPidLive: supervisorPid !== null ? pidLive(supervisorPid) : false,
     supervisorPidMtimeMs,
     stateMtimeMs,
@@ -116,8 +118,13 @@ export async function collectFleetTruthProbeInput(
   };
 }
 
+function isOwnSupervisorPid(input: FleetTruthProbeInput): boolean {
+  return Boolean(input.supervisorPid && input.ownSupervisorPid && input.supervisorPid === input.ownSupervisorPid);
+}
+
 function fleetTruthFindings(input: FleetTruthProbeInput): FleetTruthFindingKind[] {
   const findings: FleetTruthFindingKind[] = [];
+  if (isOwnSupervisorPid(input)) return findings;
   const heartbeatAge = ageMs(input.nowMs, input.heartbeatEpochMs ?? input.stateMtimeMs);
   if (input.supervisorPidLive && heartbeatAge !== undefined && heartbeatAge > input.heartbeatStaleMs) {
     findings.push("zombie");

--- a/apps/dev/src/core/operational-probes/types.ts
+++ b/apps/dev/src/core/operational-probes/types.ts
@@ -57,6 +57,7 @@ export interface QueueVisibilityProbeInput {
 
 export interface FleetTruthProbeInput {
   readonly supervisorPid?: number | null;
+  readonly ownSupervisorPid?: number;
   readonly supervisorPidLive: boolean;
   readonly supervisorPidMtimeMs?: number;
   readonly stateMtimeMs?: number;

--- a/apps/dev/tests/fleet-truth.test.ts
+++ b/apps/dev/tests/fleet-truth.test.ts
@@ -79,6 +79,45 @@ describe("fleet truth operational probe", () => {
     expect(unknown.evidence).toContain("version_unknown");
   });
 
+  it("does not flag the booting supervisor's own fresh pid before state is stamped", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "red-skills-fleet-truth-"));
+    const pidPath = join(dir, "afk-supervisor.pid");
+    const statePath = join(dir, "afk-supervisor.state.json");
+
+    await writeFile(pidPath, `${process.pid}\n`, "utf8");
+    const pidStat = await stat(pidPath);
+    const facts = await collectFleetTruthProbeInput(
+      { supervisorPidPath: pidPath, fleetStatePath: statePath },
+      {
+        nowMs: pidStat.mtimeMs + 5_000,
+        heartbeatStaleMs: 300_000,
+        latestBundleVersion: "2.64.0",
+      },
+    );
+    const result = runFleetTruthProbe({ remoteUrls: [], fleetTruth: facts });
+
+    expect(result.verdict).toBe("ok");
+    expect(result.evidence).not.toContain("version_unknown");
+  });
+
+  it("still flags stale foreign supervisors with unknown versions", () => {
+    const result = runFleetTruthProbe({
+      remoteUrls: [],
+      fleetTruth: {
+        supervisorPid: 4242,
+        ownSupervisorPid: process.pid,
+        supervisorPidLive: true,
+        supervisorPidMtimeMs: 1_000,
+        nowMs: 601_000,
+        heartbeatStaleMs: 300_000,
+        latestBundleVersion: "2.64.0",
+      },
+    });
+
+    expect(result.verdict).toBe("red");
+    expect(result.evidence).toContain("version_unknown");
+  });
+
   it("gates SIGTERM, verifies live process exit, and leaves refusal untouched", async () => {
     const dir = await mkdtemp(join(tmpdir(), "red-skills-fleet-truth-"));
     const pidPath = join(dir, "afk-supervisor.pid");


### PR DESCRIPTION
Automated AFK landing for #2030. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2030

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786899570&installation_id=129708444&pr_number=2032&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2032&signature=43abfca74b634ca780cd9b53ebde05eab2379b7da1480eda891e51df313581fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->