### PR TITLE
fix: #1692 Contract: remove legacy .red location fallbacks after a migration release ships

### DIFF
--- a/apps/brain/src/resident-brain.ts
+++ b/apps/brain/src/resident-brain.ts
@@ -2,7 +2,8 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   SHARED_STORE_REL,
-  legacySharedStorePath,
+  isLegacySharedStorePath,
+  legacySharedStoreError,
   resolveSharedStorePath,
   sharedStorePath as sharedStorePathForRoot,
 } from "@reddb-io/shared/red-paths.js";
@@ -33,9 +34,8 @@ const DEFAULT_RSP_BYTE_BUDGET = 64 * 1024 * 1024;
 export function shouldUseResidentBrain(config: ResolvedBrainConfig): boolean {
   if (!config.connectionString.startsWith("file://")) return false;
   const path = config.connectionString.slice("file://".length);
-  // Accept both the canonical state-tier path and the legacy tmp-tier path so a
-  // connection string pointed at either shares the resident during the transition.
-  return path === sharedStorePathForRoot(config.rootDir) || path === legacySharedStorePath(config.rootDir);
+  if (isLegacySharedStorePath(config.rootDir, path)) throw legacySharedStoreError();
+  return path === sharedStorePathForRoot(config.rootDir);
 }
 
 export async function openResidentBrainStore(config: ResolvedBrainConfig): Promise<BrainStoreLike> {
@@ -46,8 +46,6 @@ export async function openResidentBrainStore(config: ResolvedBrainConfig): Promi
 }
 
 export function sharedStoreUri(rootDir: string): string {
-  // Honor the transition window: open the legacy tmp-tier store if it still
-  // exists and setup has not yet migrated it to the state tier.
   return `file://${resolveSharedStorePath(resolve(rootDir), existsSync)}`;
 }
 

--- a/apps/brain/tests/resident-brain.test.ts
+++ b/apps/brain/tests/resident-brain.test.ts
@@ -17,8 +17,10 @@ describe("shouldUseResidentBrain", () => {
     expect(shouldUseResidentBrain(config("file:///repo/.red/state/red-skills.rdb"))).toBe(true);
   });
 
-  it("still uses the resident for the legacy tmp-tier store during the transition", () => {
-    expect(shouldUseResidentBrain(config("file:///repo/.red/tmp/red-skills.rdb"))).toBe(true);
+  it("rejects the legacy tmp-tier store with a migration path", () => {
+    expect(() => shouldUseResidentBrain(config("file:///repo/.red/tmp/red-skills.rdb"))).toThrow(
+      "Run `rsp setup` to migrate it to .red/state/red-skills.rdb",
+    );
   });
 
   it("does not use the resident for a private brain store", () => {

--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,7 +1,7 @@
 import { constants } from "node:fs";
 import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { afkPaths, preferExistingPath } from "../runtime/wire.js";
+import { afkPaths } from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
@@ -122,14 +122,10 @@ async function writeResizeRequest(path: string, target: number, shrinkMode: Elas
 
 export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetStopResult> {
   const paths = afkPaths(root);
-  const tmp = paths.tmpDir;
   const stateAfk = dirname(paths.supervisorPidPath);
-  // Speak to the supervisor at whichever layout it wrote its pid — a legacy (tmp)
-  // supervisor watches the tmp stop file, a migrated one watches state/afk. Write
-  // the stop sentinel adjacent to the live pid so either generation sees it.
-  const pidFile = preferExistingPath(paths.supervisorPidPath, join(tmp, "afk-supervisor.pid"));
+  const pidFile = paths.supervisorPidPath;
   const stopFile = join(dirname(pidFile), "afk-supervisor.stop");
-  const supervisor = await reapStaleSupervisorState([stateAfk, tmp], isLivePid);
+  const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
   if (supervisor.status === "stale") {
     stdout.write(`no fleet running (stale supervisor files — cleaned).\n`);
     return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
@@ -174,16 +170,15 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   const parsed = parseFleetArgs(args);
   if (!Number.isInteger(parsed.target) || parsed.target < 0) throw new Error("fleet target must be a non-negative integer");
   const paths = afkPaths(root);
-  const tmp = paths.tmpDir;
   const stateAfk = dirname(paths.supervisorPidPath);
-  await mkdir(tmp, { recursive: true });
+  await mkdir(paths.tmpDir, { recursive: true });
   await mkdir(stateAfk, { recursive: true });
   // One-time boot migration: relocate legacy `.red/tmp` durable artifacts to the
   // state tier before any supervisor path is read/written (issue #1685).
   await migrateLegacyDevPaths(root).catch(() => undefined);
   const pidFile = paths.supervisorPidPath;
   const logFile = paths.supervisorLogPath;
-  const supervisor = await reapStaleSupervisorState([stateAfk, tmp], isLivePid);
+  const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
   if (supervisor.status === "stale") {
     stdout.write(`cleaned stale supervisor files before fleet launch.\n`);
   }

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -27,7 +27,6 @@ import {
 import { isRunner, type Runner } from "../types/runner.js";
 import {
   afkPaths,
-  preferExistingPath,
   collectPrecheckFacts,
   collectBootOptions,
   collectMonitorInputs,
@@ -1842,7 +1841,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // dispatch (#1087) is exempt too: its isolated namespace/lane/origin can
   // never collide with the fleet, so it must boot whether or not a fleet is up.
   if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
-    const pidFile = preferExistingPath(paths.supervisorPidPath, join(paths.tmpDir, "afk-supervisor.pid"));
+    const pidFile = paths.supervisorPidPath;
     const exempt = isNamespacedDispatch({
       origin: dispatchIdentity.origin,
       kind: dispatchIdentity.kind,

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -739,8 +739,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   // Ensure the workers root exists so the event-driven wake's fs.watch (#934) can
   // attach from boot rather than waiting for the first worker to create it.
   await import("../runtime/fs.js").then((m) => m.ensureDir(join(tmp, "workers")));
-  // Reap dead supervisor artifacts across the state home and the legacy tmp home.
-  await reapStaleSupervisorState([stateAfk, tmp], isAlive);
+  await reapStaleSupervisorState(stateAfk, isAlive);
   // single-supervisor lock
   if (existsSync(pidFile)) {
     try {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -169,25 +169,6 @@ export function afkPaths(root: string): AfkPaths {
   };
 }
 
-/**
- * Prefer the canonical (state-tier) path; fall back to the legacy `.red/tmp`
- * location when only the legacy copy is present. This keeps a durable artifact
- * READABLE across the one-release window before the boot migration
- * (runtime/red-path-migration.ts) relocates it — the back-compat read the
- * migration's "nothing deleted on ambiguity" rule pairs with (issue #1685).
- */
-export function preferExistingPath(current: string, legacy: string): string {
-  if (existsSync(current)) return current;
-  if (existsSync(legacy)) return legacy;
-  return current;
-}
-
-/** Legacy `.red/tmp` companion of a relocated supervisor/statusline artifact,
- * for {@link preferExistingPath} fallback reads. */
-function legacyTmpPath(root: string, name: string): string {
-  return join(rp.tmpDir(root), name);
-}
-
 // ---------- config-derived run settings ----------
 
 export interface RunSettings {
@@ -835,9 +816,7 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
     : (await readHistoryRecords(paths.historyPath, { read: fsx.readText })).map((r) => ({ event: r.event, epoch: r.epoch }));
   const fleet =
     (await readCastleMonitorFleetState(castlePaths)) ??
-    (await readFleetState(
-      preferExistingPath(paths.fleetStatePath, legacyTmpPath(root, "afk-supervisor.state.json")),
-    ));
+    (await readFleetState(paths.fleetStatePath));
   if (fleet?.bundleVersion) {
     fleet.latestBundleVersion = readDevBundleCacheState(fleet.bundleVersion).laneNewestVersion ?? undefined;
   }
@@ -845,8 +824,7 @@ export async function collectMonitorInputs(root = process.cwd(), repo = ""): Pro
   // Remote facts: read the statusline TTL cache passively (no refresh — the monitor
   // is read-only; the statusline owns the cache lifecycle). Include queue/human counts
   // and the cache age so the render can show a stale marker when the data is old.
-  const cachePath = preferExistingPath(paths.statuslineCachePath, legacyTmpPath(root, "statusline-cache.json"));
-  const cached = readStatuslineCache(cachePath);
+  const cached = readStatuslineCache(paths.statuslineCachePath);
   const nowS = Math.floor(Date.now() / 1000);
   const remoteExtra = cached !== null
     ? { remoteQueue: cached.queue, remoteHuman: cached.human, remoteCacheAgeS: nowS - cached.ts }
@@ -1124,7 +1102,7 @@ export function startDetachedStatuslineCountRefresh(
  *
  * The `rq` ready-for-agent / `rh` ready-for-human counts are GitHub-derived and
  * cached for {@link STATUSLINE_CACHE_TTL_S} seconds in
- * `.red/tmp/statusline-cache.json`. The cache refreshes on every stale or cold
+ * `.red/state/statusline/statusline-cache.json`. The cache refreshes on every stale or cold
  * render — awaited with a bounded deadline so a hanging gh CLI cannot block the
  * statusline process indefinitely. The refresh runs even when there are no live
  * workers so the queue/human badges stay current while the fleet is idle.
@@ -1225,9 +1203,7 @@ export async function collectStatuslineAfk(
   // fleet is idle (workers == 0).
   const cachePath = statuslineCountCachePath(ctx.root);
   const nowS = Math.floor(Date.now() / 1000);
-  const cached = readStatuslineCache(
-    preferExistingPath(cachePath, legacyTmpPath(ctx.root, "statusline-cache.json")),
-  );
+  const cached = readStatuslineCache(cachePath);
   let queue = cached?.queue ?? 0;
   let human = cached?.human ?? 0;
 
@@ -1303,14 +1279,10 @@ export async function collectStatuslineFleet(
   nowS: number = Math.floor(Date.now() / 1000),
 ): Promise<FleetInput | undefined> {
   const paths = afkPaths(ctx.root);
-  const pid = readSupervisorPid(
-    preferExistingPath(paths.supervisorPidPath, legacyTmpPath(ctx.root, "afk-supervisor.pid")),
-  );
+  const pid = readSupervisorPid(paths.supervisorPidPath);
   if (pid === null || !isLivePid(pid)) return undefined;
 
-  const state = await readFleetState(
-    preferExistingPath(paths.fleetStatePath, legacyTmpPath(ctx.root, "afk-supervisor.state.json")),
-  );
+  const state = await readFleetState(paths.fleetStatePath);
   if (!state) return undefined;
   if (nowS - state.epoch > maxAgeS) return undefined;
 
@@ -1441,7 +1413,7 @@ function writeRepoStatsCacheAtomic(path: string, cache: RepoStatsCache): void {
  * resolved base ref)
  * measured at the project root. All three are EXPENSIVE FETCHED numbers (gh/git
  * subprocesses), so all three are cached together for {@link
- * STATUSLINE_CACHE_TTL_S} seconds in `.red/tmp/statusline-repo-cache.json`: a
+ * STATUSLINE_CACHE_TTL_S} seconds in `.red/state/statusline/statusline-repo-cache.json`: a
  * fresh render serves them WITHOUT any gh/git subprocess; a cold/stale render
  * pays one bounded refresh (issue #1178 — never a per-render git diff). Every
  * field is fail-open: any gh/git error leaves it 0.
@@ -1454,9 +1426,7 @@ export async function collectStatuslineRepo(
   const paths = afkPaths(ctx.root);
   const cachePath = paths.statuslineRepoCachePath;
   const nowS = Math.floor(Date.now() / 1000);
-  const cached = readRepoStatsCache(
-    preferExistingPath(cachePath, legacyTmpPath(ctx.root, "statusline-repo-cache.json")),
-  );
+  const cached = readRepoStatsCache(cachePath);
   const cacheMatchesBase = cached?.baseRef === baseRef;
   let openPrs = cached?.openPrs ?? 0;
   let todayPrs = cached?.todayPrs ?? 0;
@@ -1782,8 +1752,8 @@ export async function collectPrecheckFacts(
   const supervisorCfg = resolveSupervisorConfig();
   const fleetTruth = await collectFleetTruthProbeInput(
     {
-      supervisorPidPath: preferExistingPath(paths.supervisorPidPath, legacyTmpPath(ctx.root, "afk-supervisor.pid")),
-      fleetStatePath: preferExistingPath(paths.fleetStatePath, legacyTmpPath(ctx.root, "afk-supervisor.state.json")),
+      supervisorPidPath: paths.supervisorPidPath,
+      fleetStatePath: paths.fleetStatePath,
     },
     {
       heartbeatStaleMs: supervisorCfg.supervisorStaleS * 1000,

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -26,13 +26,13 @@ function scratch(): string {
 }
 
 function writeSupervisorArtifacts(root: string, pid: number | string): Record<string, string> {
-  const tmp = join(root, ".red", "tmp");
-  mkdirSync(tmp, { recursive: true });
+  const stateAfk = join(root, ".red", "state", "afk");
+  mkdirSync(stateAfk, { recursive: true });
   const paths = {
-    pid: join(tmp, "afk-supervisor.pid"),
-    state: join(tmp, "afk-supervisor.state.json"),
-    log: join(tmp, "afk-supervisor.log"),
-    firehose: join(tmp, "afk-supervisor.log.jsonl"),
+    pid: join(stateAfk, "afk-supervisor.pid"),
+    state: join(stateAfk, "afk-supervisor.state.json"),
+    log: join(stateAfk, "afk-supervisor.log"),
+    firehose: join(stateAfk, "afk-supervisor.log.jsonl"),
   };
   writeFileSync(paths.pid, String(pid), "utf8");
   writeFileSync(paths.state, "{not json", "utf8");

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -80,7 +80,7 @@ async function writeFreshLivenessLane(
 
 /** Pre-seed a FRESH gh count cache so collectStatuslineAfk never calls gh. */
 async function seedFreshCache(root: string, queue: number, human: number): Promise<void> {
-  const dir = join(root, ".red", "tmp");
+  const dir = join(root, ".red", "state", "statusline");
   await mkdir(dir, { recursive: true });
   const ts = Math.floor(Date.now() / 1000);
   await writeFile(join(dir, "statusline-cache.json"), JSON.stringify({ queue, human, ts }), "utf8");
@@ -93,7 +93,7 @@ async function seedFreshRepoCache(
   openIssues: number,
   todayPrs = 0,
 ): Promise<void> {
-  const dir = join(root, ".red", "tmp");
+  const dir = join(root, ".red", "state", "statusline");
   await mkdir(dir, { recursive: true });
   const ts = Math.floor(Date.now() / 1000);
   await writeFile(
@@ -107,7 +107,7 @@ async function writeFleetSnapshot(
   root: string,
   over: Record<string, unknown> = {},
 ): Promise<void> {
-  const dir = join(root, ".red", "tmp");
+  const dir = join(root, ".red", "state", "afk");
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, "afk-supervisor.pid"), `${process.pid}\n`, "utf8");
   await writeFile(
@@ -660,7 +660,7 @@ describe("statusline command — rendered line", () => {
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 2, 0);
     await writeFleetSnapshot(root);
-    await writeFile(join(root, ".red", "tmp", "afk-supervisor.pid"), "999999999\n", "utf8");
+    await writeFile(join(root, ".red", "state", "afk", "afk-supervisor.pid"), "999999999\n", "utf8");
 
     const out = sink();
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -766,9 +766,8 @@ describe("collectStatuslineAfk — cache discipline", () => {
   it("stale cache: serves stale values immediately and starts one detached refresh", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-cache.json");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
 
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
       writeFileSync(cachePath, JSON.stringify({ queue: 5, human: 3, ts: staleTs }), "utf8");
@@ -796,9 +795,8 @@ describe("collectStatuslineAfk — cache discipline", () => {
   it("stale cache: concurrent renders share one detached refresh lock", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-cache.json");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
       writeFileSync(
         cachePath,
         JSON.stringify({ queue: 8, human: 1, ts: nowS() - STATUSLINE_CACHE_TTL_S - 10 }),
@@ -827,9 +825,8 @@ describe("collectStatuslineAfk — cache discipline", () => {
   it("fresh cache: read without a gh refresh (ts and values unchanged)", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-cache.json");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
 
       const freshTs = nowS();
       writeFileSync(cachePath, JSON.stringify({ queue: 7, human: 2, ts: freshTs }), "utf8");
@@ -858,9 +855,8 @@ describe("collectStatuslineAfk — cache discipline", () => {
   it("fresh TOON cache: reads queue/human without a gh refresh", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-cache.json");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
       const freshTs = nowS();
       writeFileSync(cachePath, encode({ queue: 11, human: 4, ts: freshTs }), "utf8");
       writeRenderableAttempt(root, "w1", 55, new Date().toISOString());
@@ -878,9 +874,8 @@ describe("collectStatuslineAfk — cache discipline", () => {
   it("0 live workers: still starts detached stale refresh before returning null", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-afk-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-cache.json");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
 
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 10;
       writeFileSync(cachePath, JSON.stringify({ queue: 9, human: 1, ts: staleTs }), "utf8");
@@ -907,7 +902,9 @@ describe("collectStatuslineAfk — cache discipline", () => {
       const tmpDir = join(root, ".red", "tmp");
       mkdirSync(tmpDir, { recursive: true });
       // Fresh gh cache → collectStatuslineAfk makes no gh call.
-      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 0, human: 0, ts: nowS() }), "utf8");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ queue: 0, human: 0, ts: nowS() }), "utf8");
 
       // A worker whose orchestrator process is ALIVE (pid resolves) but whose
       // agent-stream activity froze long ago — exactly a long feedback-gate /
@@ -949,7 +946,9 @@ describe("collectStatuslineAfk — cache discipline", () => {
       mkdirSync(tmpDir, { recursive: true });
       // Fresh gh cache → no gh subprocess either; this render must be fully
       // subprocess-free.
-      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 0, human: 0, ts: nowS() }), "utf8");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ queue: 0, human: 0, ts: nowS() }), "utf8");
 
       // A live worker whose writer-stamped LOC is 0/0 but which points at a REAL
       // git worktree (the project root) with a non-empty diff vs origin/main. The
@@ -1097,9 +1096,8 @@ describe("collectStatuslineRepo — cache discipline", () => {
   it("fresh cache: read without a gh refresh (ts unchanged)", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-repo-cache.json");
+      const cachePath = afkPaths(root).statuslineRepoCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
 
       const freshTs = nowS();
       writeFileSync(cachePath, JSON.stringify({ openPrs: 4, openIssues: 10, ts: freshTs }), "utf8");
@@ -1117,9 +1115,8 @@ describe("collectStatuslineRepo — cache discipline", () => {
   it("fresh cache: serves the local diffstat from cache without a git subprocess (#1178)", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-repo-cache.json");
+      const cachePath = afkPaths(root).statuslineRepoCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
 
       // root is NOT a git repo, so any live `git diff` would return 0/0. A
       // non-zero localAdded/localRemoved in the result can therefore only come
@@ -1145,9 +1142,8 @@ describe("collectStatuslineRepo — cache discipline", () => {
   it("fresh TOON repo cache: serves the local diffstat without a refresh", async () => {
     const root = mkdtempSync(join(tmpdir(), "afk-sl-repo-"));
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
-      const cachePath = join(tmpDir, "statusline-repo-cache.json");
+      const cachePath = afkPaths(root).statuslineRepoCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
       const freshTs = nowS();
       writeFileSync(
         cachePath,
@@ -1394,10 +1390,10 @@ describe("collectMonitorInputs — remote facts (TTL cache) (#1029)", () => {
   it("exposes queue/human from a fresh statusline cache with low age", async () => {
     const root = scratch();
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
       const freshTs = nowS();
-      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 4, human: 2, ts: freshTs }));
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ queue: 4, human: 2, ts: freshTs }));
       const result = await collectMonitorInputs(root);
       expect(result.remoteQueue).toBe(4);
       expect(result.remoteHuman).toBe(2);
@@ -1412,10 +1408,10 @@ describe("collectMonitorInputs — remote facts (TTL cache) (#1029)", () => {
   it("reports a stale age when the cache is older than the TTL", async () => {
     const root = scratch();
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 30;
-      writeFileSync(join(tmpDir, "statusline-cache.json"), JSON.stringify({ queue: 7, human: 1, ts: staleTs }));
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ queue: 7, human: 1, ts: staleTs }));
       const result = await collectMonitorInputs(root);
       expect(result.remoteQueue).toBe(7);
       expect(result.remoteHuman).toBe(1);
@@ -1429,10 +1425,9 @@ describe("collectMonitorInputs — remote facts (TTL cache) (#1029)", () => {
   it("does NOT refresh the cache (monitor is read-only; statusline owns cache lifecycle)", async () => {
     const root = scratch();
     try {
-      const tmpDir = join(root, ".red", "tmp");
-      mkdirSync(tmpDir, { recursive: true });
       const staleTs = nowS() - STATUSLINE_CACHE_TTL_S - 30;
-      const cachePath = join(tmpDir, "statusline-cache.json");
+      const cachePath = afkPaths(root).statuslineCachePath;
+      mkdirSync(dirname(cachePath), { recursive: true });
       writeFileSync(cachePath, JSON.stringify({ queue: 9, human: 3, ts: staleTs }));
       await collectMonitorInputs(root);
       // The cache timestamp must NOT have changed — the monitor never refreshes it.

--- a/apps/memory/src/resident-memory.ts
+++ b/apps/memory/src/resident-memory.ts
@@ -1,8 +1,9 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
-  LEGACY_SHARED_STORE_REL,
   SHARED_STORE_REL,
+  isLegacySharedStorePath,
+  legacySharedStoreError,
   resolveSharedStorePath,
 } from "@reddb-io/shared/red-paths.js";
 import {
@@ -31,13 +32,9 @@ export interface ResidentIngestPayload {
 export function shouldUseResidentMemory(rootDir: string, config: MemoryConfig): boolean {
   if (config.mode !== "graph") return false;
   const storePath = config.storePath ?? "";
-  // Accept both the canonical state-tier path and the legacy tmp-tier path so a
-  // config pointed at either resolves to the resident during the transition.
-  for (const rel of [SHARED_STORE_REL, LEGACY_SHARED_STORE_REL]) {
-    if (storePath === rel) return true;
-    if (resolve(rootDir, storePath).endsWith(`/${rel}`)) return true;
-  }
-  return false;
+  if (isLegacySharedStorePath(rootDir, storePath)) throw legacySharedStoreError();
+  if (storePath === SHARED_STORE_REL) return true;
+  return resolve(rootDir, storePath) === resolve(rootDir, SHARED_STORE_REL);
 }
 
 export async function residentMemoryRequest(

--- a/apps/memory/tests/resident-memory.test.ts
+++ b/apps/memory/tests/resident-memory.test.ts
@@ -14,9 +14,13 @@ describe("shouldUseResidentMemory", () => {
     expect(shouldUseResidentMemory(ROOT, graphConfig("/repo/.red/state/red-skills.rdb"))).toBe(true);
   });
 
-  it("still uses the resident for the legacy tmp-tier shared store during the transition", () => {
-    expect(shouldUseResidentMemory(ROOT, graphConfig(".red/tmp/red-skills.rdb"))).toBe(true);
-    expect(shouldUseResidentMemory(ROOT, graphConfig("/repo/.red/tmp/red-skills.rdb"))).toBe(true);
+  it("rejects the legacy tmp-tier shared store with a migration path", () => {
+    expect(() => shouldUseResidentMemory(ROOT, graphConfig(".red/tmp/red-skills.rdb"))).toThrow(
+      "Run `rsp setup` to migrate it to .red/state/red-skills.rdb",
+    );
+    expect(() => shouldUseResidentMemory(ROOT, graphConfig("/repo/.red/tmp/red-skills.rdb"))).toThrow(
+      "Run `rsp setup` to migrate it to .red/state/red-skills.rdb",
+    );
   });
 
   it("does not use the resident for a private graph store or in markdown-only mode", () => {

--- a/apps/rsp/src/config.ts
+++ b/apps/rsp/src/config.ts
@@ -78,8 +78,6 @@ export function resolveRspConfig(cwd: string, env: NodeJS.ProcessEnv, explicitSt
     DEFAULT_RSP_MEASUREMENT_HOLDOUT_SHARE,
   );
   const storeRoot = resolveResidentPaths(cwd).rootDir;
-  // Honor the transition window: open the legacy tmp-tier store if it still
-  // exists and setup has not yet migrated it to the state tier.
   const storeUri =
     explicitStoreUri ?? env.RSP_STORE_URI ?? `file://${resolveSharedStorePath(resolve(storeRoot), existsSync)}`;
 

--- a/apps/rsp/tests/config.test.ts
+++ b/apps/rsp/tests/config.test.ts
@@ -155,4 +155,14 @@ describe("resolveRspConfig", () => {
     expect(config.enabled).toBe(false);
     await expect(stat(join(root, ".red"))).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it("fails clearly instead of opening a legacy tmp-tier shared store", async () => {
+    const root = await tempRoot();
+    await mkdir(join(root, ".red", "tmp"), { recursive: true });
+    await writeFile(join(root, ".red", "tmp", "red-skills.rdb"), "legacy", "utf8");
+
+    expect(() => resolveRspConfig(root, {}, undefined)).toThrow(
+      "Run `rsp setup` to migrate it to .red/state/red-skills.rdb",
+    );
+  });
 });

--- a/packages/shared/red-paths.test.ts
+++ b/packages/shared/red-paths.test.ts
@@ -5,6 +5,7 @@ import {
   MEMORY_ROOT_ENV,
   ROOT_OVERRIDE_ENV_VARS,
   SHARED_STORE_REL,
+  isLegacySharedStorePath,
   legacySharedStorePath,
   resolveSharedStorePath,
   WORKERS_NAMESPACE_ENV,
@@ -100,9 +101,10 @@ describe("resolveSharedStorePath (transition-window fallback)", () => {
     expect(resolved).toBe(sharedStorePath(ROOT));
   });
 
-  it("falls back to the legacy tmp store when only that exists", () => {
-    const resolved = resolveSharedStorePath(ROOT, (p) => p === legacySharedStorePath(ROOT));
-    expect(resolved).toBe(legacySharedStorePath(ROOT));
+  it("fails clearly when only the legacy tmp store exists", () => {
+    expect(() => resolveSharedStorePath(ROOT, (p) => p === legacySharedStorePath(ROOT))).toThrow(
+      "Run `rsp setup` to migrate it to .red/state/red-skills.rdb",
+    );
   });
 
   it("defaults to the state-tier store when neither exists", () => {
@@ -111,6 +113,12 @@ describe("resolveSharedStorePath (transition-window fallback)", () => {
 
   it("prefers state over legacy when both exist", () => {
     expect(resolveSharedStorePath(ROOT, () => true)).toBe(sharedStorePath(ROOT));
+  });
+
+  it("recognizes explicit legacy shared-store paths for contract checks", () => {
+    expect(isLegacySharedStorePath(ROOT, ".red/tmp/red-skills.rdb")).toBe(true);
+    expect(isLegacySharedStorePath(ROOT, "/repo/.red/tmp/red-skills.rdb")).toBe(true);
+    expect(isLegacySharedStorePath(ROOT, ".red/state/red-skills.rdb")).toBe(false);
   });
 });
 

--- a/packages/shared/red-paths.ts
+++ b/packages/shared/red-paths.ts
@@ -14,9 +14,8 @@
  * resolution takes an explicit `exists` probe. Nothing reads `process` or the
  * filesystem on its own, so the whole surface is unit-testable without mocks.
  *
- * This is the EXPAND half of an expand-contract chain: it adds the authority
- * with ZERO behavior change and ZERO consumers. Migrating the runtimes onto it
- * is the contract half, tracked separately.
+ * This module started as the EXPAND half of an expand-contract chain. The
+ * contract phase now makes the state-tier paths authoritative at runtime.
  */
 import { isAbsolute, join, resolve } from "node:path";
 
@@ -130,9 +129,7 @@ export function sharedStorePath(root: string): string {
 
 /**
  * The pre-ADR-0098 shared store location under the disposable tmp tier. Kept as
- * a named constant so the one-time setup migration and the transition-window
- * fallback read ({@link resolveSharedStorePath}) point at the SAME legacy path
- * instead of each re-spelling `.red/tmp/red-skills.rdb`.
+ * a named constant for the setup migration and explicit legacy-layout checks.
  */
 export const LEGACY_SHARED_STORE_REL = ".red/tmp/red-skills.rdb";
 
@@ -142,10 +139,9 @@ export function legacySharedStorePath(root: string): string {
 }
 
 /**
- * Resolve the shared store path a consumer should OPEN, honoring the migration
- * transition window: prefer the canonical state-tier location, fall back to the
- * legacy tmp-tier file when only that exists, and default to the state-tier path
- * when neither is present (so a fresh store is created in the new home).
+ * Resolve the shared store path a consumer should OPEN. The contract phase
+ * removed legacy tmp-tier fallback reads: if only the legacy store exists, fail
+ * clearly instead of silently continuing to write disposable state.
  *
  * `exists` is injected so this stays pure and unit-testable without mocks.
  */
@@ -153,8 +149,20 @@ export function resolveSharedStorePath(root: string, exists: (path: string) => b
   const primary = sharedStorePath(root);
   if (exists(primary)) return primary;
   const legacy = legacySharedStorePath(root);
-  if (exists(legacy)) return legacy;
+  if (exists(legacy)) throw legacySharedStoreError();
   return primary;
+}
+
+/** True when a path names the pre-ADR-0098 tmp-tier shared store for `root`. */
+export function isLegacySharedStorePath(root: string, path: string): boolean {
+  return path === LEGACY_SHARED_STORE_REL || resolve(root, path) === legacySharedStorePath(root);
+}
+
+/** Error used by contract-phase readers that encounter an unmigrated shared store. */
+export function legacySharedStoreError(): Error {
+  return new Error(
+    "Legacy shared store found at .red/tmp/red-skills.rdb. Run `rsp setup` to migrate it to .red/state/red-skills.rdb before using rsp, memory, or brain.",
+  );
 }
 
 // ── Tmp-tier worker lanes (ADR 0098 §2) ─────────────────────────────────────


### PR DESCRIPTION
Automated AFK landing for #1692. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1692

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786907162&installation_id=129708444&pr_number=2043&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2043&signature=9ed708f4517fd9c376c2f602142ea7b0d2071c39c93249b8d20f905c92c1ec4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->