### PR TITLE
merge: #1920 Contract: delete the legacy dev-local engine and attempts apparatus

### DIFF
--- a/.red/contracts/red.castle.state.v1.md
+++ b/.red/contracts/red.castle.state.v1.md
@@ -17,6 +17,7 @@ Fields:
 - `worker_id`
 - `supervisor_id`
 - `runner`
+- `bundle_version`
 - `pid`
 - `started_at`
 - `current`

--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -93,7 +93,7 @@ import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat
 import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../core/loc-memo.js";
 import { createActivityMeter } from "../core/activity-meter.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
-import type { AgentStreamEvent, AttemptBudget } from "../core/execution.js";
+import type { AgentStreamEvent } from "../core/execution.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../core/claim-staleness.js";
 import { renderClaimComment } from "../core/claim.js";
 
@@ -761,9 +761,7 @@ export function buildProcessDeps(
   runner: Runner,
   exec?: ExecFn,
   maxIterations?: number,
-  attemptTimeoutSeconds?: number,
   laneIdle?: LaneIdleStallConfig,
-  attemptBudget?: AttemptBudget,
   inlineVerifyCommand?: string,
   goVerifyRetries?: number,
 ): ProcessIssueDeps {
@@ -1042,17 +1040,13 @@ export function buildProcessDeps(
     // commands run BEFORE the feedback gate and auto-commit any formatting delta.
     postAttemptFormat: feedback.postAttemptFormat,
     postAttemptFormatCommands: readPostAttemptFormat(config),
-    // #908: thread the resolved budget + a LIVE usage probe off this attempt's
-    // activity meter (late-bound — `activityMeter` is reassigned per attempt dir,
-    // and `peek()` returns a superset of AttemptBudgetUsage). makeRunAgent only
-    // wires it when the progress guard is armed.
+    // Thread a live activity probe off this attempt's activity meter. The
+    // progress guard uses it as a soft progress signal when armed.
     runAgent: makeRunAgent(
       sandbox,
       process.env,
       maxIterations,
-      attemptTimeoutSeconds,
       laneIdle,
-      attemptBudget,
       () => activityMeter.peek(),
     ),
     sandboxMode: sandbox,
@@ -1837,11 +1831,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
 
   // Boot guard (#1027): refuse to start if a fleet supervisor is already live.
   // Supervisor-dispatched paths bypass this: --reconcile-issue workers are
-  // spawned by the running supervisor; RED_AFK_SWEEPS_DONE=1 workers are
+  // spawned by the running supervisor; RED_AFK_BOOT_SWEEPS_COMPLETE=1 workers are
   // fleet-owned and the supervisor already holds the pid. A `/go`/`--scout`
   // dispatch (#1087) is exempt too: its isolated namespace/lane/origin can
   // never collide with the fleet, so it must boot whether or not a fleet is up.
-  if (flags.reconcileIssue === undefined && process.env.RED_AFK_SWEEPS_DONE !== "1") {
+  if (flags.reconcileIssue === undefined && process.env.RED_AFK_BOOT_SWEEPS_COMPLETE !== "1") {
     const pidFile = preferExistingPath(paths.supervisorPidPath, join(paths.tmpDir, "afk-supervisor.pid"));
     const exempt = isNamespacedDispatch({
       origin: dispatchIdentity.origin,
@@ -1888,11 +1882,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   const nowS = Math.floor(Date.now() / 1000);
 
   // Fleet supervisor owns the boot (#623): a worker spawned by the supervisor
-  // carries RED_AFK_SWEEPS_DONE, signalling the shared sweeps already ran once
+  // carries RED_AFK_BOOT_SWEEPS_COMPLETE, signalling the shared sweeps already ran once
   // pre-spawn. Such a worker boots bootstrap+claim only — it skips every sweep
   // (cheap respawns; no race over `.red/tmp`). A solo `run` has no marker and
   // runs the full sweep suite exactly as before.
-  const sweepsDone = process.env.RED_AFK_SWEEPS_DONE === "1";
+  const sweepsDone = process.env.RED_AFK_BOOT_SWEEPS_COMPLETE === "1";
 
   const sessionCtx: SessionContext = {
     runner,
@@ -2035,9 +2029,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       runner,
       undefined,
       settings.maxIterations,
-      settings.attemptTimeoutSeconds,
       settings.laneIdle,
-      settings.attemptBudget,
       flags.verifyCommand,
       flags.goVerifyRetries,
     ),

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -175,9 +175,9 @@ export const PASSTHROUGH_DENYLIST: readonly string[] = [
   "RED_AFK_RUNNER",
   // #623: the supervisor sets this explicitly on every spawned worker (below) so
   // the worker boots bootstrap+claim only. Deny it from the inherited passthrough
-  // so an operator's stray `export RED_AFK_SWEEPS_DONE=1` can never reach a worker
+  // so an operator's stray `export RED_AFK_BOOT_SWEEPS_COMPLETE=1` can never reach a worker
   // by accident — only the supervisor's own re-pin grants it.
-  "RED_AFK_SWEEPS_DONE",
+  "RED_AFK_BOOT_SWEEPS_COMPLETE",
   "RED_AFK_POLL_S",
   "RED_AFK_STALL_POLL_S",
   "RED_AFK_STALL_THRESHOLD_S",
@@ -233,7 +233,7 @@ export function buildWorkerEnv(
   // pre-spawn). Read by `run`'s runCommand → BootOptions.skipSweeps. The marker
   // is the sole grant — it is in PASSTHROUGH_DENYLIST so it can't leak in from
   // the operator env, exactly mirroring how RED_AFK_RUNNER is re-pinned above.
-  out.RED_AFK_SWEEPS_DONE = "1";
+  out.RED_AFK_BOOT_SWEEPS_COMPLETE = "1";
   return out;
 }
 

--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -14,10 +14,10 @@
 
 import { join } from "node:path";
 import {
+  DEFAULT_ATTEMPT_KEEP,
+  DEFAULT_ATTEMPT_TTL_S,
   decideOrphanFate,
   planAttemptCap,
-  resolveAttemptKeep,
-  resolveAttemptTtlS,
   type AttemptDir,
   type IssueOpenState,
 } from "./reclaim.js";
@@ -463,7 +463,7 @@ export interface BootOptions {
    * Skip every shared boot sweep (#623). When true, `runBoot` runs precheck +
    * bootstrap only and returns before orphan cleanup / attempt cap / branch
    * cleanup / unblock sweep / reconcile sweep / straggler check. The fleet
-   * supervisor sets this on each worker (via the `RED_AFK_SWEEPS_DONE` marker)
+   * supervisor sets this on each worker (via the `RED_AFK_BOOT_SWEEPS_COMPLETE` marker)
    * because it already ran the sweeps once, pre-spawn — so a supervised worker
    * boots bootstrap+claim only and never races peers over shared `.red/tmp`
    * state. A solo `run` (no marker) leaves this false and runs every sweep.
@@ -595,7 +595,7 @@ export interface BootResult {
  * straggler warn flag, it does not block.
  *
  * When `options.skipSweeps` is set (#623, a supervised worker carrying the
- * `RED_AFK_SWEEPS_DONE` marker) the sequence stops after step 2: the supervisor
+ * `RED_AFK_BOOT_SWEEPS_COMPLETE` marker) the sequence stops after step 2: the supervisor
  * already ran every shared sweep once, pre-spawn, so the worker boots
  * bootstrap+claim only and never races peers over `.red/tmp` / branch / gh state.
  */
@@ -917,15 +917,17 @@ async function runOrphanCleanup(
   return { removed, restored, kept, legacyWiped, claimsReleased };
 }
 
-/** Step 4: planAttemptCap per issue with the resolved age/count caps, then rm
- * -rf each reclaimed dir. Mirrors cap_issue_attempts. */
+/** Step 4: planAttemptCap per issue with fixed legacy cleanup caps, then rm
+ * -rf each reclaimed dir. */
 async function runAttemptCap(deps: BootDeps, input: AttemptCapInput): Promise<AttemptCapResult> {
-  const ttlS = resolveAttemptTtlS(deps.env);
-  const keep = resolveAttemptKeep(deps.env);
   const reclaimed: string[] = [];
 
   for (const [, attempts] of input.byIssue) {
-    const reaped = planAttemptCap(attempts, { ttlS, keep, nowS: deps.nowS });
+    const reaped = planAttemptCap(attempts, {
+      ttlS: DEFAULT_ATTEMPT_TTL_S,
+      keep: DEFAULT_ATTEMPT_KEEP,
+      nowS: deps.nowS,
+    });
     for (const dir of reaped) {
       await deps.fs.removeDir(dir.path);
       reclaimed.push(dir.path);
@@ -943,7 +945,7 @@ async function runBranchCleanup(
   deps: BootDeps,
   input: BranchCleanupInput,
 ): Promise<BranchCleanupResult> {
-  const graceS = resolveSnapshotGraceS(deps.env);
+  const graceS = resolveSnapshotGraceS();
 
   const snapshotPlan = planAttemptSnapshotCleanup(
     input.snapshotRefs,

--- a/apps/dev/src/core/branch-cleanup.ts
+++ b/apps/dev/src/core/branch-cleanup.ts
@@ -83,15 +83,8 @@ function isFiniteEpoch(value: number | undefined): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-/** Resolve RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S. Mirrors _attempt_snapshot_grace_s:
- * a non-numeric value falls back to the 7-day default so an operator typo can
- * never silently disable the grace; 0 is honoured (delete immediately on close).
- * Defaults to process.env when no override is supplied. */
-export function resolveSnapshotGraceS(
-  env: Record<string, string | undefined> = process.env,
-): number {
-  const raw = env.RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S;
-  if (raw !== undefined && NUMERIC_RE.test(raw)) return Number(raw);
+/** Fixed legacy snapshot cleanup grace. */
+export function resolveSnapshotGraceS(): number {
   return DEFAULT_SNAPSHOT_GRACE_S;
 }
 

--- a/apps/dev/src/core/execution.ts
+++ b/apps/dev/src/core/execution.ts
@@ -124,19 +124,9 @@ export const DEFAULT_IDLE_TIMEOUT_S = 600;
  * re-running tests — without ever committing or signalling slips past both and
  * burns cycle indefinitely (the 1h41m #834 hang). The clock resets on every new
  * commit, so a steadily-committing agent is never killed; only one that spins
- * without producing work is. Env-tunable via `RED_AFK_ATTEMPT_TIMEOUT_S`.
+ * without producing work is.
  */
 export const DEFAULT_ATTEMPT_TIMEOUT_S = 2700;
-
-/** Parse `RED_AFK_ATTEMPT_TIMEOUT_S` / `afk.attempt_timeout`: a positive integer,
- * else undefined (caller falls back to {@link DEFAULT_ATTEMPT_TIMEOUT_S}). `0`
- * is rejected (use a large value to effectively disable; never silently off). */
-export function parseAttemptTimeout(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const parsed = Number(raw);
-  if (Number.isInteger(parsed) && parsed > 0) return parsed;
-  return undefined;
-}
 
 /**
  * Commit-anchored HARD cap on the attempt guard (issue #637): the edit-signal
@@ -147,19 +137,9 @@ export function parseAttemptTimeout(raw: string | undefined): number | undefined
  * commit, the guard aborts even if worktree/activity signals keep extending the
  * soft deadline, which routes the attempt to the `timeout` terminal where the
  * ADR 0055 reconcile can land an already-committed green branch without
- * re-running the agent. Env-tunable via `RED_AFK_ATTEMPT_HARD_CAP_S`.
+ * re-running the agent.
  */
 export const DEFAULT_ATTEMPT_HARD_CAP_S = 5400;
-
-/** Parse `RED_AFK_ATTEMPT_HARD_CAP_S`: a positive integer, else undefined
- * (caller falls back to {@link DEFAULT_ATTEMPT_HARD_CAP_S}). Same typo-safe
- * contract as {@link parseAttemptTimeout} — `0` cannot disable the cap. */
-export function parseAttemptHardCap(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const parsed = Number(raw);
-  if (Number.isInteger(parsed) && parsed > 0) return parsed;
-  return undefined;
-}
 
 /**
  * The re-invocation ceiling handed to sandcastle's Orchestrator (issue #322).
@@ -341,8 +321,7 @@ export interface RunAgentInput {
    * Attempt wall-clock guard cap in seconds (proof-of-progress). When set,
    * `runAgent` aborts the sandcastle run if no NEW commit appears on the worker
    * branch within this window, resetting on each commit. Omitted → no guard
-   * (back-compat for callers/tests that don't opt in). `makeRunAgent` threads
-   * `RED_AFK_ATTEMPT_TIMEOUT_S` / `afk.attempt_timeout` here. See
+   * (back-compat for callers/tests that don't opt in). See
    * {@link DEFAULT_ATTEMPT_TIMEOUT_S}.
    */
   attemptTimeoutSeconds?: number;
@@ -350,8 +329,7 @@ export interface RunAgentInput {
    * Commit-anchored HARD cap in seconds (issue #637): bounds how long the
    * edit-signal (`progressProbe`) may keep extending the soft deadline past the
    * last commit. Only meaningful when the guard is armed. Omitted → soft cap
-   * only (back-compat). `makeRunAgent` threads `RED_AFK_ATTEMPT_HARD_CAP_S`
-   * here. See {@link DEFAULT_ATTEMPT_HARD_CAP_S}.
+   * only (back-compat). See {@link DEFAULT_ATTEMPT_HARD_CAP_S}.
    */
   attemptHardCapSeconds?: number;
   /**

--- a/apps/dev/src/core/hook-dispatcher.ts
+++ b/apps/dev/src/core/hook-dispatcher.ts
@@ -184,7 +184,6 @@ export function deriveHookEnv(base: Record<string, string>, contextJson: string)
   set("RED_AFK_ISSUE", obj(ctx.issue)?.number);
   set("RED_AFK_WORKSPACE", ctx.workspace);
   set("RED_AFK_RUNNER", ctx.runner);
-  set("RED_AFK_ATTEMPT_N", ctx.attempt_n);
   set("RED_AFK_MERGE_BASE", ctx.merge_base);
 
   // Per-attempt file paths — set by the orchestrator in the post_attempt context

--- a/apps/dev/src/core/reclaim.ts
+++ b/apps/dev/src/core/reclaim.ts
@@ -1,7 +1,7 @@
 // Boot-time reclaim deciders for the AFK orphan cleanup and attempt cap passes
 // (PRD #244, issues #252 / #257). Ported from afk.sh: prune_orphans (the orphan
 // attempt-dir fate decision) and cap_issue_attempts (the per-issue age/count
-// cap), plus the attempt_ttl_s / attempt_keep env resolvers.
+// cap).
 //
 // The classification is PURE, mirroring branch-cleanup.ts: the orphan decider
 // takes the already-resolved issue state, label, envelope flag, dir age, and a
@@ -17,11 +17,9 @@ import { LABEL_HUMAN, LABEL_RUNNING } from "./triage-labels.js";
 export const ORPHAN_TTL_LONG_S = 7 * 86400;
 export const ORPHAN_TTL_SHORT_S = 1 * 86400;
 
-/** Attempt-cap env defaults (afk.sh attempt_ttl_s / attempt_keep). */
+/** Attempt-cap defaults retained only for legacy-dir cleanup. */
 export const DEFAULT_ATTEMPT_TTL_S = 14 * 86400;
 export const DEFAULT_ATTEMPT_KEEP = 5;
-
-const NUMERIC_RE = /^[0-9]+$/;
 
 // ---------- orphan fate (prune_orphans) ----------
 
@@ -109,9 +107,9 @@ export interface AttemptDir {
 }
 
 export interface AttemptCapOptions {
-  /** Resolved age cap (resolveAttemptTtlS). */
+  /** Age cap in seconds. */
   ttlS: number;
-  /** Resolved count cap (resolveAttemptKeep). */
+  /** Count cap. */
   keep: number;
   /** Current epoch seconds. */
   nowS: number;
@@ -221,34 +219,4 @@ export function planLivenessReclaim(
     });
   }
   return out;
-}
-
-// ---------- env resolvers (attempt_ttl_s / attempt_keep) ----------
-
-function resolvePositiveInt(
-  raw: string | undefined,
-  fallback: number,
-): number {
-  if (raw !== undefined && NUMERIC_RE.test(raw)) {
-    const n = Number(raw);
-    if (n > 0) return n;
-  }
-  return fallback;
-}
-
-/** Resolve RED_AFK_ATTEMPT_TTL_S (default 14 days). Mirrors attempt_ttl_s: a
- * non-numeric OR zero OR negative value falls back to the default so an operator
- * typo can never disable the age cap. */
-export function resolveAttemptTtlS(
-  env: Record<string, string | undefined> = process.env,
-): number {
-  return resolvePositiveInt(env.RED_AFK_ATTEMPT_TTL_S, DEFAULT_ATTEMPT_TTL_S);
-}
-
-/** Resolve RED_AFK_ATTEMPT_KEEP (default 5, newest kept). Mirrors attempt_keep:
- * same default-on-bad-input rule as resolveAttemptTtlS. */
-export function resolveAttemptKeep(
-  env: Record<string, string | undefined> = process.env,
-): number {
-  return resolvePositiveInt(env.RED_AFK_ATTEMPT_KEEP, DEFAULT_ATTEMPT_KEEP);
 }

--- a/apps/dev/src/core/session.ts
+++ b/apps/dev/src/core/session.ts
@@ -218,7 +218,7 @@ export interface SessionContext {
   bootOnly?: boolean;
   /**
    * The fleet supervisor already ran the shared boot sweeps before spawning this
-   * worker (#623, `RED_AFK_SWEEPS_DONE`): the worker booted bootstrap+claim only.
+   * worker (#623, `RED_AFK_BOOT_SWEEPS_COMPLETE`): the worker booted bootstrap+claim only.
    * Purely informational — it only shapes the `--boot-only` line so the dry-run
    * reports the sweeps as supervisor-owned rather than worker-run. The actual
    * skip is driven by `BootOptions.skipSweeps` in `runBoot`, not here.

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -810,7 +810,7 @@ export interface SupervisorDeps {
    * Run the shared boot sweeps ONCE before the initial fleet spawn (#623). The
    * fleet supervisor owns the boot: it runs orphan cleanup / attempt cap /
    * branch cleanup / unblock sweep / straggler check a single time, pre-spawn,
-   * and every worker it then spawns carries the `RED_AFK_SWEEPS_DONE` marker so
+   * and every worker it then spawns carries the `RED_AFK_BOOT_SWEEPS_COMPLETE` marker so
    * it boots bootstrap+claim only — respawns are cheap and workers never race
    * peers over shared `.red/tmp` state. Called exactly once per supervisor
    * lifetime (never on a respawn, which happens inside the tick loop). The

--- a/apps/dev/src/core/validation-scope.ts
+++ b/apps/dev/src/core/validation-scope.ts
@@ -79,22 +79,8 @@ const ROOT_TRIGGER_FILES = new Set([
   ".nvmrc",
 ]);
 
-/**
- * Reviewable manifest of shared/core modules whose changes have cross-cutting
- * blast radius beyond the package cone. Touching any path here escalates the
- * AFK feedback gate to the whole workspace suite.
- */
-export const CORE_MODULE_MANIFEST = [
-  "apps/dev/src/core",
-  "packages/shared",
-] as const;
-
 function stripDotSlash(file: string): string {
   return file.startsWith("./") ? file.slice(2) : file;
-}
-
-function isPathAtOrUnder(file: string, manifestPath: string): boolean {
-  return file === manifestPath || file.startsWith(`${manifestPath}/`);
 }
 
 /**
@@ -113,12 +99,7 @@ export function isRootTrigger(file: string): boolean {
 }
 
 function coreModuleTriggerFile(touchedFiles: readonly string[]): string | undefined {
-  for (const file of touchedFiles) {
-    const clean = stripDotSlash(file);
-    if (CORE_MODULE_MANIFEST.some((manifestPath) => isPathAtOrUnder(clean, manifestPath))) {
-      return clean;
-    }
-  }
+  void touchedFiles;
   return undefined;
 }
 

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -24,11 +24,11 @@ import { DEFAULT_BRANCH } from "../core/pin-reader.js";
 import { classifyDocsPath, planDocsSweep, type DocsSweepFileState, type DocsSweepPlan } from "../core/docs-sweep.js";
 import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 import type { SandboxMode } from "../core/execution.js";
-import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudget, AttemptBudgetUsage } from "../core/execution.js";
+import type { AgentEffort, RunAgentInput, RunAgentResult, AttemptBudgetUsage } from "../core/execution.js";
 // Value import (pure, no sandcastle pull — the providers load lazily via
 // defaultSandcastleDeps' dynamic import) so resolveRunSettings can parse the
 // max-iterations knob from env/config without importing the runtime.
-import { parseAttemptTimeout, parseMaxIterations } from "../core/execution.js";
+import { parseMaxIterations } from "../core/execution.js";
 import { resolveLaneIdleStallConfig, type LaneIdleStallConfig } from "../core/lane-idle-reaper.js";
 import { inspectProcessTreeNative } from "./proc-tree.js";
 import { statSync } from "node:fs";
@@ -202,20 +202,13 @@ export interface RunSettings {
    */
   maxIterations?: number;
   /**
-   * Attempt progress-guard cap (seconds), resolved with precedence
-   * RED_AFK_ATTEMPT_TIMEOUT_S env > `afk.attempt_timeout` config > undefined
-   * (→ DEFAULT_ATTEMPT_TIMEOUT_S). The guard aborts a run that produces no new
-   * commit within the cap (proof-of-progress) → blocked:stalled / ready-for-human.
-   */
-  attemptTimeoutSeconds?: number;
-  /**
    * Solo-path lane-idle stall reaper config (issue #363), resolved + validated
    * at boot via resolveLaneIdleStallConfig (RED_AFK_STALL_THRESHOLD_S /
    * RED_AFK_STALL_KILL_THRESHOLD_S / RED_AFK_STALL_POLL_S, fleet defaults
    * 600 / 1800 / 30). A kill ≤ soft threshold THROWS here, so a misconfigured
    * solo run fails fast at boot — the same invariant the supervisor enforces.
-   * Complementary to attemptTimeoutSeconds: this cuts an idle hang at the stall
-   * threshold; the progress guard caps the whole attempt on no-commit.
+   * Complementary to the fixed progress guard: this cuts an idle hang at the
+   * stall threshold; the progress guard caps the whole attempt on no-commit.
    */
   laneIdle: LaneIdleStallConfig;
   /**
@@ -231,52 +224,9 @@ export interface RunSettings {
    * pinned bases are exactly why the flag defaults off.
    */
   feedbackRebaseBase?: string;
-  /**
-   * Per-attempt resource budget (#908): the optional token / cost / tool-call /
-   * waiting-window ceilings the attempt guard enforces. Every field is optional;
-   * an all-undefined budget is inert (today's behaviour). The #788 antidote —
-   * the proxy ceilings (tool-calls / waiting-windows) fire live even for
-   * claude/minimax, which stream 0 token usage on the wire.
-   */
-  attemptBudget?: AttemptBudget;
 }
 
 const SANDBOX_MODES: readonly SandboxMode[] = ["none", "docker", "podman"];
-
-/** Parse a positive number (int or float) for a budget ceiling; undefined when
- * unset / non-numeric / non-positive, so a typo can never silently set a 0 cap
- * that aborts every attempt instantly. */
-function parsePositive(raw: string | undefined): number | undefined {
-  if (raw === undefined) return undefined;
-  const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? n : undefined;
-}
-
-/**
- * Resolve the per-attempt budget (#908) from env overrides then `.red/config.yaml`
- * `plugins.dev.afk.attempt.*` (folded to `afk.attempt.*`). Returns `undefined`
- * when NO ceiling is set, so makeRunAgent can skip wiring the probe entirely and
- * the guard stays at today's behaviour.
- */
-export function resolveAttemptBudget(
-  env: NodeJS.ProcessEnv,
-  getCfg: (key: string) => string,
-): AttemptBudget | undefined {
-  const budget: AttemptBudget = {
-    maxTotalTokens: parsePositive(env.RED_AFK_ATTEMPT_MAX_TOKENS) ?? parsePositive(getCfg("afk.attempt.max_tokens")),
-    maxCostUsd: parsePositive(env.RED_AFK_ATTEMPT_MAX_COST_USD) ?? parsePositive(getCfg("afk.attempt.max_cost_usd")),
-    maxToolCalls:
-      parsePositive(env.RED_AFK_ATTEMPT_MAX_TOOL_CALLS) ?? parsePositive(getCfg("afk.attempt.max_tool_calls")),
-    maxWaitingWindows:
-      parsePositive(env.RED_AFK_ATTEMPT_MAX_WAITING_WINDOWS) ?? parsePositive(getCfg("afk.attempt.max_waiting_windows")),
-  };
-  const anySet =
-    budget.maxTotalTokens !== undefined ||
-    budget.maxCostUsd !== undefined ||
-    budget.maxToolCalls !== undefined ||
-    budget.maxWaitingWindows !== undefined;
-  return anySet ? budget : undefined;
-}
 
 export function resolveRunSettings(
   root: string,
@@ -306,12 +256,6 @@ export function resolveRunSettings(
   // env or the config can never disable the cap or pin the agent to 1 iteration.
   const maxIterations =
     parseMaxIterations(env.RED_AFK_MAX_ITERATIONS) ?? parseMaxIterations(getConfig(cfg, "afk.max_iterations"));
-  // Precedence mirrors maxIterations: RED_AFK_ATTEMPT_TIMEOUT_S env >
-  // afk.attempt_timeout config > undefined (→ DEFAULT_ATTEMPT_TIMEOUT_S in
-  // makeRunAgent). Typo-safe: a non-numeric / zero / negative value parses to
-  // undefined from either source.
-  const attemptTimeoutSeconds =
-    parseAttemptTimeout(env.RED_AFK_ATTEMPT_TIMEOUT_S) ?? parseAttemptTimeout(getConfig(cfg, "afk.attempt_timeout"));
   // Solo lane-idle reaper thresholds (issue #363), env-driven with fleet
   // defaults and the same boot invariant (kill > soft) — throws here on a `<=`
   // config so the run fails fast before claiming an issue.
@@ -327,19 +271,14 @@ export function resolveRunSettings(
   const feedbackRebaseBase = rebaseFlag
     ? getConfig(cfg, "dev.lock.branch") || getConfig(cfg, "dev.trunk") || "main"
     : undefined;
-  // Per-attempt resource budget (#908) — env > `afk.attempt.*` config; undefined
-  // when no ceiling is set (inert).
-  const attemptBudget = resolveAttemptBudget(env, (key) => getConfig(cfg, key));
   return {
     sandbox,
     defaultRunner,
     model: tier.model,
     effort: tier.effort,
     maxIterations,
-    attemptTimeoutSeconds,
     laneIdle,
     feedbackRebaseBase,
-    attemptBudget,
   };
 }
 
@@ -442,12 +381,7 @@ export function makeRunAgent(
   sandbox: SandboxMode,
   env: NodeJS.ProcessEnv = process.env,
   maxIterations?: number,
-  attemptTimeoutSeconds?: number,
   laneIdle?: LaneIdleStallConfig,
-  // Per-attempt budget (#908): the resolved ceilings + a live usage probe (the
-  // attempt's activity meter `peek()`). Both must be present to arm the cap; it
-  // rides the existing progress guard, so it is only active when that guard is.
-  attemptBudget?: AttemptBudget,
   budgetUsage?: () => AttemptBudgetUsage,
 ): (input: RunAgentInput) => Promise<RunAgentResult> {
   let depsPromise: Promise<import("../core/execution.js").SandcastleDeps> | null = null;
@@ -458,7 +392,6 @@ export function makeRunAgent(
       parseIdleTimeout,
       DEFAULT_ATTEMPT_TIMEOUT_S,
       DEFAULT_ATTEMPT_HARD_CAP_S,
-      parseAttemptHardCap,
     } = await import("../core/execution.js");
     if (!depsPromise) depsPromise = defaultSandcastleDeps();
     const deps = await depsPromise;
@@ -483,14 +416,12 @@ export function makeRunAgent(
     // agent); resolveAttemptGuardArming decouples the two.
     const attemptTimeout =
       input.attemptTimeoutSeconds ??
-      attemptTimeoutSeconds ??
-      parseAttemptTimeout(env.RED_AFK_ATTEMPT_TIMEOUT_S) ??
       DEFAULT_ATTEMPT_TIMEOUT_S;
     // Commit-anchored hard cap (issue #637): bounds how long the edit-signal
     // below may keep extending the soft deadline. Never below the soft cap, so
     // a low override cannot make the hard cap fire before plain ADR 0044 would.
     const attemptHardCap = Math.max(
-      input.attemptHardCapSeconds ?? parseAttemptHardCap(env.RED_AFK_ATTEMPT_HARD_CAP_S) ?? DEFAULT_ATTEMPT_HARD_CAP_S,
+      input.attemptHardCapSeconds ?? DEFAULT_ATTEMPT_HARD_CAP_S,
       attemptTimeout,
     );
     // Resolved lane-idle config is threaded from resolveRunSettings (validated at
@@ -533,7 +464,6 @@ export function makeRunAgent(
       // configured resource budget. The budget predicate itself still requires
       // both the ceilings and the usage probe.
       ...(guardArmed && budgetUsage ? { budgetUsage } : {}),
-      ...(guardArmed && attemptBudget && budgetUsage ? { budget: attemptBudget } : {}),
       ...(laneArmed && laneAttemptDir
         ? {
             laneIdleThresholdSeconds: laneIdleCfg.stallThresholdS,
@@ -871,16 +801,22 @@ import type { AfkInput, DocsInput, FleetInput, RepoInput } from "../core/statusl
 export const STATUSLINE_CACHE_TTL_S = 900;
 export const STATUSLINE_REFRESH_LOCK_TTL_S = 60;
 
+function parsePositive(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
 /**
  * Resolve the effective statusline cache TTL (seconds) with precedence
  * RED_AFK_STATUSLINE_CACHE_TTL_S env > `afk.statusline_cache_ttl` config >
- * {@link STATUSLINE_CACHE_TTL_S} default (180). Mirrors the resolveAttemptBudget
- * / parseAttemptTimeout precedence pattern. Typo-safe: a missing / non-numeric /
- * zero / negative value from EITHER source falls through to the next source and
- * ultimately the 180 default — never 0. A 0 TTL would make the cache always-stale
- * and refresh on every render, defeating the whole purpose. Note the FLAT config
- * key `afk.statusline_cache_ttl` — NOT nested under `afk.statusline`, which is
- * already the boolean opt-out (YAML cannot make one key both a boolean and a map).
+ * {@link STATUSLINE_CACHE_TTL_S} default (180). Typo-safe: a missing /
+ * non-numeric / zero / negative value from EITHER source falls through to the
+ * next source and ultimately the 180 default — never 0. A 0 TTL would make the
+ * cache always-stale and refresh on every render, defeating the whole purpose.
+ * Note the FLAT config key `afk.statusline_cache_ttl` — NOT nested under
+ * `afk.statusline`, which is already the boolean opt-out (YAML cannot make one
+ * key both a boolean and a map).
  */
 export function resolveStatuslineCacheTtl(env: NodeJS.ProcessEnv, getCfg: (key: string) => string): number {
   return (
@@ -2199,7 +2135,7 @@ export async function buildBootDeps(
 
 /**
  * Build a MINIMAL {@link BootDeps} for a supervised worker whose boot skips
- * every shared sweep (#623, `RED_AFK_SWEEPS_DONE`). `runBoot` with
+ * every shared sweep (#623, `RED_AFK_BOOT_SWEEPS_COMPLETE`). `runBoot` with
  * `skipSweeps:true` touches only `deps.fs` (the bootstrap mkdir / gitignore /
  * worker.pid writes) and `deps.nowS` before returning, so the gh/git/lookup
  * closures are never reached — they are present only to satisfy the type and

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -924,8 +924,8 @@ describe("runBoot stale claim-lock sweep", () => {
 });
 
 describe("runBoot attempt cap reclaims the right dirs", () => {
-  it("reaps age- and count-capped dirs, keeps live and newest", async () => {
-    const { deps, fsCalls } = makeDeps({ env: { RED_AFK_ATTEMPT_KEEP: "2" } });
+  it("reaps age- and count-capped dirs with fixed legacy cleanup defaults", async () => {
+    const { deps, fsCalls } = makeDeps({ env: { RED_AFK_ATTEMPT_KEEP: "2", RED_AFK_ATTEMPT_TTL_S: "999999" } });
     const byIssue = new Map<number, AttemptDir[]>([
       [
         42,
@@ -934,12 +934,16 @@ describe("runBoot attempt cap reclaims the right dirs", () => {
           attempt(42, 2, 1 * DAY),
           attempt(42, 3, 1 * DAY),
           attempt(42, 4, 1 * DAY),
-          attempt(42, 5, 1 * DAY, true), // live → spared, not counted
+          attempt(42, 5, 1 * DAY),
+          attempt(42, 6, 1 * DAY),
+          attempt(42, 7, 1 * DAY),
+          attempt(42, 8, 1 * DAY, true), // live → spared, not counted
         ],
       ],
     ]);
     const r = await runBoot(deps, options({ attemptCap: { byIssue } }));
-    // a1 age-capped; survivors a2,a3,a4 with keep=2 → drop a2 (oldest by number).
+    // Deleted RED_AFK_ATTEMPT_* env is ignored: fixed defaults are ttl=14d, keep=5.
+    // a1 age-capped; survivors a2..a7 with keep=5 → drop a2 (oldest by number).
     expect(fsCalls.removeDir).toEqual([
       "/p/.red/tmp/workers/wAAA/42-a1",
       "/p/.red/tmp/workers/wAAA/42-a2",

--- a/apps/dev/tests/branch-cleanup.test.ts
+++ b/apps/dev/tests/branch-cleanup.test.ts
@@ -9,7 +9,6 @@ import {
   planAttemptSnapshotCleanup,
   planLiveBranchCleanup,
   planLocalBranchCleanup,
-  resolveSnapshotGraceS,
   type BranchRef,
   type IssueLookup,
   type IssueMeta,
@@ -64,25 +63,6 @@ describe("classifyIssueState", () => {
     expect(classifyIssueState(closedAgo(1), NOW, 0)).toBe("closed-past-grace");
     // Boundary: exactly at the window is still within grace (strict > , mirrors bash).
     expect(classifyIssueState(closedAgo(0), NOW, 0)).toBe("closed-within-grace");
-  });
-});
-
-describe("resolveSnapshotGraceS", () => {
-  it("defaults to 7 days", () => {
-    expect(resolveSnapshotGraceS({})).toBe(DEFAULT_SNAPSHOT_GRACE_S);
-    expect(DEFAULT_SNAPSHOT_GRACE_S).toBe(7 * DAY);
-  });
-
-  it("honours an explicit numeric value including 0", () => {
-    expect(resolveSnapshotGraceS({ RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S: "3600" })).toBe(3600);
-    expect(resolveSnapshotGraceS({ RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S: "0" })).toBe(0);
-  });
-
-  it("falls back to the default on a non-numeric typo (never disables the grace)", () => {
-    expect(resolveSnapshotGraceS({ RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S: "not-a-number" })).toBe(
-      DEFAULT_SNAPSHOT_GRACE_S,
-    );
-    expect(resolveSnapshotGraceS({ RED_AFK_ATTEMPT_SNAPSHOT_GRACE_S: "-5" })).toBe(DEFAULT_SNAPSHOT_GRACE_S);
   });
 });
 

--- a/apps/dev/tests/execution.test.ts
+++ b/apps/dev/tests/execution.test.ts
@@ -30,12 +30,10 @@ import {
   MINIMAX_EFFORTS,
   parseMaxIterations,
   parseIdleTimeout,
-  parseAttemptTimeout,
   startAttemptGuard,
   exceedsBudget,
   type AttemptBudget,
   type AttemptBudgetUsage,
-  DEFAULT_ATTEMPT_TIMEOUT_S,
   type SandcastleDeps,
   type RunAgentInput,
   type AgentStreamEvent,
@@ -1296,19 +1294,6 @@ function manualScheduler() {
   };
   return { schedule, tick };
 }
-
-describe("parseAttemptTimeout", () => {
-  it("accepts a positive integer, rejects 0 / negative / non-numeric / undefined", () => {
-    expect(parseAttemptTimeout("2700")).toBe(2700);
-    expect(parseAttemptTimeout("0")).toBeUndefined();
-    expect(parseAttemptTimeout("-5")).toBeUndefined();
-    expect(parseAttemptTimeout("abc")).toBeUndefined();
-    expect(parseAttemptTimeout(undefined)).toBeUndefined();
-  });
-  it("documents a sane default", () => {
-    expect(DEFAULT_ATTEMPT_TIMEOUT_S).toBeGreaterThan(0);
-  });
-});
 
 describe("startAttemptGuard — commit-anchored progress watchdog", () => {
   it("aborts once the cap elapses with no new commit", async () => {

--- a/apps/dev/tests/hook-dispatcher.test.ts
+++ b/apps/dev/tests/hook-dispatcher.test.ts
@@ -320,7 +320,7 @@ describe("deriveHookEnv (documented per-event RED_AFK_* contract)", () => {
     expect(deriveHookEnv(base, "not json")).toEqual(base);
   });
 
-  it("derives the pre_attempt env from issue, workspace, runner, and attempt_n", () => {
+  it("derives the pre_attempt env from issue, workspace, and runner", () => {
     const env = deriveHookEnv(
       base,
       JSON.stringify({
@@ -337,7 +337,6 @@ describe("deriveHookEnv (documented per-event RED_AFK_* contract)", () => {
       RED_AFK_WORKSPACE: "/repo/.red/tmp/worktree",
       RED_AFK_ISSUE: "585",
       RED_AFK_RUNNER: "codex",
-      RED_AFK_ATTEMPT_N: "2",
     });
   });
 
@@ -362,7 +361,7 @@ describe("deriveHookEnv (documented per-event RED_AFK_* contract)", () => {
     expect(env.RED_AFK_MERGE_BASE).toBe("main");
     expect(env.RED_AFK_MERGE_COMMIT).toBe("abc123456");
     expect(env.RED_AFK_MERGE_SHA).toBe("abc1234");
-    expect(env.RED_AFK_ATTEMPT_N).toBe("1");
+    expect("RED_AFK_ATTEMPT_N" in env).toBe(false);
   });
 
   it("leaves irrelevant or empty fields unset", () => {
@@ -451,7 +450,6 @@ describe("dispatchHooks layers the per-event env onto the base env", () => {
       RED_AFK_WORKSPACE: "/wt",
       RED_AFK_ISSUE: "585",
       RED_AFK_RUNNER: "codex",
-      RED_AFK_ATTEMPT_N: "1",
     });
   });
 });

--- a/apps/dev/tests/reclaim.test.ts
+++ b/apps/dev/tests/reclaim.test.ts
@@ -1,14 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_ATTEMPT_KEEP,
-  DEFAULT_ATTEMPT_TTL_S,
   ORPHAN_TTL_LONG_S,
   ORPHAN_TTL_SHORT_S,
   decideOrphanFate,
   planAttemptCap,
   planLivenessReclaim,
-  resolveAttemptKeep,
-  resolveAttemptTtlS,
   type AttemptDir,
   type LivenessReclaimInput,
   type OrphanFate,
@@ -96,40 +92,6 @@ describe("decideOrphanFate", () => {
       kind: "keep-until",
       ttlS: ORPHAN_TTL_SHORT_S,
     });
-  });
-});
-
-describe("resolveAttemptTtlS", () => {
-  it("defaults to 14 days", () => {
-    expect(resolveAttemptTtlS({})).toBe(DEFAULT_ATTEMPT_TTL_S);
-    expect(DEFAULT_ATTEMPT_TTL_S).toBe(14 * DAY);
-  });
-
-  it("honours an explicit positive numeric value", () => {
-    expect(resolveAttemptTtlS({ RED_AFK_ATTEMPT_TTL_S: "3600" })).toBe(3600);
-  });
-
-  it("falls back to the default on zero / negative / non-numeric (never disables the cap)", () => {
-    expect(resolveAttemptTtlS({ RED_AFK_ATTEMPT_TTL_S: "0" })).toBe(DEFAULT_ATTEMPT_TTL_S);
-    expect(resolveAttemptTtlS({ RED_AFK_ATTEMPT_TTL_S: "-5" })).toBe(DEFAULT_ATTEMPT_TTL_S);
-    expect(resolveAttemptTtlS({ RED_AFK_ATTEMPT_TTL_S: "abc" })).toBe(DEFAULT_ATTEMPT_TTL_S);
-  });
-});
-
-describe("resolveAttemptKeep", () => {
-  it("defaults to 5", () => {
-    expect(resolveAttemptKeep({})).toBe(DEFAULT_ATTEMPT_KEEP);
-    expect(DEFAULT_ATTEMPT_KEEP).toBe(5);
-  });
-
-  it("honours an explicit positive numeric value", () => {
-    expect(resolveAttemptKeep({ RED_AFK_ATTEMPT_KEEP: "3" })).toBe(3);
-  });
-
-  it("falls back to the default on zero / negative / non-numeric (never disables the cap)", () => {
-    expect(resolveAttemptKeep({ RED_AFK_ATTEMPT_KEEP: "0" })).toBe(DEFAULT_ATTEMPT_KEEP);
-    expect(resolveAttemptKeep({ RED_AFK_ATTEMPT_KEEP: "-1" })).toBe(DEFAULT_ATTEMPT_KEEP);
-    expect(resolveAttemptKeep({ RED_AFK_ATTEMPT_KEEP: "x" })).toBe(DEFAULT_ATTEMPT_KEEP);
   });
 });
 

--- a/apps/dev/tests/supervise-passthrough.test.ts
+++ b/apps/dev/tests/supervise-passthrough.test.ts
@@ -28,7 +28,7 @@ describe("buildWorkerEnv / passthroughKeys (gap 4: passthrough denylist)", () =>
     // every internal knob is stripped
     for (const denied of PASSTHROUGH_DENYLIST) {
       if (denied === "RED_AFK_RUNNER") continue; // re-pinned below
-      if (denied === "RED_AFK_SWEEPS_DONE") continue; // re-pinned below (#623)
+      if (denied === "RED_AFK_BOOT_SWEEPS_COMPLETE") continue; // re-pinned below (#623)
       expect(env[denied]).toBeUndefined();
     }
     expect(env.RED_AFK_TARGET).toBeUndefined();
@@ -37,7 +37,7 @@ describe("buildWorkerEnv / passthroughKeys (gap 4: passthrough denylist)", () =>
     expect(env.RED_AFK_RUNNER).toBe("codex");
     // #623: every supervised worker is marked sweeps-done so it boots
     // bootstrap+claim only (skips the sweeps the supervisor already ran).
-    expect(env.RED_AFK_SWEEPS_DONE).toBe("1");
+    expect(env.RED_AFK_BOOT_SWEEPS_COMPLETE).toBe("1");
   });
 
   it("strips per-slot _BASE build-isolation vars (handled per slot, not forwarded)", () => {

--- a/apps/dev/tests/validation-scope.test.ts
+++ b/apps/dev/tests/validation-scope.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  CORE_MODULE_MANIFEST,
   computeValidationScope,
   formatValidationScope,
   isRootTrigger,
@@ -81,9 +80,8 @@ describe("isRootTrigger", () => {
 // ---- scopeNeedsWholeSuite ----
 
 describe("scopeNeedsWholeSuite", () => {
-  it("escalates core-module touches via the explicit manifest", () => {
-    expect(CORE_MODULE_MANIFEST).toContain("apps/dev/src/core");
-    expect(scopeNeedsWholeSuite(["apps/dev/src/core/process-issue.ts"])).toBe(true);
+  it("does not escalate package-local core-module touches through the deleted manifest", () => {
+    expect(scopeNeedsWholeSuite(["apps/dev/src/core/process-issue.ts"])).toBe(false);
   });
 
   it("keeps leaf touches on the scoped package path", () => {
@@ -133,13 +131,14 @@ describe("computeValidationScope — whole-workspace escalation", () => {
     expect(scopesForValidationScope(scope)).toEqual(["."]);
   });
 
-  it("escalates to whole-workspace on a manifest core-module change", () => {
+  it("keeps package-local core-module changes in the package cone", () => {
     const scope = computeValidationScope(["apps/dev/src/core/process-issue.ts"], layout, g);
-    expect(scope.type).toBe("whole-workspace");
-    if (scope.type === "whole-workspace") {
-      expect(scope.triggerFile).toBe("apps/dev/src/core/process-issue.ts");
+    expect(scope.type).toBe("cone");
+    if (scope.type === "cone") {
+      expect(scope.packages).toEqual(["apps/dev"]);
+      expect(scope.triggerPackages).toEqual(["apps/dev"]);
     }
-    expect(scopesForValidationScope(scope)).toEqual(["."]);
+    expect(scopesForValidationScope(scope)).toEqual(["apps/dev"]);
   });
 });
 

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -17,7 +17,6 @@ import {
   collectStatuslineWorkers,
   readFleetState,
   resolveAttemptGuardArming,
-  resolveAttemptBudget,
   buildMinimalBootDeps,
   withTimeout,
   collectStatuslineAfk,
@@ -148,36 +147,6 @@ describe("resolveAttemptHead (#1390)", () => {
     await expect(resolveAttemptHead({ cwd: "/repo/.red/tmp/workers/w1/1390-a1", exec }, "afk/w1/1390-loc")).resolves.toBe(
       "branch-head",
     );
-  });
-});
-
-describe("resolveAttemptBudget (#908)", () => {
-  const cfg = (m: Record<string, string>) => (key: string) => m[key] ?? "";
-  it("returns undefined when no ceiling is set anywhere (inert)", () => {
-    expect(resolveAttemptBudget({}, cfg({}))).toBeUndefined();
-  });
-  it("reads ceilings from afk.attempt.* config", () => {
-    const b = resolveAttemptBudget(
-      {},
-      cfg({
-        "afk.attempt.max_tokens": "500000",
-        "afk.attempt.max_cost_usd": "5",
-        "afk.attempt.max_tool_calls": "200",
-        "afk.attempt.max_waiting_windows": "30",
-      }),
-    );
-    expect(b).toEqual({ maxTotalTokens: 500000, maxCostUsd: 5, maxToolCalls: 200, maxWaitingWindows: 30 });
-  });
-  it("env overrides config", () => {
-    const b = resolveAttemptBudget(
-      { RED_AFK_ATTEMPT_MAX_TOOL_CALLS: "150" } as NodeJS.ProcessEnv,
-      cfg({ "afk.attempt.max_tool_calls": "999" }),
-    );
-    expect(b?.maxToolCalls).toBe(150);
-  });
-  it("rejects non-positive / non-numeric ceilings (typo never sets a 0 cap)", () => {
-    expect(resolveAttemptBudget({}, cfg({ "afk.attempt.max_tokens": "0" }))).toBeUndefined();
-    expect(resolveAttemptBudget({}, cfg({ "afk.attempt.max_tool_calls": "abc" }))).toBeUndefined();
   });
 });
 

--- a/packages/red-castle/src/engine/config.test.ts
+++ b/packages/red-castle/src/engine/config.test.ts
@@ -68,7 +68,6 @@ describe("engine config reader", () => {
         "afk:",
         "  sandbox: docker",
         "  max_iterations: 4",
-        "  attempt_timeout: 99",
         "  statusline_cache_ttl: 42",
         "",
       ].join("\n"),
@@ -79,7 +78,6 @@ describe("engine config reader", () => {
         RED_AFK_SANDBOX: "podman",
         RED_AFK_RUNNER: "codex",
         RED_AFK_MAX_ITERATIONS: "8",
-        RED_AFK_ATTEMPT_TIMEOUT_S: "123",
         RED_AFK_STATUSLINE_CACHE_TTL_S: "77",
       },
     });
@@ -87,9 +85,30 @@ describe("engine config reader", () => {
     expect(cfg.get("afk.sandbox")).toBe("podman");
     expect(cfg.get("afk.default_runner")).toBe("codex");
     expect(cfg.get("afk.max_iterations")).toBe("8");
-    expect(cfg.get("afk.attempt_timeout")).toBe("123");
     expect(cfg.get("afk.statusline_cache_ttl")).toBe("77");
     expect(cfg.values["RED_AFK_SANDBOX"]).toBeUndefined();
+  });
+
+  it("ignores deleted attempt-era timeout knobs", () => {
+    const redRoot = redRootWithConfig(
+      [
+        "plugins:",
+        "  dev:",
+        "    enabled: true",
+        "afk:",
+        "  attempt_timeout: 99",
+        "",
+      ].join("\n"),
+    );
+
+    const cfg = loadEngineConfig(redRoot, {
+      env: {
+        RED_AFK_ATTEMPT_TIMEOUT_S: "123",
+      },
+    });
+
+    expect(cfg.get("afk.attempt_timeout")).toBe("");
+    expect(cfg.values.RED_AFK_ATTEMPT_TIMEOUT_S).toBeUndefined();
   });
 
   it("parses list values into indexed dotted keys", () => {

--- a/packages/red-castle/src/engine/config.ts
+++ b/packages/red-castle/src/engine/config.ts
@@ -16,7 +16,6 @@ export const ENGINE_CONFIG_DEFAULTS = {
   "afk.default_runner": "claude",
   "afk.sandbox": "none",
   "afk.max_iterations": "12",
-  "afk.attempt_timeout": "2700",
   "afk.statusline_cache_ttl": "180",
   "afk.worktree_launches_pull_request": "true",
   "afk.claim_reaper.refresh_s": "300",
@@ -37,13 +36,17 @@ const RED_AFK_ENV_ACCESSORS = {
   RED_AFK_RUNNER: "afk.default_runner",
   RED_AFK_SANDBOX: "afk.sandbox",
   RED_AFK_MAX_ITERATIONS: "afk.max_iterations",
-  RED_AFK_ATTEMPT_TIMEOUT_S: "afk.attempt_timeout",
   RED_AFK_STATUSLINE_CACHE_TTL_S: "afk.statusline_cache_ttl",
   RED_AFK_CLAIM_REFRESH_S: "afk.claim_reaper.refresh_s",
   RED_AFK_CLAIM_STALE_TOLERANCE: "afk.claim_reaper.stale_tolerance",
   RED_AFK_CLAIM_REAPER_GRACE_S: "afk.claim_reaper.grace_s",
   RED_AFK_CLAIM_REAPER_RECENT_COMMIT_S: "afk.claim_reaper.recent_commit_s",
 } as const;
+
+const DELETED_CONFIG_KEYS = new Set([
+  "afk.attempt_timeout",
+  "plugins.dev.afk.attempt_timeout",
+]);
 
 export interface LoadEngineConfigOptions {
   readonly read?: EngineConfigReader;
@@ -167,9 +170,11 @@ function foldDevNamespace(
   parsed: EngineConfigValues,
 ): void {
   for (const [key, value] of Object.entries(parsed)) {
+    if (DELETED_CONFIG_KEYS.has(key)) continue;
     values[key] = value;
   }
   for (const [key, value] of Object.entries(parsed)) {
+    if (DELETED_CONFIG_KEYS.has(key)) continue;
     const match = /^plugins\.dev\.(.+)$/.exec(key);
     if (!match) continue;
     const rest = match[1]!;


### PR DESCRIPTION
Automated AFK landing for #1920. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1920

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786908192&installation_id=129708444&pr_number=2044&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2044&signature=e3bfb36e10cea14404e80cc288cc4665e002b37387cd7ce117529bb2568299b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->