### PR TITLE
fix: #2047 Statusline block-1 shows worktree dir name instead of repo name (basename(cwd) vs git common-dir)

### DIFF
--- a/apps/dev/src/commands/statusline.ts
+++ b/apps/dev/src/commands/statusline.ts
@@ -17,7 +17,7 @@
 // else `.workspace.current_dir // .cwd`, else `process.cwd()`.
 
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, dirname } from "node:path";
 import { configFile } from "@reddb-io/shared/red-paths.js";
 import { readBuildInfo } from "@reddb-io/build-info";
 import { decode } from "@reddb-io/toon";
@@ -28,6 +28,7 @@ import { renderStatuslineLegend } from "../core/statusline-legend.js";
 import { renderStatuslineThemed } from "../core/statusline-style.js";
 import { loadConfig, getConfig } from "../core/config.js";
 import { branchLockPath, readLockedBranch } from "../runtime/lock.js";
+import { git as gitExec } from "../runtime/exec.js";
 import { resolveRspConfig } from "../../../rsp/src/config.js";
 import { resolveResidentPaths } from "../../../rsp/src/resident-client.js";
 import {
@@ -250,15 +251,25 @@ async function resolveProject(root: string): Promise<ProjectInput> {
   const version = readBuildInfo("dev").version;
   const bundleCache = readDevBundleCacheState(version);
   const latestCachedVersion = bundleCache.laneNewestVersion;
+  const repoBasename = await resolveRepoBasename(root);
   const base: ProjectInput = latestCachedVersion === undefined
-    ? { basename: basename(root), version }
-    : { basename: basename(root), version, latestCachedVersion };
+    ? { basename: repoBasename, version }
+    : { basename: repoBasename, version, latestCachedVersion };
   const withPointer = bundleCache.pointerVersion ? { ...base, pointerVersion: bundleCache.pointerVersion } : base;
   const branch = await gitx.currentBranch(ctx);
   if (branch) return { ...withPointer, branch };
   const sha = await gitx.headShortSha(ctx);
   if (sha) return { ...withPointer, detachedSha: sha };
   return withPointer;
+}
+
+async function resolveRepoBasename(root: string): Promise<string> {
+  const fallback = basename(root);
+  const commonDir = await gitExec(["rev-parse", "--path-format=absolute", "--git-common-dir"], { cwd: root });
+  if (commonDir.code !== 0) return fallback;
+  const gitCommonDir = commonDir.stdout.trim();
+  if (!gitCommonDir) return fallback;
+  return basename(dirname(gitCommonDir)) || fallback;
 }
 
 /** Project the Claude Code payload into the renderer's block-2/3 input. */

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, mkdir, writeFile, rm, readFile, utimes } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer, type Server, type Socket } from "node:net";
 import { Readable } from "node:stream";
@@ -209,6 +209,17 @@ async function initRepoWithDevelopTrunk(root: string): Promise<void> {
   await writeFile(join(root, "work.txt"), "work\n", "utf8");
   git(root, ["add", "work.txt"]);
   git(root, ["commit", "-m", "feature work"]);
+}
+
+async function initSimpleRepo(root: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  git(root, ["init"]);
+  git(root, ["config", "user.email", "agent@example.test"]);
+  git(root, ["config", "user.name", "Agent"]);
+  git(root, ["checkout", "-b", "main"]);
+  await writeFile(join(root, "README.md"), "# repo\n", "utf8");
+  git(root, ["add", "README.md"]);
+  git(root, ["commit", "-m", "initial"]);
 }
 
 async function withFakeGh<T>(fn: () => Promise<T>): Promise<T> {
@@ -704,6 +715,76 @@ describe("statusline command — rendered line", () => {
     expect(line).not.toContain("Opus");
     expect(line).not.toContain("%");
     expect(line.length).toBeGreaterThan(0);
+  });
+
+  it("uses the primary checkout repo name and keeps the active branch", async () => {
+    const repo = join(root, "red-request");
+    await initSimpleRepo(repo);
+    await seedFreshRepoCache(repo, 0, 0);
+    await seedFreshCache(repo, 0, 0);
+
+    const out = sink();
+    const oldNoColor = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const code = await withFakeGh(() => statuslineCommand([repo], repo, out.stream, fakeStdin(PAYLOAD)));
+      expect(code).toBe(0);
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+
+    expect(stripAnsi(out.text())).toMatch(/^red-request \(main\)(?: v[^ ·]+)?(?: ·|$)/);
+  });
+
+  it("uses the common git dir repo name in linked worktrees while keeping the worktree ref", async () => {
+    const repo = join(root, "red-request");
+    await initSimpleRepo(repo);
+    const worktree = join(root, "worktree-bump-reddb-1231");
+    git(repo, ["worktree", "add", "-b", "bump-reddb-1231", worktree]);
+    await seedFreshRepoCache(worktree, 0, 0);
+    await seedFreshCache(worktree, 0, 0);
+
+    const oldNoColor = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const branchOut = sink();
+      const branchCode = await withFakeGh(() => statuslineCommand([worktree], worktree, branchOut.stream, fakeStdin(PAYLOAD)));
+      expect(branchCode).toBe(0);
+      const branchText = stripAnsi(branchOut.text());
+      expect(branchText).toMatch(/^red-request \(bump-reddb-1231\)(?: v[^ ·]+)?(?: ·|$)/);
+      expect(branchText).not.toContain("worktree-bump-reddb-1231");
+
+      git(worktree, ["checkout", "--detach", "HEAD"]);
+      const sha = git(worktree, ["rev-parse", "--short", "HEAD"]);
+      const detachedOut = sink();
+      const detachedCode = await withFakeGh(() => statuslineCommand([worktree], worktree, detachedOut.stream, fakeStdin(PAYLOAD)));
+      expect(detachedCode).toBe(0);
+      expect(stripAnsi(detachedOut.text())).toMatch(new RegExp(`^red-request \\(detached ${sha}\\)(?: v[^ ·]+)?(?: ·|$)`));
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+  });
+
+  it("falls back to the cwd basename outside git", async () => {
+    const dir = join(root, "not-a-git-repo");
+    await mkdir(dir, { recursive: true });
+    await seedFreshRepoCache(dir, 0, 0);
+    await seedFreshCache(dir, 0, 0);
+
+    const out = sink();
+    const oldNoColor = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const code = await withFakeGh(() => statuslineCommand([dir], dir, out.stream, fakeStdin("")));
+      expect(code).toBe(0);
+    } finally {
+      if (oldNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = oldNoColor;
+    }
+
+    expect(stripAnsi(out.text()).trim()).toMatch(new RegExp(`^${basename(dir)}(?: v[^ ·]+)?$`));
   });
 
   it("emits nothing when the per-project opt-out is set", async () => {


### PR DESCRIPTION
Automated AFK landing for #2047. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2047

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786913574&installation_id=129708444&pr_number=2048&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2048&signature=7f6bd6475bd8271b6b2aea8cab0d410f443e9b7c3ed080a710b037891dbe014f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->