### PR TITLE
feat: #2038 statusline/monitor cross-check supervisor busy-slots against real worker liveness (churn marker)

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -93,6 +93,11 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
       parked: hb.slotsParked,
     },
     spawns_this_tick: hb.spawnsThisTick,
+    churn: {
+      window_s: hb.churn.windowS,
+      deaths: hb.churn.deaths,
+      respawns: hb.churn.respawns,
+    },
     ...(hb.drainBudget
       ? {
           drain_budget: {
@@ -139,6 +144,11 @@ async function writeCastleSupervisorSnapshot(
           parked: hb.slotsParked,
         },
         spawns_this_tick: hb.spawnsThisTick,
+        churn: {
+          window_s: hb.churn.windowS,
+          deaths: hb.churn.deaths,
+          respawns: hb.churn.respawns,
+        },
         ...(hb.drainBudget
           ? {
               drain_budget: {
@@ -684,6 +694,9 @@ function buildSupervisorDeps(
               slots_total: String(stamped.slotsTotal),
               slots_parked: String(stamped.slotsParked),
               spawns_this_tick: String(stamped.spawnsThisTick),
+              churn_window_s: String(stamped.churn.windowS),
+              churn_deaths: String(stamped.churn.deaths),
+              churn_respawns: String(stamped.churn.respawns),
               drain_budget_tier: stamped.drainBudget?.tier ?? null,
               drain_budget_spent_usd: stamped.drainBudget?.spentUsd.toFixed(4) ?? null,
               drain_budget_limit_usd: stamped.drainBudget?.limitUsd.toFixed(4) ?? null,

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -174,6 +174,14 @@ export interface FleetInput {
   queue: number;
   /** Parked slots from the supervisor snapshot. */
   parked?: number;
+  /** True when local worker liveness/heartbeat evidence does not corroborate busy slots. */
+  degraded?: boolean;
+  /** Recent supervisor death/respawn churn, read from the supervisor snapshot. */
+  churn?: {
+    windowS: number;
+    deaths: number;
+    respawns: number;
+  };
   /** Dev bundle version the running supervisor was launched from. */
   bundleVersion?: string;
   /** Stable pointer version the shim would serve from the local cache. */
@@ -487,7 +495,7 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   const busy = Math.max(0, Math.floor(fleet.busy));
   const total = Math.max(0, Math.floor(fleet.total));
   const queue = Math.max(0, Math.floor(fleet.queue));
-  const parts = [`flt=${runner} ${busy}/${total}`];
+  const parts = [`flt=${runner} ${busy}/${total}${fleet.degraded ? "†" : ""}`];
   if (fleet.bundleVersion) {
     const versions = [fleet.bundleVersion, fleet.pointerVersion, fleet.latestBundleVersion]
       .filter((v): v is string => Boolean(v));

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -709,6 +709,8 @@ export interface FleetHeartbeat {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  /** Recent supervisor churn inside the configured circuit window. */
+  churn: FleetChurnStats;
   /** Optional per-drain budget status; absent when no budget is configured. */
   drainBudget?: DrainBudgetStatus;
   /** Per-slot details for non-closed slots. Empty array when all slots are closed. */
@@ -857,6 +859,20 @@ export interface ReapContestState {
   deadlineEpoch: number;
 }
 
+export interface FleetChurnStats {
+  /** Sliding window size in seconds. */
+  windowS: number;
+  /** Worker deaths observed inside the window. */
+  deaths: number;
+  /** Worker respawns observed inside the window. */
+  respawns: number;
+}
+
+interface SupervisorChurnState {
+  deaths: number[];
+  respawns: number[];
+}
+
 /** The supervisor's per-slot bookkeeping, mirroring the SLOT_* arrays. A fresh
  * slot is `freshSlot()`. The tick mutates these in place (the bash arrays are
  * global mutable state); tests inspect them after each tick. */
@@ -941,6 +957,8 @@ export interface SupervisorState {
    * the event lane delivered. Updated by runSupervisor after each iteration.
    */
   wakeStats: WakeStats;
+  /** Recent death/respawn timestamps for cheap churn reporting. */
+  churn: SupervisorChurnState;
   /** Once HARD_STOP is reached, no new workers are spawned for this supervisor. */
   drainBudgetHardStopped: boolean;
   /** Last budget tier logged, to avoid repeating unchanged OK/WARNING/CRITICAL. */
@@ -958,9 +976,35 @@ export function initSupervisorState(target: number): SupervisorState {
     lastProgressEpoch: 0,
     lastUnblockSweepEpoch: 0,
     wakeStats: freshWakeStats(),
+    churn: { deaths: [], respawns: [] },
     drainBudgetHardStopped: false,
     lastHeartbeatStateWriteEpoch: 0,
     heartbeatStateWriteMisses: 0,
+  };
+}
+
+function pruneChurnWindow(values: number[], now: number, windowS: number): number[] {
+  return values.filter((epoch) => now - epoch <= windowS);
+}
+
+function pushRepeated(values: number[], epoch: number, count: number): void {
+  for (let i = 0; i < count; i += 1) values.push(epoch);
+}
+
+function recordTickChurn(
+  state: SupervisorState,
+  result: Pick<TickResult, "deaths" | "respawned">,
+  epoch: number,
+  windowS: number,
+): FleetChurnStats {
+  pushRepeated(state.churn.deaths, epoch, result.deaths.length);
+  pushRepeated(state.churn.respawns, epoch, result.respawned.length);
+  state.churn.deaths = pruneChurnWindow(state.churn.deaths, epoch, windowS);
+  state.churn.respawns = pruneChurnWindow(state.churn.respawns, epoch, windowS);
+  return {
+    windowS,
+    deaths: state.churn.deaths.length,
+    respawns: state.churn.respawns.length,
   };
 }
 
@@ -1206,13 +1250,14 @@ async function emitFleetHeartbeat(
   deps: SupervisorDeps,
   result: TickResult,
   runner: string,
-  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS">,
+  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS" | "circuitWindowS">,
 ): Promise<{ heartbeat: FleetHeartbeat; write: FleetHeartbeatEmitResult }> {
   // Queue depth was fetched once by superviseTick at the start of this tick
   // and stored in result.queueDepth — reuse it here so there is exactly one
   // readyQueueDepth call per tick (0 on a stop tick or abandoned tick).
   const readyForAgent = result.queueDepth;
   const epoch = deps.now();
+  const churn = recordTickChurn(state, result, epoch, config.circuitWindowS);
   const heartbeat: FleetHeartbeat = {
     ts: isoFromEpoch(epoch),
     epoch,
@@ -1221,6 +1266,7 @@ async function emitFleetHeartbeat(
     readyForAgent,
     ...fleetSlotCounts(state, deps),
     spawnsThisTick: result.respawned.length,
+    churn,
     ...(result.drainBudget ? { drainBudget: result.drainBudget } : {}),
     slotDetails: buildSlotDetails(state, config),
   };

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -573,6 +573,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     ready_for_agent?: unknown;
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
     spawns_this_tick?: unknown;
+    churn?: { window_s?: unknown; deaths?: unknown; respawns?: unknown };
     slot_details?: unknown;
   };
   const epoch = Number(rec.epoch ?? 0);
@@ -607,6 +608,15 @@ function parseFleetState(raw: unknown): FleetState | null {
     slotsTotal: Number(rec.slots?.total ?? 0) || 0,
     slotsParked: Number(rec.slots?.parked ?? 0) || 0,
     spawnsThisTick: Number(rec.spawns_this_tick ?? 0) || 0,
+    ...(rec.churn && typeof rec.churn === "object"
+      ? {
+          churn: {
+            windowS: Number(rec.churn.window_s ?? 0) || 0,
+            deaths: Number(rec.churn.deaths ?? 0) || 0,
+            respawns: Number(rec.churn.respawns ?? 0) || 0,
+          },
+        }
+      : {}),
     ...(slotDetails !== undefined ? { slotDetails } : {}),
   };
 }
@@ -1285,6 +1295,9 @@ export async function collectStatuslineFleet(
   const state = await readFleetState(paths.fleetStatePath);
   if (!state) return undefined;
   if (nowS - state.epoch > maxAgeS) return undefined;
+  const workerRecords = currentRenderableWorkerRecords(await readAllWorkerStates(paths.tmpDir, { nowMs: nowS * 1000 }));
+  const freshWorkers = workerRecords.filter((rec) => rec.active).length;
+  const degraded = state.slotsBusy > 0 && freshWorkers < state.slotsBusy;
 
   return {
     runner: state.runner,
@@ -1292,6 +1305,8 @@ export async function collectStatuslineFleet(
     total: state.slotsTotal,
     queue: state.readyForAgent,
     parked: state.slotsParked,
+    degraded: degraded || undefined,
+    churn: state.churn,
     bundleVersion: state.bundleVersion,
   };
 }

--- a/apps/dev/tests/castle-acceptance-harness.test.ts
+++ b/apps/dev/tests/castle-acceptance-harness.test.ts
@@ -158,6 +158,7 @@ describe("castle acceptance harness", () => {
           ready_for_agent: 0,
           slots: { busy: 2, free: 0, total: 2, parked: 0 },
           spawns_this_tick: 2,
+          churn: { window_s: 90, deaths: 2, respawns: 2 },
         },
         queue: [],
         completed: [PROVEN_TICKET.number],
@@ -231,6 +232,7 @@ describe("castle acceptance harness", () => {
       slotsFree: 0,
       slotsTotal: 2,
       spawnsThisTick: 2,
+      churn: { windowS: 90, deaths: 2, respawns: 2 },
     });
     expect(history).toEqual([{ event: "done", epoch: NOW_EPOCH }]);
 
@@ -238,7 +240,7 @@ describe("castle acceptance harness", () => {
       renderCompactDashboardToon(workers, history, NOW_EPOCH, fleet),
     ) as {
       workers: Array<{ id: string; issue: number }>;
-      fleet: { slots_busy: number; slots_free: number };
+      fleet: { slots_busy: number; slots_free: number; churn_deaths: number; churn_respawns: number };
       proving_drain: { drained: number; required: number; remaining: number; passed: number };
       summary: string;
     };
@@ -246,7 +248,7 @@ describe("castle acceptance harness", () => {
       1917,
       1918,
     ]);
-    expect(monitor.fleet).toMatchObject({ slots_busy: 2, slots_free: 0 });
+    expect(monitor.fleet).toMatchObject({ slots_busy: 2, slots_free: 0, churn_deaths: 2, churn_respawns: 2 });
     expect(monitor.proving_drain).toMatchObject({
       drained: 1,
       required: 20,

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -435,6 +435,20 @@ describe("monitor — compact dashboard", () => {
     );
   });
 
+  it("surfaces recent supervisor churn on the fleet line", () => {
+    const line = renderFleetLine(
+      baseFleet({
+        readyForAgent: 7,
+        slotsBusy: 2,
+        slotsFree: 0,
+        spawnsThisTick: 2,
+        churn: { windowS: 90, deaths: 2, respawns: 2 },
+      }),
+      1780138815,
+    );
+    expect(line).toContain("churn:2 deaths/2 respawns/90s");
+  });
+
   it("carries parked:N unconditionally — zero when all slots closed", () => {
     const line = renderFleetLine(baseFleet(), 1780138815);
     expect(line).toContain("parked:0");

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -87,6 +87,16 @@ describe("statusline — fleet block", () => {
       latestBundleVersion: "2.64.0",
     })).toBe("flt=codex 0/2 @2.63.0!<2.64.0 q=4");
   });
+
+  it("marks busy slots as degraded when local liveness disagrees", () => {
+    expect(renderFleetBlock({
+      runner: "codex",
+      busy: 2,
+      total: 2,
+      queue: 4,
+      degraded: true,
+    })).toBe("flt=codex 2/2† q=4");
+  });
 });
 
 describe("statusline — humanizeAlive", () => {

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -1621,6 +1621,22 @@ describe("runSupervisor", () => {
     });
   });
 
+  it("emits recent deaths and respawns in the fleet heartbeat churn window", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn((pid: number) => pid !== 1001),
+      readyQueueDepth: vi.fn(async () => 5),
+    });
+    const state = initSupervisorState(1);
+    let probes = 0;
+
+    await runSupervisor(state, deps, config({ target: 1, pollIntervalS: 15, circuitWindowS: 90 }), () => ++probes >= 2);
+
+    expect(io.emitFleetHeartbeat).toHaveBeenCalledTimes(2);
+    expect(io.emitFleetHeartbeat.mock.calls[0]![0]).toMatchObject({
+      churn: { windowS: 90, deaths: 1, respawns: 1 },
+    });
+  });
+
   it("repairs a stale state heartbeat writer from the current tick snapshot", async () => {
     let clock = NOW;
     let probes = 0;

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -597,6 +597,31 @@ describe("collectMonitorInputs", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("drops stale supervisor self-report when the supervisor pid is dead", async () => {
+    const root = scratch();
+    try {
+      const paths = afkPaths(root);
+      mkdirSync(dirname(paths.fleetStatePath), { recursive: true });
+      writeFileSync(paths.supervisorPidPath, "999999999\n");
+      writeFileSync(
+        paths.fleetStatePath,
+        JSON.stringify({
+          ts: "2026-05-30T11:00:00Z",
+          epoch: Math.floor(Date.now() / 1000) - 10_000,
+          runner: "codex",
+          ready_for_agent: 9,
+          slots: { busy: 2, free: 0, total: 2, parked: 0 },
+          spawns_this_tick: 2,
+          churn: { window_s: 90, deaths: 2, respawns: 2 },
+        }),
+      );
+
+      await expect(collectStatuslineFleet({ root, repo: "reddb-io/red-skills", remote: "origin" })).resolves.toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("withTimeout — bounded cold-cache refresh", () => {

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -15,6 +15,7 @@ import {
   resolveRunSettings,
   collectMonitorInputs,
   collectStatuslineWorkers,
+  collectStatuslineFleet,
   readFleetState,
   resolveAttemptGuardArming,
   resolveAttemptBudget,
@@ -545,6 +546,7 @@ describe("collectMonitorInputs", () => {
           ready_for_agent: 9,
           slots: { busy: 1, free: 2, total: 3, parked: 0 },
           spawns_this_tick: 1,
+          churn: { window_s: 90, deaths: 2, respawns: 2 },
         }),
       );
 
@@ -555,9 +557,42 @@ describe("collectMonitorInputs", () => {
         slotsFree: 2,
         slotsTotal: 3,
         spawnsThisTick: 1,
+        churn: { windowS: 90, deaths: 2, respawns: 2 },
       });
       const { fleet } = await collectMonitorInputs(root);
       expect(fleet?.readyForAgent).toBe(9);
+      expect(fleet?.churn?.deaths).toBe(2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("marks the statusline fleet segment degraded when busy slots have no fresh local workers", async () => {
+    const root = scratch();
+    try {
+      const paths = afkPaths(root);
+      mkdirSync(dirname(paths.fleetStatePath), { recursive: true });
+      writeFileSync(paths.supervisorPidPath, `${process.pid}\n`);
+      writeFileSync(
+        paths.fleetStatePath,
+        JSON.stringify({
+          ts: "2026-05-30T11:00:00Z",
+          epoch: Math.floor(Date.now() / 1000),
+          runner: "codex",
+          ready_for_agent: 9,
+          slots: { busy: 2, free: 0, total: 2, parked: 0 },
+          spawns_this_tick: 2,
+          churn: { window_s: 90, deaths: 2, respawns: 2 },
+        }),
+      );
+
+      await expect(collectStatuslineFleet({ root, repo: "reddb-io/red-skills", remote: "origin" })).resolves.toMatchObject({
+        runner: "codex",
+        busy: 2,
+        total: 2,
+        degraded: true,
+        churn: { windowS: 90, deaths: 2, respawns: 2 },
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/red-castle/src/engine/monitor-readers.ts
+++ b/packages/red-castle/src/engine/monitor-readers.ts
@@ -234,6 +234,7 @@ function fleetFromSupervisorSnapshot(
   if (snapshot.kind !== "supervisor") return null;
   const current = asRecord(snapshot.current);
   const slots = asRecord(current.slots);
+  const churn = asRecord(current.churn);
   const epoch = numberField(
     current,
     "epoch",
@@ -256,6 +257,15 @@ function fleetFromSupervisorSnapshot(
     slotsTotal: numberField(slots, "total"),
     slotsParked: numberField(slots, "parked"),
     spawnsThisTick: numberField(current, "spawns_this_tick"),
+    ...(Object.keys(churn).length > 0
+      ? {
+          churn: {
+            windowS: numberField(churn, "window_s"),
+            deaths: numberField(churn, "deaths"),
+            respawns: numberField(churn, "respawns"),
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -249,6 +249,12 @@ export interface FleetState {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  /** Recent supervisor death/respawn churn inside a sliding window. */
+  churn?: {
+    windowS: number;
+    deaths: number;
+    respawns: number;
+  };
   /** Per-slot details for non-closed slots. Absent/empty = all slots closed.
    * Absent on state files written before this field was added (#630). */
   slotDetails?: SlotDetail[];
@@ -288,11 +294,16 @@ export function renderFleetLine(fleet: FleetState, now: number): string {
   const bundle = fleet.bundleVersion
     ? `  bundle:${fleet.bundleVersion}${compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0 ? `<${fleet.latestBundleVersion}` : ""}`
     : "";
+  const churn =
+    fleet.churn && (fleet.churn.deaths > 0 || fleet.churn.respawns > 0)
+      ? `  churn:${fleet.churn.deaths} deaths/${fleet.churn.respawns} respawns/${fleet.churn.windowS}s`
+      : "";
   return (
     `fleet [${status}] last ticked ${formatElapsed(age)} ago` +
     `  ready:${fleet.readyForAgent}` +
     `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}` +
     `  spawns:${fleet.spawnsThisTick}` +
+    churn +
     bundle
   );
 }
@@ -663,6 +674,9 @@ export function renderCompactDashboardToon(
       slots_free: fleet.slotsFree,
       slots_parked: fleet.slotsParked,
       spawns: fleet.spawnsThisTick,
+      churn_deaths: fleet.churn?.deaths ?? 0,
+      churn_respawns: fleet.churn?.respawns ?? 0,
+      churn_window_s: fleet.churn?.windowS ?? 0,
       bundle_version: fleet.bundleVersion ?? "",
       latest_bundle_version: fleet.latestBundleVersion ?? "",
       version_skew: compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0 ? 1 : 0,


### PR DESCRIPTION
Closes #2038

The statusline fleet segment rendered the supervisor's self-reported slot state, so a spawn/die churn loop displayed a healthy `flt 2/2` over zero real work (seen live on 2026-07-17). This adds ground-truth corroboration: the supervisor state carries recent deaths/respawns, and the statusline/monitor reader compares self-reported busy slots against live worker pids + fresh heartbeats, rendering a degraded/churn marker when they disagree. Local reads only (ADR 0084); no network in render.

Human-reviewed sensitive-path land (statusline.ts + supervisor.ts): diff reviewed, scoped, merges clean; landing via PR+CI per the 14GB-box gate rule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786914171&installation_id=129708444&pr_number=2050&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2050&signature=9f5ab8d0c1aa32acc28d893e822a1ee05218bdbcc8db93f4c94b448338f504b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->