### PR TITLE
feat: #2038 Statusline/monitor: cross-check supervisor busy-slots against real worker liveness and surface churn instead of trusting self-report

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -93,6 +93,11 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
       parked: hb.slotsParked,
     },
     spawns_this_tick: hb.spawnsThisTick,
+    churn: {
+      deaths: hb.churn.deaths,
+      respawns: hb.churn.respawns,
+      window_s: hb.churn.windowS,
+    },
     ...(hb.drainBudget
       ? {
           drain_budget: {
@@ -139,6 +144,11 @@ async function writeCastleSupervisorSnapshot(
           parked: hb.slotsParked,
         },
         spawns_this_tick: hb.spawnsThisTick,
+        churn: {
+          deaths: hb.churn.deaths,
+          respawns: hb.churn.respawns,
+          window_s: hb.churn.windowS,
+        },
         ...(hb.drainBudget
           ? {
               drain_budget: {

--- a/apps/dev/src/core/statusline.ts
+++ b/apps/dev/src/core/statusline.ts
@@ -174,6 +174,14 @@ export interface FleetInput {
   queue: number;
   /** Parked slots from the supervisor snapshot. */
   parked?: number;
+  /** True when supervisor busy slots are not corroborated by fresh local worker
+   * liveness. Rendered as a visible marker on the occupancy token. */
+  degraded?: boolean;
+  /** Recent death/respawn churn from the supervisor snapshot. Zero/absent stays
+   * silent so healthy fleets render exactly as before. */
+  churnDeaths?: number;
+  churnRespawns?: number;
+  churnWindowS?: number;
   /** Dev bundle version the running supervisor was launched from. */
   bundleVersion?: string;
   /** Stable pointer version the shim would serve from the local cache. */
@@ -487,7 +495,7 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   const busy = Math.max(0, Math.floor(fleet.busy));
   const total = Math.max(0, Math.floor(fleet.total));
   const queue = Math.max(0, Math.floor(fleet.queue));
-  const parts = [`flt=${runner} ${busy}/${total}`];
+  const parts = [`flt=${runner} ${busy}/${total}${fleet.degraded ? "†" : ""}`];
   if (fleet.bundleVersion) {
     const versions = [fleet.bundleVersion, fleet.pointerVersion, fleet.latestBundleVersion]
       .filter((v): v is string => Boolean(v));
@@ -501,6 +509,12 @@ export function renderFleetBlock(fleet: FleetInput | undefined): string | null {
   parts.push(`q=${queue}`);
   if (fleet.parked !== undefined && fleet.parked > 0) {
     parts.push(`prk=${Math.floor(fleet.parked)}`);
+  }
+  const churnDeaths = Math.max(0, Math.floor(fleet.churnDeaths ?? 0));
+  const churnRespawns = Math.max(0, Math.floor(fleet.churnRespawns ?? 0));
+  if (churnDeaths > 0 || churnRespawns > 0) {
+    const windowS = Math.max(1, Math.floor(fleet.churnWindowS ?? 1));
+    parts.push(`churn=${churnDeaths}d/${churnRespawns}r/${windowS}s`);
   }
   return parts.join(" ");
 }

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -709,6 +709,14 @@ export interface FleetHeartbeat {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  /** Recent supervisor churn over a bounded window. Lets read-only surfaces
+   * distinguish useful busy slots from fast death/respawn thrash without
+   * parsing logs. */
+  churn: {
+    deaths: number;
+    respawns: number;
+    windowS: number;
+  };
   /** Optional per-drain budget status; absent when no budget is configured. */
   drainBudget?: DrainBudgetStatus;
   /** Per-slot details for non-closed slots. Empty array when all slots are closed. */
@@ -949,6 +957,9 @@ export interface SupervisorState {
   lastHeartbeatStateWriteEpoch: number;
   /** Consecutive ticks whose state heartbeat write did not land. */
   heartbeatStateWriteMisses: number;
+  /** Rolling death/respawn event epochs for the fleet heartbeat churn stat. */
+  churnDeathEpochs: number[];
+  churnRespawnEpochs: number[];
 }
 
 /** Build the initial runtime for `target` slots. */
@@ -961,6 +972,8 @@ export function initSupervisorState(target: number): SupervisorState {
     drainBudgetHardStopped: false,
     lastHeartbeatStateWriteEpoch: 0,
     heartbeatStateWriteMisses: 0,
+    churnDeathEpochs: [],
+    churnRespawnEpochs: [],
   };
 }
 
@@ -1201,18 +1214,44 @@ function buildSlotDetails(
   return details;
 }
 
+function pruneEpochsInWindow(epochs: readonly number[], now: number, windowS: number): number[] {
+  const floor = now - Math.max(1, windowS);
+  return epochs.filter((epoch) => epoch >= floor);
+}
+
+function updateChurnStats(
+  state: SupervisorState,
+  result: Pick<TickResult, "deaths" | "respawned">,
+  now: number,
+  windowS: number,
+): FleetHeartbeat["churn"] {
+  const resolvedWindowS = Math.max(1, windowS);
+  state.churnDeathEpochs = pruneEpochsInWindow(state.churnDeathEpochs, now, resolvedWindowS);
+  state.churnRespawnEpochs = pruneEpochsInWindow(state.churnRespawnEpochs, now, resolvedWindowS);
+  for (const _ of result.deaths) state.churnDeathEpochs.push(now);
+  for (const _ of result.respawned) state.churnRespawnEpochs.push(now);
+  state.churnDeathEpochs = pruneEpochsInWindow(state.churnDeathEpochs, now, resolvedWindowS);
+  state.churnRespawnEpochs = pruneEpochsInWindow(state.churnRespawnEpochs, now, resolvedWindowS);
+  return {
+    deaths: state.churnDeathEpochs.length,
+    respawns: state.churnRespawnEpochs.length,
+    windowS: resolvedWindowS,
+  };
+}
+
 async function emitFleetHeartbeat(
   state: SupervisorState,
   deps: SupervisorDeps,
   result: TickResult,
   runner: string,
-  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS">,
+  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS" | "circuitWindowS">,
 ): Promise<{ heartbeat: FleetHeartbeat; write: FleetHeartbeatEmitResult }> {
   // Queue depth was fetched once by superviseTick at the start of this tick
   // and stored in result.queueDepth — reuse it here so there is exactly one
   // readyQueueDepth call per tick (0 on a stop tick or abandoned tick).
   const readyForAgent = result.queueDepth;
   const epoch = deps.now();
+  const churn = updateChurnStats(state, result, epoch, config.circuitWindowS);
   const heartbeat: FleetHeartbeat = {
     ts: isoFromEpoch(epoch),
     epoch,
@@ -1221,6 +1260,7 @@ async function emitFleetHeartbeat(
     readyForAgent,
     ...fleetSlotCounts(state, deps),
     spawnsThisTick: result.respawned.length,
+    churn,
     ...(result.drainBudget ? { drainBudget: result.drainBudget } : {}),
     slotDetails: buildSlotDetails(state, config),
   };

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -510,6 +510,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     ready_for_agent?: unknown;
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
     spawns_this_tick?: unknown;
+    churn?: { deaths?: unknown; respawns?: unknown; window_s?: unknown };
     slot_details?: unknown;
   };
   const epoch = Number(rec.epoch ?? 0);
@@ -544,6 +545,9 @@ function parseFleetState(raw: unknown): FleetState | null {
     slotsTotal: Number(rec.slots?.total ?? 0) || 0,
     slotsParked: Number(rec.slots?.parked ?? 0) || 0,
     spawnsThisTick: Number(rec.spawns_this_tick ?? 0) || 0,
+    churnDeaths: Number(rec.churn?.deaths ?? 0) || 0,
+    churnRespawns: Number(rec.churn?.respawns ?? 0) || 0,
+    churnWindowS: Number(rec.churn?.window_s ?? 0) || 0,
     ...(slotDetails !== undefined ? { slotDetails } : {}),
   };
 }
@@ -1222,6 +1226,10 @@ export async function collectStatuslineFleet(
   const state = await readFleetState(paths.fleetStatePath);
   if (!state) return undefined;
   if (nowS - state.epoch > maxAgeS) return undefined;
+  const workers = currentRenderableWorkerRecords(
+    await readAllWorkerStates(paths.tmpDir, { nowMs: nowS * 1000 }),
+  );
+  const freshWorkers = workers.filter((worker) => worker.active).length;
 
   return {
     runner: state.runner,
@@ -1229,6 +1237,10 @@ export async function collectStatuslineFleet(
     total: state.slotsTotal,
     queue: state.readyForAgent,
     parked: state.slotsParked,
+    degraded: state.slotsBusy > 0 && freshWorkers === 0,
+    churnDeaths: state.churnDeaths,
+    churnRespawns: state.churnRespawns,
+    churnWindowS: state.churnWindowS,
     bundleVersion: state.bundleVersion,
   };
 }

--- a/apps/dev/tests/castle-engine-toon-uniformity.test.ts
+++ b/apps/dev/tests/castle-engine-toon-uniformity.test.ts
@@ -61,6 +61,7 @@ function sampleHeartbeat(): FleetHeartbeat {
     slotsTotal: 2,
     slotsParked: 0,
     spawnsThisTick: 0,
+    churn: { deaths: 2, respawns: 2, windowS: 300 },
   } as FleetHeartbeat;
 }
 
@@ -96,6 +97,7 @@ describe("castle-engine write-surface TOON uniformity", () => {
     const decoded = decode(bytes) as Record<string, unknown>;
     expect(decoded.epoch).toBe(42);
     expect(decoded.slots).toEqual({ busy: 1, free: 1, total: 2, parked: 0 });
+    expect(decoded.churn).toEqual({ deaths: 2, respawns: 2, window_s: 300 });
   });
 
   it("the fresh-relaunch supervisor heartbeat stamp is TOON, never raw JSON", async () => {

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -435,6 +435,31 @@ describe("monitor — compact dashboard", () => {
     );
   });
 
+  it("marks busy fleet state degraded when no active worker corroborates it", () => {
+    const out = renderCompactDashboard(
+      [],
+      fixtureEvents,
+      1780138815,
+      baseFleet({ readyForAgent: 7, slotsBusy: 2, slotsFree: 0 }),
+    );
+    expect(out.split("\n")[1]).toContain("fleet [degraded]");
+  });
+
+  it("surfaces recent supervisor churn on the fleet line", () => {
+    const line = renderFleetLine(
+      baseFleet({
+        readyForAgent: 7,
+        slotsBusy: 1,
+        slotsFree: 1,
+        churnDeaths: 2,
+        churnRespawns: 2,
+        churnWindowS: 300,
+      }),
+      1780138815,
+    );
+    expect(line).toContain("churn deaths:2 respawns:2/300s");
+  });
+
   it("carries parked:N unconditionally — zero when all slots closed", () => {
     const line = renderFleetLine(baseFleet(), 1780138815);
     expect(line).toContain("parked:0");

--- a/apps/dev/tests/statusline-command.test.ts
+++ b/apps/dev/tests/statusline-command.test.ts
@@ -6,6 +6,7 @@ import { createServer, type Server, type Socket } from "node:net";
 import { Readable } from "node:stream";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { decode, encode } from "@reddb-io/toon";
+import { LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
 import {
   statuslineCommand,
   resolveRoot,
@@ -76,7 +77,7 @@ async function writeFreshLivenessLane(
   const dir = join(root, ".red", "tmp", namespace, worker, attempt);
   await mkdir(dir, { recursive: true });
   const record = JSON.stringify({ at: Date.now(), kind: "iteration" }) + "\n";
-  await writeFile(join(dir, "liveness.lane.jsonl"), record, "utf8");
+  await writeFile(join(dir, LIVENESS_LANE_FILENAME), record, "utf8");
 }
 
 /** Pre-seed a FRESH gh count cache so collectStatuslineAfk never calls gh. */
@@ -663,9 +664,28 @@ describe("statusline command — rendered line", () => {
 
     const rows = stripAnsi(out.text()).trimEnd().split("\n");
     expect(rows).toHaveLength(1);
-    expect(rows[0]).toContain("flt=codex 1/1");
+    expect(rows[0]).toContain("flt=codex 1/1†");
     expect(rows[0]).toContain("q=2");
     expect(rows[0]).not.toContain("wrk=");
+  });
+
+  it("leaves a healthy fleet segment unmarked when a busy slot has fresh worker liveness", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 2, 0);
+    await writeFleetSnapshot(root);
+    await writeWorkerState(root, "wLIVE", "2038-a1", {
+      worker_id: "wLIVE",
+      runner: "codex",
+      started_at: new Date().toISOString(),
+      current: { number: 2038, started_at: new Date().toISOString() },
+    });
+    await writeFreshLivenessLane(root, "wLIVE", "2038-a1");
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("flt=codex 1/1 q=2");
+    expect(stripAnsi(out.text())).not.toContain("flt=codex 1/1†");
   });
 
   it("suppresses the fleet segment when the supervisor pid is dead", async () => {
@@ -691,6 +711,19 @@ describe("statusline command — rendered line", () => {
     expect(stripAnsi(out.text())).not.toContain("flt=");
   });
 
+  it("suppresses a dead supervisor with stale state instead of rendering degraded", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 2, 0);
+    await writeFleetSnapshot(root, { epoch: Math.floor(Date.now() / 1000) - 3600 });
+    await writeFile(afkPaths(root).supervisorPidPath, "999999999\n", "utf8");
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).not.toContain("flt=");
+    expect(stripAnsi(out.text())).not.toContain("†");
+  });
+
   it("surfaces parked slots in the fleet segment", async () => {
     await seedFreshRepoCache(root, 0, 0);
     await seedFreshCache(root, 4, 0);
@@ -703,6 +736,19 @@ describe("statusline command — rendered line", () => {
     const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
     expect(code).toBe(0);
     expect(stripAnsi(out.text())).toContain("prk=1");
+  });
+
+  it("surfaces supervisor churn stats from the local fleet snapshot", async () => {
+    await seedFreshRepoCache(root, 0, 0);
+    await seedFreshCache(root, 4, 0);
+    await writeFleetSnapshot(root, {
+      churn: { deaths: 2, respawns: 2, window_s: 300 },
+    });
+
+    const out = sink();
+    const code = await statuslineCommand([root], root, out.stream, fakeStdin(PAYLOAD));
+    expect(code).toBe(0);
+    expect(stripAnsi(out.text())).toContain("churn=2d/2r/300s");
   });
 
   it("renders only the project block outside Claude Code (empty stdin)", async () => {

--- a/apps/dev/tests/statusline.test.ts
+++ b/apps/dev/tests/statusline.test.ts
@@ -382,6 +382,29 @@ describe("statusline — fleet block", () => {
     );
   });
 
+  it("marks a fleet degraded when local worker liveness does not corroborate busy slots", () => {
+    expect(renderFleetBlock({ runner: "codex", busy: 2, total: 2, queue: 7, degraded: true })).toBe(
+      "flt=codex 2/2† q=7",
+    );
+  });
+
+  it("shows churn only when recent deaths or respawns are present", () => {
+    expect(
+      renderFleetBlock({
+        runner: "codex",
+        busy: 2,
+        total: 2,
+        queue: 7,
+        churnDeaths: 2,
+        churnRespawns: 2,
+        churnWindowS: 300,
+      }),
+    ).toBe("flt=codex 2/2 q=7 churn=2d/2r/300s");
+    expect(renderFleetBlock({ runner: "codex", busy: 2, total: 2, queue: 7 })).toBe(
+      "flt=codex 2/2 q=7",
+    );
+  });
+
   it("omits the parked part when fleet.parked is zero", () => {
     expect(renderFleetBlock({ runner: "codex", busy: 0, total: 3, queue: 0 })).toBe(
       "flt=codex 0/3 q=0",

--- a/apps/dev/tests/wire.test.ts
+++ b/apps/dev/tests/wire.test.ts
@@ -515,6 +515,7 @@ describe("collectMonitorInputs", () => {
           ready_for_agent: 9,
           slots: { busy: 1, free: 2, total: 3, parked: 0 },
           spawns_this_tick: 1,
+          churn: { deaths: 2, respawns: 1, window_s: 300 },
         }),
       );
 
@@ -525,6 +526,9 @@ describe("collectMonitorInputs", () => {
         slotsFree: 2,
         slotsTotal: 3,
         spawnsThisTick: 1,
+        churnDeaths: 2,
+        churnRespawns: 1,
+        churnWindowS: 300,
       });
       const { fleet } = await collectMonitorInputs(root);
       expect(fleet?.readyForAgent).toBe(9);

--- a/packages/red-castle/src/engine/monitor-readers.ts
+++ b/packages/red-castle/src/engine/monitor-readers.ts
@@ -234,6 +234,7 @@ function fleetFromSupervisorSnapshot(
   if (snapshot.kind !== "supervisor") return null;
   const current = asRecord(snapshot.current);
   const slots = asRecord(current.slots);
+  const churn = asRecord(current.churn);
   const epoch = numberField(
     current,
     "epoch",
@@ -256,6 +257,9 @@ function fleetFromSupervisorSnapshot(
     slotsTotal: numberField(slots, "total"),
     slotsParked: numberField(slots, "parked"),
     spawnsThisTick: numberField(current, "spawns_this_tick"),
+    churnDeaths: numberField(churn, "deaths"),
+    churnRespawns: numberField(churn, "respawns"),
+    churnWindowS: numberField(churn, "window_s"),
   };
 }
 

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -249,6 +249,9 @@ export interface FleetState {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  churnDeaths?: number;
+  churnRespawns?: number;
+  churnWindowS?: number;
   /** Per-slot details for non-closed slots. Absent/empty = all slots closed.
    * Absent on state files written before this field was added (#630). */
   slotDetails?: SlotDetail[];
@@ -277,22 +280,30 @@ export function formatElapsed(seconds: number): string {
   return `${pad(hh)}:${pad(mm)}:${pad(ss)}`;
 }
 
-export function renderFleetLine(fleet: FleetState, now: number): string {
+export function renderFleetLine(fleet: FleetState, now: number, degraded = false): string {
   const age = now - fleet.epoch;
   const stale = age >= FLEET_STALE_AFTER_S;
   const status = stale
     ? "wedged"
-    : fleet.readyForAgent === 0 && fleet.slotsBusy === 0
-      ? "idle"
-      : "draining";
+    : degraded
+      ? "degraded"
+      : fleet.readyForAgent === 0 && fleet.slotsBusy === 0
+        ? "idle"
+        : "draining";
   const bundle = fleet.bundleVersion
     ? `  bundle:${fleet.bundleVersion}${compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0 ? `<${fleet.latestBundleVersion}` : ""}`
+    : "";
+  const churnDeaths = Math.max(0, Math.floor(fleet.churnDeaths ?? 0));
+  const churnRespawns = Math.max(0, Math.floor(fleet.churnRespawns ?? 0));
+  const churn = churnDeaths > 0 || churnRespawns > 0
+    ? `  churn deaths:${churnDeaths} respawns:${churnRespawns}/${Math.max(1, Math.floor(fleet.churnWindowS ?? 1))}s`
     : "";
   return (
     `fleet [${status}] last ticked ${formatElapsed(age)} ago` +
     `  ready:${fleet.readyForAgent}` +
     `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}` +
     `  spawns:${fleet.spawnsThisTick}` +
+    churn +
     bundle
   );
 }
@@ -540,7 +551,8 @@ export function renderCompactDashboard(
   const header = `${buildSparkline(events, now).line}   Δ fleet ${formatDiff(added, removed)}${sourceFrag}`;
   let prefix: string;
   if (fleet) {
-    const fleetLine = renderFleetLine(fleet, now);
+    const degraded = fleet.slotsBusy > 0 && !workers.some((w) => compactWorkerTag(w) === "live");
+    const fleetLine = renderFleetLine(fleet, now, degraded);
     const details = renderSlotDetails(fleet, now);
     prefix = details.length > 0
       ? `${header}\n${fleetLine}\n${details.join("\n")}`
@@ -650,19 +662,26 @@ export function renderCompactDashboardToon(
   if (fleet) {
     const age = now - fleet.epoch;
     const stale = age >= FLEET_STALE_AFTER_S;
+    const degraded = fleet.slotsBusy > 0 && active === 0;
     const status = stale
       ? "wedged"
-      : fleet.readyForAgent === 0 && fleet.slotsBusy === 0
-        ? "idle"
-        : "draining";
+      : degraded
+        ? "degraded"
+        : fleet.readyForAgent === 0 && fleet.slotsBusy === 0
+          ? "idle"
+          : "draining";
     root.fleet = {
       status,
+      degraded: degraded ? 1 : 0,
       ticked_ago: formatElapsed(age),
       ready: fleet.readyForAgent,
       slots_busy: fleet.slotsBusy,
       slots_free: fleet.slotsFree,
       slots_parked: fleet.slotsParked,
       spawns: fleet.spawnsThisTick,
+      churn_deaths: fleet.churnDeaths ?? 0,
+      churn_respawns: fleet.churnRespawns ?? 0,
+      churn_window_s: fleet.churnWindowS ?? 0,
       bundle_version: fleet.bundleVersion ?? "",
       latest_bundle_version: fleet.latestBundleVersion ?? "",
       version_skew: compareSemver(fleet.latestBundleVersion, fleet.bundleVersion) > 0 ? 1 : 0,


### PR DESCRIPTION
Automated AFK landing for #2038. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2038

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786916814&installation_id=129708444&pr_number=2055&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2055&signature=e334f6f1b78bdaa2064a5641a943cd83b37e3057bfc3ded038ea60ce62b70187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->