### PR TITLE
fix: #2056 stop kills orphaned detached workers + supervisor SIGTERM handler

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -125,13 +125,28 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
   const stateAfk = dirname(paths.supervisorPidPath);
   const pidFile = paths.supervisorPidPath;
   const stopFile = join(dirname(pidFile), "afk-supervisor.stop");
+  // Detached workers survive the supervisor's death (#2056): they are spawned
+  // `detached: true` so they are NOT in the supervisor's process tree. Every stop
+  // path must sweep them — otherwise a "stopped" report is a lie while orphaned
+  // workers keep claiming, committing, and merging. Reuse the watchdog's
+  // detached-worker killer + claim reconcile so no issue is stranded in `running`.
+  const io = buildWatchdogIO(root, stdout);
+  const sweepOrphans = async (): Promise<void> => {
+    const killed = await io.killWorkers();
+    if (killed > 0) {
+      await io.reconcile();
+      stdout.write(`terminated ${killed} orphaned worker${killed === 1 ? "" : "s"} and reconciled their claims.\n`);
+    }
+  };
   const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
   if (supervisor.status === "stale") {
+    await sweepOrphans();
     stdout.write(`no fleet running (stale supervisor files — cleaned).\n`);
     return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
   }
   const pid = supervisor.pid;
   if (!pid) {
+    await sweepOrphans();
     stdout.write("no fleet running.\n");
     return { status: "none" };
   }
@@ -139,6 +154,10 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     if (!(await fileExists(pidFile)) || !isLivePid(pid)) {
+      // The supervisor's own terminateAll should have killed its slots on clean
+      // exit, but sweep detached survivors anyway — a slot the loop lost track of
+      // (moved-pid, mid-spawn) would otherwise outlive the "stopped" report.
+      await sweepOrphans();
       stdout.write(`🛑 fleet stopped (supervisor pid=${pid} exited).\n`);
       return { status: "stopped", pid };
     }
@@ -157,6 +176,8 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
     // SIGKILL skips the supervisor's own `finally`, so clean its control files.
     await rm(pidFile, { force: true });
     await rm(stopFile, { force: true });
+    // killTree of the supervisor pid misses the detached workers — sweep them.
+    await sweepOrphans();
     stdout.write(`🛑 fleet stopped (supervisor pid=${pid} killed after graceful-stop timeout).\n`);
     return { status: "stopped", pid };
   }

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -17,6 +17,7 @@ import {
   initSupervisorState,
   resolveSupervisorConfig,
   runSupervisor,
+  terminateAll,
   type SpawnPolicy,
   type SupervisorDeps,
 } from "../core/supervisor.js";
@@ -786,6 +787,30 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   const deps = buildSupervisorDeps(root, tmp, slotLogsDir, logFd, firehoseFile, stateFile, config.runner, ghCtx, slotArgs, hookEnvBase);
 
   const stopRequested = (): boolean => existsSync(stopFile);
+
+  // A bare `kill <supervisor-pid>` (SIGTERM/SIGINT) must not orphan the detached
+  // slot workers or leave the pid/stop control files behind (#2056). Without a
+  // handler the signal skips the `finally` below, stranding both. Translate the
+  // signal into the same clean shutdown the stop-file path performs: terminate
+  // every live slot (SIGTERM→grace→SIGKILL→confirm via terminateAll), clean the
+  // control files, then exit with the conventional 128+signal code.
+  let shuttingDown = false;
+  const onSignal = (signal: "SIGTERM" | "SIGINT"): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    void (async () => {
+      try {
+        await terminateAll(state, deps);
+      } catch {
+        // best-effort — still clean control files and exit.
+      }
+      rmSync(pidFile, { force: true });
+      rmSync(stopFile, { force: true });
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    })();
+  };
+  process.once("SIGTERM", () => onSignal("SIGTERM"));
+  process.once("SIGINT", () => onSignal("SIGINT"));
 
   try {
     await runSupervisor(state, deps, config, stopRequested);

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -32,8 +32,9 @@ export interface WatchdogIO {
    * (#579). Workers are spawned `detached: true` (nohup'd) so they are NOT
    * children of the supervisor and killTree misses them. Best-effort: a failed
    * kill on one worker must not block the rest of the recovery sequence.
+   * Returns the number of live workers actually killed (#2056).
    */
-  killWorkers(): Promise<void>;
+  killWorkers(): Promise<number>;
   /** Remove the supervisor pid + stop control files so a relaunch is unblocked. */
   clearControlFiles(): Promise<void>;
   /** Reconcile claims/labels the wedged supervisor left so no issue is stranded

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -113,17 +113,19 @@ export function buildWatchdogIO(
       await killTreeAndWait(pid);
     },
 
-    killWorkers: async () => {
+    killWorkers: async (): Promise<number> => {
       // Workers are spawned detached (nohup'd) so they are NOT children of the
       // supervisor — killTree misses them. Enumerate every worker dir and kill
       // any still-alive PID recorded in worker.pid. Best-effort per worker: a
-      // failed read or kill on one worker must not block the rest.
+      // failed read or kill on one worker must not block the rest. Returns the
+      // number of live workers actually killed so callers can report it (#2056).
       let workerDirs: string[];
       try {
         workerDirs = await readdir(paths.workersRoot);
       } catch {
-        return;
+        return 0;
       }
+      let killed = 0;
       for (const workerDir of workerDirs) {
         const pidPath = join(paths.workersRoot, workerDir, "worker.pid");
         try {
@@ -132,11 +134,13 @@ export function buildWatchdogIO(
           const workerPid = Number(raw);
           if (isLivePid(workerPid)) {
             await killTreeAndWait(workerPid);
+            killed += 1;
           }
         } catch {
           // best-effort: missing/bad pid file is not an error.
         }
       }
+      return killed;
     },
 
     clearControlFiles: async () => {

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -90,6 +90,32 @@ describe("fleet command stale supervisor state", () => {
     }
   });
 
+  it("stopFleet kills orphaned detached workers when the supervisor pid is stale (#2056)", async () => {
+    const root = scratch();
+    try {
+      writeSupervisorArtifacts(root, 999_999_999); // dead supervisor pid
+      // Two orphaned workers with live pids. They are spawned detached, so they
+      // are NOT in the supervisor's process tree and survive its death.
+      const workersRoot = join(root, ".red", "tmp", "workers");
+      mkdirSync(join(workersRoot, "wAAAA"), { recursive: true });
+      mkdirSync(join(workersRoot, "wBBBB"), { recursive: true });
+      writeFileSync(join(workersRoot, "wAAAA", "worker.pid"), "111111", "utf8");
+      writeFileSync(join(workersRoot, "wBBBB", "worker.pid"), "222222", "utf8");
+      // Supervisor pid dead; both worker pids alive.
+      vi.mocked(isLivePid).mockImplementation((pid: number) => pid === 111111 || pid === 222222);
+      killTreeMocks.killTreeAndWait.mockResolvedValue(true);
+
+      const result = await stopFleet(root, stream());
+
+      expect(result.status).toBe("stale");
+      // Every live orphan was killed — "stopped" is never a lie while workers merge.
+      expect(killTreeMocks.killTreeAndWait).toHaveBeenCalledWith(111111);
+      expect(killTreeMocks.killTreeAndWait).toHaveBeenCalledWith(222222);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("stopFleet leaves live supervisor files untouched", async () => {
     const root = scratch();
     try {


### PR DESCRIPTION
Closes #2056

Detached workers survive the supervisor's death (they are spawned `detached: true`, outside its process tree). `stopFleet`'s stale/none branches printed "no fleet running" and returned **without killing them** — orphans kept claiming, committing, and merging after the operator believed the fleet was stopped. Confirmed live during this session: a `fleet stop` reported "supervisor exited" while a worker (w26LK) was still alive.

- `stopFleet` now sweeps orphaned workers (`killWorkers` + claim `reconcile`) in **every** exit branch (stale, none, graceful, killed) and reports the count terminated.
- `killWorkers` returns the number of live workers killed.
- `superviseCommand` installs a `SIGTERM`/`SIGINT` handler that runs `terminateAll` + cleans control files, so a bare `kill <supervisor-pid>` is a clean stop instead of orphaning workers + pid file.
- Regression test: dead supervisor + 2 live detached workers → stop kills both.

Part of the castle operability hardening (supervisor understandability + takeover). Typecheck + fleet-command/stop-command/supervise-passthrough suites green locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786917582&installation_id=129708444&pr_number=2057&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2057&signature=4a17997c8be07172ea73f964f1166a9698a8e31ad84462e7b113c06f33d02520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->