### PR TITLE
fix: #2054 Base-freshness probe kills worker sessions (not just supervisor boot) when local main is behind origin — fleet churns after every release

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -365,6 +365,17 @@ async function tryBootAutoApplyBaseFreshness(
   return true;
 }
 
+/** True when this base-freshness finding has guard=passed and finding=local-trunk-behind-origin.
+ * Worker sessions (skipSweeps) can skip the fatal halt for this case because they branch from
+ * origin/main directly — a behind local main does not affect their work. */
+function isGuardPassedBaseFreshnessFinding(
+  finding: OperationalProbeReport["findings"][number],
+): boolean {
+  if (finding.id !== BASE_FRESHNESS_PROBE_ID) return false;
+  const data = finding.data as Partial<BaseFreshnessProbeData> | undefined;
+  return data?.finding === "local-trunk-behind-origin" && data.guard?.guard === "passed";
+}
+
 // ---------- step inputs ----------
 
 /** Bootstrap paths, pre-resolved by the caller from worker-paths.ts so this
@@ -609,7 +620,14 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   const redProbe = operationalProbes.findings[0];
   if (redProbe) {
     const applied = await tryBootAutoApplyBaseFreshness(deps, redProbe);
-    if (!applied) throw new BootHaltError("operational-probe", redProbe);
+    if (!applied) {
+      // Worker sessions (skipSweeps) branch from origin/main, so local-main-behind-origin
+      // does not affect their branch base. The guarded FF dep is absent on this path; when
+      // the guard passes, downgrade to a non-fatal finding instead of halting the session.
+      // Guard-refused cases (dirty, off-trunk, diverged) still refuse regardless.
+      const workerSessionExempt = options.skipSweeps === true && isGuardPassedBaseFreshnessFinding(redProbe);
+      if (!workerSessionExempt) throw new BootHaltError("operational-probe", redProbe);
+    }
     const nextRedProbe = operationalProbes.findings[1];
     if (nextRedProbe) throw new BootHaltError("operational-probe", nextRedProbe);
   }

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -657,6 +657,154 @@ describe("runBoot skipSweeps — supervisor-owned boot (#623)", () => {
     expect(result.bootstrap).toBeUndefined();
     expect(calls).toEqual([]);
   });
+
+  // Regression test for #2054: base-freshness probe kills worker sessions when local
+  // main is behind origin after a release. Workers branch from origin/main, so a
+  // behind local main does not affect their work — downgrade to non-fatal when guard passes.
+  it("does NOT halt on base-freshness guard=passed — worker branches from origin/main anyway", async () => {
+    // No fastForwardLocalBase dep (matches buildMinimalBootDeps for worker sessions).
+    const { deps, fsCalls } = makeDeps();
+
+    const result = await runBoot(
+      deps,
+      options({
+        skipSweeps: true,
+        operationalProbes: {
+          remoteUrls: [],
+          baseFreshness: {
+            trunk: "main",
+            remote: "origin",
+            localSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+            remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ahead: 0,
+            behind: 1,
+            remoteReachable: true,
+            guard: {
+              guard: "passed",
+              target: "main",
+              remote: "origin",
+              currentBranch: "main",
+              evidence: "guard passed: on-trunk clean-tree ancestor (main -> origin/main)",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.bootstrap).toEqual({ ok: true });
+    // The finding is still recorded in the probe report (visible in logs) but non-fatal.
+    expect(result.operationalProbes?.findings).toHaveLength(1);
+    expect(result.operationalProbes?.findings[0]?.id).toBe("afk.base-freshness");
+    // Bootstrap ran normally.
+    expect(fsCalls.ensureDir).toContain("/p/.red/tmp");
+  });
+
+  it.each([
+    [
+      "off-trunk",
+      {
+        guard: "refused" as const,
+        target: "main",
+        remote: "origin",
+        currentBranch: "feature/work",
+        failed: "not-on-trunk" as const,
+        failedCondition: "on-trunk" as const,
+        evidence: "condition failed: on-trunk (current=feature/work expected=main)",
+      },
+    ],
+    [
+      "dirty tree",
+      {
+        guard: "refused" as const,
+        target: "main",
+        remote: "origin",
+        currentBranch: "main",
+        failed: "dirty-tree" as const,
+        failedCondition: "clean-tree" as const,
+        evidence: "condition failed: clean-tree (1 dirty path(s))",
+      },
+    ],
+    [
+      "diverged",
+      {
+        guard: "refused" as const,
+        target: "main",
+        remote: "origin",
+        currentBranch: "main",
+        failed: "not-ancestor" as const,
+        failedCondition: "ancestor" as const,
+        evidence: "condition failed: ancestor (main is not an ancestor of origin/main)",
+      },
+    ],
+  ])("still halts on base-freshness guard=refused in worker session: %s", async (_name, guard) => {
+    const { deps } = makeDeps();
+
+    await expect(
+      runBoot(
+        deps,
+        options({
+          skipSweeps: true,
+          operationalProbes: {
+            remoteUrls: [],
+            baseFreshness: {
+              trunk: "main",
+              remote: "origin",
+              localSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+              remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              ahead: 0,
+              behind: 1,
+              remoteReachable: true,
+              guard,
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/Operational probe red: AFK local trunk freshness/);
+  });
+
+  it("still halts on a second red probe even when base-freshness guard=passed is exempt", async () => {
+    const { deps } = makeDeps();
+
+    await expect(
+      runBoot(
+        deps,
+        options({
+          skipSweeps: true,
+          operationalProbes: {
+            remoteUrls: [],
+            baseFreshness: {
+              trunk: "main",
+              remote: "origin",
+              localSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+              remoteSha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              ahead: 0,
+              behind: 1,
+              remoteReachable: true,
+              guard: {
+                guard: "passed",
+                target: "main",
+                remote: "origin",
+                currentBranch: "main",
+                evidence: "guard passed: on-trunk clean-tree ancestor (main -> origin/main)",
+              },
+            },
+            configCoherence: {
+              path: "/repo/.red/config.yaml",
+              displayPath: ".red/config.yaml",
+              fileLoaded: true,
+              discarded: true,
+              parseFailure: { message: "malformed YAML at line 3", line: 3 },
+              rootAccessorCollisions: [],
+              resolved: { trunk: "main", gate: "", lock: "" },
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      phase: "operational-probe",
+      probe: { id: "config.coherence" },
+    });
+  });
 });
 
 describe("runBoot tmp janitor", () => {


### PR DESCRIPTION
Automated AFK landing for #2054. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #2054

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786917733&installation_id=129708444&pr_number=2058&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2058&signature=fd1b591fcc9809705a2db9d37f2d9b1b06620588fd6a292b935f9689208a2ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->