### PR TITLE
fix: #2054 supervised workers skip boot operational probes (no per-spawn fleet churn)

### DIFF
--- a/apps/dev/src/core/boot.ts
+++ b/apps/dev/src/core/boot.ts
@@ -605,9 +605,19 @@ export async function runBoot(deps: BootDeps, options: BootOptions): Promise<Boo
   if (!pre.ok) return { precheck: pre };
 
   // ---- 1a. operational probes ----
-  const operationalProbes = await runOperationalProbes(options.operationalProbes ?? options.precheck);
-  const redProbe = operationalProbes.findings[0];
-  if (redProbe) {
+  // Supervised workers (RED_AFK_SWEEPS_DONE → options.skipSweeps) inherit the
+  // supervisor's boot validation and boot bootstrap+claim only (#623). Running
+  // the shared boot self-diagnosis on every worker spawn is redundant, and a
+  // transient red kills the WORKER instead of the supervisor — e.g. the local
+  // trunk 1 commit behind origin after a release version bump (#2054), or a
+  // mis-read fleet-truth (#2037) — surfacing as spawn/die fleet churn. Workers
+  // branch from origin, so local trunk freshness is irrelevant to their work.
+  // Only the supervisor's own boot and a standalone run evaluate the probes.
+  const operationalProbes = options.skipSweeps
+    ? undefined
+    : await runOperationalProbes(options.operationalProbes ?? options.precheck);
+  const redProbe = operationalProbes?.findings[0];
+  if (operationalProbes && redProbe) {
     const applied = await tryBootAutoApplyBaseFreshness(deps, redProbe);
     if (!applied) throw new BootHaltError("operational-probe", redProbe);
     const nextRedProbe = operationalProbes.findings[1];

--- a/apps/dev/tests/boot.test.ts
+++ b/apps/dev/tests/boot.test.ts
@@ -657,6 +657,27 @@ describe("runBoot skipSweeps — supervisor-owned boot (#623)", () => {
     expect(result.bootstrap).toBeUndefined();
     expect(calls).toEqual([]);
   });
+
+  it("does NOT halt on a red operational probe — the worker inherits the supervisor's validation (#2054/#2037)", async () => {
+    const { deps } = makeDeps();
+    // The https remote trips the SSH-only probe red; on a standalone/supervisor
+    // boot this halts. Under skipSweeps a base-freshness red (local trunk behind
+    // origin after a release, #2054) or a mis-read fleet-truth (#2037) would too.
+    // A supervised worker must NOT die on any of them — that red-per-spawn is the
+    // spawn/die fleet churn. It boots bootstrap+claim only and skips the probes.
+    const result = await runBoot(
+      deps,
+      options({
+        skipSweeps: true,
+        precheck: facts({
+          remoteUrls: [{ name: "origin", url: "https://github.com/reddb-io/red-skills.git" }],
+        }),
+      }),
+    );
+    expect(result.precheck.ok).toBe(true);
+    expect(result.bootstrap).toEqual({ ok: true });
+    expect(result.operationalProbes).toBeUndefined();
+  });
 });
 
 describe("runBoot tmp janitor", () => {


### PR DESCRIPTION
Closes #2054

Every worker session ran the shared boot operational probes and halted on any red finding. Supervised workers carry **minimal boot deps without the guarded fast-forward**, so a base-freshness red — local trunk 1 commit behind origin, which happens after **every release** version bump — killed each spawned worker. The supervisor respawned it, it died again: `respawned=2 deaths=2` per tick, `busy=2` looking healthy over zero real work. The same class killed workers via the fleet-truth mis-read (#2037).

Fix: gate the operational-probe block on `!options.skipSweeps`. A supervised worker (`RED_AFK_SWEEPS_DONE`) inherits the supervisor's boot validation and boots bootstrap+claim only (#623) — it branches from `origin`, so local trunk freshness is irrelevant to its work. The supervisor's own boot and a standalone `run` still evaluate the probes (auto-fixing guarded base-freshness or halting).

- Regression test: red operational probe + `skipSweeps` → boots (no `BootHaltError`).
- 72 boot tests + typecheck green locally.

This is the root cause of the recurring 'fleet churns after every release' instability seen all session. Part of the castle operability hardening.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786917894&installation_id=129708444&pr_number=2059&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2059&signature=6ff56decefca23c09c6d82a38b2e3a3de5693f22f94b8b8923175997eb23f27b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->