### PR TITLE
feat: #2060 fleet status — read-only ground-truth verb for the supervisor

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -1,7 +1,8 @@
 import { constants } from "node:fs";
 import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { afkPaths } from "../runtime/wire.js";
+import { encode as encodeToon } from "@reddb-io/toon";
+import { afkPaths, collectMonitorInputs, resolveRepoSlug } from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
@@ -48,9 +49,10 @@ function parseShrinkMode(raw: string | undefined, flag: string): ElasticShrinkMo
   throw new Error(`${flag} must be hard-kill or drain-then-retire`);
 }
 
-function parseFleetArgs(args: readonly string[]): { stop: boolean; target: number; request?: string; runnerFlag?: string; drainBudgetUsd?: number; shrinkMode?: ElasticShrinkMode; passthrough: string[] } {
+function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boolean; target: number; request?: string; runnerFlag?: string; drainBudgetUsd?: number; shrinkMode?: ElasticShrinkMode; passthrough: string[] } {
   const passthrough: string[] = [];
   let stop = false;
+  let status = false;
   let target: number | undefined;
   let request: string | undefined;
   let runnerFlag: string | undefined;
@@ -61,6 +63,10 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; target: numbe
     const arg = args[i]!;
     if (arg === "stop") {
       stop = true;
+      continue;
+    }
+    if (arg === "status") {
+      status = true;
       continue;
     }
     if (arg === "--request" || arg === "-r") {
@@ -107,7 +113,7 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; target: numbe
     }
     passthrough.push(arg);
   }
-  return { stop, target: target ?? 2, request, runnerFlag, drainBudgetUsd, shrinkMode, passthrough };
+  return { stop, status, target: target ?? 2, request, runnerFlag, drainBudgetUsd, shrinkMode, passthrough };
 }
 
 async function writeResizeRequest(path: string, target: number, shrinkMode: ElasticShrinkMode): Promise<void> {
@@ -185,6 +191,73 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
     `✗ supervisor pid=${pid} survived SIGKILL; still live — see .red/state/castle/afk-supervisor.log.\n`,
   );
   return { status: "timeout", pid };
+}
+
+export interface FleetStatusResult {
+  status: "reported";
+}
+
+/**
+ * Read-only fleet ground truth in one place (#2060). Answers "what is actually
+ * running right now?" — the question that today requires cross-referencing the
+ * supervisor pid, N worker pids, the in-process slot map, and two snapshot files.
+ * Local reads only (ADR 0084); never mutates. Renders TOON (the agent-facing
+ * output mandate). Surfaces the classifySupervisor health verdict and whether a
+ * watchdog respawn would fire, so "why is nothing running?" is answerable.
+ */
+export async function statusFleet(root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetStatusResult> {
+  const io = buildWatchdogIO(root, stdout);
+  const liveness = await io.liveness();
+  const cfg = resolveSupervisorConfig();
+  const now = Math.floor(Date.now() / 1000);
+  const health = classifySupervisor(liveness, now, cfg.supervisorStaleS, cfg.progressStaleS);
+  const repo = await resolveRepoSlug(root).catch(() => "");
+  const inputs = await collectMonitorInputs(root, repo);
+  const fleet = inputs.fleet;
+  const liveWorkers = inputs.workers.filter((w) => w.pidLive === true || w.live);
+  const heartbeatAgeS = liveness.lastHeartbeatEpoch !== null ? now - liveness.lastHeartbeatEpoch : -1;
+
+  // A dead supervisor with ready-for-agent work and fewer live workers than the
+  // target is what the watchdog would respawn — surface it so an operator who
+  // sees "no workers" knows the recovery will (or won't) fire on the next tick.
+  const wouldRespawn =
+    health === "absent" &&
+    (fleet?.readyForAgent ?? 0) > 0 &&
+    liveWorkers.length < (fleet?.slotsTotal ?? cfg.target);
+
+  const report = {
+    supervisor: {
+      pid: liveness.pid ?? 0,
+      alive: liveness.pidAlive,
+      health,
+      runner: fleet?.runner ?? "",
+      target: fleet?.slotsTotal ?? 0,
+      bundle_version: fleet?.bundleVersion ?? "",
+      bundle_latest: fleet?.latestBundleVersion ?? "",
+      heartbeat_age_s: heartbeatAgeS,
+      would_respawn: wouldRespawn,
+    },
+    slots: {
+      busy: fleet?.slotsBusy ?? 0,
+      free: fleet?.slotsFree ?? 0,
+      parked: fleet?.slotsParked ?? 0,
+      total: fleet?.slotsTotal ?? 0,
+    },
+    churn: {
+      deaths: fleet?.churnDeaths ?? 0,
+      respawns: fleet?.churnRespawns ?? 0,
+      window_s: fleet?.churnWindowS ?? 0,
+    },
+    live_workers: liveWorkers.map((w) => ({
+      id: w.state.worker_id,
+      pid: w.state.pid,
+      issue: String(w.state.current.number),
+      activity: w.state.current.activity,
+      origin: w.state.origin ?? "afk",
+    })),
+  };
+  stdout.write(`${encodeToon(report)}\n`);
+  return { status: "reported" };
 }
 
 export async function launchFleet(args: readonly string[], root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetLaunchResult> {
@@ -267,7 +340,9 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
 export async function fleetCommand(args: string[], cwd = process.cwd()): Promise<number> {
   const parsed = parseFleetArgs(args);
   try {
-    if (parsed.stop) {
+    if (parsed.status) {
+      await statusFleet(cwd);
+    } else if (parsed.stop) {
       await stopFleet(cwd);
     } else {
       await launchFleet(args, cwd);

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -17,7 +17,7 @@ vi.mock("../src/runtime/supervisor-spawn.js", () => ({
   spawnSupervisor: vi.fn(async () => 43210),
 }));
 
-import { launchFleet, stopFleet } from "../src/commands/fleet.js";
+import { launchFleet, statusFleet, stopFleet } from "../src/commands/fleet.js";
 import { isLivePid } from "../src/runtime/kill-tree.js";
 import { spawnSupervisor } from "../src/runtime/supervisor-spawn.js";
 import { afkPaths } from "../src/runtime/wire.js";
@@ -111,6 +111,30 @@ describe("fleet command stale supervisor state", () => {
       // Every live orphan was killed — "stopped" is never a lie while workers merge.
       expect(killTreeMocks.killTreeAndWait).toHaveBeenCalledWith(111111);
       expect(killTreeMocks.killTreeAndWait).toHaveBeenCalledWith(222222);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("statusFleet reports supervisor + slots ground truth read-only, no supervisor → absent (#2060)", async () => {
+    const root = scratch();
+    try {
+      const writes: string[] = [];
+      const out = {
+        write: vi.fn((s: string) => {
+          writes.push(s);
+          return true;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      const result = await statusFleet(root, out);
+
+      expect(result).toEqual({ status: "reported" });
+      const text = writes.join("");
+      expect(text).toContain("supervisor");
+      expect(text).toContain("health");
+      // A clean scratch has no supervisor pid → classifySupervisor returns absent.
+      expect(text).toMatch(/health:\s*absent/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/plugins/dev/skills/engineering/afk/SKILL.md
+++ b/plugins/dev/skills/engineering/afk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: afk
 description: Autonomous loop that drains the `ready-for-agent` queue on the issue tracker. Each iteration claims an issue, runs it in an isolated worktree, executes with claude or codex, merges back to main, and closes the issue. Use when the user wants to run AFK execution, drain a Spec, hammer specific issues, or otherwise let agents grind through the backlog.
-argument-hint: "[--spec N | --issues N,N,N] [--runner claude|codex|opencode] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] [--boot-only] | fleet [N] | fleet stop | monitor | dashboard | daily-review | weekly-review | retake N | reap"
+argument-hint: "[--spec N | --issues N,N,N] [--runner claude|codex|opencode] [--alternate] [--fallback-runner] [--request TEXT] [-n N] [--once] [--boot-only] | fleet [N] | fleet stop | fleet status | monitor | dashboard | daily-review | weekly-review | retake N | reap"
 ---
 
 # /afk
@@ -63,6 +63,10 @@ contract live in [`docs/OPERATIONS.md`](./docs/OPERATIONS.md).
 - `/afk fleet [N]` - supervise `N` concurrent workers; read
   [`fleet.md`](./fleet.md) before launch or stop operations.
 - `/afk fleet stop` - gracefully stop the fleet supervisor and auto-monitor.
+- `/afk fleet status` - read-only fleet ground truth: supervisor pid, health
+  verdict, runner, slot occupancy, bundle version/skew, churn, live workers, and
+  whether a watchdog respawn would fire. Answers "what is actually running?"
+  without cross-referencing pid files and snapshots by hand.
 - `/afk reap` - run branch hygiene without starting a worker.
 
 For GitHub Actions adoption, use [`actions-lane.md`](./actions-lane.md). The


### PR DESCRIPTION
Closes #2060

Adds `red-skills-dev fleet status` — the single read-only command that answers "what is actually running right now?". Today that state is scattered across the supervisor pid file, N worker pid files, the never-persisted in-process slot map, and two snapshot files, and the `classifySupervisor` health verdict is only computed inside the launch pre-check / opt-in watchdog.

Prints (TOON, local reads only per ADR 0084): supervisor pid + liveness + health verdict, runner, target, slot occupancy (busy/free/parked), bundle version + newest-cached skew, heartbeat age, churn (deaths/respawns/window), the live workers with issue + activity, and whether a watchdog respawn would fire.

- Test: no supervisor → `health: absent`, reports cleanly.
- Documented in the afk SKILL.md.

Part of the castle operability program (supervisor understandability, goal a).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786918384&installation_id=129708444&pr_number=2061&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2061&signature=52d58bb87c61c5a511aa13344abc21d253fe442c071ced56bd5690b41933fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->