### PR TITLE
fix: #2063 Castle supervisor structured lane: emit supervisor.* records, retire the prose dual-write

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -7,7 +7,7 @@
 // native — no bash anywhere in the loop.
 
 import { spawn } from "node:child_process";
-import { existsSync, openSync, closeSync, readFileSync, writeFileSync, writeSync, rmSync, renameSync } from "node:fs";
+import { existsSync, openSync, closeSync, readFileSync, writeFileSync, rmSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { readBuildInfo } from "@reddb-io/build-info";
 import {
@@ -55,6 +55,7 @@ import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 import {
   castleStateSnapshotPath,
   createEnginePaths,
+  createCastleLaneWriters,
   writeCastleStateSnapshot,
 } from "@reddb-io/red-castle/engine";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
@@ -423,9 +424,9 @@ function buildSupervisorDeps(
   root: string,
   tmpDir: string,
   slotLogsDir: string,
-  logFd: number,
   firehosePath: string,
   statePath: string,
+  supervisorId: string,
   runner: string,
   ghCtx: ghx.GhContext,
   slotArgs: readonly string[],
@@ -434,14 +435,25 @@ function buildSupervisorDeps(
   const bundle = process.argv[1];
   const bundleVersion = readBuildInfo("dev").version;
   const now = () => Math.floor(Date.now() / 1000);
-  // Per-tick / boot liveness line into afk-supervisor.log (best-effort). Shared
-  // by `log` and the pre-spawn boot sweeps so both land in the supervisor log.
+  const supervisorWriter = createCastleLaneWriters(
+    createEnginePaths(join(root, ".red")),
+  ).supervisor(supervisorId);
+  const emitSupervisorEvent: NonNullable<SupervisorDeps["emitSupervisorEvent"]> = async (record) => {
+    await supervisorWriter.append({
+      supervisor_id: supervisorId,
+      ...record,
+    });
+  };
+  // Legacy prose strings are retained only as a derived structured event. The
+  // human view reads the supervisor lane; no supervisor-owned prose log is
+  // dual-written.
   const logLine = (line: string): void => {
-    try {
-      writeSync(logFd, `[${new Date().toISOString()}] ${line}\n`);
-    } catch {
-      // best-effort: a log-write failure must never affect the loop.
-    }
+    void Promise.resolve(
+      emitSupervisorEvent({
+        kind: "supervisor.message",
+        payload: { message: line },
+      }),
+    ).catch(() => undefined);
   };
   // Fleet hook resolution: library defaults-dir + project .red/hooks/ layering,
   // same convention as worker hooks (ADR 0026, #830, #833).
@@ -499,12 +511,15 @@ function buildSupervisorDeps(
           "--reconcile-issue", String(candidate.issue),
           ...slotArgs,
         ];
+        const slotLogFile = slotLogPath(tmpDir, slot, slotLogsDir);
+        const slotFd = openSync(slotLogFile, "a");
         const child = spawn(process.execPath, [bundle, ...runArgs], {
           cwd: root,
           env: buildSlotEnv(workerEnv, slot, undefined, slotRetirePath(statePath, slot)),
           detached: true,
-          stdio: ["ignore", logFd, logFd],
+          stdio: ["ignore", slotFd, slotFd],
         });
+        closeSync(slotFd);
         child.on("exit", (code) => {
           // null means the process was killed by a signal; treat as non-clean (1).
           slotExitCodes.set(slot, code ?? 1);
@@ -537,7 +552,7 @@ function buildSupervisorDeps(
         await teardownIterDirNative(info, root);
       },
       parkedSlotWork: (slot, lastPid) =>
-        parkedSlotWorkFor(tmpDir, slot, lastPid, afkPaths(root).supervisorLogPath, slotLogsDir),
+        parkedSlotWorkFor(tmpDir, slot, lastPid, supervisorWriter.path, slotLogsDir),
       removeDir: async (path) => {
         try {
           await removeDirNative(path);
@@ -617,8 +632,8 @@ function buildSupervisorDeps(
     wake: buildStateChangeWake(join(tmpDir, "workers")),
     // Env for the bounded stalled re-claim cap (#402): RED_AFK_RETRY_STALLED.
     recoveryEnv: process.env,
-    // Per-tick liveness line into afk-supervisor.log (best-effort). Makes a
-    // healthy fleet's heartbeat — and a wedged one's silence — observable.
+    // Derived human-readable messages are stored in the structured supervisor
+    // lane, not dual-written to a prose supervisor log.
     log: logLine,
     // Fleet supervisor owns the boot (#623): runSupervisor calls this ONCE before
     // the initial spawn. Runs the full shared sweep suite over real IO and logs
@@ -722,6 +737,7 @@ function buildSupervisorDeps(
         return { stateWritten: false, stateError: heartbeatWriteError(err) };
       }
     },
+    emitSupervisorEvent,
   };
 }
 
@@ -736,7 +752,6 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   const stateAfk = dirname(paths.supervisorPidPath);
   const pidFile = paths.supervisorPidPath;
   const stopFile = paths.supervisorStopPath;
-  const logFile = paths.supervisorLogPath;
   const firehoseFile = paths.fleetFirehosePath;
   const stateFile = paths.fleetStatePath;
   const slotLogsDir = slotLogDir(tmp);
@@ -768,12 +783,12 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   if (existsSync(stopFile)) rmSync(stopFile, { force: true });
   rmSync(paths.supervisorResizePath, { force: true });
 
-  const logFd = openSync(logFile, "a");
   const values = loadConfig(paths.configPath, { warn: () => undefined });
   const config = resolveSupervisorConfig(process.env, (key) => getConfig(values, key));
   const state = initSupervisorState(config.target);
   const repo = await resolveRepoSlug(root).catch(() => "");
   const ghCtx = { cwd: root, repo };
+  const supervisorId = `s${process.pid}`;
   // The filter/policy flags fleet.ts forwarded (--spec/--issues/--alternate/
   // --fallback-runner/--request), threaded into every slot's `run --once`.
   const slotArgs = slotFilterArgs(args);
@@ -784,7 +799,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
     RED_AFK_RUNNER: config.runner,
     ...(repo.length > 0 ? { RED_AFK_REPO: repo } : {}),
   };
-  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, logFd, firehoseFile, stateFile, config.runner, ghCtx, slotArgs, hookEnvBase);
+  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, config.runner, ghCtx, slotArgs, hookEnvBase);
 
   const stopRequested = (): boolean => existsSync(stopFile);
 

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -44,6 +44,7 @@ import {
 import type { FleetHookContext, FleetHookDispatchResult } from "./fleet-hook-dispatcher.js";
 import type { FleetHookName } from "./fleet-hook-config.js";
 import { encode as encodeToon } from "@reddb-io/toon";
+import type { CastleLaneRecord } from "@reddb-io/red-castle/engine";
 
 // ---------- tunables ----------
 
@@ -734,6 +735,18 @@ export interface FleetHeartbeatEmitResult {
   firehoseError?: string;
 }
 
+export type SupervisorEventKind =
+  | "supervisor.boot-sweep"
+  | "supervisor.tick"
+  | "supervisor.dead-slot-reconcile"
+  | "supervisor.wake"
+  | "supervisor.scale"
+  | "supervisor.message";
+
+export type SupervisorEventRecord = Omit<CastleLaneRecord, "at" | "kind"> & {
+  kind: SupervisorEventKind;
+};
+
 /** The slot's current iteration, resolved from the filesystem. Mirrors the
  * fields reap_stalled_slot pulls out of afk.state.json. */
 export interface IterDirInfo {
@@ -814,6 +827,12 @@ export interface SupervisorDeps {
    * whether that repair landed.
    */
   repairFleetHeartbeat?(heartbeat: FleetHeartbeat): FleetHeartbeatEmitResult | void | Promise<FleetHeartbeatEmitResult | void>;
+  /**
+   * Structured supervisor event sink. The native CLI binds this to the castle
+   * supervisor lane writer (`supervisor.log.toonl`). Best-effort; never throws
+   * out of the loop.
+   */
+  emitSupervisorEvent?(record: SupervisorEventRecord): void | Promise<void>;
   /**
    * Run the shared boot sweeps ONCE before the initial fleet spawn (#623). The
    * fleet supervisor owns the boot: it runs orphan cleanup / attempt cap /
@@ -975,6 +994,17 @@ export function initSupervisorState(target: number): SupervisorState {
     churnDeathEpochs: [],
     churnRespawnEpochs: [],
   };
+}
+
+async function emitSupervisorEvent(
+  deps: SupervisorDeps,
+  record: SupervisorEventRecord,
+): Promise<void> {
+  try {
+    await deps.emitSupervisorEvent?.(record);
+  } catch {
+    // best-effort: telemetry IO must not affect supervisor scheduling.
+  }
 }
 
 // ---------- discard / no-sentinel envelopes (compose envelope.ts) ----------
@@ -2159,6 +2189,17 @@ export async function superviseTick(
   const spawnPolicy = spawnPolicyForBudget(state, drainBudget);
 
   const resize = await resolveElasticResize(deps, config);
+  const slotsBeforeResize = state.slots.length;
+  if (resize.target !== slotsBeforeResize) {
+    await emitSupervisorEvent(deps, {
+      kind: "supervisor.scale",
+      payload: {
+        from: slotsBeforeResize,
+        to: resize.target,
+        mode: resize.shrinkMode,
+      },
+    });
+  }
   if (resize.target >= state.slots.length) {
     for (const slot of state.slots) slot.retiring = false;
   }
@@ -2264,6 +2305,10 @@ export async function superviseTick(
     if (pid === null || !deps.proc.isAlive(pid)) {
       if (pid !== null) {
         deps.log?.(`dead slot reconciled: slot ${i} pid=${pid}`);
+        await emitSupervisorEvent(deps, {
+          kind: "supervisor.dead-slot-reconcile",
+          payload: { slot: i, pid },
+        });
       }
       // Dispatch on_slot_death before the slot is recycled. Best-effort.
       if (deps.dispatchFleetHook) {
@@ -2405,14 +2450,29 @@ export async function runSupervisor(
   if (deps.bootSweeps) {
     try {
       await deps.bootSweeps();
+      await emitSupervisorEvent(deps, {
+        kind: "supervisor.boot-sweep",
+        payload: { status: "passed" },
+      });
     } catch (err) {
       if (err instanceof BootHaltError) {
         deps.log?.(`boot sweeps halted: ${err.message}`);
+        await emitSupervisorEvent(deps, {
+          kind: "supervisor.boot-sweep",
+          payload: { status: "halted", reason: err.message },
+        });
         return;
       }
       deps.log?.(
         `boot sweeps failed: ${err instanceof Error ? err.message : String(err)} — spawning workers anyway`,
       );
+      await emitSupervisorEvent(deps, {
+        kind: "supervisor.boot-sweep",
+        payload: {
+          status: "failed",
+          error: err instanceof Error ? err.message : String(err),
+        },
+      });
     }
   }
 
@@ -2488,6 +2548,23 @@ export async function runSupervisor(
         `crash-reconciled=${result.crashReconciled.length} ` +
         `ready=${heartbeat.readyForAgent} busy=${heartbeat.slotsBusy} free=${heartbeat.slotsFree}`,
     );
+    await emitSupervisorEvent(deps, {
+      kind: "supervisor.tick",
+      payload: {
+        slots: state.slots.length,
+        respawned: result.respawned.length,
+        deaths: result.deaths.length,
+        parked: result.parked.length,
+        idle_parked: result.idleParked.length,
+        half_opened: result.halfOpened.length,
+        reaped: result.reaped.length,
+        unblocked: result.unblocked.length,
+        crash_reconciled: result.crashReconciled.length,
+        ready_for_agent: heartbeat.readyForAgent,
+        slots_busy: heartbeat.slotsBusy,
+        slots_free: heartbeat.slotsFree,
+      },
+    });
     if (result.stopped) {
       // post_fleet: informational — fires after all workers are terminated.
       // Best-effort: hook failure is logged but never prevents clean exit.
@@ -2518,6 +2595,15 @@ export async function runSupervisor(
       wake: deps.wake,
     });
     recordWake(state.wakeStats, reason);
+    await emitSupervisorEvent(deps, {
+      kind: "supervisor.wake",
+      payload: {
+        source: reason,
+        event_wakes: state.wakeStats.event,
+        timer_wakes: state.wakeStats.timer,
+        total_wakes: state.wakeStats.total,
+      },
+    });
     if (reason === "event") {
       deps.log?.(
         `wake: event-driven (idle wakes reduced — ${state.wakeStats.event}/${state.wakeStats.total} wakes event-driven)`,

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -126,6 +126,8 @@ interface FakeIo {
   fleetCostUsd: ReturnType<typeof vi.fn>;
   resizeRequest: ReturnType<typeof vi.fn>;
   attemptBranchHead: ReturnType<typeof vi.fn>;
+  emitSupervisorEvent: ReturnType<typeof vi.fn>;
+  bootSweeps: ReturnType<typeof vi.fn>;
   logLines: string[];
   now: ReturnType<typeof vi.fn>;
 }
@@ -173,6 +175,8 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     fleetCostUsd: vi.fn(() => 0),
     resizeRequest: vi.fn(async () => null),
     attemptBranchHead: vi.fn(async () => undefined as string | undefined),
+    emitSupervisorEvent: vi.fn(async () => {}),
+    bootSweeps: vi.fn(async () => {}),
     logLines: [],
     now: vi.fn(() => NOW),
     ...(over as Partial<FakeIo>),
@@ -214,6 +218,8 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     unblockSweep: io.unblockSweep,
     attemptBranchHead: io.attemptBranchHead,
     resizeRequest: io.resizeRequest,
+    emitSupervisorEvent: io.emitSupervisorEvent,
+    bootSweeps: io.bootSweeps,
   };
   return { deps, io };
 }
@@ -1484,6 +1490,52 @@ describe("superviseTick — crash reconcile on respawn (#815)", () => {
 // ---------- runSupervisor end-to-end shape ----------
 
 describe("runSupervisor", () => {
+  it("emits structured supervisor lane records for boot, tick, reconcile, wake, and scale", async () => {
+    let clock = NOW;
+    let probes = 0;
+    const stop = () => {
+      probes += 1;
+      if (probes >= 2) clock = NOW + 15;
+      return probes >= 2;
+    };
+    const { deps, io } = makeDeps({
+      bootSweeps: vi.fn(async () => {}),
+      now: vi.fn(() => clock),
+      isAlive: vi.fn((pid: number) => pid !== 7000),
+      resizeRequest: vi.fn()
+        .mockResolvedValueOnce({ target: 2, shrinkMode: "drain-then-retire" })
+        .mockResolvedValueOnce(null),
+      spawnSlot: vi.fn(async (slot: number) => ({
+        pid: slot === 0 ? 7000 : 8000 + slot,
+        spawnEpoch: clock,
+      })),
+      readyQueueDepth: vi.fn(async () => 1),
+    });
+    const waitForEvent = vi.fn(async () => undefined);
+    const state = initSupervisorState(1);
+
+    await runSupervisor(
+      state,
+      { ...deps, wake: { waitForEvent } },
+      config({ target: 1, pollIntervalS: 15, eventFallbackS: 60 }),
+      stop,
+    );
+
+    const kinds = io.emitSupervisorEvent.mock.calls.map((call) => call[0].kind);
+    expect(kinds).toContain("supervisor.boot-sweep");
+    expect(kinds).toContain("supervisor.scale");
+    expect(kinds).toContain("supervisor.dead-slot-reconcile");
+    expect(kinds).toContain("supervisor.tick");
+    expect(kinds).toContain("supervisor.wake");
+    expect(io.emitSupervisorEvent.mock.calls.every((call) => call[0].kind.startsWith("supervisor."))).toBe(true);
+    expect(io.emitSupervisorEvent.mock.calls.find((call) => call[0].kind === "supervisor.scale")?.[0]).toMatchObject({
+      payload: { from: 1, to: 2, mode: "drain-then-retire" },
+    });
+    expect(io.emitSupervisorEvent.mock.calls.find((call) => call[0].kind === "supervisor.tick")?.[0]).toMatchObject({
+      payload: expect.objectContaining({ ready_for_agent: 1, slots_busy: 1 }),
+    });
+  });
+
   it("spawns the initial fleet then exits on the stop-file", async () => {
     const { deps, io } = makeDeps({ isAlive: vi.fn(() => true) });
     const state = initSupervisorState(2);


### PR DESCRIPTION
Automated AFK landing for #2063. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2063

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786920708&installation_id=129708444&pr_number=2068&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2068&signature=ebf1867fe004e1d89f979f8dabece3115ab0904bb2503a662804d764b8663839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->