### PR TITLE
fix: #2064 Castle worker structured lane: worker.* records + liveness.toonl on all runners + snapshot migration

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -91,6 +91,7 @@ import { initStateSync, readPidStartTime, updateState, writeIdentitySync } from 
 import { buildProgressHeartbeat, formatIterationMarker } from "../core/heartbeat.js";
 import { resolveAttemptLoc, locMemoPath, type LocMemo } from "../core/loc-memo.js";
 import { createActivityMeter } from "../core/activity-meter.js";
+import { createCastleWorkerLaneBridge } from "../core/castle-worker-lane-bridge.js";
 import { DEFAULT_MAX_ITERATIONS } from "../core/execution.js";
 import type { AgentStreamEvent } from "../core/execution.js";
 import { makeStaleClaimPredicate, resolveClaimStalenessConfig } from "../core/claim-staleness.js";
@@ -763,10 +764,16 @@ export function buildProcessDeps(
   laneIdle?: LaneIdleStallConfig,
   inlineVerifyCommand?: string,
   goVerifyRetries?: number,
+  workerId = "unknown",
 ): ProcessIssueDeps {
   const ghCtx: GhContext = { cwd: ctx.root, repo: ctx.repo, exec };
   const gitCtx: GitContext = { cwd: ctx.root, exec };
   const paths = afkPaths(ctx.root);
+  const castleBridge = createCastleWorkerLaneBridge({
+    redRoot: join(ctx.root, ".red"),
+    workerId,
+    attemptDir: () => current.attemptDir,
+  });
   const lockPath = branchLockPath(ctx.root);
   // Per-agentic-iteration boundary tracking (observability): when sandcastle's
   // re-invocation count (event.iteration) ticks, emit "iteration N ended/started"
@@ -1271,6 +1278,10 @@ export function buildProcessDeps(
         ts,
         fields: { extra: { iteration: String(event.iteration), kind: event.type } },
       }).catch(() => {});
+      void castleBridge.record("worker.heartbeat", {
+        event: event.type,
+        iteration: String(event.iteration),
+      }).catch(() => {});
       // Firehose lane (issue #250): every record in the uniform envelope. The
       // native port left this unopened; restore it so the post-mortem firehose
       // carries the agent turns alongside the (future) heartbeat/hook records.
@@ -1417,6 +1428,11 @@ export function buildProcessDeps(
           "current.worktree": worktree,
           ...(info.base ? { "current.base": info.base } : {}),
         }).catch(() => {});
+        await castleBridge.record("worker.heartbeat", {
+          signal: "attempt-guard",
+          seconds_since_progress: secs,
+          head,
+        }).catch(() => {});
       })();
     },
     // Worker-vitals provider for the on_heartbeat hook context (ADR 0065/#832):
@@ -1456,12 +1472,21 @@ export function buildProcessDeps(
     // feedback gate, `merging` at landing. Best-effort, swallowed; the calm title
     // signal must never fail the run.
     markPhase: (phase) => {
-      void updateState(join(current.attemptDir, "afk.state.json"), {
-        "current.phase": phase,
-      }).catch(() => {});
+      void (async () => {
+        await updateState(join(current.attemptDir, "afk.state.json"), {
+          "current.phase": phase,
+        }).catch(() => {});
+        await castleBridge.snapshot().catch(() => {});
+      })();
     },
     markState: (patch) => {
-      void updateState(join(current.attemptDir, "afk.state.json"), patch).catch(() => {});
+      void (async () => {
+        await updateState(join(current.attemptDir, "afk.state.json"), patch).catch(() => {});
+        await castleBridge.snapshot().catch(() => {});
+      })();
+    },
+    recordWorkerEvent: (kind, payload) => {
+      void castleBridge.record(kind, payload).catch(() => {});
     },
     historyPath: paths.historyPath,
     historyClock: { ts: new Date().toISOString(), epoch: Math.floor(Date.now() / 1000) },
@@ -1970,6 +1995,11 @@ export async function runCommand(options: RunOptions): Promise<number> {
   // Per-issue mutable attempt context the process deps' envelope/iter-log close
   // over; buildProcessInput resets it before each processIssue call.
   const current: CurrentAttempt = { attemptDir: "" };
+  const castleBridge = createCastleWorkerLaneBridge({
+    redRoot: join(ctx.root, ".red"),
+    workerId,
+    attemptDir: () => current.attemptDir,
+  });
 
   // --request/-r special block, threaded into the handoff the agent reads.
   const requestBlock = specialUserRequestBlock(flags.request);
@@ -2015,7 +2045,10 @@ export async function runCommand(options: RunOptions): Promise<number> {
         return result;
       }
       const sp = join(pi.attemptDir, "afk.state.json");
-      if (await fsx.pathExists(sp)) await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
+      if (await fsx.pathExists(sp)) {
+        await updateState(sp, { pid: 0 }, { allowPidReset: true }).catch(() => {});
+        await castleBridge.snapshot().catch(() => {});
+      }
       return result;
     },
     processDeps: buildProcessDeps(
@@ -2031,6 +2064,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
       settings.laneIdle,
       flags.verifyCommand,
       flags.goVerifyRetries,
+      workerId,
     ),
     // Session-scoped lifecycle hooks (PRD #207): the castle drain owns the
     // session state machine, while dev supplies the existing hook dispatcher so
@@ -2118,6 +2152,7 @@ export async function runCommand(options: RunOptions): Promise<number> {
           number: candidate.number,
           started_at: startedAt,
         });
+        void castleBridge.snapshot().catch(() => {});
       } catch {
         // Best-effort — a failed seed must never block the worker's actual work.
       }

--- a/apps/dev/src/core/castle-worker-lane-bridge.test.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.test.ts
@@ -1,0 +1,83 @@
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  castleLanePath,
+  castleStateSnapshotPath,
+  createEnginePaths,
+  readCastleLaneRecords,
+  readCastleStateSnapshot,
+} from "@reddb-io/red-castle/engine";
+import { parseLivenessRecords } from "@reddb-io/red-castle";
+import { initStateSync } from "./state.js";
+import { createCastleWorkerLaneBridge } from "./castle-worker-lane-bridge.js";
+
+describe("createCastleWorkerLaneBridge", () => {
+  it("writes worker lifecycle, liveness, and state snapshot as honest TOON lanes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "castle-worker-lane-"));
+    const redRoot = join(root, ".red");
+    const workerId = "wAB12";
+    const attemptDir = join(redRoot, "tmp", "workers", workerId, "2064-a1");
+    await mkdir(attemptDir, { recursive: true });
+    initStateSync(join(attemptDir, "afk.state.json"), {
+      worker_id: workerId,
+      pid: 1234,
+      runner: "codex",
+      origin: "afk",
+      started_at: "2026-07-17T00:00:00.000Z",
+      "current.kind": "afk",
+      "current.number": 2064,
+      "current.title": "Structured lane worker records",
+      "current.activity": "setup",
+      "current.phase": "setup",
+    });
+    const bridge = createCastleWorkerLaneBridge({
+      redRoot,
+      workerId,
+      attemptDir: () => attemptDir,
+      nowIso: () => "2026-07-17T00:00:01.000Z",
+      nowMs: () => Date.parse("2026-07-17T00:00:01.000Z"),
+    });
+
+    await bridge.record("worker.claimed", { branch: "afk/wAB12/2064-slice" });
+
+    const paths = createEnginePaths(redRoot);
+    const workerPath = castleLanePath(paths, "worker", workerId);
+    const livenessPath = castleLanePath(paths, "liveness", workerId);
+    expect(workerPath.endsWith("worker.log.toonl")).toBe(true);
+    expect(livenessPath.endsWith("liveness.toonl")).toBe(true);
+
+    await expect(readFile(workerPath, "utf8")).resolves.toContain("worker.claimed");
+    await expect(readFile(livenessPath, "utf8")).resolves.toContain("worker.heartbeat");
+
+    const workerRecords = await readCastleLaneRecords(workerPath);
+    expect(workerRecords).toEqual([
+      expect.objectContaining({
+        kind: "worker.claimed",
+        worker_id: workerId,
+        issue: 2064,
+        attempt: 1,
+      }),
+    ]);
+
+    const attemptLiveness = parseLivenessRecords(await readFile(join(attemptDir, "liveness.toonl"), "utf8"));
+    expect(attemptLiveness).toEqual([
+      expect.objectContaining({ at: Date.parse("2026-07-17T00:00:01.000Z") }),
+    ]);
+
+    const snapshot = await readCastleStateSnapshot(castleStateSnapshotPath(paths, "worker", workerId));
+    expect(snapshot).toEqual(expect.objectContaining({
+      kind: "worker",
+      id: workerId,
+      worker_id: workerId,
+      runner: "codex",
+      pid: 1234,
+    }));
+    expect(snapshot?.current).toEqual(expect.objectContaining({
+      number: 2064,
+      title: "Structured lane worker records",
+      origin: "afk",
+    }));
+  });
+});

--- a/apps/dev/src/core/castle-worker-lane-bridge.ts
+++ b/apps/dev/src/core/castle-worker-lane-bridge.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  createCastleLaneWriters,
+  createEnginePaths,
+  castleStateSnapshotPath,
+  writeCastleStateSnapshot,
+  type CastleLaneKind,
+  type CastleStateSnapshot,
+} from "@reddb-io/red-castle/engine";
+import { LivenessLane, LIVENESS_LANE_FILENAME } from "@reddb-io/red-castle";
+import { parseStateDocument } from "./state.js";
+import type { AfkState } from "../types/state.js";
+
+export type WorkerLifecycleKind =
+  | "worker.claimed"
+  | "worker.steered"
+  | "worker.validated"
+  | "worker.landed"
+  | "worker.blocked"
+  | "worker.heartbeat"
+  | (string & {});
+
+export interface CastleWorkerLaneBridge {
+  record(kind: WorkerLifecycleKind, payload?: Record<string, unknown>): Promise<void>;
+  snapshot(): Promise<void>;
+}
+
+export interface CastleWorkerLaneBridgeOptions {
+  redRoot: string;
+  workerId: string;
+  attemptDir: () => string;
+  nowIso?: () => string;
+  nowMs?: () => number;
+}
+
+function currentIssue(state: AfkState): number | undefined {
+  const raw = state.current.number;
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string" && /^[1-9][0-9]*$/.test(raw)) return Number(raw);
+  return undefined;
+}
+
+function currentAttempt(attemptDir: string): number | undefined {
+  const match = /-a([1-9][0-9]*)$/.exec(attemptDir);
+  return match ? Number(match[1]) : undefined;
+}
+
+function compactCurrent(state: AfkState): Record<string, unknown> {
+  return {
+    ...state.current,
+    origin: state.origin || state.current.kind,
+  };
+}
+
+function snapshotFromState(
+  workerId: string,
+  state: AfkState,
+  updatedAt: string,
+): CastleStateSnapshot {
+  return {
+    kind: "worker",
+    id: workerId,
+    version: 1,
+    updated_at: updatedAt,
+    worker_id: state.worker_id || workerId,
+    runner: state.runner || undefined,
+    pid: state.pid,
+    started_at: state.started_at || state.current.started_at || updatedAt,
+    current: compactCurrent(state),
+    envelope: state.envelope,
+  };
+}
+
+function readAttemptState(attemptDir: string): AfkState | null {
+  if (!attemptDir) return null;
+  try {
+    return parseStateDocument(readFileSync(join(attemptDir, "afk.state.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function createCastleWorkerLaneBridge(
+  options: CastleWorkerLaneBridgeOptions,
+): CastleWorkerLaneBridge {
+  const paths = createEnginePaths(options.redRoot);
+  const writers = createCastleLaneWriters(paths, { clock: options.nowIso });
+  const nowIso = options.nowIso ?? (() => new Date().toISOString());
+  const nowMs = options.nowMs ?? (() => Date.now());
+
+  async function snapshot(): Promise<void> {
+    const state = readAttemptState(options.attemptDir());
+    if (!state) return;
+    await writeCastleStateSnapshot(
+      castleStateSnapshotPath(paths, "worker", options.workerId),
+      snapshotFromState(options.workerId, state, nowIso()),
+    );
+  }
+
+  async function record(
+    kind: WorkerLifecycleKind,
+    payload: Record<string, unknown> = {},
+  ): Promise<void> {
+    const attemptDir = options.attemptDir();
+    const state = readAttemptState(attemptDir);
+    const issue = state ? currentIssue(state) : undefined;
+    const attempt = currentAttempt(attemptDir);
+    await writers.worker(options.workerId).append({
+      kind: kind as CastleLaneKind,
+      worker_id: options.workerId,
+      issue,
+      attempt,
+      payload,
+    });
+    await writers.liveness(options.workerId).append({
+      kind: "worker.heartbeat",
+      worker_id: options.workerId,
+      issue,
+      attempt,
+      payload: { signal: kind },
+    });
+    if (attemptDir) {
+      await new LivenessLane({
+        path: join(attemptDir, LIVENESS_LANE_FILENAME),
+        clock: nowMs,
+      }).record("iteration-start");
+    }
+    await snapshot();
+  }
+
+  return { record, snapshot };
+}

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -632,6 +632,13 @@ export interface ProcessIssueDeps {
    */
   markState?(patch: Record<string, unknown>): void;
   /**
+   * Append a structured castle worker lifecycle record. The CLI binds this to
+   * `.red/tmp/workers/<id>/worker.log.toonl`, `liveness.toonl`, and the durable
+   * `.red/state/castle/workers/<id>/state.toon` snapshot. Optional so tests and
+   * older callers keep their existing behavior.
+   */
+  recordWorkerEvent?(kind: `worker.${string}`, payload?: Record<string, unknown>): void;
+  /**
    * Stamp the attempt's macro-lifecycle phase (issue #811) — the calm signal the
    * task-mirror title surfaces. processIssue calls it at the orchestrator-owned
    * lifecycle points the inner-agent stream cannot see: `validating` at the start
@@ -895,6 +902,9 @@ function timeoutNotes(reason: RunAgentResult["timeoutReason"] | undefined): stri
 
 function markTerminalState(deps: ProcessIssueDeps, outcome: ProcessOutcome): void {
   deps.markState?.(stateExitPatch(outcome));
+  if (outcome !== "done") {
+    deps.recordWorkerEvent?.("worker.blocked", { outcome });
+  }
 }
 
 // ---------- the orchestration ----------
@@ -1525,6 +1535,7 @@ export async function processIssue(
     await releaseClaim();
     return claimLost(issue, hooksFired);
   }
+  deps.recordWorkerEvent?.("worker.claimed", { title: input.title });
 
   // ---- branch ref + base ----
   const slug = slugifyRef(input.title);
@@ -1586,6 +1597,10 @@ export async function processIssue(
   const handoffPath = `${input.attemptDir}/handoff.md`;
   await deps.fs.writeHandoff(handoffPath, handoff);
   deps.appendIterLog(formatStartedMarker(issue, startedAt));
+  deps.recordWorkerEvent?.("worker.steered", {
+    handoff: handoffPath,
+    output_shaping: outputShaping.variant,
+  });
 
   const taskClass =
     (await deps
@@ -2467,6 +2482,11 @@ export async function processIssue(
     // Both gates passed — the close path's sidecar/envelope carries their union.
     validationSidecar = [...feedback.sidecar, ...backpressureSidecar];
     lastValidationScope = feedback.validationScope;
+    deps.recordWorkerEvent?.("worker.validated", {
+      feedback_records: feedback.sidecar.length,
+      backpressure_records: backpressureSidecar.length,
+      scope: feedback.validationScope?.type ?? "",
+    });
     break;
   }
 
@@ -2659,6 +2679,7 @@ export async function processIssue(
   const mergeSha = landing.mergeSha ?? (await deps.git.headShortSha());
   const durationS = deps.nowEpoch() - startedEpoch;
   markLandingPhase("cascade");
+  deps.recordWorkerEvent?.("worker.landed", { merge_sha: mergeSha, base });
   // Write the machine-readable validation sidecar ($ITER_DIR/validation.jsonl,
   // SKILL.md) the Memory bridge consumes. Best-effort: never fails the close.
   await writeValidationSidecar(deps, input.attemptDir, validationSidecar);
@@ -3203,6 +3224,7 @@ async function emitDone(
  * ready-for-human, preserve the attempt dir. Mirrors the do_merge-false branch. */
 async function mergeFailed(c: StageCommon, _reason: string, locked = false): Promise<ProcessIssueResult> {
   const { deps, input } = c;
+  deps.recordWorkerEvent?.("worker.blocked", { outcome: "merge-conflict", reason: _reason });
   const decision = await routeRecovery(deps, input.issue, "merge-conflict", recoveryOrdinalFor(input));
   if (decision === "escalate") {
     await writeCurrentBlockerBestEffort(


### PR DESCRIPTION
Automated AFK landing for #2064. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2064

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786921956&installation_id=129708444&pr_number=2069&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2069&signature=5b1c312d3e9edd2fee0a3539c18ae0603d80d2d1c3436bb7d40def6eceb253c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->