### PR TITLE
fix: #2072 Trunk-freshness S1: wire the resolver into first-attempt lands (mechanical tier before parking)

### DIFF
--- a/apps/dev/src/commands/run.ts
+++ b/apps/dev/src/commands/run.ts
@@ -1091,6 +1091,7 @@ export function buildProcessDeps(
       const { execTool } = await import("../runtime/exec.js");
       await execTool(invocation.command, invocation.args, { cwd });
     },
+    resolveMechanicalConflict: makeMechanicalConflictResolver(gitCtx),
     // Isolated landing worktree for the LOCKED path (#572): a detached worktree at
     // <base> so the locked merge/push/rollback never `git -C`'s the primary
     // checkout. The primary branch is sacred — a rejected push's `reset --hard`

--- a/apps/dev/src/core/process-issue.ts
+++ b/apps/dev/src/core/process-issue.ts
@@ -503,6 +503,13 @@ export interface ProcessIssueDeps {
    */
   conflictResolver?: ConflictResolver;
   /**
+   * Mechanical-conflict resolver for the PR path's fresh-base rebase. When the
+   * first-attempt DONE path hits a rebase conflict, doLanding gives this port a
+   * chance to resolve closed-allowlist conflicts before parking
+   * blocked:merge-conflict. It returns false for genuine content conflicts.
+   */
+  resolveMechanicalConflict?: (repo: string) => Promise<boolean>;
+  /**
    * Landing-mode flag, decoupled from the lock (ADR 0030 amended, #842). Resolved
    * from `afk.worktree_launches_pull_request` (default `true`) by the CLI. `true`
    * → the attempt lands via an admin-merged PR into the resolved base; `false` →
@@ -2545,6 +2552,7 @@ export async function processIssue(
       remoteGit: deps.remoteGit,
       fireHook,
       conflictResolver: deps.conflictResolver,
+      resolveMechanicalConflict: deps.resolveMechanicalConflict,
       waitForReview: deps.waitForReview,
       ciAwait: deps.ciAwait,
       findMainRedRepairIssue: deps.gh.findMainRedRepairIssue,

--- a/apps/dev/tests/landing.test.ts
+++ b/apps/dev/tests/landing.test.ts
@@ -40,6 +40,8 @@ interface Harness {
   resolverCwds: string[];
   /** dirs the post-merge gate was invoked with (#1335). */
   postMergeGateDirs: string[];
+  /** dirs the mechanical rebase-conflict resolver was invoked with (#2072). */
+  mechanicalResolverDirs: string[];
   /** landing visibility phase transitions published for statusline (#1427). */
   landingPhases: string[];
 }
@@ -88,6 +90,8 @@ interface Opts {
   noRebaseWorktree?: boolean;
   /** rc the rebase in the rebase worktree returns (1 → real conflict → abort). */
   rebaseCode?: number;
+  /** First-attempt PR-path mechanical rebase-conflict resolver result. */
+  mechanicalConflictResolve?: "resolve" | "decline";
   /** rc the force-with-lease push returns (1 → reject on every attempt). */
   rebasePushCode?: number;
   /**
@@ -149,6 +153,7 @@ function harness(opts: Opts = {}): Harness {
   let mainRedRepairLookups = 0;
   const resolverCwds: string[] = [];
   const postMergeGateDirs: string[] = [];
+  const mechanicalResolverDirs: string[] = [];
   const landingPhases: string[] = [];
   let mergeResolved = false;
   let prCreated = false;
@@ -273,6 +278,12 @@ function harness(opts: Opts = {}): Harness {
           removedRebaseWorktrees.push(dir);
         }
       : undefined,
+    resolveMechanicalConflict: opts.mechanicalConflictResolve
+      ? async (dir) => {
+          mechanicalResolverDirs.push(dir);
+          return opts.mechanicalConflictResolve === "resolve";
+        }
+      : undefined,
     // #1102/#1373: only wired when the test opts in (opt-in — absent → guard skipped).
     getDiffPaths: opts.sensitivePaths || opts.changedFiles
       ? async () => ({
@@ -349,6 +360,7 @@ function harness(opts: Opts = {}): Harness {
     },
     resolverCwds,
     postMergeGateDirs,
+    mechanicalResolverDirs,
     landingPhases,
   };
 }
@@ -1215,6 +1227,71 @@ describe("doLanding — post-merge-integration gate (#1335)", () => {
     const r = await doLanding(h.deps, h.input, h.hooks);
     expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
     expect(h.postMergeGateDirs).toEqual([]);
+  });
+});
+
+describe("doLanding — first-attempt mechanical conflict resolution (#2072)", () => {
+  it("PR rebase conflict resolved mechanically → revalidates inside the land-lock before merging", async () => {
+    const trace: string[] = [];
+    const landLock: LandLock = {
+      acquire: async () => {
+        trace.push("enter");
+        return async () => {
+          trace.push("exit");
+        };
+      },
+    };
+    const h = harness({
+      locked: false,
+      openPr: true,
+      rebaseCode: 1,
+      mechanicalConflictResolve: "resolve",
+      postMergeGate: true,
+      landLock,
+    });
+
+    const resolve = h.deps.resolveMechanicalConflict!;
+    h.deps.resolveMechanicalConflict = async (dir) => {
+      trace.push(`resolve:${dir}`);
+      return resolve(dir);
+    };
+    const gate = h.deps.postMergeGate!;
+    h.deps.postMergeGate = async (dir) => {
+      trace.push(`gate:${dir}`);
+      return gate(dir);
+    };
+    const exec = h.deps.mergeExec;
+    h.deps.mergeExec = async (args) => {
+      if (args.join(" ").includes("pr merge")) trace.push("merge");
+      return exec(args);
+    };
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: true, locked: false });
+    expect(h.mechanicalResolverDirs).toEqual([RWT]);
+    expect(h.postMergeGateDirs).toEqual([RWT]);
+    expect(joined(h.mergeCalls).some((c) => c === `git -C ${RWT} rebase --abort`)).toBe(false);
+    expect(trace).toEqual(["enter", `resolve:${RWT}`, `gate:${RWT}`, "merge", "exit"]);
+  });
+
+  it("PR rebase conflict outside the mechanical allowlist → aborts and parks as pr-conflict", async () => {
+    const h = harness({
+      locked: false,
+      openPr: true,
+      rebaseCode: 1,
+      mechanicalConflictResolve: "decline",
+      postMergeGate: true,
+    });
+
+    const r = await doLanding(h.deps, h.input, h.hooks);
+
+    expect(r).toEqual({ ok: false, reason: "pr-conflict", locked: false });
+    expect(h.mechanicalResolverDirs).toEqual([RWT]);
+    expect(h.postMergeGateDirs).toEqual([]);
+    const j = joined(h.mergeCalls);
+    expect(j).toContain(`git -C ${RWT} rebase --abort`);
+    expect(j.some((c) => c.includes("pr merge"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Automated AFK landing for #2072. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2072

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786925916&installation_id=129708444&pr_number=2077&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2077&signature=59968ae5b73e96ee94baba2db9a68beff9992b7ffac4e36b980565b533cebca5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->