### PR TITLE
Trunk-freshness/castle: #2065 live runner switch + ACK'd directive channel (TOON-consistent)

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -2,7 +2,7 @@ import { constants } from "node:fs";
 import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { encode as encodeToon } from "@reddb-io/toon";
-import { afkPaths, collectMonitorInputs, resolveRepoSlug } from "../runtime/wire.js";
+import { afkPaths, collectMonitorInputs, readFleetState, resolveRepoSlug } from "../runtime/wire.js";
 import { migrateLegacyDevPaths } from "../runtime/red-path-migration.js";
 import { parseRunnerFlag, detectRunner } from "../core/runner-detection.js";
 import { callerProcessTreeNative } from "../runtime/caller-process.js";
@@ -116,14 +116,36 @@ function parseFleetArgs(args: readonly string[]): { stop: boolean; status: boole
   return { stop, status, target: target ?? 2, request, runnerFlag, drainBudgetUsd, shrinkMode, passthrough };
 }
 
-async function writeResizeRequest(path: string, target: number, shrinkMode: ElasticShrinkMode): Promise<void> {
+async function writeResizeRequest(
+  path: string,
+  target: number,
+  shrinkMode: ElasticShrinkMode,
+  runner?: string,
+): Promise<void> {
   const tmp = `${path}.tmp`;
+  const request = {
+    target,
+    ...(runner !== undefined ? { runner } : {}),
+    shrink_mode: shrinkMode,
+  };
   await writeFile(
     tmp,
-    encodeToon({ target, shrink_mode: shrinkMode }),
+    encodeToon(request),
     "utf8",
   );
   await rename(tmp, path);
+}
+
+function directiveAck(
+  state: Awaited<ReturnType<typeof readFleetState>>,
+  request: { target: number; shrinkMode: ElasticShrinkMode; runner?: string },
+): "applied" | "pending" {
+  if (!state) return "pending";
+  const appliedTarget = state.target ?? state.slotsTotal;
+  if (appliedTarget !== request.target) return "pending";
+  if ((state.shrinkMode ?? request.shrinkMode) !== request.shrinkMode) return "pending";
+  if (request.runner !== undefined && state.runner !== request.runner) return "pending";
+  return "applied";
 }
 
 export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStream = process.stdout): Promise<FleetStopResult> {
@@ -231,7 +253,7 @@ export async function statusFleet(root = process.cwd(), stdout: NodeJS.WritableS
       alive: liveness.pidAlive,
       health,
       runner: fleet?.runner ?? "",
-      target: fleet?.slotsTotal ?? 0,
+      target: fleet?.target ?? fleet?.slotsTotal ?? 0,
       bundle_version: fleet?.bundleVersion ?? "",
       bundle_latest: fleet?.latestBundleVersion ?? "",
       heartbeat_age_s: heartbeatAgeS,
@@ -290,9 +312,16 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     const health = classifySupervisor(liveness, io.now(), cfg.supervisorStaleS, cfg.progressStaleS);
     if (health !== "quiescent") {
       const shrinkMode = parsed.shrinkMode ?? cfg.shrinkMode;
-      await writeResizeRequest(paths.supervisorResizePath, parsed.target, shrinkMode);
+      const directiveRunner = parsed.runnerFlag ? detectRunner({ flag: parsed.runnerFlag }).runner : undefined;
+      await writeResizeRequest(paths.supervisorResizePath, parsed.target, shrinkMode, directiveRunner);
+      const ack = directiveAck(await readFleetState(paths.fleetStatePath), {
+        target: parsed.target,
+        shrinkMode,
+        ...(directiveRunner !== undefined ? { runner: directiveRunner } : {}),
+      });
       stdout.write(
-        `fleet resize requested (supervisor pid=${existing}, target=${parsed.target}, shrink-mode=${shrinkMode})\n`,
+        `fleet directive ${ack} (supervisor pid=${existing}, target=${parsed.target}` +
+          `${directiveRunner !== undefined ? `, runner=${directiveRunner}` : ""}, shrink-mode=${shrinkMode})\n`,
       );
       return { status: "resized", pid: existing, target: parsed.target, log: logFile };
     }

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -58,7 +58,7 @@ import {
   createCastleLaneWriters,
   writeCastleStateSnapshot,
 } from "@reddb-io/red-castle/engine";
-import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
+import { decodeDevSnapshotSniff, encodeDevSnapshotToon } from "../core/toon-snapshot.js";
 
 function isAlive(pid: number): boolean {
   try {
@@ -70,7 +70,7 @@ function isAlive(pid: number): boolean {
 }
 
 function fleetHeartbeatMessage(hb: FleetHeartbeat): string {
-  return `fleet tick ready=${hb.readyForAgent} busy=${hb.slotsBusy} free=${hb.slotsFree} spawns=${hb.spawnsThisTick}`;
+  return `fleet tick target=${hb.target} runner=${hb.runner} shrink-mode=${hb.shrinkMode} ready=${hb.readyForAgent} busy=${hb.slotsBusy} free=${hb.slotsFree} spawns=${hb.spawnsThisTick}`;
 }
 
 /**
@@ -85,7 +85,9 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
     ts: hb.ts,
     epoch: hb.epoch,
     ...(hb.lastProgressEpoch > 0 ? { last_progress_epoch: hb.lastProgressEpoch } : {}),
+    ...(hb.target !== undefined ? { target: hb.target } : {}),
     runner: hb.runner,
+    ...(hb.shrinkMode !== undefined ? { shrink_mode: hb.shrinkMode } : {}),
     ...(hb.bundleVersion ? { bundle_version: hb.bundleVersion } : {}),
     ready_for_agent: hb.readyForAgent,
     slots: {
@@ -138,6 +140,8 @@ async function writeCastleSupervisorSnapshot(
       current: {
         epoch: hb.epoch,
         last_progress_epoch: hb.lastProgressEpoch,
+        ...(hb.target !== undefined ? { target: hb.target } : {}),
+        ...(hb.shrinkMode !== undefined ? { shrink_mode: hb.shrinkMode } : {}),
         ready_for_agent: hb.readyForAgent,
         slots: {
           busy: hb.slotsBusy,
@@ -275,8 +279,13 @@ function slotRetirePath(statePath: string, slot: number): string {
 
 function readResizeRequest(path: string): ElasticResizeRequest | null {
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as {
+    // Sniff-decode: the launcher writes the directive as TOON (encodeToon), but
+    // tolerate a legacy JSON directive left by an older bundle. JSON.parse alone
+    // would throw on the TOON body and silently drop every resize/runner
+    // directive (the write side is TOON on main).
+    const parsed = decodeDevSnapshotSniff(readFileSync(path, "utf8")) as {
       target?: unknown;
+      runner?: unknown;
       shrink_mode?: unknown;
       shrinkMode?: unknown;
     };
@@ -286,9 +295,11 @@ function readResizeRequest(path: string): ElasticResizeRequest | null {
       rawMode === "hard-kill" || rawMode === "drain-then-retire"
         ? rawMode
         : undefined;
+    const runner = typeof parsed.runner === "string" && parsed.runner.length > 0 ? parsed.runner : undefined;
     return {
       target: parsed.target as number,
       ...(shrinkMode !== undefined ? { shrinkMode } : {}),
+      ...(runner !== undefined ? { runner } : {}),
     };
   } catch {
     return null;
@@ -473,14 +484,16 @@ function buildSupervisorDeps(
   // (gap 4). Operator-set RED_AFK_* vars (RED_AFK_SKIP_PERF, etc) and the rest of
   // the environment survive. RED_AFK_RUNNER is re-added explicitly below so the
   // worker's detection cascade pins the supervisor's runner.
-  const workerEnv = buildWorkerEnv(process.env, runner);
+  let activeRunner = runner;
+  let workerEnv = buildWorkerEnv(process.env, activeRunner);
+  let hookEnv = { ...hookEnvBase, RED_AFK_RUNNER: activeRunner };
 
   return {
     proc: {
       spawnSlot: async (slot, policy) => {
         // Forward the Spec/Ticket filter + runner-swap policy so a supervised
         // fleet honours the same filter a single `/afk run` would (gap 5).
-        const runArgs = ["run", "--once", "--runner", runner, ...slotArgs];
+        const runArgs = ["run", "--once", "--runner", activeRunner, ...slotArgs];
         // Each slot gets its own log file so the circuit-trip sweep can
         // resolve which worker IDs ran in the slot via parseWorkerIdsFromLog
         // (mirrors spawn_slot's per-slot slot_log in supervisor.sh).
@@ -507,7 +520,7 @@ function buildSupervisorDeps(
       },
       spawnReconcileWorker: async (slot, candidate) => {
         const runArgs = [
-          "run", "--once", "--runner", runner,
+          "run", "--once", "--runner", activeRunner,
           "--reconcile-issue", String(candidate.issue),
           ...slotArgs,
         ];
@@ -668,13 +681,18 @@ function buildSupervisorDeps(
     },
     attemptBranchHead: (branch) => gitx.branchHead({ cwd: root }, branch),
     resizeRequest: async () => readResizeRequest(afkPaths(root).supervisorResizePath),
+    configureRunner: (nextRunner) => {
+      activeRunner = nextRunner;
+      workerEnv = buildWorkerEnv(process.env, activeRunner);
+      hookEnv = { ...hookEnvBase, RED_AFK_RUNNER: activeRunner };
+    },
     // Fleet-scoped lifecycle hooks (#833). Commands are resolved from the same
     // .red/hooks/<point>/ + library layering as worker hooks. Best-effort:
     // a dispatch failure is returned to the caller; the caller catches and logs.
     dispatchFleetHook: async (name, context) => {
       const commands = fleetHooks[name];
       return dispatchFleetHook(name, commands, context, fleetHookExec, {
-        env: hookEnvBase,
+        env: hookEnv,
         log: logLine,
       });
     },
@@ -703,6 +721,8 @@ function buildSupervisorDeps(
             extra: {
               scope: "fleet",
               runner: stamped.runner,
+              target: String(stamped.target),
+              shrink_mode: stamped.shrinkMode,
               bundle_version: stamped.bundleVersion ?? null,
               ready_for_agent: String(stamped.readyForAgent),
               slots_busy: String(stamped.slotsBusy),

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -207,6 +207,7 @@ export type ElasticShrinkMode = "hard-kill" | "drain-then-retire";
 export interface ElasticResizeRequest {
   target: number;
   shrinkMode?: ElasticShrinkMode;
+  runner?: string;
 }
 
 export type DrainBudgetTier = "OK" | "WARNING" | "CRITICAL" | "HARD_STOP";
@@ -702,6 +703,10 @@ export interface FleetHeartbeat {
   /** Runner this fleet was launched with — lets the watchdog relaunch a recovered
    * supervisor with the same runner instead of re-detecting from its own tree. */
   runner: string;
+  /** Desired worker count most recently applied from config/directive. */
+  target: number;
+  /** Runtime shrink behavior most recently applied from config/directive. */
+  shrinkMode: ElasticShrinkMode;
   /** Dev bundle version the running supervisor was launched from. */
   bundleVersion?: string;
   readyForAgent: number;
@@ -872,6 +877,8 @@ export interface SupervisorDeps {
   /** Runtime elastic fleet request, typically read from the state/afk control
    * file written by `fleet N`. Null means keep the launched config target. */
   resizeRequest?(): Promise<ElasticResizeRequest | null>;
+  /** Re-pin real runtime spawn/hook configuration when a live directive changes runner. */
+  configureRunner?(runner: string): void | Promise<void>;
 }
 
 // ---------- per-slot runtime state ----------
@@ -1180,6 +1187,8 @@ export interface TickResult {
   unblocked: number[];
   /** Slots removed from the runtime fleet by elastic shrink this tick. */
   retiredSlots: number[];
+  /** True when a live directive changed the fleet runner this tick. */
+  runnerChanged: boolean;
   /** True when the stop-file was honoured and all workers terminated. */
   stopped: boolean;
   /** Ready-queue depth sampled at the start of this tick (0 on an abandoned
@@ -1273,8 +1282,7 @@ async function emitFleetHeartbeat(
   state: SupervisorState,
   deps: SupervisorDeps,
   result: TickResult,
-  runner: string,
-  config: Pick<SupervisorConfig, "halfOpenBaseS" | "halfOpenCapS" | "circuitWindowS">,
+  config: Pick<SupervisorConfig, "runner" | "target" | "shrinkMode" | "halfOpenBaseS" | "halfOpenCapS" | "circuitWindowS">,
 ): Promise<{ heartbeat: FleetHeartbeat; write: FleetHeartbeatEmitResult }> {
   // Queue depth was fetched once by superviseTick at the start of this tick
   // and stored in result.queueDepth — reuse it here so there is exactly one
@@ -1286,7 +1294,9 @@ async function emitFleetHeartbeat(
     ts: isoFromEpoch(epoch),
     epoch,
     lastProgressEpoch: state.lastProgressEpoch,
-    runner,
+    runner: config.runner,
+    target: config.target,
+    shrinkMode: config.shrinkMode,
     readyForAgent,
     ...fleetSlotCounts(state, deps),
     spawnsThisTick: result.respawned.length,
@@ -1801,7 +1811,49 @@ async function resolveElasticResize(
   return {
     target,
     shrinkMode: request?.shrinkMode ?? config.shrinkMode,
+    runner:
+      typeof request?.runner === "string" && request.runner.length > 0
+        ? request.runner
+        : config.runner,
   };
+}
+
+async function applyRunnerDirective(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  config: SupervisorConfig,
+  runner: string,
+  result: TickResult,
+): Promise<boolean> {
+  if (runner === config.runner) return false;
+  const from = config.runner;
+  await deps.configureRunner?.(runner);
+  config.runner = runner;
+  await emitSupervisorEvent(deps, {
+    kind: "supervisor.scale",
+    payload: {
+      from: state.slots.length,
+      to: state.slots.length,
+      mode: "drain-then-retire",
+      runner_from: from,
+      runner_to: runner,
+    },
+  });
+  for (let i = 0; i < state.slots.length; i += 1) {
+    const slot = state.slots[i]!;
+    if (slot.retiring) continue;
+    slot.retiring = true;
+    const pid = slot.pid;
+    if (pid !== null && deps.proc.isAlive(pid)) {
+      try {
+        await deps.proc.requestSlotRetire?.(i, pid);
+      } catch {
+        // best-effort
+      }
+    }
+  }
+  result.runnerChanged = true;
+  return true;
 }
 
 async function growFleetToTarget(
@@ -1902,6 +1954,12 @@ async function retireDrainedSlots(
     if (!slot.retiring) continue;
     const pid = slot.pid;
     if (pid !== null && deps.proc.isAlive(pid)) continue;
+    try {
+      const reconciled = await reconcileDeadWorkerClaim(deps.fs.resolveIterDir(i), deps);
+      if (reconciled !== null) result.crashReconciled.push(reconciled);
+    } catch {
+      // best-effort
+    }
     await retireSlotAt(state, i, result);
   }
 }
@@ -2163,6 +2221,7 @@ export async function superviseTick(
     reconciledSlots: [],
     unblocked: [],
     retiredSlots: [],
+    runnerChanged: false,
     stopped: false,
     queueDepth: 0,
     abandoned: false,
@@ -2189,6 +2248,9 @@ export async function superviseTick(
   const spawnPolicy = spawnPolicyForBudget(state, drainBudget);
 
   const resize = await resolveElasticResize(deps, config);
+  const runnerChanged = await applyRunnerDirective(state, deps, config, resize.runner, result);
+  config.target = resize.target;
+  config.shrinkMode = resize.shrinkMode;
   const slotsBeforeResize = state.slots.length;
   if (resize.target !== slotsBeforeResize) {
     await emitSupervisorEvent(deps, {
@@ -2200,7 +2262,7 @@ export async function superviseTick(
       },
     });
   }
-  if (resize.target >= state.slots.length) {
+  if (resize.target > state.slots.length && !runnerChanged) {
     for (const slot of state.slots) slot.retiring = false;
   }
   if (resize.target > state.slots.length && spawnPolicy !== "hard-stop") {
@@ -2538,7 +2600,7 @@ export async function runSupervisor(
     if (!result.abandoned) {
       state.lastProgressEpoch = deps.now();
     }
-    const { heartbeat, write } = await emitFleetHeartbeat(state, deps, result, config.runner, config);
+    const { heartbeat, write } = await emitFleetHeartbeat(state, deps, result, config);
     await superviseHeartbeatStateWrite(state, deps, heartbeat, write);
     deps.log?.(
       `tick: slots=${state.slots.length} respawned=${result.respawned.length} ` +
@@ -2615,7 +2677,7 @@ export async function runSupervisor(
 /** A non-stop tick result (the abandon/error fallback). The `abandoned` flag
  * tells runSupervisor not to advance lastProgressEpoch for this pass. */
 function continueResult(): TickResult {
-  return { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], stopped: false, queueDepth: 0, abandoned: true };
+  return { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], runnerChanged: false, stopped: false, queueDepth: 0, abandoned: true };
 }
 
 /**

--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -113,7 +113,9 @@ export function stampFreshFleetHeartbeat(
     // A fresh relaunch stamp counts as progress: the new supervisor is
     // healthy until proven otherwise, so seed both epochs to `epoch`.
     last_progress_epoch: epoch,
+    target,
     runner,
+    shrink_mode: "drain-then-retire",
     ready_for_agent: 0,
     slots: { busy: 0, free: target, total: target, parked: 0 },
     spawns_this_tick: 0,

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -509,7 +509,9 @@ function parseFleetState(raw: unknown): FleetState | null {
     ts?: unknown;
     epoch?: unknown;
     last_progress_epoch?: unknown;
+    target?: unknown;
     runner?: unknown;
+    shrink_mode?: unknown;
     bundle_version?: unknown;
     ready_for_agent?: unknown;
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
@@ -520,6 +522,11 @@ function parseFleetState(raw: unknown): FleetState | null {
   const epoch = Number(rec.epoch ?? 0);
   if (!Number.isFinite(epoch) || epoch <= 0) return null;
   const rawProgress = Number(rec.last_progress_epoch ?? 0);
+  const target = Number(rec.target ?? 0);
+  const shrinkMode =
+    rec.shrink_mode === "hard-kill" || rec.shrink_mode === "drain-then-retire"
+      ? rec.shrink_mode
+      : undefined;
 
   let slotDetails: SlotDetail[] | undefined;
   if (Array.isArray(rec.slot_details)) {
@@ -542,6 +549,8 @@ function parseFleetState(raw: unknown): FleetState | null {
     epoch,
     lastProgressEpoch: Number.isFinite(rawProgress) && rawProgress > 0 ? rawProgress : undefined,
     runner: typeof rec.runner === "string" ? rec.runner : "",
+    target: Number.isFinite(target) && target >= 0 ? target : undefined,
+    ...(shrinkMode !== undefined ? { shrinkMode } : {}),
     bundleVersion: typeof rec.bundle_version === "string" ? rec.bundle_version : undefined,
     readyForAgent: Number(rec.ready_for_agent ?? 0) || 0,
     slotsBusy: Number(rec.slots?.busy ?? 0) || 0,

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -233,7 +233,7 @@ describe("fleet command stale supervisor state", () => {
       expect(result).toMatchObject({ status: "resized", pid: 12345, target: 4 });
       expect(spawnSupervisor).not.toHaveBeenCalled();
       expect(writes.join("")).toContain("fleet directive applied");
-      expect(JSON.parse(readFileSync(afkPaths(root).supervisorResizePath, "utf8"))).toEqual({
+      expect(decode(readFileSync(afkPaths(root).supervisorResizePath, "utf8"))).toEqual({
         target: 4,
         runner: "codex",
         shrink_mode: "drain-then-retire",

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -178,15 +178,65 @@ describe("fleet command stale supervisor state", () => {
         "utf8",
       );
       vi.mocked(isLivePid).mockReturnValue(true);
-      const out = stream();
+      const writes: string[] = [];
+      const out = {
+        write: vi.fn((s: string) => {
+          writes.push(s);
+          return true;
+        }),
+      } as unknown as NodeJS.WritableStream;
 
       const result = await launchFleet(["4", "--shrink-mode", "hard-kill"], root, out);
 
       expect(result).toMatchObject({ status: "resized", pid: 12345, target: 4 });
       expect(spawnSupervisor).not.toHaveBeenCalled();
+      expect(writes.join("")).toContain("fleet directive pending");
       expect(decode(readFileSync(afkPaths(root).supervisorResizePath, "utf8"))).toEqual({
         target: 4,
         shrink_mode: "hard-kill",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("launchFleet reports applied when a live runner directive already matches the heartbeat", async () => {
+    const root = scratch();
+    try {
+      const stateAfk = join(root, ".red", "state", "castle");
+      mkdirSync(stateAfk, { recursive: true });
+      writeFileSync(join(stateAfk, "afk-supervisor.pid"), "12345", "utf8");
+      const epoch = Math.floor(Date.now() / 1000);
+      writeFileSync(
+        join(stateAfk, "afk-supervisor.state.json"),
+        JSON.stringify({
+          epoch,
+          last_progress_epoch: epoch,
+          target: 4,
+          runner: "codex",
+          shrink_mode: "drain-then-retire",
+          slots: { busy: 1, free: 3, total: 4, parked: 0 },
+        }),
+        "utf8",
+      );
+      vi.mocked(isLivePid).mockReturnValue(true);
+      const writes: string[] = [];
+      const out = {
+        write: vi.fn((s: string) => {
+          writes.push(s);
+          return true;
+        }),
+      } as unknown as NodeJS.WritableStream;
+
+      const result = await launchFleet(["4", "--runner", "codex"], root, out);
+
+      expect(result).toMatchObject({ status: "resized", pid: 12345, target: 4 });
+      expect(spawnSupervisor).not.toHaveBeenCalled();
+      expect(writes.join("")).toContain("fleet directive applied");
+      expect(JSON.parse(readFileSync(afkPaths(root).supervisorResizePath, "utf8"))).toEqual({
+        target: 4,
+        runner: "codex",
+        shrink_mode: "drain-then-retire",
       });
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -126,6 +126,7 @@ interface FakeIo {
   fleetCostUsd: ReturnType<typeof vi.fn>;
   resizeRequest: ReturnType<typeof vi.fn>;
   attemptBranchHead: ReturnType<typeof vi.fn>;
+  configureRunner: ReturnType<typeof vi.fn>;
   emitSupervisorEvent: ReturnType<typeof vi.fn>;
   bootSweeps: ReturnType<typeof vi.fn>;
   logLines: string[];
@@ -175,6 +176,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     fleetCostUsd: vi.fn(() => 0),
     resizeRequest: vi.fn(async () => null),
     attemptBranchHead: vi.fn(async () => undefined as string | undefined),
+    configureRunner: vi.fn(async () => {}),
     emitSupervisorEvent: vi.fn(async () => {}),
     bootSweeps: vi.fn(async () => {}),
     logLines: [],
@@ -217,6 +219,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     repairFleetHeartbeat: io.repairFleetHeartbeat,
     unblockSweep: io.unblockSweep,
     attemptBranchHead: io.attemptBranchHead,
+    configureRunner: io.configureRunner,
     resizeRequest: io.resizeRequest,
     emitSupervisorEvent: io.emitSupervisorEvent,
     bootSweeps: io.bootSweeps,
@@ -577,6 +580,7 @@ describe("guardedTick — abandoned flag", () => {
       reconciledSlots: [],
       unblocked: [],
       retiredSlots: [],
+      runnerChanged: false,
       stopped: false,
       queueDepth: 0,
       abandoned: false,
@@ -1335,6 +1339,63 @@ describe("superviseTick — elastic fleet resize (#1913)", () => {
     expect(io.spawnSlot).not.toHaveBeenCalled();
     expect(result.retiredSlots).toEqual([1]);
   });
+
+  it("switches runner at runtime by retiring every live slot before respawning on the new runner", async () => {
+    const live = new Set([5000, 5001]);
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn((pid: number) => live.has(pid)),
+      resizeRequest: vi.fn(async () => ({ target: 2, runner: "codex", shrinkMode: "drain-then-retire" })),
+      spawnSlot: vi.fn(async (slot: number) => ({ pid: 9000 + slot, spawnEpoch: NOW })),
+    });
+    const cfg = config({ target: 2, runner: "claude" });
+    const state = initSupervisorState(2);
+    state.slots[0]!.pid = 5000;
+    state.slots[1]!.pid = 5001;
+
+    let result = await superviseTick(state, deps, cfg, () => false);
+
+    expect(cfg.runner).toBe("codex");
+    expect(io.configureRunner).toHaveBeenCalledWith("codex");
+    expect(state.slots).toHaveLength(2);
+    expect(state.slots.every((slot) => slot.retiring)).toBe(true);
+    expect(io.requestSlotRetire).toHaveBeenCalledWith(0, 5000);
+    expect(io.requestSlotRetire).toHaveBeenCalledWith(1, 5001);
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(result.runnerChanged).toBe(true);
+
+    live.clear();
+    io.lastExitCode.mockReturnValue(0);
+    result = await superviseTick(state, deps, cfg, () => false);
+
+    expect(state.slots).toHaveLength(0);
+    expect(result.retiredSlots).toEqual([1, 0]);
+
+    result = await superviseTick(state, deps, cfg, () => false);
+
+    expect(state.slots).toHaveLength(2);
+    expect(io.spawnSlot).toHaveBeenCalledWith(0);
+    expect(io.spawnSlot).toHaveBeenCalledWith(1);
+    expect(result.respawned).toEqual([0, 1]);
+  });
+
+  it("treats an unchanged runner directive as a no-op", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      resizeRequest: vi.fn(async () => ({ target: 2, runner: "claude", shrinkMode: "drain-then-retire" })),
+    });
+    const cfg = config({ target: 2, runner: "claude" });
+    const state = initSupervisorState(2);
+    state.slots[0]!.pid = 5000;
+    state.slots[1]!.pid = 5001;
+
+    const result = await superviseTick(state, deps, cfg, () => false);
+
+    expect(io.configureRunner).not.toHaveBeenCalled();
+    expect(io.requestSlotRetire).not.toHaveBeenCalled();
+    expect(io.spawnSlot).not.toHaveBeenCalled();
+    expect(state.slots.every((slot) => !slot.retiring)).toBe(true);
+    expect(result.runnerChanged).toBe(false);
+  });
 });
 
 // ---------- crash reconcile (#815, ADR 0071 Pattern 5) ----------
@@ -1660,6 +1721,9 @@ describe("runSupervisor", () => {
     expect(io.emitFleetHeartbeat).toHaveBeenCalledTimes(2);
     expect(io.emitFleetHeartbeat.mock.calls[0]![0]).toMatchObject({
       ts: new Date(NOW * 1000).toISOString(),
+      target: 1,
+      runner: "claude",
+      shrinkMode: "drain-then-retire",
       readyForAgent: 5,
       slotsBusy: 1,
       slotsFree: 0,
@@ -1766,8 +1830,8 @@ describe("envelope builders", () => {
 describe("guardedTick — per-tick wall-clock ceiling (unwedgeable loop)", () => {
   const never = (): Promise<void> => new Promise<void>(() => {});
   const immediate = (): Promise<void> => Promise.resolve();
-  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], stopped: false, queueDepth: 0, abandoned: false };
-  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], stopped: false, queueDepth: 0, abandoned: true };
+  const okResult = { respawned: [1], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], runnerChanged: false, stopped: false, queueDepth: 0, abandoned: false };
+  const CONTINUE = { respawned: [], deaths: [], parked: [], idleParked: [], halfOpened: [], reaped: [], crashReconciled: [], reconciledSlots: [], unblocked: [], retiredSlots: [], runnerChanged: false, stopped: false, queueDepth: 0, abandoned: true };
 
   it("returns the tick result when it completes before the ceiling", async () => {
     const logs: string[] = [];

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -239,6 +239,10 @@ export interface FleetState {
   lastProgressEpoch?: number;
   /** Runner the fleet was launched with (default "" for pre-#407 state files). */
   runner: string;
+  /** Desired worker count currently applied by the live supervisor. */
+  target?: number;
+  /** Runtime shrink behavior currently applied by the live supervisor. */
+  shrinkMode?: "hard-kill" | "drain-then-retire";
   /** Dev bundle version the running supervisor was launched from. */
   bundleVersion?: string;
   /** Newest compatible dev bundle seen in the local cache. */

--- a/plugins/dev/skills/engineering/afk/fleet.md
+++ b/plugins/dev/skills/engineering/afk/fleet.md
@@ -36,12 +36,18 @@ not part of the current fleet contract.
 `N` is optional and defaults to `2`. Parse it as a non-negative integer; reject anything else (including `stop`, which is the other subcommand and routes below). Steps the agent must perform, in order:
 
 1. **Resolve runner.** Determine the active runner using the same intent as the normal AFK cascade: explicit user `--runner` if present, else `RED_AFK_RUNNER`, else runner env/process/path signals, else `claude`. The resolved value is carried into the supervisor as `RED_AFK_RUNNER=<runner>` so detached workers do not fall through to the supervisor's historical `claude` fallback. Under Codex, this must resolve to `codex`.
-2. **PID-file pre-check.** Read `.red/tmp/supervisors/default/afk-supervisor.pid`. If it exists and `kill -0 <pid>` succeeds, refuse the launch:
+2. **PID-file pre-check / live directive.** Read `.red/tmp/supervisors/default/afk-supervisor.pid`. If it exists and `kill -0 <pid>` succeeds, do not launch a second supervisor. Instead the bundle command writes the `afk-supervisor.resize` directive file in the supervisor runtime lane (`.red/tmp/supervisors/default/`) as the live directive:
+   - `fleet <N>` changes the desired worker count while keeping the current runner.
+   - `fleet <N> --shrink-mode hard-kill|drain-then-retire` changes the resize shrink behavior. The default is `drain-then-retire`.
+   - `fleet <N> --runner <runner>` asks the running supervisor to switch runner. A changed runner is applied by re-pinning the supervisor's worker env, marking every live slot `drain-then-retire`, letting in-flight claims finish, then respawning replacement slots on the new runner. An unchanged runner is a no-op.
+   After writing the directive, the launcher reads `.red/tmp/supervisors/default/state.toon` and prints `fleet directive applied ...` when the heartbeat already echoes the requested target/runner/shrink-mode, or `fleet directive pending ...` while waiting for the next supervisor tick to apply it.
+
+   Older launch guidance used to say a live supervisor is refused:
    ```
    ✗ fleet already running (supervisor pid=<pid>, log .red/tmp/supervisors/default/supervisor.log.toonl).
      to stop it: /dev:afk fleet stop
    ```
-   Do **not** touch the file or attempt to recover. A stale PID file (file exists but `kill -0` fails) is left alone — the `fleet` command clears it itself when it acquires the supervisor lock.
+   That remains the model for truly conflicting second supervisors, but `fleet <N>` is now the supported live resize/switch surface. A stale PID file (file exists but `kill -0` fails) is left alone — the `fleet` command clears it itself when it acquires the supervisor lock.
 3. **Launch the fleet.** From the project root, run the bundle's `fleet` command with the target and any flags:
    ```bash
    RED_AFK_RUNNER=<runner> red-skills-dev fleet <N> [--request <text>]


### PR DESCRIPTION
Resolves the parked `blocked:merge-conflict` on **#2065** (castle Spec #2062 S3), rebased off the stale `wDIGD` attempt onto current `main`.

## What lands

The live fleet directive channel — talk to a running supervisor without relaunching:
- `fleet <N> --runner <r>` asks the supervisor to switch runner (re-pin worker env, mark live slots `drain-then-retire`, let claims finish, respawn on the new runner; unchanged runner = no-op).
- `fleet <N>` / `--shrink-mode` keep resizing.
- The launcher prints `fleet directive applied|pending` by reading the supervisor state snapshot.

## Conflict resolution (semantic, not mechanical)

The one real conflict was the resize-file **encoding**. The stale branch wrote/read it as **JSON**; `main` writes it as **TOON** (`encodeToon`). I resolved **toward TOON** to honor the TOON mandate (no regression off TOON):
- `writeResizeRequest` → `encodeToon(request)` (TOON, now including `runner`).
- `readResizeRequest` → `decodeDevSnapshotSniff` (JSON-first-then-TOON) instead of `JSON.parse`.

**This also fixes a latent `main` bug**: `main` wrote the resize file as TOON but read it with `JSON.parse`, so `JSON.parse(TOON)` threw and **elastic resize silently never applied**. The sniff decoder fixes both the new runner directive and the pre-existing resize path, staying backward-compatible with any legacy JSON directive.

`fleet.md` doc paths updated to the post-#2053 runtime lane (`.red/tmp/supervisors/default/`). `supervisor.test.ts` resize/runner tests use a mocked dep (unaffected); `fleet-command.test.ts` asserts the TOON-decoded directive.

Closes #2065

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786930789&installation_id=129708444&pr_number=2080&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2080&signature=c21ad17969e65670214c54d1125e92cfc90e785d8b7dbf5a3229bd81018f5c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->