### PR TITLE
fix: #2074 Trunk-freshness S3: continuous freshness tick (supervisor fetches origin/trunk, throttled)

### DIFF
--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -97,6 +97,20 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
       parked: hb.slotsParked,
     },
     spawns_this_tick: hb.spawnsThisTick,
+    ...(hb.trunkFreshness
+      ? {
+          trunk_freshness: {
+            status: hb.trunkFreshness.status,
+            refreshed_at_epoch: hb.trunkFreshness.refreshedAtEpoch,
+            interval_s: hb.trunkFreshness.intervalS,
+            ...(hb.trunkFreshness.nextDueEpoch !== undefined ? { next_due_epoch: hb.trunkFreshness.nextDueEpoch } : {}),
+            ...(hb.trunkFreshness.remoteRef ? { remote_ref: hb.trunkFreshness.remoteRef } : {}),
+            ...(hb.trunkFreshness.mirrorRef ? { mirror_ref: hb.trunkFreshness.mirrorRef } : {}),
+            ...(hb.trunkFreshness.sha ? { sha: hb.trunkFreshness.sha } : {}),
+            ...(hb.trunkFreshness.message ? { message: hb.trunkFreshness.message } : {}),
+          },
+        }
+      : {}),
     churn: {
       deaths: hb.churn.deaths,
       respawns: hb.churn.respawns,
@@ -150,6 +164,20 @@ async function writeCastleSupervisorSnapshot(
           parked: hb.slotsParked,
         },
         spawns_this_tick: hb.spawnsThisTick,
+        ...(hb.trunkFreshness
+          ? {
+              trunk_freshness: {
+                status: hb.trunkFreshness.status,
+                refreshed_at_epoch: hb.trunkFreshness.refreshedAtEpoch,
+                interval_s: hb.trunkFreshness.intervalS,
+                ...(hb.trunkFreshness.nextDueEpoch !== undefined ? { next_due_epoch: hb.trunkFreshness.nextDueEpoch } : {}),
+                ...(hb.trunkFreshness.remoteRef ? { remote_ref: hb.trunkFreshness.remoteRef } : {}),
+                ...(hb.trunkFreshness.mirrorRef ? { mirror_ref: hb.trunkFreshness.mirrorRef } : {}),
+                ...(hb.trunkFreshness.sha ? { sha: hb.trunkFreshness.sha } : {}),
+                ...(hb.trunkFreshness.message ? { message: hb.trunkFreshness.message } : {}),
+              },
+            }
+          : {}),
         churn: {
           deaths: hb.churn.deaths,
           respawns: hb.churn.respawns,
@@ -440,6 +468,7 @@ function buildSupervisorDeps(
   supervisorId: string,
   runner: string,
   ghCtx: ghx.GhContext,
+  trunk: string,
   slotArgs: readonly string[],
   hookEnvBase: Record<string, string>,
 ): SupervisorDeps {
@@ -679,6 +708,25 @@ function buildSupervisorDeps(
         return [];
       }
     },
+    refreshTrunkMirror: async () => {
+      const base = trunk.trim() || "main";
+      const refreshed = await gitx.resolveFreshBase({ cwd: root }, { base, remote: "origin" });
+      if (refreshed.ok) {
+        return {
+          status: "refreshed",
+          remoteRef: `origin/${base}`,
+          mirrorRef: refreshed.baseRef,
+          sha: refreshed.sha,
+        };
+      }
+      return {
+        status: "failed",
+        remoteRef: `origin/${base}`,
+        mirrorRef: gitx.FLEET_TRUNK,
+        ...(refreshed.sha ? { sha: refreshed.sha } : {}),
+        message: refreshed.message,
+      };
+    },
     attemptBranchHead: (branch) => gitx.branchHead({ cwd: root }, branch),
     resizeRequest: async () => readResizeRequest(afkPaths(root).supervisorResizePath),
     configureRunner: (nextRunner) => {
@@ -734,6 +782,16 @@ function buildSupervisorDeps(
               drain_budget_spent_usd: stamped.drainBudget?.spentUsd.toFixed(4) ?? null,
               drain_budget_limit_usd: stamped.drainBudget?.limitUsd.toFixed(4) ?? null,
               drain_budget_percent: stamped.drainBudget ? (stamped.drainBudget.percent * 100).toFixed(2) : null,
+              trunk_freshness_status: stamped.trunkFreshness?.status ?? null,
+              trunk_freshness_remote_ref: stamped.trunkFreshness?.remoteRef ?? null,
+              trunk_freshness_mirror_ref: stamped.trunkFreshness?.mirrorRef ?? null,
+              trunk_freshness_sha: stamped.trunkFreshness?.sha ?? null,
+              trunk_freshness_refreshed_at_epoch: stamped.trunkFreshness
+                ? String(stamped.trunkFreshness.refreshedAtEpoch)
+                : null,
+              trunk_freshness_next_due_epoch: stamped.trunkFreshness?.nextDueEpoch !== undefined
+                ? String(stamped.trunkFreshness.nextDueEpoch)
+                : null,
             },
           },
         });
@@ -807,6 +865,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   const config = resolveSupervisorConfig(process.env, (key) => getConfig(values, key));
   const state = initSupervisorState(config.target);
   const repo = await resolveRepoSlug(root).catch(() => "");
+  const trunk = getConfig(values, "dev.trunk") || "main";
   const ghCtx = { cwd: root, repo };
   const supervisorId = `s${process.pid}`;
   // The filter/policy flags fleet.ts forwarded (--spec/--issues/--alternate/
@@ -819,7 +878,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
     RED_AFK_RUNNER: config.runner,
     ...(repo.length > 0 ? { RED_AFK_REPO: repo } : {}),
   };
-  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, config.runner, ghCtx, slotArgs, hookEnvBase);
+  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, config.runner, ghCtx, trunk, slotArgs, hookEnvBase);
 
   const stopRequested = (): boolean => existsSync(stopFile);
 

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -147,6 +147,13 @@ export interface SupervisorConfig {
    */
   unblockSweepIntervalS: number;
   /**
+   * RED_AFK_TRUNK_FRESHNESS_INTERVAL_S — minimum seconds between supervisor
+   * refreshes of `origin/<trunk>` into the fleet-owned `red-trunk` mirror
+   * (default 60). The first eligible tick refreshes immediately; later ticks
+   * inside this window report `throttled` and avoid another remote fetch.
+   */
+  trunkFreshnessIntervalS: number;
+  /**
    * RED_AFK_SUPERVISOR_MAX_RESTARTS — crash-loop bound for the dead-supervisor
    * watchdog (#1097, default 5). When a supervisor is found DEAD (its pid file
    * points to a no-longer-alive process) with a non-empty `ready-for-agent` queue
@@ -196,6 +203,7 @@ export const SUPERVISOR_DEFAULTS = {
   halfOpenBaseS: SLOT_CIRCUIT_DEFAULTS.halfOpenBaseS,
   halfOpenCapS: SLOT_CIRCUIT_DEFAULTS.halfOpenCapS,
   unblockSweepIntervalS: 60,
+  trunkFreshnessIntervalS: 60,
   supervisorMaxRestarts: 5,
   supervisorRestartWindowS: 300,
   reapContestWindowS: 30,
@@ -331,6 +339,10 @@ export function resolveSupervisorConfig(
     unblockSweepIntervalS:
       num("RED_AFK_UNBLOCK_SWEEP_INTERVAL_S", SUPERVISOR_DEFAULTS.unblockSweepIntervalS) ||
       SUPERVISOR_DEFAULTS.unblockSweepIntervalS,
+    trunkFreshnessIntervalS:
+      num("RED_AFK_TRUNK_FRESHNESS_INTERVAL_S", SUPERVISOR_DEFAULTS.trunkFreshnessIntervalS) ||
+      parsePositiveNumber(getCfg("afk.trunk_freshness_interval_s")) ||
+      SUPERVISOR_DEFAULTS.trunkFreshnessIntervalS,
     // 0 would disable the crash-loop bound (endless respawns) — floor back to the
     // default so a typo can never turn the safety net into an infinite loop.
     supervisorMaxRestarts:
@@ -687,6 +699,29 @@ export interface HeartbeatSlotDetail {
   retryAt?: number;
 }
 
+export type TrunkFreshnessStatus = "refreshed" | "failed" | "throttled";
+
+export interface TrunkFreshnessOutcome {
+  status: TrunkFreshnessStatus;
+  /** Remote ref fetched by the refresh implementation, usually `origin/<trunk>`. */
+  remoteRef?: string;
+  /** Fleet-owned mirror ref advanced by the refresh implementation. */
+  mirrorRef?: string;
+  /** Resolved remote tip SHA when the refresh reached the remote. */
+  sha?: string;
+  /** Epoch seconds of the most recent attempted refresh. */
+  refreshedAtEpoch: number;
+  /** Next epoch at which another remote fetch is allowed. */
+  nextDueEpoch?: number;
+  /** Minimum configured interval between remote fetches. */
+  intervalS: number;
+  /** Short best-effort diagnostic for failed refreshes. */
+  message?: string;
+}
+
+export type TrunkMirrorRefreshResult =
+  Omit<TrunkFreshnessOutcome, "refreshedAtEpoch" | "nextDueEpoch" | "intervalS">;
+
 export interface FleetHeartbeat {
   /** ISO-8601 timestamp for the supervisor tick. */
   ts: string;
@@ -725,6 +760,8 @@ export interface FleetHeartbeat {
   };
   /** Optional per-drain budget status; absent when no budget is configured. */
   drainBudget?: DrainBudgetStatus;
+  /** Latest supervisor tick outcome for the fleet-owned trunk mirror. */
+  trunkFreshness?: TrunkFreshnessOutcome;
   /** Per-slot details for non-closed slots. Empty array when all slots are closed. */
   slotDetails: HeartbeatSlotDetail[];
 }
@@ -863,6 +900,12 @@ export interface SupervisorDeps {
    */
   unblockSweep?(): Promise<number[]>;
   /**
+   * Refresh `origin/<trunk>` into the fleet-owned `red-trunk` mirror. The
+   * supervisor owns throttling and observability; the injected runtime owns the
+   * concrete git exec.
+   */
+  refreshTrunkMirror?(): Promise<TrunkMirrorRefreshResult>;
+  /**
    * Dispatch a fleet-scoped lifecycle hook at a supervisor checkpoint. Receives
    * the fleet-scoped context (slot, pid, death ring, runner — no issue/worktree
    * fields). Best-effort: throws from the hook executor are caught by the
@@ -968,6 +1011,10 @@ export interface SupervisorState {
    * queue still self-heals within one interval without a per-tick gh cost.
    */
   lastUnblockSweepEpoch: number;
+  /** Epoch seconds of the last attempted supervisor trunk-mirror refresh. */
+  lastTrunkFreshnessEpoch: number;
+  /** Last recorded trunk freshness outcome for heartbeat/status surfacing. */
+  lastTrunkFreshness?: TrunkFreshnessOutcome;
   /**
    * Cumulative wake accounting (#934): how many health-check loop iterations woke
    * on a worker state-change event vs the safety-net timer. Lets the supervisor
@@ -994,6 +1041,7 @@ export function initSupervisorState(target: number): SupervisorState {
     slots: Array.from({ length: target }, () => freshSlot()),
     lastProgressEpoch: 0,
     lastUnblockSweepEpoch: 0,
+    lastTrunkFreshnessEpoch: 0,
     wakeStats: freshWakeStats(),
     drainBudgetHardStopped: false,
     lastHeartbeatStateWriteEpoch: 0,
@@ -1185,6 +1233,8 @@ export interface TickResult {
    * this tick (#844). Empty when the sweep was throttled, unwired, found nothing
    * to promote, or failed (best-effort). */
   unblocked: number[];
+  /** Latest continuous trunk freshness tick outcome, when the seam is wired. */
+  trunkFreshness?: TrunkFreshnessOutcome;
   /** Slots removed from the runtime fleet by elastic shrink this tick. */
   retiredSlots: number[];
   /** True when a live directive changed the fleet runner this tick. */
@@ -1302,6 +1352,9 @@ async function emitFleetHeartbeat(
     spawnsThisTick: result.respawned.length,
     churn,
     ...(result.drainBudget ? { drainBudget: result.drainBudget } : {}),
+    ...(result.trunkFreshness ?? state.lastTrunkFreshness
+      ? { trunkFreshness: result.trunkFreshness ?? state.lastTrunkFreshness }
+      : {}),
     slotDetails: buildSlotDetails(state, config),
   };
   let rawWrite: FleetHeartbeatEmitResult | void = undefined;
@@ -1318,6 +1371,20 @@ async function emitFleetHeartbeat(
 
 function shortError(message: string | undefined): string {
   return message && message.length > 0 ? ` error=${message}` : "";
+}
+
+function trunkFreshnessEventPayload(outcome: TrunkFreshnessOutcome | undefined): Record<string, string | number> {
+  if (outcome === undefined) return {};
+  return {
+    trunk_freshness_status: outcome.status,
+    trunk_freshness_refreshed_at_epoch: outcome.refreshedAtEpoch,
+    trunk_freshness_interval_s: outcome.intervalS,
+    ...(outcome.nextDueEpoch !== undefined ? { trunk_freshness_next_due_epoch: outcome.nextDueEpoch } : {}),
+    ...(outcome.remoteRef !== undefined ? { trunk_freshness_remote_ref: outcome.remoteRef } : {}),
+    ...(outcome.mirrorRef !== undefined ? { trunk_freshness_mirror_ref: outcome.mirrorRef } : {}),
+    ...(outcome.sha !== undefined ? { trunk_freshness_sha: outcome.sha } : {}),
+    ...(outcome.message !== undefined ? { trunk_freshness_message: outcome.message } : {}),
+  };
 }
 
 async function superviseHeartbeatStateWrite(
@@ -2191,15 +2258,57 @@ export async function dispatchReconcileIfPossible(
   return freeIdx;
 }
 
+async function refreshTrunkMirrorIfDue(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+  config: Pick<SupervisorConfig, "trunkFreshnessIntervalS">,
+): Promise<TrunkFreshnessOutcome | undefined> {
+  if (!deps.refreshTrunkMirror) return undefined;
+
+  const now = deps.now();
+  const intervalS = Math.max(1, config.trunkFreshnessIntervalS);
+  if (state.lastTrunkFreshnessEpoch > 0 && now - state.lastTrunkFreshnessEpoch < intervalS) {
+    const throttled: TrunkFreshnessOutcome = {
+      status: "throttled",
+      refreshedAtEpoch: state.lastTrunkFreshnessEpoch,
+      nextDueEpoch: state.lastTrunkFreshnessEpoch + intervalS,
+      intervalS,
+    };
+    state.lastTrunkFreshness = throttled;
+    return throttled;
+  }
+
+  state.lastTrunkFreshnessEpoch = now;
+  let outcome: TrunkFreshnessOutcome;
+  try {
+    const refreshed = await deps.refreshTrunkMirror();
+    outcome = {
+      ...refreshed,
+      refreshedAtEpoch: now,
+      intervalS,
+    };
+  } catch (err) {
+    outcome = {
+      status: "failed",
+      refreshedAtEpoch: now,
+      intervalS,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+  state.lastTrunkFreshness = outcome;
+  return outcome;
+}
+
 /**
  * superviseTick — advance the health-check loop one cycle (the body of
  * supervisor.sh's `while :` at ~1122-1141). In order:
  *   1. honour the stop-file: terminate every worker and return early.
- *   2. sample ready-queue depth (single fetch per tick, shared with heartbeat).
- *   3. un-park idle-parked slots when the queue has work.
- *   4. respawn / park dead non-parked, non-idle-parked, non-spawning slots.
- *   5. poll the passive stall detector + gated hard reaper (pollStallDetector).
- *   6. reconcile dispatch: fill a free slot with a reconcile worker if eligible.
+ *   2. refresh the fleet-owned trunk mirror when the throttle allows it.
+ *   3. sample ready-queue depth (single fetch per tick, shared with heartbeat).
+ *   4. un-park idle-parked slots when the queue has work.
+ *   5. respawn / park dead non-parked, non-idle-parked, non-spawning slots.
+ *   6. poll the passive stall detector + gated hard reaper (pollStallDetector).
+ *   7. reconcile dispatch: fill a free slot with a reconcile worker if eligible.
  *
  * `stopRequested` is the injected stop-file probe (the bash `[[ -f $STOP_FILE ]]`
  * check). The real loop is `while (!await superviseTick(...).stopped)`.
@@ -2232,6 +2341,8 @@ export async function superviseTick(
     result.stopped = true;
     return result;
   }
+
+  result.trunkFreshness = await refreshTrunkMirrorIfDue(state, deps, config);
 
   // Sample queue depth once per tick for idle-park / un-park decisions and the
   // fleet heartbeat. Best-effort: 0 on any failure or missing implementation.
@@ -2608,6 +2719,7 @@ export async function runSupervisor(
         `half-opened=${result.halfOpened.length} reaped=${result.reaped.length} ` +
         `unblocked=${result.unblocked.length} ` +
         `crash-reconciled=${result.crashReconciled.length} ` +
+        `trunk=${heartbeat.trunkFreshness?.status ?? "unwired"} ` +
         `ready=${heartbeat.readyForAgent} busy=${heartbeat.slotsBusy} free=${heartbeat.slotsFree}`,
     );
     await emitSupervisorEvent(deps, {
@@ -2625,6 +2737,7 @@ export async function runSupervisor(
         ready_for_agent: heartbeat.readyForAgent,
         slots_busy: heartbeat.slotsBusy,
         slots_free: heartbeat.slotsFree,
+        ...trunkFreshnessEventPayload(heartbeat.trunkFreshness),
       },
     });
     if (result.stopped) {

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -517,6 +517,16 @@ function parseFleetState(raw: unknown): FleetState | null {
     slots?: { busy?: unknown; free?: unknown; total?: unknown; parked?: unknown };
     spawns_this_tick?: unknown;
     churn?: { deaths?: unknown; respawns?: unknown; window_s?: unknown };
+    trunk_freshness?: {
+      status?: unknown;
+      refreshed_at_epoch?: unknown;
+      interval_s?: unknown;
+      next_due_epoch?: unknown;
+      remote_ref?: unknown;
+      mirror_ref?: unknown;
+      sha?: unknown;
+      message?: unknown;
+    };
     slot_details?: unknown;
   };
   const epoch = Number(rec.epoch ?? 0);
@@ -544,6 +554,33 @@ function parseFleetState(raw: unknown): FleetState | null {
     }
   }
 
+  let trunkFreshness: FleetState["trunkFreshness"] | undefined;
+  if (rec.trunk_freshness !== undefined && rec.trunk_freshness !== null) {
+    const raw = rec.trunk_freshness;
+    const status = raw.status;
+    const refreshedAtEpoch = Number(raw.refreshed_at_epoch ?? 0);
+    const intervalS = Number(raw.interval_s ?? 0);
+    if (
+      (status === "refreshed" || status === "failed" || status === "throttled") &&
+      Number.isFinite(refreshedAtEpoch) &&
+      refreshedAtEpoch > 0 &&
+      Number.isFinite(intervalS) &&
+      intervalS > 0
+    ) {
+      const nextDueEpoch = Number(raw.next_due_epoch);
+      trunkFreshness = {
+        status,
+        refreshedAtEpoch,
+        intervalS,
+        ...(Number.isFinite(nextDueEpoch) && nextDueEpoch > 0 ? { nextDueEpoch } : {}),
+        ...(typeof raw.remote_ref === "string" ? { remoteRef: raw.remote_ref } : {}),
+        ...(typeof raw.mirror_ref === "string" ? { mirrorRef: raw.mirror_ref } : {}),
+        ...(typeof raw.sha === "string" ? { sha: raw.sha } : {}),
+        ...(typeof raw.message === "string" ? { message: raw.message } : {}),
+      };
+    }
+  }
+
   return {
     ts: typeof rec.ts === "string" ? rec.ts : "",
     epoch,
@@ -561,6 +598,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     churnDeaths: Number(rec.churn?.deaths ?? 0) || 0,
     churnRespawns: Number(rec.churn?.respawns ?? 0) || 0,
     churnWindowS: Number(rec.churn?.window_s ?? 0) || 0,
+    ...(trunkFreshness !== undefined ? { trunkFreshness } : {}),
     ...(slotDetails !== undefined ? { slotDetails } : {}),
   };
 }

--- a/apps/dev/tests/fleet-hooks.test.ts
+++ b/apps/dev/tests/fleet-hooks.test.ts
@@ -51,6 +51,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     halfOpenBaseS: 60,
     halfOpenCapS: 3600,
     unblockSweepIntervalS: 60,
+    trunkFreshnessIntervalS: 60,
     supervisorMaxRestarts: 5,
     supervisorRestartWindowS: 300,
     reapContestWindowS: 30,

--- a/apps/dev/tests/monitor.test.ts
+++ b/apps/dev/tests/monitor.test.ts
@@ -388,6 +388,34 @@ describe("monitor — compact dashboard", () => {
       expect(decoded.fleet.version_skew).toBe(1);
     });
 
+    it("includes trunk freshness fields in the fleet status block", () => {
+      const out = renderCompactDashboardToon([], fixtureEvents, 1780138815, {
+        ...baseFleet(),
+        trunkFreshness: {
+          status: "refreshed",
+          refreshedAtEpoch: 1780138800,
+          intervalS: 60,
+          remoteRef: "origin/main",
+          mirrorRef: "red-trunk",
+          sha: "abc123",
+        },
+      });
+      const decoded = decode(out) as {
+        fleet: {
+          trunk_freshness_status: string;
+          trunk_freshness_refreshed_at: string;
+          trunk_freshness_remote_ref: string;
+          trunk_freshness_mirror_ref: string;
+          trunk_freshness_sha: string;
+        };
+      };
+      expect(decoded.fleet.trunk_freshness_status).toBe("refreshed");
+      expect(decoded.fleet.trunk_freshness_refreshed_at).toBe("00:00:15");
+      expect(decoded.fleet.trunk_freshness_remote_ref).toBe("origin/main");
+      expect(decoded.fleet.trunk_freshness_mirror_ref).toBe("red-trunk");
+      expect(decoded.fleet.trunk_freshness_sha).toBe("abc123");
+    });
+
     it("is materially cheaper than JSON for a typical multi-worker board (#995)", () => {
       // The token win is the whole point of TOON as the default agent-facing
       // render (#995): the worker table names its 20 columns ONCE, where JSON
@@ -458,6 +486,24 @@ describe("monitor — compact dashboard", () => {
       1780138815,
     );
     expect(line).toContain("churn deaths:2 respawns:2/300s");
+  });
+
+  it("surfaces the trunk freshness outcome on the fleet line", () => {
+    const line = renderFleetLine(
+      baseFleet({
+        trunkFreshness: {
+          status: "refreshed",
+          refreshedAtEpoch: 1780138800,
+          intervalS: 60,
+          remoteRef: "origin/main",
+          mirrorRef: "red-trunk",
+          sha: "abc123",
+        },
+      }),
+      1780138815,
+    );
+
+    expect(line).toContain("trunk:refreshed");
   });
 
   it("carries parked:N unconditionally — zero when all slots closed", () => {

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -80,6 +80,7 @@ function config(over: Partial<SupervisorConfig> = {}): SupervisorConfig {
     halfOpenBaseS: 60,
     halfOpenCapS: 3600,
     unblockSweepIntervalS: 60,
+    trunkFreshnessIntervalS: 60,
     supervisorMaxRestarts: 5,
     supervisorRestartWindowS: 300,
     reapContestWindowS: 30,
@@ -123,6 +124,7 @@ interface FakeIo {
   emitFleetHeartbeat: ReturnType<typeof vi.fn>;
   repairFleetHeartbeat: ReturnType<typeof vi.fn>;
   unblockSweep: ReturnType<typeof vi.fn>;
+  refreshTrunkMirror: ReturnType<typeof vi.fn>;
   fleetCostUsd: ReturnType<typeof vi.fn>;
   resizeRequest: ReturnType<typeof vi.fn>;
   attemptBranchHead: ReturnType<typeof vi.fn>;
@@ -173,6 +175,12 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     emitFleetHeartbeat: vi.fn(async () => {}),
     repairFleetHeartbeat: vi.fn(async () => ({ stateWritten: true })),
     unblockSweep: vi.fn(async (): Promise<number[]> => []),
+    refreshTrunkMirror: vi.fn(async () => ({
+      status: "refreshed",
+      remoteRef: "origin/main",
+      mirrorRef: "red-trunk",
+      sha: "abc123",
+    })),
     fleetCostUsd: vi.fn(() => 0),
     resizeRequest: vi.fn(async () => null),
     attemptBranchHead: vi.fn(async () => undefined as string | undefined),
@@ -218,6 +226,7 @@ function makeDeps(over: Partial<Record<keyof FakeIo, unknown>> = {}): {
     emitFleetHeartbeat: io.emitFleetHeartbeat,
     repairFleetHeartbeat: io.repairFleetHeartbeat,
     unblockSweep: io.unblockSweep,
+    refreshTrunkMirror: io.refreshTrunkMirror,
     attemptBranchHead: io.attemptBranchHead,
     configureRunner: io.configureRunner,
     resizeRequest: io.resizeRequest,
@@ -2376,6 +2385,128 @@ describe("superviseTick — periodic dependency Unblock Sweep (#844)", () => {
 
     expect(result.unblocked).toEqual([]);
     expect(state.lastUnblockSweepEpoch).toBe(0); // never stamped
+  });
+});
+
+// ---------- continuous trunk freshness tick (#2074) ----------
+
+describe("superviseTick — continuous trunk freshness (#2074)", () => {
+  it("refreshes the fleet trunk mirror on the first eligible tick", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      refreshTrunkMirror: vi.fn(async () => ({
+        status: "refreshed",
+        remoteRef: "origin/main",
+        mirrorRef: "red-trunk",
+        sha: "abc123",
+      })),
+    });
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 9001;
+
+    const result = await superviseTick(state, deps, config({ trunkFreshnessIntervalS: 60 }), () => false);
+
+    expect(io.refreshTrunkMirror).toHaveBeenCalledOnce();
+    expect(state.lastTrunkFreshnessEpoch).toBe(NOW);
+    expect(result.trunkFreshness).toEqual({
+      status: "refreshed",
+      remoteRef: "origin/main",
+      mirrorRef: "red-trunk",
+      sha: "abc123",
+      refreshedAtEpoch: NOW,
+      intervalS: 60,
+    });
+  });
+
+  it("throttles mirror refreshes inside the configured interval", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      now: vi.fn(() => NOW),
+      refreshTrunkMirror: vi.fn(async () => ({
+        status: "refreshed",
+        remoteRef: "origin/main",
+        mirrorRef: "red-trunk",
+        sha: "abc123",
+      })),
+    });
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 9001;
+    state.lastTrunkFreshnessEpoch = NOW - 30;
+
+    const result = await superviseTick(state, deps, config({ trunkFreshnessIntervalS: 60 }), () => false);
+
+    expect(io.refreshTrunkMirror).not.toHaveBeenCalled();
+    expect(state.lastTrunkFreshnessEpoch).toBe(NOW - 30);
+    expect(result.trunkFreshness).toEqual({
+      status: "throttled",
+      refreshedAtEpoch: NOW - 30,
+      nextDueEpoch: NOW + 30,
+      intervalS: 60,
+    });
+  });
+
+  it("records failed mirror refreshes and still throttles the next attempt", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      refreshTrunkMirror: vi.fn(async () => ({
+        status: "failed",
+        remoteRef: "origin/main",
+        mirrorRef: "red-trunk",
+        message: "fetch failed",
+      })),
+    });
+    const state = initSupervisorState(1);
+    state.slots[0]!.pid = 9001;
+
+    const result = await superviseTick(state, deps, config({ trunkFreshnessIntervalS: 60 }), () => false);
+
+    expect(io.refreshTrunkMirror).toHaveBeenCalledOnce();
+    expect(state.lastTrunkFreshnessEpoch).toBe(NOW);
+    expect(result.trunkFreshness).toEqual({
+      status: "failed",
+      remoteRef: "origin/main",
+      mirrorRef: "red-trunk",
+      message: "fetch failed",
+      refreshedAtEpoch: NOW,
+      intervalS: 60,
+    });
+  });
+
+  it("surfaces the latest freshness outcome in heartbeat and structured tick events", async () => {
+    let probes = 0;
+    const stop = () => {
+      probes += 1;
+      return probes >= 2;
+    };
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn(() => true),
+      refreshTrunkMirror: vi.fn(async () => ({
+        status: "refreshed",
+        remoteRef: "origin/main",
+        mirrorRef: "red-trunk",
+        sha: "abc123",
+      })),
+    });
+    const state = initSupervisorState(1);
+
+    await runSupervisor(state, deps, config({ target: 1, trunkFreshnessIntervalS: 60 }), stop);
+
+    expect(io.emitFleetHeartbeat.mock.calls[0]?.[0]).toMatchObject({
+      trunkFreshness: {
+        status: "refreshed",
+        remoteRef: "origin/main",
+        mirrorRef: "red-trunk",
+        sha: "abc123",
+      },
+    });
+    expect(io.emitSupervisorEvent.mock.calls.find((call) => call[0].kind === "supervisor.tick")?.[0]).toMatchObject({
+      payload: expect.objectContaining({
+        trunk_freshness_status: "refreshed",
+        trunk_freshness_remote_ref: "origin/main",
+        trunk_freshness_mirror_ref: "red-trunk",
+        trunk_freshness_sha: "abc123",
+      }),
+    });
   });
 });
 

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -228,6 +228,17 @@ export interface SlotDetail {
   retryAt?: number;
 }
 
+export interface FleetTrunkFreshness {
+  status: "refreshed" | "failed" | "throttled";
+  refreshedAtEpoch: number;
+  intervalS: number;
+  nextDueEpoch?: number;
+  remoteRef?: string;
+  mirrorRef?: string;
+  sha?: string;
+  message?: string;
+}
+
 export interface FleetState {
   ts: string;
   epoch: number;
@@ -253,6 +264,7 @@ export interface FleetState {
   slotsTotal: number;
   slotsParked: number;
   spawnsThisTick: number;
+  trunkFreshness?: FleetTrunkFreshness;
   churnDeaths?: number;
   churnRespawns?: number;
   churnWindowS?: number;
@@ -302,11 +314,13 @@ export function renderFleetLine(fleet: FleetState, now: number, degraded = false
   const churn = churnDeaths > 0 || churnRespawns > 0
     ? `  churn deaths:${churnDeaths} respawns:${churnRespawns}/${Math.max(1, Math.floor(fleet.churnWindowS ?? 1))}s`
     : "";
+  const trunk = fleet.trunkFreshness ? `  trunk:${fleet.trunkFreshness.status}` : "";
   return (
     `fleet [${status}] last ticked ${formatElapsed(age)} ago` +
     `  ready:${fleet.readyForAgent}` +
     `  slots busy:${fleet.slotsBusy} free:${fleet.slotsFree} parked:${fleet.slotsParked}` +
     `  spawns:${fleet.spawnsThisTick}` +
+    trunk +
     churn +
     bundle
   );
@@ -683,6 +697,13 @@ export function renderCompactDashboardToon(
       slots_free: fleet.slotsFree,
       slots_parked: fleet.slotsParked,
       spawns: fleet.spawnsThisTick,
+      trunk_freshness_status: fleet.trunkFreshness?.status ?? "",
+      trunk_freshness_refreshed_at: fleet.trunkFreshness
+        ? formatElapsed(Math.max(0, now - fleet.trunkFreshness.refreshedAtEpoch))
+        : "",
+      trunk_freshness_remote_ref: fleet.trunkFreshness?.remoteRef ?? "",
+      trunk_freshness_mirror_ref: fleet.trunkFreshness?.mirrorRef ?? "",
+      trunk_freshness_sha: fleet.trunkFreshness?.sha ?? "",
       churn_deaths: fleet.churnDeaths ?? 0,
       churn_respawns: fleet.churnRespawns ?? 0,
       churn_window_s: fleet.churnWindowS ?? 0,


### PR DESCRIPTION
Automated AFK landing for #2074. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2074

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786931605&installation_id=129708444&pr_number=2082&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2082&signature=d29dfbca89e9dfcce1a1f23bdd4f05ff70ad9ca1d51603c045647adf84ddf812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->