### PR TITLE
fix: #2067 Supervisor takeover/adoption: persist slot->pid, adopt live workers on relaunch, reap dead snapshots, legible kill-resistance

### DIFF
--- a/apps/dev/src/commands/fleet.ts
+++ b/apps/dev/src/commands/fleet.ts
@@ -169,13 +169,13 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
   const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
   if (supervisor.status === "stale") {
     await sweepOrphans();
-    stdout.write(`no fleet running (stale supervisor files — cleaned).\n`);
+    stdout.write(`no fleet running (reason=dead supervisor pid; stale files cleaned).\n`);
     return { status: "stale", ...(supervisor.pid !== undefined ? { pid: supervisor.pid } : {}) };
   }
   const pid = supervisor.pid;
   if (!pid) {
     await sweepOrphans();
-    stdout.write("no fleet running.\n");
+    stdout.write("no fleet running (reason=no supervisor pid).\n");
     return { status: "none" };
   }
   await writeFile(stopFile, "", "utf8");
@@ -186,7 +186,7 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
       // exit, but sweep detached survivors anyway — a slot the loop lost track of
       // (moved-pid, mid-spawn) would otherwise outlive the "stopped" report.
       await sweepOrphans();
-      stdout.write(`🛑 fleet stopped (supervisor pid=${pid} exited).\n`);
+      stdout.write(`🛑 fleet stopped (reason=operator stop requested; supervisor pid=${pid} exited).\n`);
       return { status: "stopped", pid };
     }
     await sleep(1_000);
@@ -206,7 +206,7 @@ export async function stopFleet(root = process.cwd(), stdout: NodeJS.WritableStr
     await rm(stopFile, { force: true });
     // killTree of the supervisor pid misses the detached workers — sweep them.
     await sweepOrphans();
-    stdout.write(`🛑 fleet stopped (supervisor pid=${pid} killed after graceful-stop timeout).\n`);
+    stdout.write(`🛑 fleet stopped (reason=graceful stop timeout; supervisor pid=${pid} killed).\n`);
     return { status: "stopped", pid };
   }
   stdout.write(
@@ -294,6 +294,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
   await migrateLegacyDevPaths(root).catch(() => undefined);
   const pidFile = paths.supervisorPidPath;
   const logFile = paths.supervisorLogPath;
+  const priorFleetState = await readFleetState(paths.fleetStatePath).catch(() => null);
   const supervisor = await reapStaleSupervisorState(stateAfk, isLivePid);
   if (supervisor.status === "stale") {
     stdout.write(`cleaned stale supervisor files before fleet launch.\n`);
@@ -347,6 +348,7 @@ export async function launchFleet(args: readonly string[], root = process.cwd(),
     request: parsed.request,
     drainBudgetUsd: parsed.drainBudgetUsd,
     shrinkMode: parsed.shrinkMode,
+    adoptSlotPids: priorFleetState?.slotPids ?? [],
   });
   if (!supervisorPid) {
     let tail = "";

--- a/apps/dev/src/commands/supervise.ts
+++ b/apps/dev/src/commands/supervise.ts
@@ -14,6 +14,7 @@ import {
   type FleetHeartbeat,
   type FleetHeartbeatEmitResult,
   type ElasticResizeRequest,
+  type HeartbeatSlotPid,
   initSupervisorState,
   resolveSupervisorConfig,
   runSupervisor,
@@ -28,6 +29,7 @@ import {
   collectPrecheckFacts,
   collectBootOptions,
   buildBootDeps,
+  readFleetState,
   type RepoContext,
 } from "../runtime/wire.js";
 import { formatPreconditionFailure, runBoot, type BootResult, type BootstrapInput } from "../core/boot.js";
@@ -51,7 +53,7 @@ import { resolveFleetHooks } from "../core/fleet-hook-config.js";
 import { dispatchFleetHook } from "../core/fleet-hook-dispatcher.js";
 import { makeHookExec, makeHookResolveOptions } from "../runtime/hooks.js";
 import { getConfig, loadConfig } from "../core/config.js";
-import { reapStaleSupervisorState } from "../runtime/supervisor-state.js";
+import { reapDeadSupervisorSnapshotDirs, reapStaleSupervisorState } from "../runtime/supervisor-state.js";
 import {
   castleStateSnapshotPath,
   createEnginePaths,
@@ -96,6 +98,7 @@ export function fleetHeartbeatState(hb: FleetHeartbeat): string {
       total: hb.slotsTotal,
       parked: hb.slotsParked,
     },
+    slot_pids: hb.slotPids.map((entry) => ({ slot: entry.slot, pid: entry.pid })),
     spawns_this_tick: hb.spawnsThisTick,
     ...(hb.trunkFreshness
       ? {
@@ -163,6 +166,7 @@ async function writeCastleSupervisorSnapshot(
           total: hb.slotsTotal,
           parked: hb.slotsParked,
         },
+        slot_pids: hb.slotPids.map((entry) => ({ slot: entry.slot, pid: entry.pid })),
         spawns_this_tick: hb.spawnsThisTick,
         ...(hb.trunkFreshness
           ? {
@@ -334,6 +338,29 @@ function readResizeRequest(path: string): ElasticResizeRequest | null {
   }
 }
 
+function parseAdoptSlotPids(raw: string | undefined): HeartbeatSlotPid[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const out: HeartbeatSlotPid[] = [];
+    const seen = new Set<number>();
+    for (const entry of parsed) {
+      if (entry === null || typeof entry !== "object") continue;
+      const rec = entry as { slot?: unknown; pid?: unknown };
+      const slot = Number(rec.slot);
+      const pid = Number(rec.pid);
+      if (!Number.isSafeInteger(slot) || slot < 0 || seen.has(slot)) continue;
+      if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+      seen.add(slot);
+      out.push({ slot, pid });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Parse the supervisor's own argv (forwarded by fleet.ts) into the filter /
  * runner-swap policy flags each slot's `run --once` must carry, so a supervised
@@ -471,6 +498,7 @@ function buildSupervisorDeps(
   trunk: string,
   slotArgs: readonly string[],
   hookEnvBase: Record<string, string>,
+  adoptSlotPids: readonly HeartbeatSlotPid[] = [],
 ): SupervisorDeps {
   const bundle = process.argv[1];
   const bundleVersion = readBuildInfo("dev").version;
@@ -504,7 +532,9 @@ function buildSupervisorDeps(
   });
   const fleetHookExec = makeHookExec(root, resolveOptions.libraryHooksDir);
   // slot index → live orchestrator pid (SLOT_PIDS parity).
-  const slotPids = new Map<number, number>();
+  const slotPids = new Map<number, number>(
+    adoptSlotPids.map((entry) => [entry.slot, entry.pid] as const),
+  );
   // slot index → exit code of the most recent worker for that slot.
   const slotExitCodes = new Map<number, number>();
   // Worker env (build_passthrough_env parity): start from the supervisor's full
@@ -571,6 +601,7 @@ function buildSupervisorDeps(
         slotPids.set(slot, pid);
         return { pid, spawnEpoch: now() };
       },
+      slotPid: (slot) => slotPids.get(slot) ?? null,
       lastExitCode: (slot) => slotExitCodes.get(slot) ?? null,
       isAlive,
       requestSlotRetire: async (slot) => {
@@ -840,9 +871,20 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
   await import("../runtime/fs.js").then((m) => m.ensureDir(tmp));
   await import("../runtime/fs.js").then((m) => m.ensureDir(stateAfk));
   await import("../runtime/fs.js").then((m) => m.ensureDir(slotLogsDir));
+  await reapDeadSupervisorSnapshotDirs(
+    join(root, ".red", "state", "castle", "supervisors"),
+    isAlive,
+    process.pid,
+  );
   // Ensure the workers root exists so the event-driven wake's fs.watch (#934) can
   // attach from boot rather than waiting for the first worker to create it.
   await import("../runtime/fs.js").then((m) => m.ensureDir(join(tmp, "workers")));
+  const envAdoptSlotPids = parseAdoptSlotPids(process.env.RED_AFK_ADOPT_SLOT_PIDS);
+  const stateAdoptSlotPids =
+    envAdoptSlotPids.length > 0
+      ? []
+      : ((await readFleetState(stateFile).catch(() => null))?.slotPids ?? []);
+  const adoptSlotPids = envAdoptSlotPids.length > 0 ? envAdoptSlotPids : stateAdoptSlotPids;
   await reapStaleSupervisorState(stateAfk, isAlive);
   // single-supervisor lock
   if (existsSync(pidFile)) {
@@ -878,7 +920,7 @@ export async function superviseCommand(args: string[], cwd = process.cwd()): Pro
     RED_AFK_RUNNER: config.runner,
     ...(repo.length > 0 ? { RED_AFK_REPO: repo } : {}),
   };
-  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, config.runner, ghCtx, trunk, slotArgs, hookEnvBase);
+  const deps = buildSupervisorDeps(root, tmp, slotLogsDir, firehoseFile, stateFile, supervisorId, config.runner, ghCtx, trunk, slotArgs, hookEnvBase, adoptSlotPids);
 
   const stopRequested = (): boolean => existsSync(stopFile);
 

--- a/apps/dev/src/core/supervisor.ts
+++ b/apps/dev/src/core/supervisor.ts
@@ -570,6 +570,9 @@ export interface SupervisorProc {
   spawnSlot(slot: number, policy?: SpawnPolicy): Promise<{ pid: number; spawnEpoch: number }>;
   /** True when the pid is alive (kill -0). Mirrors `kill -0 "$pid"`. */
   isAlive(pid: number): boolean;
+  /** Last persisted worker pid for a slot, used by a relaunched supervisor to
+   * adopt surviving detached workers instead of spawning a parallel fleet. */
+  slotPid?(slot: number): number | null;
   /** kill_tree the pid and its descendants: SIGTERM, grace, then SIGKILL, and
    * CONFIRM the tree is gone (handled by the impl). Mirrors sup_kill_tree.
    * Returns true when death is confirmed, false when the tree survived SIGKILL;
@@ -699,6 +702,11 @@ export interface HeartbeatSlotDetail {
   retryAt?: number;
 }
 
+export interface HeartbeatSlotPid {
+  slot: number;
+  pid: number;
+}
+
 export type TrunkFreshnessStatus = "refreshed" | "failed" | "throttled";
 
 export interface TrunkFreshnessOutcome {
@@ -764,6 +772,8 @@ export interface FleetHeartbeat {
   trunkFreshness?: TrunkFreshnessOutcome;
   /** Per-slot details for non-closed slots. Empty array when all slots are closed. */
   slotDetails: HeartbeatSlotDetail[];
+  /** Persisted slot -> worker pid map for supervisor takeover/adoption. */
+  slotPids: HeartbeatSlotPid[];
 }
 
 export interface FleetHeartbeatEmitResult {
@@ -1303,6 +1313,17 @@ function buildSlotDetails(
   return details;
 }
 
+function buildSlotPidMap(state: SupervisorState): HeartbeatSlotPid[] {
+  const out: HeartbeatSlotPid[] = [];
+  for (let i = 0; i < state.slots.length; i += 1) {
+    const pid = state.slots[i]!.pid;
+    if (pid !== null && Number.isSafeInteger(pid) && pid > 0) {
+      out.push({ slot: i, pid });
+    }
+  }
+  return out;
+}
+
 function pruneEpochsInWindow(epochs: readonly number[], now: number, windowS: number): number[] {
   const floor = now - Math.max(1, windowS);
   return epochs.filter((epoch) => epoch >= floor);
@@ -1356,6 +1377,7 @@ async function emitFleetHeartbeat(
       ? { trunkFreshness: result.trunkFreshness ?? state.lastTrunkFreshness }
       : {}),
     slotDetails: buildSlotDetails(state, config),
+    slotPids: buildSlotPidMap(state),
   };
   let rawWrite: FleetHeartbeatEmitResult | void = undefined;
   try {
@@ -2592,6 +2614,53 @@ export async function terminateAll(state: SupervisorState, deps: SupervisorDeps)
   }
 }
 
+export interface SupervisorAdoptionResult {
+  adopted: HeartbeatSlotPid[];
+  dead: HeartbeatSlotPid[];
+}
+
+export async function adoptPersistedSlotPids(
+  state: SupervisorState,
+  deps: SupervisorDeps,
+): Promise<SupervisorAdoptionResult> {
+  const result: SupervisorAdoptionResult = { adopted: [], dead: [] };
+  if (!deps.proc.slotPid) return result;
+
+  for (let i = 0; i < state.slots.length; i += 1) {
+    const slot = state.slots[i]!;
+    if (slot.pid !== null) continue;
+    const pid = deps.proc.slotPid(i);
+    if (pid === null || !Number.isSafeInteger(pid) || pid <= 0) continue;
+    if (deps.proc.isAlive(pid)) {
+      slot.pid = pid;
+      slot.spawnEpoch = 0;
+      slot.stalled = false;
+      slot.stallSinceEpoch = 0;
+      slot.reaped = false;
+      result.adopted.push({ slot: i, pid });
+    } else {
+      result.dead.push({ slot: i, pid });
+    }
+  }
+
+  if (result.adopted.length > 0 || result.dead.length > 0) {
+    deps.log?.(
+      `takeover adoption: adopted=${result.adopted.length} dead=${result.dead.length} target=${state.slots.length}`,
+    );
+    await emitSupervisorEvent(deps, {
+      kind: "supervisor.message",
+      payload: {
+        message: "takeover adoption",
+        adopted: result.adopted.length,
+        dead: result.dead.length,
+        target: state.slots.length,
+      },
+    });
+  }
+
+  return result;
+}
+
 /**
  * The supervisor's startup + health-check loop, composing the steps above. This
  * is the testable shape of supervisor.sh's main body (~1109-1141): validate
@@ -2670,11 +2739,17 @@ export async function runSupervisor(
     }
   }
 
+  // Adopt live detached workers from the previous supervisor's persisted
+  // slot->pid snapshot before spawning the initial fleet. Dead pids are left as
+  // empty slots, so the spawn loop fills only the remainder.
+  await adoptPersistedSlotPids(state, deps);
+
   // Spawn the initial fleet to target.
   const initialBudget = readDrainBudget(state, deps, config);
   logDrainBudgetTransition(state, deps, initialBudget, 0);
   for (let i = 0; i < state.slots.length; i += 1) {
     const slot = state.slots[i]!;
+    if (slot.pid !== null && deps.proc.isAlive(slot.pid)) continue;
     const spawned = await spawnSlotForBudget(i, deps, state, initialBudget);
     if (spawned === null) continue;
     slot.pid = spawned.pid;

--- a/apps/dev/src/core/watchdog.ts
+++ b/apps/dev/src/core/watchdog.ts
@@ -350,6 +350,9 @@ async function recoverDeadSupervisor(
   } catch (err) {
     io.log(`watchdog: relaunch failed: ${err instanceof Error ? err.message : String(err)}`);
   }
-  io.log(`watchdog: dead supervisor respawned — fresh fleet relaunched (target ${signals.target}).`);
+  io.log(
+    `watchdog: dead supervisor respawned — reason=${signals.readyForAgent} ready stranded, ` +
+      `${signals.liveWorkers}/${signals.target} live worker(s); fresh fleet relaunched.`,
+  );
   return { ...base, respawnedDeadSupervisor: true };
 }

--- a/apps/dev/src/runtime/supervisor-spawn.ts
+++ b/apps/dev/src/runtime/supervisor-spawn.ts
@@ -9,7 +9,7 @@ import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { encodeDevSnapshotToon } from "../core/toon-snapshot.js";
-import type { ElasticShrinkMode } from "../core/supervisor.js";
+import type { ElasticShrinkMode, HeartbeatSlotPid } from "../core/supervisor.js";
 import { afkPaths } from "./wire.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -56,6 +56,8 @@ export interface SpawnSupervisorOptions {
   drainBudgetUsd?: number;
   /** Initial shrink mode for runtime target decreases. */
   shrinkMode?: ElasticShrinkMode;
+  /** Prior supervisor slot -> worker pid map for takeover/adoption. */
+  adoptSlotPids?: readonly HeartbeatSlotPid[];
 }
 
 /**
@@ -80,6 +82,9 @@ export async function spawnSupervisor(opts: SpawnSupervisorOptions): Promise<num
   if (opts.request) env.RED_AFK_REQUEST = opts.request;
   if (opts.drainBudgetUsd !== undefined) env.RED_AFK_DRAIN_MAX_COST_USD = String(opts.drainBudgetUsd);
   if (opts.shrinkMode !== undefined) env.RED_AFK_SHRINK_MODE = opts.shrinkMode;
+  if (opts.adoptSlotPids && opts.adoptSlotPids.length > 0) {
+    env.RED_AFK_ADOPT_SLOT_PIDS = JSON.stringify(opts.adoptSlotPids);
+  }
 
   const child = spawn(process.execPath, [process.argv[1]!, "__supervise", ...childArgs], {
     cwd: opts.root,
@@ -118,6 +123,7 @@ export function stampFreshFleetHeartbeat(
     shrink_mode: "drain-then-retire",
     ready_for_agent: 0,
     slots: { busy: 0, free: target, total: target, parked: 0 },
+    slot_pids: [],
     spawns_this_tick: 0,
   });
   const tmp = `${statePath}.tmp`;

--- a/apps/dev/src/runtime/supervisor-state.ts
+++ b/apps/dev/src/runtime/supervisor-state.ts
@@ -86,3 +86,32 @@ export async function reapStaleSupervisorState(
   }
   return { status: "stale", ...(pid !== null ? { pid } : {}), removed };
 }
+
+export async function reapDeadSupervisorSnapshotDirs(
+  supervisorsRoot: string,
+  isLivePid: (pid: number) => boolean = defaultIsLivePid,
+  currentPid: number = process.pid,
+): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(supervisorsRoot);
+  } catch {
+    return [];
+  }
+
+  const removed: string[] = [];
+  for (const entry of entries) {
+    const match = /^s([1-9][0-9]*)$/.exec(entry);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    if (!Number.isSafeInteger(pid) || pid === currentPid || isLivePid(pid)) continue;
+    const dir = join(supervisorsRoot, entry);
+    try {
+      await rm(dir, { recursive: true, force: true });
+      removed.push(dir);
+    } catch {
+      // Best-effort cleanup; a failed remove remains visible for the next boot.
+    }
+  }
+  return removed;
+}

--- a/apps/dev/src/runtime/watchdog-io.ts
+++ b/apps/dev/src/runtime/watchdog-io.ts
@@ -8,6 +8,7 @@ import { constants } from "node:fs";
 import { access, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { SupervisorLiveness } from "../core/supervisor.js";
+import type { HeartbeatSlotPid } from "../core/supervisor.js";
 import type { DeadSupervisorSignals, WatchdogIO } from "../core/watchdog.js";
 import { afkPaths, readFleetState, resolveRepoSlug } from "./wire.js";
 import { listStaleClaimDirs, removeDir } from "./fs.js";
@@ -65,6 +66,7 @@ export function buildWatchdogIO(
   // wedged supervisor left no usable heartbeat.
   let lastTarget = 2;
   let lastRunner = "";
+  let lastSlotPids: HeartbeatSlotPid[] = [];
 
   // Count worker processes that survived the supervisor's death. Workers are
   // spawned detached, so they outlive the supervisor; the dead-supervisor net
@@ -99,6 +101,7 @@ export function buildWatchdogIO(
       if (fleet) {
         if (fleet.slotsTotal > 0) lastTarget = fleet.slotsTotal;
         if (fleet.runner) lastRunner = fleet.runner;
+        lastSlotPids = fleet.slotPids ?? [];
       }
       return {
         pid,
@@ -167,7 +170,7 @@ export function buildWatchdogIO(
           processTree: callerProcessTreeNative(),
           scriptPath: process.argv[1],
         }).runner;
-      await spawnSupervisor({ root, target: lastTarget, runner });
+      await spawnSupervisor({ root, target: lastTarget, runner, adoptSlotPids: lastSlotPids });
       // Stamp a fresh heartbeat so the very next watchdog pass (a monitor cron
       // tick firing every poll) sees the new supervisor as healthy and does not
       // double-fire while it boots.

--- a/apps/dev/src/runtime/wire.ts
+++ b/apps/dev/src/runtime/wire.ts
@@ -528,6 +528,7 @@ function parseFleetState(raw: unknown): FleetState | null {
       message?: unknown;
     };
     slot_details?: unknown;
+    slot_pids?: unknown;
   };
   const epoch = Number(rec.epoch ?? 0);
   if (!Number.isFinite(epoch) || epoch <= 0) return null;
@@ -551,6 +552,22 @@ function parseFleetState(raw: unknown): FleetState | null {
       const rawRetry = entry.retry_at !== undefined ? Number(entry.retry_at) : undefined;
       const retryAt = rawRetry !== undefined && Number.isFinite(rawRetry) ? rawRetry : undefined;
       slotDetails.push({ index: idx, status: status as SlotDetail["status"], ...(retryAt !== undefined ? { retryAt } : {}) });
+    }
+  }
+
+  let slotPids: FleetState["slotPids"] | undefined;
+  if (Array.isArray(rec.slot_pids)) {
+    slotPids = [];
+    const seen = new Set<number>();
+    for (const p of rec.slot_pids as unknown[]) {
+      if (p === null || typeof p !== "object") continue;
+      const entry = p as { slot?: unknown; pid?: unknown };
+      const slot = Number(entry.slot);
+      const pid = Number(entry.pid);
+      if (!Number.isSafeInteger(slot) || slot < 0 || seen.has(slot)) continue;
+      if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+      seen.add(slot);
+      slotPids.push({ slot, pid });
     }
   }
 
@@ -600,6 +617,7 @@ function parseFleetState(raw: unknown): FleetState | null {
     churnWindowS: Number(rec.churn?.window_s ?? 0) || 0,
     ...(trunkFreshness !== undefined ? { trunkFreshness } : {}),
     ...(slotDetails !== undefined ? { slotDetails } : {}),
+    ...(slotPids !== undefined ? { slotPids } : {}),
   };
 }
 

--- a/apps/dev/tests/castle-engine-toon-uniformity.test.ts
+++ b/apps/dev/tests/castle-engine-toon-uniformity.test.ts
@@ -50,6 +50,8 @@ function sampleHeartbeat(): FleetHeartbeat {
     epoch: 42,
     lastProgressEpoch: 41,
     runner: "claude",
+    target: 2,
+    shrinkMode: "drain-then-retire",
     bundleVersion: "9.9.9",
     readyForAgent: 3,
     slotsBusy: 1,
@@ -58,7 +60,9 @@ function sampleHeartbeat(): FleetHeartbeat {
     slotsParked: 0,
     spawnsThisTick: 0,
     churn: { deaths: 2, respawns: 2, windowS: 300 },
-  } as FleetHeartbeat;
+    slotDetails: [],
+    slotPids: [{ slot: 0, pid: 12345 }],
+  };
 }
 
 describe("castle-engine write-surface TOON uniformity", () => {
@@ -93,6 +97,7 @@ describe("castle-engine write-surface TOON uniformity", () => {
     const decoded = decode(bytes) as Record<string, unknown>;
     expect(decoded.epoch).toBe(42);
     expect(decoded.slots).toEqual({ busy: 1, free: 1, total: 2, parked: 0 });
+    expect(decoded.slot_pids).toEqual([{ slot: 0, pid: 12345 }]);
     expect(decoded.churn).toEqual({ deaths: 2, respawns: 2, window_s: 300 });
   });
 
@@ -105,6 +110,7 @@ describe("castle-engine write-surface TOON uniformity", () => {
     const decoded = decode(bytes) as Record<string, unknown>;
     expect(decoded.epoch).toBe(7);
     expect(decoded.slots).toEqual({ busy: 0, free: 2, total: 2, parked: 0 });
+    expect(decoded.slot_pids).toEqual([]);
   });
 
   it("the supervisor restart ledger is TOON, never raw JSON", async () => {

--- a/apps/dev/tests/fleet-command.test.ts
+++ b/apps/dev/tests/fleet-command.test.ts
@@ -75,6 +75,36 @@ describe("fleet command stale supervisor state", () => {
     }
   });
 
+  it("launchFleet passes the prior slot pid map to the relaunched supervisor", async () => {
+    const root = scratch();
+    try {
+      const paths = writeSupervisorArtifacts(root, 999_999_999);
+      const epoch = Math.floor(Date.now() / 1000);
+      writeFileSync(
+        paths.state,
+        JSON.stringify({
+          ts: new Date(epoch * 1000).toISOString(),
+          epoch,
+          runner: "codex",
+          ready_for_agent: 2,
+          slots: { busy: 2, free: 0, total: 2, parked: 0 },
+          slot_pids: [{ slot: 0, pid: 11111 }, { slot: 1, pid: 22222 }],
+          spawns_this_tick: 0,
+        }),
+        "utf8",
+      );
+
+      await launchFleet(["2", "--runner", "codex"], root, stream());
+
+      expect(spawnSupervisor).toHaveBeenCalledWith(expect.objectContaining({
+        adoptSlotPids: [{ slot: 0, pid: 11111 }, { slot: 1, pid: 22222 }],
+      }));
+      expect(existsSync(paths.state)).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("stopFleet removes dead supervisor pid/state/log files", async () => {
     const root = scratch();
     try {

--- a/apps/dev/tests/supervisor-state.test.ts
+++ b/apps/dev/tests/supervisor-state.test.ts
@@ -1,0 +1,40 @@
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { reapDeadSupervisorSnapshotDirs } from "../src/runtime/supervisor-state.js";
+
+function scratch(): string {
+  return mkdtempSync(join(tmpdir(), "afk-supervisor-state-"));
+}
+
+describe("reapDeadSupervisorSnapshotDirs", () => {
+  it("removes dead s<PID> supervisor snapshot dirs and preserves live/current dirs", async () => {
+    const root = scratch();
+    try {
+      const supervisors = join(root, ".red", "state", "castle", "supervisors");
+      const dead = join(supervisors, "s111");
+      const live = join(supervisors, "s222");
+      const current = join(supervisors, "s333");
+      const named = join(supervisors, "default");
+      for (const dir of [dead, live, current, named]) {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "state.toon"), "state\n", "utf8");
+      }
+
+      const removed = await reapDeadSupervisorSnapshotDirs(
+        supervisors,
+        (pid) => pid === 222,
+        333,
+      );
+
+      expect(removed).toEqual([dead]);
+      expect(existsSync(dead)).toBe(false);
+      expect(existsSync(live)).toBe(true);
+      expect(existsSync(current)).toBe(true);
+      expect(existsSync(named)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/dev/tests/supervisor.test.ts
+++ b/apps/dev/tests/supervisor.test.ts
@@ -6,6 +6,7 @@ import {
   buildCrashEnvelope,
   buildDiscardEnvelope,
   buildReaperEnvelope,
+  adoptPersistedSlotPids,
   decideCrashReconcile,
   dispatchReconcileIfPossible,
   reconcileDeadWorkerClaim,
@@ -1560,6 +1561,27 @@ describe("superviseTick — crash reconcile on respawn (#815)", () => {
 // ---------- runSupervisor end-to-end shape ----------
 
 describe("runSupervisor", () => {
+  it("adopts live persisted slot pids and leaves dead ones for spawn", async () => {
+    const { deps, io } = makeDeps({
+      isAlive: vi.fn((pid: number) => pid === 5000),
+      spawnSlot: vi.fn(async (slot: number) => ({ pid: 9000 + slot, spawnEpoch: NOW })),
+    });
+    deps.proc.slotPid = vi.fn((slot: number) => (slot === 0 ? 5000 : slot === 1 ? 6000 : null));
+    const state = initSupervisorState(2);
+
+    const adoption = await adoptPersistedSlotPids(state, deps);
+
+    expect(adoption.adopted).toEqual([{ slot: 0, pid: 5000 }]);
+    expect(adoption.dead).toEqual([{ slot: 1, pid: 6000 }]);
+    expect(state.slots[0]!.pid).toBe(5000);
+    expect(state.slots[1]!.pid).toBeNull();
+
+    await runSupervisor(state, deps, config({ target: 2 }), () => true);
+
+    expect(io.spawnSlot).toHaveBeenCalledTimes(1);
+    expect(io.spawnSlot).toHaveBeenCalledWith(1);
+  });
+
   it("emits structured supervisor lane records for boot, tick, reconcile, wake, and scale", async () => {
     let clock = NOW;
     let probes = 0;

--- a/apps/dev/tests/troubleshooting-playbook-contract.test.ts
+++ b/apps/dev/tests/troubleshooting-playbook-contract.test.ts
@@ -17,6 +17,7 @@ const TROUBLESHOOTING_DOCS = [
       "## Base-stale decision procedure",
       "## Requeue escalation map",
       "## Release-pipeline playbook",
+      "## Fleet stop and takeover verification",
     ],
   },
   {

--- a/packages/red-castle/src/engine/monitor.ts
+++ b/packages/red-castle/src/engine/monitor.ts
@@ -228,6 +228,11 @@ export interface SlotDetail {
   retryAt?: number;
 }
 
+export interface SlotPid {
+  slot: number;
+  pid: number;
+}
+
 export interface FleetTrunkFreshness {
   status: "refreshed" | "failed" | "throttled";
   refreshedAtEpoch: number;
@@ -271,6 +276,8 @@ export interface FleetState {
   /** Per-slot details for non-closed slots. Absent/empty = all slots closed.
    * Absent on state files written before this field was added (#630). */
   slotDetails?: SlotDetail[];
+  /** Persisted supervisor slot -> worker pid map for takeover/adoption. */
+  slotPids?: SlotPid[];
 }
 
 export const FLEET_STALE_AFTER_S = 180;

--- a/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
+++ b/plugins/dev/skills/engineering/afk/TROUBLESHOOTING.md
@@ -217,3 +217,44 @@ release trigger even though the code diff is already on `main`.
 
 This playbook establishes the documentation contract for release troubleshooting
 in #1863; the durable release policy remains the conventional-commit pipeline.
+
+## Fleet stop and takeover verification
+
+### Symptom
+
+A fleet supervisor was stopped, killed, relaunched, or watchdog-respawned, and
+you need to prove whether workers were cleanly stopped or adopted by the new
+supervisor.
+
+### Confirm
+
+1. Run `red-skills-dev fleet status` and read the supervisor health, target,
+   slot counts, and live worker list.
+2. Check `.red/tmp/supervisors/default/state.toon` for `slot_pids`. A relaunched
+   supervisor uses this map to adopt live detached workers into their original
+   slots before spawning replacements.
+3. For a clean stop, verify `afk-supervisor.pid` is gone and no live worker pids
+   remain under `.red/tmp/workers/*/worker.pid`.
+4. For takeover, compare the pre-relaunch `slot_pids` with the post-relaunch
+   state: live pids should remain in slots, dead pids should disappear, and
+   `spawns_this_tick` should fill only the missing remainder.
+5. Check `.red/state/castle/supervisors/` for stale `s<PID>` snapshot dirs. Dead
+   supervisor dirs should be removed on the next supervisor boot.
+
+### Recover
+
+1. Prefer `red-skills-dev fleet stop` for a clean stop; it writes the stop file,
+   waits for the supervisor, then sweeps detached orphan workers.
+2. If the supervisor died unexpectedly, let `red-skills-dev fleet` or the
+   watchdog relaunch it. The relaunch should report why it respawned, including
+   ready work stranded and live workers versus target.
+3. If live workers were not adopted, stop the fleet, verify no pids remain live,
+   then relaunch from a clean state.
+4. If stale castle supervisor dirs remain after boot, remove only dead `s<PID>`
+   dirs after confirming the pid is not live.
+
+### Root fix
+
+Supervisor snapshots persist slot pids so takeover is automatic. This playbook
+is the manual verification path for #2067 and should stay aligned with the
+state snapshot contract.


### PR DESCRIPTION
Automated AFK landing for #2067. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2067

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786934495&installation_id=129708444&pr_number=2088&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2088&signature=5c71befe5c0af1b7582ff2aec17de27c4605b0c3d93a07caa9b2c76472c15370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->