### PR TITLE
fix: #2076 Trunk-freshness S5: cascade-rebase-on-land (rebase DONE-waiting siblings, exclude active trees)

### DIFF
--- a/packages/red-castle/src/engine/landing.test.ts
+++ b/packages/red-castle/src/engine/landing.test.ts
@@ -127,4 +127,100 @@ describe("castle landing coordinator", () => {
     });
     expect(t.closed).toEqual([1911]);
   });
+
+  it("cascade-rebases DONE-waiting siblings after a successful land while skipping active workers", async () => {
+    const t = tracker();
+    const calls: string[] = [];
+    const cascadeRebase = vi.fn(async ({ issue }: { issue: number }) => {
+      calls.push(`cascade:${issue}`);
+      if (issue === 2002) {
+        return {
+          ok: false as const,
+          outcome: "parked" as const,
+          message: "agent ladder parked semantic conflict",
+        };
+      }
+      return { ok: true as const, outcome: "rebased" as const };
+    });
+
+    const result = await runCastleLanding({
+      issue: 2001,
+      branch: "worker/2001",
+      base: "main",
+      gate: gate(true, ["approved"]),
+      tracker: {
+        ...t,
+        async closeIssue(issue) {
+          calls.push(`close:${issue}`);
+          await t.closeIssue(issue);
+        },
+        async commentOnIssue(issue, body) {
+          calls.push(`comment:${issue}`);
+          await t.commentOnIssue(issue, body);
+        },
+      },
+      land: async () => {
+        calls.push("land");
+        return { ok: true, mergeSha: "trunk-tip" };
+      },
+      cascade: {
+        siblings: [
+          { issue: 2002, branch: "worker/2002", state: "done-waiting" },
+          { issue: 2003, branch: "worker/2003", state: "done-waiting" },
+          { issue: 2004, branch: "worker/2004", state: "active" },
+        ],
+        rebase: cascadeRebase,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      mergeSha: "trunk-tip",
+      cascade: [
+        {
+          issue: 2002,
+          branch: "worker/2002",
+          status: "parked",
+          message: "agent ladder parked semantic conflict",
+        },
+        {
+          issue: 2003,
+          branch: "worker/2003",
+          status: "rebased",
+        },
+        {
+          issue: 2004,
+          branch: "worker/2004",
+          status: "skipped-active",
+        },
+      ],
+    });
+    expect(cascadeRebase).toHaveBeenCalledTimes(2);
+    expect(cascadeRebase).toHaveBeenNthCalledWith(1, {
+      issue: 2002,
+      branch: "worker/2002",
+      base: "main",
+      trunkTip: "trunk-tip",
+    });
+    expect(cascadeRebase).toHaveBeenNthCalledWith(2, {
+      issue: 2003,
+      branch: "worker/2003",
+      base: "main",
+      trunkTip: "trunk-tip",
+    });
+    expect(calls).toEqual([
+      "land",
+      "cascade:2002",
+      "comment:2002",
+      "cascade:2003",
+      "comment:2003",
+      "comment:2004",
+      "close:2001",
+    ]);
+    expect(t.comments.map((comment) => comment.body)).toEqual([
+      "🤖 Castle cascade rebase: worker/2002 parked after the landing rebase ladder: agent ladder parked semantic conflict.",
+      "🤖 Castle cascade rebase: worker/2003 rebased onto trunk-tip.",
+      "🤖 Castle cascade rebase: worker/2004 skipped because the worker is active.",
+    ]);
+  });
 });

--- a/packages/red-castle/src/engine/landing.ts
+++ b/packages/red-castle/src/engine/landing.ts
@@ -22,8 +22,55 @@ export type CastleLandingMergeResult =
   | { ok: true; mergeSha?: string }
   | { ok: false; reason: string; message?: string };
 
+export interface CastleCascadeSibling {
+  issue: number;
+  branch: string;
+  base?: string;
+  state: "done-waiting" | "active";
+}
+
+export interface CastleCascadeRebaseInput {
+  issue: number;
+  branch: string;
+  base?: string;
+  trunkTip?: string;
+}
+
+export type CastleCascadeRebaseResult =
+  | { ok: true; outcome?: "rebased" | "already-current"; message?: string }
+  | { ok: false; outcome: "parked"; message?: string };
+
+export type CastleCascadeSiblingOutcome =
+  | {
+      issue: number;
+      branch: string;
+      status: "rebased" | "already-current" | "parked";
+      message?: string;
+    }
+  | {
+      issue: number;
+      branch: string;
+      status: "skipped-active";
+    };
+
+export interface CastleLandingCascadeInput {
+  siblings: readonly CastleCascadeSibling[];
+  /**
+   * Rebase one DONE-waiting sibling through the same resolution ladder used on
+   * the DONE landing path: mechanical, then bounded agent, then park.
+   * `runCastleLanding` calls this only after a successful land, while the caller
+   * still owns the land-lock / merge-queue serialization context.
+   */
+  rebase(input: CastleCascadeRebaseInput): Promise<CastleCascadeRebaseResult>;
+}
+
 export type CastleLandingResult =
-  | { ok: true; mergeSha?: string; cleanupError?: string }
+  | {
+      ok: true;
+      mergeSha?: string;
+      cleanupError?: string;
+      cascade?: CastleCascadeSiblingOutcome[];
+    }
   | {
       ok: false;
       reason: "gate-failed" | "gate-parked" | "land-failed";
@@ -38,6 +85,7 @@ export interface RunCastleLandingInput {
   tracker: CastleLandingTracker;
   land(input: CastleLandingMergeInput): Promise<CastleLandingMergeResult>;
   cleanupBranch?(branch: string): Promise<void>;
+  cascade?: CastleLandingCascadeInput;
 }
 
 function firstBlockingSinkOutcome(
@@ -48,6 +96,72 @@ function firstBlockingSinkOutcome(
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function renderCascadeComment(
+  outcome: CastleCascadeSiblingOutcome,
+  trunkTip?: string,
+): string {
+  if (outcome.status === "skipped-active") {
+    return `🤖 Castle cascade rebase: ${outcome.branch} skipped because the worker is active.`;
+  }
+  if (outcome.status === "parked") {
+    const suffix = outcome.message ? `: ${outcome.message}` : "";
+    return `🤖 Castle cascade rebase: ${outcome.branch} parked after the landing rebase ladder${suffix}.`;
+  }
+  const target = trunkTip ?? "the new trunk tip";
+  return `🤖 Castle cascade rebase: ${outcome.branch} ${outcome.status === "already-current" ? "already current with" : "rebased onto"} ${target}.`;
+}
+
+async function runCascadeRebase(
+  input: RunCastleLandingInput,
+  trunkTip?: string,
+): Promise<CastleCascadeSiblingOutcome[] | undefined> {
+  if (!input.cascade) return undefined;
+
+  const outcomes: CastleCascadeSiblingOutcome[] = [];
+  for (const sibling of input.cascade.siblings) {
+    if (sibling.state === "active") {
+      const outcome: CastleCascadeSiblingOutcome = {
+        issue: sibling.issue,
+        branch: sibling.branch,
+        status: "skipped-active",
+      };
+      outcomes.push(outcome);
+      await input.tracker.commentOnIssue(
+        sibling.issue,
+        renderCascadeComment(outcome, trunkTip),
+      );
+      continue;
+    }
+
+    const rebased = await input.cascade.rebase({
+      issue: sibling.issue,
+      branch: sibling.branch,
+      base: sibling.base ?? input.base,
+      trunkTip,
+    });
+    const outcome: CastleCascadeSiblingOutcome = rebased.ok
+      ? {
+          issue: sibling.issue,
+          branch: sibling.branch,
+          status: rebased.outcome ?? "rebased",
+          ...(rebased.message ? { message: rebased.message } : {}),
+        }
+      : {
+          issue: sibling.issue,
+          branch: sibling.branch,
+          status: "parked",
+          ...(rebased.message ? { message: rebased.message } : {}),
+        };
+    outcomes.push(outcome);
+    await input.tracker.commentOnIssue(
+      sibling.issue,
+      renderCascadeComment(outcome, trunkTip),
+    );
+  }
+
+  return outcomes;
 }
 
 export async function runCastleLanding(
@@ -77,6 +191,8 @@ export async function runCastleLanding(
     };
   }
 
+  const cascade = await runCascadeRebase(input, landed.mergeSha);
+
   await input.tracker.closeIssue(input.issue);
 
   let cleanupError: string | undefined;
@@ -86,7 +202,10 @@ export async function runCastleLanding(
     cleanupError = errorMessage(error);
   }
 
-  return cleanupError
-    ? { ok: true, mergeSha: landed.mergeSha, cleanupError }
-    : { ok: true, mergeSha: landed.mergeSha };
+  return {
+    ok: true,
+    ...(landed.mergeSha ? { mergeSha: landed.mergeSha } : {}),
+    ...(cleanupError ? { cleanupError } : {}),
+    ...(cascade ? { cascade } : {}),
+  };
 }


### PR DESCRIPTION
Automated AFK landing for #2076. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #2076

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/red-skills/pr/2089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786935275&installation_id=129708444&pr_number=2089&repository=reddb-io%2Fred-skills&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Fred-skills%2Fpull%2F2089&signature=831c8104f4251a6db6515d2242bdc49b609c83cb46f9779d94254760a290a343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->